### PR TITLE
refactor(idp-protocol): streamline package.json and enhance NullIdpPr…

### DIFF
--- a/packages/idp-protocol/package.json
+++ b/packages/idp-protocol/package.json
@@ -41,8 +41,7 @@
     "typescript": "^5.7.3"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "exports": {
     ".": {

--- a/packages/idp-protocol/src/middleware/protocol-middleware.ts
+++ b/packages/idp-protocol/src/middleware/protocol-middleware.ts
@@ -177,5 +177,7 @@ export class IdpProtocolMiddleware {
       const fullPath = `${this.basePath}${path}`;
       app.all(fullPath, this.createRouteHandler(handler));
     });
+
+    this.provider.registerRoutes(app);
   }
 }

--- a/packages/idp-protocol/src/providers/null-provider.ts
+++ b/packages/idp-protocol/src/providers/null-provider.ts
@@ -1,6 +1,6 @@
 import { IdpProvider } from '../types/provider.js';
 import { AuthResult, Payload } from '../types/models.js';
-import { Request, Response, NextFunction } from 'express';
+import { Express, Request, Response, NextFunction } from 'express';
 
 /**
  * NULL IDP Provider - single user, single project
@@ -29,8 +29,8 @@ export class NullIdpProvider implements IdpProvider {
     };
   }
 
-  signInMiddleware(_req: Request, res: Response, _next: NextFunction): Promise<void> {
-    const isLocalhost = _req.hostname === 'localhost' || _req.hostname === '127.0.0.1';
+  signInMiddleware(req: Request, res: Response, _next: NextFunction): Promise<void> {
+    const isLocalhost = req.hostname === 'localhost' || req.hostname === '127.0.0.1';
 
     res.cookie('refreshToken', this.defaultRefreshToken, {
       httpOnly: true,
@@ -46,18 +46,22 @@ export class NullIdpProvider implements IdpProvider {
     return Promise.resolve(res.redirect('/'));
   }
 
-  accessTokenMiddleware(_req: Request, res: Response, _next: NextFunction): Promise<Response> {
-    if (!_req.cookies.refreshToken) {
+  accessTokenMiddleware(req: Request, res: Response, _next: NextFunction): Promise<Response> {
+    if (!req.cookies.refreshToken) {
       return Promise.resolve(res.status(401).json({ message: 'Unauthorized' }));
     }
     return Promise.resolve(res.json({ accessToken: this.defaultAccessToken }));
   }
 
-  userApiMiddleware(_req: Request, res: Response, _next: NextFunction): Promise<Response<Payload>> {
-    if (!_req.cookies.refreshToken) {
+  userApiMiddleware(req: Request, res: Response, _next: NextFunction): Promise<Response<Payload>> {
+    if (!req.cookies.refreshToken) {
       return Promise.resolve(res.status(401).json({ message: 'Unauthorized' }));
     }
     return Promise.resolve(res.json(this.defaultPayload));
+  }
+
+  registerRoutes(_app: Express): void {
+    // Nothing to register
   }
 
   async initialize(): Promise<void> {

--- a/packages/idp-protocol/src/types/provider.ts
+++ b/packages/idp-protocol/src/types/provider.ts
@@ -1,5 +1,5 @@
 import { Payload, AuthResult } from './models.js';
-import { NextFunction, Request, Response } from 'express';
+import { Express, NextFunction, Request, Response } from 'express';
 
 /**
  * Simplified IDP Provider interface.
@@ -32,6 +32,13 @@ export interface IdpProvider {
    * If the IDP implementation does not support user, this method should call the `next()` function.
    */
   userApiMiddleware(req: Request, res: Response, next: NextFunction): Promise<Response<Payload>>;
+
+  /**
+   * Register routes with the express app.
+   * @param app - The express app to register the routes with.
+   * @param basePath - The base path to register the routes with.
+   */
+  registerRoutes(app: Express): void;
 
   /**
    * Introspect a token


### PR DESCRIPTION
…ovider

- Removed 'src' from the files list in package.json to simplify package structure.
- Added registerRoutes method to NullIdpProvider interface and implemented it in the class.
- Updated middleware methods to use 'req' instead of '_req' for consistency and clarity.