### PR TITLE
feat(migration): rename Bing Ads connector to Microsoft Ads

### DIFF
--- a/apps/backend/src/migrations/1758720208111-rename-bing-ads-connector-to-microsoft-ads.ts
+++ b/apps/backend/src/migrations/1758720208111-rename-bing-ads-connector-to-microsoft-ads.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NewMigration1758720208111 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        UPDATE data_mart 
+        SET definition = REPLACE(definition, '"name":"BingAds"', '"name":"MicrosoftAds"')
+        WHERE definitionType='CONNECTOR'
+        AND definition LIKE '%"source":%"name":"BingAds"%'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        UPDATE data_mart 
+        SET definition = REPLACE(definition, '"name":"MicrosoftAds"', '"name":"BingAds"')
+        WHERE definitionType='CONNECTOR'
+        AND definition LIKE '%"source":%"name":"MicrosoftAds"%'
+    `);
+  }
+}


### PR DESCRIPTION
This pull request introduces a database migration to update the naming of a connector in the `data_mart` table. The migration ensures consistency by renaming "BingAds" to "MicrosoftAds" and provides a rollback option.