### PR TITLE
docs(linkedin): update label to "Primary Client Secret" in LinkedIn Ads and Pages sources

### DIFF
--- a/packages/connectors/src/Sources/LinkedInAds/CREDENTIALS.md
+++ b/packages/connectors/src/Sources/LinkedInAds/CREDENTIALS.md
@@ -50,7 +50,7 @@ When access is granted, the **Advertising API** will appear under the **Added Pr
 
 Navigate to the **Auth** tab of your LinkedIn app.
 
-Copy the Client ID and Client Secret, you will need it later.
+Copy the Client ID and Primary Client Secret, you will need it later.
 
 ![LinkedIn Ads Credentials](res/linkedin_clientsecret.png)
 

--- a/packages/connectors/src/Sources/LinkedInAds/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/LinkedInAds/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 Before proceeding, please make sure that:
 
-- You have created a **refresh token** (as described in [CREDENTIALS](CREDENTIALS)) and securely saved your **Client ID** and **Client Secret**.  
+- You have created a **refresh token** (as described in [CREDENTIALS](CREDENTIALS)) and securely saved your **Client ID** and **Primary Client Secret**.  
 - You have [set up **OWOX Data Marts**](https://docs.owox.com/docs/getting-started/quick-start/) and created at least one storage in the **Storages** section.  
 
 ![LinkedIn Ads Storage](res/linkedin_ads_storage.png)
@@ -21,7 +21,7 @@ Before proceeding, please make sure that:
 2. Click **Set up connector** and choose **LinkedIn Ads**.  
 3. Fill in the required fields:
     - **Client ID** – paste the ID you saved earlier.
-    - **Client Secret** – paste the secret you saved earlier.
+    - **Primary Client Secret** – paste the secret you saved earlier.
     - **Refresh Token** – paste the token you created following the [CREDENTIALS](CREDENTIALS) tutorial.
     - **Account URNs** – you can find this value on your [LinkedIn Campaign Manager](https://www.linkedin.com/campaignmanager/).
     - Leave the other fields as default and proceed to the next step.

--- a/packages/connectors/src/Sources/LinkedInAds/Source.js
+++ b/packages/connectors/src/Sources/LinkedInAds/Source.js
@@ -17,8 +17,8 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
       ClientSecret: {
         isRequired: true,
         requiredType: "string",
-        label: "Client Secret",
-        description: "LinkedIn API Client Secret for authentication",
+        label: "Primary Client Secret",
+        description: "LinkedIn API Primary Client Secret for authentication",
         attributes: [CONFIG_ATTRIBUTES.SECRET]
       },
       RefreshToken: {

--- a/packages/connectors/src/Sources/LinkedInPages/CREDENTIALS.md
+++ b/packages/connectors/src/Sources/LinkedInPages/CREDENTIALS.md
@@ -46,7 +46,7 @@ When access is granted, the **Community Management API** will appear under the *
 
 Navigate to the **Auth** tab of your LinkedIn app.
 
-Copy the Client ID and Client Secret, you will need it later.
+Copy the Client ID and Primary Client Secret, you will need it later.
 
 ![LinkedIn Pages Credentials](res/linkedin_clientsecret.png)
 

--- a/packages/connectors/src/Sources/LinkedInPages/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/LinkedInPages/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 Before proceeding, please make sure that:
 
-- You have created a **refresh token** (as described in [CREDENTIALS](CREDENTIALS)) and securely saved your **Client ID** and **Client Secret**.  
+- You have created a **refresh token** (as described in [CREDENTIALS](CREDENTIALS)) and securely saved your **Client ID** and **Primary Client Secret**.  
 - You have [set up **OWOX Data Marts**](https://docs.owox.com/docs/getting-started/quick-start/) and created at least one storage in the **Storages** section.  
 
 ![LinkedIn Pages Storage](res/linkedin_pages_storage.png)
@@ -21,7 +21,7 @@ Before proceeding, please make sure that:
 2. Click **Set up connector** and choose **LinkedIn Pages**.  
 3. Fill in the required fields:
     - **Client ID** – paste the ID you saved earlier.
-    - **Client Secret** – paste the secret you saved earlier.
+    - **Primary Client Secret** – paste the secret you saved earlier.
     - **Refresh Token** – paste the token you created following the [CREDENTIALS](CREDENTIALS) tutorial.
     - **Organization URNs** – you can find this value on your LinkedIn company page.
     - Leave the other fields as default and proceed to the next step.

--- a/packages/connectors/src/Sources/LinkedInPages/Source.js
+++ b/packages/connectors/src/Sources/LinkedInPages/Source.js
@@ -17,8 +17,8 @@ var LinkedInPagesSource = class LinkedInPagesSource extends AbstractSource {
       ClientSecret: {
         isRequired: true,
         requiredType: "string",
-        label: "Client Secret",
-        description: "LinkedIn API Client Secret for authentication",
+        label: "Primary Client Secret",
+        description: "LinkedIn API Primary Client Secret for authentication",
         attributes: [CONFIG_ATTRIBUTES.SECRET]
       },
       RefreshToken: {


### PR DESCRIPTION
- Changed all references of "Client Secret" to "Primary Client Secret" in LinkedIn Ads and LinkedIn Pages documentation and source code.
- Updated labels and descriptions in the connector configuration.
- Revised setup instructions in CREDENTIALS and GETTING_STARTED guides for consistency with LinkedIn app terminology.