### PR TITLE
perf(backend): add index on data_mart_run.status

### DIFF
--- a/apps/backend/src/data-marts/services/connector-execution.service.ts
+++ b/apps/backend/src/data-marts/services/connector-execution.service.ts
@@ -456,7 +456,6 @@ export class ConnectorExecutionService implements OnApplicationBootstrap {
   async getDataMartRunsByStatus(status: DataMartRunStatus): Promise<DataMartRun[]> {
     return this.dataMartRunRepository.find({
       where: { status },
-      order: { createdAt: 'ASC' },
       relations: ['dataMart'],
     });
   }

--- a/apps/backend/src/migrations/1760448668537-create-index-data-mart-run-status.ts
+++ b/apps/backend/src/migrations/1760448668537-create-index-data-mart-run-status.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner, TableIndex } from 'typeorm';
+
+/**
+ * Creates a composite index on data_mart_run for efficient filtering by status.
+ * Implemented via TypeORM DSL to support both MySQL and SQLite.
+ */
+export class CreateIndexDataMartRunStatus1760448668537 implements MigrationInterface {
+  public readonly name = 'CreateIndexDataMartRunStatus1760448668537';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createIndex(
+      'data_mart_run',
+      new TableIndex({
+        name: 'idx_dmr_status',
+        columnNames: ['status'],
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('data_mart_run', 'idx_dmr_status');
+  }
+}


### PR DESCRIPTION
<img width="2388" height="1345" alt="CleanShot 2025-10-14 at 16 49 56 2" src="https://github.com/user-attachments/assets/3e3c7749-2cc7-4069-8e66-6277e2552a0f" />

```sql
EXPLAIN SELECT
  `DataMartRun`.`id` AS `DataMartRun_id`,
  `DataMartRun`.`dataMartId` AS `DataMartRun_dataMartId`,
  `DataMartRun`.`definitionRun` AS `DataMartRun_definitionRun`,
  `DataMartRun`.`status` AS `DataMartRun_status`,
  `DataMartRun`.`logs` AS `DataMartRun_logs`,
  `DataMartRun`.`errors` AS `DataMartRun_errors`,
  `DataMartRun`.`createdAt` AS `DataMartRun_createdAt`,
  `DataMartRun`.`additionalParams` AS `DataMartRun_additionalParams`,
  `DataMartRun__DataMartRun_dataMart`.`id` AS `DataMartRun__DataMartRun_dataMart_id`,
  `DataMartRun__DataMartRun_dataMart`.`title` AS `DataMartRun__DataMartRun_dataMart_title`,
  `DataMartRun__DataMartRun_dataMart`.`schema` AS `DataMartRun__DataMartRun_dataMart_schema`,
  `DataMartRun__DataMartRun_dataMart`.`definitionType` AS `DataMartRun__DataMartRun_dataMart_definitionType`,
  `DataMartRun__DataMartRun_dataMart`.`definition` AS `DataMartRun__DataMartRun_dataMart_definition`,
  `DataMartRun__DataMartRun_dataMart`.`status` AS `DataMartRun__DataMartRun_dataMart_status`,
  `DataMartRun__DataMartRun_dataMart`.`description` AS `DataMartRun__DataMartRun_dataMart_description`,
  `DataMartRun__DataMartRun_dataMart`.`projectId` AS `DataMartRun__DataMartRun_dataMart_projectId`,
  `DataMartRun__DataMartRun_dataMart`.`createdById` AS `DataMartRun__DataMartRun_dataMart_createdById`,
  `DataMartRun__DataMartRun_dataMart`.`deletedAt` AS `DataMartRun__DataMartRun_dataMart_deletedAt`,
  `DataMartRun__DataMartRun_dataMart`.`createdAt` AS `DataMartRun__DataMartRun_dataMart_createdAt`,
  `DataMartRun__DataMartRun_dataMart`.`modifiedAt` AS `DataMartRun__DataMartRun_dataMart_modifiedAt`,
  `DataMartRun__DataMartRun_dataMart`.`storageId` AS `DataMartRun__DataMartRun_dataMart_storageId`,
  `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`id` AS `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d_id`,
  `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`type` AS `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d_type`,
  `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`projectId` AS `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d_projectId`,
  `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`title` AS `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d_title`,
  `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`credentials` AS `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d_credentials`,
  `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`config` AS `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d_config`,
  `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`deletedAt` AS `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d_deletedAt`,
  `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`createdAt` AS `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d_createdAt`,
  `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`modifiedAt` AS `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d_modifiedAt`
FROM `data_mart_run` `DataMartRun`
LEFT JOIN `data_mart` `DataMartRun__DataMartRun_dataMart`
  ON `DataMartRun__DataMartRun_dataMart`.`id` = `DataMartRun`.`dataMartId`
  AND (`DataMartRun__DataMartRun_dataMart`.`deletedAt` IS NULL)
LEFT JOIN `data_storage` `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`
  ON `6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`id` = `DataMartRun__DataMartRun_dataMart`.`storageId`
  AND (`6bfd6ac97467a8b9b7326e80e1ba5cbac9178b4d`.`deletedAt` IS NULL)
WHERE (`DataMartRun`.`status` = 'SUCCESS')
ORDER BY `DataMartRun`.`createdAt` ASC;
```