### PR TITLE
fix(FacebookMarketing): update API base URL and refactor insights data fetching logic

### DIFF
--- a/.changeset/giant-rabbits-grin.md
+++ b/.changeset/giant-rabbits-grin.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Update API version and refactor insights data fetching logic
+
+- Updated the Facebook Graph API base URL to use version 23.0 directly in the code, removing the configurable ApiBaseUrl parameter.
+- Refactored the insights data fetching logic to pass the API base URL explicitly to helper methods.
+- Modified _fetchInsightsData and_buildInsightsUrl to accept and use the API base URL as a parameter.
+- Removed the unsupported activity_recency field from adAccountInsightsFields.
+- Improved code clarity and maintainability by simplifying how the API URL is constructed and used throughout the Facebook Marketing source integration.

--- a/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/ad-account-insights-fields.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/ad-account-insights-fields.js
@@ -28,10 +28,6 @@ var adAccountInsightsFields = {
     'description': 'The total number of actions people took that are attributed to your ads. Actions may include engagement, clicks or conversions.',
     'type': 'list<AdsActionStats>'
   },
-  'activity_recency': {
-    'description': 'activity_recency',
-    'type': 'string'
-  },
   'ad_click_actions': {
     'description': 'ad_click_actions',
     'type': 'list<AdsActionStats>'


### PR DESCRIPTION
- Updated the Facebook Graph API base URL to use version 23.0 directly in the code, removing the configurable ApiBaseUrl parameter.
- Refactored the insights data fetching logic to pass the API base URL explicitly to helper methods.
- Modified `_fetchInsightsData` and `_buildInsightsUrl` to accept and use the API base URL as a parameter.
- Removed the unused activity_recency field from adAccountInsightsFields.
- Improved code clarity and maintainability by simplifying how the API URL is constructed and used throughout the Facebook Marketing source integration.