### PR TITLE
Changed 'table' to 'dataset'

### DIFF
--- a/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
+++ b/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
@@ -247,7 +247,7 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
         query += `ALTER TABLE \`${this.config.DestinationDatasetID.value}.${this.config.DestinationTableName.value}\`\n\n`;
         query += columns.join(",\n");
         this.executeQuery(query);
-        this.config.logMessage(`Columns '${newColumns.join(",")}' were added to ${this.config.DestinationDatasetID.value} table`);
+        this.config.logMessage(`Columns '${newColumns.join(",")}' were added to ${this.config.DestinationDatasetID.value} dataset`);
       }
 
 


### PR DESCRIPTION
In the log sections, it's more appropriate to write 'Columns 'name,currency,account_id' were added to project.dataset dataset': 
![image](https://github.com/user-attachments/assets/4aad1827-8048-4fcf-ae73-b0ed5e554f15)

