### PR TITLE
fix: resolve stack overflow in Microsoft Ads connector for large datasets

### DIFF
--- a/packages/connectors/src/Sources/MicrosoftAds/Helper.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Helper.js
@@ -62,11 +62,11 @@ const MicrosoftAdsHelper = {
     const response = await HttpUtils.fetch(url);
     const blob = await response.getBlob();
     const files = FileUtils.unzip(blob);
-    const allRows = [];
+    let allRows = [];
     files.forEach(file => {
       const csvText = file.getDataAsString();
       const rows = FileUtils.parseCsv(csvText);
-      allRows.push(...rows);
+      allRows = allRows.concat(rows);
     });
     return allRows;
   },
@@ -118,7 +118,7 @@ const MicrosoftAdsHelper = {
       const status = record.Status || record.CampaignStatus || '';
       return type === 'Campaign' && status !== 'Deleted';
     });
-    
+
     return campaigns.map(campaign => campaign.Id);
   }
 };


### PR DESCRIPTION
## Problem

The MicrosoftAds connector was throwing `RangeError: Maximum call stack size exceeded` when processing campaign data with large datasets (>10,000 rows). 

## Solution

Replaced `allRows.push(...rows)` with `allRows = allRows.concat(rows)` in Helper.js to avoid stack overflow with large arrays.