### PR TITLE
docs(owox): updated docs with linter rules

### DIFF
--- a/apps/owox/CONTRIBUTING.md
+++ b/apps/owox/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# OWOX Data Marts CLI
+# Contributing
 
 A command-line interface for running OWOX Data Marts application. This CLI provides a simple way to start the pre-built OWOX Data Marts server with frontend and backend components.
 

--- a/apps/owox/CONTRIBUTING.md
+++ b/apps/owox/CONTRIBUTING.md
@@ -20,8 +20,7 @@ This document is intended for contributors and advanced users who want to work o
 
 If you're just looking to **get started quickly**, please refer to the [Quick Start guide](./README.md).
 
-
-# Usage
+## Usage
 
 <!-- usage -->
 
@@ -39,35 +38,35 @@ USAGE
 
 <!-- usagestop -->
 
-# Local Development: npm link
+## Local Development: npm link
 
 For local development and testing of this CLI, especially when it's not published to a public npm registry, you can use `npm link`. This command creates a symbolic link from your local package to the global npm directory, allowing you to run `owox` from any directory on your system as if it were globally installed.
 
-## Using `npm link`
+### Using `npm link`
 
 To link your local `owox` CLI globally, navigate to the `apps/owox` directory and execute:
 
 ```sh-session
-$ npm link
+npm link
 ```
 
 After successfully linking, you can run `owox` commands from any directory:
 
 ```sh-session
-$ owox serve --port 8080
+owox serve --port 8080
 ```
 
-## Using `npm unlink -g owox`
+### Using `npm unlink -g owox`
 
 If you need to remove the global symbolic link to your local `owox` CLI, navigate to the `apps/owox` directory and execute:
 
 ```sh-session
-$ npm unlink -g owox
+npm unlink -g owox
 ```
 
 This will remove the global link, and `owox` will no longer be accessible globally unless re-linked or installed through an npm registry.
 
-# Commands
+## Commands
 
 <!-- commands -->
 
@@ -78,7 +77,7 @@ This will remove the global link, and `owox` will no longer be accessible global
 
 Start the OWOX Data Marts application in production mode
 
-```
+```sh-session
 USAGE
   $ owox serve [-p <value>]
 
@@ -101,7 +100,7 @@ _See code: [src/commands/serve.ts](https://github.com/OWOX/owox-data-marts/blob/
 
 Display help for owox.
 
-```
+```sh-session
 USAGE
   $ owox help [COMMAND...] [-n]
 
@@ -119,7 +118,7 @@ _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v6.0.2
 
 <!-- commandsstop -->
 
-# FAQ
+## FAQ
 
 This section explains the purpose of the files located in the `bin` directory of the CLI.
 

--- a/apps/owox/PUBLISHING.md
+++ b/apps/owox/PUBLISHING.md
@@ -1,4 +1,4 @@
-# Publishing Guide for OWOX CLI
+# Publishing
 
 This guide explains the automated publishing process for the OWOX Data Marts CLI package to npm.
 

--- a/apps/owox/PUBLISHING.md
+++ b/apps/owox/PUBLISHING.md
@@ -9,6 +9,7 @@ The `owox` CLI package is published automatically through GitHub Actions. For de
 ## Automated Publishing Process
 
 The publishing process automatically:
+
 - Runs the `prepack` script (which generates OCLIF manifest)
 - Runs the `prepublishOnly` script (which runs security audit, tests and linting)
 - Publishes the package to the appropriate npm tag

--- a/apps/owox/README.md
+++ b/apps/owox/README.md
@@ -1,12 +1,10 @@
-# OWOX Data Marts CLI
+# Quick Start 🚀 (no-code setup)
 
 A command-line interface for running OWOX Data Marts application. This CLI provides a simple way to start the pre-built OWOX Data Marts server with frontend and backend components.
 
 [![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
 [![Version](https://img.shields.io/npm/v/owox.svg)](https://npmjs.org/package/owox)
 [![Downloads/week](https://img.shields.io/npm/dw/owox.svg)](https://npmjs.org/package/owox)
-
-## Quick Start 🚀 (no-code setup)
 
 1. **Make sure Node.js ≥ 22.16.0 is installed**
 

--- a/apps/owox/README.md
+++ b/apps/owox/README.md
@@ -6,35 +6,34 @@ A command-line interface for running OWOX Data Marts application. This CLI provi
 [![Version](https://img.shields.io/npm/v/owox.svg)](https://npmjs.org/package/owox)
 [![Downloads/week](https://img.shields.io/npm/dw/owox.svg)](https://npmjs.org/package/owox)
 
+## Quick Start 🚀 (no-code setup)
 
+1. **Make sure Node.js ≥ 22.16.0 is installed**
 
-# Quick Start 🚀 (no-code setup)
+   If you don't have it installed, [download it here](https://nodejs.org/en/download)
+   (Windows / macOS / Linux installers are all listed there)
 
-0. **Make sure Node.js ≥ 22.16.0 is installed**
+2. **Open your terminal** and run **one** command
 
-   If you don't have it installed, [download it here](https://nodejs.org/en/download)   
-   <sub>(Windows / macOS / Linux installers are all listed there)</sub>
-
-2. **Open your terminal** and run **one** command  
    ```bash
    npm install -g owox
    ```
- 
-   <sub>You’ll see a list of added packages. Some warns are possible — just ignore them.</sub>
 
+   (You'll see a list of added packages. Some warns are possible — just ignore them.)
 
 3. **Start OWOX Data Marts** locally
+
    ```bash
    owox serve
    ```
- 
-   <sub>Expected output:
-🚀 Starting OWOX Data Marts...
-📦 Starting server on port 3000...</sub>
 
-4. **Open** your browser at **http://localhost:3000** and explore! 🎉
+   (Expected output:
+   🚀 Starting OWOX Data Marts...
+   📦 Starting server on port 3000...)
+
+4. **Open** your browser at **<http://localhost:3000>** and explore! 🎉
 
 ---
 
-👉 Ready to contribute or run in development mode? 
+👉 Ready to contribute or run in development mode?
 Check out [CONTRIBUTING.md](./CONTRIBUTING.md) for advanced setup and CLI commands.


### PR DESCRIPTION
This commit addresses various Markdown linting issues across `CONTRIBUTING.md` and `README.md`. It primarily focuses on correcting heading hierarchy, specifying languages for code blocks, and standardizing list formatting to improve document clarity and adherence to style guidelines.