### PR TITLE
refactor: convert boolean parameters to proper boolean type

### DIFF
--- a/.changeset/boolean-parameters-breaking-change.md
+++ b/.changeset/boolean-parameters-breaking-change.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Breaking Change: Convert boolean parameters to proper boolean type
+
+Updated boolean configuration parameters to use proper `boolean` type instead of `string` or `bool` types:
+
+- **ProcessShortLinks** (FacebookMarketing): `string` → `boolean`
+- **SandboxMode** (TikTokAds): `bool` → `boolean`  
+- **IncludeDeleted** (TikTokAds): `bool` → `boolean`

--- a/packages/connectors/src/Sources/FacebookMarketing/Source.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/Source.js
@@ -41,8 +41,8 @@ var FacebookMarketingSource = class FacebookMarketingSource extends AbstractSour
           description: "List of fields to fetch from Facebook API"
         },
         ProcessShortLinks: {
-          requiredType: "string",
-          default: "true",
+          requiredType: "boolean",
+          default: true,
           label: "Process Short Links",
           description: "Enable automatic processing of short links in link_url_asset field"
         },
@@ -259,7 +259,7 @@ var FacebookMarketingSource = class FacebookMarketingSource extends AbstractSour
       const allData = results.length === 1 ? results[0].data : this._mergeInsightsResults(results);
       
       // Process short links if link_url_asset data is present
-      if (this.config.ProcessShortLinks.value === "true" && allData.length > 0 && allData.some(record => record.link_url_asset)) {
+      if (this.config.ProcessShortLinks.value && allData.length > 0 && allData.some(record => record.link_url_asset)) {
         return processShortLinks(allData, { 
           shortLinkField: 'link_url_asset',
           urlFieldName: 'website_url'

--- a/packages/connectors/src/Sources/TikTokAds/Source.js
+++ b/packages/connectors/src/Sources/TikTokAds/Source.js
@@ -70,13 +70,13 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
         description: "Maximum number of days to fetch data for"
       },
       IncludeDeleted: {
-        requiredType: "bool",
+        requiredType: "boolean",
         default: false,
         label: "Include Deleted",
         description: "Include deleted entities in results"
       },
       SandboxMode: {
-        requiredType: "bool",
+        requiredType: "boolean",
         default: false,
         label: "Sandbox Mode",
         description: "Use sandbox environment for testing"
@@ -161,7 +161,7 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
       this.config.AppId.value,
       this.config.AccessToken.value,
       this.config.AppSecret.value,
-      this.config.SandboxMode && this.config.SandboxMode.value === true
+      this.config.SandboxMode && this.config.SandboxMode.value
     );
     
     // Store the current advertiser ID so it can be used if missing in records
@@ -180,7 +180,7 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
 
     // Filter parameter for including deleted entities
     let filtering = null;
-    if (this.config.IncludeDeleted && this.config.IncludeDeleted.value === true) {
+    if (this.config.IncludeDeleted && this.config.IncludeDeleted.value) {
       if (nodeName === 'campaigns') {
         filtering = {"secondary_status": "CAMPAIGN_STATUS_ALL"};
       } else if (nodeName === 'ad_groups') {


### PR DESCRIPTION
Updated boolean configuration parameters to use proper `boolean` type instead of `string` or `bool` types:

- **ProcessShortLinks** (FacebookMarketing): `string` → `boolean`
- **SandboxMode** (TikTokAds): `bool` → `boolean`  
- **IncludeDeleted** (TikTokAds): `bool` → `boolean`