### PR TITLE
refactor(owox): remove cach from static file serving

### DIFF
--- a/apps/owox/src/web/static-config.ts
+++ b/apps/owox/src/web/static-config.ts
@@ -46,15 +46,8 @@ export function setupWebStaticAssets(app: Express, options: StaticAssetsOptions 
     return false;
   }
 
-  // Serve static files with optimized headers
-  app.use(
-    express.static(distPath, {
-      // Cache configuration for static resources
-      etag: true,
-      lastModified: true,
-      maxAge: '1d', // 1 day for static resources
-    })
-  );
+  // Serve static files
+  app.use(express.static(distPath));
 
   // Configure SPA fallback for client-side routing
   setupSpaFallback(app, distPath, options);


### PR DESCRIPTION
This pull request makes a small change to how static files are served in the `setupWebStaticAssets` function. The cache configuration for static resources has been removed, and static files are now served without custom headers.