### PR TITLE
fix: comment out unimplemented fields in Facebook Marketing API schemas

### DIFF
--- a/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
@@ -3,6 +3,7 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ * Commented endpoints will be implemented later.
  */
 
 var FacebookMarketingFieldsSchema = {
@@ -85,12 +86,12 @@ var FacebookMarketingFieldsSchema = {
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/adcreatives",
         "destinationName": "ad_group_adcreatives"
     },
-    "ad-group/insights": {
-        "description": "Insights on your advertising performance.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights",
-        "fields": adGroupInsightsFields,
-        "destinationName": "ad_group_insights"
-    },
+    // "ad-group/insights": {
+    //     "description": "Insights on your advertising performance.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights",
+    //     "fields": adGroupInsightsFields,
+    //     "destinationName": "ad_group_insights"
+    // },
     "ad-group/leads": {
         "description": "Any leads associated with a Lead Ad.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/leads",
@@ -101,25 +102,25 @@ var FacebookMarketingFieldsSchema = {
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/previews",
         "destinationName": "ad_group_previews"
      },
-    "ad-creative": {
-        "overview": "Ad Creative",
-        "description": "Format for your image, carousel, collection, or video ad.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-creative/",
-        "fields": adCreativeFields,
-        "destinationName": "ad_creative"
-    },
+    // "ad-creative": {
+    //     "overview": "Ad Creative",
+    //     "description": "Format for your image, carousel, collection, or video ad.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-creative/",
+    //     "fields": adCreativeFields,
+    //     "destinationName": "ad_creative"
+    // },
     "ad-creative/previews": {
         "description": "Generate ad previews from the existing ad creative object.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-creative/previews",
         "destinationName": "ad_creative_previews"
     },
-    "ad-campaign": {
-        "overview": "Ad Set",
-        "description": "Contains all ads that share the same budget, schedule, bid, and targeting.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/",
-        "fields": adCampaignFields,
-        "destinationName": "ad_campaign"
-    },
+    // "ad-campaign": {
+    //     "overview": "Ad Set",
+    //     "description": "Contains all ads that share the same budget, schedule, bid, and targeting.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/",
+    //     "fields": adCampaignFields,
+    //     "destinationName": "ad_campaign"
+    // },
     "ad-campaign/activities": {
         "description": "Log of actions taken on the ad set.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/activities",
@@ -140,13 +141,13 @@ var FacebookMarketingFieldsSchema = {
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/insights",
         "destinationName": "ad_campaign_insights"
     },
-    "ad-campaign-group": {
-        "overview": "Ad Campaign",
-        "description": "Defines your ad campaigns' objective. Contains one or more ad set.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/",
-        "fields": adCampaignGroupFields,
-        "destinationName": "ad_campaign_group"
-    },
+    // "ad-campaign-group": {
+    //     "overview": "Ad Campaign",
+    //     "description": "Defines your ad campaigns' objective. Contains one or more ad set.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/",
+    //     "fields": adCampaignGroupFields,
+    //     "destinationName": "ad_campaign_group"
+    // },
     "ad-campaign-group/ads": {
         "description": "Data necessary for an ad, such as creative elements and measurement information.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/ads",
@@ -157,10 +158,10 @@ var FacebookMarketingFieldsSchema = {
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/adsets",
         "destinationName": "ad_campaign_group_adsets"
     },
-    "ad-campaign-group/insights": {
-        "description": "Insights on your advertising performance.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/insights",
-        "fields" : adCampaignInsightsFields,
-        "destinationName": "ad_campaign_group_insights"
-    }
+    // "ad-campaign-group/insights": {
+    //     "description": "Insights on your advertising performance.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/insights",
+    //     "fields" : adCampaignInsightsFields,
+    //     "destinationName": "ad_campaign_group_insights"
+    // }
 }

--- a/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
@@ -31,11 +31,11 @@ var FacebookMarketingFieldsSchema = {
         "destinationName": "ad_account_adcreatives",
         "limit": 100
     },
-    "ad-account/adimages": {
-        "description": "Library of images to use in ad creatives. Can be uploaded and managed independently.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/adimages",
-        "destinationName": "ad_account_adimages"
-    },
+    // "ad-account/adimages": {
+    //     "description": "Library of images to use in ad creatives. Can be uploaded and managed independently.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/adimages",
+    //     "destinationName": "ad_account_adimages"
+    // },
     "ad-account/ads": {
         "description": "Data for an ad, such as creative elements and measurement information.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/ads",
@@ -44,26 +44,26 @@ var FacebookMarketingFieldsSchema = {
         "destinationName": "ad_account_ads",
         "limit": 100
     },
-    "ad-account/adsets": {
-        "description": "Contain all ads that share the same budget, schedule, bid, and targeting.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/adsets",
-        "destinationName": "ad_account_adsets"
-    },
-    "ad-account/advideos": {
-        "description": "Library of videos for use in ad creatives. Can be uploaded and managed independently.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/advideos",
-        "destinationName": "ad_account_advideos"
-    },
-    "ad-account/campaigns": {
-        "description": "Define your campaigns' objective and contain one or more ad sets.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/campaigns",
-        "destinationName": "ad_account_campaigns"
-    },
-    "ad-account/customaudiences": {
-        "description": "The custom audiences owned by/shared with this ad account.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/customaudiences",
-        "destinationName": "ad_account_customaudiences"
-    },
+    // "ad-account/adsets": {
+    //     "description": "Contain all ads that share the same budget, schedule, bid, and targeting.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/adsets",
+    //     "destinationName": "ad_account_adsets"
+    // },
+    // "ad-account/advideos": {
+    //     "description": "Library of videos for use in ad creatives. Can be uploaded and managed independently.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/advideos",
+    //     "destinationName": "ad_account_advideos"
+    // },
+    // "ad-account/campaigns": {
+    //     "description": "Define your campaigns' objective and contain one or more ad sets.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/campaigns",
+    //     "destinationName": "ad_account_campaigns"
+    // },
+    // "ad-account/customaudiences": {
+    //     "description": "The custom audiences owned by/shared with this ad account.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/customaudiences",
+    //     "destinationName": "ad_account_customaudiences"
+    // },
     "ad-account/insights": {
         "description": "Interface for insights. De-dupes results across child objects, provides sorting, and async reports.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights",
@@ -81,27 +81,27 @@ var FacebookMarketingFieldsSchema = {
         "destinationName": "ad_group",
         "limit": 100
     },
-    "ad-group/adcreatives": {
-        "description": "Defines your ad's appearance and content.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/adcreatives",
-        "destinationName": "ad_group_adcreatives"
-    },
+    // "ad-group/adcreatives": {
+    //     "description": "Defines your ad's appearance and content.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/adcreatives",
+    //     "destinationName": "ad_group_adcreatives"
+    // },
     // "ad-group/insights": {
     //     "description": "Insights on your advertising performance.",
     //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights",
     //     "fields": adGroupInsightsFields,
     //     "destinationName": "ad_group_insights"
     // },
-    "ad-group/leads": {
-        "description": "Any leads associated with a Lead Ad.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/leads",
-        "destinationName": "ad_group_leads"
-    },
-    "ad-group/previews": {
-        "description": "Generate ad previews from an existing ad.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/previews",
-        "destinationName": "ad_group_previews"
-     },
+    // "ad-group/leads": {
+    //     "description": "Any leads associated with a Lead Ad.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/leads",
+    //     "destinationName": "ad_group_leads"
+    // },
+    // "ad-group/previews": {
+    //     "description": "Generate ad previews from an existing ad.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/previews",
+    //     "destinationName": "ad_group_previews"
+    //  },
     // "ad-creative": {
     //     "overview": "Ad Creative",
     //     "description": "Format for your image, carousel, collection, or video ad.",
@@ -109,11 +109,11 @@ var FacebookMarketingFieldsSchema = {
     //     "fields": adCreativeFields,
     //     "destinationName": "ad_creative"
     // },
-    "ad-creative/previews": {
-        "description": "Generate ad previews from the existing ad creative object.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-creative/previews",
-        "destinationName": "ad_creative_previews"
-    },
+    // "ad-creative/previews": {
+    //     "description": "Generate ad previews from the existing ad creative object.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-creative/previews",
+    //     "destinationName": "ad_creative_previews"
+    // },
     // "ad-campaign": {
     //     "overview": "Ad Set",
     //     "description": "Contains all ads that share the same budget, schedule, bid, and targeting.",
@@ -121,26 +121,26 @@ var FacebookMarketingFieldsSchema = {
     //     "fields": adCampaignFields,
     //     "destinationName": "ad_campaign"
     // },
-    "ad-campaign/activities": {
-        "description": "Log of actions taken on the ad set.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/activities",
-        "destinationName": "ad_campaign_activities"
-    },
-    "ad-campaign/adcreatives": {
-        "description": "Defines your ad's content and appearance.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/adcreatives",
-        "destinationName": "ad_campaign_adcreatives"
-    },
-    "ad-campaign/ads": {
-        "description": "Data necessary for an ad, such as creative elements and measurement information.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campagin/ads",
-        "destinationName": "ad_campaign_ads"
-    },
-    "ad-campaign/insights": {
-        "description": "Insights on your advertising performance.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/insights",
-        "destinationName": "ad_campaign_insights"
-    },
+    // "ad-campaign/activities": {
+    //     "description": "Log of actions taken on the ad set.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/activities",
+    //     "destinationName": "ad_campaign_activities"
+    // },
+    // "ad-campaign/adcreatives": {
+    //     "description": "Defines your ad's content and appearance.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/adcreatives",
+    //     "destinationName": "ad_campaign_adcreatives"
+    // },
+    // "ad-campaign/ads": {
+    //     "description": "Data necessary for an ad, such as creative elements and measurement information.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campagin/ads",
+    //     "destinationName": "ad_campaign_ads"
+    // },
+    // "ad-campaign/insights": {
+    //     "description": "Insights on your advertising performance.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign/insights",
+    //     "destinationName": "ad_campaign_insights"
+    // },
     // "ad-campaign-group": {
     //     "overview": "Ad Campaign",
     //     "description": "Defines your ad campaigns' objective. Contains one or more ad set.",
@@ -148,16 +148,16 @@ var FacebookMarketingFieldsSchema = {
     //     "fields": adCampaignGroupFields,
     //     "destinationName": "ad_campaign_group"
     // },
-    "ad-campaign-group/ads": {
-        "description": "Data necessary for an ad, such as creative elements and measurement information.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/ads",
-        "destinationName": "ad_campaign_group_ads"
-    },
-    "ad-campaign-group/adsets": {
-        "description": "Contain all ads that share the same budget, schedule, bid, and targeting.",
-        "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/adsets",
-        "destinationName": "ad_campaign_group_adsets"
-    },
+    // "ad-campaign-group/ads": {
+    //     "description": "Data necessary for an ad, such as creative elements and measurement information.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/ads",
+    //     "destinationName": "ad_campaign_group_ads"
+    // },
+    // "ad-campaign-group/adsets": {
+    //     "description": "Contain all ads that share the same budget, schedule, bid, and targeting.",
+    //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/adsets",
+    //     "destinationName": "ad_campaign_group_adsets"
+    // },
     // "ad-campaign-group/insights": {
     //     "description": "Insights on your advertising performance.",
     //     "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/insights",

--- a/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/ad-account-fields.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/ad-account-fields.js
@@ -23,6 +23,11 @@ var adAccountFields = {
   'description': 'Ad Account creation request purchase order fields associated with this Ad Account.',
   'type': 'AdAccountPromotableObjects'
 },
+// Commented out because this field can cause confusion or errors.
+// 'ad_account_promotable_objects': {
+//   'description': 'Ad Account creation request purchase order fields associated with this Ad Account.',
+//   'type': 'AdAccountPromotableObjects'
+// },
 'age': {
   'description': 'Amount of time the ad account has been open, in days.',
   'type': 'float'
@@ -107,6 +112,11 @@ var adAccountFields = {
   'description': 'Whether DirectDeals ToS are accepted.',
   'type': 'bool'
 },
+// Commented out because this field can cause confusion or errors.
+// 'direct_deals_tos_accepted': {
+//   'description': 'Whether DirectDeals ToS are accepted.',
+//   'type': 'bool'
+// },
 'disable_reason': {
   'description': 'The reason why the account was disabled. Possible reasons are:',
   'type': 'unsigned int32'
@@ -155,6 +165,11 @@ var adAccountFields = {
   'description': 'Indicates whether a Facebook page has authorized this ad account to place ads with political content. If you try to place an ad with political content using this ad account for this page, and this page has not authorized this ad account for ads with political content, your ad will be disapproved. See Breaking Changes, Marketing API, Ads with Political Content and Facebook Advertising Policies',
   'type': 'bool'
 },
+// Commented out because this field can cause confusion or errors.
+// 'has_page_authorized_adaccount': {
+//   'description': 'Indicates whether a Facebook page has authorized this ad account to place ads with political content. If you try to place an ad with political content using this ad account for this page, and this page has not authorized this ad account for ads with political content, your ad will be disapproved. See Breaking Changes, Marketing API, Ads with Political Content and Facebook Advertising Policies',
+//   'type': 'bool'
+// },
 'io_number': {
   'description': 'The Insertion Order (IO) number.',
   'type': 'numeric string'
@@ -227,6 +242,11 @@ var adAccountFields = {
   'description': 'Whether or not to show the pre-paid checkout experience to an advertiser. If true, the advertiser is eligible for checkout, or they are already locked in to checkout and haven\'t graduated to postpay.',
   'type': 'bool'
 },
+// Commented out because this field can cause confusion or errors.
+// 'show_checkout_experience': {
+//   'description': 'Whether or not to show the pre-paid checkout experience to an advertiser. If true, the advertiser is eligible for checkout, or they are already locked in to checkout and haven\'t graduated to postpay.',
+//   'type': 'bool'
+// },
 'spend_cap': {
   'description': 'The maximum amount that can be spent by this Ad Account. When the amount is reached, all delivery stops. A value of 0 means no spending-cap. Setting a new spend cap only applies to spend AFTER the time at which you set it. Value specified in basic unit of the currency, for example \'cents\' for USD.',
   'type': 'numeric string'

--- a/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/ad-account-fields.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/ad-account-fields.js
@@ -19,10 +19,6 @@ var adAccountFields = {
   'description': 'Status of the account:',
   'type': 'unsigned int32'
 },
-'ad_account_promotable_objects': {
-  'description': 'Ad Account creation request purchase order fields associated with this Ad Account.',
-  'type': 'AdAccountPromotableObjects'
-},
 // Commented out because this field can cause confusion or errors.
 // 'ad_account_promotable_objects': {
 //   'description': 'Ad Account creation request purchase order fields associated with this Ad Account.',
@@ -108,10 +104,6 @@ var adAccountFields = {
   'description': 'This is the default value for creating L2 object of dsa_payor',
   'type': 'string'
 },
-'direct_deals_tos_accepted': {
-  'description': 'Whether DirectDeals ToS are accepted.',
-  'type': 'bool'
-},
 // Commented out because this field can cause confusion or errors.
 // 'direct_deals_tos_accepted': {
 //   'description': 'Whether DirectDeals ToS are accepted.',
@@ -159,10 +151,6 @@ var adAccountFields = {
 },
 'has_migrated_permissions': {
   'description': 'Whether this account has migrated permissions',
-  'type': 'bool'
-},
-'has_page_authorized_adaccount': {
-  'description': 'Indicates whether a Facebook page has authorized this ad account to place ads with political content. If you try to place an ad with political content using this ad account for this page, and this page has not authorized this ad account for ads with political content, your ad will be disapproved. See Breaking Changes, Marketing API, Ads with Political Content and Facebook Advertising Policies',
   'type': 'bool'
 },
 // Commented out because this field can cause confusion or errors.
@@ -237,10 +225,6 @@ var adAccountFields = {
 'rf_spec': {
   'description': 'Reach and Frequency limits configuration. See Reach and Frequency',
   'type': 'ReachFrequencySpec'
-},
-'show_checkout_experience': {
-  'description': 'Whether or not to show the pre-paid checkout experience to an advertiser. If true, the advertiser is eligible for checkout, or they are already locked in to checkout and haven\'t graduated to postpay.',
-  'type': 'bool'
 },
 // Commented out because this field can cause confusion or errors.
 // 'show_checkout_experience': {

--- a/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/ad-account-user-fields.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/ad-account-user-fields.js
@@ -14,11 +14,12 @@ var adAccountUserFields = {
   'name': {
     'description': 'User public full name',
     'type': 'string'
-  },
-  'tasks': {
-    'description': 'Tasks of App Scoped User',
-    'type': 'list<string>'
-  
   }
+  // Commented because this field is lead to mistake despite to presence in schema.
+  // 'tasks': {
+  //   'description': 'Tasks of App Scoped User',
+  //   'type': 'list<string>'
+  
+  // }
 }
   


### PR DESCRIPTION
All unnecessary and unimplemented fields are commented out. 