### PR TITLE
feat(web): Create and select new storage from DataMart form

### DIFF
--- a/.changeset/create-storage-in-new-data-mart-form.md
+++ b/.changeset/create-storage-in-new-data-mart-form.md
@@ -1,0 +1,8 @@
+---
+'owox': minor
+---
+
+# Enhance DataMartCreateForm with New Storage Creation
+
+- Updated storage selection to allow **creating new storage directly** from the form.  
+- Refined **CreateDataMartPage styling** for better visual consistency.

--- a/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
@@ -17,14 +17,19 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  SelectSeparator,
 } from '@owox/ui/components/select';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { type DataMart, useDataMartForm, dataMartSchema, type DataMartFormData } from '../model';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useDataStorage } from '../../../data-storage/shared/model/hooks/useDataStorage';
 import { DataStorageTypeModel } from '../../../data-storage/shared/types/data-storage-type.model.ts';
 import { Button } from '@owox/ui/components/button';
+import { DataStorageTypeDialog } from '../../../data-storage/shared/components/DataStorageTypeDialog';
+import { DataStorageType } from '../../../data-storage/shared/model/types/data-storage-type.enum';
+import { Plus } from 'lucide-react';
+import { toast } from 'react-hot-toast';
 
 interface DataMartFormProps {
   initialData?: {
@@ -35,7 +40,14 @@ interface DataMartFormProps {
 
 export function DataMartCreateForm({ initialData, onSuccess }: DataMartFormProps) {
   const { handleCreate, isSubmitting, serverError } = useDataMartForm();
-  const { dataStorages, loading: loadingStorages, fetchDataStorages } = useDataStorage();
+  const {
+    dataStorages,
+    loading: loadingStorages,
+    fetchDataStorages,
+    createDataStorage,
+    getDataStorageById,
+  } = useDataStorage();
+  const [isTypeDialogOpen, setIsTypeDialogOpen] = useState(false);
 
   useEffect(() => {
     void fetchDataStorages();
@@ -57,95 +69,136 @@ export function DataMartCreateForm({ initialData, onSuccess }: DataMartFormProps
     }
   };
 
+  const openCreateNewDataStorageDialog = () => {
+    setIsTypeDialogOpen(true);
+  };
+
+  const createNewDataStorage = async (type: DataStorageType) => {
+    try {
+      const newStorage = await createDataStorage(type);
+      if (newStorage?.id) {
+        await getDataStorageById(newStorage.id);
+        form.setValue('storageId', newStorage.id);
+        toast.success(`Storage "${newStorage.title}" created successfully`);
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to create new storage');
+    }
+    setIsTypeDialogOpen(false);
+  };
+
   return (
-    <Form {...form}>
-      <AppForm
-        onSubmit={e => {
-          void form.handleSubmit(onSubmit)(e);
+    <>
+      <Form {...form}>
+        <AppForm
+          onSubmit={e => {
+            void form.handleSubmit(onSubmit)(e);
+          }}
+        >
+          <FormLayout variant='light'>
+            {serverError && (
+              <div className='rounded bg-red-100 p-3 text-red-700'>{serverError.message}</div>
+            )}
+
+            <FormField
+              control={form.control}
+              name='title'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Title</FormLabel>
+                  <FormControl>
+                    <Input
+                      id='title'
+                      placeholder='Enter title'
+                      {...field}
+                      disabled={isSubmitting}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name='storageId'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Storage</FormLabel>
+                  <FormControl>
+                    <Select
+                      onValueChange={value => {
+                        if (value === 'create_new') {
+                          openCreateNewDataStorageDialog();
+                        } else {
+                          field.onChange(value);
+                        }
+                      }}
+                      value={field.value}
+                      disabled={isSubmitting || loadingStorages}
+                    >
+                      <SelectTrigger className='w-full'>
+                        <SelectValue placeholder='Select a storage' />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {loadingStorages && (
+                            <SelectItem value='loading' disabled>
+                              Loading...
+                            </SelectItem>
+                          )}
+                          {!loadingStorages &&
+                            dataStorages.map(storage => {
+                              const Icon = DataStorageTypeModel.getInfo(storage.type).icon;
+                              return (
+                                <SelectItem key={storage.id} value={storage.id}>
+                                  <div className='flex items-center gap-2'>
+                                    <Icon size={20} />
+                                    <span>{storage.title}</span>
+                                  </div>
+                                </SelectItem>
+                              );
+                            })}
+                          {!loadingStorages && dataStorages.length > 0 && <SelectSeparator />}
+                          <SelectItem value='create_new'>
+                            <div className='flex items-center gap-2'>
+                              <div className='flex h-5 w-5 items-center justify-center'>
+                                <Plus size={20} />
+                              </div>
+                              <span>Create new storage</span>
+                            </div>
+                          </SelectItem>
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </FormLayout>
+          <FormActions variant='light'>
+            <Button type='submit'>Create Data Mart</Button>
+            <Button
+              variant='outline'
+              type='button'
+              onClick={() => {
+                window.history.back();
+              }}
+            >
+              Go back
+            </Button>
+          </FormActions>
+        </AppForm>
+      </Form>
+
+      <DataStorageTypeDialog
+        isOpen={isTypeDialogOpen}
+        onClose={() => {
+          setIsTypeDialogOpen(false);
         }}
-      >
-        <FormLayout variant='light'>
-          {serverError && (
-            <div className='rounded bg-red-100 p-3 text-red-700'>{serverError.message}</div>
-          )}
-
-          <FormField
-            control={form.control}
-            name='title'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Title</FormLabel>
-                <FormControl>
-                  <Input id='title' placeholder='Enter title' {...field} disabled={isSubmitting} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name='storageId'
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Storage</FormLabel>
-                <FormControl>
-                  <Select
-                    onValueChange={value => {
-                      field.onChange(value);
-                    }}
-                    value={field.value}
-                    disabled={isSubmitting || loadingStorages}
-                  >
-                    <SelectTrigger className='w-full'>
-                      <SelectValue placeholder='Select a storage' />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {loadingStorages && (
-                          <SelectItem value='loading' disabled>
-                            Loading...
-                          </SelectItem>
-                        )}
-                        {!loadingStorages && dataStorages.length === 0 && (
-                          <SelectItem value='empty' disabled>
-                            No storages available
-                          </SelectItem>
-                        )}
-                        {!loadingStorages &&
-                          dataStorages.map(storage => {
-                            const Icon = DataStorageTypeModel.getInfo(storage.type).icon;
-                            return (
-                              <SelectItem key={storage.id} value={storage.id}>
-                                <div className='flex items-center gap-2'>
-                                  <Icon size={20} />
-                                  <span>{storage.title}</span>
-                                </div>
-                              </SelectItem>
-                            );
-                          })}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </FormLayout>
-        <FormActions variant='light'>
-          <Button type='submit'>Create Data Mart</Button>
-          <Button
-            variant='outline'
-            type='button'
-            onClick={() => {
-              window.history.back();
-            }}
-          >
-            Go back
-          </Button>
-        </FormActions>
-      </AppForm>
-    </Form>
+        onSelect={type => createNewDataStorage(type)}
+      />
+    </>
   );
 }

--- a/apps/web/src/pages/data-marts/create/CreateDataMartPage.tsx
+++ b/apps/web/src/pages/data-marts/create/CreateDataMartPage.tsx
@@ -12,7 +12,7 @@ export default function CreateDataMartPage() {
   return (
     <div className='flex h-full w-full items-center justify-center'>
       <div className='mx-auto my-auto w-lg'>
-        <div className='dm-card !rounded-xl !p-8'>
+        <div className='bg-muted/50 dark:bg-sidebar rounded-xl border-b border-gray-200 p-12 pt-8 dark:border-gray-700/50'>
           <h2 className='mb-4 text-xl font-medium'>Create Data Mart</h2>
           <DataStorageProvider>
             <DataMartProvider>


### PR DESCRIPTION
## Description
This update enhances the DataMart creation workflow by allowing users to create and select new data storage types directly from the form, along with UI and state management improvements.

## Key changes
- Added a **dialog** for creating new data storage types.  
- Integrated **state management** and improved **error handling** with toast notifications.  
- Updated storage selection to allow **creating and selecting new storage directly** from the form.  
- Refined **CreateDataMartPage styling** for better visual consistency.  

## User Flow
<img width="3410" height="929" alt="Frame 23137480" src="https://github.com/user-attachments/assets/e804dd7a-a7dd-4f10-8343-c2fda40868c9" />
