### PR TITLE
feat(backend): add configuration of log levels

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -5,6 +5,7 @@ DB_TYPE=sqlite
 SQLITE_DB_PATH=./path/to/database/backend.db
 
 LOG_FORMAT=json
+LOG_LEVELS=log,warn,error,debug,verbose,fatal
 
 DB_HOST=localhost
 DB_PORT=3312


### PR DESCRIPTION
## Add configurable log levels support

### Changes
- **Logger Service**: Added support for configurable log levels via `LOG_LEVELS` environment variable
- **Default Behavior**: Changed default log levels to `log`, `warn`, `error` (previously included all levels)
- **Configuration**: 
  - `LOG_LEVELS` accepts comma-separated values (e.g., `log,warn,error,debug`)
  - Falls back to defaults with warning if invalid levels provided
  - Validates against NestJS supported levels: `log`, `error`, `warn`, `debug`, `verbose`, `fatal`

### Usage Examples
```bash
# Default (basic levels only)
# No LOG_LEVELS needed - outputs: log, warn, error

# Development with debug
LOG_LEVELS=log,warn,error,debug

# Full debugging
LOG_LEVELS=log,warn,error,debug,verbose
```

### Breaking Change
⚠️ **Default log output now excludes `debug` and `verbose` levels.** Set `LOG_LEVELS=log,error,warn,debug,verbose,fatal` to restore previous behavior.