### PR TITLE
fix: record fields in data mart schema editor, schema for connector

### DIFF
--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-data-mart-schema.provider.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-data-mart-schema.provider.ts
@@ -75,8 +75,9 @@ export class BigQueryDataMartSchemaProvider implements DataMartSchemaProvider {
     if (isTableDefinition(dataMartDefinition) || isViewDefinition(dataMartDefinition)) {
       [projectId, datasetId, tableId] = dataMartDefinition.fullyQualifiedName.split('.');
     } else if (isConnectorDefinition(dataMartDefinition)) {
+      const tablePath = dataMartDefinition.connector.storage.fullyQualifiedName.split('.');
       [projectId, datasetId, tableId] =
-        dataMartDefinition.connector.storage.fullyQualifiedName.split('.');
+        tablePath.length === 2 ? [config.projectId, ...tablePath] : tablePath;
     }
 
     const adapter = this.adapterFactory.create(credentials, config);

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
@@ -72,6 +72,16 @@ export interface BaseSchemaTableProps<T extends BaseSchemaField> {
     row: Row<T>;
     updateField: (index: number, updatedField: Partial<T>) => void;
   }) => React.ReactNode;
+  /** Custom cell for the alias column */
+  aliasColumnCell?: (props: {
+    row: Row<T>;
+    updateField: (index: number, updatedField: Partial<T>) => void;
+  }) => React.ReactNode;
+  /** Custom cell for the description column */
+  descriptionColumnCell?: (props: {
+    row: Row<T>;
+    updateField: (index: number, updatedField: Partial<T>) => void;
+  }) => React.ReactNode;
   /** Custom cell for the actions column */
   actionsColumnCell?: (props: { row: Row<T>; table: Table<T> }) => React.ReactNode;
   /** Drag-and-drop context component */
@@ -99,6 +109,8 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
   nameColumnHeader,
   nameColumnCell,
   primaryKeyColumnCell,
+  aliasColumnCell,
+  descriptionColumnCell,
   actionsColumnCell,
   dragContext,
   dragContextProps,
@@ -217,15 +229,20 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
           </Tooltip>
         ),
         size: 80,
-        cell: ({ row }) => (
-          <EditableText
-            value={row.getValue('alias')}
-            onValueChange={value => {
-              updateField(row.index, { alias: value } as Partial<T>);
-            }}
-            placeholder='-'
-          />
-        ),
+        cell: ({ row }) => {
+          if (aliasColumnCell) {
+            return aliasColumnCell({ row, updateField });
+          }
+          return (
+            <EditableText
+              value={row.getValue('alias')}
+              onValueChange={value => {
+                updateField(row.index, { alias: value } as Partial<T>);
+              }}
+              placeholder='-'
+            />
+          );
+        },
       },
       {
         accessorKey: 'description',
@@ -235,16 +252,21 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
             <TooltipContent>Detailed information about the field</TooltipContent>
           </Tooltip>
         ),
-        cell: ({ row }) => (
-          <EditableText
-            value={row.getValue('description')}
-            onValueChange={value => {
-              updateField(row.index, { description: value } as Partial<T>);
-            }}
-            minRows={5}
-            placeholder='-'
-          />
-        ),
+        cell: ({ row }) => {
+          if (descriptionColumnCell) {
+            return descriptionColumnCell({ row, updateField });
+          }
+          return (
+            <EditableText
+              value={row.getValue('description')}
+              onValueChange={value => {
+                updateField(row.index, { description: value } as Partial<T>);
+              }}
+              minRows={5}
+              placeholder='-'
+            />
+          );
+        },
       },
       {
         id: 'actions',
@@ -272,6 +294,8 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
       nameColumnHeader,
       nameColumnCell,
       primaryKeyColumnCell,
+      aliasColumnCell,
+      descriptionColumnCell,
       actionsColumnCell,
     ]
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.tsx
@@ -75,7 +75,6 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
   const renderTypeCell = useCallback(
     ({
       row,
-      updateField,
     }: {
       row: Row<BigQuerySchemaField>;
       updateField: (index: number, updatedField: Partial<BigQuerySchemaField>) => void;
@@ -88,7 +87,7 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
         }}
       />
     ),
-    []
+    [updateField]
   );
 
   // Define additional columns specific to BigQuery
@@ -139,7 +138,6 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
   const nameColumnCell = useCallback(
     ({
       row,
-      updateField,
     }: {
       row: Row<BigQuerySchemaField>;
       updateField: (index: number, updatedField: Partial<BigQuerySchemaField>) => void;
@@ -187,14 +185,13 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
         </div>
       );
     },
-    [flattenedFields, expandedRecords, hasRecordFields, toggleRecordExpansion]
+    [flattenedFields, expandedRecords, hasRecordFields, toggleRecordExpansion, updateField]
   );
 
   // Custom primary key column cell that only shows checkbox for top-level non-record fields
   const primaryKeyColumnCell = useCallback(
     ({
       row,
-      updateField,
     }: {
       row: Row<BigQuerySchemaField>;
       updateField: (index: number, updatedField: Partial<BigQuerySchemaField>) => void;
@@ -219,7 +216,46 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
       // Return empty div for non-top-level fields or record types
       return <div />;
     },
-    [flattenedFields]
+    [flattenedFields, updateField]
+  );
+
+  // Custom description column cell that uses updateField from useNestedFieldOperations
+  const descriptionColumnCell = useCallback(
+    ({
+      row,
+    }: {
+      row: Row<BigQuerySchemaField>;
+      updateField: (index: number, updatedField: Partial<BigQuerySchemaField>) => void;
+    }) => (
+      <EditableText
+        value={row.getValue('description')}
+        onValueChange={value => {
+          updateField(row.index, { description: value });
+        }}
+        minRows={5}
+        placeholder='-'
+      />
+    ),
+    [updateField]
+  );
+
+  // Custom alias column cell that uses updateField from useNestedFieldOperations
+  const aliasColumnCell = useCallback(
+    ({
+      row,
+    }: {
+      row: Row<BigQuerySchemaField>;
+      updateField: (index: number, updatedField: Partial<BigQuerySchemaField>) => void;
+    }) => (
+      <EditableText
+        value={row.getValue('alias')}
+        onValueChange={value => {
+          updateField(row.index, { alias: value });
+        }}
+        placeholder='-'
+      />
+    ),
+    [updateField]
   );
 
   // Custom actions column cell with add nested field option for record types
@@ -269,6 +305,8 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
         nameColumnHeader={nameColumnHeader}
         nameColumnCell={nameColumnCell}
         primaryKeyColumnCell={primaryKeyColumnCell}
+        aliasColumnCell={aliasColumnCell}
+        descriptionColumnCell={descriptionColumnCell}
         actionsColumnCell={actionsColumnCell}
         dragContext={SortableContext}
         dragContextProps={{


### PR DESCRIPTION
## Fix record field handling in data mart schema editor

**What was fixed:**
- Correct handling of record fields in BigQuery data mart schema editor
- Fixed schema handling for connector-defined data marts

**Affected components:**
- Backend: BigQuery schema provider and report reader services
- Frontend: schema table components (BaseSchemaTable, BigQuerySchemaTable)

This fix ensures stable operation of the schema editor when working with nested data structures and connector-defined data marts.