### PR TITLE
feat(web): add error boundaries for graceful crash handling

### DIFF
--- a/.changeset/hello-ruslan.md
+++ b/.changeset/hello-ruslan.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Add error boundaries to gracefully handle unexpected application crashes
+
+Replace the default React "Unexpected Application Error" screen with user-friendly fallback UI. When a page crashes, users now see a styled error page with options to navigate home or reload — instead of raw technical stack traces. The sidebar stays visible for in-layout errors, so users can navigate away without a full page reload.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -79,6 +79,36 @@ npm run preview
 - `npm run format:check` - Check code formatting
 - `npm run preview` - Preview the production build
 
+## Error Handling
+
+The app uses React Router `errorElement` to catch runtime errors and display a user-friendly fallback instead of the default React crash screen.
+
+There are two error boundary components in `src/components/errors/`:
+
+- **`RootErrorBoundary`** — full-page fallback when `MainLayout` itself crashes (uses a plain `<a href="/">` since the router may be broken).
+- **`LayoutErrorBoundary`** — in-layout fallback when a child page crashes. The sidebar stays visible so users can navigate away without reloading.
+
+### Dev-only error details
+
+Both components include a collapsible block that shows the error message and stack trace:
+
+```tsx
+{import.meta.env.DEV && error instanceof Error && (
+  <details>
+    <summary>Error details</summary>
+    <pre>{error.message}{'\n\n'}{error.stack}</pre>
+  </details>
+)}
+```
+
+| Part | Purpose |
+|---|---|
+| `import.meta.env.DEV` | Vite built-in — `true` during `npm run dev`, `false` in production builds. Vite statically replaces it at build time, so the entire block is tree-shaken out of the production bundle. |
+| `error instanceof Error` | TypeScript type guard — ensures `.message` and `.stack` are safely accessible. Non-`Error` throws (e.g. strings, Response objects) skip this block. |
+| `<details>` / `<summary>` | Native HTML disclosure widget — collapsed by default, click to expand. No JS needed. |
+
+In production, users see only the friendly message and action buttons. In development, developers can expand the details to see the full stack trace inline without opening browser DevTools.
+
 ## Related Documentation
 
 - For information about the overall project, see the [main README](../../README.md)

--- a/apps/web/src/components/errors/LayoutErrorBoundary.tsx
+++ b/apps/web/src/components/errors/LayoutErrorBoundary.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from 'react';
+import { useRouteError, isRouteErrorResponse, Link } from 'react-router-dom';
+import { Button } from '@owox/ui/components/button';
+import { AlertTriangle, ChevronRight } from 'lucide-react';
+import { logRouteError } from './logRouteError';
+
+export function LayoutErrorBoundary() {
+  const error = useRouteError();
+
+  useEffect(() => {
+    logRouteError(error);
+  }, [error]);
+
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return null;
+  }
+
+  return (
+    <div className='dm-empty-state-404page'>
+      <div className='dm-empty-state-404page-foreground'>
+        <AlertTriangle className='dm-empty-state-ico' strokeWidth={1} />
+
+        <h1 className='dm-empty-state-title'>Something went wrong</h1>
+
+        <p className='dm-empty-state-subtitle'>
+          The app hit an unexpected glitch. Don&apos;t worry — your data is safe.
+          <br />
+          Try navigating to another section or heading home.
+        </p>
+
+        <div className='flex items-center gap-3'>
+          <Button variant='default' asChild>
+            <Link to={'/'} className='flex items-center gap-1' aria-label='Guide Me Home'>
+              Guide Me Home
+              <ChevronRight className='h-4 w-4' />
+            </Link>
+          </Button>
+          <Button
+            variant='outline'
+            onClick={() => {
+              window.location.reload();
+            }}
+          >
+            Reload Page
+          </Button>
+        </div>
+
+        {import.meta.env.DEV && error instanceof Error && (
+          <details className='mt-8 w-full max-w-2xl'>
+            <summary className='text-muted-foreground cursor-pointer text-sm'>
+              Error details
+            </summary>
+            <pre className='text-muted-foreground mt-2 overflow-auto rounded border p-4 text-xs'>
+              {error.message}
+              {'\n\n'}
+              {error.stack}
+            </pre>
+          </details>
+        )}
+      </div>
+
+      <div className='dm-empty-state-404page-background' />
+    </div>
+  );
+}

--- a/apps/web/src/components/errors/RootErrorBoundary.tsx
+++ b/apps/web/src/components/errors/RootErrorBoundary.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from 'react';
+import { useRouteError, isRouteErrorResponse } from 'react-router-dom';
+import { Button } from '@owox/ui/components/button';
+import { AlertTriangle, ChevronRight } from 'lucide-react';
+import { logRouteError } from './logRouteError';
+
+export function RootErrorBoundary() {
+  const error = useRouteError();
+
+  useEffect(() => {
+    logRouteError(error);
+  }, [error]);
+
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return null;
+  }
+
+  return (
+    <div className='dm-empty-state-404page'>
+      <div className='dm-empty-state-404page-foreground'>
+        <AlertTriangle className='dm-empty-state-ico' strokeWidth={1} />
+
+        <h1 className='dm-empty-state-title'>Something went wrong</h1>
+
+        <p className='dm-empty-state-subtitle'>
+          The app hit an unexpected glitch. Don&apos;t worry — your data is safe.
+          <br />
+          Please try reloading the page or going back to the home page.
+        </p>
+
+        <div className='flex items-center gap-3'>
+          <Button variant='default' asChild>
+            <a href='/' className='flex items-center gap-1' aria-label='Guide Me Home'>
+              Guide Me Home
+              <ChevronRight className='h-4 w-4' />
+            </a>
+          </Button>
+          <Button
+            variant='outline'
+            onClick={() => {
+              window.location.reload();
+            }}
+          >
+            Reload Page
+          </Button>
+        </div>
+
+        {import.meta.env.DEV && error instanceof Error && (
+          <details className='mt-8 w-full max-w-2xl'>
+            <summary className='text-muted-foreground cursor-pointer text-sm'>
+              Error details
+            </summary>
+            <pre className='text-muted-foreground mt-2 overflow-auto rounded border p-4 text-xs'>
+              {error.message}
+              {'\n\n'}
+              {error.stack}
+            </pre>
+          </details>
+        )}
+      </div>
+
+      <div className='dm-empty-state-404page-background' />
+    </div>
+  );
+}

--- a/apps/web/src/components/errors/index.ts
+++ b/apps/web/src/components/errors/index.ts
@@ -1,0 +1,2 @@
+export { RootErrorBoundary } from './RootErrorBoundary';
+export { LayoutErrorBoundary } from './LayoutErrorBoundary';

--- a/apps/web/src/components/errors/logRouteError.ts
+++ b/apps/web/src/components/errors/logRouteError.ts
@@ -1,0 +1,9 @@
+export function logRouteError(error: unknown): void {
+  if (error instanceof Error) {
+    console.error('[RouteError]', error.message, error.stack);
+  } else if (error instanceof Response) {
+    console.error('[RouteError] Response', error.status, error.statusText);
+  } else {
+    console.error('[RouteError] Unknown', error);
+  }
+}

--- a/apps/web/src/routes/data-marts/routes.tsx
+++ b/apps/web/src/routes/data-marts/routes.tsx
@@ -10,19 +10,23 @@ import PrevInsightsListView from '../../features/data-marts/insights-prev/compon
 import PrevInsightDetailsView from '../../features/data-marts/insights-prev/components/InsightDetailsView.tsx';
 import InsightsListView from '../../features/data-marts/insights/components/InsightsListView.tsx';
 import InsightDetailsView from '../../features/data-marts/insights/components/InsightDetailsView.tsx';
+import { LayoutErrorBoundary } from '../../components/errors';
 
 export const dataMartDetailsRoutes: RouteObject[] = [
   {
     path: 'overview',
     element: <DataMartOverviewContent />,
+    errorElement: <LayoutErrorBoundary />,
   },
   {
     path: 'data-setup',
     element: <DataMartDataSetupContent />,
+    errorElement: <LayoutErrorBoundary />,
   },
   {
     path: 'insights',
     element: <DataMartInsightsContent />,
+    errorElement: <LayoutErrorBoundary />,
     children: [
       { index: true, element: <PrevInsightsListView /> },
       { path: ':insightId', element: <PrevInsightDetailsView /> },
@@ -31,6 +35,7 @@ export const dataMartDetailsRoutes: RouteObject[] = [
   {
     path: 'insights-v2',
     element: <DataMartNextInsightsContent />,
+    errorElement: <LayoutErrorBoundary />,
     children: [
       { index: true, element: <InsightsListView /> },
       { path: ':insightId', element: <InsightDetailsView /> },
@@ -39,17 +44,21 @@ export const dataMartDetailsRoutes: RouteObject[] = [
   {
     path: 'reports',
     element: <DataMartDestinationsContent />,
+    errorElement: <LayoutErrorBoundary />,
   },
   {
     path: 'triggers',
     element: <DataMartTriggersContent />,
+    errorElement: <LayoutErrorBoundary />,
   },
   {
     path: 'run-history',
     element: <DataMartRunHistoryContent />,
+    errorElement: <LayoutErrorBoundary />,
   },
   {
     index: true,
     element: <DataMartOverviewContent />,
+    errorElement: <LayoutErrorBoundary />,
   },
 ];

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -11,49 +11,60 @@ import { ProjectNotificationsPage } from '../pages/notifications/project';
 import { dataMartDetailsRoutes } from './data-marts/routes';
 import { ProjectRedirect } from '../components/ProjectRedirect';
 import { oauthRoutes } from './oauth.routes';
+import { RootErrorBoundary, LayoutErrorBoundary } from '../components/errors';
 
 const routes: RouteObject[] = [
   {
     index: true,
     path: '/',
     element: <ProjectRedirect />,
+    errorElement: <RootErrorBoundary />,
   },
   {
     path: '/ui/:projectId',
     element: <MainLayout />,
+    errorElement: <RootErrorBoundary />,
     children: [
       {
         path: 'about',
         element: <About />,
+        errorElement: <LayoutErrorBoundary />,
       },
       {
         index: true,
         element: <DataMartsPage />,
+        errorElement: <LayoutErrorBoundary />,
       },
       {
         path: 'data-marts',
         element: <DataMartsPage />,
+        errorElement: <LayoutErrorBoundary />,
       },
       {
         path: 'data-marts/create',
         element: <CreateDataMartPage />,
+        errorElement: <LayoutErrorBoundary />,
       },
       {
         path: 'data-marts/:id',
         element: <DataMartDetailsPage />,
+        errorElement: <LayoutErrorBoundary />,
         children: dataMartDetailsRoutes,
       },
       {
         path: 'data-storages',
         element: <DataStorageListPage />,
+        errorElement: <LayoutErrorBoundary />,
       },
       {
         path: 'data-destinations',
         element: <DataDestinationListPage />,
+        errorElement: <LayoutErrorBoundary />,
       },
       {
         path: 'notifications',
         element: <ProjectNotificationsPage />,
+        errorElement: <LayoutErrorBoundary />,
       },
       {
         path: '*',
@@ -61,10 +72,14 @@ const routes: RouteObject[] = [
       },
     ],
   },
-  oauthRoutes,
+  {
+    ...oauthRoutes,
+    errorElement: <RootErrorBoundary />,
+  },
   {
     path: '*',
     element: <NotFound />,
+    errorElement: <RootErrorBoundary />,
   },
 ];
 


### PR DESCRIPTION
## Preview

### Before
<img width="1025" height="727" alt="CleanShot 2026-04-09 at 13 48 35" src="https://github.com/user-attachments/assets/0f88316b-8d17-4b10-a391-921f0ad282a5" />

### After
<img width="1025" height="727" alt="CleanShot 2026-04-09 at 13 39 58" src="https://github.com/user-attachments/assets/ac2f67f0-cb69-49ee-a10a-b11d35a33738" />

## Summary
- Add `RootErrorBoundary` and `LayoutErrorBoundary` components to replace the default React "Unexpected Application Error" crash screen with a user-friendly fallback UI
- Wire `errorElement` into all route definitions so errors are caught at the correct level — layout-level errors preserve the sidebar, root-level errors render a full-page fallback
- Add `logRouteError` utility as a single integration point for error logging (console now, Sentry later)