### PR TITLE
fix(CriteoAds): hardcode Criteo API Version and update documentation link

### DIFF
--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/CriteoAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/CriteoAdsFieldsSchema.js
@@ -9,7 +9,7 @@ var CriteoAdsFieldsSchema = {
   statistics: {
     overview: "Criteo Statistics",
     description: "Statistics and metrics for Criteo advertising campaigns.",
-    documentation: "https://developers.criteo.com/marketing-solutions/v2024.01/docs/campaign-statistics",
+    documentation: "https://developers.criteo.com/marketing-solutions/docs/campaign-statistics",
     fields: adStatisticsFields,
     uniqueKeys: ["CampaignId", "AdvertiserId", "AdsetId", "AdId", "Day"],
     destinationName: "criteo_ads_statistics",

--- a/packages/connectors/src/Sources/CriteoAds/Source.js
+++ b/packages/connectors/src/Sources/CriteoAds/Source.js
@@ -61,12 +61,6 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
         default: 30,
         label: "Max Fetching Days",
         description: "Maximum number of days to fetch data for"
-      },
-      ApiVersion: {
-        requiredType: "string",
-        value: "2025-04",
-        label: "API Version",
-        description: "Criteo API version"
       }
     }));
 
@@ -168,7 +162,8 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
    * @private
    */
   _makeApiRequest(requestBody) {
-    const apiUrl = `https://api.criteo.com/${this.config.ApiVersion.value}/statistics/report`;
+    const apiVersion = "2025-07";
+    const apiUrl = `https://api.criteo.com/${apiVersion}/statistics/report`;
     const options = {
       method: 'post',
       headers: {


### PR DESCRIPTION
Removed ApiVersion from config and hardcoded API version to 2025-07 in Source.js. Updated documentation link in CriteoAdsFieldsSchema.js to the latest format.