### PR TITLE
fix(backend): update static configurations

### DIFF
--- a/apps/backend/src/config/express-static.config.ts
+++ b/apps/backend/src/config/express-static.config.ts
@@ -46,7 +46,7 @@ export function setupStaticAssets(app: NestExpressApplication, pathPrefix: strin
     if (req.path.startsWith(`/${pathPrefix}`)) {
       next();
     } else {
-      res.sendFile(join(distPath, 'index.html'));
+      res.sendFile('index.html', { root: distPath });
     }
   });
 }


### PR DESCRIPTION
Fix static file serving: use Express 'root' option for index.html

Previously, the server attempted to serve the SPA entry point using an absolute path with res.sendFile(join(distPath, 'index.html')), which could fail due to path resolution issues across environments. This PR switches to res.sendFile('index.html', { root: distPath }), leveraging Express's built-in path resolution. This ensures consistent and reliable serving of index.html for client-side routes, fixing the 404 error on page reload.

![CleanShot 2025-07-15 at 12 28 51](https://github.com/user-attachments/assets/462ae2c7-ef55-4cc4-9ed2-128589f81f7e)
