### PR TITLE
feat(facebook): Add `cost_per_result`, `results` and `result_rate` insights fields

### DIFF
--- a/.changeset/old-bikes-send.md
+++ b/.changeset/old-bikes-send.md
@@ -2,8 +2,8 @@
 'owox': minor
 ---
 
-# Add cost_per_result and result_rate fields
+# Add cost_per_result, results and result_rate fields
 
 ## Description
 
-Added `cost_per_result` and `result_rate` fields to the Facebook Ad Account Insights report schema, allowing for better cost efficiency analysis.
+Added `cost_per_result`, `results` and `result_rate` fields to the Facebook Ad Account Insights report schema, allowing for better cost efficiency analysis.

--- a/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/ad-account-insights-fields.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/ad-account-insights-fields.js
@@ -320,6 +320,10 @@ var adAccountInsightsFields = {
     'description': 'The percentage of results you received out of all the views of your ads.',
     'type': DATA_TYPES.ARRAY
   },
+  'results': {
+    'description': 'The number of results you received out of all the views of your ads.',
+    'type': DATA_TYPES.ARRAY
+  },
   'shops_assisted_purchases': {
     'description': 'shops_assisted_purchases',
     'type': DATA_TYPES.STRING


### PR DESCRIPTION
This PR adds support for the `cost_per_result`, `results` and `result_rate` fields in the _ad-account-insights_ endpoint of the Facebook Marketing connector.

Changes:

- Added `cost_per_result` (Type: ARRAY) to ad-account-insights-fields.js
- Added `result_rate` (Type: ARRAY) to ad-account-insights-fields.js
- Added `results` (Type: ARRAY) to ad-account-insights-fields.js