### PR TITLE
fix(web): restore storage type icons in Data Mart creation form

### DIFF
--- a/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
@@ -19,6 +19,7 @@ import { Combobox } from '../../../../shared/components/Combobox/combobox';
 import { DataStorageHealthIndicator, DataStorageType } from '../../../data-storage';
 import { DataStorageTypeDialog } from '../../../data-storage/shared/components/DataStorageTypeDialog';
 import { useDataStorage } from '../../../data-storage/shared/model/hooks/useDataStorage';
+import type { DataStorageList } from '../../../data-storage/shared/model/types/data-storage-list.ts';
 import { DataStorageTypeModel } from '../../../data-storage/shared/types/data-storage-type.model.ts';
 import { type DataMart, type DataMartFormData, dataMartSchema, useDataMartForm } from '../model';
 
@@ -30,6 +31,19 @@ interface DataMartFormProps {
 }
 
 const CREATE_NEW_STORAGE_VALUE = 'create_new';
+
+function StorageTypeIcon({
+  storages,
+  storageId,
+}: {
+  storages: DataStorageList;
+  storageId: string;
+}) {
+  const storage = storages.find(s => s.id === storageId);
+  if (!storage) return null;
+  const Icon = DataStorageTypeModel.getInfo(storage.type).icon;
+  return <Icon size={20} className='shrink-0' />;
+}
 
 export function DataMartCreateForm({ initialData, onSuccess }: DataMartFormProps) {
   const { handleCreate, isSubmitting, serverError } = useDataMartForm();
@@ -185,12 +199,7 @@ export function DataMartCreateForm({ initialData, onSuccess }: DataMartFormProps
                                 variant='compact'
                               />
                             </div>
-                            {(() => {
-                              const storage = dataStorages.find(s => s.id === option.value);
-                              if (!storage) return null;
-                              const Icon = DataStorageTypeModel.getInfo(storage.type).icon;
-                              return <Icon size={20} className='shrink-0' />;
-                            })()}
+                            <StorageTypeIcon storages={dataStorages} storageId={option.value} />
                             <span className='min-w-0 truncate'>{option.label}</span>
                           </div>
                         )

--- a/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
@@ -19,6 +19,7 @@ import { Combobox } from '../../../../shared/components/Combobox/combobox';
 import { DataStorageHealthIndicator, DataStorageType } from '../../../data-storage';
 import { DataStorageTypeDialog } from '../../../data-storage/shared/components/DataStorageTypeDialog';
 import { useDataStorage } from '../../../data-storage/shared/model/hooks/useDataStorage';
+import { DataStorageTypeModel } from '../../../data-storage/shared/types/data-storage-type.model.ts';
 import { type DataMart, type DataMartFormData, dataMartSchema, useDataMartForm } from '../model';
 
 interface DataMartFormProps {
@@ -184,6 +185,12 @@ export function DataMartCreateForm({ initialData, onSuccess }: DataMartFormProps
                                 variant='compact'
                               />
                             </div>
+                            {(() => {
+                              const storage = dataStorages.find(s => s.id === option.value);
+                              if (!storage) return null;
+                              const Icon = DataStorageTypeModel.getInfo(storage.type).icon;
+                              return <Icon size={20} className='shrink-0' />;
+                            })()}
                             <span className='min-w-0 truncate'>{option.label}</span>
                           </div>
                         )


### PR DESCRIPTION
# Problem

When PR #986 replaced the storage `Select` with a searchable `Combobox` in the Data Mart creation form, the storage type icons (BigQuery, Snowflake, Athena, etc.) were dropped from the dropdown list. The `DataStorageTypeModel` import was removed and the `renderLabel` callback only rendered the health indicator and title, omitting the icon that visually identifies each storage type.

# Solution

Re-imported `DataStorageTypeModel` and added the storage type icon back into the `renderLabel` callback. The icon is resolved by looking up the storage object from `dataStorages` by ID, then calling `DataStorageTypeModel.getInfo(storage.type).icon` — the same approach used in the original `Select` implementation.

# Changes

- Re-added `DataStorageTypeModel` import to `DataMartCreateForm.tsx`
- Added storage type icon rendering between the health indicator and title in the Combobox `renderLabel` callback
