### PR TITLE
feat(web): Refine the Data Mart Page (Layout, Menu, and Texts)

### DIFF
--- a/apps/web/src/features/connectors/edit/components/ConnectorDefinitionField/ConnectorConfigurationItem.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorDefinitionField/ConnectorConfigurationItem.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@owox/ui/components/button';
 import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
-import { Info, Trash2 } from 'lucide-react';
+import { Info, Trash2, Settings } from 'lucide-react';
 import { DataMartConnectorView } from '../../DataMartConnectorView';
 import { DataStorageType } from '../../../../data-storage';
 import type { ConnectorConfig, ConnectorDefinitionConfig } from '../../../../data-marts/edit/model';
@@ -51,11 +51,15 @@ export function ConnectorConfigurationItem({
   const getConnectorSubtitle = () => {
     const node = connectorDef.connector.source.node || 'No node selected';
     return (
-      <div className='flex flex-wrap gap-2'>
-        <span>
-          <span className='text-muted-foreground/75'>Node:</span>{' '}
-          <span className='text-muted-foreground font-medium'>{node}</span>
-        </span>
+      <div className='flex flex-wrap items-center gap-2'>
+        <span className='text-muted-foreground/75'>Node:</span>{' '}
+        <span className='text-muted-foreground font-medium'>{node}</span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Settings className='h-4 w-4' />
+          </TooltipTrigger>
+          <TooltipContent>Open connector configuration</TooltipContent>
+        </Tooltip>
       </div>
     );
   };
@@ -95,10 +99,8 @@ export function ConnectorConfigurationItem({
                 <Info className='h-4 w-4' />
               </TooltipTrigger>
               <TooltipContent>
-                <p>
-                  The dataset and table are created (if not exist) after the first run of the data
-                  mart.
-                </p>
+                The dataset and table are automatically created during the first run of the data
+                mart, if they don't already exist
               </TooltipContent>
             </Tooltip>
           </div>
@@ -120,10 +122,8 @@ export function ConnectorConfigurationItem({
                 <Info className='h-4 w-4' />
               </TooltipTrigger>
               <TooltipContent>
-                <p>
-                  The database and table are created (if not exist) after the first run of the data
-                  mart.
-                </p>
+                The database and table are automatically created during the first run of the data
+                mart, if they don't already exist
               </TooltipContent>
             </Tooltip>
           </div>
@@ -143,7 +143,7 @@ export function ConnectorConfigurationItem({
   };
 
   return (
-    <div className='flex w-full items-center pb-4'>
+    <div className='border-border flex w-full items-center rounded-lg border-1 p-1 dark:bg-white/2'>
       <div className='flex-grow'>
         <div className='grid grid-cols-2 items-center gap-4'>
           <DataMartConnectorView
@@ -162,7 +162,7 @@ export function ConnectorConfigurationItem({
               icon={getConnectorIcon(connectorDef.connector.source.name)}
               title={connectorDef.connector.source.name || 'Connector'}
               subtitle={getConnectorSubtitle()}
-              className='min-h-[80px] cursor-pointer transition-colors'
+              className='bg-background hover:bg-muted min-h-[80px] cursor-pointer border-0 transition-colors hover:shadow-none'
             />
           </DataMartConnectorView>
 
@@ -175,20 +175,18 @@ export function ConnectorConfigurationItem({
         </div>
       </div>
 
-      <div className='shrink-0 pl-4'>
+      <div className='shrink-0 px-4'>
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
               type='button'
               variant='ghost'
-              size='sm'
               onClick={() => {
                 if (canRemoveConfiguration()) {
                   onRemoveConfiguration(configIndex);
                 }
               }}
               disabled={!canRemoveConfiguration()}
-              className='disabled:text-muted-foreground/50 text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-950/50'
             >
               <Trash2 className='h-4 w-4' />
             </Button>

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
@@ -185,9 +185,9 @@ export function ConnectorDefinitionField({ control, storageType }: ConnectorDefi
         control={control}
         name='definition'
         render={({ field }) => (
-          <FormItem className='space-y-0'>
+          <FormItem>
             <FormControl>
-              <div className='space-y-4'>
+              <div className='space-y-3'>
                 {!isConnectorConfigured(field.value as ConnectorDefinitionConfig) ||
                 datamartStatus === DataMartStatus.DRAFT ? (
                   <ConnectorSetupButton
@@ -195,8 +195,8 @@ export function ConnectorDefinitionField({ control, storageType }: ConnectorDefi
                     onSetupConnector={setupConnector}
                   />
                 ) : (
-                  <div className='space-y-4'>
-                    <div className='flex items-center justify-between gap-3'>
+                  <div className='space-y-3'>
+                    <div className='flex items-center justify-between'>
                       <div className='flex items-center gap-2'>
                         <AddConfigurationButton
                           storageType={storageType}
@@ -215,16 +215,15 @@ export function ConnectorDefinitionField({ control, storageType }: ConnectorDefi
                         {isConnectorConfigured(field.value as ConnectorDefinitionConfig) &&
                           renderEditFieldsButton(field.value as ConnectorDefinitionConfig)}
                       </div>
-                      <div className='mr-13 flex items-center gap-2'>
+                      <div className='flex items-center gap-2'>
                         <Button
-                          variant='ghost'
-                          className='flex h-12 items-center gap-2'
+                          variant='outline'
                           onClick={() => {
                             void handleManualRun();
                           }}
                         >
                           <Play className='h-4 w-4' />
-                          <span>Manual Run</span>
+                          Manual Run
                         </Button>
                       </div>
                     </div>

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@owox/ui/components/dropdown-menu';
 import { ConfirmationDialog } from '../../../../shared/components/ConfirmationDialog';
@@ -165,22 +166,24 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
           </div>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button className='rounded p-1 hover:bg-gray-100'>
+              <Button variant='ghost'>
                 <MoreVertical className='h-5 w-5' />
-              </button>
+              </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align='end'>
               {dataMart.status.code === DataMartStatus.PUBLISHED &&
                 dataMart.definitionType === DataMartDefinitionType.CONNECTOR && (
-                  <DropdownMenuItem
-                    className='text-blue-600'
-                    onClick={() => {
-                      void handleManualRun();
-                    }}
-                  >
-                    <Play className='mr-2 h-4 w-4' />
-                    Manual Run
-                  </DropdownMenuItem>
+                  <>
+                    <DropdownMenuItem
+                      onClick={() => {
+                        void handleManualRun();
+                      }}
+                    >
+                      <Play className='mr-2 h-4 w-4' />
+                      Manual Run
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </>
                 )}
               <DropdownMenuItem
                 className='text-red-600'

--- a/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerForm/FormDescriptions/ReportSelectionDescription.tsx
+++ b/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerForm/FormDescriptions/ReportSelectionDescription.tsx
@@ -19,7 +19,7 @@ export default function ReportSelectionDescription() {
             Sheets report).
           </p>
           <p>
-            You can use an existing one or create a new one on the <strong>Destinations tab</strong>{' '}
+            You can use an existing one or create a new one on the <strong>Destinations</strong> tab{' '}
             of this Data Mart.
           </p>
         </AccordionContent>

--- a/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerForm/FormDescriptions/TriggerTypeOptionsDescription.tsx
+++ b/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerForm/FormDescriptions/TriggerTypeOptionsDescription.tsx
@@ -4,7 +4,6 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@owox/ui/components/accordion';
-import { Separator } from '@owox/ui/components/separator';
 
 /**
  * Accordion about trigger type options
@@ -16,41 +15,12 @@ export default function TriggerTypeOptionsDescription() {
         <AccordionTrigger>How do I choose a type?</AccordionTrigger>
         <AccordionContent>
           <p className='mb-2'>
-            Trigger types define what will be automatically run on a schedule. There are two
-            options:
-          </p>
-          <p className='mb-2'>
             <strong>Report Run</strong> - runs a report to import data from the specified Data
             Storage into a Destination provider (e.g. Google Sheets document).
           </p>
           <p className='mb-2'>
             <strong>Connector Run</strong> - runs a connector (e.g., Facebook Ads) configured in the
             Data Mart to update raw data in the selected Data Storage.
-          </p>
-          <Separator className='my-4' />
-          <p className='mb-2'>
-            <strong>Example #1:</strong>
-            <br />
-            If you have a connector-based Data Mart and want to update a Google Sheets report, set
-            up two triggers:
-          </p>
-          <ol className='list-inside list-decimal space-y-2 text-sm'>
-            <li>
-              Connector Run - fetches raw data from the data source (e.g., Facebook API) into your
-              Data Storage (e.g. Google BigQuery).
-            </li>
-            <li>
-              Report Run - loads the processed data from the same Data Storage (e.g. Google
-              BigQuery) into the Google Sheets document.
-            </li>
-          </ol>
-          <Separator className='my-4' />
-          <p>
-            <strong>Example #2:</strong>
-            <br />
-            If your Data Mart is based on a SQL query, table, view, or pattern, and you want to
-            update a Google Sheets report, use a single Report Run trigger to run the query and send
-            the result to the Google Sheets document.
           </p>
         </AccordionContent>
       </AccordionItem>


### PR DESCRIPTION
### Summary


Improved UI and text clarity in the Data Mart page: updated the Connector block layout, polished the dropdown menu, and refreshed descriptions.

<img width="1495" height="1470" alt="Frame 1761" src="https://github.com/user-attachments/assets/559c7add-e218-4733-8eea-9dc977200b7b" />

<img width="888" height="650" alt="Frame 1762" src="https://github.com/user-attachments/assets/ed98567f-61a2-4335-949f-e97d3d9f6a7e" />


<img width="1495" height="569" alt="Frame 1760" src="https://github.com/user-attachments/assets/b3abc99e-243c-4892-a870-ff44eb2846fd" />
