### PR TITLE
refactor(LinkedInAds): remove unused fields

### DIFF
--- a/packages/connectors/src/Sources/LinkedInAds/LinkedInAdsAPIReference/adCampaignFields.js
+++ b/packages/connectors/src/Sources/LinkedInAds/LinkedInAdsAPIReference/adCampaignFields.js
@@ -97,10 +97,6 @@ var adCampaignFields = {
     'description': 'Amount to bid per click, impression, or other event depending on the pricing model. The amount of money as a real number string. The amount should be non-negative if the bidding strategy is manual, target cost, or cost cap bidding. The default is 0 with the currency code set to match that of the associated account. ISO currency code.',
     'type': 'object'
   },
-  'versionTag': {
-    'description': 'Each entity has a version tag associated with it. The version tag is initiated to 1 when the entity is created. Each single update to the entity increases its version tag by 1.',
-    'type': 'string'
-  },
   'status': {
     'description': 'ACTIVE - Denotes that the campaign is fully servable.',
     'type': 'string'

--- a/packages/connectors/src/Sources/LinkedInAds/LinkedInAdsAPIReference/creativesFields.js
+++ b/packages/connectors/src/Sources/LinkedInAds/LinkedInAdsAPIReference/creativesFields.js
@@ -31,10 +31,6 @@ var creativesFields = {
     'description': 'Unique ID for a creative (e.g.,SponsoredCreativeUrn). Read-only',
     'type': 'string'
   },
-  'inlineContent': {
-    'description': 'Inline content sponsored in the creative such as ugcPost in order to reduce the number of user calls.',
-    'type': 'object'
-  },
   'intendedStatus': {
     'description': 'Creative user intended status. The creative intended status is set independently from parent entity status, but parent entity status overrides creative intended status in effect. For example, parent entity status may be PAUSED while creative status is ACTIVE, in which case the creative\'s effective status is PAUSED, and not served.ACTIVE - Creative development is complete and the creative is available for review and can be served.',
     'type': 'string'


### PR DESCRIPTION
 The `versionTag` field was removed from `adCampaignFields`, and the `inlineContent` field was removed from `creativesFields`. No functional changes to data processing or API integration are introduced in this update.