### PR TITLE
fix: update MaxFetchingDays property

### DIFF
--- a/packages/connectors/src/Sources/BankOfCanada/Source.js
+++ b/packages/connectors/src/Sources/BankOfCanada/Source.js
@@ -43,7 +43,7 @@ constructor( configRange ) {
     MaxFetchingDays: {
       requiredType: "number",
       isRequired: true,
-      value: 30,
+      default: 30,
       label: "Max Fetching Days",
       description: "Maximum number of days to fetch data for"
     }

--- a/packages/connectors/src/Sources/CriteoAds/Source.js
+++ b/packages/connectors/src/Sources/CriteoAds/Source.js
@@ -58,7 +58,7 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
       },
       MaxFetchingDays: {
         requiredType: "number",
-        value: 30,
+        default: 30,
         label: "Max Fetching Days",
         description: "Maximum number of days to fetch data for"
       },


### PR DESCRIPTION
Fixes the _MaxFetchingDays_ property in both BankOfCanada and CriteoAds sources to use `default` instead of `value` for consistency and correct configuration behavior.