### PR TITLE
fix(conntectors): Returned ignoring the launch of the eslinter

### DIFF
--- a/packages/connectors/eslint.config.js
+++ b/packages/connectors/eslint.config.js
@@ -30,6 +30,6 @@ export default [
   eslintConfigPrettier,
   // Ignore patterns
   {
-    ignores: ['dist/**', 'node_modules/**'],
+    ignores: ['dist/**', 'node_modules/**', 'src/**/*'],
   },
 ];

--- a/packages/eslint-config/node.js
+++ b/packages/eslint-config/node.js
@@ -1,7 +1,4 @@
-import js from '@eslint/js';
-import eslintConfigPrettier from 'eslint-config-prettier';
 import globals from 'globals';
-import tseslint from 'typescript-eslint';
 
 import { config as baseConfig } from './base.js';
 


### PR DESCRIPTION
@zapolsky @amarchenk0 , in #159 , I removed the `'src/**/*'` folder ignore in the ESLint configuration for connectors. It turned out that this should not have been done, because the final configuration is not yet available.