### PR TITLE
fix(google-sheets): sheet access denial error

### DIFF
--- a/.changeset/google-sheets-permission-error.md
+++ b/.changeset/google-sheets-permission-error.md
@@ -4,4 +4,4 @@
 
 # Clearer error when Google Sheet access is denied
 
-When access validation fails due to missing sharing permissions, the error now starts with "You don't have access to this Google Sheet" and then tells users exactly what to do: share the spreadsheet with the account used for authentication (service account email or connected Google account) and grant Editor permission — instead of showing the raw Google API error "The caller does not have permission".
+When access validation fails due to missing sharing permissions, the error now clearly states that the account used for authentication doesn't have access to the sheet and tells users exactly what to do: share the spreadsheet with it (service account email or connected Google account) and grant Editor permission — instead of showing the raw Google API error "The caller does not have permission".

--- a/.changeset/google-sheets-permission-error.md
+++ b/.changeset/google-sheets-permission-error.md
@@ -4,4 +4,4 @@
 
 # Clearer error when Google Sheet access is denied
 
-When access validation fails due to missing sharing permissions, the error now clearly states that the account used for authentication doesn't have access to the sheet and tells users exactly what to do: share the spreadsheet with it (service account email or connected Google account) and grant Editor permission — instead of showing the raw Google API error "The caller does not have permission".
+When access validation fails due to missing sharing permissions, the error now clearly states that the account used for authentication doesn't have access to the sheet and tells users exactly what to do: share the spreadsheet with it and grant Editor permission — instead of showing the raw Google API error "The caller does not have permission".

--- a/.changeset/google-sheets-permission-error.md
+++ b/.changeset/google-sheets-permission-error.md
@@ -4,4 +4,4 @@
 
 # Clearer error when Google Sheet access is denied
 
-When access validation fails due to missing sharing permissions, the error now tells users exactly what to do: share the spreadsheet with the account used for authentication (service account email or connected Google account) and grant Editor permission — instead of showing the raw Google API error "The caller does not have permission".
+When access validation fails due to missing sharing permissions, the error now starts with "You don't have access to this Google Sheet" and then tells users exactly what to do: share the spreadsheet with the account used for authentication (service account email or connected Google account) and grant Editor permission — instead of showing the raw Google API error "The caller does not have permission".

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-access-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-access-validator.ts
@@ -71,7 +71,7 @@ export class GoogleSheetsAccessValidator implements DataDestinationAccessValidat
       const rawMessage = error instanceof Error ? error.message : '';
       this.logger.warn('Access check failed', error);
       const message = rawMessage.toLowerCase().includes('does not have permission')
-        ? "You don't have access to this Google Sheet. Please share the spreadsheet with the account used for authentication (service account email or connected Google account) and grant Editor permission."
+        ? "The account used for authentication doesn't have access to this Google Sheet. Please share the spreadsheet with it (service account email or connected Google account) and grant Editor permission."
         : rawMessage || 'Access check failed';
       return new ValidationResult(false, message);
     }

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-access-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-access-validator.ts
@@ -71,7 +71,7 @@ export class GoogleSheetsAccessValidator implements DataDestinationAccessValidat
       const rawMessage = error instanceof Error ? error.message : '';
       this.logger.warn('Access check failed', error);
       const message = rawMessage.toLowerCase().includes('does not have permission')
-        ? "The account used for authentication doesn't have access to this Google Sheet. Please share the spreadsheet with it (service account email or connected Google account) and grant Editor permission."
+        ? "The account used for authentication doesn't have access to this Google Sheet. Please share the spreadsheet with it and grant Editor permission."
         : rawMessage || 'Access check failed';
       return new ValidationResult(false, message);
     }

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-access-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-access-validator.ts
@@ -71,7 +71,7 @@ export class GoogleSheetsAccessValidator implements DataDestinationAccessValidat
       const rawMessage = error instanceof Error ? error.message : '';
       this.logger.warn('Access check failed', error);
       const message = rawMessage.toLowerCase().includes('does not have permission')
-        ? 'Please share the spreadsheet with the account used for authentication (service account email or connected Google account) and grant Editor permission.'
+        ? "You don't have access to this Google Sheet. Please share the spreadsheet with the account used for authentication (service account email or connected Google account) and grant Editor permission."
         : rawMessage || 'Access check failed';
       return new ValidationResult(false, message);
     }


### PR DESCRIPTION
# Problem

The previous iteration of this message (merged in #1131) already replaced Google's raw "The caller does not have permission" string, but stopped short of explaining what was wrong before telling the user what to do.

# Changes

- Updated the Google Sheets access-denied error in `google-sheets-access-validator.ts` to start with "The account used for authentication doesn't have access to this Google Sheet."
- Updated `.changeset/google-sheets-permission-error.md` to describe the new two-part wording (cause + action)