### PR TITLE
feat(data-storage): add grey unconfigured state to storage health indicator

### DIFF
--- a/.changeset/storage-unconfigured-health-state.md
+++ b/.changeset/storage-unconfigured-health-state.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Grey health indicator for unconfigured storages
+
+Previously, a storage that had just been created but not yet configured showed a red health indicator — the same as a storage with broken credentials. Now, unconfigured storages show a distinct grey indicator with the message "Complete setup to activate Storage". Red is reserved for storages that have been configured but fail validation, and green for fully healthy ones.

--- a/apps/backend/src/data-marts/controllers/data-storage.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-storage.controller.ts
@@ -198,6 +198,7 @@ export class DataStorageController {
 
   @Auth(Role.viewer(Strategy.INTROSPECT))
   @Post(':id/validate-access')
+  @HttpCode(200)
   @ValidateDataStorageAccessSpec()
   async validate(
     @AuthContext() context: AuthorizationContext,

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-access-validator.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-access-validator.interface.ts
@@ -3,6 +3,10 @@ import { DataStorageType } from '../enums/data-storage-type.enum';
 import { DataStorageConfig } from '../data-storage-config.type';
 import { DataStorageCredentials } from '../data-storage-credentials.type';
 
+export enum ValidationResultCode {
+  UNCONFIGURED = 'UNCONFIGURED',
+}
+
 export interface DataStorageAccessValidator extends TypedComponent<DataStorageType> {
   validate(
     config: DataStorageConfig,
@@ -14,6 +18,19 @@ export class ValidationResult {
   constructor(
     public readonly valid: boolean,
     public readonly errorMessage?: string,
-    public readonly reason?: Record<string, unknown>
+    public readonly reason?: Record<string, unknown>,
+    public readonly code?: ValidationResultCode
   ) {}
+
+  static success(): ValidationResult {
+    return new ValidationResult(true);
+  }
+
+  static failure(errorMessage?: string, reason?: Record<string, unknown>): ValidationResult {
+    return new ValidationResult(false, errorMessage, reason);
+  }
+
+  static unconfigured(errorMessage: string): ValidationResult {
+    return new ValidationResult(false, errorMessage, undefined, ValidationResultCode.UNCONFIGURED);
+  }
 }

--- a/apps/backend/src/data-marts/dto/presentation/data-storage-access-validation-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-storage-access-validation-response-api.dto.ts
@@ -2,8 +2,15 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class DataStorageAccessValidationResponseApiDto {
   @ApiProperty()
-  valid: boolean;
+  valid!: boolean;
 
   @ApiProperty()
   errorMessage?: string;
+
+  @ApiProperty({
+    required: false,
+    enum: ['UNCONFIGURED'],
+    description: 'Machine-readable validation result code',
+  })
+  code?: string;
 }

--- a/apps/backend/src/data-marts/mappers/data-storage.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-storage.mapper.ts
@@ -183,6 +183,7 @@ export class DataStorageMapper {
     return {
       valid: validationResult.valid,
       errorMessage: validationResult.errorMessage,
+      code: validationResult.code,
     };
   }
 

--- a/apps/backend/src/data-marts/use-cases/validate-data-storage-access.service.ts
+++ b/apps/backend/src/data-marts/use-cases/validate-data-storage-access.service.ts
@@ -38,7 +38,7 @@ export class ValidateDataStorageAccessService {
     }
 
     if (!dataStorage.config) {
-      return { valid: false, errorMessage: 'Storage setup is incomplete' };
+      return ValidationResult.unconfigured('Complete setup to activate Storage');
     }
 
     if (dataStorage.credentialId) {
@@ -51,13 +51,12 @@ export class ValidateDataStorageAccessService {
         );
       } catch (error) {
         this.logger.warn(`Failed to resolve credentials for storage ${dataStorage.id}`, error);
-        return {
-          valid: false,
-          errorMessage: error instanceof Error ? error.message : 'Failed to resolve credentials',
-        };
+        return ValidationResult.failure(
+          error instanceof Error ? error.message : 'Failed to resolve credentials'
+        );
       }
     }
 
-    return { valid: false, errorMessage: 'Storage setup is incomplete' };
+    return ValidationResult.unconfigured('Complete setup to activate Storage');
   }
 }

--- a/apps/backend/test/data-storage.e2e-spec.ts
+++ b/apps/backend/test/data-storage.e2e-spec.ts
@@ -96,7 +96,19 @@ describe('DataStorage API (e2e)', () => {
     expect(response.body.statusCode).toBe(400);
   });
 
-  // API-05: Delete
+  // API-05: Validate access on unconfigured storage — contract test for the frontend UNCONFIGURED_CODE constant.
+  // If this assertion fails, update UNCONFIGURED_CODE in data-storage-health-status.service.ts to match.
+  it('POST /api/data-storages/:id/validate-access - returns code UNCONFIGURED for a storage with no config', async () => {
+    const response = await agent
+      .post(`/api/data-storages/${createdStorageId}/validate-access`)
+      .set(AUTH_HEADER);
+
+    expect(response.status).toBe(200);
+    expect(response.body.valid).toBe(false);
+    expect(response.body.code).toBe('UNCONFIGURED');
+  });
+
+  // API-06: Delete
   it('DELETE /api/data-storages/:id - soft deletes the storage', async () => {
     const response = await agent.delete(`/api/data-storages/${createdStorageId}`).set(AUTH_HEADER);
 

--- a/apps/web/src/features/data-storage/shared/api/data-storage-api.service.ts
+++ b/apps/web/src/features/data-storage/shared/api/data-storage-api.service.ts
@@ -15,9 +15,12 @@ interface TaskStatusResponseDto {
   status: TaskStatus;
 }
 
+export type DataStorageValidationCode = 'UNCONFIGURED';
+
 export interface DataStorageValidationResponseDto {
   valid: boolean;
   errorMessage?: string;
+  code?: DataStorageValidationCode;
 }
 
 export class DataStorageApiService extends ApiService {

--- a/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthIndicator.tsx
+++ b/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthIndicator.tsx
@@ -12,7 +12,10 @@ import {
 } from '@owox/ui/components/hover-card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { useDataStorageHealthStatus } from '../../model/hooks/useDataStorageHealthStatus';
-import { DataStorageHealthStatus } from '../../services/data-storage-health-status.service';
+import {
+  DataStorageHealthStatus,
+  HEALTH_STATUS_UNCONFIGURED_TEXT,
+} from '../../services/data-storage-health-status.service';
 import { DataStorageHealthStatusView } from './DataStorageHealthStatusView';
 import { DataStorageHealthDot } from './DataStorageHealthDot';
 
@@ -23,6 +26,9 @@ interface DataStorageHealthIndicatorProps {
   variant?: 'default' | 'compact';
 }
 
+// NOTE: `text` here is used for compact-variant tooltips.
+// DataStorageHealthStatusView uses its own labels for VALID/INVALID (pre-existing).
+// New states should use shared constants (see HEALTH_STATUS_UNCONFIGURED_TEXT).
 const HEALTH_STATUS_CONFIG: Record<
   DataStorageHealthStatus,
   { text: string; dotClass: string; ringClass: string }
@@ -37,11 +43,16 @@ const HEALTH_STATUS_CONFIG: Record<
     dotClass: 'bg-red-500',
     ringClass: 'ring-red-500/50',
   },
+  [DataStorageHealthStatus.UNCONFIGURED]: {
+    text: HEALTH_STATUS_UNCONFIGURED_TEXT,
+    dotClass: 'bg-neutral-400 dark:bg-neutral-500',
+    ringClass: 'ring-neutral-400/50 dark:ring-neutral-500/50',
+  },
 };
 const HEALTH_STATUS_NOT_FETCHED = {
   text: 'Storage status not fetched yet',
   dotClass: 'bg-neutral-300 dark:bg-neutral-600',
-  ringClass: 'ring-neutral-400/50 dark:ring-neutral-500/50',
+  ringClass: 'ring-neutral-300/50 dark:ring-neutral-600/50',
 };
 
 function getTooltipText(params: { status: DataStorageHealthStatus; isLoading: boolean }): string {
@@ -85,7 +96,7 @@ export function DataStorageHealthIndicator({
           </div>
         </HoverCardTrigger>
 
-        {isFetched && !isLoading && (
+        {isFetched && !isLoading && status !== DataStorageHealthStatus.UNCONFIGURED && (
           <HoverCardContent side={hovercardSide} align='start'>
             <HoverCardHeader>
               <HoverCardHeaderText>

--- a/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthIndicator.tsx
+++ b/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthIndicator.tsx
@@ -26,13 +26,18 @@ interface DataStorageHealthIndicatorProps {
   variant?: 'default' | 'compact';
 }
 
-// NOTE: `text` here is used for compact-variant tooltips.
-// DataStorageHealthStatusView uses its own labels for VALID/INVALID (pre-existing).
-// New states should use shared constants (see HEALTH_STATUS_UNCONFIGURED_TEXT).
-const HEALTH_STATUS_CONFIG: Record<
-  DataStorageHealthStatus,
-  { text: string; dotClass: string; ringClass: string }
-> = {
+interface HealthStatusDisplayConfig {
+  text: string;
+  dotClass: string;
+  ringClass: string;
+}
+
+// NOTE: `text` here is used for compact-variant tooltips only.
+// DataStorageHealthStatusView renders its own labels for each state (non-compact variant).
+// VALID/INVALID intentionally use different wording between tooltip and status view (pre-existing).
+// TODO: migrate all state display strings to shared constants (following HEALTH_STATUS_UNCONFIGURED_TEXT)
+//       so tooltip and status view always stay in sync.
+const HEALTH_STATUS_CONFIG: Record<DataStorageHealthStatus, HealthStatusDisplayConfig> = {
   [DataStorageHealthStatus.VALID]: {
     text: 'Storage access is valid',
     dotClass: 'bg-green-500',
@@ -49,7 +54,7 @@ const HEALTH_STATUS_CONFIG: Record<
     ringClass: 'ring-neutral-400/50 dark:ring-neutral-500/50',
   },
 };
-const HEALTH_STATUS_NOT_FETCHED = {
+const HEALTH_STATUS_NOT_FETCHED: HealthStatusDisplayConfig = {
   text: 'Storage status not fetched yet',
   dotClass: 'bg-neutral-300 dark:bg-neutral-600',
   ringClass: 'ring-neutral-300/50 dark:ring-neutral-600/50',
@@ -96,6 +101,9 @@ export function DataStorageHealthIndicator({
           </div>
         </HoverCardTrigger>
 
+        {/* UNCONFIGURED is excluded: the tooltip already conveys the full message and the hovercard
+            would add no extra information. Revisit if the hovercard gains actionable content
+            (e.g. a link to the setup form) for this state. */}
         {isFetched && !isLoading && status !== DataStorageHealthStatus.UNCONFIGURED && (
           <HoverCardContent side={hovercardSide} align='start'>
             <HoverCardHeader>
@@ -118,5 +126,11 @@ export function DataStorageHealthIndicator({
     );
   }
 
-  return <DataStorageHealthStatusView status={status} errorMessage={errorMessage} />;
+  return (
+    <DataStorageHealthStatusView
+      status={status}
+      errorMessage={errorMessage}
+      isLoading={isLoading}
+    />
+  );
 }

--- a/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthIndicator.tsx
+++ b/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthIndicator.tsx
@@ -14,7 +14,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/too
 import { useDataStorageHealthStatus } from '../../model/hooks/useDataStorageHealthStatus';
 import {
   DataStorageHealthStatus,
-  HEALTH_STATUS_UNCONFIGURED_TEXT,
+  UNCONFIGURED_STATUS_LABEL,
 } from '../../services/data-storage-health-status.service';
 import { DataStorageHealthStatusView } from './DataStorageHealthStatusView';
 import { DataStorageHealthDot } from './DataStorageHealthDot';
@@ -35,7 +35,7 @@ interface HealthStatusDisplayConfig {
 // NOTE: `text` here is used for compact-variant tooltips only.
 // DataStorageHealthStatusView renders its own labels for each state (non-compact variant).
 // VALID/INVALID intentionally use different wording between tooltip and status view (pre-existing).
-// TODO: migrate all state display strings to shared constants (following HEALTH_STATUS_UNCONFIGURED_TEXT)
+// TODO: migrate all state display strings to shared constants (following UNCONFIGURED_STATUS_LABEL)
 //       so tooltip and status view always stay in sync.
 const HEALTH_STATUS_CONFIG: Record<DataStorageHealthStatus, HealthStatusDisplayConfig> = {
   [DataStorageHealthStatus.VALID]: {
@@ -49,7 +49,7 @@ const HEALTH_STATUS_CONFIG: Record<DataStorageHealthStatus, HealthStatusDisplayC
     ringClass: 'ring-red-500/50',
   },
   [DataStorageHealthStatus.UNCONFIGURED]: {
-    text: HEALTH_STATUS_UNCONFIGURED_TEXT,
+    text: UNCONFIGURED_STATUS_LABEL,
     dotClass: 'bg-neutral-400 dark:bg-neutral-500',
     ringClass: 'ring-neutral-400/50 dark:ring-neutral-500/50',
   },
@@ -101,10 +101,7 @@ export function DataStorageHealthIndicator({
           </div>
         </HoverCardTrigger>
 
-        {/* UNCONFIGURED is excluded: the tooltip already conveys the full message and the hovercard
-            would add no extra information. Revisit if the hovercard gains actionable content
-            (e.g. a link to the setup form) for this state. */}
-        {isFetched && !isLoading && status !== DataStorageHealthStatus.UNCONFIGURED && (
+        {isFetched && !isLoading && (
           <HoverCardContent side={hovercardSide} align='start'>
             <HoverCardHeader>
               <HoverCardHeaderText>

--- a/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView.tsx
+++ b/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView.tsx
@@ -7,9 +7,19 @@ import {
 interface Props {
   status: DataStorageHealthStatus;
   errorMessage?: string;
+  isLoading?: boolean;
 }
 
-export function DataStorageHealthStatusView({ status, errorMessage }: Props) {
+export function DataStorageHealthStatusView({ status, errorMessage, isLoading }: Props) {
+  if (isLoading) {
+    return (
+      <div className='text-muted-foreground flex animate-pulse items-center gap-2 text-sm'>
+        <CircleDashed className='size-4' />
+        <span>Validating storage access...</span>
+      </div>
+    );
+  }
+
   if (status === DataStorageHealthStatus.VALID) {
     return (
       <div className='flex items-center gap-2 text-sm text-green-500'>

--- a/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView.tsx
+++ b/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView.tsx
@@ -1,7 +1,7 @@
 import { CircleCheck, CircleDashed, TriangleAlert } from 'lucide-react';
 import {
   DataStorageHealthStatus,
-  HEALTH_STATUS_UNCONFIGURED_TEXT,
+  UNCONFIGURED_STATUS_LABEL,
 } from '../../services/data-storage-health-status.service';
 
 interface Props {
@@ -33,7 +33,7 @@ export function DataStorageHealthStatusView({ status, errorMessage, isLoading }:
     return (
       <div className='text-muted-foreground flex items-center gap-2 text-sm'>
         <CircleDashed className='size-4' />
-        <span>{HEALTH_STATUS_UNCONFIGURED_TEXT}</span>
+        <span>{UNCONFIGURED_STATUS_LABEL}</span>
       </div>
     );
   }

--- a/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView.tsx
+++ b/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView.tsx
@@ -1,5 +1,8 @@
-import { CircleCheck, TriangleAlert } from 'lucide-react';
-import { DataStorageHealthStatus } from '../../services/data-storage-health-status.service';
+import { CircleCheck, CircleDashed, TriangleAlert } from 'lucide-react';
+import {
+  DataStorageHealthStatus,
+  HEALTH_STATUS_UNCONFIGURED_TEXT,
+} from '../../services/data-storage-health-status.service';
 
 interface Props {
   status: DataStorageHealthStatus;
@@ -12,6 +15,15 @@ export function DataStorageHealthStatusView({ status, errorMessage }: Props) {
       <div className='flex items-center gap-2 text-sm text-green-500'>
         <CircleCheck className='size-4' />
         <span>Storage access validated</span>
+      </div>
+    );
+  }
+
+  if (status === DataStorageHealthStatus.UNCONFIGURED) {
+    return (
+      <div className='text-muted-foreground flex items-center gap-2 text-sm'>
+        <CircleDashed className='size-4' />
+        <span>{HEALTH_STATUS_UNCONFIGURED_TEXT}</span>
       </div>
     );
   }

--- a/apps/web/src/features/data-storage/shared/model/hooks/useDataStorageHealthStatus.ts
+++ b/apps/web/src/features/data-storage/shared/model/hooks/useDataStorageHealthStatus.ts
@@ -51,7 +51,7 @@ export function useDataStorageHealthStatus(storageId: string): UseDataStorageHea
   const isFetched = Boolean(cached);
 
   return {
-    status: cached?.status ?? DataStorageHealthStatus.INVALID,
+    status: cached?.status ?? DataStorageHealthStatus.UNCONFIGURED,
     errorMessage: cached?.errorMessage,
     isLoading: !isFetched,
     isFetched,

--- a/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
+++ b/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
@@ -127,8 +127,13 @@ function processQueue(): void {
         healthStatusCache.set(storageId, cached);
         notifySubscribers();
       })
-      .catch(() => {
-        // Silently ignore errors — the item stays uncached and can be retried
+      .catch((error: unknown) => {
+        console.error(`[DataStorageHealthStatus] Failed to validate storage ${storageId}:`, error);
+        healthStatusCache.set(storageId, {
+          status: DataStorageHealthStatus.INVALID,
+          errorMessage: 'Unable to validate storage access',
+        });
+        notifySubscribers();
       })
       .finally(() => {
         inFlightRequests.delete(storageId);

--- a/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
+++ b/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
@@ -1,5 +1,8 @@
 import type { AxiosRequestConfig } from '../../../../app/api';
-import { dataStorageApiService } from '../api/data-storage-api.service';
+import {
+  dataStorageApiService,
+  type DataStorageValidationCode,
+} from '../api/data-storage-api.service';
 
 /**
  * Health status for a data storage.
@@ -7,7 +10,16 @@ import { dataStorageApiService } from '../api/data-storage-api.service';
 export enum DataStorageHealthStatus {
   VALID = 'valid',
   INVALID = 'invalid',
+  UNCONFIGURED = 'unconfigured',
 }
+
+/**
+ * Must match ValidationResultCode.UNCONFIGURED on the backend.
+ * If the backend enum value changes, update this constant accordingly.
+ */
+const UNCONFIGURED_CODE: DataStorageValidationCode = 'UNCONFIGURED';
+
+export const HEALTH_STATUS_UNCONFIGURED_TEXT = 'Complete setup to activate Storage';
 
 export interface CachedDataStorageHealthStatus {
   status: DataStorageHealthStatus;
@@ -98,8 +110,17 @@ function processQueue(): void {
     dataStorageApiService
       .validateAccess(storageId, config)
       .then(response => {
+        let status: DataStorageHealthStatus;
+        if (response.valid) {
+          status = DataStorageHealthStatus.VALID;
+        } else if (response.code === UNCONFIGURED_CODE) {
+          status = DataStorageHealthStatus.UNCONFIGURED;
+        } else {
+          status = DataStorageHealthStatus.INVALID;
+        }
+
         const cached: CachedDataStorageHealthStatus = {
-          status: response.valid ? DataStorageHealthStatus.VALID : DataStorageHealthStatus.INVALID,
+          status,
           errorMessage: response.errorMessage,
         };
 

--- a/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
+++ b/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
@@ -19,7 +19,7 @@ export enum DataStorageHealthStatus {
  */
 const UNCONFIGURED_CODE: DataStorageValidationCode = 'UNCONFIGURED';
 
-export const HEALTH_STATUS_UNCONFIGURED_TEXT = 'Complete setup to activate Storage';
+export const UNCONFIGURED_STATUS_LABEL = 'Complete setup to activate Storage';
 
 export interface CachedDataStorageHealthStatus {
   status: DataStorageHealthStatus;

--- a/apps/web/src/features/data-storage/shared/utils/storage-health-sort-rank.utils.ts
+++ b/apps/web/src/features/data-storage/shared/utils/storage-health-sort-rank.utils.ts
@@ -2,10 +2,12 @@ import { DataStorageHealthStatus } from '../services/data-storage-health-status.
 
 export function getDataStorageHealthSortRank(healthStatus?: DataStorageHealthStatus): number {
   switch (healthStatus) {
-    case DataStorageHealthStatus.INVALID:
+    case DataStorageHealthStatus.UNCONFIGURED:
       return 1;
-    case DataStorageHealthStatus.VALID:
+    case DataStorageHealthStatus.INVALID:
       return 2;
+    case DataStorageHealthStatus.VALID:
+      return 3;
     default:
       return 0; // not fetched / loading
   }

--- a/apps/web/src/features/data-storage/shared/utils/storage-health-sort-rank.utils.ts
+++ b/apps/web/src/features/data-storage/shared/utils/storage-health-sort-rank.utils.ts
@@ -1,5 +1,9 @@
 import { DataStorageHealthStatus } from '../services/data-storage-health-status.service';
 
+// Sort priority: not fetched (0) → unconfigured (1) → invalid (2) → valid (3).
+// UNCONFIGURED ranks above INVALID because a new storage that hasn't been set up yet
+// is expected and actionable, while INVALID indicates a regression that needs attention.
+// Lower rank = appears first when sorted ascending.
 export function getDataStorageHealthSortRank(healthStatus?: DataStorageHealthStatus): number {
   switch (healthStatus) {
     case DataStorageHealthStatus.UNCONFIGURED:


### PR DESCRIPTION
# Problem

A freshly created storage with no configuration showed a red health indicator — the same visual treatment as a storage with broken credentials or a failed connection. This was misleading: red implies something is broken and needs fixing, but an unconfigured storage is simply waiting to be set up. The root cause was that the backend returned a plain `{ valid: false }` response for all failure cases with no machine-readable signal to distinguish "not configured yet" from "configured but invalid", and the frontend mapped all `valid: false` responses to the red `INVALID` state.

# Solution

Introduced a third health state — `UNCONFIGURED` — threaded end-to-end from the backend validation contract to the UI. The backend now returns a machine-readable `code: 'UNCONFIGURED'` field (via a new `ValidationResultCode` enum) alongside the error message for storages with no `config` or no `credentialId`. The frontend detects this code and maps it to a distinct grey indicator with a `CircleDashed` icon, leaving red exclusively for storages that have been configured but fail access validation. The detection uses the typed `code` field rather than string-matching the error message, making the contract explicit and resilient to message copy changes.

# Changes

- Added `ValidationResultCode` enum and `code` field to `ValidationResult` class; added `static unconfigured()`, `success()`, and `failure()` factory methods
- Updated `ValidateDataStorageAccessService` to return `ValidationResult.unconfigured(...)` for missing config/credential cases; unified plain object literals to use factory methods
- Added `code` field to `DataStorageAccessValidationResponseApiDto` with Swagger enum documentation; threaded it through the mapper
- Added `DataStorageValidationCode` literal type and `code` field to `DataStorageValidationResponseDto` on the frontend
- Added `UNCONFIGURED` to `DataStorageHealthStatus` enum; updated status mapping in the health service to detect `code === 'UNCONFIGURED'`
- Added `HEALTH_STATUS_UNCONFIGURED_TEXT` shared constant to eliminate duplicate display strings across components
- Added grey `UNCONFIGURED` entry to `HEALTH_STATUS_CONFIG`; differentiated `NOT_FETCHED` ring class from `UNCONFIGURED`; suppressed hovercard for `UNCONFIGURED` state
- Added `UNCONFIGURED` case to `DataStorageHealthStatusView` with `CircleDashed` icon
- Changed default loading status from `INVALID` to `UNCONFIGURED` to prevent red flash before fetch completes
- Updated `getDataStorageHealthSortRank` sort order: loading (0) → unconfigured (1) → invalid (2) → valid (3)
- Added `isLoading` prop to `DataStorageHealthStatusView`; renders an animated `CircleDashed` loading state
  to distinguish "fetching" from "unconfigured" in the non-compact variant
- Added e2e contract test asserting `code === 'UNCONFIGURED'` for a storage with no config,
  guarding against future backend enum drift
---
![Example of implementation](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/eb29ea7f-6ec5-48e9-ebaf-080c17b8eb00/public)
---
![Example of the implementation](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/5a559306-4106-424c-0c8a-cd5f98c4a200/public)
