### PR TITLE
feat(backend): added cross-platform sqlite db path

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,7 +2,7 @@ TYPEORM_LOGGING=true
 RUN_MIGRATIONS=false
 DB_TYPE=sqlite
 
-DB_NAME=/path/to/db/backend.db
+SQLITE_DB_PATH=./path/to/database/backend.db
 
 
 DB_HOST=localhost

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -56,6 +56,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "env-paths": "^3.0.0",
     "mysql2": "^3.14.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/apps/backend/src/config/data-source-options.config.ts
+++ b/apps/backend/src/config/data-source-options.config.ts
@@ -1,64 +1,13 @@
 import { ConfigService } from '@nestjs/config';
 import { DataSourceOptions, LoggerOptions } from 'typeorm';
 import { Logger } from '@nestjs/common';
-import envPaths from 'env-paths';
-import { existsSync, mkdirSync } from 'fs';
-import { dirname, join } from 'path';
+import { getSqliteDatabasePath } from './get-sqlite-database-path';
 
 const logger = new Logger('DataSourceOptions');
 
 export enum DbType {
   sqlite = 'sqlite',
   mysql = 'mysql',
-}
-
-/**
- * Determines the SQLite database file path based on configuration.
- *
- * If `SQLITE_DB_PATH` environment variable is set, uses that path directly.
- * Otherwise, uses cross-platform application data directory with 'owox/sqlite/app.db' structure.
- * Automatically creates the database directory if it doesn't exist.
- *
- * @param config - NestJS ConfigService instance for accessing environment variables
- * @returns The absolute path to the SQLite database file
- * @throws {Error} When database directory cannot be created due to permissions or other filesystem errors
- *
- * @example
- * ```typescript
- * // With SQLITE_DB_PATH env variable
- * SQLITE_DB_PATH=./var/sqlite/app.db
- * // Returns: /project/root/var/sqlite/app.db
- *
- * // Without env variable (macOS example)
- * // Returns: ~/Library/Application Support/owox/sqlite/app.db
- * ```
- */
-function getSqliteDatabasePath(config: ConfigService): string {
-  const envDbPath = config.get<string>('SQLITE_DB_PATH');
-
-  let dbPath: string;
-
-  if (envDbPath) {
-    logger.log(`Using SQLite database path from \`SQLITE_DB_PATH\` env: ${envDbPath}`);
-    dbPath = envDbPath;
-  } else {
-    const paths = envPaths('owox', { suffix: '' });
-    logger.log(`Using system app data directory for SQLite: ${paths.data}`);
-    dbPath = join(paths.data, 'sqlite', 'app.db');
-  }
-
-  const dbDir = dirname(dbPath);
-  if (!existsSync(dbDir)) {
-    try {
-      mkdirSync(dbDir, { recursive: true });
-      logger.log(`Created SQLite database directory: ${dbDir}`);
-    } catch (error) {
-      throw new Error(`Failed to create SQLite database directory: ${dbDir}. ${error.message}`);
-    }
-  }
-
-  logger.log(`Using SQLite database path: ${dbPath}`);
-  return dbPath;
 }
 
 export function createDataSourceOptions(config: ConfigService): DataSourceOptions {

--- a/apps/backend/src/config/data-source-options.config.ts
+++ b/apps/backend/src/config/data-source-options.config.ts
@@ -1,12 +1,64 @@
 import { ConfigService } from '@nestjs/config';
 import { DataSourceOptions, LoggerOptions } from 'typeorm';
 import { Logger } from '@nestjs/common';
+import envPaths from 'env-paths';
+import { existsSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
 
 const logger = new Logger('DataSourceOptions');
 
 export enum DbType {
   sqlite = 'sqlite',
   mysql = 'mysql',
+}
+
+/**
+ * Determines the SQLite database file path based on configuration.
+ *
+ * If `SQLITE_DB_PATH` environment variable is set, uses that path directly.
+ * Otherwise, uses cross-platform application data directory with 'owox/sqlite/app.db' structure.
+ * Automatically creates the database directory if it doesn't exist.
+ *
+ * @param config - NestJS ConfigService instance for accessing environment variables
+ * @returns The absolute path to the SQLite database file
+ * @throws {Error} When database directory cannot be created due to permissions or other filesystem errors
+ *
+ * @example
+ * ```typescript
+ * // With SQLITE_DB_PATH env variable
+ * SQLITE_DB_PATH=./var/sqlite/app.db
+ * // Returns: /project/root/var/sqlite/app.db
+ *
+ * // Without env variable (macOS example)
+ * // Returns: ~/Library/Application Support/owox/sqlite/app.db
+ * ```
+ */
+function getSqliteDatabasePath(config: ConfigService): string {
+  const envDbPath = config.get<string>('SQLITE_DB_PATH');
+
+  let dbPath: string;
+
+  if (envDbPath) {
+    logger.log(`Using SQLite database path from \`SQLITE_DB_PATH\` env: ${envDbPath}`);
+    dbPath = envDbPath;
+  } else {
+    const paths = envPaths('owox', { suffix: '' });
+    logger.log(`Using system app data directory for SQLite: ${paths.data}`);
+    dbPath = join(paths.data, 'sqlite', 'app.db');
+  }
+
+  const dbDir = dirname(dbPath);
+  if (!existsSync(dbDir)) {
+    try {
+      mkdirSync(dbDir, { recursive: true });
+      logger.log(`Created SQLite database directory: ${dbDir}`);
+    } catch (error) {
+      throw new Error(`Failed to create SQLite database directory: ${dbDir}. ${error.message}`);
+    }
+  }
+
+  logger.log(`Using SQLite database path: ${dbPath}`);
+  return dbPath;
 }
 
 export function createDataSourceOptions(config: ConfigService): DataSourceOptions {
@@ -26,7 +78,7 @@ export function createDataSourceOptions(config: ConfigService): DataSourceOption
   const dbConfigs: Record<DbType, DataSourceOptions> = {
     [DbType.sqlite]: {
       type: DbType.sqlite,
-      database: config.get<string>('DB_NAME') ?? 'var/sqlite/backend.db',
+      database: getSqliteDatabasePath(config),
       ...baseOptions,
     },
     [DbType.mysql]: {

--- a/apps/backend/src/config/get-sqlite-database-path.ts
+++ b/apps/backend/src/config/get-sqlite-database-path.ts
@@ -1,0 +1,55 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import envPaths from 'env-paths';
+import { existsSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+
+const logger = new Logger('SQLiteDatabasePath');
+
+/**
+ * Determines the SQLite database file path based on configuration.
+ *
+ * If `SQLITE_DB_PATH` environment variable is set, uses that path directly.
+ * Otherwise, uses cross-platform application data directory with 'owox/sqlite/app.db' structure.
+ * Automatically creates the database directory if it doesn't exist.
+ *
+ * @param config - NestJS ConfigService instance for accessing environment variables
+ * @returns The absolute path to the SQLite database file
+ * @throws {Error} When database directory cannot be created due to permissions or other filesystem errors
+ *
+ * @example
+ * ```typescript
+ * // With SQLITE_DB_PATH env variable
+ * SQLITE_DB_PATH=./var/sqlite/app.db
+ * // Returns: /project/root/var/sqlite/app.db
+ *
+ * // Without env variable (macOS example)
+ * // Returns: ~/Library/Application Support/owox/sqlite/app.db
+ * ```
+ */
+export function getSqliteDatabasePath(config: ConfigService): string {
+  const envDbPath = config.get<string>('SQLITE_DB_PATH');
+
+  let dbPath: string;
+
+  if (envDbPath) {
+    logger.log(`Using SQLite database path from \`SQLITE_DB_PATH\` env: ${envDbPath}`);
+    dbPath = envDbPath;
+  } else {
+    const paths = envPaths('owox', { suffix: '' });
+    dbPath = join(paths.data, 'sqlite', 'app.db');
+    logger.log(`Using system app data directory for SQLite: ${dbPath}`);
+  }
+
+  const dbDir = dirname(dbPath);
+  if (!existsSync(dbDir)) {
+    try {
+      mkdirSync(dbDir, { recursive: true });
+      logger.log(`Created SQLite database directory: ${dbDir}`);
+    } catch (error) {
+      throw new Error(`Failed to create SQLite database directory: ${dbDir}. ${error.message}`);
+    }
+  }
+
+  return dbPath;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@nestjs/typeorm": "^11.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
+        "env-paths": "^3.0.0",
         "mysql2": "^3.14.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -125,6 +126,18 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "apps/backend/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "apps/backend/node_modules/typeorm": {


### PR DESCRIPTION
This PR introduces enhanced logic for determining the SQLite database file path, improving flexibility and cross-platform compatibility.

**Key Changes:**

*   **Dynamic SQLite Path Resolution:**
    *   A new function `getSqliteDatabasePath` has been implemented in `apps/backend/src/config/data-source-options.config.ts`.
    *   This function allows specifying the SQLite database path via the `SQLITE_DB_PATH` environment variable.
    *   If `SQLITE_DB_PATH` is not set, the database will automatically be stored in the system's application data directory (e.g., `~/Library/Application Support/owox/sqlite/app.db` on macOS) using the `env-paths` library.
    *   Automatically creates necessary directories if they do not exist.

*   **Configuration Updates:**
    *   The `apps/backend/.env.example` file has been updated to use `SQLITE_DB_PATH` instead of `DB_NAME`.
    *   A new `env-paths` dependency has been added to `apps/backend/package.json` for cross-platform path resolution.

**Why was this done?**

These changes provide greater flexibility in deploying and using the backend across different operating systems, as the SQLite database path can now be easily configured or automatically determined according to OS standards.