### PR TITLE
Actualize OpenAPI specs for data mart APIs

### DIFF
--- a/apps/backend/src/data-marts/controllers/data-destination.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-destination.controller.ts
@@ -47,6 +47,7 @@ import {
   OAuthCredentialStatusSpec,
   OAuthStatusSpec,
   OAuthRevokeSpec,
+  UpdateDataDestinationAvailabilitySpec,
 } from './spec/data-destination.api';
 import { ApiTags } from '@nestjs/swagger';
 import { DeleteDataDestinationService } from '../use-cases/delete-data-destination.service';
@@ -239,7 +240,7 @@ export class DataDestinationController {
   @Auth(Role.viewer())
   @Post(':id/oauth/authorize')
   @HttpCode(200)
-  @OAuthAuthorizeSpec()
+  @OAuthAuthorizeSpec(true)
   async generateOAuthAuthorizationUrl(
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string,
@@ -278,6 +279,7 @@ export class DataDestinationController {
   @Auth(Role.viewer(Strategy.INTROSPECT))
   @Put(':id/availability')
   @HttpCode(204)
+  @UpdateDataDestinationAvailabilitySpec()
   async updateAvailability(
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string,

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.ts
@@ -54,6 +54,7 @@ import {
   CancelDataMartRunSpec,
   CreateDataMartSpec,
   DeleteDataMartSpec,
+  GetMemberOwnershipWarningsSpec,
   GetDataMartRunByIdSpec,
   GetDataMartRunsSpec,
   GetDataMartSpec,
@@ -61,6 +62,7 @@ import {
   ListDataMartsSpec,
   PublishDataMartSpec,
   RunDataMartSpec,
+  UpdateDataMartAvailabilitySpec,
   UpdateDataMartDefinitionSpec,
   UpdateDataMartDescriptionSpec,
   UpdateDataMartSchemaSpec,
@@ -135,6 +137,7 @@ export class DataMartController {
 
   @Auth(Role.admin(Strategy.INTROSPECT))
   @Get('member-ownership-warnings')
+  @GetMemberOwnershipWarningsSpec()
   async getMemberOwnershipWarnings(@AuthContext() context: AuthorizationContext) {
     return this.memberOwnershipWarningsService.getWarnings(context.projectId);
   }
@@ -320,6 +323,7 @@ export class DataMartController {
   @Auth(Role.viewer(Strategy.INTROSPECT))
   @Put(':id/availability')
   @HttpCode(204)
+  @UpdateDataMartAvailabilitySpec()
   async updateAvailability(
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string,

--- a/apps/backend/src/data-marts/controllers/data-storage.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-storage.controller.ts
@@ -58,6 +58,7 @@ import {
   OAuthExchangeSpec,
   OAuthStatusSpec,
   OAuthRevokeSpec,
+  UpdateStorageAvailabilitySpec,
 } from './spec/data-storage.api';
 
 @Controller('data-storages')
@@ -250,6 +251,7 @@ export class DataStorageController {
   @Auth(Role.viewer(Strategy.INTROSPECT))
   @Put(':id/availability')
   @HttpCode(204)
+  @UpdateStorageAvailabilitySpec()
   async updateAvailability(
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string,

--- a/apps/backend/src/data-marts/controllers/spec/connector.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/connector.api.ts
@@ -1,50 +1,86 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { ConnectorDefinitionResponseApiDto } from '../../dto/presentation/connector-definition-response-api.dto';
 import { ConnectorSpecificationResponseApiDto } from '../../dto/presentation/connector-specification-response-api.dto';
 import { ConnectorFieldsResponseApiDto } from '../../dto/presentation/connector-fields-response-api.dto';
 import { ConnectorOAuthCredentialsResponseApiDto } from '../../dto/presentation/connector-oauth-credentials-response-api.dto';
-import { ConnectorOAuthStatusResponseApiDto } from 'src/data-marts/dto/presentation/connector-oauth-credentials-status-response-api.dto';
+import { ConnectorOAuthStatusResponseApiDto } from '../../dto/presentation/connector-oauth-credentials-status-response-api.dto';
 import { ConnectorOAuthSettingsResponseApiDto } from '../../dto/presentation/connector-oauth-settings-response-api.dto';
+import { ExchangeOAuthCredentialsDto } from '../../dto/presentation/exchange-oauth-credentials.dto';
 
 export function GetAvailableConnectorsSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Get available connectors' }),
-    ApiResponse({ status: 200, type: [ConnectorDefinitionResponseApiDto] })
+    ApiOkResponse({ type: ConnectorDefinitionResponseApiDto, isArray: true })
   );
 }
 
 export function GetConnectorSpecificationSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Get connector specification' }),
-    ApiResponse({ status: 200, type: ConnectorSpecificationResponseApiDto })
+    ApiParam({ name: 'connectorName', description: 'Connector name' }),
+    ApiOkResponse({ type: ConnectorSpecificationResponseApiDto, isArray: true }),
+    ApiResponse({ status: 404, description: 'Connector not found' })
   );
 }
 
 export function GetConnectorFieldsSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Get connector fields' }),
-    ApiResponse({ status: 200, type: [ConnectorFieldsResponseApiDto] })
+    ApiParam({ name: 'connectorName', description: 'Connector name' }),
+    ApiOkResponse({ type: ConnectorFieldsResponseApiDto, isArray: true }),
+    ApiResponse({ status: 404, description: 'Connector not found' })
   );
 }
 
 export function ExchangeOAuthCredentialsSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Exchange OAuth credentials for a connector' }),
-    ApiResponse({ status: 200, type: ConnectorOAuthCredentialsResponseApiDto })
+    ApiParam({ name: 'connectorName', description: 'Connector name' }),
+    ApiBody({ type: ExchangeOAuthCredentialsDto }),
+    ApiCreatedResponse({
+      type: ConnectorOAuthCredentialsResponseApiDto,
+      description: 'OAuth credentials exchanged successfully',
+    }),
+    ApiResponse({ status: 400, description: 'Invalid OAuth credentials payload' })
   );
 }
 
 export function GetConnectorOAuthStatusSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Get connector OAuth status' }),
-    ApiResponse({ status: 200, type: ConnectorOAuthStatusResponseApiDto })
+    ApiParam({ name: 'connectorName', description: 'Connector name' }),
+    ApiParam({ name: 'credentialId', description: 'OAuth credential ID' }),
+    ApiOkResponse({
+      type: ConnectorOAuthStatusResponseApiDto,
+      description: 'OAuth credential status',
+    })
   );
 }
 
 export function GetConnectorOAuthSettingsSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Get OAuth settings (UI variables) for a connector' }),
-    ApiResponse({ status: 200, type: ConnectorOAuthSettingsResponseApiDto })
+    ApiParam({ name: 'connectorName', description: 'Connector name' }),
+    ApiQuery({
+      name: 'path',
+      required: true,
+      type: String,
+      example: 'AuthType.oauth2',
+      description: 'Path to the OAuth configuration in connector specification',
+    }),
+    ApiOkResponse({
+      type: ConnectorOAuthSettingsResponseApiDto,
+      description: 'OAuth UI settings',
+    }),
+    ApiResponse({ status: 404, description: 'Connector not found' })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/data-destination.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-destination.api.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/swagger';
 import { CreateDataDestinationApiDto } from '../../dto/presentation/create-data-destination-api.dto';
 import { UpdateDataDestinationApiDto } from '../../dto/presentation/update-data-destination-api.dto';
+import { UpdateDestinationAvailabilityApiDto } from '../../dto/presentation/update-availability-api.dto';
 import { DataDestinationResponseApiDto } from '../../dto/presentation/data-destination-response-api.dto';
 import { DataDestinationByTypeResponseApiDto } from '../../dto/presentation/data-destination-by-type-response-api.dto';
 import { GenerateAuthorizationUrlRequestDto } from '../../dto/presentation/google-oauth/generate-authorization-url-request.dto';
@@ -156,22 +157,7 @@ export function UpdateDataDestinationAvailabilitySpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Update Data Destination availability' }),
     ApiParam({ name: 'id', description: 'Data Destination ID' }),
-    ApiBody({
-      schema: {
-        type: 'object',
-        required: ['availableForUse', 'availableForMaintenance'],
-        properties: {
-          availableForUse: {
-            type: 'boolean',
-            example: true,
-          },
-          availableForMaintenance: {
-            type: 'boolean',
-            example: false,
-          },
-        },
-      },
-    }),
+    ApiBody({ type: UpdateDestinationAvailabilityApiDto }),
     ApiNoContentResponse({ description: 'Data Destination availability updated' })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/data-destination.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-destination.api.ts
@@ -7,6 +7,7 @@ import {
   ApiOkResponse,
   ApiNoContentResponse,
   ApiResponse,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { CreateDataDestinationApiDto } from '../../dto/presentation/create-data-destination-api.dto';
 import { UpdateDataDestinationApiDto } from '../../dto/presentation/update-data-destination-api.dto';
@@ -19,6 +20,7 @@ import { ExchangeAuthorizationCodeResponseDto } from '../../dto/presentation/goo
 import { GoogleOAuthStatusResponseDto } from '../../dto/presentation/google-oauth/google-oauth-status-response.dto';
 import { GoogleOAuthSettingsResponseDto } from '../../dto/presentation/google-oauth/oauth-settings-response.dto';
 import { DataDestinationType } from '../../data-destination-types/enums/data-destination-type.enum';
+import { OwnerFilter } from '../../enums/owner-filter.enum';
 
 export function ListDataDestinationsByTypeSpec() {
   return applyDecorators(
@@ -56,6 +58,13 @@ export function GetDataDestinationSpec() {
 export function ListDataDestinationsSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Get all Data Destinations' }),
+    ApiQuery({
+      name: 'ownerFilter',
+      required: false,
+      enum: OwnerFilter,
+      example: OwnerFilter.HAS_OWNERS,
+      description: 'Filter Data Destinations by whether they have owners',
+    }),
     ApiOkResponse({ type: [DataDestinationResponseApiDto] })
   );
 }
@@ -64,7 +73,7 @@ export function DeleteDataDestinationSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Delete Data Destination by ID' }),
     ApiParam({ name: 'id', description: 'Data Destination ID' }),
-    ApiNoContentResponse({ description: 'Data Destination successfully deleted' })
+    ApiOkResponse({ description: 'Data Destination successfully deleted' })
   );
 }
 
@@ -72,7 +81,7 @@ export function RotateSecretKeySpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Rotate secret key for Data Destination' }),
     ApiParam({ name: 'id', description: 'Data Destination ID' }),
-    ApiOkResponse({ type: DataDestinationResponseApiDto })
+    ApiCreatedResponse({ type: DataDestinationResponseApiDto })
   );
 }
 
@@ -86,14 +95,21 @@ export function OAuthSettingsSpec() {
   );
 }
 
-export function OAuthAuthorizeSpec() {
+export function OAuthAuthorizeSpec(withDestinationId = false) {
   return applyDecorators(
-    ApiOperation({ summary: 'Generate Google OAuth authorization URL for a Data Destination' }),
+    ApiOperation({
+      summary: withDestinationId
+        ? 'Generate Google OAuth authorization URL for a Data Destination'
+        : 'Generate Google OAuth authorization URL for Data Destination credentials',
+    }),
+    ...(withDestinationId ? [ApiParam({ name: 'id', description: 'Data Destination ID' })] : []),
     ApiBody({ type: GenerateAuthorizationUrlRequestDto }),
     ApiOkResponse({
       type: GenerateAuthorizationUrlResponseDto,
       description: 'Authorization URL and state token',
-    })
+    }),
+    ApiResponse({ status: 400, description: 'Invalid redirect URI' }),
+    ApiResponse({ status: 503, description: 'Google OAuth is not configured' })
   );
 }
 
@@ -106,7 +122,8 @@ export function OAuthExchangeSpec() {
       description: 'OAuth credential created successfully',
     }),
     ApiResponse({ status: 400, description: 'Invalid authorization code or state' }),
-    ApiResponse({ status: 403, description: 'OAuth state does not belong to your project' })
+    ApiResponse({ status: 403, description: 'OAuth state does not belong to your project' }),
+    ApiResponse({ status: 503, description: 'Google OAuth is not configured' })
   );
 }
 
@@ -132,5 +149,29 @@ export function OAuthRevokeSpec() {
     ApiOperation({ summary: 'Revoke Google OAuth credentials for a Data Destination' }),
     ApiParam({ name: 'id', description: 'Data Destination ID' }),
     ApiNoContentResponse({ description: 'OAuth credentials revoked' })
+  );
+}
+
+export function UpdateDataDestinationAvailabilitySpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update Data Destination availability' }),
+    ApiParam({ name: 'id', description: 'Data Destination ID' }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        required: ['availableForUse', 'availableForMaintenance'],
+        properties: {
+          availableForUse: {
+            type: 'boolean',
+            example: true,
+          },
+          availableForMaintenance: {
+            type: 'boolean',
+            example: false,
+          },
+        },
+      },
+    }),
+    ApiNoContentResponse({ description: 'Data Destination availability updated' })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
@@ -18,11 +18,11 @@ import { UpdateDataMartTitleApiDto } from '../../dto/presentation/update-data-ma
 import { UpdateDataMartDefinitionApiDto } from '../../dto/presentation/update-data-mart-definition-api.dto';
 import { UpdateDataMartSchemaApiDto } from '../../dto/presentation/update-data-mart-schema-api.dto';
 import { DataMartValidationResponseApiDto } from '../../dto/presentation/data-mart-validation-response-api.dto';
-import { SqlDryRunRequestApiDto } from '../../dto/presentation/sql-dry-run-request-api.dto';
-import { SqlDryRunResponseApiDto } from '../../dto/presentation/sql-dry-run-response-api.dto';
 import { DataMartRunsResponseApiDto } from '../../dto/presentation/data-mart-runs-response-api.dto';
 import { DataMartRunResponseApiDto } from '../../dto/presentation/data-mart-run-response-api.dto';
 import { UpdateDataMartOwnersApiDto } from '../../dto/presentation/update-data-mart-owners-api.dto';
+import { PaginatedDataMartsResponseApiDto } from '../../dto/presentation/paginated-data-marts-response-api.dto';
+import { OwnerFilter } from '../../enums/owner-filter.enum';
 
 export function CreateDataMartSpec() {
   return applyDecorators(
@@ -35,7 +35,21 @@ export function CreateDataMartSpec() {
 export function ListDataMartsSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'List all DataMarts' }),
-    ApiResponse({ status: 200, type: DataMartResponseApiDto, isArray: true })
+    ApiQuery({
+      name: 'offset',
+      required: false,
+      type: Number,
+      example: 0,
+      description: 'Number of DataMarts to skip before returning results',
+    }),
+    ApiQuery({
+      name: 'ownerFilter',
+      required: false,
+      enum: OwnerFilter,
+      example: OwnerFilter.HAS_OWNERS,
+      description: 'Filter DataMarts by whether they have technical or business owners',
+    }),
+    ApiResponse({ status: 200, type: PaginatedDataMartsResponseApiDto })
   );
 }
 
@@ -102,23 +116,51 @@ export function UpdateDataMartOwnersSpec() {
 export function DeleteDataMartSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Soft delete DataMart' }),
-    ApiParam({ name: 'id', type: String }),
-    ApiNoContentResponse({ description: 'DataMart deleted' })
+    ApiParam({ name: 'id', description: 'DataMart ID' }),
+    ApiOkResponse({ description: 'DataMart deleted' })
   );
 }
 
 export function RunDataMartSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Manual run DataMart' }),
-    ApiParam({ name: 'id', type: String }),
-    ApiNoContentResponse({ description: 'DataMart run' })
+    ApiParam({ name: 'id', description: 'DataMart ID' }),
+    ApiBody({
+      required: false,
+      schema: {
+        type: 'object',
+        properties: {
+          payload: {
+            type: 'object',
+            additionalProperties: true,
+            example: { key: 'value' },
+            description: 'Optional payload for the manual run',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 201,
+      description: 'DataMart run created',
+      schema: {
+        type: 'object',
+        required: ['runId'],
+        properties: {
+          runId: {
+            type: 'string',
+            format: 'uuid',
+            example: '123e4567-e89b-12d3-a456-426614174000',
+          },
+        },
+      },
+    })
   );
 }
 
 export function ValidateDataMartDefinitionSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Validate DataMart definition' }),
-    ApiParam({ name: 'id', type: String }),
+    ApiParam({ name: 'id', description: 'DataMart ID' }),
     ApiOkResponse({ type: DataMartValidationResponseApiDto })
   );
 }
@@ -132,21 +174,24 @@ export function UpdateDataMartSchemaSpec() {
   );
 }
 
-export function SqlDryRunSpec() {
-  return applyDecorators(
-    ApiOperation({ summary: 'Execute SQL dry run validation' }),
-    ApiParam({ name: 'id', description: 'DataMart ID' }),
-    ApiBody({ type: SqlDryRunRequestApiDto }),
-    ApiOkResponse({ type: SqlDryRunResponseApiDto })
-  );
-}
-
 export function GetDataMartRunsSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Get DataMart run history' }),
     ApiParam({ name: 'id', description: 'DataMart ID' }),
-    ApiQuery({ name: 'limit', description: 'Limit the number of runs to return', required: false }),
-    ApiQuery({ name: 'offset', description: 'Offset for pagination', required: false }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      example: 20,
+      description: 'Maximum number of runs to return',
+    }),
+    ApiQuery({
+      name: 'offset',
+      required: false,
+      type: Number,
+      example: 0,
+      description: 'Number of runs to skip before returning results',
+    }),
     ApiOkResponse({ type: DataMartRunsResponseApiDto })
   );
 }
@@ -174,5 +219,56 @@ export function GetDataMartRunByIdSpec() {
     ApiParam({ name: 'id', description: 'DataMart ID' }),
     ApiParam({ name: 'runId', description: 'Run ID' }),
     ApiOkResponse({ type: DataMartRunResponseApiDto })
+  );
+}
+
+export function GetMemberOwnershipWarningsSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'List member ownership warnings' }),
+    ApiOkResponse({
+      description:
+        'Technical-owner warnings for project members whose role makes ownership ineffective',
+      schema: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['userId', 'warning'],
+          properties: {
+            userId: {
+              type: 'string',
+              example: 'user-123',
+            },
+            warning: {
+              type: 'string',
+              example: 'Technical Owner — requires Technical User role to be effective',
+            },
+          },
+        },
+      },
+    })
+  );
+}
+
+export function UpdateDataMartAvailabilitySpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update DataMart availability' }),
+    ApiParam({ name: 'id', description: 'DataMart ID' }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        required: ['availableForReporting', 'availableForMaintenance'],
+        properties: {
+          availableForReporting: {
+            type: 'boolean',
+            example: true,
+          },
+          availableForMaintenance: {
+            type: 'boolean',
+            example: false,
+          },
+        },
+      },
+    }),
+    ApiNoContentResponse({ description: 'DataMart availability updated' })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
@@ -22,6 +22,8 @@ import { DataMartRunsResponseApiDto } from '../../dto/presentation/data-mart-run
 import { DataMartRunResponseApiDto } from '../../dto/presentation/data-mart-run-response-api.dto';
 import { UpdateDataMartOwnersApiDto } from '../../dto/presentation/update-data-mart-owners-api.dto';
 import { PaginatedDataMartsResponseApiDto } from '../../dto/presentation/paginated-data-marts-response-api.dto';
+import { RunDataMartRequestApiDto } from '../../dto/presentation/run-data-mart-request-api.dto';
+import { UpdateDataMartAvailabilityApiDto } from '../../dto/presentation/update-availability-api.dto';
 import { OwnerFilter } from '../../enums/owner-filter.enum';
 
 export function CreateDataMartSpec() {
@@ -125,20 +127,7 @@ export function RunDataMartSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Manual run DataMart' }),
     ApiParam({ name: 'id', description: 'DataMart ID' }),
-    ApiBody({
-      required: false,
-      schema: {
-        type: 'object',
-        properties: {
-          payload: {
-            type: 'object',
-            additionalProperties: true,
-            example: { key: 'value' },
-            description: 'Optional payload for the manual run',
-          },
-        },
-      },
-    }),
+    ApiBody({ type: RunDataMartRequestApiDto, required: false }),
     ApiResponse({
       status: 201,
       description: 'DataMart run created',
@@ -253,22 +242,7 @@ export function UpdateDataMartAvailabilitySpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Update DataMart availability' }),
     ApiParam({ name: 'id', description: 'DataMart ID' }),
-    ApiBody({
-      schema: {
-        type: 'object',
-        required: ['availableForReporting', 'availableForMaintenance'],
-        properties: {
-          availableForReporting: {
-            type: 'boolean',
-            example: true,
-          },
-          availableForMaintenance: {
-            type: 'boolean',
-            example: false,
-          },
-        },
-      },
-    }),
+    ApiBody({ type: UpdateDataMartAvailabilityApiDto }),
     ApiNoContentResponse({ description: 'DataMart availability updated' })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/data-storage.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-storage.api.ts
@@ -14,6 +14,7 @@ import { DataStorageListResponseApiDto } from '../../dto/presentation/data-stora
 import { DataStorageResponseApiDto } from '../../dto/presentation/data-storage-response-api.dto';
 import { DataStorageByTypeResponseApiDto } from '../../dto/presentation/data-storage-by-type-response-api.dto';
 import { UpdateDataStorageApiDto } from '../../dto/presentation/update-data-storage-api.dto';
+import { UpdateStorageAvailabilityApiDto } from '../../dto/presentation/update-availability-api.dto';
 import { GenerateAuthorizationUrlRequestDto } from '../../dto/presentation/google-oauth/generate-authorization-url-request.dto';
 import { GenerateAuthorizationUrlResponseDto } from '../../dto/presentation/google-oauth/generate-authorization-url-response.dto';
 import { ExchangeAuthorizationCodeRequestDto } from '../../dto/presentation/google-oauth/exchange-authorization-code-request.dto';
@@ -141,22 +142,7 @@ export function UpdateStorageAvailabilitySpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Update Data Storage availability' }),
     ApiParam({ name: 'id', description: 'Data Storage ID' }),
-    ApiBody({
-      schema: {
-        type: 'object',
-        required: ['availableForUse', 'availableForMaintenance'],
-        properties: {
-          availableForUse: {
-            type: 'boolean',
-            example: true,
-          },
-          availableForMaintenance: {
-            type: 'boolean',
-            example: false,
-          },
-        },
-      },
-    }),
+    ApiBody({ type: UpdateStorageAvailabilityApiDto }),
     ApiNoContentResponse({ description: 'Data Storage availability updated' })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/data-storage.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-storage.api.ts
@@ -5,6 +5,7 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiResponse,
 } from '@nestjs/swagger';
 import { CreateDataStorageApiDto } from '../../dto/presentation/create-data-storage-api.dto';
@@ -20,6 +21,7 @@ import { ExchangeAuthorizationCodeResponseDto } from '../../dto/presentation/goo
 import { GoogleOAuthStatusResponseDto } from '../../dto/presentation/google-oauth/google-oauth-status-response.dto';
 import { GoogleOAuthSettingsResponseDto } from '../../dto/presentation/google-oauth/oauth-settings-response.dto';
 import { DataStorageType } from '../../data-storage-types/enums/data-storage-type.enum';
+import { OwnerFilter } from '../../enums/owner-filter.enum';
 
 export function ListDataStoragesByTypeSpec() {
   return applyDecorators(
@@ -57,6 +59,13 @@ export function GetDataStorageSpec() {
 export function ListDataStoragesSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Get all Data Storages' }),
+    ApiQuery({
+      name: 'ownerFilter',
+      required: false,
+      enum: OwnerFilter,
+      example: OwnerFilter.HAS_OWNERS,
+      description: 'Filter Data Storages by whether they have owners',
+    }),
     ApiOkResponse({ type: [DataStorageListResponseApiDto] })
   );
 }
@@ -65,7 +74,7 @@ export function DeleteDataStorageSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Delete Data Storage by ID' }),
     ApiParam({ name: 'id', description: 'Data Storage ID' }),
-    ApiResponse({ status: 204, description: 'Data Storage successfully deleted' })
+    ApiOkResponse({ description: 'Data Storage successfully deleted' })
   );
 }
 
@@ -80,8 +89,7 @@ export function ValidateDataStorageAccessSpec() {
 export function OAuthSettingsSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Get Google OAuth settings (client ID, redirect URI, scopes)' }),
-    ApiOkResponse({ type: GoogleOAuthSettingsResponseDto, description: 'OAuth settings' }),
-    ApiResponse({ status: 503, description: 'Google OAuth is not configured' })
+    ApiOkResponse({ type: GoogleOAuthSettingsResponseDto, description: 'OAuth settings' })
   );
 }
 
@@ -94,7 +102,8 @@ export function OAuthAuthorizeSpec() {
       type: GenerateAuthorizationUrlResponseDto,
       description: 'Authorization URL and state token',
     }),
-    ApiResponse({ status: 400, description: 'Invalid redirect URI' })
+    ApiResponse({ status: 400, description: 'Invalid redirect URI' }),
+    ApiResponse({ status: 503, description: 'Google OAuth is not configured' })
   );
 }
 
@@ -107,7 +116,8 @@ export function OAuthExchangeSpec() {
       description: 'OAuth credential created successfully',
     }),
     ApiResponse({ status: 400, description: 'Invalid authorization code or state' }),
-    ApiResponse({ status: 403, description: 'OAuth state does not belong to your project' })
+    ApiResponse({ status: 403, description: 'OAuth state does not belong to your project' }),
+    ApiResponse({ status: 503, description: 'Google OAuth is not configured' })
   );
 }
 
@@ -124,5 +134,29 @@ export function OAuthRevokeSpec() {
     ApiOperation({ summary: 'Revoke Google OAuth credentials for a Data Storage' }),
     ApiParam({ name: 'id', description: 'Data Storage ID' }),
     ApiNoContentResponse({ description: 'OAuth credentials revoked' })
+  );
+}
+
+export function UpdateStorageAvailabilitySpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update Data Storage availability' }),
+    ApiParam({ name: 'id', description: 'Data Storage ID' }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        required: ['availableForUse', 'availableForMaintenance'],
+        properties: {
+          availableForUse: {
+            type: 'boolean',
+            example: true,
+          },
+          availableForMaintenance: {
+            type: 'boolean',
+            example: false,
+          },
+        },
+      },
+    }),
+    ApiNoContentResponse({ description: 'Data Storage availability updated' })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/report.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.api.ts
@@ -5,10 +5,12 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { ReportResponseApiDto } from '../../dto/presentation/report-response-api.dto';
 import { CreateReportRequestApiDto } from '../../dto/presentation/create-report-request-api.dto';
 import { UpdateReportRequestApiDto } from '../../dto/presentation/update-report-request-api.dto';
+import { OwnerFilter } from '../../enums/owner-filter.enum';
 
 export function CreateReportSpec() {
   return applyDecorators(
@@ -35,6 +37,13 @@ export function ListReportsByDataMartSpec() {
 export function ListReportsByProjectSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Get all reports for a project' }),
+    ApiQuery({
+      name: 'ownerFilter',
+      required: false,
+      enum: OwnerFilter,
+      example: OwnerFilter.HAS_OWNERS,
+      description: 'Filter reports by whether they have owners',
+    }),
     ApiOkResponse({
       description: 'List of reports for the project',
       type: [ReportResponseApiDto],
@@ -65,10 +74,10 @@ export function DeleteReportSpec() {
 
 export function RunReportSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'Run a report by ID' }),
+    ApiOperation({ summary: 'Trigger a manual report run' }),
     ApiParam({ name: 'id', description: 'Report ID' }),
-    ApiOkResponse({
-      description: 'The report has been successfully started.',
+    ApiCreatedResponse({
+      description: 'The manual report run trigger has been successfully created.',
     })
   );
 }
@@ -87,11 +96,11 @@ export function UpdateReportSpec() {
 
 export function ListReportsByInsightTemplateSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'Get all reports for an insight template' }),
+    ApiOperation({ summary: 'Get email reports that use an insight template' }),
     ApiParam({ name: 'dataMartId', description: 'Data mart ID' }),
     ApiParam({ name: 'insightTemplateId', description: 'Insight template ID' }),
     ApiOkResponse({
-      description: 'List of reports for the insight template',
+      description: 'List of email reports that use the insight template as their template source',
       type: [ReportResponseApiDto],
     })
   );

--- a/apps/backend/src/data-marts/controllers/spec/scheduled-trigger.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/scheduled-trigger.api.ts
@@ -1,7 +1,7 @@
 import { applyDecorators } from '@nestjs/common';
 import {
   ApiBody,
-  ApiNoContentResponse,
+  ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
@@ -10,48 +10,134 @@ import {
 import { CreateScheduledTriggerRequestApiDto } from '../../dto/presentation/create-scheduled-trigger-request-api.dto';
 import { ScheduledTriggerResponseApiDto } from '../../dto/presentation/scheduled-trigger-response-api.dto';
 import { UpdateScheduledTriggerRequestApiDto } from '../../dto/presentation/update-scheduled-trigger-request-api.dto';
+import { ScheduledTriggerType } from '../../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { ScheduledReportRunConfigType } from '../../scheduled-trigger-types/scheduled-report-run/schemas/scheduled-report-run-config.schema';
 
 export function CreateScheduledTriggerSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'Create a new scheduled trigger for a DataMart' }),
+    ApiOperation({
+      summary: 'Create a scheduled trigger for a DataMart',
+      description:
+        'Creates a scheduled connector run or report run trigger for a published DataMart. REPORT_RUN triggers require triggerConfig.reportId and report mutation access. CONNECTOR_RUN triggers must not include triggerConfig and require a Technical User role.',
+    }),
     ApiParam({ name: 'dataMartId', description: 'DataMart ID' }),
-    ApiBody({ type: CreateScheduledTriggerRequestApiDto }),
-    ApiResponse({ status: 201, type: ScheduledTriggerResponseApiDto })
+    ApiBody({
+      type: CreateScheduledTriggerRequestApiDto,
+      description:
+        'Set isActive to true to schedule the next run immediately. If omitted, isActive defaults to false.',
+      examples: {
+        reportRun: {
+          summary: 'Schedule a report run',
+          value: {
+            type: ScheduledTriggerType.REPORT_RUN,
+            cronExpression: '0 9 * * *',
+            timeZone: 'UTC',
+            isActive: true,
+            triggerConfig: {
+              type: ScheduledReportRunConfigType,
+              reportId: '9cabc24e-1234-4a5a-8b12-abcdef123456',
+            },
+          },
+        },
+        connectorRun: {
+          summary: 'Schedule a connector run',
+          value: {
+            type: ScheduledTriggerType.CONNECTOR_RUN,
+            cronExpression: '0 * * * *',
+            timeZone: 'UTC',
+            isActive: false,
+          },
+        },
+      },
+    }),
+    ApiCreatedResponse({
+      description: 'Scheduled trigger created',
+      type: ScheduledTriggerResponseApiDto,
+    }),
+    ApiResponse({
+      status: 400,
+      description:
+        'Invalid request, invalid cron expression, invalid trigger config, or DataMart is not published',
+    }),
+    ApiResponse({
+      status: 403,
+      description:
+        'Insufficient permissions to manage the requested trigger type or report trigger target',
+    }),
+    ApiResponse({ status: 404, description: 'DataMart or report not found' })
   );
 }
 
 export function ListScheduledTriggersSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'List all scheduled triggers for a DataMart' }),
+    ApiOperation({
+      summary: 'List scheduled triggers for a DataMart',
+      description:
+        'Returns scheduled triggers for the DataMart in the current project, including createdByUser projections when available.',
+    }),
     ApiParam({ name: 'dataMartId', description: 'DataMart ID' }),
-    ApiResponse({ status: 200, type: ScheduledTriggerResponseApiDto, isArray: true })
+    ApiOkResponse({ type: ScheduledTriggerResponseApiDto, isArray: true })
   );
 }
 
 export function GetScheduledTriggerSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'Get a scheduled trigger by ID' }),
+    ApiOperation({
+      summary: 'Get a scheduled trigger by ID',
+      description:
+        'Returns a scheduled trigger that belongs to the specified DataMart and project.',
+    }),
     ApiParam({ name: 'dataMartId', description: 'DataMart ID' }),
     ApiParam({ name: 'id', description: 'Scheduled Trigger ID' }),
-    ApiResponse({ status: 200, type: ScheduledTriggerResponseApiDto })
+    ApiOkResponse({ type: ScheduledTriggerResponseApiDto }),
+    ApiResponse({ status: 404, description: 'Scheduled trigger not found' })
   );
 }
 
 export function UpdateScheduledTriggerSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'Update a scheduled trigger' }),
+    ApiOperation({
+      summary: 'Update a scheduled trigger',
+      description:
+        'Updates cronExpression, timeZone, and isActive. Trigger type and triggerConfig are immutable. Permission checks are based on the existing trigger type.',
+    }),
     ApiParam({ name: 'dataMartId', description: 'DataMart ID' }),
     ApiParam({ name: 'id', description: 'Scheduled Trigger ID' }),
     ApiBody({ type: UpdateScheduledTriggerRequestApiDto }),
-    ApiOkResponse({ type: ScheduledTriggerResponseApiDto })
+    ApiOkResponse({
+      description: 'Scheduled trigger updated',
+      type: ScheduledTriggerResponseApiDto,
+    }),
+    ApiResponse({
+      status: 400,
+      description:
+        'Invalid request, invalid cron expression, invalid stored trigger config, or DataMart is not published',
+    }),
+    ApiResponse({
+      status: 403,
+      description:
+        'Insufficient permissions to manage the requested trigger type or report trigger target',
+    }),
+    ApiResponse({ status: 404, description: 'Scheduled trigger not found' })
   );
 }
 
 export function DeleteScheduledTriggerSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'Delete a scheduled trigger' }),
+    ApiOperation({
+      summary: 'Delete a scheduled trigger',
+      description:
+        'Deletes a scheduled trigger after applying permission checks based on the existing trigger type.',
+    }),
     ApiParam({ name: 'dataMartId', description: 'DataMart ID' }),
     ApiParam({ name: 'id', description: 'Scheduled Trigger ID' }),
-    ApiNoContentResponse({ description: 'Scheduled trigger deleted' })
+    ApiOkResponse({ description: 'Scheduled trigger deleted' }),
+    ApiResponse({ status: 400, description: 'Invalid stored trigger config' }),
+    ApiResponse({
+      status: 403,
+      description:
+        'Insufficient permissions to manage the requested trigger type or report trigger target',
+    }),
+    ApiResponse({ status: 404, description: 'Scheduled trigger not found' })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/sql-dry-run-trigger.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/sql-dry-run-trigger.api.ts
@@ -1,6 +1,15 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation, ApiBody, ApiParam, ApiCreatedResponse } from '@nestjs/swagger';
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { TriggerStatus } from '../../../common/scheduler/shared/entities/trigger-status';
 import { SqlDryRunRequestApiDto } from '../../dto/presentation/sql-dry-run-request-api.dto';
+import { SqlDryRunResponseApiDto } from '../../dto/presentation/sql-dry-run-response-api.dto';
 
 /**
  * API spec for creating a new SQL dry run trigger
@@ -10,7 +19,7 @@ export function CreateSqlDryRunTriggerSpec() {
     ApiOperation({
       summary: 'Create a new SQL dry run trigger',
       description:
-        'Initiates an asynchronous SQL validation process. Returns a trigger ID that can be used to check the validation status and retrieve results.',
+        'Creates an asynchronous SQL dry run trigger for the specified DataMart. Poll the trigger status, then retrieve the SQL dry run result when processing is finished.',
     }),
     ApiParam({ name: 'dataMartId', description: 'DataMart ID' }),
     ApiBody({ type: SqlDryRunRequestApiDto }),
@@ -18,14 +27,89 @@ export function CreateSqlDryRunTriggerSpec() {
       description: 'Trigger created successfully',
       schema: {
         type: 'object',
+        required: ['triggerId'],
         properties: {
           triggerId: {
             type: 'string',
+            format: 'uuid',
             description: 'ID of the created trigger',
             example: '550e8400-e29b-41d4-a716-446655440000',
           },
         },
       },
     })
+  );
+}
+
+/**
+ * API spec for getting SQL dry run trigger status
+ */
+export function GetSqlDryRunTriggerStatusSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Get SQL dry run trigger status',
+      description: 'Returns the current scheduler status for the SQL dry run trigger.',
+    }),
+    ApiParam({ name: 'dataMartId', description: 'DataMart ID' }),
+    ApiParam({ name: 'triggerId', description: 'SQL dry run trigger ID' }),
+    ApiOkResponse({
+      description: 'Current trigger status',
+      schema: {
+        type: 'object',
+        required: ['status'],
+        properties: {
+          status: {
+            type: 'string',
+            enum: Object.values(TriggerStatus),
+            example: TriggerStatus.IDLE,
+            description: 'Current trigger status',
+          },
+        },
+      },
+    }),
+    ApiResponse({ status: 404, description: 'Trigger not found' })
+  );
+}
+
+/**
+ * API spec for getting SQL dry run trigger result
+ */
+export function GetSqlDryRunTriggerResponseSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Get SQL dry run result',
+      description:
+        'Returns and removes the SQL dry run result when the trigger succeeds. SQL validation failures are returned as isValid=false with an error message.',
+    }),
+    ApiParam({ name: 'dataMartId', description: 'DataMart ID' }),
+    ApiParam({ name: 'triggerId', description: 'SQL dry run trigger ID' }),
+    ApiOkResponse({
+      description: 'SQL dry run result',
+      type: SqlDryRunResponseApiDto,
+    }),
+    ApiResponse({ status: 400, description: 'Trigger failed or was cancelled' }),
+    ApiResponse({ status: 404, description: 'Trigger not found' }),
+    ApiResponse({ status: 408, description: 'Trigger response is not ready' })
+  );
+}
+
+/**
+ * API spec for cancelling SQL dry run trigger processing
+ */
+export function CancelSqlDryRunTriggerSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Cancel SQL dry run trigger',
+      description:
+        'Cancels a SQL dry run trigger owned by the current user. Idle or successful triggers are removed; ready or processing triggers are marked as cancelling.',
+    }),
+    ApiParam({ name: 'dataMartId', description: 'DataMart ID' }),
+    ApiParam({ name: 'triggerId', description: 'SQL dry run trigger ID' }),
+    ApiOkResponse({
+      description: 'Trigger cancellation accepted or trigger removed',
+    }),
+    ApiResponse({ status: 400, description: "Trigger can't be cancelled at current state" }),
+    ApiResponse({ status: 403, description: 'Current user is not allowed to cancel this trigger' }),
+    ApiResponse({ status: 404, description: 'Trigger not found' })
   );
 }

--- a/apps/backend/src/data-marts/controllers/sql-dry-run-trigger.controller.ts
+++ b/apps/backend/src/data-marts/controllers/sql-dry-run-trigger.controller.ts
@@ -1,18 +1,24 @@
-import { Controller, Post, Body, Param, ForbiddenException } from '@nestjs/common';
+import { Body, Controller, Delete, ForbiddenException, Get, Param, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Auth, AuthContext, AuthorizationContext, Role, Strategy } from '../../idp';
 import { UiTriggerController } from '../../common/scheduler/shared/ui-trigger-controller';
+import { TriggerStatus } from '../../common/scheduler/shared/entities/trigger-status';
 import { SqlDryRunTriggerService } from '../services/sql-dry-run-trigger.service';
 import { SqlDryRunResponseApiDto } from '../dto/presentation/sql-dry-run-response-api.dto';
 import { SqlDryRunRequestApiDto } from '../dto/presentation/sql-dry-run-request-api.dto';
-import { CreateSqlDryRunTriggerSpec } from './spec/sql-dry-run-trigger.api';
+import {
+  CancelSqlDryRunTriggerSpec,
+  CreateSqlDryRunTriggerSpec,
+  GetSqlDryRunTriggerResponseSpec,
+  GetSqlDryRunTriggerStatusSpec,
+} from './spec/sql-dry-run-trigger.api';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 
 /**
  * Controller for SQL dry run triggers.
  * Provides endpoints for creating, checking status, retrieving results, and cancelling SQL validation triggers.
  *
- * Inherited endpoints from UiTriggerController:
+ * Lifecycle endpoints delegated to UiTriggerController:
  * - GET /:triggerId/status - Get trigger status
  * - GET /:triggerId - Get trigger response (result)
  * - DELETE /:triggerId - Cancel/abort trigger
@@ -63,5 +69,33 @@ export class SqlDryRunTriggerController extends UiTriggerController<SqlDryRunRes
     );
 
     return { triggerId };
+  }
+
+  @GetSqlDryRunTriggerStatusSpec()
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get('/:triggerId/status')
+  public override async getTriggerStatus(
+    @Param('triggerId') triggerId: string
+  ): Promise<{ status: TriggerStatus }> {
+    return super.getTriggerStatus(triggerId);
+  }
+
+  @GetSqlDryRunTriggerResponseSpec()
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get('/:triggerId')
+  public override async getTriggerResponse(
+    @Param('triggerId') triggerId: string
+  ): Promise<SqlDryRunResponseApiDto> {
+    return super.getTriggerResponse(triggerId);
+  }
+
+  @CancelSqlDryRunTriggerSpec()
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Delete('/:triggerId')
+  public override async abortTriggerRun(
+    @Param('triggerId') triggerId: string,
+    @AuthContext() context: AuthorizationContext
+  ): Promise<void> {
+    return super.abortTriggerRun(triggerId, context);
   }
 }

--- a/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional } from 'class-validator';
 import { MaxJsonSize } from '../../../common/validators/max-json-size.validator';
 
@@ -12,7 +12,7 @@ export class RunDataMartRequestApiDto {
    */
   @IsOptional()
   @MaxJsonSize(MAX_PAYLOAD_SIZE_BYTES)
-  @ApiProperty({
+  @ApiPropertyOptional({
     example: { key: 'value' },
     description: `Payload for the manual run.
     If not provided, the data mart will be run with the default payload.

--- a/apps/backend/src/data-marts/dto/presentation/update-availability-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-availability-api.dto.ts
@@ -1,25 +1,50 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean } from 'class-validator';
 
 export class UpdateDataMartAvailabilityApiDto {
+  @ApiProperty({
+    description: 'Whether the DataMart is available for reporting',
+    example: true,
+  })
   @IsBoolean()
   availableForReporting: boolean;
 
+  @ApiProperty({
+    description: 'Whether the DataMart is available for maintenance',
+    example: false,
+  })
   @IsBoolean()
   availableForMaintenance: boolean;
 }
 
 export class UpdateStorageAvailabilityApiDto {
+  @ApiProperty({
+    description: 'Whether the Data Storage is available for use',
+    example: true,
+  })
   @IsBoolean()
   availableForUse: boolean;
 
+  @ApiProperty({
+    description: 'Whether the Data Storage is available for maintenance',
+    example: false,
+  })
   @IsBoolean()
   availableForMaintenance: boolean;
 }
 
 export class UpdateDestinationAvailabilityApiDto {
+  @ApiProperty({
+    description: 'Whether the Data Destination is available for use',
+    example: true,
+  })
   @IsBoolean()
   availableForUse: boolean;
 
+  @ApiProperty({
+    description: 'Whether the Data Destination is available for maintenance',
+    example: false,
+  })
   @IsBoolean()
   availableForMaintenance: boolean;
 }


### PR DESCRIPTION
## Summary
- Actualize Swagger/OpenAPI specs for data mart, data storage, data destination, connector, report, scheduled trigger, and SQL dry run trigger APIs.
- Add coverage for availability endpoints, member ownership warnings, owner filters, pagination parameters, OAuth error responses, manual run responses, and scheduled trigger behavior.
- Explicitly expose and document SQL dry run trigger status, result, and cancel endpoints.

## Context
- This work was triggered by an incorrect `ListDataMartsSpec`, then expanded to actualize related specs against the current implementation.
- The changes were generated by GPT-5.4 by applying the prompt template `"Actualize X spec considering current implementation"` to the corresponding spec files.

## Testing
- Tested `ListDataMartsSpec`.
- I understand the lack of broader testing here; suggestions for how to properly test these OpenAPI spec-only changes are welcome.