### PR TITLE
feat: publish run connector based data marts

### DIFF
--- a/.changeset/publish-and-run-connector-data-mart.md
+++ b/.changeset/publish-and-run-connector-data-mart.md
@@ -1,0 +1,14 @@
+---
+'owox': minor
+---
+
+# Improved Data Mart Publishing Experience
+
+Publishing a Connector-based Data Marts is now smoother and more intuitive.
+
+- Data starts loading automatically after publishing connector-based Data Mart
+- Guidance now focuses on scheduling automatic updates instead of manual runs
+- Promo messages appear only once to reduce distractions
+- Updated button labels and tooltips for better clarity
+
+These changes make it easier to get started and keep your data up to date.

--- a/apps/backend/src/data-marts/dto/domain/publish-data-mart.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/publish-data-mart.command.ts
@@ -3,6 +3,7 @@ export class PublishDataMartCommand {
     public readonly id: string,
     public readonly projectId: string,
     public readonly userId: string = '',
-    public readonly roles: string[] = []
+    public readonly roles: string[] = [],
+    public readonly createdById: string
   ) {}
 }

--- a/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
@@ -347,7 +347,13 @@ export class DataMartMapper {
   }
 
   toPublishCommand(id: string, context: AuthorizationContext): PublishDataMartCommand {
-    return new PublishDataMartCommand(id, context.projectId, context.userId, context.roles ?? []);
+    return new PublishDataMartCommand(
+      id,
+      context.projectId,
+      context.userId,
+      context.roles ?? [],
+      context.userId
+    );
   }
 
   toDeleteCommand(id: string, context: AuthorizationContext): DeleteDataMartCommand {

--- a/apps/backend/src/data-marts/use-cases/publish-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-mart.service.ts
@@ -13,9 +13,12 @@ import { DataMartService } from '../services/data-mart.service';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 import { RunType } from '../../common/scheduler/shared/types';
 import { ConnectorExecutionService } from '../services/connector/connector-execution.service';
+import { Logger } from '@nestjs/common';
 
 @Injectable()
 export class PublishDataMartService {
+  private readonly logger = new Logger(PublishDataMartService.name);
+
   constructor(
     private readonly dataMartService: DataMartService,
     private readonly definitionValidatorFacade: DataMartDefinitionValidatorFacade,
@@ -60,12 +63,6 @@ export class PublishDataMartService {
 
     await this.dataMartService.save(dataMart);
 
-    if (dataMart.definitionType === DataMartDefinitionType.CONNECTOR) {
-      await this.connectorExecutionService.run(dataMart, command.createdById, RunType.manual, {
-        runType: 'INCREMENTAL',
-      });
-    }
-
     await this.producer.produceEvent(
       new DataMartPublishedEvent(
         dataMart.id,
@@ -74,6 +71,24 @@ export class PublishDataMartService {
         previousStatus
       )
     );
+
+    if (dataMart.definitionType === DataMartDefinitionType.CONNECTOR) {
+      this.connectorExecutionService
+        .run(dataMart, command.createdById, RunType.manual, {
+          runType: 'INCREMENTAL',
+        })
+        .catch(error => {
+          this.logger.error(
+            `Failed to auto-run connector after publishing data mart ${dataMart.id}`,
+            error?.stack,
+            {
+              dataMartId: dataMart.id,
+              projectId: dataMart.projectId,
+              userId: command.createdById,
+            }
+          );
+        });
+    }
 
     return this.mapper.toDomainDto(dataMart);
   }

--- a/apps/backend/src/data-marts/use-cases/publish-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-mart.service.ts
@@ -11,6 +11,8 @@ import { DataMartPublishedEvent } from '../events/data-mart-published.event';
 import { DataMartMapper } from '../mappers/data-mart.mapper';
 import { DataMartService } from '../services/data-mart.service';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import { RunType } from '../../common/scheduler/shared/types';
+import { ConnectorExecutionService } from '../services/connector/connector-execution.service';
 
 @Injectable()
 export class PublishDataMartService {
@@ -20,7 +22,8 @@ export class PublishDataMartService {
     private readonly mapper: DataMartMapper,
     @Inject(OWOX_PRODUCER)
     private readonly producer: OwoxProducer,
-    private readonly accessDecisionService: AccessDecisionService
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly connectorExecutionService: ConnectorExecutionService
   ) {}
 
   async run(command: PublishDataMartCommand): Promise<DataMartDto> {
@@ -56,6 +59,12 @@ export class PublishDataMartService {
     dataMart.status = DataMartStatus.PUBLISHED;
 
     await this.dataMartService.save(dataMart);
+
+    if (dataMart.definitionType === DataMartDefinitionType.CONNECTOR) {
+      await this.connectorExecutionService.run(dataMart, command.createdById, RunType.manual, {
+        runType: 'INCREMENTAL',
+      });
+    }
 
     await this.producer.produceEvent(
       new DataMartPublishedEvent(

--- a/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.ts
@@ -50,7 +50,7 @@ export class PublishDataStorageDraftsService {
     for (const draftId of draftIds) {
       try {
         await this.publishDataMartService.run(
-          new PublishDataMartCommand(draftId, command.projectId)
+          new PublishDataMartCommand(draftId, command.projectId, command.userId)
         );
         await this.schemaActualizeTriggerService.createTrigger(
           command.userId,

--- a/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.ts
@@ -50,7 +50,7 @@ export class PublishDataStorageDraftsService {
     for (const draftId of draftIds) {
       try {
         await this.publishDataMartService.run(
-          new PublishDataMartCommand(draftId, command.projectId, command.userId)
+          new PublishDataMartCommand(draftId, command.projectId, command.userId, [], command.userId)
         );
         await this.schemaActualizeTriggerService.createTrigger(
           command.userId,

--- a/apps/web/e2e/fixtures/api-helpers.ts
+++ b/apps/web/e2e/fixtures/api-helpers.ts
@@ -163,7 +163,27 @@ export class ApiHelpers {
     const datamart = await this.createDataMart(storage.id, title);
     await this.setConnectorDefinition(datamart.id);
     await this.publish(datamart.id);
+    // Cancel auto-run triggered by publish so tests can trigger their own manual runs.
+    await this.cancelActiveRuns(datamart.id);
     return { storage, datamart };
+  }
+
+  /**
+   * Cancels any PENDING/RUNNING runs for a data mart.
+   * PublishDataMartService now auto-runs connector DMs on publish (fire-and-forget).
+   * This prevents "Connector is already running" errors in tests that trigger manual runs.
+   */
+  async cancelActiveRuns(dataMartId: string): Promise<void> {
+    // Brief delay to let the fire-and-forget create the run record
+    await new Promise(resolve => setTimeout(resolve, 100));
+    const res = await this.page.request.get(`/api/data-marts/${dataMartId}/runs`);
+    if (!res.ok()) return;
+    const body = await res.json();
+    for (const run of (body.runs ?? []) as { id: string; status: string }[]) {
+      if (run.status === 'PENDING' || run.status === 'RUNNING') {
+        await this.page.request.post(`/api/data-marts/${dataMartId}/runs/${run.id}/cancel`);
+      }
+    }
   }
 
   /**

--- a/apps/web/e2e/specs/datamart-detail.spec.ts
+++ b/apps/web/e2e/specs/datamart-detail.spec.ts
@@ -95,7 +95,7 @@ test.describe('DataMart Detail - Manual Run', () => {
     await page.getByRole('menuitem', { name: /Manual Run/ }).click();
 
     // ConnectorRunSheet opens as a dialog. Scope the Run button to the dialog
-    // to avoid collisions with the toast notification "Manual Run..." button.
+    // to avoid ambiguity with other buttons on the page.
     const sheet = page.locator('[data-slot="sheet-content"]');
     await expect(sheet).toBeVisible({ timeout: 10000 });
     const runButton = sheet.getByRole('button', { name: 'Run' });

--- a/apps/web/e2e/specs/run-history.spec.ts
+++ b/apps/web/e2e/specs/run-history.spec.ts
@@ -16,7 +16,7 @@ async function triggerManualRun(page: import('@playwright/test').Page, datamartI
   // Click "Manual Run..." menu item
   await page.getByRole('menuitem', { name: /Manual Run/ }).click();
 
-  // Scope Run button to the sheet content to avoid toast button collision
+  // Scope Run button to the sheet content to avoid ambiguity with other buttons
   const sheet = page.locator('[data-slot="sheet-content"]');
   await expect(sheet).toBeVisible({ timeout: 10000 });
   // Click Run and wait for the API response confirming the run was accepted
@@ -29,10 +29,11 @@ async function triggerManualRun(page: import('@playwright/test').Page, datamartI
 
 // ---------------------------------------------------------------------------
 // RUN-01: Empty state renders on Run History tab when no runs exist.
+// Uses a SQL-type published DM because connector DMs now auto-run on publish.
 // ---------------------------------------------------------------------------
 test.describe('Run History - Empty State', () => {
   test('shows empty state when no runs exist (RUN-01)', async ({ page, apiHelpers }) => {
-    const { datamart } = await apiHelpers.createPublishedConnectorDataMart();
+    const { datamart } = await apiHelpers.createPublishedDataMart();
     await page.goto(`/ui/0/data-marts/${datamart.id}/run-history`);
 
     // RunHistory renders empty state with runHistoryEmptyState testid

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -74,7 +74,6 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
-  const [isRunSheetOpen, setIsRunSheetOpen] = useState(false);
   const lastRunIdRef = useRef<string | null>(null);
 
   const {
@@ -113,21 +112,18 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
   const { showPromo, dismissAllPromos } = useDataMartNextStepPromo();
 
   // Show promo once a published data mart page is opened.
-  // For CONNECTOR type — show LOAD_DATA promo, for others — USE_DATA promo.
+  // For CONNECTOR type — show SCHEDULE_DATA promo, for others — USE_DATA promo.
   // Show once to prevent multiple toasts for the same data mart.
   useEffect(() => {
     if (!dataMartId) return;
     if (!isPublished) return;
 
     showPromo({
-      step: isConnector ? PromoStep.LOAD_DATA : PromoStep.USE_DATA,
+      step: isConnector ? PromoStep.SCHEDULE_DATA : PromoStep.USE_DATA,
       projectId,
       dataMartId,
       isInsightsEnabled: shouldShowInsights,
       showOnce: true,
-      onManualRunClick: () => {
-        setIsRunSheetOpen(true);
-      },
     });
   }, [dataMartId, isPublished, isConnector, showPromo, projectId, shouldShowInsights]);
 
@@ -165,14 +161,11 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
 
       // Show promo toast based on a data mart type
       showPromo({
-        step: isConnector ? PromoStep.LOAD_DATA : PromoStep.USE_DATA,
+        step: isConnector ? PromoStep.SCHEDULE_DATA : PromoStep.USE_DATA,
         projectId,
         dataMartId,
         isInsightsEnabled: shouldShowInsights,
         showOnce: true,
-        onManualRunClick: () => {
-          setIsRunSheetOpen(true);
-        },
       });
     } catch (error) {
       console.log(error instanceof Error ? error.message : 'Failed to publish Data Mart');
@@ -519,21 +512,6 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
           })();
         }}
       />
-
-      {/* Controlled ConnectorRunView for toast "Run Now" action */}
-      {isConnector && (
-        <ConnectorRunView
-          configuration={dataMartDefinition ?? null}
-          onManualRun={data => {
-            void handleManualRun({
-              runType: data.runType,
-              data: data.data,
-            });
-          }}
-          open={isRunSheetOpen}
-          onOpenChange={setIsRunSheetOpen}
-        />
-      )}
     </div>
   );
 }

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -114,7 +114,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
 
   // Show promo once a published data mart page is opened.
   // For CONNECTOR type — show LOAD_DATA promo, for others — USE_DATA promo.
-  // Suppressible to prevent multiple toasts for the same data mart.
+  // Show once to prevent multiple toasts for the same data mart.
   useEffect(() => {
     if (!dataMartId) return;
     if (!isPublished) return;
@@ -124,7 +124,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
       projectId,
       dataMartId,
       isInsightsEnabled: shouldShowInsights,
-      suppressible: true,
+      showOnce: true,
       onManualRunClick: () => {
         setIsRunSheetOpen(true);
       },
@@ -169,7 +169,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
         projectId,
         dataMartId,
         isInsightsEnabled: shouldShowInsights,
-        suppressible: true,
+        showOnce: true,
         onManualRunClick: () => {
           setIsRunSheetOpen(true);
         },
@@ -245,7 +245,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
             projectId,
             dataMartId,
             isInsightsEnabled: shouldShowInsights,
-            suppressible: true,
+            showOnce: true,
           });
         }
       }

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -88,6 +88,10 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
     validationErrors: dataMartValidationErrors = [],
   } = dataMart ?? {};
 
+  const isConnector = dataMartDefinitionType === DataMartDefinitionType.CONNECTOR;
+  const isPublished = dataMartStatus.code === DataMartStatus.PUBLISHED;
+  const isDraft = dataMartStatus.code === DataMartStatus.DRAFT;
+
   const onActualizeSuccess = useCallback(() => {
     if (!dataMartId) return;
     void getDataMart(dataMartId);
@@ -108,13 +112,12 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
 
   const { showPromo, dismissAllPromos } = useDataMartNextStepPromo();
 
-  // Show promo every time a published data mart page is opened.
+  // Show promo once a published data mart page is opened.
   // For CONNECTOR type — show LOAD_DATA promo, for others — USE_DATA promo.
+  // Suppressible to prevent multiple toasts for the same data mart.
   useEffect(() => {
     if (!dataMartId) return;
-    if (dataMartStatus.code !== DataMartStatus.PUBLISHED) return;
-
-    const isConnector = dataMartDefinitionType === DataMartDefinitionType.CONNECTOR;
+    if (!isPublished) return;
 
     showPromo({
       step: isConnector ? PromoStep.LOAD_DATA : PromoStep.USE_DATA,
@@ -126,14 +129,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
         setIsRunSheetOpen(true);
       },
     });
-  }, [
-    dataMartId,
-    dataMartStatus.code,
-    dataMartDefinitionType,
-    showPromo,
-    projectId,
-    shouldShowInsights,
-  ]);
+  }, [dataMartId, isPublished, isConnector, showPromo, projectId, shouldShowInsights]);
 
   // Dismiss all promo toasts when leaving the data mart page
   useEffect(() => {
@@ -168,13 +164,12 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
       void runSchemaActualization();
 
       // Show promo toast based on a data mart type
-      const isConnector = dataMartDefinitionType === DataMartDefinitionType.CONNECTOR;
-
       showPromo({
         step: isConnector ? PromoStep.LOAD_DATA : PromoStep.USE_DATA,
         projectId,
         dataMartId,
         isInsightsEnabled: shouldShowInsights,
+        suppressible: true,
         onManualRunClick: () => {
           setIsRunSheetOpen(true);
         },
@@ -186,7 +181,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
     }
   }, [
     dataMartId,
-    dataMartDefinitionType,
+    isConnector,
     publishDataMart,
     runSchemaActualization,
     showPromo,
@@ -197,20 +192,20 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
   const handleManualRun = useCallback(
     async (payload: Record<string, unknown>) => {
       if (!dataMartId) return;
-      if (dataMartStatus.code !== DataMartStatus.PUBLISHED) {
+      if (!isPublished) {
         toast.error('Manual run is only available for published Data Marts');
         return;
       }
       lastRunIdRef.current = runs[0]?.id || null;
       await runDataMart({ id: dataMartId, payload });
     },
-    [dataMartId, dataMartStatus, runDataMart, runs]
+    [dataMartId, isPublished, runDataMart, runs]
   );
 
   // Show promo after the first successful manual connector run
   useEffect(() => {
     if (!isManualRunTriggered || !runs.length) return;
-    if (dataMartDefinitionType !== DataMartDefinitionType.CONNECTOR) return;
+    if (!isConnector) return;
 
     const latestRun = runs[0];
     if (latestRun.id === lastRunIdRef.current) return;
@@ -250,6 +245,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
             projectId,
             dataMartId,
             isInsightsEnabled: shouldShowInsights,
+            suppressible: true,
           });
         }
       }
@@ -257,7 +253,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
   }, [
     runs,
     isManualRunTriggered,
-    dataMartDefinitionType,
+    isConnector,
     resetManualRunTriggered,
     showPromo,
     projectId,
@@ -287,6 +283,14 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
       </div>
     );
   }
+
+  // Config for publish button and tooltip based on data mart type
+  const publishText = {
+    buttonLabel: isConnector ? 'Publish & Run Data Mart' : 'Publish Data Mart',
+    tooltipText: isConnector
+      ? 'Publish and start loading data'
+      : 'Publish to enable reports and scheduled runs',
+  };
 
   return (
     <div className='min-w-[600px] px-12 py-6' data-testid='datamartDetails'>
@@ -323,11 +327,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
               <TooltipTrigger asChild>
                 <div className={cn('mr-4', !canPublish ? 'pt-1.5' : '')}>
                   <StatusLabel
-                    type={
-                      dataMartStatus.code === DataMartStatus.PUBLISHED
-                        ? StatusTypeEnum.SUCCESS
-                        : StatusTypeEnum.NEUTRAL
-                    }
+                    type={isPublished ? StatusTypeEnum.SUCCESS : StatusTypeEnum.NEUTRAL}
                     variant='subtle'
                   >
                     {dataMartStatus.displayName}
@@ -335,12 +335,12 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
                 </div>
               </TooltipTrigger>
               <TooltipContent side='bottom'>
-                {dataMartStatus.code === DataMartStatus.PUBLISHED
+                {isPublished
                   ? 'Your published Data Mart is ready for scheduled runs'
                   : 'Draft Data Mart is not available for scheduled runs. Publish it to activate scheduling.'}
               </TooltipContent>
             </Tooltip>
-            {dataMartStatus.code === DataMartStatus.DRAFT && (
+            {isDraft && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <div className='relative'>
@@ -357,7 +357,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
                       data-testid='datamartPublishButton'
                     >
                       <CircleCheckBig className='h-4 w-4' />
-                      Publish Data Mart
+                      {publishText.buttonLabel}
                     </Button>
                     <div
                       className={cn(
@@ -380,7 +380,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
                       </ul>
                     </>
                   ) : (
-                    <p>You can publish this Data Mart now</p>
+                    <p>{publishText.tooltipText}</p>
                   )}
                 </TooltipContent>
               </Tooltip>
@@ -393,7 +393,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align='end'>
-              {dataMartDefinitionType === DataMartDefinitionType.CONNECTOR && (
+              {isConnector && (
                 <>
                   <ConnectorRunView
                     configuration={dataMartDefinition ?? null}
@@ -521,7 +521,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
       />
 
       {/* Controlled ConnectorRunView for toast "Run Now" action */}
-      {dataMartDefinitionType === DataMartDefinitionType.CONNECTOR && (
+      {isConnector && (
         <ConnectorRunView
           configuration={dataMartDefinition ?? null}
           onManualRun={data => {

--- a/apps/web/src/features/data-marts/edit/hooks/useDataMartNextStepPromo.tsx
+++ b/apps/web/src/features/data-marts/edit/hooks/useDataMartNextStepPromo.tsx
@@ -8,10 +8,11 @@ import { storageService } from '../../../../services';
 // Set to track currently visible promo toasts
 const activePromoToasts = new Set<string>();
 
-const SUPPRESSION_KEY_PREFIX = 'promo_suppressed_';
+// Prefix for storing globally shown promos (per user, across all data marts)
+const SHOW_ONCE_KEY_PREFIX = 'promo_shown_once_';
 
 /**
- * Enum for next step promo types
+ * Next-step promo types shown after key data mart actions
  */
 export enum PromoStep {
   /** Promote loading data: run manually or create scheduled trigger */
@@ -20,18 +21,18 @@ export enum PromoStep {
   USE_DATA = 'use_data',
 }
 
-function getSuppressionKey(step: PromoStep): string {
-  return `${SUPPRESSION_KEY_PREFIX}${step}`;
+function getShownOnceKey(step: PromoStep): string {
+  return `${SHOW_ONCE_KEY_PREFIX}${step}`;
 }
 
-/** Returns true if the promo has been shown and should not appear again */
-function isPromoSuppressed(step: PromoStep): boolean {
-  return storageService.get(getSuppressionKey(step), 'boolean') === true;
+/** Returns true if the promo was already shown once globally (across all data marts) */
+function isPromoShownOnce(step: PromoStep): boolean {
+  return storageService.get(getShownOnceKey(step), 'boolean') === true;
 }
 
-/** Suppress the promo permanently */
-function suppressPromo(step: PromoStep): void {
-  storageService.set(getSuppressionKey(step), true);
+/** Marks the promo as shown globally so it will never appear again for this user */
+function markPromoAsShownOnce(step: PromoStep): void {
+  storageService.set(getShownOnceKey(step), true);
 }
 
 interface ShowPromoOptions {
@@ -47,8 +48,8 @@ interface ShowPromoOptions {
   onManualRunClick?: () => void;
   /** Toast display duration in ms. Defaults to Infinity */
   duration?: number;
-  /** When true, auto-suppresses after first show so promo never appears again */
-  suppressible?: boolean;
+  /** When true, the promo is shown only once globally (across all data marts) */
+  showOnce?: boolean;
 }
 
 /**
@@ -63,18 +64,19 @@ export function useDataMartNextStepPromo() {
       isInsightsEnabled,
       onManualRunClick,
       duration = Infinity,
-      suppressible = false,
+      showOnce = false,
     }: ShowPromoOptions) => {
-      if (suppressible && isPromoSuppressed(step)) return;
-
-      // Auto-suppress after first show
-      if (suppressible) suppressPromo(step);
+      // Skip if this promo was already shown once globally
+      if (showOnce && isPromoShownOnce(step)) return;
 
       // Single ID per data mart to prevent multiple toasts for the same data mart
       const toastId = `promo_${dataMartId}`;
 
       // If a promo toast is already visible for this data mart — skip entirely
       if (activePromoToasts.has(toastId)) return;
+
+      // Mark promo as shown to prevent future displays (one-time promo)
+      if (showOnce) markPromoAsShownOnce(step);
 
       // Common toast lifecycle callbacks
       const onDismiss = () => activePromoToasts.delete(toastId);

--- a/apps/web/src/features/data-marts/edit/hooks/useDataMartNextStepPromo.tsx
+++ b/apps/web/src/features/data-marts/edit/hooks/useDataMartNextStepPromo.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@owox/ui/components/button';
-import { CalendarClock, FileText, Play, Sparkles } from 'lucide-react';
+import { CalendarClock, FileText, History, Sparkles } from 'lucide-react';
 import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -15,8 +15,8 @@ const SHOW_ONCE_KEY_PREFIX = 'promo_shown_once_';
  * Next-step promo types shown after key data mart actions
  */
 export enum PromoStep {
-  /** Promote loading data: run manually or create scheduled trigger */
-  LOAD_DATA = 'load_data',
+  /** Promote scheduling data: create scheduled trigger */
+  SCHEDULE_DATA = 'schedule_data',
   /** Promote using data: create insights or reports */
   USE_DATA = 'use_data',
 }
@@ -44,8 +44,6 @@ interface ShowPromoOptions {
   dataMartId: string;
   /** Whether insights feature is enabled */
   isInsightsEnabled?: boolean;
-  /** Callback to open manual run sheet (for LOAD_DATA step) */
-  onManualRunClick?: () => void;
   /** Toast display duration in ms. Defaults to Infinity */
   duration?: number;
   /** When true, the promo is shown only once globally (across all data marts) */
@@ -62,7 +60,6 @@ export function useDataMartNextStepPromo() {
       projectId,
       dataMartId,
       isInsightsEnabled,
-      onManualRunClick,
       duration = Infinity,
       showOnce = false,
     }: ShowPromoOptions) => {
@@ -86,39 +83,30 @@ export function useDataMartNextStepPromo() {
       activePromoToasts.add(toastId);
 
       switch (step) {
-        case PromoStep.LOAD_DATA:
-          toast(
-            <div className='text-foreground text-sm'>Data Mart is ready to load your data</div>,
-            {
-              id: toastId,
-              closeButton: true,
-              onDismiss,
-              onAutoClose,
-              description: (
-                <div className='mt-2 flex gap-2'>
-                  <Button
-                    size='sm'
-                    variant='outline'
-                    onClick={() => {
-                      toast.dismiss(toastId);
-                      onManualRunClick?.();
-                    }}
-                  >
-                    <Play className='h-4 w-4' />
-                    Manual Run…
-                  </Button>
-
-                  <Button size='sm' variant='ghost' asChild onClick={() => toast.dismiss(toastId)}>
-                    <Link to={`/ui/${projectId}/data-marts/${dataMartId}/triggers`}>
-                      <CalendarClock className='h-4 w-4' />
-                      Schedule Trigger…
-                    </Link>
-                  </Button>
-                </div>
-              ),
-              duration,
-            }
-          );
+        case PromoStep.SCHEDULE_DATA:
+          toast(<div className='text-foreground text-sm'>Keep your data fresh automatically</div>, {
+            id: toastId,
+            closeButton: true,
+            onDismiss,
+            onAutoClose,
+            description: (
+              <div className='mt-2 flex gap-2'>
+                <Button size='sm' variant='outline' asChild onClick={() => toast.dismiss(toastId)}>
+                  <Link to={`/ui/${projectId}/data-marts/${dataMartId}/triggers`}>
+                    <CalendarClock className='h-4 w-4' />
+                    Schedule Updates
+                  </Link>
+                </Button>
+                <Button size='sm' variant='ghost' asChild onClick={() => toast.dismiss(toastId)}>
+                  <Link to={`/ui/${projectId}/data-marts/${dataMartId}/run-history`}>
+                    <History className='h-4 w-4' />
+                    View Run History
+                  </Link>
+                </Button>
+              </div>
+            ),
+            duration,
+          });
           break;
 
         case PromoStep.USE_DATA:

--- a/apps/web/src/features/data-marts/edit/hooks/useDataMartNextStepPromo.tsx
+++ b/apps/web/src/features/data-marts/edit/hooks/useDataMartNextStepPromo.tsx
@@ -9,8 +9,6 @@ import { storageService } from '../../../../services';
 const activePromoToasts = new Set<string>();
 
 const SUPPRESSION_KEY_PREFIX = 'promo_suppressed_';
-const SUPPRESSION_DURATION_DAYS = 14;
-const MS_PER_DAY = 86_400_000;
 
 /**
  * Enum for next step promo types
@@ -26,20 +24,14 @@ function getSuppressionKey(step: PromoStep): string {
   return `${SUPPRESSION_KEY_PREFIX}${step}`;
 }
 
-/** Returns true if the promo is currently suppressed by the user */
+/** Returns true if the promo has been shown and should not appear again */
 function isPromoSuppressed(step: PromoStep): boolean {
-  const raw = storageService.get(getSuppressionKey(step));
-  if (!raw) return false;
-  // storageService stores numbers as strings internally (via String()),
-  // so we convert back with Number()
-  const suppressedUntil = Number(raw);
-  return Number.isFinite(suppressedUntil) && Date.now() < suppressedUntil;
+  return storageService.get(getSuppressionKey(step), 'boolean') === true;
 }
 
-/** Suppress the promo for the given number of days */
-function suppressPromo(step: PromoStep, days: number): void {
-  const until = Date.now() + days * MS_PER_DAY;
-  storageService.set(getSuppressionKey(step), until);
+/** Suppress the promo permanently */
+function suppressPromo(step: PromoStep): void {
+  storageService.set(getSuppressionKey(step), true);
 }
 
 interface ShowPromoOptions {
@@ -55,7 +47,7 @@ interface ShowPromoOptions {
   onManualRunClick?: () => void;
   /** Toast display duration in ms. Defaults to Infinity */
   duration?: number;
-  /** When true, checks suppression and shows "Don't show for N days" button */
+  /** When true, auto-suppresses after first show so promo never appears again */
   suppressible?: boolean;
 }
 
@@ -75,23 +67,14 @@ export function useDataMartNextStepPromo() {
     }: ShowPromoOptions) => {
       if (suppressible && isPromoSuppressed(step)) return;
 
+      // Auto-suppress after first show
+      if (suppressible) suppressPromo(step);
+
       // Single ID per data mart to prevent multiple toasts for the same data mart
       const toastId = `promo_${dataMartId}`;
 
       // If a promo toast is already visible for this data mart — skip entirely
       if (activePromoToasts.has(toastId)) return;
-
-      const suppressButton = suppressible ? (
-        <button
-          className='text-muted-foreground hover:text-foreground mx-auto mt-3 block cursor-pointer text-xs underline-offset-2 hover:underline'
-          onClick={() => {
-            suppressPromo(step, SUPPRESSION_DURATION_DAYS);
-            toast.dismiss(toastId);
-          }}
-        >
-          Don't show for {SUPPRESSION_DURATION_DAYS} days
-        </button>
-      ) : null;
 
       // Common toast lifecycle callbacks
       const onDismiss = () => activePromoToasts.delete(toastId);
@@ -110,33 +93,25 @@ export function useDataMartNextStepPromo() {
               onDismiss,
               onAutoClose,
               description: (
-                <div>
-                  <div className='mt-2 flex gap-2'>
-                    <Button
-                      size='sm'
-                      variant='outline'
-                      onClick={() => {
-                        toast.dismiss(toastId);
-                        onManualRunClick?.();
-                      }}
-                    >
-                      <Play className='h-4 w-4' />
-                      Manual Run…
-                    </Button>
+                <div className='mt-2 flex gap-2'>
+                  <Button
+                    size='sm'
+                    variant='outline'
+                    onClick={() => {
+                      toast.dismiss(toastId);
+                      onManualRunClick?.();
+                    }}
+                  >
+                    <Play className='h-4 w-4' />
+                    Manual Run…
+                  </Button>
 
-                    <Button
-                      size='sm'
-                      variant='ghost'
-                      asChild
-                      onClick={() => toast.dismiss(toastId)}
-                    >
-                      <Link to={`/ui/${projectId}/data-marts/${dataMartId}/triggers`}>
-                        <CalendarClock className='h-4 w-4' />
-                        Schedule Trigger…
-                      </Link>
-                    </Button>
-                  </div>
-                  {suppressButton}
+                  <Button size='sm' variant='ghost' asChild onClick={() => toast.dismiss(toastId)}>
+                    <Link to={`/ui/${projectId}/data-marts/${dataMartId}/triggers`}>
+                      <CalendarClock className='h-4 w-4' />
+                      Schedule Trigger…
+                    </Link>
+                  </Button>
                 </div>
               ),
               duration,
@@ -151,35 +126,32 @@ export function useDataMartNextStepPromo() {
             onDismiss,
             onAutoClose,
             description: (
-              <div>
-                <div className='mt-2 flex gap-2'>
-                  {isInsightsEnabled && (
-                    <Button
-                      size='sm'
-                      variant='outline'
-                      asChild
-                      onClick={() => toast.dismiss(toastId)}
-                    >
-                      <Link to={`/ui/${projectId}/data-marts/${dataMartId}/insights-v2`}>
-                        <Sparkles className='h-4 w-4' />
-                        Create Insights…
-                      </Link>
-                    </Button>
-                  )}
-
+              <div className='mt-2 flex gap-2'>
+                {isInsightsEnabled && (
                   <Button
                     size='sm'
-                    variant={isInsightsEnabled ? 'ghost' : 'outline'}
+                    variant='outline'
                     asChild
                     onClick={() => toast.dismiss(toastId)}
                   >
-                    <Link to={`/ui/${projectId}/data-marts/${dataMartId}/reports`}>
-                      <FileText className='h-4 w-4' />
-                      Create Report…
+                    <Link to={`/ui/${projectId}/data-marts/${dataMartId}/insights-v2`}>
+                      <Sparkles className='h-4 w-4' />
+                      Create Insights…
                     </Link>
                   </Button>
-                </div>
-                {suppressButton}
+                )}
+
+                <Button
+                  size='sm'
+                  variant={isInsightsEnabled ? 'ghost' : 'outline'}
+                  asChild
+                  onClick={() => toast.dismiss(toastId)}
+                >
+                  <Link to={`/ui/${projectId}/data-marts/${dataMartId}/reports`}>
+                    <FileText className='h-4 w-4' />
+                    Create Report…
+                  </Link>
+                </Button>
               </div>
             ),
             duration,

--- a/packages/test-utils/src/helpers/setup-connector-data-mart.ts
+++ b/packages/test-utils/src/helpers/setup-connector-data-mart.ts
@@ -17,7 +17,7 @@ import { DataMartBuilder } from '../fixtures/data-mart.builder';
  */
 export async function setupConnectorDataMart(
   agent: supertest.Agent,
-  app: INestApplication,
+  app: INestApplication
 ): Promise<{ storageId: string; dataMartId: string }> {
   // Resolve DataSource and entity repositories from the backend workspace
   const backendRoot = require.resolve('@owox/backend/package.json');
@@ -44,12 +44,13 @@ export async function setupConnectorDataMart(
   await dataSource.query(
     `INSERT INTO data_storage_credentials (id, projectId, type, credentials, createdAt, modifiedAt)
      VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
-    [credentialId, '0', 'google_service_account', JSON.stringify({ type: 'test-credentials' })],
+    [credentialId, '0', 'google_service_account', JSON.stringify({ type: 'test-credentials' })]
   );
-  await dataSource.query(
-    `UPDATE data_storage SET config = ?, credentialId = ? WHERE id = ?`,
-    [JSON.stringify({ projectId: 'test-project', dataset: 'test_dataset' }), credentialId, storageId],
-  );
+  await dataSource.query(`UPDATE data_storage SET config = ?, credentialId = ? WHERE id = ?`, [
+    JSON.stringify({ projectId: 'test-project', dataset: 'test_dataset' }),
+    credentialId,
+    storageId,
+  ]);
 
   // Step 3: Create data mart
   const dataMartRes = await agent
@@ -83,10 +84,22 @@ export async function setupConnectorDataMart(
   expect(defRes.status).toBe(200);
 
   // Step 5: Publish
-  const publishRes = await agent
-    .put(`/api/data-marts/${dataMartId}/publish`)
-    .set(AUTH_HEADER);
+  const publishRes = await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER);
   expect(publishRes.status).toBe(200);
+
+  // Step 6: Cancel auto-run triggered by publish.
+  // PublishDataMartService now fires a connector run on publish (fire-and-forget).
+  // Allow event loop to process the async run creation, then cancel any active runs
+  // so downstream tests can trigger their own manual runs without "already running" errors.
+  await new Promise(resolve => setTimeout(resolve, 100));
+  const runsRes = await agent.get(`/api/data-marts/${dataMartId}/runs`).set(AUTH_HEADER);
+  if (runsRes.body?.runs) {
+    for (const run of runsRes.body.runs as Array<{ id: string; status: string }>) {
+      if (run.status === 'PENDING' || run.status === 'RUNNING') {
+        await agent.post(`/api/data-marts/${dataMartId}/runs/${run.id}/cancel`).set(AUTH_HEADER);
+      }
+    }
+  }
 
   return { storageId, dataMartId };
 }


### PR DESCRIPTION
## Improved Publishing Experience for Data Marts

We’ve improved the Data Mart publishing experience to make it clearer, more predictable, and easier to use.

### 🚀 More Reliable "Publish & Run"

Publishing a Data Mart with a connector is now more consistent and reliable.

When you click **Publish & Run**, your data starts loading automatically — no extra steps required.

This means:
- A smoother publishing flow
- Fewer unexpected interruptions
- More confidence that your data is loading right away

<img width="1137" height="537" alt="image" src="https://github.com/user-attachments/assets/a196c64b-138b-4af0-8bab-7ae48d1d5855" />

---

### 🧭 Smarter Guidance After Publishing

We’ve improved what happens after publishing to better guide your next step.

Instead of suggesting manual runs, we now help you **set up automatic updates** — so your data stays fresh without extra effort.

<img width="423" height="159" alt="Screenshot 2026-04-16 at 18 06 52" src="https://github.com/user-attachments/assets/ead3eebc-eb8c-4592-a5a7-6b07a1594085" />

---

### ✨ Cleaner and Less Distracting Notifications

We simplified promotional messages to reduce noise:

- Promos are shown only once per step
- They won’t repeat as you navigate between Data Marts
- Messaging is more relevant to what you should do next

This makes the experience more focused and less distracting.

---

### 🔘 Clearer Publish Button and Messaging

We also improved the publish button and tooltip text:

- More intuitive labels
- Clearer descriptions of what happens next
- Better alignment with actual system behavior

This helps you better understand what to expect when publishing a Data Mart.
