### PR TITLE
feat(backend): make migration handling for multiple instances

### DIFF
--- a/apps/backend/src/config/migrations.config.ts
+++ b/apps/backend/src/config/migrations.config.ts
@@ -20,13 +20,86 @@ export async function runMigrationsIfNeeded(config: ConfigService): Promise<void
     await dataSource.initialize();
   }
 
-  const migrations = await dataSource.runMigrations();
-  if (migrations.length === 0) {
-    logger.log('No new migrations to run');
-  } else {
-    logger.log(`Executed ${migrations.length} migration(s):`);
-    migrations.forEach(m => {
-      logger.log(`- ${m.name}`);
-    });
+  const releaseLock = await acquireMigrationsLock(dataSource, logger);
+  try {
+    const migrations = await dataSource.runMigrations();
+    if (migrations.length === 0) {
+      logger.log('No new migrations to run');
+    } else {
+      logger.log(`Executed ${migrations.length} migration(s):`);
+      migrations.forEach(m => {
+        logger.log(`- ${m.name}`);
+      });
+    }
+  } finally {
+    await releaseLock().catch(err =>
+      logger.error(`Failed to release migrations lock: ${String(err)}`)
+    );
+    await dataSource.destroy();
   }
+}
+
+const LOCK_TABLE_NAME = '__migrations_lock__';
+const WAIT_DELAY_SECONDS = 5; // Wait 5 seconds between retries
+const MAX_WAIT_SECONDS = 5 * 60; // Max 5 minutes total
+
+/**
+ * Acquires a distributed lock for running migrations to prevent multiple instances
+ * from running the same migration simultaneously.
+ *
+ * **How it works:**
+ * 1. Attempts to create a temporary lock table `__migrations_lock__`
+ * 2. If table creation succeeds - lock is acquired, migration can proceed
+ * 3. If table already exists - another instance is running migrations, wait and retry
+ * 4. After migration completes - lock table is dropped to release the lock
+ *
+ * **Multi-instance safety:**
+ * - Service 0 creates lock table and runs migrations
+ * - Services 1-9 wait until lock table is dropped
+ * - After lock release, services 1-9 check migration status and skip already completed ones
+ *
+ * @see https://github.com/typeorm/typeorm/issues/4588 - Known TypeORM issue with multiple instances
+ *
+ * @param dataSource - TypeORM DataSource instance
+ * @param logger - Logger instance for debugging
+ * @returns Promise that resolves to a release function
+ */
+async function acquireMigrationsLock(
+  dataSource: DataSource,
+  logger: ReturnType<typeof createLogger>
+): Promise<() => Promise<void>> {
+  const createSql = `CREATE TABLE ${LOCK_TABLE_NAME} (id INTEGER)`;
+  const dropSql = `DROP TABLE ${LOCK_TABLE_NAME}`;
+
+  const startAt = Date.now();
+
+  while (true) {
+    try {
+      await dataSource.query(createSql);
+      logger.log(`Acquired migrations lock using table ${LOCK_TABLE_NAME}`);
+      break;
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isAlreadyExists = message.toLowerCase().includes('already exists');
+      if (!isAlreadyExists) {
+        throw error;
+      }
+
+      if (Date.now() - startAt > MAX_WAIT_SECONDS * 1000) {
+        throw new Error(`Timed out waiting for migrations lock after ${MAX_WAIT_SECONDS} seconds`);
+      }
+
+      logger.log(`Another instance is running migrations. Waiting ${WAIT_DELAY_SECONDS}s...`);
+      await sleepInSeconds(WAIT_DELAY_SECONDS);
+    }
+  }
+
+  return async () => {
+    await dataSource.query(dropSql);
+    logger.log(`Released migrations lock by dropping ${LOCK_TABLE_NAME}`);
+  };
+}
+
+function sleepInSeconds(seconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, seconds * 1000));
 }


### PR DESCRIPTION
## Description

Acquires a distributed lock for running migrations to prevent multiple instances from running the same migration simultaneously. Known TypeORM [issue](https://github.com/typeorm/typeorm/issues/4588) with multiple instances.

### How it works
1. Attempts to create a temporary lock table `__migrations_lock__`
2. If table creation succeeds - lock is acquired, migration can proceed
3. If table already exists - another instance is running migrations, wait and retry
4. After migration completes - lock table is dropped to release the lock
 
 
### Multi-instance safety
- Service 0 creates lock table and runs migrations
- Services 1-9 wait until lock table is dropped
- After lock release, services 1-9 check migration status and skip already completed ones

### Problems
- If for some reason the `__migrations_lock__` table is not deleted, you will need to do it manually. This is an expected workaround.

## Testing
Tested on SQLite and MySQL. For testing, the new migration `1757508895085-new-migration.ts` was used.

```typescript
import { MigrationInterface, QueryRunner } from "typeorm";

export class NewMigration1757508895085 implements MigrationInterface {
    name = 'NewMigration1757508895085';

    public async up(queryRunner: QueryRunner): Promise<void> {
        
        // Check if we're using SQLite (simple heuristic based on connection type)
        const connection = queryRunner.connection;
        const isSQLite = connection.options.type === 'sqlite';
        
        if (isSQLite) {
            await new Promise(resolve => setTimeout(resolve, 1 * 60 * 1000));
        }
        
        // Actual migration logic
        await queryRunner.query(`SELECT SLEEP(60);`);
    }
    
    public async down(_queryRunner: QueryRunner): Promise<void> {
        // Migration rollback is not possible as data has been deleted
    }
}
```

To simulate launching N instances simultaneously, a script was used.
```bash
#!/bin/bash
# chmod +x test-simple.sh

MAIN_JS="/Users/andrewlaskevych/Projects/owox-data-marts-main/apps/backend/dist/src/main.js"

# Colors
RED='\033[0;31m'
GREEN='\033[0;32m'
BLUE='\033[0;34m'
YELLOW='\033[1;33m'
PURPLE='\033[0;35m'
CYAN='\033[0;36m'
WHITE='\033[1;37m'
ORANGE='\033[0;33m'
NC='\033[0m'

echo -e "${YELLOW}=== Testing Migration Lock Mechanism ===${NC}"
echo -e "${YELLOW}Starting 8 instances simultaneously...${NC}"
echo ""

cleanup() {
    echo -e "\n${YELLOW}Stopping all instances...${NC}"
    pkill -f "node.*main.js" 2>/dev/null
    echo -e "${YELLOW}Done${NC}"
    exit 0
}

trap cleanup SIGINT SIGTERM

# Starting 8 instances with logs in separate files
echo -e "${GREEN}[INSTANCE-1]${NC} Starting on port 2030..."
PORT=2030 node "$MAIN_JS" > /tmp/instance1.log 2>&1 &
PID1=$!

echo -e "${BLUE}[INSTANCE-2]${NC} Starting on port 2070..."  
PORT=2070 node "$MAIN_JS" > /tmp/instance2.log 2>&1 &
PID2=$!

echo -e "${RED}[INSTANCE-3]${NC} Starting on port 2050..."
PORT=2050 node "$MAIN_JS" > /tmp/instance3.log 2>&1 &
PID3=$!

echo -e "${PURPLE}[INSTANCE-4]${NC} Starting on port 2040..."
PORT=2040 node "$MAIN_JS" > /tmp/instance4.log 2>&1 &
PID4=$!

echo -e "${CYAN}[INSTANCE-5]${NC} Starting on port 2080..."
PORT=2080 node "$MAIN_JS" > /tmp/instance5.log 2>&1 &
PID5=$!

echo -e "${WHITE}[INSTANCE-6]${NC} Starting on port 2090..."
PORT=2090 node "$MAIN_JS" > /tmp/instance6.log 2>&1 &
PID6=$!

echo -e "${ORANGE}[INSTANCE-7]${NC} Starting on port 2100..."
PORT=2100 node "$MAIN_JS" > /tmp/instance7.log 2>&1 &
PID7=$!

echo -e "${GREEN}[INSTANCE-8]${NC} Starting on port 2110..."
PORT=2110 node "$MAIN_JS" > /tmp/instance8.log 2>&1 &
PID8=$!

echo ""
echo -e "${YELLOW}Instances started:${NC}"
echo -e "${GREEN}  Instance 1: PID $PID1 (port 2030)${NC}"
echo -e "${BLUE}  Instance 2: PID $PID2 (port 2070)${NC}"
echo -e "${RED}  Instance 3: PID $PID3 (port 2050)${NC}"
echo -e "${PURPLE}  Instance 4: PID $PID4 (port 2040)${NC}"
echo -e "${CYAN}  Instance 5: PID $PID5 (port 2080)${NC}"
echo -e "${WHITE}  Instance 6: PID $PID6 (port 2090)${NC}"
echo -e "${ORANGE}  Instance 7: PID $PID7 (port 2100)${NC}"
echo -e "${GREEN}  Instance 8: PID $PID8 (port 2110)${NC}"
echo ""
echo -e "${YELLOW}Logs are being written to:${NC}"
echo "  /tmp/instance1.log - /tmp/instance8.log"
echo ""
echo -e "${YELLOW}Commands to view logs:${NC}"
echo -e "${GREEN}  tail -f /tmp/instance1.log${NC}"
echo -e "${BLUE}  tail -f /tmp/instance2.log${NC}"
echo -e "${RED}  tail -f /tmp/instance3.log${NC}"
echo -e "${PURPLE}  tail -f /tmp/instance4.log${NC}"
echo -e "${CYAN}  tail -f /tmp/instance5.log${NC}"
echo -e "${WHITE}  tail -f /tmp/instance6.log${NC}"
echo -e "${ORANGE}  tail -f /tmp/instance7.log${NC}"
echo -e "${GREEN}  tail -f /tmp/instance8.log${NC}"
echo ""
echo -e "${YELLOW}View all logs at once:${NC}"
echo -e "${CYAN}  tail -f /tmp/instance*.log${NC}"
echo ""
echo -e "${YELLOW}Check which instance acquired the lock:${NC}"
echo -e "${CYAN}  grep -H \"Acquired migrations lock\" /tmp/instance*.log${NC}"
echo ""
echo -e "${YELLOW}See migration lock status:${NC}"
echo -e "${CYAN}  grep -H \"Another instance is running\" /tmp/instance*.log | head -10${NC}"
echo ""
echo -e "${YELLOW}Press Ctrl+C to stop all instances${NC}"

wait

cleanup
```

## Logs
<img width="2560" height="902" alt="CleanShot 2025-09-11 at 17 05 05" src="https://github.com/user-attachments/assets/be0ff78c-b45a-4572-a7f9-786424ae73f6" />

