### PR TITLE
refactor(web): update Logo component export pattern 

### DIFF
--- a/apps/web/src/components/Logo/Logo.tsx
+++ b/apps/web/src/components/Logo/Logo.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import logoSvg from '../../assets/logo.svg';
 
 interface LogoProps {
@@ -7,8 +6,6 @@ interface LogoProps {
   className?: string;
 }
 
-const Logo: React.FC<LogoProps> = ({ width = 45, height = 36, className = '' }) => {
+export const Logo = ({ width = 45, height = 36, className = '' }: LogoProps) => {
   return <img src={logoSvg} alt='OWOX Logo' width={width} height={height} className={className} />;
 };
-
-export default Logo;

--- a/apps/web/src/components/Logo/index.ts
+++ b/apps/web/src/components/Logo/index.ts
@@ -1,3 +1,3 @@
-import Logo from './Logo';
+import { Logo } from './Logo';
 
 export default Logo;


### PR DESCRIPTION
## Changes
- Changed Logo component export from default to named export
- Removed unnecessary React import
- Simplified component syntax by removing React.FC type
- Updated component import in index.ts file

## Motivation
This change aligns with modern React practices by:
- Using named exports for better tree-shaking
- Removing redundant React import (not needed since React 17+)
- Simplifying component type definitions