### PR TITLE
fix(backend): mask credentials for all data-mart-run types

### DIFF
--- a/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
@@ -37,9 +37,9 @@ import { CancelDataMartRunCommand } from '../dto/domain/cancel-data-mart-run.com
 import { ConnectorSecretService } from '../services/connector-secret.service';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { RunType } from '../../common/scheduler/shared/types';
-import { DataMartRunType } from '../enums/data-mart-run-type.enum';
 import { DataMartDefinition } from '../dto/schemas/data-mart-table-definitions/data-mart-definition';
 import { ListDataMartsByConnectorNameCommand } from '../dto/domain/list-data-mart-by-connector-name';
+import { isConnectorDefinition } from '../dto/schemas/data-mart-table-definitions/data-mart-definition.guards';
 
 @Injectable()
 export class DataMartMapper {
@@ -260,10 +260,8 @@ export class DataMartMapper {
     const maskedRuns = await Promise.all(
       runs.map(async run => {
         let maskedDefinitionRun: DataMartDefinition | undefined;
-        if (run.type === DataMartRunType.CONNECTOR && run.definitionRun) {
-          maskedDefinitionRun = await this.connectorSecretService.mask(
-            run.definitionRun as ConnectorDefinition
-          );
+        if (run.definitionRun && isConnectorDefinition(run.definitionRun)) {
+          maskedDefinitionRun = await this.connectorSecretService.mask(run.definitionRun);
         }
 
         return {


### PR DESCRIPTION
This pull request makes a targeted update to the logic for masking data mart runs, improving type safety and maintainability. The main change is the replacement of a direct enum comparison with a type guard function to determine if a run's definition should be masked.