### PR TITLE
feat(TikTokAds): mark App ID and App Secret as required fields

### DIFF
--- a/packages/connectors/src/Sources/TikTokAds/Source.js
+++ b/packages/connectors/src/Sources/TikTokAds/Source.js
@@ -17,11 +17,13 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
       },
       AppId: {
         requiredType: "string",
+        isRequired: true,
         label: "App ID",
         description: "TikTok Ads API Application ID"
       },
       AppSecret: {
         requiredType: "string",
+        isRequired: true,
         label: "App Secret",
         description: "TikTok Ads API Application Secret"
       },


### PR DESCRIPTION
Mark App ID and App Secret as required fields so users won't miss them and avoid the `Error fetching advertiser for advertiser 7504697128674066433: To fetch advertiser data, both AppId and AppSecret must be provided` issue. 