### PR TITLE
Feat(Web): Destination tab updates

### DIFF
--- a/.changeset/destination-cards-in-destination-tab.md
+++ b/.changeset/destination-cards-in-destination-tab.md
@@ -1,0 +1,8 @@
+---
+'owox': minor
+---
+
+# Show Individual Destination Cards in Destination Tab
+
+The Destination tab now displays a separate card for each specific destination in the project.  
+Each card shows only the reports belonging to that destination, making it easier to find and manage reports at a glance.

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/LookerStudioJsonConfigDescription.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/LookerStudioJsonConfigDescription.tsx
@@ -19,7 +19,7 @@ export default function LookerStudioJsonConfigDescription() {
             Looker Studio.
           </p>
           <ul className='list-inside space-y-2 text-sm'>
-            <li>You can copy this JSON config to use in Looker Studio Connector.</li>
+            <li>You need to copy this JSON config to use it in the Looker Studio Connector.</li>
             <li>
               If you need to rotate a previous secret key, you can use the corresponding function in
               the menu on the destinations list.

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
@@ -11,12 +11,14 @@ import type { DataMartReport } from '../../../shared/model/types/data-mart-repor
 import { GoogleSheetsReportEditForm } from '../GoogleSheetsReportEditForm';
 import { DataDestinationProvider } from '../../../../../data-destination';
 import { ReportFormMode } from '../../../shared';
+import type { DataDestinationResponseDto } from '../../../../../data-destination/shared/services/types';
 
 interface GoogleSheetsReportEditSheetProps {
   isOpen: boolean;
   onClose: () => void;
   initialReport?: DataMartReport;
   mode: ReportFormMode;
+  preSelectedDestination?: DataDestinationResponseDto | null;
 }
 
 export function GoogleSheetsReportEditSheet({
@@ -24,6 +26,7 @@ export function GoogleSheetsReportEditSheet({
   onClose,
   initialReport,
   mode,
+  preSelectedDestination,
 }: GoogleSheetsReportEditSheetProps) {
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
@@ -82,6 +85,7 @@ export function GoogleSheetsReportEditSheet({
               onDirtyChange={handleFormDirtyChange}
               onSubmit={handleFormSubmitSuccess}
               onCancel={handleClose}
+              preSelectedDestination={preSelectedDestination}
             />
           </DataDestinationProvider>
         </SheetContent>

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -295,7 +295,7 @@ export const LookerStudioReportEditForm = forwardRef<
                               <CopyToClipboardButton
                                 content={jsonConfig}
                                 buttonText='Copy JSON Config'
-                                className='mt-1 w-full'
+                                className='my-2 w-full'
                                 size='sm'
                               />
                               <FormDescription>

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -44,6 +44,7 @@ import { ReportFormMode } from '../../../shared';
 import { Button } from '@owox/ui/components/button';
 import LookerStudioJsonConfigDescription from '../../../../../data-destination/edit/components/DataDestinationEditForm/FormDescriptions/LookerStudioJsonConfigDescription.tsx';
 import LookerStudioCacheLifetimeDescription from './LookerStudioCacheLifetimeDescription.tsx';
+import type { DataDestinationResponseDto } from '../../../../../data-destination/shared/services/types';
 
 interface LookerStudioReportEditFormProps {
   initialReport?: DataMartReport;
@@ -53,6 +54,7 @@ interface LookerStudioReportEditFormProps {
   onFormErrorChange?: (error: string | null) => void;
   onSubmit?: () => void;
   onCancel?: () => void;
+  preSelectedDestination?: DataDestinationResponseDto | null;
 }
 
 // Cache time options in seconds
@@ -82,6 +84,7 @@ export const LookerStudioReportEditForm = forwardRef<
       onFormErrorChange,
       onSubmit,
       onCancel,
+      preSelectedDestination,
     },
     ref
   ) => {
@@ -127,6 +130,7 @@ export const LookerStudioReportEditForm = forwardRef<
       onSuccess: () => {
         onSubmit?.();
       },
+      preSelectedDestination,
     });
 
     useEffect(() => {
@@ -147,9 +151,11 @@ export const LookerStudioReportEditForm = forwardRef<
           cacheLifetime: initialReport.destinationConfig.cacheLifetime,
         });
       } else if (mode === ReportFormMode.CREATE) {
-        reset({ title: '', dataDestinationId: '', cacheLifetime: 300 });
+        // Pre-select destination if provided
+        const destinationId = preSelectedDestination?.id ?? '';
+        reset({ title: '', dataDestinationId: destinationId, cacheLifetime: 300 });
       }
-    }, [initialReport, mode, reset, filteredDestinations]);
+    }, [initialReport, mode, reset, filteredDestinations, preSelectedDestination]);
 
     useEffect(() => {
       onDirtyChange?.(isDirty);
@@ -174,7 +180,7 @@ export const LookerStudioReportEditForm = forwardRef<
                       Title
                     </FormLabel>
                     <FormControl>
-                      <Input id={titleInputId} placeholder='Report title' {...field} />
+                      <Input id={titleInputId} placeholder='Enter a report title' {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -212,7 +218,7 @@ export const LookerStudioReportEditForm = forwardRef<
                                   const IconComponent = typeInfo.icon;
                                   return (
                                     <div className='flex w-full min-w-0 items-center gap-2'>
-                                      <IconComponent className='h-4 w-4 flex-shrink-0' />
+                                      <IconComponent className='flex-shrink-0' size={18} />
                                       <div className='flex min-w-0 flex-col'>
                                         <span className='truncate'>
                                           {selectedDestination.title}
@@ -233,7 +239,7 @@ export const LookerStudioReportEditForm = forwardRef<
                           return (
                             <SelectItem key={destination.id} value={destination.id}>
                               <div className='flex w-full min-w-0 items-center gap-2'>
-                                <IconComponent className='h-4 w-4 flex-shrink-0' />
+                                <IconComponent className='flex-shrink-0' size={18} />
                                 <div className='flex min-w-0 flex-col'>
                                   <span className='truncate'>{destination.title}</span>
                                 </div>
@@ -244,7 +250,7 @@ export const LookerStudioReportEditForm = forwardRef<
                       </SelectContent>
                     </Select>
                     {filteredDestinations.length === 0 && !loadingDestinations && (
-                      <Alert className='mt-2'>
+                      <Alert>
                         <AlertCircle className='h-4 w-4' />
                         <AlertTitle>No Looker Studio destinations available</AlertTitle>
                         <AlertDescription>
@@ -275,7 +281,8 @@ export const LookerStudioReportEditForm = forwardRef<
                           );
                           return (
                             <>
-                              <FormDescription className='mt-2'>
+                              <FormLabel className='mt-2'>JSON Configuration</FormLabel>
+                              <FormDescription className='mb-1'>
                                 To connect to Looker Studio, you need to copy the JSON configuration
                                 and use it in the
                                 <ExternalAnchor
@@ -285,13 +292,13 @@ export const LookerStudioReportEditForm = forwardRef<
                                   Looker Studio connector
                                 </ExternalAnchor>
                               </FormDescription>
-                              <div className='mt-2 flex items-center'>
-                                <CopyToClipboardButton
-                                  content={jsonConfig}
-                                  buttonText='Copy JSON Config'
-                                />
-                              </div>
-                              <FormDescription className='mt-2'>
+                              <CopyToClipboardButton
+                                content={jsonConfig}
+                                buttonText='Copy JSON Config'
+                                className='w-full'
+                                size='sm'
+                              />
+                              <FormDescription>
                                 <LookerStudioJsonConfigDescription />
                               </FormDescription>
                             </>
@@ -347,19 +354,17 @@ export const LookerStudioReportEditForm = forwardRef<
               type='submit'
               className='w-full'
               aria-label={
-                mode === ReportFormMode.CREATE
-                  ? 'Connect to Looker Studio'
-                  : 'Save connection settings'
+                mode === ReportFormMode.CREATE ? 'Create new report' : 'Save changes to report'
               }
               disabled={!isDirty || isSubmitting}
             >
               {isSubmitting
                 ? mode === ReportFormMode.CREATE
-                  ? 'Connecting...'
+                  ? 'Creating...'
                   : 'Saving...'
                 : mode === ReportFormMode.CREATE
-                  ? 'Connect to Looker Studio'
-                  : 'Save Changes'}
+                  ? 'Create new report'
+                  : 'Save changes to report'}
             </Button>
             {onCancel && (
               <Button

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -280,28 +280,28 @@ export const LookerStudioReportEditForm = forwardRef<
                             selectedDestination.credentials
                           );
                           return (
-                            <>
-                              <FormLabel className='mt-2'>JSON Configuration</FormLabel>
-                              <FormDescription className='mb-1'>
-                                To connect to Looker Studio, you need to copy the JSON configuration
-                                and use it in the
+                            <div className='mt-2 flex flex-col gap-1'>
+                              <FormLabel>Connect to Looker Studio</FormLabel>
+                              <FormDescription>
+                                Copy this JSON configuration from here and paste it into the{' '}
                                 <ExternalAnchor
                                   className='underline'
                                   href='https://datastudio.google.com/datasources/create?connectorId=AKfycbz6kcYn3qGuG0jVNFjcDnkXvVDiz4hewKdAFjOm-_d4VkKVcBidPjqZO991AvGL3FtM4A'
                                 >
                                   Looker Studio connector
-                                </ExternalAnchor>
+                                </ExternalAnchor>{' '}
+                                settings to enable data fetching.
                               </FormDescription>
                               <CopyToClipboardButton
                                 content={jsonConfig}
                                 buttonText='Copy JSON Config'
-                                className='w-full'
+                                className='mt-1 w-full'
                                 size='sm'
                               />
                               <FormDescription>
                                 <LookerStudioJsonConfigDescription />
                               </FormDescription>
-                            </>
+                            </div>
                           );
                         }
                         return null;

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
@@ -11,12 +11,14 @@ import type { DataMartReport } from '../../../shared/model/types/data-mart-repor
 import { LookerStudioReportEditForm } from '../LookerStudioReportEditForm';
 import { DataDestinationProvider } from '../../../../../data-destination';
 import { ReportFormMode } from '../../../shared';
+import type { DataDestinationResponseDto } from '../../../../../data-destination/shared/services/types';
 
 interface LookerStudioReportEditSheetProps {
   isOpen: boolean;
   onClose: () => void;
   initialReport?: DataMartReport;
   mode: ReportFormMode;
+  preSelectedDestination?: DataDestinationResponseDto | null;
 }
 
 export function LookerStudioReportEditSheet({
@@ -24,9 +26,11 @@ export function LookerStudioReportEditSheet({
   onClose,
   initialReport,
   mode,
+  preSelectedDestination,
 }: LookerStudioReportEditSheetProps) {
   const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
+
   const handleClose = useCallback(() => {
     if (isDirty) {
       setShowUnsavedDialog(true);
@@ -35,19 +39,16 @@ export function LookerStudioReportEditSheet({
     }
   }, [isDirty, onClose]);
 
-  // Memoize confirm close handler
   const confirmClose = useCallback(() => {
     setShowUnsavedDialog(false);
     setIsDirty(false);
     onClose();
   }, [onClose]);
 
-  // Handle form dirty state change
   const handleFormDirtyChange = useCallback((dirty: boolean) => {
     setIsDirty(dirty);
   }, []);
 
-  // Handle form submission success
   const handleFormSubmitSuccess = useCallback(() => {
     setIsDirty(false);
     onClose();
@@ -84,6 +85,7 @@ export function LookerStudioReportEditSheet({
               onDirtyChange={handleFormDirtyChange}
               onSubmit={handleFormSubmitSuccess}
               onCancel={handleClose}
+              preSelectedDestination={preSelectedDestination}
             />
           </DataDestinationProvider>
         </SheetContent>

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useGoogleSheetsReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useGoogleSheetsReportForm.ts
@@ -11,6 +11,7 @@ import {
   ReportFormMode,
   useReport,
 } from '../../shared';
+import type { DataDestinationResponseDto } from '../../../../data-destination/shared/services/types';
 
 export const GoogleSheetsReportEditFormSchema = z.object({
   title: z.string().min(1, 'Title is required'),
@@ -25,6 +26,7 @@ interface UseGoogleSheetsReportFormOptions {
   mode: ReportFormMode;
   dataMartId: string;
   onSuccess?: () => void;
+  preSelectedDestination?: DataDestinationResponseDto | null;
 }
 
 export function useGoogleSheetsReportForm({
@@ -32,6 +34,7 @@ export function useGoogleSheetsReportForm({
   mode,
   dataMartId,
   onSuccess,
+  preSelectedDestination,
 }: UseGoogleSheetsReportFormOptions) {
   const [formError, setFormError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -53,7 +56,7 @@ export function useGoogleSheetsReportForm({
         isGoogleSheetsDestinationConfig(initialReport.destinationConfig)
           ? `https://docs.google.com/spreadsheets/d/${initialReport.destinationConfig.spreadsheetId}/edit#gid=${initialReport.destinationConfig.sheetId}`
           : '',
-      dataDestinationId: initialReport?.dataDestination.id ?? '',
+      dataDestinationId: initialReport?.dataDestination.id ?? preSelectedDestination?.id ?? '', // Use preSelectedDestination here
     },
     mode: 'onTouched',
   });

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../shared/model/types/data-mart-report.ts';
 import { isLookerStudioDestinationConfig } from '../../shared/model/types/data-mart-report.ts';
 import { DestinationTypeConfigEnum, useReport } from '../../shared';
+import type { DataDestinationResponseDto } from '../../../../data-destination/shared/services/types';
 
 // Define the form schema
 const lookerStudioReportFormSchema = z.object({
@@ -23,12 +24,14 @@ interface UseLookerStudioReportFormProps {
   initialReport?: DataMartReport;
   dataMartId: string;
   onSuccess?: () => void;
+  preSelectedDestination?: DataDestinationResponseDto | null;
 }
 
 export function useLookerStudioReportForm({
   initialReport,
   dataMartId,
   onSuccess,
+  preSelectedDestination,
 }: UseLookerStudioReportFormProps) {
   const [formError, setFormError] = useState<string | null>(null);
   const { createReport, updateReport } = useReport();
@@ -37,7 +40,7 @@ export function useLookerStudioReportForm({
     resolver: zodResolver(lookerStudioReportFormSchema),
     defaultValues: {
       title: initialReport?.title ?? '',
-      dataDestinationId: initialReport?.dataDestination.id ?? '',
+      dataDestinationId: initialReport?.dataDestination.id ?? preSelectedDestination?.id ?? '',
       cacheLifetime:
         initialReport?.destinationConfig &&
         isLookerStudioDestinationConfig(initialReport.destinationConfig)

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsActionsCell/GoogleSheetsActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsActionsCell/GoogleSheetsActionsCell.tsx
@@ -25,7 +25,6 @@ export function GoogleSheetsActionsCell({
   onDeleteSuccess,
   onEditReport,
 }: GoogleSheetsActionsCellProps) {
-  const [, setIsDeleting] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -37,15 +36,12 @@ export function GoogleSheetsActionsCell({
   // Memoize delete handler to avoid unnecessary re-renders
   const handleDelete = useCallback(async () => {
     try {
-      setIsDeleting(true);
       await deleteReport(row.original.id);
       await fetchReportsByDataMartId(row.original.dataMart.id);
       onDeleteSuccess?.();
       setIsDeleteDialogOpen(false);
     } catch (error) {
       console.error('Failed to delete Google Sheet:', error);
-    } finally {
-      setIsDeleting(false);
     }
   }, [
     deleteReport,

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsActionsCell/GoogleSheetsActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsActionsCell/GoogleSheetsActionsCell.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@owox/ui/components/dropdown-menu';
+import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
 import { getGoogleSheetTabUrl } from '../../../shared';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report.ts';
 import { isGoogleSheetsDestinationConfig } from '../../../shared/model/types/data-mart-report.ts';
@@ -16,7 +17,7 @@ import { useReport } from '../../../shared';
 interface GoogleSheetsActionsCellProps {
   row: { original: DataMartReport };
   onDeleteSuccess?: () => void;
-  onEditReport?: (reportId: string) => void;
+  onEditReport?: (report: DataMartReport) => void;
 }
 
 export function GoogleSheetsActionsCell({
@@ -24,9 +25,10 @@ export function GoogleSheetsActionsCell({
   onDeleteSuccess,
   onEditReport,
 }: GoogleSheetsActionsCellProps) {
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [, setIsDeleting] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { deleteReport, fetchReportsByDataMartId, runReport } = useReport();
 
   // Generate unique ID for the actions menu
@@ -39,6 +41,7 @@ export function GoogleSheetsActionsCell({
       await deleteReport(row.original.id);
       await fetchReportsByDataMartId(row.original.dataMart.id);
       onDeleteSuccess?.();
+      setIsDeleteDialogOpen(false);
     } catch (error) {
       console.error('Failed to delete Google Sheet:', error);
     } finally {
@@ -53,9 +56,9 @@ export function GoogleSheetsActionsCell({
   ]);
 
   const handleEdit = useCallback(() => {
-    onEditReport?.(row.original.id);
+    onEditReport?.(row.original);
     setMenuOpen(false);
-  }, [onEditReport, row.original.id]);
+  }, [onEditReport, row.original]);
 
   const handleRun = useCallback(async () => {
     try {
@@ -67,6 +70,11 @@ export function GoogleSheetsActionsCell({
       setIsRunning(false);
     }
   }, [runReport, row.original.id]);
+
+  const handleDeleteClick = useCallback(() => {
+    setIsDeleteDialogOpen(true);
+    setMenuOpen(false);
+  }, []);
 
   return (
     <div
@@ -99,55 +107,69 @@ export function GoogleSheetsActionsCell({
           >
             Edit report
           </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={e => {
-              e.stopPropagation();
-              void handleRun();
-            }}
-            disabled={isRunning}
-            role='menuitem'
-            aria-label={isRunning ? 'Running report...' : `Run report: ${row.original.title}`}
-            className='flex items-center gap-1'
-          >
-            {isRunning ? 'Running...' : 'Run report'}
-            <Play className='h-3 w-3' aria-hidden='true' />
-          </DropdownMenuItem>
           {isGoogleSheetsDestinationConfig(row.original.destinationConfig) && (
-            <DropdownMenuItem asChild>
-              <a
-                href={getGoogleSheetTabUrl(
-                  row.original.destinationConfig.spreadsheetId,
-                  row.original.destinationConfig.sheetId
-                )}
-                target='_blank'
-                rel='noopener noreferrer'
-                className='flex items-center gap-1'
-                role='menuitem'
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
                 onClick={e => {
                   e.stopPropagation();
+                  void handleRun();
                 }}
+                disabled={isRunning}
+                role='menuitem'
+                aria-label={isRunning ? 'Running report...' : `Run report: ${row.original.title}`}
+                className='flex items-center gap-1'
               >
-                Open document
-                <SquareArrowOutUpRight className='h-3 w-3' aria-hidden='true' />
-              </a>
-            </DropdownMenuItem>
+                {isRunning ? 'Running...' : 'Run report'}
+                <Play className='h-3 w-3' aria-hidden='true' />
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a
+                  href={getGoogleSheetTabUrl(
+                    row.original.destinationConfig.spreadsheetId,
+                    row.original.destinationConfig.sheetId
+                  )}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='flex items-center gap-1'
+                  role='menuitem'
+                  onClick={e => {
+                    e.stopPropagation();
+                  }}
+                >
+                  Open document
+                  <SquareArrowOutUpRight className='h-3 w-3' aria-hidden='true' />
+                </a>
+              </DropdownMenuItem>
+            </>
           )}
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className='text-red-600'
             onClick={e => {
               e.stopPropagation();
-              void handleDelete();
+              handleDeleteClick();
             }}
-            disabled={isDeleting}
             role='menuitem'
-            aria-label={isDeleting ? 'Deleting report...' : `Delete report: ${row.original.title}`}
+            aria-label={`Delete report: ${row.original.title}`}
           >
-            {isDeleting ? 'Deleting...' : 'Delete'}
+            Delete
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <ConfirmationDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        title='Delete Report'
+        description={`Are you sure you want to delete "${row.original.title}"? This action cannot be undone.`}
+        confirmLabel='Delete'
+        cancelLabel='Cancel'
+        onConfirm={() => {
+          void handleDelete();
+        }}
+        variant='destructive'
+      />
     </div>
   );
 }

--- a/apps/web/src/features/data-marts/reports/list/components/LookerStudioActionsCell/LookerStudioActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/LookerStudioActionsCell/LookerStudioActionsCell.tsx
@@ -14,7 +14,7 @@ import { useReport } from '../../../shared';
 interface LookerStudioActionsCellProps {
   row: { original: DataMartReport };
   onDeleteSuccess?: () => void;
-  onEditReport?: (reportId: string) => void;
+  onEditReport?: (report: DataMartReport) => void;
 }
 
 export function LookerStudioActionsCell({
@@ -50,9 +50,9 @@ export function LookerStudioActionsCell({
   ]);
 
   const handleEdit = useCallback(() => {
-    onEditReport?.(row.original.id);
+    onEditReport?.(row.original);
     setMenuOpen(false);
-  }, [onEditReport, row.original.id]);
+  }, [onEditReport, row.original]);
 
   return (
     <div

--- a/apps/web/src/features/data-marts/reports/list/components/columns/columns.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/columns/columns.tsx
@@ -27,7 +27,7 @@ export const getGoogleSheetsColumns = ({
   onEditReport,
 }: {
   onDeleteSuccess?: () => void;
-  onEditReport?: (reportId: string) => void;
+  onEditReport?: (report: DataMartReport) => void;
 } = {}): (ColumnDef<DataMartReport> & {
   meta?: { hidden?: boolean; title?: string };
 })[] => [
@@ -83,7 +83,7 @@ export const getLookerStudioColumns = ({
   onEditReport,
 }: {
   onDeleteSuccess?: () => void;
-  onEditReport?: (reportId: string) => void;
+  onEditReport?: (report: DataMartReport) => void;
 } = {}): (ColumnDef<DataMartReport> & {
   meta?: { hidden?: boolean; title?: string };
 })[] => [

--- a/apps/web/src/features/data-marts/reports/shared/components/DestinationCard/DestinationCard.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/DestinationCard/DestinationCard.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import {
+  CollapsibleCard,
+  CollapsibleCardHeader,
+  CollapsibleCardHeaderTitle,
+  CollapsibleCardContent,
+  CollapsibleCardFooter,
+  CollapsibleCardHeaderActions,
+} from '../../../../../../shared/components/CollapsibleCard';
+import { DataDestinationTypeModel } from '../../../../../data-destination/shared/types';
+import {
+  DataDestinationType,
+  DataDestinationStatus,
+} from '../../../../../data-destination/shared/enums';
+import type { DataDestinationResponseDto } from '../../../../../data-destination/shared/services/types';
+import type { DataMartReport } from '../../model/types/data-mart-report';
+import { GoogleSheetsReportsTable } from '../../../list/components/GoogleSheetsReportsTable/GoogleSheetsReportsTable';
+import { LookerStudioReportsTable } from '../../../list/components/LookerStudioReportsTable/LookerStudioReportsTable';
+import { GoogleSheetsReportEditSheet } from '../../../edit/components/GoogleSheetsReportEditSheet';
+import { LookerStudioReportEditSheet } from '../../../edit/components/LookerStudioReportEditSheet';
+import { ReportFormMode } from '../../../shared';
+import { Button } from '../../../../../../shared/components/Button';
+import { PlusIcon } from 'lucide-react';
+
+interface DestinationCardProps {
+  destination: DataDestinationResponseDto;
+}
+
+export function DestinationCard({ destination }: DestinationCardProps) {
+  const destinationInfo = DataDestinationTypeModel.getInfo(destination.type);
+  const [isAddReportOpen, setIsAddReportOpen] = useState(false);
+  const [isEditReportOpen, setIsEditReportOpen] = useState(false);
+  const [editingReport, setEditingReport] = useState<DataMartReport | null>(null);
+
+  // Only show destinations that are active
+  if (destinationInfo.status !== DataDestinationStatus.ACTIVE) {
+    return null;
+  }
+
+  const handleAddReport = () => {
+    setIsAddReportOpen(true);
+  };
+
+  const handleEditReport = (report: DataMartReport) => {
+    setEditingReport(report);
+    setIsEditReportOpen(true);
+  };
+
+  const handleCloseAddReport = () => {
+    setIsAddReportOpen(false);
+  };
+
+  const handleCloseEditReport = () => {
+    setIsEditReportOpen(false);
+    setEditingReport(null);
+  };
+
+  // Determine which edit sheet to show based on destination type
+  const renderAddReportSheet = () => {
+    if (destination.type === DataDestinationType.GOOGLE_SHEETS) {
+      return (
+        <GoogleSheetsReportEditSheet
+          isOpen={isAddReportOpen}
+          onClose={handleCloseAddReport}
+          mode={ReportFormMode.CREATE}
+          preSelectedDestination={destination}
+        />
+      );
+    } else if (destination.type === DataDestinationType.LOOKER_STUDIO) {
+      return (
+        <LookerStudioReportEditSheet
+          isOpen={isAddReportOpen}
+          onClose={handleCloseAddReport}
+          mode={ReportFormMode.CREATE}
+          preSelectedDestination={destination}
+        />
+      );
+    }
+    return null;
+  };
+
+  const renderEditReportSheet = () => {
+    if (!editingReport) return null;
+
+    if (destination.type === DataDestinationType.GOOGLE_SHEETS) {
+      return (
+        <GoogleSheetsReportEditSheet
+          isOpen={isEditReportOpen}
+          onClose={handleCloseEditReport}
+          initialReport={editingReport}
+          mode={ReportFormMode.EDIT}
+        />
+      );
+    } else if (destination.type === DataDestinationType.LOOKER_STUDIO) {
+      return (
+        <LookerStudioReportEditSheet
+          isOpen={isEditReportOpen}
+          onClose={handleCloseEditReport}
+          initialReport={editingReport}
+          mode={ReportFormMode.EDIT}
+        />
+      );
+    }
+    return null;
+  };
+
+  // Render the appropriate table based on destination type
+  const renderDestinationTable = () => {
+    if (destination.type === DataDestinationType.GOOGLE_SHEETS) {
+      return <GoogleSheetsReportsTable destination={destination} onEditReport={handleEditReport} />;
+    } else if (destination.type === DataDestinationType.LOOKER_STUDIO) {
+      return <LookerStudioReportsTable destination={destination} onEditReport={handleEditReport} />;
+    }
+    return null;
+  };
+
+  return (
+    <>
+      <CollapsibleCard name={destination.id} collapsible defaultCollapsed={false}>
+        <CollapsibleCardHeader>
+          <CollapsibleCardHeaderTitle
+            icon={destinationInfo.icon}
+            tooltip={`List of reports to ${destinationInfo.displayName}`}
+          >
+            {destination.title}
+          </CollapsibleCardHeaderTitle>
+          <CollapsibleCardHeaderActions>
+            <Button onClick={handleAddReport} variant='outline' size='sm'>
+              <PlusIcon className='h-4 w-4' />
+              Add Report
+            </Button>
+          </CollapsibleCardHeaderActions>
+        </CollapsibleCardHeader>
+        <CollapsibleCardContent>{renderDestinationTable()}</CollapsibleCardContent>
+        <CollapsibleCardFooter></CollapsibleCardFooter>
+      </CollapsibleCard>
+
+      {renderAddReportSheet()}
+      {renderEditReportSheet()}
+    </>
+  );
+}

--- a/apps/web/src/features/data-marts/reports/shared/components/DestinationCard/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/components/DestinationCard/index.ts
@@ -1,0 +1,1 @@
+export { DestinationCard } from './DestinationCard';

--- a/apps/web/src/features/data-marts/reports/shared/components/EmptyDataMartDestinationsState/EmptyDataMartDestinationsState.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/EmptyDataMartDestinationsState/EmptyDataMartDestinationsState.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@owox/ui/components/button';
+import { ArchiveRestore, ChevronRight } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+export function EmptyDataMartDestinationsState() {
+  return (
+    <div className='dm-card'>
+      <div className='dm-empty-state'>
+        <ArchiveRestore className='dm-empty-state-ico' strokeWidth={1} />
+        <h2 className='dm-empty-state-title'>Google Sheets, Looker Studio… and friends!</h2>
+        <p className='dm-empty-state-subtitle'>
+          To send your Data Mart's data to your favorite tools, create a Destination first.
+        </p>
+        <Button variant='outline' asChild>
+          <Link to='/data-destinations' className='flex items-center gap-1'>
+            Go to Destinations
+            <ChevronRight className='h-4 w-4' />
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/reports/shared/components/EmptyDataMartDestinationsState/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/components/EmptyDataMartDestinationsState/index.ts
@@ -1,0 +1,1 @@
+export { EmptyDataMartDestinationsState } from './EmptyDataMartDestinationsState';

--- a/apps/web/src/features/data-marts/reports/shared/components/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/components/index.ts
@@ -1,0 +1,3 @@
+export * from './DestinationCard';
+export * from './ReportHoverCard';
+export * from './EmptyDataMartDestinationsState';

--- a/apps/web/src/features/data-marts/reports/shared/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/index.ts
@@ -3,3 +3,4 @@ export * from './model';
 export * from './services';
 export * from './enums';
 export * from './models';
+export * from './components';

--- a/apps/web/src/features/data-marts/reports/shared/model/context/reducer.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/context/reducer.ts
@@ -1,9 +1,11 @@
 import { type ReportAction, ReportActionType } from './types.ts';
 import type { DataMartReport } from '../types/data-mart-report.ts';
+import type { DataDestinationResponseDto } from '../../../../../data-destination/shared/services/types';
 import { ReportStatusEnum } from '../../enums';
 
 export interface ReportState {
   reports: DataMartReport[];
+  destinations: DataDestinationResponseDto[];
   currentReport: DataMartReport | null;
   loading: boolean;
   error: string | null;
@@ -12,6 +14,7 @@ export interface ReportState {
 
 export const initialReportState: ReportState = {
   reports: [],
+  destinations: [],
   currentReport: null,
   loading: false,
   error: null,
@@ -34,6 +37,13 @@ export function reducer(state: ReportState, action: ReportAction): ReportState {
       return {
         ...state,
         reports: action.payload,
+        loading: false,
+        error: null,
+      };
+    case ReportActionType.FETCH_DESTINATIONS_SUCCESS:
+      return {
+        ...state,
+        destinations: action.payload,
         loading: false,
         error: null,
       };
@@ -70,6 +80,7 @@ export function reducer(state: ReportState, action: ReportAction): ReportState {
       };
     case ReportActionType.FETCH_REPORTS_ERROR:
     case ReportActionType.FETCH_REPORT_ERROR:
+    case ReportActionType.FETCH_DESTINATIONS_ERROR:
     case ReportActionType.CREATE_REPORT_ERROR:
     case ReportActionType.UPDATE_REPORT_ERROR:
     case ReportActionType.DELETE_REPORT_ERROR:

--- a/apps/web/src/features/data-marts/reports/shared/model/context/types.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/context/types.ts
@@ -1,11 +1,16 @@
 import React from 'react';
 import type { ReportState } from './reducer.ts';
 import type { DataMartReport } from '../types/data-mart-report.ts';
+import type { DataDestinationResponseDto } from '../../../../../data-destination/shared/services/types';
 
 export enum ReportActionType {
   FETCH_REPORTS_START = 'FETCH_REPORTS_START',
   FETCH_REPORTS_SUCCESS = 'FETCH_REPORTS_SUCCESS',
   FETCH_REPORTS_ERROR = 'FETCH_REPORTS_ERROR',
+
+  FETCH_DESTINATIONS_START = 'FETCH_DESTINATIONS_START',
+  FETCH_DESTINATIONS_SUCCESS = 'FETCH_DESTINATIONS_SUCCESS',
+  FETCH_DESTINATIONS_ERROR = 'FETCH_DESTINATIONS_ERROR',
 
   FETCH_REPORT_START = 'FETCH_REPORT_START',
   FETCH_REPORT_SUCCESS = 'FETCH_REPORT_SUCCESS',
@@ -36,6 +41,9 @@ export type ReportAction =
   | { type: ReportActionType.FETCH_REPORTS_START }
   | { type: ReportActionType.FETCH_REPORTS_SUCCESS; payload: DataMartReport[] }
   | { type: ReportActionType.FETCH_REPORTS_ERROR; payload: string }
+  | { type: ReportActionType.FETCH_DESTINATIONS_START }
+  | { type: ReportActionType.FETCH_DESTINATIONS_SUCCESS; payload: DataDestinationResponseDto[] }
+  | { type: ReportActionType.FETCH_DESTINATIONS_ERROR; payload: string }
   | { type: ReportActionType.FETCH_REPORT_START }
   | { type: ReportActionType.FETCH_REPORT_SUCCESS; payload: DataMartReport }
   | { type: ReportActionType.FETCH_REPORT_ERROR; payload: string }

--- a/apps/web/src/features/data-marts/reports/shared/model/hooks/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useReport';
+export * from './useColumnVisibility';

--- a/apps/web/src/features/data-marts/reports/shared/model/hooks/useColumnVisibility.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/hooks/useColumnVisibility.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useMemo } from 'react';
+import type { ColumnDef } from '@tanstack/react-table';
+
+// Define proper type for column meta with hidden property
+interface ColumnMetaWithHidden {
+  hidden?: boolean;
+}
+
+/**
+ * Custom hook for managing column visibility functionality
+ * @param columns - Table columns configuration
+ * @returns Object containing column visibility state and setter
+ */
+export function useColumnVisibility<TData>(columns: ColumnDef<TData>[]) {
+  /**
+   * Generates default hidden columns configuration
+   */
+  const defaultHiddenColumns: Record<string, boolean> = useMemo(
+    () =>
+      Array.isArray(columns)
+        ? (Object.fromEntries(
+            columns
+              .filter(col => col.meta && (col.meta as ColumnMetaWithHidden).hidden)
+              .map(col => [
+                'id' in col && col.id
+                  ? col.id
+                  : 'accessorKey' in col && typeof col.accessorKey === 'string'
+                    ? col.accessorKey
+                    : undefined,
+                false,
+              ])
+              .filter(([key]) => key !== undefined)
+          ) as Record<string, boolean>)
+        : {},
+    [columns]
+  );
+
+  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>({});
+
+  /**
+   * Initialize column visibility with default hidden columns
+   */
+  useEffect(() => {
+    setColumnVisibility(defaultHiddenColumns);
+  }, [defaultHiddenColumns]);
+
+  return {
+    columnVisibility,
+    setColumnVisibility,
+    defaultHiddenColumns,
+  };
+}

--- a/apps/web/src/features/data-marts/reports/shared/model/hooks/useReport.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/hooks/useReport.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react';
 import { reportService, reportStatusPollingService } from '../../services';
+import { dataDestinationService } from '../../../../../data-destination/shared/services';
 import type { CreateReportRequestDto, UpdateReportRequestDto } from '../../services';
 import type { ReportStatusPollingConfig } from '../../services';
 import { useReportContext, ReportActionType } from '../context';
@@ -7,6 +8,19 @@ import { mapReportDtoToEntity } from '../mappers';
 
 export function useReport() {
   const { state, dispatch } = useReportContext();
+
+  const fetchDestinations = useCallback(async () => {
+    dispatch({ type: ReportActionType.FETCH_DESTINATIONS_START });
+    try {
+      const destinations = await dataDestinationService.getDataDestinations();
+      dispatch({ type: ReportActionType.FETCH_DESTINATIONS_SUCCESS, payload: destinations });
+    } catch (error) {
+      dispatch({
+        type: ReportActionType.FETCH_DESTINATIONS_ERROR,
+        payload: error instanceof Error ? error.message : 'Failed to fetch destinations',
+      });
+    }
+  }, [dispatch]);
 
   const fetchReports = useCallback(async () => {
     dispatch({ type: ReportActionType.FETCH_REPORTS_START });
@@ -184,11 +198,13 @@ export function useReport() {
   }, [stopAllPolling]);
 
   return {
+    destinations: state.destinations,
     reports: state.reports,
     currentReport: state.currentReport,
     loading: state.loading,
     error: state.error,
     polledReportIds: state.polledReportIds,
+    fetchDestinations,
     fetchReports,
     fetchReportsByDataMartId,
     fetchReportById,

--- a/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
+++ b/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
@@ -1,59 +1,61 @@
+import { useEffect, useState } from 'react';
 import {
-  CollapsibleCard,
-  CollapsibleCardHeader,
-  CollapsibleCardHeaderTitle,
-  CollapsibleCardContent,
-  CollapsibleCardFooter,
-} from '../../../shared/components/CollapsibleCard';
-import { GoogleSheetsIcon, LookerStudioIcon } from '../../../shared';
-import { ReportsProvider } from '../../../features/data-marts/reports/shared';
-import {
-  GoogleSheetsReportsTable,
-  LookerStudioReportsTable,
-} from '../../../features/data-marts/reports/list';
-import {
-  DataDestinationStatus,
-  DataDestinationType,
-  DataDestinationTypeModel,
-} from '../../../features/data-destination';
+  ReportsProvider,
+  useReport,
+  DestinationCard,
+  EmptyDataMartDestinationsState,
+} from '../../../features/data-marts/reports/shared';
+import { useOutletContext } from 'react-router-dom';
+import type { DataMartContextType } from '../../../features/data-marts/edit/model/context/types';
+import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
+
+function DataMartDestinationsContentInner() {
+  const { dataMart } = useOutletContext<DataMartContextType>();
+  const { destinations, fetchDestinations, fetchReportsByDataMartId } = useReport();
+
+  // Add loading state management
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Fetch destinations and reports when component mounts
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsLoading(true);
+      try {
+        if (!dataMart) return;
+        await Promise.all([fetchDestinations(), fetchReportsByDataMartId(dataMart.id)]);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void fetchData();
+  }, [fetchDestinations, fetchReportsByDataMartId, dataMart]);
+
+  if (!dataMart) {
+    return null;
+  }
+
+  return (
+    <div className='flex flex-col gap-4'>
+      {isLoading ? (
+        <SkeletonList />
+      ) : destinations.length === 0 ? (
+        <EmptyDataMartDestinationsState />
+      ) : (
+        destinations.map(destination => (
+          <DestinationCard key={destination.id} destination={destination} />
+        ))
+      )}
+    </div>
+  );
+}
 
 export default function DataMartDestinationsContent() {
   return (
-    <div className='flex flex-col gap-4'>
-      <ReportsProvider>
-        <CollapsibleCard name='googlesheets' collapsible defaultCollapsed={false}>
-          <CollapsibleCardHeader>
-            <CollapsibleCardHeaderTitle
-              icon={GoogleSheetsIcon}
-              tooltip='List of report exports to Google Sheets'
-            >
-              Google Sheets
-            </CollapsibleCardHeaderTitle>
-          </CollapsibleCardHeader>
-          <CollapsibleCardContent>
-            <GoogleSheetsReportsTable></GoogleSheetsReportsTable>
-          </CollapsibleCardContent>
-          <CollapsibleCardFooter></CollapsibleCardFooter>
-        </CollapsibleCard>
-
-        {DataDestinationTypeModel.getInfo(DataDestinationType.LOOKER_STUDIO).status ===
-          DataDestinationStatus.ACTIVE && (
-          <CollapsibleCard name='lookerstudio' collapsible defaultCollapsed={false}>
-            <CollapsibleCardHeader>
-              <CollapsibleCardHeaderTitle
-                icon={LookerStudioIcon}
-                tooltip='Looker Studio Destinations that make this Data Mart available as a data source in Looker Studio connector'
-              >
-                Looker Studio
-              </CollapsibleCardHeaderTitle>
-            </CollapsibleCardHeader>
-            <CollapsibleCardContent>
-              <LookerStudioReportsTable></LookerStudioReportsTable>
-            </CollapsibleCardContent>
-            <CollapsibleCardFooter></CollapsibleCardFooter>
-          </CollapsibleCard>
-        )}
-      </ReportsProvider>
-    </div>
+    <ReportsProvider>
+      <DataMartDestinationsContentInner />
+    </ReportsProvider>
   );
 }

--- a/apps/web/src/shared/components/CollapsibleCard/CollapsibleCardHeaderTitle.tsx
+++ b/apps/web/src/shared/components/CollapsibleCard/CollapsibleCardHeaderTitle.tsx
@@ -31,7 +31,7 @@ export function CollapsibleCardHeaderTitle({
       <div className='flex items-center gap-2'>
         {/* Card icon */}
         <div className='text-foreground flex h-7 w-7 items-center justify-center rounded-sm bg-gray-200/50 transition-colors duration-200 group-hover:bg-gray-200/75 dark:bg-white/8 dark:group-hover:bg-white/10'>
-          <Icon className='h-4 w-4' strokeWidth={2.25} />
+          <Icon size={18} />
         </div>
         <CardTitle className='text-md text-foreground leading-none font-medium'>
           {children}

--- a/packages/ui/src/components/common/copyable-field.tsx
+++ b/packages/ui/src/components/common/copyable-field.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+import { cn } from '@owox/ui/lib/utils';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@owox/ui/components/tooltip';
+
+interface CopyableFieldProps {
+  value: string;
+  children?: React.ReactNode;
+}
+
+export function CopyableField({ value, children }: CopyableFieldProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!value) return;
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            role='button'
+            tabIndex={0}
+            onClick={handleCopy}
+            onKeyDown={e => e.key === 'Enter' && handleCopy()}
+            className={cn(
+              'flex cursor-pointer items-center justify-between gap-2 select-none',
+              'text-muted-foreground border-input rounded-md border px-3 py-1.5 text-sm',
+              'hover:bg-accent hover:text-accent-foreground transition-colors'
+            )}
+          >
+            <span className='truncate'>{children || value || 'No data'}</span>
+            {copied ? <Check className='h-4 w-4 text-green-500' /> : <Copy className='h-4 w-4' />}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{copied ? 'Copied!' : 'Click to copy'}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
# Display Individual Destination Cards in Destination Tab

## Description
This update changes the Destination tab to display a separate card for each specific destination in the project, instead of grouping reports by destination type.


<img width="1899" height="2413" alt="Frame 23137228" src="https://github.com/user-attachments/assets/924a0226-f0d4-4555-831f-b62863f32b88" />


## What’s new
- Shows **one card per destination**, making the layout more granular and clear.  
- Each card lists **only the reports** that belong to that specific destination.  
- Updated data fetching to retrieve the full destinations list and filter reports by destination ID.  

## Why
To provide a clearer, more organized view of destinations, making it easier for users to locate and manage reports tied to specific destinations.
