### PR TITLE
docs(idp-owox): document SIGN_UP_URL environment variable 

### DIFF
--- a/packages/idp-owox/README.md
+++ b/packages/idp-owox/README.md
@@ -23,7 +23,8 @@ IDP_OWOX_DEFAULT_HEADERS={"x-trace-id":"debug-local"}
 
 # IDP App configuration
 IDP_OWOX_CLIENT_ID=app-owox
-IDP_OWOX_PLATFORM_SIGN_IN_URL=https://bi.owox.com/ui/p/signin
+IDP_OWOX_PLATFORM_SIGN_IN_URL=https://platform.owox.com/ui/p/signin
+IDP_OWOX_PLATFORM_SIGN_UP_URL=https://platform.owox.com/ui/p/signup
 IDP_OWOX_CALLBACK_URL=/auth/callback
 
 # JWT validation


### PR DESCRIPTION
## Changes
- Added missing `IDP_OWOX_PLATFORM_SIGN_UP_URL` configuration parameter to README.md

## Purpose
This parameter was likely already supported by the code but was missing from the documentation. This change ensures the README contains complete configuration documentation for all available environment variables.

## Type
Documentation update - no code changes, only README improvement.
