### PR TITLE
feat(web): add links to slack and docs in projects menu

### DIFF
--- a/apps/web/src/app/store/default-flags.ts
+++ b/apps/web/src/app/store/default-flags.ts
@@ -8,4 +8,6 @@ export const DEFAULT_FLAGS: Record<string, unknown> = {
   MENU_FEEDBACK_VISIBLE: 'true',
   MENU_ISSUES_VISIBLE: 'true',
   MENU_LICENSE_VISIBLE: 'true',
+  MENU_HELP_CENTER_VISIBLE: 'true',
+  MENU_SLACK_COMMUNITY_VISIBLE: 'true',
 };

--- a/apps/web/src/components/AppSidebar/ProjectMenu/items.ts
+++ b/apps/web/src/components/AppSidebar/ProjectMenu/items.ts
@@ -1,14 +1,14 @@
 import type { ProjectMenuItem } from './types';
-import { GitHubIcon, OWOXBIIcon } from '../../../shared';
+import { GitHubIcon, OWOXBIIcon, SlackIcon } from '../../../shared';
 import {
   Gem,
-  AlertCircle,
+  BadgeAlert,
   Scale,
   MessageCircle,
   Settings,
   BriefcaseBusiness,
   Users,
-  MessageCircleQuestion,
+  Info,
 } from 'lucide-react';
 
 export const projectMenuItems: ProjectMenuItem[] = [
@@ -27,30 +27,6 @@ export const projectMenuItems: ProjectMenuItem[] = [
     icon: Gem,
     visible: { flagKey: 'MENU_UPGRADE_OPTIONS_VISIBLE', expectedValue: 'true' },
     group: 'community',
-  },
-  {
-    type: 'menu-item',
-    title: 'Leave your feedback',
-    href: 'https://github.com/OWOX/owox-data-marts/discussions',
-    icon: MessageCircle,
-    visible: { flagKey: 'MENU_FEEDBACK_VISIBLE', expectedValue: 'true' },
-    group: 'feedback',
-  },
-  {
-    type: 'menu-item',
-    title: 'Issues',
-    href: 'https://github.com/OWOX/owox-data-marts/issues',
-    icon: AlertCircle,
-    visible: { flagKey: 'MENU_ISSUES_VISIBLE', expectedValue: 'true' },
-    group: 'feedback',
-  },
-  {
-    type: 'menu-item',
-    title: 'License',
-    href: 'https://github.com/OWOX/owox-data-marts#License-1-ov-file',
-    icon: Scale,
-    visible: { flagKey: 'MENU_LICENSE_VISIBLE', expectedValue: 'true' },
-    group: 'legal',
   },
   {
     type: 'menu-item',
@@ -94,18 +70,50 @@ export const projectMenuItems: ProjectMenuItem[] = [
   },
   {
     type: 'menu-item',
+    title: 'Documentation',
+    href: 'https://docs.owox.com/?utm_source=app_owox_com&utm_medium=community_edition&utm_campaign=documentation&utm_keyword=documentation&utm_content=header_dropdown',
+    icon: Info,
+    visible: { flagKey: 'MENU_HELP_CENTER_VISIBLE', expectedValue: 'true' },
+    group: 'feedback',
+  },
+  {
+    type: 'menu-item',
+    title: 'Leave Feedback',
+    href: 'https://github.com/OWOX/owox-data-marts/discussions',
+    icon: MessageCircle,
+    visible: { flagKey: 'MENU_FEEDBACK_VISIBLE', expectedValue: 'true' },
+    group: 'feedback',
+  },
+  {
+    type: 'menu-item',
+    title: 'Issues',
+    href: 'https://github.com/OWOX/owox-data-marts/issues',
+    icon: BadgeAlert,
+    visible: { flagKey: 'MENU_ISSUES_VISIBLE', expectedValue: 'true' },
+    group: 'feedback',
+  },
+  {
+    type: 'menu-item',
+    title: 'Slack Community',
+    href: 'https://join.slack.com/t/owox-data-marts/shared_invite/zt-3fffrsau9-UlobJVlXzRLpXmvs0ffvoQ',
+    icon: SlackIcon,
+    visible: { flagKey: 'MENU_SLACK_COMMUNITY_VISIBLE', expectedValue: 'true' },
+    group: 'feedback',
+  },
+  {
+    type: 'menu-item',
+    title: 'License',
+    href: 'https://github.com/OWOX/owox-data-marts#License-1-ov-file',
+    icon: Scale,
+    visible: { flagKey: 'MENU_LICENSE_VISIBLE', expectedValue: 'true' },
+    group: 'legal',
+  },
+  {
+    type: 'menu-item',
     title: 'OWOX BI',
     href: 'https://bi.owox.com/',
     icon: OWOXBIIcon,
     visible: { flagKey: 'MENU_OWOX_BI_VISIBLE', expectedValue: 'true' },
-    group: 'external',
-  },
-  {
-    type: 'menu-item',
-    title: 'Help Center',
-    href: 'https://support.owox.com/',
-    icon: MessageCircleQuestion,
-    visible: { flagKey: 'MENU_HELP_CENTER_VISIBLE', expectedValue: 'true' },
     group: 'external',
   },
 ];

--- a/apps/web/src/shared/icons/icons.types.ts
+++ b/apps/web/src/shared/icons/icons.types.ts
@@ -10,6 +10,7 @@ import { type AwsRedshiftIcon } from './aws-redshift-icon';
 import { type AzureSynapseIcon } from './azure-synapse-icon';
 import { type RawBase64Icon } from './raw-base64-icon';
 import { type OWOXBIIcon } from './owox-bi-icon';
+import { type SlackIcon } from './slack-icon';
 import { type LucideIcon } from 'lucide-react';
 
 export type LocalIcon =
@@ -24,5 +25,6 @@ export type LocalIcon =
   | typeof AwsRedshiftIcon
   | typeof AzureSynapseIcon
   | typeof OWOXBIIcon
+  | typeof SlackIcon
   | typeof RawBase64Icon;
 export type AppIcon = LucideIcon | LocalIcon;

--- a/apps/web/src/shared/icons/index.ts
+++ b/apps/web/src/shared/icons/index.ts
@@ -10,4 +10,5 @@ export * from './aws-redshift-icon';
 export * from './azure-synapse-icon';
 export * from './raw-base64-icon';
 export * from './owox-bi-icon';
+export * from './slack-icon';
 export * from './icons.types';

--- a/apps/web/src/shared/icons/slack-icon.tsx
+++ b/apps/web/src/shared/icons/slack-icon.tsx
@@ -1,0 +1,26 @@
+interface SlackIconProps {
+  className?: string;
+  size?: number;
+}
+
+export const SlackIcon = ({ className, size = 24 }: SlackIconProps) => {
+  return (
+    <svg
+      role='img'
+      viewBox='0 0 24 24'
+      width={size}
+      height={size}
+      className={className}
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <rect width='3' height='8' x='13' y='2' rx='1.5' />
+      <path d='M19 8.5V10h1.5A1.5 1.5 0 1 0 19 8.5' />
+      <rect width='3' height='8' x='8' y='14' rx='1.5' />
+      <path d='M5 15.5V14H3.5A1.5 1.5 0 1 0 5 15.5' />
+      <rect width='8' height='3' x='14' y='13' rx='1.5' />
+      <path d='M15.5 19H14v1.5a1.5 1.5 0 1 0 1.5-1.5' />
+      <rect width='8' height='3' x='2' y='8' rx='1.5' />
+      <path d='M8.5 5H10V3.5A1.5 1.5 0 1 0 8.5 5' />
+    </svg>
+  );
+};


### PR DESCRIPTION
# Add Links to Slack and Docs in Project Menu

This update improves accessibility to support and documentation by adding quick links directly in the Project Menu.
To help users quickly find assistance and explore documentation without leaving the app.

<img width="1453" height="870" alt="Frame 23137493" src="https://github.com/user-attachments/assets/36ef78a7-9260-46fd-967d-307b6e0863f4" />
