### PR TITLE
refactor: Moved the legacy BigQuery setup notification from the Data Marts page to the Storages page

### DIFF
--- a/apps/web/src/pages/data-marts/list/DataMartsPage.tsx
+++ b/apps/web/src/pages/data-marts/list/DataMartsPage.tsx
@@ -7,19 +7,11 @@ import { useEffect } from 'react';
 import { getDataMartColumns } from '../../../features/data-marts/list/components/DataMartTable/columns/columns.tsx';
 import { ConnectorContextProvider } from '../../../features/connectors/shared/model/context';
 import { useConnector } from '../../../features/connectors/shared/model/hooks/useConnector.ts';
-import PageNotificationLegacyStorageSetup from './PageNotificationLegacyStorageSetup';
-import { DataMartStatus } from '../../../features/data-marts/shared/enums/data-mart-status.enum';
-import { DataStorageType } from '../../../features/data-storage/shared/model/types/data-storage-type.enum.ts';
 
 const DataMartTableWithContext = () => {
   const { items, loadDataMarts, deleteDataMart, publishDataMart, refreshList, loading } =
     useDataMartList();
   const { connectors, fetchAvailableConnectors } = useConnector();
-  const hasDraftWithLegacyStorage = items.some(
-    item =>
-      item.status.code === DataMartStatus.DRAFT &&
-      item.storageType === DataStorageType.LEGACY_GOOGLE_BIGQUERY
-  );
 
   useEffect(() => {
     void fetchAvailableConnectors();
@@ -30,18 +22,15 @@ const DataMartTableWithContext = () => {
   }, [loadDataMarts]);
 
   return (
-    <>
-      {hasDraftWithLegacyStorage && <PageNotificationLegacyStorageSetup />}
-      <DataMartTable
-        connectors={connectors}
-        columns={getDataMartColumns({ connectors })}
-        data={items}
-        deleteDataMart={deleteDataMart}
-        publishDataMart={publishDataMart}
-        refetchDataMarts={refreshList}
-        isLoading={loading}
-      />
-    </>
+    <DataMartTable
+      connectors={connectors}
+      columns={getDataMartColumns({ connectors })}
+      data={items}
+      deleteDataMart={deleteDataMart}
+      publishDataMart={publishDataMart}
+      refetchDataMarts={refreshList}
+      isLoading={loading}
+    />
   );
 };
 

--- a/apps/web/src/pages/data-marts/list/PageNotificationLegacyStorageSetup.tsx
+++ b/apps/web/src/pages/data-marts/list/PageNotificationLegacyStorageSetup.tsx
@@ -6,13 +6,13 @@ import {
   CollapsibleCardFooter,
   CollapsibleCardHeaderActions,
 } from '../../../shared/components/CollapsibleCard/index.ts';
-import { Info, Database, BookOpen } from 'lucide-react';
+import { Info, BookOpen, Airplay } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Button } from '../../../shared/components/Button/index.tsx';
-import { useProjectRoute } from '../../../shared/hooks';
+import { useContentPopovers } from '../../../app/store/hooks/useContentPopovers';
 
 export default function PageNotificationLegacyStorageSetup() {
-  const { scope } = useProjectRoute();
+  const { open } = useContentPopovers();
   return (
     <div className='mb-4'>
       <CollapsibleCard collapsible name='notification-legacy-storage-setup'>
@@ -59,15 +59,12 @@ export default function PageNotificationLegacyStorageSetup() {
                 </ol>
               </div>
               <div className='flex items-center gap-2'>
-                <Button asChild>
-                  <Link
-                    to={scope(
-                      `/data-storages?filters=%5B%7B"f"%3A"type"%2C"o"%3A"eq"%2C"v"%3A%5B"LEGACY_GOOGLE_BIGQUERY"%5D%7D%5D`
-                    )}
-                  >
-                    <Database className='size-4' />
-                    Select a storage
-                  </Link>
+                <Button
+                  onClick={() => {
+                    open('video-4-legacy-storage-setup');
+                  }}
+                >
+                  <Airplay className='size-4' /> Watch video (30 seconds)
                 </Button>
                 <Button variant='outline' asChild>
                   <Link

--- a/apps/web/src/pages/data-marts/list/index.ts
+++ b/apps/web/src/pages/data-marts/list/index.ts
@@ -1,2 +1,1 @@
 export * from './DataMartsPage';
-export * from './PageNotificationLegacyStorageSetup';

--- a/apps/web/src/pages/data-storage/DataStorageListPage.tsx
+++ b/apps/web/src/pages/data-storage/DataStorageListPage.tsx
@@ -3,12 +3,12 @@ import { DataStorageProvider } from '../../features/data-storage/shared/model/co
 import { DataStorageList } from '../../features/data-storage/list/components';
 import { useDataStorage } from '../../features/data-storage/shared/model/hooks/useDataStorage';
 import { DataStorageType } from '../../features/data-storage/shared/model/types/data-storage-type.enum';
-import PageNotificationLegacyStorageSetup from '../data-marts/list/PageNotificationLegacyStorageSetup';
 import {
   getCachedDataStorageHealthStatus,
   DataStorageHealthStatus,
   subscribeToDataStorageHealthStatusUpdates,
 } from '../../features/data-storage/shared/services/data-storage-health-status.service';
+import { PageNotificationLegacyStorageSetup } from './PageNotificationLegacyStorageSetup.tsx';
 
 const DataStorageListWithContext = ({
   shouldOpenDialog,

--- a/apps/web/src/pages/data-storage/DataStorageListPage.tsx
+++ b/apps/web/src/pages/data-storage/DataStorageListPage.tsx
@@ -1,6 +1,53 @@
+import { useState, useEffect } from 'react';
 import { DataStorageProvider } from '../../features/data-storage/shared/model/context';
 import { DataStorageList } from '../../features/data-storage/list/components';
-import { useState } from 'react';
+import { useDataStorage } from '../../features/data-storage/shared/model/hooks/useDataStorage';
+import { DataStorageType } from '../../features/data-storage/shared/model/types/data-storage-type.enum';
+import PageNotificationLegacyStorageSetup from '../data-marts/list/PageNotificationLegacyStorageSetup';
+import {
+  getCachedDataStorageHealthStatus,
+  DataStorageHealthStatus,
+  subscribeToDataStorageHealthStatusUpdates,
+} from '../../features/data-storage/shared/services/data-storage-health-status.service';
+
+const DataStorageListWithContext = ({
+  shouldOpenDialog,
+  onTypeDialogClose,
+}: {
+  shouldOpenDialog: boolean;
+  onTypeDialogClose: () => void;
+}) => {
+  const { dataStorages } = useDataStorage();
+
+  const [, setForceUpdate] = useState(0);
+
+  useEffect(() => {
+    return subscribeToDataStorageHealthStatusUpdates(() => {
+      setForceUpdate(forceUpdate => forceUpdate + 1);
+    });
+  }, []);
+
+  const hasLegacyStorageWithoutAccess = dataStorages.some(storage => {
+    if (storage.type !== DataStorageType.LEGACY_GOOGLE_BIGQUERY) {
+      return false;
+    }
+
+    const cached = getCachedDataStorageHealthStatus(storage.id);
+
+    return cached?.status === DataStorageHealthStatus.INVALID;
+  });
+
+  return (
+    <>
+      {hasLegacyStorageWithoutAccess && <PageNotificationLegacyStorageSetup />}
+
+      <DataStorageList
+        initialTypeDialogOpen={shouldOpenDialog}
+        onTypeDialogClose={onTypeDialogClose}
+      />
+    </>
+  );
+};
 
 export const DataStorageListPage = () => {
   const [shouldOpenDialog, setShouldOpenDialog] = useState(false);
@@ -13,8 +60,8 @@ export const DataStorageListPage = () => {
 
       <div className='dm-page-content'>
         <DataStorageProvider>
-          <DataStorageList
-            initialTypeDialogOpen={shouldOpenDialog}
+          <DataStorageListWithContext
+            shouldOpenDialog={shouldOpenDialog}
             onTypeDialogClose={() => {
               setShouldOpenDialog(false);
             }}

--- a/apps/web/src/pages/data-storage/PageNotificationLegacyStorageSetup.tsx
+++ b/apps/web/src/pages/data-storage/PageNotificationLegacyStorageSetup.tsx
@@ -5,13 +5,13 @@ import {
   CollapsibleCardContent,
   CollapsibleCardFooter,
   CollapsibleCardHeaderActions,
-} from '../../../shared/components/CollapsibleCard/index.ts';
+} from '../../shared/components/CollapsibleCard/index.ts';
 import { Info, BookOpen, Airplay } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { Button } from '../../../shared/components/Button/index.tsx';
-import { useContentPopovers } from '../../../app/store/hooks/useContentPopovers';
+import { Button } from '../../shared/components/Button/index.tsx';
+import { useContentPopovers } from '../../app/store/hooks/useContentPopovers.ts';
 
-export default function PageNotificationLegacyStorageSetup() {
+export function PageNotificationLegacyStorageSetup() {
   const { open } = useContentPopovers();
   return (
     <div className='mb-4'>

--- a/apps/web/src/pages/data-storage/index.ts
+++ b/apps/web/src/pages/data-storage/index.ts
@@ -1,1 +1,1 @@
-export { DataStorageListPage } from './DataStorageListPage.tsx';
+export * from './DataStorageListPage';


### PR DESCRIPTION
The notification now appears when a BigQuery storage requires additional setup, helping users complete configuration in the right place. This improves clarity and reduces confusion during the setup process.

Also simplified the Data Marts page by removing outdated notification logic and improving overall structure.