### PR TITLE
feat(backend): Tables support added for markdown parser

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -93,6 +93,7 @@
     "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",
+    "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "rxjs": "^7.8.1",

--- a/apps/backend/src/common/markdown/github-markdown-css.ts
+++ b/apps/backend/src/common/markdown/github-markdown-css.ts
@@ -1,3 +1,143 @@
+const printVariables = (variables: Record<string, string>) =>
+  Object.keys(variables)
+    .map(k => `  ${k}: ${variables[k]};`)
+    .join('\n');
+
+const mergeVariables = (light: Record<string, string>, dark: Record<string, string>) =>
+  Object.keys(light)
+    .map(k => `  ${k}: light-dark(${light[k]}, ${dark[k]});`)
+    .join('\n');
+
+const GITHUB_LIGHT_THEME_VARIABLES: Record<string, string> = {
+  '--focus-outlineColor': '#0969da',
+  '--fgColor-default': '#1f2328',
+  '--fgColor-muted': '#59636e',
+  '--fgColor-accent': '#0969da',
+  '--fgColor-success': '#1a7f37',
+  '--fgColor-attention': '#9a6700',
+  '--fgColor-danger': '#d1242f',
+  '--fgColor-done': '#8250df',
+  '--bgColor-default': '#ffffff',
+  '--bgColor-muted': '#f6f8fa',
+  '--bgColor-neutral-muted': '#818b981f',
+  '--bgColor-attention-muted': '#fff8c5',
+  '--borderColor-default': '#d1d9e0',
+  '--borderColor-muted': '#d1d9e0b3',
+  '--borderColor-neutral-muted': '#d1d9e0b3',
+  '--borderColor-accent-emphasis': '#0969da',
+  '--borderColor-success-emphasis': '#1a7f37',
+  '--borderColor-attention-emphasis': '#9a6700',
+  '--borderColor-danger-emphasis': '#cf222e',
+  '--borderColor-done-emphasis': '#8250df',
+  '--color-prettylights-syntax-comment': '#59636e',
+  '--color-prettylights-syntax-constant': '#0550ae',
+  '--color-prettylights-syntax-constant-other-reference-link': '#0a3069',
+  '--color-prettylights-syntax-entity': '#6639ba',
+  '--color-prettylights-syntax-storage-modifier-import': '#1f2328',
+  '--color-prettylights-syntax-entity-tag': '#0550ae',
+  '--color-prettylights-syntax-keyword': '#cf222e',
+  '--color-prettylights-syntax-string': '#0a3069',
+  '--color-prettylights-syntax-variable': '#953800',
+  '--color-prettylights-syntax-brackethighlighter-unmatched': '#82071e',
+  '--color-prettylights-syntax-brackethighlighter-angle': '#59636e',
+  '--color-prettylights-syntax-invalid-illegal-text': '#f6f8fa',
+  '--color-prettylights-syntax-invalid-illegal-bg': '#82071e',
+  '--color-prettylights-syntax-carriage-return-text': '#f6f8fa',
+  '--color-prettylights-syntax-carriage-return-bg': '#cf222e',
+  '--color-prettylights-syntax-string-regexp': '#116329',
+  '--color-prettylights-syntax-markup-list': '#3b2300',
+  '--color-prettylights-syntax-markup-heading': '#0550ae',
+  '--color-prettylights-syntax-markup-italic': '#1f2328',
+  '--color-prettylights-syntax-markup-bold': '#1f2328',
+  '--color-prettylights-syntax-markup-deleted-text': '#82071e',
+  '--color-prettylights-syntax-markup-deleted-bg': '#ffebe9',
+  '--color-prettylights-syntax-markup-inserted-text': '#116329',
+  '--color-prettylights-syntax-markup-inserted-bg': '#dafbe1',
+  '--color-prettylights-syntax-markup-changed-text': '#953800',
+  '--color-prettylights-syntax-markup-changed-bg': '#ffd8b5',
+  '--color-prettylights-syntax-markup-ignored-text': '#d1d9e0',
+  '--color-prettylights-syntax-markup-ignored-bg': '#0550ae',
+  '--color-prettylights-syntax-meta-diff-range': '#8250df',
+  '--color-prettylights-syntax-sublimelinter-gutter-mark': '#818b98',
+};
+
+const GITHUB_DARK_THEME_VARIABLES: Record<string, string> = {
+  '--focus-outlineColor': '#1f6feb',
+  '--fgColor-default': '#f0f6fc',
+  '--fgColor-muted': '#9198a1',
+  '--fgColor-accent': '#4493f8',
+  '--fgColor-success': '#3fb950',
+  '--fgColor-attention': '#d29922',
+  '--fgColor-danger': '#f85149',
+  '--fgColor-done': '#ab7df8',
+  '--bgColor-default': 'oklch(20.5% 0 0)',
+  '--bgColor-muted': '#151b23',
+  '--bgColor-neutral-muted': '#656c7633',
+  '--bgColor-attention-muted': '#bb800926',
+  '--borderColor-default': '#3d444d',
+  '--borderColor-muted': '#3d444db3',
+  '--borderColor-neutral-muted': '#3d444db3',
+  '--borderColor-accent-emphasis': '#1f6feb',
+  '--borderColor-success-emphasis': '#238636',
+  '--borderColor-attention-emphasis': '#9e6a03',
+  '--borderColor-danger-emphasis': '#da3633',
+  '--borderColor-done-emphasis': '#8957e5',
+  '--color-prettylights-syntax-comment': '#9198a1',
+  '--color-prettylights-syntax-constant': '#79c0ff',
+  '--color-prettylights-syntax-constant-other-reference-link': '#a5d6ff',
+  '--color-prettylights-syntax-entity': '#d2a8ff',
+  '--color-prettylights-syntax-storage-modifier-import': '#f0f6fc',
+  '--color-prettylights-syntax-entity-tag': '#7ee787',
+  '--color-prettylights-syntax-keyword': '#ff7b72',
+  '--color-prettylights-syntax-string': '#a5d6ff',
+  '--color-prettylights-syntax-variable': '#ffa657',
+  '--color-prettylights-syntax-brackethighlighter-unmatched': '#f85149',
+  '--color-prettylights-syntax-brackethighlighter-angle': '#9198a1',
+  '--color-prettylights-syntax-invalid-illegal-text': '#f0f6fc',
+  '--color-prettylights-syntax-invalid-illegal-bg': '#8e1519',
+  '--color-prettylights-syntax-carriage-return-text': '#f0f6fc',
+  '--color-prettylights-syntax-carriage-return-bg': '#b62324',
+  '--color-prettylights-syntax-string-regexp': '#7ee787',
+  '--color-prettylights-syntax-markup-list': '#f2cc60',
+  '--color-prettylights-syntax-markup-heading': '#1f6feb',
+  '--color-prettylights-syntax-markup-italic': '#f0f6fc',
+  '--color-prettylights-syntax-markup-bold': '#f0f6fc',
+  '--color-prettylights-syntax-markup-deleted-text': '#ffdcd7',
+  '--color-prettylights-syntax-markup-deleted-bg': '#67060c',
+  '--color-prettylights-syntax-markup-inserted-text': '#aff5b4',
+  '--color-prettylights-syntax-markup-inserted-bg': '#033a16',
+  '--color-prettylights-syntax-markup-changed-text': '#ffdfb6',
+  '--color-prettylights-syntax-markup-changed-bg': '#5a1e02',
+  '--color-prettylights-syntax-markup-ignored-text': '#f0f6fc',
+  '--color-prettylights-syntax-markup-ignored-bg': '#1158c7',
+  '--color-prettylights-syntax-meta-diff-range': '#d2a8ff',
+  '--color-prettylights-syntax-sublimelinter-gutter-mark': '#3d444d',
+};
+
+export const GITHUB_LIGHT_THEME_VARIABLES_CSS = `
+.markdown-body {
+  /* light */
+  color-scheme: light;
+  ${printVariables(GITHUB_LIGHT_THEME_VARIABLES)}
+}
+`;
+
+export const GITHUB_DARK_THEME_VARIABLES_CSS = `
+.markdown-body {
+  /* dark */
+  color-scheme: dark;
+  ${printVariables(GITHUB_LIGHT_THEME_VARIABLES)}
+}
+`;
+
+export const GITHUB_DYNAMIC_THEME_VARIABLES_CSS = `
+.markdown-body {
+  /* dynamic */
+  color-scheme: light dark;
+  ${mergeVariables(GITHUB_LIGHT_THEME_VARIABLES, GITHUB_DARK_THEME_VARIABLES)}
+}
+`;
+
 export const GITHUB_MARKDOWN_CSS = `
 .markdown-body {
   --base-size-4: 0.25rem;
@@ -10,118 +150,6 @@ export const GITHUB_MARKDOWN_CSS = `
   --base-text-weight-semibold: 600;
   --fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
   --fgColor-accent: Highlight;
-}
-@media (prefers-color-scheme: dark) {
-  .markdown-body, [data-theme="dark"] {
-    /* dark */
-    color-scheme: dark;
-    --focus-outlineColor: #1f6feb;
-    --fgColor-default: #f0f6fc;
-    --fgColor-muted: #9198a1;
-    --fgColor-accent: #4493f8;
-    --fgColor-success: #3fb950;
-    --fgColor-attention: #d29922;
-    --fgColor-danger: #f85149;
-    --fgColor-done: #ab7df8;
-    --bgColor-default: #0d1117;
-    --bgColor-muted: #151b23;
-    --bgColor-neutral-muted: #656c7633;
-    --bgColor-attention-muted: #bb800926;
-    --borderColor-default: #3d444d;
-    --borderColor-muted: #3d444db3;
-    --borderColor-neutral-muted: #3d444db3;
-    --borderColor-accent-emphasis: #1f6feb;
-    --borderColor-success-emphasis: #238636;
-    --borderColor-attention-emphasis: #9e6a03;
-    --borderColor-danger-emphasis: #da3633;
-    --borderColor-done-emphasis: #8957e5;
-    --color-prettylights-syntax-comment: #9198a1;
-    --color-prettylights-syntax-constant: #79c0ff;
-    --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
-    --color-prettylights-syntax-entity: #d2a8ff;
-    --color-prettylights-syntax-storage-modifier-import: #f0f6fc;
-    --color-prettylights-syntax-entity-tag: #7ee787;
-    --color-prettylights-syntax-keyword: #ff7b72;
-    --color-prettylights-syntax-string: #a5d6ff;
-    --color-prettylights-syntax-variable: #ffa657;
-    --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
-    --color-prettylights-syntax-brackethighlighter-angle: #9198a1;
-    --color-prettylights-syntax-invalid-illegal-text: #f0f6fc;
-    --color-prettylights-syntax-invalid-illegal-bg: #8e1519;
-    --color-prettylights-syntax-carriage-return-text: #f0f6fc;
-    --color-prettylights-syntax-carriage-return-bg: #b62324;
-    --color-prettylights-syntax-string-regexp: #7ee787;
-    --color-prettylights-syntax-markup-list: #f2cc60;
-    --color-prettylights-syntax-markup-heading: #1f6feb;
-    --color-prettylights-syntax-markup-italic: #f0f6fc;
-    --color-prettylights-syntax-markup-bold: #f0f6fc;
-    --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
-    --color-prettylights-syntax-markup-deleted-bg: #67060c;
-    --color-prettylights-syntax-markup-inserted-text: #aff5b4;
-    --color-prettylights-syntax-markup-inserted-bg: #033a16;
-    --color-prettylights-syntax-markup-changed-text: #ffdfb6;
-    --color-prettylights-syntax-markup-changed-bg: #5a1e02;
-    --color-prettylights-syntax-markup-ignored-text: #f0f6fc;
-    --color-prettylights-syntax-markup-ignored-bg: #1158c7;
-    --color-prettylights-syntax-meta-diff-range: #d2a8ff;
-    --color-prettylights-syntax-sublimelinter-gutter-mark: #3d444d;
-  }
-}
-@media (prefers-color-scheme: light) {
-  .markdown-body, [data-theme="light"] {
-    /* light */
-    color-scheme: light;
-    --focus-outlineColor: #0969da;
-    --fgColor-default: #1f2328;
-    --fgColor-muted: #59636e;
-    --fgColor-accent: #0969da;
-    --fgColor-success: #1a7f37;
-    --fgColor-attention: #9a6700;
-    --fgColor-danger: #d1242f;
-    --fgColor-done: #8250df;
-    --bgColor-default: #ffffff;
-    --bgColor-muted: #f6f8fa;
-    --bgColor-neutral-muted: #818b981f;
-    --bgColor-attention-muted: #fff8c5;
-    --borderColor-default: #d1d9e0;
-    --borderColor-muted: #d1d9e0b3;
-    --borderColor-neutral-muted: #d1d9e0b3;
-    --borderColor-accent-emphasis: #0969da;
-    --borderColor-success-emphasis: #1a7f37;
-    --borderColor-attention-emphasis: #9a6700;
-    --borderColor-danger-emphasis: #cf222e;
-    --borderColor-done-emphasis: #8250df;
-    --color-prettylights-syntax-comment: #59636e;
-    --color-prettylights-syntax-constant: #0550ae;
-    --color-prettylights-syntax-constant-other-reference-link: #0a3069;
-    --color-prettylights-syntax-entity: #6639ba;
-    --color-prettylights-syntax-storage-modifier-import: #1f2328;
-    --color-prettylights-syntax-entity-tag: #0550ae;
-    --color-prettylights-syntax-keyword: #cf222e;
-    --color-prettylights-syntax-string: #0a3069;
-    --color-prettylights-syntax-variable: #953800;
-    --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
-    --color-prettylights-syntax-brackethighlighter-angle: #59636e;
-    --color-prettylights-syntax-invalid-illegal-text: #f6f8fa;
-    --color-prettylights-syntax-invalid-illegal-bg: #82071e;
-    --color-prettylights-syntax-carriage-return-text: #f6f8fa;
-    --color-prettylights-syntax-carriage-return-bg: #cf222e;
-    --color-prettylights-syntax-string-regexp: #116329;
-    --color-prettylights-syntax-markup-list: #3b2300;
-    --color-prettylights-syntax-markup-heading: #0550ae;
-    --color-prettylights-syntax-markup-italic: #1f2328;
-    --color-prettylights-syntax-markup-bold: #1f2328;
-    --color-prettylights-syntax-markup-deleted-text: #82071e;
-    --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
-    --color-prettylights-syntax-markup-inserted-text: #116329;
-    --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
-    --color-prettylights-syntax-markup-changed-text: #953800;
-    --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
-    --color-prettylights-syntax-markup-ignored-text: #d1d9e0;
-    --color-prettylights-syntax-markup-ignored-bg: #0550ae;
-    --color-prettylights-syntax-meta-diff-range: #8250df;
-    --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
-  }
 }
 
 .markdown-body {

--- a/apps/backend/src/common/markdown/markdown-parser.service.ts
+++ b/apps/backend/src/common/markdown/markdown-parser.service.ts
@@ -1,11 +1,37 @@
 import { Injectable } from '@nestjs/common';
 import juice from 'juice';
-import rehypeSanitize from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
 import { remark } from 'remark';
+import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
-import { GITHUB_MARKDOWN_CSS } from './github-markdown-css';
+import {
+  GITHUB_DARK_THEME_VARIABLES_CSS,
+  GITHUB_DYNAMIC_THEME_VARIABLES_CSS,
+  GITHUB_LIGHT_THEME_VARIABLES_CSS,
+  GITHUB_MARKDOWN_CSS,
+} from './github-markdown-css';
+
+const EXTENDED_SCHEMA_FOR_SANITIZE = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames || []), 'table', 'thead', 'tbody', 'tr', 'th', 'td'],
+  attributes: {
+    ...(defaultSchema.attributes || {}),
+    th: [...(defaultSchema.attributes?.th || []), 'align', 'rowspan', 'colspan'],
+    td: [...(defaultSchema.attributes?.td || []), 'align', 'rowspan', 'colspan'],
+    table: [...(defaultSchema.attributes?.table || []), 'border', 'cellpadding', 'cellspacing'],
+  },
+};
+
+/**
+ * The color theme of the rendered Markdown.
+ */
+export enum COLOR_THEME {
+  LIGHT = 'LIGHT',
+  DARK = 'DARK',
+  DYNAMIC = 'DYNAMIC',
+}
 
 /**
  * A service class for parsing Markdown content into sanitized HTML.
@@ -16,20 +42,44 @@ import { GITHUB_MARKDOWN_CSS } from './github-markdown-css';
  */
 @Injectable()
 export class MarkdownParser {
-  public async parseToHtml(markdown: string): Promise<string> {
+  public async parseToHtml(markdown: string, theme = COLOR_THEME.DYNAMIC): Promise<string> {
     const html = await remark()
       .use(remarkParse)
+      .use(remarkGfm)
       .use(remarkRehype)
-      .use(rehypeSanitize) // filter out potentially dangerous HTML
+      .use(rehypeSanitize, EXTENDED_SCHEMA_FOR_SANITIZE) // filter out potentially dangerous HTML
       .use(rehypeStringify)
       .process(markdown);
 
     const content = `<div class="markdown-body">${String(html)}</div>`;
 
-    return juice.inlineContent(content, GITHUB_MARKDOWN_CSS, {
+    return juice.inlineContent(content, this.getColorThemeCss(theme), {
       preserveMediaQueries: true,
+      applyAttributesTableElements: true,
       applyWidthAttributes: true,
       applyHeightAttributes: true,
+      resolveCSSVariables: true,
     });
+  }
+
+  private getColorThemeCss(theme: COLOR_THEME): string {
+    let cssVariables: string;
+    switch (theme) {
+      case COLOR_THEME.LIGHT:
+        cssVariables = GITHUB_LIGHT_THEME_VARIABLES_CSS;
+        break;
+      case COLOR_THEME.DARK:
+        cssVariables = GITHUB_DARK_THEME_VARIABLES_CSS;
+        break;
+      case COLOR_THEME.DYNAMIC:
+        cssVariables = GITHUB_DYNAMIC_THEME_VARIABLES_CSS;
+        break;
+      default:
+        throw new Error(`Unsupported color theme: ${theme}`);
+    }
+    return `
+      ${cssVariables}
+      ${GITHUB_MARKDOWN_CSS}
+    `;
   }
 }

--- a/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.ts
@@ -4,7 +4,10 @@ import {
   EMAIL_PROVIDER_FACADE,
   EmailProviderFacade,
 } from '../../../../../common/email/shared/email-provider.facade';
-import { MarkdownParser } from '../../../../../common/markdown/markdown-parser.service';
+import {
+  COLOR_THEME,
+  MarkdownParser,
+} from '../../../../../common/markdown/markdown-parser.service';
 import { ReportDataBatch } from '../../../../dto/domain/report-data-batch.dto';
 import { ReportDataDescription } from '../../../../dto/domain/report-data-description.dto';
 import { Report } from '../../../../entities/report.entity';
@@ -78,7 +81,11 @@ abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
     }
 
     // TODO: integrate with AI Insights
-    const reportHtml = await this.markdownParser.parseToHtml(this.emailConfig.messageTemplate);
+    const reportHtml = await this.markdownParser.parseToHtml(
+      this.emailConfig.messageTemplate,
+      COLOR_THEME.LIGHT
+    );
+
     const emailHtml = renderEmailReportTemplate({
       dataMartId: this.report.dataMart.id,
       dataMartTitle: this.report.dataMart.title,

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "rehype-sanitize": "^6.0.0",
         "rehype-stringify": "^10.0.1",
         "remark": "^15.0.1",
+        "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "rxjs": "^7.8.1",


### PR DESCRIPTION
### Short PR description
- Added Markdown tables support (GFM) with extended sanitization for `table`.
- Removed `@media` rules from CSS to ensure reliable style inlining for emails via `juice` (many email clients ignore media queries).