### PR TITLE
feat(web): add direct linking for data storages and destinations

### DIFF
--- a/.changeset/direct-linking-for-storage-and-destination.md
+++ b/.changeset/direct-linking-for-storage-and-destination.md
@@ -1,0 +1,8 @@
+---
+'owox': minor
+---
+
+# Add direct linking for Data Storages and Destinations
+
+- Added support for direct links to specific Data Storages and Destinations via URL parameters, making it easier to share specific entities with others.
+- Automatically synchronizes the URL with the currently opened entity.

--- a/apps/web/src/shared/hooks/index.ts
+++ b/apps/web/src/shared/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useProjectId } from './useProjectId';
 export { useProjectRoute } from './useProjectRoute';
 export { useActionLock } from './useActionLock';
+export { useUrlParam } from './useUrlParam';

--- a/apps/web/src/shared/hooks/useUrlParam.ts
+++ b/apps/web/src/shared/hooks/useUrlParam.ts
@@ -1,0 +1,40 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+/**
+ * Hook for managing a specific URL query parameter.
+ * @param name - The name of the query parameter.
+ * @returns An object containing the current value, a setter, and a remover.
+ */
+export function useUrlParam(name: string) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const value = searchParams.get(name);
+
+  const setParam = useCallback(
+    (newValue: string) => {
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev);
+          next.set(name, newValue);
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [name, setSearchParams]
+  );
+
+  const removeParam = useCallback(() => {
+    setSearchParams(
+      prev => {
+        const next = new URLSearchParams(prev);
+        next.delete(name);
+        return next;
+      },
+      { replace: true }
+    );
+  }, [name, setSearchParams]);
+
+  return { value, setParam, removeParam };
+}


### PR DESCRIPTION

![CleanShot 2025-12-24 at 14 11 48](https://github.com/user-attachments/assets/1d3e051d-2e9f-40f2-9d88-4ddf06f26f43)


### Description:
This PR introduces support for direct linking (deep linking) to specific data storages and destinations via URL query parameters. This improvement enhances the user experience by allowing users to share direct links to entities and maintain UI state across page reloads.

### Key Changes:
*   **Direct Linking Support**: Added logic to automatically open the edit or details view when an `id` parameter is present in the URL for both Storages and Destinations.
*   **New `useUrlParam` Hook**: Implemented a reusable hook for synchronized management of URL query parameters.
*   **Deep Link Validation**: Added checks to verify if the entity from the URL exists in the loaded data. If not found, an error toast is displayed and the invalid parameter is removed.
*   **URL Synchronization**: Ensured the `id` parameter is added to the URL when opening an entity and removed when closing the view or completing an action (save/delete).
