### PR TITLE
chore: update code format scripts in package.json 

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,6 @@ coverage
 
 # Dependencies
 package-lock.json
+
+# Astro framework
+.astro

--- a/packages/idp-owox/package.json
+++ b/packages/idp-owox/package.json
@@ -14,8 +14,8 @@
     "test": "jest",
     "lint": "eslint . --config ./eslint.config.js",
     "lint:fix": "eslint . --fix --config ./eslint.config.js",
-    "format": "prettier --write \"**/*.{ts,js,json,md}\"",
-    "format:check": "prettier --check \"**/*.{ts,js,json,md}\"",
+    "format": "prettier --write \"**/*.{ts,js,json,md}\" --ignore-path ../../.prettierignore",
+    "format:check": "prettier --check \"**/*.{ts,js,json,md}\" --ignore-path ../../.prettierignore",
     "typecheck": "tsc --noEmit",
     "prepack": "npm run build",
     "prepublishOnly": "npm audit && npm run lint && npm run typecheck"


### PR DESCRIPTION
Update the path for the `.prettierignore` file in the format scripts to ensure proper formatting checks and application. Additionally, include the `.astro` directory in the `.prettierignore` file.