### PR TITLE
feat(web): add new DataMartPlusIcon component and fix Slack icon

### DIFF
--- a/apps/web/src/features/data-marts/list/components/DataMartTable/components/EmptyDataMartsState.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/components/EmptyDataMartsState.tsx
@@ -1,13 +1,14 @@
 import { Link } from 'react-router-dom';
 import { useProjectRoute } from '../../../../../../shared/hooks';
 import { Button } from '@owox/ui/components/button';
-import { Plus, PackagePlus } from 'lucide-react';
+import { Plus } from 'lucide-react';
+import { DataMartPlusIcon } from '../../../../../../shared';
 
 export function EmptyDataMartsState() {
   const { scope } = useProjectRoute();
   return (
     <div className='dm-empty-state'>
-      <PackagePlus className='dm-empty-state-ico' strokeWidth={1} />
+      <DataMartPlusIcon className='dm-empty-state-ico' />
       <h2 className='dm-empty-state-title'>Create your first Data Mart</h2>
       <p className='dm-empty-state-subtitle'>
         Data Marts help you organize and analyze your data effectively.

--- a/apps/web/src/shared/icons/data-mart-plus-icon.tsx
+++ b/apps/web/src/shared/icons/data-mart-plus-icon.tsx
@@ -1,0 +1,34 @@
+interface DataMartPlusIconProps {
+  className?: string;
+  size?: number;
+}
+
+export const DataMartPlusIcon = ({ className, size = 24 }: DataMartPlusIconProps) => {
+  return (
+    <svg
+      role='img'
+      viewBox='0 0 24 24'
+      width={size}
+      height={size}
+      className={className}
+      xmlns='http://www.w3.org/2000/svg'
+      fill='none'
+    >
+      <path d='M16 16H22' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' />
+      <path d='M19 13V19' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' />
+      <path
+        d='M21 9.99795V7.99795C20.9996 7.64722 20.9071 7.30276 20.7315 6.99911C20.556 6.69546 20.3037 6.44331 20 6.26795L13 2.26795C12.696 2.09241 12.3511 2 12 2C11.6489 2 11.304 2.09241 11 2.26795L4 6.26795C3.69626 6.44331 3.44398 6.69546 3.26846 6.99911C3.09294 7.30276 3.00036 7.64722 3 7.99795V15.9979C3.00036 16.3487 3.09294 16.6931 3.26846 16.9968C3.44398 17.3004 3.69626 17.5526 4 17.7279L11 21.7279C11.304 21.9035 11.6489 21.9959 12 21.9959C12.3511 21.9959 12.696 21.9035 13 21.7279L15 20.5879'
+        stroke='currentColor'
+        stroke-linecap='round'
+        stroke-linejoin='round'
+      />
+      <path
+        d='M3.28906 7L11.9991 12L20.7091 7'
+        stroke='currentColor'
+        stroke-linecap='round'
+        stroke-linejoin='round'
+      />
+      <path d='M12 22V12' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' />
+    </svg>
+  );
+};

--- a/apps/web/src/shared/icons/icons.types.ts
+++ b/apps/web/src/shared/icons/icons.types.ts
@@ -11,6 +11,7 @@ import { type AzureSynapseIcon } from './azure-synapse-icon';
 import { type RawBase64Icon } from './raw-base64-icon';
 import { type OWOXBIIcon } from './owox-bi-icon';
 import { type SlackIcon } from './slack-icon';
+import { type DataMartPlusIcon } from './data-mart-plus-icon';
 import { type LucideIcon } from 'lucide-react';
 
 export type LocalIcon =
@@ -26,5 +27,6 @@ export type LocalIcon =
   | typeof AzureSynapseIcon
   | typeof OWOXBIIcon
   | typeof SlackIcon
+  | typeof DataMartPlusIcon
   | typeof RawBase64Icon;
 export type AppIcon = LucideIcon | LocalIcon;

--- a/apps/web/src/shared/icons/index.ts
+++ b/apps/web/src/shared/icons/index.ts
@@ -11,4 +11,5 @@ export * from './azure-synapse-icon';
 export * from './raw-base64-icon';
 export * from './owox-bi-icon';
 export * from './slack-icon';
+export * from './data-mart-plus-icon';
 export * from './icons.types';

--- a/apps/web/src/shared/icons/slack-icon.tsx
+++ b/apps/web/src/shared/icons/slack-icon.tsx
@@ -13,14 +13,14 @@ export const SlackIcon = ({ className, size = 24 }: SlackIconProps) => {
       className={className}
       xmlns='http://www.w3.org/2000/svg'
     >
-      <rect width='3' height='8' x='13' y='2' rx='1.5' />
-      <path d='M19 8.5V10h1.5A1.5 1.5 0 1 0 19 8.5' />
-      <rect width='3' height='8' x='8' y='14' rx='1.5' />
-      <path d='M5 15.5V14H3.5A1.5 1.5 0 1 0 5 15.5' />
-      <rect width='8' height='3' x='14' y='13' rx='1.5' />
-      <path d='M15.5 19H14v1.5a1.5 1.5 0 1 0 1.5-1.5' />
-      <rect width='8' height='3' x='2' y='8' rx='1.5' />
-      <path d='M8.5 5H10V3.5A1.5 1.5 0 1 0 8.5 5' />
+      <rect fill='currentColor' width='3' height='8' x='13' y='2' rx='1.5' />
+      <path fill='currentColor' d='M19 8.5V10h1.5A1.5 1.5 0 1 0 19 8.5' />
+      <rect fill='currentColor' width='3' height='8' x='8' y='14' rx='1.5' />
+      <path fill='currentColor' d='M5 15.5V14H3.5A1.5 1.5 0 1 0 5 15.5' />
+      <rect fill='currentColor' width='8' height='3' x='14' y='13' rx='1.5' />
+      <path fill='currentColor' d='M15.5 19H14v1.5a1.5 1.5 0 1 0 1.5-1.5' />
+      <rect fill='currentColor' width='8' height='3' x='2' y='8' rx='1.5' />
+      <path fill='currentColor' d='M8.5 5H10V3.5A1.5 1.5 0 1 0 8.5 5' />
     </svg>
   );
 };


### PR DESCRIPTION
# Update Icons for Consistent Look Across Themes

<img width="1560" height="1128" alt="Frame 23137497" src="https://github.com/user-attachments/assets/0540099f-e5cc-425a-b0df-6a695f8f4225" />

- Added new **DataMartPlusIcon** component for Data Marts section  
- Fixed **Slack icon** appearance in dark theme for better visibility  
- Improved overall visual consistency across light and dark modes