### PR TITLE
feat(docs): Add Google Ads source documentation: credentials, setup, and usage guides

### DIFF
--- a/packages/connectors/src/Sources/GoogleAds/CREDENTIALS.md
+++ b/packages/connectors/src/Sources/GoogleAds/CREDENTIALS.md
@@ -1,0 +1,68 @@
+# How to Obtain the Access Token for the Google Ads Source
+
+To connect to the **Google Ads API** and start importing data with OWOX Data Marts, follow the steps below.
+
+## Step 1: Create a Service Account in Google Cloud Platform (GCP)
+
+1. Open your GCP project and navigate to  
+   **IAM & Admin → Service Accounts → Create Service Account**.  
+2. Enter a **name** and **description**, then click **Create and Continue**.  
+3. Assign the following roles:  
+   - **BigQuery User**  
+   - **BigQuery Data Editor**  
+4. Click **Continue**, then **Done**.  
+5. Locate the newly created service account, click the **three dots** (⋮) on the right-hand side, and select **Manage Keys**.  
+6. In the **Keys** tab, click **Add Key → Create New Key → JSON**.  
+7. The JSON key file will be downloaded automatically — please **store it securely**, as you will need it later.  
+
+## Step 2: Set Up Access in Google Ads
+
+**Prerequisites**:
+
+You must have a **Manager (MCC)** account in Google Ads.  
+If you don’t have one yet, follow Google’s instructions to create it:  
+👉 [Create a Manager Account](https://support.google.com/google-ads/answer/7459399?hl=en)
+
+**Add the Service Account to Google Ads**:
+
+1. Open your **Google Ads account** and go to **Admin → Access and Security**.  
+2. Click the **+ (plus)** button to add a new user.  
+3. Paste your **service account email address**.  
+4. Assign **Read-only** permissions.  
+5. Click **Add account**
+
+## Step 3: Register in the API Center
+
+1. In the same **Admin** section of Google Ads, open **API Center**.  
+2. Fill in the required form fields:  
+   - **API Contact Email**  
+   - **Company Name**  
+   - **Company URL**  
+   - **Company Type**  
+   - **Intended Use** — e.g., “For in-house marketing analytics and retrieving ad data for reporting.”  
+   - **Principal Place of Business**  
+3. Accept the Terms and Conditions checkbox.  
+4. Click **Create Token**.
+
+## Step 4: Save Your Developer Token and Customer ID
+
+After completing the registration:
+
+- Copy and securely save your **Developer Token**.  
+- Copy your **Customer ID** (from the top of your Google Ads account).  
+
+At this point, you should have the following credentials:
+
+| Credential | Description |
+|-------------|-------------|
+| **Service Account Key (JSON)** | Used for authentication from your GCP project |
+| **Developer Token** | Authorizes access to the Google Ads API |
+| **Customer ID** | Identifies your specific Google Ads account |
+
+## Step 5: Use the Credentials to Obtain the Access Token
+
+Use the credentials you gathered above to retrieve the access token and connect to Google Ads, as described in the  
+👉 [GETTING_STARTED](GETTING_STARTED.md) guide.
+
+✅ **You’re all set!**  
+You can now use your service account, developer token, and customer ID to access and import data from Google Ads via OWOX Data Marts.

--- a/packages/connectors/src/Sources/GoogleAds/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/GoogleAds/GETTING_STARTED.md
@@ -1,0 +1,57 @@
+# How to Import Data from the Google Ads Source
+
+Before proceeding, please make sure that:
+
+- You have already created a credentials, as described in [CREDENTIALS](CREDENTIALS.md).  
+- You [have run **OWOX Data Marts**](https://docs.owox.com/docs/getting-started/quick-start/) and created at least one storage in the **Storages** section.
+
+## Create the Data Mart
+
+- Click **New Data Mart**.
+- Enter a title and select the Storage.
+- Click **Create Data Mart**.
+
+## Set Up the Connector
+
+1. Select **Connector** as the input source type.
+2. Click Set up connector and choose Google Ads.
+3. Fill in the required fields.
+
+## Configure Data Import
+
+1. Choose one of the available endpoints.
+2. Select the required **fields**.
+3. Specify the **dataset** where the data will be stored, or leave it as default.
+4. Click **Finish**, then **Save and Publish Data Mart**.
+
+## Run the Data Mart
+
+Now you have **two options** for importing data from Google Ads:
+
+Option 1: Import Current Day's Data
+
+Choose **Manual run → Incremental load** to load data for the **current day**.
+
+> ℹ️ If you click **Incremental load** again after a successful initial load,  
+> the connector will import: **Current day's data**, plus **Additional days**, based on the value in the **Reimport Lookback Window** field.
+
+Option 2: Manual Backfill for Specific Date Range
+
+Choose **Backfill (custom period)** to load historical data for a custom time range.
+
+1. Select the **Start Date** and **End Date**  
+2. Click the **Run** button
+
+The process is complete when the **Run history** tab shows the message:  
+**"Success"**  
+
+## Access Your Data
+
+The data will be written to the dataset specified earlier.
+
+If you encounter any issues:
+
+1. Check the Run history for specific error messages
+2. Please [visit Q&A](https://github.com/OWOX/owox-data-marts/discussions/categories/q-a) first
+3. If you want to report a bug, please [open an issue](https://github.com/OWOX/owox-data-marts/issues)
+4. Join the [discussion forum](https://github.com/OWOX/owox-data-marts/discussions) to ask questions or propose improvements

--- a/packages/connectors/src/Sources/GoogleAds/README.md
+++ b/packages/connectors/src/Sources/GoogleAds/README.md
@@ -1,0 +1,28 @@
+# Google Ads Source
+
+The **Google Ads Source** allows you to transfer raw data from Google Ads advertising service. Use this data for in-depth analysis and reporting.
+
+## Getting Started
+
+To begin, check out [**GETTING STARTED.md**](GETTING_STARTED.md) for step-by-step instructions.
+
+## Table of Contents
+
+- [**GETTING STARTED**](GETTING_STARTED.md) – quick and easy setup guide.
+- [**README**](README.md) – general information about the source.
+- [**CREDENTIALS**](CREDENTIALS.md) – detailed guides for each step of the data retrieval process.
+- [**Q&A**](https://github.com/OWOX/owox-data-marts/discussions/categories/q-a) – troubleshooting common issues.
+
+## Support & Feedback
+
+- If you encounter an issue, please check the [**Q&A**](https://github.com/OWOX/owox-data-marts/discussions/categories/q-a) section first.
+- To report a bug, open an [**issue**](https://github.com/OWOX/owox-data-marts/issues)
+- Have an idea or want a new integration? Submit a [**feature request**](https://github.com/OWOX/owox-data-marts/discussions)
+
+## Other Data Sources
+
+Looking for other data sources? Check out our [full list of data sources](../../../../../README.md#data-sources).
+
+## License
+
+This source is part of the OWOX Data Marts project and is distributed under the [MIT license](../../../../../licenses/MIT.md).


### PR DESCRIPTION
Added comprehensive documentation for the Google Ads source, including step-by-step guides for obtaining credentials, setting up the connector, and importing data. Includes README.md, CREDENTIALS.md, and GETTING_STARTED.md with troubleshooting and support resources.