### PR TITLE
feat(backend): added PublicOriginService and generate Looker Studio deploymentUrl

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ LOG_FORMAT=
 # Port number for the application server
 # Default: 3000 
 PORT=
+
+# Base URL of the application [scheme + host (+ optional port)]
+# Examples: http://localhost:3000, https://data-marts.example.com
+# Default: http://localhost:${PORT}
+PUBLIC_ORIGIN=
 # -------------------------------------------------------------------------------------------
 
 # --- @owox/backend variables ---------------------------------------------------------------

--- a/apps/backend/src/bootstrap.ts
+++ b/apps/backend/src/bootstrap.ts
@@ -10,11 +10,11 @@ import { runMigrationsIfNeeded } from './config/migrations.config';
 import { loadEnv } from './load-env';
 import { Express, text } from 'express';
 import { AppModule } from './app.module';
+import { DEFAULT_PORT } from './config/constants';
 
 const logger = createLogger('Bootstrap');
 const PATH_PREFIX = 'api';
 const SWAGGER_PATH = 'swagger-ui';
-const DEFAULT_PORT = 3000;
 
 // HTTP server timeout configuration (in milliseconds)
 const SERVER_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes - overall request timeout

--- a/apps/backend/src/common/common.module.ts
+++ b/apps/backend/src/common/common.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { PublicOriginService } from './config/public-origin.service';
 import { SchedulerModule } from './scheduler/scheduler.module';
 
 @Module({
   imports: [SchedulerModule],
-  exports: [SchedulerModule],
+  providers: [PublicOriginService],
+  exports: [SchedulerModule, PublicOriginService],
 })
 export class CommonModule {}

--- a/apps/backend/src/common/config/public-origin.service.spec.ts
+++ b/apps/backend/src/common/config/public-origin.service.spec.ts
@@ -1,0 +1,239 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PublicOriginService } from './public-origin.service';
+
+describe('PublicOriginService', () => {
+  let service: PublicOriginService;
+  let config: jest.Mocked<ConfigService>;
+
+  beforeEach(async () => {
+    config = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PublicOriginService, { provide: ConfigService, useValue: config }],
+    }).compile();
+
+    service = module.get(PublicOriginService);
+  });
+
+  describe('ensureHttps', () => {
+    it('converts http to https', () => {
+      expect(service.ensureHttps('http://example.com')).toBe('https://example.com');
+    });
+
+    it('adds https when protocol is missing', () => {
+      expect(service.ensureHttps('example.com')).toBe('https://example.com');
+    });
+
+    it('keeps https as is', () => {
+      expect(service.ensureHttps('https://example.com')).toBe('https://example.com');
+    });
+  });
+
+  describe('getLookerStudioDeploymentUrl', () => {
+    const PORT = 3000;
+
+    beforeEach(() => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'PORT') return PORT as unknown as string;
+        if (key === 'PUBLIC_ORIGIN') return '' as unknown as string;
+        return '' as unknown as string;
+      });
+    });
+
+    it('uses LOOKER_STUDIO_DESTINATION_ORIGIN when provided (https)', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN')
+          return 'https://data-marts.example.com:2077';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe('https://data-marts.example.com:2077');
+    });
+
+    it('normalizes http → https for LOOKER_STUDIO_DESTINATION_ORIGIN', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return 'http://data-marts.example.com:2077';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe('https://data-marts.example.com:2077');
+    });
+
+    it('handles LOOKER_STUDIO_DESTINATION_ORIGIN as host:port', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return 'data-marts.example.com:2077';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe('https://data-marts.example.com:2077');
+    });
+
+    it('falls back to PUBLIC_ORIGIN when LS is empty', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return '';
+        if (key === 'PUBLIC_ORIGIN') return 'my-domain.example.com';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe('https://my-domain.example.com');
+    });
+
+    it('prefers LOOKER_STUDIO_DESTINATION_ORIGIN over PUBLIC_ORIGIN when both provided', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return 'http://ls.example.com:4444';
+        if (key === 'PUBLIC_ORIGIN') return 'public.example.com';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe('https://ls.example.com:4444');
+    });
+
+    it('falls back to https://localhost:PORT when both empty', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return '';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe(`https://localhost:${PORT}`);
+    });
+
+    it('edge: space inside hostname → fallback to localhost', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return 'https://exa mple.com';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe(`https://localhost:${PORT}`);
+    });
+
+    it('edge: space after protocol → fallback to localhost', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return 'http:// example.com';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe(`https://localhost:${PORT}`);
+    });
+
+    it('edge: space before dot → fallback to localhost', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return 'example .com';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe(`https://localhost:${PORT}`);
+    });
+
+    it('edge: spaces around host and port → fallback to localhost', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return 'exa mple . com : 8080';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe(`https://localhost:${PORT}`);
+    });
+
+    it('edge: space before port → fallback to localhost', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return 'example.com :443';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe(`https://localhost:${PORT}`);
+    });
+
+    it('edge: non-numeric port → fallback to localhost', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return 'example.com:abc';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe(`https://localhost:${PORT}`);
+    });
+
+    it('edge: only protocol → fallback to localhost', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return 'https://';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe(`https://localhost:${PORT}`);
+    });
+
+    it('edge: missing scheme marker → fallback to localhost', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return '://example.com';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe(`https://localhost:${PORT}`);
+    });
+
+    it('invalid PORT as string → falls back to DEFAULT_PORT', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return '';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return 'HELLO WORLD' as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe('https://localhost:3000');
+    });
+
+    it('invalid PORT as negative number → falls back to DEFAULT_PORT', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'LOOKER_STUDIO_DESTINATION_ORIGIN') return '';
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return -1 as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getLookerStudioDeploymentUrl()).toBe('https://localhost:3000');
+    });
+  });
+
+  describe('getPublicOrigin', () => {
+    it('returns PUBLIC_ORIGIN when provided', () => {
+      const PORT = 4000;
+      config.get.mockImplementation((key: string) => {
+        if (key === 'PUBLIC_ORIGIN') return 'http://my-public.example.com';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getPublicOrigin()).toBe('http://my-public.example.com');
+    });
+
+    it('falls back to http://localhost:PORT when PUBLIC_ORIGIN is empty', () => {
+      const PORT = 4321;
+      config.get.mockImplementation((key: string) => {
+        if (key === 'PUBLIC_ORIGIN') return '';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getPublicOrigin()).toBe(`http://localhost:${PORT}`);
+    });
+
+    it('falls back to http://localhost:PORT when PUBLIC_ORIGIN is invalid', () => {
+      const PORT = 5555;
+      config.get.mockImplementation((key: string) => {
+        if (key === 'PUBLIC_ORIGIN') return 'exa mple.com';
+        if (key === 'PORT') return PORT as unknown as string;
+        return '' as unknown as string;
+      });
+      expect(service.getPublicOrigin()).toBe(`http://localhost:${PORT}`);
+    });
+  });
+});

--- a/apps/backend/src/common/config/public-origin.service.ts
+++ b/apps/backend/src/common/config/public-origin.service.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DEFAULT_PORT } from '../../config/constants';
+
+/**
+ * Service for deriving and validating public origins used by the application.
+ *
+ * Responsibilities:
+ * - Normalize origin strings by adding protocols (http/https) when missing
+ * - Validate URL structure (hostname and protocol)
+ * - Provide a consistent, safe fallback for public-facing URLs
+ */
+@Injectable()
+export class PublicOriginService {
+  constructor(private readonly config: ConfigService) {}
+
+  /**
+   * Ensures an HTTPS scheme is present in the provided value.
+   *
+   * Behavior:
+   * - If value has no scheme → adds http:// first, then upgrades to https://
+   * - If value already uses https:// → returns as is
+   * - If value uses http:// → converts to https://
+   *
+   * @param value Raw origin or host (may be missing scheme)
+   * @returns Origin string with https scheme
+   */
+  ensureHttps(value: string): string {
+    const withHttp = this.ensureHttp(value);
+    if (withHttp.startsWith('https://')) return withHttp;
+    return `https://${withHttp.slice('http://'.length)}`;
+  }
+
+  /**
+   * Ensures an HTTP scheme is present in the provided value.
+   *
+   * Behavior:
+   * - If value has no scheme → adds http://
+   * - If value already has http:// or https:// → returns as is
+   *
+   * @param value Raw origin or host (may be missing scheme)
+   * @returns Origin string with http or https scheme
+   */
+  ensureHttp(value: string): string {
+    if (value.startsWith('http://') || value.startsWith('https://')) return value;
+    return `http://${value}`;
+  }
+
+  /**
+   * Validates a URL string to be a well-formed http/https URL with a hostname.
+   *
+   * @param value URL string to validate (must already contain a scheme)
+   * @returns True if the URL is valid and has http/https scheme, false otherwise
+   */
+  private isValidUrl(value: string): boolean {
+    try {
+      const url = new URL(value);
+      return Boolean(url.hostname) && (url.protocol === 'http:' || url.protocol === 'https:');
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Returns a normalized deployment URL for Looker Studio connector.
+   *
+   * Resolution order:
+   * 1) LOOKER_STUDIO_DESTINATION_ORIGIN (normalized to https and validated)
+   * 2) PUBLIC_ORIGIN (via getPublicOrigin), then normalized to https
+   *
+   * @returns HTTPS origin suitable for exposing to Looker Studio
+   */
+  getLookerStudioDeploymentUrl(): string {
+    const lsOrigin = (this.config.get<string>('LOOKER_STUDIO_DESTINATION_ORIGIN') || '').trim();
+    const publicOrigin = this.getPublicOrigin();
+    if (lsOrigin) {
+      const candidateWithHttps = this.ensureHttps(lsOrigin);
+      if (this.isValidUrl(candidateWithHttps)) return candidateWithHttps;
+    }
+    return this.ensureHttps(publicOrigin);
+  }
+
+  /**
+   * Returns the application's public origin.
+   *
+   * Behavior:
+   * - Reads PUBLIC_ORIGIN, adds http scheme if missing and validates
+   * - On empty or invalid PUBLIC_ORIGIN → returns http://localhost:PORT (with PORT fallback to DEFAULT_PORT)
+   *
+   * @returns Public origin URL string (http)
+   */
+  getPublicOrigin(): string {
+    const rawPort = this.config.get<number | string>('PORT');
+    const normalizedPort = Number(rawPort);
+    const port =
+      Number.isFinite(normalizedPort) && normalizedPort > 0 ? normalizedPort : DEFAULT_PORT;
+    const publicOriginRaw = (this.config.get<string>('PUBLIC_ORIGIN') || '').trim();
+    if (publicOriginRaw) {
+      const withProtocol = this.ensureHttp(publicOriginRaw);
+      if (this.isValidUrl(withProtocol)) return withProtocol;
+    }
+    return `http://localhost:${port}`;
+  }
+}

--- a/apps/backend/src/common/config/public-origin.service.ts
+++ b/apps/backend/src/common/config/public-origin.service.ts
@@ -62,9 +62,9 @@ export class PublicOriginService {
   }
 
   /**
-   * Returns a normalized deployment URL for Looker Studio connector.
+   * Returns a normalized deployment URL for Looker Studio.
    *
-   * Resolution order:
+   * Priority order:
    * 1) LOOKER_STUDIO_DESTINATION_ORIGIN (normalized to https and validated)
    * 2) PUBLIC_ORIGIN (via getPublicOrigin), then normalized to https
    *
@@ -74,9 +74,10 @@ export class PublicOriginService {
     const lsOrigin = (this.config.get<string>('LOOKER_STUDIO_DESTINATION_ORIGIN') || '').trim();
     const publicOrigin = this.getPublicOrigin();
     if (lsOrigin) {
-      const candidateWithHttps = this.ensureHttps(lsOrigin);
-      if (this.isValidUrl(candidateWithHttps)) return candidateWithHttps;
+      const lsOriginWithHttps = this.ensureHttps(lsOrigin);
+      if (this.isValidUrl(lsOriginWithHttps)) return lsOriginWithHttps;
     }
+
     return this.ensureHttps(publicOrigin);
   }
 
@@ -90,15 +91,14 @@ export class PublicOriginService {
    * @returns Public origin URL string (http)
    */
   getPublicOrigin(): string {
-    const rawPort = this.config.get<number | string>('PORT');
-    const normalizedPort = Number(rawPort);
-    const port =
-      Number.isFinite(normalizedPort) && normalizedPort > 0 ? normalizedPort : DEFAULT_PORT;
+    const rawPort = Number(this.config.get<number | string>('PORT'));
+    const port = Number.isFinite(rawPort) && rawPort > 0 ? rawPort : DEFAULT_PORT;
     const publicOriginRaw = (this.config.get<string>('PUBLIC_ORIGIN') || '').trim();
     if (publicOriginRaw) {
       const withProtocol = this.ensureHttp(publicOriginRaw);
       if (this.isValidUrl(withProtocol)) return withProtocol;
     }
+
     return `http://localhost:${port}`;
   }
 }

--- a/apps/backend/src/config/constants.ts
+++ b/apps/backend/src/config/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_PORT = 3000;

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/schemas/looker-studio-connector-credentials.schema.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/schemas/looker-studio-connector-credentials.schema.ts
@@ -5,15 +5,6 @@ export const LookerStudioConnectorCredentialsType = 'looker-studio-credentials';
 export const LookerStudioConnectorCredentialsSchema = z
   .object({
     type: z.literal(LookerStudioConnectorCredentialsType),
-    deploymentUrl: z
-      .string()
-      .min(1, 'Deployment URL is required')
-      .url(
-        'The deployment URL should include the protocol (https://) and domain name. A port may also be included if necessary (e.g., https://example.com:8080)'
-      )
-      .refine(url => url.startsWith('https://'), {
-        message: 'Deployment URL must use HTTPS protocol',
-      }),
     destinationSecretKey: z.string().optional(),
   })
   .passthrough();

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -86,6 +86,7 @@ import { ConnectorState } from './entities/connector-state.entity';
 import { ReportDataCache } from './entities/report-data-cache.entity';
 import { IdpModule } from '../idp/idp.module';
 import { createOperationTimeoutMiddleware } from '../common/middleware/operation-timeout.middleware';
+import { CommonModule } from '../common/common.module';
 
 @Module({
   imports: [
@@ -100,6 +101,7 @@ import { createOperationTimeoutMiddleware } from '../common/middleware/operation
       ReportDataCache,
     ]),
     SchedulerModule,
+    CommonModule,
     IdpModule,
   ],
   controllers: [

--- a/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
@@ -16,10 +16,14 @@ import { CreateDataDestinationApiDto } from '../dto/presentation/create-data-des
 import { DataDestinationResponseApiDto } from '../dto/presentation/data-destination-response-api.dto';
 import { UpdateDataDestinationApiDto } from '../dto/presentation/update-data-destination-api.dto';
 import { DataDestination } from '../entities/data-destination.entity';
+import { PublicOriginService } from '../../common/config/public-origin.service';
 
 @Injectable()
 export class DataDestinationMapper {
-  constructor(private readonly credentialsUtils: DataDestinationCredentialsUtils) {}
+  constructor(
+    private readonly credentialsUtils: DataDestinationCredentialsUtils,
+    private readonly publicOriginService: PublicOriginService
+  ) {}
   toCreateCommand(
     context: AuthorizationContext,
     dto: CreateDataDestinationApiDto
@@ -47,7 +51,11 @@ export class DataDestinationMapper {
       dataDestination.type,
       dataDestination.projectId,
       (dataDestination.type === DataDestinationType.LOOKER_STUDIO
-        ? { ...dataDestination.credentials, destinationId: dataDestination.id }
+        ? {
+            ...dataDestination.credentials,
+            destinationId: dataDestination.id,
+            deploymentUrl: this.publicOriginService.getLookerStudioDeploymentUrl(),
+          }
         : dataDestination.credentials) as DataDestinationCredentialsDto,
       dataDestination.createdAt,
       dataDestination.modifiedAt

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/LookerStudioFields.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/LookerStudioFields.tsx
@@ -8,7 +8,6 @@ import {
   FormMessage,
   FormDescription,
 } from '@owox/ui/components/form';
-import { Input } from '@owox/ui/components/input';
 import { SecureJsonInput } from '../../../../../shared';
 import { useMemo } from 'react';
 import { isLookerStudioCredentials } from '../../../shared/model/types/looker-studio-credentials.ts';
@@ -22,7 +21,7 @@ export function LookerStudioFields({ form }: LookerStudioFieldsProps) {
   const credentials = form.getValues('credentials');
 
   const lookerStudioCredentials = useMemo(() => {
-    if (isLookerStudioCredentials(credentials)) {
+    if (credentials && isLookerStudioCredentials(credentials)) {
       return credentials;
     }
     return { deploymentUrl: '', destinationId: '', destinationSecretKey: '' };
@@ -34,24 +33,6 @@ export function LookerStudioFields({ form }: LookerStudioFieldsProps) {
 
   return (
     <>
-      <FormField
-        control={form.control}
-        name='credentials.deploymentUrl'
-        render={({ field }) => (
-          <FormItem className='w-full'>
-            <FormLabel tooltip='Enter the deployment URL that the Looker Studio connector will use'>
-              Deployment URL
-            </FormLabel>
-            <FormControl>
-              <Input placeholder='https://example.com' {...field} value={field.value || ''} />
-            </FormControl>
-            <FormDescription>
-              The deployment URL that the Looker Studio connector will use to access your data
-            </FormDescription>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
       {lookerStudioCredentials.destinationSecretKey && (
         <FormField
           control={form.control}

--- a/apps/web/src/features/data-destination/shared/model/mappers/looker-studio.mapper.ts
+++ b/apps/web/src/features/data-destination/shared/model/mappers/looker-studio.mapper.ts
@@ -27,13 +27,8 @@ export class LookerStudioMapper implements DestinationMapper {
     const lookerStudioFormData = formData;
     const updateRequest: UpdateDataDestinationRequestDto = {
       title: lookerStudioFormData.title ?? '',
+      credentials: { type: DataDestinationCredentialsType.LOOKER_STUDIO_CREDENTIALS },
     };
-    if (lookerStudioFormData.credentials) {
-      updateRequest.credentials = {
-        deploymentUrl: (lookerStudioFormData.credentials as LookerStudioCredentials).deploymentUrl,
-        type: DataDestinationCredentialsType.LOOKER_STUDIO_CREDENTIALS,
-      };
-    }
     return updateRequest;
   }
 
@@ -42,10 +37,7 @@ export class LookerStudioMapper implements DestinationMapper {
     return {
       title: lookerStudioFormData.title,
       type: DataDestinationType.LOOKER_STUDIO,
-      credentials: {
-        deploymentUrl: (lookerStudioFormData.credentials as LookerStudioCredentials).deploymentUrl,
-        type: DataDestinationCredentialsType.LOOKER_STUDIO_CREDENTIALS,
-      },
+      credentials: { type: DataDestinationCredentialsType.LOOKER_STUDIO_CREDENTIALS },
     };
   }
 

--- a/apps/web/src/features/data-destination/shared/model/types/looker-studio-credentials.ts
+++ b/apps/web/src/features/data-destination/shared/model/types/looker-studio-credentials.ts
@@ -1,7 +1,7 @@
 import type { DataDestination } from './data-destination.ts';
 
 export interface LookerStudioCredentials {
-  deploymentUrl: string;
+  deploymentUrl?: string;
   destinationId?: string;
   destinationSecretKey?: string;
 }
@@ -9,5 +9,5 @@ export interface LookerStudioCredentials {
 export function isLookerStudioCredentials(
   credentials: DataDestination['credentials']
 ): credentials is LookerStudioCredentials {
-  return 'deploymentUrl' in credentials;
+  return 'destinationSecretKey' in credentials;
 }

--- a/apps/web/src/features/data-destination/shared/services/types/create-data-destination.request.dto.ts
+++ b/apps/web/src/features/data-destination/shared/services/types/create-data-destination.request.dto.ts
@@ -1,23 +1,23 @@
-import { DataDestinationType } from '../../enums';
 import type { GoogleServiceAccountCredentialsDto } from '../../../../../shared/types';
-import type { LookerStudioCredentialsRequestDto } from './looker-studio-credentials.request.dto.ts';
+import { DataDestinationCredentialsType, DataDestinationType } from '../../enums';
 
 /**
  * Data transfer object for creating a new data destination
  */
-export interface CreateDataDestinationRequestDto {
-  /**
-   * Title of the data destination
-   */
-  title: string;
-
-  /**
-   * Type of the data destination
-   */
-  type: DataDestinationType;
-
-  /**
-   * Credentials required for the selected destination type
-   */
-  credentials: GoogleServiceAccountCredentialsDto | LookerStudioCredentialsRequestDto;
-}
+export type CreateDataDestinationRequestDto =
+  | {
+      /** Title of the data destination */
+      title: string;
+      /** Type of the data destination */
+      type: DataDestinationType.GOOGLE_SHEETS;
+      /** Credentials required for Google Sheets */
+      credentials: GoogleServiceAccountCredentialsDto;
+    }
+  | {
+      /** Title of the data destination */
+      title: string;
+      /** Type of the data destination */
+      type: DataDestinationType.LOOKER_STUDIO;
+      /** Minimal credentials object for Looker Studio */
+      credentials: { type: DataDestinationCredentialsType.LOOKER_STUDIO_CREDENTIALS };
+    };

--- a/apps/web/src/features/data-destination/shared/services/types/looker-studio-credentials.request.dto.ts
+++ b/apps/web/src/features/data-destination/shared/services/types/looker-studio-credentials.request.dto.ts
@@ -1,7 +1,0 @@
-/**
- * Looker Studio credentials DTO interface
- * Used by Data Destination module
- */
-export interface LookerStudioCredentialsRequestDto {
-  deploymentUrl: string;
-}

--- a/apps/web/src/features/data-destination/shared/services/types/update-data-destination.request.dto.ts
+++ b/apps/web/src/features/data-destination/shared/services/types/update-data-destination.request.dto.ts
@@ -1,5 +1,4 @@
 import { type GoogleServiceAccountCredentialsDto } from '../../../../../shared/types';
-import type { LookerStudioCredentialsRequestDto } from './looker-studio-credentials.request.dto.ts';
 
 /**
  * Data transfer object for updating a data destination
@@ -13,5 +12,5 @@ export interface UpdateDataDestinationRequestDto {
   /**
    * Credentials for the selected destination type
    */
-  credentials?: GoogleServiceAccountCredentialsDto | LookerStudioCredentialsRequestDto;
+  credentials?: GoogleServiceAccountCredentialsDto;
 }

--- a/apps/web/src/features/data-destination/shared/types/data-destination.schema.ts
+++ b/apps/web/src/features/data-destination/shared/types/data-destination.schema.ts
@@ -18,7 +18,7 @@ const googleSheetsDestinationSchema = baseDataDestinationSchema.extend({
 // Using the shared schema for Looker Studio credentials
 const lookerStudioDestinationSchema = baseDataDestinationSchema.extend({
   type: z.literal(DataDestinationType.LOOKER_STUDIO),
-  credentials: lookerStudioCredentialsSchema,
+  credentials: lookerStudioCredentialsSchema.optional(),
 });
 
 // Combined schema with conditional validation based on type

--- a/apps/web/src/features/data-destination/shared/types/looker-studio-credentials.schema.ts
+++ b/apps/web/src/features/data-destination/shared/types/looker-studio-credentials.schema.ts
@@ -5,15 +5,7 @@ import { z } from 'zod';
  * Used by Data Destination module
  */
 export const lookerStudioCredentialsSchema = z.object({
-  deploymentUrl: z
-    .string()
-    .min(1, 'Deployment URL is required')
-    .url(
-      'The deployment URL should include the protocol (https://) and domain name. A port may also be included if necessary (e.g., https://example.com:8080)'
-    )
-    .refine(url => url.startsWith('https://'), {
-      message: 'Deployment URL must use HTTPS protocol',
-    }),
+  deploymentUrl: z.string().optional(),
   destinationId: z.string().optional(),
   destinationSecretKey: z.string().optional(),
 });

--- a/docs/getting-started/deployment-guide/digitalocean.md
+++ b/docs/getting-started/deployment-guide/digitalocean.md
@@ -35,6 +35,7 @@ Start with default settings and tune as you go. After creating an app, you'll ha
 Go to App's `Settings` tab and edit `App-Level Environment Variables` via the `Bulk Editor` button with configuration **like** that:
 
 ```text
+PUBLIC_ORIGIN=https://octopus-app-wqkna.ondigitalocean.app
 DB_TYPE=mysql
 DB_HOST=db-mysql-nyc3-77688-do-user-25711522-0.j.db.ondigitalocean.com
 DB_PORT=25060

--- a/docs/getting-started/deployment-guide/environment-variables.md
+++ b/docs/getting-started/deployment-guide/environment-variables.md
@@ -23,6 +23,17 @@ Depending on the selected database type for the backend (`DB_TYPE`) and identity
 
 The complete list of all available environment variables is located in the [.env.example](https://github.com/OWOX/owox-data-marts/blob/main/.env.example) file in the project root directory.
 
+### Public URLs
+
+- **PUBLIC_ORIGIN**: Base public URL of the application (scheme + host [+ optional port]).
+  - Examples: `http://localhost:3000`, `https://data-marts.example.com`
+  - Default: `http://localhost:${PORT}`
+  - In production, set this to your actual deployment URL.
+
+- **LOOKER_STUDIO_DESTINATION_ORIGIN**: Public origin used to generate the deployment URL for the Looker Studio Destination.
+  - If empty, it falls back to `PUBLIC_ORIGIN`.
+  - Example: `https://looker.example.com`
+
 ### MySQL SSL
 
 `DB_MYSQL_SSL`, `IDP_BETTER_AUTH_MYSQL_SSL`, `IDP_OWOX_MYSQL_SSL`  enable TLS for MySQL (mysql2). Supported formats:

--- a/docs/getting-started/deployment-guide/render.md
+++ b/docs/getting-started/deployment-guide/render.md
@@ -44,10 +44,11 @@ Go **Environment** section in menu and set:
 
 | NAME_OF_VARIABLE               | Value (example)                                              | Notes                                                                                                          |
 |--------------------------------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| `PUBLIC_ORIGIN`                | `https://owox-your-company-name.onrender.com`               | Public origin (external URL) of your app. It is formed automatically from the name you entered. Just copy it from UI.                                              |
 | `IDP_PROVIDER`                 | `better-auth`                                               | Authentication provider                                                        |
 | `IDP_BETTER_AUTH_SECRET`       | `your_secret_key`                                           | Recommended: use a 32-character key. You can generate one with command `openssl rand -base64 32` in local terminal.                      |
 | `IDP_BETTER_AUTH_BASE_URL`     | `https://owox-your-company-name.onrender.com`               | Deployment URL. It is formed automatically from the name you entered. Just copy it from UI|
-| `IDP_BETTER_AUTH_TRUSTED_ORIGINS` | `http://localhost:10000,https://owox-your-company-name.onrender.com` | Comma-separated list of allowed origins. Include both local development (`http://localhost:10000`) and your production `BASE_URL`. |
+| `IDP_BETTER_AUTH_TRUSTED_ORIGINS` | `http://localhost:10000,https://owox-your-company-name.onrender.com` | Comma-separated list of allowed origins. Include both local development (`http://localhost:10000`) and your production `PUBLIC_ORIGIN`. |
 
 ### Step 2: Add first admin
 
@@ -70,7 +71,7 @@ Go **Environment** section in menu and set:
   - Ensure the persistent disk is attached
 
 - **App runs but blank page**  
-  - Verify `BASE_URL` is set correctly
+  - Verify `PUBLIC_ORIGIN` is set correctly
   - Check logs for missing dependencies or misconfigured variables
 
 ---


### PR DESCRIPTION
## Review

- **Backend**
  - Added `PublicOriginService` with `ensureHttp`, `ensureHttps`, `isValidUrl` and JSDoc.
  - Fallbacks: invalid `PUBLIC_ORIGIN` → `http://localhost:PORT`; invalid LS origin → use `PUBLIC_ORIGIN`.
  - Added unit tests for `PublicOriginService`.

- **Web**
  - Stopped sending `deploymentUrl` for Looker Studio.
  - Updated DTOs to discriminated unions; LS sends minimal credentials object.
  - Updated mappers
  
- **Docs**
  - Added `PUBLIC_ORIGIN` to deployment guides: Render, DigitalOcean
  - Added description of `PUBLIC_ORIGIN` and `LOOKER_STUDIO_DESTINATION_ORIGIN` to environment variables
  
## Result
<img width="922" height="783" alt="CleanShot 2025-09-26 at 12 23 06" src="https://github.com/user-attachments/assets/a84afd6a-c2dd-4a4d-a789-c3f85c9d81bd" />

- `PUBLIC_ORIGIN` not defined
- `LOOKER_STUDIO_DESTINATION_ORIGIN` not defined
---
<img width="922" height="783" alt="CleanShot 2025-09-26 at 12 26 35" src="https://github.com/user-attachments/assets/5921f710-f862-471b-a197-a8fb79b68589" />

- `PUBLIC_ORIGIN` = http://data-marts.example.com/
- `LOOKER_STUDIO_DESTINATION_ORIGIN` not defined
---
<img width="922" height="783" alt="CleanShot 2025-09-26 at 12 38 45" src="https://github.com/user-attachments/assets/40140de7-ba30-4e13-8512-cf2b6a04ee5b" />

- `PUBLIC_ORIGIN` = data-marts.example.com:4151
- `LOOKER_STUDIO_DESTINATION_ORIGIN` not defined
---
<img width="922" height="778" alt="CleanShot 2025-09-26 at 12 57 57" src="https://github.com/user-attachments/assets/09471ac7-fbd6-47ca-87d6-2e4d981b757d" />

- `PUBLIC_ORIGIN` = https://data-marts.example.com/
- `LOOKER_STUDIO_DESTINATION_ORIGIN` = looker.example.com
---
<img width="923" height="778" alt="CleanShot 2025-09-26 at 15 26 17" src="https://github.com/user-attachments/assets/2b738d1a-7a6a-44d4-844b-a91d6f786afe" />

- `PUBLIC_ORIGIN` = https://data-marts.example.com/
- `LOOKER_STUDIO_DESTINATION_ORIGIN` = exa mple . com : 8080
---
<img width="923" height="778" alt="CleanShot 2025-09-26 at 15 28 34" src="https://github.com/user-attachments/assets/9fd53ac4-ccd5-4f69-95bf-80b8671157e3" />

- `PUBLIC_ORIGIN` = exa mple . com : 8080
- `LOOKER_STUDIO_DESTINATION_ORIGIN` = exa mple . com : 8080

---
<img width="923" height="778" alt="CleanShot 2025-09-26 at 15 32 33" src="https://github.com/user-attachments/assets/eb5d8db1-df7e-4b4e-957f-953660fb05e6" />

- `PUBLIC_ORIGIN` = not defined
- `LOOKER_STUDIO_DESTINATION_ORIGIN` = https://looker.example.com