### PR TITLE
feat(LinkedIn): enhance table naming and date partitioning

### DIFF
--- a/src/Integrations/LinkedIn/Helper.js
+++ b/src/Integrations/LinkedIn/Helper.js
@@ -62,5 +62,20 @@ var LinkedInHelper = {
    */
   formatDateForUrl: function(date) {
     return `(year:${date.getFullYear()},month:${date.getMonth() + 1},day:${date.getDate()})`;
+  },
+
+  /**
+   * Convert a string to snake_case:
+   * - Inserts an underscore between lowercase-to-uppercase transitions
+   * - Converts the entire string to lowercase
+   * - Replaces any non-alphanumeric or underscore characters with '_'
+   * @param {string} str
+   * @returns {string}
+   */
+  toSnakeCase: function(str) {
+    return str
+      .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+      .toLowerCase()
+      .replace(/[^a-z0-9_]/g, '_');
   }
 };

--- a/src/Integrations/LinkedIn/LinkedInAdsAPIReference/adAnalyticsFields.js
+++ b/src/Integrations/LinkedIn/LinkedInAdsAPIReference/adAnalyticsFields.js
@@ -85,7 +85,8 @@ var adAnalyticsFields = {
     'description': 'Date range covered by the report data point. Date is specified in UTC. Start and end date are inclusive. Start date is required. End date is optional and defaults to today.',
     'type': 'string',
     'GoogleSheetsFormat': '@',
-    'GoogleBigQueryType': 'date'
+    'GoogleBigQueryType': 'date',
+    'GoogleBigQueryPartitioned': true
   },
   'documentCompletions': {
     'description': 'The number of times users reached 100% of the document\'s length, including those that skipped to this point. This metric is only available for document ads and not all dimensions.',

--- a/src/Integrations/LinkedIn/Pipeline.js
+++ b/src/Integrations/LinkedIn/Pipeline.js
@@ -9,7 +9,7 @@ var LinkedInPipeline = class LinkedInPipeline extends AbstractPipeline {
   constructor(config, connector, storageName = "GoogleSheetsStorage") {
     super(config.mergeParameters({
       DestinationTableNamePrefix: {
-        default: ""
+        default: connector.apiType === LinkedInApiTypes.ADS ? "linkedin_ads_" : "linkedin_pages_"
       }
     }), connector);
 
@@ -150,7 +150,7 @@ var LinkedInPipeline = class LinkedInPipeline extends AbstractPipeline {
       this.storages[nodeName] = new globalThis[this.storageName](
         this.config.mergeParameters({
           DestinationSheetName: { value: nodeName },
-          DestinationTableName: { value: this.config.DestinationTableNamePrefix.value + nodeName.replace(/[^a-zA-Z0-9_]/g, "_") }
+          DestinationTableName: { value: this.config.DestinationTableNamePrefix.value + LinkedInHelper.toSnakeCase(nodeName) }
         }),
         uniqueFields,
         this.connector.fieldsSchema[nodeName]["fields"],


### PR DESCRIPTION
## Changes
- Added `toSnakeCase` helper function for consistent table naming across LinkedIn integration
- Implemented automatic table prefix based on API type:
  - `linkedin_ads_` for Ads API
  - `linkedin_pages_` for Pages API
- Added `GoogleBigQueryPartitioned` flag for date fields to optimize BigQuery performance