### PR TITLE
feat(backend): connector run graceful shutdown

### DIFF
--- a/apps/backend/src/common/scheduler/README.md
+++ b/apps/backend/src/common/scheduler/README.md
@@ -206,11 +206,12 @@ When the application receives a shutdown signal, the graceful shutdown service:
 
 1. Prevents new triggers from being processed
 2. Tracks active trigger processing
-3. Waits for active processing to complete
-4. Only terminates after all processing is complete or a configurable timeout is
-   reached
+3. Signals OS processes when available (`SIGTERM`; `SIGKILL` after timeout)
+4. Waits for active processing to complete or until the configurable timeout
+
+Internally, the service exposes helpers (`isInShutdownMode`, `registerActiveProcess`/`unregisterActiveProcess`, `updateProcessPid`) and `initiateShutdown(signal)`, which is invoked by the module lifecycle (`onModuleDestroy`).
 
 The timeout for graceful shutdown can be configured using the
 `SCHEDULER_GRACEFUL_SHUTDOWN_TIMEOUT_MINUTES` environment variable. If active
 processes are still running when the timeout is reached, the application will
-log details about these processes and then terminate.
+log details about these processes, send `SIGKILL` to known PIDs, and then terminate.

--- a/apps/backend/src/common/scheduler/services/runners/abstract-trigger-runner.service.ts
+++ b/apps/backend/src/common/scheduler/services/runners/abstract-trigger-runner.service.ts
@@ -82,11 +82,10 @@ export abstract class AbstractTriggerRunnerService<T extends TimeBasedTrigger>
 
     // Check if the application is shutting down
     if (this.shutdownService.isInShutdownMode()) {
-      const shutdownError = new Error(
-        `Cannot process trigger ${trigger.id}: Application is shutting down`
+      this.logger.warn(
+        `[${this.handlerName}] Cannot process trigger ${trigger.id}: Application is shutting down.`
       );
-      this.logger.warn(`[${this.handlerName}] ${shutdownError.message}`);
-      throw shutdownError;
+      return;
     }
 
     try {

--- a/apps/backend/src/data-marts/connector-types/connector-message/services/connector-output-capture.service.ts
+++ b/apps/backend/src/data-marts/connector-types/connector-message/services/connector-output-capture.service.ts
@@ -9,13 +9,17 @@ import { ConnectorMessageType } from '../../enums/connector-message-type-enum';
 export class ConnectorOutputCaptureService {
   constructor(private readonly connectorMessageParserService: ConnectorMessageParserService) {}
 
-  createCapture(onMessage: (message: ConnectorMessage) => void): ConnectorOutputCapture {
+  createCapture(
+    onMessage: (message: ConnectorMessage) => void,
+    onSpawn: (pid: number) => void
+  ): ConnectorOutputCapture {
     return {
       logCapture: {
         onStdout: (message: string) => this.captureMessage(message).forEach(onMessage),
         onStderr: (message: string) => this.captureError(message).forEach(onMessage),
         passThrough: false,
       },
+      onSpawn,
     };
   }
 

--- a/apps/backend/src/data-marts/connector-types/interfaces/connector-output-capture.interface.ts
+++ b/apps/backend/src/data-marts/connector-types/interfaces/connector-output-capture.interface.ts
@@ -4,4 +4,5 @@ export interface ConnectorOutputCapture {
     onStderr: (message: string) => void;
     passThrough: boolean;
   };
+  onSpawn: (pid: number) => void;
 }

--- a/apps/backend/src/data-marts/enums/data-mart-run-status.enum.ts
+++ b/apps/backend/src/data-marts/enums/data-mart-run-status.enum.ts
@@ -4,4 +4,5 @@ export enum DataMartRunStatus {
   SUCCESS = 'SUCCESS',
   FAILED = 'FAILED',
   CANCELLED = 'CANCELLED',
+  INTERRUPTED = 'INTERRUPTED',
 }

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/StatusBadge.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/StatusBadge.tsx
@@ -40,6 +40,15 @@ export function StatusBadge({ status }: StatusBadgeProps) {
           Cancelled
         </Badge>
       );
+    case RunStatus.INTERRUPTED:
+      return (
+        <Badge
+          variant='secondary'
+          className='bg-gray-50 text-gray-500 dark:bg-gray-950 dark:text-gray-400'
+        >
+          Interrupted
+        </Badge>
+      );
     default:
       return (
         <Badge

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/icons.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/icons.tsx
@@ -7,6 +7,7 @@ import {
   Circle,
   Loader2,
   Ban,
+  CircleStop,
 } from 'lucide-react';
 import { RunStatus, LogLevel } from './types';
 
@@ -23,6 +24,8 @@ export function getStatusIcon(status: RunStatus) {
             return <Loader2 className='text-primary h-4 w-4 animate-spin' />;
           case RunStatus.CANCELLED:
             return <Ban className='h-4 w-4 text-gray-500' />;
+          case RunStatus.INTERRUPTED:
+            return <CircleStop className='h-4 w-4 text-gray-500' />;
           default:
             return <Circle className='h-4 w-4 text-gray-500' />;
         }

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/types.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/types.ts
@@ -12,6 +12,7 @@ export enum RunStatus {
   SUCCESS = 'SUCCESS',
   FAILED = 'FAILED',
   CANCELLED = 'CANCELLED',
+  INTERRUPTED = 'INTERRUPTED',
 }
 
 export enum LogViewType {

--- a/apps/web/src/features/data-marts/shared/utils/status.utils.ts
+++ b/apps/web/src/features/data-marts/shared/utils/status.utils.ts
@@ -34,6 +34,7 @@ export const mapRunStatusToStatusType = (status: RunStatus): StatusTypeEnum => {
       return StatusTypeEnum.INFO;
     case RunStatus.FAILED:
     case RunStatus.CANCELLED:
+    case RunStatus.INTERRUPTED:
       return StatusTypeEnum.ERROR;
     default:
       return StatusTypeEnum.NEUTRAL;
@@ -74,6 +75,8 @@ export const getRunStatusText = (status: RunStatus): string => {
       return 'Failed';
     case RunStatus.CANCELLED:
       return 'Cancelled';
+    case RunStatus.INTERRUPTED:
+      return 'Interrupted';
     default:
       return 'Unknown';
   }


### PR DESCRIPTION
# Before
Graceful shutdown stops the NestJS application, but the running connectors keep working.

# After
## Backend
### GracefulShutdownService
- it is possible to update the PID of a running process
- after initiating with `initiateShutdown()`, the received signal (`SIGINT`, `SIGTERM`) is sent to all active processes with a PID
- after the `SCHEDULER_GRACEFUL_SHUTDOWN_TIMEOUT_MINUTES` elapses, a `SIGKILL` signal is sent to active processes

#### Example
```bash
(base) andrewlaskevych@Andrews-MacBook-Air owox-data-marts-main % pstree -p 50129
\-+- 50129 andrewlaskevych node --enable-source-maps /Users/andrewlaskevych/Projects/owox-data-marts-main/apps/backend/dist/src/main
  |-+= 51532 andrewlaskevych node main.js
  | \--- 51565 andrewlaskevych /Users/andrewlaskevych/.nvm/versions/node/v22.16.0/bin/node /private/var/folders/83/ccyjdwvj40q32n_cw66b_r7r0000gn/T/owox-connector-runner/**/node_modules/sync-rpc/lib/worker.js
  |-+= 51542 andrewlaskevych node main.js
  | |--- 51618 andrewlaskevych /Users/andrewlaskevych/.nvm/versions/node/v22.16.0/bin/node /private/var/folders/83/ccyjdwvj40q32n_cw66b_r7r0000gn/T/owox-connector-runner/**/node_modules/sync-rpc/lib/worker.js
  | \--- 51953 andrewlaskevych nc 127.0.0.1 65059
  |-+= 51552 andrewlaskevych node main.js
  | |--- 51670 andrewlaskevych /Users/andrewlaskevych/.nvm/versions/node/v22.16.0/bin/node /private/var/folders/83/ccyjdwvj40q32n_cw66b_r7r0000gn/T/owox-connector-runner/**/node_modules/sync-rpc/lib/worker.js
  | \--- 51925 andrewlaskevych nc 127.0.0.1 65065
  \-+= 51562 andrewlaskevych node main.js
    |--- 51719 andrewlaskevych /Users/andrewlaskevych/.nvm/versions/node/v22.16.0/bin/node /private/var/folders/83/ccyjdwvj40q32n_cw66b_r7r0000gn/T/owox-connector-runner/**/node_modules/sync-rpc/lib/worker.js
    \--- 51883 andrewlaskevych nc 127.0.0.1 65072
```

- **50129** (backend) receive `SIGTERM`
- `GracefulShutdownService` send `SIGTERM` to all process in group: **51532**, **51542**, **51552**
**51562**


### ConnectorExecutionService
- registers and unregisters the connector start process in the `GracefulShutdownService`
- if a graceful shutdown occurs, the connector run will be stopped with status `INTERRUPTED`
- after starting the NestJS application (`onApplicationBootstrap` [docs](https://docs.nestjs.com/fundamentals/lifecycle-events)), start all `DataMartRun` with status `INTERRUPTED`

## UI
- display the `INTERRUPTED` status in the Run History tab
<img width="1287" height="573" alt="CleanShot 2025-09-10 at 11 07 19" src="https://github.com/user-attachments/assets/24f24529-f51c-4778-948a-3d64356ab7d2" />

## Connector Runner
- the connector is launched in a dedicated process group (`detached: true`) so that `GracefulShutdownService` can send a signal to all processes at once