### PR TITLE
feat: Add sign-up middleware support to IDP providers

### DIFF
--- a/packages/idp-better-auth/src/providers/better-auth-provider.ts
+++ b/packages/idp-better-auth/src/providers/better-auth-provider.ts
@@ -101,6 +101,14 @@ export class BetterAuthProvider
     return this.middlewareService.signInMiddleware(req, res, next);
   }
 
+  async signUpMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void | Response> {
+    return this.middlewareService.signInMiddleware(req, res, next);
+  }
+
   async signOutMiddleware(
     req: Request,
     res: Response,

--- a/packages/idp-better-auth/src/providers/better-auth-provider.ts
+++ b/packages/idp-better-auth/src/providers/better-auth-provider.ts
@@ -106,6 +106,9 @@ export class BetterAuthProvider
     res: Response,
     next: NextFunction
   ): Promise<void | Response> {
+    // Trade-off: Currently redirects to sign-in flow as Better Auth doesn't have
+    // a separate sign-up implementation yet. The product uses magic link authentication
+    // where sign-up and sign-in are handled through the same flow.
     return this.middlewareService.signInMiddleware(req, res, next);
   }
 

--- a/packages/idp-owox/src/config.ts
+++ b/packages/idp-owox/src/config.ts
@@ -132,11 +132,15 @@ const IdpEnvSchema = z
     IDP_OWOX_PLATFORM_SIGN_IN_URL: z
       .string()
       .url({ message: 'IDP_OWOX_PLATFORM_SIGN_IN_URL must be a valid URL' }),
+    IDP_OWOX_PLATFORM_SIGN_UP_URL: z
+      .string()
+      .url({ message: 'IDP_OWOX_PLATFORM_SIGN_UP_URL must be a valid URL' }),
     IDP_OWOX_CALLBACK_URL: z.string().min(1, 'IDP_OWOX_CALLBACK_URL is required'),
   })
   .transform(e => ({
     clientId: e.IDP_OWOX_CLIENT_ID,
     platformSignInUrl: e.IDP_OWOX_PLATFORM_SIGN_IN_URL,
+    platformSignUpUrl: e.IDP_OWOX_PLATFORM_SIGN_UP_URL,
     callbackUrl: e.IDP_OWOX_CALLBACK_URL,
   }));
 

--- a/packages/idp-protocol/README.md
+++ b/packages/idp-protocol/README.md
@@ -44,6 +44,7 @@ import { IdpProvider } from '@owox/idp-protocol';
 interface IdpProvider {
   // Middleware handlers
   signInMiddleware(req: Request, res: Response, next: NextFunction): Promise<void | Response>;
+  signUpMiddleware(req: Request, res: Response, next: NextFunction): Promise<void | Response>;
   signOutMiddleware(req: Request, res: Response, next: NextFunction): Promise<void | Response>;
   accessTokenMiddleware(req: Request, res: Response, next: NextFunction): Promise<void | Response>;
   userApiMiddleware(req: Request, res: Response, next: NextFunction): Promise<Response<Payload>>;
@@ -114,7 +115,7 @@ import { IdpProtocolMiddleware, NullIdpProvider } from '@owox/idp-protocol';
 const app = express();
 const provider = new NullIdpProvider();
 
-// Basic usage with default routes (/auth/sign-in, /auth/sign-out, /auth/access-token, /auth/api/user)
+// Basic usage with default routes (/auth/sign-in, /auth/sign-up, /auth/sign-out, /auth/access-token, /auth/api/user, /auth/api/projects)
 const middleware = new IdpProtocolMiddleware(provider);
 middleware.register(app);
 
@@ -123,6 +124,7 @@ const middleware = new IdpProtocolMiddleware(provider, {
   basePath: '/api/v1/auth',
   routes: {
     signIn: '/login',
+    signUp: '/register',
     signOut: '/logout',
     accessToken: '/token',
     user: '/me',
@@ -267,6 +269,7 @@ const middleware = new IdpProtocolMiddleware(provider, {
   basePath: '/api/v1/auth',
   routes: {
     signIn: ProtocolRoute.SIGN_IN, // '/sign-in'
+    signUp: ProtocolRoute.SIGN_UP, // '/sign-up'
     signOut: ProtocolRoute.SIGN_OUT, // '/sign-out'
     accessToken: '/token', // Custom route
     user: ProtocolRoute.USER, // '/api/user'

--- a/packages/idp-protocol/src/middleware/protocol-middleware.ts
+++ b/packages/idp-protocol/src/middleware/protocol-middleware.ts
@@ -8,6 +8,7 @@ import { IdpProvider } from '../types/provider.js';
  */
 export enum ProtocolRoute {
   SIGN_IN = '/sign-in',
+  SIGN_UP = '/sign-up',
   SIGN_OUT = '/sign-out',
   ACCESS_TOKEN = '/access-token',
   USER = '/api/user',
@@ -33,6 +34,7 @@ export interface IdpProtocolMiddlewareOptions {
   basePath?: string;
   routes?: {
     signIn?: string;
+    signUp?: string;
     signOut?: string;
     accessToken?: string;
     user?: string;
@@ -88,6 +90,7 @@ export class IdpProtocolMiddleware {
     this.basePath = this.normalizeBasePath(options.basePath ?? this.DEFAULT_BASE_PATH);
     this.routes = {
       signIn: options.routes?.signIn ?? ProtocolRoute.SIGN_IN,
+      signUp: options.routes?.signUp ?? ProtocolRoute.SIGN_UP,
       signOut: options.routes?.signOut ?? ProtocolRoute.SIGN_OUT,
       accessToken: options.routes?.accessToken ?? ProtocolRoute.ACCESS_TOKEN,
       user: options.routes?.user ?? ProtocolRoute.USER,
@@ -158,6 +161,11 @@ export class IdpProtocolMiddleware {
         path: this.routes.signIn,
         handler: (req: Request, res: Response, next: NextFunction) =>
           this.provider.signInMiddleware(req, res, next),
+      },
+      {
+        path: this.routes.signUp,
+        handler: (req: Request, res: Response, next: NextFunction) =>
+          this.provider.signUpMiddleware(req, res, next),
       },
       {
         path: this.routes.signOut,

--- a/packages/idp-protocol/src/providers/null-provider.ts
+++ b/packages/idp-protocol/src/providers/null-provider.ts
@@ -30,16 +30,11 @@ export class NullIdpProvider implements IdpProvider {
   }
 
   signInMiddleware(req: Request, res: Response, _next: NextFunction): Promise<void> {
-    const isSecure =
-      req.protocol !== 'http' && !(req.hostname === 'localhost' || req.hostname === '127.0.0.1');
+    return this.setAuthCookieAndRedirect(req, res);
+  }
 
-    res.cookie('refreshToken', this.defaultRefreshToken, {
-      httpOnly: true,
-      secure: isSecure,
-      sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 30 * 1000,
-    });
-    return Promise.resolve(res.redirect('/'));
+  signUpMiddleware(req: Request, res: Response, _next: NextFunction): Promise<void> {
+    return this.setAuthCookieAndRedirect(req, res);
   }
 
   signOutMiddleware(_req: Request, res: Response, _next: NextFunction): Promise<void> {
@@ -92,5 +87,25 @@ export class NullIdpProvider implements IdpProvider {
 
   async revokeToken(_token: string): Promise<void> {
     // No-op for NULL provider
+  }
+
+  /**
+   * Sets the authentication cookie in the response and redirects the user to the root path.
+   *
+   * @param {Request} req The HTTP request object containing the client's request.
+   * @param {Response} res The HTTP response object used to send back the response, including the cookie and redirect.
+   * @return {Promise<void>} A promise that resolves when the cookie is set and the redirect response is sent to the client.
+   */
+  private setAuthCookieAndRedirect(req: Request, res: Response): Promise<void> {
+    const isSecure =
+      req.protocol !== 'http' && !(req.hostname === 'localhost' || req.hostname === '127.0.0.1');
+
+    res.cookie('refreshToken', this.defaultRefreshToken, {
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 24 * 30 * 1000,
+    });
+    return Promise.resolve(res.redirect('/'));
   }
 }

--- a/packages/idp-protocol/src/types/provider.ts
+++ b/packages/idp-protocol/src/types/provider.ts
@@ -13,6 +13,13 @@ export interface IdpProvider {
   signInMiddleware(req: Request, res: Response, next: NextFunction): Promise<void | Response>;
 
   /**
+   * Sign up middleware. This method is used to handle the user registration request and send the sign up response.
+   * <br/>
+   * If the IDP implementation does not support sign up, this method should call the `next()` function.
+   */
+  signUpMiddleware(req: Request, res: Response, next: NextFunction): Promise<void | Response>;
+
+  /**
    * Sign out middleware. This method is used to handle the sign out request and use response to send the sign out response.
    * <br/>
    * If the IDP implementation does not support sign out, this method should call the `next()` function.


### PR DESCRIPTION
- Introduced `signUpMiddleware` in `IdpProvider` for handling user registration requests.
- Updated `ProtocolRoute` and middleware registration to include `/sign-up` route.
- Enabled sign-up functionality for `owox` IDP provider.
- Refactored URL redirection logic for auth endpoints.