### PR TITLE
feat(web): add System option for automatic theme selection in User Menu

### DIFF
--- a/.changeset/add-system-option-in-theme-switcher.md
+++ b/.changeset/add-system-option-in-theme-switcher.md
@@ -1,0 +1,8 @@
+---
+'owox': minor
+---
+
+# Add System Theme Option to User Menu
+
+- Added **System** option to the theme switcher for automatic theme selection.  
+- Enhanced **UserMenu** with theme selection and submenu support for better usability.  

--- a/apps/web/src/components/AppSidebar/UserMenu/UserMenu.tsx
+++ b/apps/web/src/components/AppSidebar/UserMenu/UserMenu.tsx
@@ -32,13 +32,7 @@ export function UserMenu() {
           avatar={avatar}
           initials={initials}
         />
-        <UserMenuContent
-          items={UserMenuItems({
-            theme,
-            setTheme,
-            signOut,
-          })}
-        />
+        <UserMenuContent items={UserMenuItems({ theme, setTheme, signOut })} />
       </DropdownMenu>
     </div>
   );

--- a/apps/web/src/components/AppSidebar/UserMenu/UserMenuContent.tsx
+++ b/apps/web/src/components/AppSidebar/UserMenu/UserMenuContent.tsx
@@ -2,8 +2,12 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 } from '@owox/ui/components/dropdown-menu';
 import type { UserMenuItem } from './types';
+import { CheckIcon } from 'lucide-react';
 
 interface UserMenuContentProps {
   items: UserMenuItem[];
@@ -12,20 +16,50 @@ interface UserMenuContentProps {
 export function UserMenuContent({ items }: UserMenuContentProps) {
   return (
     <DropdownMenuContent align='start' side='top' sideOffset={8} className='w-56'>
-      {items.map((item, index) =>
-        item.type === 'separator' ? (
-          <DropdownMenuSeparator key={`sep-${String(index)}`} />
-        ) : (
+      {items.map((item, index) => {
+        if (item.type === 'separator') {
+          return <DropdownMenuSeparator key={`sep-${String(index)}`} />;
+        }
+
+        if (item.type === 'submenu') {
+          const { submenu } = item;
+
+          return (
+            <DropdownMenuSub key={item.title}>
+              <DropdownMenuSubTrigger className='flex items-center gap-2 px-2 py-1.5'>
+                <item.icon className='size-4' />
+                {item.title}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {submenu.options.map(option => (
+                  <DropdownMenuItem
+                    key={option.value}
+                    className='flex items-center gap-2 px-2 py-1.5'
+                    onClick={() => {
+                      submenu.onChange(option.value);
+                    }}
+                  >
+                    {option.icon && <option.icon className='size-4' />}
+                    {option.label}
+                    {submenu.value === option.value && <CheckIcon className='ml-auto size-4' />}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          );
+        }
+
+        return (
           <DropdownMenuItem
             key={item.title}
             onClick={item.onClick}
-            className={`flex items-center gap-2 ${item.className ?? ''}`}
+            className={`flex items-center gap-2 px-2 py-1.5 ${item.className ?? ''}`}
           >
-            <item.icon className='size-4' />
+            <item.icon className={`size-4 ${item.className ?? ''}`} />
             {item.title}
           </DropdownMenuItem>
-        )
-      )}
+        );
+      })}
     </DropdownMenuContent>
   );
 }

--- a/apps/web/src/components/AppSidebar/UserMenu/items.ts
+++ b/apps/web/src/components/AppSidebar/UserMenu/items.ts
@@ -1,27 +1,49 @@
-import { LogOut, Moon, Sun } from 'lucide-react';
+import { LogOut, Monitor, Moon, Sun } from 'lucide-react';
 import type { UserMenuItem } from './types';
 
-interface UserMenuItemsParams {
+export const UserMenuItems = ({
+  theme,
+  setTheme,
+  signOut,
+}: {
   theme: string | undefined;
   setTheme: (theme: string) => void;
   signOut: () => void;
-}
-
-export function UserMenuItems({ theme, setTheme, signOut }: UserMenuItemsParams): UserMenuItem[] {
-  return [
-    {
-      title: `Switch to ${theme === 'light' ? 'dark' : 'light'} mode`,
-      icon: theme === 'light' ? Moon : Sun,
-      onClick: () => {
-        setTheme(theme === 'light' ? 'dark' : 'light');
+}): UserMenuItem[] => [
+  {
+    type: 'submenu',
+    title: 'Appearance',
+    icon: getAppearanceIcon(theme),
+    submenu: {
+      value: theme,
+      onChange: (value: string) => {
+        setTheme(value);
       },
+      options: [
+        { value: 'system', label: 'System', icon: Monitor },
+        { value: 'light', label: 'Light', icon: Sun },
+        { value: 'dark', label: 'Dark', icon: Moon },
+      ],
     },
-    { type: 'separator' },
-    {
-      title: 'Sign out',
-      icon: LogOut,
-      onClick: signOut,
-      className: 'text-red-600 focus:text-red-600',
-    },
-  ];
+  },
+  { type: 'separator' },
+  {
+    type: 'item',
+    title: 'Sign out',
+    icon: LogOut,
+    onClick: signOut,
+    className: 'text-red-600 focus:text-red-600',
+  },
+];
+
+function getAppearanceIcon(theme: string | undefined) {
+  switch (theme) {
+    case 'light':
+      return Sun;
+    case 'dark':
+      return Moon;
+    case 'system':
+    default:
+      return Monitor;
+  }
 }

--- a/apps/web/src/components/AppSidebar/UserMenu/types.ts
+++ b/apps/web/src/components/AppSidebar/UserMenu/types.ts
@@ -2,16 +2,26 @@ import type { LucideIcon } from 'lucide-react';
 
 export type UserMenuItem =
   | {
+      type: 'item';
       title: string;
       icon: LucideIcon;
       onClick: () => void;
       className?: string;
-      type?: never;
     }
   | {
       type: 'separator';
-      title?: never;
-      icon?: never;
-      onClick?: never;
-      className?: never;
+    }
+  | {
+      type: 'submenu';
+      title: string;
+      icon: LucideIcon;
+      submenu: {
+        value: string | undefined;
+        onChange: (value: string) => void;
+        options: {
+          value: string;
+          label: string;
+          icon?: LucideIcon;
+        }[];
+      };
     };


### PR DESCRIPTION
# Add System Theme Option to User Menu

Previously, users could switch between Light and Dark themes. This update adds a **System** option, allowing the app to automatically match the user's system theme preference, enhancing the personalization experience.

<img width="1541" height="870" alt="Frame 23137492" src="https://github.com/user-attachments/assets/206c8992-ea2b-4b13-a78c-68cb44b9bc26" />

## Key changes
- Added **System** option to the theme switcher for automatic theme selection.  
- Enhanced **UserMenu** with theme selection and submenu support for better usability.  

## Why
To make theme switching smarter and more aligned with user preferences by default.
