### PR TITLE
fix(LinkedIn): Remove API version config and hardcode LinkedIn-Version header

### DIFF
--- a/packages/connectors/src/Sources/LinkedInAds/Source.js
+++ b/packages/connectors/src/Sources/LinkedInAds/Source.js
@@ -26,12 +26,6 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
         label: "Refresh Token",
         description: "LinkedIn API Refresh Token for authentication"
       },
-      Version: {
-        requiredType: "string",
-        default: "202504",
-        label: "API Version",
-        description: "LinkedIn API version"
-      },
       ReimportLookbackWindow: {
         requiredType: "number",
         isRequired: true,
@@ -381,7 +375,7 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
     });
 
     const headers = {
-      "LinkedIn-Version": this.config.Version.value,
+      "LinkedIn-Version": "202509",
       "X-RestLi-Protocol-Version": "2.0.0",
     };
     

--- a/packages/connectors/src/Sources/LinkedInPages/Source.js
+++ b/packages/connectors/src/Sources/LinkedInPages/Source.js
@@ -26,12 +26,6 @@ var LinkedInPagesSource = class LinkedInPagesSource extends AbstractSource {
         label: "Refresh Token",
         description: "LinkedIn API Refresh Token for authentication"
       },
-      Version: {
-        requiredType: "string",
-        default: "202504",
-        label: "API Version",
-        description: "LinkedIn API version"
-      },
       ReimportLookbackWindow: {
         requiredType: "number",
         isRequired: true,
@@ -198,7 +192,7 @@ var LinkedInPagesSource = class LinkedInPagesSource extends AbstractSource {
     });
     
     const headers = {
-      "LinkedIn-Version": this.config.Version.value,
+      "LinkedIn-Version": "202509",
       "X-RestLi-Protocol-Version": "2.0.0",
     };
       


### PR DESCRIPTION
Deleted API version from connector configuration and set the LinkedIn-Version header to 202509 in both LinkedIn Ads and LinkedIn Pages sources.