### PR TITLE
fix(web): Fix Members menu item URL for better-auth provider

### DIFF
--- a/apps/web/src/components/AppSidebar/ProjectMenu/items.ts
+++ b/apps/web/src/components/AppSidebar/ProjectMenu/items.ts
@@ -87,7 +87,7 @@ export const projectMenuItems: ProjectMenuItem[] = [
   {
     type: 'menu-item',
     title: 'Members',
-    href: 'https://app.owox.com/auth',
+    href: '/auth',
     icon: Users,
     visible: { flagKey: 'IDP_PROVIDER', expectedValue: 'better-auth' },
     group: 'project',


### PR DESCRIPTION
## Changes
Updated Members menu item href from external URL (`https://app.owox.com/auth`) to local route (`/auth`) for better-auth provider

## Context
This change ensures that when using the better-auth provider, users are directed to the local authentication page instead of an external URL.
