### PR TITLE
feat(backend): implement Google Sheets export functionality

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -46,6 +46,8 @@
     "migration:create-template": "ts-node commands/create-migration-template.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-athena": "^3.839.0",
+    "@google-cloud/bigquery": "^8.1.0",
     "@google-cloud/pubsub": "^4.0.7",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
@@ -57,6 +59,8 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "env-paths": "^3.0.0",
+    "googleapis": "^150.0.1",
+    "luxon": "^3.6.1",
     "mysql2": "^3.14.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/apps/backend/src/common/schemas/google-service-account-key.schema.ts
+++ b/apps/backend/src/common/schemas/google-service-account-key.schema.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+const privateKeyRegex = /^-----BEGIN PRIVATE KEY-----\n[\s\S]*\n-----END PRIVATE KEY-----\n?$/;
+
+export const GoogleServiceAccountKeySchema = z
+  .object({
+    type: z.literal('service_account'),
+    project_id: z.string().min(1, 'project_id is required'),
+    private_key_id: z.string().min(1, 'private_key_id is required'),
+    private_key: z
+      .string()
+      .min(1, 'private_key is required')
+      .regex(privateKeyRegex, 'private_key must be a valid PEM format private key'),
+    client_email: z.string().email('client_email must be a valid email'),
+    client_id: z.string().min(1, 'client_id is required'),
+    auth_uri: z
+      .string()
+      .url('auth_uri must be a valid URL')
+      .default('https://accounts.google.com/o/oauth2/auth'),
+    token_uri: z
+      .string()
+      .url('token_uri must be a valid URL')
+      .default('https://oauth2.googleapis.com/token'),
+    auth_provider_x509_cert_url: z
+      .string()
+      .url('auth_provider_x509_cert_url must be a valid URL')
+      .default('https://www.googleapis.com/oauth2/v1/certs'),
+    client_x509_cert_url: z.string().url('client_x509_cert_url must be a valid URL'),
+    universe_domain: z.string().default('googleapis.com'),
+  })
+  .passthrough();
+
+export type GoogleServiceAccountKey = z.infer<typeof GoogleServiceAccountKeySchema>;

--- a/apps/backend/src/common/zod/zod-transformer.ts
+++ b/apps/backend/src/common/zod/zod-transformer.ts
@@ -1,0 +1,19 @@
+import { ValueTransformer } from 'typeorm';
+import { ZodTypeAny } from 'zod';
+
+/**
+ * Creates a value transformer that uses a Zod schema for validation.
+ *
+ * @param {ZodTypeAny} schema - The Zod schema used to validate and transform the value.
+ * @return {ValueTransformer} A value transformer object that validates data using the provided schema during both `to` and `from` operations.
+ */
+export function createZodTransformer<T>(schema: ZodTypeAny): ValueTransformer {
+  return {
+    to(value: T): T {
+      return schema.parse(value); // validate before save
+    },
+    from(value: unknown): T {
+      return schema.parse(value); // validate after load
+    },
+  };
+}

--- a/apps/backend/src/data-marts/controllers/data-destination.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-destination.controller.ts
@@ -1,0 +1,89 @@
+import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { CreateDataDestinationApiDto } from '../dto/presentation/create-data-destination-api.dto';
+import { CreateDataDestinationService } from '../use-cases/create-data-destination.service';
+import { DataDestinationMapper } from '../mappers/data-destination.mapper';
+import { UpdateDataDestinationApiDto } from '../dto/presentation/update-data-destination-api.dto';
+import { DataDestinationResponseApiDto } from '../dto/presentation/data-destination-response-api.dto';
+import { UpdateDataDestinationService } from '../use-cases/update-data-destination.service';
+import { GetDataDestinationService } from '../use-cases/get-data-destination.service';
+import { ListDataDestinationsService } from '../use-cases/list-data-destinations.service';
+import {
+  AuthContext,
+  AuthorizationContext,
+} from '../../common/authorization-context/authorization.context';
+import {
+  CreateDataDestinationSpec,
+  DeleteDataDestinationSpec,
+  GetDataDestinationSpec,
+  ListDataDestinationsSpec,
+  UpdateDataDestinationSpec,
+} from './spec/data-destination.api';
+import { ApiTags } from '@nestjs/swagger';
+import { DeleteDataDestinationService } from '../use-cases/delete-data-destination.service';
+
+@Controller('data-destinations')
+@ApiTags('DataDestinations')
+export class DataDestinationController {
+  constructor(
+    private readonly createService: CreateDataDestinationService,
+    private readonly updateService: UpdateDataDestinationService,
+    private readonly getService: GetDataDestinationService,
+    private readonly listService: ListDataDestinationsService,
+    private readonly deleteService: DeleteDataDestinationService,
+    private readonly mapper: DataDestinationMapper
+  ) {}
+
+  @Post()
+  @CreateDataDestinationSpec()
+  async create(
+    @AuthContext() context: AuthorizationContext,
+    @Body() dto: CreateDataDestinationApiDto
+  ): Promise<DataDestinationResponseApiDto> {
+    const command = this.mapper.toCreateCommand(context, dto);
+    const dataDestinationDto = await this.createService.run(command);
+    return this.mapper.toApiResponse(dataDestinationDto);
+  }
+
+  @Put(':id')
+  @UpdateDataDestinationSpec()
+  async update(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string,
+    @Body() dto: UpdateDataDestinationApiDto
+  ): Promise<DataDestinationResponseApiDto> {
+    const command = this.mapper.toUpdateCommand(id, context, dto);
+    const dataDestinationDto = await this.updateService.run(command);
+    return this.mapper.toApiResponse(dataDestinationDto);
+  }
+
+  @Get(':id')
+  @GetDataDestinationSpec()
+  async get(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string
+  ): Promise<DataDestinationResponseApiDto> {
+    const command = this.mapper.toGetCommand(id, context);
+    const dataDestinationDto = await this.getService.run(command);
+    return this.mapper.toApiResponse(dataDestinationDto);
+  }
+
+  @Get()
+  @ListDataDestinationsSpec()
+  async getAll(
+    @AuthContext() context: AuthorizationContext
+  ): Promise<DataDestinationResponseApiDto[]> {
+    const command = this.mapper.toListCommand(context);
+    const dataDestinationsDto = await this.listService.run(command);
+    return this.mapper.toResponseList(dataDestinationsDto);
+  }
+
+  @Delete(':id')
+  @DeleteDataDestinationSpec()
+  async delete(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string
+  ): Promise<void> {
+    const command = this.mapper.toDeleteCommand(id, context);
+    await this.deleteService.run(command);
+  }
+}

--- a/apps/backend/src/data-marts/controllers/report.controller.ts
+++ b/apps/backend/src/data-marts/controllers/report.controller.ts
@@ -1,0 +1,116 @@
+import { Controller, Get, Post, Put, Body, Param, Delete } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import {
+  AuthContext,
+  AuthorizationContext,
+} from '../../common/authorization-context/authorization.context';
+import { ReportMapper } from '../mappers/report.mapper';
+import { CreateReportRequestApiDto } from '../dto/presentation/create-report-request-api.dto';
+import { UpdateReportRequestApiDto } from '../dto/presentation/update-report-request-api.dto';
+import { ReportResponseApiDto } from '../dto/presentation/report-response-api.dto';
+import { CreateReportService } from '../use-cases/create-report.service';
+import { GetReportService } from '../use-cases/get-report.service';
+import { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
+import { ListReportsByProjectService } from '../use-cases/list-reports-by-project.service';
+import { DeleteReportService } from '../use-cases/delete-report.service';
+import { RunReportService } from '../use-cases/run-report.service';
+import { UpdateReportService } from '../use-cases/update-report.service';
+import {
+  CreateReportSpec,
+  GetReportSpec,
+  ListReportsByDataMartSpec,
+  ListReportsByProjectSpec,
+  DeleteReportSpec,
+  RunReportSpec,
+  UpdateReportSpec,
+} from './spec/report.api';
+
+@Controller('reports')
+@ApiTags('Reports')
+export class ReportController {
+  constructor(
+    private readonly createReportService: CreateReportService,
+    private readonly getReportService: GetReportService,
+    private readonly listReportsByDataMartService: ListReportsByDataMartService,
+    private readonly listReportsByProjectService: ListReportsByProjectService,
+    private readonly deleteReportService: DeleteReportService,
+    private readonly runReportService: RunReportService,
+    private readonly updateReportService: UpdateReportService,
+    private readonly mapper: ReportMapper
+  ) {}
+
+  @Post()
+  @CreateReportSpec()
+  async create(
+    @AuthContext() context: AuthorizationContext,
+    @Body() dto: CreateReportRequestApiDto
+  ): Promise<ReportResponseApiDto> {
+    const command = this.mapper.toCreateDomainCommand(context, dto);
+    const report = await this.createReportService.run(command);
+    return this.mapper.toResponse(report);
+  }
+
+  @Get(':id')
+  @GetReportSpec()
+  async get(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string
+  ): Promise<ReportResponseApiDto> {
+    const command = this.mapper.toGetCommand(id, context);
+    const report = await this.getReportService.run(command);
+    return this.mapper.toResponse(report);
+  }
+
+  @Get('data-mart/:dataMartId')
+  @ListReportsByDataMartSpec()
+  async listByDataMart(
+    @AuthContext() context: AuthorizationContext,
+    @Param('dataMartId') dataMartId: string
+  ): Promise<ReportResponseApiDto[]> {
+    const command = this.mapper.toListByDataMartCommand(dataMartId, context);
+    const reports = await this.listReportsByDataMartService.run(command);
+    return this.mapper.toResponseList(reports);
+  }
+
+  @Get()
+  @ListReportsByProjectSpec()
+  async listByProject(
+    @AuthContext() context: AuthorizationContext
+  ): Promise<ReportResponseApiDto[]> {
+    const command = this.mapper.toListByProjectCommand(context);
+    const reports = await this.listReportsByProjectService.run(command);
+    return this.mapper.toResponseList(reports);
+  }
+
+  @Delete(':id')
+  @DeleteReportSpec()
+  async delete(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string
+  ): Promise<void> {
+    const command = this.mapper.toGetCommand(id, context);
+    await this.deleteReportService.run(command);
+  }
+
+  @Post(':id/run')
+  @RunReportSpec()
+  async runReport(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string
+  ): Promise<void> {
+    const command = this.mapper.toRunReportCommand(id, context);
+    this.runReportService.runAsync(command);
+  }
+
+  @Put(':id')
+  @UpdateReportSpec()
+  async update(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string,
+    @Body() dto: UpdateReportRequestApiDto
+  ): Promise<ReportResponseApiDto> {
+    const command = this.mapper.toUpdateDomainCommand(id, context, dto);
+    const report = await this.updateReportService.run(command);
+    return this.mapper.toResponse(report);
+  }
+}

--- a/apps/backend/src/data-marts/controllers/spec/data-destination.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-destination.api.ts
@@ -1,0 +1,52 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiBody,
+  ApiParam,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiNoContentResponse,
+} from '@nestjs/swagger';
+import { CreateDataDestinationApiDto } from '../../dto/presentation/create-data-destination-api.dto';
+import { UpdateDataDestinationApiDto } from '../../dto/presentation/update-data-destination-api.dto';
+import { DataDestinationResponseApiDto } from '../../dto/presentation/data-destination-response-api.dto';
+
+export function CreateDataDestinationSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Create a new Data Destination' }),
+    ApiBody({ type: CreateDataDestinationApiDto }),
+    ApiCreatedResponse({ type: DataDestinationResponseApiDto })
+  );
+}
+
+export function UpdateDataDestinationSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update Data Destination by ID' }),
+    ApiParam({ name: 'id', description: 'Data Destination ID' }),
+    ApiBody({ type: UpdateDataDestinationApiDto }),
+    ApiOkResponse({ type: DataDestinationResponseApiDto })
+  );
+}
+
+export function GetDataDestinationSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get a Data Destination by ID' }),
+    ApiParam({ name: 'id', description: 'Data Destination ID' }),
+    ApiOkResponse({ type: DataDestinationResponseApiDto })
+  );
+}
+
+export function ListDataDestinationsSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get all Data Destinations' }),
+    ApiOkResponse({ type: [DataDestinationResponseApiDto] })
+  );
+}
+
+export function DeleteDataDestinationSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Delete Data Destination by ID' }),
+    ApiParam({ name: 'id', description: 'Data Destination ID' }),
+    ApiNoContentResponse({ description: 'Data Destination successfully deleted' })
+  );
+}

--- a/apps/backend/src/data-marts/controllers/spec/report.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.api.ts
@@ -1,0 +1,86 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+} from '@nestjs/swagger';
+import { ReportResponseApiDto } from '../../dto/presentation/report-response-api.dto';
+import { CreateReportRequestApiDto } from '../../dto/presentation/create-report-request-api.dto';
+import { UpdateReportRequestApiDto } from '../../dto/presentation/update-report-request-api.dto';
+
+export function CreateReportSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Create a new report' }),
+    ApiBody({ type: CreateReportRequestApiDto }),
+    ApiCreatedResponse({
+      description: 'The report has been successfully created.',
+      type: ReportResponseApiDto,
+    })
+  );
+}
+
+export function ListReportsByDataMartSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get all reports for a data mart' }),
+    ApiParam({ name: 'dataMartId', description: 'Data mart ID' }),
+    ApiOkResponse({
+      description: 'List of reports for the data mart',
+      type: [ReportResponseApiDto],
+    })
+  );
+}
+
+export function ListReportsByProjectSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get all reports for a project' }),
+    ApiOkResponse({
+      description: 'List of reports for the project',
+      type: [ReportResponseApiDto],
+    })
+  );
+}
+
+export function GetReportSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get a report by ID' }),
+    ApiParam({ name: 'id', description: 'Report ID' }),
+    ApiOkResponse({
+      description: 'The report',
+      type: ReportResponseApiDto,
+    })
+  );
+}
+
+export function DeleteReportSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Delete a report' }),
+    ApiParam({ name: 'id', description: 'Report ID' }),
+    ApiOkResponse({
+      description: 'The report has been successfully deleted.',
+    })
+  );
+}
+
+export function RunReportSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Run a report by ID' }),
+    ApiParam({ name: 'id', description: 'Report ID' }),
+    ApiOkResponse({
+      description: 'The report has been successfully started.',
+    })
+  );
+}
+
+export function UpdateReportSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update an existing report' }),
+    ApiParam({ name: 'id', description: 'Report ID' }),
+    ApiBody({ type: UpdateReportRequestApiDto }),
+    ApiOkResponse({
+      description: 'The report has been successfully updated.',
+      type: ReportResponseApiDto,
+    })
+  );
+}

--- a/apps/backend/src/data-marts/data-destination-types/data-destination-config.guards.ts
+++ b/apps/backend/src/data-marts/data-destination-types/data-destination-config.guards.ts
@@ -1,0 +1,17 @@
+import { DataDestinationConfig, DataDestinationConfigSchema } from './data-destination-config.type';
+import {
+  GoogleSheetsConfig,
+  GoogleSheetsConfigType,
+} from './google-sheets/schemas/google-sheets-config.schema';
+
+export function isValidDataDestinationConfig(
+  destination: unknown
+): destination is DataDestinationConfig {
+  return DataDestinationConfigSchema.safeParse(destination).success;
+}
+
+export function isGoogleSheetsDestination(
+  definition: DataDestinationConfig
+): definition is GoogleSheetsConfig {
+  return definition.type === GoogleSheetsConfigType;
+}

--- a/apps/backend/src/data-marts/data-destination-types/data-destination-config.type.ts
+++ b/apps/backend/src/data-marts/data-destination-types/data-destination-config.type.ts
@@ -1,0 +1,6 @@
+import { GoogleSheetsConfigSchema } from './google-sheets/schemas/google-sheets-config.schema';
+import { z } from 'zod';
+
+export const DataDestinationConfigSchema = z.discriminatedUnion('type', [GoogleSheetsConfigSchema]);
+
+export type DataDestinationConfig = z.infer<typeof DataDestinationConfigSchema>;

--- a/apps/backend/src/data-marts/data-destination-types/data-destination-credentials.guards.ts
+++ b/apps/backend/src/data-marts/data-destination-types/data-destination-credentials.guards.ts
@@ -1,0 +1,20 @@
+import {
+  DataDestinationCredentials,
+  DataDestinationCredentialsSchema,
+} from './data-destination-credentials.type';
+import {
+  GoogleSheetsCredentials,
+  GoogleSheetsCredentialsType,
+} from './google-sheets/schemas/google-sheets-credentials.schema';
+
+export function isValidDataDestinationCredentials(
+  credentials: unknown
+): credentials is DataDestinationCredentials {
+  return DataDestinationCredentialsSchema.safeParse(credentials).success;
+}
+
+export function isGoogleSheetsCredentials(
+  credentials: DataDestinationCredentials
+): credentials is GoogleSheetsCredentials {
+  return credentials.type === GoogleSheetsCredentialsType;
+}

--- a/apps/backend/src/data-marts/data-destination-types/data-destination-credentials.type.ts
+++ b/apps/backend/src/data-marts/data-destination-types/data-destination-credentials.type.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import { GoogleSheetsCredentialsSchema } from './google-sheets/schemas/google-sheets-credentials.schema';
+
+export const DataDestinationCredentialsSchema = z.discriminatedUnion('type', [
+  GoogleSheetsCredentialsSchema,
+]);
+
+export type DataDestinationCredentials = z.infer<typeof DataDestinationCredentialsSchema>;

--- a/apps/backend/src/data-marts/data-destination-types/data-destination-facades.ts
+++ b/apps/backend/src/data-marts/data-destination-types/data-destination-facades.ts
@@ -1,0 +1,7 @@
+import { DataDestinationAccessValidatorFacade } from './facades/data-destination-access-validator.facade';
+import { DataDestinationCredentialsValidatorFacade } from './facades/data-destination-credentials-validator.facade';
+
+export const dataDestinationFacadesProviders = [
+  DataDestinationAccessValidatorFacade,
+  DataDestinationCredentialsValidatorFacade,
+];

--- a/apps/backend/src/data-marts/data-destination-types/data-destination-providers.ts
+++ b/apps/backend/src/data-marts/data-destination-types/data-destination-providers.ts
@@ -1,0 +1,52 @@
+import { DataDestinationAccessValidator } from './interfaces/data-destination-access-validator.interface';
+import { DataDestinationCredentialsValidator } from './interfaces/data-destination-credentials-validator.interface';
+import { GoogleSheetsAccessValidator } from './google-sheets/services/google-sheets-access-validator';
+import { GoogleSheetsCredentialsValidator } from './google-sheets/services/google-sheets-credentials-validator';
+import { DataDestinationType } from './enums/data-destination-type.enum';
+import { TypeResolver } from '../../common/resolver/type-resolver';
+import { GoogleSheetsReportWriter } from './google-sheets/services/google-sheets-report-writer';
+import { DataDestinationReportWriter } from './interfaces/data-destination-report-writer.interface';
+import { SheetHeaderFormatter } from './google-sheets/services/sheet-formatters/sheet-header-formatter';
+import { SheetMetadataFormatter } from './google-sheets/services/sheet-formatters/sheet-metadata-formatter';
+import { GoogleSheetsApiAdapterFactory } from './google-sheets/adapters/google-sheets-api-adapter.factory';
+
+export const DATA_DESTINATION_ACCESS_VALIDATOR_RESOLVER = Symbol(
+  'DATA_DESTINATION_ACCESS_VALIDATOR_RESOLVER'
+);
+export const DATA_DESTINATION_CREDENTIALS_VALIDATOR_RESOLVER = Symbol(
+  'DATA_DESTINATION_CREDENTIALS_VALIDATOR_RESOLVER'
+);
+export const DATA_DESTINATION_REPORT_WRITER_RESOLVER = Symbol(
+  'DATA_DESTINATION_REPORT_WRITER_RESOLVER'
+);
+
+const accessValidatorProviders = [GoogleSheetsAccessValidator];
+const credentialsValidatorProviders = [GoogleSheetsCredentialsValidator];
+const reportWriterProviders = [GoogleSheetsReportWriter];
+const googleSheetsUtilityProviders = [SheetHeaderFormatter, SheetMetadataFormatter];
+
+export const dataDestinationResolverProviders = [
+  ...accessValidatorProviders,
+  ...credentialsValidatorProviders,
+  ...reportWriterProviders,
+  ...googleSheetsUtilityProviders,
+  GoogleSheetsApiAdapterFactory,
+  {
+    provide: DATA_DESTINATION_ACCESS_VALIDATOR_RESOLVER,
+    useFactory: (...validators: DataDestinationAccessValidator[]) =>
+      new TypeResolver<DataDestinationType, DataDestinationAccessValidator>(validators),
+    inject: accessValidatorProviders,
+  },
+  {
+    provide: DATA_DESTINATION_CREDENTIALS_VALIDATOR_RESOLVER,
+    useFactory: (...validators: DataDestinationCredentialsValidator[]) =>
+      new TypeResolver<DataDestinationType, DataDestinationCredentialsValidator>(validators),
+    inject: credentialsValidatorProviders,
+  },
+  {
+    provide: DATA_DESTINATION_REPORT_WRITER_RESOLVER,
+    useFactory: (...writers: DataDestinationReportWriter[]) =>
+      new TypeResolver<DataDestinationType, DataDestinationReportWriter>(writers),
+    inject: reportWriterProviders,
+  },
+];

--- a/apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum.ts
+++ b/apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum.ts
@@ -1,0 +1,12 @@
+export enum DataDestinationType {
+  GOOGLE_SHEETS = 'GOOGLE_SHEETS',
+}
+
+export function toHumanReadable(type: DataDestinationType): string {
+  switch (type) {
+    case DataDestinationType.GOOGLE_SHEETS:
+      return 'Google Sheets';
+    default:
+      return type;
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/facades/data-destination-access-validator.facade.ts
+++ b/apps/backend/src/data-marts/data-destination-types/facades/data-destination-access-validator.facade.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { TypeResolver } from '../../../common/resolver/type-resolver';
+import { DataDestinationType } from '../enums/data-destination-type.enum';
+import { DataDestinationAccessValidator } from '../interfaces/data-destination-access-validator.interface';
+import { DATA_DESTINATION_ACCESS_VALIDATOR_RESOLVER } from '../data-destination-providers';
+import { DataDestinationConfig } from '../data-destination-config.type';
+import { AccessValidationException } from '../../../common/exceptions/access-validation.exception';
+import { DataDestination } from '../../entities/data-destination.entity';
+
+@Injectable()
+export class DataDestinationAccessValidatorFacade {
+  constructor(
+    @Inject(DATA_DESTINATION_ACCESS_VALIDATOR_RESOLVER)
+    private readonly resolver: TypeResolver<DataDestinationType, DataDestinationAccessValidator>
+  ) {}
+
+  async checkAccess(
+    type: DataDestinationType,
+    destinationConfig: DataDestinationConfig,
+    dataDestination: DataDestination
+  ): Promise<void> {
+    const validationResult = await this.resolver
+      .resolve(type)
+      .validate(destinationConfig, dataDestination);
+    if (!validationResult.valid) {
+      throw new AccessValidationException(validationResult.errorMessage!, validationResult.reason);
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/facades/data-destination-credentials-validator.facade.ts
+++ b/apps/backend/src/data-marts/data-destination-types/facades/data-destination-credentials-validator.facade.ts
@@ -1,0 +1,28 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { TypeResolver } from '../../../common/resolver/type-resolver';
+import { DataDestinationType } from '../enums/data-destination-type.enum';
+import { DATA_DESTINATION_CREDENTIALS_VALIDATOR_RESOLVER } from '../data-destination-providers';
+import { AccessValidationException } from '../../../common/exceptions/access-validation.exception';
+import { DataDestinationCredentials } from '../data-destination-credentials.type';
+import { DataDestinationCredentialsValidator } from '../interfaces/data-destination-credentials-validator.interface';
+
+@Injectable()
+export class DataDestinationCredentialsValidatorFacade {
+  constructor(
+    @Inject(DATA_DESTINATION_CREDENTIALS_VALIDATOR_RESOLVER)
+    private readonly resolver: TypeResolver<
+      DataDestinationType,
+      DataDestinationCredentialsValidator
+    >
+  ) {}
+
+  async checkCredentials(
+    type: DataDestinationType,
+    credentials: DataDestinationCredentials
+  ): Promise<void> {
+    const validationResult = await this.resolver.resolve(type).validate(credentials);
+    if (!validationResult.valid) {
+      throw new AccessValidationException(validationResult.errorMessage!, validationResult.reason);
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api-adapter.factory.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api-adapter.factory.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+import { GoogleSheetsApiAdapter } from './google-sheets-api.adapter';
+import { GoogleSheetsCredentials } from '../schemas/google-sheets-credentials.schema';
+
+@Injectable()
+export class GoogleSheetsApiAdapterFactory {
+  create(credentials: GoogleSheetsCredentials): GoogleSheetsApiAdapter {
+    return new GoogleSheetsApiAdapter(credentials);
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
@@ -1,0 +1,183 @@
+import { Logger } from '@nestjs/common';
+import { GoogleAuth } from 'google-auth-library';
+import { google, sheets_v4 } from 'googleapis';
+import { GoogleServiceAccountKey } from '../../../../common/schemas/google-service-account-key.schema';
+import { GoogleSheetsCredentials } from '../schemas/google-sheets-credentials.schema';
+
+/**
+ * Adapter for Google Sheets API operations
+ */
+export class GoogleSheetsApiAdapter {
+  private static readonly SHEETS_SCOPE = ['https://www.googleapis.com/auth/spreadsheets'];
+  private static readonly LOGGER = new Logger(GoogleSheetsApiAdapter.name);
+
+  private readonly service: sheets_v4.Sheets;
+
+  /**
+   * @param credentials - Google Sheets credentials containing service account key
+   * @throws Error if invalid credentials are provided
+   */
+  constructor(credentials: GoogleSheetsCredentials) {
+    this.service = google.sheets({
+      version: 'v4',
+      auth: GoogleSheetsApiAdapter.createGoogleAuth(credentials.serviceAccountKey),
+    });
+  }
+
+  /**
+   * Validates Google Sheets credentials
+   *
+   * @param credentials - Google Sheets credentials to validate
+   * @returns True if credentials are valid, false otherwise
+   */
+  public static async validateCredentials(credentials: GoogleSheetsCredentials): Promise<boolean> {
+    try {
+      const googleAuth = GoogleSheetsApiAdapter.createGoogleAuth(credentials.serviceAccountKey);
+      const authClient = await googleAuth.getClient();
+      await authClient.getAccessToken();
+      return true;
+    } catch (error) {
+      GoogleSheetsApiAdapter.LOGGER.warn('Failed to validate Google Sheets credentials', error);
+      return false;
+    }
+  }
+
+  /**
+   * Retrieves spreadsheet metadata
+   *
+   * @param spreadsheetId - ID of the spreadsheet to retrieve
+   * @param fields - Optional fields to include in the response
+   */
+  public async getSpreadsheet(
+    spreadsheetId: string,
+    fields: string = 'properties,sheets.properties'
+  ): Promise<sheets_v4.Schema$Spreadsheet> {
+    const resp = await this.executeWithRetry(() =>
+      this.service.spreadsheets.get({
+        spreadsheetId,
+        includeGridData: false,
+        fields,
+      })
+    );
+    return resp.data;
+  }
+
+  /**
+   * Finds a sheet by its ID within a spreadsheet
+   */
+  public findSheetById(
+    spreadsheet: sheets_v4.Schema$Spreadsheet,
+    sheetId: number
+  ): sheets_v4.Schema$Sheet | undefined {
+    return spreadsheet.sheets?.find(s => s?.properties?.sheetId === sheetId);
+  }
+
+  /**
+   * Clears all content from a sheet
+   */
+  public async clearSheet(spreadsheetId: string, sheetTitle: string): Promise<void> {
+    await this.executeWithRetry(() =>
+      this.service.spreadsheets.values.clear({
+        spreadsheetId,
+        range: `'${sheetTitle}'`,
+      })
+    );
+  }
+
+  /**
+   * Updates values in a sheet
+   */
+  public async updateValues(
+    spreadsheetId: string,
+    range: string,
+    values: unknown[][]
+  ): Promise<void> {
+    await this.executeWithRetry(() =>
+      this.service.spreadsheets.values.update({
+        spreadsheetId,
+        range,
+        valueInputOption: 'USER_ENTERED',
+        requestBody: {
+          values,
+        },
+      })
+    );
+  }
+
+  /**
+   * Appends rows or columns to a sheet in a Google Spreadsheet.
+   */
+  public async appendDimensionToSheet(
+    spreadsheetId: string,
+    sheetId: number,
+    size: number,
+    dimension: 'ROWS' | 'COLUMNS'
+  ): Promise<void> {
+    const requests: sheets_v4.Schema$Request[] = [
+      {
+        appendDimension: {
+          dimension: dimension,
+          sheetId: sheetId,
+          length: size,
+        },
+      },
+    ];
+    await this.batchUpdate(spreadsheetId, requests);
+  }
+
+  /**
+   * Performs a batch update operation on a spreadsheet
+   */
+  public async batchUpdate(
+    spreadsheetId: string,
+    requests: sheets_v4.Schema$Request[]
+  ): Promise<void> {
+    await this.executeWithRetry(() =>
+      this.service.spreadsheets.batchUpdate({
+        spreadsheetId,
+        requestBody: { requests },
+      })
+    );
+  }
+
+  /**
+   * Creates a GoogleAuth instance
+   */
+  private static createGoogleAuth(serviceAccountKey: GoogleServiceAccountKey): GoogleAuth {
+    return new GoogleAuth({
+      credentials: serviceAccountKey,
+      scopes: GoogleSheetsApiAdapter.SHEETS_SCOPE,
+    });
+  }
+
+  /**
+   * Executes an API call with exponential backoff retry for quota-exceeded errors
+   */
+  private async executeWithRetry<T>(apiCallFn: () => Promise<T>): Promise<T> {
+    const maxRetries = 5;
+    const maxDelayMs = 30000; // 30 seconds
+    const baseDelayMs = 1000; // 1 second
+
+    let retryCount = 0;
+    while (retryCount < maxRetries) {
+      try {
+        return await apiCallFn();
+      } catch (error) {
+        if (!error.message.includes('Quota exceeded')) {
+          throw error;
+        }
+
+        const delayMs = Math.min(Math.pow(2, retryCount) * baseDelayMs, maxDelayMs);
+        GoogleSheetsApiAdapter.LOGGER.warn(
+          `Google API quota exceeded. Retrying in ${delayMs / 1000} seconds. ` +
+            `Retry ${retryCount + 1}/${maxRetries}`
+        );
+
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+        retryCount++;
+      }
+    }
+
+    throw new Error('Maximum retry attempts exceeded');
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/schemas/google-sheets-config.schema.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/schemas/google-sheets-config.schema.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * Type identifier for Google Sheets configuration
+ */
+export const GoogleSheetsConfigType = 'google-sheets-config';
+
+/**
+ * Schema for validating Google Sheets configuration
+ * Defines the structure and validation rules for Google Sheets destination configuration
+ */
+export const GoogleSheetsConfigSchema = z.object({
+  /**
+   * Configuration type identifier
+   */
+  type: z.literal(GoogleSheetsConfigType),
+
+  /**
+   * ID of the Google Spreadsheet
+   * This is the unique identifier found in the spreadsheet URL
+   */
+  spreadsheetId: z.string().min(1, 'Correction Google Spreadsheet ID is required'),
+
+  /**
+   * ID of the specific sheet within the spreadsheet
+   * Each sheet in a Google Spreadsheet has a unique numeric ID
+   */
+  sheetId: z.number().min(0, 'Correction Google Spreadsheet sheet ID is required'),
+});
+
+/**
+ * Type definition for Google Sheets configuration
+ * Represents the structure of a validated Google Sheets configuration object
+ */
+export type GoogleSheetsConfig = z.infer<typeof GoogleSheetsConfigSchema>;

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/schemas/google-sheets-credentials.schema.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/schemas/google-sheets-credentials.schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { GoogleServiceAccountKeySchema } from '../../../../common/schemas/google-service-account-key.schema';
+
+/**
+ * Type identifier for Google Sheets credentials
+ */
+export const GoogleSheetsCredentialsType = 'google-sheets-credentials';
+
+/**
+ * Schema for validating Google Sheets credentials
+ * Defines the structure and validation rules for Google Sheets API authentication
+ */
+export const GoogleSheetsCredentialsSchema = z
+  .object({
+    /**
+     * Credentials type identifier
+     */
+    type: z.literal(GoogleSheetsCredentialsType),
+
+    /**
+     * Google service account key used for authentication
+     * Contains the necessary credentials for accessing Google Sheets API
+     */
+    serviceAccountKey: GoogleServiceAccountKeySchema,
+  })
+  .passthrough();
+
+/**
+ * Type definition for Google Sheets credentials
+ * Represents the structure of a validated Google Sheets credentials object
+ */
+export type GoogleSheetsCredentials = z.infer<typeof GoogleSheetsCredentialsSchema>;

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-access-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-access-validator.ts
@@ -1,0 +1,78 @@
+import {
+  DataDestinationAccessValidator,
+  ValidationResult,
+} from '../../interfaces/data-destination-access-validator.interface';
+import { DataDestinationType } from '../../enums/data-destination-type.enum';
+import { DataDestinationConfig } from '../../data-destination-config.type';
+import { Injectable, Logger } from '@nestjs/common';
+import { GoogleSheetsCredentialsSchema } from '../schemas/google-sheets-credentials.schema';
+import { GoogleSheetsConfigSchema } from '../schemas/google-sheets-config.schema';
+import { DataDestination } from '../../../entities/data-destination.entity';
+import { GoogleSheetsApiAdapter } from '../adapters/google-sheets-api.adapter';
+
+/**
+ * Validator for Google Sheets access
+ * Validates that the provided credentials and configuration allow access to the specified sheet
+ */
+@Injectable()
+export class GoogleSheetsAccessValidator implements DataDestinationAccessValidator {
+  private readonly logger = new Logger(GoogleSheetsAccessValidator.name);
+  readonly type = DataDestinationType.GOOGLE_SHEETS;
+
+  /**
+   * Validates access to a Google Sheets destination
+   *
+   * @param destinationConfig - Configuration for the Google Sheets destination
+   * @param dataDestination - Data destination entity containing credentials
+   * @returns Validation result with success status and optional error details
+   */
+  async validate(
+    destinationConfig: DataDestinationConfig,
+    dataDestination: DataDestination
+  ): Promise<ValidationResult> {
+    const credentials = dataDestination.credentials;
+
+    const credentialsOpt = GoogleSheetsCredentialsSchema.safeParse(credentials);
+    if (!credentialsOpt.success) {
+      this.logger.warn('Invalid credentials format', credentialsOpt.error);
+      return new ValidationResult(false, 'Invalid credentials', {
+        errors: credentialsOpt.error.errors,
+      });
+    }
+
+    const configOpt = GoogleSheetsConfigSchema.safeParse(destinationConfig);
+    if (!configOpt.success) {
+      this.logger.warn('Invalid configuration format', configOpt.error);
+      return new ValidationResult(false, 'Invalid configuration', {
+        errors: configOpt.error.errors,
+      });
+    }
+
+    try {
+      const adapter = new GoogleSheetsApiAdapter(credentials);
+      const spreadsheet = await adapter.getSpreadsheet(
+        configOpt.data.spreadsheetId,
+        'properties.title,sheets.properties.sheetId,sheets.properties.title'
+      );
+      const sheet = adapter.findSheetById(spreadsheet, configOpt.data.sheetId);
+
+      if (!spreadsheet?.properties?.title || !sheet || !sheet?.properties?.title) {
+        this.logger.warn(
+          `Failed to find sheet ${configOpt.data.sheetId} in spreadsheet ${configOpt.data.spreadsheetId}`
+        );
+        return new ValidationResult(
+          false,
+          `Failed to find sheet ${configOpt.data.sheetId} in spreadsheet ${configOpt.data.spreadsheetId}`
+        );
+      }
+
+      return new ValidationResult(true, undefined, undefined, {
+        spreadsheetTitle: spreadsheet.properties?.title,
+        sheetTitle: sheet.properties?.title,
+      });
+    } catch (error) {
+      this.logger.warn('Access check failed', error);
+      return new ValidationResult(false, 'Access check failed');
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-credentials-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-credentials-validator.ts
@@ -1,0 +1,49 @@
+import { DataDestinationType } from '../../enums/data-destination-type.enum';
+import { DataDestinationCredentials } from '../../data-destination-credentials.type';
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  DataDestinationCredentialsValidator,
+  ValidationResult,
+} from '../../interfaces/data-destination-credentials-validator.interface';
+import { GoogleSheetsCredentialsSchema } from '../schemas/google-sheets-credentials.schema';
+import { GoogleSheetsApiAdapter } from '../adapters/google-sheets-api.adapter';
+
+/**
+ * Validator for Google Sheets credentials
+ * Validates that the provided credentials are valid for Google Sheets API access
+ */
+@Injectable()
+export class GoogleSheetsCredentialsValidator implements DataDestinationCredentialsValidator {
+  private readonly logger = new Logger(GoogleSheetsCredentialsValidator.name);
+  readonly type = DataDestinationType.GOOGLE_SHEETS;
+
+  /**
+   * Validates Google Sheets credentials
+   *
+   * @param credentials - Credentials to validate
+   * @returns Validation result with success status and optional error details
+   */
+  async validate(credentials: DataDestinationCredentials): Promise<ValidationResult> {
+    const credentialsOpt = GoogleSheetsCredentialsSchema.safeParse(credentials);
+    if (!credentialsOpt.success) {
+      this.logger.warn('Invalid credentials format', credentialsOpt.error);
+      return new ValidationResult(false, 'Invalid credentials', {
+        errors: credentialsOpt.error.errors,
+      });
+    }
+
+    try {
+      const isValid = await GoogleSheetsApiAdapter.validateCredentials(credentialsOpt.data);
+
+      if (!isValid) {
+        this.logger.warn('Invalid credentials');
+        return new ValidationResult(false, 'Invalid credentials');
+      }
+
+      return new ValidationResult(true);
+    } catch (error) {
+      this.logger.warn('Invalid credentials', error);
+      return new ValidationResult(false, 'Invalid credentials');
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -1,0 +1,236 @@
+import { DataDestinationReportWriter } from '../../interfaces/data-destination-report-writer.interface';
+import { DataDestinationType } from '../../enums/data-destination-type.enum';
+import { Injectable, Logger, Scope } from '@nestjs/common';
+import { isGoogleSheetsDestination } from '../../data-destination-config.guards';
+import { isGoogleSheetsCredentials } from '../../data-destination-credentials.guards';
+import { GoogleSheetsConfig } from '../schemas/google-sheets-config.schema';
+import { DateTime } from 'luxon';
+import { Report } from '../../../entities/report.entity';
+import { ReportDataDescription } from '../../../dto/domain/report-data-description.dto';
+import { ReportDataBatch } from '../../../dto/domain/report-data-batch.dto';
+import { SheetHeaderFormatter } from './sheet-formatters/sheet-header-formatter';
+import { SheetMetadataFormatter } from './sheet-formatters/sheet-metadata-formatter';
+import { GoogleSheetsApiAdapter } from '../adapters/google-sheets-api.adapter';
+import { GoogleSheetsApiAdapterFactory } from '../adapters/google-sheets-api-adapter.factory';
+
+/**
+ * Service for writing report data to Google Sheets
+ * Handles preparation, writing, and finalization of report data in Google Sheets
+ */
+@Injectable({ scope: Scope.TRANSIENT })
+export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
+  readonly type = DataDestinationType.GOOGLE_SHEETS;
+
+  private readonly logger = new Logger(GoogleSheetsReportWriter.name);
+
+  private adapter: GoogleSheetsApiAdapter;
+
+  // State for current write operation
+  private destination: GoogleSheetsConfig;
+  private spreadsheetTimeZone: string;
+  private sheetTitle: string;
+  private dataMartTitle: string;
+  private writtenRowsCount = 0;
+  private availableRowsCount = 0;
+  private availableColumnsCount = 0;
+
+  constructor(
+    private readonly headerFormatter: SheetHeaderFormatter,
+    private readonly metadataFormatter: SheetMetadataFormatter,
+    private readonly adapterFactory: GoogleSheetsApiAdapterFactory
+  ) {}
+
+  /**
+   * Prepares the Google Sheets document for writing report data
+   * This method initializes the service, finds the sheet, prepares columns, clears the sheet, and writes headers
+   */
+  public async prepareToWriteReport(
+    report: Report,
+    reportDataDescription: ReportDataDescription
+  ): Promise<void> {
+    return this.executeWithErrorHandling(async () => {
+      await this.initializeService(report);
+
+      await this.prepareSheetColumns(reportDataDescription.dataHeaders.length);
+
+      if (reportDataDescription.estimatedDataRowsCount) {
+        await this.ensureRowsAvailable(reportDataDescription.estimatedDataRowsCount + 1); // +1 for headers
+      }
+
+      await this.clearSheet();
+      await this.writeHeaders(reportDataDescription.dataHeaders);
+    }, 'Preparing Google Sheets document for report');
+  }
+
+  /**
+   * Writes a batch of report data to the sheet
+   *
+   * @param reportDataBatch - Batch of data to write to the sheet
+   * @throws Error if writing fails
+   */
+  public async writeReportDataBatch(reportDataBatch: ReportDataBatch): Promise<void> {
+    return this.executeWithErrorHandling(async () => {
+      const rows = reportDataBatch.dataRows;
+      if (!rows.length) {
+        return;
+      }
+
+      await this.ensureRowsAvailable(rows.length);
+
+      const rowToWrite = this.writtenRowsCount + 1;
+      const range = `'${this.sheetTitle}'!${rowToWrite}:${rowToWrite + rows.length}`;
+      await this.adapter.updateValues(this.destination.spreadsheetId, range, rows);
+
+      this.writtenRowsCount += rows.length;
+    }, 'Writing data batch to Google Sheets');
+  }
+
+  /**
+   * Finalizes the report by setting tab color, freezing header row, and adding metadata
+   */
+  public async finalize(): Promise<void> {
+    return this.executeWithErrorHandling(async () => {
+      if (this.writtenRowsCount > 0) {
+        const dateNow = DateTime.now().setZone(this.spreadsheetTimeZone);
+        const dateNowFormatted = `${dateNow.toFormat('yyyy LLL d, HH:mm:ss')} ${dateNow.zoneName}`;
+
+        await this.adapter.batchUpdate(this.destination.spreadsheetId, [
+          this.metadataFormatter.createTabColorAndFreezeHeaderRequest(this.destination.sheetId),
+          this.metadataFormatter.createMetadataNoteRequest(
+            this.destination.sheetId,
+            dateNowFormatted,
+            this.dataMartTitle
+          ),
+        ]);
+      }
+    }, 'Finalizing report with metadata and formatting');
+  }
+
+  /**
+   * Initializes the Google Sheets service with credentials and finds the target sheet
+   */
+  private async initializeService(report: Report): Promise<void> {
+    return this.executeWithErrorHandling(async () => {
+      if (!isGoogleSheetsDestination(report.destinationConfig)) {
+        throw new Error('Invalid Google Sheets destination configuration provided');
+      }
+      this.destination = report.destinationConfig;
+
+      if (!isGoogleSheetsCredentials(report.dataDestination.credentials)) {
+        throw new Error('Invalid Google Sheets credentials provided');
+      }
+      this.adapter = this.adapterFactory.create(report.dataDestination.credentials);
+
+      const spreadsheet = await this.adapter.getSpreadsheet(this.destination.spreadsheetId);
+      const sheet = this.adapter.findSheetById(spreadsheet, this.destination.sheetId);
+
+      if (!sheet) {
+        throw new Error(
+          `Failed to find sheet ${this.destination.sheetId} in spreadsheet ${this.destination.spreadsheetId}`
+        );
+      }
+
+      if (!sheet.properties?.title) {
+        throw new Error('Sheet title is undefined');
+      }
+
+      this.sheetTitle = sheet.properties?.title;
+      this.availableRowsCount = sheet.properties?.gridProperties?.rowCount ?? 0;
+      this.availableColumnsCount = sheet.properties?.gridProperties?.columnCount ?? 0;
+      this.spreadsheetTimeZone = spreadsheet.properties?.timeZone ?? 'UTC';
+      this.dataMartTitle = report.dataMart.title;
+    }, 'Initializing Google Sheets service and locating target sheet');
+  }
+
+  /**
+   * Prepares the sheet columns by adding columns if needed
+   */
+  private async prepareSheetColumns(columnsCount: number): Promise<void> {
+    return this.executeWithErrorHandling(async () => {
+      const columnsToAllocate = columnsCount - this.availableColumnsCount;
+
+      if (columnsToAllocate <= 0) {
+        return;
+      }
+
+      await this.adapter.appendDimensionToSheet(
+        this.destination.spreadsheetId,
+        this.destination.sheetId,
+        columnsToAllocate,
+        'COLUMNS'
+      );
+    }, 'Adding columns to sheet as needed');
+  }
+
+  /**
+   * Ensures there are enough rows in the sheet for the data to be written
+   */
+  private async ensureRowsAvailable(rowsToWrite: number): Promise<void> {
+    return this.executeWithErrorHandling(async () => {
+      const rowsNeeded = this.writtenRowsCount + rowsToWrite;
+      const rowsToAllocate = rowsNeeded - this.availableRowsCount;
+
+      if (rowsToAllocate <= 0) {
+        return;
+      }
+
+      await this.adapter.appendDimensionToSheet(
+        this.destination.spreadsheetId,
+        this.destination.sheetId,
+        rowsToAllocate,
+        'ROWS'
+      );
+
+      this.availableRowsCount += rowsToAllocate;
+    }, 'Adding rows to sheet to accommodate data');
+  }
+
+  /**
+   * Clears all content from the sheet
+   */
+  private async clearSheet(): Promise<void> {
+    return this.executeWithErrorHandling(async () => {
+      await this.adapter.clearSheet(this.destination.spreadsheetId, this.sheetTitle);
+    }, 'Clearing all content from sheet');
+  }
+
+  /**
+   * Writes and formats the header row
+   */
+  private async writeHeaders(columnTitles: string[]): Promise<void> {
+    return this.executeWithErrorHandling(async () => {
+      // Format headers
+      await this.adapter.batchUpdate(this.destination.spreadsheetId, [
+        this.headerFormatter.createHeaderFormatRequest(
+          this.destination.sheetId,
+          columnTitles.length
+        ),
+      ]);
+
+      // Write header values
+      await this.adapter.updateValues(this.destination.spreadsheetId, `'${this.sheetTitle}'`, [
+        columnTitles,
+      ]);
+
+      this.writtenRowsCount++;
+    }, 'Writing and formatting column headers');
+  }
+
+  /**
+   * Executes an operation with consistent error handling and logging
+   */
+  private async executeWithErrorHandling<T>(
+    operation: () => Promise<T>,
+    operationName: string
+  ): Promise<T> {
+    try {
+      this.logger.debug(`${operationName} started`);
+      const result = await operation();
+      this.logger.debug(`${operationName} completed`);
+      return result;
+    } catch (error) {
+      this.logger.error(`${operationName} failed: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-header-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-header-formatter.ts
@@ -1,0 +1,66 @@
+import { sheets_v4 } from 'googleapis';
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Service for formatting headers in Google Sheets
+ * Provides methods to create header formatting requests
+ */
+@Injectable()
+export class SheetHeaderFormatter {
+  /**
+   * Background color for header cells
+   * Light gray color (RGB: 243, 243, 243)
+   */
+  private static readonly HEADER_BACKGROUND_COLOR = {
+    red: 243 / 255,
+    green: 243 / 255,
+    blue: 243 / 255,
+    alpha: 1.0,
+  };
+
+  /**
+   * Text color for header cells
+   * Dark gray color (RGB: 25, 25, 25)
+   */
+  private static readonly HEADER_TEXT_COLOR = {
+    red: 0.1,
+    green: 0.1,
+    blue: 0.1,
+    alpha: 1.0,
+  };
+
+  /**
+   * Creates a request to format the header row
+   * Applies background color and bold text to the header row
+   *
+   * @param sheetId - ID of the sheet to format
+   * @param columnsCount - Number of columns to format
+   * @returns Google Sheets API request object for header formatting
+   */
+  public createHeaderFormatRequest(
+    sheetId: number,
+    columnsCount: number
+  ): sheets_v4.Schema$Request {
+    return {
+      repeatCell: {
+        range: {
+          sheetId: sheetId,
+          startRowIndex: 0,
+          endRowIndex: 1,
+          startColumnIndex: 0,
+          endColumnIndex: columnsCount,
+        },
+        cell: {
+          userEnteredFormat: {
+            backgroundColor: SheetHeaderFormatter.HEADER_BACKGROUND_COLOR,
+            textFormat: {
+              bold: true,
+              foregroundColor: SheetHeaderFormatter.HEADER_TEXT_COLOR,
+            },
+          },
+        },
+        fields: 'userEnteredFormat.textFormat,userEnteredFormat.backgroundColor',
+      },
+    };
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.ts
@@ -1,0 +1,77 @@
+import { sheets_v4 } from 'googleapis';
+import { Injectable } from '@nestjs/common';
+
+/**
+ * Service for formatting metadata in Google Sheets
+ * Provides methods to create metadata formatting requests
+ */
+@Injectable()
+export class SheetMetadataFormatter {
+  /**
+   * Tab color for sheets
+   * Blue color (RGB: 30, 136, 229)
+   */
+  private static readonly TAB_COLOR = {
+    red: 30 / 255,
+    green: 136 / 255,
+    blue: 229 / 255,
+    alpha: 1.0,
+  };
+
+  /**
+   * Creates a request to set tab color and freeze the header row
+   *
+   * @param sheetId - ID of the sheet to format
+   * @returns Google Sheets API request object for tab color and frozen header
+   */
+  public createTabColorAndFreezeHeaderRequest(sheetId: number): sheets_v4.Schema$Request {
+    return {
+      updateSheetProperties: {
+        properties: {
+          sheetId: sheetId,
+          gridProperties: {
+            frozenRowCount: 1,
+          },
+          tabColorStyle: {
+            rgbColor: SheetMetadataFormatter.TAB_COLOR,
+          },
+        },
+        fields: 'tabColorStyle,gridProperties.frozenRowCount',
+      },
+    };
+  }
+
+  /**
+   * Creates a request to add a metadata note to the first cell
+   *
+   * @param sheetId - ID of the sheet to add the note to
+   * @param dateFormatted - Formatted date string for the metadata note
+   * @param dataMartTitle - Title of the data mart
+   * @returns Google Sheets API request object for metadata note
+   */
+  public createMetadataNoteRequest(
+    sheetId: number,
+    dateFormatted: string,
+    dataMartTitle: string
+  ): sheets_v4.Schema$Request {
+    const metadataNote =
+      `Imported via OWOX Data Marts Community Edition at ${dateFormatted}\n` +
+      `Data Mart: ${dataMartTitle}`;
+
+    return {
+      repeatCell: {
+        range: {
+          sheetId: sheetId,
+          startRowIndex: 0,
+          endRowIndex: 1,
+          startColumnIndex: 0,
+          endColumnIndex: 1,
+        },
+        cell: {
+          note: metadataNote,
+        },
+        fields: 'note',
+      },
+    };
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/interfaces/data-destination-access-validator.interface.ts
+++ b/apps/backend/src/data-marts/data-destination-types/interfaces/data-destination-access-validator.interface.ts
@@ -1,0 +1,35 @@
+import { TypedComponent } from '../../../common/resolver/typed-component.resolver';
+import { DataDestinationType } from '../enums/data-destination-type.enum';
+import { DataDestinationConfig } from '../data-destination-config.type';
+import { DataDestination } from '../../entities/data-destination.entity';
+
+/**
+ * Interface for validating access to data destinations
+ * Implementations verify if the system can access the configured destination
+ */
+export interface DataDestinationAccessValidator extends TypedComponent<DataDestinationType> {
+  /**
+   * Validates access to a data destination
+   *
+   * @param destinationConfig - Configuration for the data destination
+   * @param dataDestination - The data destination entity
+   * @returns A validation result indicating success or failure with error details
+   */
+  validate(
+    destinationConfig: DataDestinationConfig,
+    dataDestination: DataDestination
+  ): Promise<ValidationResult>;
+}
+
+/**
+ * Result of a data destination access validation
+ * Contains validation status and additional information
+ */
+export class ValidationResult {
+  constructor(
+    public readonly valid: boolean,
+    public readonly errorMessage?: string,
+    public readonly reason?: Record<string, unknown>,
+    public readonly discoveredValues?: { spreadsheetTitle: string; sheetTitle: string }
+  ) {}
+}

--- a/apps/backend/src/data-marts/data-destination-types/interfaces/data-destination-credentials-validator.interface.ts
+++ b/apps/backend/src/data-marts/data-destination-types/interfaces/data-destination-credentials-validator.interface.ts
@@ -1,0 +1,29 @@
+import { TypedComponent } from '../../../common/resolver/typed-component.resolver';
+import { DataDestinationType } from '../enums/data-destination-type.enum';
+import { DataDestinationCredentials } from '../data-destination-credentials.type';
+
+/**
+ * Interface for validating credentials for data destinations
+ * Implementations verify if the provided credentials are valid for the destination type
+ */
+export interface DataDestinationCredentialsValidator extends TypedComponent<DataDestinationType> {
+  /**
+   * Validates credentials for a data destination
+   *
+   * @param credentials - The credentials to validate
+   * @returns A validation result indicating success or failure with error details
+   */
+  validate(credentials: DataDestinationCredentials): Promise<ValidationResult>;
+}
+
+/**
+ * Result of a credentials validation
+ * Contains validation status and error information
+ */
+export class ValidationResult {
+  constructor(
+    public readonly valid: boolean,
+    public readonly errorMessage?: string,
+    public readonly reason?: Record<string, unknown>
+  ) {}
+}

--- a/apps/backend/src/data-marts/data-destination-types/interfaces/data-destination-report-writer.interface.ts
+++ b/apps/backend/src/data-marts/data-destination-types/interfaces/data-destination-report-writer.interface.ts
@@ -1,0 +1,32 @@
+import { TypedComponent } from '../../../common/resolver/typed-component.resolver';
+import { DataDestinationType } from '../enums/data-destination-type.enum';
+import { ReportDataDescription } from '../../dto/domain/report-data-description.dto';
+import { ReportDataBatch } from '../../dto/domain/report-data-batch.dto';
+import { Report } from '../../entities/report.entity';
+
+/**
+ * Interface for writing reports to data destinations
+ * Implementations handle the specifics of writing data to different destination types
+ */
+export interface DataDestinationReportWriter extends TypedComponent<DataDestinationType> {
+  /**
+   * Prepares the destination for writing a report
+   *
+   * @param report - The report entity to be written
+   * @param reportDataDescription - Description of the report data structure
+   */
+  prepareToWriteReport(report: Report, reportDataDescription: ReportDataDescription): Promise<void>;
+
+  /**
+   * Writes a batch of report data to the destination
+   *
+   * @param reportDataBatch - Batch of data to write
+   */
+  writeReportDataBatch(reportDataBatch: ReportDataBatch): Promise<void>;
+
+  /**
+   * Finalizes the report writing process
+   * Performs any necessary cleanup or finalization steps
+   */
+  finalize(): Promise<void>;
+}

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -2,34 +2,62 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
 import { DataMartController } from './controllers/data-mart.controller';
 import { DataStorageController } from './controllers/data-storage.controller';
+import { DataDestinationController } from './controllers/data-destination.controller';
+import { ReportController } from './controllers/report.controller';
 import { CreateDataMartService } from './use-cases/create-data-mart.service';
 import { ListDataMartsService } from './use-cases/list-data-marts.service';
 import { GetDataMartService } from './use-cases/get-data-mart.service';
 import { DataMartMapper } from './mappers/data-mart.mapper';
 import { DataStorageService } from './services/data-storage.service';
 import { DataStorageMapper } from './mappers/data-storage.mapper';
+import { DataDestinationService } from './services/data-destination.service';
+import { DataDestinationMapper } from './mappers/data-destination.mapper';
+import { ReportMapper } from './mappers/report.mapper';
 import { GetDataStorageService } from './use-cases/get-data-storage.service';
 import { CreateDataStorageService } from './use-cases/create-data-storage.service';
 import { UpdateDataStorageService } from './use-cases/update-data-storage.service';
+import { GetDataDestinationService } from './use-cases/get-data-destination.service';
+import { CreateDataDestinationService } from './use-cases/create-data-destination.service';
+import { UpdateDataDestinationService } from './use-cases/update-data-destination.service';
+import { CreateReportService } from './use-cases/create-report.service';
+import { GetReportService } from './use-cases/get-report.service';
+import { ListReportsByDataMartService } from './use-cases/list-reports-by-data-mart.service';
+import { ListReportsByProjectService } from './use-cases/list-reports-by-project.service';
+import { DeleteReportService } from './use-cases/delete-report.service';
+import { RunReportService } from './use-cases/run-report.service';
+import { UpdateReportService } from './use-cases/update-report.service';
 import { DataMart } from './entities/data-mart.entity';
 import { DataStorage } from './entities/data-storage.entity';
 import { dataStorageFacadesProviders } from './data-storage-types/data-storage-facades';
 import { dataStorageResolverProviders } from './data-storage-types/data-storage-providers';
+import { dataDestinationFacadesProviders } from './data-destination-types/data-destination-facades';
+import { dataDestinationResolverProviders } from './data-destination-types/data-destination-providers';
 import { UpdateDataMartDefinitionService } from './use-cases/update-data-mart-definition.service';
 import { DataMartService } from './services/data-mart.service';
 import { PublishDataMartService } from './use-cases/publish-data-mart.service';
 import { UpdateDataMartDescriptionService } from './use-cases/update-data-mart-description.service';
 import { UpdateDataMartTitleService } from './use-cases/update-data-mart-title.service';
 import { ListDataStoragesService } from './use-cases/list-data-storages.service';
+import { ListDataDestinationsService } from './use-cases/list-data-destinations.service';
 import { DeleteDataStorageService } from './use-cases/delete-data-storage.service';
+import { DeleteDataDestinationService } from './use-cases/delete-data-destination.service';
 import { DeleteDataMartService } from './use-cases/delete-data-mart.service';
+import { DataDestination } from './entities/data-destination.entity';
+import { Report } from './entities/report.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([DataMart, DataStorage])],
-  controllers: [DataMartController, DataStorageController],
+  imports: [TypeOrmModule.forFeature([DataMart, DataStorage, DataDestination, Report])],
+  controllers: [
+    DataMartController,
+    DataStorageController,
+    DataDestinationController,
+    ReportController,
+  ],
   providers: [
     ...dataStorageResolverProviders,
     ...dataStorageFacadesProviders,
+    ...dataDestinationResolverProviders,
+    ...dataDestinationFacadesProviders,
     DataMartService,
     CreateDataMartService,
     ListDataMartsService,
@@ -41,12 +69,27 @@ import { DeleteDataMartService } from './use-cases/delete-data-mart.service';
     DataMartMapper,
     DataStorageService,
     DataStorageMapper,
+    DataDestinationService,
+    DataDestinationMapper,
     ListDataStoragesService,
+    ListDataDestinationsService,
     DeleteDataStorageService,
+    DeleteDataDestinationService,
     DeleteDataMartService,
     GetDataStorageService,
+    GetDataDestinationService,
     CreateDataStorageService,
+    CreateDataDestinationService,
     UpdateDataStorageService,
+    UpdateDataDestinationService,
+    ReportMapper,
+    CreateReportService,
+    GetReportService,
+    ListReportsByDataMartService,
+    ListReportsByProjectService,
+    DeleteReportService,
+    RunReportService,
+    UpdateReportService,
   ],
 })
 export class DataMartsModule {}

--- a/apps/backend/src/data-marts/data-storage-types/athena/adapters/athena-api-adapter.factory.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/adapters/athena-api-adapter.factory.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { AthenaApiAdapter } from './athena-api.adapter';
+import { AthenaCredentials } from '../schemas/athena-credentials.schema';
+import { AthenaConfig } from '../schemas/athena-config.schema';
+
+/**
+ * Factory for creating Athena API adapters
+ */
+@Injectable()
+export class AthenaApiAdapterFactory {
+  /**
+   * Creates a new Athena API adapter
+   *
+   * @param credentials - Athena credentials
+   * @param config - Athena configuration
+   * @returns A new Athena API adapter instance
+   */
+  create(credentials: AthenaCredentials, config: AthenaConfig): AthenaApiAdapter {
+    return new AthenaApiAdapter(credentials, config);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/athena/adapters/athena-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/adapters/athena-api.adapter.ts
@@ -1,0 +1,169 @@
+import { Logger } from '@nestjs/common';
+import {
+  AthenaClient,
+  GetQueryExecutionCommand,
+  GetQueryResultsCommand,
+  QueryExecutionState,
+  StartQueryExecutionCommand,
+} from '@aws-sdk/client-athena';
+import { AthenaConfig } from '../schemas/athena-config.schema';
+import { AthenaCredentials } from '../schemas/athena-credentials.schema';
+import { ResultSetMetadata } from '@aws-sdk/client-athena/dist-types/models/models_0';
+import { GetQueryResultsCommandOutput } from '@aws-sdk/client-athena/dist-types/commands/GetQueryResultsCommand';
+
+/**
+ * Adapter for Athena API operations
+ */
+export class AthenaApiAdapter {
+  private readonly logger = new Logger(AthenaApiAdapter.name);
+
+  private readonly athenaClient: AthenaClient;
+
+  /**
+   * @param credentials - Athena credentials
+   * @param config - Athena configuration
+   * @throws Error if invalid credentials or config are provided
+   * @returns Configuration values needed by the reader
+   */
+  constructor(credentials: AthenaCredentials, config: AthenaConfig) {
+    // Create Athena client
+    this.athenaClient = new AthenaClient({
+      region: config.region,
+      credentials: {
+        accessKeyId: credentials.accessKeyId,
+        secretAccessKey: credentials.secretAccessKey,
+        sessionToken: credentials.sessionToken,
+      },
+    });
+  }
+
+  /**
+   * Executes a query in Athena
+   *
+   * @param query - SQL query to execute
+   * @param databaseName - Database name to use for the query
+   * @param outputBucket - S3 bucket for query results
+   * @param outputPrefix - S3 prefix for query results
+   * @returns Query execution ID
+   */
+  public async executeQuery(
+    query: string,
+    databaseName: string,
+    outputBucket: string,
+    outputPrefix: string
+  ): Promise<{ queryExecutionId: string }> {
+    const startQueryCommand = new StartQueryExecutionCommand({
+      QueryString: query,
+      QueryExecutionContext: {
+        Database: databaseName,
+      },
+      ResultConfiguration: {
+        OutputLocation: `s3://${outputBucket}/${outputPrefix}`,
+      },
+    });
+
+    const response = await this.athenaClient.send(startQueryCommand);
+    const queryExecutionId = response.QueryExecutionId;
+
+    if (!queryExecutionId) {
+      throw new Error('Failed to start query execution');
+    }
+
+    return { queryExecutionId };
+  }
+
+  /**
+   * Waits for a query to complete
+   *
+   * @param queryExecutionId - Query execution ID to wait for
+   */
+  public async waitForQueryToComplete(queryExecutionId: string): Promise<void> {
+    if (!queryExecutionId) {
+      throw new Error('No query execution ID');
+    }
+
+    const getQueryExecutionCommand = new GetQueryExecutionCommand({
+      QueryExecutionId: queryExecutionId,
+    });
+
+    let status: QueryExecutionState | undefined;
+
+    do {
+      // Wait a bit before checking again
+      await new Promise(resolve => setTimeout(resolve, 1000));
+
+      const response = await this.athenaClient.send(getQueryExecutionCommand);
+      status = response.QueryExecution?.Status?.State;
+
+      this.logger.debug(`Query status: ${status}`);
+
+      if (status === QueryExecutionState.FAILED) {
+        const errorMessage = response.QueryExecution?.Status?.StateChangeReason || 'Unknown error';
+        throw new Error(`Query execution failed: ${errorMessage}`);
+      }
+
+      if (status === QueryExecutionState.CANCELLED) {
+        throw new Error('Query execution was cancelled');
+      }
+    } while (status !== QueryExecutionState.SUCCEEDED);
+  }
+
+  /**
+   * Gets query results metadata
+   *
+   * @param queryExecutionId - Query execution ID to get metadata for
+   */
+  public async getQueryResultsMetadata(queryExecutionId: string): Promise<ResultSetMetadata> {
+    if (!queryExecutionId) {
+      throw new Error('No query execution ID');
+    }
+
+    const resultsCommand = new GetQueryResultsCommand({
+      QueryExecutionId: queryExecutionId,
+      MaxResults: 1, // Just get metadata
+    });
+
+    const results = await this.athenaClient.send(resultsCommand);
+
+    if (
+      !results.ResultSet ||
+      !results.ResultSet.ResultSetMetadata ||
+      !results.ResultSet.ResultSetMetadata.ColumnInfo
+    ) {
+      throw new Error('Failed to get query results metadata');
+    }
+
+    return results.ResultSet.ResultSetMetadata;
+  }
+
+  /**
+   * Gets query results
+   *
+   * @param queryExecutionId - Query execution ID to get results for
+   * @param batchId - Token for pagination
+   * @param maxResults - Maximum number of results to return
+   */
+  public async getQueryResults(
+    queryExecutionId: string,
+    batchId?: string,
+    maxResults: number = 1000
+  ): Promise<GetQueryResultsCommandOutput> {
+    if (!queryExecutionId) {
+      throw new Error('No query execution ID');
+    }
+
+    const resultsCommand = new GetQueryResultsCommand({
+      QueryExecutionId: queryExecutionId,
+      MaxResults: maxResults,
+      NextToken: batchId,
+    });
+
+    const results = await this.athenaClient.send(resultsCommand);
+
+    if (!results.ResultSet || !results.ResultSet.Rows) {
+      throw new Error('Failed to get query results');
+    }
+
+    return results;
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/athena/adapters/s3-api-adapter.factory.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/adapters/s3-api-adapter.factory.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { S3ApiAdapter } from './s3-api.adapter';
+import { AthenaCredentials } from '../schemas/athena-credentials.schema';
+import { AthenaConfig } from '../schemas/athena-config.schema';
+
+/**
+ * Factory for creating S3 API adapters
+ */
+@Injectable()
+export class S3ApiAdapterFactory {
+  /**
+   * Creates a new S3 API adapter
+   *
+   * @param credentials - Athena credentials
+   * @param config - Athena configuration
+   * @returns A new S3 API adapter instance
+   */
+  create(credentials: AthenaCredentials, config: AthenaConfig): S3ApiAdapter {
+    return new S3ApiAdapter(credentials, config);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/athena/adapters/s3-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/adapters/s3-api.adapter.ts
@@ -1,0 +1,76 @@
+import { Logger } from '@nestjs/common';
+import { S3Client, DeleteObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { AthenaConfig } from '../schemas/athena-config.schema';
+import { AthenaCredentials } from '../schemas/athena-credentials.schema';
+
+/**
+ * Adapter for S3 API operations related to Athena query results
+ */
+export class S3ApiAdapter {
+  private readonly logger = new Logger(S3ApiAdapter.name);
+  private readonly s3Client: S3Client;
+
+  /**
+   * Compatible with Athena credentials
+   *
+   * @param credentials - Athena credentials
+   * @param config - Athena configuration
+   * @throws Error if invalid credentials or config are provided
+   */
+  constructor(credentials: AthenaCredentials, config: AthenaConfig) {
+    this.s3Client = new S3Client({
+      region: config.region,
+      credentials: {
+        accessKeyId: credentials.accessKeyId,
+        secretAccessKey: credentials.secretAccessKey,
+        sessionToken: credentials.sessionToken,
+      },
+    });
+  }
+
+  /**
+   * Cleans up S3 output files
+   *
+   * @param outputBucket - S3 bucket containing query results
+   * @param outputPrefix - S3 prefix for query results
+   */
+  public async cleanupOutputFiles(outputBucket: string, outputPrefix: string): Promise<void> {
+    if (!outputBucket || !outputPrefix) {
+      this.logger.debug('No output location to clean up');
+      return;
+    }
+
+    try {
+      // List objects in the output location
+      const listCommand = new ListObjectsV2Command({
+        Bucket: outputBucket,
+        Prefix: outputPrefix,
+      });
+
+      const listedObjects = await this.s3Client.send(listCommand);
+
+      if (!listedObjects.Contents || listedObjects.Contents.length === 0) {
+        this.logger.debug('No objects to delete');
+        return;
+      }
+
+      // Delete each object
+      for (const object of listedObjects.Contents) {
+        if (!object.Key) continue;
+
+        const deleteCommand = new DeleteObjectCommand({
+          Bucket: outputBucket,
+          Key: object.Key,
+        });
+
+        await this.s3Client.send(deleteCommand);
+        this.logger.debug(`Deleted object: ${object.Key}`);
+      }
+
+      this.logger.debug('Successfully cleaned up query results');
+    } catch (error) {
+      this.logger.error('Error cleaning up query results', error);
+      throw error;
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/athena/schemas/athena-credentials.schema.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/schemas/athena-credentials.schema.ts
@@ -8,4 +8,4 @@ export const AthenaCredentialsSchema = z
   })
   .passthrough();
 
-export type AthenaCredentialsDto = z.infer<typeof AthenaCredentialsSchema>;
+export type AthenaCredentials = z.infer<typeof AthenaCredentialsSchema>;

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-report-reader.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-report-reader.service.ts
@@ -1,0 +1,189 @@
+import { DataStorageReportReader } from '../../interfaces/data-storage-report-reader.interface';
+import { Injectable, Logger, Scope } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { Report } from '../../../entities/report.entity';
+import { ReportDataDescription } from '../../../dto/domain/report-data-description.dto';
+import { ReportDataBatch } from '../../../dto/domain/report-data-batch.dto';
+import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
+import {
+  isSqlDefinition,
+  isTableDefinition,
+  isTablePatternDefinition,
+  isViewDefinition,
+} from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition.guards';
+import { SqlDefinition } from '../../../dto/schemas/data-mart-table-definitions/sql-definition.schema';
+import { ViewDefinition } from '../../../dto/schemas/data-mart-table-definitions/view-definition.schema';
+import { TableDefinition } from '../../../dto/schemas/data-mart-table-definitions/table-definition.schema';
+import { DataStorage } from '../../../entities/data-storage.entity';
+import { AthenaApiAdapter } from '../adapters/athena-api.adapter';
+import { AthenaApiAdapterFactory } from '../adapters/athena-api-adapter.factory';
+import { S3ApiAdapter } from '../adapters/s3-api.adapter';
+import { S3ApiAdapterFactory } from '../adapters/s3-api-adapter.factory';
+import { isAthenaCredentials } from '../../data-storage-credentials.guards';
+import { isAthenaConfig } from '../../data-storage-config.guards';
+
+@Injectable({ scope: Scope.TRANSIENT })
+export class AthenaReportReader implements DataStorageReportReader {
+  private readonly logger = new Logger(AthenaReportReader.name);
+  readonly type = DataStorageType.AWS_ATHENA;
+
+  private athenaAdapter: AthenaApiAdapter;
+  private s3Adapter: S3ApiAdapter;
+  private queryExecutionId?: string;
+  private outputBucket: string;
+  private outputPrefix: string;
+  private databaseName: string;
+
+  constructor(
+    private readonly athenaAdapterFactory: AthenaApiAdapterFactory,
+    private readonly s3AdapterFactory: S3ApiAdapterFactory
+  ) {}
+
+  async prepareReportData(report: Report): Promise<ReportDataDescription> {
+    const { storage, definition } = report.dataMart;
+    if (!storage || !definition) {
+      throw new Error('Data Mart is not properly configured');
+    }
+
+    await this.prepareApiAdapters(storage);
+    await this.prepareQueryExecution(definition);
+
+    if (!this.queryExecutionId) {
+      throw new Error('Query execution ID not set');
+    }
+
+    await this.athenaAdapter.waitForQueryToComplete(this.queryExecutionId);
+
+    // Get query results metadata
+    const metadata = await this.athenaAdapter.getQueryResultsMetadata(this.queryExecutionId);
+    if (!metadata.ColumnInfo) {
+      throw new Error('Failed to get query results metadata');
+    }
+
+    const dataHeaders = metadata.ColumnInfo.map(col => col.Name || '');
+
+    return new ReportDataDescription(dataHeaders);
+  }
+
+  async readReportDataBatch(batchId?: string, maxDataRows = 1000): Promise<ReportDataBatch> {
+    if (!this.athenaAdapter) {
+      throw new Error('Report data must be prepared before read');
+    }
+
+    if (!this.queryExecutionId) {
+      throw new Error('Query execution ID not set');
+    }
+
+    const results = await this.athenaAdapter.getQueryResults(
+      this.queryExecutionId,
+      batchId,
+      maxDataRows
+    );
+
+    if (!results.ResultSet || !results.ResultSet.Rows) {
+      throw new Error('Failed to get query results');
+    }
+
+    // Skip the header row if this is the first batch
+    const startIndex = !batchId ? 1 : 0;
+    const rows = results.ResultSet.Rows.slice(startIndex);
+
+    // Map rows to the expected format
+    const mappedRows = rows.map(row => {
+      if (!row.Data) return [];
+      return row.Data.map(cell => cell.VarCharValue);
+    });
+
+    return new ReportDataBatch(mappedRows, results.NextToken);
+  }
+
+  async finalize(): Promise<void> {
+    this.logger.debug('Finalizing report read');
+
+    if (!this.s3Adapter) {
+      this.logger.debug('No S3 adapter to clean up');
+      return;
+    }
+
+    if (!this.outputBucket || !this.outputPrefix) {
+      this.logger.debug('No output location to clean up');
+      return;
+    }
+
+    try {
+      await this.s3Adapter.cleanupOutputFiles(this.outputBucket, this.outputPrefix);
+    } catch (error) {
+      this.logger.error('Error cleaning up query results', error);
+      throw error;
+    }
+  }
+
+  private async prepareApiAdapters(storage: DataStorage): Promise<void> {
+    try {
+      if (!isAthenaCredentials(storage.credentials)) {
+        throw new Error('Athena credentials are not properly configured');
+      }
+
+      if (!isAthenaConfig(storage.config)) {
+        throw new Error('Athena config is not properly configured');
+      }
+
+      this.athenaAdapter = this.athenaAdapterFactory.create(storage.credentials, storage.config);
+      this.s3Adapter = this.s3AdapterFactory.create(storage.credentials, storage.config);
+
+      this.outputBucket = storage.config.outputBucket;
+      this.databaseName = storage.config.databaseName;
+
+      this.logger.debug('Athena and S3 adapters created successfully');
+    } catch (error) {
+      this.logger.error('Failed to create adapters', error);
+      throw error;
+    }
+  }
+
+  private async prepareQueryExecution(dataMartDefinition: DataMartDefinition): Promise<void> {
+    this.logger.debug('Preparing query execution', dataMartDefinition);
+    try {
+      if (isTableDefinition(dataMartDefinition)) {
+        await this.prepareTableData(dataMartDefinition);
+      } else if (isSqlDefinition(dataMartDefinition)) {
+        await this.prepareSqlData(dataMartDefinition);
+      } else if (isViewDefinition(dataMartDefinition)) {
+        await this.prepareViewData(dataMartDefinition);
+      } else if (isTablePatternDefinition(dataMartDefinition)) {
+        throw new Error('Table pattern queries are not supported in Athena');
+      } else {
+        throw new Error('Invalid data mart definition');
+      }
+    } catch (error) {
+      this.logger.error('Failed to prepare query execution', error);
+      throw error;
+    }
+  }
+
+  private async prepareSqlData(dataMartDefinition: SqlDefinition): Promise<void> {
+    await this.executeQuery(dataMartDefinition.sqlQuery);
+  }
+
+  private async prepareViewData(dataMartDefinition: ViewDefinition): Promise<void> {
+    await this.executeQuery(`SELECT * FROM ${dataMartDefinition.fullyQualifiedName}`);
+  }
+
+  private async prepareTableData(dataMartDefinition: TableDefinition): Promise<void> {
+    await this.executeQuery(`SELECT * FROM ${dataMartDefinition.fullyQualifiedName}`);
+  }
+
+  private async executeQuery(query: string): Promise<void> {
+    // Generate a unique output location prefix
+    this.outputPrefix = `owox-data-marts/${Date.now()}-${Math.random().toString(36).substring(2, 15)}`;
+
+    const result = await this.athenaAdapter.executeQuery(
+      query,
+      this.databaseName,
+      this.outputBucket,
+      this.outputPrefix
+    );
+
+    this.queryExecutionId = result.queryExecutionId;
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api-adapter.factory.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api-adapter.factory.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { BigQueryApiAdapter } from './bigquery-api.adapter';
+import { BigQueryCredentials } from '../schemas/bigquery-credentials.schema';
+import { BigQueryConfig } from '../schemas/bigquery-config.schema';
+
+/**
+ * Factory for creating BigQuery API adapters
+ */
+@Injectable()
+export class BigQueryApiAdapterFactory {
+  /**
+   * Creates a new BigQuery API adapter
+   *
+   * @param credentials - BigQuery credentials
+   * @param config - BigQuery configuration
+   * @returns A new BigQuery API adapter instance
+   */
+  create(credentials: BigQueryCredentials, config: BigQueryConfig): BigQueryApiAdapter {
+    return new BigQueryApiAdapter(credentials, config);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.ts
@@ -1,0 +1,60 @@
+import { BigQuery, Job, Table } from '@google-cloud/bigquery';
+import { BigQueryCredentials } from '../schemas/bigquery-credentials.schema';
+import { BigQueryConfig } from '../schemas/bigquery-config.schema';
+
+/**
+ * Adapter for BigQuery API operations
+ */
+export class BigQueryApiAdapter {
+  private readonly bigQuery: BigQuery;
+
+  /**
+   * @param credentials - BigQuery credentials
+   * @param config - BigQuery configuration
+   * @throws Error if invalid credentials or config are provided
+   */
+  constructor(credentials: BigQueryCredentials, config: BigQueryConfig) {
+    this.bigQuery = new BigQuery({
+      projectId: config.projectId,
+      location: config.location,
+      credentials: credentials,
+      scopes: [
+        'https://www.googleapis.com/auth/bigquery',
+        'https://www.googleapis.com/auth/drive.readonly',
+      ],
+    });
+  }
+
+  /**
+   * Executes a SQL query
+   */
+  public async executeQuery(query: string): Promise<{ jobId: string }> {
+    const [, , res] = await this.bigQuery.query(query, { maxResults: 0 });
+    if (!res || !res.jobReference || !res.jobReference.jobId) {
+      throw new Error('Unexpected error during getting sql result job id');
+    }
+    return { jobId: res.jobReference.jobId };
+  }
+
+  /**
+   * Gets job information by job ID
+   */
+  public async getJob(jobId: string): Promise<Job> {
+    const job = this.bigQuery.job(jobId);
+    const [jobResult] = await job.get();
+    return jobResult;
+  }
+
+  /**
+   * Creates a table reference
+   *
+   * @param projectId - Google Cloud project ID
+   * @param datasetId - BigQuery dataset ID
+   * @param tableId - BigQuery table ID
+   * @returns Table reference
+   */
+  public createTableReference(projectId: string, datasetId: string, tableId: string): Table {
+    const dataset = this.bigQuery.dataset(datasetId, { projectId: projectId });
+    return dataset.table(tableId);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/schemas/bigquery-credentials.schema.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/schemas/bigquery-credentials.schema.ts
@@ -1,10 +1,6 @@
 import { z } from 'zod';
+import { GoogleServiceAccountKeySchema } from '../../../../common/schemas/google-service-account-key.schema';
 
-export const BigQueryCredentialsSchema = z
-  .object({
-    private_key: z.string().min(1, 'private_key is required'),
-    client_email: z.string().min(1, 'client_email is required'),
-  })
-  .passthrough();
+export const BigQueryCredentialsSchema = GoogleServiceAccountKeySchema.extend({});
 
-export type BigQueryCredentialsDto = z.infer<typeof BigQueryCredentialsSchema>;
+export type BigQueryCredentials = z.infer<typeof BigQueryCredentialsSchema>;

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-reader.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-reader.service.ts
@@ -1,0 +1,149 @@
+import { DataStorageReportReader } from '../../interfaces/data-storage-report-reader.interface';
+import { ReportDataDescription } from '../../../dto/domain/report-data-description.dto';
+import { ReportDataBatch } from '../../../dto/domain/report-data-batch.dto';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { Injectable, Logger, Scope } from '@nestjs/common';
+import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
+import { DataStorage } from '../../../entities/data-storage.entity';
+import {
+  isSqlDefinition,
+  isTableDefinition,
+  isTablePatternDefinition,
+  isViewDefinition,
+} from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition.guards';
+import { TableDefinition } from '../../../dto/schemas/data-mart-table-definitions/table-definition.schema';
+import { SqlDefinition } from '../../../dto/schemas/data-mart-table-definitions/sql-definition.schema';
+import { ViewDefinition } from '../../../dto/schemas/data-mart-table-definitions/view-definition.schema';
+import { TablePatternDefinition } from '../../../dto/schemas/data-mart-table-definitions/table-pattern-definition.schema';
+import { Report } from '../../../entities/report.entity';
+import { BigQueryApiAdapterFactory } from '../adapters/bigquery-api-adapter.factory';
+import { BigQueryApiAdapter } from '../adapters/bigquery-api.adapter';
+import { Table } from '@google-cloud/bigquery';
+import { isBigqueryCredentials } from '../../data-storage-credentials.guards';
+import { isBigQueryConfig } from '../../data-storage-config.guards';
+
+@Injectable({ scope: Scope.TRANSIENT })
+export class BigQueryReportReader implements DataStorageReportReader {
+  private readonly logger = new Logger(BigQueryReportReader.name);
+  readonly type = DataStorageType.GOOGLE_BIGQUERY;
+
+  private adapter: BigQueryApiAdapter;
+  private reportResultTable: Table;
+  private dataHeaders: string[];
+
+  constructor(private readonly adapterFactory: BigQueryApiAdapterFactory) {}
+
+  public async prepareReportData(report: Report): Promise<ReportDataDescription> {
+    const { storage, definition } = report.dataMart;
+    if (!storage || !definition) {
+      throw new Error('Data Mart is not properly configured');
+    }
+
+    await this.prepareBigQuery(storage);
+    await this.prepareReportResultTable(definition);
+
+    //const metaData = await this.adapter.getTableMetadata(this.reportResultTable);
+    const [metaData] = await this.reportResultTable.getMetadata();
+    if (!metaData.numRows || !metaData.schema || !metaData.schema.fields) {
+      throw new Error('Failed to get table metadata');
+    }
+
+    this.dataHeaders = metaData.schema.fields.map(f => f.name!);
+
+    return new ReportDataDescription(this.dataHeaders, parseInt(metaData.numRows));
+  }
+
+  public async readReportDataBatch(batchId?: string, maxRows = 10000): Promise<ReportDataBatch> {
+    if (!this.adapter || !this.reportResultTable) {
+      throw new Error('Report data must be prepared before read');
+    }
+
+    const [rows, nextBatch] = await this.reportResultTable.getRows({
+      pageToken: batchId,
+      maxResults: maxRows,
+      autoPaginate: false,
+    });
+
+    const mappedRows = rows.map(r => this.dataHeaders.map(h => r[h].value ?? r[h]));
+    return new ReportDataBatch(mappedRows, nextBatch?.pageToken);
+  }
+
+  public async finalize(): Promise<void> {
+    this.logger.debug('Finalizing report read');
+    // no additional actions required
+  }
+
+  private async prepareReportResultTable(dataMartDefinition: DataMartDefinition): Promise<void> {
+    this.logger.debug('Preparing report result table', dataMartDefinition);
+    try {
+      if (isTableDefinition(dataMartDefinition)) {
+        await this.prepareTableData(dataMartDefinition);
+      } else if (isSqlDefinition(dataMartDefinition)) {
+        await this.prepareSqlData(dataMartDefinition);
+      } else if (isViewDefinition(dataMartDefinition)) {
+        await this.prepareViewData(dataMartDefinition);
+      } else if (isTablePatternDefinition(dataMartDefinition)) {
+        await this.prepareTablePatternData(dataMartDefinition);
+      } else {
+        throw new Error('Invalid data mart definition');
+      }
+    } catch (error) {
+      this.logger.error('Failed to prepare report data', error);
+      throw error;
+    }
+  }
+
+  private async prepareSqlData(dataMartDefinition: SqlDefinition): Promise<void> {
+    await this.prepareQueryData(dataMartDefinition.sqlQuery);
+  }
+
+  private async prepareViewData(dataMartDefinition: ViewDefinition): Promise<void> {
+    await this.prepareQueryData(`SELECT * FROM \`${dataMartDefinition.fullyQualifiedName}\``);
+  }
+
+  private async prepareTablePatternData(dataMartDefinition: TablePatternDefinition): Promise<void> {
+    await this.prepareQueryData(`SELECT * FROM \`${dataMartDefinition.pattern}*\``);
+  }
+
+  private async prepareQueryData(query: string): Promise<void> {
+    const { jobId } = await this.adapter.executeQuery(query);
+    const jobResult = await this.adapter.getJob(jobId);
+    const destinationTable = jobResult.metadata.configuration.query.destinationTable;
+    this.defineReportResultTable(
+      destinationTable.projectId,
+      destinationTable.datasetId,
+      destinationTable.tableId
+    );
+  }
+
+  private async prepareTableData(dataMartDefinition: TableDefinition): Promise<void> {
+    const tableRef = dataMartDefinition.fullyQualifiedName.split('.');
+    // project.dataset.table
+    this.defineReportResultTable(tableRef[0], tableRef[1], tableRef[2]);
+  }
+
+  private defineReportResultTable(projectId: string, datasetId: string, tableId: string): void {
+    this.reportResultTable = this.adapter.createTableReference(projectId, datasetId, tableId);
+    if (!this.reportResultTable) {
+      throw new Error('Report result table not set');
+    }
+  }
+
+  private async prepareBigQuery(dataStorage: DataStorage): Promise<void> {
+    try {
+      if (!isBigqueryCredentials(dataStorage.credentials)) {
+        throw new Error('Google BigQuery credentials are not properly configured');
+      }
+
+      if (!isBigQueryConfig(dataStorage.config)) {
+        throw new Error('Google BigQuery config is not properly configured');
+      }
+
+      this.adapter = this.adapterFactory.create(dataStorage.credentials, dataStorage.config);
+      this.logger.debug('BigQuery adapter created successfully');
+    } catch (error) {
+      this.logger.error('Failed to create BigQuery adapter', error);
+      throw error;
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-config.guards.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-config.guards.ts
@@ -1,0 +1,10 @@
+import { BigQueryConfig, BigQueryConfigSchema } from './bigquery/schemas/bigquery-config.schema';
+import { AthenaConfig, AthenaConfigSchema } from './athena/schemas/athena-config.schema';
+
+export function isBigQueryConfig(config: unknown): config is BigQueryConfig {
+  return BigQueryConfigSchema.safeParse(config).success;
+}
+
+export function isAthenaConfig(config: unknown): config is AthenaConfig {
+  return AthenaConfigSchema.safeParse(config).success;
+}

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-credentials.guards.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-credentials.guards.ts
@@ -1,0 +1,16 @@
+import {
+  BigQueryCredentials,
+  BigQueryCredentialsSchema,
+} from './bigquery/schemas/bigquery-credentials.schema';
+import {
+  AthenaCredentials,
+  AthenaCredentialsSchema,
+} from './athena/schemas/athena-credentials.schema';
+
+export function isBigqueryCredentials(credentials: unknown): credentials is BigQueryCredentials {
+  return BigQueryCredentialsSchema.safeParse(credentials).success;
+}
+
+export function isAthenaCredentials(credentials: unknown): credentials is AthenaCredentials {
+  return AthenaCredentialsSchema.safeParse(credentials).success;
+}

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-credentials.type.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-credentials.type.ts
@@ -1,0 +1,4 @@
+import { BigQueryCredentials } from './bigquery/schemas/bigquery-credentials.schema';
+import { AthenaCredentials } from './athena/schemas/athena-credentials.schema';
+
+export type DataStorageCredentials = BigQueryCredentials | AthenaCredentials;

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
@@ -3,19 +3,36 @@ import { BigQueryAccessValidator } from './bigquery/services/bigquery-access.val
 import { AthenaAccessValidator } from './athena/services/athena-access.validator';
 import { DataStorageType } from './enums/data-storage-type.enum';
 import { TypeResolver } from '../../common/resolver/type-resolver';
+import { BigQueryReportReader } from './bigquery/services/bigquery-report-reader.service';
+import { DataStorageReportReader } from './interfaces/data-storage-report-reader.interface';
+import { AthenaReportReader } from './athena/services/athena-report-reader.service';
+import { BigQueryApiAdapterFactory } from './bigquery/adapters/bigquery-api-adapter.factory';
+import { AthenaApiAdapterFactory } from './athena/adapters/athena-api-adapter.factory';
+import { S3ApiAdapterFactory } from './athena/adapters/s3-api-adapter.factory';
 
 export const DATA_STORAGE_ACCESS_VALIDATOR_RESOLVER = Symbol(
   'DATA_STORAGE_ACCESS_VALIDATOR_RESOLVER'
 );
+export const DATA_STORAGE_REPORT_READER_RESOLVER = Symbol('DATA_STORAGE_REPORT_READER_RESOLVER');
 
 const accessValidatorProviders = [BigQueryAccessValidator, AthenaAccessValidator];
+const storageDataProviders = [BigQueryReportReader, AthenaReportReader];
+const adapterFactories = [BigQueryApiAdapterFactory, AthenaApiAdapterFactory, S3ApiAdapterFactory];
 
 export const dataStorageResolverProviders = [
   ...accessValidatorProviders,
+  ...storageDataProviders,
+  ...adapterFactories,
   {
     provide: DATA_STORAGE_ACCESS_VALIDATOR_RESOLVER,
     useFactory: (...validators: DataStorageAccessValidator[]) =>
       new TypeResolver<DataStorageType, DataStorageAccessValidator>(validators),
     inject: accessValidatorProviders,
+  },
+  {
+    provide: DATA_STORAGE_REPORT_READER_RESOLVER,
+    useFactory: (...storageDataProviders: DataStorageReportReader[]) =>
+      new TypeResolver<DataStorageType, DataStorageReportReader>(storageDataProviders),
+    inject: storageDataProviders,
   },
 ];

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-report-reader.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-report-reader.interface.ts
@@ -1,0 +1,25 @@
+import { TypedComponent } from '../../../common/resolver/typed-component.resolver';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+import { Report } from '../../entities/report.entity';
+import { ReportDataDescription } from '../../dto/domain/report-data-description.dto';
+import { ReportDataBatch } from '../../dto/domain/report-data-batch.dto';
+
+/**
+ * Interface for reading report data from a data storage
+ */
+export interface DataStorageReportReader extends TypedComponent<DataStorageType> {
+  /**
+   * Prepares report data for reading
+   */
+  prepareReportData(report: Report): Promise<ReportDataDescription>;
+
+  /**
+   * Reads a batch of report data
+   */
+  readReportDataBatch(batchId?: string, maxDataRows?: number): Promise<ReportDataBatch>;
+
+  /**
+   * Finalizes the report reading process
+   */
+  finalize(): Promise<void>;
+}

--- a/apps/backend/src/data-marts/dto/domain/create-data-destination.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/create-data-destination.command.ts
@@ -1,0 +1,11 @@
+import { DataDestinationType } from '../../data-destination-types/enums/data-destination-type.enum';
+import { DataDestinationCredentials } from '../../data-destination-types/data-destination-credentials.type';
+
+export class CreateDataDestinationCommand {
+  constructor(
+    public readonly projectId: string,
+    public readonly title: string,
+    public readonly type: DataDestinationType,
+    public readonly credentials: DataDestinationCredentials
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/create-report.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/create-report.command.ts
@@ -1,0 +1,12 @@
+import { DataDestinationConfig } from '../../data-destination-types/data-destination-config.type';
+
+export class CreateReportCommand {
+  constructor(
+    public readonly projectId: string,
+    public readonly userId: string,
+    public readonly title: string,
+    public readonly dataMartId: string,
+    public readonly dataDestinationId: string,
+    public readonly destinationConfig: DataDestinationConfig
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/data-destination.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/data-destination.dto.ts
@@ -1,0 +1,14 @@
+import { DataDestinationType } from '../../data-destination-types/enums/data-destination-type.enum';
+import { DataDestinationCredentials } from '../../data-destination-types/data-destination-credentials.type';
+
+export class DataDestinationDto {
+  constructor(
+    public readonly id: string,
+    public readonly title: string,
+    public readonly type: DataDestinationType,
+    public readonly projectId: string,
+    public readonly credentials: DataDestinationCredentials,
+    public readonly createdAt: Date,
+    public readonly modifiedAt: Date
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/delete-data-destination.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/delete-data-destination.command.ts
@@ -1,0 +1,6 @@
+export class DeleteDataDestinationCommand {
+  constructor(
+    public readonly id: string,
+    public readonly projectId: string
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/get-data-destination.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/get-data-destination.command.ts
@@ -1,0 +1,6 @@
+export class GetDataDestinationCommand {
+  constructor(
+    public readonly id: string,
+    public readonly projectId: string
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/get-report.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/get-report.command.ts
@@ -1,0 +1,7 @@
+export class GetReportCommand {
+  constructor(
+    public readonly id: string,
+    public readonly projectId: string,
+    public readonly userId: string
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/list-data-destinations.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/list-data-destinations.command.ts
@@ -1,0 +1,3 @@
+export class ListDataDestinationsCommand {
+  constructor(public readonly projectId: string) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/list-reports-by-data-mart.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/list-reports-by-data-mart.command.ts
@@ -1,0 +1,7 @@
+export class ListReportsByDataMartCommand {
+  constructor(
+    public readonly dataMartId: string,
+    public readonly projectId: string,
+    public readonly userId: string
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/list-reports-by-project.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/list-reports-by-project.command.ts
@@ -1,0 +1,6 @@
+export class ListReportsByProjectCommand {
+  constructor(
+    public readonly projectId: string,
+    public readonly userId: string
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/report-data-batch.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/report-data-batch.dto.ts
@@ -1,0 +1,6 @@
+export class ReportDataBatch {
+  constructor(
+    public readonly dataRows: unknown[][],
+    public readonly nextDataBatchId?: string | null
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/report-data-description.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/report-data-description.dto.ts
@@ -1,0 +1,19 @@
+/**
+ * Describes the structure and metadata of report data.
+ * Contains information about headers and optionally the estimated number of data rows.
+ */
+export class ReportDataDescription {
+  constructor(
+    /**
+     * Array of column headers for the report data.
+     */
+    public readonly dataHeaders: string[],
+    /**
+     * Optional estimated count of data rows.
+     * Note: This value may not always be available in advance for all data sources.
+     * Some data storage providers (like Athena) cannot reliably determine the row count
+     * before retrieving the actual data.
+     */
+    public readonly estimatedDataRowsCount?: number
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/report.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/report.dto.ts
@@ -1,0 +1,20 @@
+import { DataMartDto } from './data-mart.dto';
+import { DataDestinationDto } from './data-destination.dto';
+import { ReportRunStatus } from '../../enums/report-run-status.enum';
+import { DataDestinationConfig } from '../../data-destination-types/data-destination-config.type';
+
+export class ReportDto {
+  constructor(
+    public readonly id: string,
+    public readonly title: string,
+    public readonly dataMart: DataMartDto,
+    public readonly dataDestinationAccess: DataDestinationDto,
+    public readonly destinationConfig: DataDestinationConfig,
+    public readonly createdAt: Date,
+    public readonly modifiedAt: Date,
+    public readonly lastRunAt?: Date,
+    public readonly lastRunError?: string,
+    public readonly lastRunStatus?: ReportRunStatus,
+    public readonly runsCount: number = 0
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/run-report.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/run-report.command.ts
@@ -1,0 +1,4 @@
+export interface RunReportCommand {
+  reportId: string;
+  userId: string;
+}

--- a/apps/backend/src/data-marts/dto/domain/update-data-destination.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/update-data-destination.command.ts
@@ -1,0 +1,10 @@
+import { DataDestinationCredentials } from '../../data-destination-types/data-destination-credentials.type';
+
+export class UpdateDataDestinationCommand {
+  constructor(
+    public readonly id: string,
+    public readonly projectId: string,
+    public readonly title: string,
+    public readonly credentials: DataDestinationCredentials
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/update-report.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/update-report.command.ts
@@ -1,0 +1,12 @@
+import { DataDestinationConfig } from '../../data-destination-types/data-destination-config.type';
+
+export class UpdateReportCommand {
+  constructor(
+    public readonly id: string,
+    public readonly projectId: string,
+    public readonly userId: string,
+    public readonly title: string,
+    public readonly dataDestinationId: string,
+    public readonly destinationConfig: DataDestinationConfig
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/presentation/create-data-destination-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/create-data-destination-api.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { DataDestinationType } from '../../data-destination-types/enums/data-destination-type.enum';
+import { IsEnum, IsNotEmpty, IsObject, IsString } from 'class-validator';
+import { DataDestinationCredentials } from '../../data-destination-types/data-destination-credentials.type';
+
+export class CreateDataDestinationApiDto {
+  @ApiProperty({ example: 'My Google Sheets Destination' })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({ enum: DataDestinationType })
+  @IsEnum(DataDestinationType)
+  type: DataDestinationType;
+
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: true,
+    description: 'Credentials required for the selected destination type',
+  })
+  @IsObject()
+  credentials: DataDestinationCredentials;
+}

--- a/apps/backend/src/data-marts/dto/presentation/create-report-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/create-report-request-api.dto.ts
@@ -1,0 +1,25 @@
+import { IsNotEmpty, IsString, IsObject } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { DataDestinationConfig } from '../../data-destination-types/data-destination-config.type';
+
+export class CreateReportRequestApiDto {
+  @ApiProperty({ example: 'My Report' })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({ description: 'ID of the data mart' })
+  @IsString()
+  @IsNotEmpty()
+  dataMartId: string;
+
+  @ApiProperty({ description: 'ID of the data destination' })
+  @IsString()
+  @IsNotEmpty()
+  dataDestinationId: string;
+
+  @ApiProperty({ description: 'Configuration for the data destination' })
+  @IsObject()
+  @IsNotEmpty()
+  destinationConfig: DataDestinationConfig;
+}

--- a/apps/backend/src/data-marts/dto/presentation/data-destination-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-destination-response-api.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { DataDestinationType } from '../../data-destination-types/enums/data-destination-type.enum';
+import { DataDestinationCredentials } from '../../data-destination-types/data-destination-credentials.type';
+
+export class DataDestinationResponseApiDto {
+  @ApiProperty({ example: 'abc123e4-5678-90ab-cdef-1234567890ab' })
+  id: string;
+
+  @ApiProperty({ example: 'My Google Sheets Destination' })
+  title: string;
+
+  @ApiProperty({ enum: DataDestinationType, example: DataDestinationType.GOOGLE_SHEETS })
+  type: DataDestinationType;
+
+  @ApiProperty({ example: 'my-project' })
+  projectId: string;
+
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: true,
+    description: 'Credentials for the destination',
+  })
+  credentials: DataDestinationCredentials;
+
+  @ApiProperty({ example: '2024-01-01T12:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2024-01-02T15:30:00.000Z' })
+  modifiedAt: Date;
+}

--- a/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { DataMartResponseApiDto } from './data-mart-response-api.dto';
+import { DataDestinationResponseApiDto } from './data-destination-response-api.dto';
+import { ReportRunStatus } from '../../enums/report-run-status.enum';
+import { DataDestinationConfig } from '../../data-destination-types/data-destination-config.type';
+
+export class ReportResponseApiDto {
+  @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
+  id: string;
+
+  @ApiProperty({ example: 'My Report' })
+  title: string;
+
+  @ApiProperty()
+  dataMart: DataMartResponseApiDto;
+
+  @ApiProperty()
+  dataDestinationAccess: DataDestinationResponseApiDto;
+
+  @ApiProperty()
+  destinationConfig: DataDestinationConfig;
+
+  @ApiProperty({ nullable: true })
+  lastRunAt?: Date;
+
+  @ApiProperty({ enum: ReportRunStatus, nullable: true })
+  lastRunStatus?: ReportRunStatus;
+
+  @ApiProperty({ nullable: true })
+  lastRunError?: string;
+
+  @ApiProperty({ example: 0 })
+  runsCount: number;
+
+  @ApiProperty({ example: '2024-01-01T12:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2024-01-02T15:30:00.000Z' })
+  modifiedAt: Date;
+}

--- a/apps/backend/src/data-marts/dto/presentation/update-data-destination-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-data-destination-api.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsObject, IsString } from 'class-validator';
+import { DataDestinationCredentials } from '../../data-destination-types/data-destination-credentials.type';
+
+export class UpdateDataDestinationApiDto {
+  @ApiProperty({ example: 'My Updated Google Sheets Destination' })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: true,
+    description: 'Credentials required for the selected destination type',
+  })
+  @IsObject()
+  credentials: DataDestinationCredentials;
+}

--- a/apps/backend/src/data-marts/dto/presentation/update-report-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-report-request-api.dto.ts
@@ -1,0 +1,20 @@
+import { IsNotEmpty, IsString, IsObject } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { DataDestinationConfig } from '../../data-destination-types/data-destination-config.type';
+
+export class UpdateReportRequestApiDto {
+  @ApiProperty({ example: 'My Report' })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({ description: 'ID of the data destination' })
+  @IsString()
+  @IsNotEmpty()
+  dataDestinationId: string;
+
+  @ApiProperty({ description: 'Configuration for the data destination' })
+  @IsObject()
+  @IsNotEmpty()
+  destinationConfig: DataDestinationConfig;
+}

--- a/apps/backend/src/data-marts/dto/schemas/data-mart-table-definitions/data-mart-definition.guards.ts
+++ b/apps/backend/src/data-marts/dto/schemas/data-mart-table-definitions/data-mart-definition.guards.ts
@@ -1,0 +1,26 @@
+import { DataMartDefinition } from './data-mart-definition';
+import { SqlDefinition, SqlDefinitionSchema } from './sql-definition.schema';
+import { TableDefinition, TableDefinitionSchema } from './table-definition.schema';
+import {
+  TablePatternDefinition,
+  TablePatternDefinitionSchema,
+} from './table-pattern-definition.schema';
+import { ViewDefinition, ViewDefinitionSchema } from './view-definition.schema';
+
+export function isSqlDefinition(definition: DataMartDefinition): definition is SqlDefinition {
+  return SqlDefinitionSchema.safeParse(definition).success;
+}
+
+export function isTableDefinition(definition: DataMartDefinition): definition is TableDefinition {
+  return TableDefinitionSchema.safeParse(definition).success;
+}
+
+export function isTablePatternDefinition(
+  definition: DataMartDefinition
+): definition is TablePatternDefinition {
+  return TablePatternDefinitionSchema.safeParse(definition).success;
+}
+
+export function isViewDefinition(definition: DataMartDefinition): definition is ViewDefinition {
+  return ViewDefinitionSchema.safeParse(definition).success;
+}

--- a/apps/backend/src/data-marts/entities/data-destination.entity.ts
+++ b/apps/backend/src/data-marts/entities/data-destination.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
+import {
+  DataDestinationCredentials,
+  DataDestinationCredentialsSchema,
+} from '../data-destination-types/data-destination-credentials.type';
+import { createZodTransformer } from '../../common/zod/zod-transformer';
+
+@Entity()
+export class DataDestination {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column()
+  type: DataDestinationType;
+
+  @Column()
+  projectId: string;
+
+  @Column({
+    type: 'json',
+    transformer: createZodTransformer<DataDestinationCredentials>(DataDestinationCredentialsSchema),
+  })
+  credentials: DataDestinationCredentials;
+
+  @DeleteDateColumn({ nullable: true })
+  deletedAt?: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  modifiedAt: Date;
+}

--- a/apps/backend/src/data-marts/entities/report.entity.ts
+++ b/apps/backend/src/data-marts/entities/report.entity.ts
@@ -1,0 +1,58 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { DataMart } from './data-mart.entity';
+import { DataDestination } from './data-destination.entity';
+import { createZodTransformer } from '../../common/zod/zod-transformer';
+import { ReportRunStatus } from '../enums/report-run-status.enum';
+import {
+  DataDestinationConfig,
+  DataDestinationConfigSchema,
+} from '../data-destination-types/data-destination-config.type';
+
+@Entity()
+export class Report {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @ManyToOne(() => DataMart, { eager: true, cascade: true })
+  @JoinColumn()
+  dataMart: DataMart;
+
+  @ManyToOne(() => DataDestination, { eager: true, cascade: true })
+  @JoinColumn()
+  dataDestination: DataDestination;
+
+  @Column({
+    type: 'json',
+    transformer: createZodTransformer<DataDestinationConfig>(DataDestinationConfigSchema),
+  })
+  destinationConfig: DataDestinationConfig;
+
+  @Column({ nullable: true })
+  lastRunAt?: Date;
+
+  @Column({ nullable: true })
+  lastRunStatus?: ReportRunStatus;
+
+  @Column({ nullable: true })
+  lastRunError?: string;
+
+  @Column({ default: 0 })
+  runsCount: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  modifiedAt: Date;
+}

--- a/apps/backend/src/data-marts/enums/report-run-status.enum.ts
+++ b/apps/backend/src/data-marts/enums/report-run-status.enum.ts
@@ -1,0 +1,5 @@
+export enum ReportRunStatus {
+  SUCCESS = 'SUCCESS',
+  ERROR = 'ERROR',
+  RUNNING = 'RUNNING',
+}

--- a/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
@@ -1,0 +1,79 @@
+import { DataDestinationDto } from '../dto/domain/data-destination.dto';
+import { DataDestination } from '../entities/data-destination.entity';
+import { CreateDataDestinationApiDto } from '../dto/presentation/create-data-destination-api.dto';
+import { CreateDataDestinationCommand } from '../dto/domain/create-data-destination.command';
+import { UpdateDataDestinationApiDto } from '../dto/presentation/update-data-destination-api.dto';
+import { UpdateDataDestinationCommand } from '../dto/domain/update-data-destination.command';
+import { DataDestinationResponseApiDto } from '../dto/presentation/data-destination-response-api.dto';
+import { Injectable } from '@nestjs/common';
+import { AuthorizationContext } from '../../common/authorization-context/authorization.context';
+import { GetDataDestinationCommand } from '../dto/domain/get-data-destination.command';
+import { DeleteDataDestinationCommand } from '../dto/domain/delete-data-destination.command';
+import { ListDataDestinationsCommand } from '../dto/domain/list-data-destinations.command';
+
+@Injectable()
+export class DataDestinationMapper {
+  toCreateCommand(
+    context: AuthorizationContext,
+    dto: CreateDataDestinationApiDto
+  ): CreateDataDestinationCommand {
+    return new CreateDataDestinationCommand(
+      context.projectId,
+      dto.title,
+      dto.type,
+      dto.credentials
+    );
+  }
+
+  toUpdateCommand(
+    id: string,
+    context: AuthorizationContext,
+    dto: UpdateDataDestinationApiDto
+  ): UpdateDataDestinationCommand {
+    return new UpdateDataDestinationCommand(id, context.projectId, dto.title, dto.credentials);
+  }
+
+  toDomainDto(dataDestination: DataDestination): DataDestinationDto {
+    return new DataDestinationDto(
+      dataDestination.id,
+      dataDestination.title,
+      dataDestination.type,
+      dataDestination.projectId,
+      dataDestination.credentials,
+      dataDestination.createdAt,
+      dataDestination.modifiedAt
+    );
+  }
+
+  toDomainDtoList(dataDestinations: DataDestination[]): DataDestinationDto[] {
+    return dataDestinations.map(dataDestination => this.toDomainDto(dataDestination));
+  }
+
+  toApiResponse(dataDestinationDto: DataDestinationDto): DataDestinationResponseApiDto {
+    return {
+      id: dataDestinationDto.id,
+      title: dataDestinationDto.title,
+      type: dataDestinationDto.type,
+      projectId: dataDestinationDto.projectId,
+      credentials: dataDestinationDto.credentials,
+      createdAt: dataDestinationDto.createdAt,
+      modifiedAt: dataDestinationDto.modifiedAt,
+    };
+  }
+
+  toGetCommand(id: string, context: AuthorizationContext) {
+    return new GetDataDestinationCommand(id, context.projectId);
+  }
+
+  toListCommand(context: AuthorizationContext) {
+    return new ListDataDestinationsCommand(context.projectId);
+  }
+
+  toResponseList(dataDestinations: DataDestinationDto[]): DataDestinationResponseApiDto[] {
+    return dataDestinations.map(dataDestinationDto => this.toApiResponse(dataDestinationDto));
+  }
+
+  toDeleteCommand(id: string, context: AuthorizationContext): DeleteDataDestinationCommand {
+    return new DeleteDataDestinationCommand(id, context.projectId);
+  }
+}

--- a/apps/backend/src/data-marts/mappers/report.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+import { Report } from '../entities/report.entity';
+import { ReportDto } from '../dto/domain/report.dto';
+import { CreateReportCommand } from '../dto/domain/create-report.command';
+import { UpdateReportCommand } from '../dto/domain/update-report.command';
+import { CreateReportRequestApiDto } from '../dto/presentation/create-report-request-api.dto';
+import { UpdateReportRequestApiDto } from '../dto/presentation/update-report-request-api.dto';
+import { ReportResponseApiDto } from '../dto/presentation/report-response-api.dto';
+import { GetReportCommand } from '../dto/domain/get-report.command';
+import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data-mart.command';
+import { ListReportsByProjectCommand } from '../dto/domain/list-reports-by-project.command';
+import { RunReportCommand } from '../dto/domain/run-report.command';
+import { AuthorizationContext } from '../../common/authorization-context/authorization.context';
+import { DataMartMapper } from './data-mart.mapper';
+import { DataDestinationMapper } from './data-destination.mapper';
+
+@Injectable()
+export class ReportMapper {
+  constructor(
+    private readonly dataMartMapper: DataMartMapper,
+    private readonly dataDestinationMapper: DataDestinationMapper
+  ) {}
+
+  toCreateDomainCommand(
+    context: AuthorizationContext,
+    dto: CreateReportRequestApiDto
+  ): CreateReportCommand {
+    return new CreateReportCommand(
+      context.projectId,
+      context.userId,
+      dto.title,
+      dto.dataMartId,
+      dto.dataDestinationId,
+      dto.destinationConfig
+    );
+  }
+
+  toDomainDto(entity: Report): ReportDto {
+    return new ReportDto(
+      entity.id,
+      entity.title,
+      this.dataMartMapper.toDomainDto(entity.dataMart),
+      this.dataDestinationMapper.toDomainDto(entity.dataDestination),
+      entity.destinationConfig,
+      entity.createdAt,
+      entity.modifiedAt,
+      entity.lastRunAt,
+      entity.lastRunError,
+      entity.lastRunStatus,
+      entity.runsCount
+    );
+  }
+
+  toDomainDtoList(entities: Report[]): ReportDto[] {
+    return entities.map(entity => this.toDomainDto(entity));
+  }
+
+  toResponse(dto: ReportDto): ReportResponseApiDto {
+    return {
+      id: dto.id,
+      title: dto.title,
+      dataMart: this.dataMartMapper.toResponse(dto.dataMart),
+      dataDestinationAccess: this.dataDestinationMapper.toApiResponse(dto.dataDestinationAccess),
+      destinationConfig: dto.destinationConfig,
+      lastRunAt: dto.lastRunAt,
+      lastRunStatus: dto.lastRunStatus,
+      lastRunError: dto.lastRunError,
+      runsCount: dto.runsCount,
+      createdAt: dto.createdAt,
+      modifiedAt: dto.modifiedAt,
+    };
+  }
+
+  toResponseList(dtos: ReportDto[]): ReportResponseApiDto[] {
+    return dtos.map(dto => this.toResponse(dto));
+  }
+
+  toGetCommand(id: string, context: AuthorizationContext): GetReportCommand {
+    return new GetReportCommand(id, context.projectId, context.userId);
+  }
+
+  toListByDataMartCommand(
+    dataMartId: string,
+    context: AuthorizationContext
+  ): ListReportsByDataMartCommand {
+    return new ListReportsByDataMartCommand(dataMartId, context.projectId, context.userId);
+  }
+
+  toListByProjectCommand(context: AuthorizationContext): ListReportsByProjectCommand {
+    return new ListReportsByProjectCommand(context.projectId, context.userId);
+  }
+
+  toRunReportCommand(id: string, context: AuthorizationContext): RunReportCommand {
+    return {
+      reportId: id,
+      userId: context.userId,
+    };
+  }
+
+  toUpdateDomainCommand(
+    id: string,
+    context: AuthorizationContext,
+    dto: UpdateReportRequestApiDto
+  ): UpdateReportCommand {
+    return new UpdateReportCommand(
+      id,
+      context.projectId,
+      context.userId,
+      dto.title,
+      dto.dataDestinationId,
+      dto.destinationConfig
+    );
+  }
+}

--- a/apps/backend/src/data-marts/services/data-destination.service.ts
+++ b/apps/backend/src/data-marts/services/data-destination.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DataDestination } from '../entities/data-destination.entity';
+
+@Injectable()
+export class DataDestinationService {
+  constructor(
+    @InjectRepository(DataDestination)
+    private readonly dataDestinationRepository: Repository<DataDestination>
+  ) {}
+
+  async getByIdAndProjectId(projectId: string, id: string): Promise<DataDestination> {
+    const entity = await this.dataDestinationRepository.findOne({ where: { id, projectId } });
+
+    if (!entity) {
+      throw new NotFoundException(
+        `DataDestination with id ${id} and projectId ${projectId} not found`
+      );
+    }
+
+    return entity;
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
@@ -1,0 +1,32 @@
+import { CreateDataDestinationCommand } from '../dto/domain/create-data-destination.command';
+import { Repository } from 'typeorm';
+import { DataDestination } from '../entities/data-destination.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Injectable } from '@nestjs/common';
+import { DataDestinationDto } from '../dto/domain/data-destination.dto';
+import { DataDestinationMapper } from '../mappers/data-destination.mapper';
+import { DataDestinationCredentialsValidatorFacade } from '../data-destination-types/facades/data-destination-credentials-validator.facade';
+
+@Injectable()
+export class CreateDataDestinationService {
+  constructor(
+    @InjectRepository(DataDestination)
+    private readonly repository: Repository<DataDestination>,
+    private readonly mapper: DataDestinationMapper,
+    private readonly credentialsValidator: DataDestinationCredentialsValidatorFacade
+  ) {}
+
+  async run(command: CreateDataDestinationCommand): Promise<DataDestinationDto> {
+    await this.credentialsValidator.checkCredentials(command.type, command.credentials);
+
+    const entity = this.repository.create({
+      title: command.title,
+      type: command.type,
+      projectId: command.projectId,
+      credentials: command.credentials,
+    });
+
+    const savedEntity = await this.repository.save(entity);
+    return this.mapper.toDomainDto(savedEntity);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/create-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-report.service.ts
@@ -1,0 +1,77 @@
+import { Repository } from 'typeorm';
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Report } from '../entities/report.entity';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataDestination } from '../entities/data-destination.entity';
+import { ReportMapper } from '../mappers/report.mapper';
+import { CreateReportCommand } from '../dto/domain/create-report.command';
+import { ReportDto } from '../dto/domain/report.dto';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
+import { DataDestinationAccessValidatorFacade } from '../data-destination-types/facades/data-destination-access-validator.facade';
+
+@Injectable()
+export class CreateReportService {
+  constructor(
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    @InjectRepository(DataMart)
+    private readonly dataMartRepository: Repository<DataMart>,
+    @InjectRepository(DataDestination)
+    private readonly dataDestinationRepository: Repository<DataDestination>,
+    private readonly dataDestinationAccessValidationFacade: DataDestinationAccessValidatorFacade,
+    private readonly mapper: ReportMapper
+  ) {}
+
+  async run(command: CreateReportCommand): Promise<ReportDto> {
+    // Get the data mart and verify it's in published status
+    const dataMart = await this.dataMartRepository.findOne({
+      where: {
+        id: command.dataMartId,
+        projectId: command.projectId,
+      },
+    });
+
+    if (!dataMart) {
+      throw new BadRequestException(`Data mart with ID ${command.dataMartId} not found`);
+    }
+
+    if (dataMart.status !== DataMartStatus.PUBLISHED) {
+      throw new BadRequestException(
+        `Cannot create report for data mart with status ${dataMart.status}. Data mart must be in PUBLISHED status.`
+      );
+    }
+
+    // Get the data destination
+    const dataDestination = await this.dataDestinationRepository.findOne({
+      where: {
+        id: command.dataDestinationId,
+        projectId: command.projectId,
+      },
+    });
+
+    if (!dataDestination) {
+      throw new BadRequestException(
+        `Data destination with ID ${command.dataDestinationId} not found`
+      );
+    }
+
+    await this.dataDestinationAccessValidationFacade.checkAccess(
+      dataDestination.type,
+      command.destinationConfig,
+      dataDestination
+    );
+
+    // Create and save the report
+    const report = this.reportRepository.create({
+      title: command.title,
+      dataMart,
+      dataDestination,
+      destinationConfig: command.destinationConfig,
+    });
+
+    const newReport = await this.reportRepository.save(report);
+
+    return this.mapper.toDomainDto(newReport);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/delete-data-destination.service.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-data-destination.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DataDestination } from '../entities/data-destination.entity';
+import { Report } from '../entities/report.entity';
+import { DeleteDataDestinationCommand } from '../dto/domain/delete-data-destination.command';
+import { DataDestinationService } from '../services/data-destination.service';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+
+@Injectable()
+export class DeleteDataDestinationService {
+  constructor(
+    @InjectRepository(DataDestination)
+    private readonly dataDestinationRepository: Repository<DataDestination>,
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    private readonly dataDestinationService: DataDestinationService
+  ) {}
+
+  async run(command: DeleteDataDestinationCommand): Promise<void> {
+    const destination = await this.dataDestinationService.getByIdAndProjectId(
+      command.projectId,
+      command.id
+    );
+
+    const reportsCount = await this.reportRepository.count({
+      where: {
+        dataDestination: {
+          id: destination.id,
+        },
+      },
+    });
+
+    if (reportsCount > 0) {
+      throw new BusinessViolationException(
+        `Cannot delete the destination because it is referenced by ${reportsCount} existing report(s).`
+      );
+    }
+
+    await this.dataDestinationRepository.softDelete({
+      id: command.id,
+      projectId: command.projectId,
+    });
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/delete-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-report.service.ts
@@ -1,0 +1,30 @@
+import { Repository } from 'typeorm';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Report } from '../entities/report.entity';
+import { GetReportCommand } from '../dto/domain/get-report.command';
+
+@Injectable()
+export class DeleteReportService {
+  constructor(
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>
+  ) {}
+
+  async run(command: GetReportCommand): Promise<void> {
+    const report = await this.reportRepository.findOne({
+      where: {
+        id: command.id,
+        dataMart: {
+          projectId: command.projectId,
+        },
+      },
+    });
+
+    if (!report) {
+      throw new NotFoundException(`Report with ID ${command.id} not found`);
+    }
+
+    await this.reportRepository.remove(report);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/get-data-destination.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-data-destination.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { DataDestinationMapper } from '../mappers/data-destination.mapper';
+import { DataDestinationDto } from '../dto/domain/data-destination.dto';
+import { DataDestinationService } from '../services/data-destination.service';
+import { GetDataDestinationCommand } from '../dto/domain/get-data-destination.command';
+
+@Injectable()
+export class GetDataDestinationService {
+  constructor(
+    private readonly dataDestinationService: DataDestinationService,
+    private readonly dataDestinationMapper: DataDestinationMapper
+  ) {}
+
+  async run(command: GetDataDestinationCommand): Promise<DataDestinationDto> {
+    const dataDestinationEntity = await this.dataDestinationService.getByIdAndProjectId(
+      command.projectId,
+      command.id
+    );
+
+    return this.dataDestinationMapper.toDomainDto(dataDestinationEntity);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/get-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report.service.ts
@@ -1,0 +1,34 @@
+import { Repository } from 'typeorm';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Report } from '../entities/report.entity';
+import { ReportMapper } from '../mappers/report.mapper';
+import { GetReportCommand } from '../dto/domain/get-report.command';
+import { ReportDto } from '../dto/domain/report.dto';
+
+@Injectable()
+export class GetReportService {
+  constructor(
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    private readonly mapper: ReportMapper
+  ) {}
+
+  async run(command: GetReportCommand): Promise<ReportDto> {
+    const report = await this.reportRepository.findOne({
+      where: {
+        id: command.id,
+        dataMart: {
+          projectId: command.projectId,
+        },
+      },
+      relations: ['dataMart', 'dataDestination'],
+    });
+
+    if (!report) {
+      throw new NotFoundException(`Report with ID ${command.id} not found`);
+    }
+
+    return this.mapper.toDomainDto(report);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/list-data-destinations.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-data-destinations.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DataDestination } from '../entities/data-destination.entity';
+import { DataDestinationMapper } from '../mappers/data-destination.mapper';
+import { DataDestinationDto } from '../dto/domain/data-destination.dto';
+import { ListDataDestinationsCommand } from '../dto/domain/list-data-destinations.command';
+
+@Injectable()
+export class ListDataDestinationsService {
+  constructor(
+    @InjectRepository(DataDestination)
+    private readonly dataDestinationRepo: Repository<DataDestination>,
+    private readonly mapper: DataDestinationMapper
+  ) {}
+
+  async run(command: ListDataDestinationsCommand): Promise<DataDestinationDto[]> {
+    const dataDestinations = await this.dataDestinationRepo.find({
+      where: { projectId: command.projectId },
+    });
+    return this.mapper.toDomainDtoList(dataDestinations);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-data-mart.service.ts
@@ -1,0 +1,30 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Report } from '../entities/report.entity';
+import { ReportMapper } from '../mappers/report.mapper';
+import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data-mart.command';
+import { ReportDto } from '../dto/domain/report.dto';
+
+@Injectable()
+export class ListReportsByDataMartService {
+  constructor(
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    private readonly mapper: ReportMapper
+  ) {}
+
+  async run(command: ListReportsByDataMartCommand): Promise<ReportDto[]> {
+    // Find all reports for the data mart
+    const reports = await this.reportRepository.find({
+      where: {
+        dataMart: {
+          id: command.dataMartId,
+        },
+      },
+      relations: ['dataMart', 'dataDestination'],
+    });
+
+    return this.mapper.toDomainDtoList(reports);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.ts
@@ -1,0 +1,30 @@
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Report } from '../entities/report.entity';
+import { ReportMapper } from '../mappers/report.mapper';
+import { ListReportsByProjectCommand } from '../dto/domain/list-reports-by-project.command';
+import { ReportDto } from '../dto/domain/report.dto';
+
+@Injectable()
+export class ListReportsByProjectService {
+  constructor(
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    private readonly mapper: ReportMapper
+  ) {}
+
+  async run(command: ListReportsByProjectCommand): Promise<ReportDto[]> {
+    // Get all data reports for the project
+    const reports = await this.reportRepository.find({
+      where: {
+        dataMart: {
+          projectId: command.projectId,
+        },
+      },
+      relations: ['dataMart', 'dataDestination'],
+    });
+
+    return this.mapper.toDomainDtoList(reports);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
@@ -1,0 +1,326 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RunReportService } from './run-report.service';
+import { Report } from '../entities/report.entity';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataStorage } from '../entities/data-storage.entity';
+import { DataDestination } from '../entities/data-destination.entity';
+import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
+import { BigQueryReportReader } from '../data-storage-types/bigquery/services/bigquery-report-reader.service';
+import { AthenaReportReader } from '../data-storage-types/athena/services/athena-report-reader.service';
+import { GoogleSheetsReportWriter } from '../data-destination-types/google-sheets/services/google-sheets-report-writer';
+import { SqlDefinition } from '../dto/schemas/data-mart-table-definitions/sql-definition.schema';
+import { GoogleSheetsConfig } from '../data-destination-types/google-sheets/schemas/google-sheets-config.schema';
+import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
+import { RunReportCommand } from '../dto/domain/run-report.command';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
+import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../data-storage-types/data-storage-providers';
+import { DATA_DESTINATION_REPORT_WRITER_RESOLVER } from '../data-destination-types/data-destination-providers';
+import { SheetHeaderFormatter } from '../data-destination-types/google-sheets/services/sheet-formatters/sheet-header-formatter';
+import { SheetMetadataFormatter } from '../data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter';
+import { GoogleSheetsApiAdapterFactory } from '../data-destination-types/google-sheets/adapters/google-sheets-api-adapter.factory';
+import { BigQueryApiAdapterFactory } from '../data-storage-types/bigquery/adapters/bigquery-api-adapter.factory';
+import { AthenaApiAdapterFactory } from '../data-storage-types/athena/adapters/athena-api-adapter.factory';
+import { S3ApiAdapterFactory } from '../data-storage-types/athena/adapters/s3-api-adapter.factory';
+
+describe.skip('RunReportService', () => {
+  let service: RunReportService;
+  let reportRepository: Repository<Report>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RunReportService,
+        BigQueryReportReader,
+        AthenaReportReader,
+        GoogleSheetsReportWriter,
+        SheetHeaderFormatter,
+        SheetMetadataFormatter,
+        GoogleSheetsApiAdapterFactory,
+        BigQueryApiAdapterFactory,
+        AthenaApiAdapterFactory,
+        S3ApiAdapterFactory,
+        {
+          provide: getRepositoryToken(Report),
+          useClass: Repository,
+        },
+        {
+          provide: DATA_STORAGE_REPORT_READER_RESOLVER,
+          useFactory: () => {
+            return {
+              resolve: (type: DataStorageType) => {
+                if (type === DataStorageType.GOOGLE_BIGQUERY) {
+                  return module.resolve<BigQueryReportReader>(BigQueryReportReader);
+                }
+                if (type === DataStorageType.AWS_ATHENA) {
+                  return module.resolve<AthenaReportReader>(AthenaReportReader);
+                }
+                return null;
+              },
+            };
+          },
+        },
+        {
+          provide: DATA_DESTINATION_REPORT_WRITER_RESOLVER,
+          useFactory: () => {
+            return {
+              resolve: (type: DataDestinationType) => {
+                if (type === DataDestinationType.GOOGLE_SHEETS) {
+                  return module.resolve<GoogleSheetsReportWriter>(GoogleSheetsReportWriter);
+                }
+                return null;
+              },
+            };
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<RunReportService>(RunReportService);
+    reportRepository = module.get<Repository<Report>>(getRepositoryToken(Report));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('Manual Test for RunReportService', () => {
+    /**
+     * Manual test for running a report with BigQuery as data source and Google Sheets as destination.
+     *
+     * To use this test:
+     * 1. Replace the SERVICE_ACCOUNT_KEY with your actual service account key JSON
+     * 2. Configure the SQL_QUERY, SPREADSHEET_ID, and SHEET_ID as needed
+     * 3. Uncomment the test and run it with: npm test -- -t "should run a report manually"
+     */
+    it.skip(
+      'should run a report with BigQuery',
+      async () => {
+        // ============= CONFIGURATION (MODIFY THESE VALUES) =============
+
+        // Service account key for both BigQuery and Google Sheets
+        // This should be a JSON string of your service account key
+        const SERVICE_ACCOUNT_KEY = ``;
+
+        // BigQuery configuration
+        const BQ_PROJECT_ID = '';
+        const BQ_LOCATION = 'us'; // e.g., 'us', 'eu', etc.
+
+        // SQL query to execute
+        const SQL_QUERY = '';
+
+        // Google Sheets configuration
+        const SPREADSHEET_ID = '1hKsqRGXCsLeOOK1VFE6GYt7j5JGJp1YMmy37NfCwoes'; // ID from the URL of your Google Sheet
+        const SHEET_ID = 1037644677; // Usually 0 for the first sheet, or find the gid in the URL
+
+        // ===============================================================
+
+        // Parse the service account key to extract client_email
+        const parsedCreds = JSON.parse(SERVICE_ACCOUNT_KEY);
+
+        // Create data storage (BigQuery)
+        const dataStorage: DataStorage = {
+          id: 'test-storage-id',
+          type: DataStorageType.GOOGLE_BIGQUERY,
+          projectId: BQ_PROJECT_ID,
+          credentials: parsedCreds,
+          config: {
+            projectId: BQ_PROJECT_ID,
+            location: BQ_LOCATION,
+          },
+          createdAt: new Date(),
+          modifiedAt: new Date(),
+        };
+
+        // Create data destination (Google Sheets)
+        const dataDestination: DataDestination = {
+          id: 'test-destination-id',
+          title: 'Test Google Sheets Destination',
+          type: DataDestinationType.GOOGLE_SHEETS,
+          projectId: BQ_PROJECT_ID,
+          credentials: {
+            type: 'google-sheets-credentials',
+            serviceAccountKey: parsedCreds,
+          },
+          createdAt: new Date(),
+          modifiedAt: new Date(),
+        };
+
+        // Create SQL definition
+        const sqlDefinition: SqlDefinition = {
+          sqlQuery: SQL_QUERY,
+        };
+
+        // Create data mart
+        const dataMart: DataMart = {
+          id: 'test-datamart-id',
+          title: 'Test Data Mart',
+          storage: dataStorage,
+          status: DataMartStatus.PUBLISHED,
+          definitionType: DataMartDefinitionType.SQL,
+          definition: sqlDefinition,
+          projectId: BQ_PROJECT_ID,
+          createdById: 'test-user',
+          createdAt: new Date(),
+          modifiedAt: new Date(),
+        };
+
+        // Create Google Sheets config
+        const sheetsConfig: GoogleSheetsConfig = {
+          type: 'google-sheets-config',
+          spreadsheetId: SPREADSHEET_ID,
+          sheetId: SHEET_ID,
+        };
+
+        // Create report
+        const report: Report = {
+          id: 'test-report-id',
+          title: 'Test Report',
+          dataMart: dataMart,
+          dataDestination: dataDestination,
+          destinationConfig: sheetsConfig,
+          runsCount: 0,
+          createdAt: new Date(),
+          modifiedAt: new Date(),
+        };
+
+        // Mock repository to return our test report
+        jest.spyOn(reportRepository, 'findOne').mockResolvedValue(report);
+        jest.spyOn(reportRepository, 'save').mockResolvedValue(report);
+
+        // Note: We're using real services for everything except the repository
+        // This means BigQueryReportReader and GoogleSheetsReportWriter will use their actual implementations
+        // The TypeResolver has been configured to return the real service instances
+
+        // Run the report
+        const command = { reportId: 'test-report-id' } as RunReportCommand;
+        await service.run(command);
+      },
+      5 * 60 * 1000
+    ); // Increase timeout for BigQuery operations
+
+    /**
+     * Manual test for running a report with AWS Athena as data source and Google Sheets as destination.
+     *
+     * To use this test:
+     * 1. Configure the AWS credentials (ACCESS_KEY_ID, SECRET_ACCESS_KEY)
+     * 2. Configure the AWS_REGION, DATABASE_NAME, OUTPUT_BUCKET, and SQL_QUERY
+     * 3. Configure the SPREADSHEET_ID and SHEET_ID for Google Sheets
+     * 4. Uncomment the test and run it with: npm test -- -t "should run a report with Athena"
+     */
+    it.skip(
+      'should run a report with Athena',
+      async () => {
+        // ============= CONFIGURATION (MODIFY THESE VALUES) =============
+
+        // AWS Credentials
+        const ACCESS_KEY_ID = '';
+        const SECRET_ACCESS_KEY = '';
+        const SESSION_TOKEN = ''; // Optional
+
+        // Athena configuration
+        const AWS_REGION = '';
+        const DATABASE_NAME = '';
+        const OUTPUT_BUCKET = '';
+
+        // SQL query to execute
+        const SQL_QUERY = '';
+
+        // Google Sheets configuration
+        const SPREADSHEET_ID = '1hKsqRGXCsLeOOK1VFE6GYt7j5JGJp1YMmy37NfCwoes'; // ID from the URL of your Google Sheet
+        const SHEET_ID = 599439254; // Usually 0 for the first sheet, or find the gid in the URL
+
+        // Service account key for Google Sheets
+        // This should be a JSON string of your service account key
+        const GOOGLE_SERVICE_ACCOUNT_KEY = ``;
+
+        // ===============================================================
+
+        // Parse the Google service account key
+        const parsedGoogleCreds = JSON.parse(GOOGLE_SERVICE_ACCOUNT_KEY || '{}');
+
+        // Create data storage (Athena)
+        const dataStorage: DataStorage = {
+          id: 'test-athena-storage-id',
+          type: DataStorageType.AWS_ATHENA,
+          projectId: 'test-project',
+          credentials: {
+            accessKeyId: ACCESS_KEY_ID,
+            secretAccessKey: SECRET_ACCESS_KEY,
+            sessionToken: SESSION_TOKEN,
+          },
+          config: {
+            region: AWS_REGION,
+            databaseName: DATABASE_NAME,
+            outputBucket: OUTPUT_BUCKET,
+          },
+          createdAt: new Date(),
+          modifiedAt: new Date(),
+        };
+
+        // Create data destination (Google Sheets)
+        const dataDestination: DataDestination = {
+          id: 'test-destination-id',
+          title: 'Test Google Sheets Destination',
+          type: DataDestinationType.GOOGLE_SHEETS,
+          projectId: 'test-project',
+          credentials: {
+            type: 'google-sheets-credentials',
+            serviceAccountKey: parsedGoogleCreds,
+          },
+          createdAt: new Date(),
+          modifiedAt: new Date(),
+        };
+
+        // Create SQL definition
+        const sqlDefinition: SqlDefinition = {
+          sqlQuery: SQL_QUERY,
+        };
+
+        // Create data mart
+        const dataMart: DataMart = {
+          id: 'test-datamart-id',
+          title: 'Test Athena Data Mart',
+          storage: dataStorage,
+          status: DataMartStatus.PUBLISHED,
+          definitionType: DataMartDefinitionType.SQL,
+          definition: sqlDefinition,
+          projectId: 'test-project',
+          createdById: 'test-user',
+          createdAt: new Date(),
+          modifiedAt: new Date(),
+        };
+
+        // Create Google Sheets config
+        const sheetsConfig: GoogleSheetsConfig = {
+          type: 'google-sheets-config',
+          spreadsheetId: SPREADSHEET_ID,
+          sheetId: SHEET_ID,
+        };
+
+        // Create report
+        const report: Report = {
+          id: 'test-athena-report-id',
+          title: 'Test Athena Report',
+          dataMart: dataMart,
+          dataDestination: dataDestination,
+          destinationConfig: sheetsConfig,
+          runsCount: 0,
+          createdAt: new Date(),
+          modifiedAt: new Date(),
+        };
+
+        // Mock repository to return our test report
+        jest.spyOn(reportRepository, 'findOne').mockResolvedValue(report);
+        jest.spyOn(reportRepository, 'save').mockResolvedValue(report);
+
+        // Run the report
+        const command = { reportId: 'test-athena-report-id' } as RunReportCommand;
+        await service.run(command);
+      },
+      5 * 60 * 1000
+    ); // Increase timeout for Athena operations
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/update-data-destination.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-destination.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataDestination } from '../entities/data-destination.entity';
+import { Repository } from 'typeorm';
+import { DataDestinationMapper } from '../mappers/data-destination.mapper';
+import { DataDestinationDto } from '../dto/domain/data-destination.dto';
+import { UpdateDataDestinationCommand } from '../dto/domain/update-data-destination.command';
+import { DataDestinationService } from '../services/data-destination.service';
+import { DataDestinationCredentialsValidatorFacade } from '../data-destination-types/facades/data-destination-credentials-validator.facade';
+
+@Injectable()
+export class UpdateDataDestinationService {
+  constructor(
+    @InjectRepository(DataDestination)
+    private readonly dataDestinationRepository: Repository<DataDestination>,
+    private readonly dataDestinationService: DataDestinationService,
+    private readonly dataDestinationMapper: DataDestinationMapper,
+    private readonly credentialsValidator: DataDestinationCredentialsValidatorFacade
+  ) {}
+
+  async run(command: UpdateDataDestinationCommand): Promise<DataDestinationDto> {
+    const entity = await this.dataDestinationService.getByIdAndProjectId(
+      command.projectId,
+      command.id
+    );
+
+    await this.credentialsValidator.checkCredentials(entity.type, command.credentials);
+
+    entity.title = command.title;
+    entity.credentials = command.credentials;
+
+    const updatedEntity = await this.dataDestinationRepository.save(entity);
+    return this.dataDestinationMapper.toDomainDto(updatedEntity);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/update-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-report.service.ts
@@ -1,0 +1,71 @@
+import { Repository } from 'typeorm';
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Report } from '../entities/report.entity';
+import { DataDestination } from '../entities/data-destination.entity';
+import { ReportMapper } from '../mappers/report.mapper';
+import { UpdateReportCommand } from '../dto/domain/update-report.command';
+import { ReportDto } from '../dto/domain/report.dto';
+import { DataDestinationAccessValidatorFacade } from '../data-destination-types/facades/data-destination-access-validator.facade';
+
+@Injectable()
+export class UpdateReportService {
+  constructor(
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    @InjectRepository(DataDestination)
+    private readonly dataDestinationRepository: Repository<DataDestination>,
+    private readonly dataDestinationAccessValidationFacade: DataDestinationAccessValidatorFacade,
+    private readonly mapper: ReportMapper
+  ) {}
+
+  async run(command: UpdateReportCommand): Promise<ReportDto> {
+    // Find the existing report
+    const report = await this.reportRepository.findOne({
+      where: {
+        id: command.id,
+        dataMart: {
+          projectId: command.projectId,
+        },
+      },
+      relations: ['dataMart', 'dataDestination'],
+    });
+
+    if (!report) {
+      throw new NotFoundException(`Report with ID ${command.id} not found`);
+    }
+
+    // Get the data destination if it's being changed
+    let dataDestination: DataDestination | null = report.dataDestination;
+    if (command.dataDestinationId !== dataDestination.id) {
+      dataDestination = await this.dataDestinationRepository.findOne({
+        where: {
+          id: command.dataDestinationId,
+          projectId: command.projectId,
+        },
+      });
+
+      if (!dataDestination) {
+        throw new BadRequestException(
+          `Data destination with ID ${command.dataDestinationId} not found`
+        );
+      }
+    }
+
+    // Validate access to the data destination
+    await this.dataDestinationAccessValidationFacade.checkAccess(
+      dataDestination.type,
+      command.destinationConfig,
+      dataDestination
+    );
+
+    // Update the report
+    report.title = command.title;
+    report.dataDestination = dataDestination;
+    report.destinationConfig = command.destinationConfig;
+
+    const updatedReport = await this.reportRepository.save(report);
+
+    return this.mapper.toDomainDto(updatedReport);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,8 @@
       "version": "0.0.0",
       "license": "ELv2",
       "dependencies": {
+        "@aws-sdk/client-athena": "^3.839.0",
+        "@google-cloud/bigquery": "^8.1.0",
         "@google-cloud/pubsub": "^4.0.7",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
@@ -53,6 +55,8 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
         "env-paths": "^3.0.0",
+        "googleapis": "^150.0.1",
+        "luxon": "^3.6.1",
         "mysql2": "^3.14.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -714,7 +718,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -730,7 +733,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -743,7 +745,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -757,7 +758,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -771,7 +771,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -786,7 +785,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -796,7 +794,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -808,7 +805,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -821,7 +817,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -835,7 +830,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -843,6 +837,379 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-athena/-/client-athena-3.839.0.tgz",
+      "integrity": "sha512-zLVmPgaKFg9wwkw1uqQIxnaWEzx7+2YApXLSpobB/i3TOdFx1M7YUFDolp0ZXy3gmTpYXmqG0SZmqX8rvqjyBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/credential-provider-node": "3.839.0",
+        "@aws-sdk/middleware-host-header": "3.821.0",
+        "@aws-sdk/middleware-logger": "3.821.0",
+        "@aws-sdk/middleware-recursion-detection": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.839.0",
+        "@aws-sdk/region-config-resolver": "3.821.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@aws-sdk/util-user-agent-browser": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.839.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.6.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.13",
+        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.21",
+        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/client-sso": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.839.0.tgz",
+      "integrity": "sha512-AZABysUhbfcwXVlMo97/vwHgsfJNF81wypCAowpqAJkSjP2KrqsqHpb71/RoR2w8JGmEnBBXRD4wIxDhnmifWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/middleware-host-header": "3.821.0",
+        "@aws-sdk/middleware-logger": "3.821.0",
+        "@aws-sdk/middleware-recursion-detection": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.839.0",
+        "@aws-sdk/region-config-resolver": "3.821.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@aws-sdk/util-user-agent-browser": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.839.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.6.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.13",
+        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.21",
+        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/core": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.839.0.tgz",
+      "integrity": "sha512-KdwL5RaK7eUIlOpdOoZ5u+2t4X1rdX/MTZgz3IV/aBzjVUoGsp+uUnbyqXomLQSUitPHp72EE/NHDsvWW/IHvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/xml-builder": "3.821.0",
+        "@smithy/core": "^3.6.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.839.0.tgz",
+      "integrity": "sha512-cWTadewPPz1OvObZJB+olrgh8VwcgIVcT293ZUT9V0CMF0UU7QaPwJP7uNXcNxltTh+sk1yhjH4UlcnJigZZbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.839.0.tgz",
+      "integrity": "sha512-fv0BZwrDhWDju4D1MCLT4I2aPjr0dVQ6P+MpqvcGNOA41Oa9UdRhYTV5iuy5NLXzIzoCmnS+XfSq5Kbsf6//xw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.839.0.tgz",
+      "integrity": "sha512-GHm0hF4CiDxIDR7TauMaA6iI55uuSqRxMBcqTAHaTPm6+h1A+MS+ysQMxZ+Jvwtoy8WmfTIGrJVxSCw0sK2hvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/credential-provider-env": "3.839.0",
+        "@aws-sdk/credential-provider-http": "3.839.0",
+        "@aws-sdk/credential-provider-process": "3.839.0",
+        "@aws-sdk/credential-provider-sso": "3.839.0",
+        "@aws-sdk/credential-provider-web-identity": "3.839.0",
+        "@aws-sdk/nested-clients": "3.839.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.839.0.tgz",
+      "integrity": "sha512-7bR+U2h+ft0V8chyeu9Bh/pvau4ZkQMeRt5f0dAULoepZQ77QQVRP4H04yJPTg9DCtqbVULQ3uf5YOp1/08vQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.839.0",
+        "@aws-sdk/credential-provider-http": "3.839.0",
+        "@aws-sdk/credential-provider-ini": "3.839.0",
+        "@aws-sdk/credential-provider-process": "3.839.0",
+        "@aws-sdk/credential-provider-sso": "3.839.0",
+        "@aws-sdk/credential-provider-web-identity": "3.839.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.839.0.tgz",
+      "integrity": "sha512-qShpekjociUZ+isyQNa0P7jo+0q3N2+0eJDg8SGyP6K6hHTcGfiqxTDps+IKl6NreCPhZCBzyI9mWkP0xSDR6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.839.0.tgz",
+      "integrity": "sha512-w10zBLHhU8SBQcdrSPMI02haLoRGZg+gP7mH/Er8VhIXfHefbr7o4NirmB0hwdw/YAH8MLlC9jj7c2SJlsNhYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.839.0",
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/token-providers": "3.839.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.839.0.tgz",
+      "integrity": "sha512-EvqTc7J1kgmiuxknpCp1S60hyMQvmKxsI5uXzQtcogl/N55rxiXEqnCLI5q6p33q91PJegrcMCM5Q17Afhm5qA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/nested-clients": "3.839.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.839.0.tgz",
+      "integrity": "sha512-2u74uRM1JWq6Sf7+3YpjejPM9YkomGt4kWhrmooIBEq1k5r2GTbkH7pNCxBQwBueXM21jAGVDxxeClpTx+5hig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@smithy/core": "^3.6.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.839.0.tgz",
+      "integrity": "sha512-Glic0pg2THYP3aRhJORwJJBe1JLtJoEdWV/MFZNyzCklfMwEzpWtZAyxy+tQyFmMeW50uBAnh2R0jhMMcf257w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/middleware-host-header": "3.821.0",
+        "@aws-sdk/middleware-logger": "3.821.0",
+        "@aws-sdk/middleware-recursion-detection": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.839.0",
+        "@aws-sdk/region-config-resolver": "3.821.0",
+        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@aws-sdk/util-user-agent-browser": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.839.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.6.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.13",
+        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.21",
+        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/token-providers": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.839.0.tgz",
+      "integrity": "sha512-2nlafqdSbet/2WtYIoZ7KEGFowFonPBDYlTjrUvwU2yooE10VhvzhLSCTB2aKIVzo2Z2wL5WGFQsqAY5QwK6Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.839.0",
+        "@aws-sdk/nested-clients": "3.839.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-athena/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.839.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.839.0.tgz",
+      "integrity": "sha512-MuunkIG1bJVMtTH7MbjXOrhHleU5wjHz5eCAUc6vj7M9rwol71nqjj9b8RLnkO5gsJcKc29Qk8iV6xQuzKWNMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.839.0",
+        "@aws-sdk/types": "3.821.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-cloudfront": {
@@ -1254,7 +1621,6 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.821.0.tgz",
       "integrity": "sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.821.0",
@@ -1285,7 +1651,6 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.821.0.tgz",
       "integrity": "sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.821.0",
@@ -1300,7 +1665,6 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.821.0.tgz",
       "integrity": "sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.821.0",
@@ -1426,7 +1790,6 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.821.0.tgz",
       "integrity": "sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.821.0",
@@ -1481,7 +1844,6 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
       "integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -1508,7 +1870,6 @@
       "version": "3.828.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
       "integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.821.0",
@@ -1524,7 +1885,6 @@
       "version": "3.804.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.804.0.tgz",
       "integrity": "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1537,7 +1897,6 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.821.0.tgz",
       "integrity": "sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.821.0",
@@ -1575,7 +1934,6 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
       "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -2529,11 +2887,101 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@google-cloud/bigquery": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-8.1.0.tgz",
+      "integrity": "sha512-eDleD/IHKQIRm4GmMnwJvPkx4PgSaK8m8DCmDmVOf0gIhqPLSdvOAEeM4QjyyZGUGjV4yHyJfEJxzULTzl22Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/common": "^6.0.0",
+        "@google-cloud/paginator": "^6.0.0",
+        "@google-cloud/precise-date": "^5.0.0",
+        "@google-cloud/promisify": "^5.0.0",
+        "arrify": "^3.0.0",
+        "big.js": "^6.2.2",
+        "duplexify": "^4.1.3",
+        "extend": "^3.0.2",
+        "is": "^3.3.0",
+        "stream-events": "^1.0.5",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-6.0.0.tgz",
+      "integrity": "sha512-IXh04DlkLMxWgYLIUYuHHKXKOUwPDzDgke1ykkkJPe48cGIS9kkL2U/o0pm4ankHLlvzLF/ma1eO86n/bkumIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.0",
+        "duplexify": "^4.1.3",
+        "extend": "^3.0.2",
+        "google-auth-library": "^10.0.0-rc.1",
+        "html-entities": "^2.5.2",
+        "retry-request": "^8.0.0",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/@google-cloud/promisify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.1.0.tgz",
+      "integrity": "sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.0.0.tgz",
+      "integrity": "sha512-g5nmMnzC+94kBxOKkLGpK1ikvolTFCC3s2qtE4F+1EuArcJ7HHC23RDQVt3Ra3CqpUYZ+oXNKZ8n5Cn5yug8DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-5.0.0.tgz",
+      "integrity": "sha512-9h0Gvw92EvPdE8AK8AgZPbMnH5ftDyPtKm7/KUfcJVaPEPjwGDsJd1QV0H8esBDV4II41R/2lDWH1epBqIoKUw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google-cloud/projectify": {
       "version": "4.0.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-5.0.0.tgz",
+      "integrity": "sha512-N8qS6dlORGHwk7WjGXKOSsLjIjNINCPicsOX6gyyLiYk7mq3MtII96NZ9N2ahwA2vnkLmZODOIH9rlNniYWvCQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google-cloud/pubsub": {
@@ -6093,7 +6541,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
       "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6134,7 +6581,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
       "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
@@ -6151,7 +6597,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.6.0.tgz",
       "integrity": "sha512-Pgvfb+TQ4wUNLyHzvgCP4aYZMh16y7GcfF59oirRHcgGgkH1e/s9C0nv/v3WP+Quymyr5je71HeFQCwh+44XLg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.0.8",
@@ -6172,7 +6617,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
       "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
@@ -6264,7 +6708,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
       "integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.2",
@@ -6297,7 +6740,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
       "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6328,7 +6770,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
       "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6342,7 +6783,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
       "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6370,7 +6810,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
       "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.2",
@@ -6385,7 +6824,6 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.13.tgz",
       "integrity": "sha512-xg3EHV/Q5ZdAO5b0UiIMj3RIOCobuS40pBBODguUDVdko6YK6QIzCVRrHTogVuEKglBWqWenRnZ71iZnLL3ZAQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.6.0",
@@ -6405,7 +6843,6 @@
       "version": "4.1.14",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.14.tgz",
       "integrity": "sha512-eoXaLlDGpKvdmvt+YBfRXE7HmIEtFF+DJCbTPwuLunP0YUnrydl+C4tS+vEM0+nyxXrX3PSUFqC+lP1+EHB1Tw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
@@ -6426,7 +6863,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
       "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.2",
@@ -6441,7 +6877,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
       "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6455,7 +6890,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
       "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.4",
@@ -6471,7 +6905,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
       "integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.0.4",
@@ -6488,7 +6921,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
       "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6502,7 +6934,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
       "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6516,7 +6947,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
       "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6531,7 +6961,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
       "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6545,7 +6974,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.6.tgz",
       "integrity": "sha512-RRoTDL//7xi4tn5FrN2NzH17jbgmnKidUqd4KvquT0954/i6CXXkh1884jBiunq24g9cGtPBEXlU40W6EpNOOg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1"
@@ -6558,7 +6986,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
       "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6572,7 +6999,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
       "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
@@ -6592,7 +7018,6 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.5.tgz",
       "integrity": "sha512-+lynZjGuUFJaMdDYSTMnP/uPBBXXukVfrJlP+1U/Dp5SFTEI++w6NMga8DjOENxecOF71V9Z2DllaVDYRnGlkg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.6.0",
@@ -6611,7 +7036,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
       "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6624,7 +7048,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
       "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^4.0.4",
@@ -6639,7 +7062,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
       "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -6654,7 +7076,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
       "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6667,7 +7088,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
       "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6680,7 +7100,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
       "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
@@ -6694,7 +7113,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
       "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6707,7 +7125,6 @@
       "version": "4.0.21",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.21.tgz",
       "integrity": "sha512-wM0jhTytgXu3wzJoIqpbBAG5U6BwiubZ6QKzSbP7/VbmF1v96xlAbX2Am/mz0Zep0NLvLh84JT0tuZnk3wmYQA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.4",
@@ -6724,7 +7141,6 @@
       "version": "4.0.21",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.21.tgz",
       "integrity": "sha512-/F34zkoU0GzpUgLJydHY8Rxu9lBn8xQC/s/0M0U9lLBkYbA1htaAFjWYJzpzsbXPuri5D1H8gjp2jBum05qBrA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.1.4",
@@ -6743,7 +7159,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
       "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
@@ -6758,7 +7173,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
       "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6771,7 +7185,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
       "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6785,7 +7198,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.6.tgz",
       "integrity": "sha512-+YekoF2CaSMv6zKrA6iI/N9yva3Gzn4L6n35Luydweu5MMPYpiGZlWqehPHDHyNbnyaYlz/WJyYAZnC+loBDZg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^4.0.6",
@@ -6800,7 +7212,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
       "integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.0.4",
@@ -6820,7 +7231,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
       "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6833,7 +7243,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
       "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -7686,7 +8095,6 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/validator": {
@@ -9607,6 +10015,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/arrify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
+      "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "dev": true,
@@ -9867,6 +10287,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.0",
       "license": "MIT",
@@ -9956,7 +10389,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -11011,6 +11443,15 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -13508,7 +13949,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
       "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13551,6 +13991,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fflate": {
@@ -13838,6 +14301,18 @@
         "node": ">= 14.17"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "dev": true,
@@ -14004,6 +14479,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
+      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/generate-function": {
@@ -14241,6 +14744,24 @@
         "csstype": "^3.0.10"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.1.0.tgz",
+      "integrity": "sha512-GspVjZj1RbyRWpQ9FbAXMKjFGzZwDKnUHi66JJ+tcjcu5/xYAP1pdlWotCuIkMwjfVsxxDvsGZXGLzRt72D0sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/google-gax": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
@@ -14408,6 +14929,44 @@
         "node": ">= 6"
       }
     },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "150.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-150.0.1.tgz",
+      "integrity": "sha512-9Wa9vm3WtDpss0VFBHsbZWcoRccpOSWdpz7YIfb1LBXopZJEg/Zc8ymmaSgvDkP4FhN+pqPS9nZjO7REAJWSUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.0.0-rc.1",
+        "googleapis-common": "^8.0.2-rc.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.2-rc.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.2-rc.0.tgz",
+      "integrity": "sha512-JTcxRvmFa9Ec1uyfMEimEMeeKq1sHNZX3vn2qmoUMtnvixXXvcqTcbDZvEZXkEWpGlPlOf4joyep6/qs0BrLyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.0.0-rc.1",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "license": "MIT",
@@ -14450,6 +15009,19 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/happy-dom": {
       "version": "18.0.1",
@@ -14589,6 +15161,22 @@
       "version": "2.8.9",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -14875,6 +15463,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
+      "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/is-array-buffer": {
@@ -18063,12 +18660,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-gyp": {
@@ -22896,6 +23531,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/retry-request": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.0.tgz",
+      "integrity": "sha512-dJkZNmyV9C8WKUmbdj1xcvVlXBSvsUQCkg89TCK8rD72RdSn9A2jlXlS2VuYSTHoPJjJEfUHhjNYrlvuksF9cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.12",
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "dev": true,
@@ -24551,7 +25200,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
       "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24764,6 +25412,46 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.0.tgz",
+      "integrity": "sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/terser": {
@@ -25703,6 +26391,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "license": "MIT",
@@ -26060,6 +26754,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {


### PR DESCRIPTION
This PR adds the ability to export data from BigQuery and Athena data sources to Google Sheets.

## Key Components

- **Data Sources**: Added adapters and report readers for BigQuery and Athena
- **Data Destinations**: Implemented Google Sheets as a data destination with API adapters
- **Core Infrastructure**: Created base interfaces and types for data storage and destinations
- **Entity Models**: Added entities and DTOs for reports and data destinations
- **Business Logic**: Implemented services for creating, updating, and running reports
- **API Layer**: Added controllers with OpenAPI specifications

## Technical Details

- Added Google API integration for Sheets access and manipulation
- Implemented credential validation and access verification for data destinations
- Created sheet formatting utilities for headers and metadata
- Added support for paginated data export with batching