### PR TITLE
feat(backend): Consumption tracking added

### DIFF
--- a/apps/backend/src/common/pubsub/pubsub.service.ts
+++ b/apps/backend/src/common/pubsub/pubsub.service.ts
@@ -1,0 +1,55 @@
+import { PubSub } from '@google-cloud/pubsub';
+import { Logger, OnModuleDestroy } from '@nestjs/common';
+
+export class PubSubService implements OnModuleDestroy {
+  private readonly logger = new Logger(PubSubService.name);
+  private readonly client: PubSub;
+
+  constructor(params?: { projectId?: string }) {
+    const projectId =
+      params?.projectId || process.env.GCLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT;
+    this.client = new PubSub({ projectId });
+  }
+
+  public async ensureTopicExists(topicName: string): Promise<void> {
+    const topic = this.client.topic(topicName);
+    const [exists] = await topic.exists();
+    if (!exists) {
+      await this.client.createTopic(topicName);
+      this.logger.log(`Created topic: ${topicName}`);
+    }
+  }
+
+  public async publishMessage(
+    topicName: string,
+    payloadObject: unknown,
+    attributes?: Record<string, string>
+  ): Promise<string> {
+    await this.ensureTopicExists(topicName);
+    const dataString = JSON.stringify(payloadObject);
+    const data = Buffer.from(dataString);
+    const msgId = await this.client.topic(topicName).publishMessage({ data, attributes });
+    this.logger.debug(`Published message to ${topicName}: ${msgId} ${dataString}`);
+    return msgId;
+  }
+
+  public async publishMessageWithDefaultWrap(
+    topicName: string,
+    payloadObject: unknown,
+    attributes?: Record<string, string>
+  ): Promise<string> {
+    const wrappedPayload = {
+      version: '1.0',
+      body: payloadObject,
+      order: Date.now(),
+      producer: {
+        name: 'OWOX Data Marts',
+      },
+    };
+    return this.publishMessage(topicName, wrappedPayload, attributes);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.client.close();
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/interfaces/data-destination-report-writer.interface.ts
+++ b/apps/backend/src/data-marts/data-destination-types/interfaces/data-destination-report-writer.interface.ts
@@ -27,6 +27,8 @@ export interface DataDestinationReportWriter extends TypedComponent<DataDestinat
   /**
    * Finalizes the report writing process
    * Performs any necessary cleanup or finalization steps
+   *
+   * @param processingError - Optional error that occurred during report processing
    */
-  finalize(): Promise<void>;
+  finalize(processingError?: Error): Promise<void>;
 }

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
@@ -3,6 +3,7 @@ import { BusinessViolationException } from '../../../../common/exceptions/busine
 import { CachedReaderData } from '../../../dto/domain/cached-reader-data.dto';
 import { Report } from '../../../entities/report.entity';
 import { ReportRunStatus } from '../../../enums/report-run-status.enum';
+import { ConsumptionTrackingService } from '../../../services/consumption-tracking.service';
 import { ReportService } from '../../../services/report.service';
 import { ConnectionConfigSchema } from '../schemas/connection-config.schema';
 import { ConnectorRequestConfigV1Schema } from '../schemas/connector-request-config.schema.v1';
@@ -28,7 +29,8 @@ export class LookerStudioConnectorApiService {
     private readonly schemaService: LookerStudioConnectorApiSchemaService,
     private readonly dataService: LookerStudioConnectorApiDataService,
     private readonly cacheService: ReportDataCacheService,
-    private readonly reportService: ReportService
+    private readonly reportService: ReportService,
+    private readonly consumptionTrackingService: ConsumptionTrackingService
   ) {}
 
   public async getConfig(request: GetConfigRequest): Promise<GetConfigResponse> {
@@ -60,6 +62,7 @@ export class LookerStudioConnectorApiService {
           await this.reportService.updateRunStatus(report.id, ReportRunStatus.ERROR, error.message);
         } else {
           await this.reportService.updateRunStatus(report.id, ReportRunStatus.SUCCESS);
+          await this.consumptionTrackingService.registerLookerReportRunConsumption(report);
         }
       }
     }

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -6,6 +6,7 @@ import { DataDestinationController } from './controllers/data-destination.contro
 import { LookerStudioConnectorController } from './controllers/external/looker-studio-connector.controller';
 import { ReportController } from './controllers/report.controller';
 import { ScheduledTriggerController } from './controllers/scheduled-trigger.controller';
+import { ConsumptionTrackingService } from './services/consumption-tracking.service';
 import { ReportDataCacheService } from './services/report-data-cache.service';
 import { CreateDataMartService } from './use-cases/create-data-mart.service';
 import { ListDataMartsService } from './use-cases/list-data-marts.service';
@@ -177,6 +178,7 @@ import { IdpModule } from '../idp/idp.module';
     ConnectorOutputCaptureService,
     ConnectorMessageParserService,
     ConnectorStateService,
+    ConsumptionTrackingService,
   ],
 })
 export class DataMartsModule {}

--- a/apps/backend/src/data-marts/services/connector-execution.service.ts
+++ b/apps/backend/src/data-marts/services/connector-execution.service.ts
@@ -27,6 +27,7 @@ import { ConnectorOutputCaptureService } from '../connector-types/connector-mess
 import { ConnectorMessageType } from '../connector-types/enums/connector-message-type-enum';
 import { ConnectorOutputState } from '../connector-types/interfaces/connector-output-state';
 import { ConnectorStateService } from '../connector-types/connector-message/services/connector-state.service';
+import { ConsumptionTrackingService } from './consumption-tracking.service';
 import { DataMartService } from './data-mart.service';
 import { DataMartStatus } from '../enums/data-mart-status.enum';
 
@@ -46,7 +47,8 @@ export class ConnectorExecutionService {
     private readonly dataMartRunRepository: Repository<DataMartRun>,
     private readonly connectorOutputCaptureService: ConnectorOutputCaptureService,
     private readonly connectorStateService: ConnectorStateService,
-    private readonly dataMartService: DataMartService
+    private readonly dataMartService: DataMartService,
+    private readonly consumptionTracker: ConsumptionTrackingService
   ) {}
 
   async cancelRun(dataMartId: string, runId: string): Promise<void> {
@@ -163,6 +165,7 @@ export class ConnectorExecutionService {
     const state: ConnectorOutputState = { state: {}, at: '' };
     const capturedLogs: ConnectorMessage[] = [];
     const capturedErrors: ConnectorMessage[] = [];
+    let hasSuccessfulRun = false;
 
     try {
       await this.dataMartRunRepository.update(runId, {
@@ -182,6 +185,7 @@ export class ConnectorExecutionService {
 
       const successCount = configurationResults.filter(r => r.success).length;
       const totalCount = configurationResults.length;
+      hasSuccessfulRun = successCount > 0;
       this.logger.log(
         `Connector execution completed: ${successCount}/${totalCount} configurations successful for DataMart ${dataMart.id}`
       );
@@ -197,6 +201,11 @@ export class ConnectorExecutionService {
     } finally {
       await this.updateRunStatus(runId, capturedLogs, capturedErrors);
       await this.updateRunState(dataMart.id, state);
+
+      if (hasSuccessfulRun) {
+        // Register connector run consumption only if at least one configuration succeeded
+        await this.consumptionTracker.registerConnectorRunConsumption(dataMart, runId);
+      }
 
       this.logger.debug(`Actualizing schema for DataMart ${dataMart.id} after connector execution`);
       await this.dataMartService.actualizeSchema(

--- a/apps/backend/src/data-marts/services/consumption-tracking.service.ts
+++ b/apps/backend/src/data-marts/services/consumption-tracking.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PubSubService } from '../../common/pubsub/pubsub.service';
+import { GoogleSheetsConfig } from '../data-destination-types/google-sheets/schemas/google-sheets-config.schema';
+import { ConnectorDefinition as DataMartConnectorDefinition } from '../dto/schemas/data-mart-table-definitions/connector-definition.schema';
+import { DataMart } from '../entities/data-mart.entity';
+import { Report } from '../entities/report.entity';
+import { ConnectorService } from './connector.service';
+
+@Injectable()
+export class ConsumptionTrackingService {
+  private readonly logger = new Logger(ConsumptionTrackingService.name);
+
+  private readonly pubSubService?: PubSubService;
+
+  private readonly connectorRunConsumptionTopic?: string;
+  private readonly sheetsReportRunConsumptionTopic?: string;
+  private readonly lookerReportRunConsumptionTopic?: string;
+
+  constructor(
+    private readonly connectorService: ConnectorService,
+    configService: ConfigService
+  ) {
+    const consumptionPubSubProject = configService.get<string>('CONSUMPTION_PUBSUB_PROJECT_ID');
+    if (consumptionPubSubProject) {
+      this.pubSubService = new PubSubService({ projectId: consumptionPubSubProject });
+      this.logger.log(`Consumption PubSub project ID: ${consumptionPubSubProject}`);
+
+      this.connectorRunConsumptionTopic = configService.get<string>(
+        'CONSUMPTION_CONNECTOR_RUN_TOPIC'
+      );
+      if (this.connectorRunConsumptionTopic) {
+        this.logger.log(`Consumption Connector Run topic: ${this.connectorRunConsumptionTopic}`);
+      }
+
+      this.sheetsReportRunConsumptionTopic = configService.get<string>(
+        'CONSUMPTION_SHEETS_REPORT_RUN_TOPIC'
+      );
+      if (this.sheetsReportRunConsumptionTopic) {
+        this.logger.log(
+          `Consumption Sheets Report Run topic: ${this.sheetsReportRunConsumptionTopic}`
+        );
+      }
+
+      this.lookerReportRunConsumptionTopic = configService.get<string>(
+        'CONSUMPTION_LOOKER_REPORT_RUN_TOPIC'
+      );
+      if (this.lookerReportRunConsumptionTopic) {
+        this.logger.log(
+          `Consumption Looker Report Run topic: ${this.lookerReportRunConsumptionTopic}`
+        );
+      }
+    }
+  }
+
+  public async registerConnectorRunConsumption(
+    dataMart: DataMart,
+    connectorRunId: string
+  ): Promise<void> {
+    if (!this.pubSubService || !this.connectorRunConsumptionTopic) {
+      this.logger.debug('Connector run consumption tracking is not configured, skipping...');
+      return;
+    }
+    const definition = dataMart.definition as DataMartConnectorDefinition;
+    const { connector } = definition;
+    const connectorName = connector.source.name;
+    const connectorTitle = (await this.connectorService.getAvailableConnectors()).filter(
+      c => c.name === connectorName
+    )[0]?.title;
+    await this.sendConsumptionCommand(this.connectorRunConsumptionTopic, {
+      ...this.baseDataMartConsumptionPayload(dataMart),
+      inputSource: connectorTitle ? connectorTitle : connectorName,
+      processRunId: connectorRunId,
+    });
+  }
+
+  public async registerSheetsReportRunConsumption(
+    report: Report,
+    sheetsDetails: {
+      googleSheetsDocumentTitle: string;
+      googleSheetsListTitle: string;
+    }
+  ): Promise<void> {
+    if (!this.pubSubService || !this.sheetsReportRunConsumptionTopic) {
+      this.logger.debug('Google Sheets report consumption tracking is not configured, skipping...');
+      return;
+    }
+    const reportConfig = report.destinationConfig as GoogleSheetsConfig;
+    await this.sendConsumptionCommand(this.sheetsReportRunConsumptionTopic, {
+      ...this.baseReportConsumptionPayload(report),
+      googleSheetsDocumentId: reportConfig.spreadsheetId,
+      googleSheetsDocumentTitle: sheetsDetails.googleSheetsDocumentTitle,
+      googleSheetsListId: reportConfig.sheetId,
+      googleSheetsListTitle: sheetsDetails.googleSheetsListTitle,
+    });
+  }
+
+  public async registerLookerReportRunConsumption(report: Report): Promise<void> {
+    if (!this.pubSubService || !this.lookerReportRunConsumptionTopic) {
+      this.logger.debug('Looker Studio report consumption tracking is not configured, skipping...');
+      return;
+    }
+    await this.sendConsumptionCommand(
+      this.lookerReportRunConsumptionTopic,
+      this.baseReportConsumptionPayload(report)
+    );
+  }
+
+  private async sendConsumptionCommand(topic: string, cmd: unknown): Promise<void> {
+    try {
+      const messageId = await this.pubSubService?.publishMessageWithDefaultWrap(topic, cmd);
+      this.logger.log(
+        `Sent consumption command to PubSub. Message: ${messageId}. Topic: ${topic}. CMD: ${JSON.stringify(cmd)}`
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to send consumption command to PubSub: ${error.message}. Topic: ${topic}. CMD: ${JSON.stringify(cmd)}`,
+        error.stack
+      );
+    }
+  }
+
+  private baseDataMartConsumptionPayload(dataMart: DataMart) {
+    return {
+      projectId: dataMart.projectId,
+      dataMartId: dataMart.id,
+      dataMartTitle: dataMart.title,
+      dataStorageId: dataMart.storage.id,
+      dataStorageTitle: dataMart.storage.title,
+      dataStorageType: dataMart.storage.type,
+      runTime: new Date().toISOString(),
+    };
+  }
+
+  private baseReportConsumptionPayload(report: Report) {
+    return {
+      ...this.baseDataMartConsumptionPayload(report.dataMart),
+      dataDestinationId: report.dataDestination.id,
+      dataDestinationTitle: report.dataDestination.title,
+      dataDestinationType: report.dataDestination.type,
+      reportRunId: `${report.id}-${Date.now()}`,
+    };
+  }
+}


### PR DESCRIPTION
### Summary
Added backend consumption tracking to capture usage metrics for analytics and billing.

### Changes
- New service to send consumption metrics.
- Integrated into connector/job lifecycle (start/finish, success/error).
- Publishes events via Pub/Sub for async aggregation.

### Implementation
- Hooks auto-send metrics on run and completion.
- Standardized event schema.
