### PR TITLE
fix(idp-better-auth): remove magic link warning message

### DIFF
--- a/packages/idp-better-auth/src/templates/admin-add-user.html
+++ b/packages/idp-better-auth/src/templates/admin-add-user.html
@@ -143,8 +143,6 @@
         </div>
         <div class="ml-3 flex-1">
           <h3 class="text-lg font-medium text-success mb-2">Magic Link Generated Successfully!</h3>
-          <p class="text-sm text-success mb-4">☝️ <strong>Share carefully with colleague via email only.</strong> This is a one-time link; messenger can auto-open URL and make it unusable</p>
-          
           <div class="bg-white border border-success/20 rounded-md p-3">
             <label class="block text-sm font-medium text-success mb-2">Magic Link:</label>
             <div class="flex items-center space-x-2">

--- a/packages/idp-better-auth/src/templates/admin-user-details.html
+++ b/packages/idp-better-auth/src/templates/admin-user-details.html
@@ -169,8 +169,6 @@
         </div>
         <div class="ml-3 flex-1">
           <h3 class="text-lg font-medium text-success mb-2">Magic Link Generated Successfully!</h3>
-          <p class="text-sm text-success mb-4">☝️ <strong>Share carefully with colleague via email only.</strong> This is a one-time link; messenger can auto-open URL and make it unusable</p>
-
           <div class="bg-white border border-success/20 rounded-md p-3">
             <label class="block text-sm font-medium text-success mb-2">Magic Link:</label>
             <div class="flex items-center space-x-2">


### PR DESCRIPTION
# Add user
<img width="1454" height="1007" alt="CleanShot 2025-10-06 at 11 53 47" src="https://github.com/user-attachments/assets/a3301779-45d2-46e7-8fd4-93a9cdc85324" />

# Reset user password
<img width="1454" height="1011" alt="CleanShot 2025-10-06 at 11 56 21" src="https://github.com/user-attachments/assets/baa92a6f-577e-4bc1-8b0c-790e3550f869" />
