### PR TITLE
fix: escape ASCII control characters in BigQuery string literals

### DIFF
--- a/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
+++ b/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
@@ -542,7 +542,7 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
   //---- obfuscateSpecialCharacters ----------------------------------
     obfuscateSpecialCharacters(inputString) {
   
-      return String(inputString).replace(/\\/g, '\\\\').replace(/[\r\n]/g, ' ').replace(/'/g, "\\'").replace(/"/g, '\\"'); 
+      return String(inputString).replace(/\\/g, '\\\\').replace(/[\x00-\x1F]/g, ' ').replace(/'/g, "\\'").replace(/"/g, '\\"'); 
   
     }
 


### PR DESCRIPTION
BigQuery queries were failing with "Unclosed string literal" error when record fields contained control characters like `\r\n` (carriage return + line feed). These characters were not being escaped and were interpreted as actual line breaks in SQL queries, breaking the string literals.
