### PR TITLE
feat(docs): add trailing slash to the astro config

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -10,6 +10,7 @@ const { site, base } = getConfig();
 export default defineConfig({
   site,
   base,
+  trailingSlash: 'always',
   integrations: [
     starlight({
       title: 'OWOX Docs',

--- a/apps/docs/scripts/env-config.js
+++ b/apps/docs/scripts/env-config.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 export const getConfig = () => {
   const { NODE_ENV, DOCS_SITE, DOCS_BASE } = process.env;
 

--- a/apps/docs/scripts/utils.js
+++ b/apps/docs/scripts/utils.js
@@ -1,3 +1,4 @@
+// @ts-check
 import path from 'node:path';
 
 /**
@@ -104,4 +105,25 @@ export function isLocalLinkPathInSameDirectory(linkPath) {
     linkPath !== './' &&
     linkPath.split('/').length === 2
   );
+}
+
+/**
+ * Normalizes the suffix for a directory-style URL.
+ * If the path contains a hash (#), ensures there is a slash before it.
+ * If there is no hash, adds a trailing slash to the path.
+ *
+ * @param {string} linkPath - The input path or URL.
+ * @returns {string} - The normalized path with the correct suffix for a directory-style URL.
+ */
+export function normalizeSuffixForDirectoryStyleURL(linkPath) {
+  let result = '';
+  if (linkPath.includes('/#')) {
+    result = linkPath;
+  } else if (linkPath.includes('#')) {
+    result = linkPath.replace('#', '/#');
+  } else {
+    result = linkPath + '/';
+  }
+
+  return result;
 }


### PR DESCRIPTION
- Add a trailing slash to the astro.config.mjs (now all URLs will end with "/" )
- Update the strategy for creating a link path from relative to root-relative (which fixes some problems with site page URLs )