### PR TITLE
org: fix preparing release

### DIFF
--- a/.changeset/connector-target-setup-editable-defaults.md
+++ b/.changeset/connector-target-setup-editable-defaults.md
@@ -6,5 +6,5 @@
 
 - Added editable dataset/database and table fields with sensible defaults
 - Defaults come from sanitized destination name: dataset/database `${sanitizedDestinationName}_owox`, table `${sanitizedDestinationName}`
-- Inline validation: required, `^[A-Za-z][A-Za-z0-9_]*$`, accessible error state
+- Inline validation: required, `^[A-Za-z][A-Za-z0-9_]*$ `, accessible error state
 - Helper text shows full path: `{dataset}.{table}`

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -39,8 +39,9 @@ jobs:
 
       - name: Commit fixed changelogs
         run: |
+          set -e
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git add .
-          git commit -m "chore: fix changelog headings and update package-lock.json" || echo "No changes to commit"
+          git commit -m "chore: fix changelog headings and update package-lock.json"
           git push


### PR DESCRIPTION
This pull request makes a small update to the release workflow by ensuring that the changelog commit step fails if there are no changes to commit, rather than silently continuing. This improves the reliability of the workflow.