### PR TITLE
refactor: enhance Reddit Ads connector reporting logic with new field definitions

### DIFF
--- a/.changeset/thick-otters-melt.md
+++ b/.changeset/thick-otters-melt.md
@@ -1,0 +1,5 @@
+---
+'owox': minor
+---
+
+# refactor: enhance Reddit Ads connector reporting logic with new field definitions

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/FieldsSchema.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/FieldsSchema.js
@@ -90,7 +90,7 @@ var RedditFieldsSchema = {
     "overview": "User Ad Metrics by country",
     "description": "Retrieve ad performance metrics and details from Reddit Ads API by country.",
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
-    "fields": reportFields,
+    "fields": reportCountryFields,
     "uniqueKeys": ["ad_id", "date", "country"],
     "destinationName": "reddit_ads_report_by_COUNTRY",
     "isTimeSeries": true
@@ -99,7 +99,7 @@ var RedditFieldsSchema = {
     "overview": "User Ad Metrics by ad_group_id",
     "description": "Retrieve ad performance metrics and details from Reddit Ads API by ad_group_id.",
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
-    "fields": reportFields,
+    "fields": reportAdGroupIdFields,
     "uniqueKeys": ["ad_id", "date", "ad_group_id"],
     "destinationName": "reddit_ads_report_by_AD_GROUP_ID",
     "isTimeSeries": true
@@ -108,7 +108,7 @@ var RedditFieldsSchema = {
     "overview": "User Ad Metrics by campaign_id",
     "description": "Retrieve ad performance metrics and details from Reddit Ads API by campaign_id.",
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
-    "fields": reportFields,
+    "fields": reportCampaignIdFields,
     "uniqueKeys": ["ad_id", "date", "campaign_id"],
     "destinationName": "reddit_ads_report_by_CAMPAIGN_ID",
     "isTimeSeries": true
@@ -117,7 +117,7 @@ var RedditFieldsSchema = {
     "overview": "User Ad Metrics by dma",
     "description": "Retrieve ad performance metrics and details from Reddit Ads API by dma.",
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
-    "fields": reportFields,
+    "fields": reportDmaBasedFields,
     "uniqueKeys": ["ad_id", "date", "dma"],
     "destinationName": "reddit_ads_report_by_DMA",
     "isTimeSeries": true
@@ -126,7 +126,7 @@ var RedditFieldsSchema = {
     "overview": "User Ad Metrics by interest",
     "description": "Retrieve ad performance metrics and details from Reddit Ads API by interest.",
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
-    "fields": reportFields,
+    "fields": reportInterestFields,
     "uniqueKeys": ["ad_id", "date", "interest"],
     "destinationName": "reddit_ads_report_by_INTEREST",
     "isTimeSeries": true
@@ -135,7 +135,7 @@ var RedditFieldsSchema = {
     "overview": "User Ad Metrics by keyword",
     "description": "Retrieve ad performance metrics and details from Reddit Ads API by keyword.",
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
-    "fields": reportFields,
+    "fields": reportKeywordFields,
     "uniqueKeys": ["ad_id", "date", "keyword"],
     "destinationName": "reddit_ads_report_by_KEYWORD",
     "isTimeSeries": true
@@ -144,7 +144,7 @@ var RedditFieldsSchema = {
     "overview": "User Ad Metrics by placement",
     "description": "Retrieve ad performance metrics and details from Reddit Ads API by placement.",
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
-    "fields": reportFields,
+    "fields": reportPlacementFields,
     "uniqueKeys": ["ad_id", "date", "placement"],
     "destinationName": "reddit_ads_report_by_PLACEMENT",
     "isTimeSeries": true
@@ -153,7 +153,7 @@ var RedditFieldsSchema = {
     "overview": "User Ad Metrics by account_id",
     "description": "Retrieve ad performance metrics and details from Reddit Ads API by account_id.",
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
-    "fields": reportFields,
+    "fields": reportAdAccountIdFields,
     "uniqueKeys": ["ad_id", "date", "account_id"],
     "destinationName": "reddit_ads_report_by_AD_ACCOUNT_ID",
     "isTimeSeries": true
@@ -162,7 +162,7 @@ var RedditFieldsSchema = {
     "overview": "User Ad Metrics by community",
     "description": "Retrieve ad performance metrics and details from Reddit Ads API by community.",
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
-    "fields": reportFields,
+    "fields": reportCommunityFields,
     "uniqueKeys": ["ad_id", "date", "community"],
     "destinationName": "reddit_ads_report_by_COMMUNITY",
     "isTimeSeries": true

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-adaccountid.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-adaccountid.js
@@ -225,7 +225,7 @@ var reportAdAccountIdFields = {
     'type': 'number'
   },
   'account_id': {
-    'description': '[ONLY in AD_ACCOUNT_ID based report] as account_id \n The ID of the account.',
+    'description': '[ONLY in AD_ACCOUNT_ID based report] as account_id The ID of the account.',
     'type': 'string'
   },
   'currency': {

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-adaccountid.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-adaccountid.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-var reportFields = {
+var reportAdAccountIdFields = {
   'ad_id': {
     'description': 'The ID of the ad.',
     'type': 'string'
@@ -223,6 +223,10 @@ var reportFields = {
   'frequency': {
     'description': 'The average number of times each user saw the ad.',
     'type': 'number'
+  },
+  'account_id': {
+    'description': '[ONLY in AD_ACCOUNT_ID based report] as account_id \n The ID of the account.',
+    'type': 'string'
   },
   'currency': {
     'description': 'The currency of the account.',

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-adgroupid.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-adgroupid.js
@@ -5,9 +5,13 @@
  * file that was distributed with this source code.
  */
 
-var reportFields = {
+var reportAdGroupIdFields = {
   'ad_id': {
     'description': 'The ID of the ad.',
+    'type': 'string'
+  },
+  'ad_group_id': {
+    'description': '[ONLY in AD_GROUP_ID based report] The ID of the ad group.',
     'type': 'string'
   },
   'date': {

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-campaignid.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-campaignid.js
@@ -5,9 +5,13 @@
  * file that was distributed with this source code.
  */
 
-var reportFields = {
+var reportCampaignIdFields = {
   'ad_id': {
     'description': 'The ID of the ad.',
+    'type': 'string'
+  },
+  'campaign_id': {
+    'description': '[ONLY in CAMPAIGN_ID based report] The ID of the campaign.',
     'type': 'string'
   },
   'date': {
@@ -15,6 +19,10 @@ var reportFields = {
     'type': 'datetime',
     'GoogleBigQueryType': 'date', 
     'GoogleBigQueryPartitioned': true
+  },
+  'dma': {
+    'description': '[ONLY in DMA based report] The Designated Market Area (DMA) targeted for the reports.',
+    'type': 'string'
   },
   'clicks': {
     'description': 'The number of clicks detected for this report period.',

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-community.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-community.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-var reportFields = {
+var reportCommunityFields = {
   'ad_id': {
     'description': 'The ID of the ad.',
     'type': 'string'
@@ -171,6 +171,10 @@ var reportFields = {
   'conversion_view_content_views': {
     'description': 'The view through conversions count.',
     'type': 'integer'
+  },
+  'community': {
+    'description': '[ONLY in COMMUNITY based report] The community/subreddit being targeted.',
+    'type': 'string'
   },
   'cpc': {
     'description': 'The cost-per-click for this period.',

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-country.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-country.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-var reportFields = {
+var reportCountryFields = {
   'ad_id': {
     'description': 'The ID of the ad.',
     'type': 'string'
@@ -171,6 +171,10 @@ var reportFields = {
   'conversion_view_content_views': {
     'description': 'The view through conversions count.',
     'type': 'integer'
+  },
+  'country': {
+    'description': '[ONLY in COUNTRY based report] The country targeted for the report.',
+    'type': 'string'
   },
   'cpc': {
     'description': 'The cost-per-click for this period.',

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-dmabased.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-dmabased.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-var reportFields = {
+var reportDmaBasedFields = {
   'ad_id': {
     'description': 'The ID of the ad.',
     'type': 'string'
@@ -15,6 +15,10 @@ var reportFields = {
     'type': 'datetime',
     'GoogleBigQueryType': 'date', 
     'GoogleBigQueryPartitioned': true
+  },
+  'dma': {
+    'description': '[ONLY in DMA based report] The Designated Market Area (DMA) targeted for the reports.',
+    'type': 'string'
   },
   'clicks': {
     'description': 'The number of clicks detected for this report period.',

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-interest.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-interest.js
@@ -201,7 +201,7 @@ var reportInterestFields = {
     'type': 'integer'
   },
   'interest': {
-    'description': '[ONLY in INTEREST based report] \nThe interests of the users being targeted.',
+    'description': '[ONLY in INTEREST based report] The interests of the users being targeted.',
     'type': 'string'
   },
   'post_id': {

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-interest.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-interest.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-var reportFields = {
+var reportInterestFields = {
   'ad_id': {
     'description': 'The ID of the ad.',
     'type': 'string'
@@ -199,6 +199,10 @@ var reportFields = {
   'impressions': {
     'description': 'The number of impressions served for this report period.',
     'type': 'integer'
+  },
+  'interest': {
+    'description': '[ONLY in INTEREST based report] \nThe interests of the users being targeted.',
+    'type': 'string'
   },
   'post_id': {
     'description': 'The unique identifier of the post.',

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-keyword.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-keyword.js
@@ -229,7 +229,7 @@ var reportKeywordFields = {
     'type': 'string'
   },
   'keyword': {
-    'description': '[ONLY in KEYWORD based report] \n The keyword for the ad.',
+    'description': '[ONLY in KEYWORD based report] The keyword for the ad.',
     'type': 'string'
   }
 };

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-keyword.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-keyword.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-var reportFields = {
+var reportKeywordFields = {
   'ad_id': {
     'description': 'The ID of the ad.',
     'type': 'string'
@@ -226,6 +226,10 @@ var reportFields = {
   },
   'currency': {
     'description': 'The currency of the account.',
+    'type': 'string'
+  },
+  'keyword': {
+    'description': '[ONLY in KEYWORD based report] \n The keyword for the ad.',
     'type': 'string'
   }
 };

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-placement.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-placement.js
@@ -229,7 +229,7 @@ var reportPlacementFields = {
     'type': 'string'
   },
   'placement': {
-    'description': '[ONLY in PLACEMENT based report] \n Enum representing the placement of a creative.',
+    'description': '[ONLY in PLACEMENT based report] Enum representing the placement of a creative.',
     'type': 'string'
   }
 };

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-placement.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/ad-reports-placement.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-var reportFields = {
+var reportPlacementFields = {
   'ad_id': {
     'description': 'The ID of the ad.',
     'type': 'string'
@@ -226,6 +226,10 @@ var reportFields = {
   },
   'currency': {
     'description': 'The currency of the account.',
+    'type': 'string'
+  },
+  'placement': {
+    'description': '[ONLY in PLACEMENT based report] \n Enum representing the placement of a creative.',
     'type': 'string'
   }
 };


### PR DESCRIPTION
These commits refactor and extend the Reddit Ads connector’s reporting logic. The changes introduce new field definitions for segmented reports (by country, ad group, campaign, DMA, interest, keyword, placement, community, and ad account ID), and update the main schema to use these specialized field sets. This enhances the accuracy and maintainability of the data model, ensuring that each report type includes only relevant fields.

List of changes:

- Added new field definition files for segmented Reddit Ads reports.
- Updated FieldsSchema.js to reference the new specialized field sets for each segmented report type.
- Improved the clarity and maintainability of the Reddit Ads reporting schema by ensuring each report type uses only the fields relevant to its segmentation.