### PR TITLE
feat: remove MaxFetchingDays parameter and refactor date range logic

### DIFF
--- a/.changeset/remove-max-fetching-days.md
+++ b/.changeset/remove-max-fetching-days.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Remove MaxFetchingDays parameter and improve incremental fetching logic
+
+Removed the `MaxFetchingDays` parameter from all data source connectors. The incremental data fetching now works as follows:
+
+- **First run (no state)**: Data fetching starts from the 1st of the previous month
+- **Subsequent runs**: Data is fetched from the `LastRequestedDate` (with `ReimportLookbackWindow` applied) up to today
+- **Manual backfill**: Continues to work as before, fetching data for the specified date range

--- a/packages/connectors/CREATING_CONNECTOR.md
+++ b/packages/connectors/CREATING_CONNECTOR.md
@@ -61,13 +61,6 @@ var YourDataSourceSource = class YourDataSourceSource extends AbstractSource {
         description: "End date for data import",
         attributes: [CONFIG_ATTRIBUTES.MANUAL_BACKFILL, CONFIG_ATTRIBUTES.HIDE_IN_CONFIG_FORM]
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 31,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch in one run"
-      },
       ReimportLookbackWindow: {
         requiredType: "number",
         isRequired: true,
@@ -170,7 +163,6 @@ Configuration parameters are defined in the Source constructor using `config.mer
 
 - `StartDate` — start date for initial import
 - `EndDate` — end date for backfill operations
-- `MaxFetchingDays` — maximum days per import run
 - `ReimportLookbackWindow` — days to reimport for data consistency
 - `CreateEmptyTables` — whether to create tables with no data
 

--- a/packages/connectors/src/Core/AbstractConnector.js
+++ b/packages/connectors/src/Core/AbstractConnector.js
@@ -254,7 +254,7 @@ var AbstractConnector = class AbstractConnector {
         endDate = today;
       }
 
-      // Calculate days between start and end date (no MaxFetchingDays limit for manual backfill)
+      // Calculate days between start and end date
       const daysToFetch = Math.max(
         0,
         Math.floor((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1
@@ -273,10 +273,9 @@ var AbstractConnector = class AbstractConnector {
     _getIncrementalDateRange() {
       let startDate = this._getIncrementalStartDate();
       
-      // Calculate days to fetch directly (limited by MaxFetchingDays and today)
+      // Calculate days to fetch from startDate to today
       const today = new Date();
-      const maxDaysToToday = Math.floor((today.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
-      const daysToFetch = Math.max(0, Math.min(this.config.MaxFetchingDays.value, maxDaysToToday));
+      const daysToFetch = Math.max(0, Math.floor((today.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1);
 
       return [startDate, daysToFetch];
     }
@@ -289,20 +288,17 @@ var AbstractConnector = class AbstractConnector {
      * @private
      */
     _getIncrementalStartDate() {
-      // If lastRequestedDate exists, always use it (ignore StartDate)
+      // If lastRequestedDate exists, always use it (apply lookback window)
       if (this.config.LastRequestedDate && this.config.LastRequestedDate.value) {
         let lastRequestedDate = this._parseLastRequestedDate();
         let lookbackDate = this._applyLookbackWindow(lastRequestedDate);
         return lookbackDate;
       }
 
-      // If StartDate exists, use it
-      if (this.config.StartDate && this.config.StartDate.value) {
-        return this.config.StartDate.value;
-      }
-
-      // If neither LastRequestedDate nor StartDate exists, use today's date
-      return new Date();
+      // First run: no state exists
+      // Start from the 1st of last month
+      const today = new Date();
+      return new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() - 1, 1));
     }
     //----------------------------------------------------------------
 

--- a/packages/connectors/src/Sources/BankOfCanada/Source.js
+++ b/packages/connectors/src/Sources/BankOfCanada/Source.js
@@ -34,13 +34,6 @@ constructor( configRange ) {
       label: "Clean Up To Keep Window",
       description: "Number of days to keep data before cleaning up"
     },
-    MaxFetchingDays: {
-      requiredType: "number",
-      isRequired: true,
-      default: 30,
-      label: "Max Fetching Days",
-      description: "Maximum number of days to fetch data for"
-    },
     Fields: {
       isRequired: true,
       requiredType: "string",

--- a/packages/connectors/src/Sources/CriteoAds/Source.js
+++ b/packages/connectors/src/Sources/CriteoAds/Source.js
@@ -58,12 +58,6 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
         description: "Your Criteo API Client Secret",
         attributes: [CONFIG_ATTRIBUTES.SECRET]
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        default: 30,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
-      },
       CreateEmptyTables: {
         requiredType: "boolean",
         default: true,

--- a/packages/connectors/src/Sources/FacebookMarketing/Connector.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/Connector.js
@@ -104,7 +104,7 @@ var FacebookMarketingConnector = class FacebookMarketingConnector extends Abstra
     */
     startImportProcessOfTimeSeriesData(accountsIds, timeSeriesNodes, startDate, daysToFetch = 1) {
 
-      // start requesting data day by day from startDate to startDate + MaxFetchingDays
+      // start requesting data day by day from startDate to startDate + daysToFetch
       for(var daysShift = 0; daysShift < daysToFetch; daysShift++) {
 
       //this.config.logMessage(`Start importing data for ${EnvironmentAdapter.formatDate(startDate, "UTC", "yyyy-MM-dd")}`);

--- a/packages/connectors/src/Sources/FacebookMarketing/Source.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/Source.js
@@ -64,13 +64,6 @@ var FacebookMarketingSource = class FacebookMarketingSource extends AbstractSour
           requiredType: "number",
           label: "Clean Up To Keep Window",
           description: "Number of days to keep data before cleaning up"
-        },
-        MaxFetchingDays: {
-          requiredType: "number",
-          isRequired: true,
-          default: 31,
-          label: "Max Fetching Days",
-          description: "Maximum number of days to fetch data for"
         }
       }));
       

--- a/packages/connectors/src/Sources/GitHub/Source.js
+++ b/packages/connectors/src/Sources/GitHub/Source.js
@@ -45,13 +45,6 @@ var GitHubSource = class GitHubSource extends AbstractSource {
         label: "Clean Up To Keep Window",
         description: "Number of days to keep data before cleaning up"
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 30,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
-      },
       Fields: {
         isRequired: true,
         requiredType: "string",

--- a/packages/connectors/src/Sources/GoogleAds/Source.js
+++ b/packages/connectors/src/Sources/GoogleAds/Source.js
@@ -111,13 +111,6 @@ var GoogleAdsSource = class GoogleAdsSource extends AbstractSource {
         requiredType: "number",
         label: "Clean Up To Keep Window",
         description: "Number of days to keep data before cleaning up"
-      },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 31,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
       }
     }));
     

--- a/packages/connectors/src/Sources/LinkedInAds/Source.js
+++ b/packages/connectors/src/Sources/LinkedInAds/Source.js
@@ -40,13 +40,6 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
         label: "Clean Up To Keep Window",
         description: "Number of days to keep data before cleaning up"
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 31,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
-      },
       StartDate: {
         requiredType: "date",
         label: "Start Date",

--- a/packages/connectors/src/Sources/LinkedInPages/Source.js
+++ b/packages/connectors/src/Sources/LinkedInPages/Source.js
@@ -40,13 +40,6 @@ var LinkedInPagesSource = class LinkedInPagesSource extends AbstractSource {
         label: "Clean Up To Keep Window",
         description: "Number of days to keep data before cleaning up"
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 31,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
-      },
       StartDate: {
         requiredType: "date",
         label: "Start Date",

--- a/packages/connectors/src/Sources/MicrosoftAds/Source.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Source.js
@@ -67,13 +67,6 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
         label: "Reimport Lookback Window",
         description: "Number of days to look back when reimporting data"
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 30,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
-      },
       ReportTimezone: {
         requiredType: "string",
         default: "GreenwichMeanTimeDublinEdinburghLisbonLondon",

--- a/packages/connectors/src/Sources/OpenExchangeRates/Source.js
+++ b/packages/connectors/src/Sources/OpenExchangeRates/Source.js
@@ -39,13 +39,6 @@ constructor(config) {
         label: "Reimport Lookback Window",
         description: "Number of days to look back when reimporting data"
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 30,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
-      },
       Symbols: {
         requiredType: "string",
         label: "Currency Symbols",

--- a/packages/connectors/src/Sources/OpenHolidays/Source.js
+++ b/packages/connectors/src/Sources/OpenHolidays/Source.js
@@ -46,13 +46,6 @@ var OpenHolidaysSource = class OpenHolidaysSource extends AbstractSource {
         label: "Clean Up To Keep Window",
         description: "Number of days to keep data before cleaning up"
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 30,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
-      },
       Fields: {
         isRequired: true,
         requiredType: "string",

--- a/packages/connectors/src/Sources/RedditAds/Source.js
+++ b/packages/connectors/src/Sources/RedditAds/Source.js
@@ -80,13 +80,6 @@ var RedditAdsSource = class RedditAdsSource extends AbstractSource {
         label: "Clean Up To Keep Window",
         description: "Number of days to keep data before cleaning up"
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 31,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
-      },
       CreateEmptyTables: {
         requiredType: "boolean",
         default: true,

--- a/packages/connectors/src/Sources/TikTokAds/Source.js
+++ b/packages/connectors/src/Sources/TikTokAds/Source.js
@@ -64,13 +64,6 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
         label: "Clean Up To Keep Window",
         description: "Number of days to keep data before cleaning up"
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 31,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
-      },
       IncludeDeleted: {
         requiredType: "boolean",
         default: false,

--- a/packages/connectors/src/Sources/XAds/Source.js
+++ b/packages/connectors/src/Sources/XAds/Source.js
@@ -66,13 +66,6 @@ var XAdsSource = class XAdsSource extends AbstractSource {
         label: "Clean Up To Keep Window",
         description: "Number of days to keep data before cleaning up"
       },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 31,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
-      },
       Version: {
         requiredType: "string",
         default: "12",

--- a/packages/connectors/src/Templates/PublicEndPoint/Source.js
+++ b/packages/connectors/src/Templates/PublicEndPoint/Source.js
@@ -39,13 +39,6 @@ var YOUR_DATE_SOURCE_Source = class YOUR_DATE_SOURCE_Source extends AbstractSour
         default: "Data",
         label: "Destination Sheet Name",
         description: "Name of the sheet where data will be stored"
-      },
-      MaxFetchingDays: {
-        requiredType: "number",
-        isRequired: true,
-        default: 30,
-        label: "Max Fetching Days",
-        description: "Maximum number of days to fetch data for"
       }
     }));
   


### PR DESCRIPTION
Removed the `MaxFetchingDays` parameter from all data source connectors. The incremental data fetching now works as follows:

- **First run (no state)**: Data fetching starts from the 1st of the previous month
- **Subsequent runs**: Data is fetched from the `LastRequestedDate` (with `ReimportLookbackWindow` applied) up to today
- **Manual backfill**: Continues to work as before, fetching data for the specified date range
