### PR TITLE
refactor: streamline package.json formatting for release pr

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,14 +11,7 @@
   "engines": {
     "node": ">=22.16.0"
   },
-  "keywords": [
-    "owox",
-    "data-marts",
-    "web-app",
-    "react",
-    "typescript",
-    "tailwind"
-  ],
+  "keywords": ["owox", "data-marts", "web-app", "react", "typescript", "tailwind"],
   "homepage": "https://github.com/OWOX/owox-data-marts",
   "repository": {
     "type": "git",
@@ -29,9 +22,7 @@
     "url": "https://github.com/OWOX/owox-data-marts/issues"
   },
   "main": "./dist/index.html",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -b && vite build",
     "dev": "vite --config vite.config.ts",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "format:check": "npm run format:check --workspaces --if-present",
     "format:root": "prettier --write \"**/*.{js,ts,mjs,yml,yaml,json}\" --ignore-path .prettierignore.root",
     "format:root:check": "prettier --check \"**/*.{js,ts,mjs,yml,yaml,json}\" --ignore-path .prettierignore.root",
-    "format:packages": "prettier --write apps/backend/package.json apps/owox/package.json packages/connector-runner/package.json packages/connectors/package.json",
+    "format:packages": "node tools/format-package-info.mjs",
     "lint": "npm run lint --workspaces --if-present",
     "lint:fix": "npm run lint:fix --workspaces --if-present",
     "lint:root": "eslint . --config ./eslint.config.mjs",

--- a/tools/format-package-info.mjs
+++ b/tools/format-package-info.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { resolve, join } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT_DIR = resolve(__dirname, '..');
+
+/**
+ * Reads the changeset configuration and extracts the list of packages
+ * that are configured for synchronized versioning (fixed packages).
+ *
+ * @returns {Set<string>} A Set containing package names from the first fixed group,
+ *                        or empty Set if no fixed configuration exists
+ * @throws {Error} If .changeset/config.json file doesn't exist or contains invalid JSON
+ * @throws {SyntaxError} If the config file contains malformed JSON
+ */
+function getPublishingPackages() {
+  const configPath = join(ROOT_DIR, '.changeset', 'config.json');
+  const config = JSON.parse(readFileSync(configPath, 'utf8'));
+
+  return new Set(config.fixed?.[0] || []);
+}
+
+/**
+ * Reads the main package.json file and discovers all workspace directories
+ * by expanding workspace patterns and scanning for subdirectories.
+ *
+ * @returns {string[]} Array of absolute paths to all workspace directories
+ * @throws {Error} If package.json file doesn't exist or contains invalid JSON
+ * @throws {SyntaxError} If the package.json file contains malformed JSON
+ * @throws {Error} If workspace directories cannot be read or accessed
+ */
+function getWorkspacesDirs() {
+  const mainPackageJsonPath = join(ROOT_DIR, 'package.json');
+  const mainPackageJson = JSON.parse(readFileSync(mainPackageJsonPath, 'utf8'));
+  const workspaces = mainPackageJson.workspaces || [];
+
+  const workspaceDirs = [];
+  for (const workspace of workspaces) {
+    const workspaceDir = workspace.replace('/*', '');
+    const possiblePath = join(ROOT_DIR, workspaceDir);
+
+    const entries = readdirSync(possiblePath);
+
+    for (const entry of entries) {
+      const entryPath = join(possiblePath, entry);
+      if (statSync(entryPath).isDirectory()) {
+        workspaceDirs.push(entryPath);
+      }
+    }
+  }
+
+  return workspaceDirs;
+}
+
+/**
+ * Discovers and returns paths to package.json files for packages that are
+ * configured in the changeset fixed configuration. Uses single-pass optimization
+ * with early exit when all packages are found.
+ *
+ * @returns {string[]} Array of absolute paths to package.json files for fixed packages
+ * @throws {Error} If not all expected packages are found in the workspace
+ * @throws {Error} If package.json files contain invalid JSON
+ * @throws {SyntaxError} If any package.json file contains malformed JSON
+ */
+function getPackagePaths() {
+  const fixedPackagesSet = getPublishingPackages();
+  if (fixedPackagesSet.size === 0) {
+    return [];
+  }
+
+  const workspaceDirs = getWorkspacesDirs();
+
+  const packagePaths = [];
+
+  // Single pass through all workspaces
+  for (const workspaceDir of workspaceDirs) {
+    const packageJsonPath = join(workspaceDir, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+      if (fixedPackagesSet.has(pkg.name)) {
+        packagePaths.push(packageJsonPath);
+      }
+    }
+
+    // Early exit if we found all packages
+    if (packagePaths.length === fixedPackagesSet.size) {
+      break;
+    }
+  }
+
+  // Error if not all packages found
+  if (packagePaths.length < fixedPackagesSet.size) {
+    throw new Error(
+      `Expected ${fixedPackagesSet.size} packages, but found only ${packagePaths.length}`
+    );
+  }
+
+  return packagePaths;
+}
+
+/**
+ * Executes prettier on the specified package.json files. Automatically detects
+ * if running in check mode (--check flag) or format mode (--write flag) based
+ * on command line arguments.
+ *
+ * @param {string[]} packagePaths - Array of absolute paths to package.json files to format
+ * @throws {Error} If prettier command execution fails
+ * @throws {Error} If prettier binary is not found in node_modules/.bin
+ * @throws {Error} In check mode, if any files are not properly formatted
+ */
+function runPrettier(packagePaths) {
+  const prettierFlag = process.argv.includes('--check') ? '--check' : '--write';
+
+  const command = `prettier ${prettierFlag} ${packagePaths.join(' ')}`;
+
+  execSync(command, {
+    cwd: ROOT_DIR,
+    stdio: 'inherit',
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${join(ROOT_DIR, 'node_modules', '.bin')}${process.platform === 'win32' ? ';' : ':'}${process.env.PATH}`,
+    },
+  });
+}
+
+/**
+ * Main entry point for the prettier-packages script. Orchestrates the process
+ * of discovering packages from changeset configuration and formatting their
+ * package.json files using prettier.
+ *
+ * @throws {Error} If no package.json files are found to format
+ * @throws {Error} If any step in the process fails (file reading, prettier execution, etc.)
+ */
+function main() {
+  const packagePaths = getPackagePaths();
+
+  if (packagePaths.length === 0) {
+    throw new Error('No package.json files found to format. ');
+  }
+
+  runPrettier(packagePaths);
+}
+
+// Run the script
+main();


### PR DESCRIPTION
This pull request introduces an automated script to format `package.json` files for all fixed-versioned packages, improving the consistency and maintainability of package metadata formatting across the repository. The main change replaces the previous hardcoded list of files for formatting with a dynamic approach that discovers relevant packages using the changeset configuration. Minor formatting updates are also made in some workspaces.

**Automated formatting for package metadata:**

- Added a new script `tools/format-package-info.mjs` that automatically discovers all fixed-versioned packages (as defined in `.changeset/config.json`) and formats their `package.json` files using Prettier. The script supports both formatting and check modes.
- Updated the root `package.json` to use the new script for the `format:packages` command, replacing the static file list with automated discovery and formatting.