### PR TITLE
fix(backend): fixed scheduled triggers error with data mart

### DIFF
--- a/apps/backend/src/common/scheduler/services/fetchers/time-based-trigger-fetcher.service.ts
+++ b/apps/backend/src/common/scheduler/services/fetchers/time-based-trigger-fetcher.service.ts
@@ -93,6 +93,7 @@ export class TimeBasedTriggerFetcherService<T extends TimeBasedTrigger> {
   private async findTriggersReadyForProcessing(currentTime: Date): Promise<T[]> {
     return this.repository
       .createQueryBuilder('t')
+      .leftJoinAndSelect('t.dataMart', 'dataMart')
       .where('t.nextRunTimestamp IS NOT NULL')
       .andWhere('t.nextRunTimestamp <= :currentTime', { currentTime })
       .andWhere('t.isActive = true')


### PR DESCRIPTION
### Query Before
```sql
SELECT
  "t"."id" AS "t_id",
  "t"."nextRunTimestamp" AS "t_nextRunTimestamp",
  "t"."lastRunTimestamp" AS "t_lastRunTimestamp",
  "t"."isActive" AS "t_isActive",
  "t"."version" AS "t_version",
  "t"."status" AS "t_status",
  "t"."cronExpression" AS "t_cronExpression",
  "t"."timeZone" AS "t_timeZone",
  "t"."type" AS "t_type",
  "t"."triggerConfig" AS "t_triggerConfig",
  "t"."createdById" AS "t_createdById",
  "t"."createdAt" AS "t_createdAt",
  "t"."modifiedAt" AS "t_modifiedAt",
  "t"."dataMartId" AS "t_dataMartId"
FROM "data_mart_scheduled_trigger" AS "t"
WHERE
  "t"."nextRunTimestamp" IS NOT NULL
  AND "t"."nextRunTimestamp" <= '2025-08-21T10:24:00.023Z'
  AND "t"."isActive" = true
  AND "t"."status" = 'IDLE'
ORDER BY
  "t"."nextRunTimestamp" ASC;
```

### Query After
```sql
SELECT
  "t"."id" AS "t_id",
  "t"."nextRunTimestamp" AS "t_nextRunTimestamp",
  "t"."lastRunTimestamp" AS "t_lastRunTimestamp",
  "t"."isActive" AS "t_isActive",
  "t"."version" AS "t_version",
  "t"."status" AS "t_status",
  "t"."cronExpression" AS "t_cronExpression",
  "t"."timeZone" AS "t_timeZone",
  "t"."type" AS "t_type",
  "t"."triggerConfig" AS "t_triggerConfig",
  "t"."createdById" AS "t_createdById",
  "t"."createdAt" AS "t_createdAt",
  "t"."modifiedAt" AS "t_modifiedAt",
  "t"."dataMartId" AS "t_dataMartId",
  "dataMart"."id" AS "dataMart_id",
  "dataMart"."title" AS "dataMart_title",
  "dataMart"."schema" AS "dataMart_schema",
  "dataMart"."definitionType" AS "dataMart_definitionType",
  "dataMart"."definition" AS "dataMart_definition",
  "dataMart"."status" AS "dataMart_status",
  "dataMart"."description" AS "dataMart_description",
  "dataMart"."projectId" AS "dataMart_projectId",
  "dataMart"."createdById" AS "dataMart_createdById",
  "dataMart"."deletedAt" AS "dataMart_deletedAt",
  "dataMart"."createdAt" AS "dataMart_createdAt",
  "dataMart"."modifiedAt" AS "dataMart_modifiedAt",
  "dataMart"."storageId" AS "dataMart_storageId"
FROM "data_mart_scheduled_trigger" AS "t"
LEFT JOIN "data_mart" AS "dataMart"
  ON "dataMart"."id" = "t"."dataMartId"
  AND ("dataMart"."deletedAt" IS NULL")
WHERE
  "t"."nextRunTimestamp" IS NOT NULL
  AND "t"."nextRunTimestamp" <= '2025-08-21T10:13:00.008Z'
  AND "t"."isActive" = true
  AND "t"."status" = 'IDLE'
ORDER BY
  "t"."nextRunTimestamp" ASC;
```