### PR TITLE
Improve Swagger API discoverability

### DIFF
--- a/apps/backend/src/bootstrap.ts
+++ b/apps/backend/src/bootstrap.ts
@@ -80,7 +80,7 @@ export async function bootstrap(options: BootstrapOptions): Promise<NestExpressA
   const normalizedUrl = appUrl.replace('[::1]', 'localhost');
 
   logger.log(`Application is running on: ${normalizedUrl}`);
-  logger.log(`Swagger is available at: ${normalizedUrl}/${SWAGGER_PATH}`);
+  logger.log(`Swagger is available at: ${normalizedUrl}/${PATH_PREFIX}/${SWAGGER_PATH}`);
 
   return app;
 }

--- a/apps/backend/src/config/swagger.config.ts
+++ b/apps/backend/src/config/swagger.config.ts
@@ -3,13 +3,16 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
 export function setupSwagger(app: INestApplication, path: string): void {
   const config = new DocumentBuilder()
-    .setTitle('Backend API')
+    .setTitle('OWOX Data Marts API')
     .setDescription('REST API used by frontend clients and service integrations.')
     .setVersion('1.0')
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup(path, app, document, {
-    useGlobalPrefix: false,
+    useGlobalPrefix: true,
+    jsonDocumentUrl: 'openapi.json',
+    raw: ['json', 'yaml'],
+    yamlDocumentUrl: 'openapi.yaml',
   });
 }


### PR DESCRIPTION
## Impact

Swagger UI is now discoverable at `/api/swagger-ui`.

The OpenAPI specs are now available at:

- `/api/openapi.json`
- `/api/openapi.yaml`

These routes match the backend API namespace and avoid root-route collisions with the web app or other Express handlers.

## What was wrong

The backend API uses the global `/api` prefix, but Swagger was registered outside that namespace at `/swagger-ui`.

That worked in backend-only scenarios where no other Express handler owned root-level routes. In the full application, however, other HTTP handlers are registered on the same Express app before the backend bootstrap, including static web assets and the SPA fallback. The SPA fallback only excludes `/api`, so `/swagger-ui` could be treated as a frontend route and return the web app instead of Swagger.

This made Swagger discovery environment-dependent: the same logged URL could work in one startup mode and be intercepted in another. It also left Swagger competing with other root-level HTTP handlers instead of keeping API documentation with the API routes.