### PR TITLE
fix(idp-better-auth): fix viewer role

### DIFF
--- a/apps/backend/src/data-marts/controllers/connector.controller.ts
+++ b/apps/backend/src/data-marts/controllers/connector.controller.ts
@@ -13,7 +13,7 @@ import { SpecificationConnectorService } from '../use-cases/connector/specificat
 import { FieldsConnectorService } from '../use-cases/connector/fields-connector.service';
 import { ConnectorMapper } from '../mappers/connector.mapper';
 import { Auth } from '../../idp';
-import { Role, Strategy } from '../../idp/types/role-config.types';
+import { Role } from '../../idp/types/role-config.types';
 
 @Controller('connectors')
 @ApiTags('Connectors')
@@ -25,7 +25,7 @@ export class ConnectorController {
     private readonly mapper: ConnectorMapper
   ) {}
 
-  @Auth(Role.viewer(Strategy.PARSE))
+  @Auth(Role.none())
   @Get()
   @GetAvailableConnectorsSpec()
   async getAvailableConnectors(): Promise<ConnectorDefinitionResponseApiDto[]> {
@@ -33,7 +33,7 @@ export class ConnectorController {
     return this.mapper.toDefinitionResponseList(connectors);
   }
 
-  @Auth(Role.viewer(Strategy.PARSE))
+  @Auth(Role.none())
   @Get(':connectorName/specification')
   @GetConnectorSpecificationSpec()
   async getConnectorSpecification(
@@ -43,7 +43,7 @@ export class ConnectorController {
     return this.mapper.toSpecificationResponse(specification);
   }
 
-  @Auth(Role.viewer(Strategy.PARSE))
+  @Auth(Role.none())
   @Get(':connectorName/fields')
   @GetConnectorFieldsSpec()
   async getConnectorFields(

--- a/apps/backend/src/data-marts/controllers/connector.controller.ts
+++ b/apps/backend/src/data-marts/controllers/connector.controller.ts
@@ -13,7 +13,7 @@ import { SpecificationConnectorService } from '../use-cases/connector/specificat
 import { FieldsConnectorService } from '../use-cases/connector/fields-connector.service';
 import { ConnectorMapper } from '../mappers/connector.mapper';
 import { Auth } from '../../idp';
-import { Role } from '../../idp/types/role-config.types';
+import { Role, Strategy } from '../../idp/types/role-config.types';
 
 @Controller('connectors')
 @ApiTags('Connectors')
@@ -25,7 +25,7 @@ export class ConnectorController {
     private readonly mapper: ConnectorMapper
   ) {}
 
-  @Auth(Role.none())
+  @Auth(Role.viewer(Strategy.PARSE))
   @Get()
   @GetAvailableConnectorsSpec()
   async getAvailableConnectors(): Promise<ConnectorDefinitionResponseApiDto[]> {
@@ -33,7 +33,7 @@ export class ConnectorController {
     return this.mapper.toDefinitionResponseList(connectors);
   }
 
-  @Auth(Role.none())
+  @Auth(Role.viewer(Strategy.PARSE))
   @Get(':connectorName/specification')
   @GetConnectorSpecificationSpec()
   async getConnectorSpecification(
@@ -43,7 +43,7 @@ export class ConnectorController {
     return this.mapper.toSpecificationResponse(specification);
   }
 
-  @Auth(Role.none())
+  @Auth(Role.viewer(Strategy.PARSE))
   @Get(':connectorName/fields')
   @GetConnectorFieldsSpec()
   async getConnectorFields(

--- a/packages/idp-better-auth/src/providers/better-auth-provider.ts
+++ b/packages/idp-better-auth/src/providers/better-auth-provider.ts
@@ -46,15 +46,17 @@ export class BetterAuthProvider
     const cryptoService = new CryptoService(this.auth);
     const magicLinkService = new MagicLinkService(this.auth, cryptoService);
 
-    // Initialize all business logic services
-    this.authenticationService = new AuthenticationService(this.auth, cryptoService);
-    this.tokenService = new TokenService(this.auth, cryptoService);
+    // Initialize UserManagementService first
     this.userManagementService = new UserManagementService(
       this.auth,
       magicLinkService,
       cryptoService,
       this.store
     );
+
+    // Initialize all other business logic services
+    this.authenticationService = new AuthenticationService(this.auth, cryptoService);
+    this.tokenService = new TokenService(this.auth, cryptoService, this.userManagementService);
     this.requestHandlerService = new RequestHandlerService(this.auth);
     this.pageService = new PageService(
       this.authenticationService,


### PR DESCRIPTION
This pull request updates how user roles are handled and injected into authentication tokens in the Better Auth provider. The most important changes are the addition of a dependency on `UserManagementService` in `TokenService`, and the dynamic assignment of user roles in token payloads based on database values rather than hardcoded roles.

**User role management and token payloads:**

- `TokenService` now depends on `UserManagementService` to retrieve user roles dynamically, instead of assigning a hardcoded `'admin'` role. The user’s actual role is fetched from the database and included in the token payload if available.

**Service initialization order and dependencies:**

- In `BetterAuthProvider`, `UserManagementService` is now initialized before `TokenService`, and passed as a dependency to ensure roles can be fetched when tokens are created.