### PR TITLE
feat(migrations): add migration to drop foreign key from data-mart-ru…

### DIFF
--- a/apps/backend/src/migrations/1762511215226-drop-foreign-key-to-report-in-data-mart-run.ts
+++ b/apps/backend/src/migrations/1762511215226-drop-foreign-key-to-report-in-data-mart-run.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner, TableForeignKey } from 'typeorm';
+
+export class DropForeignKeyToReportInDataMartRun1762511215226 implements MigrationInterface {
+  private readonly TABLE_NAME = 'data_mart_run';
+  public readonly name = 'DropForeignKeyToReportInDataMartRun1762511215226';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable(this.TABLE_NAME);
+    const foreignKey = table?.foreignKeys.find(fk => fk.columnNames.indexOf('reportId') !== -1);
+    if (foreignKey) {
+      await queryRunner.dropForeignKey(this.TABLE_NAME, foreignKey);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable(this.TABLE_NAME);
+    const foreignKey = table?.foreignKeys.find(fk => fk.columnNames.indexOf('reportId') !== -1);
+    if (!foreignKey) {
+      await queryRunner.createForeignKey(
+        this.TABLE_NAME,
+        new TableForeignKey({
+          columnNames: ['reportId'],
+          referencedTableName: 'report',
+          referencedColumnNames: ['id'],
+          onDelete: 'NO ACTION',
+          onUpdate: 'NO ACTION',
+        })
+      );
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a new migration to remove the foreign key constraint from the `reportId` column in the `data_mart_run` table, and provides a way to restore it if needed. 