### PR TITLE
fix(backend): add primary key to migrations lock table for MySQL compatibility

### DIFF
--- a/apps/backend/src/config/migrations.config.ts
+++ b/apps/backend/src/config/migrations.config.ts
@@ -68,7 +68,7 @@ async function acquireMigrationsLock(
   dataSource: DataSource,
   logger: ReturnType<typeof createLogger>
 ): Promise<() => Promise<void>> {
-  const createSql = `CREATE TABLE ${LOCK_TABLE_NAME} (id INTEGER)`;
+  const createSql = `CREATE TABLE ${LOCK_TABLE_NAME} (id INTEGER PRIMARY KEY)`;
   const dropSql = `DROP TABLE ${LOCK_TABLE_NAME}`;
 
   const startAt = Date.now();


### PR DESCRIPTION
# Error
```
Sep 16 13:47:29
 query failed: CREATE TABLE __migrations_lock__ (id INTEGER)
Sep 16 13:47:29
 error: Error: Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set. Add a primary key to the table or unset this variable to avoid this message. Note that tables without a primary key can cause performance problems in row-based replication, so please consult your DBA before changing this setting.
```