### PR TITLE
feat(web): Improve UI and UX of Data Marts List Page

### DIFF
--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartActionsCell.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartActionsCell.tsx
@@ -20,6 +20,7 @@ interface DataMartActionsCellProps {
 
 export const DataMartActionsCell = ({ row, onDeleteSuccess }: DataMartActionsCellProps) => {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { deleteDataMart, refreshList } = useDataMartList();
 
   const handleDelete = async () => {
@@ -35,11 +36,11 @@ export const DataMartActionsCell = ({ row, onDeleteSuccess }: DataMartActionsCel
 
   return (
     <div className='text-right'>
-      <DropdownMenu>
+      <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
         <DropdownMenuTrigger asChild>
           <Button
             variant='ghost'
-            className='dm-card-table-body-row-actionbtn opacity-0 transition-opacity group-hover:opacity-100'
+            className={`dm-card-table-body-row-actionbtn opacity-0 transition-opacity ${isMenuOpen ? 'opacity-100' : 'group-hover:opacity-100'}`}
             aria-label='Open menu'
           >
             <MoreHorizontal className='dm-card-table-body-row-actionbtn-icon' />

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartActionsCell.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartActionsCell.tsx
@@ -37,23 +37,26 @@ export const DataMartActionsCell = ({ row, onDeleteSuccess }: DataMartActionsCel
     <div className='text-right'>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant='ghost' className='h-8 w-8 p-0'>
-            <span className='sr-only'>Open menu</span>
-            <MoreHorizontal className='h-4 w-4' />
+          <Button
+            variant='ghost'
+            className='dm-card-table-body-row-actionbtn opacity-0 transition-opacity group-hover:opacity-100'
+            aria-label='Open menu'
+          >
+            <MoreHorizontal className='dm-card-table-body-row-actionbtn-icon' />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align='end'>
           <DropdownMenuItem>
             <Link
               to={`/data-marts/${row.original.id}/overview`}
-              className='flex w-full items-center'
+              className='dm-card-table-body-row-actiondropdownitem'
             >
               Open
             </Link>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
-            className='text-red-600'
+            className='dm-card-table-body-row-actiondropdownitem text-red-600'
             onClick={() => {
               setIsDeleteDialogOpen(true);
             }}

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
@@ -38,12 +38,14 @@ import {
 import { Check, Search, Trash2, Plus } from 'lucide-react';
 import { toast, Toaster } from 'react-hot-toast';
 import { EmptyDataMartsState } from './EmptyDataMartsState';
+import { DataMartsTableSkeleton } from '../../../../../shared/components/CardSkeleton';
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   deleteDataMart: (id: string) => Promise<void>;
   refetchDataMarts: () => Promise<void>;
+  isLoading?: boolean;
 }
 
 export function DataMartTable<TData, TValue>({
@@ -51,6 +53,7 @@ export function DataMartTable<TData, TValue>({
   data,
   deleteDataMart,
   refetchDataMarts,
+  isLoading,
 }: DataTableProps<TData, TValue>) {
   const navigate = useNavigate();
   const [sorting, setSorting] = useState<SortingState>([{ id: 'title', desc: false }]);
@@ -156,6 +159,15 @@ export function DataMartTable<TData, TValue>({
     },
     enableRowSelection: true,
   });
+
+  if (isLoading) {
+    return (
+      <div>
+        <Toaster />
+        <DataMartsTableSkeleton />
+      </div>
+    );
+  }
 
   if (!data.length) {
     return (

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import {
   type ColumnDef,
   flexRender,
@@ -26,12 +26,6 @@ import {
 import { Button } from '@owox/ui/components/button';
 import { Input } from '@owox/ui/components/input';
 import {
-  DropdownMenu,
-  DropdownMenuItem,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@owox/ui/components/dropdown-menu';
-import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -41,7 +35,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@owox/ui/components/alert-dialog';
-import { ChevronDown, Check, Search, Trash2 } from 'lucide-react';
+import { Check, Search, Trash2, Plus } from 'lucide-react';
 import { toast, Toaster } from 'react-hot-toast';
 
 interface DataTableProps<TData, TValue> {
@@ -97,6 +91,7 @@ export function DataMartTable<TData, TValue>({
     columns: [
       {
         id: 'select',
+        size: 30,
         header: ({ table }) => (
           <button
             type='button'
@@ -104,7 +99,7 @@ export function DataMartTable<TData, TValue>({
             aria-checked={table.getIsAllRowsSelected()}
             data-state={table.getIsAllRowsSelected() ? 'checked' : 'unchecked'}
             aria-label='Select all rows'
-            className='peer border-input dark:bg-input/30 data-[state=checked]:bg-brand-blue-500 data-[state=checked]:text-brand-blue-500-foreground dark:data-[state=checked]:bg-brand-blue-500 data-[state=checked]:border-brand-blue-500 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50'
+            className='peer border-input data-[state=checked]:bg-brand-blue-500 data-[state=checked]:text-brand-blue-500-foreground dark:data-[state=checked]:bg-brand-blue-500 data-[state=checked]:border-brand-blue-500 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border bg-white shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white/8'
             onClick={table.getToggleAllRowsSelectedHandler()}
           >
             {table.getIsAllRowsSelected() && (
@@ -125,7 +120,7 @@ export function DataMartTable<TData, TValue>({
             aria-checked={row.getIsSelected()}
             data-state={row.getIsSelected() ? 'checked' : 'unchecked'}
             aria-label='Select row'
-            className='peer border-input dark:bg-input/30 data-[state=checked]:bg-brand-blue-500 data-[state=checked]:text-brand-blue-500-foreground dark:data-[state=checked]:bg-brand-blue-500 data-[state=checked]:border-brand-blue-500 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50'
+            className='peer border-input data-[state=checked]:bg-brand-blue-500 data-[state=checked]:text-brand-blue-500-foreground dark:data-[state=checked]:bg-brand-blue-500 data-[state=checked]:border-brand-blue-500 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border bg-white shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white/8'
             onClick={row.getToggleSelectedHandler()}
           >
             {row.getIsSelected() && (
@@ -162,73 +157,60 @@ export function DataMartTable<TData, TValue>({
   });
 
   return (
-    <div>
+    <div className='dm-card'>
       <Toaster />
-      <div className='flex items-center pb-4'>
-        <div className='relative w-sm'>
-          <Search className='text-muted-foreground absolute top-2.5 left-2 h-4 w-4' />
-          <Input
-            placeholder='Search by title'
-            value={table.getColumn('title')?.getFilterValue() as string}
-            onChange={event => table.getColumn('title')?.setFilterValue(event.target.value)}
-            className='pl-8'
-          />
-        </div>
-        {hasSelectedRows && (
-          <Button
-            variant='destructive'
-            size='sm'
-            className='ml-2 flex items-center gap-1'
-            onClick={() => {
-              setShowDeleteConfirmation(true);
-            }}
-            disabled={isDeleting}
-          >
-            <Trash2 className='h-4 w-4' />
-            Delete
-          </Button>
-        )}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant='outline' className='ml-auto font-normal'>
-              Show columns <ChevronDown className='ml-2 h-4 w-4' />
+      {/* TOOLBAR */}
+      <div className='dm-card-toolbar'>
+        {/* LEFT Column */}
+        <div className='dm-card-toolbar-left'>
+          {/* BTNs for selected Rows */}
+          {hasSelectedRows && (
+            <Button
+              variant='destructive'
+              size='sm'
+              className='dm-card-toolbar-btn-delete'
+              onClick={() => {
+                setShowDeleteConfirmation(true);
+              }}
+              disabled={isDeleting}
+            >
+              <Trash2 className='h-4 w-4' />
             </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align='end'>
-            {table
-              .getAllColumns()
-              .filter(column => column.getCanHide())
-              .map(column => {
-                return (
-                  <DropdownMenuItem key={column.id} className='capitalize'>
-                    <div className='flex items-center space-x-2'>
-                      <input
-                        type='checkbox'
-                        checked={column.getIsVisible()}
-                        onChange={e => {
-                          column.toggleVisibility(e.target.checked);
-                        }}
-                        className='h-4 w-4'
-                      />
-                      <span>{column.id}</span>
-                    </div>
-                  </DropdownMenuItem>
-                );
-              })}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+          )}
+          {/* Search */}
+          <div className='dm-card-toolbar-search'>
+            <Search className='dm-card-toolbar-search-icon' />
+            <Input
+              placeholder='Search by title'
+              value={table.getColumn('title')?.getFilterValue() as string}
+              onChange={event => table.getColumn('title')?.setFilterValue(event.target.value)}
+              className='dm-card-toolbar-search-input'
+            />
+          </div>
+        </div>
 
-      <div className='w-full rounded-md border'>
-        <Table>
-          <TableHeader className='bg-muted'>
+        {/* RIGHT Column */}
+        <Link to={'/data-marts/create'}>
+          <Button variant='outline' size='sm' className='dm-card-toolbar-btn-primary'>
+            <Plus className='h-4 w-4' />
+            New Data Mart
+          </Button>
+        </Link>
+      </div>
+      {/* end: TOOLBAR */}
+
+      {/* DM CARD TABLE */}
+      <div className='dm-card-table-wrap'>
+        <Table className='dm-card-table' role='table' aria-label='Data Marts table'>
+          <TableHeader className='dm-card-table-header'>
             {table.getHeaderGroups().map(headerGroup => (
-              <TableRow key={headerGroup.id}>
+              <TableRow key={headerGroup.id} className='dm-card-table-header-row'>
                 {headerGroup.headers.map(header => {
                   return (
                     <TableHead
                       key={header.id}
                       className='[&:has([role=checkbox])]:pl-5 [&>[role=checkbox]]:translate-y-[2px]'
+                      style={{ width: header.getSize() }}
                     >
                       {header.isPlaceholder
                         ? null
@@ -239,13 +221,13 @@ export function DataMartTable<TData, TValue>({
               </TableRow>
             ))}
           </TableHeader>
-          <TableBody>
+          <TableBody className='dm-card-table-body'>
             {table.getRowModel().rows.length ? (
               table.getRowModel().rows.map(row => (
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && 'selected'}
-                  className='hover:bg-muted/50 cursor-pointer'
+                  className='dm-card-table-body-row group'
                   onClick={e => {
                     if (
                       e.target instanceof HTMLElement &&
@@ -264,6 +246,7 @@ export function DataMartTable<TData, TValue>({
                     <TableCell
                       key={cell.id}
                       className={`[&:has([role=checkbox])]pr-0 px-5 whitespace-normal [&>[role=checkbox]]:translate-y-[2px] ${cell.column.id === 'actions' ? 'actions-cell' : ''}`}
+                      style={{ width: cell.column.getSize() }}
                     >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>
@@ -272,7 +255,7 @@ export function DataMartTable<TData, TValue>({
               ))
             ) : (
               <TableRow>
-                <TableCell colSpan={columns.length + 1} className='h-24 text-center'>
+                <TableCell colSpan={columns.length + 1} className='dm-card-table-body-row-empty'>
                   No results.
                 </TableCell>
               </TableRow>
@@ -280,7 +263,7 @@ export function DataMartTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <div className='flex items-center justify-end space-x-2 py-4'>
+      <div className='dm-card-pagination'>
         <Button
           variant='outline'
           size='sm'
@@ -309,7 +292,7 @@ export function DataMartTable<TData, TValue>({
           <AlertDialogHeader>
             <AlertDialogTitle>Are you sure?</AlertDialogTitle>
             <AlertDialogDescription>
-              This action will delete {Object.keys(rowSelection).length} selected data mart
+              You're about to delete {Object.keys(rowSelection).length} selected data mart
               {Object.keys(rowSelection).length !== 1 ? 's' : ''}. This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
@@ -95,7 +95,7 @@ export function DataMartTable<TData, TValue>({
     columns: [
       {
         id: 'select',
-        size: 30,
+        size: 40,
         header: ({ table }) => (
           <button
             type='button'
@@ -234,7 +234,13 @@ export function DataMartTable<TData, TValue>({
                     <TableHead
                       key={header.id}
                       className='[&:has([role=checkbox])]:pl-5 [&>[role=checkbox]]:translate-y-[2px]'
-                      style={{ width: header.getSize() }}
+                      style={
+                        header.column.id === 'select'
+                          ? { width: 40, minWidth: 40, maxWidth: 40 }
+                          : header.column.id === 'actions'
+                            ? { width: 80, minWidth: 80, maxWidth: 80 }
+                            : { width: `${String(header.getSize())}%` }
+                      }
                     >
                       {header.isPlaceholder
                         ? null
@@ -269,8 +275,14 @@ export function DataMartTable<TData, TValue>({
                   {row.getVisibleCells().map(cell => (
                     <TableCell
                       key={cell.id}
-                      className={`[&:has([role=checkbox])]pr-0 px-5 whitespace-normal [&>[role=checkbox]]:translate-y-[2px] ${cell.column.id === 'actions' ? 'actions-cell' : ''}`}
-                      style={{ width: cell.column.getSize() }}
+                      className={`[&:has([role=checkbox])]pr-0 px-5 whitespace-normal [&>[role=checkbox]]:translate-y-[2px] ${cell.column.id === 'actions' ? 'actions-cell' : ''} ${cell.column.id === 'createdAt' ? 'whitespace-nowrap' : ''}`}
+                      style={
+                        cell.column.id === 'select'
+                          ? { width: 40, minWidth: 40, maxWidth: 40 }
+                          : cell.column.id === 'actions'
+                            ? { width: 80, minWidth: 80, maxWidth: 80 }
+                            : { width: `${String(cell.column.getSize())}%` }
+                      }
                     >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>
@@ -280,7 +292,7 @@ export function DataMartTable<TData, TValue>({
             ) : (
               <TableRow>
                 <TableCell colSpan={columns.length + 1} className='dm-card-table-body-row-empty'>
-                  No results.
+                  No results
                 </TableCell>
               </TableRow>
             )}

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
@@ -37,6 +37,7 @@ import {
 } from '@owox/ui/components/alert-dialog';
 import { Check, Search, Trash2, Plus } from 'lucide-react';
 import { toast, Toaster } from 'react-hot-toast';
+import { EmptyDataMartsState } from './EmptyDataMartsState';
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -156,6 +157,15 @@ export function DataMartTable<TData, TValue>({
     enableRowSelection: true,
   });
 
+  if (!data.length) {
+    return (
+      <div className='dm-card'>
+        <Toaster />
+        <EmptyDataMartsState />
+      </div>
+    );
+  }
+
   return (
     <div className='dm-card'>
       <Toaster />
@@ -190,12 +200,14 @@ export function DataMartTable<TData, TValue>({
         </div>
 
         {/* RIGHT Column */}
-        <Link to={'/data-marts/create'}>
-          <Button variant='outline' size='sm' className='dm-card-toolbar-btn-primary'>
-            <Plus className='h-4 w-4' />
-            New Data Mart
-          </Button>
-        </Link>
+        <div className='dm-card-toolbar-right'>
+          <Link to={'/data-marts/create'}>
+            <Button variant='outline' className='dm-card-toolbar-btn-primary'>
+              <Plus className='h-4 w-4' />
+              New Data Mart
+            </Button>
+          </Link>
+        </div>
       </div>
       {/* end: TOOLBAR */}
 
@@ -263,6 +275,9 @@ export function DataMartTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
+      {/* end: DM CARD TABLE */}
+
+      {/* DM CARD PAGINATION */}
       <div className='dm-card-pagination'>
         <Button
           variant='outline'
@@ -285,6 +300,7 @@ export function DataMartTable<TData, TValue>({
           Next
         </Button>
       </div>
+      {/* end: DM CARD PAGINATION */}
 
       {/* Delete Confirmation Dialog */}
       <AlertDialog open={showDeleteConfirmation} onOpenChange={setShowDeleteConfirmation}>

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/EmptyDataMartsState.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/EmptyDataMartsState.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom';
+import { Button } from '@owox/ui/components/button';
+import { Plus, PackagePlus } from 'lucide-react';
+
+export function EmptyDataMartsState() {
+  return (
+    <div className='dm-empty-state'>
+      <PackagePlus className='dm-empty-state-ico' strokeWidth={1} />
+      <h2 className='dm-empty-state-title'>Create your first Data Mart</h2>
+      <p className='dm-empty-state-subtitle'>
+        Data Marts help you organize and analyze your data effectively.
+      </p>
+      <Link to={'/data-marts/create'}>
+        <Button variant='outline'>
+          <Plus className='h-4 w-4' />
+          New Data Mart
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/SortableHeader.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/SortableHeader.tsx
@@ -1,5 +1,5 @@
 import { type Column } from '@tanstack/react-table';
-import { ArrowUpDown } from 'lucide-react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 import { Button } from '@owox/ui/components/button';
 
 interface SortableHeaderProps<TData> {
@@ -14,14 +14,18 @@ export function SortableHeader<TData>({ column, children }: SortableHeaderProps<
       onClick={() => {
         column.toggleSorting(column.getIsSorted() === 'asc');
       }}
-      className='px-4 hover:bg-gray-200'
+      className='group dm-card-table-header-row-btn'
     >
       {children}
-      <ArrowUpDown
-        className={`ml-2 h-4 w-4 transition-opacity ${
-          column.getIsSorted() ? 'opacity-100' : 'opacity-0 group-hover/header:opacity-70'
-        }`}
-      />
+      <span className='flex h-4 w-4 items-center justify-center' aria-hidden='true'>
+        {column.getIsSorted() === 'asc' && <ChevronUp className='text-foreground h-4 w-4' />}
+        {column.getIsSorted() === 'desc' && <ChevronDown className='text-foreground h-4 w-4' />}
+        {!column.getIsSorted() && (
+          <span className='opacity-0 transition-opacity duration-150 group-hover:opacity-100'>
+            <ChevronUp className='text-muted-foreground h-4 w-4' />
+          </span>
+        )}
+      </span>
     </Button>
   );
 }

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/ToggleColumnsHeader.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/ToggleColumnsHeader.tsx
@@ -1,5 +1,5 @@
 import { type Table } from '@tanstack/react-table';
-import { MoreHorizontal } from 'lucide-react';
+import { MoreHorizontal, Check } from 'lucide-react';
 import { Button } from '@owox/ui/components/button';
 import {
   DropdownMenu,
@@ -33,14 +33,27 @@ export function ToggleColumnsHeader<TData>({ table }: ToggleColumnsHeaderProps<T
               return (
                 <DropdownMenuItem key={column.id} className='capitalize'>
                   <label className='flex items-center space-x-2'>
-                    <input
-                      type='checkbox'
-                      checked={column.getIsVisible()}
-                      onChange={e => {
-                        column.toggleVisibility(e.target.checked);
+                    <button
+                      type='button'
+                      role='checkbox'
+                      aria-checked={column.getIsVisible()}
+                      data-state={column.getIsVisible() ? 'checked' : 'unchecked'}
+                      aria-label={`Toggle column ${column.id}`}
+                      className='peer border-input data-[state=checked]:bg-brand-blue-500 data-[state=checked]:text-brand-blue-500-foreground dark:data-[state=checked]:bg-brand-blue-500 data-[state=checked]:border-brand-blue-500 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border bg-white shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white/8'
+                      onClick={() => {
+                        column.toggleVisibility(!column.getIsVisible());
                       }}
-                      className='h-4 w-4'
-                    />
+                    >
+                      {column.getIsVisible() && (
+                        <span
+                          data-state='checked'
+                          data-slot='checkbox-indicator'
+                          className='pointer-events-none flex items-center justify-center text-current transition-none'
+                        >
+                          <Check className='size-3.5' />
+                        </span>
+                      )}
+                    </button>
                     <span>{column.id}</span>
                   </label>
                 </DropdownMenuItem>

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/ToggleColumnsHeader.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/ToggleColumnsHeader.tsx
@@ -1,0 +1,53 @@
+import { type Table } from '@tanstack/react-table';
+import { MoreHorizontal } from 'lucide-react';
+import { Button } from '@owox/ui/components/button';
+import {
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@owox/ui/components/dropdown-menu';
+
+interface ToggleColumnsHeaderProps<TData> {
+  table: Table<TData>;
+}
+
+export function ToggleColumnsHeader<TData>({ table }: ToggleColumnsHeaderProps<TData>) {
+  return (
+    <div className='px-3 text-right'>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant='ghost'
+            className='dm-card-table-body-row-actionbtn'
+            aria-label='Toggle columns'
+          >
+            <MoreHorizontal className='dm-card-table-body-row-actionbtn-icon' />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='end'>
+          {table
+            .getAllColumns()
+            .filter(column => column.getCanHide() && column.id !== 'actions')
+            .map(column => {
+              return (
+                <DropdownMenuItem key={column.id} className='capitalize'>
+                  <label className='flex items-center space-x-2'>
+                    <input
+                      type='checkbox'
+                      checked={column.getIsVisible()}
+                      onChange={e => {
+                        column.toggleVisibility(e.target.checked);
+                      }}
+                      className='h-4 w-4'
+                    />
+                    <span>{column.id}</span>
+                  </label>
+                </DropdownMenuItem>
+              );
+            })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/columns.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/columns.tsx
@@ -18,13 +18,13 @@ export const getDataMartColumns = ({
 }: DataMartTableColumnsProps = {}): ColumnDef<DataMartListItem>[] => [
   {
     accessorKey: 'title',
-    size: 400,
+    size: 60, // responsive width in %
     header: ({ column }) => <SortableHeader column={column}>Title</SortableHeader>,
     cell: ({ row }) => <div>{row.getValue('title')}</div>,
   },
   {
     accessorKey: 'storageType',
-    size: 80,
+    size: 10, // responsive width in %
     header: ({ column }) => <SortableHeader column={column}>Storage</SortableHeader>,
     cell: ({ row }) => {
       const type = row.getValue<DataStorageType>('storageType');
@@ -39,7 +39,7 @@ export const getDataMartColumns = ({
   },
   {
     accessorKey: 'status',
-    size: 120,
+    size: 15, // responsive width in %
     header: ({ column }) => <SortableHeader column={column}>Status</SortableHeader>,
     cell: ({ row }) => {
       const statusInfo = row.getValue<DataMartStatusInfo>('status');
@@ -53,7 +53,7 @@ export const getDataMartColumns = ({
   },
   {
     accessorKey: 'createdAt',
-    size: 100,
+    size: 15, // responsive width in %
     header: ({ column }) => <SortableHeader column={column}>Created at</SortableHeader>,
     cell: ({ row }) => {
       const date = row.getValue<Date>('createdAt');
@@ -68,7 +68,7 @@ export const getDataMartColumns = ({
   },
   {
     id: 'actions',
-    size: 80,
+    size: 80, // fixed width in pixels
     header: ({ table }) => <ToggleColumnsHeader table={table} />,
     cell: ({ row }) => <DataMartActionsCell row={row} onDeleteSuccess={onDeleteSuccess} />,
   },

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/columns.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/columns.tsx
@@ -7,6 +7,7 @@ import { StatusLabel } from '../../../../../shared/components/StatusLabel';
 import { DataStorageType } from '../../../../data-storage';
 import { DataStorageTypeModel } from '../../../../data-storage/shared/types/data-storage-type.model.ts';
 import { DataMartActionsCell } from './DataMartActionsCell';
+import { ToggleColumnsHeader } from './ToggleColumnsHeader';
 
 interface DataMartTableColumnsProps {
   onDeleteSuccess?: () => void;
@@ -17,20 +18,14 @@ export const getDataMartColumns = ({
 }: DataMartTableColumnsProps = {}): ColumnDef<DataMartListItem>[] => [
   {
     accessorKey: 'title',
-    header: ({ column }) => (
-      <div className='group/header min-w-64'>
-        <SortableHeader column={column}>Title</SortableHeader>
-      </div>
-    ),
-    cell: ({ row }) => <div className='overflow-hidden text-ellipsis'>{row.getValue('title')}</div>,
+    size: 400,
+    header: ({ column }) => <SortableHeader column={column}>Title</SortableHeader>,
+    cell: ({ row }) => <div>{row.getValue('title')}</div>,
   },
   {
     accessorKey: 'storageType',
-    header: ({ column }) => (
-      <div className='group/header whitespace-nowrap'>
-        <SortableHeader column={column}>Storage</SortableHeader>
-      </div>
-    ),
+    size: 80,
+    header: ({ column }) => <SortableHeader column={column}>Storage</SortableHeader>,
     cell: ({ row }) => {
       const type = row.getValue<DataStorageType>('storageType');
       const { displayName, icon: Icon } = DataStorageTypeModel.getInfo(type);
@@ -44,11 +39,8 @@ export const getDataMartColumns = ({
   },
   {
     accessorKey: 'status',
-    header: ({ column }) => (
-      <div className='group/header whitespace-nowrap'>
-        <SortableHeader column={column}>Status</SortableHeader>
-      </div>
-    ),
+    size: 120,
+    header: ({ column }) => <SortableHeader column={column}>Status</SortableHeader>,
     cell: ({ row }) => {
       const statusInfo = row.getValue<DataMartStatusInfo>('status');
 
@@ -61,11 +53,8 @@ export const getDataMartColumns = ({
   },
   {
     accessorKey: 'createdAt',
-    header: ({ column }) => (
-      <div className='group/header whitespace-nowrap'>
-        <SortableHeader column={column}>Created at</SortableHeader>
-      </div>
-    ),
+    size: 100,
+    header: ({ column }) => <SortableHeader column={column}>Created at</SortableHeader>,
     cell: ({ row }) => {
       const date = row.getValue<Date>('createdAt');
       const formatted = new Intl.DateTimeFormat('en-US', {
@@ -79,6 +68,8 @@ export const getDataMartColumns = ({
   },
   {
     id: 'actions',
+    size: 80,
+    header: ({ table }) => <ToggleColumnsHeader table={table} />,
     cell: ({ row }) => <DataMartActionsCell row={row} onDeleteSuccess={onDeleteSuccess} />,
   },
 ];

--- a/apps/web/src/pages/data-marts/list/DataMartsPage.tsx
+++ b/apps/web/src/pages/data-marts/list/DataMartsPage.tsx
@@ -5,9 +5,6 @@ import {
 } from '../../../features/data-marts/list';
 import { useEffect } from 'react';
 import { getDataMartColumns } from '../../../features/data-marts/list/components/DataMartTable/columns.tsx';
-import { Button } from '@owox/ui/components/button';
-import { Plus } from 'lucide-react';
-import { Link } from 'react-router-dom';
 
 const DataMartTableWithContext = () => {
   const { items, loadDataMarts, deleteDataMart, refreshList } = useDataMartList();
@@ -28,17 +25,11 @@ const DataMartTableWithContext = () => {
 
 export default function DataMartsPage() {
   return (
-    <div>
-      <header className='flex items-center justify-between px-12 pt-6 pb-4'>
-        <h1 className='text-2xl font-medium'>Data Marts</h1>
-        <Link to={'/data-marts/create'}>
-          <Button variant='secondary' size='sm'>
-            <Plus className='mr-2 h-4 w-4' />
-            New Data Mart
-          </Button>
-        </Link>
+    <div className='dm-page'>
+      <header className='dm-page-header'>
+        <h1 className='dm-page-header-title'>Data Marts</h1>
       </header>
-      <div className='px-4 sm:px-12'>
+      <div className='dm-page-content'>
         <DataMartListProvider>
           <DataMartTableWithContext />
         </DataMartListProvider>

--- a/apps/web/src/pages/data-marts/list/DataMartsPage.tsx
+++ b/apps/web/src/pages/data-marts/list/DataMartsPage.tsx
@@ -7,7 +7,7 @@ import { useEffect } from 'react';
 import { getDataMartColumns } from '../../../features/data-marts/list/components/DataMartTable/columns.tsx';
 
 const DataMartTableWithContext = () => {
-  const { items, loadDataMarts, deleteDataMart, refreshList } = useDataMartList();
+  const { items, loadDataMarts, deleteDataMart, refreshList, loading } = useDataMartList();
 
   useEffect(() => {
     void loadDataMarts();
@@ -19,6 +19,7 @@ const DataMartTableWithContext = () => {
       data={items}
       deleteDataMart={deleteDataMart}
       refetchDataMarts={refreshList}
+      isLoading={loading}
     />
   );
 };

--- a/apps/web/src/shared/components/CardSkeleton/CardSkeleton.tsx
+++ b/apps/web/src/shared/components/CardSkeleton/CardSkeleton.tsx
@@ -1,0 +1,6 @@
+import { Skeleton } from '@owox/ui/components/skeleton';
+export function DataMartsTableSkeleton() {
+  return (
+    <Skeleton className='h-72 w-full rounded-xl border-b border-gray-200 bg-gray-200/50 dark:border-white/10 dark:bg-gray-600/20' />
+  );
+}

--- a/apps/web/src/shared/components/CardSkeleton/index.ts
+++ b/apps/web/src/shared/components/CardSkeleton/index.ts
@@ -1,0 +1,1 @@
+export * from './CardSkeleton.tsx';

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -257,7 +257,7 @@
   @apply flex items-center gap-2 border-muted dark:border-muted/50 bg-white dark:bg-white/2;
 }
 .dm-card-table-wrap {
-  @apply w-full;
+  @apply w-full table-fixed;
 }
 .dm-card-table {
   @apply w-full;
@@ -287,7 +287,7 @@
   @apply block w-full cursor-default;
 }
 .dm-card-table-body-row-empty {
-  @apply h-48 text-center;
+  @apply h-32 text-center text-muted-foreground;
 }
 
 .dm-card-pagination {
@@ -299,7 +299,7 @@
   @apply flex flex-col items-center justify-center pt-22 pb-24;
 }
 .dm-empty-state-ico {
-  @apply h-16 w-16 text-gray-500 opacity-50 mb-6;
+  @apply h-16 w-16 text-gray-500/50 dark:text-gray-200/50 mb-6;
 }
 .dm-empty-state-title {
   @apply text-center text-xl font-medium text-foreground mb-3;

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -196,6 +196,23 @@
   }
 }
 
+/* DM Animations */
+@keyframes fadeUp {
+  0% {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.dm-animate-fade-up {
+  animation: fadeUp 0.3s ease-out forwards;
+}
+/* end: DM Animations */
+
 /* .dm-page {} */
 
 /* DM Page: Header */

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -233,6 +233,9 @@
 .dm-card-toolbar-btn-delete {
   @apply mx-2.5 h-8;
 }
+.dm-card-toolbar-right {
+  @apply flex items-center gap-2;
+}
 .dm-card-toolbar-btn-primary {
   @apply flex items-center gap-2 border-muted dark:border-muted/50 bg-white dark:bg-white/2;
 }
@@ -267,9 +270,23 @@
   @apply block w-full cursor-default;
 }
 .dm-card-table-body-row-empty {
-  @apply h-24 text-center;
+  @apply h-48 text-center;
 }
 
 .dm-card-pagination {
   @apply flex items-center justify-end space-x-2 pt-4;
+}
+
+/* DM Empty State Block */
+.dm-empty-state {
+  @apply flex flex-col items-center justify-center pt-22 pb-24;
+}
+.dm-empty-state-ico {
+  @apply h-16 w-16 text-gray-500 opacity-50 mb-6;
+}
+.dm-empty-state-title {
+  @apply text-center text-xl font-medium text-foreground mb-3;
+}
+.dm-empty-state-subtitle {
+  @apply text-center text-muted-foreground mb-8;
 }

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -195,3 +195,81 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* .dm-page {} */
+
+/* DM Page: Header */
+.dm-page-header {
+  @apply px-12 py-6;
+}
+.dm-page-header-title {
+  @apply text-2xl font-medium;
+}
+
+/* DM Page: Content */
+.dm-page-content {
+  @apply px-4 sm:px-12;
+}
+
+/* DM Card */
+.dm-card {
+  @apply rounded-xl p-4 bg-muted/50 dark:bg-white/2 border-b border-gray-200 dark:border-white/8;
+}
+.dm-card-toolbar {
+  @apply flex items-center justify-between gap-2 pb-4;
+}
+.dm-card-toolbar-left {
+  @apply flex items-center gap-2;
+}
+.dm-card-toolbar-search {
+  @apply relative w-xs;
+}
+.dm-card-toolbar-search-icon {
+  @apply text-muted-foreground absolute top-2.5 left-2 h-4 w-4;
+}
+.dm-card-toolbar-search-input {
+  @apply pl-8 rounded-md border border-muted dark:border-muted/50 bg-white dark:bg-white/2;
+}
+.dm-card-toolbar-btn-delete {
+  @apply mx-2.5 h-8;
+}
+.dm-card-toolbar-btn-primary {
+  @apply flex items-center gap-2 border-muted dark:border-muted/50 bg-white dark:bg-white/2;
+}
+.dm-card-table-wrap {
+  @apply w-full;
+}
+.dm-card-table {
+  @apply w-full;
+}
+.dm-card-table-header {
+  @apply bg-transparent;
+}
+.dm-card-table-header-row {
+  @apply hover:bg-transparent;
+}
+.dm-card-table-header-row-btn {
+  @apply h-8 inline-flex gap-1 cursor-pointer items-center hover:bg-white dark:hover:bg-white/4 hover:shadow-sm transition-colors duration-200;
+}
+.dm-card-table-body {
+  @apply border-b border-gray-200 bg-white dark:bg-white/1 dark:border-0;
+}
+.dm-card-table-body-row {
+  @apply cursor-pointer hover:bg-black/4 dark:hover:bg-white/2 transition-colors duration-200;
+}
+.dm-card-table-body-row-actionbtn {
+  @apply h-8 hover:bg-white dark:hover:bg-white/4 hover:shadow-sm transition-colors transition-shadow duration-200;
+}
+.dm-card-table-body-row-actionbtn-icon {
+  @apply h-4 w-4 text-muted-foreground;
+}
+.dm-card-table-body-row-actiondropdownitem {
+  @apply block w-full cursor-default;
+}
+.dm-card-table-body-row-empty {
+  @apply h-24 text-center;
+}
+
+.dm-card-pagination {
+  @apply flex items-center justify-end space-x-2 pt-4;
+}


### PR DESCRIPTION
![Frame 5](https://github.com/user-attachments/assets/65b1015a-ef94-4596-a7b0-8d11686ed480)

This pull request includes a series of UI and UX improvements for the Data Marts list page:

- New layout and styling for the table and page elements.
- Empty state component for better user guidance when no Data Marts exist.
- Loading state with skeleton component to improve perceived performance.
- Responsive layout improvements for better display on different screen sizes.
- Refined action cell menu behavior for a more intuitive user experience.
- Column visibility management with a new toggle component for flexible table views.

All changes focus on improving visual consistency, responsiveness, and usability across the page.