### PR TITLE
feat(backend): added json per-line logger as default

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -4,6 +4,7 @@ DB_TYPE=sqlite
 
 SQLITE_DB_PATH=./path/to/database/backend.db
 
+LOG_FORMAT=pretty
 
 DB_HOST=localhost
 DB_PORT=3312

--- a/apps/backend/src/common/logger/logger.service.ts
+++ b/apps/backend/src/common/logger/logger.service.ts
@@ -1,0 +1,97 @@
+import { ConsoleLogger } from '@nestjs/common';
+
+/**
+ * Logger configuration object
+ */
+interface LoggerConfig {
+  json: boolean;
+  colors: boolean;
+}
+
+/**
+ * Creates logger configuration based on environment variables.
+ *
+ * Environment variable: LOG_FORMAT
+ * - undefined/any value except 'pretty' → JSON format (default, production-ready)
+ * - 'pretty' → Human-readable format with colors (development-friendly)
+ *
+ * This configuration is automatically applied to ensure consistent logging
+ * across all application components and deployment environments.
+ *
+ * @returns Logger configuration object with JSON format and colors settings
+ *
+ * @example
+ * ```typescript
+ * // Production (default): structured JSON logs
+ * // No LOG_FORMAT needed
+ * const config = createLoggerConfig();
+ * // Result: { json: true, colors: false }
+ *
+ * // Development: pretty formatted logs
+ * // LOG_FORMAT=pretty
+ * const config = createLoggerConfig();
+ * // Result: { json: false, colors: true }
+ * ```
+ */
+function createLoggerConfig(): LoggerConfig {
+  const usePrettyFormat = process.env.LOG_FORMAT === 'pretty';
+  return {
+    json: !usePrettyFormat,
+    colors: usePrettyFormat,
+  };
+}
+
+/**
+ * Creates a configured logger instance that supports both JSON and pretty formatting.
+ *
+ * This logger is designed for multiple usage contexts:
+ *
+ * **1. Bootstrap Phase (before NestJS initialization):**
+ * Used in contexts where DI container is not yet available:
+ * - main.ts (before app creation)
+ * - load-env.ts (environment loading)
+ * - data-source.ts (database configuration at module level)
+ * - migrations.config.ts (may be called outside NestJS context)
+ *
+ * **2. Global NestJS Logger (via app.useLogger()):**
+ * When set as the global logger, all NestJS components automatically use this logger:
+ * - Controllers, Services, Guards, Interceptors
+ * - Built-in NestJS modules (TypeORM, etc.)
+ * - Any component using `new Logger(context)` from '@nestjs/common'
+ *
+ * **3. Direct Instantiation:**
+ * Can be used directly in any TypeScript/Node.js context that needs logging.
+ *
+ * @param context - Optional context name that appears in log entries to identify the source
+ * @returns Configured ConsoleLogger instance with JSON/pretty format support
+ *
+ * @example
+ * ```typescript
+ * // Bootstrap usage (before NestJS app creation)
+ * import { createLogger } from './common/logger/logger.service';
+ * const logger = createLogger('Bootstrap');
+ * logger.log('Starting application...');
+ *
+ * // Global NestJS logger setup
+ * import { NestFactory } from '@nestjs/core';
+ * const app = await NestFactory.create(AppModule);
+ * app.useLogger(createLogger());
+ *
+ * // After app.useLogger(), all NestJS components use this logger:
+ * import { Logger, Injectable } from '@nestjs/common';
+ * @Injectable()
+ * export class SomeService {
+ *   private readonly logger = new Logger(SomeService.name);
+ *   // This logger will use our custom format automatically
+ * }
+ *
+ * // Direct usage in any context
+ * const logger = createLogger('MyModule');
+ * logger.log('Custom message');
+ * ```
+ *
+ * @see {@link https://docs.nestjs.com/techniques/logger NestJS Logger Documentation}
+ */
+export function createLogger(context?: string): ConsoleLogger {
+  return new ConsoleLogger(context || '', createLoggerConfig());
+}

--- a/apps/backend/src/config/data-source-options.config.ts
+++ b/apps/backend/src/config/data-source-options.config.ts
@@ -1,9 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { DataSourceOptions, LoggerOptions } from 'typeorm';
-import { Logger } from '@nestjs/common';
+import { createLogger } from '../common/logger/logger.service';
 import { getSqliteDatabasePath } from './get-sqlite-database-path';
-
-const logger = new Logger('DataSourceOptions');
 
 export enum DbType {
   sqlite = 'sqlite',
@@ -11,6 +9,8 @@ export enum DbType {
 }
 
 export function createDataSourceOptions(config: ConfigService): DataSourceOptions {
+  const logger = createLogger('DataSourceOptions');
+
   const dbType = config.get<DbType>('DB_TYPE') ?? DbType.sqlite;
   logger.log(
     `Using DB_TYPE: ${config.get('DB_TYPE') ? `${dbType} (from env)` : `${dbType} (default)`}`

--- a/apps/backend/src/config/express-static.config.ts
+++ b/apps/backend/src/config/express-static.config.ts
@@ -1,14 +1,14 @@
-import { Logger } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { NextFunction, Request, Response } from 'express';
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { createLogger } from '../common/logger/logger.service';
 
 /**
  * Determines the correct path for web static assets based on execution mode
  */
 function getWebDistPath(): string | null {
-  const logger = new Logger('StaticAssets');
+  const logger = createLogger('StaticAssets');
 
   const publishedPath = join(__dirname, '..', '..', 'public');
   const devPath = join(__dirname, '..', '..', '..', '..', 'web', 'dist');

--- a/apps/backend/src/config/get-sqlite-database-path.ts
+++ b/apps/backend/src/config/get-sqlite-database-path.ts
@@ -1,10 +1,8 @@
-import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import envPaths from 'env-paths';
 import { existsSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
-
-const logger = new Logger('SQLiteDatabasePath');
+import { createLogger } from '../common/logger/logger.service';
 
 /**
  * Determines the SQLite database file path based on configuration.
@@ -28,6 +26,8 @@ const logger = new Logger('SQLiteDatabasePath');
  * ```
  */
 export function getSqliteDatabasePath(config: ConfigService): string {
+  const logger = createLogger('SQLiteDatabasePath');
+
   const envDbPath = config.get<string>('SQLITE_DB_PATH');
 
   let dbPath: string;

--- a/apps/backend/src/config/migrations.config.ts
+++ b/apps/backend/src/config/migrations.config.ts
@@ -1,10 +1,10 @@
-import dataSource from '../data-source';
-import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-
-const logger = new Logger('MigrationRunner');
+import { createLogger } from '../common/logger/logger.service';
+import dataSource from '../data-source';
 
 export async function runMigrationsIfNeeded(config: ConfigService): Promise<void> {
+  const logger = createLogger('MigrationRunner');
+
   const shouldRun = config.get<string>('RUN_MIGRATIONS') === 'true';
 
   if (!shouldRun) {

--- a/apps/backend/src/load-env.ts
+++ b/apps/backend/src/load-env.ts
@@ -1,9 +1,7 @@
 import { config as dotenvConfig } from 'dotenv';
-import { Logger } from '@nestjs/common';
-import { join } from 'path';
 import { existsSync } from 'fs';
-
-const logger = new Logger('LoadEnv');
+import { join } from 'path';
+import { createLogger } from './common/logger/logger.service';
 
 let isLoaded = false;
 
@@ -19,17 +17,22 @@ export function loadEnv(): void {
   const baseEnvPath = join(baseDirPath, baseEnvName);
   const devEnvPath = join(baseDirPath, devEnvName);
 
+  const logs: string[] = [];
+
   const baseEnvExist = existsSync(baseEnvPath);
   if (baseEnvExist) {
     dotenvConfig({ path: baseEnvPath });
-    logger.log(`Loaded ${baseEnvName} from ${baseEnvPath}`);
+    logs.push(`Loaded ${baseEnvName} from ${baseEnvPath}`);
   }
 
   const devEnvExist = existsSync(devEnvPath);
   if (devEnvExist) {
     dotenvConfig({ path: devEnvPath, override: true });
-    logger.log(`Loaded ${devEnvName} from ${devEnvPath}`);
+    logs.push(`Loaded and overrided ${devEnvName} from ${devEnvPath}`);
   }
+
+  const logger = createLogger('LoadEnv');
+  logs.map(message => logger.log(message));
 
   if (!baseEnvExist && !devEnvExist) {
     logger.warn(`No ${baseEnvName} or ${devEnvName} file found`);

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -2,7 +2,7 @@ import { loadEnv } from './load-env';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import { Logger } from '@nestjs/common';
+import { createLogger } from './common/logger/logger.service';
 import { setupSwagger } from './config/swagger.config';
 import { setupGlobalPipes } from './config/global-pipes.config';
 import { setupStaticAssets } from './config/express-static.config';
@@ -10,7 +10,7 @@ import { BaseExceptionFilter } from './common/exceptions/base-exception.filter';
 import { ConfigService } from '@nestjs/config';
 import { runMigrationsIfNeeded } from './config/migrations.config';
 
-const logger = new Logger('Bootstrap');
+const logger = createLogger('Bootstrap');
 const PATH_PREFIX = 'api';
 const SWAGGER_PATH = 'swagger-ui';
 const DEFAULT_PORT = 3000;
@@ -22,9 +22,10 @@ async function bootstrap() {
   await runMigrationsIfNeeded(configService);
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    logger: ['error', 'warn', 'log'],
+    logger,
   });
 
+  app.useLogger(createLogger());
   app.useGlobalFilters(new BaseExceptionFilter());
   app.setGlobalPrefix(PATH_PREFIX);
   setupGlobalPipes(app);


### PR DESCRIPTION
Implements unified logging with environment-based format selection:
- JSON format by default (production-ready)
- Pretty format via `LOG_FORMAT=pretty` (development)
- Works in bootstrap, global NestJS logger, and direct usage
- Comprehensive JSDoc documentation with examples

**Usage:**
- Production: `npm start` (JSON logs)
- Development: update `.env.dev` set `LOG_FORMAT=pretty`