### PR TITLE
refactor(owox): updare serve

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -16,7 +16,7 @@
   "engines": {
     "node": ">=22.16.0"
   },
-  "main": "./dist/main.js",
+  "main": "./dist/src/main.js",
   "files": ["dist/", "README.md"],
   "scripts": {
     "build": "npm run build:clean && npm run build:web && npm run build:app && npm run copy:assets",


### PR DESCRIPTION
After discussing with @amarchenk0, I questioned whether we needed to process signals in `owox serve`. If signal processing is removed, then `kill -2 {PID}` (SIGINT) and `kill -15 {PID}` (SIGTERM) of the main process do not terminate child processes.

In this PR, I refactored the code and fixed the bug when `owox senve` don't find `@owox/backend`. I did not remove signal handling.