### PR TITLE
fix(backend): add migration to rename Bing Ads to Microsoft Ads in data_mart_run

### DIFF
--- a/apps/backend/src/migrations/1760960349899-rename-bing-ads-to-microsoft-ads-in-data-mart-run.ts
+++ b/apps/backend/src/migrations/1760960349899-rename-bing-ads-to-microsoft-ads-in-data-mart-run.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameBingAdsToMicrosoftAdsInDataMartRun1760960349899 implements MigrationInterface {
+  public readonly name = 'RenameBingAdsToMicrosoftAdsInDataMartRun1760960349899';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        UPDATE data_mart_run 
+        SET definitionRun = REPLACE(
+          REPLACE(definitionRun, '"name":"BingAds"', '"name":"MicrosoftAds"'),
+          '"name": "BingAds"', 
+          '"name": "MicrosoftAds"'
+          )
+        WHERE
+          definitionRun LIKE '%"source":%"name":"BingAds"%' 
+          OR definitionRun LIKE '%"source":%"name": "BingAds"%'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+        UPDATE data_mart_run
+        SET definitionRun = REPLACE(
+          REPLACE(definitionRun, '"name":"MicrosoftAds"', '"name":"BingAds"'),
+          '"name": "MicrosoftAds"', 
+          '"name": "BingAds"'
+          )
+        WHERE 
+          definitionRun LIKE '%"source":%"name":"MicrosoftAds"%' 
+          OR definitionRun LIKE '%"source":%"name": "MicrosoftAds"%'
+    `);
+  }
+}


### PR DESCRIPTION
Migration renames the connector in `definitionRun` so that the Run History page loads correctly.