### PR TITLE
fix(backend): report delete no longer fails due to cache FK

### DIFF
--- a/apps/backend/src/data-marts/entities/report-data-cache.entity.ts
+++ b/apps/backend/src/data-marts/entities/report-data-cache.entity.ts
@@ -1,14 +1,15 @@
 import {
-  Entity,
-  PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
-  ManyToOne,
+  Entity,
+  Index,
   JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
-import { ReportDataDescription } from '../dto/domain/report-data-description.dto';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { DataStorageReportReaderState } from '../data-storage-types/interfaces/data-storage-report-reader-state.interface';
+import { ReportDataDescription } from '../dto/domain/report-data-description.dto';
 import { Report } from './report.entity';
 
 /**
@@ -25,8 +26,9 @@ export class ReportDataCache {
   /**
    * Reference to the report
    */
-  @ManyToOne(() => Report)
-  @JoinColumn()
+  @Index('IDX_report_data_cache_reportId')
+  @ManyToOne(() => Report, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'reportId' })
   report: Report;
 
   /**

--- a/apps/backend/src/migrations/1756904880000-add-cascade-to-report-data-cache-fk.ts
+++ b/apps/backend/src/migrations/1756904880000-add-cascade-to-report-data-cache-fk.ts
@@ -1,0 +1,69 @@
+import { MigrationInterface, QueryRunner, TableForeignKey, TableIndex } from 'typeorm';
+
+export class AddCascadeToReportDataCacheFk1756904880000 implements MigrationInterface {
+  name = 'AddCascadeToReportDataCacheFk1756904880000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Ensure table exists
+    const table = await queryRunner.getTable('report_data_cache');
+    if (!table) {
+      throw new Error('Table "report_data_cache" not found');
+    }
+
+    // Drop existing FK on reportId if present
+    const existingFk = table.foreignKeys.find(
+      fk => fk.columnNames.length === 1 && fk.columnNames[0] === 'reportId'
+    );
+    if (existingFk) {
+      await queryRunner.dropForeignKey('report_data_cache', existingFk);
+    }
+
+    // Ensure there is an index on reportId (useful/required for MySQL)
+    const hasReportIdIndex = table.indices.some(
+      idx => idx.columnNames.length === 1 && idx.columnNames[0] === 'reportId'
+    );
+    if (!hasReportIdIndex) {
+      await queryRunner.createIndex(
+        'report_data_cache',
+        new TableIndex({ name: 'IDX_report_data_cache_reportId', columnNames: ['reportId'] })
+      );
+    }
+
+    // Create new FK with ON DELETE CASCADE
+    await queryRunner.createForeignKey(
+      'report_data_cache',
+      new TableForeignKey({
+        columnNames: ['reportId'],
+        referencedTableName: 'report',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+        onUpdate: 'NO ACTION',
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('report_data_cache');
+    if (!table) return;
+
+    // Drop current FK on reportId
+    const fk = table.foreignKeys.find(
+      f => f.columnNames.length === 1 && f.columnNames[0] === 'reportId'
+    );
+    if (fk) {
+      await queryRunner.dropForeignKey('report_data_cache', fk);
+    }
+
+    // Recreate FK without cascade (revert to NO ACTION)
+    await queryRunner.createForeignKey(
+      'report_data_cache',
+      new TableForeignKey({
+        columnNames: ['reportId'],
+        referencedTableName: 'report',
+        referencedColumnNames: ['id'],
+        onDelete: 'NO ACTION',
+        onUpdate: 'NO ACTION',
+      })
+    );
+  }
+}


### PR DESCRIPTION
### Summary
- Cascade delete report_data_cache on report removal.
- Add migration (SQLite/MySQL) to recreate FK with ON DELETE CASCADE and ensure index on reportId.
- Align entity: onDelete: 'CASCADE', explicit JoinColumn name (reportId), and index.

### Impact
- Fixes FK constraint error; related cache rows are removed automatically when a report is deleted.

### Migration
- apps/backend/src/migrations/1756904880000-add-cascade-to-report-data-cache-fk.ts