### PR TITLE
Bump `happy-dom` to v20.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20669,9 +20669,9 @@
       }
     },
     "node_modules/happy-dom": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.0.tgz",
-      "integrity": "sha512-GkWnwIFxVGCf2raNrxImLo397RdGhLapj5cT3R2PT7FwL62Ze1DROhzmYW7+J3p9105DYMVenEejEbnq5wA37w==",
+      "version": "20.0.2",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.0.2.tgz",
+      "integrity": "sha512-pYOyu624+6HDbY+qkjILpQGnpvZOusItCk+rvF5/V+6NkcgTKnbOldpIy22tBnxoaLtlM9nXgoqAcW29/B7CIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Updated `happy-dom` dependency in `package-lock.json` to v20.0.2. This update fixes a critical vulnerability.