### PR TITLE
feat(migration): add migration to rename bing ads connector to microsoft ads, again

### DIFF
--- a/apps/backend/src/migrations/1758809780933-rename-bing-ads-connector-to-microsoft-ads-for-all-db.ts
+++ b/apps/backend/src/migrations/1758809780933-rename-bing-ads-connector-to-microsoft-ads-for-all-db.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameBingAdsConnectorToMicrosoftAdsForAllDb1758809780933
+  implements MigrationInterface
+{
+  public readonly name = 'RenameBingAdsConnectorToMicrosoftAdsForAllDb1758809780933';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        UPDATE data_mart 
+        SET definition = REPLACE(
+          REPLACE(definition, '"name":"BingAds"', '"name":"MicrosoftAds"'),
+          '"name": "BingAds"', 
+          '"name": "MicrosoftAds"'
+          )
+        WHERE definitionType='CONNECTOR'
+        AND (
+          definition LIKE '%"source":%"name":"BingAds"%' 
+          OR definition LIKE '%"source":%"name": "BingAds"%'
+          )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        UPDATE data_mart 
+        SET definition = REPLACE(
+          REPLACE(definition, '"name":"MicrosoftAds"', '"name":"BingAds"'),
+          '"name": "MicrosoftAds"', 
+          '"name": "BingAds"'
+          )
+        WHERE definitionType='CONNECTOR'
+        AND (
+          definition LIKE '%"source":%"name":"MicrosoftAds"%' 
+          OR definition LIKE '%"source":%"name": "MicrosoftAds"%'
+          )
+    `);
+  }
+}


### PR DESCRIPTION
This pull request adds a new migration to update connector names in the database for consistency. Specifically, it renames all instances of "BingAds" to "MicrosoftAds" in the `data_mart` table for connector definitions, and provides a way to revert this change if needed.
