### PR TITLE
fix(web): fix 403 status code error handler

### DIFF
--- a/apps/web/src/app/api/apiClient.ts
+++ b/apps/web/src/app/api/apiClient.ts
@@ -6,7 +6,6 @@ import axios, {
   AxiosHeaders,
 } from 'axios';
 import { showApiErrorToast } from '../../shared/utils';
-import type { ApiError } from './api-error.interface.ts';
 import { AuthStateManager } from './auth-state-manager';
 import { getTokenProvider } from './token-provider';
 
@@ -104,12 +103,16 @@ apiClient.interceptors.response.use(
     if (error.response?.status === 403) {
       showApiErrorToast(error, 'Access forbidden - insufficient permissions');
 
-      const data = error.response.data as ApiError;
-      window.dispatchEvent(
-        new CustomEvent('auth:forbidden', {
-          detail: { message: data.message },
-        })
-      );
+      // Don't dispatch auth:forbidden event for 403 errors
+      // 403 doesn't mean authentication problem - user is authenticated but lacks permission
+      // Let individual components handle 403 errors appropriately
+
+      // const data = error.response.data as ApiError;
+      // window.dispatchEvent(
+      //   new CustomEvent('auth:forbidden', {
+      //     detail: { message: data.message },
+      //   })
+      // );
     }
 
     if (error.response?.status === 400) {

--- a/apps/web/src/features/idp/context/AuthContext.tsx
+++ b/apps/web/src/features/idp/context/AuthContext.tsx
@@ -204,20 +204,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
       signOut();
     };
 
-    const handleForbidden = (event: Event) => {
-      const customEvent = event as CustomEvent<{ message?: string }>;
-      dispatch({
-        type: 'SET_ERROR',
-        payload: customEvent.detail.message ?? 'Access forbidden',
-      });
-    };
+    // const handleForbidden = (event: Event) => {
+    //   const customEvent = event as CustomEvent<{ message?: string }>;
+    //   dispatch({
+    //     type: 'SET_ERROR',
+    //     payload: customEvent.detail.message ?? 'Access forbidden',
+    //   });
+    // };
 
     window.addEventListener('auth:logout', handleLogout);
-    window.addEventListener('auth:forbidden', handleForbidden);
+    // window.addEventListener('auth:forbidden', handleForbidden);
 
     return () => {
       window.removeEventListener('auth:logout', handleLogout);
-      window.removeEventListener('auth:forbidden', handleForbidden);
+      // window.removeEventListener('auth:forbidden', handleForbidden);
       clearTokenProvider();
     };
   }, [signOut]);


### PR DESCRIPTION
This pull request updates how 403 "forbidden" API errors are handled in the frontend authentication flow. Instead of dispatching a global `auth:forbidden` event when a 403 is encountered, the code now leaves it up to individual components to handle these errors as appropriate. This makes the error handling more flexible and avoids conflating authentication issues with authorization issues.