### PR TITLE
feat: joinable data marts and extendable output schema

### DIFF
--- a/.changeset/add-data-mart-relationships-and-blended-reports.md
+++ b/.changeset/add-data-mart-relationships-and-blended-reports.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Joinable Data Marts and Joined Reports
+
+You can now connect data marts to each other and build reports that combine fields from several joined data marts in a single output.
+
+On a data mart's **Data Setup** tab, the new **Joinable Data Marts** block lets you add joinable data marts, configure join conditions, choose which fields each joined data mart exposes, and override their aliases or aggregations. When editing a Google Sheets, Looker Studio, or Email report, the **Report Columns** picker now shows fields from the data mart together with fields available from joined data marts, so a single report can combine columns from several data marts at once. The generated SQL is available for inspection, and any joined report can be saved as a standalone data mart.
+
+Supported on BigQuery, Snowflake, Redshift, Athena, and Databricks.

--- a/apps/backend/src/data-marts/controllers/data-mart-relationship.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart-relationship.controller.ts
@@ -1,0 +1,89 @@
+import { Controller, Get, Post, Patch, Delete, Body, Param } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { AuthContext, AuthorizationContext, Auth } from '../../idp';
+import { Role, Strategy } from '../../idp/types/role-config.types';
+import { RelationshipMapper } from '../mappers/relationship.mapper';
+import { CreateRelationshipRequestApiDto } from '../dto/presentation/create-relationship-request-api.dto';
+import { UpdateRelationshipRequestApiDto } from '../dto/presentation/update-relationship-request-api.dto';
+import { RelationshipResponseApiDto } from '../dto/presentation/relationship-response-api.dto';
+import { CreateDataMartRelationshipService } from '../use-cases/create-data-mart-relationship.service';
+import { UpdateDataMartRelationshipService } from '../use-cases/update-data-mart-relationship.service';
+import { DeleteDataMartRelationshipService } from '../use-cases/delete-data-mart-relationship.service';
+import { ListDataMartRelationshipsService } from '../use-cases/list-data-mart-relationships.service';
+import { GetDataMartRelationshipService } from '../use-cases/get-data-mart-relationship.service';
+import {
+  CreateRelationshipSpec,
+  ListRelationshipsByDataMartSpec,
+  GetRelationshipSpec,
+  UpdateRelationshipSpec,
+  DeleteRelationshipSpec,
+} from './spec/data-mart-relationship.api';
+
+@Controller('data-marts/:dataMartId/relationships')
+@ApiTags('Data Mart Relationships')
+export class DataMartRelationshipController {
+  constructor(
+    private readonly createService: CreateDataMartRelationshipService,
+    private readonly updateService: UpdateDataMartRelationshipService,
+    private readonly deleteService: DeleteDataMartRelationshipService,
+    private readonly listService: ListDataMartRelationshipsService,
+    private readonly getService: GetDataMartRelationshipService,
+    private readonly mapper: RelationshipMapper
+  ) {}
+
+  @Auth(Role.editor(Strategy.INTROSPECT))
+  @Post()
+  @CreateRelationshipSpec()
+  async create(
+    @AuthContext() context: AuthorizationContext,
+    @Param('dataMartId') dataMartId: string,
+    @Body() dto: CreateRelationshipRequestApiDto
+  ): Promise<RelationshipResponseApiDto> {
+    const command = this.mapper.toCreateCommand(dataMartId, context, dto);
+    const relationship = await this.createService.run(command);
+    return this.mapper.toResponse(relationship);
+  }
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get()
+  @ListRelationshipsByDataMartSpec()
+  async list(@Param('dataMartId') dataMartId: string): Promise<RelationshipResponseApiDto[]> {
+    return this.listService.run(dataMartId);
+  }
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get(':id')
+  @GetRelationshipSpec()
+  async get(
+    @Param('dataMartId') dataMartId: string,
+    @Param('id') id: string
+  ): Promise<RelationshipResponseApiDto> {
+    return this.getService.run(id, dataMartId);
+  }
+
+  @Auth(Role.editor(Strategy.INTROSPECT))
+  @Patch(':id')
+  @UpdateRelationshipSpec()
+  async update(
+    @AuthContext() context: AuthorizationContext,
+    @Param('dataMartId') dataMartId: string,
+    @Param('id') id: string,
+    @Body() dto: UpdateRelationshipRequestApiDto
+  ): Promise<RelationshipResponseApiDto> {
+    const command = this.mapper.toUpdateCommand(id, dataMartId, context, dto);
+    const relationship = await this.updateService.run(command);
+    return this.mapper.toResponse(relationship);
+  }
+
+  @Auth(Role.editor(Strategy.INTROSPECT))
+  @Delete(':id')
+  @DeleteRelationshipSpec()
+  async remove(
+    @AuthContext() context: AuthorizationContext,
+    @Param('dataMartId') dataMartId: string,
+    @Param('id') id: string
+  ): Promise<void> {
+    const command = this.mapper.toGetCommand(id, dataMartId, context);
+    await this.deleteService.run(command);
+  }
+}

--- a/apps/backend/src/data-marts/controllers/data-mart-relationship.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart-relationship.controller.ts
@@ -40,8 +40,7 @@ export class DataMartRelationshipController {
     @Body() dto: CreateRelationshipRequestApiDto
   ): Promise<RelationshipResponseApiDto> {
     const command = this.mapper.toCreateCommand(dataMartId, context, dto);
-    const relationship = await this.createService.run(command);
-    return this.mapper.toResponse(relationship);
+    return this.createService.run(command);
   }
 
   @Auth(Role.viewer(Strategy.PARSE))
@@ -71,8 +70,7 @@ export class DataMartRelationshipController {
     @Body() dto: UpdateRelationshipRequestApiDto
   ): Promise<RelationshipResponseApiDto> {
     const command = this.mapper.toUpdateCommand(id, dataMartId, context, dto);
-    const relationship = await this.updateService.run(command);
-    return this.mapper.toResponse(relationship);
+    return this.updateService.run(command);
   }
 
   @Auth(Role.editor(Strategy.INTROSPECT))

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.ts
@@ -12,6 +12,8 @@ import {
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Auth, AuthContext, AuthorizationContext, Role, Strategy } from '../../idp';
+import { BlendableSchemaDto } from '../dto/domain/blendable-schema.dto';
+import { BlendableSchemaService } from '../services/blendable-schema.service';
 import { BatchDataMartHealthStatusRequestApiDto } from '../dto/presentation/batch-data-mart-health-status-request-api.dto';
 import { BatchDataMartHealthStatusResponseApiDto } from '../dto/presentation/batch-data-mart-health-status-response-api.dto';
 import { CreateDataMartRequestApiDto } from '../dto/presentation/create-data-mart-request-api.dto';
@@ -23,6 +25,7 @@ import { DataMartValidationResponseApiDto } from '../dto/presentation/data-mart-
 import { PaginatedDataMartsResponseApiDto } from '../dto/presentation/paginated-data-marts-response-api.dto';
 import { RunDataMartRequestApiDto } from '../dto/presentation/run-data-mart-request-api.dto';
 import { UpdateDataMartDefinitionApiDto } from '../dto/presentation/update-data-mart-definition-api.dto';
+import { UpdateBlendedFieldsConfigApiDto } from '../dto/presentation/update-blended-fields-config-api.dto';
 import { UpdateDataMartDescriptionApiDto } from '../dto/presentation/update-data-mart-description-api.dto';
 import { UpdateDataMartOwnersApiDto } from '../dto/presentation/update-data-mart-owners-api.dto';
 import { UpdateDataMartSchemaApiDto } from '../dto/presentation/update-data-mart-schema-api.dto';
@@ -42,6 +45,7 @@ import { PublishDataMartService } from '../use-cases/publish-data-mart.service';
 import { RunDataMartService } from '../use-cases/run-data-mart.service';
 import { UpdateDataMartDefinitionService } from '../use-cases/update-data-mart-definition.service';
 import { UpdateDataMartDescriptionService } from '../use-cases/update-data-mart-description.service';
+import { UpdateBlendedFieldsConfigService } from '../use-cases/update-blended-fields-config.service';
 import { UpdateDataMartSchemaService } from '../use-cases/update-data-mart-schema.service';
 import { UpdateDataMartOwnersService } from '../use-cases/update-data-mart-owners.service';
 import { UpdateAvailabilityService } from '../use-cases/update-availability.service';
@@ -94,7 +98,9 @@ export class DataMartController {
     private readonly batchDataMartHealthStatusService: BatchDataMartHealthStatusService,
     private readonly updateOwnersService: UpdateDataMartOwnersService,
     private readonly updateAvailabilityService: UpdateAvailabilityService,
-    private readonly memberOwnershipWarningsService: MemberOwnershipWarningsService
+    private readonly memberOwnershipWarningsService: MemberOwnershipWarningsService,
+    private readonly blendableSchemaService: BlendableSchemaService,
+    private readonly updateBlendedFieldsConfigService: UpdateBlendedFieldsConfigService
   ) {}
 
   @Auth(Role.editor(Strategy.INTROSPECT))
@@ -280,6 +286,18 @@ export class DataMartController {
     return this.mapper.toResponse(dataMart);
   }
 
+  @Auth(Role.editor(Strategy.INTROSPECT))
+  @Put(':id/blended-fields-config')
+  async updateBlendedFieldsConfig(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string,
+    @Body() dto: UpdateBlendedFieldsConfigApiDto
+  ): Promise<DataMartResponseApiDto> {
+    const command = this.mapper.toUpdateBlendedFieldsConfigCommand(id, context, dto);
+    const result = await this.updateBlendedFieldsConfigService.run(command);
+    return this.mapper.toResponse(result);
+  }
+
   @Auth(Role.viewer(Strategy.PARSE))
   @Get(':id/runs')
   @GetDataMartRunsSpec()
@@ -337,5 +355,14 @@ export class DataMartController {
       dto.availableForReporting,
       dto.availableForMaintenance
     );
+  }
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get(':id/blendable-schema')
+  async getBlendableSchema(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') dataMartId: string
+  ): Promise<BlendableSchemaDto> {
+    return this.blendableSchemaService.computeBlendableSchema(dataMartId, context.projectId);
   }
 }

--- a/apps/backend/src/data-marts/controllers/data-storage-relationship.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-storage-relationship.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Auth } from '../../idp';
+import { Role, Strategy } from '../../idp/types/role-config.types';
+import { RelationshipMapper } from '../mappers/relationship.mapper';
+import { RelationshipResponseApiDto } from '../dto/presentation/relationship-response-api.dto';
+import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
+import { ListRelationshipsByStorageSpec } from './spec/data-mart-relationship.api';
+
+@Controller('data-storages/:storageId/relationships')
+@ApiTags('Data Storage Relationships')
+export class DataStorageRelationshipController {
+  constructor(
+    private readonly relationshipService: DataMartRelationshipService,
+    private readonly mapper: RelationshipMapper
+  ) {}
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get()
+  @ListRelationshipsByStorageSpec()
+  async listByStorage(
+    @Param('storageId') storageId: string
+  ): Promise<RelationshipResponseApiDto[]> {
+    const relationships = await this.relationshipService.findByStorageId(storageId);
+    return this.mapper.toResponseList(relationships);
+  }
+}

--- a/apps/backend/src/data-marts/controllers/report.controller.ts
+++ b/apps/backend/src/data-marts/controllers/report.controller.ts
@@ -24,6 +24,8 @@ import { ListReportsByInsightTemplateService } from '../use-cases/list-reports-b
 import { DeleteReportService } from '../use-cases/delete-report.service';
 import { RunReportService } from '../use-cases/run-report.service';
 import { UpdateReportService } from '../use-cases/update-report.service';
+import { GetReportGeneratedSqlService } from '../use-cases/get-report-generated-sql.service';
+import { CopyReportAsDataMartService } from '../use-cases/copy-report-as-data-mart.service';
 import {
   CreateReportSpec,
   GetReportSpec,
@@ -33,6 +35,8 @@ import {
   RunReportSpec,
   UpdateReportSpec,
   ListReportsByInsightTemplateSpec,
+  GetReportGeneratedSqlSpec,
+  CopyReportAsDataMartSpec,
 } from './spec/report.api';
 import { RunType } from '../../common/scheduler/shared/types';
 import { OwnerFilter } from '../enums/owner-filter.enum';
@@ -49,6 +53,8 @@ export class ReportController {
     private readonly deleteReportService: DeleteReportService,
     private readonly runReportService: RunReportService,
     private readonly updateReportService: UpdateReportService,
+    private readonly getReportGeneratedSqlService: GetReportGeneratedSqlService,
+    private readonly copyReportAsDataMartService: CopyReportAsDataMartService,
     private readonly mapper: ReportMapper
   ) {}
 
@@ -151,5 +157,30 @@ export class ReportController {
     const command = this.mapper.toUpdateDomainCommand(id, context, dto);
     const report = await this.updateReportService.run(command);
     return this.mapper.toResponse(report);
+  }
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get(':id/generated-sql')
+  @GetReportGeneratedSqlSpec()
+  async getGeneratedSql(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string
+  ): Promise<{ sql: string }> {
+    return this.getReportGeneratedSqlService.run(id, context.projectId);
+  }
+
+  @Auth(Role.editor(Strategy.INTROSPECT))
+  @Post(':id/copy-as-data-mart')
+  @CopyReportAsDataMartSpec()
+  async copyAsDataMart(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string
+  ): Promise<{ dataMartId: string }> {
+    const dataMart = await this.copyReportAsDataMartService.run(
+      id,
+      context.userId,
+      context.projectId
+    );
+    return { dataMartId: dataMart.id };
   }
 }

--- a/apps/backend/src/data-marts/controllers/report.controller.ts
+++ b/apps/backend/src/data-marts/controllers/report.controller.ts
@@ -166,7 +166,8 @@ export class ReportController {
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string
   ): Promise<{ sql: string }> {
-    return this.getReportGeneratedSqlService.run(id, context.projectId);
+    const command = this.mapper.toGetGeneratedSqlCommand(id, context);
+    return this.getReportGeneratedSqlService.run(command);
   }
 
   @Auth(Role.editor(Strategy.INTROSPECT))
@@ -176,11 +177,8 @@ export class ReportController {
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string
   ): Promise<{ dataMartId: string }> {
-    const dataMart = await this.copyReportAsDataMartService.run(
-      id,
-      context.userId,
-      context.projectId
-    );
+    const command = this.mapper.toCopyAsDataMartCommand(id, context);
+    const dataMart = await this.copyReportAsDataMartService.run(command);
     return { dataMartId: dataMart.id };
   }
 }

--- a/apps/backend/src/data-marts/controllers/spec/data-mart-relationship.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-mart-relationship.api.ts
@@ -1,0 +1,82 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+} from '@nestjs/swagger';
+import { RelationshipResponseApiDto } from '../../dto/presentation/relationship-response-api.dto';
+import { CreateRelationshipRequestApiDto } from '../../dto/presentation/create-relationship-request-api.dto';
+import { UpdateRelationshipRequestApiDto } from '../../dto/presentation/update-relationship-request-api.dto';
+
+export function CreateRelationshipSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Create a new relationship for a data mart' }),
+    ApiParam({ name: 'dataMartId', description: 'Source data mart ID' }),
+    ApiBody({ type: CreateRelationshipRequestApiDto }),
+    ApiCreatedResponse({
+      description: 'The relationship has been successfully created.',
+      type: RelationshipResponseApiDto,
+    })
+  );
+}
+
+export function ListRelationshipsByDataMartSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'List all relationships for a data mart' }),
+    ApiParam({ name: 'dataMartId', description: 'Source data mart ID' }),
+    ApiOkResponse({
+      description: 'List of relationships for the data mart',
+      type: [RelationshipResponseApiDto],
+    })
+  );
+}
+
+export function GetRelationshipSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get a relationship by ID' }),
+    ApiParam({ name: 'dataMartId', description: 'Source data mart ID' }),
+    ApiParam({ name: 'id', description: 'Relationship ID' }),
+    ApiOkResponse({
+      description: 'The relationship',
+      type: RelationshipResponseApiDto,
+    })
+  );
+}
+
+export function UpdateRelationshipSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Update an existing relationship' }),
+    ApiParam({ name: 'dataMartId', description: 'Source data mart ID' }),
+    ApiParam({ name: 'id', description: 'Relationship ID' }),
+    ApiBody({ type: UpdateRelationshipRequestApiDto }),
+    ApiOkResponse({
+      description: 'The relationship has been successfully updated.',
+      type: RelationshipResponseApiDto,
+    })
+  );
+}
+
+export function DeleteRelationshipSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Delete a relationship' }),
+    ApiParam({ name: 'dataMartId', description: 'Source data mart ID' }),
+    ApiParam({ name: 'id', description: 'Relationship ID' }),
+    ApiNoContentResponse({
+      description: 'The relationship has been successfully deleted.',
+    })
+  );
+}
+
+export function ListRelationshipsByStorageSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'List all relationships for a data storage' }),
+    ApiParam({ name: 'storageId', description: 'Data storage ID' }),
+    ApiOkResponse({
+      description: 'List of relationships for the data storage',
+      type: [RelationshipResponseApiDto],
+    })
+  );
+}

--- a/apps/backend/src/data-marts/controllers/spec/report.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.api.ts
@@ -105,3 +105,25 @@ export function ListReportsByInsightTemplateSpec() {
     })
   );
 }
+
+export function GetReportGeneratedSqlSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get the generated SQL for a report' }),
+    ApiParam({ name: 'id', description: 'Report ID' }),
+    ApiOkResponse({
+      description: 'The generated SQL query for the report.',
+      schema: { type: 'object', properties: { sql: { type: 'string' } } },
+    })
+  );
+}
+
+export function CopyReportAsDataMartSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Copy a report as a new data mart with SQL definition' }),
+    ApiParam({ name: 'id', description: 'Report ID' }),
+    ApiCreatedResponse({
+      description: 'The new data mart has been successfully created.',
+      schema: { type: 'object', properties: { dataMartId: { type: 'string' } } },
+    })
+  );
+}

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -336,6 +336,10 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
         columnsToAllocate,
         'COLUMNS'
       );
+
+      // Keep local tracking in sync so subsequent requests (header format
+      // reset, etc.) operate on the correct column range.
+      this.availableColumnsCount += columnsToAllocate;
     }, 'Adding columns to sheet as needed');
   }
 
@@ -389,7 +393,12 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
         this.metadataFormatter.createNoteRequest(sheetId, h.description, 0, i)
       );
 
+      // Reset header-row formatting across ALL columns first, then apply
+      // the new header format only to the columns we are about to write.
+      // Without this reset, columns that were part of a previous (wider)
+      // report keep the old gray header background on empty cells.
       await this.adapter.batchUpdate(spreadsheetId, [
+        this.headerFormatter.createHeaderClearFormatRequest(sheetId, this.availableColumnsCount),
         this.headerFormatter.createHeaderFormatRequest(sheetId, headers.length),
         ...descriptions,
       ]);

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-header-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-header-formatter.ts
@@ -63,4 +63,39 @@ export class SheetHeaderFormatter {
       },
     };
   }
+
+  /**
+   * Creates a request to reset header-row formatting (background and text
+   * format) across every column of the sheet.
+   *
+   * This is applied BEFORE `createHeaderFormatRequest` to wipe leftover
+   * styling from previous runs — otherwise columns that are no longer part
+   * of the selection keep the old gray header background (visible on the
+   * right side of the sheet as empty-but-styled cells).
+   *
+   * @param sheetId - ID of the sheet to reset
+   * @param totalColumnsCount - Total number of columns currently allocated
+   *   on the sheet (equals `sheet.properties.gridProperties.columnCount`).
+   * @returns Google Sheets API request object for clearing header row format
+   */
+  public createHeaderClearFormatRequest(
+    sheetId: number,
+    totalColumnsCount: number
+  ): sheets_v4.Schema$Request {
+    return {
+      repeatCell: {
+        range: {
+          sheetId: sheetId,
+          startRowIndex: 0,
+          endRowIndex: 1,
+          startColumnIndex: 0,
+          endColumnIndex: totalColumnsCount,
+        },
+        cell: {
+          userEnteredFormat: {},
+        },
+        fields: 'userEnteredFormat.textFormat,userEnteredFormat.backgroundColor',
+      },
+    };
+  }
 }

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
@@ -457,7 +457,7 @@ describe('LookerStudioConnectorApiService', () => {
       setupRun({ needsBlending: true, blendedSql: 'SELECT 1' });
       blendedReportDataService.logBlendedSqlIfNeeded.mockImplementation((decision, logger) => {
         if (decision?.needsBlending && decision.blendedSql && logger) {
-          logger.log({ type: 'blended-sql', sql: decision.blendedSql });
+          logger.log({ type: 'joined-data-marts-sql', sql: decision.blendedSql });
         }
       });
 
@@ -471,7 +471,7 @@ describe('LookerStudioConnectorApiService', () => {
       expect(reportRunService.finish).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          logs: expect.arrayContaining([expect.stringContaining('"type":"blended-sql"')]),
+          logs: expect.arrayContaining([expect.stringContaining('"type":"joined-data-marts-sql"')]),
           errors: [],
         })
       );

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
@@ -11,6 +11,8 @@ jest.mock('@owox/internal-helpers', () => ({
 }));
 
 // Import after mocking
+import { SystemTimeService } from '../../../../common/scheduler/services/system-time.service';
+import { BlendedReportDataService } from '../../../services/blended-report-data.service';
 import { ConsumptionTrackingService } from '../../../services/consumption-tracking.service';
 import { LookerStudioReportRunService } from '../../../services/looker-studio-report-run.service';
 import { ProjectBalanceService } from '../../../services/project-balance.service';
@@ -30,6 +32,8 @@ describe('LookerStudioConnectorApiService', () => {
   let consumptionTrackingService: jest.Mocked<ConsumptionTrackingService>;
   let projectBalanceService: jest.Mocked<ProjectBalanceService>;
   let eventDispatcher: jest.Mocked<{ publishExternal: jest.Mock }>;
+  let blendedReportDataService: jest.Mocked<BlendedReportDataService>;
+  let systemTimeService: jest.Mocked<SystemTimeService>;
 
   const originalEnv = process.env;
 
@@ -68,6 +72,15 @@ describe('LookerStudioConnectorApiService', () => {
       publishExternal: jest.fn(),
     };
 
+    blendedReportDataService = {
+      resolveBlendingDecision: jest.fn().mockResolvedValue({ needsBlending: false }),
+      logBlendedSqlIfNeeded: jest.fn(),
+    } as unknown as jest.Mocked<BlendedReportDataService>;
+
+    systemTimeService = {
+      now: jest.fn().mockReturnValue(new Date('2026-04-17T00:00:00.000Z').toISOString()),
+    } as unknown as jest.Mocked<SystemTimeService>;
+
     service = new LookerStudioConnectorApiService(
       {} as LookerStudioConnectorApiConfigService,
       {} as LookerStudioConnectorApiSchemaService,
@@ -77,7 +90,9 @@ describe('LookerStudioConnectorApiService', () => {
       consumptionTrackingService,
       eventDispatcher as any,
       reportRunService,
-      projectBalanceService
+      projectBalanceService,
+      blendedReportDataService,
+      systemTimeService
     );
 
     (service as any).logger = {
@@ -379,6 +394,104 @@ describe('LookerStudioConnectorApiService', () => {
 
         expect(mockReportRun.markAsUnsuccessful).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('blended SQL logging', () => {
+    const setupRun = (blendingDecision: unknown = { needsBlending: false }) => {
+      const mockReport = createMockReport();
+      const mockCachedReader = {
+        fromCache: true,
+        reader: {},
+        dataDescription: { dataHeaders: [] },
+        blendingDecision,
+      };
+      const mockReportRun = {
+        markAsSuccess: jest.fn(),
+        markAsUnsuccessful: jest.fn(),
+        getReport: jest.fn().mockReturnValue(mockReport),
+        getReportId: jest.fn().mockReturnValue('report-1'),
+      };
+
+      reportService.getByIdAndLookerStudioSecret.mockResolvedValue(mockReport);
+      cacheService.getOrCreateCachedReader.mockResolvedValue(mockCachedReader as any);
+      reportRunService.create.mockResolvedValue(mockReportRun as any);
+      return { mockReport, mockReportRun };
+    };
+
+    it('forwards cached blending decision to logBlendedSqlIfNeeded on full extraction', async () => {
+      const decision = {
+        needsBlending: true,
+        blendedSql: 'WITH cte AS (SELECT 1) SELECT * FROM cte',
+      };
+      setupRun(decision);
+
+      dataService.getData.mockResolvedValue({
+        response: { schema: [], rows: [], filtersApplied: [] },
+        meta: { limitExceeded: false, rowsSent: 0, bytesSent: undefined, limitReason: undefined },
+      } as any);
+
+      await service.getData(createMockRequest(false));
+
+      expect(blendedReportDataService.resolveBlendingDecision).not.toHaveBeenCalled();
+      expect(blendedReportDataService.logBlendedSqlIfNeeded).toHaveBeenCalledWith(
+        decision,
+        expect.objectContaining({ log: expect.any(Function), asArrays: expect.any(Function) })
+      );
+    });
+
+    it('does not log blended SQL on sample extraction', async () => {
+      setupRun({ needsBlending: true, blendedSql: 'SELECT 1' });
+
+      dataService.getData.mockResolvedValue({
+        response: { schema: [], rows: [], filtersApplied: [] },
+        meta: { limitExceeded: false, rowsSent: 0, bytesSent: undefined, limitReason: undefined },
+      } as any);
+
+      await service.getData(createMockRequest(true));
+
+      expect(blendedReportDataService.logBlendedSqlIfNeeded).not.toHaveBeenCalled();
+    });
+
+    it('passes collected logs to finish when blending produced SQL', async () => {
+      setupRun({ needsBlending: true, blendedSql: 'SELECT 1' });
+      blendedReportDataService.logBlendedSqlIfNeeded.mockImplementation((decision, logger) => {
+        if (decision?.needsBlending && decision.blendedSql && logger) {
+          logger.log({ type: 'blended-sql', sql: decision.blendedSql });
+        }
+      });
+
+      dataService.getData.mockResolvedValue({
+        response: { schema: [], rows: [], filtersApplied: [] },
+        meta: { limitExceeded: false, rowsSent: 0, bytesSent: undefined, limitReason: undefined },
+      } as any);
+
+      await service.getData(createMockRequest(false));
+
+      expect(reportRunService.finish).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          logs: expect.arrayContaining([expect.stringContaining('"type":"blended-sql"')]),
+          errors: [],
+        })
+      );
+    });
+
+    it('still persists empty logs/errors when blending is not needed', async () => {
+      setupRun({ needsBlending: false });
+
+      dataService.getData.mockResolvedValue({
+        response: { schema: [], rows: [], filtersApplied: [] },
+        meta: { limitExceeded: false, rowsSent: 0, bytesSent: undefined, limitReason: undefined },
+      } as any);
+
+      await service.getData(createMockRequest(false));
+
+      expect(blendedReportDataService.logBlendedSqlIfNeeded).toHaveBeenCalled();
+      expect(reportRunService.finish).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ logs: [], errors: [] })
+      );
     });
   });
 });

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
@@ -3,10 +3,16 @@ import { Response } from 'express';
 import { BusinessViolationException } from '../../../../common/exceptions/business-violation.exception';
 import { ProjectOperationBlockedException } from '../../../../common/exceptions/project-operation-blocked.exception';
 import { OwoxEventDispatcher } from '../../../../common/event-dispatcher/owox-event-dispatcher';
+import { SystemTimeService } from '../../../../common/scheduler/services/system-time.service';
 import { CachedReaderData } from '../../../dto/domain/cached-reader-data.dto';
 import { Report } from '../../../entities/report.entity';
 import { LookerReportRunEvent } from '../../../events/looker-report-run.event';
 import { LookerStudioReportRun } from '../../../models/looker-studio-report-run.model';
+import {
+  createReportRunLogger,
+  ReportRunLogger,
+} from '../../../report-run-logging/report-run-logger';
+import { BlendedReportDataService } from '../../../services/blended-report-data.service';
 import { ConsumptionTrackingService } from '../../../services/consumption-tracking.service';
 import { LookerStudioReportRunService } from '../../../services/looker-studio-report-run.service';
 import { ProjectBalanceService } from '../../../services/project-balance.service';
@@ -69,7 +75,9 @@ export class LookerStudioConnectorApiService {
     private readonly consumptionTrackingService: ConsumptionTrackingService,
     private readonly eventDispatcher: OwoxEventDispatcher,
     private readonly lookerStudioReportRunService: LookerStudioReportRunService,
-    private readonly projectBalanceService: ProjectBalanceService
+    private readonly projectBalanceService: ProjectBalanceService,
+    private readonly blendedReportDataService: BlendedReportDataService,
+    private readonly systemTimeService: SystemTimeService
   ) {}
 
   /**
@@ -182,6 +190,12 @@ export class LookerStudioConnectorApiService {
       throw new InternalServerErrorException('Failed to create report run');
     }
 
+    const reportRunLogger = createReportRunLogger(this.systemTimeService);
+    this.blendedReportDataService.logBlendedSqlIfNeeded(
+      cachedReader.blendingDecision,
+      reportRunLogger
+    );
+
     try {
       await this.projectBalanceService.verifyCanPerformOperations(report.dataMart.projectId);
       const context = await this.dataService.prepareStreamingContext(
@@ -200,13 +214,14 @@ export class LookerStudioConnectorApiService {
           new BusinessViolationException(
             limitReason ??
               `Looker Studio streaming response truncated (unknown reason), rows sent: ${rowCount}, bytes sent: ${bytesWritten}`
-          )
+          ),
+          reportRunLogger
         );
       } else {
-        await this.handleSuccessfulReportRun(reportRun, cachedReader);
+        await this.handleSuccessfulReportRun(reportRun, cachedReader, reportRunLogger);
       }
     } catch (e) {
-      await this.handleFailedReportRun(reportRun, e);
+      await this.handleFailedReportRun(reportRun, e, reportRunLogger);
       // If headers haven't been sent yet, throw to let error handler respond
       if (!res.headersSent) {
         throw e;
@@ -347,6 +362,12 @@ export class LookerStudioConnectorApiService {
       throw new InternalServerErrorException('Failed to create report run');
     }
 
+    const reportRunLogger = createReportRunLogger(this.systemTimeService);
+    this.blendedReportDataService.logBlendedSqlIfNeeded(
+      cachedReader.blendingDecision,
+      reportRunLogger
+    );
+
     try {
       await this.projectBalanceService.verifyCanPerformOperations(report.dataMart.projectId);
       const { response, meta } = await this.dataService.getData(request, report, cachedReader);
@@ -357,15 +378,16 @@ export class LookerStudioConnectorApiService {
           new BusinessViolationException(
             meta.limitReason ??
               `Looker Studio response truncated (unknown reason), rows sent: ${meta.rowsSent}`
-          )
+          ),
+          reportRunLogger
         );
       } else {
-        await this.handleSuccessfulReportRun(reportRun, cachedReader);
+        await this.handleSuccessfulReportRun(reportRun, cachedReader, reportRunLogger);
       }
 
       return response;
     } catch (e) {
-      await this.handleFailedReportRun(reportRun, e);
+      await this.handleFailedReportRun(reportRun, e, reportRunLogger);
       throw e;
     }
   }
@@ -384,11 +406,12 @@ export class LookerStudioConnectorApiService {
    */
   private async handleSuccessfulReportRun(
     reportRun: LookerStudioReportRun,
-    cachedReader: CachedReaderData
+    cachedReader: CachedReaderData,
+    reportRunLogger?: ReportRunLogger
   ) {
     reportRun.markAsSuccess();
 
-    const saved = await this.saveReportRunResultSafely(reportRun);
+    const saved = await this.saveReportRunResultSafely(reportRun, reportRunLogger);
     if (saved) {
       this.logger.log(`Report ${reportRun.getReportId()} completed successfully`);
     }
@@ -416,9 +439,13 @@ export class LookerStudioConnectorApiService {
    * @param reportRun - Failed report run
    * @param error - Error that caused the failure
    */
-  private async handleFailedReportRun(reportRun: LookerStudioReportRun, error: Error | string) {
+  private async handleFailedReportRun(
+    reportRun: LookerStudioReportRun,
+    error: Error | string,
+    reportRunLogger?: ReportRunLogger
+  ) {
     reportRun.markAsUnsuccessful(error);
-    await this.saveReportRunResultSafely(reportRun);
+    await this.saveReportRunResultSafely(reportRun, reportRunLogger);
     if (error instanceof ProjectOperationBlockedException) {
       this.logger.warn(`Report ${reportRun.getReportId()} execution restricted: ${error.message}`);
     } else {
@@ -445,9 +472,13 @@ export class LookerStudioConnectorApiService {
    *
    * @returns true if saved successfully, false otherwise
    */
-  private async saveReportRunResultSafely(reportRun: LookerStudioReportRun): Promise<boolean> {
+  private async saveReportRunResultSafely(
+    reportRun: LookerStudioReportRun,
+    reportRunLogger?: ReportRunLogger
+  ): Promise<boolean> {
     try {
-      await this.lookerStudioReportRunService.finish(reportRun);
+      const context = reportRunLogger ? reportRunLogger.asArrays() : undefined;
+      await this.lookerStudioReportRunService.finish(reportRun, context);
       return true;
     } catch (saveError) {
       this.logger.error(

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -84,6 +84,7 @@ import { UpdateDataMartDefinitionService } from './use-cases/update-data-mart-de
 import { DataMartService } from './services/data-mart.service';
 import { ScheduledTriggerService } from './services/scheduled-trigger.service';
 import { PublishDataMartService } from './use-cases/publish-data-mart.service';
+import { UpdateBlendedFieldsConfigService } from './use-cases/update-blended-fields-config.service';
 import { UpdateDataMartDescriptionService } from './use-cases/update-data-mart-description.service';
 import { UpdateDataMartOwnersService } from './use-cases/update-data-mart-owners.service';
 import { UpdateDataMartTitleService } from './use-cases/update-data-mart-title.service';
@@ -303,6 +304,20 @@ import { ProjectSetupProgressListenerService } from './services/project-setup-pr
 import { ProjectSetupProgressController } from './controllers/project-setup-progress.controller';
 import { GetProjectSetupProgressService } from './use-cases/get-project-setup-progress.service';
 import { ProjectSetupProgressMapper } from './mappers/project-setup-progress.mapper';
+import { DataMartRelationship } from './entities/data-mart-relationship.entity';
+import { DataMartRelationshipService } from './services/data-mart-relationship.service';
+import { BlendableSchemaService } from './services/blendable-schema.service';
+import { BlendedReportDataService } from './services/blended-report-data.service';
+import { RelationshipMapper } from './mappers/relationship.mapper';
+import { CreateDataMartRelationshipService } from './use-cases/create-data-mart-relationship.service';
+import { UpdateDataMartRelationshipService } from './use-cases/update-data-mart-relationship.service';
+import { DeleteDataMartRelationshipService } from './use-cases/delete-data-mart-relationship.service';
+import { ListDataMartRelationshipsService } from './use-cases/list-data-mart-relationships.service';
+import { GetDataMartRelationshipService } from './use-cases/get-data-mart-relationship.service';
+import { GetReportGeneratedSqlService } from './use-cases/get-report-generated-sql.service';
+import { CopyReportAsDataMartService } from './use-cases/copy-report-as-data-mart.service';
+import { DataMartRelationshipController } from './controllers/data-mart-relationship.controller';
+import { DataStorageRelationshipController } from './controllers/data-storage-relationship.controller';
 
 @Module({
   imports: [
@@ -344,6 +359,7 @@ import { ProjectSetupProgressMapper } from './mappers/project-setup-progress.map
       ReportRunTrigger,
       ProjectSetupProgress,
       ProjectSetupUserProgress,
+      DataMartRelationship,
     ]),
     CommonModule,
     IdpModule,
@@ -370,6 +386,8 @@ import { ProjectSetupProgressMapper } from './mappers/project-setup-progress.map
     MarkdownParserController,
     LegacyDataMartsSyncController,
     ProjectSetupProgressController,
+    DataMartRelationshipController,
+    DataStorageRelationshipController,
   ],
   providers: [
     ...dataStorageResolverProviders,
@@ -387,6 +405,7 @@ import { ProjectSetupProgressMapper } from './mappers/project-setup-progress.map
     ListDataMartRunsService,
     UpdateDataMartDefinitionService,
     PublishDataMartService,
+    UpdateBlendedFieldsConfigService,
     UpdateDataMartDescriptionService,
     UpdateDataMartOwnersService,
     UpdateDataMartTitleService,
@@ -615,6 +634,17 @@ import { ProjectSetupProgressMapper } from './mappers/project-setup-progress.map
     ProjectSetupProgressListenerService,
     GetProjectSetupProgressService,
     ProjectSetupProgressMapper,
+    DataMartRelationshipService,
+    BlendableSchemaService,
+    BlendedReportDataService,
+    RelationshipMapper,
+    CreateDataMartRelationshipService,
+    UpdateDataMartRelationshipService,
+    DeleteDataMartRelationshipService,
+    ListDataMartRelationshipsService,
+    GetDataMartRelationshipService,
+    GetReportGeneratedSqlService,
+    CopyReportAsDataMartService,
   ],
 })
 export class DataMartsModule {

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-blended-query-builder.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataMartRelationship } from '../../../entities/data-mart-relationship.entity';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import {
+  BlendedQueryContext,
+  ResolvedRelationshipChain,
+} from '../../interfaces/blended-query-builder.interface';
+import { AthenaBlendedQueryBuilder } from './athena-blended-query-builder';
+
+function makeRelationship(overrides: Partial<DataMartRelationship> = {}): DataMartRelationship {
+  return {
+    id: 'rel-1',
+    targetAlias: 'orders',
+    joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+    blendedFields: [],
+    projectId: 'proj',
+    createdById: 'user-1',
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    ...overrides,
+  } as DataMartRelationship;
+}
+
+function makeChain(
+  partial: Omit<ResolvedRelationshipChain, 'targetDataMartTitle' | 'targetDataMartUrl'>
+): ResolvedRelationshipChain {
+  return {
+    ...partial,
+    targetDataMartTitle: 'Test Subsidiary',
+    targetDataMartUrl: '/ui/proj/data-marts/sub-1/data-setup',
+  };
+}
+
+function buildContext(chains: ResolvedRelationshipChain[], columns: string[]): BlendedQueryContext {
+  return {
+    mainTableReference: '"mydb"."customers"',
+    mainDataMartTitle: 'Test Main',
+    mainDataMartUrl: '/ui/proj/data-marts/main-1/data-setup',
+    chains,
+    columns,
+  };
+}
+
+describe('AthenaBlendedQueryBuilder', () => {
+  let builder: AthenaBlendedQueryBuilder;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AthenaBlendedQueryBuilder],
+    }).compile();
+
+    builder = module.get(AthenaBlendedQueryBuilder);
+  });
+
+  it('should have type AWS_ATHENA', () => {
+    expect(builder.type).toBe(DataStorageType.AWS_ATHENA);
+  });
+
+  it("uses ARRAY_JOIN(ARRAY_AGG(CAST(field AS VARCHAR)), ', ') for STRING_AGG aggregation", () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '"mydb"."orders"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_name',
+          outputAlias: 'order_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['order_names']));
+
+    expect(sql).toContain(
+      "ARRAY_JOIN(ARRAY_AGG(CAST(order_name AS VARCHAR)), ', ') AS order_names"
+    );
+    expect(sql).not.toContain('STRING_AGG');
+    expect(sql).not.toContain('LISTAGG');
+    expect(sql).not.toContain('COLLECT_LIST');
+  });
+
+  it('uses COUNT(DISTINCT field) for COUNT_DISTINCT aggregation', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '"mydb"."orders"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'customer_id',
+          outputAlias: 'unique_customers',
+          isHidden: false,
+          aggregateFunction: 'COUNT_DISTINCT',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['unique_customers']));
+
+    expect(sql).toContain('COUNT(DISTINCT customer_id) AS unique_customers');
+  });
+
+  it('uses " (double-quote) quoting for identifiers', () => {
+    const chain = makeChain({
+      relationship: makeRelationship({
+        targetAlias: "Product's",
+        joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'product_id' }],
+      }),
+      targetTableReference: '"mydb"."products"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'name',
+          outputAlias: 'product_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['product_names']));
+
+    expect(sql).toContain('"Product\'s_raw" AS (');
+    expect(sql).toContain('"Product\'s" AS (');
+    // Double-quotes, not backticks
+    expect(sql).not.toMatch(/`Product's`/);
+  });
+
+  it('uses COUNT function correctly', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '"mydb"."orders"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_id',
+          outputAlias: 'order_count',
+          isHidden: false,
+          aggregateFunction: 'COUNT',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['order_count']));
+
+    expect(sql).toContain('COUNT(order_id) AS order_count');
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-blended-query-builder.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
+
+@Injectable()
+export class AthenaBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
+  readonly type = DataStorageType.AWS_ATHENA;
+  protected readonly identifierQuoteChar = '"';
+
+  protected buildStringAgg(fieldName: string): string {
+    return `ARRAY_JOIN(ARRAY_AGG(CAST(${fieldName} AS VARCHAR)), ', ')`;
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-data-mart-schema.provider.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-data-mart-schema.provider.ts
@@ -132,6 +132,7 @@ export class AthenaDataMartSchemaProvider implements DataMartSchemaProvider {
       type,
       description,
       isPrimaryKey: false,
+      isHiddenForReporting: false,
       status: DataMartSchemaFieldStatus.CONNECTED,
     };
   }

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-query.builder.ts
@@ -19,14 +19,20 @@ export class AthenaQueryBuilder implements DataMartQueryBuilder {
   readonly type = DataStorageType.AWS_ATHENA;
 
   buildQuery(definition: DataMartDefinition, queryOptions?: DataMartQueryOptions): string {
+    const selectList = this.buildSelectList(queryOptions?.columns);
     let query: string;
 
     if (isTableDefinition(definition) || isViewDefinition(definition)) {
-      query = `SELECT * FROM ${escapeAthenaIdentifier(definition.fullyQualifiedName)}`;
+      query = `SELECT ${selectList} FROM ${escapeAthenaIdentifier(definition.fullyQualifiedName)}`;
     } else if (isConnectorDefinition(definition)) {
-      query = `SELECT * FROM ${escapeAthenaIdentifier(definition.connector.storage.fullyQualifiedName)}`;
+      query = `SELECT ${selectList} FROM ${escapeAthenaIdentifier(definition.connector.storage.fullyQualifiedName)}`;
     } else if (isSqlDefinition(definition)) {
-      query = definition.sqlQuery.trim();
+      if (queryOptions?.columns?.length) {
+        const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
+        query = `SELECT ${selectList} FROM (${cleanQuery})`;
+      } else {
+        query = definition.sqlQuery.trim();
+      }
     } else if (isTablePatternDefinition(definition)) {
       throw new Error('Table pattern queries are not supported in Athena');
     } else {
@@ -41,5 +47,12 @@ export class AthenaQueryBuilder implements DataMartQueryBuilder {
     }
 
     return query;
+  }
+
+  private buildSelectList(columns?: string[]): string {
+    if (!columns || columns.length === 0) {
+      return '*';
+    }
+    return columns.map(col => escapeAthenaIdentifier(col)).join(', ');
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-report-headers-generator.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-report-headers-generator.service.ts
@@ -23,7 +23,10 @@ export class AthenaReportHeadersGenerator implements ReportHeadersGenerator {
     }
 
     return dataMartSchema.fields
-      .filter(field => field.status !== DataMartSchemaFieldStatus.DISCONNECTED)
+      .filter(
+        field =>
+          field.status !== DataMartSchemaFieldStatus.DISCONNECTED && !field.isHiddenForReporting
+      )
       .map(field => new ReportDataHeader(field.name, field.alias, field.description, field.type));
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-report-reader.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-report-reader.service.ts
@@ -1,6 +1,9 @@
 import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
 import { isAthenaDataMartSchema } from '../../data-mart-schema.guards';
-import { DataStorageReportReader } from '../../interfaces/data-storage-report-reader.interface';
+import {
+  DataStorageReportReader,
+  PrepareReportDataOptions,
+} from '../../interfaces/data-storage-report-reader.interface';
 import { DataStorageReportReaderState } from '../../interfaces/data-storage-report-reader-state.interface';
 import {
   AthenaReaderState,
@@ -20,6 +23,7 @@ import { S3ApiAdapterFactory } from '../adapters/s3-api-adapter.factory';
 import { isAthenaConfig } from '../../data-storage-config.guards';
 import { AthenaQueryBuilder } from './athena-query.builder';
 import { AthenaReportHeadersGenerator } from './athena-report-headers-generator.service';
+import { resolveReportDataHeaders } from '../../utils/report-data-headers.utils';
 @Injectable({ scope: Scope.TRANSIENT })
 export class AthenaReportReader implements DataStorageReportReader {
   private readonly logger = new Logger(AthenaReportReader.name);
@@ -32,6 +36,7 @@ export class AthenaReportReader implements DataStorageReportReader {
   private outputPrefix: string;
   private reportDataHeaders: ReportDataHeader[];
   private reportConfig: { storage: DataStorage; definition: DataMartDefinition };
+  private pendingQuery?: string;
 
   constructor(
     private readonly athenaAdapterFactory: AthenaApiAdapterFactory,
@@ -40,7 +45,10 @@ export class AthenaReportReader implements DataStorageReportReader {
     private readonly headersGenerator: AthenaReportHeadersGenerator
   ) {}
 
-  async prepareReportData(report: Report): Promise<ReportDataDescription> {
+  async prepareReportData(
+    report: Report,
+    options?: PrepareReportDataOptions
+  ): Promise<ReportDataDescription> {
     const { storage, definition, schema } = report.dataMart;
     if (!storage || !definition) {
       throw new Error('Data Mart is not properly configured');
@@ -56,7 +64,13 @@ export class AthenaReportReader implements DataStorageReportReader {
 
     this.reportConfig = { storage, definition };
 
-    this.reportDataHeaders = this.headersGenerator.generateHeaders(schema);
+    this.reportDataHeaders = resolveReportDataHeaders(
+      this.headersGenerator.generateHeaders(schema),
+      options
+    );
+    this.pendingQuery =
+      options?.sqlOverride ??
+      this.athenaQueryBuilder.buildQuery(definition, { columns: options?.columnFilter });
 
     await this.prepareApiAdapters(storage);
 
@@ -166,7 +180,7 @@ export class AthenaReportReader implements DataStorageReportReader {
   private async prepareQueryExecution(dataMartDefinition: DataMartDefinition): Promise<void> {
     this.logger.debug('Preparing query execution', dataMartDefinition);
     try {
-      const query = this.athenaQueryBuilder.buildQuery(dataMartDefinition);
+      const query = this.pendingQuery ?? this.athenaQueryBuilder.buildQuery(dataMartDefinition);
       await this.executeQuery(query);
     } catch (error) {
       this.logger.error('Failed to prepare query execution', error);

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-schema-merger.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-schema-merger.ts
@@ -60,6 +60,7 @@ export class AthenaSchemaMerger implements DataMartSchemaMerger {
           ...existingField,
           description: newField.description || existingField.description,
           alias: existingField.alias || newField.alias,
+          isHiddenForReporting: existingField.isHiddenForReporting ?? false,
           status:
             existingField.type === newField.type
               ? DataMartSchemaFieldStatus.CONNECTED

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-blended-query-builder.spec.ts
@@ -1,0 +1,146 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataMartRelationship } from '../../../entities/data-mart-relationship.entity';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import {
+  BlendedQueryContext,
+  ResolvedRelationshipChain,
+} from '../../interfaces/blended-query-builder.interface';
+import { BigQueryBlendedQueryBuilder } from './bigquery-blended-query-builder';
+
+function makeRelationship(overrides: Partial<DataMartRelationship> = {}): DataMartRelationship {
+  return {
+    id: 'rel-1',
+    targetAlias: 'orders',
+    joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+    blendedFields: [],
+    projectId: 'proj',
+    createdById: 'user-1',
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    ...overrides,
+  } as DataMartRelationship;
+}
+
+function makeChain(
+  partial: Omit<ResolvedRelationshipChain, 'targetDataMartTitle' | 'targetDataMartUrl'>
+): ResolvedRelationshipChain {
+  return {
+    ...partial,
+    targetDataMartTitle: 'Test Subsidiary',
+    targetDataMartUrl: '/ui/proj/data-marts/sub-1/data-setup',
+  };
+}
+
+function buildContext(chains: ResolvedRelationshipChain[], columns: string[]): BlendedQueryContext {
+  return {
+    mainTableReference: '`project`.`dataset`.`customers`',
+    mainDataMartTitle: 'Test Main',
+    mainDataMartUrl: '/ui/proj/data-marts/main-1/data-setup',
+    chains,
+    columns,
+  };
+}
+
+describe('BigQueryBlendedQueryBuilder', () => {
+  let builder: BigQueryBlendedQueryBuilder;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BigQueryBlendedQueryBuilder],
+    }).compile();
+
+    builder = module.get(BigQueryBlendedQueryBuilder);
+  });
+
+  it('should have type GOOGLE_BIGQUERY', () => {
+    expect(builder.type).toBe(DataStorageType.GOOGLE_BIGQUERY);
+  });
+
+  it('uses STRING_AGG(CAST(... AS STRING)) for STRING_AGG aggregation', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '`project`.`dataset`.`orders`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_name',
+          outputAlias: 'order_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['order_names']));
+
+    expect(sql).toContain("STRING_AGG(CAST(order_name AS STRING), ', ') AS order_names");
+    expect(sql).not.toContain('LISTAGG');
+    expect(sql).not.toContain('ARRAY_JOIN');
+  });
+
+  it('uses backtick quoting for identifiers', () => {
+    const chain = makeChain({
+      relationship: makeRelationship({
+        targetAlias: "Product's",
+        joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'product_id' }],
+      }),
+      targetTableReference: '`p`.`d`.`products`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'name',
+          outputAlias: 'product_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['product_names']));
+
+    expect(sql).toContain("`Product's_raw` AS (");
+    expect(sql).toContain("`Product's` AS (");
+    // Backticks, not double-quotes
+    expect(sql).not.toMatch(/"Product's"/);
+  });
+
+  it('uses COUNT function correctly', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '`project`.`dataset`.`orders`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_id',
+          outputAlias: 'order_count',
+          isHidden: false,
+          aggregateFunction: 'COUNT',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['order_count']));
+
+    expect(sql).toContain('COUNT(order_id) AS order_count');
+  });
+
+  it('uses COUNT(DISTINCT field) for COUNT_DISTINCT aggregation', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '`project`.`dataset`.`orders`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'customer_id',
+          outputAlias: 'unique_customers',
+          isHidden: false,
+          aggregateFunction: 'COUNT_DISTINCT',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['unique_customers']));
+
+    expect(sql).toContain('COUNT(DISTINCT customer_id) AS unique_customers');
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-blended-query-builder.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
+
+@Injectable()
+export class BigQueryBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
+  readonly type = DataStorageType.GOOGLE_BIGQUERY;
+  protected readonly identifierQuoteChar = '`';
+
+  protected buildStringAgg(fieldName: string): string {
+    return `STRING_AGG(CAST(${fieldName} AS STRING), ', ')`;
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-data-mart-schema.provider.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-data-mart-schema.provider.ts
@@ -126,6 +126,7 @@ export class BigQueryDataMartSchemaProvider implements DataMartSchemaProvider {
         mode: parsedFieldMode,
         description: field.description,
         isPrimaryKey: primaryKeyColumns?.includes(field.name!) || false,
+        isHiddenForReporting: false,
         status: DataMartSchemaFieldStatus.CONNECTED,
       };
 

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.spec.ts
@@ -1,0 +1,71 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BigQueryQueryBuilder } from './bigquery-query.builder';
+import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
+
+function tableDefinition(fqn: string): DataMartDefinition {
+  return {
+    type: 'table',
+    fullyQualifiedName: fqn,
+  } as unknown as DataMartDefinition;
+}
+
+function sqlDefinition(query: string): DataMartDefinition {
+  return {
+    type: 'sql',
+    sqlQuery: query,
+  } as unknown as DataMartDefinition;
+}
+
+describe('BigQueryQueryBuilder', () => {
+  let builder: BigQueryQueryBuilder;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BigQueryQueryBuilder],
+    }).compile();
+
+    builder = module.get(BigQueryQueryBuilder);
+  });
+
+  describe('buildQuery (without columns option)', () => {
+    it('returns SELECT * for a table definition', async () => {
+      const sql = await builder.buildQuery(tableDefinition('proj.dataset.tbl'));
+      expect(sql).toBe('SELECT * FROM `proj`.`dataset`.`tbl`');
+    });
+
+    it('returns user SQL untouched for a SQL definition', async () => {
+      const sql = await builder.buildQuery(sqlDefinition('SELECT a, b FROM t'));
+      expect(sql).toBe('SELECT a, b FROM t');
+    });
+  });
+
+  describe('buildQuery with columns filter', () => {
+    it('projects only specified columns on a table definition', async () => {
+      const sql = await builder.buildQuery(tableDefinition('proj.dataset.tbl'), {
+        columns: ['campaign_name', 'date_column'],
+      });
+      expect(sql).toBe('SELECT `campaign_name`, `date_column` FROM `proj`.`dataset`.`tbl`');
+    });
+
+    it('escapes nested RECORD paths as backtick-separated parts', async () => {
+      const sql = await builder.buildQuery(tableDefinition('proj.dataset.tbl'), {
+        columns: ['address.city', 'user_id'],
+      });
+      expect(sql).toBe('SELECT `address`.`city`, `user_id` FROM `proj`.`dataset`.`tbl`');
+    });
+
+    it('wraps SQL definition queries when columns are provided', async () => {
+      const sql = await builder.buildQuery(sqlDefinition('SELECT a, b, c FROM t;'), {
+        columns: ['a', 'c'],
+      });
+      expect(sql).toBe('SELECT `a`, `c` FROM (SELECT a, b, c FROM t)');
+    });
+
+    it('ignores empty columns list and falls back to SELECT *', async () => {
+      const sql = await builder.buildQuery(tableDefinition('proj.dataset.tbl'), {
+        columns: [],
+      });
+      expect(sql).toBe('SELECT * FROM `proj`.`dataset`.`tbl`');
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.ts
@@ -8,24 +8,46 @@ import {
   isViewDefinition,
 } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition.guards';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
-import { DataMartQueryBuilderAsync } from '../../interfaces/data-mart-query-builder.interface';
+import {
+  DataMartQueryBuilderAsync,
+  DataMartQueryOptions,
+} from '../../interfaces/data-mart-query-builder.interface';
 import { escapeBigQueryIdentifier } from '../utils/bigquery-identifier.utils';
 
 @Injectable()
 export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
   readonly type: DataStorageType = DataStorageType.GOOGLE_BIGQUERY;
 
-  async buildQuery(definition: DataMartDefinition): Promise<string> {
+  async buildQuery(
+    definition: DataMartDefinition,
+    queryOptions?: DataMartQueryOptions
+  ): Promise<string> {
+    const selectList = this.buildSelectList(queryOptions?.columns);
+
     if (isTableDefinition(definition) || isViewDefinition(definition)) {
-      return `SELECT * FROM ${escapeBigQueryIdentifier(definition.fullyQualifiedName)}`;
+      return `SELECT ${selectList} FROM ${escapeBigQueryIdentifier(definition.fullyQualifiedName)}`;
     } else if (isConnectorDefinition(definition)) {
-      return `SELECT * FROM ${escapeBigQueryIdentifier(definition.connector.storage.fullyQualifiedName)}`;
+      return `SELECT ${selectList} FROM ${escapeBigQueryIdentifier(definition.connector.storage.fullyQualifiedName)}`;
     } else if (isSqlDefinition(definition)) {
+      // Wrap user SQL only when a column filter is provided; otherwise keep
+      // the original query untouched so custom logic (CTEs, ORDER BY, etc.)
+      // is preserved.
+      if (queryOptions?.columns?.length) {
+        const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
+        return `SELECT ${selectList} FROM (${cleanQuery})`;
+      }
       return definition.sqlQuery;
     } else if (isTablePatternDefinition(definition)) {
-      return `SELECT * FROM ${escapeBigQueryIdentifier(definition.pattern + '*')}`;
+      return `SELECT ${selectList} FROM ${escapeBigQueryIdentifier(definition.pattern + '*')}`;
     } else {
       throw new Error('Invalid data mart definition');
     }
+  }
+
+  private buildSelectList(columns?: string[]): string {
+    if (!columns || columns.length === 0) {
+      return '*';
+    }
+    return columns.map(col => escapeBigQueryIdentifier(col)).join(', ');
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-headers-generator.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-headers-generator.service.ts
@@ -26,9 +26,11 @@ export class BigQueryReportHeadersGenerator implements ReportHeadersGenerator {
     }
 
     const headers: ReportDataHeader[] = [];
-    dataMartSchema.fields.forEach(field => {
-      headers.push(...this.getHeadersForField(field));
-    });
+    dataMartSchema.fields
+      .filter(field => !field.isHiddenForReporting)
+      .forEach(field => {
+        headers.push(...this.getHeadersForField(field));
+      });
     return headers;
   }
 

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-reader.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-reader.service.ts
@@ -15,7 +15,11 @@ import { isBigQueryDataMartSchema } from '../../data-mart-schema.guards';
 import { isBigQueryConfig } from '../../data-storage-config.guards';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { DataStorageReportReaderState } from '../../interfaces/data-storage-report-reader-state.interface';
-import { DataStorageReportReader } from '../../interfaces/data-storage-report-reader.interface';
+import {
+  DataStorageReportReader,
+  PrepareReportDataOptions,
+} from '../../interfaces/data-storage-report-reader.interface';
+import { resolveReportDataHeaders } from '../../utils/report-data-headers.utils';
 import { BigQueryApiAdapterFactory } from '../adapters/bigquery-api-adapter.factory';
 import { BigQueryApiAdapter } from '../adapters/bigquery-api.adapter';
 import {
@@ -44,6 +48,8 @@ export class BigQueryReportReader implements DataStorageReportReader {
     definition: DataMartDefinition;
     definitionType: DataMartDefinitionType;
   };
+  private sqlOverride?: string;
+  private columnFilter?: string[];
 
   constructor(
     protected readonly adapterFactory: BigQueryApiAdapterFactory,
@@ -52,7 +58,10 @@ export class BigQueryReportReader implements DataStorageReportReader {
     protected readonly credentialsResolver: DataStorageCredentialsResolver
   ) {}
 
-  public async prepareReportData(report: Report): Promise<ReportDataDescription> {
+  public async prepareReportData(
+    report: Report,
+    options?: PrepareReportDataOptions
+  ): Promise<ReportDataDescription> {
     const { storage, definitionType, definition, schema } = report.dataMart;
     if (!storage || !definition || !definitionType) {
       throw new Error('Data Mart is not properly configured');
@@ -76,8 +85,13 @@ export class BigQueryReportReader implements DataStorageReportReader {
       definitionType,
       definition,
     };
+    this.sqlOverride = options?.sqlOverride;
+    this.columnFilter = options?.columnFilter;
 
-    this.reportDataHeaders = this.headersGenerator.generateHeaders(schema);
+    this.reportDataHeaders = resolveReportDataHeaders(
+      this.headersGenerator.generateHeaders(schema),
+      options
+    );
 
     this.adapter = await this.adapterFactory.createFromStorage(storage, storage.config);
     this.contextGcpProject = storage.config.projectId;
@@ -128,6 +142,13 @@ export class BigQueryReportReader implements DataStorageReportReader {
   ): Promise<void> {
     this.logger.debug('Preparing report result table', dataMartDefinition);
     try {
+      // When a SQL override is present (e.g. blended SQL), bypass the
+      // TABLE/CONNECTOR fast path and always execute the override query.
+      if (this.sqlOverride) {
+        await this.prepareQueryData(this.sqlOverride);
+        return;
+      }
+
       if (
         definitionType === DataMartDefinitionType.TABLE &&
         isTableDefinition(dataMartDefinition)
@@ -143,7 +164,9 @@ export class BigQueryReportReader implements DataStorageReportReader {
           tablePath.length === 2 ? [this.contextGcpProject, ...tablePath] : tablePath;
         this.defineReportResultTable(projectId, datasetId, tableId);
       } else {
-        const query = await this.bigQueryQueryBuilder.buildQuery(dataMartDefinition);
+        const query = await this.bigQueryQueryBuilder.buildQuery(dataMartDefinition, {
+          columns: this.columnFilter,
+        });
         await this.prepareQueryData(query);
       }
     } catch (error) {

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-schema-merger.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-schema-merger.ts
@@ -130,6 +130,7 @@ export class BigQuerySchemaMerger implements DataMartSchemaMerger {
 
     return {
       ...existingField,
+      isHiddenForReporting: existingField.isHiddenForReporting ?? false,
       status,
       fields: mergedFields,
     };
@@ -153,6 +154,7 @@ export class BigQuerySchemaMerger implements DataMartSchemaMerger {
   private updateSimpleField(existingField: SchemaField, hasTypeMismatch: boolean): SchemaField {
     return {
       ...existingField,
+      isHiddenForReporting: existingField.isHiddenForReporting ?? false,
       status: this.getConnectedFieldStatus(hasTypeMismatch),
     };
   }

--- a/apps/backend/src/data-marts/data-storage-types/data-mart-schema.utils.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-mart-schema.utils.ts
@@ -17,6 +17,10 @@ export function createBaseFieldSchemaForType<T extends z.ZodTypeAny>(schemaField
         .boolean()
         .default(false)
         .describe('Is field must be a part of a data mart primary key'),
+      isHiddenForReporting: z
+        .boolean()
+        .default(false)
+        .describe('Hide field from reporting and blending'),
       status: z
         .nativeEnum(DataMartSchemaFieldStatus)
         .describe('Field status relatively to the actual data mart schema'),

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-facades.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-facades.ts
@@ -1,3 +1,4 @@
+import { BlendedQueryBuilderFacade } from './facades/blended-query-builder.facade';
 import { DataMartDefinitionValidatorFacade } from './facades/data-mart-definition-validator-facade.service';
 import { DataMartQueryBuilderFacade } from './facades/data-mart-query-builder.facade';
 import { DataMartSchemaMergerFacade } from './facades/data-mart-schema-merger.facade';
@@ -18,4 +19,5 @@ export const dataStorageFacadesProviders = [
   SqlDryRunExecutorFacade,
   SqlRunExecutorFacade,
   CreateViewExecutorFacade,
+  BlendedQueryBuilderFacade,
 ];

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
@@ -12,9 +12,11 @@ import { AthenaReportHeadersGenerator } from './athena/services/athena-report-he
 import { AthenaReportReader } from './athena/services/athena-report-reader.service';
 import { AthenaSchemaMerger } from './athena/services/athena-schema-merger';
 import { AthenaSqlDryRunExecutor } from './athena/services/athena-sql-dry-run.executor';
+import { AthenaBlendedQueryBuilder } from './athena/services/athena-blended-query-builder';
 import { AthenaSqlRunExecutor } from './athena/services/athena-sql-run.executor';
 import { BigQueryApiAdapterFactory } from './bigquery/adapters/bigquery-api-adapter.factory';
 import { BigQueryAccessValidator } from './bigquery/services/bigquery-access.validator';
+import { BigQueryBlendedQueryBuilder } from './bigquery/services/bigquery-blended-query-builder';
 import { BigQueryCreateViewExecutor } from './bigquery/services/bigquery-create-view.executor';
 import { BigQueryDataMartSchemaParser } from './bigquery/services/bigquery-data-mart-schema.parser';
 import { BigQueryDataMartSchemaProvider } from './bigquery/services/bigquery-data-mart-schema.provider';
@@ -49,9 +51,11 @@ import { DatabricksReportHeadersGenerator } from './databricks/services/databric
 import { DatabricksReportReader } from './databricks/services/databricks-report-reader.service';
 import { DatabricksSchemaMerger } from './databricks/services/databricks-schema-merger';
 import { DatabricksSqlDryRunExecutor } from './databricks/services/databricks-sql-dry-run.executor';
+import { DatabricksBlendedQueryBuilder } from './databricks/services/databricks-blended-query-builder';
 import { DatabricksSqlRunExecutor } from './databricks/services/databricks-sql-run.executor';
 import { DataStorageType } from './enums/data-storage-type.enum';
 import { DataStoragePublicCredentialsFactory } from './factories/data-storage-public-credentials.factory';
+import { BlendedQueryBuilder } from './interfaces/blended-query-builder.interface';
 import { CreateViewExecutor } from './interfaces/create-view-executor.interface';
 import {
   DataMartQueryBuilder,
@@ -77,6 +81,7 @@ import { RedshiftReportHeadersGenerator } from './redshift/services/redshift-rep
 import { RedshiftReportReader } from './redshift/services/redshift-report-reader.service';
 import { RedshiftSchemaMerger } from './redshift/services/redshift-schema-merger';
 import { RedshiftSqlDryRunExecutor } from './redshift/services/redshift-sql-dry-run.executor';
+import { RedshiftBlendedQueryBuilder } from './redshift/services/redshift-blended-query-builder';
 import { RedshiftSqlRunExecutor } from './redshift/services/redshift-sql-run.executor';
 import { SnowflakeApiAdapterFactory } from './snowflake/adapters/snowflake-api-adapter.factory';
 import { SnowflakeAccessValidator } from './snowflake/services/snowflake-access.validator';
@@ -89,8 +94,10 @@ import { SnowflakeReportHeadersGenerator } from './snowflake/services/snowflake-
 import { SnowflakeReportReader } from './snowflake/services/snowflake-report-reader.service';
 import { SnowflakeSchemaMerger } from './snowflake/services/snowflake-schema-merger';
 import { SnowflakeSqlDryRunExecutor } from './snowflake/services/snowflake-sql-dry-run.executor';
+import { SnowflakeBlendedQueryBuilder } from './snowflake/services/snowflake-blended-query-builder';
 import { SnowflakeSqlRunExecutor } from './snowflake/services/snowflake-sql-run.executor';
 
+export const BLENDED_QUERY_BUILDER_RESOLVER = Symbol('BLENDED_QUERY_BUILDER_RESOLVER');
 export const DATA_STORAGE_ACCESS_VALIDATOR_RESOLVER = Symbol(
   'DATA_STORAGE_ACCESS_VALIDATOR_RESOLVER'
 );
@@ -206,6 +213,13 @@ const publicCredentialsProviders = [
   DataStorageCredentialsUtils,
 ];
 const legacyBigQueryProviders = [LegacyBigQuerySqlPreprocessor];
+const blendedQueryBuilderProviders = [
+  BigQueryBlendedQueryBuilder,
+  SnowflakeBlendedQueryBuilder,
+  RedshiftBlendedQueryBuilder,
+  AthenaBlendedQueryBuilder,
+  DatabricksBlendedQueryBuilder,
+];
 
 export const dataStorageResolverProviders = [
   ...accessValidatorProviders,
@@ -222,6 +236,7 @@ export const dataStorageResolverProviders = [
   ...createViewExecutorProviders,
   ...publicCredentialsProviders,
   ...legacyBigQueryProviders,
+  ...blendedQueryBuilderProviders,
   {
     provide: DATA_MART_QUERY_BUILDER_RESOLVER,
     useFactory: async (...builders: (DataMartQueryBuilder | DataMartQueryBuilderAsync)[]) =>
@@ -287,5 +302,11 @@ export const dataStorageResolverProviders = [
     useFactory: (...executors: CreateViewExecutor[]) =>
       new TypeResolver<DataStorageType, CreateViewExecutor>(executors),
     inject: createViewExecutorProviders,
+  },
+  {
+    provide: BLENDED_QUERY_BUILDER_RESOLVER,
+    useFactory: (...builders: BlendedQueryBuilder[]) =>
+      new TypeResolver<DataStorageType, BlendedQueryBuilder>(builders),
+    inject: blendedQueryBuilderProviders,
   },
 ];

--- a/apps/backend/src/data-marts/data-storage-types/databricks/schemas/databricks-data-mart-schema.schema.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/schemas/databricks-data-mart-schema.schema.ts
@@ -6,6 +6,10 @@ const DatabricksSchemaFieldSchema = z.object({
   name: z.string(),
   type: z.nativeEnum(DatabricksFieldType),
   isPrimaryKey: z.boolean().optional(),
+  isHiddenForReporting: z
+    .boolean()
+    .default(false)
+    .describe('Hide field from reporting and blending'),
   description: z.string().optional(),
   alias: z.string().optional(),
   status: z.nativeEnum(DataMartSchemaFieldStatus),

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataMartRelationship } from '../../../entities/data-mart-relationship.entity';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import {
+  BlendedQueryContext,
+  ResolvedRelationshipChain,
+} from '../../interfaces/blended-query-builder.interface';
+import { DatabricksBlendedQueryBuilder } from './databricks-blended-query-builder';
+
+function makeRelationship(overrides: Partial<DataMartRelationship> = {}): DataMartRelationship {
+  return {
+    id: 'rel-1',
+    targetAlias: 'orders',
+    joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+    blendedFields: [],
+    projectId: 'proj',
+    createdById: 'user-1',
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    ...overrides,
+  } as DataMartRelationship;
+}
+
+function makeChain(
+  partial: Omit<ResolvedRelationshipChain, 'targetDataMartTitle' | 'targetDataMartUrl'>
+): ResolvedRelationshipChain {
+  return {
+    ...partial,
+    targetDataMartTitle: 'Test Subsidiary',
+    targetDataMartUrl: '/ui/proj/data-marts/sub-1/data-setup',
+  };
+}
+
+function buildContext(chains: ResolvedRelationshipChain[], columns: string[]): BlendedQueryContext {
+  return {
+    mainTableReference: '`catalog`.`schema`.`customers`',
+    mainDataMartTitle: 'Test Main',
+    mainDataMartUrl: '/ui/proj/data-marts/main-1/data-setup',
+    chains,
+    columns,
+  };
+}
+
+describe('DatabricksBlendedQueryBuilder', () => {
+  let builder: DatabricksBlendedQueryBuilder;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DatabricksBlendedQueryBuilder],
+    }).compile();
+
+    builder = module.get(DatabricksBlendedQueryBuilder);
+  });
+
+  it('should have type DATABRICKS', () => {
+    expect(builder.type).toBe(DataStorageType.DATABRICKS);
+  });
+
+  it("uses CONCAT_WS(', ', COLLECT_LIST(CAST(field AS STRING))) for STRING_AGG aggregation", () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '`catalog`.`schema`.`orders`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_name',
+          outputAlias: 'order_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['order_names']));
+
+    expect(sql).toContain(
+      "CONCAT_WS(', ', COLLECT_LIST(CAST(order_name AS STRING))) AS order_names"
+    );
+    expect(sql).not.toContain('STRING_AGG');
+    expect(sql).not.toContain('LISTAGG');
+    expect(sql).not.toContain('ARRAY_JOIN');
+  });
+
+  it('uses COUNT(DISTINCT field) for COUNT_DISTINCT aggregation', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '`catalog`.`schema`.`orders`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'customer_id',
+          outputAlias: 'unique_customers',
+          isHidden: false,
+          aggregateFunction: 'COUNT_DISTINCT',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['unique_customers']));
+
+    expect(sql).toContain('COUNT(DISTINCT customer_id) AS unique_customers');
+  });
+
+  it('uses ` (backtick) quoting for identifiers', () => {
+    const chain = makeChain({
+      relationship: makeRelationship({
+        targetAlias: "Product's",
+        joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'product_id' }],
+      }),
+      targetTableReference: '`catalog`.`schema`.`products`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'name',
+          outputAlias: 'product_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['product_names']));
+
+    expect(sql).toContain("`Product's_raw` AS (");
+    expect(sql).toContain("`Product's` AS (");
+    // Backticks, not double-quotes
+    expect(sql).not.toMatch(/"Product's"/);
+  });
+
+  it('uses COUNT function correctly', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '`catalog`.`schema`.`orders`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_id',
+          outputAlias: 'order_count',
+          isHidden: false,
+          aggregateFunction: 'COUNT',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['order_count']));
+
+    expect(sql).toContain('COUNT(order_id) AS order_count');
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
+
+@Injectable()
+export class DatabricksBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
+  readonly type = DataStorageType.DATABRICKS;
+  protected readonly identifierQuoteChar = '`';
+
+  protected buildStringAgg(fieldName: string): string {
+    return `CONCAT_WS(', ', COLLECT_LIST(CAST(${fieldName} AS STRING)))`;
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-data-mart-schema.provider.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-data-mart-schema.provider.ts
@@ -77,6 +77,7 @@ export class DatabricksDataMartSchemaProvider implements DataMartSchemaProvider 
             name: fieldName,
             type: DatabricksFieldType.STRING,
             isPrimaryKey: false,
+            isHiddenForReporting: false,
             status: DataMartSchemaFieldStatus.CONNECTED,
           })),
         };
@@ -161,6 +162,7 @@ export class DatabricksDataMartSchemaProvider implements DataMartSchemaProvider 
       type: this.parseDatabricksFieldType(type),
       description: description || undefined,
       isPrimaryKey,
+      isHiddenForReporting: false,
       status: DataMartSchemaFieldStatus.CONNECTED,
     };
   }

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-query.builder.ts
@@ -12,23 +12,32 @@ import {
   DataMartQueryBuilder,
   DataMartQueryOptions,
 } from '../../interfaces/data-mart-query-builder.interface';
-import { escapeFullyQualifiedIdentifier } from '../utils/databricks-identifier.utils';
+import {
+  escapeDatabricksIdentifier,
+  escapeFullyQualifiedIdentifier,
+} from '../utils/databricks-identifier.utils';
 
 @Injectable()
 export class DatabricksQueryBuilder implements DataMartQueryBuilder {
   readonly type = DataStorageType.DATABRICKS;
 
   buildQuery(definition: DataMartDefinition, queryOptions?: DataMartQueryOptions): string {
+    const selectList = this.buildSelectList(queryOptions?.columns);
     let query: string;
 
     if (isTableDefinition(definition) || isViewDefinition(definition)) {
       const parts = definition.fullyQualifiedName.split('.');
-      query = `SELECT * FROM ${escapeFullyQualifiedIdentifier(parts)}`;
+      query = `SELECT ${selectList} FROM ${escapeFullyQualifiedIdentifier(parts)}`;
     } else if (isConnectorDefinition(definition)) {
       const parts = definition.connector.storage.fullyQualifiedName.split('.');
-      query = `SELECT * FROM ${escapeFullyQualifiedIdentifier(parts)}`;
+      query = `SELECT ${selectList} FROM ${escapeFullyQualifiedIdentifier(parts)}`;
     } else if (isSqlDefinition(definition)) {
-      query = definition.sqlQuery.trim();
+      if (queryOptions?.columns?.length) {
+        const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
+        query = `SELECT ${selectList} FROM (${cleanQuery})`;
+      } else {
+        query = definition.sqlQuery.trim();
+      }
     } else if (isTablePatternDefinition(definition)) {
       throw new Error('Table pattern definitions are not supported for Databricks');
     } else {
@@ -41,5 +50,12 @@ export class DatabricksQueryBuilder implements DataMartQueryBuilder {
     }
 
     return query;
+  }
+
+  private buildSelectList(columns?: string[]): string {
+    if (!columns || columns.length === 0) {
+      return '*';
+    }
+    return columns.map(col => escapeDatabricksIdentifier(col)).join(', ');
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-report-headers-generator.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-report-headers-generator.service.ts
@@ -23,7 +23,10 @@ export class DatabricksReportHeadersGenerator implements ReportHeadersGenerator 
     }
 
     return dataMartSchema.fields
-      .filter(field => field.status !== DataMartSchemaFieldStatus.DISCONNECTED)
+      .filter(
+        field =>
+          field.status !== DataMartSchemaFieldStatus.DISCONNECTED && !field.isHiddenForReporting
+      )
       .map(field => new ReportDataHeader(field.name, field.alias, field.description, field.type));
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-report-reader.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-report-reader.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, Logger, Scope } from '@nestjs/common';
 import { castError } from '@owox/internal-helpers';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
-import { DataStorageReportReader } from '../../interfaces/data-storage-report-reader.interface';
+import {
+  DataStorageReportReader,
+  PrepareReportDataOptions,
+} from '../../interfaces/data-storage-report-reader.interface';
 import { ReportDataBatch } from '../../../dto/domain/report-data-batch.dto';
 import { ReportDataDescription } from '../../../dto/domain/report-data-description.dto';
 import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
@@ -19,6 +22,7 @@ import {
   DatabricksReaderState,
   isDatabricksReaderState,
 } from '../interfaces/databricks-reader-state.interface';
+import { resolveReportDataHeaders } from '../../utils/report-data-headers.utils';
 @Injectable({ scope: Scope.TRANSIENT })
 export class DatabricksReportReader implements DataStorageReportReader {
   private readonly logger = new Logger(DatabricksReportReader.name);
@@ -39,7 +43,10 @@ export class DatabricksReportReader implements DataStorageReportReader {
     private readonly headersGenerator: DatabricksReportHeadersGenerator
   ) {}
 
-  async prepareReportData(report: Report): Promise<ReportDataDescription> {
+  async prepareReportData(
+    report: Report,
+    options?: PrepareReportDataOptions
+  ): Promise<ReportDataDescription> {
     const { storage, definition, schema } = report.dataMart;
     if (!storage || !definition) {
       throw new Error('Data Mart is not properly configured');
@@ -54,11 +61,16 @@ export class DatabricksReportReader implements DataStorageReportReader {
     }
 
     this.reportConfig = { storage, definition };
-    this.reportDataHeaders = this.headersGenerator.generateHeaders(schema);
+    this.reportDataHeaders = resolveReportDataHeaders(
+      this.headersGenerator.generateHeaders(schema),
+      options
+    );
 
     this.adapter = await this.adapterFactory.createFromStorage(storage);
 
-    const query = this.queryBuilder.buildQuery(definition);
+    const query =
+      options?.sqlOverride ??
+      this.queryBuilder.buildQuery(definition, { columns: options?.columnFilter });
     this.logger.debug(`Executing query: ${query}`);
 
     this.queryCursor = await this.adapter.openQueryCursor(query);

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-schema-merger.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-schema-merger.ts
@@ -75,6 +75,7 @@ export class DatabricksSchemaMerger implements DataMartSchemaMerger {
 
     return {
       ...existingField,
+      isHiddenForReporting: existingField.isHiddenForReporting ?? false,
       status: this.getConnectedFieldStatus(hasTypeMismatch),
     };
   }

--- a/apps/backend/src/data-marts/data-storage-types/databricks/utils/databricks-identifier.utils.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/utils/databricks-identifier.utils.ts
@@ -6,7 +6,7 @@
 
 import { createIdentifierEscaper } from '../../utils/identifier-escaper.utils';
 
-const escapeDatabricksIdentifier = createIdentifierEscaper({ quoteChar: '`' });
+export const escapeDatabricksIdentifier = createIdentifierEscaper({ quoteChar: '`' });
 
 /**
  * Escapes a fully qualified Databricks identifier (catalog.schema.table)

--- a/apps/backend/src/data-marts/data-storage-types/facades/blended-query-builder.facade.ts
+++ b/apps/backend/src/data-marts/data-storage-types/facades/blended-query-builder.facade.ts
@@ -1,0 +1,24 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { TypeResolver } from '../../../common/resolver/type-resolver';
+import { BLENDED_QUERY_BUILDER_RESOLVER } from '../data-storage-providers';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+import {
+  BlendedQueryBuilder,
+  BlendedQueryContext,
+} from '../interfaces/blended-query-builder.interface';
+
+@Injectable()
+export class BlendedQueryBuilderFacade {
+  constructor(
+    @Inject(BLENDED_QUERY_BUILDER_RESOLVER)
+    private readonly resolver: TypeResolver<DataStorageType, BlendedQueryBuilder>
+  ) {}
+
+  async buildBlendedQuery(
+    storageType: DataStorageType,
+    context: BlendedQueryContext
+  ): Promise<string> {
+    const builder = await this.resolver.resolve(storageType);
+    return builder.buildBlendedQuery(context);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/field-type-compatibility.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/field-type-compatibility.spec.ts
@@ -1,0 +1,140 @@
+import { areTypesCompatible, isPrimitiveFieldType } from './field-type-compatibility';
+
+describe('isPrimitiveFieldType', () => {
+  it.each([
+    ['RECORD'],
+    ['STRUCT'],
+    ['JSON'],
+    ['RANGE'],
+    ['INTERVAL'],
+    ['VARIANT'],
+    ['OBJECT'],
+    ['ARRAY'],
+    ['MAP'],
+    ['ROW'],
+    ['SUPER'],
+  ])('returns false for complex type %s', type => {
+    expect(isPrimitiveFieldType(type)).toBe(false);
+  });
+
+  it.each([
+    ['STRING'],
+    ['INTEGER'],
+    ['INT64'],
+    ['FLOAT'],
+    ['FLOAT64'],
+    ['BOOLEAN'],
+    ['BOOL'],
+    ['DATE'],
+    ['TIMESTAMP'],
+    ['BYTES'],
+    ['NUMERIC'],
+    ['DECIMAL'],
+    ['VARCHAR'],
+  ])('returns true for primitive type %s', type => {
+    expect(isPrimitiveFieldType(type)).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isPrimitiveFieldType('record')).toBe(false);
+    expect(isPrimitiveFieldType('string')).toBe(true);
+    expect(isPrimitiveFieldType('Array')).toBe(false);
+  });
+});
+
+describe('areTypesCompatible', () => {
+  describe('identical types', () => {
+    it('returns true for the same type', () => {
+      expect(areTypesCompatible('STRING', 'STRING')).toBe(true);
+      expect(areTypesCompatible('INTEGER', 'INTEGER')).toBe(true);
+    });
+
+    it('is case-insensitive for identical types', () => {
+      expect(areTypesCompatible('string', 'STRING')).toBe(true);
+    });
+  });
+
+  describe('numeric group', () => {
+    it('returns true for INTEGER and FLOAT', () => {
+      expect(areTypesCompatible('INTEGER', 'FLOAT')).toBe(true);
+    });
+
+    it('returns true for INT64 and BIGINT', () => {
+      expect(areTypesCompatible('INT64', 'BIGINT')).toBe(true);
+    });
+
+    it('returns true for NUMERIC and DECIMAL', () => {
+      expect(areTypesCompatible('NUMERIC', 'DECIMAL')).toBe(true);
+    });
+
+    it('returns true for FLOAT64 and DOUBLE', () => {
+      expect(areTypesCompatible('FLOAT64', 'DOUBLE')).toBe(true);
+    });
+
+    it('returns true for BIGNUMERIC and NUMBER', () => {
+      expect(areTypesCompatible('BIGNUMERIC', 'NUMBER')).toBe(true);
+    });
+  });
+
+  describe('string group', () => {
+    it('returns true for STRING and VARCHAR', () => {
+      expect(areTypesCompatible('STRING', 'VARCHAR')).toBe(true);
+    });
+
+    it('returns true for CHAR and NCHAR', () => {
+      expect(areTypesCompatible('CHAR', 'NCHAR')).toBe(true);
+    });
+
+    it('returns true for TEXT and NVARCHAR', () => {
+      expect(areTypesCompatible('TEXT', 'NVARCHAR')).toBe(true);
+    });
+  });
+
+  describe('boolean group', () => {
+    it('returns true for BOOLEAN and BOOL', () => {
+      expect(areTypesCompatible('BOOLEAN', 'BOOL')).toBe(true);
+    });
+  });
+
+  describe('date/time group', () => {
+    it('returns true for TIMESTAMP and TIMESTAMPTZ', () => {
+      expect(areTypesCompatible('TIMESTAMP', 'TIMESTAMPTZ')).toBe(true);
+    });
+
+    it('returns true for DATETIME and TIMESTAMP_NTZ', () => {
+      expect(areTypesCompatible('DATETIME', 'TIMESTAMP_NTZ')).toBe(true);
+    });
+
+    it('returns true for DATE and TIMESTAMP', () => {
+      expect(areTypesCompatible('DATE', 'TIMESTAMP')).toBe(true);
+    });
+  });
+
+  describe('binary group', () => {
+    it('returns true for BYTES and BYTEA', () => {
+      expect(areTypesCompatible('BYTES', 'BYTEA')).toBe(true);
+    });
+
+    it('returns true for BINARY and VARBINARY', () => {
+      expect(areTypesCompatible('BINARY', 'VARBINARY')).toBe(true);
+    });
+  });
+
+  describe('incompatible types across groups', () => {
+    it('returns false for STRING and INTEGER', () => {
+      expect(areTypesCompatible('STRING', 'INTEGER')).toBe(false);
+    });
+
+    it('returns false for BOOLEAN and DATE', () => {
+      expect(areTypesCompatible('BOOLEAN', 'DATE')).toBe(false);
+    });
+
+    it('returns false for BYTES and FLOAT', () => {
+      expect(areTypesCompatible('BYTES', 'FLOAT')).toBe(false);
+    });
+
+    it('returns false for VARCHAR and TIMESTAMP', () => {
+      expect(areTypesCompatible('VARCHAR', 'TIMESTAMP')).toBe(false);
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/field-type-compatibility.ts
+++ b/apps/backend/src/data-marts/data-storage-types/field-type-compatibility.ts
@@ -1,0 +1,87 @@
+// Non-joinable (complex) types that should be excluded from join conditions.
+// Covers BigQuery, Snowflake, Redshift, Athena, and Databricks.
+const COMPLEX_TYPES = new Set([
+  // BigQuery
+  'RECORD',
+  'STRUCT',
+  'JSON',
+  'RANGE',
+  'INTERVAL',
+  // Snowflake
+  'VARIANT',
+  'OBJECT',
+  // Athena / Databricks
+  'ARRAY',
+  'MAP',
+  'ROW',
+  // Redshift
+  'SUPER',
+]);
+
+export function isPrimitiveFieldType(type: string): boolean {
+  return !COMPLEX_TYPES.has(type.toUpperCase());
+}
+
+// Types within the same group are considered compatible for join conditions.
+const NUMERIC_TYPES = [
+  'INTEGER',
+  'INT',
+  'INT2',
+  'INT4',
+  'INT8',
+  'INT64',
+  'BIGINT',
+  'SMALLINT',
+  'TINYINT',
+  'BYTEINT',
+  'FLOAT',
+  'FLOAT4',
+  'FLOAT8',
+  'FLOAT64',
+  'DOUBLE',
+  'DOUBLE PRECISION',
+  'REAL',
+  'NUMERIC',
+  'DECIMAL',
+  'DEC',
+  'BIGNUMERIC',
+  'BIGDECIMAL',
+  'NUMBER',
+  'FIXED',
+];
+
+const NUMERIC_TYPE_SET = new Set(NUMERIC_TYPES);
+
+const TYPE_GROUPS: string[][] = [
+  NUMERIC_TYPES,
+  ['STRING', 'VARCHAR', 'CHAR', 'TEXT', 'NVARCHAR', 'NCHAR'],
+  ['BOOLEAN', 'BOOL'],
+  [
+    'DATE',
+    'TIME',
+    'DATETIME',
+    'TIMESTAMP',
+    'TIMESTAMP_LTZ',
+    'TIMESTAMP_NTZ',
+    'TIMESTAMP_TZ',
+    'TIMESTAMPTZ',
+  ],
+  ['BYTES', 'BINARY', 'VARBINARY', 'BYTEA'],
+];
+
+export function areTypesCompatible(type1: string, type2: string): boolean {
+  const upper1 = type1.toUpperCase();
+  const upper2 = type2.toUpperCase();
+
+  if (upper1 === upper2) return true;
+
+  for (const group of TYPE_GROUPS) {
+    if (group.includes(upper1) && group.includes(upper2)) return true;
+  }
+
+  return false;
+}
+
+export function isNumericFieldType(type: string): boolean {
+  return NUMERIC_TYPE_SET.has(type.toUpperCase());
+}

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
@@ -1,0 +1,938 @@
+import { DataMartRelationship } from '../../entities/data-mart-relationship.entity';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+import { BlendedQueryContext, ResolvedRelationshipChain } from './blended-query-builder.interface';
+import { AbstractBlendedQueryBuilder } from './abstract-blended-query-builder';
+
+/**
+ * Minimal concrete implementation for testing the abstract base class.
+ * Uses backtick quoting and a simple STRING_AGG syntax (no CAST) so that
+ * existing SQL-shape assertions stay readable — dialect-specific CASTs are
+ * covered by the per-dialect builder specs.
+ */
+class TestBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
+  readonly type = DataStorageType.GOOGLE_BIGQUERY;
+  protected get identifierQuoteChar() {
+    return '`';
+  }
+  protected buildStringAgg(fieldName: string): string {
+    return `STRING_AGG(${fieldName})`;
+  }
+}
+
+function makeRelationship(overrides: Partial<DataMartRelationship> = {}): DataMartRelationship {
+  return {
+    id: 'rel-1',
+    targetAlias: 'orders',
+    joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+    blendedFields: [
+      {
+        targetFieldName: 'order_name',
+        outputAlias: 'order_names',
+        isHidden: false,
+        aggregateFunction: 'STRING_AGG',
+      },
+    ],
+    projectId: 'proj',
+    createdById: 'user-1',
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    ...overrides,
+  } as DataMartRelationship;
+}
+
+function makeChain(
+  partial: Omit<ResolvedRelationshipChain, 'targetDataMartTitle' | 'targetDataMartUrl'>
+): ResolvedRelationshipChain {
+  return {
+    ...partial,
+    targetDataMartTitle: 'Test Subsidiary',
+    targetDataMartUrl: '/ui/proj/data-marts/sub-1/data-setup',
+  };
+}
+
+function buildContext(chains: ResolvedRelationshipChain[], columns: string[]): BlendedQueryContext {
+  return {
+    mainTableReference: 'main_table',
+    mainDataMartTitle: 'Test Main',
+    mainDataMartUrl: '/ui/proj/data-marts/main-1/data-setup',
+    chains,
+    columns,
+  };
+}
+
+describe('AbstractBlendedQueryBuilder', () => {
+  let builder: TestBlendedQueryBuilder;
+
+  beforeEach(() => {
+    builder = new TestBlendedQueryBuilder();
+  });
+
+  describe('CTE structure', () => {
+    it('starts with WITH and contains main CTE', () => {
+      const chain = makeChain({
+        relationship: makeRelationship(),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'order_name',
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([chain], ['customer_name', 'order_names'])
+      );
+
+      expect(sql.trimStart().startsWith('WITH')).toBe(true);
+      expect(sql).toContain('main AS (');
+      expect(sql).toContain('orders_raw AS (');
+      expect(sql).toContain('orders AS (');
+      expect(sql).toContain('FROM orders_raw');
+      expect(sql).toContain('GROUP BY customer_id');
+    });
+
+    it('includes SQL comments with data mart title and URL above each raw CTE', () => {
+      const chain = makeChain({
+        relationship: makeRelationship(),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'order_name',
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery({
+        mainTableReference: 'customers_table',
+        mainDataMartTitle: 'Customers DM',
+        mainDataMartUrl: 'https://app.example.com/dm-main',
+        chains: [chain],
+        columns: ['order_names'],
+      });
+
+      expect(sql).toContain('-- Customers DM');
+      expect(sql).toContain('-- https://app.example.com/dm-main');
+      expect(sql).toContain('-- Test Subsidiary');
+      expect(sql).toContain('-- /ui/proj/data-marts/sub-1/data-setup');
+    });
+
+    it('places raw CTE before aggregation CTE within each subtree', () => {
+      const chain1 = makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'orders',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'order_name',
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+      const chain2 = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-2',
+          targetAlias: 'payments',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'payer_id' }],
+        }),
+        targetTableReference: 'payments_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'amount',
+            outputAlias: 'total_amount',
+            isHidden: false,
+            aggregateFunction: 'MAX',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([chain1, chain2], ['customer_name', 'order_names', 'total_amount'])
+      );
+
+      const ordersRawPos = sql.indexOf('orders_raw AS (');
+      const ordersAggPos = sql.indexOf('\n  orders AS (');
+      expect(ordersRawPos).toBeLessThan(ordersAggPos);
+
+      const paymentsRawPos = sql.indexOf('payments_raw AS (');
+      const paymentsAggPos = sql.indexOf('\n  payments AS (');
+      expect(paymentsRawPos).toBeLessThan(paymentsAggPos);
+    });
+
+    it('separates CTEs with a blank line', () => {
+      const chain = makeChain({
+        relationship: makeRelationship(),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'order_name',
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(buildContext([chain], ['order_names']));
+      expect(sql).toContain('),\n\n');
+    });
+  });
+
+  describe('multiple subsidiaries', () => {
+    it('generates multiple LEFT JOINs for root-level chains', () => {
+      const chain1 = makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'orders',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'order_name',
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+      const chain2 = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-2',
+          targetAlias: 'payments',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'payer_id' }],
+        }),
+        targetTableReference: 'payments_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'amount',
+            outputAlias: 'total_amount',
+            isHidden: false,
+            aggregateFunction: 'MAX',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([chain1, chain2], ['customer_name', 'order_names', 'total_amount'])
+      );
+
+      expect(sql).toContain('ON main.id = orders.customer_id');
+      expect(sql).toContain('ON main.id = payments.payer_id');
+      expect(sql).toContain('MAX(amount) AS total_amount');
+    });
+  });
+
+  describe('multi-key join', () => {
+    it('generates AND in ON clause for multiple join keys', () => {
+      const chain = makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'events',
+          joinConditions: [
+            { sourceFieldName: 'project_id', targetFieldName: 'evt_project_id' },
+            { sourceFieldName: 'user_id', targetFieldName: 'evt_user_id' },
+          ],
+        }),
+        targetTableReference: 'events_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'event_name',
+            outputAlias: 'event_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(buildContext([chain], ['event_names']));
+
+      expect(sql).toContain(
+        'ON main.project_id = events.evt_project_id AND main.user_id = events.evt_user_id'
+      );
+      expect(sql).toContain('GROUP BY evt_project_id, evt_user_id');
+    });
+  });
+
+  describe('column selection', () => {
+    it('includes only specified columns in SELECT', () => {
+      const chain = makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'orders',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'order_name',
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+          {
+            targetFieldName: 'revenue',
+            outputAlias: 'total_revenue',
+            isHidden: false,
+            aggregateFunction: 'SUM',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([chain], ['customer_name', 'order_names'])
+      );
+
+      expect(sql).toContain('orders.order_names');
+      expect(sql).not.toContain('orders.total_revenue');
+      expect(sql).toContain('SUM(revenue) AS total_revenue');
+    });
+  });
+
+  describe('identifier quoting', () => {
+    it('quotes unsafe identifiers and leaves safe ones unquoted', () => {
+      const chain = makeChain({
+        relationship: makeRelationship({
+          targetAlias: "Product's",
+          joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'product_id' }],
+        }),
+        targetTableReference: 'products_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'product_name',
+            outputAlias: "Product's__product_name",
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([chain], ['campaign_name', "Product's__product_name"])
+      );
+
+      expect(sql).toContain("`Product's_raw` AS (");
+      expect(sql).toContain("`Product's` AS (");
+      expect(sql).toContain("`Product's`.`Product's__product_name`");
+      expect(sql).toContain("LEFT JOIN `Product's` ON main.product_id = `Product's`.product_id");
+      expect(sql).toContain('main.campaign_name');
+      expect(sql).not.toContain('`main`');
+    });
+
+    it('quotes column names with special characters in joinConditions', () => {
+      const chain = makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'orders',
+          joinConditions: [{ sourceFieldName: "user's_id", targetFieldName: "owner's_id" }],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: "order's_name",
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(buildContext([chain], ['order_names']));
+
+      expect(sql).toContain("LEFT JOIN orders ON main.`user's_id` = orders.`owner's_id`");
+      expect(sql).toContain("GROUP BY `owner's_id`");
+    });
+  });
+
+  describe('explicit raw CTE projection', () => {
+    it('main raw CTE projects only requested native columns + join keys', () => {
+      const chain = makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'orders',
+          joinConditions: [{ sourceFieldName: 'customer_id', targetFieldName: 'cust_id' }],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'order_name',
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([chain], ['customer_name', 'order_names'])
+      );
+
+      expect(sql).not.toContain('SELECT *');
+      expect(sql).toMatch(/main AS \(\s*SELECT\s+customer_id,\s+customer_name\s+FROM main_table/);
+      expect(sql).toMatch(/orders_raw AS \(\s*SELECT\s+cust_id,\s+order_name\s+FROM orders_table/);
+    });
+
+    it('intermediate raw CTE includes join keys for downstream chain', () => {
+      const ab = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-ab',
+          targetAlias: 'b',
+          joinConditions: [{ sourceFieldName: 'b_id', targetFieldName: 'b_id' }],
+        }),
+        targetTableReference: 'b_table',
+        parentAlias: 'main',
+        blendedFields: [],
+      });
+      const bc = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-bc',
+          targetAlias: 'c',
+          joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'product_id' }],
+        }),
+        targetTableReference: 'c_table',
+        parentAlias: 'b',
+        blendedFields: [
+          {
+            targetFieldName: 'product_name',
+            outputAlias: 'b_c__product_name',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([ab, bc], ['campaign_id', 'b_c__product_name'])
+      );
+
+      expect(sql).not.toContain('SELECT *');
+      expect(sql).toMatch(/b_raw AS \(\s*SELECT\s+b_id,\s+product_id\s+FROM b_table/);
+    });
+
+    it('deduplicates and sorts projected columns for stable SQL output', () => {
+      const chain = makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'orders',
+          joinConditions: [
+            { sourceFieldName: 'customer_id', targetFieldName: 'cust_id' },
+            { sourceFieldName: 'project_id', targetFieldName: 'proj_id' },
+          ],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'cust_id',
+            outputAlias: 'count_cust',
+            isHidden: false,
+            aggregateFunction: 'COUNT',
+          },
+          {
+            targetFieldName: 'order_name',
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(buildContext([chain], ['order_names', 'count_cust']));
+
+      expect(sql).toMatch(
+        /orders_raw AS \(\s*SELECT\s+cust_id,\s+order_name,\s+proj_id\s+FROM orders_table/
+      );
+    });
+
+    it('falls back to SELECT * when a field uses dot-notation (nested struct)', () => {
+      const chain = makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'events',
+          joinConditions: [{ sourceFieldName: 'user_id', targetFieldName: 'user.id' }],
+        }),
+        targetTableReference: 'events_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'event_name',
+            outputAlias: 'event_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([chain], ['customer_name', 'event_names'])
+      );
+
+      expect(sql).toContain('events_raw AS (\n    SELECT * FROM events_table');
+    });
+  });
+
+  describe('hidden fields', () => {
+    it('hidden fields are excluded from SELECT but available in the aggregation CTE', () => {
+      const chain = makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'orders',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'order_name',
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+          {
+            targetFieldName: 'internal_flag',
+            outputAlias: 'hidden_flag',
+            isHidden: true,
+            aggregateFunction: 'MAX',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([chain], ['customer_name', 'order_names', 'hidden_flag'])
+      );
+
+      expect(sql).toContain('main.hidden_flag');
+      expect(sql).toContain('MAX(internal_flag) AS hidden_flag');
+    });
+  });
+
+  describe('bottom-up blending', () => {
+    it('intermediate node uses _joined CTE and groups by parent key only', () => {
+      const ab = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-ab',
+          targetAlias: 'b',
+          joinConditions: [{ sourceFieldName: 'b_id', targetFieldName: 'b_id' }],
+        }),
+        targetTableReference: 'b_table',
+        parentAlias: 'main',
+        blendedFields: [],
+      });
+      const bc = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-bc',
+          targetAlias: 'c',
+          joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'product_id' }],
+        }),
+        targetTableReference: 'c_table',
+        parentAlias: 'b',
+        blendedFields: [
+          {
+            targetFieldName: 'product_name',
+            outputAlias: 'b_c__product_name',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([ab, bc], ['campaign_id', 'b_c__product_name'])
+      );
+
+      // C (leaf) aggregation
+      expect(sql).toContain('c AS (');
+      expect(sql).toContain('FROM c_raw');
+
+      // B has _joined CTE that LEFT JOINs with aggregated C
+      expect(sql).toContain('b_joined AS (');
+      expect(sql).toContain('LEFT JOIN c ON b_raw.product_id = c.product_id');
+
+      // B aggregation reads from b_joined and groups by b_id ONLY
+      expect(sql).toMatch(
+        /\n {2}b AS \(\s*SELECT\s+b_id,[\s\S]*?FROM b_joined\s+GROUP BY b_id\s+\)/
+      );
+
+      // Final JOIN only to B, not C
+      expect(sql).toContain('LEFT JOIN b ON main.b_id = b.b_id');
+      const finalSection = sql.split('FROM main\n')[1];
+      expect(finalSection).not.toContain('LEFT JOIN c ON');
+
+      // b_c__product_name surfaced through B
+      expect(sql).toContain('b.b_c__product_name');
+    });
+
+    it('shared join key between parent and child is handled correctly', () => {
+      const ab = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-ab',
+          targetAlias: 'b',
+          joinConditions: [{ sourceFieldName: 'shared_id', targetFieldName: 'shared_id' }],
+        }),
+        targetTableReference: 'b_table',
+        parentAlias: 'main',
+        blendedFields: [],
+      });
+      const bc = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-bc',
+          targetAlias: 'c',
+          joinConditions: [{ sourceFieldName: 'shared_id', targetFieldName: 'shared_id' }],
+        }),
+        targetTableReference: 'c_table',
+        parentAlias: 'b',
+        blendedFields: [
+          {
+            targetFieldName: 'val',
+            outputAlias: 'c_val',
+            isHidden: false,
+            aggregateFunction: 'MAX',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(buildContext([ab, bc], ['campaign_id', 'c_val']));
+
+      expect(sql).toMatch(
+        /\n {2}b AS \(\s*SELECT\s+shared_id,\s+MAX\(c_val\) AS c_val\s+FROM b_joined\s+GROUP BY shared_id\s+\)/
+      );
+      expect(sql).toMatch(
+        /\n {2}c AS \(\s*SELECT\s+shared_id,\s+MAX\(val\) AS c_val\s+FROM c_raw\s+GROUP BY shared_id\s+\)/
+      );
+    });
+
+    it('3-level chain: cascading re-aggregation (A→B→C→D)', () => {
+      const ab = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-ab',
+          targetAlias: 'b',
+          joinConditions: [{ sourceFieldName: 'a_key', targetFieldName: 'a_key' }],
+        }),
+        targetTableReference: 'b_table',
+        parentAlias: 'main',
+        blendedFields: [],
+      });
+      const bc = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-bc',
+          targetAlias: 'c',
+          joinConditions: [{ sourceFieldName: 'b_key', targetFieldName: 'b_key' }],
+        }),
+        targetTableReference: 'c_table',
+        parentAlias: 'b',
+        blendedFields: [],
+      });
+      const cd = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-cd',
+          targetAlias: 'd',
+          joinConditions: [{ sourceFieldName: 'c_key', targetFieldName: 'c_key' }],
+        }),
+        targetTableReference: 'd_table',
+        parentAlias: 'c',
+        blendedFields: [
+          {
+            targetFieldName: 'value',
+            outputAlias: 'd_value',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(buildContext([ab, bc, cd], ['col_a', 'd_value']));
+
+      // D (leaf) aggregates by c_key
+      expect(sql).toContain('FROM d_raw');
+      expect(sql).toContain('GROUP BY c_key');
+
+      // C (intermediate) has _joined CTE with D, aggregates by b_key
+      expect(sql).toContain('c_joined AS (');
+      expect(sql).toContain('LEFT JOIN d ON c_raw.c_key = d.c_key');
+      expect(sql).toMatch(/\n {2}c AS \([\s\S]*?FROM c_joined\s+GROUP BY b_key\s+\)/);
+
+      // B (intermediate) has _joined CTE with C, aggregates by a_key
+      expect(sql).toContain('b_joined AS (');
+      expect(sql).toContain('LEFT JOIN c ON b_raw.b_key = c.b_key');
+      expect(sql).toMatch(/\n {2}b AS \([\s\S]*?FROM b_joined\s+GROUP BY a_key\s+\)/);
+
+      // Final SELECT references only main and b
+      expect(sql).toContain('LEFT JOIN b ON main.a_key = b.a_key');
+      expect(sql).toContain('b.d_value');
+    });
+
+    it('multiple children at one node: _joined CTE has multiple LEFT JOINs', () => {
+      const ab = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-ab',
+          targetAlias: 'orders',
+          joinConditions: [{ sourceFieldName: 'campaign_id', targetFieldName: 'campaign_id' }],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'order_name',
+            outputAlias: 'order_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+      const bc = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-bc',
+          targetAlias: 'products',
+          joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'product_id' }],
+        }),
+        targetTableReference: 'products_table',
+        parentAlias: 'orders',
+        blendedFields: [
+          {
+            targetFieldName: 'product_name',
+            outputAlias: 'product_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+      const bd = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-bd',
+          targetAlias: 'customers',
+          joinConditions: [{ sourceFieldName: 'customer_id', targetFieldName: 'customer_id' }],
+        }),
+        targetTableReference: 'customers_table',
+        parentAlias: 'orders',
+        blendedFields: [
+          {
+            targetFieldName: 'customer_name',
+            outputAlias: 'customer_names',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext(
+          [ab, bc, bd],
+          ['campaign_name', 'order_names', 'product_names', 'customer_names']
+        )
+      );
+
+      expect(sql).toContain('orders_joined AS (');
+      expect(sql).toContain('LEFT JOIN products ON orders_raw.product_id = products.product_id');
+      expect(sql).toContain(
+        'LEFT JOIN customers ON orders_raw.customer_id = customers.customer_id'
+      );
+
+      expect(sql).toMatch(
+        /\n {2}orders AS \([\s\S]*?FROM orders_joined\s+GROUP BY campaign_id\s+\)/
+      );
+
+      expect(sql).toContain('orders.order_names');
+      expect(sql).toContain('orders.product_names');
+      expect(sql).toContain('orders.customer_names');
+
+      const finalJoins = sql.split('FROM main\n')[1];
+      expect(finalJoins).toContain('LEFT JOIN orders ON');
+      expect(finalJoins).not.toContain('LEFT JOIN products ON');
+      expect(finalJoins).not.toContain('LEFT JOIN customers ON');
+    });
+
+    it('re-aggregation: COUNT becomes SUM at parent level', () => {
+      const ab = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-ab',
+          targetAlias: 'orders',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [],
+      });
+      const bc = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-bc',
+          targetAlias: 'items',
+          joinConditions: [{ sourceFieldName: 'order_id', targetFieldName: 'order_id' }],
+        }),
+        targetTableReference: 'items_table',
+        parentAlias: 'orders',
+        blendedFields: [
+          {
+            targetFieldName: 'item_id',
+            outputAlias: 'item_count',
+            isHidden: false,
+            aggregateFunction: 'COUNT',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([ab, bc], ['customer_name', 'item_count'])
+      );
+
+      expect(sql).toContain('COUNT(item_id) AS item_count');
+      expect(sql).toContain('SUM(item_count) AS item_count');
+    });
+
+    it('re-aggregation: COUNT_DISTINCT becomes SUM at parent level', () => {
+      const ab = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-ab',
+          targetAlias: 'orders',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [],
+      });
+      const bc = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-bc',
+          targetAlias: 'items',
+          joinConditions: [{ sourceFieldName: 'order_id', targetFieldName: 'order_id' }],
+        }),
+        targetTableReference: 'items_table',
+        parentAlias: 'orders',
+        blendedFields: [
+          {
+            targetFieldName: 'item_id',
+            outputAlias: 'unique_items',
+            isHidden: false,
+            aggregateFunction: 'COUNT_DISTINCT',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([ab, bc], ['customer_name', 'unique_items'])
+      );
+
+      expect(sql).toContain('COUNT(DISTINCT item_id) AS unique_items');
+      expect(sql).toContain('SUM(unique_items) AS unique_items');
+    });
+
+    it('empty blendedFields on intermediate node: passthrough only', () => {
+      const ab = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-ab',
+          targetAlias: 'orders',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+        }),
+        targetTableReference: 'orders_table',
+        parentAlias: 'main',
+        blendedFields: [],
+      });
+      const bc = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-bc',
+          targetAlias: 'items',
+          joinConditions: [{ sourceFieldName: 'order_id', targetFieldName: 'order_id' }],
+        }),
+        targetTableReference: 'items_table',
+        parentAlias: 'orders',
+        blendedFields: [
+          {
+            targetFieldName: 'sku',
+            outputAlias: 'item_skus',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(buildContext([ab, bc], ['customer_name', 'item_skus']));
+
+      expect(sql).toContain('orders_joined AS (');
+      expect(sql).toMatch(
+        /\n {2}orders AS \([\s\S]*?FROM orders_joined\s+GROUP BY customer_id\s+\)/
+      );
+      expect(sql).toContain('STRING_AGG(item_skus) AS item_skus');
+      expect(sql).toContain('orders.item_skus');
+    });
+
+    it('row-count guarantee: only root-level LEFT JOINs in final FROM clause', () => {
+      const chainA = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-a',
+          targetAlias: 'a',
+          joinConditions: [{ sourceFieldName: 'a_id', targetFieldName: 'a_id' }],
+        }),
+        targetTableReference: 'a_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'a_val',
+            outputAlias: 'a_vals',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+      const chainB = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-b',
+          targetAlias: 'b',
+          joinConditions: [{ sourceFieldName: 'b_id', targetFieldName: 'b_id' }],
+        }),
+        targetTableReference: 'b_table',
+        parentAlias: 'a',
+        blendedFields: [
+          {
+            targetFieldName: 'b_val',
+            outputAlias: 'b_vals',
+            isHidden: false,
+            aggregateFunction: 'MAX',
+          },
+        ],
+      });
+      const chainD = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-d',
+          targetAlias: 'd',
+          joinConditions: [{ sourceFieldName: 'd_id', targetFieldName: 'd_id' }],
+        }),
+        targetTableReference: 'd_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'd_val',
+            outputAlias: 'd_vals',
+            isHidden: false,
+            aggregateFunction: 'COUNT',
+          },
+        ],
+      });
+
+      const sql = builder.buildBlendedQuery(
+        buildContext([chainA, chainB, chainD], ['root_col', 'a_vals', 'b_vals', 'd_vals'])
+      );
+
+      const fromSection = sql.split('FROM main\n')[1];
+      const leftJoins = fromSection.match(/LEFT JOIN \w+ ON/g) ?? [];
+      expect(leftJoins).toHaveLength(2);
+      expect(fromSection).toContain('LEFT JOIN a ON main.a_id = a.a_id');
+      expect(fromSection).toContain('LEFT JOIN d ON main.d_id = d.d_id');
+
+      expect(sql).toContain('a.a_vals');
+      expect(sql).toContain('a.b_vals');
+      expect(sql).toContain('d.d_vals');
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
@@ -1,0 +1,515 @@
+import {
+  BlendedQueryBuilder,
+  BlendedQueryContext,
+  ResolvedRelationshipChain,
+} from './blended-query-builder.interface';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+import { AggregateFunction } from '../../dto/schemas/relationship-schemas';
+
+interface BlendTreeNode {
+  chain: ResolvedRelationshipChain;
+  children: BlendTreeNode[];
+}
+
+/**
+ * Tracks a blended field flowing upward through the tree during bottom-up
+ * aggregation. At the leaf level this is the original field; at each
+ * intermediate level the aggregated result is re-aggregated using
+ * {@link getReAggregateFunction}.
+ */
+interface PassthroughField {
+  outputAlias: string;
+  aggregateFunction: AggregateFunction;
+  isHidden: boolean;
+}
+
+/**
+ * Base class for blended SQL query builders.
+ *
+ * Produces CTE-based SQL using a **bottom-up** join strategy that guarantees
+ * the result row count never exceeds the main data mart's row count.
+ *
+ * The algorithm works by processing leaf data marts first, aggregating them
+ * by their join key to the parent, then LEFT JOINing the aggregated results
+ * into the parent's raw data, and aggregating again — all the way up to the
+ * root level. At each level the GROUP BY contains ONLY the join key to that
+ * node's parent, ensuring at most one output row per parent-key value.
+ *
+ * ```sql
+ * WITH
+ *   main AS (SELECT ... FROM <mainTable>),
+ *
+ *   -- leaf: aggregate by join key to parent
+ *   c_raw AS (SELECT ... FROM <cTable>),
+ *   c AS (SELECT parent_key, AGG(field) FROM c_raw GROUP BY parent_key),
+ *
+ *   -- intermediate: join raw data with aggregated children, then aggregate
+ *   b_raw AS (SELECT ... FROM <bTable>),
+ *   b_joined AS (SELECT b_raw.*, c.child_col FROM b_raw LEFT JOIN c ON ...),
+ *   b AS (SELECT main_key, AGG(own_field), RE_AGG(child_col) FROM b_joined GROUP BY main_key)
+ *
+ * SELECT main.col, b.own_field, b.child_col
+ * FROM main
+ * LEFT JOIN b ON main.key = b.key
+ * ```
+ *
+ * Subclasses only need to override `buildAggregation` to provide
+ * dialect-specific aggregate expressions (STRING_AGG is the only function
+ * that differs between dialects today).
+ */
+export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder {
+  abstract readonly type: DataStorageType;
+
+  /**
+   * The quoting character this dialect uses for identifiers (BigQuery/Databricks
+   * use backticks; Snowflake/Redshift/Athena use double quotes). Subclasses
+   * provide this so the abstract builder can safely emit user-controlled names
+   * (aliases, column names with apostrophes/spaces, reserved keywords, etc.)
+   * without breaking the generated SQL.
+   */
+  protected abstract get identifierQuoteChar(): string;
+
+  buildBlendedQuery(context: BlendedQueryContext): string {
+    const { mainTableReference, mainDataMartTitle, mainDataMartUrl, chains, columns } = context;
+    const columnSet = new Set(columns);
+
+    const cteBlocks: string[] = [];
+
+    // 1. Raw CTE for main data mart — projects only the columns actually referenced.
+    const roots = this.buildTree(chains);
+    const mainColumns = this.collectMainReferences(roots, columnSet);
+    cteBlocks.push(
+      this.buildRawCte('main', mainTableReference, mainDataMartTitle, mainDataMartUrl, mainColumns)
+    );
+
+    // 2. Bottom-up CTEs for each subtree rooted at a direct child of main.
+    //    Post-order traversal ensures leaf CTEs come first.
+    for (const root of roots) {
+      const { ctes } = this.buildSubtreeCtes(root);
+      cteBlocks.push(...ctes);
+    }
+
+    const withClause = `WITH\n${cteBlocks.join(',\n\n')}`;
+
+    const selectParts = this.buildSelectParts(roots, columnSet);
+    const joinParts = this.buildJoinParts(roots);
+    const selectClause = selectParts.length > 0 ? selectParts.join(',\n  ') : '*';
+
+    const body =
+      `SELECT\n  ${selectClause}\nFROM main` +
+      (joinParts.length > 0 ? '\n' + joinParts.join('\n') : '');
+
+    return `${withClause}\n\n${body}`;
+  }
+
+  /**
+   * Wraps a single identifier (CTE alias, column alias, single-segment column
+   * name) in dialect-specific quotes only when needed — names that already
+   * match `[A-Za-z_][A-Za-z0-9_]*` stay unquoted to keep the generated SQL
+   * readable. The quote character itself is escaped by doubling, the standard
+   * SQL convention across all supported dialects.
+   */
+  protected quoteIdentifier(name: string): string {
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) return name;
+    const q = this.identifierQuoteChar;
+    return `${q}${name.split(q).join(q + q)}${q}`;
+  }
+
+  /**
+   * Quotes a (possibly dotted) column reference, treating each segment
+   * independently. `user.email` becomes e.g. `` `user`.`email` `` — required
+   * for nested struct fields in BigQuery — while a flat `Product's_id` becomes
+   * `` `Product's_id` ``.
+   */
+  protected quoteFieldRef(ref: string): string {
+    return ref
+      .split('.')
+      .map(seg => this.quoteIdentifier(seg))
+      .join('.');
+  }
+
+  /**
+   * Converts the flat sorted `chains` array into a forest of trees where
+   * root nodes are chains with `parentAlias === 'main'`.
+   */
+  private buildTree(chains: ResolvedRelationshipChain[]): BlendTreeNode[] {
+    const nodeMap = new Map<string, BlendTreeNode>();
+    for (const chain of chains) {
+      nodeMap.set(chain.relationship.targetAlias, { chain, children: [] });
+    }
+    const roots: BlendTreeNode[] = [];
+    for (const chain of chains) {
+      const node = nodeMap.get(chain.relationship.targetAlias)!;
+      if (chain.parentAlias === 'main') {
+        roots.push(node);
+      } else {
+        const parentNode = nodeMap.get(chain.parentAlias);
+        if (parentNode) parentNode.children.push(node);
+      }
+    }
+    return roots;
+  }
+
+  /**
+   * Recursively builds CTEs for a subtree using post-order (bottom-up)
+   * traversal. Returns the CTE blocks and the list of output columns
+   * (passthrough fields) that this subtree exposes after aggregation.
+   */
+  private buildSubtreeCtes(node: BlendTreeNode): {
+    ctes: string[];
+    passthroughFields: PassthroughField[];
+  } {
+    const ctes: string[] = [];
+
+    // 1. Recurse into children first (post-order)
+    const childPassthroughs = new Map<string, PassthroughField[]>();
+    for (const child of node.children) {
+      const childResult = this.buildSubtreeCtes(child);
+      ctes.push(...childResult.ctes);
+      childPassthroughs.set(child.chain.relationship.targetAlias, childResult.passthroughFields);
+    }
+
+    const { chain } = node;
+    const alias = chain.relationship.targetAlias;
+
+    // 2. Raw CTE for this node
+    const subsidiaryColumns = this.collectSubsidiaryReferences(chain, node.children);
+    ctes.push(
+      this.buildRawCte(
+        `${alias}_raw`,
+        chain.targetTableReference,
+        chain.targetDataMartTitle,
+        chain.targetDataMartUrl,
+        subsidiaryColumns
+      )
+    );
+
+    // 3. If this node has children, emit a _joined CTE
+    const hasChildren = node.children.length > 0;
+    if (hasChildren) {
+      ctes.push(this.buildJoinedCte(node, childPassthroughs));
+    }
+
+    // 4. Aggregation CTE — groups by parent join keys only
+    const allPassthroughFields = this.collectAllPassthroughs(childPassthroughs);
+    ctes.push(this.buildAggregationCte(chain, hasChildren, allPassthroughFields));
+
+    // 5. Compute passthrough fields for the parent level:
+    //    own blended fields + re-mapped child passthrough fields
+    const passthroughFields: PassthroughField[] = chain.blendedFields.map(f => ({
+      outputAlias: f.outputAlias,
+      aggregateFunction: f.aggregateFunction,
+      isHidden: f.isHidden,
+    }));
+    for (const pt of allPassthroughFields) {
+      passthroughFields.push({
+        outputAlias: pt.outputAlias,
+        aggregateFunction: this.getReAggregateFunction(pt.aggregateFunction),
+        isHidden: pt.isHidden,
+      });
+    }
+
+    return { ctes, passthroughFields };
+  }
+
+  private collectAllPassthroughs(
+    childPassthroughs: Map<string, PassthroughField[]>
+  ): PassthroughField[] {
+    const result: PassthroughField[] = [];
+    for (const fields of childPassthroughs.values()) {
+      result.push(...fields);
+    }
+    return result;
+  }
+
+  /**
+   * Builds the `{alias}_joined` CTE that LEFT JOINs a node's raw data with
+   * all of its children's aggregated CTEs.
+   */
+  private buildJoinedCte(
+    node: BlendTreeNode,
+    childPassthroughs: Map<string, PassthroughField[]>
+  ): string {
+    const { chain } = node;
+    const alias = chain.relationship.targetAlias;
+    const rawAlias = `${alias}_raw`;
+    const joinedAlias = `${alias}_joined`;
+    const quotedRawAlias = this.quoteIdentifier(rawAlias);
+    const quotedJoinedAlias = this.quoteIdentifier(joinedAlias);
+
+    // SELECT columns: parent join keys + own blended fields from raw, then child outputs
+    const selectParts: string[] = [];
+
+    // Parent join keys from raw
+    for (const jc of chain.relationship.joinConditions) {
+      selectParts.push(`${quotedRawAlias}.${this.quoteFieldRef(jc.targetFieldName)}`);
+    }
+
+    // Own blended field columns from raw
+    const seen = new Set(selectParts);
+    for (const field of chain.blendedFields) {
+      const ref = `${quotedRawAlias}.${this.quoteFieldRef(field.targetFieldName)}`;
+      if (!seen.has(ref)) {
+        seen.add(ref);
+        selectParts.push(ref);
+      }
+    }
+
+    // Child aggregated outputs + JOIN clauses (single pass over children)
+    const joinClauses: string[] = [];
+    for (const child of node.children) {
+      const childAlias = child.chain.relationship.targetAlias;
+      const quotedChildAlias = this.quoteIdentifier(childAlias);
+
+      for (const pt of childPassthroughs.get(childAlias) ?? []) {
+        selectParts.push(`${quotedChildAlias}.${this.quoteIdentifier(pt.outputAlias)}`);
+      }
+
+      const onParts = child.chain.relationship.joinConditions.map(
+        jc =>
+          `${quotedRawAlias}.${this.quoteFieldRef(jc.sourceFieldName)} = ${quotedChildAlias}.${this.quoteFieldRef(jc.targetFieldName)}`
+      );
+      joinClauses.push(`LEFT JOIN ${quotedChildAlias} ON ${onParts.join(' AND ')}`);
+    }
+
+    return (
+      `  ${quotedJoinedAlias} AS (\n` +
+      `    SELECT\n` +
+      `      ${selectParts.join(',\n      ')}\n` +
+      `    FROM ${quotedRawAlias}\n` +
+      `    ${joinClauses.join('\n    ')}\n` +
+      `  )`
+    );
+  }
+
+  private buildRawCte(
+    alias: string,
+    tableReference: string,
+    title: string,
+    url: string,
+    columns: string[]
+  ): string {
+    // Fall back to `*` when no explicit columns are known or any column uses
+    // dot-notation (BigQuery nested struct path) — projecting `user.email`
+    // directly would rename it to `email`, breaking downstream references.
+    const safeForExplicitProjection = columns.length > 0 && columns.every(c => !c.includes('.'));
+    const header = `  -- ${title}\n  -- ${url}\n  ${this.quoteIdentifier(alias)} AS (\n`;
+    if (!safeForExplicitProjection) {
+      return `${header}    SELECT * FROM ${tableReference}\n  )`;
+    }
+    const projection = columns.map(c => this.quoteIdentifier(c)).join(',\n      ');
+    return `${header}    SELECT\n      ${projection}\n    FROM ${tableReference}\n  )`;
+  }
+
+  /**
+   * Columns of the main DM that need to be projected in its raw CTE:
+   *  - native columns from the user's `columnConfig` (everything in `columnSet`
+   *    that is not the outputAlias of a non-hidden subsidiary blended field)
+   *  - join keys used by root-level (direct children of main) chains
+   */
+  private collectMainReferences(roots: BlendTreeNode[], columnSet: Set<string>): string[] {
+    const subsidiaryOutputAliases = this.collectAllOutputAliases(roots);
+
+    const refs = new Set<string>();
+    for (const col of columnSet) {
+      if (!subsidiaryOutputAliases.has(col)) refs.add(col);
+    }
+    for (const root of roots) {
+      for (const jc of root.chain.relationship.joinConditions) refs.add(jc.sourceFieldName);
+    }
+    return Array.from(refs).sort();
+  }
+
+  /**
+   * Recursively collects all non-hidden outputAlias values from a tree.
+   * In bottom-up mode, deep blended fields are surfaced through root nodes,
+   * so we need to traverse the entire tree.
+   */
+  private collectAllOutputAliases(nodes: BlendTreeNode[]): Set<string> {
+    const result = new Set<string>();
+    for (const node of nodes) {
+      for (const field of node.chain.blendedFields) {
+        if (!field.isHidden) result.add(field.outputAlias);
+      }
+      const childAliases = this.collectAllOutputAliases(node.children);
+      for (const alias of childAliases) result.add(alias);
+    }
+    return result;
+  }
+
+  /**
+   * Columns of a subsidiary DM that need to be projected in its raw CTE:
+   *  - join keys this subsidiary uses to join to its parent (targetFieldName)
+   *  - aggregated columns (blendedFields.targetFieldName)
+   *  - join keys used by children (sourceFieldName — needed for the _joined CTE)
+   */
+  private collectSubsidiaryReferences(
+    chain: ResolvedRelationshipChain,
+    children: BlendTreeNode[]
+  ): string[] {
+    const refs = new Set<string>();
+    for (const jc of chain.relationship.joinConditions) refs.add(jc.targetFieldName);
+    for (const field of chain.blendedFields) refs.add(field.targetFieldName);
+    for (const child of children) {
+      for (const jc of child.chain.relationship.joinConditions) refs.add(jc.sourceFieldName);
+    }
+    return Array.from(refs).sort();
+  }
+
+  /**
+   * Builds the aggregation CTE for a single node. Groups by parent join keys
+   * ONLY — child join keys are no longer needed because downstream joins happen
+   * inside the `_joined` CTE, not in the final FROM/JOIN clause.
+   *
+   * For intermediate nodes (hasChildren=true), the source is the `_joined` CTE
+   * and passthrough fields from children are re-aggregated. For leaf nodes,
+   * the source is the `_raw` CTE.
+   */
+  private buildAggregationCte(
+    chain: ResolvedRelationshipChain,
+    hasChildren: boolean,
+    passthroughFields: PassthroughField[]
+  ): string {
+    const { relationship, blendedFields } = chain;
+    const alias = this.quoteIdentifier(relationship.targetAlias);
+    const sourceAlias = hasChildren
+      ? this.quoteIdentifier(`${relationship.targetAlias}_joined`)
+      : this.quoteIdentifier(`${relationship.targetAlias}_raw`);
+
+    // Keys this subsidiary uses to join to its parent — always grouped on.
+    const parentJoinKeys = relationship.joinConditions.map(jc =>
+      this.quoteFieldRef(jc.targetFieldName)
+    );
+
+    const groupByKeys = [...parentJoinKeys];
+
+    // Own blended field aggregations
+    const aggregatedParts = blendedFields.map(field => {
+      const aggregated = this.buildAggregation(
+        field.aggregateFunction,
+        this.quoteFieldRef(field.targetFieldName)
+      );
+      return `${aggregated} AS ${this.quoteIdentifier(field.outputAlias)}`;
+    });
+
+    // Passthrough fields from children — re-aggregated
+    const passthroughParts = passthroughFields.map(pt => {
+      const reAggFunc = this.getReAggregateFunction(pt.aggregateFunction);
+      const aggregated = this.buildAggregation(reAggFunc, this.quoteIdentifier(pt.outputAlias));
+      return `${aggregated} AS ${this.quoteIdentifier(pt.outputAlias)}`;
+    });
+
+    const selectItems = [...groupByKeys, ...aggregatedParts, ...passthroughParts];
+
+    return (
+      `  ${alias} AS (\n` +
+      `    SELECT\n` +
+      `      ${selectItems.join(',\n      ')}\n` +
+      `    FROM ${sourceAlias}\n` +
+      `    GROUP BY ${groupByKeys.join(', ')}\n` +
+      `  )`
+    );
+  }
+
+  /**
+   * Final SELECT: references main columns and blended columns from root-level
+   * aggregation CTEs only. Deep blended fields are surfaced through root nodes
+   * via re-aggregation.
+   */
+  private buildSelectParts(roots: BlendTreeNode[], columnSet: Set<string>): string[] {
+    const parts: string[] = [];
+
+    // Build a map: outputAlias → root alias that surfaces it.
+    // Non-hidden blended fields from any depth are routed to their root ancestor.
+    const outputAliasToRoot = new Map<string, string>();
+    for (const root of roots) {
+      this.mapOutputAliasesToRoot(root, root.chain.relationship.targetAlias, outputAliasToRoot);
+    }
+
+    for (const col of columnSet) {
+      const rootAlias = outputAliasToRoot.get(col);
+      if (rootAlias) {
+        parts.push(`${this.quoteIdentifier(rootAlias)}.${this.quoteIdentifier(col)}`);
+      } else {
+        parts.push(`main.${this.quoteIdentifier(col)}`);
+      }
+    }
+
+    return parts;
+  }
+
+  /**
+   * Recursively maps every non-hidden outputAlias in a subtree to the root
+   * alias that will surface it after bottom-up aggregation.
+   */
+  private mapOutputAliasesToRoot(
+    node: BlendTreeNode,
+    rootAlias: string,
+    result: Map<string, string>
+  ): void {
+    for (const field of node.chain.blendedFields) {
+      if (!field.isHidden) result.set(field.outputAlias, rootAlias);
+    }
+    for (const child of node.children) {
+      this.mapOutputAliasesToRoot(child, rootAlias, result);
+    }
+  }
+
+  /**
+   * Final JOINs: only root-level nodes (direct children of main) are LEFT
+   * JOINed to main. Deeper joins happen inside `_joined` CTEs.
+   */
+  private buildJoinParts(roots: BlendTreeNode[]): string[] {
+    return roots.map(root => {
+      const { relationship, parentAlias } = root.chain;
+      const alias = this.quoteIdentifier(relationship.targetAlias);
+      const parent = this.quoteIdentifier(parentAlias);
+
+      const onParts = relationship.joinConditions.map(
+        jc =>
+          `${parent}.${this.quoteFieldRef(jc.sourceFieldName)} = ${alias}.${this.quoteFieldRef(jc.targetFieldName)}`
+      );
+      const onClause = onParts.join(' AND ');
+
+      return `LEFT JOIN ${alias} ON ${onClause}`;
+    });
+  }
+
+  /**
+   * Maps an aggregate function to the function used when re-aggregating an
+   * already-aggregated value at a higher tree level. SUM-of-SUMs and
+   * MAX-of-MAXes stay idempotent; COUNT and COUNT_DISTINCT become SUM
+   * (distinct-sum across parent groups is approximate — same caveat as COUNT);
+   * ANY_VALUE becomes MAX (safe across all dialects).
+   */
+  protected getReAggregateFunction(aggregateFunction: AggregateFunction): AggregateFunction {
+    switch (aggregateFunction) {
+      case 'COUNT':
+      case 'COUNT_DISTINCT':
+        return 'SUM';
+      case 'ANY_VALUE':
+        return 'MAX';
+      default:
+        return aggregateFunction;
+    }
+  }
+
+  protected buildAggregation(aggregateFunction: AggregateFunction, fieldName: string): string {
+    switch (aggregateFunction) {
+      case 'STRING_AGG':
+        return this.buildStringAgg(fieldName);
+      case 'COUNT':
+        return `COUNT(${fieldName})`;
+      case 'COUNT_DISTINCT':
+        return `COUNT(DISTINCT ${fieldName})`;
+      default:
+        return `${aggregateFunction}(${fieldName})`;
+    }
+  }
+
+  /**
+   * Must wrap `fieldName` in a CAST to the dialect's native string type so
+   * non-string inputs don't raise runtime errors.
+   */
+  protected abstract buildStringAgg(fieldName: string): string;
+}

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/blended-query-builder.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/blended-query-builder.interface.ts
@@ -1,0 +1,36 @@
+import { DataMartRelationship } from '../../entities/data-mart-relationship.entity';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+import { AggregateFunction } from '../../dto/schemas/relationship-schemas';
+
+export interface BlendedFieldConfig {
+  targetFieldName: string;
+  outputAlias: string;
+  isHidden: boolean;
+  aggregateFunction: AggregateFunction;
+}
+
+export interface ResolvedRelationshipChain {
+  relationship: DataMartRelationship;
+  targetTableReference: string;
+  parentAlias: string;
+  blendedFields: BlendedFieldConfig[];
+  /** Title of the target data mart — used in the SQL comment above its raw CTE. */
+  targetDataMartTitle: string;
+  /** URL to the target data mart page — used in the SQL comment above its raw CTE. */
+  targetDataMartUrl: string;
+}
+
+export interface BlendedQueryContext {
+  mainTableReference: string;
+  /** Title of the root data mart — used in the SQL comment above the `main` CTE. */
+  mainDataMartTitle: string;
+  /** URL to the root data mart page — used in the SQL comment above the `main` CTE. */
+  mainDataMartUrl: string;
+  chains: ResolvedRelationshipChain[];
+  columns: string[];
+}
+
+export interface BlendedQueryBuilder {
+  readonly type: DataStorageType;
+  buildBlendedQuery(context: BlendedQueryContext): string;
+}

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/data-mart-query-builder.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/data-mart-query-builder.interface.ts
@@ -3,6 +3,13 @@ import { DataMartDefinition } from '../../dto/schemas/data-mart-table-definition
 
 export interface DataMartQueryOptions {
   limit?: number;
+  /**
+   * Optional list of column expressions to project via SELECT.
+   * When set, `SELECT *` is replaced with `SELECT <escaped-columns>`.
+   * Each builder escapes per its dialect. SQL-definition data marts are
+   * wrapped as `SELECT <cols> FROM (<user-sql>)` to avoid mutating user SQL.
+   */
+  columns?: string[];
 }
 
 export interface DataMartQueryBuilder {

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-report-reader.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-report-reader.interface.ts
@@ -7,13 +7,43 @@ import { ReportDataBatch } from '../../dto/domain/report-data-batch.dto';
 import { DataStorageReportReaderState } from './data-storage-report-reader-state.interface';
 
 /**
+ * Optional runtime hints for report data preparation.
+ *
+ * Both fields are derived from `report.columnConfig` via `BlendedReportDataService`.
+ * Readers should:
+ * - execute `sqlOverride` instead of the definition-derived query when it is set
+ *   (used to run pre-built blended SQL);
+ * - pass `columnFilter` to the underlying `DataMartQueryBuilder` and restrict
+ *   `reportDataHeaders` to exactly this list (preserving the user-chosen order).
+ *
+ * When both are undefined the reader behaves as before — every non-hidden
+ * column is surfaced with `SELECT *`.
+ */
+export interface PrepareReportDataOptions {
+  sqlOverride?: string;
+  columnFilter?: string[];
+  /**
+   * Precomputed headers for columns that originate from blended schema
+   * (not native). Readers merge these with native headers produced by
+   * their own headers generator, keeping the `columnFilter` order.
+   *
+   * This lets readers stay oblivious to blended-field metadata while still
+   * producing a correct ordered header list for destinations.
+   */
+  blendedDataHeaders?: ReportDataHeader[];
+}
+
+/**
  * Interface for reading report data from a data storage
  */
 export interface DataStorageReportReader extends TypedComponent<DataStorageType> {
   /**
    * Prepares report data for reading
    */
-  prepareReportData(report: Report): Promise<ReportDataDescription>;
+  prepareReportData(
+    report: Report,
+    options?: PrepareReportDataOptions
+  ): Promise<ReportDataDescription>;
 
   /**
    * Reads a batch of report data

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataMartRelationship } from '../../../entities/data-mart-relationship.entity';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import {
+  BlendedQueryContext,
+  ResolvedRelationshipChain,
+} from '../../interfaces/blended-query-builder.interface';
+import { RedshiftBlendedQueryBuilder } from './redshift-blended-query-builder';
+
+function makeRelationship(overrides: Partial<DataMartRelationship> = {}): DataMartRelationship {
+  return {
+    id: 'rel-1',
+    targetAlias: 'orders',
+    joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+    blendedFields: [],
+    projectId: 'proj',
+    createdById: 'user-1',
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    ...overrides,
+  } as DataMartRelationship;
+}
+
+function makeChain(
+  partial: Omit<ResolvedRelationshipChain, 'targetDataMartTitle' | 'targetDataMartUrl'>
+): ResolvedRelationshipChain {
+  return {
+    ...partial,
+    targetDataMartTitle: 'Test Subsidiary',
+    targetDataMartUrl: '/ui/proj/data-marts/sub-1/data-setup',
+  };
+}
+
+function buildContext(chains: ResolvedRelationshipChain[], columns: string[]): BlendedQueryContext {
+  return {
+    mainTableReference: '"myschema"."customers"',
+    mainDataMartTitle: 'Test Main',
+    mainDataMartUrl: '/ui/proj/data-marts/main-1/data-setup',
+    chains,
+    columns,
+  };
+}
+
+describe('RedshiftBlendedQueryBuilder', () => {
+  let builder: RedshiftBlendedQueryBuilder;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RedshiftBlendedQueryBuilder],
+    }).compile();
+
+    builder = module.get(RedshiftBlendedQueryBuilder);
+  });
+
+  it('should have type AWS_REDSHIFT', () => {
+    expect(builder.type).toBe(DataStorageType.AWS_REDSHIFT);
+  });
+
+  it("uses LISTAGG(CAST(field AS VARCHAR), ', ') for STRING_AGG aggregation", () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '"myschema"."orders"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_name',
+          outputAlias: 'order_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['order_names']));
+
+    expect(sql).toContain("LISTAGG(CAST(order_name AS VARCHAR), ', ') AS order_names");
+    expect(sql).not.toContain('STRING_AGG');
+    expect(sql).not.toContain('ARRAY_JOIN');
+    expect(sql).not.toContain('COLLECT_LIST');
+  });
+
+  it('uses COUNT(DISTINCT field) for COUNT_DISTINCT aggregation', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '"myschema"."orders"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'customer_id',
+          outputAlias: 'unique_customers',
+          isHidden: false,
+          aggregateFunction: 'COUNT_DISTINCT',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['unique_customers']));
+
+    expect(sql).toContain('COUNT(DISTINCT customer_id) AS unique_customers');
+  });
+
+  it('uses " (double-quote) quoting for identifiers', () => {
+    const chain = makeChain({
+      relationship: makeRelationship({
+        targetAlias: "Product's",
+        joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'product_id' }],
+      }),
+      targetTableReference: '"myschema"."products"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'name',
+          outputAlias: 'product_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['product_names']));
+
+    expect(sql).toContain('"Product\'s_raw" AS (');
+    expect(sql).toContain('"Product\'s" AS (');
+    // Double-quotes, not backticks
+    expect(sql).not.toMatch(/`Product's`/);
+  });
+
+  it('uses COUNT function correctly', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '"myschema"."orders"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_id',
+          outputAlias: 'order_count',
+          isHidden: false,
+          aggregateFunction: 'COUNT',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['order_count']));
+
+    expect(sql).toContain('COUNT(order_id) AS order_count');
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
+
+@Injectable()
+export class RedshiftBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
+  readonly type = DataStorageType.AWS_REDSHIFT;
+  protected readonly identifierQuoteChar = '"';
+
+  protected buildStringAgg(fieldName: string): string {
+    return `LISTAGG(CAST(${fieldName} AS VARCHAR), ', ')`;
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-data-mart-schema.provider.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-data-mart-schema.provider.ts
@@ -87,6 +87,7 @@ export class RedshiftDataMartSchemaProvider implements DataMartSchemaProvider {
       type,
       description: description || undefined,
       isPrimaryKey: false,
+      isHiddenForReporting: false,
       status: DataMartSchemaFieldStatus.CONNECTED,
     };
   }

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-query.builder.ts
@@ -19,14 +19,20 @@ export class RedshiftQueryBuilder implements DataMartQueryBuilder {
   readonly type = DataStorageType.AWS_REDSHIFT;
 
   buildQuery(definition: DataMartDefinition, queryOptions?: DataMartQueryOptions): string {
+    const selectList = this.buildSelectList(queryOptions?.columns);
     let query: string;
 
     if (isTableDefinition(definition) || isViewDefinition(definition)) {
-      query = `SELECT * FROM ${escapeRedshiftIdentifier(definition.fullyQualifiedName)}`;
+      query = `SELECT ${selectList} FROM ${escapeRedshiftIdentifier(definition.fullyQualifiedName)}`;
     } else if (isConnectorDefinition(definition)) {
-      query = `SELECT * FROM ${escapeRedshiftIdentifier(definition.connector.storage.fullyQualifiedName)}`;
+      query = `SELECT ${selectList} FROM ${escapeRedshiftIdentifier(definition.connector.storage.fullyQualifiedName)}`;
     } else if (isSqlDefinition(definition)) {
-      query = definition.sqlQuery.trim();
+      if (queryOptions?.columns?.length) {
+        const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
+        query = `SELECT ${selectList} FROM (${cleanQuery})`;
+      } else {
+        query = definition.sqlQuery.trim();
+      }
     } else if (isTablePatternDefinition(definition)) {
       throw new Error('Table pattern queries are not supported in Redshift');
     } else {
@@ -39,5 +45,12 @@ export class RedshiftQueryBuilder implements DataMartQueryBuilder {
     }
 
     return query;
+  }
+
+  private buildSelectList(columns?: string[]): string {
+    if (!columns || columns.length === 0) {
+      return '*';
+    }
+    return columns.map(col => escapeRedshiftIdentifier(col)).join(', ');
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-report-headers-generator.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-report-headers-generator.service.ts
@@ -23,7 +23,10 @@ export class RedshiftReportHeadersGenerator implements ReportHeadersGenerator {
     }
 
     return dataMartSchema.fields
-      .filter(field => field.status !== DataMartSchemaFieldStatus.DISCONNECTED)
+      .filter(
+        field =>
+          field.status !== DataMartSchemaFieldStatus.DISCONNECTED && !field.isHiddenForReporting
+      )
       .map(field => new ReportDataHeader(field.name, field.alias, field.description, field.type));
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-report-reader.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-report-reader.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, Logger, Scope } from '@nestjs/common';
-import { DataStorageReportReader } from '../../interfaces/data-storage-report-reader.interface';
+import {
+  DataStorageReportReader,
+  PrepareReportDataOptions,
+} from '../../interfaces/data-storage-report-reader.interface';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { Report } from '../../../entities/report.entity';
 import { ReportDataDescription } from '../../../dto/domain/report-data-description.dto';
@@ -14,6 +17,7 @@ import { isRedshiftDataMartSchema } from '../../data-mart-schema.guards';
 import { RedshiftReaderState } from '../interfaces/redshift-reader-state.interface';
 import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
 import { DataStorage } from '../../../entities/data-storage.entity';
+import { resolveReportDataHeaders } from '../../utils/report-data-headers.utils';
 
 @Injectable({ scope: Scope.TRANSIENT })
 export class RedshiftReportReader implements DataStorageReportReader {
@@ -27,6 +31,7 @@ export class RedshiftReportReader implements DataStorageReportReader {
     storage: DataStorage;
     definition: DataMartDefinition;
   };
+  private pendingQuery?: string;
 
   constructor(
     private readonly adapterFactory: RedshiftApiAdapterFactory,
@@ -34,7 +39,10 @@ export class RedshiftReportReader implements DataStorageReportReader {
     private readonly headersGenerator: RedshiftReportHeadersGenerator
   ) {}
 
-  async prepareReportData(report: Report): Promise<ReportDataDescription> {
+  async prepareReportData(
+    report: Report,
+    options?: PrepareReportDataOptions
+  ): Promise<ReportDataDescription> {
     const { storage, definition, schema } = report.dataMart;
 
     if (!storage || !definition) {
@@ -46,7 +54,13 @@ export class RedshiftReportReader implements DataStorageReportReader {
     }
 
     this.reportConfig = { storage, definition };
-    this.reportDataHeaders = this.headersGenerator.generateHeaders(schema);
+    this.reportDataHeaders = resolveReportDataHeaders(
+      this.headersGenerator.generateHeaders(schema),
+      options
+    );
+    this.pendingQuery =
+      options?.sqlOverride ??
+      this.queryBuilder.buildQuery(definition, { columns: options?.columnFilter });
 
     this.adapter = await this.adapterFactory.createFromStorage(storage);
 
@@ -95,7 +109,7 @@ export class RedshiftReportReader implements DataStorageReportReader {
       throw new Error('Adapter not initialized');
     }
 
-    const query = this.queryBuilder.buildQuery(this.reportConfig.definition);
+    const query = this.pendingQuery ?? this.queryBuilder.buildQuery(this.reportConfig.definition);
 
     const { statementId } = await this.adapter.executeQuery(query);
     this.statementId = statementId;

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-schema-merger.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-schema-merger.ts
@@ -56,6 +56,7 @@ export class RedshiftSchemaMerger implements DataMartSchemaMerger {
         ...newField,
         alias: existingField.alias || newField.alias,
         isPrimaryKey: existingField.isPrimaryKey ?? newField.isPrimaryKey ?? false,
+        isHiddenForReporting: existingField.isHiddenForReporting ?? false,
         description: existingField.description ?? newField.description,
         status: hasTypeMismatch
           ? DataMartSchemaFieldStatus.CONNECTED_WITH_DEFINITION_MISMATCH

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DataMartRelationship } from '../../../entities/data-mart-relationship.entity';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import {
+  BlendedQueryContext,
+  ResolvedRelationshipChain,
+} from '../../interfaces/blended-query-builder.interface';
+import { SnowflakeBlendedQueryBuilder } from './snowflake-blended-query-builder';
+
+function makeRelationship(overrides: Partial<DataMartRelationship> = {}): DataMartRelationship {
+  return {
+    id: 'rel-1',
+    targetAlias: 'orders',
+    joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+    blendedFields: [],
+    projectId: 'proj',
+    createdById: 'user-1',
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    ...overrides,
+  } as DataMartRelationship;
+}
+
+function makeChain(
+  partial: Omit<ResolvedRelationshipChain, 'targetDataMartTitle' | 'targetDataMartUrl'>
+): ResolvedRelationshipChain {
+  return {
+    ...partial,
+    targetDataMartTitle: 'Test Subsidiary',
+    targetDataMartUrl: '/ui/proj/data-marts/sub-1/data-setup',
+  };
+}
+
+function buildContext(chains: ResolvedRelationshipChain[], columns: string[]): BlendedQueryContext {
+  return {
+    mainTableReference: 'mydb."myschema"."customers"',
+    mainDataMartTitle: 'Test Main',
+    mainDataMartUrl: '/ui/proj/data-marts/main-1/data-setup',
+    chains,
+    columns,
+  };
+}
+
+describe('SnowflakeBlendedQueryBuilder', () => {
+  let builder: SnowflakeBlendedQueryBuilder;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SnowflakeBlendedQueryBuilder],
+    }).compile();
+
+    builder = module.get(SnowflakeBlendedQueryBuilder);
+  });
+
+  it('should have type SNOWFLAKE', () => {
+    expect(builder.type).toBe(DataStorageType.SNOWFLAKE);
+  });
+
+  it("uses LISTAGG(CAST(field AS VARCHAR), ', ') for STRING_AGG aggregation", () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: 'mydb."myschema"."orders"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_name',
+          outputAlias: 'order_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['order_names']));
+
+    expect(sql).toContain("LISTAGG(CAST(order_name AS VARCHAR), ', ') AS order_names");
+    expect(sql).not.toContain('STRING_AGG');
+    expect(sql).not.toContain('ARRAY_JOIN');
+    expect(sql).not.toContain('COLLECT_LIST');
+  });
+
+  it('uses COUNT(DISTINCT field) for COUNT_DISTINCT aggregation', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: 'mydb."myschema"."orders"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'customer_id',
+          outputAlias: 'unique_customers',
+          isHidden: false,
+          aggregateFunction: 'COUNT_DISTINCT',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['unique_customers']));
+
+    expect(sql).toContain('COUNT(DISTINCT customer_id) AS unique_customers');
+  });
+
+  it('uses " (double-quote) quoting for identifiers', () => {
+    const chain = makeChain({
+      relationship: makeRelationship({
+        targetAlias: "Product's",
+        joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'product_id' }],
+      }),
+      targetTableReference: 'mydb."myschema"."products"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'name',
+          outputAlias: 'product_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['product_names']));
+
+    expect(sql).toContain('"Product\'s_raw" AS (');
+    expect(sql).toContain('"Product\'s" AS (');
+    // Double-quotes, not backticks
+    expect(sql).not.toMatch(/`Product's`/);
+  });
+
+  it('uses COUNT function correctly', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: 'mydb."myschema"."orders"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_id',
+          outputAlias: 'order_count',
+          isHidden: false,
+          aggregateFunction: 'COUNT',
+        },
+      ],
+    });
+
+    const sql = builder.buildBlendedQuery(buildContext([chain], ['order_count']));
+
+    expect(sql).toContain('COUNT(order_id) AS order_count');
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
+
+@Injectable()
+export class SnowflakeBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
+  readonly type = DataStorageType.SNOWFLAKE;
+  protected readonly identifierQuoteChar = '"';
+
+  protected buildStringAgg(fieldName: string): string {
+    return `LISTAGG(CAST(${fieldName} AS VARCHAR), ', ')`;
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-data-mart-schema.provider.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-data-mart-schema.provider.ts
@@ -71,6 +71,7 @@ export class SnowflakeDataMartSchemaProvider implements DataMartSchemaProvider {
             name: fieldName,
             type: SnowflakeFieldType.STRING,
             isPrimaryKey: false,
+            isHiddenForReporting: false,
             status: DataMartSchemaFieldStatus.CONNECTED,
           })),
         };
@@ -197,6 +198,7 @@ export class SnowflakeDataMartSchemaProvider implements DataMartSchemaProvider {
       type: parseSnowflakeFieldType(type) || SnowflakeFieldType.STRING,
       description: description || undefined,
       isPrimaryKey,
+      isHiddenForReporting: false,
       status: DataMartSchemaFieldStatus.CONNECTED,
     };
   }

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-query.builder.ts
@@ -19,14 +19,20 @@ export class SnowflakeQueryBuilder implements DataMartQueryBuilder {
   readonly type = DataStorageType.SNOWFLAKE;
 
   buildQuery(definition: DataMartDefinition, queryOptions?: DataMartQueryOptions): string {
+    const selectList = this.buildSelectList(queryOptions?.columns);
     let query: string;
 
     if (isTableDefinition(definition) || isViewDefinition(definition)) {
-      query = `SELECT * FROM ${escapeSnowflakeIdentifier(definition.fullyQualifiedName)}`;
+      query = `SELECT ${selectList} FROM ${escapeSnowflakeIdentifier(definition.fullyQualifiedName)}`;
     } else if (isConnectorDefinition(definition)) {
-      query = `SELECT * FROM ${escapeSnowflakeIdentifier(definition.connector.storage.fullyQualifiedName)}`;
+      query = `SELECT ${selectList} FROM ${escapeSnowflakeIdentifier(definition.connector.storage.fullyQualifiedName)}`;
     } else if (isSqlDefinition(definition)) {
-      query = definition.sqlQuery;
+      if (queryOptions?.columns?.length) {
+        const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
+        query = `SELECT ${selectList} FROM (${cleanQuery})`;
+      } else {
+        query = definition.sqlQuery;
+      }
     } else if (isTablePatternDefinition(definition)) {
       // Snowflake doesn't support table patterns like BigQuery
       // This would need to be implemented differently, possibly using INFORMATION_SCHEMA
@@ -41,5 +47,12 @@ export class SnowflakeQueryBuilder implements DataMartQueryBuilder {
     }
 
     return query;
+  }
+
+  private buildSelectList(columns?: string[]): string {
+    if (!columns || columns.length === 0) {
+      return '*';
+    }
+    return columns.map(col => escapeSnowflakeIdentifier(col)).join(', ');
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-report-headers-generator.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-report-headers-generator.service.ts
@@ -23,7 +23,10 @@ export class SnowflakeReportHeadersGenerator implements ReportHeadersGenerator {
     }
 
     return dataMartSchema.fields
-      .filter(field => field.status !== DataMartSchemaFieldStatus.DISCONNECTED)
+      .filter(
+        field =>
+          field.status !== DataMartSchemaFieldStatus.DISCONNECTED && !field.isHiddenForReporting
+      )
       .map(field => new ReportDataHeader(field.name, field.alias, field.description, field.type));
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-report-reader.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-report-reader.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Logger, Scope } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
-import { DataStorageReportReader } from '../../interfaces/data-storage-report-reader.interface';
+import {
+  DataStorageReportReader,
+  PrepareReportDataOptions,
+} from '../../interfaces/data-storage-report-reader.interface';
 import { ReportDataBatch } from '../../../dto/domain/report-data-batch.dto';
 import { ReportDataDescription } from '../../../dto/domain/report-data-description.dto';
 import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
@@ -17,6 +20,7 @@ import {
   SnowflakeReaderState,
   isSnowflakeReaderState,
 } from '../interfaces/snowflake-reader-state.interface';
+import { resolveReportDataHeaders } from '../../utils/report-data-headers.utils';
 @Injectable({ scope: Scope.TRANSIENT })
 export class SnowflakeReportReader implements DataStorageReportReader {
   private readonly logger = new Logger(SnowflakeReportReader.name);
@@ -34,7 +38,10 @@ export class SnowflakeReportReader implements DataStorageReportReader {
     private readonly headersGenerator: SnowflakeReportHeadersGenerator
   ) {}
 
-  async prepareReportData(report: Report): Promise<ReportDataDescription> {
+  async prepareReportData(
+    report: Report,
+    options?: PrepareReportDataOptions
+  ): Promise<ReportDataDescription> {
     const { storage, definition, schema } = report.dataMart;
     if (!storage || !definition) {
       throw new Error('Data Mart is not properly configured');
@@ -49,11 +56,16 @@ export class SnowflakeReportReader implements DataStorageReportReader {
     }
 
     this.reportConfig = { storage, definition };
-    this.reportDataHeaders = this.headersGenerator.generateHeaders(schema);
+    this.reportDataHeaders = resolveReportDataHeaders(
+      this.headersGenerator.generateHeaders(schema),
+      options
+    );
 
     this.adapter = await this.adapterFactory.createFromStorage(storage);
 
-    const query = this.queryBuilder.buildQuery(definition);
+    const query =
+      options?.sqlOverride ??
+      this.queryBuilder.buildQuery(definition, { columns: options?.columnFilter });
     this.logger.debug(`Executing query: ${query}`);
 
     const result = await this.adapter.executeQuery(query);

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-schema-merger.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-schema-merger.ts
@@ -78,6 +78,7 @@ export class SnowflakeSchemaMerger implements DataMartSchemaMerger {
       alias: existingField.alias,
       description: existingField.description ?? newField.description,
       isPrimaryKey: existingField.isPrimaryKey ?? newField.isPrimaryKey ?? false,
+      isHiddenForReporting: existingField.isHiddenForReporting ?? false,
       status: this.getConnectedFieldStatus(hasTypeMismatch),
     };
   }

--- a/apps/backend/src/data-marts/data-storage-types/utils/report-data-headers.utils.ts
+++ b/apps/backend/src/data-marts/data-storage-types/utils/report-data-headers.utils.ts
@@ -1,0 +1,38 @@
+import { ReportDataHeader } from '../../dto/domain/report-data-header.dto';
+import { PrepareReportDataOptions } from '../interfaces/data-storage-report-reader.interface';
+
+/**
+ * Resolves the final list of report data headers from the native schema
+ * headers and an optional column filter produced by
+ * `BlendedReportDataService.resolveBlendingDecision`.
+ *
+ * Behavior:
+ * - When `options` is not provided or `columnFilter` is empty, returns the
+ *   native headers unchanged (default: every column from the schema).
+ * - When `columnFilter` is set, returns a new list containing only the
+ *   headers whose `name` appears in the filter, preserving the filter order.
+ * - Columns not found in native headers fall back to the blended headers
+ *   supplied via `options.blendedDataHeaders`, and finally to a minimal
+ *   `ReportDataHeader(name, name)` placeholder so the reader still emits a
+ *   column (e.g. for SQL override results that contain unknown names).
+ */
+export function resolveReportDataHeaders(
+  nativeHeaders: ReportDataHeader[],
+  options?: PrepareReportDataOptions
+): ReportDataHeader[] {
+  const filter = options?.columnFilter;
+  if (!filter || filter.length === 0) {
+    return nativeHeaders;
+  }
+
+  const nativeByName = new Map(nativeHeaders.map(h => [h.name, h]));
+  const blendedByName = new Map((options?.blendedDataHeaders ?? []).map(h => [h.name, h]));
+
+  return filter.map(col => {
+    const native = nativeByName.get(col);
+    if (native) return native;
+    const blended = blendedByName.get(col);
+    if (blended) return blended;
+    return new ReportDataHeader(col, col);
+  });
+}

--- a/apps/backend/src/data-marts/dto/domain/blendable-schema.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/blendable-schema.dto.ts
@@ -1,0 +1,38 @@
+import { DataMartSchema } from '../../data-storage-types/data-mart-schema.type';
+import { AggregateFunction } from '../schemas/relationship-schemas';
+
+export class BlendedFieldDto {
+  name: string;
+  sourceRelationshipId: string;
+  sourceDataMartId: string;
+  sourceDataMartTitle: string;
+  targetAlias: string;
+  originalFieldName: string;
+  type: string;
+  alias: string;
+  description: string;
+  isHidden: boolean;
+  aggregateFunction: AggregateFunction;
+  transitiveDepth: number;
+  aliasPath: string;
+  outputPrefix: string;
+}
+
+export class AvailableSourceDto {
+  aliasPath: string;
+  title: string;
+  description?: string;
+  defaultAlias: string;
+  depth: number;
+  fieldCount: number;
+  isIncluded: boolean;
+  relationshipId: string;
+  dataMartId: string;
+}
+
+export class BlendableSchemaDto {
+  nativeFields: DataMartSchema['fields'];
+  nativeDescription?: string;
+  blendedFields: BlendedFieldDto[];
+  availableSources: AvailableSourceDto[];
+}

--- a/apps/backend/src/data-marts/dto/domain/cached-reader-data.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/cached-reader-data.dto.ts
@@ -1,4 +1,5 @@
 import { DataStorageReportReader } from '../../data-storage-types/interfaces/data-storage-report-reader.interface';
+import { BlendingDecision } from '../../services/blended-report-data.service';
 import { ReportDataDescription } from './report-data-description.dto';
 
 /**
@@ -14,4 +15,11 @@ export interface CachedReaderData {
 
   /** Indicates whether the data was retrieved from cache */
   fromCache: boolean;
+
+  /**
+   * Blending decision produced while preparing the reader. Carried on the
+   * DTO so consumers (e.g. Looker run logger) can inspect the resolved SQL
+   * without re-running metadata lookups.
+   */
+  blendingDecision: BlendingDecision;
 }

--- a/apps/backend/src/data-marts/dto/domain/copy-report-as-data-mart.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/copy-report-as-data-mart.command.ts
@@ -1,7 +1,6 @@
-export class GetRelationshipCommand {
+export class CopyReportAsDataMartCommand {
   constructor(
-    public readonly relationshipId: string,
-    public readonly sourceDataMartId: string,
+    public readonly reportId: string,
     public readonly userId: string,
     public readonly projectId: string,
     public readonly roles: string[]

--- a/apps/backend/src/data-marts/dto/domain/create-relationship.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/create-relationship.command.ts
@@ -1,0 +1,12 @@
+import { JoinCondition } from '../schemas/relationship-schemas';
+
+export class CreateRelationshipCommand {
+  constructor(
+    public readonly sourceDataMartId: string,
+    public readonly targetDataMartId: string,
+    public readonly targetAlias: string,
+    public readonly joinConditions: JoinCondition[],
+    public readonly userId: string,
+    public readonly projectId: string
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/create-relationship.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/create-relationship.command.ts
@@ -7,6 +7,7 @@ export class CreateRelationshipCommand {
     public readonly targetAlias: string,
     public readonly joinConditions: JoinCondition[],
     public readonly userId: string,
-    public readonly projectId: string
+    public readonly projectId: string,
+    public readonly roles: string[]
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/create-report.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/create-report.command.ts
@@ -9,6 +9,7 @@ export class CreateReportCommand {
     public readonly dataDestinationId: string,
     public readonly destinationConfig: DataDestinationConfig,
     public readonly ownerIds?: string[],
-    public readonly roles: string[] = []
+    public readonly roles: string[] = [],
+    public readonly columnConfig?: string[] | null
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/data-mart.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/data-mart.dto.ts
@@ -5,6 +5,7 @@ import { DataStorageDto } from './data-storage.dto';
 import { DataMartStatus } from '../../enums/data-mart-status.enum';
 import { DataMartSchema } from '../../data-storage-types/data-mart-schema.type';
 import { ConnectorState as ConnectorStateData } from '../../connector-types/interfaces/connector-state';
+import { BlendedFieldsConfig } from '../schemas/blended-fields-config.schemas';
 
 export class DataMartDto {
   constructor(
@@ -25,6 +26,7 @@ export class DataMartDto {
     public readonly businessOwnerUsers: UserProjectionDto[] = [],
     public readonly technicalOwnerUsers: UserProjectionDto[] = [],
     public readonly availableForReporting: boolean = true,
-    public readonly availableForMaintenance: boolean = true
+    public readonly availableForMaintenance: boolean = true,
+    public readonly blendedFieldsConfig?: BlendedFieldsConfig
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/get-relationship.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/get-relationship.command.ts
@@ -1,0 +1,8 @@
+export class GetRelationshipCommand {
+  constructor(
+    public readonly relationshipId: string,
+    public readonly sourceDataMartId: string,
+    public readonly userId: string,
+    public readonly projectId: string
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/get-report-generated-sql.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/get-report-generated-sql.command.ts
@@ -1,7 +1,6 @@
-export class GetRelationshipCommand {
+export class GetReportGeneratedSqlCommand {
   constructor(
-    public readonly relationshipId: string,
-    public readonly sourceDataMartId: string,
+    public readonly reportId: string,
     public readonly userId: string,
     public readonly projectId: string,
     public readonly roles: string[]

--- a/apps/backend/src/data-marts/dto/domain/report.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/report.dto.ts
@@ -18,6 +18,7 @@ export class ReportDto {
     public readonly lastRunStatus?: ReportRunStatus,
     public readonly runsCount: number = 0,
     public readonly createdByUser: UserProjectionDto | null = null,
-    public readonly ownerUsers: UserProjectionDto[] = []
+    public readonly ownerUsers: UserProjectionDto[] = [],
+    public readonly columnConfig?: string[] | null
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/update-blended-fields-config.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/update-blended-fields-config.command.ts
@@ -1,0 +1,9 @@
+import { BlendedFieldsConfig } from '../schemas/blended-fields-config.schemas';
+
+export class UpdateBlendedFieldsConfigCommand {
+  constructor(
+    public readonly id: string,
+    public readonly projectId: string,
+    public readonly blendedFieldsConfig: BlendedFieldsConfig | null
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/update-blended-fields-config.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/update-blended-fields-config.command.ts
@@ -4,6 +4,8 @@ export class UpdateBlendedFieldsConfigCommand {
   constructor(
     public readonly id: string,
     public readonly projectId: string,
-    public readonly blendedFieldsConfig: BlendedFieldsConfig | null
+    public readonly blendedFieldsConfig: BlendedFieldsConfig | null,
+    public readonly userId: string,
+    public readonly roles: string[]
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/update-relationship.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/update-relationship.command.ts
@@ -1,0 +1,12 @@
+import { JoinCondition } from '../schemas/relationship-schemas';
+
+export class UpdateRelationshipCommand {
+  constructor(
+    public readonly relationshipId: string,
+    public readonly sourceDataMartId: string,
+    public readonly userId: string,
+    public readonly projectId: string,
+    public readonly targetAlias?: string,
+    public readonly joinConditions?: JoinCondition[]
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/update-relationship.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/update-relationship.command.ts
@@ -6,6 +6,7 @@ export class UpdateRelationshipCommand {
     public readonly sourceDataMartId: string,
     public readonly userId: string,
     public readonly projectId: string,
+    public readonly roles: string[],
     public readonly targetAlias?: string,
     public readonly joinConditions?: JoinCondition[]
   ) {}

--- a/apps/backend/src/data-marts/dto/domain/update-report.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/update-report.command.ts
@@ -9,6 +9,7 @@ export class UpdateReportCommand {
     public readonly title: string,
     public readonly dataDestinationId: string,
     public readonly destinationConfig: DataDestinationConfig,
-    public readonly ownerIds?: string[]
+    public readonly ownerIds?: string[],
+    public readonly columnConfig?: string[] | null
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/presentation/create-relationship-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/create-relationship-request-api.dto.ts
@@ -1,0 +1,38 @@
+import { IsString, IsArray, ValidateNested, MinLength } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class JoinConditionApiDto {
+  @ApiProperty({ example: 'user_id', description: 'Field name in the source data mart' })
+  @IsString()
+  @MinLength(1)
+  sourceFieldName: string;
+
+  @ApiProperty({ example: 'user_id', description: 'Field name in the target data mart' })
+  @IsString()
+  @MinLength(1)
+  targetFieldName: string;
+}
+
+export class CreateRelationshipRequestApiDto {
+  @ApiProperty({
+    example: '9cabc24e-1234-4a5a-8b12-abcdef123456',
+    description: 'ID of the target data mart to blend with',
+  })
+  @IsString()
+  targetDataMartId: string;
+
+  @ApiProperty({ example: 'orders', description: 'Alias for the target data mart in the blend' })
+  @IsString()
+  @MinLength(1)
+  targetAlias: string;
+
+  @ApiProperty({
+    type: [JoinConditionApiDto],
+    description: 'Conditions used to join the data marts',
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => JoinConditionApiDto)
+  joinConditions: JoinConditionApiDto[];
+}

--- a/apps/backend/src/data-marts/dto/presentation/create-relationship-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/create-relationship-request-api.dto.ts
@@ -1,6 +1,9 @@
-import { IsString, IsArray, ValidateNested, MinLength } from 'class-validator';
+import { IsString, IsArray, ValidateNested, MinLength, Matches } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
+import { ALIAS_SEGMENT_ERROR, ALIAS_SEGMENT_REGEX } from '../schemas/blended-fields-config.schemas';
+
+const TARGET_ALIAS_MESSAGE = `targetAlias ${ALIAS_SEGMENT_ERROR}`;
 
 export class JoinConditionApiDto {
   @ApiProperty({ example: 'user_id', description: 'Field name in the source data mart' })
@@ -22,9 +25,14 @@ export class CreateRelationshipRequestApiDto {
   @IsString()
   targetDataMartId: string;
 
-  @ApiProperty({ example: 'orders', description: 'Alias for the target data mart in the blend' })
+  @ApiProperty({
+    example: 'orders',
+    description: 'Alias for the target data mart in the blend',
+    pattern: ALIAS_SEGMENT_REGEX.source,
+  })
   @IsString()
   @MinLength(1)
+  @Matches(ALIAS_SEGMENT_REGEX, { message: TARGET_ALIAS_MESSAGE })
   targetAlias: string;
 
   @ApiProperty({

--- a/apps/backend/src/data-marts/dto/presentation/create-report-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/create-report-request-api.dto.ts
@@ -30,4 +30,15 @@ export class CreateReportRequestApiDto {
   @IsString({ each: true })
   @IsNotEmpty({ each: true })
   ownerIds?: string[];
+
+  @ApiProperty({
+    description: 'Selected columns for the report (null = all native columns)',
+    nullable: true,
+    required: false,
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  columnConfig?: string[] | null;
 }

--- a/apps/backend/src/data-marts/dto/presentation/data-mart-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-mart-response-api.dto.ts
@@ -8,6 +8,7 @@ import { DataStorageResponseApiDto } from './data-storage-response-api.dto';
 import { DataMartSchema } from '../../data-storage-types/data-mart-schema.type';
 import { ConnectorState as ConnectorStateData } from '../../connector-types/interfaces/connector-state';
 import { ConnectorStateResponseApiDto } from './connector-state-response-api.dto';
+import { BlendedFieldsConfig } from '../schemas/blended-fields-config.schemas';
 
 export class DataMartResponseApiDto {
   @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
@@ -51,6 +52,9 @@ export class DataMartResponseApiDto {
 
   @ApiProperty({ type: [UserProjectionDto] })
   technicalOwnerUsers: UserProjection[];
+
+  @ApiProperty({ required: false })
+  blendedFieldsConfig?: BlendedFieldsConfig;
 
   @ApiProperty({ example: '2024-01-01T12:00:00.000Z' })
   createdAt: Date;

--- a/apps/backend/src/data-marts/dto/presentation/relationship-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/relationship-response-api.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { JoinCondition } from '../schemas/relationship-schemas';
+import { DataMartStatus } from '../../enums/data-mart-status.enum';
+import { UserProjectionDto } from '../../../idp/dto/domain/user-projection.dto';
+
+export class DataMartRefApiDto {
+  @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
+  id: string;
+
+  @ApiProperty({ example: 'My Data Mart' })
+  title: string;
+
+  @ApiProperty({ example: 'Revenue by channel', required: false })
+  description?: string;
+
+  @ApiProperty({ enum: DataMartStatus, example: DataMartStatus.PUBLISHED })
+  status: DataMartStatus;
+}
+
+export class RelationshipResponseApiDto {
+  @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
+  id: string;
+
+  @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
+  dataStorageId: string;
+
+  @ApiProperty({ type: DataMartRefApiDto })
+  sourceDataMart: DataMartRefApiDto;
+
+  @ApiProperty({ type: DataMartRefApiDto })
+  targetDataMart: DataMartRefApiDto;
+
+  @ApiProperty({ example: 'orders' })
+  targetAlias: string;
+
+  @ApiProperty()
+  joinConditions: JoinCondition[];
+
+  @ApiProperty({ example: 'user-id-123' })
+  createdById: string;
+
+  @ApiProperty({ example: '2024-01-01T12:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2024-01-02T15:30:00.000Z' })
+  modifiedAt: Date;
+
+  @ApiProperty({ type: UserProjectionDto, required: false, nullable: true })
+  createdByUser?: UserProjectionDto | null;
+}

--- a/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
@@ -21,6 +21,9 @@ export class ReportResponseApiDto {
   @ApiProperty()
   destinationConfig: DataDestinationConfig;
 
+  @ApiProperty({ nullable: true, required: false, type: [String] })
+  columnConfig?: string[] | null;
+
   @ApiProperty({ nullable: true })
   lastRunAt?: Date;
 

--- a/apps/backend/src/data-marts/dto/presentation/update-blended-fields-config-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-blended-fields-config-api.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional } from 'class-validator';
+import { BlendedFieldsConfig } from '../schemas/blended-fields-config.schemas';
+
+export class UpdateBlendedFieldsConfigApiDto {
+  @ApiProperty({ required: false, nullable: true })
+  @IsOptional()
+  blendedFieldsConfig?: BlendedFieldsConfig | null;
+}

--- a/apps/backend/src/data-marts/dto/presentation/update-relationship-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-relationship-request-api.dto.ts
@@ -1,0 +1,35 @@
+import {
+  IsString,
+  IsArray,
+  ArrayMinSize,
+  ValidateNested,
+  MinLength,
+  IsOptional,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { JoinConditionApiDto } from './create-relationship-request-api.dto';
+
+export class UpdateRelationshipRequestApiDto {
+  @ApiProperty({
+    example: 'orders',
+    description: 'Alias for the target data mart in the blend',
+    required: false,
+  })
+  @IsString()
+  @MinLength(1)
+  @IsOptional()
+  targetAlias?: string;
+
+  @ApiProperty({
+    type: [JoinConditionApiDto],
+    description: 'Conditions used to join the data marts',
+    required: false,
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => JoinConditionApiDto)
+  @IsOptional()
+  joinConditions?: JoinConditionApiDto[];
+}

--- a/apps/backend/src/data-marts/dto/presentation/update-relationship-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-relationship-request-api.dto.ts
@@ -5,9 +5,11 @@ import {
   ValidateNested,
   MinLength,
   IsOptional,
+  Matches,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
+import { ALIAS_SEGMENT_ERROR, ALIAS_SEGMENT_REGEX } from '../schemas/blended-fields-config.schemas';
 import { JoinConditionApiDto } from './create-relationship-request-api.dto';
 
 export class UpdateRelationshipRequestApiDto {
@@ -15,9 +17,11 @@ export class UpdateRelationshipRequestApiDto {
     example: 'orders',
     description: 'Alias for the target data mart in the blend',
     required: false,
+    pattern: ALIAS_SEGMENT_REGEX.source,
   })
   @IsString()
   @MinLength(1)
+  @Matches(ALIAS_SEGMENT_REGEX, { message: `targetAlias ${ALIAS_SEGMENT_ERROR}` })
   @IsOptional()
   targetAlias?: string;
 

--- a/apps/backend/src/data-marts/dto/presentation/update-report-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-report-request-api.dto.ts
@@ -25,4 +25,15 @@ export class UpdateReportRequestApiDto {
   @IsString({ each: true })
   @IsNotEmpty({ each: true })
   ownerIds?: string[];
+
+  @ApiProperty({
+    description: 'Selected columns for the report (null = all native columns)',
+    nullable: true,
+    required: false,
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  columnConfig?: string[] | null;
 }

--- a/apps/backend/src/data-marts/dto/schemas/blended-fields-config.schemas.spec.ts
+++ b/apps/backend/src/data-marts/dto/schemas/blended-fields-config.schemas.spec.ts
@@ -1,0 +1,95 @@
+import {
+  BlendedFieldsConfigSchema,
+  BlendedSourceSchema,
+  BlendedFieldOverrideSchema,
+} from './blended-fields-config.schemas';
+
+describe('BlendedFieldOverrideSchema', () => {
+  it('should accept empty object', () => {
+    const result = BlendedFieldOverrideSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it('should accept isHidden only', () => {
+    const result = BlendedFieldOverrideSchema.parse({ isHidden: true });
+    expect(result.isHidden).toBe(true);
+  });
+
+  it('should accept aggregateFunction only', () => {
+    const result = BlendedFieldOverrideSchema.parse({ aggregateFunction: 'SUM' });
+    expect(result.aggregateFunction).toBe('SUM');
+  });
+
+  it('should reject invalid aggregateFunction', () => {
+    expect(() => BlendedFieldOverrideSchema.parse({ aggregateFunction: 'INVALID' })).toThrow();
+  });
+
+  it.each(['STRING_AGG', 'MAX', 'MIN', 'SUM', 'COUNT', 'COUNT_DISTINCT', 'ANY_VALUE'])(
+    'should accept aggregateFunction: %s',
+    fn => {
+      expect(BlendedFieldOverrideSchema.parse({ aggregateFunction: fn }).aggregateFunction).toBe(
+        fn
+      );
+    }
+  );
+});
+
+describe('BlendedSourceSchema', () => {
+  it('should accept minimal valid source', () => {
+    const result = BlendedSourceSchema.parse({ path: 'orders', alias: 'ord' });
+    expect(result.path).toBe('orders');
+    expect(result.alias).toBe('ord');
+    expect(result.fields).toBeUndefined();
+  });
+
+  it('should accept source with fields', () => {
+    const result = BlendedSourceSchema.parse({
+      path: 'orders.products',
+      alias: 'ord_prod',
+      fields: {
+        revenue: { aggregateFunction: 'SUM' },
+        internal_id: { isHidden: true },
+      },
+    });
+    expect(result.fields?.revenue?.aggregateFunction).toBe('SUM');
+    expect(result.fields?.internal_id?.isHidden).toBe(true);
+  });
+
+  it('should reject empty path', () => {
+    expect(() => BlendedSourceSchema.parse({ path: '', alias: 'a' })).toThrow();
+  });
+
+  it('should reject empty alias', () => {
+    expect(() => BlendedSourceSchema.parse({ path: 'p', alias: '' })).toThrow();
+  });
+});
+
+describe('BlendedFieldsConfigSchema', () => {
+  it('should accept minimal config with empty sources', () => {
+    const result = BlendedFieldsConfigSchema.parse({
+      sources: [],
+    });
+    expect(result.sources).toEqual([]);
+  });
+
+  it('should accept config with sources and overrides', () => {
+    const result = BlendedFieldsConfigSchema.parse({
+      sources: [
+        {
+          path: 'all_bq_types.test_structure',
+          alias: 'bq_test',
+          fields: {
+            revenue: { aggregateFunction: 'SUM' },
+            internal_id: { isHidden: true },
+          },
+        },
+      ],
+    });
+    expect(result.sources).toHaveLength(1);
+    expect(result.sources[0].path).toBe('all_bq_types.test_structure');
+  });
+
+  it('should reject missing sources', () => {
+    expect(() => BlendedFieldsConfigSchema.parse({})).toThrow();
+  });
+});

--- a/apps/backend/src/data-marts/dto/schemas/blended-fields-config.schemas.ts
+++ b/apps/backend/src/data-marts/dto/schemas/blended-fields-config.schemas.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { AGGREGATE_FUNCTIONS } from './relationship-schemas';
+
+export const BlendedFieldOverrideSchema = z.object({
+  alias: z.string().optional(),
+  isHidden: z.boolean().optional(),
+  aggregateFunction: z.enum(AGGREGATE_FUNCTIONS).optional(),
+});
+export type BlendedFieldOverride = z.infer<typeof BlendedFieldOverrideSchema>;
+
+export const BlendedSourceSchema = z.object({
+  path: z.string().min(1),
+  alias: z.string().min(1),
+  isExcluded: z.boolean().optional(),
+  fields: z.record(z.string(), BlendedFieldOverrideSchema).optional(),
+});
+export type BlendedSource = z.infer<typeof BlendedSourceSchema>;
+
+export const BlendedFieldsConfigSchema = z.object({
+  sources: z.array(BlendedSourceSchema),
+});
+export type BlendedFieldsConfig = z.infer<typeof BlendedFieldsConfigSchema>;

--- a/apps/backend/src/data-marts/dto/schemas/blended-fields-config.schemas.ts
+++ b/apps/backend/src/data-marts/dto/schemas/blended-fields-config.schemas.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 import { AGGREGATE_FUNCTIONS } from './relationship-schemas';
 
+// `path` / `targetAlias` segments flow into SQL identifiers (CTE names, column prefixes)
+// in the generated blended query, so they must stay inside a safe character set even
+// when the UI is bypassed. `BlendedSource.alias` is a free-form display label shown in
+// report column headers and is NOT validated against this regex.
+export const ALIAS_SEGMENT_REGEX = /^[a-z0-9_]+$/;
+export const ALIAS_PATH_REGEX = /^[a-z0-9_]+(\.[a-z0-9_]+)*$/;
+export const ALIAS_SEGMENT_ERROR = 'must contain only lowercase letters, numbers, and underscores';
+
 export const BlendedFieldOverrideSchema = z.object({
   alias: z.string().optional(),
   isHidden: z.boolean().optional(),
@@ -9,7 +17,13 @@ export const BlendedFieldOverrideSchema = z.object({
 export type BlendedFieldOverride = z.infer<typeof BlendedFieldOverrideSchema>;
 
 export const BlendedSourceSchema = z.object({
-  path: z.string().min(1),
+  path: z
+    .string()
+    .min(1)
+    .regex(
+      ALIAS_PATH_REGEX,
+      'path must be a dot-separated chain of alias segments (e.g. "orders" or "orders.items")'
+    ),
   alias: z.string().min(1),
   isExcluded: z.boolean().optional(),
   fields: z.record(z.string(), BlendedFieldOverrideSchema).optional(),

--- a/apps/backend/src/data-marts/dto/schemas/relationship-schemas.spec.ts
+++ b/apps/backend/src/data-marts/dto/schemas/relationship-schemas.spec.ts
@@ -1,0 +1,88 @@
+import {
+  JoinConditionsSchema,
+  JoinConditionsUpdateSchema,
+  ReportColumnConfigSchema,
+} from './relationship-schemas';
+
+describe('JoinConditionsSchema', () => {
+  it('should accept a valid array of join conditions', () => {
+    const input = [{ sourceFieldName: 'user_id', targetFieldName: 'id' }];
+    const result = JoinConditionsSchema.parse(input);
+    expect(result).toEqual(input);
+  });
+
+  it('should accept multiple join conditions', () => {
+    const input = [
+      { sourceFieldName: 'user_id', targetFieldName: 'id' },
+      { sourceFieldName: 'project_id', targetFieldName: 'project_id' },
+    ];
+    const result = JoinConditionsSchema.parse(input);
+    expect(result).toEqual(input);
+  });
+
+  it('should accept an empty array (draft state)', () => {
+    expect(JoinConditionsSchema.parse([])).toEqual([]);
+  });
+
+  it('should reject empty sourceFieldName', () => {
+    const input = [{ sourceFieldName: '', targetFieldName: 'id' }];
+    expect(() => JoinConditionsSchema.parse(input)).toThrow();
+  });
+
+  it('should reject empty targetFieldName', () => {
+    const input = [{ sourceFieldName: 'user_id', targetFieldName: '' }];
+    expect(() => JoinConditionsSchema.parse(input)).toThrow();
+  });
+
+  it('should reject missing required fields', () => {
+    const input = [{ sourceFieldName: 'user_id' }];
+    expect(() => JoinConditionsSchema.parse(input)).toThrow();
+  });
+});
+
+describe('JoinConditionsUpdateSchema', () => {
+  it('should accept a valid array of join conditions', () => {
+    const input = [{ sourceFieldName: 'user_id', targetFieldName: 'id' }];
+    const result = JoinConditionsUpdateSchema.parse(input);
+    expect(result).toEqual(input);
+  });
+
+  it('should reject an empty array', () => {
+    expect(() => JoinConditionsUpdateSchema.parse([])).toThrow();
+  });
+
+  it('should reject empty sourceFieldName', () => {
+    const input = [{ sourceFieldName: '', targetFieldName: 'id' }];
+    expect(() => JoinConditionsUpdateSchema.parse(input)).toThrow();
+  });
+
+  it('should reject empty targetFieldName', () => {
+    const input = [{ sourceFieldName: 'user_id', targetFieldName: '' }];
+    expect(() => JoinConditionsUpdateSchema.parse(input)).toThrow();
+  });
+});
+
+describe('ReportColumnConfigSchema', () => {
+  it('should accept null', () => {
+    const result = ReportColumnConfigSchema.parse(null);
+    expect(result).toBeNull();
+  });
+
+  it('should accept a valid array of strings', () => {
+    const input = ['column_a', 'column_b', 'column_c'];
+    const result = ReportColumnConfigSchema.parse(input);
+    expect(result).toEqual(input);
+  });
+
+  it('should reject an empty array', () => {
+    expect(() => ReportColumnConfigSchema.parse([])).toThrow();
+  });
+
+  it('should reject an array with empty strings', () => {
+    expect(() => ReportColumnConfigSchema.parse(['valid', ''])).toThrow();
+  });
+
+  it('should reject undefined', () => {
+    expect(() => ReportColumnConfigSchema.parse(undefined)).toThrow();
+  });
+});

--- a/apps/backend/src/data-marts/dto/schemas/relationship-schemas.ts
+++ b/apps/backend/src/data-marts/dto/schemas/relationship-schemas.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 
+// Keep this list in sync with `AGGREGATE_FUNCTIONS` on the web side
+// (`apps/web/src/features/data-marts/shared/types/relationship.types.ts`).
+// The two declarations mirror each other so the blended SQL builder and
+// the UI expose identical options.
 export const AGGREGATE_FUNCTIONS = [
   'STRING_AGG',
   'MAX',

--- a/apps/backend/src/data-marts/dto/schemas/relationship-schemas.ts
+++ b/apps/backend/src/data-marts/dto/schemas/relationship-schemas.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const AGGREGATE_FUNCTIONS = [
+  'STRING_AGG',
+  'MAX',
+  'MIN',
+  'SUM',
+  'COUNT',
+  'COUNT_DISTINCT',
+  'ANY_VALUE',
+] as const;
+export type AggregateFunction = (typeof AGGREGATE_FUNCTIONS)[number];
+
+export const JoinConditionSchema = z.object({
+  sourceFieldName: z.string().min(1),
+  targetFieldName: z.string().min(1),
+});
+export type JoinCondition = z.infer<typeof JoinConditionSchema>;
+export const JoinConditionsSchema = z.array(JoinConditionSchema);
+export const JoinConditionsUpdateSchema = z.array(JoinConditionSchema).min(1);
+
+export const ReportColumnConfigSchema = z.array(z.string().min(1)).min(1).nullable();
+export type ReportColumnConfig = z.infer<typeof ReportColumnConfigSchema>;

--- a/apps/backend/src/data-marts/entities/data-mart-relationship.entity.ts
+++ b/apps/backend/src/data-marts/entities/data-mart-relationship.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { CreatorAwareEntity } from './creator-aware-entity.interface';
+import { DataStorage } from './data-storage.entity';
+import { DataMart } from './data-mart.entity';
+import { createZodTransformer } from '../../common/zod/zod-transformer';
+import { JoinCondition, JoinConditionsSchema } from '../dto/schemas/relationship-schemas';
+
+@Entity()
+export class DataMartRelationship implements CreatorAwareEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => DataStorage, { eager: true })
+  @JoinColumn()
+  dataStorage: DataStorage;
+
+  @ManyToOne(() => DataMart, { eager: true })
+  @JoinColumn()
+  sourceDataMart: DataMart;
+
+  @ManyToOne(() => DataMart, { eager: true })
+  @JoinColumn()
+  targetDataMart: DataMart;
+
+  @Column({ length: 255 })
+  targetAlias: string;
+
+  @Column({
+    type: 'json',
+    transformer: createZodTransformer<JoinCondition[]>(JoinConditionsSchema),
+  })
+  joinConditions: JoinCondition[];
+
+  @Column()
+  projectId: string;
+
+  @Column()
+  createdById: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  modifiedAt: Date;
+}

--- a/apps/backend/src/data-marts/entities/data-mart.entity.ts
+++ b/apps/backend/src/data-marts/entities/data-mart.entity.ts
@@ -20,6 +20,10 @@ import { createZodTransformer } from '../../common/zod/zod-transformer';
 import { ConnectorState } from './connector-state.entity';
 import { DataMartTechnicalOwner } from './data-mart-technical-owner.entity';
 import { DataMartBusinessOwner } from './data-mart-business-owner.entity';
+import {
+  BlendedFieldsConfig,
+  BlendedFieldsConfigSchema,
+} from '../dto/schemas/blended-fields-config.schemas';
 
 @Entity()
 export class DataMart implements CreatorAwareEntity {
@@ -72,6 +76,13 @@ export class DataMart implements CreatorAwareEntity {
 
   @OneToMany(() => DataMartTechnicalOwner, owner => owner.dataMart)
   technicalOwners: DataMartTechnicalOwner[];
+
+  @Column({
+    type: 'json',
+    transformer: createZodTransformer<BlendedFieldsConfig>(BlendedFieldsConfigSchema, false),
+    nullable: true,
+  })
+  blendedFieldsConfig?: BlendedFieldsConfig;
 
   @Column()
   createdById: string;

--- a/apps/backend/src/data-marts/entities/report.entity.ts
+++ b/apps/backend/src/data-marts/entities/report.entity.ts
@@ -47,6 +47,13 @@ export class Report implements CreatorAwareEntity {
   })
   destinationConfig: DataDestinationConfig;
 
+  @Column({
+    type: 'json',
+    nullable: true,
+    default: null,
+  })
+  columnConfig?: string[] | null;
+
   @Column({ nullable: true })
   lastRunAt?: Date;
 

--- a/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
@@ -27,6 +27,7 @@ import { RunDataMartCommand } from '../dto/domain/run-data-mart.command';
 import { SqlDryRunResult } from '../dto/domain/sql-dry-run-result.dto';
 import { SqlDryRunCommand } from '../dto/domain/sql-dry-run.command';
 import { UpdateDataMartDefinitionCommand } from '../dto/domain/update-data-mart-definition.command';
+import { UpdateBlendedFieldsConfigCommand } from '../dto/domain/update-blended-fields-config.command';
 import { UpdateDataMartDescriptionCommand } from '../dto/domain/update-data-mart-description.command';
 import { UpdateDataMartSchemaCommand } from '../dto/domain/update-data-mart-schema.command';
 import { UpdateDataMartTitleCommand } from '../dto/domain/update-data-mart-title.command';
@@ -45,6 +46,7 @@ import { PaginatedDataMartsResponseApiDto } from '../dto/presentation/paginated-
 import { SqlDryRunRequestApiDto } from '../dto/presentation/sql-dry-run-request-api.dto';
 import { SqlDryRunResponseApiDto } from '../dto/presentation/sql-dry-run-response-api.dto';
 import { UpdateDataMartDefinitionApiDto } from '../dto/presentation/update-data-mart-definition-api.dto';
+import { UpdateBlendedFieldsConfigApiDto } from '../dto/presentation/update-blended-fields-config-api.dto';
 import { UpdateDataMartDescriptionApiDto } from '../dto/presentation/update-data-mart-description-api.dto';
 import { UpdateDataMartSchemaApiDto } from '../dto/presentation/update-data-mart-schema-api.dto';
 import { UpdateDataMartTitleApiDto } from '../dto/presentation/update-data-mart-title-api.dto';
@@ -109,7 +111,8 @@ export class DataMartMapper {
       businessOwnerUsers,
       technicalOwnerUsers,
       entity.availableForReporting ?? true,
-      entity.availableForMaintenance ?? true
+      entity.availableForMaintenance ?? true,
+      entity.blendedFieldsConfig
     );
   }
 
@@ -141,6 +144,7 @@ export class DataMartMapper {
       connectorState: dto.connectorState,
       triggersCount: dto.triggersCount,
       reportsCount: dto.reportsCount,
+      blendedFieldsConfig: dto.blendedFieldsConfig,
       createdByUser: dto.createdByUser,
       businessOwnerUsers: dto.businessOwnerUsers,
       technicalOwnerUsers: dto.technicalOwnerUsers,
@@ -343,6 +347,18 @@ export class DataMartMapper {
       dto.description,
       context.userId,
       context.roles ?? []
+    );
+  }
+
+  toUpdateBlendedFieldsConfigCommand(
+    id: string,
+    context: AuthorizationContext,
+    dto: UpdateBlendedFieldsConfigApiDto
+  ): UpdateBlendedFieldsConfigCommand {
+    return new UpdateBlendedFieldsConfigCommand(
+      id,
+      context.projectId,
+      dto.blendedFieldsConfig ?? null
     );
   }
 

--- a/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
@@ -358,7 +358,9 @@ export class DataMartMapper {
     return new UpdateBlendedFieldsConfigCommand(
       id,
       context.projectId,
-      dto.blendedFieldsConfig ?? null
+      dto.blendedFieldsConfig ?? null,
+      context.userId,
+      context.roles ?? []
     );
   }
 

--- a/apps/backend/src/data-marts/mappers/relationship.mapper.spec.ts
+++ b/apps/backend/src/data-marts/mappers/relationship.mapper.spec.ts
@@ -1,0 +1,207 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { Test, TestingModule } from '@nestjs/testing';
+import { RelationshipMapper } from './relationship.mapper';
+import { AuthorizationContext } from '../../idp';
+import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataStorage } from '../entities/data-storage.entity';
+import { CreateRelationshipRequestApiDto } from '../dto/presentation/create-relationship-request-api.dto';
+import { UpdateRelationshipRequestApiDto } from '../dto/presentation/update-relationship-request-api.dto';
+
+const mockContext: AuthorizationContext = {
+  userId: 'user-123',
+  projectId: 'project-456',
+};
+
+const mockSourceDataMart = { id: 'source-dm-1', title: 'Source Mart' } as DataMart;
+const mockTargetDataMart = { id: 'target-dm-2', title: 'Target Mart' } as DataMart;
+const mockDataStorage = { id: 'storage-1' } as DataStorage;
+
+const mockEntity: DataMartRelationship = {
+  id: 'rel-1',
+  dataStorage: mockDataStorage,
+  sourceDataMart: mockSourceDataMart,
+  targetDataMart: mockTargetDataMart,
+  targetAlias: 'orders',
+  joinConditions: [{ sourceFieldName: 'user_id', targetFieldName: 'user_id' }],
+  projectId: 'project-456',
+  createdById: 'user-123',
+  createdAt: new Date('2024-01-01T00:00:00.000Z'),
+  modifiedAt: new Date('2024-01-02T00:00:00.000Z'),
+};
+
+describe('RelationshipMapper', () => {
+  let mapper: RelationshipMapper;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RelationshipMapper],
+    }).compile();
+
+    mapper = module.get<RelationshipMapper>(RelationshipMapper);
+  });
+
+  describe('toCreateCommand', () => {
+    it('should map API DTO to CreateRelationshipCommand', () => {
+      const dto: CreateRelationshipRequestApiDto = {
+        targetDataMartId: 'target-dm-2',
+        targetAlias: 'orders',
+        joinConditions: [{ sourceFieldName: 'user_id', targetFieldName: 'user_id' }],
+      };
+
+      const command = mapper.toCreateCommand('source-dm-1', mockContext, dto);
+
+      expect(command.sourceDataMartId).toBe('source-dm-1');
+      expect(command.targetDataMartId).toBe('target-dm-2');
+      expect(command.targetAlias).toBe('orders');
+      expect(command.userId).toBe('user-123');
+      expect(command.projectId).toBe('project-456');
+      expect(command.joinConditions).toEqual([
+        { sourceFieldName: 'user_id', targetFieldName: 'user_id' },
+      ]);
+    });
+  });
+
+  describe('toUpdateCommand', () => {
+    it('should map API DTO to UpdateRelationshipCommand with all optional fields', () => {
+      const dto: UpdateRelationshipRequestApiDto = {
+        targetAlias: 'new_alias',
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      };
+
+      const command = mapper.toUpdateCommand('rel-1', 'source-dm-1', mockContext, dto);
+
+      expect(command.relationshipId).toBe('rel-1');
+      expect(command.sourceDataMartId).toBe('source-dm-1');
+      expect(command.userId).toBe('user-123');
+      expect(command.projectId).toBe('project-456');
+      expect(command.targetAlias).toBe('new_alias');
+      expect(command.joinConditions).toEqual([{ sourceFieldName: 'id', targetFieldName: 'id' }]);
+    });
+
+    it('should produce undefined for optional fields when not provided', () => {
+      const dto: UpdateRelationshipRequestApiDto = {};
+
+      const command = mapper.toUpdateCommand('rel-1', 'source-dm-1', mockContext, dto);
+
+      expect(command.targetAlias).toBeUndefined();
+      expect(command.joinConditions).toBeUndefined();
+    });
+  });
+
+  describe('toGetCommand', () => {
+    it('should map to GetRelationshipCommand', () => {
+      const command = mapper.toGetCommand('rel-1', 'source-dm-1', mockContext);
+
+      expect(command.relationshipId).toBe('rel-1');
+      expect(command.sourceDataMartId).toBe('source-dm-1');
+      expect(command.userId).toBe('user-123');
+      expect(command.projectId).toBe('project-456');
+    });
+  });
+
+  describe('toResponse', () => {
+    it('should map entity to RelationshipResponseApiDto', () => {
+      const response = mapper.toResponse(mockEntity);
+
+      expect(response.id).toBe('rel-1');
+      expect(response.dataStorageId).toBe('storage-1');
+      expect(response.sourceDataMart).toEqual({
+        id: 'source-dm-1',
+        title: 'Source Mart',
+        description: undefined,
+      });
+      expect(response.targetDataMart).toEqual({
+        id: 'target-dm-2',
+        title: 'Target Mart',
+        description: undefined,
+      });
+      expect(response.targetAlias).toBe('orders');
+      expect(response.joinConditions).toEqual([
+        { sourceFieldName: 'user_id', targetFieldName: 'user_id' },
+      ]);
+      expect(response.createdById).toBe('user-123');
+      expect(response.createdAt).toEqual(new Date('2024-01-01T00:00:00.000Z'));
+      expect(response.modifiedAt).toEqual(new Date('2024-01-02T00:00:00.000Z'));
+    });
+  });
+
+  describe('toResponseList', () => {
+    it('should map array of entities to array of RelationshipResponseApiDto', () => {
+      const secondEntity: DataMartRelationship = {
+        ...mockEntity,
+        id: 'rel-2',
+        targetAlias: 'sessions',
+      };
+
+      const responses = mapper.toResponseList([mockEntity, secondEntity]);
+
+      expect(responses).toHaveLength(2);
+      expect(responses[0].id).toBe('rel-1');
+      expect(responses[1].id).toBe('rel-2');
+      expect(responses[1].targetAlias).toBe('sessions');
+    });
+
+    it('should return empty array for empty input', () => {
+      const responses = mapper.toResponseList([]);
+      expect(responses).toHaveLength(0);
+    });
+  });
+});
+
+describe('CreateRelationshipRequestApiDto validation', () => {
+  it('should pass validation when joinConditions is an empty array (draft state)', async () => {
+    const dto = plainToInstance(CreateRelationshipRequestApiDto, {
+      targetDataMartId: 'target-dm-1',
+      targetAlias: 'orders',
+      joinConditions: [],
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should pass validation when joinConditions has items', async () => {
+    const dto = plainToInstance(CreateRelationshipRequestApiDto, {
+      targetDataMartId: 'target-dm-1',
+      targetAlias: 'orders',
+      joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe('UpdateRelationshipRequestApiDto validation', () => {
+  it('should fail validation when joinConditions is an empty array', async () => {
+    const dto = plainToInstance(UpdateRelationshipRequestApiDto, {
+      joinConditions: [],
+    });
+
+    const errors = await validate(dto);
+    const joinConditionsError = errors.find(e => e.property === 'joinConditions');
+    expect(joinConditionsError).toBeDefined();
+    expect(joinConditionsError?.constraints).toHaveProperty('arrayMinSize');
+  });
+
+  it('should pass validation when joinConditions has at least one item', async () => {
+    const dto = plainToInstance(UpdateRelationshipRequestApiDto, {
+      joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+    });
+
+    const errors = await validate(dto);
+    const joinConditionsError = errors.find(e => e.property === 'joinConditions');
+    expect(joinConditionsError).toBeUndefined();
+  });
+
+  it('should pass validation when joinConditions is omitted (optional field)', async () => {
+    const dto = plainToInstance(UpdateRelationshipRequestApiDto, {
+      targetAlias: 'new_alias',
+    });
+
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/apps/backend/src/data-marts/mappers/relationship.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/relationship.mapper.ts
@@ -27,7 +27,8 @@ export class RelationshipMapper {
       dto.targetAlias,
       dto.joinConditions.map(c => this.toJoinCondition(c)),
       context.userId,
-      context.projectId
+      context.projectId,
+      context.roles ?? []
     );
   }
 
@@ -42,6 +43,7 @@ export class RelationshipMapper {
       dataMartId,
       context.userId,
       context.projectId,
+      context.roles ?? [],
       dto.targetAlias,
       dto.joinConditions?.map(c => this.toJoinCondition(c))
     );
@@ -56,7 +58,8 @@ export class RelationshipMapper {
       relationshipId,
       dataMartId,
       context.userId,
-      context.projectId
+      context.projectId,
+      context.roles ?? []
     );
   }
 

--- a/apps/backend/src/data-marts/mappers/relationship.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/relationship.mapper.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+import { AuthorizationContext } from '../../idp';
+import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { CreateRelationshipCommand } from '../dto/domain/create-relationship.command';
+import { UpdateRelationshipCommand } from '../dto/domain/update-relationship.command';
+import { GetRelationshipCommand } from '../dto/domain/get-relationship.command';
+import {
+  CreateRelationshipRequestApiDto,
+  JoinConditionApiDto,
+} from '../dto/presentation/create-relationship-request-api.dto';
+import { UpdateRelationshipRequestApiDto } from '../dto/presentation/update-relationship-request-api.dto';
+import { RelationshipResponseApiDto } from '../dto/presentation/relationship-response-api.dto';
+import { JoinCondition } from '../dto/schemas/relationship-schemas';
+import { UserProjectionDto } from '../../idp/dto/domain/user-projection.dto';
+import { UserProjectionsListDto } from '../../idp/dto/domain/user-projections-list.dto';
+
+@Injectable()
+export class RelationshipMapper {
+  toCreateCommand(
+    dataMartId: string,
+    context: AuthorizationContext,
+    dto: CreateRelationshipRequestApiDto
+  ): CreateRelationshipCommand {
+    return new CreateRelationshipCommand(
+      dataMartId,
+      dto.targetDataMartId,
+      dto.targetAlias,
+      dto.joinConditions.map(c => this.toJoinCondition(c)),
+      context.userId,
+      context.projectId
+    );
+  }
+
+  toUpdateCommand(
+    relationshipId: string,
+    dataMartId: string,
+    context: AuthorizationContext,
+    dto: UpdateRelationshipRequestApiDto
+  ): UpdateRelationshipCommand {
+    return new UpdateRelationshipCommand(
+      relationshipId,
+      dataMartId,
+      context.userId,
+      context.projectId,
+      dto.targetAlias,
+      dto.joinConditions?.map(c => this.toJoinCondition(c))
+    );
+  }
+
+  toGetCommand(
+    relationshipId: string,
+    dataMartId: string,
+    context: AuthorizationContext
+  ): GetRelationshipCommand {
+    return new GetRelationshipCommand(
+      relationshipId,
+      dataMartId,
+      context.userId,
+      context.projectId
+    );
+  }
+
+  toResponse(
+    entity: DataMartRelationship,
+    createdByUser: UserProjectionDto | null = null
+  ): RelationshipResponseApiDto {
+    return {
+      id: entity.id,
+      dataStorageId: entity.dataStorage.id,
+      sourceDataMart: {
+        id: entity.sourceDataMart.id,
+        title: entity.sourceDataMart.title,
+        description: entity.sourceDataMart.description,
+        status: entity.sourceDataMart.status,
+      },
+      targetDataMart: {
+        id: entity.targetDataMart.id,
+        title: entity.targetDataMart.title,
+        description: entity.targetDataMart.description,
+        status: entity.targetDataMart.status,
+      },
+      targetAlias: entity.targetAlias,
+      joinConditions: entity.joinConditions,
+      createdById: entity.createdById,
+      createdAt: entity.createdAt,
+      modifiedAt: entity.modifiedAt,
+      createdByUser,
+    };
+  }
+
+  toResponseList(
+    entities: DataMartRelationship[],
+    userProjectionsList?: UserProjectionsListDto
+  ): RelationshipResponseApiDto[] {
+    return entities.map(entity =>
+      this.toResponse(
+        entity,
+        entity.createdById ? (userProjectionsList?.getByUserId(entity.createdById) ?? null) : null
+      )
+    );
+  }
+
+  private toJoinCondition(dto: JoinConditionApiDto): JoinCondition {
+    return {
+      sourceFieldName: dto.sourceFieldName,
+      targetFieldName: dto.targetFieldName,
+    };
+  }
+}

--- a/apps/backend/src/data-marts/mappers/report.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.ts
@@ -12,6 +12,8 @@ import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data
 import { ListReportsByProjectCommand } from '../dto/domain/list-reports-by-project.command';
 import { ListReportsByInsightTemplateCommand } from '../dto/domain/list-reports-by-insight-template.command';
 import { RunReportCommand } from '../dto/domain/run-report.command';
+import { CopyReportAsDataMartCommand } from '../dto/domain/copy-report-as-data-mart.command';
+import { GetReportGeneratedSqlCommand } from '../dto/domain/get-report-generated-sql.command';
 import { AuthorizationContext } from '../../idp';
 import { DataMartMapper } from './data-mart.mapper';
 import { DataDestinationMapper } from './data-destination.mapper';
@@ -176,6 +178,30 @@ export class ReportMapper {
       dto.destinationConfig,
       dto.ownerIds,
       dto.columnConfig
+    );
+  }
+
+  toCopyAsDataMartCommand(
+    reportId: string,
+    context: AuthorizationContext
+  ): CopyReportAsDataMartCommand {
+    return new CopyReportAsDataMartCommand(
+      reportId,
+      context.userId,
+      context.projectId,
+      context.roles ?? []
+    );
+  }
+
+  toGetGeneratedSqlCommand(
+    reportId: string,
+    context: AuthorizationContext
+  ): GetReportGeneratedSqlCommand {
+    return new GetReportGeneratedSqlCommand(
+      reportId,
+      context.userId,
+      context.projectId,
+      context.roles ?? []
     );
   }
 }

--- a/apps/backend/src/data-marts/mappers/report.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.ts
@@ -40,7 +40,8 @@ export class ReportMapper {
       dto.dataDestinationId,
       dto.destinationConfig,
       dto.ownerIds,
-      context.roles ?? []
+      context.roles ?? [],
+      dto.columnConfig
     );
   }
 
@@ -62,7 +63,8 @@ export class ReportMapper {
       entity.lastRunStatus,
       entity.runsCount,
       createdByUser,
-      ownerUsers
+      ownerUsers,
+      entity.columnConfig
     );
   }
 
@@ -85,6 +87,7 @@ export class ReportMapper {
         dto.dataDestinationAccess
       ),
       destinationConfig: dto.destinationConfig,
+      columnConfig: dto.columnConfig,
       lastRunAt: dto.lastRunAt,
       lastRunStatus: dto.lastRunStatus,
       lastRunError: dto.lastRunError,
@@ -171,7 +174,8 @@ export class ReportMapper {
       dto.title,
       dto.dataDestinationId,
       dto.destinationConfig,
-      dto.ownerIds
+      dto.ownerIds,
+      dto.columnConfig
     );
   }
 }

--- a/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
@@ -1,0 +1,668 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BlendableSchemaService } from './blendable-schema.service';
+import { DataMartRelationshipService } from './data-mart-relationship.service';
+import { DataMartService } from './data-mart.service';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { BlendedFieldsConfig } from '../dto/schemas/blended-fields-config.schemas';
+
+function makeDataMart(overrides: Partial<DataMart> = {}): DataMart {
+  return {
+    id: 'dm-1',
+    title: 'Data Mart 1',
+    schema: undefined,
+    projectId: 'project-1',
+    createdById: 'user-1',
+    status: 'draft' as DataMart['status'],
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    storage: {} as unknown as DataMart['storage'],
+    ...overrides,
+  } as DataMart;
+}
+
+function makeRelationship(overrides: Partial<DataMartRelationship> = {}): DataMartRelationship {
+  return {
+    id: 'rel-1',
+    targetAlias: 'customers',
+    // Non-empty joinConditions by default so fixtures exercise the "configured"
+    // relationship path. Tests that want an unconfigured relationship should
+    // override this explicitly to `[]`.
+    joinConditions: [{ sourceFieldName: 'customer_id', targetFieldName: 'id' }],
+    projectId: 'project-1',
+    createdById: 'user-1',
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    sourceDataMart: makeDataMart({ id: 'dm-1' }),
+    targetDataMart: makeDataMart({ id: 'dm-2', title: 'Data Mart 2' }),
+    dataStorage: {} as unknown as DataMartRelationship['dataStorage'],
+    ...overrides,
+  } as DataMartRelationship;
+}
+
+function makeSchema(fields: Array<{ name: string; type: string; isHiddenForReporting?: boolean }>) {
+  return {
+    type: 'bigquery-data-mart-schema',
+    fields,
+  } as unknown as DataMart['schema'];
+}
+
+describe('BlendableSchemaService', () => {
+  let service: BlendableSchemaService;
+  let relationshipService: jest.Mocked<DataMartRelationshipService>;
+  let dataMartService: jest.Mocked<DataMartService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BlendableSchemaService,
+        {
+          provide: DataMartRelationshipService,
+          useValue: {
+            findBySourceDataMartId: jest.fn(),
+          },
+        },
+        {
+          provide: DataMartService,
+          useValue: {
+            getByIdAndProjectId: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<BlendableSchemaService>(BlendableSchemaService);
+    relationshipService = module.get(DataMartRelationshipService);
+    dataMartService = module.get(DataMartService);
+  });
+
+  describe('computeBlendableSchema', () => {
+    it('should return native fields and empty blendedFields when no relationships exist', async () => {
+      const nativeSchemaFields = [{ name: 'id', type: 'STRING' }];
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({
+          id: 'dm-1',
+          schema: makeSchema(nativeSchemaFields),
+        })
+      );
+      relationshipService.findBySourceDataMartId.mockResolvedValue([]);
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+
+      expect(result.nativeFields).toEqual(nativeSchemaFields);
+      expect(result.blendedFields).toEqual([]);
+    });
+
+    it('should return empty arrays when schema is undefined and no relationships exist', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ schema: undefined }));
+      relationshipService.findBySourceDataMartId.mockResolvedValue([]);
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+
+      expect(result.nativeFields).toEqual([]);
+      expect(result.blendedFields).toEqual([]);
+    });
+
+    it('should skip relationships with no join conditions and their downstream children', async () => {
+      // Scenario: A→B (no joinConditions, "not configured") → C (fully configured).
+      // The unconfigured edge produces no valid SQL, so B, its fields, and any
+      // descendants reached only via B must be excluded from the blendable schema.
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+
+      const unconfigured = makeRelationship({
+        id: 'rel-unconfigured',
+        targetAlias: 'b',
+        joinConditions: [],
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-b',
+          schema: makeSchema([{ name: 'field_b', type: 'STRING' }]),
+        }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (sourceId: string) => {
+        if (sourceId === 'dm-a') return [unconfigured];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-a', 'project-1');
+
+      expect(result.availableSources).toEqual([]);
+      expect(result.blendedFields).toEqual([]);
+    });
+
+    it('should dynamically compute blended fields from target schema (AUTO_BLEND_ALL default)', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({ id: 'dm-1', blendedFieldsConfig: undefined })
+      );
+
+      const relationship = makeRelationship({
+        id: 'rel-1',
+        targetAlias: 'customers',
+        targetDataMart: makeDataMart({
+          id: 'dm-2',
+          title: 'Customers DM',
+          schema: makeSchema([
+            { name: 'customer_name', type: 'STRING' },
+            { name: 'customer_age', type: 'INTEGER' },
+          ]),
+        }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-1') return [relationship];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+
+      expect(result.blendedFields).toHaveLength(2);
+
+      const nameField = result.blendedFields[0];
+      expect(nameField.name).toBe('customers__customer_name');
+      expect(nameField.aliasPath).toBe('customers');
+      expect(nameField.outputPrefix).toBe('Customers DM');
+      expect(nameField.sourceRelationshipId).toBe('rel-1');
+      expect(nameField.sourceDataMartId).toBe('dm-2');
+      expect(nameField.sourceDataMartTitle).toBe('Customers DM');
+      expect(nameField.targetAlias).toBe('customers');
+      expect(nameField.originalFieldName).toBe('customer_name');
+      expect(nameField.type).toBe('STRING');
+      expect(nameField.isHidden).toBe(false);
+      expect(nameField.aggregateFunction).toBe('STRING_AGG');
+      expect(nameField.transitiveDepth).toBe(1);
+
+      const ageField = result.blendedFields[1];
+      expect(ageField.name).toBe('customers__customer_age');
+      expect(ageField.type).toBe('INTEGER');
+      // Numeric default: SUM, not STRING_AGG
+      expect(ageField.aggregateFunction).toBe('SUM');
+    });
+
+    it.each([
+      'INTEGER',
+      'INT',
+      'INT64',
+      'SMALLINT',
+      'BIGINT',
+      'TINYINT',
+      'FLOAT',
+      'FLOAT64',
+      'DOUBLE',
+      'DOUBLE PRECISION',
+      'REAL',
+      'NUMERIC',
+      'BIGNUMERIC',
+      'DECIMAL',
+      'NUMBER',
+    ])('should default aggregateFunction to SUM for numeric type %s', async numericType => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({ id: 'dm-1', blendedFieldsConfig: undefined })
+      );
+
+      const relationship = makeRelationship({
+        id: 'rel-1',
+        targetAlias: 't',
+        targetDataMart: makeDataMart({
+          id: 'dm-2',
+          title: 'Target',
+          schema: makeSchema([{ name: 'val', type: numericType }]),
+        }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-1') return [relationship];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+      const field = result.blendedFields.find(f => f.originalFieldName === 'val')!;
+      expect(field.aggregateFunction).toBe('SUM');
+    });
+
+    it.each(['STRING', 'DATE', 'TIMESTAMP', 'BOOLEAN', 'JSON', 'VARCHAR'])(
+      'should default aggregateFunction to STRING_AGG for non-numeric type %s',
+      async nonNumericType => {
+        dataMartService.getByIdAndProjectId.mockResolvedValue(
+          makeDataMart({ id: 'dm-1', blendedFieldsConfig: undefined })
+        );
+
+        const relationship = makeRelationship({
+          id: 'rel-1',
+          targetAlias: 't',
+          targetDataMart: makeDataMart({
+            id: 'dm-2',
+            title: 'Target',
+            schema: makeSchema([{ name: 'val', type: nonNumericType }]),
+          }),
+        });
+
+        relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+          if (id === 'dm-1') return [relationship];
+          return [];
+        });
+
+        const result = await service.computeBlendableSchema('dm-1', 'project-1');
+        const field = result.blendedFields.find(f => f.originalFieldName === 'val')!;
+        expect(field.aggregateFunction).toBe('STRING_AGG');
+      }
+    );
+
+    it('should apply overrides from blendedFieldsConfig sources', async () => {
+      const config: BlendedFieldsConfig = {
+        sources: [
+          {
+            path: 'orders',
+            alias: 'ord',
+            fields: {
+              revenue: { aggregateFunction: 'SUM' },
+              internal_id: { isHidden: true },
+            },
+          },
+        ],
+      };
+
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({ id: 'dm-1', blendedFieldsConfig: config })
+      );
+
+      const relationship = makeRelationship({
+        id: 'rel-1',
+        targetAlias: 'orders',
+        targetDataMart: makeDataMart({
+          id: 'dm-2',
+          title: 'Orders',
+          schema: makeSchema([
+            { name: 'revenue', type: 'FLOAT' },
+            { name: 'internal_id', type: 'STRING' },
+            { name: 'status', type: 'STRING' },
+          ]),
+        }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-1') return [relationship];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+
+      expect(result.blendedFields).toHaveLength(3);
+
+      const revenueField = result.blendedFields.find(f => f.originalFieldName === 'revenue')!;
+      expect(revenueField.name).toBe('orders__revenue');
+      expect(revenueField.outputPrefix).toBe('ord');
+      expect(revenueField.aggregateFunction).toBe('SUM');
+      expect(revenueField.isHidden).toBe(false);
+
+      const hiddenField = result.blendedFields.find(f => f.originalFieldName === 'internal_id')!;
+      expect(hiddenField.isHidden).toBe(true);
+
+      const statusField = result.blendedFields.find(f => f.originalFieldName === 'status')!;
+      expect(statusField.aggregateFunction).toBe('STRING_AGG');
+      expect(statusField.isHidden).toBe(false);
+    });
+
+    it('should apply alias overrides from blendedFieldsConfig sources', async () => {
+      const config: BlendedFieldsConfig = {
+        sources: [
+          {
+            path: 'orders',
+            alias: 'ord',
+            fields: {
+              revenue: { alias: 'Total Revenue' },
+              status: { alias: 'Order Status', aggregateFunction: 'MAX' },
+            },
+          },
+        ],
+      };
+
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({ id: 'dm-1', blendedFieldsConfig: config })
+      );
+
+      const relationship = makeRelationship({
+        id: 'rel-1',
+        targetAlias: 'orders',
+        targetDataMart: makeDataMart({
+          id: 'dm-2',
+          title: 'Orders',
+          schema: makeSchema([
+            { name: 'revenue', type: 'FLOAT' },
+            { name: 'status', type: 'STRING' },
+            { name: 'no_override', type: 'STRING' },
+          ]),
+        }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-1') return [relationship];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+
+      const revenueField = result.blendedFields.find(f => f.originalFieldName === 'revenue')!;
+      expect(revenueField.alias).toBe('Total Revenue');
+
+      const statusField = result.blendedFields.find(f => f.originalFieldName === 'status')!;
+      expect(statusField.alias).toBe('Order Status');
+      expect(statusField.aggregateFunction).toBe('MAX');
+
+      const noOverrideField = result.blendedFields.find(
+        f => f.originalFieldName === 'no_override'
+      )!;
+      expect(noOverrideField.alias).toBe('');
+    });
+
+    it('throws a clear error when a relationship targets a soft-deleted data mart', async () => {
+      // Scenario: A→B exists, but B has been soft-deleted. TypeORM eager join leaves
+      // rel.targetDataMart undefined. We should fail loud with a message that names
+      // the broken relationship so the user can act on it.
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+
+      const orphanRel = {
+        id: 'rel-broken',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: undefined,
+        joinConditions: [{ sourceFieldName: 'a_id', targetFieldName: 'b_id' }],
+      } as unknown as DataMartRelationship;
+      relationshipService.findBySourceDataMartId.mockResolvedValue([orphanRel]);
+
+      await expect(service.computeBlendableSchema('dm-a', 'project-1')).rejects.toThrow(
+        /relationship.+rel-broken.+deleted/i
+      );
+    });
+
+    it('should resolve transitive relationships (A→B→C) with depth=2', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+
+      const relAtoB = makeRelationship({
+        id: 'rel-ab',
+        targetAlias: 'b_alias',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-b',
+          title: 'DM B',
+          schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+        }),
+      });
+
+      const relBtoC = makeRelationship({
+        id: 'rel-bc',
+        targetAlias: 'c_alias',
+        sourceDataMart: makeDataMart({ id: 'dm-b' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-c',
+          title: 'DM C',
+          schema: makeSchema([{ name: 'order_id', type: 'INTEGER' }]),
+        }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-a') return [relAtoB];
+        if (id === 'dm-b') return [relBtoC];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-a', 'project-1');
+
+      expect(result.blendedFields).toHaveLength(2);
+
+      const bField = result.blendedFields[0];
+      expect(bField.name).toBe('b_alias__b_field');
+      expect(bField.aliasPath).toBe('b_alias');
+      expect(bField.transitiveDepth).toBe(1);
+
+      const cField = result.blendedFields[1];
+      expect(cField.name).toBe('b_alias_c_alias__order_id');
+      expect(cField.aliasPath).toBe('b_alias.c_alias');
+      expect(cField.outputPrefix).toBe('DM C');
+      expect(cField.transitiveDepth).toBe(2);
+    });
+
+    it('should prevent infinite loops via cycle protection (visited set on alias path)', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+
+      const relAtoB = makeRelationship({
+        id: 'rel-ab',
+        targetAlias: 'b_alias',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({ id: 'dm-b', title: 'DM B' }),
+      });
+
+      const relBtoA = makeRelationship({
+        id: 'rel-ba',
+        targetAlias: 'a_alias',
+        sourceDataMart: makeDataMart({ id: 'dm-b' }),
+        targetDataMart: makeDataMart({ id: 'dm-a', title: 'DM A' }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-a') return [relAtoB];
+        if (id === 'dm-b') return [relBtoA];
+        return [];
+      });
+
+      // Should terminate without error — bounded by MAX_TRANSITIVE_DEPTH (10)
+      const result = await service.computeBlendableSchema('dm-a', 'project-1');
+      expect(result.blendedFields).toEqual([]);
+    });
+
+    it('should support diamond pattern — same DM via two different paths', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-root' }));
+
+      const sharedDm = makeDataMart({
+        id: 'dm-shared',
+        title: 'Shared DM',
+        schema: makeSchema([{ name: 'shared_field', type: 'STRING' }]),
+      });
+
+      const dmLeft = makeDataMart({ id: 'dm-left', title: 'Left DM' });
+      const dmRight = makeDataMart({ id: 'dm-right', title: 'Right DM' });
+
+      const relRootToLeft = makeRelationship({
+        id: 'rel-root-left',
+        targetAlias: 'left',
+        sourceDataMart: makeDataMart({ id: 'dm-root' }),
+        targetDataMart: dmLeft,
+      });
+
+      const relRootToRight = makeRelationship({
+        id: 'rel-root-right',
+        targetAlias: 'right',
+        sourceDataMart: makeDataMart({ id: 'dm-root' }),
+        targetDataMart: dmRight,
+      });
+
+      const relLeftToShared = makeRelationship({
+        id: 'rel-left-shared',
+        targetAlias: 'shared',
+        sourceDataMart: dmLeft,
+        targetDataMart: sharedDm,
+      });
+
+      const relRightToShared = makeRelationship({
+        id: 'rel-right-shared',
+        targetAlias: 'shared',
+        sourceDataMart: dmRight,
+        targetDataMart: sharedDm,
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-root') return [relRootToLeft, relRootToRight];
+        if (id === 'dm-left') return [relLeftToShared];
+        if (id === 'dm-right') return [relRightToShared];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-root', 'project-1');
+
+      // Should have fields from both paths: left.shared and right.shared
+      const leftSharedFields = result.blendedFields.filter(f => f.aliasPath === 'left.shared');
+      const rightSharedFields = result.blendedFields.filter(f => f.aliasPath === 'right.shared');
+
+      expect(leftSharedFields).toHaveLength(1);
+      expect(rightSharedFields).toHaveLength(1);
+      expect(leftSharedFields[0].name).toBe('left_shared__shared_field');
+      expect(rightSharedFields[0].name).toBe('right_shared__shared_field');
+    });
+
+    it('should silently ignore orphaned sources that do not match any relationship path', async () => {
+      const config: BlendedFieldsConfig = {
+        sources: [
+          { path: 'nonexistent_path', alias: 'ghost' },
+          { path: 'orders', alias: 'ord' },
+        ],
+      };
+
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({ id: 'dm-1', blendedFieldsConfig: config })
+      );
+
+      const relationship = makeRelationship({
+        id: 'rel-1',
+        targetAlias: 'orders',
+        targetDataMart: makeDataMart({
+          id: 'dm-2',
+          title: 'Orders',
+          schema: makeSchema([{ name: 'revenue', type: 'FLOAT' }]),
+        }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-1') return [relationship];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+
+      // Should not throw — orphaned 'nonexistent_path' is silently ignored
+      expect(result.blendedFields).toHaveLength(1);
+      expect(result.blendedFields[0].name).toBe('orders__revenue');
+    });
+
+    it('should filter out isHiddenForReporting fields from target schema', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-1' }));
+
+      const relationship = makeRelationship({
+        id: 'rel-1',
+        targetAlias: 'target',
+        targetDataMart: makeDataMart({
+          id: 'dm-2',
+          title: 'Target',
+          schema: makeSchema([
+            { name: 'visible', type: 'STRING' },
+            { name: 'hidden', type: 'STRING', isHiddenForReporting: true },
+          ]),
+        }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-1') return [relationship];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+
+      expect(result.blendedFields).toHaveLength(1);
+      expect(result.blendedFields[0].originalFieldName).toBe('visible');
+    });
+
+    it('should expose nativeDescription and availableSources[i].description for the reporting UI', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({
+          id: 'dm-1',
+          description: 'Root data mart description',
+        })
+      );
+
+      const relationship = makeRelationship({
+        id: 'rel-1',
+        targetAlias: 'orders',
+        targetDataMart: makeDataMart({
+          id: 'dm-2',
+          title: 'Orders',
+          description: 'Linked orders data mart',
+          schema: makeSchema([{ name: 'revenue', type: 'FLOAT' }]),
+        }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-1') return [relationship];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+
+      expect(result.nativeDescription).toBe('Root data mart description');
+      expect(result.availableSources).toHaveLength(1);
+      expect(result.availableSources[0].description).toBe('Linked orders data mart');
+    });
+
+    it('should return undefined descriptions when data marts have no description set', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-1' }));
+
+      const relationship = makeRelationship({
+        id: 'rel-1',
+        targetAlias: 'orders',
+        targetDataMart: makeDataMart({
+          id: 'dm-2',
+          title: 'Orders',
+          schema: makeSchema([{ name: 'revenue', type: 'FLOAT' }]),
+        }),
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-1') return [relationship];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+
+      expect(result.nativeDescription).toBeUndefined();
+      expect(result.availableSources[0].description).toBeUndefined();
+    });
+
+    it('should return blended fields from multiple relationships to the same target DM with different aliases', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-1' }));
+
+      const targetSchema = makeSchema([
+        { name: 'revenue', type: 'FLOAT' },
+        { name: 'country', type: 'STRING' },
+      ]);
+      const targetDm = makeDataMart({
+        id: 'dm-2',
+        title: 'Orders DM',
+        schema: targetSchema,
+      });
+
+      const rel1 = makeRelationship({
+        id: 'rel-1',
+        targetAlias: 'orders',
+        targetDataMart: targetDm,
+      });
+
+      const rel2 = makeRelationship({
+        id: 'rel-2',
+        targetAlias: 'orders_v2',
+        targetDataMart: targetDm,
+      });
+
+      relationshipService.findBySourceDataMartId.mockImplementation(async (id: string) => {
+        if (id === 'dm-1') return [rel1, rel2];
+        return [];
+      });
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1');
+
+      // Both aliases should produce fields independently
+      expect(result.blendedFields).toHaveLength(4);
+      expect(result.blendedFields[0].name).toBe('orders__revenue');
+      expect(result.blendedFields[1].name).toBe('orders__country');
+      expect(result.blendedFields[2].name).toBe('orders_v2__revenue');
+      expect(result.blendedFields[3].name).toBe('orders_v2__country');
+    });
+  });
+});

--- a/apps/backend/src/data-marts/services/blendable-schema.service.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.ts
@@ -1,0 +1,206 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  AvailableSourceDto,
+  BlendableSchemaDto,
+  BlendedFieldDto,
+} from '../dto/domain/blendable-schema.dto';
+import { DataMartRelationshipService } from './data-mart-relationship.service';
+import { DataMartService } from './data-mart.service';
+import { DataMartSchema } from '../data-storage-types/data-mart-schema.type';
+import { DataMartSchemaFieldStatus } from '../data-storage-types/enums/data-mart-schema-field-status.enum';
+import { isNumericFieldType } from '../data-storage-types/field-type-compatibility';
+import { BlendedFieldsConfig, BlendedSource } from '../dto/schemas/blended-fields-config.schemas';
+import { AggregateFunction } from '../dto/schemas/relationship-schemas';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+
+const MAX_TRANSITIVE_DEPTH = 10;
+
+const DEFAULT_CONFIG: BlendedFieldsConfig = {
+  sources: [],
+};
+
+function getDefaultAggregateFunction(rawFieldType: string): AggregateFunction {
+  return isNumericFieldType(rawFieldType) ? 'SUM' : 'STRING_AGG';
+}
+
+interface RawSchemaField {
+  name: string;
+  type: string;
+  status?: string;
+  alias?: string;
+  description?: string;
+  fields?: RawSchemaField[];
+}
+
+interface FlatSchemaField {
+  name: string;
+  type: string;
+  alias?: string;
+  description?: string;
+}
+
+export function flattenSchemaFields(fields: RawSchemaField[], prefix = ''): FlatSchemaField[] {
+  const result: FlatSchemaField[] = [];
+  for (const field of fields) {
+    if (field.status === DataMartSchemaFieldStatus.DISCONNECTED) continue;
+    const fullName = prefix ? `${prefix}.${field.name}` : field.name;
+    if (field.fields && field.fields.length > 0) {
+      result.push(...flattenSchemaFields(field.fields, fullName));
+    } else {
+      result.push({
+        name: fullName,
+        type: field.type,
+        alias: field.alias,
+        description: field.description,
+      });
+    }
+  }
+  return result;
+}
+
+interface CollectContext {
+  sourceId: string;
+  parentPath: string;
+  sourcesByPath: Map<string, BlendedSource>;
+  result: BlendedFieldDto[];
+  availableSources: AvailableSourceDto[];
+  visited: Set<string>;
+  depth: number;
+}
+
+@Injectable()
+export class BlendableSchemaService {
+  private readonly logger = new Logger(BlendableSchemaService.name);
+
+  constructor(
+    private readonly relationshipService: DataMartRelationshipService,
+    private readonly dataMartService: DataMartService
+  ) {}
+
+  async computeBlendableSchema(dataMartId: string, projectId: string): Promise<BlendableSchemaDto> {
+    const dataMart = await this.dataMartService.getByIdAndProjectId(dataMartId, projectId);
+    const nativeFields = (dataMart.schema?.fields ?? []).filter(
+      f => !f.isHiddenForReporting
+    ) as DataMartSchema['fields'];
+
+    const config: BlendedFieldsConfig = dataMart.blendedFieldsConfig ?? DEFAULT_CONFIG;
+    const sourcesByPath = new Map(config.sources.map(s => [s.path, s]));
+
+    const blendedFields: BlendedFieldDto[] = [];
+    const availableSources: AvailableSourceDto[] = [];
+    const visited = new Set<string>();
+
+    await this.collectBlendedFields({
+      sourceId: dataMartId,
+      parentPath: '',
+      sourcesByPath,
+      result: blendedFields,
+      availableSources,
+      visited,
+      depth: 1,
+    });
+
+    return {
+      nativeFields,
+      nativeDescription: dataMart.description ?? undefined,
+      blendedFields,
+      availableSources,
+    };
+  }
+
+  private async collectBlendedFields(ctx: CollectContext): Promise<void> {
+    if (ctx.depth > MAX_TRANSITIVE_DEPTH) {
+      this.logger.warn(
+        `Blendable schema traversal hit MAX_TRANSITIVE_DEPTH=${MAX_TRANSITIVE_DEPTH} ` +
+          `at path "${ctx.parentPath}". Deeper relationships are silently truncated — ` +
+          `restructure the relationship graph or raise the limit.`
+      );
+      return;
+    }
+
+    const relationships = await this.relationshipService.findBySourceDataMartId(ctx.sourceId);
+
+    for (const rel of relationships) {
+      // Skip relationships that don't have join conditions configured yet. They — and any
+      // relationships they transitively expose — must not surface in the reporting column
+      // picker, since without a JOIN there is no valid SQL to produce their rows.
+      if (!rel.joinConditions || rel.joinConditions.length === 0) continue;
+
+      // TypeORM eager join silently drops soft-deleted DMs, leaving targetDataMart undefined.
+      // Surface this as a clear, actionable error so report-run failures point to the broken
+      // relationship rather than collapsing into a generic "cannot read 'schema' of undefined".
+      if (!rel.targetDataMart) {
+        throw new BusinessViolationException(
+          `Relationship "${rel.targetAlias ?? rel.id}" (id=${rel.id}) targets a data mart that has been deleted. ` +
+            `Remove this relationship or restore the target data mart before running reports that depend on it.`,
+          { relationshipId: rel.id, targetAlias: rel.targetAlias }
+        );
+      }
+
+      const currentPath = ctx.parentPath ? `${ctx.parentPath}.${rel.targetAlias}` : rel.targetAlias;
+
+      if (ctx.visited.has(currentPath)) continue;
+      ctx.visited.add(currentPath);
+
+      const sourceConfig = ctx.sourcesByPath.get(currentPath);
+      const isExcluded = sourceConfig?.isExcluded === true;
+
+      const targetSchemaFields = (rel.targetDataMart.schema?.fields ?? []).filter(
+        f => !f.isHiddenForReporting
+      );
+      const flatTargetFields = flattenSchemaFields(targetSchemaFields);
+
+      // `sqlPrefix` is SQL‑safe because each `targetAlias` segment in
+      // `currentPath` is validated against `^[a-z0-9_]+$` in the Join
+      // Settings form. `displayPrefix` is free‑form and must never flow
+      // into SQL identifiers.
+      const sqlPrefix = currentPath.replace(/\./g, '_');
+      const displayPrefix = sourceConfig?.alias ?? rel.targetDataMart.title;
+
+      // Always collect available source metadata
+      const availableSource = new AvailableSourceDto();
+      availableSource.aliasPath = currentPath;
+      availableSource.title = rel.targetDataMart.title;
+      availableSource.description = rel.targetDataMart.description ?? undefined;
+      availableSource.defaultAlias = displayPrefix;
+      availableSource.depth = ctx.depth;
+      availableSource.fieldCount = flatTargetFields.length;
+      availableSource.isIncluded = !isExcluded;
+      availableSource.relationshipId = rel.id;
+      availableSource.dataMartId = rel.targetDataMart.id;
+      ctx.availableSources.push(availableSource);
+
+      for (const field of flatTargetFields) {
+        const fieldOverride = sourceConfig?.fields?.[field.name];
+
+        const dto = new BlendedFieldDto();
+        // Replace dots in nested struct field paths (e.g. `struct.field`) with
+        // underscores so the resulting alias is a valid SQL identifier.
+        dto.name = `${sqlPrefix}__${field.name.replace(/\./g, '_')}`;
+        dto.aliasPath = currentPath;
+        dto.outputPrefix = displayPrefix;
+        dto.sourceRelationshipId = rel.id;
+        dto.sourceDataMartId = rel.targetDataMart.id;
+        dto.sourceDataMartTitle = rel.targetDataMart.title;
+        dto.targetAlias = rel.targetAlias;
+        dto.originalFieldName = field.name;
+        dto.type = field.type;
+        dto.alias = fieldOverride?.alias ?? field.alias ?? '';
+        dto.description = field.description ?? '';
+        dto.isHidden = fieldOverride?.isHidden ?? false;
+        dto.aggregateFunction =
+          fieldOverride?.aggregateFunction ?? getDefaultAggregateFunction(field.type);
+        dto.transitiveDepth = ctx.depth;
+
+        ctx.result.push(dto);
+      }
+
+      await this.collectBlendedFields({
+        ...ctx,
+        sourceId: rel.targetDataMart.id,
+        parentPath: currentPath,
+        depth: ctx.depth + 1,
+      });
+    }
+  }
+}

--- a/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
@@ -87,6 +87,7 @@ describe('BlendedReportDataService', () => {
           useValue: {
             findBySourceDataMartId: jest.fn(),
             findById: jest.fn(),
+            findByIds: jest.fn().mockResolvedValue([]),
           },
         },
         {
@@ -504,10 +505,12 @@ describe('BlendedReportDataService', () => {
         joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
       } as unknown as DataMartRelationship;
       relationshipService.findBySourceDataMartId.mockResolvedValue([relAB]);
-      relationshipService.findById.mockImplementation(async (id: string) => {
-        if (id === 'rel-ab') return relAB;
-        if (id === 'rel-bc') return relBC;
-        return null;
+      relationshipService.findByIds.mockImplementation(async (ids: string[]) => {
+        const byId: Record<string, DataMartRelationship> = {
+          'rel-ab': relAB,
+          'rel-bc': relBC,
+        };
+        return ids.map(id => byId[id]).filter(Boolean);
       });
       tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
 
@@ -593,10 +596,12 @@ describe('BlendedReportDataService', () => {
       } as unknown as DataMartRelationship;
 
       relationshipService.findBySourceDataMartId.mockResolvedValue([relAB]);
-      relationshipService.findById.mockImplementation(async (id: string) => {
-        if (id === 'rel-ab') return relAB;
-        if (id === 'rel-bc') return relBC;
-        return null;
+      relationshipService.findByIds.mockImplementation(async (ids: string[]) => {
+        const byId: Record<string, DataMartRelationship> = {
+          'rel-ab': relAB,
+          'rel-bc': relBC,
+        };
+        return ids.map(id => byId[id]).filter(Boolean);
       });
       tableReferenceService.resolveTableName.mockImplementation(async (id: string) => {
         if (id === 'dm-1') return '`p`.`d`.`main`';
@@ -662,8 +667,8 @@ describe('BlendedReportDataService', () => {
       const sql = 'WITH cte AS (SELECT 1) SELECT * FROM cte';
       service.logBlendedSqlIfNeeded({ needsBlending: true, blendedSql: sql }, logger);
       expect(logger.log).toHaveBeenCalledWith({
-        type: 'blended-sql',
-        message: 'Blended SQL used for report execution',
+        type: 'joined-data-marts-sql',
+        message: 'SQL over joined Data Marts used for report execution',
         sql,
       });
     });

--- a/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
@@ -1,0 +1,671 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BlendedReportDataService } from './blended-report-data.service';
+import { BlendableSchemaService } from './blendable-schema.service';
+import { DataMartRelationshipService } from './data-mart-relationship.service';
+import { DataMartTableReferenceService } from './data-mart-table-reference.service';
+import { BlendedQueryBuilderFacade } from '../data-storage-types/facades/blended-query-builder.facade';
+import { DataMartQueryBuilderFacade } from '../data-storage-types/facades/data-mart-query-builder.facade';
+import { Report } from '../entities/report.entity';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataStorage } from '../entities/data-storage.entity';
+import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
+import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { BlendableSchemaDto, BlendedFieldDto } from '../dto/domain/blendable-schema.dto';
+import { PublicOriginService } from '../../common/config/public-origin.service';
+
+function makeReport(overrides: Partial<Report> = {}): Report {
+  const storage = { id: 'storage-1', type: DataStorageType.GOOGLE_BIGQUERY } as DataStorage;
+  const dataMart = {
+    id: 'dm-1',
+    title: 'Main DM',
+    projectId: 'project-1',
+    storage,
+    definition: { sqlQuery: 'SELECT 1' },
+  } as unknown as DataMart;
+
+  return {
+    id: 'report-1',
+    title: 'Test Report',
+    dataMart,
+    columnConfig: null,
+    ...overrides,
+  } as Report;
+}
+
+function makeBlendableSchema(blendedFieldNames: string[] = []): BlendableSchemaDto {
+  return {
+    nativeFields: [],
+    availableSources: blendedFieldNames.map((_, i) => ({
+      aliasPath: `alias_${i}`,
+      title: `Target DM ${i}`,
+      defaultAlias: `alias_${i}`,
+      depth: 1,
+      fieldCount: 1,
+      isIncluded: true,
+      relationshipId: `rel-${i}`,
+      dataMartId: `dm-target-${i}`,
+    })),
+    blendedFields: blendedFieldNames.map((name, i) => {
+      const field = new BlendedFieldDto();
+      field.name = name;
+      field.sourceRelationshipId = `rel-${i}`;
+      field.sourceDataMartId = `dm-target-${i}`;
+      field.sourceDataMartTitle = `Target DM ${i}`;
+      field.targetAlias = `alias_${i}`;
+      field.originalFieldName = name;
+      field.type = 'STRING';
+      field.isHidden = false;
+      field.aggregateFunction = 'STRING_AGG';
+      field.transitiveDepth = 1;
+      field.aliasPath = `alias_${i}`;
+      field.outputPrefix = `alias_${i}`;
+      return field;
+    }),
+  };
+}
+
+describe('BlendedReportDataService', () => {
+  let service: BlendedReportDataService;
+  let blendableSchemaService: jest.Mocked<BlendableSchemaService>;
+  let relationshipService: jest.Mocked<DataMartRelationshipService>;
+  let tableReferenceService: jest.Mocked<DataMartTableReferenceService>;
+  let blendedQueryBuilderFacade: jest.Mocked<BlendedQueryBuilderFacade>;
+  let _queryBuilderFacade: jest.Mocked<DataMartQueryBuilderFacade>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BlendedReportDataService,
+        {
+          provide: BlendableSchemaService,
+          useValue: {
+            computeBlendableSchema: jest.fn(),
+          },
+        },
+        {
+          provide: DataMartRelationshipService,
+          useValue: {
+            findBySourceDataMartId: jest.fn(),
+            findById: jest.fn(),
+          },
+        },
+        {
+          provide: DataMartTableReferenceService,
+          useValue: {
+            resolveTableName: jest.fn(),
+          },
+        },
+        {
+          provide: BlendedQueryBuilderFacade,
+          useValue: {
+            buildBlendedQuery: jest.fn(),
+          },
+        },
+        {
+          provide: DataMartQueryBuilderFacade,
+          useValue: {
+            buildQuery: jest.fn(),
+          },
+        },
+        {
+          provide: PublicOriginService,
+          useValue: {
+            getPublicOrigin: jest.fn().mockReturnValue('https://app.example.com'),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(BlendedReportDataService);
+    blendableSchemaService = module.get(BlendableSchemaService);
+    relationshipService = module.get(DataMartRelationshipService);
+    tableReferenceService = module.get(DataMartTableReferenceService);
+    blendedQueryBuilderFacade = module.get(BlendedQueryBuilderFacade);
+    _queryBuilderFacade = module.get(DataMartQueryBuilderFacade);
+  });
+
+  describe('resolveBlendingDecision', () => {
+    it('returns needsBlending=false when columnConfig is null', async () => {
+      const report = makeReport({ columnConfig: null });
+
+      const result = await service.resolveBlendingDecision(report);
+
+      expect(result).toEqual({ needsBlending: false });
+      expect(blendableSchemaService.computeBlendableSchema).not.toHaveBeenCalled();
+    });
+
+    it('returns needsBlending=false when columnConfig is undefined', async () => {
+      const report = makeReport({ columnConfig: undefined });
+
+      const result = await service.resolveBlendingDecision(report);
+
+      expect(result).toEqual({ needsBlending: false });
+    });
+
+    it('returns needsBlending=false with columnFilter when no blended columns match', async () => {
+      const columnConfig = ['native_field_1', 'native_field_2'];
+      const report = makeReport({ columnConfig });
+
+      blendableSchemaService.computeBlendableSchema.mockResolvedValue(
+        makeBlendableSchema(['blended_field'])
+      );
+
+      const result = await service.resolveBlendingDecision(report);
+
+      expect(result).toEqual({
+        needsBlending: false,
+        columnFilter: columnConfig,
+        blendedDataHeaders: [],
+      });
+      expect(blendableSchemaService.computeBlendableSchema).toHaveBeenCalledWith(
+        'dm-1',
+        'project-1'
+      );
+    });
+
+    it('returns needsBlending=true with blendedSql when blended columns are present', async () => {
+      const columnConfig = ['native_field', 'blended_field'];
+      const report = makeReport({ columnConfig });
+
+      const blendedField = new BlendedFieldDto();
+      blendedField.name = 'blended_field';
+      blendedField.sourceRelationshipId = 'rel-1';
+      blendedField.sourceDataMartId = 'dm-target-1';
+      blendedField.sourceDataMartTitle = 'Target DM';
+      blendedField.targetAlias = 'target_alias';
+      blendedField.originalFieldName = 'field';
+      blendedField.type = 'STRING';
+      blendedField.isHidden = false;
+      blendedField.aggregateFunction = 'STRING_AGG';
+      blendedField.transitiveDepth = 1;
+      blendedField.aliasPath = 'target_alias';
+      blendedField.outputPrefix = 'target_alias';
+
+      blendableSchemaService.computeBlendableSchema.mockResolvedValue({
+        nativeFields: [],
+        availableSources: [
+          {
+            aliasPath: 'target_alias',
+            title: 'Target DM',
+            defaultAlias: 'target_alias',
+            depth: 1,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-1',
+            dataMartId: 'dm-target-1',
+          },
+        ],
+        blendedFields: [blendedField],
+      });
+
+      const mockRelationship = {
+        id: 'rel-1',
+        targetAlias: 'target_alias',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-target-1' },
+        joinConditions: [],
+      } as unknown as DataMartRelationship;
+
+      relationshipService.findBySourceDataMartId.mockResolvedValue([mockRelationship]);
+      tableReferenceService.resolveTableName
+        .mockResolvedValueOnce('`project.dataset.main_table`')
+        .mockResolvedValueOnce('`project.dataset.target_table`');
+
+      blendedQueryBuilderFacade.buildBlendedQuery.mockResolvedValue(
+        'SELECT native_field, blended_field FROM ...'
+      );
+
+      const result = await service.resolveBlendingDecision(report);
+
+      expect(result.needsBlending).toBe(true);
+      expect(result.blendedSql).toBe('SELECT native_field, blended_field FROM ...');
+      expect(blendedQueryBuilderFacade.buildBlendedQuery).toHaveBeenCalledWith(
+        DataStorageType.GOOGLE_BIGQUERY,
+        expect.objectContaining({
+          mainTableReference: '`project.dataset.main_table`',
+          mainDataMartTitle: 'Main DM',
+          mainDataMartUrl: expect.stringContaining('/ui/project-1/data-marts/dm-1/data-setup'),
+          columns: columnConfig,
+          chains: expect.arrayContaining([
+            expect.objectContaining({
+              relationship: mockRelationship,
+              targetTableReference: '`project.dataset.target_table`',
+              parentAlias: 'main',
+            }),
+          ]),
+        })
+      );
+    });
+
+    it('populates blendedDataHeaders for blended columns only (native cols are reader-resolved)', async () => {
+      const columnConfig = ['native_col', 'my_alias__blended_col'];
+      const report = makeReport({ columnConfig });
+
+      const blendedField = new BlendedFieldDto();
+      blendedField.name = 'my_alias__blended_col';
+      blendedField.sourceRelationshipId = 'rel-1';
+      blendedField.sourceDataMartId = 'dm-target';
+      blendedField.sourceDataMartTitle = 'Target';
+      blendedField.targetAlias = 'alias_1';
+      blendedField.originalFieldName = 'blended_col';
+      blendedField.type = 'STRING';
+      blendedField.alias = 'Blended Display';
+      blendedField.description = 'Blended field description';
+      blendedField.isHidden = false;
+      blendedField.aggregateFunction = 'STRING_AGG';
+      blendedField.transitiveDepth = 1;
+      blendedField.aliasPath = 'alias_1';
+      blendedField.outputPrefix = 'my_alias';
+
+      blendableSchemaService.computeBlendableSchema.mockResolvedValue({
+        nativeFields: [],
+        availableSources: [
+          {
+            aliasPath: 'alias_1',
+            title: 'Target',
+            defaultAlias: 'my_alias',
+            depth: 1,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-1',
+            dataMartId: 'dm-target',
+          },
+        ],
+        blendedFields: [blendedField],
+      });
+
+      const mockRel = {
+        id: 'rel-1',
+        targetAlias: 'alias_1',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-target' },
+        joinConditions: [],
+      } as unknown as DataMartRelationship;
+
+      relationshipService.findBySourceDataMartId.mockResolvedValue([mockRel]);
+      tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
+      blendedQueryBuilderFacade.buildBlendedQuery.mockResolvedValue('SELECT ...');
+
+      const result = await service.resolveBlendingDecision(report);
+
+      // Only the blended column gets a header; native columns are resolved
+      // by the reader's own headers generator.
+      expect(result.blendedDataHeaders).toHaveLength(1);
+      expect(result.blendedDataHeaders?.[0].name).toBe('my_alias__blended_col');
+      // Exported header: "<outputPrefix> <fieldAlias|originalFieldName>".
+      expect(result.blendedDataHeaders?.[0].alias).toBe('my_alias Blended Display');
+      expect(result.blendedDataHeaders?.[0].description).toBe('Blended field description');
+      expect(result.columnFilter).toEqual(columnConfig);
+    });
+
+    it('sets parentAlias to main for direct relationships (transitiveDepth=1)', async () => {
+      const columnConfig = ['blended_field'];
+      const report = makeReport({ columnConfig });
+
+      const blendedField = new BlendedFieldDto();
+      blendedField.name = 'blended_field';
+      blendedField.sourceRelationshipId = 'rel-1';
+      blendedField.sourceDataMartId = 'dm-target';
+      blendedField.sourceDataMartTitle = 'Target';
+      blendedField.targetAlias = 'alias_1';
+      blendedField.originalFieldName = 'field';
+      blendedField.type = 'STRING';
+      blendedField.isHidden = false;
+      blendedField.aggregateFunction = 'STRING_AGG';
+      blendedField.transitiveDepth = 1;
+      blendedField.aliasPath = 'alias_1';
+      blendedField.outputPrefix = 'alias_1';
+
+      blendableSchemaService.computeBlendableSchema.mockResolvedValue({
+        nativeFields: [],
+        availableSources: [
+          {
+            aliasPath: 'alias_1',
+            title: 'Target',
+            defaultAlias: 'alias_1',
+            depth: 1,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-1',
+            dataMartId: 'dm-target',
+          },
+        ],
+        blendedFields: [blendedField],
+      });
+
+      const mockRel = {
+        id: 'rel-1',
+        targetAlias: 'alias_1',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-target' },
+        joinConditions: [],
+      } as unknown as DataMartRelationship;
+
+      relationshipService.findBySourceDataMartId.mockResolvedValue([mockRel]);
+      tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
+      blendedQueryBuilderFacade.buildBlendedQuery.mockResolvedValue('SELECT ...');
+
+      await service.resolveBlendingDecision(report);
+
+      const [, context] = blendedQueryBuilderFacade.buildBlendedQuery.mock.calls[0];
+      expect(context?.chains[0].parentAlias).toBe('main');
+    });
+
+    it('throws when two requested chains produce the same outputAlias (cross-chain collision)', async () => {
+      const columnConfig = ['shared_alias'];
+      const report = makeReport({ columnConfig });
+
+      const fieldFromB = new BlendedFieldDto();
+      fieldFromB.name = 'shared_alias';
+      fieldFromB.sourceRelationshipId = 'rel-ab';
+      fieldFromB.sourceDataMartId = 'dm-b';
+      fieldFromB.targetAlias = 'b';
+      fieldFromB.originalFieldName = 'name';
+      fieldFromB.type = 'STRING';
+      fieldFromB.isHidden = false;
+      fieldFromB.aggregateFunction = 'STRING_AGG';
+      fieldFromB.transitiveDepth = 1;
+      fieldFromB.aliasPath = 'b';
+      fieldFromB.outputPrefix = 'b';
+
+      const fieldFromC = new BlendedFieldDto();
+      fieldFromC.name = 'shared_alias';
+      fieldFromC.sourceRelationshipId = 'rel-ac';
+      fieldFromC.sourceDataMartId = 'dm-c';
+      fieldFromC.targetAlias = 'c';
+      fieldFromC.originalFieldName = 'name';
+      fieldFromC.type = 'STRING';
+      fieldFromC.isHidden = false;
+      fieldFromC.aggregateFunction = 'STRING_AGG';
+      fieldFromC.transitiveDepth = 1;
+      fieldFromC.aliasPath = 'c';
+      fieldFromC.outputPrefix = 'c';
+
+      blendableSchemaService.computeBlendableSchema.mockResolvedValue({
+        nativeFields: [],
+        availableSources: [
+          {
+            aliasPath: 'b',
+            title: 'B',
+            defaultAlias: 'b',
+            depth: 1,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-ab',
+            dataMartId: 'dm-b',
+          },
+          {
+            aliasPath: 'c',
+            title: 'C',
+            defaultAlias: 'c',
+            depth: 1,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-ac',
+            dataMartId: 'dm-c',
+          },
+        ],
+        blendedFields: [fieldFromB, fieldFromC],
+      });
+
+      const relAB = {
+        id: 'rel-ab',
+        targetAlias: 'b',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-b', title: 'B' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+      const relAC = {
+        id: 'rel-ac',
+        targetAlias: 'c',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-c', title: 'C' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+      relationshipService.findBySourceDataMartId.mockResolvedValue([relAB, relAC]);
+      tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
+
+      await expect(service.resolveBlendingDecision(report)).rejects.toThrow(
+        /outputAlias.+shared_alias.+collision|duplicate.+shared_alias/i
+      );
+    });
+
+    it('throws when two chains share the same targetAlias (CTE name collision)', async () => {
+      // A→B (alias="orders") and B→C (alias="orders") — both legit per-source but
+      // would produce duplicate CTE names in the generated SQL.
+      const columnConfig = ['b_orders__field', 'orders__field'];
+      const report = makeReport({ columnConfig });
+
+      const directField = new BlendedFieldDto();
+      directField.name = 'orders__field';
+      directField.sourceRelationshipId = 'rel-ab';
+      directField.sourceDataMartId = 'dm-b';
+      directField.targetAlias = 'orders';
+      directField.originalFieldName = 'field';
+      directField.type = 'STRING';
+      directField.isHidden = false;
+      directField.aggregateFunction = 'STRING_AGG';
+      directField.transitiveDepth = 1;
+      directField.aliasPath = 'orders';
+      directField.outputPrefix = 'orders';
+
+      const transitiveField = new BlendedFieldDto();
+      transitiveField.name = 'b_orders__field';
+      transitiveField.sourceRelationshipId = 'rel-bc';
+      transitiveField.sourceDataMartId = 'dm-c';
+      transitiveField.targetAlias = 'orders';
+      transitiveField.originalFieldName = 'field';
+      transitiveField.type = 'STRING';
+      transitiveField.isHidden = false;
+      transitiveField.aggregateFunction = 'STRING_AGG';
+      transitiveField.transitiveDepth = 2;
+      transitiveField.aliasPath = 'orders.orders';
+      transitiveField.outputPrefix = 'orders_orders';
+
+      blendableSchemaService.computeBlendableSchema.mockResolvedValue({
+        nativeFields: [],
+        availableSources: [
+          {
+            aliasPath: 'orders',
+            title: 'B',
+            defaultAlias: 'orders',
+            depth: 1,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-ab',
+            dataMartId: 'dm-b',
+          },
+          {
+            aliasPath: 'orders.orders',
+            title: 'C',
+            defaultAlias: 'orders_orders',
+            depth: 2,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-bc',
+            dataMartId: 'dm-c',
+          },
+        ],
+        blendedFields: [directField, transitiveField],
+      });
+
+      const relAB = {
+        id: 'rel-ab',
+        targetAlias: 'orders',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-b', title: 'B' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+      const relBC = {
+        id: 'rel-bc',
+        targetAlias: 'orders',
+        sourceDataMart: { id: 'dm-b' },
+        targetDataMart: { id: 'dm-c', title: 'C' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+      relationshipService.findBySourceDataMartId.mockResolvedValue([relAB]);
+      relationshipService.findById.mockImplementation(async (id: string) => {
+        if (id === 'rel-ab') return relAB;
+        if (id === 'rel-bc') return relBC;
+        return null;
+      });
+      tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
+
+      await expect(service.resolveBlendingDecision(report)).rejects.toThrow(
+        /targetAlias.+orders.+collision|duplicate.+CTE.+orders/i
+      );
+    });
+
+    it('includes intermediate relationships when only a deep (transitiveDepth>1) field is selected', async () => {
+      // Scenario: A → B → C. User only selects a field from C.
+      // Expected: chains must contain BOTH A→B and B→C, with C's parentAlias = B's targetAlias.
+      const columnConfig = ['b_c__product_name'];
+      const report = makeReport({ columnConfig });
+
+      const bField = new BlendedFieldDto();
+      bField.name = 'b__b_field';
+      bField.sourceRelationshipId = 'rel-ab';
+      bField.sourceDataMartId = 'dm-b';
+      bField.sourceDataMartTitle = 'DM B';
+      bField.targetAlias = 'b';
+      bField.originalFieldName = 'b_field';
+      bField.type = 'STRING';
+      bField.isHidden = false;
+      bField.aggregateFunction = 'STRING_AGG';
+      bField.transitiveDepth = 1;
+      bField.aliasPath = 'b';
+      bField.outputPrefix = 'b';
+
+      const cField = new BlendedFieldDto();
+      cField.name = 'b_c__product_name';
+      cField.sourceRelationshipId = 'rel-bc';
+      cField.sourceDataMartId = 'dm-c';
+      cField.sourceDataMartTitle = 'DM C';
+      cField.targetAlias = 'c';
+      cField.originalFieldName = 'product_name';
+      cField.type = 'STRING';
+      cField.isHidden = false;
+      cField.aggregateFunction = 'STRING_AGG';
+      cField.transitiveDepth = 2;
+      cField.aliasPath = 'b.c';
+      cField.outputPrefix = 'b_c';
+
+      const availableSourceB = {
+        aliasPath: 'b',
+        title: 'DM B',
+        defaultAlias: 'b',
+        depth: 1,
+        fieldCount: 1,
+        isIncluded: true,
+        relationshipId: 'rel-ab',
+        dataMartId: 'dm-b',
+      };
+      const availableSourceC = {
+        aliasPath: 'b.c',
+        title: 'DM C',
+        defaultAlias: 'b_c',
+        depth: 2,
+        fieldCount: 1,
+        isIncluded: true,
+        relationshipId: 'rel-bc',
+        dataMartId: 'dm-c',
+      };
+
+      blendableSchemaService.computeBlendableSchema.mockResolvedValue({
+        nativeFields: [],
+        availableSources: [availableSourceB, availableSourceC],
+        blendedFields: [bField, cField],
+      });
+
+      const relAB = {
+        id: 'rel-ab',
+        targetAlias: 'b',
+        sourceDataMart: { id: 'dm-1', title: 'Main DM' },
+        targetDataMart: { id: 'dm-b', title: 'DM B' },
+        joinConditions: [{ sourceFieldName: 'b_id', targetFieldName: 'b_id' }],
+      } as unknown as DataMartRelationship;
+      const relBC = {
+        id: 'rel-bc',
+        targetAlias: 'c',
+        sourceDataMart: { id: 'dm-b', title: 'DM B' },
+        targetDataMart: { id: 'dm-c', title: 'DM C' },
+        joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'product_id' }],
+      } as unknown as DataMartRelationship;
+
+      relationshipService.findBySourceDataMartId.mockResolvedValue([relAB]);
+      relationshipService.findById.mockImplementation(async (id: string) => {
+        if (id === 'rel-ab') return relAB;
+        if (id === 'rel-bc') return relBC;
+        return null;
+      });
+      tableReferenceService.resolveTableName.mockImplementation(async (id: string) => {
+        if (id === 'dm-1') return '`p`.`d`.`main`';
+        if (id === 'dm-b') return '`p`.`d`.`b`';
+        if (id === 'dm-c') return '`p`.`d`.`c`';
+        return '';
+      });
+      blendedQueryBuilderFacade.buildBlendedQuery.mockResolvedValue('SELECT ...');
+
+      await service.resolveBlendingDecision(report);
+
+      const [, context] = blendedQueryBuilderFacade.buildBlendedQuery.mock.calls[0];
+      expect(context).toBeDefined();
+      expect(context!.chains).toHaveLength(2);
+
+      // A→B chain must be present (even though no B-field is requested), with parentAlias = 'main'.
+      const abChain = context!.chains.find(c => c.relationship.id === 'rel-ab');
+      expect(abChain).toBeDefined();
+      expect(abChain!.parentAlias).toBe('main');
+      // No B-field requested → blendedFields is empty (only joinKeys remain in aggregation CTE).
+      expect(abChain!.blendedFields).toHaveLength(0);
+
+      // B→C chain must have parentAlias = 'b' (the targetAlias of A→B), NOT 'main'.
+      const bcChain = context!.chains.find(c => c.relationship.id === 'rel-bc');
+      expect(bcChain).toBeDefined();
+      expect(bcChain!.parentAlias).toBe('b');
+      expect(bcChain!.blendedFields).toHaveLength(1);
+      expect(bcChain!.blendedFields[0].outputAlias).toBe('b_c__product_name');
+
+      // Sorted by transitiveDepth: A→B (depth 1) must come before B→C (depth 2).
+      expect(context!.chains[0].relationship.id).toBe('rel-ab');
+      expect(context!.chains[1].relationship.id).toBe('rel-bc');
+    });
+  });
+
+  describe('logBlendedSqlIfNeeded', () => {
+    const makeLogger = () => ({
+      log: jest.fn(),
+      error: jest.fn(),
+      asArrays: jest.fn().mockReturnValue({ logs: [], errors: [] }),
+    });
+
+    it('does nothing when logger is undefined', () => {
+      expect(() =>
+        service.logBlendedSqlIfNeeded({ needsBlending: true, blendedSql: 'SELECT 1' }, undefined)
+      ).not.toThrow();
+    });
+
+    it('does nothing when needsBlending is false', () => {
+      const logger = makeLogger();
+      service.logBlendedSqlIfNeeded({ needsBlending: false }, logger);
+      expect(logger.log).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when blendedSql is missing even though needsBlending is true', () => {
+      const logger = makeLogger();
+      service.logBlendedSqlIfNeeded({ needsBlending: true }, logger);
+      expect(logger.log).not.toHaveBeenCalled();
+    });
+
+    it('logs blended SQL with structured payload when required', () => {
+      const logger = makeLogger();
+      const sql = 'WITH cte AS (SELECT 1) SELECT * FROM cte';
+      service.logBlendedSqlIfNeeded({ needsBlending: true, blendedSql: sql }, logger);
+      expect(logger.log).toHaveBeenCalledWith({
+        type: 'blended-sql',
+        message: 'Blended SQL used for report execution',
+        sql,
+      });
+    });
+  });
+});

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -1,0 +1,334 @@
+import { Injectable } from '@nestjs/common';
+import { BlendableSchemaService } from './blendable-schema.service';
+import { DataMartRelationshipService } from './data-mart-relationship.service';
+import { DataMartTableReferenceService } from './data-mart-table-reference.service';
+import { BlendedQueryBuilderFacade } from '../data-storage-types/facades/blended-query-builder.facade';
+import { DataMartQueryBuilderFacade } from '../data-storage-types/facades/data-mart-query-builder.facade';
+import { Report } from '../entities/report.entity';
+import { ResolvedRelationshipChain } from '../data-storage-types/interfaces/blended-query-builder.interface';
+import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
+import { AvailableSourceDto, BlendedFieldDto } from '../dto/domain/blendable-schema.dto';
+import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { PublicOriginService } from '../../common/config/public-origin.service';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { buildDataMartUrl } from '../../common/helpers/data-mart-url.helper';
+import { ReportRunLogger } from '../report-run-logging/report-run-logger';
+
+export interface BlendingDecision {
+  needsBlending: boolean;
+  blendedSql?: string;
+  columnFilter?: string[];
+  /**
+   * Precomputed headers for columns in `columnFilter` that come from
+   * blended schema (not native). Readers combine these with their own
+   * native headers to construct the final ordered header list.
+   *
+   * Only populated when `columnFilter` is set. Contains at most one entry
+   * per blended column in `columnFilter`.
+   */
+  blendedDataHeaders?: ReportDataHeader[];
+}
+
+@Injectable()
+export class BlendedReportDataService {
+  constructor(
+    private readonly relationshipService: DataMartRelationshipService,
+    private readonly blendableSchemaService: BlendableSchemaService,
+    private readonly blendedQueryBuilderFacade: BlendedQueryBuilderFacade,
+    private readonly queryBuilderFacade: DataMartQueryBuilderFacade,
+    private readonly tableReferenceService: DataMartTableReferenceService,
+    private readonly publicOriginService: PublicOriginService
+  ) {}
+
+  async resolveBlendingDecision(report: Report): Promise<BlendingDecision> {
+    const { columnConfig, dataMart } = report;
+
+    // 1. If columnConfig is null → no blending
+    if (columnConfig === null || columnConfig === undefined) {
+      return { needsBlending: false };
+    }
+
+    // 2. Compute blendable schema for the data mart
+    const blendableSchema = await this.blendableSchemaService.computeBlendableSchema(
+      dataMart.id,
+      dataMart.projectId
+    );
+
+    // 3. Check if any column in columnConfig matches a blended field name
+    const blendedFieldsByName = new Map(blendableSchema.blendedFields.map(f => [f.name, f]));
+    const hasBlendedColumns = columnConfig.some(col => blendedFieldsByName.has(col));
+
+    // Precompute headers for blended columns so readers do not need to know
+    // anything about blended schema metadata (alias/description/type).
+    const blendedDataHeaders = this.buildBlendedDataHeaders(columnConfig, blendedFieldsByName);
+
+    // 4. No blended columns → return base query with column filter
+    if (!hasBlendedColumns) {
+      return {
+        needsBlending: false,
+        columnFilter: columnConfig,
+        blendedDataHeaders,
+      };
+    }
+
+    // 5. Full blending: resolve table refs, build relationship chains, generate SQL
+    const mainTableReference = await this.tableReferenceService.resolveTableName(
+      dataMart.id,
+      dataMart.projectId
+    );
+
+    const publicOrigin = this.publicOriginService.getPublicOrigin();
+    const mainDataMartUrl = buildDataMartUrl(
+      publicOrigin,
+      dataMart.projectId,
+      dataMart.id,
+      '/data-setup'
+    );
+
+    // Load direct relationships for the main data mart
+    const allRelationships = await this.relationshipService.findBySourceDataMartId(dataMart.id);
+
+    // Build alias→tableReference map for transitive lookups
+    // We need to resolve chains: for each relationship whose blended fields appear in columnConfig,
+    // resolve target table reference and determine parentAlias
+    const chains = await this.buildRelationshipChains(
+      columnConfig,
+      blendableSchema.blendedFields,
+      blendableSchema.availableSources,
+      allRelationships,
+      dataMart.id,
+      dataMart.projectId,
+      publicOrigin
+    );
+
+    const blendedSql = await this.blendedQueryBuilderFacade.buildBlendedQuery(
+      dataMart.storage.type,
+      {
+        mainTableReference,
+        mainDataMartTitle: dataMart.title,
+        mainDataMartUrl,
+        chains,
+        columns: columnConfig,
+      }
+    );
+
+    return {
+      needsBlending: true,
+      blendedSql,
+      columnFilter: columnConfig,
+      blendedDataHeaders,
+    };
+  }
+
+  /**
+   * Emits a structured log entry with the blended SQL produced by
+   * `resolveBlendingDecision` so that users can inspect the query that was
+   * used for their run in the history UI. No-op when blending was not
+   * required, the SQL is missing, or a logger was not provided.
+   */
+  logBlendedSqlIfNeeded(decision: BlendingDecision, logger?: ReportRunLogger): void {
+    if (!logger || !decision.needsBlending || !decision.blendedSql) {
+      return;
+    }
+    logger.log({
+      type: 'blended-sql',
+      message: 'Blended SQL used for report execution',
+      sql: decision.blendedSql,
+    });
+  }
+
+  /**
+   * Builds ReportDataHeader entries for columns in `columnConfig` that come
+   * from blended schema. Columns not found in the blended schema are skipped
+   * (they are native and will be supplied by the reader's headers generator).
+   */
+  private buildBlendedDataHeaders(
+    columnConfig: string[],
+    blendedFieldsByName: Map<string, BlendedFieldDto>
+  ): ReportDataHeader[] {
+    const headers: ReportDataHeader[] = [];
+    for (const col of columnConfig) {
+      const blendedField = blendedFieldsByName.get(col);
+      if (blendedField) {
+        headers.push(
+          new ReportDataHeader(
+            blendedField.name,
+            `${blendedField.outputPrefix} ${blendedField.alias || blendedField.originalFieldName}`,
+            blendedField.description || undefined,
+            // Blended field types come from the target data mart schema.
+            // They are not typed as the concrete storage-type enum here,
+            // so we leave storageFieldType undefined — destinations only
+            // use it for formatting hints.
+            undefined
+          )
+        );
+      }
+    }
+    return headers;
+  }
+
+  /**
+   * Builds the minimal set of ResolvedRelationshipChain entries needed to satisfy
+   * the columns requested in columnConfig.
+   *
+   * For direct relationships (transitiveDepth === 1), parentAlias is 'main'.
+   * For transitive relationships (transitiveDepth > 1), parentAlias is the targetAlias
+   * of the preceding relationship in the chain.
+   *
+   * When a requested field lives at depth ≥ 2 (e.g. A→B→C, C-field requested), ALL
+   * ancestor relationships along the aliasPath are also included — otherwise the
+   * resulting SQL cannot form a valid join chain (C would try to join directly to main,
+   * using joinConditions that reference B's fields).
+   */
+  private async buildRelationshipChains(
+    columnConfig: string[],
+    blendedFields: BlendedFieldDto[],
+    availableSources: AvailableSourceDto[],
+    directRelationships: DataMartRelationship[],
+    rootDataMartId: string,
+    projectId: string,
+    publicOrigin: string
+  ): Promise<ResolvedRelationshipChain[]> {
+    const requestedNames = new Set(columnConfig);
+    const requestedBlendedFields = blendedFields.filter(f => requestedNames.has(f.name));
+
+    if (requestedBlendedFields.length === 0) {
+      return [];
+    }
+
+    // Step 1: expand requested aliasPaths to include all ancestor paths.
+    // E.g. requesting a field with aliasPath "b.c" requires both "b" and "b.c".
+    const neededPaths = new Set<string>();
+    for (const field of requestedBlendedFields) {
+      const segments = field.aliasPath.split('.');
+      for (let i = 1; i <= segments.length; i++) {
+        neededPaths.add(segments.slice(0, i).join('.'));
+      }
+    }
+
+    // Step 2: for each needed path, look up the corresponding source metadata
+    // (relationshipId + dataMartId + depth).
+    const sourceByPath = new Map(availableSources.map(s => [s.aliasPath, s]));
+    const neededSources: AvailableSourceDto[] = [];
+    for (const path of neededPaths) {
+      const src = sourceByPath.get(path);
+      if (src) neededSources.push(src);
+    }
+
+    // Step 3: load relationship entities for every needed source.
+    const directRelMap = new Map(directRelationships.map(r => [r.id, r]));
+    const relationshipsById = new Map(directRelMap);
+    for (const src of neededSources) {
+      if (!relationshipsById.has(src.relationshipId)) {
+        const rel = await this.relationshipService.findById(src.relationshipId);
+        if (rel) relationshipsById.set(src.relationshipId, rel);
+      }
+    }
+
+    // Step 4: group requested blended fields by relationship id so each chain
+    // only includes the fields that actually need to be aggregated for it.
+    const fieldsByRelId = new Map<string, BlendedFieldDto[]>();
+    for (const field of requestedBlendedFields) {
+      const bucket = fieldsByRelId.get(field.sourceRelationshipId) ?? [];
+      bucket.push(field);
+      fieldsByRelId.set(field.sourceRelationshipId, bucket);
+    }
+
+    // Step 5: sort sources by depth so parents are processed before children.
+    // This guarantees dataMartAliasMap has the parent's alias registered by the
+    // time we compute parentAlias for a child.
+    const sortedSources = [...neededSources].sort((a, b) => a.depth - b.depth);
+
+    const dataMartAliasMap = new Map<string, string>();
+    dataMartAliasMap.set(rootDataMartId, 'main');
+
+    const chains: ResolvedRelationshipChain[] = [];
+    for (const src of sortedSources) {
+      const rel = relationshipsById.get(src.relationshipId);
+      if (!rel) continue;
+
+      const parentAlias =
+        src.depth === 1 ? 'main' : (dataMartAliasMap.get(rel.sourceDataMart.id) ?? 'main');
+
+      const targetTableReference = await this.tableReferenceService.resolveTableName(
+        rel.targetDataMart.id,
+        projectId
+      );
+      const targetDataMartUrl = buildDataMartUrl(
+        publicOrigin,
+        projectId,
+        rel.targetDataMart.id,
+        '/data-setup'
+      );
+
+      const chainBlendedFields = (fieldsByRelId.get(rel.id) ?? []).map(f => ({
+        targetFieldName: f.originalFieldName,
+        outputAlias: f.name,
+        isHidden: f.isHidden,
+        aggregateFunction: f.aggregateFunction,
+      }));
+
+      chains.push({
+        relationship: rel,
+        targetTableReference,
+        parentAlias,
+        blendedFields: chainBlendedFields,
+        targetDataMartTitle: rel.targetDataMart.title,
+        targetDataMartUrl,
+      });
+
+      dataMartAliasMap.set(rel.targetDataMart.id, rel.targetAlias);
+    }
+
+    this.assertNoChainCollisions(chains);
+
+    return chains;
+  }
+
+  /**
+   * Verifies that all chains can co-exist in a single SQL query:
+   *  - `targetAlias` must be unique across chains (otherwise we emit two CTEs
+   *    with the same name).
+   *  - `outputAlias` of every blended field must be unique across all chains
+   *    (otherwise the final SELECT has two columns with the same alias).
+   *
+   * Both classes of conflict are user-fixable misconfigurations rather than
+   * platform bugs, so we surface them as `BusinessViolationException` with a
+   * pointer to the offending relationships.
+   */
+  private assertNoChainCollisions(chains: ResolvedRelationshipChain[]): void {
+    const aliasOwners = new Map<string, string[]>();
+    for (const chain of chains) {
+      const owners = aliasOwners.get(chain.relationship.targetAlias) ?? [];
+      owners.push(chain.relationship.id);
+      aliasOwners.set(chain.relationship.targetAlias, owners);
+    }
+    for (const [alias, owners] of aliasOwners) {
+      if (owners.length > 1) {
+        throw new BusinessViolationException(
+          `Duplicate CTE name: targetAlias "${alias}" is used by multiple relationships in the join chain. ` +
+            `Rename the targetAlias on one of these relationships so each chain produces a unique CTE.`,
+          { targetAlias: alias, relationshipIds: owners }
+        );
+      }
+    }
+
+    const outputAliasOwners = new Map<string, string[]>();
+    for (const chain of chains) {
+      for (const field of chain.blendedFields) {
+        const owners = outputAliasOwners.get(field.outputAlias) ?? [];
+        owners.push(chain.relationship.id);
+        outputAliasOwners.set(field.outputAlias, owners);
+      }
+    }
+    for (const [alias, owners] of outputAliasOwners) {
+      if (owners.length > 1) {
+        throw new BusinessViolationException(
+          `Duplicate output column: outputAlias "${alias}" is produced by multiple chains. ` +
+            `Rename one of the conflicting blended fields so each output column has a unique alias.`,
+          { outputAlias: alias, relationshipIds: owners }
+        );
+      }
+    }
+  }
+}

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -43,26 +43,19 @@ export class BlendedReportDataService {
   async resolveBlendingDecision(report: Report): Promise<BlendingDecision> {
     const { columnConfig, dataMart } = report;
 
-    // 1. If columnConfig is null → no blending
     if (columnConfig === null || columnConfig === undefined) {
       return { needsBlending: false };
     }
 
-    // 2. Compute blendable schema for the data mart
     const blendableSchema = await this.blendableSchemaService.computeBlendableSchema(
       dataMart.id,
       dataMart.projectId
     );
 
-    // 3. Check if any column in columnConfig matches a blended field name
     const blendedFieldsByName = new Map(blendableSchema.blendedFields.map(f => [f.name, f]));
     const hasBlendedColumns = columnConfig.some(col => blendedFieldsByName.has(col));
-
-    // Precompute headers for blended columns so readers do not need to know
-    // anything about blended schema metadata (alias/description/type).
     const blendedDataHeaders = this.buildBlendedDataHeaders(columnConfig, blendedFieldsByName);
 
-    // 4. No blended columns → return base query with column filter
     if (!hasBlendedColumns) {
       return {
         needsBlending: false,
@@ -71,7 +64,6 @@ export class BlendedReportDataService {
       };
     }
 
-    // 5. Full blending: resolve table refs, build relationship chains, generate SQL
     const mainTableReference = await this.tableReferenceService.resolveTableName(
       dataMart.id,
       dataMart.projectId
@@ -85,12 +77,7 @@ export class BlendedReportDataService {
       '/data-setup'
     );
 
-    // Load direct relationships for the main data mart
     const allRelationships = await this.relationshipService.findBySourceDataMartId(dataMart.id);
-
-    // Build alias→tableReference map for transitive lookups
-    // We need to resolve chains: for each relationship whose blended fields appear in columnConfig,
-    // resolve target table reference and determine parentAlias
     const chains = await this.buildRelationshipChains(
       columnConfig,
       blendableSchema.blendedFields,
@@ -131,8 +118,8 @@ export class BlendedReportDataService {
       return;
     }
     logger.log({
-      type: 'blended-sql',
-      message: 'Blended SQL used for report execution',
+      type: 'joined-data-marts-sql',
+      message: 'SQL over joined Data Marts used for report execution',
       sql: decision.blendedSql,
     });
   }
@@ -196,8 +183,8 @@ export class BlendedReportDataService {
       return [];
     }
 
-    // Step 1: expand requested aliasPaths to include all ancestor paths.
-    // E.g. requesting a field with aliasPath "b.c" requires both "b" and "b.c".
+    // Requesting a field at aliasPath "b.c" requires resolving "b" as well so the join
+    // chain is contiguous; otherwise C would try to join directly to main using B's keys.
     const neededPaths = new Set<string>();
     for (const field of requestedBlendedFields) {
       const segments = field.aliasPath.split('.');
@@ -206,8 +193,6 @@ export class BlendedReportDataService {
       }
     }
 
-    // Step 2: for each needed path, look up the corresponding source metadata
-    // (relationshipId + dataMartId + depth).
     const sourceByPath = new Map(availableSources.map(s => [s.aliasPath, s]));
     const neededSources: AvailableSourceDto[] = [];
     for (const path of neededPaths) {
@@ -215,18 +200,18 @@ export class BlendedReportDataService {
       if (src) neededSources.push(src);
     }
 
-    // Step 3: load relationship entities for every needed source.
     const directRelMap = new Map(directRelationships.map(r => [r.id, r]));
     const relationshipsById = new Map(directRelMap);
-    for (const src of neededSources) {
-      if (!relationshipsById.has(src.relationshipId)) {
-        const rel = await this.relationshipService.findById(src.relationshipId);
-        if (rel) relationshipsById.set(src.relationshipId, rel);
+    const missingIds = Array.from(
+      new Set(neededSources.map(src => src.relationshipId).filter(id => !relationshipsById.has(id)))
+    );
+    if (missingIds.length > 0) {
+      const fetched = await this.relationshipService.findByIds(missingIds);
+      for (const rel of fetched) {
+        relationshipsById.set(rel.id, rel);
       }
     }
 
-    // Step 4: group requested blended fields by relationship id so each chain
-    // only includes the fields that actually need to be aggregated for it.
     const fieldsByRelId = new Map<string, BlendedFieldDto[]>();
     for (const field of requestedBlendedFields) {
       const bucket = fieldsByRelId.get(field.sourceRelationshipId) ?? [];
@@ -234,9 +219,8 @@ export class BlendedReportDataService {
       fieldsByRelId.set(field.sourceRelationshipId, bucket);
     }
 
-    // Step 5: sort sources by depth so parents are processed before children.
-    // This guarantees dataMartAliasMap has the parent's alias registered by the
-    // time we compute parentAlias for a child.
+    // Parent-first order guarantees dataMartAliasMap has the parent's alias registered
+    // by the time we compute parentAlias for a child.
     const sortedSources = [...neededSources].sort((a, b) => a.depth - b.depth);
 
     const dataMartAliasMap = new Map<string, string>();

--- a/apps/backend/src/data-marts/services/data-mart-relationship.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-relationship.service.spec.ts
@@ -279,7 +279,8 @@ describe('DataMartRelationshipService', () => {
         'my_alias',
         [],
         'user-1',
-        'project-1'
+        'project-1',
+        []
       );
       const sourceDataMart = {
         id: 'dm-source',
@@ -312,7 +313,8 @@ describe('DataMartRelationshipService', () => {
         'draft_alias',
         [],
         'user-1',
-        'project-1'
+        'project-1',
+        []
       );
       const sourceDataMart = {
         id: 'dm-source',

--- a/apps/backend/src/data-marts/services/data-mart-relationship.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-relationship.service.spec.ts
@@ -1,0 +1,368 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { CreateRelationshipCommand } from '../dto/domain/create-relationship.command';
+import { DataMartSchema } from '../data-storage-types/data-mart-schema.type';
+import { DataMartSchemaFieldStatus } from '../data-storage-types/enums/data-mart-schema-field-status.enum';
+import { JoinCondition } from '../dto/schemas/relationship-schemas';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { DataStorage } from '../entities/data-storage.entity';
+import { DataMartRelationshipService } from './data-mart-relationship.service';
+
+function makeRelationship(
+  sourceId: string,
+  targetId: string,
+  overrides: Partial<DataMartRelationship> = {}
+): DataMartRelationship {
+  return {
+    id: `rel-${sourceId}-${targetId}`,
+    sourceDataMart: { id: sourceId } as DataMart,
+    targetDataMart: { id: targetId } as DataMart,
+    dataStorage: { id: 'storage-1' } as DataStorage,
+    targetAlias: 'alias',
+    joinConditions: [],
+    projectId: 'project-1',
+    createdById: 'user-1',
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    ...overrides,
+  } as DataMartRelationship;
+}
+
+describe('DataMartRelationshipService', () => {
+  let service: DataMartRelationshipService;
+  let repository: jest.Mocked<Repository<DataMartRelationship>>;
+
+  beforeEach(async () => {
+    const mockRepository: Partial<jest.Mocked<Repository<DataMartRelationship>>> = {
+      create: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DataMartRelationshipService,
+        {
+          provide: getRepositoryToken(DataMartRelationship),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DataMartRelationshipService>(DataMartRelationshipService);
+    repository = module.get(getRepositoryToken(DataMartRelationship));
+  });
+
+  describe('validateNoSelfReference', () => {
+    it('throws BusinessViolationException when source and target are the same', () => {
+      expect(() => service.validateNoSelfReference('dm-1', 'dm-1')).toThrow(
+        BusinessViolationException
+      );
+    });
+
+    it('does not throw when source and target are different', () => {
+      expect(() => service.validateNoSelfReference('dm-1', 'dm-2')).not.toThrow();
+    });
+  });
+
+  describe('validateSameStorage', () => {
+    it('throws BusinessViolationException when storage IDs differ', () => {
+      expect(() => service.validateSameStorage('storage-1', 'storage-2')).toThrow(
+        BusinessViolationException
+      );
+    });
+
+    it('does not throw when storage IDs are the same', () => {
+      expect(() => service.validateSameStorage('storage-1', 'storage-1')).not.toThrow();
+    });
+  });
+
+  describe('detectCycles', () => {
+    it('detects a direct cycle: A→B exists, adding B→A returns true', async () => {
+      const existingRelationship = makeRelationship('dm-A', 'dm-B');
+      repository.find.mockResolvedValue([existingRelationship]);
+
+      const hasCycle = await service.detectCycles('dm-B', 'dm-A', 'storage-1');
+
+      expect(hasCycle).toBe(true);
+    });
+
+    it('returns false when there is no cycle', async () => {
+      // A→B, adding A→C — no cycle
+      const existingRelationship = makeRelationship('dm-A', 'dm-B');
+      repository.find.mockResolvedValue([existingRelationship]);
+
+      const hasCycle = await service.detectCycles('dm-A', 'dm-C', 'storage-1');
+
+      expect(hasCycle).toBe(false);
+    });
+
+    it('detects a transitive cycle: A→B, B→C, adding C→A returns true', async () => {
+      const relAB = makeRelationship('dm-A', 'dm-B', { id: 'rel-AB' });
+      const relBC = makeRelationship('dm-B', 'dm-C', { id: 'rel-BC' });
+      repository.find.mockResolvedValue([relAB, relBC]);
+
+      const hasCycle = await service.detectCycles('dm-C', 'dm-A', 'storage-1');
+
+      expect(hasCycle).toBe(true);
+    });
+
+    it('returns false when there are no existing relationships', async () => {
+      repository.find.mockResolvedValue([]);
+
+      const hasCycle = await service.detectCycles('dm-A', 'dm-B', 'storage-1');
+
+      expect(hasCycle).toBe(false);
+    });
+  });
+
+  describe('findBySourceDataMartId', () => {
+    it('calls repository with correct where clause and relations', async () => {
+      const expected = [makeRelationship('dm-1', 'dm-2')];
+      repository.find.mockResolvedValue(expected);
+
+      const result = await service.findBySourceDataMartId('dm-1');
+
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { sourceDataMart: { id: 'dm-1' } },
+        relations: ['sourceDataMart', 'targetDataMart', 'dataStorage'],
+        order: { createdAt: 'ASC' },
+      });
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('validateJoinFieldTypes', () => {
+    const STATUS = DataMartSchemaFieldStatus.CONNECTED;
+
+    function makeSchema(fields: { name: string; type: string }[]): DataMartSchema {
+      return {
+        type: 'bigquery-data-mart-schema',
+        fields: fields.map(f => ({
+          name: f.name,
+          type: f.type as never,
+          status: STATUS,
+          isPrimaryKey: false,
+          mode: 'NULLABLE' as never,
+        })),
+      } as unknown as DataMartSchema;
+    }
+
+    function makeCondition(sourceFieldName: string, targetFieldName: string): JoinCondition {
+      return { sourceFieldName, targetFieldName };
+    }
+
+    it('returns empty warnings when schemas are undefined', () => {
+      const result = service.validateJoinFieldTypes(undefined, undefined, [
+        makeCondition('id', 'user_id'),
+      ]);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it('throws when source field has complex type RECORD', () => {
+      const sourceSchema = makeSchema([{ name: 'nested', type: 'RECORD' }]);
+      const targetSchema = makeSchema([{ name: 'user_id', type: 'STRING' }]);
+
+      expect(() =>
+        service.validateJoinFieldTypes(sourceSchema, targetSchema, [
+          makeCondition('nested', 'user_id'),
+        ])
+      ).toThrow(BusinessViolationException);
+    });
+
+    it('throws when target field has complex type ARRAY', () => {
+      const sourceSchema = makeSchema([{ name: 'id', type: 'STRING' }]);
+      const targetSchema = makeSchema([{ name: 'tags', type: 'ARRAY' }]);
+
+      expect(() =>
+        service.validateJoinFieldTypes(sourceSchema, targetSchema, [makeCondition('id', 'tags')])
+      ).toThrow(BusinessViolationException);
+    });
+
+    it('throws when types are incompatible (STRING vs INTEGER)', () => {
+      const sourceSchema = makeSchema([{ name: 'name', type: 'STRING' }]);
+      const targetSchema = makeSchema([{ name: 'count', type: 'INTEGER' }]);
+
+      expect(() =>
+        service.validateJoinFieldTypes(sourceSchema, targetSchema, [makeCondition('name', 'count')])
+      ).toThrow(BusinessViolationException);
+    });
+
+    it('does not throw for compatible numeric types (INTEGER vs FLOAT)', () => {
+      const sourceSchema = makeSchema([{ name: 'id', type: 'INTEGER' }]);
+      const targetSchema = makeSchema([{ name: 'amount', type: 'FLOAT' }]);
+
+      expect(() =>
+        service.validateJoinFieldTypes(sourceSchema, targetSchema, [makeCondition('id', 'amount')])
+      ).not.toThrow();
+    });
+
+    it('does not throw for identical types (STRING vs STRING)', () => {
+      const sourceSchema = makeSchema([{ name: 'user_id', type: 'STRING' }]);
+      const targetSchema = makeSchema([{ name: 'ref_id', type: 'STRING' }]);
+
+      expect(() =>
+        service.validateJoinFieldTypes(sourceSchema, targetSchema, [
+          makeCondition('user_id', 'ref_id'),
+        ])
+      ).not.toThrow();
+    });
+
+    it('does not throw when a join field exists in schema but is DISCONNECTED', () => {
+      const sourceSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'user_id',
+            type: 'STRING' as never,
+            status: DataMartSchemaFieldStatus.DISCONNECTED,
+            isPrimaryKey: false,
+            mode: 'NULLABLE' as never,
+          },
+        ],
+      } as unknown as DataMartSchema;
+      const targetSchema = makeSchema([{ name: 'ref_id', type: 'STRING' }]);
+
+      expect(() =>
+        service.validateJoinFieldTypes(sourceSchema, targetSchema, [
+          makeCondition('user_id', 'ref_id'),
+        ])
+      ).not.toThrow();
+    });
+
+    it('returns warning when source field is not found in schema', () => {
+      const sourceSchema = makeSchema([{ name: 'id', type: 'STRING' }]);
+      const targetSchema = makeSchema([{ name: 'ref_id', type: 'STRING' }]);
+
+      const { warnings } = service.validateJoinFieldTypes(sourceSchema, targetSchema, [
+        makeCondition('missing_field', 'ref_id'),
+      ]);
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('missing_field');
+    });
+
+    it('returns warning when target field is not found in schema', () => {
+      const sourceSchema = makeSchema([{ name: 'id', type: 'STRING' }]);
+      const targetSchema = makeSchema([{ name: 'ref_id', type: 'STRING' }]);
+
+      const { warnings } = service.validateJoinFieldTypes(sourceSchema, targetSchema, [
+        makeCondition('id', 'nonexistent_target'),
+      ]);
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('nonexistent_target');
+    });
+
+    it('accumulates multiple warnings for multiple missing fields', () => {
+      const sourceSchema = makeSchema([{ name: 'id', type: 'STRING' }]);
+      const targetSchema = makeSchema([{ name: 'ref_id', type: 'STRING' }]);
+
+      const { warnings } = service.validateJoinFieldTypes(sourceSchema, targetSchema, [
+        makeCondition('missing1', 'ref_id'),
+        makeCondition('missing2', 'ref_id'),
+      ]);
+
+      expect(warnings).toHaveLength(2);
+    });
+  });
+
+  describe('create', () => {
+    it('saves entity with correct fields from command', async () => {
+      const command = new CreateRelationshipCommand(
+        'dm-source',
+        'dm-target',
+        'my_alias',
+        [],
+        'user-1',
+        'project-1'
+      );
+      const sourceDataMart = {
+        id: 'dm-source',
+        storage: { id: 'storage-1' } as DataStorage,
+      } as DataMart;
+
+      const createdEntity = makeRelationship('dm-source', 'dm-target');
+      repository.create.mockReturnValue(createdEntity);
+      repository.save.mockResolvedValue(createdEntity);
+
+      const result = await service.create(command, sourceDataMart);
+
+      expect(repository.create).toHaveBeenCalledWith({
+        sourceDataMart: { id: 'dm-source' },
+        targetDataMart: { id: 'dm-target' },
+        dataStorage: { id: 'storage-1' },
+        targetAlias: 'my_alias',
+        joinConditions: [],
+        projectId: 'project-1',
+        createdById: 'user-1',
+      });
+      expect(repository.save).toHaveBeenCalledWith(createdEntity);
+      expect(result).toBe(createdEntity);
+    });
+
+    it('saves entity successfully when joinConditions is an empty array (draft state)', async () => {
+      const command = new CreateRelationshipCommand(
+        'dm-source',
+        'dm-target',
+        'draft_alias',
+        [],
+        'user-1',
+        'project-1'
+      );
+      const sourceDataMart = {
+        id: 'dm-source',
+        storage: { id: 'storage-1' } as DataStorage,
+      } as DataMart;
+
+      const createdEntity = makeRelationship('dm-source', 'dm-target', {
+        targetAlias: 'draft_alias',
+        joinConditions: [],
+      });
+      repository.create.mockReturnValue(createdEntity);
+      repository.save.mockResolvedValue(createdEntity);
+
+      const result = await service.create(command, sourceDataMart);
+
+      expect(result.joinConditions).toEqual([]);
+      expect(repository.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('validateJoinFieldTypes with empty joinConditions', () => {
+    it('returns empty warnings when joinConditions is an empty array', () => {
+      const sourceSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'id',
+            type: 'STRING' as never,
+            status: DataMartSchemaFieldStatus.CONNECTED,
+            isPrimaryKey: false,
+            mode: 'NULLABLE' as never,
+          },
+        ],
+      } as unknown as import('../data-storage-types/data-mart-schema.type').DataMartSchema;
+      const targetSchema = {
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          {
+            name: 'ref_id',
+            type: 'STRING' as never,
+            status: DataMartSchemaFieldStatus.CONNECTED,
+            isPrimaryKey: false,
+            mode: 'NULLABLE' as never,
+          },
+        ],
+      } as unknown as import('../data-storage-types/data-mart-schema.type').DataMartSchema;
+
+      const result = service.validateJoinFieldTypes(sourceSchema, targetSchema, []);
+      expect(result.warnings).toHaveLength(0);
+    });
+  });
+});

--- a/apps/backend/src/data-marts/services/data-mart-relationship.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-relationship.service.spec.ts
@@ -122,7 +122,7 @@ describe('DataMartRelationshipService', () => {
   });
 
   describe('findBySourceDataMartId', () => {
-    it('calls repository with correct where clause and relations', async () => {
+    it('calls repository with correct where clause (relations are loaded eagerly on the entity)', async () => {
       const expected = [makeRelationship('dm-1', 'dm-2')];
       repository.find.mockResolvedValue(expected);
 
@@ -130,7 +130,6 @@ describe('DataMartRelationshipService', () => {
 
       expect(repository.find).toHaveBeenCalledWith({
         where: { sourceDataMart: { id: 'dm-1' } },
-        relations: ['sourceDataMart', 'targetDataMart', 'dataStorage'],
         order: { createdAt: 'ASC' },
       });
       expect(result).toBe(expected);

--- a/apps/backend/src/data-marts/services/data-mart-relationship.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-relationship.service.spec.ts
@@ -136,6 +136,29 @@ describe('DataMartRelationshipService', () => {
     });
   });
 
+  describe('deleteAllByDataMartId', () => {
+    it('queries with OR on source and target and removes every match', async () => {
+      const asSource = makeRelationship('dm-1', 'dm-2', { id: 'rel-src' });
+      const asTarget = makeRelationship('dm-3', 'dm-1', { id: 'rel-tgt' });
+      repository.find.mockResolvedValue([asSource, asTarget]);
+
+      await service.deleteAllByDataMartId('dm-1');
+
+      expect(repository.find).toHaveBeenCalledWith({
+        where: [{ sourceDataMart: { id: 'dm-1' } }, { targetDataMart: { id: 'dm-1' } }],
+      });
+      expect(repository.remove).toHaveBeenCalledWith([asSource, asTarget]);
+    });
+
+    it('skips the remove call when no relationships reference the data mart', async () => {
+      repository.find.mockResolvedValue([]);
+
+      await service.deleteAllByDataMartId('dm-orphan');
+
+      expect(repository.remove).not.toHaveBeenCalled();
+    });
+  });
+
   describe('validateJoinFieldTypes', () => {
     const STATUS = DataMartSchemaFieldStatus.CONNECTED;
 

--- a/apps/backend/src/data-marts/services/data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-relationship.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { CreateRelationshipCommand } from '../dto/domain/create-relationship.command';
 import { UpdateRelationshipCommand } from '../dto/domain/update-relationship.command';
@@ -42,10 +42,11 @@ export class DataMartRelationshipService {
     return reloaded ?? saved;
   }
 
+  // Relations are loaded via `eager: true` on the entity; passing `relations: [...]`
+  // here would add a second set of joins.
   async findBySourceDataMartId(sourceDataMartId: string): Promise<DataMartRelationship[]> {
     return this.repository.find({
       where: { sourceDataMart: { id: sourceDataMartId } },
-      relations: ['sourceDataMart', 'targetDataMart', 'dataStorage'],
       order: { createdAt: 'ASC' },
     });
   }
@@ -53,16 +54,17 @@ export class DataMartRelationshipService {
   async findByStorageId(storageId: string): Promise<DataMartRelationship[]> {
     return this.repository.find({
       where: { dataStorage: { id: storageId } },
-      relations: ['sourceDataMart', 'targetDataMart', 'dataStorage'],
       order: { createdAt: 'ASC' },
     });
   }
 
   async findById(id: string): Promise<DataMartRelationship | null> {
-    return this.repository.findOne({
-      where: { id },
-      relations: ['sourceDataMart', 'targetDataMart', 'dataStorage'],
-    });
+    return this.repository.findOne({ where: { id } });
+  }
+
+  async findByIds(ids: string[]): Promise<DataMartRelationship[]> {
+    if (ids.length === 0) return [];
+    return this.repository.find({ where: { id: In(ids) } });
   }
 
   async update(
@@ -150,10 +152,13 @@ export class DataMartRelationshipService {
     alias: string,
     excludeId?: string
   ): Promise<void> {
-    const existing = await this.findBySourceDataMartId(sourceDataMartId);
-    const conflict = existing.find(rel => rel.targetAlias === alias && rel.id !== excludeId);
+    // Pre-check complements the `UQ_data_mart_relationship_source_alias` DB constraint
+    // so callers get a domain error rather than a raw driver exception on conflict.
+    const conflict = await this.repository.findOne({
+      where: { sourceDataMart: { id: sourceDataMartId }, targetAlias: alias },
+    });
 
-    if (conflict) {
+    if (conflict && conflict.id !== excludeId) {
       throw new BusinessViolationException(
         `Alias "${alias}" is already used in another relationship for this data mart`,
         { sourceDataMartId, alias, conflictingRelationshipId: conflict.id }
@@ -168,44 +173,19 @@ export class DataMartRelationshipService {
   ): Promise<boolean> {
     const allRelationships = await this.findByStorageId(storageId);
 
-    // Build adjacency list from existing relationships
+    // Adding source → target creates a cycle iff target can already reach source via
+    // existing edges — so the adjacency list excludes the proposed edge.
     const adjacency = new Map<string, Set<string>>();
-
     for (const rel of allRelationships) {
       const from = rel.sourceDataMart.id;
       const to = rel.targetDataMart.id;
-
       if (!adjacency.has(from)) {
         adjacency.set(from, new Set());
       }
       adjacency.get(from)!.add(to);
     }
 
-    // Add the proposed edge
-    if (!adjacency.has(targetDataMartId)) {
-      adjacency.set(targetDataMartId, new Set());
-    }
-    adjacency.get(targetDataMartId)!.add(sourceDataMartId);
-
-    // DFS from targetDataMartId to check if it can reach sourceDataMartId
-    // The proposed edge is targetDataMartId → sourceDataMartId (reversed to check for cycle:
-    // original proposed edge is sourceDataMartId → targetDataMartId,
-    // so a cycle exists if targetDataMartId can already reach sourceDataMartId via existing edges)
-    // Reset: check original direction — does targetDataMartId reach sourceDataMartId through
-    // existing edges (before adding proposed edge)?
-    // If yes → adding sourceDataMartId → targetDataMartId would create a cycle.
-
-    const adjacencyOriginal = new Map<string, Set<string>>();
-    for (const rel of allRelationships) {
-      const from = rel.sourceDataMart.id;
-      const to = rel.targetDataMart.id;
-      if (!adjacencyOriginal.has(from)) {
-        adjacencyOriginal.set(from, new Set());
-      }
-      adjacencyOriginal.get(from)!.add(to);
-    }
-
-    return this.dfsCanReach(adjacencyOriginal, targetDataMartId, sourceDataMartId, 0);
+    return this.dfsCanReach(adjacency, targetDataMartId, sourceDataMartId, 0);
   }
 
   private dfsCanReach(

--- a/apps/backend/src/data-marts/services/data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-relationship.service.ts
@@ -1,0 +1,243 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { CreateRelationshipCommand } from '../dto/domain/create-relationship.command';
+import { UpdateRelationshipCommand } from '../dto/domain/update-relationship.command';
+import {
+  areTypesCompatible,
+  isPrimitiveFieldType,
+} from '../data-storage-types/field-type-compatibility';
+import { DataMartSchema } from '../data-storage-types/data-mart-schema.type';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { DataStorage } from '../entities/data-storage.entity';
+import { JoinCondition } from '../dto/schemas/relationship-schemas';
+
+const MAX_CYCLE_DEPTH = 10;
+
+@Injectable()
+export class DataMartRelationshipService {
+  constructor(
+    @InjectRepository(DataMartRelationship)
+    private readonly repository: Repository<DataMartRelationship>
+  ) {}
+
+  async create(
+    command: CreateRelationshipCommand,
+    sourceDataMart: DataMart
+  ): Promise<DataMartRelationship> {
+    const relationship = this.repository.create({
+      sourceDataMart: { id: command.sourceDataMartId } as DataMart,
+      targetDataMart: { id: command.targetDataMartId } as DataMart,
+      dataStorage: { id: sourceDataMart.storage.id } as DataStorage,
+      targetAlias: command.targetAlias,
+      joinConditions: command.joinConditions,
+      projectId: command.projectId,
+      createdById: command.userId,
+    });
+
+    const saved = await this.repository.save(relationship);
+    const reloaded = await this.findById(saved.id);
+    return reloaded ?? saved;
+  }
+
+  async findBySourceDataMartId(sourceDataMartId: string): Promise<DataMartRelationship[]> {
+    return this.repository.find({
+      where: { sourceDataMart: { id: sourceDataMartId } },
+      relations: ['sourceDataMart', 'targetDataMart', 'dataStorage'],
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  async findByStorageId(storageId: string): Promise<DataMartRelationship[]> {
+    return this.repository.find({
+      where: { dataStorage: { id: storageId } },
+      relations: ['sourceDataMart', 'targetDataMart', 'dataStorage'],
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  async findById(id: string): Promise<DataMartRelationship | null> {
+    return this.repository.findOne({
+      where: { id },
+      relations: ['sourceDataMart', 'targetDataMart', 'dataStorage'],
+    });
+  }
+
+  async update(
+    relationship: DataMartRelationship,
+    command: UpdateRelationshipCommand
+  ): Promise<DataMartRelationship> {
+    if (command.targetAlias !== undefined) {
+      relationship.targetAlias = command.targetAlias;
+    }
+    if (command.joinConditions !== undefined) {
+      relationship.joinConditions = command.joinConditions;
+    }
+
+    return this.repository.save(relationship);
+  }
+
+  async delete(relationship: DataMartRelationship): Promise<void> {
+    await this.repository.remove(relationship);
+  }
+
+  validateJoinFieldTypes(
+    sourceSchema: DataMartSchema | undefined,
+    targetSchema: DataMartSchema | undefined,
+    joinConditions: JoinCondition[]
+  ): { warnings: string[] } {
+    const warnings: string[] = [];
+
+    if (!sourceSchema || !targetSchema) return { warnings };
+
+    const sourceFields = sourceSchema.fields ?? [];
+    const targetFields = targetSchema.fields ?? [];
+
+    for (const condition of joinConditions) {
+      const sourceField = sourceFields.find(f => f.name === condition.sourceFieldName);
+      const targetField = targetFields.find(f => f.name === condition.targetFieldName);
+
+      if (!sourceField || !targetField) {
+        const missing = !sourceField ? condition.sourceFieldName : condition.targetFieldName;
+        warnings.push(`Field not found in schema: ${missing}`);
+        continue;
+      }
+
+      if (!isPrimitiveFieldType(sourceField.type)) {
+        throw new BusinessViolationException(
+          `Field "${condition.sourceFieldName}" has complex type "${sourceField.type}" which cannot be used in join conditions`
+        );
+      }
+
+      if (!isPrimitiveFieldType(targetField.type)) {
+        throw new BusinessViolationException(
+          `Field "${condition.targetFieldName}" has complex type "${targetField.type}" which cannot be used in join conditions`
+        );
+      }
+
+      if (!areTypesCompatible(sourceField.type, targetField.type)) {
+        throw new BusinessViolationException(
+          `Incompatible types: "${condition.sourceFieldName}" (${sourceField.type}) and "${condition.targetFieldName}" (${targetField.type})`
+        );
+      }
+    }
+
+    return { warnings };
+  }
+
+  validateNoSelfReference(sourceId: string, targetId: string): void {
+    if (sourceId === targetId) {
+      throw new BusinessViolationException('A data mart cannot have a relationship with itself', {
+        sourceId,
+        targetId,
+      });
+    }
+  }
+
+  validateSameStorage(sourceStorageId: string, targetStorageId: string): void {
+    if (sourceStorageId !== targetStorageId) {
+      throw new BusinessViolationException(
+        'Source and target data marts must belong to the same storage',
+        { sourceStorageId, targetStorageId }
+      );
+    }
+  }
+
+  async validateUniqueAlias(
+    sourceDataMartId: string,
+    alias: string,
+    excludeId?: string
+  ): Promise<void> {
+    const existing = await this.findBySourceDataMartId(sourceDataMartId);
+    const conflict = existing.find(rel => rel.targetAlias === alias && rel.id !== excludeId);
+
+    if (conflict) {
+      throw new BusinessViolationException(
+        `Alias "${alias}" is already used in another relationship for this data mart`,
+        { sourceDataMartId, alias, conflictingRelationshipId: conflict.id }
+      );
+    }
+  }
+
+  async detectCycles(
+    sourceDataMartId: string,
+    targetDataMartId: string,
+    storageId: string
+  ): Promise<boolean> {
+    const allRelationships = await this.findByStorageId(storageId);
+
+    // Build adjacency list from existing relationships
+    const adjacency = new Map<string, Set<string>>();
+
+    for (const rel of allRelationships) {
+      const from = rel.sourceDataMart.id;
+      const to = rel.targetDataMart.id;
+
+      if (!adjacency.has(from)) {
+        adjacency.set(from, new Set());
+      }
+      adjacency.get(from)!.add(to);
+    }
+
+    // Add the proposed edge
+    if (!adjacency.has(targetDataMartId)) {
+      adjacency.set(targetDataMartId, new Set());
+    }
+    adjacency.get(targetDataMartId)!.add(sourceDataMartId);
+
+    // DFS from targetDataMartId to check if it can reach sourceDataMartId
+    // The proposed edge is targetDataMartId → sourceDataMartId (reversed to check for cycle:
+    // original proposed edge is sourceDataMartId → targetDataMartId,
+    // so a cycle exists if targetDataMartId can already reach sourceDataMartId via existing edges)
+    // Reset: check original direction — does targetDataMartId reach sourceDataMartId through
+    // existing edges (before adding proposed edge)?
+    // If yes → adding sourceDataMartId → targetDataMartId would create a cycle.
+
+    const adjacencyOriginal = new Map<string, Set<string>>();
+    for (const rel of allRelationships) {
+      const from = rel.sourceDataMart.id;
+      const to = rel.targetDataMart.id;
+      if (!adjacencyOriginal.has(from)) {
+        adjacencyOriginal.set(from, new Set());
+      }
+      adjacencyOriginal.get(from)!.add(to);
+    }
+
+    return this.dfsCanReach(adjacencyOriginal, targetDataMartId, sourceDataMartId, 0);
+  }
+
+  private dfsCanReach(
+    adjacency: Map<string, Set<string>>,
+    current: string,
+    target: string,
+    depth: number,
+    visited: Set<string> = new Set()
+  ): boolean {
+    if (depth > MAX_CYCLE_DEPTH) {
+      return false;
+    }
+    if (current === target) {
+      return true;
+    }
+    if (visited.has(current)) {
+      return false;
+    }
+
+    visited.add(current);
+
+    const neighbors = adjacency.get(current);
+    if (!neighbors) {
+      return false;
+    }
+
+    for (const neighbor of neighbors) {
+      if (this.dfsCanReach(adjacency, neighbor, target, depth + 1, visited)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/apps/backend/src/data-marts/services/data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-relationship.service.ts
@@ -85,6 +85,14 @@ export class DataMartRelationshipService {
     await this.repository.remove(relationship);
   }
 
+  async deleteAllByDataMartId(dataMartId: string): Promise<void> {
+    const relationships = await this.repository.find({
+      where: [{ sourceDataMart: { id: dataMartId } }, { targetDataMart: { id: dataMartId } }],
+    });
+    if (relationships.length === 0) return;
+    await this.repository.remove(relationships);
+  }
+
   validateJoinFieldTypes(
     sourceSchema: DataMartSchema | undefined,
     targetSchema: DataMartSchema | undefined,

--- a/apps/backend/src/data-marts/services/looker-studio-report-run.service.ts
+++ b/apps/backend/src/data-marts/services/looker-studio-report-run.service.ts
@@ -61,14 +61,25 @@ export class LookerStudioReportRunService {
    * Finalizes Looker Studio report run by persisting results in transaction.
    *
    * @param reportRun - Completed Looker Studio report run
+   * @param context - Optional finish context with logs/errors to append to DataMartRun
    */
   @Transactional()
-  async finish(reportRun: LookerStudioReportRun): Promise<void> {
+  async finish(
+    reportRun: LookerStudioReportRun,
+    context?: { logs?: string[]; errors?: string[] }
+  ): Promise<void> {
     await this.reportService.updateRunStatus(
       reportRun.getReport().id,
       reportRun.getReport().lastRunStatus!,
       reportRun.getReport().lastRunError
     );
-    await this.dataMartRunService.markReportRunAsFinished(reportRun.getDataMartRun());
+    const dmRun = reportRun.getDataMartRun();
+    if (context?.logs?.length) {
+      dmRun.logs = [...(dmRun.logs ?? []), ...context.logs];
+    }
+    if (context?.errors?.length) {
+      dmRun.errors = [...(dmRun.errors ?? []), ...context.errors];
+    }
+    await this.dataMartRunService.markReportRunAsFinished(dmRun);
   }
 }

--- a/apps/backend/src/data-marts/services/report-data-cache.service.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { Repository, MoreThan, LessThan } from 'typeorm';
+import { FindOptionsWhere, Repository, MoreThan, LessThan } from 'typeorm';
 import { TypeResolver } from '../../common/resolver/type-resolver';
 import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../data-storage-types/data-storage-providers';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
@@ -133,24 +133,20 @@ export class ReportDataCacheService {
     };
   }
 
-  /**
-   * Cleans up expired cache entries with proper finalization
-   * Called actively by scheduler every minute
-   */
+  private static readonly CACHE_ENTRY_RELATIONS = [
+    'report',
+    'report.dataMart',
+    'report.dataMart.storage',
+    'report.dataMart.storage.credential',
+  ];
+
   @Cron(CronExpression.EVERY_MINUTE)
   async cleanupExpiredCache(): Promise<void> {
-    const now = new Date();
+    const where: FindOptionsWhere<ReportDataCache> = { expiresAt: LessThan(new Date()) };
 
     const expiredEntries = await this.cacheRepository.find({
-      where: {
-        expiresAt: LessThan(now),
-      },
-      relations: [
-        'report',
-        'report.dataMart',
-        'report.dataMart.storage',
-        'report.dataMart.storage.credential',
-      ],
+      where,
+      relations: ReportDataCacheService.CACHE_ENTRY_RELATIONS,
     });
 
     if (expiredEntries.length === 0) {
@@ -158,23 +154,23 @@ export class ReportDataCacheService {
     }
 
     this.logger.log(`Found ${expiredEntries.length} expired cache entries to cleanup`);
+    await this.finalizeEntriesInParallel(expiredEntries);
 
-    for (const entry of expiredEntries) {
-      try {
-        await this.finalizeExpiredCacheEntry(entry);
-      } catch (error) {
-        this.logger.error(
-          `Failed to finalize cache entry ${entry.id}: ${error.message}`,
-          error.stack
+    const result = await this.cacheRepository.delete(where);
+    this.logger.log(`Cleaned up ${result.affected || 0} expired cache entries`);
+  }
+
+  private async finalizeEntriesInParallel(entries: ReportDataCache[]): Promise<void> {
+    const outcomes = await Promise.allSettled(
+      entries.map(entry => this.finalizeExpiredCacheEntry(entry))
+    );
+    for (const [index, outcome] of outcomes.entries()) {
+      if (outcome.status === 'rejected') {
+        this.logger.warn(
+          `Failed to finalize cache entry ${entries[index].id}: ${outcome.reason?.message ?? outcome.reason}`
         );
       }
     }
-
-    const result = await this.cacheRepository.delete({
-      expiresAt: LessThan(now),
-    });
-
-    this.logger.log(`Cleaned up ${result.affected || 0} expired cache entries`);
   }
 
   /**
@@ -227,36 +223,33 @@ export class ReportDataCacheService {
     return reader;
   }
 
-  /**
-   * Invalidates all cache entries for a given report. Called by
-   * `UpdateReportService` when the report's `columnConfig` changes so the
-   * next read reflects the new column selection instead of serving stale
-   * data until the TTL expires.
-   */
   async invalidateByReportId(reportId: string): Promise<void> {
+    await this.invalidateWhere({ report: { id: reportId } }, `report ${reportId}`);
+  }
+
+  async invalidateByDataMartId(dataMartId: string): Promise<void> {
+    await this.invalidateWhere(
+      { report: { dataMart: { id: dataMartId } } },
+      `data mart ${dataMartId}`
+    );
+  }
+
+  private async invalidateWhere(
+    where: FindOptionsWhere<ReportDataCache>,
+    contextLabel: string
+  ): Promise<void> {
     const entries = await this.cacheRepository.find({
-      where: { report: { id: reportId } },
-      relations: [
-        'report',
-        'report.dataMart',
-        'report.dataMart.storage',
-        'report.dataMart.storage.credential',
-      ],
+      where,
+      relations: ReportDataCacheService.CACHE_ENTRY_RELATIONS,
     });
 
-    for (const entry of entries) {
-      try {
-        await this.finalizeExpiredCacheEntry(entry);
-      } catch (error) {
-        this.logger.warn(
-          `Failed to finalize cache entry ${entry.id} during invalidation: ${error.message}`
-        );
-      }
-    }
+    if (entries.length === 0) return;
 
-    const result = await this.cacheRepository.delete({ report: { id: reportId } });
+    await this.finalizeEntriesInParallel(entries);
+
+    const result = await this.cacheRepository.delete(where);
     if (result.affected && result.affected > 0) {
-      this.logger.log(`Invalidated ${result.affected} cache entries for report ${reportId}`);
+      this.logger.log(`Invalidated ${result.affected} cache entries for ${contextLabel}`);
     }
   }
 }

--- a/apps/backend/src/data-marts/services/report-data-cache.service.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.ts
@@ -5,11 +5,15 @@ import { Repository, MoreThan, LessThan } from 'typeorm';
 import { TypeResolver } from '../../common/resolver/type-resolver';
 import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../data-storage-types/data-storage-providers';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
-import { DataStorageReportReader } from '../data-storage-types/interfaces/data-storage-report-reader.interface';
+import {
+  DataStorageReportReader,
+  PrepareReportDataOptions,
+} from '../data-storage-types/interfaces/data-storage-report-reader.interface';
 import { CachedReaderData } from '../dto/domain/cached-reader-data.dto';
 import { Report } from '../entities/report.entity';
 import { isLookerStudioConnectorConfig } from '../data-destination-types/data-destination-config.guards';
 import { ReportDataCache } from '../entities/report-data-cache.entity';
+import { BlendedReportDataService, BlendingDecision } from './blended-report-data.service';
 
 /**
  * Service for managing persistent cache of report data readers
@@ -24,8 +28,29 @@ export class ReportDataCacheService {
     @InjectRepository(ReportDataCache)
     private readonly cacheRepository: Repository<ReportDataCache>,
     @Inject(DATA_STORAGE_REPORT_READER_RESOLVER)
-    private readonly readerResolver: TypeResolver<DataStorageType, DataStorageReportReader>
+    private readonly readerResolver: TypeResolver<DataStorageType, DataStorageReportReader>,
+    private readonly blendedReportDataService: BlendedReportDataService
   ) {}
+
+  /**
+   * Resolves the column-filter / SQL-override hints that readers need from
+   * the current state of the report. Returned alongside the raw
+   * `BlendingDecision` so callers can attach it to `CachedReaderData`
+   * without issuing a second metadata resolution.
+   */
+  private async resolvePrepareOptions(
+    report: Report
+  ): Promise<{ options: PrepareReportDataOptions; decision: BlendingDecision }> {
+    const decision = await this.blendedReportDataService.resolveBlendingDecision(report);
+    return {
+      options: {
+        sqlOverride: decision.needsBlending ? decision.blendedSql : undefined,
+        columnFilter: decision.columnFilter,
+        blendedDataHeaders: decision.blendedDataHeaders,
+      },
+      decision,
+    };
+  }
 
   /**
    * Gets cached reader or creates new one if cache miss
@@ -51,6 +76,7 @@ export class ReportDataCacheService {
 
   private async executeGetOrCreateOperation(report: Report): Promise<CachedReaderData> {
     const now = new Date();
+    const { options, decision } = await this.resolvePrepareOptions(report);
 
     const cachedData = await this.cacheRepository.findOne({
       where: {
@@ -63,23 +89,28 @@ export class ReportDataCacheService {
 
     if (cachedData) {
       this.logger.debug(`Cache hit for report ${report.id}`);
-      const reader = await this.restoreReaderFromCache(cachedData, report);
+      const reader = await this.restoreReaderFromCache(cachedData, report, options);
 
       return {
         reader,
         dataDescription: cachedData.dataDescription,
         fromCache: true,
+        blendingDecision: decision,
       };
     }
 
-    return this.createNewCachedReader(report);
+    return this.createNewCachedReader(report, options, decision);
   }
 
-  private async createNewCachedReader(report: Report): Promise<CachedReaderData> {
+  private async createNewCachedReader(
+    report: Report,
+    options: PrepareReportDataOptions,
+    decision: BlendingDecision
+  ): Promise<CachedReaderData> {
     this.logger.debug(`Cache miss for report ${report.id}, creating new reader`);
 
     const reader = await this.readerResolver.resolve(report.dataMart.storage.type);
-    const dataDescription = await reader.prepareReportData(report);
+    const dataDescription = await reader.prepareReportData(report, options);
     await reader.readReportDataBatch(undefined, 1);
     const readerState = reader.getState();
 
@@ -98,6 +129,7 @@ export class ReportDataCacheService {
       reader,
       dataDescription,
       fromCache: false,
+      blendingDecision: decision,
     };
   }
 
@@ -151,7 +183,8 @@ export class ReportDataCacheService {
   private async finalizeExpiredCacheEntry(cacheEntry: ReportDataCache): Promise<void> {
     try {
       if (cacheEntry.readerState) {
-        const reader = await this.restoreReaderFromCache(cacheEntry, cacheEntry.report);
+        const { options } = await this.resolvePrepareOptions(cacheEntry.report);
+        const reader = await this.restoreReaderFromCache(cacheEntry, cacheEntry.report, options);
         await reader.finalize();
       }
       this.logger.debug(`Successfully finalized reader for cache entry ${cacheEntry.id}`);
@@ -177,17 +210,53 @@ export class ReportDataCacheService {
   }
 
   /**
-   * Restores reader from cached state
+   * Restores reader from cached state. Callers supply pre-resolved prepare
+   * options so the blending resolution is reused between the public-path
+   * (read) and cleanup-path (finalize) without a duplicate lookup.
    */
   private async restoreReaderFromCache(
     cachedData: ReportDataCache,
-    report: Report
+    report: Report,
+    options: PrepareReportDataOptions
   ): Promise<DataStorageReportReader> {
     const reader = await this.readerResolver.resolve(cachedData.storageType);
-    await reader.prepareReportData(report);
+    await reader.prepareReportData(report, options);
     if (cachedData.readerState) {
       await reader.initFromState(cachedData.readerState, cachedData.dataDescription.dataHeaders);
     }
     return reader;
+  }
+
+  /**
+   * Invalidates all cache entries for a given report. Called by
+   * `UpdateReportService` when the report's `columnConfig` changes so the
+   * next read reflects the new column selection instead of serving stale
+   * data until the TTL expires.
+   */
+  async invalidateByReportId(reportId: string): Promise<void> {
+    const entries = await this.cacheRepository.find({
+      where: { report: { id: reportId } },
+      relations: [
+        'report',
+        'report.dataMart',
+        'report.dataMart.storage',
+        'report.dataMart.storage.credential',
+      ],
+    });
+
+    for (const entry of entries) {
+      try {
+        await this.finalizeExpiredCacheEntry(entry);
+      } catch (error) {
+        this.logger.warn(
+          `Failed to finalize cache entry ${entry.id} during invalidation: ${error.message}`
+        );
+      }
+    }
+
+    const result = await this.cacheRepository.delete({ report: { id: reportId } });
+    if (result.affected && result.affected > 0) {
+      this.logger.log(`Invalidated ${result.affected} cache entries for report ${reportId}`);
+    }
   }
 }

--- a/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.spec.ts
@@ -1,0 +1,120 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { CopyReportAsDataMartService } from './copy-report-as-data-mart.service';
+import { CopyReportAsDataMartCommand } from '../dto/domain/copy-report-as-data-mart.command';
+import { EntityType, Action } from '../services/access-decision';
+
+describe('CopyReportAsDataMartService', () => {
+  const report = {
+    id: 'report-1',
+    title: 'My Report',
+    dataMart: {
+      id: 'dm-1',
+      storage: { id: 'storage-1', type: 'BIGQUERY' },
+    },
+    dataDestination: { id: 'dest-1' },
+  };
+
+  const newDataMart = { id: 'dm-new' };
+
+  const createService = (accessResults: [boolean, boolean] = [true, true]) => {
+    const reportRepository = {
+      findOne: jest.fn().mockResolvedValue(report),
+    };
+    const getGeneratedSqlService = {
+      buildForReport: jest.fn().mockResolvedValue({ sql: 'SELECT 1' }),
+    };
+    const dataMartService = {
+      create: jest.fn().mockReturnValue(newDataMart),
+      save: jest.fn().mockResolvedValue(newDataMart),
+    };
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(accessResults[1]),
+      canAccessReport: jest.fn().mockResolvedValue(accessResults[0]),
+    };
+
+    const service = new CopyReportAsDataMartService(
+      reportRepository as never,
+      getGeneratedSqlService as never,
+      dataMartService as never,
+      accessDecisionService as never
+    );
+
+    return {
+      service,
+      reportRepository,
+      getGeneratedSqlService,
+      dataMartService,
+      accessDecisionService,
+    };
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should copy report when user has RUN access on report and USE access on storage', async () => {
+    const { service, dataMartService, accessDecisionService } = createService([true, true]);
+
+    const command = new CopyReportAsDataMartCommand('report-1', 'user-1', 'proj-1', ['editor']);
+
+    const result = await service.run(command);
+
+    expect(accessDecisionService.canAccessReport).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      'report-1',
+      'dm-1',
+      Action.RUN,
+      'proj-1'
+    );
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.STORAGE,
+      'storage-1',
+      Action.USE,
+      'proj-1'
+    );
+    expect(dataMartService.save).toHaveBeenCalled();
+    expect(result).toEqual(newDataMart);
+  });
+
+  it('should throw ForbiddenException when user lacks RUN access on report', async () => {
+    const { service } = createService([false, true]);
+
+    const command = new CopyReportAsDataMartCommand('report-1', 'user-1', 'proj-1', ['viewer']);
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should throw ForbiddenException when user lacks USE access on storage', async () => {
+    const { service } = createService([true, false]);
+
+    const command = new CopyReportAsDataMartCommand('report-1', 'user-1', 'proj-1', ['editor']);
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should throw NotFoundException when report not found', async () => {
+    const { service, reportRepository } = createService([true, true]);
+    reportRepository.findOne = jest.fn().mockResolvedValue(null);
+
+    const command = new CopyReportAsDataMartCommand('report-1', 'user-1', 'proj-1', ['editor']);
+
+    await expect(service.run(command)).rejects.toThrow(NotFoundException);
+  });
+
+  it('should skip access check when userId is empty', async () => {
+    const { service, accessDecisionService } = createService([false, false]);
+
+    const command = new CopyReportAsDataMartCommand('report-1', '', 'proj-1', []);
+
+    await service.run(command);
+
+    expect(accessDecisionService.canAccessReport).not.toHaveBeenCalled();
+    expect(accessDecisionService.canAccess).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Transactional } from 'typeorm-transactional';
+import { Report } from '../entities/report.entity';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
+import { DataMartService } from '../services/data-mart.service';
+import { GetReportGeneratedSqlService } from './get-report-generated-sql.service';
+import { SqlDefinition } from '../dto/schemas/data-mart-table-definitions/sql-definition.schema';
+
+@Injectable()
+export class CopyReportAsDataMartService {
+  constructor(
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    private readonly getGeneratedSqlService: GetReportGeneratedSqlService,
+    private readonly dataMartService: DataMartService
+  ) {}
+
+  @Transactional()
+  async run(reportId: string, userId: string, projectId: string): Promise<DataMart> {
+    const report = await this.reportRepository.findOne({
+      where: {
+        id: reportId,
+        dataMart: { projectId },
+      },
+      relations: ['dataMart', 'dataMart.storage', 'dataMart.storage.credential', 'dataDestination'],
+    });
+
+    if (!report) {
+      throw new NotFoundException(`Report with ID ${reportId} not found`);
+    }
+
+    const { sql } = await this.getGeneratedSqlService.run(reportId, projectId);
+
+    const { dataMart: sourceDataMart } = report;
+
+    const definition: SqlDefinition = { sqlQuery: sql };
+
+    const newDataMart = this.dataMartService.create({
+      title: `Copy of ${report.title}`,
+      projectId,
+      createdById: userId,
+      technicalOwnerIds: [userId],
+      storage: sourceDataMart.storage,
+      definitionType: DataMartDefinitionType.SQL,
+      definition,
+      status: DataMartStatus.DRAFT,
+    });
+
+    return this.dataMartService.save(newDataMart);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
@@ -9,6 +9,8 @@ import { DataMartStatus } from '../enums/data-mart-status.enum';
 import { DataMartService } from '../services/data-mart.service';
 import { GetReportGeneratedSqlService } from './get-report-generated-sql.service';
 import { SqlDefinition } from '../dto/schemas/data-mart-table-definitions/sql-definition.schema';
+import { CopyReportAsDataMartCommand } from '../dto/domain/copy-report-as-data-mart.command';
+import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 
 @Injectable()
 export class CopyReportAsDataMartService {
@@ -16,24 +18,49 @@ export class CopyReportAsDataMartService {
     @InjectRepository(Report)
     private readonly reportRepository: Repository<Report>,
     private readonly getGeneratedSqlService: GetReportGeneratedSqlService,
-    private readonly dataMartService: DataMartService
+    private readonly dataMartService: DataMartService,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   @Transactional()
-  async run(reportId: string, userId: string, projectId: string): Promise<DataMart> {
+  async run(command: CopyReportAsDataMartCommand): Promise<DataMart> {
     const report = await this.reportRepository.findOne({
       where: {
-        id: reportId,
-        dataMart: { projectId },
+        id: command.reportId,
+        dataMart: { projectId: command.projectId },
       },
       relations: ['dataMart', 'dataMart.storage', 'dataMart.storage.credential', 'dataDestination'],
     });
 
     if (!report) {
-      throw new NotFoundException(`Report with ID ${reportId} not found`);
+      throw new NotFoundException(`Report with ID ${command.reportId} not found`);
     }
 
-    const { sql } = await this.getGeneratedSqlService.run(reportId, projectId);
+    if (command.userId) {
+      const [canRun, canUseStorage] = await Promise.all([
+        this.accessDecisionService.canAccessReport(
+          command.userId,
+          command.roles,
+          command.reportId,
+          report.dataMart.id,
+          Action.RUN,
+          command.projectId
+        ),
+        this.accessDecisionService.canAccess(
+          command.userId,
+          command.roles,
+          EntityType.STORAGE,
+          report.dataMart.storage.id,
+          Action.USE,
+          command.projectId
+        ),
+      ]);
+      if (!canRun || !canUseStorage) {
+        throw new ForbiddenException('You do not have permission to copy this report');
+      }
+    }
+
+    const { sql } = await this.getGeneratedSqlService.buildForReport(report);
 
     const { dataMart: sourceDataMart } = report;
 
@@ -41,9 +68,9 @@ export class CopyReportAsDataMartService {
 
     const newDataMart = this.dataMartService.create({
       title: `Copy of ${report.title}`,
-      projectId,
-      createdById: userId,
-      technicalOwnerIds: [userId],
+      projectId: command.projectId,
+      createdById: command.userId,
+      technicalOwnerIds: [command.userId],
       storage: sourceDataMart.storage,
       definitionType: DataMartDefinitionType.SQL,
       definition,

--- a/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.spec.ts
@@ -1,0 +1,157 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+jest.mock('../services/user-projections-fetcher.service', () => ({
+  UserProjectionsFetcherService: jest.fn(),
+}));
+
+jest.mock('../../idp/facades/idp-projections.facade', () => ({
+  IdpProjectionsFacade: jest.fn(),
+}));
+
+import { ForbiddenException } from '@nestjs/common';
+import { CreateDataMartRelationshipService } from './create-data-mart-relationship.service';
+import { CreateRelationshipCommand } from '../dto/domain/create-relationship.command';
+import { EntityType, Action } from '../services/access-decision';
+
+describe('CreateDataMartRelationshipService', () => {
+  const sourceDataMart = {
+    id: 'dm-source',
+    storage: { id: 'storage-1', type: 'BIGQUERY' },
+    schema: [],
+  };
+  const targetDataMart = {
+    id: 'dm-target',
+    storage: { id: 'storage-1', type: 'BIGQUERY' },
+    schema: [],
+  };
+  const relationship = { id: 'rel-1', createdById: 'user-1' };
+
+  const createService = (accessResults: [boolean, boolean] = [true, true]) => {
+    const relationshipService = {
+      validateNoSelfReference: jest.fn(),
+      validateSameStorage: jest.fn(),
+      validateUniqueAlias: jest.fn().mockResolvedValue(undefined),
+      detectCycles: jest.fn().mockResolvedValue(false),
+      validateJoinFieldTypes: jest.fn(),
+      create: jest.fn().mockResolvedValue(relationship),
+    };
+    const dataMartService = {
+      getByIdAndProjectId: jest
+        .fn()
+        .mockResolvedValueOnce(sourceDataMart)
+        .mockResolvedValueOnce(targetDataMart),
+    };
+    const userProjectionsFetcherService = {
+      fetchCreatedByUser: jest.fn().mockResolvedValue(null),
+    };
+    const mapper = {
+      toResponse: jest.fn().mockReturnValue({ id: 'rel-1' }),
+    };
+    const accessDecisionService = {
+      canAccess: jest
+        .fn()
+        .mockResolvedValueOnce(accessResults[0])
+        .mockResolvedValueOnce(accessResults[1]),
+    };
+
+    const service = new CreateDataMartRelationshipService(
+      relationshipService as never,
+      dataMartService as never,
+      userProjectionsFetcherService as never,
+      mapper as never,
+      accessDecisionService as never
+    );
+
+    return { service, relationshipService, dataMartService, accessDecisionService };
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should create relationship when user has EDIT access on both DataMarts', async () => {
+    const { service, relationshipService, accessDecisionService } = createService([true, true]);
+
+    const command = new CreateRelationshipCommand(
+      'dm-source',
+      'dm-target',
+      'alias1',
+      [],
+      'user-1',
+      'proj-1',
+      ['editor']
+    );
+
+    await service.run(command);
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledTimes(2);
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.DATA_MART,
+      'dm-source',
+      Action.EDIT,
+      'proj-1'
+    );
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.DATA_MART,
+      'dm-target',
+      Action.EDIT,
+      'proj-1'
+    );
+    expect(relationshipService.create).toHaveBeenCalled();
+  });
+
+  it('should throw ForbiddenException when user lacks EDIT on source DataMart', async () => {
+    const { service } = createService([false, true]);
+
+    const command = new CreateRelationshipCommand(
+      'dm-source',
+      'dm-target',
+      'alias1',
+      [],
+      'user-1',
+      'proj-1',
+      ['viewer']
+    );
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should throw ForbiddenException when user lacks EDIT on target DataMart', async () => {
+    const { service } = createService([true, false]);
+
+    const command = new CreateRelationshipCommand(
+      'dm-source',
+      'dm-target',
+      'alias1',
+      [],
+      'user-1',
+      'proj-1',
+      ['editor']
+    );
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should skip access check when userId is empty', async () => {
+    const { service, accessDecisionService } = createService([false, false]);
+
+    const command = new CreateRelationshipCommand(
+      'dm-source',
+      'dm-target',
+      'alias1',
+      [],
+      '',
+      'proj-1',
+      []
+    );
+
+    await service.run(command);
+
+    expect(accessDecisionService.canAccess).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ForbiddenException } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { CreateRelationshipCommand } from '../dto/domain/create-relationship.command';
@@ -7,6 +7,7 @@ import { RelationshipMapper } from '../mappers/relationship.mapper';
 import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
 import { DataMartService } from '../services/data-mart.service';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 
 @Injectable()
 export class CreateDataMartRelationshipService {
@@ -14,7 +15,8 @@ export class CreateDataMartRelationshipService {
     private readonly relationshipService: DataMartRelationshipService,
     private readonly dataMartService: DataMartService,
     private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
-    private readonly mapper: RelationshipMapper
+    private readonly mapper: RelationshipMapper,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   @Transactional()
@@ -28,6 +30,32 @@ export class CreateDataMartRelationshipService {
       this.dataMartService.getByIdAndProjectId(command.sourceDataMartId, command.projectId),
       this.dataMartService.getByIdAndProjectId(command.targetDataMartId, command.projectId),
     ]);
+
+    if (command.userId) {
+      const [canEditSource, canEditTarget] = await Promise.all([
+        this.accessDecisionService.canAccess(
+          command.userId,
+          command.roles,
+          EntityType.DATA_MART,
+          command.sourceDataMartId,
+          Action.EDIT,
+          command.projectId
+        ),
+        this.accessDecisionService.canAccess(
+          command.userId,
+          command.roles,
+          EntityType.DATA_MART,
+          command.targetDataMartId,
+          Action.EDIT,
+          command.projectId
+        ),
+      ]);
+      if (!canEditSource || !canEditTarget) {
+        throw new ForbiddenException(
+          'You do not have permission to create relationship between these DataMarts'
+        );
+      }
+    }
 
     this.relationshipService.validateSameStorage(
       sourceDataMart.storage.id,

--- a/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.ts
@@ -2,19 +2,23 @@ import { Injectable } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { CreateRelationshipCommand } from '../dto/domain/create-relationship.command';
-import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { RelationshipResponseApiDto } from '../dto/presentation/relationship-response-api.dto';
+import { RelationshipMapper } from '../mappers/relationship.mapper';
 import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
 import { DataMartService } from '../services/data-mart.service';
+import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
 
 @Injectable()
 export class CreateDataMartRelationshipService {
   constructor(
     private readonly relationshipService: DataMartRelationshipService,
-    private readonly dataMartService: DataMartService
+    private readonly dataMartService: DataMartService,
+    private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
+    private readonly mapper: RelationshipMapper
   ) {}
 
   @Transactional()
-  async run(command: CreateRelationshipCommand): Promise<DataMartRelationship> {
+  async run(command: CreateRelationshipCommand): Promise<RelationshipResponseApiDto> {
     this.relationshipService.validateNoSelfReference(
       command.sourceDataMartId,
       command.targetDataMartId
@@ -57,6 +61,8 @@ export class CreateDataMartRelationshipService {
       command.joinConditions
     );
 
-    return this.relationshipService.create(command, sourceDataMart);
+    const relationship = await this.relationshipService.create(command, sourceDataMart);
+    const createdByUser = await this.userProjectionsFetcherService.fetchCreatedByUser(relationship);
+    return this.mapper.toResponse(relationship, createdByUser);
   }
 }

--- a/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { CreateRelationshipCommand } from '../dto/domain/create-relationship.command';
+import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
+import { DataMartService } from '../services/data-mart.service';
+
+@Injectable()
+export class CreateDataMartRelationshipService {
+  constructor(
+    private readonly relationshipService: DataMartRelationshipService,
+    private readonly dataMartService: DataMartService
+  ) {}
+
+  @Transactional()
+  async run(command: CreateRelationshipCommand): Promise<DataMartRelationship> {
+    this.relationshipService.validateNoSelfReference(
+      command.sourceDataMartId,
+      command.targetDataMartId
+    );
+
+    const [sourceDataMart, targetDataMart] = await Promise.all([
+      this.dataMartService.getByIdAndProjectId(command.sourceDataMartId, command.projectId),
+      this.dataMartService.getByIdAndProjectId(command.targetDataMartId, command.projectId),
+    ]);
+
+    this.relationshipService.validateSameStorage(
+      sourceDataMart.storage.id,
+      targetDataMart.storage.id
+    );
+
+    await this.relationshipService.validateUniqueAlias(
+      command.sourceDataMartId,
+      command.targetAlias
+    );
+
+    const hasCycle = await this.relationshipService.detectCycles(
+      command.sourceDataMartId,
+      command.targetDataMartId,
+      sourceDataMart.storage.id
+    );
+
+    if (hasCycle) {
+      throw new BusinessViolationException(
+        'Adding this relationship would create a circular reference between data marts',
+        {
+          sourceDataMartId: command.sourceDataMartId,
+          targetDataMartId: command.targetDataMartId,
+        }
+      );
+    }
+
+    this.relationshipService.validateJoinFieldTypes(
+      sourceDataMart.schema,
+      targetDataMart.schema,
+      command.joinConditions
+    );
+
+    return this.relationshipService.create(command, sourceDataMart);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/create-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-report.service.ts
@@ -103,6 +103,7 @@ export class CreateReportService {
       dataDestination,
       createdById: command.userId,
       destinationConfig: command.destinationConfig,
+      columnConfig: command.columnConfig ?? null,
     });
 
     const newReport = await this.reportRepository.save(report);

--- a/apps/backend/src/data-marts/use-cases/delete-data-mart-relationship.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-data-mart-relationship.service.spec.ts
@@ -1,0 +1,89 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { DeleteDataMartRelationshipService } from './delete-data-mart-relationship.service';
+import { GetRelationshipCommand } from '../dto/domain/get-relationship.command';
+import { EntityType, Action } from '../services/access-decision';
+
+describe('DeleteDataMartRelationshipService', () => {
+  const relationship = {
+    id: 'rel-1',
+    sourceDataMart: { id: 'dm-source' },
+  };
+
+  const createService = (canAccess = true, foundRelationship = relationship) => {
+    const relationshipService = {
+      findById: jest.fn().mockResolvedValue(foundRelationship),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+    const reportDataCacheService = {
+      invalidateByDataMartId: jest.fn().mockResolvedValue(undefined),
+    };
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(canAccess),
+    };
+
+    const service = new DeleteDataMartRelationshipService(
+      relationshipService as never,
+      reportDataCacheService as never,
+      accessDecisionService as never
+    );
+
+    return { service, relationshipService, reportDataCacheService, accessDecisionService };
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should delete relationship when user has EDIT access on source DataMart', async () => {
+    const { service, relationshipService, accessDecisionService } = createService(true);
+
+    const command = new GetRelationshipCommand('rel-1', 'dm-source', 'user-1', 'proj-1', [
+      'editor',
+    ]);
+
+    await service.run(command);
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.DATA_MART,
+      'dm-source',
+      Action.EDIT,
+      'proj-1'
+    );
+    expect(relationshipService.delete).toHaveBeenCalledWith(relationship);
+  });
+
+  it('should throw ForbiddenException when user lacks EDIT on source DataMart', async () => {
+    const { service } = createService(false);
+
+    const command = new GetRelationshipCommand('rel-1', 'dm-source', 'user-1', 'proj-1', [
+      'viewer',
+    ]);
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should throw NotFoundException when relationship not found', async () => {
+    const { service } = createService(true, null as never);
+
+    const command = new GetRelationshipCommand('rel-1', 'dm-source', 'user-1', 'proj-1', [
+      'editor',
+    ]);
+
+    await expect(service.run(command)).rejects.toThrow(NotFoundException);
+  });
+
+  it('should skip access check when userId is empty', async () => {
+    const { service, accessDecisionService } = createService(false);
+
+    const command = new GetRelationshipCommand('rel-1', 'dm-source', '', 'proj-1', []);
+
+    await service.run(command);
+
+    expect(accessDecisionService.canAccess).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/delete-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-data-mart-relationship.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
+import { GetRelationshipCommand } from '../dto/domain/get-relationship.command';
+import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
+
+@Injectable()
+export class DeleteDataMartRelationshipService {
+  constructor(private readonly relationshipService: DataMartRelationshipService) {}
+
+  @Transactional()
+  async run(command: GetRelationshipCommand): Promise<void> {
+    const relationship = await this.relationshipService.findById(command.relationshipId);
+
+    if (!relationship || relationship.sourceDataMart.id !== command.sourceDataMartId) {
+      throw new NotFoundException(
+        `Relationship with ID ${command.relationshipId} not found for data mart ${command.sourceDataMartId}`
+      );
+    }
+
+    await this.relationshipService.delete(relationship);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/delete-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-data-mart-relationship.service.ts
@@ -2,10 +2,14 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { GetRelationshipCommand } from '../dto/domain/get-relationship.command';
 import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
+import { ReportDataCacheService } from '../services/report-data-cache.service';
 
 @Injectable()
 export class DeleteDataMartRelationshipService {
-  constructor(private readonly relationshipService: DataMartRelationshipService) {}
+  constructor(
+    private readonly relationshipService: DataMartRelationshipService,
+    private readonly reportDataCacheService: ReportDataCacheService
+  ) {}
 
   @Transactional()
   async run(command: GetRelationshipCommand): Promise<void> {
@@ -18,5 +22,6 @@ export class DeleteDataMartRelationshipService {
     }
 
     await this.relationshipService.delete(relationship);
+    await this.reportDataCacheService.invalidateByDataMartId(command.sourceDataMartId);
   }
 }

--- a/apps/backend/src/data-marts/use-cases/delete-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-data-mart-relationship.service.ts
@@ -1,14 +1,16 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { GetRelationshipCommand } from '../dto/domain/get-relationship.command';
 import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
 import { ReportDataCacheService } from '../services/report-data-cache.service';
+import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 
 @Injectable()
 export class DeleteDataMartRelationshipService {
   constructor(
     private readonly relationshipService: DataMartRelationshipService,
-    private readonly reportDataCacheService: ReportDataCacheService
+    private readonly reportDataCacheService: ReportDataCacheService,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   @Transactional()
@@ -19,6 +21,22 @@ export class DeleteDataMartRelationshipService {
       throw new NotFoundException(
         `Relationship with ID ${command.relationshipId} not found for data mart ${command.sourceDataMartId}`
       );
+    }
+
+    if (command.userId) {
+      const canEdit = await this.accessDecisionService.canAccess(
+        command.userId,
+        command.roles,
+        EntityType.DATA_MART,
+        relationship.sourceDataMart.id,
+        Action.EDIT,
+        command.projectId
+      );
+      if (!canEdit) {
+        throw new ForbiddenException(
+          'You do not have permission to manage relationships of this DataMart'
+        );
+      }
     }
 
     await this.relationshipService.delete(relationship);

--- a/apps/backend/src/data-marts/use-cases/delete-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-data-mart.service.ts
@@ -1,10 +1,12 @@
 import { Injectable, ForbiddenException } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { DeleteDataMartCommand } from '../dto/domain/delete-data-mart.command';
 import { LegacyDataMartsService } from '../services/legacy-data-marts/legacy-data-marts.service';
 import { ScheduledTriggerService } from '../services/scheduled-trigger.service';
 import { ReportService } from '../services/report.service';
 import { DataMartService } from '../services/data-mart.service';
+import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
 import { ConnectorSourceCredentialsService } from '../services/connector/connector-source-credentials.service';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 
@@ -16,9 +18,11 @@ export class DeleteDataMartService {
     private readonly reportService: ReportService,
     private readonly legacyDataMartsService: LegacyDataMartsService,
     private readonly connectorSourceCredentialsService: ConnectorSourceCredentialsService,
+    private readonly relationshipService: DataMartRelationshipService,
     private readonly accessDecisionService: AccessDecisionService
   ) {}
 
+  @Transactional()
   async run(command: DeleteDataMartCommand): Promise<void> {
     const dataMart = await this.dataMartService.getByIdAndProjectId(command.id, command.projectId);
 
@@ -53,6 +57,8 @@ export class DeleteDataMartService {
     );
 
     await this.connectorSourceCredentialsService.deleteSecretsByDataMart(command.id);
+
+    await this.relationshipService.deleteAllByDataMartId(command.id);
 
     await this.dataMartService.softDeleteByIdAndProjectId(command.id, command.projectId);
   }

--- a/apps/backend/src/data-marts/use-cases/get-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-data-mart-relationship.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { RelationshipResponseApiDto } from '../dto/presentation/relationship-response-api.dto';
+import { RelationshipMapper } from '../mappers/relationship.mapper';
+import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
+import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+
+@Injectable()
+export class GetDataMartRelationshipService {
+  constructor(
+    private readonly relationshipService: DataMartRelationshipService,
+    private readonly mapper: RelationshipMapper,
+    private readonly userProjectionsFetcherService: UserProjectionsFetcherService
+  ) {}
+
+  async run(id: string, dataMartId: string): Promise<RelationshipResponseApiDto> {
+    const relationship = await this.relationshipService.findById(id);
+
+    if (!relationship || relationship.sourceDataMart.id !== dataMartId) {
+      throw new NotFoundException(
+        `Relationship with ID ${id} not found for data mart ${dataMartId}`
+      );
+    }
+
+    const createdByUser = await this.userProjectionsFetcherService.fetchCreatedByUser(relationship);
+
+    return this.mapper.toResponse(relationship, createdByUser);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.ts
@@ -1,9 +1,11 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Report } from '../entities/report.entity';
 import { BlendedReportDataService } from '../services/blended-report-data.service';
 import { DataMartQueryBuilderFacade } from '../data-storage-types/facades/data-mart-query-builder.facade';
+import { GetReportGeneratedSqlCommand } from '../dto/domain/get-report-generated-sql.command';
+import { AccessDecisionService, Action } from '../services/access-decision';
 
 @Injectable()
 export class GetReportGeneratedSqlService {
@@ -11,22 +13,41 @@ export class GetReportGeneratedSqlService {
     @InjectRepository(Report)
     private readonly reportRepository: Repository<Report>,
     private readonly blendedReportDataService: BlendedReportDataService,
-    private readonly queryBuilderFacade: DataMartQueryBuilderFacade
+    private readonly queryBuilderFacade: DataMartQueryBuilderFacade,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
-  async run(reportId: string, projectId: string): Promise<{ sql: string }> {
+  async run(command: GetReportGeneratedSqlCommand): Promise<{ sql: string }> {
     const report = await this.reportRepository.findOne({
       where: {
-        id: reportId,
-        dataMart: { projectId },
+        id: command.reportId,
+        dataMart: { projectId: command.projectId },
       },
       relations: ['dataMart', 'dataMart.storage', 'dataMart.storage.credential', 'dataDestination'],
     });
 
     if (!report) {
-      throw new NotFoundException(`Report with ID ${reportId} not found`);
+      throw new NotFoundException(`Report with ID ${command.reportId} not found`);
     }
 
+    if (command.userId) {
+      const canSee = await this.accessDecisionService.canAccessReport(
+        command.userId,
+        command.roles,
+        command.reportId,
+        report.dataMart.id,
+        Action.SEE,
+        command.projectId
+      );
+      if (!canSee) {
+        throw new ForbiddenException('You do not have access to this report');
+      }
+    }
+
+    return this.buildForReport(report);
+  }
+
+  async buildForReport(report: Report): Promise<{ sql: string }> {
     const decision = await this.blendedReportDataService.resolveBlendingDecision(report);
 
     if (decision.needsBlending && decision.blendedSql) {
@@ -38,8 +59,6 @@ export class GetReportGeneratedSqlService {
       throw new Error('Data Mart definition is not set.');
     }
 
-    // Pass the native column filter to the query builder so the preview
-    // matches what runtime actually executes.
     const sql = await this.queryBuilderFacade.buildQuery(
       dataMart.storage.type,
       dataMart.definition,

--- a/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Report } from '../entities/report.entity';
+import { BlendedReportDataService } from '../services/blended-report-data.service';
+import { DataMartQueryBuilderFacade } from '../data-storage-types/facades/data-mart-query-builder.facade';
+
+@Injectable()
+export class GetReportGeneratedSqlService {
+  constructor(
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    private readonly blendedReportDataService: BlendedReportDataService,
+    private readonly queryBuilderFacade: DataMartQueryBuilderFacade
+  ) {}
+
+  async run(reportId: string, projectId: string): Promise<{ sql: string }> {
+    const report = await this.reportRepository.findOne({
+      where: {
+        id: reportId,
+        dataMart: { projectId },
+      },
+      relations: ['dataMart', 'dataMart.storage', 'dataMart.storage.credential', 'dataDestination'],
+    });
+
+    if (!report) {
+      throw new NotFoundException(`Report with ID ${reportId} not found`);
+    }
+
+    const decision = await this.blendedReportDataService.resolveBlendingDecision(report);
+
+    if (decision.needsBlending && decision.blendedSql) {
+      return { sql: decision.blendedSql };
+    }
+
+    const { dataMart } = report;
+    if (!dataMart.definition) {
+      throw new Error('Data Mart definition is not set.');
+    }
+
+    // Pass the native column filter to the query builder so the preview
+    // matches what runtime actually executes.
+    const sql = await this.queryBuilderFacade.buildQuery(
+      dataMart.storage.type,
+      dataMart.definition,
+      { columns: decision.columnFilter }
+    );
+
+    return { sql };
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/list-data-mart-relationships.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-data-mart-relationships.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { RelationshipResponseApiDto } from '../dto/presentation/relationship-response-api.dto';
+import { RelationshipMapper } from '../mappers/relationship.mapper';
+import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
+import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+
+@Injectable()
+export class ListDataMartRelationshipsService {
+  constructor(
+    private readonly relationshipService: DataMartRelationshipService,
+    private readonly mapper: RelationshipMapper,
+    private readonly userProjectionsFetcherService: UserProjectionsFetcherService
+  ) {}
+
+  async run(dataMartId: string): Promise<RelationshipResponseApiDto[]> {
+    const relationships = await this.relationshipService.findBySourceDataMartId(dataMartId);
+
+    const userProjectionsList =
+      await this.userProjectionsFetcherService.fetchRelevantUserProjections(relationships);
+
+    return this.mapper.toResponseList(relationships, userProjectionsList);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
@@ -31,6 +31,11 @@ describe('RunReportService', () => {
     const projectBalanceService = {
       verifyCanPerformOperations: jest.fn().mockResolvedValue(undefined),
     };
+    const blendedReportDataService = {
+      // Default: no columnConfig -> no blending, no filter.
+      resolveBlendingDecision: jest.fn().mockResolvedValue({ needsBlending: false }),
+      logBlendedSqlIfNeeded: jest.fn(),
+    };
 
     const service = new RunReportService(
       reportReaderResolver as never,
@@ -43,7 +48,8 @@ describe('RunReportService', () => {
       projectBalanceService as never,
       new ReportExecutionPolicyResolver(),
       {} as never,
-      { checkMutateAccess: jest.fn().mockResolvedValue(undefined) } as never
+      { checkMutateAccess: jest.fn().mockResolvedValue(undefined) } as never,
+      blendedReportDataService as never
     );
 
     return {
@@ -51,6 +57,7 @@ describe('RunReportService', () => {
       reportReaderResolver,
       reportWriterResolver,
       projectBalanceService,
+      blendedReportDataService,
     };
   };
 
@@ -168,5 +175,39 @@ describe('RunReportService', () => {
     expect(writer.finalize).toHaveBeenCalledWith(undefined, {
       mainRowsTruncationInfo: null,
     });
+  });
+
+  it('forwards blending decision and run logger to logBlendedSqlIfNeeded', async () => {
+    const { service, reportReaderResolver, reportWriterResolver, blendedReportDataService } =
+      createService();
+    const report = createReport(DataDestinationType.GOOGLE_SHEETS);
+    const reader = createReader();
+    const writer = createWriter(DataDestinationType.GOOGLE_SHEETS);
+
+    reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], undefined));
+
+    reportReaderResolver.resolve.mockResolvedValue(reader);
+    reportWriterResolver.resolve.mockResolvedValue(writer);
+
+    const decision = { needsBlending: true, blendedSql: 'SELECT 1' };
+    blendedReportDataService.resolveBlendingDecision.mockResolvedValue(decision);
+
+    const mockLogger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      asArrays: jest.fn().mockReturnValue({ logs: [], errors: [] }),
+    };
+
+    await (
+      service as unknown as {
+        executeReport: (report: Report, signal?: AbortSignal, logger?: unknown) => Promise<void>;
+      }
+    ).executeReport(report, undefined, mockLogger);
+
+    expect(blendedReportDataService.resolveBlendingDecision).toHaveBeenCalledWith(report);
+    expect(blendedReportDataService.logBlendedSqlIfNeeded).toHaveBeenCalledWith(
+      decision,
+      mockLogger
+    );
   });
 });

--- a/apps/backend/src/data-marts/use-cases/run-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.ts
@@ -17,6 +17,7 @@ import { DataMart } from '../entities/data-mart.entity';
 import { Report } from '../entities/report.entity';
 import { ReportRun } from '../models/report-run.model';
 import { createReportRunLogger, ReportRunLogger } from '../report-run-logging/report-run-logger';
+import { BlendedReportDataService } from '../services/blended-report-data.service';
 import { DataMartService } from '../services/data-mart.service';
 import { ProjectBalanceService } from '../services/project-balance.service';
 import { ReportRunService } from '../services/report-run.service';
@@ -88,7 +89,8 @@ export class RunReportService {
     private readonly projectBalanceService: ProjectBalanceService,
     private readonly reportExecutionPolicyResolver: ReportExecutionPolicyResolver,
     private readonly reportRunTriggerService: ReportRunTriggerService,
-    private readonly reportAccessService: ReportAccessService
+    private readonly reportAccessService: ReportAccessService,
+    private readonly blendedReportDataService: BlendedReportDataService
   ) {}
 
   /**
@@ -193,7 +195,18 @@ export class RunReportService {
     try {
       signal?.throwIfAborted();
       await this.projectBalanceService.verifyCanPerformOperations(dataMart.projectId);
-      const reportDataDescription = await reportReader.prepareReportData(report);
+
+      // Resolve blending decision up front. When the report has a column
+      // config, this produces either a pre-built blended SQL (for cross-DM
+      // joins) or a column filter (for native-only projections). Readers
+      // receive the result via PrepareReportDataOptions.
+      const blendingDecision = await this.blendedReportDataService.resolveBlendingDecision(report);
+      this.blendedReportDataService.logBlendedSqlIfNeeded(blendingDecision, reportRunLogger);
+      const reportDataDescription = await reportReader.prepareReportData(report, {
+        sqlOverride: blendingDecision.needsBlending ? blendingDecision.blendedSql : undefined,
+        columnFilter: blendingDecision.columnFilter,
+        blendedDataHeaders: blendingDecision.blendedDataHeaders,
+      });
       this.logger.debug(`Report data prepared for ${report.id}:`, reportDataDescription);
       reportWriter.setExecutionContext?.({
         runId: report.id,

--- a/apps/backend/src/data-marts/use-cases/update-blended-fields-config.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-blended-fields-config.service.spec.ts
@@ -1,0 +1,83 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+import { ForbiddenException } from '@nestjs/common';
+import { UpdateBlendedFieldsConfigService } from './update-blended-fields-config.service';
+import { UpdateBlendedFieldsConfigCommand } from '../dto/domain/update-blended-fields-config.command';
+import { EntityType, Action } from '../services/access-decision';
+
+describe('UpdateBlendedFieldsConfigService', () => {
+  const dataMart = {
+    id: 'dm-1',
+    projectId: 'proj-1',
+    blendedFieldsConfig: null,
+  };
+
+  const createService = (canAccess = true) => {
+    const dataMartService = {
+      getByIdAndProjectId: jest.fn().mockResolvedValue({ ...dataMart }),
+      save: jest.fn().mockResolvedValue(dataMart),
+    };
+    const reportDataCacheService = {
+      invalidateByDataMartId: jest.fn().mockResolvedValue(undefined),
+    };
+    const mapper = {
+      toDomainDto: jest.fn().mockReturnValue({ id: 'dm-1' }),
+    };
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(canAccess),
+    };
+
+    const service = new UpdateBlendedFieldsConfigService(
+      dataMartService as never,
+      reportDataCacheService as never,
+      mapper as never,
+      accessDecisionService as never
+    );
+
+    return { service, dataMartService, reportDataCacheService, accessDecisionService };
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should update blended fields config when user has EDIT access', async () => {
+    const { service, accessDecisionService } = createService(true);
+
+    const command = new UpdateBlendedFieldsConfigCommand('dm-1', 'proj-1', null, 'user-1', [
+      'editor',
+    ]);
+
+    await service.run(command);
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.DATA_MART,
+      'dm-1',
+      Action.EDIT,
+      'proj-1'
+    );
+  });
+
+  it('should throw ForbiddenException when user lacks EDIT access', async () => {
+    const { service } = createService(false);
+
+    const command = new UpdateBlendedFieldsConfigCommand('dm-1', 'proj-1', null, 'user-1', [
+      'viewer',
+    ]);
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should skip access check when userId is empty', async () => {
+    const { service, accessDecisionService } = createService(false);
+
+    const command = new UpdateBlendedFieldsConfigCommand('dm-1', 'proj-1', null, '', []);
+
+    await service.run(command);
+
+    expect(accessDecisionService.canAccess).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/update-blended-fields-config.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-blended-fields-config.service.ts
@@ -1,22 +1,38 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, ForbiddenException } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { DataMartMapper } from '../mappers/data-mart.mapper';
 import { DataMartDto } from '../dto/domain/data-mart.dto';
 import { DataMartService } from '../services/data-mart.service';
 import { ReportDataCacheService } from '../services/report-data-cache.service';
 import { UpdateBlendedFieldsConfigCommand } from '../dto/domain/update-blended-fields-config.command';
+import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 
 @Injectable()
 export class UpdateBlendedFieldsConfigService {
   constructor(
     private readonly dataMartService: DataMartService,
     private readonly reportDataCacheService: ReportDataCacheService,
-    private readonly mapper: DataMartMapper
+    private readonly mapper: DataMartMapper,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   @Transactional()
   async run(command: UpdateBlendedFieldsConfigCommand): Promise<DataMartDto> {
     const dataMart = await this.dataMartService.getByIdAndProjectId(command.id, command.projectId);
+
+    if (command.userId) {
+      const canEdit = await this.accessDecisionService.canAccess(
+        command.userId,
+        command.roles,
+        EntityType.DATA_MART,
+        command.id,
+        Action.EDIT,
+        command.projectId
+      );
+      if (!canEdit) {
+        throw new ForbiddenException('You do not have permission to edit this DataMart');
+      }
+    }
 
     const nextConfig = command.blendedFieldsConfig ?? undefined;
     const changed =

--- a/apps/backend/src/data-marts/use-cases/update-blended-fields-config.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-blended-fields-config.service.ts
@@ -1,21 +1,32 @@
 import { Injectable } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
 import { DataMartMapper } from '../mappers/data-mart.mapper';
 import { DataMartDto } from '../dto/domain/data-mart.dto';
 import { DataMartService } from '../services/data-mart.service';
+import { ReportDataCacheService } from '../services/report-data-cache.service';
 import { UpdateBlendedFieldsConfigCommand } from '../dto/domain/update-blended-fields-config.command';
 
 @Injectable()
 export class UpdateBlendedFieldsConfigService {
   constructor(
     private readonly dataMartService: DataMartService,
+    private readonly reportDataCacheService: ReportDataCacheService,
     private readonly mapper: DataMartMapper
   ) {}
 
+  @Transactional()
   async run(command: UpdateBlendedFieldsConfigCommand): Promise<DataMartDto> {
     const dataMart = await this.dataMartService.getByIdAndProjectId(command.id, command.projectId);
 
-    dataMart.blendedFieldsConfig = command.blendedFieldsConfig ?? undefined;
-    await this.dataMartService.save(dataMart);
+    const nextConfig = command.blendedFieldsConfig ?? undefined;
+    const changed =
+      JSON.stringify(dataMart.blendedFieldsConfig ?? null) !== JSON.stringify(nextConfig ?? null);
+
+    if (changed) {
+      dataMart.blendedFieldsConfig = nextConfig;
+      await this.dataMartService.save(dataMart);
+      await this.reportDataCacheService.invalidateByDataMartId(dataMart.id);
+    }
 
     return this.mapper.toDomainDto(dataMart);
   }

--- a/apps/backend/src/data-marts/use-cases/update-blended-fields-config.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-blended-fields-config.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { DataMartMapper } from '../mappers/data-mart.mapper';
+import { DataMartDto } from '../dto/domain/data-mart.dto';
+import { DataMartService } from '../services/data-mart.service';
+import { UpdateBlendedFieldsConfigCommand } from '../dto/domain/update-blended-fields-config.command';
+
+@Injectable()
+export class UpdateBlendedFieldsConfigService {
+  constructor(
+    private readonly dataMartService: DataMartService,
+    private readonly mapper: DataMartMapper
+  ) {}
+
+  async run(command: UpdateBlendedFieldsConfigCommand): Promise<DataMartDto> {
+    const dataMart = await this.dataMartService.getByIdAndProjectId(command.id, command.projectId);
+
+    dataMart.blendedFieldsConfig = command.blendedFieldsConfig ?? undefined;
+    await this.dataMartService.save(dataMart);
+
+    return this.mapper.toDomainDto(dataMart);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-relationship.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-relationship.service.spec.ts
@@ -1,0 +1,134 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+jest.mock('../services/user-projections-fetcher.service', () => ({
+  UserProjectionsFetcherService: jest.fn(),
+}));
+
+jest.mock('../../idp/facades/idp-projections.facade', () => ({
+  IdpProjectionsFacade: jest.fn(),
+}));
+
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { UpdateDataMartRelationshipService } from './update-data-mart-relationship.service';
+import { UpdateRelationshipCommand } from '../dto/domain/update-relationship.command';
+import { EntityType, Action } from '../services/access-decision';
+
+describe('UpdateDataMartRelationshipService', () => {
+  const relationship = {
+    id: 'rel-1',
+    sourceDataMart: { id: 'dm-source', schema: [] },
+    targetDataMart: { id: 'dm-target', schema: [] },
+    targetAlias: 'old-alias',
+    createdById: 'user-1',
+  };
+
+  const createService = (canAccess = true) => {
+    const relationshipService = {
+      findById: jest.fn().mockResolvedValue(relationship),
+      validateUniqueAlias: jest.fn().mockResolvedValue(undefined),
+      validateJoinFieldTypes: jest.fn(),
+      update: jest.fn().mockResolvedValue({ ...relationship, targetAlias: 'new-alias' }),
+    };
+    const dataMartService = {
+      findById: jest.fn().mockResolvedValue(null),
+    };
+    const userProjectionsFetcherService = {
+      fetchCreatedByUser: jest.fn().mockResolvedValue(null),
+    };
+    const reportDataCacheService = {
+      invalidateByDataMartId: jest.fn().mockResolvedValue(undefined),
+    };
+    const mapper = {
+      toResponse: jest.fn().mockReturnValue({ id: 'rel-1' }),
+    };
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(canAccess),
+    };
+
+    const service = new UpdateDataMartRelationshipService(
+      relationshipService as never,
+      dataMartService as never,
+      userProjectionsFetcherService as never,
+      reportDataCacheService as never,
+      mapper as never,
+      accessDecisionService as never
+    );
+
+    return { service, relationshipService, accessDecisionService };
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should update relationship when user has EDIT access on source DataMart', async () => {
+    const { service, accessDecisionService } = createService(true);
+
+    const command = new UpdateRelationshipCommand(
+      'rel-1',
+      'dm-source',
+      'user-1',
+      'proj-1',
+      ['editor'],
+      'new-alias',
+      undefined
+    );
+
+    await service.run(command);
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.DATA_MART,
+      'dm-source',
+      Action.EDIT,
+      'proj-1'
+    );
+  });
+
+  it('should throw ForbiddenException when user lacks EDIT on source DataMart', async () => {
+    const { service } = createService(false);
+
+    const command = new UpdateRelationshipCommand(
+      'rel-1',
+      'dm-source',
+      'user-1',
+      'proj-1',
+      ['viewer'],
+      'new-alias',
+      undefined
+    );
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should throw NotFoundException when relationship not found', async () => {
+    const { accessDecisionService } = createService(true);
+    const { relationshipService } = createService(true);
+    relationshipService.findById = jest.fn().mockResolvedValue(null);
+
+    const badService = new UpdateDataMartRelationshipService(
+      relationshipService as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      accessDecisionService as never
+    );
+
+    const command = new UpdateRelationshipCommand('rel-1', 'dm-source', 'user-1', 'proj-1', []);
+
+    await expect(badService.run(command)).rejects.toThrow(NotFoundException);
+  });
+
+  it('should skip access check when userId is empty', async () => {
+    const { service, accessDecisionService } = createService(false);
+
+    const command = new UpdateRelationshipCommand('rel-1', 'dm-source', '', 'proj-1', []);
+
+    await service.run(command);
+
+    expect(accessDecisionService.canAccess).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-relationship.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { UpdateRelationshipCommand } from '../dto/domain/update-relationship.command';
 import { RelationshipResponseApiDto } from '../dto/presentation/relationship-response-api.dto';
@@ -7,6 +7,7 @@ import { DataMartRelationshipService } from '../services/data-mart-relationship.
 import { DataMartService } from '../services/data-mart.service';
 import { ReportDataCacheService } from '../services/report-data-cache.service';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 
 @Injectable()
 export class UpdateDataMartRelationshipService {
@@ -15,7 +16,8 @@ export class UpdateDataMartRelationshipService {
     private readonly dataMartService: DataMartService,
     private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
     private readonly reportDataCacheService: ReportDataCacheService,
-    private readonly mapper: RelationshipMapper
+    private readonly mapper: RelationshipMapper,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   @Transactional()
@@ -26,6 +28,22 @@ export class UpdateDataMartRelationshipService {
       throw new NotFoundException(
         `Relationship with ID ${command.relationshipId} not found for data mart ${command.sourceDataMartId}`
       );
+    }
+
+    if (command.userId) {
+      const canEdit = await this.accessDecisionService.canAccess(
+        command.userId,
+        command.roles,
+        EntityType.DATA_MART,
+        relationship.sourceDataMart.id,
+        Action.EDIT,
+        command.projectId
+      );
+      if (!canEdit) {
+        throw new ForbiddenException(
+          'You do not have permission to manage relationships of this DataMart'
+        );
+      }
     }
 
     const oldAlias = relationship.targetAlias;

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-relationship.service.ts
@@ -1,19 +1,25 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { UpdateRelationshipCommand } from '../dto/domain/update-relationship.command';
-import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { RelationshipResponseApiDto } from '../dto/presentation/relationship-response-api.dto';
+import { RelationshipMapper } from '../mappers/relationship.mapper';
 import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
 import { DataMartService } from '../services/data-mart.service';
+import { ReportDataCacheService } from '../services/report-data-cache.service';
+import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
 
 @Injectable()
 export class UpdateDataMartRelationshipService {
   constructor(
     private readonly relationshipService: DataMartRelationshipService,
-    private readonly dataMartService: DataMartService
+    private readonly dataMartService: DataMartService,
+    private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
+    private readonly reportDataCacheService: ReportDataCacheService,
+    private readonly mapper: RelationshipMapper
   ) {}
 
   @Transactional()
-  async run(command: UpdateRelationshipCommand): Promise<DataMartRelationship> {
+  async run(command: UpdateRelationshipCommand): Promise<RelationshipResponseApiDto> {
     const relationship = await this.relationshipService.findById(command.relationshipId);
 
     if (!relationship || relationship.sourceDataMart.id !== command.sourceDataMartId) {
@@ -47,7 +53,10 @@ export class UpdateDataMartRelationshipService {
       await this.cascadeAliasRename(command.sourceDataMartId, oldAlias, command.targetAlias);
     }
 
-    return updated;
+    await this.reportDataCacheService.invalidateByDataMartId(command.sourceDataMartId);
+
+    const createdByUser = await this.userProjectionsFetcherService.fetchCreatedByUser(updated);
+    return this.mapper.toResponse(updated, createdByUser);
   }
 
   private async cascadeAliasRename(

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-relationship.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
+import { UpdateRelationshipCommand } from '../dto/domain/update-relationship.command';
+import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
+import { DataMartService } from '../services/data-mart.service';
+
+@Injectable()
+export class UpdateDataMartRelationshipService {
+  constructor(
+    private readonly relationshipService: DataMartRelationshipService,
+    private readonly dataMartService: DataMartService
+  ) {}
+
+  @Transactional()
+  async run(command: UpdateRelationshipCommand): Promise<DataMartRelationship> {
+    const relationship = await this.relationshipService.findById(command.relationshipId);
+
+    if (!relationship || relationship.sourceDataMart.id !== command.sourceDataMartId) {
+      throw new NotFoundException(
+        `Relationship with ID ${command.relationshipId} not found for data mart ${command.sourceDataMartId}`
+      );
+    }
+
+    const oldAlias = relationship.targetAlias;
+
+    if (command.targetAlias !== undefined && command.targetAlias !== oldAlias) {
+      await this.relationshipService.validateUniqueAlias(
+        command.sourceDataMartId,
+        command.targetAlias,
+        command.relationshipId
+      );
+    }
+
+    if (command.joinConditions !== undefined) {
+      this.relationshipService.validateJoinFieldTypes(
+        relationship.sourceDataMart.schema,
+        relationship.targetDataMart.schema,
+        command.joinConditions
+      );
+    }
+
+    const updated = await this.relationshipService.update(relationship, command);
+
+    // Cascade alias rename in blendedFieldsConfig paths
+    if (command.targetAlias !== undefined && command.targetAlias !== oldAlias) {
+      await this.cascadeAliasRename(command.sourceDataMartId, oldAlias, command.targetAlias);
+    }
+
+    return updated;
+  }
+
+  private async cascadeAliasRename(
+    sourceDataMartId: string,
+    oldAlias: string,
+    newAlias: string
+  ): Promise<void> {
+    const sourceDm = await this.dataMartService.findById(sourceDataMartId);
+    if (!sourceDm?.blendedFieldsConfig) return;
+
+    let changed = false;
+    const updatedSources = sourceDm.blendedFieldsConfig.sources.map(source => {
+      const updatedPath = this.replaceFirstSegment(source.path, oldAlias, newAlias);
+      if (updatedPath !== source.path) {
+        changed = true;
+        return { ...source, path: updatedPath };
+      }
+      return source;
+    });
+
+    if (changed) {
+      sourceDm.blendedFieldsConfig = {
+        ...sourceDm.blendedFieldsConfig,
+        sources: updatedSources,
+      };
+      await this.dataMartService.save(sourceDm);
+    }
+  }
+
+  private replaceFirstSegment(path: string, oldSegment: string, newSegment: string): string {
+    if (path === oldSegment) return newSegment;
+    if (path.startsWith(`${oldSegment}.`)) {
+      return `${newSegment}${path.slice(oldSegment.length)}`;
+    }
+    return path;
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/update-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-report.service.spec.ts
@@ -71,6 +71,9 @@ describe('UpdateReportService', () => {
       checkMutateAccess: jest.fn().mockResolvedValue(undefined),
       canBeOwner: jest.fn().mockResolvedValue(true),
     };
+    const reportDataCacheService = {
+      invalidateByReportId: jest.fn().mockResolvedValue(undefined),
+    };
 
     const service = new UpdateReportService(
       reportRepository as never,
@@ -81,10 +84,11 @@ describe('UpdateReportService', () => {
       userProjectionsFetcherService as never,
       idpProjectionsFacade as never,
       reportOwnerRepository as never,
-      reportAccessService as never
+      reportAccessService as never,
+      reportDataCacheService as never
     );
 
-    return { service, reportAccessService, reportRepository };
+    return { service, reportAccessService, reportRepository, reportDataCacheService };
   };
 
   beforeEach(() => {

--- a/apps/backend/src/data-marts/use-cases/update-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-report.service.ts
@@ -93,15 +93,13 @@ export class UpdateReportService {
       }
     }
 
-    // Detect columnConfig change BEFORE we overwrite the entity so we can
-    // invalidate the cache for this report after save. Serialized compare
-    // handles null, empty arrays, and order changes uniformly.
+    // Column order is part of the report output, so a serialized compare is intentional —
+    // reordering alone must rebuild the cached reader.
     const previousColumnConfig = report.columnConfig ?? null;
     const nextColumnConfig = command.columnConfig ?? null;
     const columnConfigChanged =
       JSON.stringify(previousColumnConfig) !== JSON.stringify(nextColumnConfig);
 
-    // Update the report
     report.title = command.title;
     report.dataDestination = dataDestination;
     report.destinationConfig = command.destinationConfig;
@@ -127,9 +125,6 @@ export class UpdateReportService {
     }
 
     if (columnConfigChanged) {
-      // Stale cache would otherwise serve the old column set until TTL
-      // expires (default 1h). Invalidate so the next read applies the
-      // new selection immediately.
       await this.reportDataCacheService.invalidateByReportId(updatedReport.id);
     }
 

--- a/apps/backend/src/data-marts/use-cases/update-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-report.service.ts
@@ -16,6 +16,7 @@ import { resolveOwnerUsers } from '../utils/resolve-owner-users';
 import { syncOwners } from '../utils/sync-owners';
 import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
 import { ReportAccessService } from '../services/report-access.service';
+import { ReportDataCacheService } from '../services/report-data-cache.service';
 
 @Injectable()
 export class UpdateReportService {
@@ -30,7 +31,8 @@ export class UpdateReportService {
     private readonly idpProjectionsFacade: IdpProjectionsFacade,
     @InjectRepository(ReportOwner)
     private readonly reportOwnerRepository: Repository<ReportOwner>,
-    private readonly reportAccessService: ReportAccessService
+    private readonly reportAccessService: ReportAccessService,
+    private readonly reportDataCacheService: ReportDataCacheService
   ) {}
 
   @Transactional()
@@ -91,10 +93,19 @@ export class UpdateReportService {
       }
     }
 
+    // Detect columnConfig change BEFORE we overwrite the entity so we can
+    // invalidate the cache for this report after save. Serialized compare
+    // handles null, empty arrays, and order changes uniformly.
+    const previousColumnConfig = report.columnConfig ?? null;
+    const nextColumnConfig = command.columnConfig ?? null;
+    const columnConfigChanged =
+      JSON.stringify(previousColumnConfig) !== JSON.stringify(nextColumnConfig);
+
     // Update the report
     report.title = command.title;
     report.dataDestination = dataDestination;
     report.destinationConfig = command.destinationConfig;
+    report.columnConfig = nextColumnConfig;
 
     const updatedReport = await this.reportRepository.save(report);
 
@@ -113,6 +124,13 @@ export class UpdateReportService {
           return o;
         }
       );
+    }
+
+    if (columnConfigChanged) {
+      // Stale cache would otherwise serve the old column set until TTL
+      // expires (default 1h). Invalidate so the next read applies the
+      // new selection immediately.
+      await this.reportDataCacheService.invalidateByReportId(updatedReport.id);
     }
 
     // Reload to get fresh owners

--- a/apps/backend/src/migrations/1776616688331-add-data-mart-relationship.ts
+++ b/apps/backend/src/migrations/1776616688331-add-data-mart-relationship.ts
@@ -1,21 +1,16 @@
-import {
-  MigrationInterface,
-  QueryRunner,
-  Table,
-  TableColumn,
-  TableForeignKey,
-  TableIndex,
-} from 'typeorm';
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
 import { softDropTable } from './migration-utils';
 
 export class AddDataMartRelationship1776616688331 implements MigrationInterface {
   public readonly name = 'AddDataMartRelationship1776616688331';
 
   private readonly RELATIONSHIP_TABLE = 'data_mart_relationship';
-  private readonly REPORT_TABLE = 'report';
-  private readonly COLUMN_CONFIG_COLUMN = 'columnConfig';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    if (await queryRunner.hasTable(this.RELATIONSHIP_TABLE)) {
+      return;
+    }
+
     await queryRunner.createTable(
       new Table({
         name: this.RELATIONSHIP_TABLE,
@@ -31,8 +26,30 @@ export class AddDataMartRelationship1776616688331 implements MigrationInterface 
           { name: 'createdAt', type: 'datetime', isNullable: false, default: 'CURRENT_TIMESTAMP' },
           { name: 'modifiedAt', type: 'datetime', isNullable: false, default: 'CURRENT_TIMESTAMP' },
         ],
-      }),
-      true
+        foreignKeys: [
+          {
+            columnNames: ['dataStorageId'],
+            referencedTableName: 'data_storage',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'NO ACTION',
+          },
+          {
+            columnNames: ['sourceDataMartId'],
+            referencedTableName: 'data_mart',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'NO ACTION',
+          },
+          {
+            columnNames: ['targetDataMartId'],
+            referencedTableName: 'data_mart',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+            onUpdate: 'NO ACTION',
+          },
+        ],
+      })
     );
 
     await queryRunner.createIndex(
@@ -44,65 +61,24 @@ export class AddDataMartRelationship1776616688331 implements MigrationInterface 
       })
     );
 
-    await queryRunner.createForeignKey(
+    await queryRunner.createIndex(
       this.RELATIONSHIP_TABLE,
-      new TableForeignKey({
+      new TableIndex({
+        name: 'IDX_dmr_dataStorage',
         columnNames: ['dataStorageId'],
-        referencedTableName: 'data_storage',
-        referencedColumnNames: ['id'],
-        onDelete: 'CASCADE',
-        onUpdate: 'NO ACTION',
       })
     );
 
-    await queryRunner.createForeignKey(
+    await queryRunner.createIndex(
       this.RELATIONSHIP_TABLE,
-      new TableForeignKey({
-        columnNames: ['sourceDataMartId'],
-        referencedTableName: 'data_mart',
-        referencedColumnNames: ['id'],
-        onDelete: 'CASCADE',
-        onUpdate: 'NO ACTION',
-      })
-    );
-
-    await queryRunner.createForeignKey(
-      this.RELATIONSHIP_TABLE,
-      new TableForeignKey({
+      new TableIndex({
+        name: 'IDX_dmr_targetDataMart',
         columnNames: ['targetDataMartId'],
-        referencedTableName: 'data_mart',
-        referencedColumnNames: ['id'],
-        onDelete: 'CASCADE',
-        onUpdate: 'NO ACTION',
       })
     );
-
-    const hasColumnConfig = await queryRunner.hasColumn(
-      this.REPORT_TABLE,
-      this.COLUMN_CONFIG_COLUMN
-    );
-    if (!hasColumnConfig) {
-      await queryRunner.addColumn(
-        this.REPORT_TABLE,
-        new TableColumn({
-          name: this.COLUMN_CONFIG_COLUMN,
-          type: 'json',
-          isNullable: true,
-          default: null,
-        })
-      );
-    }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    const hasColumnConfig = await queryRunner.hasColumn(
-      this.REPORT_TABLE,
-      this.COLUMN_CONFIG_COLUMN
-    );
-    if (hasColumnConfig) {
-      await queryRunner.dropColumn(this.REPORT_TABLE, this.COLUMN_CONFIG_COLUMN);
-    }
-
     await softDropTable(queryRunner, this.RELATIONSHIP_TABLE);
   }
 }

--- a/apps/backend/src/migrations/1776616688331-add-data-mart-relationship.ts
+++ b/apps/backend/src/migrations/1776616688331-add-data-mart-relationship.ts
@@ -1,0 +1,108 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableColumn,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+import { softDropTable } from './migration-utils';
+
+export class AddDataMartRelationship1776616688331 implements MigrationInterface {
+  public readonly name = 'AddDataMartRelationship1776616688331';
+
+  private readonly RELATIONSHIP_TABLE = 'data_mart_relationship';
+  private readonly REPORT_TABLE = 'report';
+  private readonly COLUMN_CONFIG_COLUMN = 'columnConfig';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: this.RELATIONSHIP_TABLE,
+        columns: [
+          { name: 'id', type: 'varchar', length: '36', isPrimary: true, isNullable: false },
+          { name: 'dataStorageId', type: 'varchar', length: '36', isNullable: false },
+          { name: 'sourceDataMartId', type: 'varchar', length: '36', isNullable: false },
+          { name: 'targetDataMartId', type: 'varchar', length: '36', isNullable: false },
+          { name: 'targetAlias', type: 'varchar', length: '255', isNullable: false },
+          { name: 'joinConditions', type: 'json', isNullable: false },
+          { name: 'projectId', type: 'varchar', length: '255', isNullable: false },
+          { name: 'createdById', type: 'varchar', length: '255', isNullable: false },
+          { name: 'createdAt', type: 'datetime', isNullable: false, default: 'CURRENT_TIMESTAMP' },
+          { name: 'modifiedAt', type: 'datetime', isNullable: false, default: 'CURRENT_TIMESTAMP' },
+        ],
+      }),
+      true
+    );
+
+    await queryRunner.createIndex(
+      this.RELATIONSHIP_TABLE,
+      new TableIndex({
+        name: 'UQ_data_mart_relationship_source_alias',
+        columnNames: ['sourceDataMartId', 'targetAlias'],
+        isUnique: true,
+      })
+    );
+
+    await queryRunner.createForeignKey(
+      this.RELATIONSHIP_TABLE,
+      new TableForeignKey({
+        columnNames: ['dataStorageId'],
+        referencedTableName: 'data_storage',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+        onUpdate: 'NO ACTION',
+      })
+    );
+
+    await queryRunner.createForeignKey(
+      this.RELATIONSHIP_TABLE,
+      new TableForeignKey({
+        columnNames: ['sourceDataMartId'],
+        referencedTableName: 'data_mart',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+        onUpdate: 'NO ACTION',
+      })
+    );
+
+    await queryRunner.createForeignKey(
+      this.RELATIONSHIP_TABLE,
+      new TableForeignKey({
+        columnNames: ['targetDataMartId'],
+        referencedTableName: 'data_mart',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+        onUpdate: 'NO ACTION',
+      })
+    );
+
+    const hasColumnConfig = await queryRunner.hasColumn(
+      this.REPORT_TABLE,
+      this.COLUMN_CONFIG_COLUMN
+    );
+    if (!hasColumnConfig) {
+      await queryRunner.addColumn(
+        this.REPORT_TABLE,
+        new TableColumn({
+          name: this.COLUMN_CONFIG_COLUMN,
+          type: 'json',
+          isNullable: true,
+          default: null,
+        })
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const hasColumnConfig = await queryRunner.hasColumn(
+      this.REPORT_TABLE,
+      this.COLUMN_CONFIG_COLUMN
+    );
+    if (hasColumnConfig) {
+      await queryRunner.dropColumn(this.REPORT_TABLE, this.COLUMN_CONFIG_COLUMN);
+    }
+
+    await softDropTable(queryRunner, this.RELATIONSHIP_TABLE);
+  }
+}

--- a/apps/backend/src/migrations/1776616688332-add-blended-fields-config-to-data-mart.ts
+++ b/apps/backend/src/migrations/1776616688332-add-blended-fields-config-to-data-mart.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddBlendedFieldsConfigToDataMart1776616688332 implements MigrationInterface {
+  public readonly name = 'AddBlendedFieldsConfigToDataMart1776616688332';
+
+  private readonly TABLE = 'data_mart';
+  private readonly COLUMN = 'blendedFieldsConfig';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const hasColumn = await queryRunner.hasColumn(this.TABLE, this.COLUMN);
+    if (!hasColumn) {
+      await queryRunner.addColumn(
+        this.TABLE,
+        new TableColumn({
+          name: this.COLUMN,
+          type: 'json',
+          isNullable: true,
+          default: null,
+        })
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const hasColumn = await queryRunner.hasColumn(this.TABLE, this.COLUMN);
+    if (hasColumn) {
+      await queryRunner.dropColumn(this.TABLE, this.COLUMN);
+    }
+  }
+}

--- a/apps/backend/src/migrations/1776616688333-add-column-config-to-report.ts
+++ b/apps/backend/src/migrations/1776616688333-add-column-config-to-report.ts
@@ -1,11 +1,11 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 import { getTable } from './migration-utils';
 
-export class AddBlendedFieldsConfigToDataMart1776616688332 implements MigrationInterface {
-  public readonly name = 'AddBlendedFieldsConfigToDataMart1776616688332';
+export class AddColumnConfigToReport1776616688333 implements MigrationInterface {
+  public readonly name = 'AddColumnConfigToReport1776616688333';
 
-  private readonly TABLE = 'data_mart';
-  private readonly COLUMN = 'blendedFieldsConfig';
+  private readonly TABLE = 'report';
+  private readonly COLUMN = 'columnConfig';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     const table = await getTable(queryRunner, this.TABLE);

--- a/apps/backend/test/looker-studio-connector.e2e-spec.ts
+++ b/apps/backend/test/looker-studio-connector.e2e-spec.ts
@@ -48,6 +48,7 @@ const mockCacheService = {
     reader: mockReader,
     dataDescription: new ReportDataDescription(MOCK_HEADERS, MOCK_ROWS.length),
     fromCache: false,
+    blendingDecision: { needsBlending: false },
   }),
 };
 
@@ -135,6 +136,7 @@ describe('Looker Studio Connector (e2e)', () => {
       reader: mockReader,
       dataDescription: new ReportDataDescription(MOCK_HEADERS, MOCK_ROWS.length),
       fromCache: false,
+      blendingDecision: { needsBlending: false },
     });
     mockReader.readReportDataBatch.mockResolvedValue(new ReportDataBatch(MOCK_ROWS, null));
     mockSchemaProviderFacade.getActualDataMartSchema.mockResolvedValue({

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -6,17 +6,17 @@ export default tseslint.config(
   {
     ignores: ['src/features/data-marts/insights-prev/**'],
   },
-  // Disable TypeScript type-checking for config files in root
-  {
-    files: ['*.config.{js,mjs,ts}'],
-    extends: [tseslint.configs.disableTypeChecked],
-  },
   // Allow numbers in template literals (e.g. field array index paths like `items.${index}.name`)
   {
     files: ['**/*.{ts,tsx}'],
     rules: {
       '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
     },
+  },
+  // Disable TypeScript type-checking for config files in root
+  {
+    files: ['*.config.{js,mjs,ts}'],
+    extends: [tseslint.configs.disableTypeChecked],
   },
   // E2E tests: disable type-checked rules and React hooks (Playwright `use` triggers false positives)
   {

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -11,6 +11,13 @@ export default tseslint.config(
     files: ['*.config.{js,mjs,ts}'],
     extends: [tseslint.configs.disableTypeChecked],
   },
+  // Allow numbers in template literals (e.g. field array index paths like `items.${index}.name`)
+  {
+    files: ['**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
+    },
+  },
   // E2E tests: disable type-checked rules and React hooks (Playwright `use` triggers false positives)
   {
     files: ['e2e/**/*.ts'],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,12 @@
     "react-hook-form": "^7.58.0",
     "react-hot-toast": "^2.5.2",
     "react-router-dom": "^7.6.2",
+    "rete": "^2.0.6",
+    "rete-area-plugin": "^2.1.5",
+    "rete-connection-plugin": "^2.0.5",
+    "rete-minimap-plugin": "^2.0.3",
+    "rete-react-plugin": "^2.1.0",
+    "styled-components": "^6.3.12",
     "tailwindcss": "^4.1.8"
   },
   "devDependencies": {

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
@@ -57,6 +57,7 @@ const VIEW_MODE_KEY = 'relationship-view-mode';
 const CONTENT_MIN_H = 480;
 
 const DEFAULT_BLENDED_FIELDS_CONFIG: BlendedFieldsConfig = { sources: [] };
+const EMPTY_STRING_ARRAY: string[] = [];
 
 interface DataMartRelationshipsContentProps {
   onRelationshipsChanged?: () => void;
@@ -229,6 +230,25 @@ export function DataMartRelationshipsContent({
         row.relationship.targetAlias.toLowerCase().includes(q)
     );
   }, [transientRows, searchQuery]);
+
+  // Backend enforces (sourceDataMartId, targetAlias) uniqueness. Precompute
+  // sibling aliases per relationship so each row gets a stable reference and
+  // the form can flag conflicts inline before the request fires.
+  const siblingAliasesByRelId = useMemo(() => {
+    const bySource = new Map<string, DataMartRelationship[]>();
+    for (const r of relationships) {
+      const arr = bySource.get(r.sourceDataMart.id);
+      if (arr) arr.push(r);
+      else bySource.set(r.sourceDataMart.id, [r]);
+    }
+    const result: Record<string, string[]> = {};
+    for (const r of relationships) {
+      result[r.id] = (bySource.get(r.sourceDataMart.id) ?? [])
+        .filter(sibling => sibling.id !== r.id)
+        .map(sibling => sibling.targetAlias);
+    }
+    return result;
+  }, [relationships]);
 
   const handleDelete = useCallback(
     async (id: string) => {
@@ -444,6 +464,7 @@ export function DataMartRelationshipsContent({
           // inherits the previous one's `isIncluded` / alias overrides.
           const source = sourceList.find(s => s.aliasPath === row.aliasPath) ?? null;
           const isNewlyCreated = rel.id === newlyCreatedId;
+          const siblingAliases = siblingAliasesByRelId[rel.id] ?? EMPTY_STRING_ARRAY;
 
           return (
             <RelationshipAccordionItem
@@ -452,6 +473,7 @@ export function DataMartRelationshipsContent({
               source={source}
               dataMartId={dataMartId}
               storageId={storageId}
+              siblingAliases={siblingAliases}
               defaultOpenTab={isNewlyCreated ? 'join-settings' : undefined}
               readOnly={false}
               onDelete={handleDelete}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
@@ -10,10 +10,12 @@ import {
 import { Skeleton } from '@owox/ui/components/skeleton';
 import { Tabs, TabsList, TabsTrigger } from '@owox/ui/components/tabs';
 import { GitMerge, Link2, List, Network, Plus } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'react-hot-toast';
+import { useQueryClient } from '@tanstack/react-query';
 import { useDataMartContext } from '../../model/context/useDataMartContext';
 import { useDebounce } from '../../../../../hooks/useDebounce';
+import { BLENDABLE_SCHEMA_QUERY_KEY } from '../../../shared/hooks/useBlendedFieldNames';
 import { Button } from '../../../../../shared/components/Button';
 import {
   CollapsibleCard,
@@ -35,9 +37,21 @@ import type {
 
 import type { SourceEntry } from './RelationshipAccordionItem';
 import { RelationshipAccordionItem } from './RelationshipAccordionItem';
-import { RelationshipCanvas } from './RelationshipCanvas';
 import { TargetDataMartPicker } from './TargetDataMartPicker';
 import { useTransientRelationships } from './useTransientRelationships';
+
+// `RelationshipCanvas` pulls in Rete.js and its plugins (~50 kB gzipped).
+// Load it only when the user switches to graph view so the default table
+// path keeps the main bundle small.
+const RelationshipCanvas = lazy(() =>
+  import('./RelationshipCanvas').then(module => ({ default: module.RelationshipCanvas }))
+);
+
+const CanvasSuspenseFallback = (
+  <div className='flex h-full w-full items-center justify-center'>
+    <Skeleton className='h-full w-full' />
+  </div>
+);
 
 const VIEW_MODE_KEY = 'relationship-view-mode';
 const CONTENT_MIN_H = 480;
@@ -90,6 +104,11 @@ export function DataMartRelationshipsContent({
   onRelationshipsChanged,
 }: DataMartRelationshipsContentProps) {
   const { dataMart } = useDataMartContext();
+  const queryClient = useQueryClient();
+
+  const invalidateBlendableSchema = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: [BLENDABLE_SCHEMA_QUERY_KEY] });
+  }, [queryClient]);
 
   const [relationships, setRelationships] = useState<DataMartRelationship[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -217,21 +236,23 @@ export function DataMartRelationshipsContent({
         await dataMartRelationshipService.deleteRelationship(dataMartId, id);
         toast.success('Relationship deleted');
         setRelationships(prev => prev.filter(r => r.id !== id));
+        invalidateBlendableSchema();
         onRelationshipsChanged?.();
       } catch {
         toast.error('Failed to delete relationship');
       }
     },
-    [dataMartId, onRelationshipsChanged]
+    [dataMartId, invalidateBlendableSchema, onRelationshipsChanged]
   );
 
   const handleRelationshipUpdated = useCallback(
     (updated: DataMartRelationship) => {
       toast.success('Relationship updated');
       setRelationships(prev => prev.map(r => (r.id === updated.id ? updated : r)));
+      invalidateBlendableSchema();
       onRelationshipsChanged?.();
     },
-    [onRelationshipsChanged]
+    [invalidateBlendableSchema, onRelationshipsChanged]
   );
 
   const saveConfigAndRefresh = useCallback(
@@ -239,9 +260,10 @@ export function DataMartRelationshipsContent({
       setLocalConfig(newConfig);
       void dataMartRelationshipService.updateBlendedFieldsConfig(dataMartId, newConfig).then(() => {
         fetchBlendableSchema();
+        invalidateBlendableSchema();
       });
     },
-    [dataMartId, fetchBlendableSchema]
+    [dataMartId, fetchBlendableSchema, invalidateBlendableSchema]
   );
 
   const handleCreated = useCallback(
@@ -250,9 +272,10 @@ export function DataMartRelationshipsContent({
       setNewlyCreatedId(newRelationship.id);
       setIsAddingNew(false);
       setRelationships(prev => [...prev, newRelationship]);
+      invalidateBlendableSchema();
       onRelationshipsChanged?.();
     },
-    [onRelationshipsChanged]
+    [invalidateBlendableSchema, onRelationshipsChanged]
   );
 
   const updateSourceConfig = useCallback(
@@ -376,20 +399,22 @@ export function DataMartRelationshipsContent({
   function renderViewContent() {
     if (viewMode === 'graph') {
       return (
-        <RelationshipCanvas
-          dataMartId={dataMartId}
-          dataMartTitle={dmTitle}
-          dataMartDescription={dmDescription}
-          dataMartStatus={dmStatusCode}
-          relationships={relationships}
-          connectedFieldCounts={connectedFieldCounts}
-          searchQuery={searchQuery}
-          showTransient={showTransient}
-          onRequestFullscreen={() => {
-            setIsFullscreen(true);
-          }}
-          style={{ height: CONTENT_MIN_H }}
-        />
+        <Suspense fallback={CanvasSuspenseFallback}>
+          <RelationshipCanvas
+            dataMartId={dataMartId}
+            dataMartTitle={dmTitle}
+            dataMartDescription={dmDescription}
+            dataMartStatus={dmStatusCode}
+            relationships={relationships}
+            connectedFieldCounts={connectedFieldCounts}
+            searchQuery={searchQuery}
+            showTransient={showTransient}
+            onRequestFullscreen={() => {
+              setIsFullscreen(true);
+            }}
+            style={{ height: CONTENT_MIN_H }}
+          />
+        </Suspense>
       );
     }
 
@@ -550,18 +575,20 @@ export function DataMartRelationshipsContent({
             </Button>
           </DialogHeader>
           {isFullscreen && (
-            <RelationshipCanvas
-              dataMartId={dataMartId}
-              dataMartTitle={dataMart.title}
-              dataMartDescription={dataMart.description}
-              dataMartStatus={dataMart.status.code}
-              relationships={relationships}
-              connectedFieldCounts={connectedFieldCounts}
-              searchQuery={searchQuery}
-              showTransient={showTransient}
-              className='rounded-none border-0'
-              style={{ width: '100%', height: '100%' }}
-            />
+            <Suspense fallback={CanvasSuspenseFallback}>
+              <RelationshipCanvas
+                dataMartId={dataMartId}
+                dataMartTitle={dataMart.title}
+                dataMartDescription={dataMart.description}
+                dataMartStatus={dataMart.status.code}
+                relationships={relationships}
+                connectedFieldCounts={connectedFieldCounts}
+                searchQuery={searchQuery}
+                showTransient={showTransient}
+                className='rounded-none border-0'
+                style={{ width: '100%', height: '100%' }}
+              />
+            </Suspense>
           )}
         </DialogContent>
       </Dialog>

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
@@ -1,0 +1,570 @@
+import { SearchInput } from '@owox/ui/components/common/search-input';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@owox/ui/components/dialog';
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@owox/ui/components/empty';
+import { Skeleton } from '@owox/ui/components/skeleton';
+import { Tabs, TabsList, TabsTrigger } from '@owox/ui/components/tabs';
+import { GitMerge, Link2, List, Network, Plus } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { useDataMartContext } from '../../model/context/useDataMartContext';
+import { useDebounce } from '../../../../../hooks/useDebounce';
+import { Button } from '../../../../../shared/components/Button';
+import {
+  CollapsibleCard,
+  CollapsibleCardContent,
+  CollapsibleCardFooter,
+  CollapsibleCardHeader,
+  CollapsibleCardHeaderTitle,
+} from '../../../../../shared/components/CollapsibleCard';
+import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
+import type {
+  AvailableSource,
+  BlendableSchema,
+  BlendedField,
+  BlendedFieldOverride,
+  BlendedFieldsConfig,
+  BlendedSource,
+  DataMartRelationship,
+} from '../../../shared/types/relationship.types';
+
+import type { SourceEntry } from './RelationshipAccordionItem';
+import { RelationshipAccordionItem } from './RelationshipAccordionItem';
+import { RelationshipCanvas } from './RelationshipCanvas';
+import { TargetDataMartPicker } from './TargetDataMartPicker';
+import { useTransientRelationships } from './useTransientRelationships';
+
+const VIEW_MODE_KEY = 'relationship-view-mode';
+const CONTENT_MIN_H = 480;
+
+const DEFAULT_BLENDED_FIELDS_CONFIG: BlendedFieldsConfig = { sources: [] };
+
+interface DataMartRelationshipsContentProps {
+  onRelationshipsChanged?: () => void;
+}
+
+function buildSourceList(
+  availableSources: AvailableSource[],
+  blendedFields: BlendedField[],
+  config: BlendedFieldsConfig
+): SourceEntry[] {
+  const fieldsByPath = new Map<string, BlendedField[]>();
+  for (const field of blendedFields) {
+    const existing = fieldsByPath.get(field.aliasPath);
+    if (existing) {
+      existing.push(field);
+    } else {
+      fieldsByPath.set(field.aliasPath, [field]);
+    }
+  }
+
+  return availableSources.map(src => {
+    const configSource = config.sources.find(s => s.path === src.aliasPath);
+    const overrideCount = configSource?.fields
+      ? Object.values(configSource.fields).filter(
+          v =>
+            v.isHidden !== undefined || v.aggregateFunction !== undefined || v.alias !== undefined
+        ).length
+      : 0;
+
+    return {
+      aliasPath: src.aliasPath,
+      title: src.title,
+      alias: configSource?.alias ?? src.defaultAlias,
+      depth: src.depth - 1,
+      fieldCount: src.fieldCount,
+      overrideCount,
+      isIncluded: src.isIncluded,
+      fields: fieldsByPath.get(src.aliasPath) ?? [],
+      dataMartId: src.dataMartId,
+    };
+  });
+}
+
+export function DataMartRelationshipsContent({
+  onRelationshipsChanged,
+}: DataMartRelationshipsContentProps) {
+  const { dataMart } = useDataMartContext();
+
+  const [relationships, setRelationships] = useState<DataMartRelationship[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isAddingNew, setIsAddingNew] = useState(false);
+  const [newlyCreatedId, setNewlyCreatedId] = useState<string | null>(null);
+  const [searchInput, setSearchInput] = useState('');
+  const searchQuery = useDebounce(searchInput, 300);
+
+  const [viewMode, setViewMode] = useState<'table' | 'graph'>(() => {
+    const stored = localStorage.getItem(VIEW_MODE_KEY);
+    return stored === 'graph' ? 'graph' : 'table';
+  });
+  const showTransient = true;
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const dataMartId = dataMart?.id ?? '';
+  const storageId = dataMart?.storage.id ?? '';
+
+  const localBlendedFieldsConfig: BlendedFieldsConfig =
+    dataMart?.blendedFieldsConfig ?? DEFAULT_BLENDED_FIELDS_CONFIG;
+  const [localConfig, setLocalConfig] = useState<BlendedFieldsConfig>(localBlendedFieldsConfig);
+
+  useEffect(() => {
+    setLocalConfig(dataMart?.blendedFieldsConfig ?? DEFAULT_BLENDED_FIELDS_CONFIG);
+  }, [dataMart?.blendedFieldsConfig]);
+
+  useEffect(() => {
+    localStorage.setItem(VIEW_MODE_KEY, viewMode);
+  }, [viewMode]);
+
+  const loadRelationships = useCallback(async () => {
+    if (!dataMartId) return;
+    setIsLoading(true);
+    try {
+      const data = await dataMartRelationshipService.getRelationships(dataMartId);
+      // Sort by createdAt ASC — oldest on top, newest at bottom
+      const sorted = [...data].sort(
+        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      );
+      setRelationships(sorted);
+    } catch {
+      toast.error('Failed to load relationships');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dataMartId]);
+
+  useEffect(() => {
+    void loadRelationships();
+  }, [loadRelationships]);
+
+  const [blendableSchema, setBlendableSchema] = useState<BlendableSchema | null>(null);
+  // Create + setRelationships can race: both trigger a schema fetch and a slow
+  // first response could overwrite a newer one. Discard anything that isn't
+  // the latest in-flight request.
+  const schemaRequestIdRef = useRef(0);
+
+  const fetchBlendableSchema = useCallback(
+    (showLoading = false) => {
+      if (!dataMartId) return;
+      const requestId = ++schemaRequestIdRef.current;
+      if (showLoading) setIsLoading(true);
+      dataMartRelationshipService
+        .getBlendableSchema(dataMartId)
+        .then(data => {
+          if (schemaRequestIdRef.current !== requestId) return;
+          setBlendableSchema(data);
+        })
+        .catch(() => {
+          if (schemaRequestIdRef.current !== requestId) return;
+          setBlendableSchema(null);
+        })
+        .finally(() => {
+          if (showLoading && schemaRequestIdRef.current === requestId) setIsLoading(false);
+        });
+    },
+    [dataMartId]
+  );
+
+  useEffect(() => {
+    fetchBlendableSchema();
+  }, [fetchBlendableSchema, relationships]);
+
+  const sourceList = useMemo(() => {
+    if (!blendableSchema) return [];
+    return buildSourceList(
+      blendableSchema.availableSources,
+      blendableSchema.blendedFields,
+      localConfig
+    );
+  }, [blendableSchema, localConfig]);
+
+  const connectedFieldCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    if (!blendableSchema) return counts;
+    for (const field of blendableSchema.blendedFields) {
+      if (field.type === 'UNKNOWN') continue;
+      const relId = field.sourceRelationshipId;
+      counts.set(relId, (counts.get(relId) ?? 0) + 1);
+    }
+    return counts;
+  }, [blendableSchema]);
+
+  const { rows: transientRows, isLoading: isLoadingTransient } = useTransientRelationships(
+    dataMartId,
+    dataMart?.title ?? '',
+    dataMart?.status.code ?? '',
+    relationships,
+    showTransient
+  );
+
+  const filteredRows = useMemo(() => {
+    if (!searchQuery) return transientRows;
+    const q = searchQuery.toLowerCase();
+    return transientRows.filter(
+      row =>
+        row.relationship.targetDataMart.title.toLowerCase().includes(q) ||
+        row.relationship.targetAlias.toLowerCase().includes(q)
+    );
+  }, [transientRows, searchQuery]);
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        await dataMartRelationshipService.deleteRelationship(dataMartId, id);
+        toast.success('Relationship deleted');
+        setRelationships(prev => prev.filter(r => r.id !== id));
+        onRelationshipsChanged?.();
+      } catch {
+        toast.error('Failed to delete relationship');
+      }
+    },
+    [dataMartId, onRelationshipsChanged]
+  );
+
+  const handleRelationshipUpdated = useCallback(
+    (updated: DataMartRelationship) => {
+      toast.success('Relationship updated');
+      setRelationships(prev => prev.map(r => (r.id === updated.id ? updated : r)));
+      onRelationshipsChanged?.();
+    },
+    [onRelationshipsChanged]
+  );
+
+  const saveConfigAndRefresh = useCallback(
+    (newConfig: BlendedFieldsConfig) => {
+      setLocalConfig(newConfig);
+      void dataMartRelationshipService.updateBlendedFieldsConfig(dataMartId, newConfig).then(() => {
+        fetchBlendableSchema();
+      });
+    },
+    [dataMartId, fetchBlendableSchema]
+  );
+
+  const handleCreated = useCallback(
+    (newRelationship: DataMartRelationship) => {
+      toast.success('Relationship added');
+      setNewlyCreatedId(newRelationship.id);
+      setIsAddingNew(false);
+      setRelationships(prev => [...prev, newRelationship]);
+      onRelationshipsChanged?.();
+    },
+    [onRelationshipsChanged]
+  );
+
+  const updateSourceConfig = useCallback(
+    (path: string, updater: (current: BlendedSource | undefined) => BlendedSource) => {
+      const existingSources = localConfig.sources.filter(s => s.path !== path);
+      const currentSource = localConfig.sources.find(s => s.path === path);
+      saveConfigAndRefresh({
+        ...localConfig,
+        sources: [...existingSources, updater(currentSource)],
+      });
+    },
+    [localConfig, saveConfigAndRefresh]
+  );
+
+  const handleSourceAliasChange = useCallback(
+    (source: SourceEntry, alias: string) => {
+      updateSourceConfig(source.aliasPath, current => ({
+        path: source.aliasPath,
+        alias,
+        ...(current?.isExcluded ? { isExcluded: true } : {}),
+        ...(current?.fields ? { fields: current.fields } : {}),
+      }));
+    },
+    [updateSourceConfig]
+  );
+
+  const handleSourceHideChange = useCallback(
+    (aliasPath: string, alias: string, isHidden: boolean) => {
+      updateSourceConfig(aliasPath, current => ({
+        path: aliasPath,
+        alias,
+        ...(isHidden && { isExcluded: true }),
+        ...(current?.fields && { fields: current.fields }),
+      }));
+    },
+    [updateSourceConfig]
+  );
+
+  const handleFieldOverrideChange = useCallback(
+    (source: SourceEntry, fieldName: string, override: Partial<BlendedFieldOverride>) => {
+      updateSourceConfig(source.aliasPath, current => {
+        const currentFields = current?.fields ?? {};
+        const merged: BlendedFieldOverride = {
+          ...(currentFields[fieldName] ?? {}),
+          ...override,
+        };
+
+        const cleanOverride: BlendedFieldOverride = {};
+        if (merged.alias !== undefined && merged.alias !== '') cleanOverride.alias = merged.alias;
+        if (merged.isHidden !== undefined) cleanOverride.isHidden = merged.isHidden;
+        if (merged.aggregateFunction !== undefined) {
+          cleanOverride.aggregateFunction = merged.aggregateFunction;
+        }
+
+        const newFields: Record<string, BlendedFieldOverride> = {};
+        for (const [key, val] of Object.entries(currentFields)) {
+          if (key !== fieldName) newFields[key] = val;
+        }
+        if (Object.keys(cleanOverride).length > 0) {
+          newFields[fieldName] = cleanOverride;
+        }
+
+        return {
+          path: source.aliasPath,
+          alias: current?.alias ?? source.alias,
+          ...(current?.isExcluded ? { isExcluded: true } : {}),
+          ...(Object.keys(newFields).length > 0 ? { fields: newFields } : {}),
+        };
+      });
+    },
+    [updateSourceConfig]
+  );
+
+  if (!dataMart) return null;
+
+  const dmTitle = dataMart.title;
+  const dmDescription = dataMart.description;
+  const dmStatusCode = dataMart.status.code;
+
+  function renderToolbar() {
+    return (
+      <div className='flex items-center justify-between gap-2 pb-4'>
+        <SearchInput
+          id='search-relationships'
+          placeholder='Search data marts'
+          value={searchInput}
+          onChange={setSearchInput}
+          debounceTime={0}
+          className='border-muted dark:border-muted/50 rounded-md border bg-white pl-8 text-sm dark:bg-white/4 dark:hover:bg-white/8'
+          aria-label='Search data marts'
+        />
+        <div className='flex items-center gap-2'>
+          {transientRows.length > 0 && (
+            <span className='text-muted-foreground mr-2 flex items-center gap-1 text-sm'>
+              <GitMerge className='h-3.5 w-3.5' />
+              {transientRows.length}
+            </span>
+          )}
+          <Tabs
+            value={viewMode}
+            onValueChange={v => {
+              setViewMode(v as 'table' | 'graph');
+            }}
+          >
+            <TabsList>
+              <TabsTrigger value='table' title='Table view'>
+                <List className='h-4 w-4' />
+                List
+              </TabsTrigger>
+              <TabsTrigger value='graph' title='Diagram view'>
+                <Network className='h-4 w-4' />
+                Graph
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+      </div>
+    );
+  }
+
+  function renderViewContent() {
+    if (viewMode === 'graph') {
+      return (
+        <RelationshipCanvas
+          dataMartId={dataMartId}
+          dataMartTitle={dmTitle}
+          dataMartDescription={dmDescription}
+          dataMartStatus={dmStatusCode}
+          relationships={relationships}
+          connectedFieldCounts={connectedFieldCounts}
+          searchQuery={searchQuery}
+          showTransient={showTransient}
+          onRequestFullscreen={() => {
+            setIsFullscreen(true);
+          }}
+          style={{ height: CONTENT_MIN_H }}
+        />
+      );
+    }
+
+    if (isLoadingTransient) {
+      return (
+        <div className='flex flex-col gap-2 p-4'>
+          <Skeleton className='h-16 w-full' />
+          <Skeleton className='h-16 w-full' />
+        </div>
+      );
+    }
+
+    if (filteredRows.length === 0 && searchQuery) {
+      return (
+        <div className='text-muted-foreground px-4 py-6 text-sm'>
+          No relationships match your search.
+        </div>
+      );
+    }
+
+    return (
+      <div className='flex flex-col gap-2 py-2'>
+        {filteredRows.map(row => {
+          const rel = row.relationship;
+          // Match by aliasPath — two relationships to the same DM must each
+          // resolve to their own source entry, otherwise a new relationship
+          // inherits the previous one's `isIncluded` / alias overrides.
+          const source = sourceList.find(s => s.aliasPath === row.aliasPath) ?? null;
+          const isNewlyCreated = rel.id === newlyCreatedId;
+
+          return (
+            <RelationshipAccordionItem
+              key={row.rowKey}
+              row={row}
+              source={source}
+              dataMartId={dataMartId}
+              storageId={storageId}
+              defaultOpenTab={isNewlyCreated ? 'join-settings' : undefined}
+              readOnly={false}
+              onDelete={handleDelete}
+              onRelationshipUpdated={handleRelationshipUpdated}
+              onAliasChange={handleSourceAliasChange}
+              onHideForReportingChange={handleSourceHideChange}
+              onFieldOverrideChange={handleFieldOverrideChange}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  function renderContent() {
+    if (isLoading) {
+      return <Skeleton className='h-[480px] w-full rounded-lg' />;
+    }
+
+    if (relationships.length === 0) {
+      return (
+        <Empty className='gap-4 p-6 md:p-8'>
+          <EmptyHeader className='max-w-none'>
+            <EmptyMedia variant='icon'>
+              <Network />
+            </EmptyMedia>
+            <EmptyTitle>No joined data marts yet</EmptyTitle>
+            <EmptyDescription>
+              Join a data mart to extend this one with fields from related sources.
+            </EmptyDescription>
+          </EmptyHeader>
+          {isAddingNew ? (
+            <TargetDataMartPicker
+              dataMartId={dataMartId}
+              storageId={storageId}
+              existingRelationships={relationships}
+              onCreated={handleCreated}
+              onCancel={() => {
+                setIsAddingNew(false);
+              }}
+            />
+          ) : (
+            <Button
+              variant='outline'
+              onClick={() => {
+                setIsAddingNew(true);
+              }}
+              className='mt-4'
+            >
+              <Plus className='h-4 w-4' />
+              Join Data Mart
+            </Button>
+          )}
+        </Empty>
+      );
+    }
+
+    return (
+      <>
+        {renderToolbar()}
+        {renderViewContent()}
+        <div className='pt-4'>
+          {isAddingNew ? (
+            <TargetDataMartPicker
+              dataMartId={dataMartId}
+              storageId={storageId}
+              existingRelationships={relationships}
+              onCreated={handleCreated}
+              onCancel={() => {
+                setIsAddingNew(false);
+              }}
+            />
+          ) : (
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => {
+                setNewlyCreatedId(null);
+                setIsAddingNew(true);
+              }}
+            >
+              <Plus className='h-4 w-4' />
+              Join Data Mart
+            </Button>
+          )}
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <CollapsibleCard collapsible name='relationships'>
+        <CollapsibleCardHeader>
+          <CollapsibleCardHeaderTitle
+            icon={Link2}
+            tooltip='Joinable data marts connected to this one'
+          >
+            Joinable Data Marts
+          </CollapsibleCardHeaderTitle>
+        </CollapsibleCardHeader>
+        <CollapsibleCardContent>{renderContent()}</CollapsibleCardContent>
+        <CollapsibleCardFooter />
+      </CollapsibleCard>
+
+      <Dialog open={isFullscreen} onOpenChange={setIsFullscreen}>
+        <DialogContent
+          className='flex h-[90vh] max-w-[95vw] flex-col gap-0 p-0 sm:max-w-[95vw]'
+          showCloseButton={false}
+        >
+          <DialogHeader className='flex-row items-center justify-between border-b px-6 py-4'>
+            <DialogTitle>Relationship Diagram</DialogTitle>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => {
+                setIsFullscreen(false);
+              }}
+            >
+              Close
+            </Button>
+          </DialogHeader>
+          {isFullscreen && (
+            <RelationshipCanvas
+              dataMartId={dataMartId}
+              dataMartTitle={dataMart.title}
+              dataMartDescription={dataMart.description}
+              dataMartStatus={dataMart.status.code}
+              relationships={relationships}
+              connectedFieldCounts={connectedFieldCounts}
+              searchQuery={searchQuery}
+              showTransient={showTransient}
+              className='rounded-none border-0'
+              style={{ width: '100%', height: '100%' }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
@@ -30,17 +30,22 @@ const joinConditionSchema = z.object({
   targetFieldName: z.string().min(1, 'Related field is required'),
 });
 
-const joinSettingsFormSchema = z.object({
-  targetAlias: z
-    .string()
-    .min(1, 'Field prefix is required')
-    .regex(/^[a-z0-9_]+$/, {
-      message: 'Field prefix must contain only lowercase letters, numbers, and underscores',
-    }),
-  joinConditions: z.array(joinConditionSchema).min(1, 'At least one join condition is required'),
-});
+function buildJoinSettingsFormSchema(siblingAliasesRef: { current: Set<string> }) {
+  return z.object({
+    targetAlias: z
+      .string()
+      .min(1, 'Field prefix is required')
+      .regex(/^[a-z0-9_]+$/, {
+        message: 'Field prefix must contain only lowercase letters, numbers, and underscores',
+      })
+      .refine(val => !siblingAliasesRef.current.has(val), {
+        message: 'This alias is already used by another joined data mart',
+      }),
+    joinConditions: z.array(joinConditionSchema).min(1, 'At least one join condition is required'),
+  });
+}
 
-type JoinSettingsFormValues = z.infer<typeof joinSettingsFormSchema>;
+type JoinSettingsFormValues = z.infer<ReturnType<typeof buildJoinSettingsFormSchema>>;
 
 interface FlatField {
   name: string;
@@ -91,6 +96,8 @@ interface JoinSettingsFormProps {
   relationship: DataMartRelationship;
   dataMartId: string;
   readOnly?: boolean;
+  /** Aliases used by other relationships that share the same source data mart. */
+  siblingAliases: string[];
   /**
    * When set, the join is inherited from a parent data mart and must be edited there.
    * Renders an informational banner with a link to the parent.
@@ -103,6 +110,7 @@ export function JoinSettingsForm({
   relationship,
   dataMartId,
   readOnly = false,
+  siblingAliases,
   inheritedFrom,
   onSaved,
 }: JoinSettingsFormProps) {
@@ -112,14 +120,30 @@ export function JoinSettingsForm({
   const [isLoadingSchemas, setIsLoadingSchemas] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
+  // Zod's `refine` closes over a ref so the schema instance stays stable while the
+  // set of taken aliases changes. Paired with `form.trigger` below to re-validate
+  // when siblings are added or renamed.
+  const siblingAliasesRef = useRef<Set<string>>(new Set(siblingAliases));
+  const formSchema = useMemo(() => buildJoinSettingsFormSchema(siblingAliasesRef), []);
+
   const form = useForm<JoinSettingsFormValues>({
-    resolver: zodResolver(joinSettingsFormSchema),
+    resolver: zodResolver(formSchema),
     mode: 'onChange',
     defaultValues: getInitialDefaults(relationship),
   });
 
-  const lastSavedKeyRef = useRef<string>(JSON.stringify(getInitialDefaults(relationship)));
-  const lastAttemptedKeyRef = useRef<string>(JSON.stringify(getInitialDefaults(relationship)));
+  useEffect(() => {
+    siblingAliasesRef.current = new Set(siblingAliases);
+    void form.trigger('targetAlias');
+  }, [siblingAliases, form]);
+
+  // Track saved/attempted state per field so targetAlias can autosave even while
+  // joinConditions are incomplete (e.g. "Join not configured" relationships).
+  const lastSavedRef = useRef({
+    targetAlias: relationship.targetAlias,
+    joinConditionsKey: JSON.stringify(relationship.joinConditions),
+  });
+  const lastAttemptedRef = useRef(lastSavedRef.current);
 
   const {
     fields: joinFields,
@@ -131,11 +155,13 @@ export function JoinSettingsForm({
   });
 
   useEffect(() => {
-    const defaults = getInitialDefaults(relationship);
-    const key = JSON.stringify(defaults);
-    form.reset(defaults);
-    lastSavedKeyRef.current = key;
-    lastAttemptedKeyRef.current = key;
+    form.reset(getInitialDefaults(relationship));
+    const snapshot = {
+      targetAlias: relationship.targetAlias,
+      joinConditionsKey: JSON.stringify(relationship.joinConditions),
+    };
+    lastSavedRef.current = snapshot;
+    lastAttemptedRef.current = snapshot;
   }, [relationship, form]);
 
   useEffect(() => {
@@ -177,15 +203,9 @@ export function JoinSettingsForm({
   const hasTypeMismatch = joinTypeMismatches.some(Boolean);
 
   const debouncedKey = useDebounce(watchedKey, 800);
-  const isValid = form.formState.isValid;
 
   useEffect(() => {
-    if (readOnly || isSaving || !isValid || hasTypeMismatch) return;
-    if (debouncedKey === lastSavedKeyRef.current) return;
-    // Without this guard a failed save keeps `lastSavedKeyRef` stale, so the
-    // next `isSaving=false` flip would re-run the effect and repost the same
-    // payload in a tight loop — a wall of error toasts the user cannot escape.
-    if (debouncedKey === lastAttemptedKeyRef.current) return;
+    if (readOnly || isSaving) return;
 
     let parsed: JoinSettingsFormValues;
     try {
@@ -194,34 +214,55 @@ export function JoinSettingsForm({
       return;
     }
 
-    lastAttemptedKeyRef.current = debouncedKey;
+    const parsedJoinKey = JSON.stringify(parsed.joinConditions);
+    const hasAliasError = !!form.formState.errors.targetAlias;
+    const joinsAreComplete =
+      parsed.joinConditions.length > 0 &&
+      parsed.joinConditions.every(jc => jc.sourceFieldName && jc.targetFieldName);
+
+    const aliasIsNew =
+      parsed.targetAlias !== lastSavedRef.current.targetAlias &&
+      parsed.targetAlias !== lastAttemptedRef.current.targetAlias;
+    const joinsAreNew =
+      parsedJoinKey !== lastSavedRef.current.joinConditionsKey &&
+      parsedJoinKey !== lastAttemptedRef.current.joinConditionsKey;
+
+    const payload: {
+      targetAlias?: string;
+      joinConditions?: JoinSettingsFormValues['joinConditions'];
+    } = {};
+    if (aliasIsNew && !hasAliasError) {
+      payload.targetAlias = parsed.targetAlias;
+    }
+    if (joinsAreNew && joinsAreComplete && !hasTypeMismatch) {
+      payload.joinConditions = parsed.joinConditions;
+    }
+    if (Object.keys(payload).length === 0) return;
+
+    // Mirror the payload into attempted refs so a failed save cannot loop on the
+    // same value (see original guard), while leaving untouched fields intact so
+    // they still eligible for their own autosave path.
+    lastAttemptedRef.current = {
+      targetAlias: payload.targetAlias ?? lastAttemptedRef.current.targetAlias,
+      joinConditionsKey: payload.joinConditions
+        ? parsedJoinKey
+        : lastAttemptedRef.current.joinConditionsKey,
+    };
     setIsSaving(true);
 
     dataMartRelationshipService
-      .updateRelationship(
-        dataMartId,
-        relationship.id,
-        {
-          targetAlias: parsed.targetAlias,
-          joinConditions: parsed.joinConditions,
-        },
-        { skipErrorToast: true }
-      )
+      .updateRelationship(dataMartId, relationship.id, payload, { skipErrorToast: true })
       .then(updated => {
-        lastSavedKeyRef.current = JSON.stringify({
+        lastSavedRef.current = {
           targetAlias: updated.targetAlias,
-          joinConditions: updated.joinConditions,
-        });
+          joinConditionsKey: JSON.stringify(updated.joinConditions),
+        };
         onSaved(updated);
       })
       .catch(() => {
-        // Suppress stale errors: the user may have already moved past this
-        // payload by the time the rejection arrives.
-        if (JSON.stringify(form.getValues()) === lastAttemptedKeyRef.current) {
-          toast.error('Failed to save join settings', {
-            id: `join-save-error-${relationship.id}`,
-          });
-        }
+        toast.error('Failed to save join settings', {
+          id: `join-save-error-${relationship.id}`,
+        });
       })
       .finally(() => {
         setIsSaving(false);
@@ -231,7 +272,6 @@ export function JoinSettingsForm({
     hasTypeMismatch,
     readOnly,
     isSaving,
-    isValid,
     dataMartId,
     relationship.id,
     onSaved,
@@ -261,48 +301,41 @@ export function JoinSettingsForm({
           </Button>
         </div>
       )}
-      {/* SQL Alias — internal, used for SQL JOIN construction. Target DM identity now lives
-          in the tabs row above, so this section only holds the SQL alias editor. Keep the
-          50/50 grid so the editor stays right-aligned and matches the Output Alias layout
-          in the Report Fields tab. */}
       <Form {...form}>
-        <div className='grid grid-cols-2 gap-3'>
-          <div />
-          <FormField
-            control={form.control}
-            name='targetAlias'
-            render={({ field }) => (
-              <FormItem
-                variant='light'
-                className='bg-muted/50 flex flex-col gap-1.5 rounded-md p-3 dark:bg-white/5'
-              >
-                <label className='flex items-center gap-1.5 text-sm font-medium'>
-                  SQL Alias
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
-                        <Info className='size-4 shrink-0' />
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side='top' className='max-w-xs'>
-                      Internal name used when building the SQL JOIN for this data mart (e.g.
-                      orders_customer_id). Not shown in the output.
-                    </TooltipContent>
-                  </Tooltip>
-                </label>
-                <FormControl>
-                  <Input
-                    {...field}
-                    placeholder='e.g. orders'
-                    disabled={readOnly}
-                    className='bg-background h-8 text-sm dark:bg-white/5'
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
+        <FormField
+          control={form.control}
+          name='targetAlias'
+          render={({ field }) => (
+            <FormItem
+              variant='light'
+              className='bg-muted/50 flex flex-col gap-1.5 rounded-md p-3 dark:bg-white/5'
+            >
+              <label className='flex items-center gap-1.5 text-sm font-medium'>
+                SQL Alias
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
+                      <Info className='size-4 shrink-0' />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side='top' className='max-w-xs'>
+                    Internal name used when building the SQL JOIN for this data mart (e.g.
+                    orders_customer_id). Not shown in the output.
+                  </TooltipContent>
+                </Tooltip>
+              </label>
+              <FormControl>
+                <Input
+                  {...field}
+                  placeholder='e.g. orders'
+                  disabled={readOnly}
+                  className='bg-background h-8 text-sm dark:bg-white/5'
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <Separator />
 

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
@@ -12,7 +12,7 @@ import { Separator } from '@owox/ui/components/separator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { cn } from '@owox/ui/lib/utils';
 import { ExternalLink, Info, Plus, Trash2 } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { z } from 'zod';
@@ -163,13 +163,17 @@ export function JoinSettingsForm({
   const watchedValues = form.watch();
   const watchedKey = JSON.stringify(watchedValues);
 
-  const joinTypeMismatches = watchedValues.joinConditions.map(jc => {
-    if (!jc.sourceFieldName || !jc.targetFieldName) return null;
-    const sourceType = sourceFields.find(f => f.name === jc.sourceFieldName)?.type;
-    const targetType = targetFields.find(f => f.name === jc.targetFieldName)?.type;
-    if (!sourceType || !targetType) return null;
-    return sourceType !== targetType ? { sourceType, targetType } : null;
-  });
+  const joinTypeMismatches = useMemo(
+    () =>
+      watchedValues.joinConditions.map(jc => {
+        if (!jc.sourceFieldName || !jc.targetFieldName) return null;
+        const sourceType = sourceFields.find(f => f.name === jc.sourceFieldName)?.type;
+        const targetType = targetFields.find(f => f.name === jc.targetFieldName)?.type;
+        if (!sourceType || !targetType) return null;
+        return sourceType !== targetType ? { sourceType, targetType } : null;
+      }),
+    [watchedValues.joinConditions, sourceFields, targetFields]
+  );
   const hasTypeMismatch = joinTypeMismatches.some(Boolean);
 
   const debouncedKey = useDebounce(watchedKey, 800);

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
@@ -1,0 +1,461 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@owox/ui/components/form';
+import { Input } from '@owox/ui/components/input';
+import { Separator } from '@owox/ui/components/separator';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { cn } from '@owox/ui/lib/utils';
+import { ExternalLink, Info, Plus, Trash2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useFieldArray, useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import { z } from 'zod';
+import { Button } from '../../../../../shared/components/Button';
+import { Combobox } from '../../../../../shared/components/Combobox/combobox';
+import { useProjectRoute } from '../../../../../shared/hooks/useProjectRoute';
+import { useDebounce } from '../../../../../hooks/useDebounce';
+import type { DataMartResponseDto } from '../../../shared';
+import { dataMartService } from '../../../shared';
+import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
+import type { DataMartRelationship } from '../../../shared/types/relationship.types';
+
+const joinConditionSchema = z.object({
+  sourceFieldName: z.string().min(1, 'Source field is required'),
+  targetFieldName: z.string().min(1, 'Related field is required'),
+});
+
+const joinSettingsFormSchema = z.object({
+  targetAlias: z
+    .string()
+    .min(1, 'Field prefix is required')
+    .regex(/^[a-z0-9_]+$/, {
+      message: 'Field prefix must contain only lowercase letters, numbers, and underscores',
+    }),
+  joinConditions: z.array(joinConditionSchema).min(1, 'At least one join condition is required'),
+});
+
+type JoinSettingsFormValues = z.infer<typeof joinSettingsFormSchema>;
+
+interface FlatField {
+  name: string;
+  type: string;
+  isHiddenForReporting?: boolean;
+}
+
+interface RawSchemaField {
+  name: string;
+  type: string;
+  isHiddenForReporting?: boolean;
+  fields?: RawSchemaField[];
+}
+
+function flattenFields(fields: RawSchemaField[], prefix = ''): FlatField[] {
+  const result: FlatField[] = [];
+  for (const field of fields) {
+    const fullName = prefix ? `${prefix}.${field.name}` : field.name;
+    if (field.fields && field.fields.length > 0) {
+      result.push(...flattenFields(field.fields, fullName));
+    } else {
+      result.push({
+        name: fullName,
+        type: field.type,
+        isHiddenForReporting: field.isHiddenForReporting,
+      });
+    }
+  }
+  return result;
+}
+
+function getSchemaFields(dm: DataMartResponseDto | null): FlatField[] {
+  if (dm?.schema == null) return [];
+  return flattenFields(dm.schema.fields as RawSchemaField[]);
+}
+
+function getInitialDefaults(relationship: DataMartRelationship): JoinSettingsFormValues {
+  return {
+    targetAlias: relationship.targetAlias,
+    joinConditions:
+      relationship.joinConditions.length > 0
+        ? relationship.joinConditions
+        : [{ sourceFieldName: '', targetFieldName: '' }],
+  };
+}
+
+interface JoinSettingsFormProps {
+  relationship: DataMartRelationship;
+  dataMartId: string;
+  readOnly?: boolean;
+  /**
+   * When set, the join is inherited from a parent data mart and must be edited there.
+   * Renders an informational banner with a link to the parent.
+   */
+  inheritedFrom?: { id: string; title: string } | null;
+  onSaved: (updated: DataMartRelationship) => void;
+}
+
+export function JoinSettingsForm({
+  relationship,
+  dataMartId,
+  readOnly = false,
+  inheritedFrom,
+  onSaved,
+}: JoinSettingsFormProps) {
+  const { scope } = useProjectRoute();
+  const [sourceDM, setSourceDM] = useState<DataMartResponseDto | null>(null);
+  const [targetDM, setTargetDM] = useState<DataMartResponseDto | null>(null);
+  const [isLoadingSchemas, setIsLoadingSchemas] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const form = useForm<JoinSettingsFormValues>({
+    resolver: zodResolver(joinSettingsFormSchema),
+    mode: 'onChange',
+    defaultValues: getInitialDefaults(relationship),
+  });
+
+  const lastSavedKeyRef = useRef<string>(JSON.stringify(getInitialDefaults(relationship)));
+  const lastAttemptedKeyRef = useRef<string>(JSON.stringify(getInitialDefaults(relationship)));
+
+  const {
+    fields: joinFields,
+    append: appendJoin,
+    remove: removeJoin,
+  } = useFieldArray({
+    control: form.control,
+    name: 'joinConditions',
+  });
+
+  useEffect(() => {
+    const defaults = getInitialDefaults(relationship);
+    const key = JSON.stringify(defaults);
+    form.reset(defaults);
+    lastSavedKeyRef.current = key;
+    lastAttemptedKeyRef.current = key;
+  }, [relationship, form]);
+
+  useEffect(() => {
+    // Inherited (transient) rows don't own the join — source schema must come from the actual
+    // relationship owner (`relationship.sourceDataMart.id`), not the data mart being viewed.
+    const sourceId = relationship.sourceDataMart.id;
+    if (!sourceId || !relationship.targetDataMart.id) return;
+    setIsLoadingSchemas(true);
+    void Promise.all([
+      dataMartService.getDataMartById(sourceId),
+      dataMartService.getDataMartById(relationship.targetDataMart.id),
+    ])
+      .then(([src, tgt]) => {
+        setSourceDM(src);
+        setTargetDM(tgt);
+      })
+      .finally(() => {
+        setIsLoadingSchemas(false);
+      });
+  }, [relationship.sourceDataMart.id, relationship.targetDataMart.id]);
+
+  const sourceFields = getSchemaFields(sourceDM);
+  const targetFields = getSchemaFields(targetDM);
+
+  const watchedValues = form.watch();
+  const watchedKey = JSON.stringify(watchedValues);
+
+  const joinTypeMismatches = watchedValues.joinConditions.map(jc => {
+    if (!jc.sourceFieldName || !jc.targetFieldName) return null;
+    const sourceType = sourceFields.find(f => f.name === jc.sourceFieldName)?.type;
+    const targetType = targetFields.find(f => f.name === jc.targetFieldName)?.type;
+    if (!sourceType || !targetType) return null;
+    return sourceType !== targetType ? { sourceType, targetType } : null;
+  });
+  const hasTypeMismatch = joinTypeMismatches.some(Boolean);
+
+  const debouncedKey = useDebounce(watchedKey, 800);
+  const isValid = form.formState.isValid;
+
+  useEffect(() => {
+    if (readOnly || isSaving || !isValid || hasTypeMismatch) return;
+    if (debouncedKey === lastSavedKeyRef.current) return;
+    // Without this guard a failed save keeps `lastSavedKeyRef` stale, so the
+    // next `isSaving=false` flip would re-run the effect and repost the same
+    // payload in a tight loop — a wall of error toasts the user cannot escape.
+    if (debouncedKey === lastAttemptedKeyRef.current) return;
+
+    let parsed: JoinSettingsFormValues;
+    try {
+      parsed = JSON.parse(debouncedKey) as JoinSettingsFormValues;
+    } catch {
+      return;
+    }
+
+    lastAttemptedKeyRef.current = debouncedKey;
+    setIsSaving(true);
+
+    dataMartRelationshipService
+      .updateRelationship(
+        dataMartId,
+        relationship.id,
+        {
+          targetAlias: parsed.targetAlias,
+          joinConditions: parsed.joinConditions,
+        },
+        { skipErrorToast: true }
+      )
+      .then(updated => {
+        lastSavedKeyRef.current = JSON.stringify({
+          targetAlias: updated.targetAlias,
+          joinConditions: updated.joinConditions,
+        });
+        onSaved(updated);
+      })
+      .catch(() => {
+        // Suppress stale errors: the user may have already moved past this
+        // payload by the time the rejection arrives.
+        if (JSON.stringify(form.getValues()) === lastAttemptedKeyRef.current) {
+          toast.error('Failed to save join settings', {
+            id: `join-save-error-${relationship.id}`,
+          });
+        }
+      })
+      .finally(() => {
+        setIsSaving(false);
+      });
+  }, [
+    debouncedKey,
+    hasTypeMismatch,
+    readOnly,
+    isSaving,
+    isValid,
+    dataMartId,
+    relationship.id,
+    onSaved,
+    form,
+  ]);
+
+  return (
+    <div className='flex flex-col gap-4 p-4'>
+      {inheritedFrom && (
+        <div className='flex min-w-0 items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200'>
+          <Info className='size-4 shrink-0' />
+          <p className='min-w-0 flex-1 truncate leading-snug'>
+            Inherited from <span className='font-semibold'>{inheritedFrom.title}</span> — edit join
+            there.
+          </p>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            className='h-7 shrink-0 bg-white/80 text-xs dark:bg-white/5'
+            onClick={() => {
+              window.open(scope(`/data-marts/${inheritedFrom.id}/data-setup`), '_blank');
+            }}
+          >
+            <ExternalLink className='size-3.5' />
+            <span className='max-w-[200px] truncate'>Open {inheritedFrom.title}</span>
+          </Button>
+        </div>
+      )}
+      {/* SQL Alias — internal, used for SQL JOIN construction. Target DM identity now lives
+          in the tabs row above, so this section only holds the SQL alias editor. Keep the
+          50/50 grid so the editor stays right-aligned and matches the Output Alias layout
+          in the Report Fields tab. */}
+      <Form {...form}>
+        <div className='grid grid-cols-2 gap-3'>
+          <div />
+          <FormField
+            control={form.control}
+            name='targetAlias'
+            render={({ field }) => (
+              <FormItem
+                variant='light'
+                className='bg-muted/50 flex flex-col gap-1.5 rounded-md p-3 dark:bg-white/5'
+              >
+                <label className='flex items-center gap-1.5 text-sm font-medium'>
+                  SQL Alias
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
+                        <Info className='size-4 shrink-0' />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side='top' className='max-w-xs'>
+                      Internal name used when building the SQL JOIN for this data mart (e.g.
+                      orders_customer_id). Not shown in the output.
+                    </TooltipContent>
+                  </Tooltip>
+                </label>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder='e.g. orders'
+                    disabled={readOnly}
+                    className='bg-background h-8 text-sm dark:bg-white/5'
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <Separator />
+
+        {/* Join Fields section */}
+        <div className='flex flex-col gap-3'>
+          <div className='flex shrink-0 items-center justify-between'>
+            <p className='flex items-center gap-1.5 text-sm font-medium'>
+              Join Fields
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
+                    <Info className='size-4 shrink-0' />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side='top' className='max-w-xs'>
+                  Define how rows are matched between the source and related data marts.
+                </TooltipContent>
+              </Tooltip>
+            </p>
+            {!readOnly && (
+              <Button
+                type='button'
+                variant='outline'
+                size='sm'
+                onClick={() => {
+                  appendJoin({ sourceFieldName: '', targetFieldName: '' });
+                }}
+              >
+                <Plus className='mr-1 h-3.5 w-3.5' />
+                Add Join Field
+              </Button>
+            )}
+          </div>
+
+          {joinFields.map((jf, index) => {
+            const mismatch = joinTypeMismatches[index];
+            return (
+              <div key={jf.id} className='flex flex-col gap-1'>
+                <div className='flex items-start gap-2'>
+                  <FormField
+                    control={form.control}
+                    name={`joinConditions.${index}.sourceFieldName`}
+                    render={({ field }) => (
+                      <FormItem variant='light' className='min-w-0 flex-1'>
+                        <FormLabel className={cn(index > 0 && 'sr-only')}>Source field</FormLabel>
+                        <FormControl>
+                          <Combobox
+                            options={sourceFields.map(f => ({
+                              value: f.name,
+                              label: f.name,
+                            }))}
+                            value={field.value}
+                            onValueChange={field.onChange}
+                            placeholder='Select field...'
+                            disabled={readOnly || isLoadingSchemas}
+                            className={cn(mismatch && 'border-destructive')}
+                            renderLabel={option => {
+                              const f = sourceFields.find(sf => sf.name === option.value);
+                              return (
+                                <span className='flex min-w-0 flex-1 items-center justify-between gap-2'>
+                                  <span className='truncate'>{option.label}</span>
+                                  {f && (
+                                    <span className='text-muted-foreground shrink-0 text-xs'>
+                                      {f.type}
+                                    </span>
+                                  )}
+                                </span>
+                              );
+                            }}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <div
+                    className={cn(
+                      'text-muted-foreground flex items-center text-base font-semibold',
+                      index === 0 ? 'mt-7' : 'mt-2'
+                    )}
+                  >
+                    =
+                  </div>
+
+                  <FormField
+                    control={form.control}
+                    name={`joinConditions.${index}.targetFieldName`}
+                    render={({ field }) => (
+                      <FormItem variant='light' className='min-w-0 flex-1'>
+                        <FormLabel className={cn(index > 0 && 'sr-only')}>Related field</FormLabel>
+                        <FormControl>
+                          <Combobox
+                            options={targetFields.map(f => ({
+                              value: f.name,
+                              label: f.name,
+                            }))}
+                            value={field.value}
+                            onValueChange={field.onChange}
+                            placeholder='Select field...'
+                            disabled={readOnly || isLoadingSchemas}
+                            className={cn(mismatch && 'border-destructive')}
+                            renderLabel={option => {
+                              const f = targetFields.find(tf => tf.name === option.value);
+                              return (
+                                <span className='flex min-w-0 flex-1 items-center justify-between gap-2'>
+                                  <span className='truncate'>{option.label}</span>
+                                  {f && (
+                                    <span className='text-muted-foreground shrink-0 text-xs'>
+                                      {f.type}
+                                    </span>
+                                  )}
+                                </span>
+                              );
+                            }}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {!readOnly && joinFields.length > 1 && (
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='sm'
+                      onClick={() => {
+                        removeJoin(index);
+                      }}
+                      className={cn(
+                        'text-destructive hover:text-destructive',
+                        index === 0 ? 'mt-7' : 'mt-2'
+                      )}
+                      aria-label='Remove join condition'
+                    >
+                      <Trash2 className='h-3.5 w-3.5' />
+                    </Button>
+                  )}
+                </div>
+
+                {mismatch != null && (
+                  <p className='text-destructive text-xs'>
+                    Type mismatch: source is {mismatch.sourceType}, target is {mismatch.targetType}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+
+          {form.formState.errors.joinConditions?.root && (
+            <p className='text-destructive text-sm'>
+              {form.formState.errors.joinConditions.root.message}
+            </p>
+          )}
+        </div>
+      </Form>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
@@ -1,0 +1,484 @@
+import { Badge } from '@owox/ui/components/badge';
+import { Collapsible, CollapsibleContent } from '@owox/ui/components/collapsible';
+import { ExpandButton } from '@owox/ui/components/common/expand-button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@owox/ui/components/dropdown-menu';
+import { Input } from '@owox/ui/components/input';
+import { Switch } from '@owox/ui/components/switch';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@owox/ui/components/tabs';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { cn } from '@owox/ui/lib/utils';
+import { Box, Columns3, ExternalLink, GitMerge, Info, MoreHorizontal, Trash2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '../../../../../shared/components/Button';
+import { ConfirmationDialog } from '../../../../../shared/components/ConfirmationDialog';
+import { UserReference } from '../../../../../shared/components/UserReference';
+import { useProjectRoute } from '../../../../../shared/hooks/useProjectRoute';
+import { useDebounce } from '../../../../../hooks/useDebounce';
+import { formatDateShort } from '../../../../../utils/date-formatters';
+import type {
+  BlendedField,
+  BlendedFieldOverride,
+  DataMartRelationship,
+  TransientRelationshipRow,
+} from '../../../shared/types/relationship.types';
+import { SourceFieldsTable } from '../DataMartSchemaSettings/SourceFieldsTable';
+import { JoinSettingsForm } from './JoinSettingsForm';
+
+export interface SourceEntry {
+  aliasPath: string;
+  title: string;
+  alias: string;
+  depth: number;
+  fieldCount: number;
+  overrideCount: number;
+  isIncluded: boolean;
+  fields: BlendedField[];
+  dataMartId: string;
+}
+
+type AccordionTab = 'fields' | 'join-settings';
+
+interface RelationshipAccordionItemProps {
+  row: TransientRelationshipRow;
+  source: SourceEntry | null;
+  dataMartId: string;
+  storageId: string;
+  /** Open this accordion on Join Settings tab on mount */
+  defaultOpenTab?: AccordionTab;
+  readOnly?: boolean;
+  onDelete: (id: string) => Promise<void>;
+  onRelationshipUpdated: (updated: DataMartRelationship) => void;
+  onAliasChange: (source: SourceEntry, alias: string) => void;
+  onHideForReportingChange: (aliasPath: string, alias: string, isHidden: boolean) => void;
+  onFieldOverrideChange: (
+    source: SourceEntry,
+    fieldName: string,
+    override: Partial<BlendedFieldOverride>
+  ) => void;
+}
+
+export function RelationshipAccordionItem({
+  row,
+  source,
+  dataMartId,
+  defaultOpenTab,
+  readOnly = false,
+  onDelete,
+  onRelationshipUpdated,
+  onAliasChange,
+  onHideForReportingChange,
+  onFieldOverrideChange,
+}: RelationshipAccordionItemProps) {
+  const { scope } = useProjectRoute();
+  const rel = row.relationship;
+  const isTransient = row.depth >= 2;
+
+  const [isOpen, setIsOpen] = useState(defaultOpenTab !== undefined);
+  const [activeTab, setActiveTab] = useState<AccordionTab>(defaultOpenTab ?? 'fields');
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Output alias doubles as the accordion's display label. Falls back to the
+  // DM title when `source` is null (join conditions not configured yet) —
+  // matches the value persisted by the creator.
+  const displayAlias = source?.alias ?? rel.targetDataMart.title;
+  const [localAlias, setLocalAlias] = useState(displayAlias);
+  const debouncedAlias = useDebounce(localAlias, 500);
+  const lastSavedAlias = useRef(displayAlias);
+
+  useEffect(() => {
+    setLocalAlias(displayAlias);
+    lastSavedAlias.current = displayAlias;
+  }, [displayAlias]);
+
+  useEffect(() => {
+    if (!source) return;
+    if (debouncedAlias !== lastSavedAlias.current) {
+      onAliasChange(source, debouncedAlias);
+      lastSavedAlias.current = debouncedAlias;
+    }
+  }, [debouncedAlias, source, onAliasChange]);
+
+  const handleAliasBlur = () => {
+    if (!source) return;
+    if (localAlias !== lastSavedAlias.current) {
+      onAliasChange(source, localAlias);
+      lastSavedAlias.current = localAlias;
+    }
+  };
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!defaultOpenTab) return;
+    setIsOpen(true);
+    setActiveTab(defaultOpenTab);
+    // Delay scroll until Collapsible finishes expanding, so the whole
+    // accordion lands in the viewport — not just the header.
+    const timeoutId = window.setTimeout(() => {
+      const el = containerRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const fullyAbove = rect.top < 80;
+      const partiallyBelow = rect.bottom > window.innerHeight - 40;
+      if (fullyAbove || partiallyBelow) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }, 250);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [defaultOpenTab]);
+
+  const handleDeleteConfirm = async () => {
+    setIsDeleting(true);
+    try {
+      await onDelete(rel.id);
+    } finally {
+      setIsDeleting(false);
+      setIsConfirmDeleteOpen(false);
+    }
+  };
+
+  const visibleCount = source?.fields.filter(f => !f.isHidden).length ?? 0;
+
+  const depth = row.depth - 1; // depth 1 = direct, show at 0 indent
+
+  const isDimmed = source != null && !source.isIncluded;
+
+  // Keep actions visible while the dropdown is open, otherwise they would
+  // disappear as soon as the pointer leaves the row to reach the menu.
+  const actionsVisible = isOpen || isMenuOpen;
+  const actionsVisibilityClass = actionsVisible
+    ? 'opacity-100'
+    : 'opacity-0 group-hover:opacity-100';
+
+  return (
+    <>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <div
+          ref={containerRef}
+          className='flex items-start gap-1.5'
+          style={{ marginLeft: `${depth * 20}px` }}
+        >
+          {isTransient && (
+            <span className='text-muted-foreground/40 mt-2.5 shrink-0 text-xs'>{'\u21B3'}</span>
+          )}
+          <div className={cn('min-w-0 flex-1', isDimmed && 'opacity-60')}>
+            {/* Header */}
+            <div
+              className={cn(
+                'group flex items-center gap-2 px-3 py-2 transition-colors',
+                'bg-white dark:bg-white/5',
+                'border border-transparent',
+                'hover:bg-muted/70 dark:hover:bg-white/8',
+                'shadow-xs dark:shadow-none',
+                isOpen ? 'border-border rounded-t-md border-b' : 'rounded-md'
+              )}
+            >
+              <ExpandButton
+                isExpanded={isOpen}
+                onToggle={() => {
+                  setIsOpen(prev => !prev);
+                }}
+              />
+
+              {/* Output alias + badges — clickable area */}
+              <div
+                className='flex min-w-0 flex-1 cursor-pointer items-center gap-2'
+                role='button'
+                tabIndex={0}
+                onClick={() => {
+                  setIsOpen(prev => !prev);
+                }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') setIsOpen(prev => !prev);
+                }}
+              >
+                <span className='truncate text-sm font-semibold'>{displayAlias}</span>
+
+                {/* Fields badge */}
+                <Badge variant='secondary' className='shrink-0 text-xs'>
+                  {visibleCount} {visibleCount === 1 ? 'field' : 'fields'}
+                </Badge>
+
+                {/* Draft / Blocked / Join not configured badges */}
+                {rel.targetDataMart.status === 'DRAFT' && (
+                  <Badge
+                    variant='outline'
+                    className='shrink-0 border-orange-400 text-[10px] text-orange-500'
+                  >
+                    Draft
+                  </Badge>
+                )}
+                {rel.joinConditions.length === 0 && (
+                  <Badge
+                    variant='outline'
+                    className='shrink-0 border-orange-400 text-[10px] text-orange-500'
+                  >
+                    Join not configured
+                  </Badge>
+                )}
+                {row.isBlocked && rel.targetDataMart.status !== 'DRAFT' && (
+                  <Badge
+                    variant='outline'
+                    className='shrink-0 border-orange-400 text-[10px] text-orange-500'
+                  >
+                    Blocked
+                  </Badge>
+                )}
+              </div>
+
+              {/* Allow for reporting — rendered for both direct and transient rows */}
+              <div
+                className={cn(
+                  'flex shrink-0 items-center gap-1.5 transition-opacity',
+                  actionsVisibilityClass
+                )}
+                onClick={e => {
+                  e.stopPropagation();
+                }}
+              >
+                <span className='text-muted-foreground text-xs'>Allow for reporting</span>
+                <Switch
+                  checked={source?.isIncluded ?? true}
+                  onCheckedChange={checked => {
+                    // Backend omits relationships without join conditions from
+                    // availableSources (source is null). The preference is still
+                    // persisted by aliasPath and becomes effective once joins
+                    // are configured.
+                    onHideForReportingChange(
+                      source?.aliasPath ?? row.aliasPath,
+                      source?.alias ?? rel.targetAlias,
+                      !checked
+                    );
+                  }}
+                />
+              </div>
+
+              {/* Dropdown menu — controlled so siblings stay visible while open */}
+              <div
+                className={cn('shrink-0 transition-opacity', actionsVisibilityClass)}
+                onClick={e => {
+                  e.stopPropagation();
+                }}
+              >
+                <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-7 w-7 cursor-pointer p-0'
+                      aria-label='More actions'
+                    >
+                      <MoreHorizontal className='h-4 w-4' />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align='end'>
+                    <DropdownMenuItem
+                      onClick={() => {
+                        window.open(
+                          scope(`/data-marts/${rel.targetDataMart.id}/data-setup`),
+                          '_blank'
+                        );
+                      }}
+                    >
+                      <ExternalLink className='h-4 w-4' />
+                      Open in new tab
+                    </DropdownMenuItem>
+                    {/* Delete is disabled for transient rows — removing an inherited relationship must happen on its source data mart. */}
+                    {isTransient ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span>
+                            <DropdownMenuItem
+                              variant='destructive'
+                              disabled
+                              onSelect={e => {
+                                e.preventDefault();
+                              }}
+                            >
+                              <Trash2 className='h-4 w-4' />
+                              Delete relationship
+                            </DropdownMenuItem>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side='left' className='max-w-xs'>
+                          This relationship is inherited. Remove it from the source data mart
+                          instead.
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <DropdownMenuItem
+                        variant='destructive'
+                        onClick={() => {
+                          setIsConfirmDeleteOpen(true);
+                        }}
+                      >
+                        <Trash2 className='h-4 w-4' />
+                        Delete relationship
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </div>
+
+            {/* Expanded content */}
+            <CollapsibleContent>
+              <div className='border-border rounded-b-md border border-t-0 bg-white shadow-xs dark:bg-white/5 dark:shadow-none'>
+                <Tabs
+                  value={activeTab}
+                  onValueChange={v => {
+                    setActiveTab(v as AccordionTab);
+                  }}
+                >
+                  {/* Segment control (left) · data mart identity (center) · creation metadata (right) */}
+                  <div className='flex items-center gap-3 px-4 pt-3'>
+                    <TabsList className='shrink-0'>
+                      <TabsTrigger value='fields'>
+                        <Columns3 className='h-4 w-4' />
+                        Report Fields
+                      </TabsTrigger>
+                      <TabsTrigger value='join-settings'>
+                        <GitMerge className='h-4 w-4' />
+                        Join Settings
+                      </TabsTrigger>
+                    </TabsList>
+                    <div className='text-muted-foreground flex min-w-0 flex-1 items-center justify-center gap-1.5 text-sm'>
+                      <Box className='size-4 shrink-0' />
+                      <span
+                        className='text-foreground max-w-[240px] truncate font-medium'
+                        title={rel.targetDataMart.title}
+                      >
+                        {rel.targetDataMart.title}
+                      </span>
+                      {rel.targetDataMart.description && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
+                              <Info className='size-4 shrink-0' />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side='top' className='max-w-xs'>
+                            {rel.targetDataMart.description}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='sm'
+                        className='text-muted-foreground/60 hover:text-muted-foreground h-5 w-5 shrink-0 p-0'
+                        onClick={() => {
+                          window.open(
+                            scope(`/data-marts/${rel.targetDataMart.id}/data-setup`),
+                            '_blank'
+                          );
+                        }}
+                        aria-label='Open target data mart in new tab'
+                      >
+                        <ExternalLink className='size-4' />
+                      </Button>
+                    </div>
+                    <div className='text-muted-foreground flex shrink-0 items-center gap-1.5 text-sm'>
+                      <span>Joined {formatDateShort(rel.createdAt)}</span>
+                      {rel.createdByUser && (
+                        <>
+                          <span>by</span>
+                          <UserReference userProjection={rel.createdByUser} />
+                        </>
+                      )}
+                    </div>
+                  </div>
+
+                  <TabsContent value='fields' className='px-4 pt-2 pb-2'>
+                    {source ? (
+                      <SourceFieldsTable
+                        fields={source.fields}
+                        onFieldOverrideChange={(fieldName, override) => {
+                          onFieldOverrideChange(source, fieldName, override);
+                        }}
+                        leadingToolbar={
+                          <div
+                            className='bg-muted/50 flex flex-col gap-1.5 rounded-md p-3 dark:bg-white/5'
+                            onClick={e => {
+                              e.stopPropagation();
+                            }}
+                          >
+                            <label className='flex items-center gap-1.5 text-sm font-medium'>
+                              Output Alias
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
+                                    <Info className='size-4 shrink-0' />
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent side='top' className='max-w-xs'>
+                                  Short name that appears in the output data schema for fields from
+                                  this data mart.
+                                </TooltipContent>
+                              </Tooltip>
+                            </label>
+                            <Input
+                              value={localAlias}
+                              onChange={e => {
+                                setLocalAlias(e.target.value);
+                              }}
+                              onBlur={handleAliasBlur}
+                              placeholder='e.g. campaign_performance'
+                              className='bg-background h-8 text-sm dark:bg-white/5'
+                            />
+                          </div>
+                        }
+                      />
+                    ) : (
+                      <p className='text-muted-foreground py-4 text-sm'>
+                        Fields will appear after configuring join conditions.
+                      </p>
+                    )}
+                  </TabsContent>
+
+                  <TabsContent value='join-settings'>
+                    <JoinSettingsForm
+                      relationship={rel}
+                      dataMartId={dataMartId}
+                      readOnly={readOnly || isTransient}
+                      inheritedFrom={
+                        isTransient ? { id: row.sourceDmId, title: row.parentDataMartTitle } : null
+                      }
+                      onSaved={updated => {
+                        onRelationshipUpdated(updated);
+                      }}
+                    />
+                  </TabsContent>
+                </Tabs>
+              </div>
+            </CollapsibleContent>
+          </div>
+        </div>
+      </Collapsible>
+
+      <ConfirmationDialog
+        open={isConfirmDeleteOpen}
+        onOpenChange={open => {
+          if (!open) setIsConfirmDeleteOpen(false);
+        }}
+        title='Delete Relationship'
+        description='Are you sure you want to delete this relationship? This action cannot be undone.'
+        confirmLabel={isDeleting ? 'Deleting...' : 'Delete'}
+        cancelLabel='Cancel'
+        variant='destructive'
+        onConfirm={() => {
+          void handleDeleteConfirm();
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
@@ -48,6 +48,8 @@ interface RelationshipAccordionItemProps {
   source: SourceEntry | null;
   dataMartId: string;
   storageId: string;
+  /** Aliases used by other relationships that share the same source data mart. */
+  siblingAliases: string[];
   /** Open this accordion on Join Settings tab on mount */
   defaultOpenTab?: AccordionTab;
   readOnly?: boolean;
@@ -66,6 +68,7 @@ export function RelationshipAccordionItem({
   row,
   source,
   dataMartId,
+  siblingAliases,
   defaultOpenTab,
   readOnly = false,
   onDelete,
@@ -343,7 +346,6 @@ export function RelationshipAccordionItem({
                     setActiveTab(v as AccordionTab);
                   }}
                 >
-                  {/* Segment control (left) · data mart identity (center) · creation metadata (right) */}
                   <div className='flex items-center gap-3 px-4 pt-3'>
                     <TabsList className='shrink-0'>
                       <TabsTrigger value='fields'>
@@ -355,7 +357,7 @@ export function RelationshipAccordionItem({
                         Join Settings
                       </TabsTrigger>
                     </TabsList>
-                    <div className='text-muted-foreground flex min-w-0 flex-1 items-center justify-center gap-1.5 text-sm'>
+                    <div className='text-muted-foreground ml-auto flex min-w-0 items-center gap-1.5 text-sm'>
                       <Box className='size-4 shrink-0' />
                       <span
                         className='text-foreground max-w-[240px] truncate font-medium'
@@ -454,6 +456,7 @@ export function RelationshipAccordionItem({
                       relationship={rel}
                       dataMartId={dataMartId}
                       readOnly={readOnly || isTransient}
+                      siblingAliases={siblingAliases}
                       inheritedFrom={
                         isTransient ? { id: row.sourceDmId, title: row.parentDataMartTitle } : null
                       }

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
@@ -115,22 +115,26 @@ export function RelationshipAccordionItem({
 
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Wait for the Collapsible's CSS expand transition before measuring so scrollIntoView
+  // targets the final layout.
+  const COLLAPSIBLE_EXPAND_DELAY_MS = 250;
+  const STICKY_HEADER_OFFSET_PX = 80;
+  const VIEWPORT_BOTTOM_OFFSET_PX = 40;
+
   useEffect(() => {
     if (!defaultOpenTab) return;
     setIsOpen(true);
     setActiveTab(defaultOpenTab);
-    // Delay scroll until Collapsible finishes expanding, so the whole
-    // accordion lands in the viewport — not just the header.
     const timeoutId = window.setTimeout(() => {
       const el = containerRef.current;
       if (!el) return;
       const rect = el.getBoundingClientRect();
-      const fullyAbove = rect.top < 80;
-      const partiallyBelow = rect.bottom > window.innerHeight - 40;
+      const fullyAbove = rect.top < STICKY_HEADER_OFFSET_PX;
+      const partiallyBelow = rect.bottom > window.innerHeight - VIEWPORT_BOTTOM_OFFSET_PX;
       if (fullyAbove || partiallyBelow) {
         el.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
-    }, 250);
+    }, COLLAPSIBLE_EXPAND_DELAY_MS);
     return () => {
       window.clearTimeout(timeoutId);
     };

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
@@ -1,0 +1,787 @@
+import { Badge } from '@owox/ui/components/badge';
+import { ExternalLink, Info, Locate, Maximize2, ZoomIn, ZoomOut } from 'lucide-react';
+import { useCallback, useEffect, useRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { GetSchemes } from 'rete';
+import { ClassicPreset, NodeEditor } from 'rete';
+import { AreaExtensions, AreaPlugin } from 'rete-area-plugin';
+import { ConnectionPlugin, Presets as ConnectionPresets } from 'rete-connection-plugin';
+import { type MinimapExtra, MinimapPlugin } from 'rete-minimap-plugin';
+import { Presets as ReactPresets, type ReactArea2D, ReactPlugin } from 'rete-react-plugin';
+import { Button } from '../../../../../shared/components/Button';
+import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
+import type { DataMartRelationship } from '../../../shared/types/relationship.types';
+
+interface RelationshipCanvasProps {
+  dataMartId: string;
+  dataMartTitle: string;
+  dataMartDescription?: string | null;
+  dataMartStatus: string;
+  relationships: DataMartRelationship[];
+  connectedFieldCounts?: Map<string, number>;
+  searchQuery: string;
+  showTransient: boolean;
+  onRequestFullscreen?: () => void;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const SOCKET = new ClassicPreset.Socket('rel');
+const NODE_W = 240;
+const SRC_H = 48;
+const TGT_H = 74;
+const H_GAP = 280;
+const V_GAP = 24;
+const MAX_DEPTH = 5;
+const NODE_BORDER = '#9ca3af'; // gray-400, visible in both themes
+const HIGHLIGHT_COLOR = '#3b82f6'; // blue-500
+const DRAFT_COLOR = '#f97316'; // orange-500
+
+class DMNode extends ClassicPreset.Node {
+  width = NODE_W;
+  height = SRC_H;
+  isSource: boolean;
+  dmId: string;
+  depth: number;
+  targetAlias?: string;
+  fieldCount?: number;
+  description?: string | null;
+  onOpenExternal?: () => void;
+  isDraft: boolean;
+  isBlocked: boolean;
+  isJoinNotConfigured: boolean;
+  highlighted = false;
+  dimmed = false;
+
+  constructor(
+    label: string,
+    dmId: string,
+    isSource: boolean,
+    depth: number,
+    opts?: {
+      targetAlias?: string;
+      fieldCount?: number;
+      description?: string | null;
+      onOpenExternal?: () => void;
+      isDraft?: boolean;
+      isBlocked?: boolean;
+      isJoinNotConfigured?: boolean;
+    }
+  ) {
+    super(label);
+    this.dmId = dmId;
+    this.isSource = isSource;
+    this.depth = depth;
+    this.targetAlias = opts?.targetAlias;
+    this.fieldCount = opts?.fieldCount;
+    this.description = opts?.description;
+    this.onOpenExternal = opts?.onOpenExternal;
+    this.isDraft = opts?.isDraft ?? false;
+    this.isBlocked = opts?.isBlocked ?? false;
+    this.isJoinNotConfigured = opts?.isJoinNotConfigured ?? false;
+    if (!isSource) this.height = TGT_H;
+  }
+}
+
+type Schemes = GetSchemes<DMNode, ClassicPreset.Connection<ClassicPreset.Node, ClassicPreset.Node>>;
+type AreaExtra = ReactArea2D<Schemes> | MinimapExtra;
+
+const { RefSocket } = ReactPresets.classic;
+
+function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Schemes>) => void }) {
+  const n = props.data;
+
+  function handleExtClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    n.onOpenExternal?.();
+  }
+
+  const outputs = Object.entries(n.outputs);
+  const inputs = Object.entries(n.inputs);
+
+  if (n.isSource) {
+    return (
+      <div
+        className='text-primary flex items-center'
+        style={{
+          width: n.width,
+          height: n.height,
+          borderRadius: 8,
+          border: `2px solid ${n.highlighted ? HIGHLIGHT_COLOR : n.isDraft ? DRAFT_COLOR : NODE_BORDER}`,
+          boxShadow: n.highlighted
+            ? `0 0 0 3px ${HIGHLIGHT_COLOR}40, 0 0 12px ${HIGHLIGHT_COLOR}60`
+            : '0 1px 4px 0 rgba(0,0,0,0.12)',
+          background: '#eff6ff',
+          fontSize: 13,
+          fontWeight: 600,
+          position: 'relative',
+          opacity: n.dimmed ? 0.15 : 1,
+          filter: n.dimmed ? 'grayscale(0.8)' : undefined,
+          animation: n.highlighted ? 'node-pulse 1.5s ease-in-out infinite' : undefined,
+          transition: 'opacity 0.2s, filter 0.2s',
+        }}
+      >
+        {n.isDraft && (
+          <span
+            style={{
+              position: 'absolute',
+              top: -18,
+              right: 4,
+              fontSize: 10,
+              fontWeight: 600,
+              color: DRAFT_COLOR,
+              lineHeight: 1,
+            }}
+          >
+            Draft
+          </span>
+        )}
+        <div className='truncate' style={{ flex: 1, padding: '0 14px' }} title={n.label}>
+          {n.label}
+        </div>
+        {outputs.map(
+          ([key, output]) =>
+            output && (
+              <div key={key} style={{ position: 'absolute', right: -5, top: '50%', marginTop: -5 }}>
+                <RefSocket
+                  name='output-socket'
+                  side='output'
+                  socketKey={key}
+                  nodeId={n.id}
+                  emit={props.emit}
+                  payload={output.socket}
+                />
+              </div>
+            )
+        )}
+      </div>
+    );
+  }
+
+  const isOrange = n.isDraft || n.isBlocked || n.isJoinNotConfigured;
+  const borderColor = isOrange ? DRAFT_COLOR : NODE_BORDER;
+  const badgeLabel = n.isDraft
+    ? 'Draft'
+    : n.isJoinNotConfigured
+      ? 'Join not configured'
+      : n.isBlocked
+        ? 'Blocked'
+        : null;
+
+  return (
+    <div
+      style={{
+        width: n.width,
+        height: n.height,
+        borderRadius: 8,
+        border: `2px solid ${n.highlighted ? HIGHLIGHT_COLOR : borderColor}`,
+        background: 'var(--background)',
+        boxShadow: n.highlighted
+          ? `0 0 0 3px ${HIGHLIGHT_COLOR}40, 0 0 12px ${HIGHLIGHT_COLOR}60`
+          : '0 1px 4px 0 rgba(0,0,0,0.12)',
+        cursor: 'default',
+        position: 'relative',
+        opacity: n.dimmed ? 0.15 : 1,
+        filter: n.dimmed ? 'grayscale(0.8)' : undefined,
+        animation: n.highlighted ? 'node-pulse 1.5s ease-in-out infinite' : undefined,
+        transition: 'opacity 0.2s, filter 0.2s',
+      }}
+    >
+      {badgeLabel && (
+        <span
+          style={{
+            position: 'absolute',
+            top: -18,
+            right: 4,
+            fontSize: 10,
+            fontWeight: 600,
+            color: DRAFT_COLOR,
+            lineHeight: 1,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {badgeLabel}
+        </span>
+      )}
+      {inputs.map(
+        ([key, input]) =>
+          input && (
+            <div
+              key={key}
+              style={{ position: 'absolute', left: -5, top: '50%', marginTop: -5, zIndex: 1 }}
+            >
+              <RefSocket
+                name='input-socket'
+                side='input'
+                socketKey={key}
+                nodeId={n.id}
+                emit={props.emit}
+                payload={input.socket}
+              />
+            </div>
+          )
+      )}
+      <div
+        className='bg-muted flex items-center justify-between'
+        style={{
+          padding: '8px 10px 8px 14px',
+          fontSize: 13,
+          fontWeight: 600,
+          borderRadius: '6px 6px 0 0',
+        }}
+      >
+        <span className='truncate' title={n.label}>
+          {n.label}
+        </span>
+        <div className='ml-2 flex shrink-0 items-center gap-0.5'>
+          {n.description && (
+            <span
+              className='text-muted-foreground hover:text-foreground inline-flex cursor-default rounded p-0.5 transition-colors'
+              title={n.description}
+            >
+              <Info style={{ width: 14, height: 14 }} />
+            </span>
+          )}
+          <button
+            className='text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded p-0.5 transition-colors'
+            onPointerDown={e => {
+              e.stopPropagation();
+            }}
+            onClick={handleExtClick}
+            title='Open in new tab'
+            aria-label='Open in new tab'
+          >
+            <ExternalLink style={{ width: 14, height: 14 }} />
+          </button>
+        </div>
+      </div>
+      <div
+        className='text-muted-foreground flex items-center gap-2'
+        style={{ padding: '6px 14px 8px', fontSize: 11, minWidth: 0 }}
+      >
+        {n.targetAlias && (
+          <Badge
+            variant='secondary'
+            className='inline-block max-w-[120px] truncate px-1.5 py-0 text-[10px]'
+            title={n.targetAlias}
+          >
+            {n.targetAlias}
+          </Badge>
+        )}
+        <span className='ml-auto shrink-0'>
+          {n.fieldCount ?? 0} field{n.fieldCount !== 1 ? 's' : ''}
+        </span>
+      </div>
+      {outputs.map(
+        ([key, output]) =>
+          output && (
+            <div
+              key={key}
+              style={{ position: 'absolute', right: -5, top: '50%', marginTop: -5, zIndex: 1 }}
+            >
+              <RefSocket
+                name='output-socket'
+                side='output'
+                socketKey={key}
+                nodeId={n.id}
+                emit={props.emit}
+                payload={output.socket}
+              />
+            </div>
+          )
+      )}
+    </div>
+  );
+}
+
+function SocketComponent() {
+  return (
+    <div
+      style={{
+        width: 10,
+        height: 10,
+        borderRadius: '50%',
+        background: NODE_BORDER,
+        border: '2px solid var(--background)',
+      }}
+    />
+  );
+}
+
+interface EditorHandle {
+  destroy: () => void;
+  fitView: () => Promise<void>;
+  zoomBy: (delta: number) => Promise<void>;
+  highlightNodes: (query: string) => void;
+}
+
+async function setupEditor(
+  container: HTMLElement,
+  dataMartId: string,
+  dataMartTitle: string,
+  dataMartDescription: string | null | undefined,
+  dataMartStatus: string,
+  initialRelationships: DataMartRelationship[],
+  fieldCounts: Map<string, number> | undefined,
+  onOpenExternal: (targetDmId: string) => void,
+  showTransient: boolean
+): Promise<EditorHandle> {
+  const editor = new NodeEditor<Schemes>();
+  const area = new AreaPlugin<Schemes, AreaExtra>(container);
+  const connPlugin = new ConnectionPlugin<Schemes, AreaExtra>();
+  const render = new ReactPlugin<Schemes, AreaExtra>({ createRoot });
+  const minimap = new MinimapPlugin<Schemes>();
+
+  const { useConnection } = ReactPresets.classic;
+
+  function DraftAwareConnection(props: {
+    data: Schemes['Connection'] & { isLoop?: boolean };
+    styles?: () => unknown;
+  }) {
+    const { path } = useConnection();
+    if (!path) return null;
+    const src = editor.getNode(props.data.source);
+    const tgt = editor.getNode(props.data.target);
+    const orange =
+      src?.isDraft === true ||
+      src?.isBlocked === true ||
+      src?.isJoinNotConfigured === true ||
+      tgt?.isDraft === true ||
+      tgt?.isBlocked === true ||
+      tgt?.isJoinNotConfigured === true;
+    const bothDimmed =
+      (src?.dimmed === true || src === undefined) && (tgt?.dimmed === true || tgt === undefined);
+
+    return (
+      <svg
+        data-testid='connection'
+        style={{
+          overflow: 'visible',
+          position: 'absolute',
+          pointerEvents: 'none',
+          width: 9999,
+          height: 9999,
+        }}
+      >
+        <path
+          d={path}
+          fill='none'
+          strokeWidth='5px'
+          stroke={orange ? DRAFT_COLOR : 'steelblue'}
+          strokeDasharray={orange ? '8 4' : undefined}
+          opacity={bothDimmed ? 0.15 : 1}
+          style={{ pointerEvents: 'auto', transition: 'opacity 0.2s' }}
+        />
+      </svg>
+    );
+  }
+
+  render.addPreset(
+    ReactPresets.classic.setup({
+      customize: {
+        node() {
+          return NodeComponent;
+        },
+        socket() {
+          return SocketComponent;
+        },
+        connection() {
+          return DraftAwareConnection;
+        },
+      },
+    })
+  );
+  render.addPreset(ReactPresets.minimap.setup());
+  connPlugin.addPreset(ConnectionPresets.classic.setup());
+
+  editor.use(area);
+  area.use(connPlugin);
+  area.use(render);
+  area.use(minimap);
+
+  interface NodeInfo {
+    id: string;
+    dmId: string;
+    title: string;
+    description?: string | null;
+    depth: number;
+    isSource: boolean;
+    targetAlias?: string;
+    fieldCount?: number;
+    isDraft?: boolean;
+    isBlocked?: boolean;
+    isJoinNotConfigured?: boolean;
+  }
+  interface EdgeInfo {
+    sourceId: string;
+    targetId: string;
+  }
+
+  const nodeInfos = new Map<string, NodeInfo>();
+  const edges: EdgeInfo[] = [];
+  const hasOutgoing = new Set<string>();
+
+  const rootIsDraft = dataMartStatus === 'DRAFT';
+
+  nodeInfos.set(dataMartId, {
+    id: dataMartId,
+    dmId: dataMartId,
+    title: dataMartTitle,
+    description: dataMartDescription,
+    depth: 0,
+    isSource: true,
+    isDraft: rootIsDraft,
+  });
+
+  let nodeCounter = 0;
+
+  async function collectGraph(
+    parentNodeKey: string,
+    rels: DataMartRelationship[],
+    depth: number,
+    ancestorDmIds: Set<string>,
+    parentBlocked: boolean
+  ) {
+    if (rels.length > 0) hasOutgoing.add(parentNodeKey);
+
+    for (const rel of rels) {
+      const dmId = rel.targetDataMart.id;
+      const nodeKey = `${dmId}-${nodeCounter++}`;
+      const isDraft = rel.targetDataMart.status === 'DRAFT';
+      const isJoinNotConfigured = rel.joinConditions.length === 0;
+      const isBlocked = parentBlocked;
+
+      edges.push({ sourceId: parentNodeKey, targetId: nodeKey });
+
+      nodeInfos.set(nodeKey, {
+        id: nodeKey,
+        dmId,
+        title: rel.targetDataMart.title,
+        description: rel.targetDataMart.description,
+        depth,
+        isSource: false,
+        targetAlias: rel.targetAlias,
+        fieldCount: fieldCounts?.get(rel.id) ?? 0,
+        isDraft,
+        isBlocked,
+        isJoinNotConfigured,
+      });
+
+      if (showTransient && depth < MAX_DEPTH && !ancestorDmIds.has(dmId)) {
+        try {
+          const childRels = await dataMartRelationshipService.getRelationships(dmId);
+          if (childRels.length > 0) {
+            const newAncestors = new Set(ancestorDmIds);
+            newAncestors.add(dmId);
+            await collectGraph(
+              nodeKey,
+              childRels,
+              depth + 1,
+              newAncestors,
+              parentBlocked || isDraft || isJoinNotConfigured
+            );
+          }
+        } catch {
+          // Render partial graph if a transitive child fetch fails
+          // (e.g. missing permission) rather than failing the canvas.
+        }
+      }
+    }
+  }
+
+  await collectGraph(dataMartId, initialRelationships, 1, new Set([dataMartId]), rootIsDraft);
+
+  const nodeMap = new Map<string, DMNode>();
+  const columns = new Map<number, DMNode[]>();
+
+  for (const [nodeKey, info] of nodeInfos) {
+    const node = new DMNode(info.title, info.dmId, info.isSource, info.depth, {
+      targetAlias: info.targetAlias,
+      fieldCount: info.fieldCount,
+      description: info.description,
+      isDraft: info.isDraft,
+      isBlocked: info.isBlocked,
+      isJoinNotConfigured: info.isJoinNotConfigured,
+      onOpenExternal: () => {
+        onOpenExternal(info.dmId);
+      },
+    });
+
+    if (hasOutgoing.has(nodeKey)) {
+      node.addOutput('out', new ClassicPreset.Output(SOCKET));
+    }
+    if (!info.isSource) {
+      node.addInput('in', new ClassicPreset.Input(SOCKET));
+    }
+
+    await editor.addNode(node);
+    nodeMap.set(nodeKey, node);
+
+    const col = columns.get(info.depth) ?? [];
+    if (!columns.has(info.depth)) columns.set(info.depth, col);
+    col.push(node);
+  }
+
+  for (const edge of edges) {
+    const src = nodeMap.get(edge.sourceId);
+    const tgt = nodeMap.get(edge.targetId);
+    if (src && tgt) {
+      await editor.addConnection(
+        new ClassicPreset.Connection(
+          src as ClassicPreset.Node,
+          'out',
+          tgt as ClassicPreset.Node,
+          'in'
+        )
+      );
+    }
+  }
+
+  const maxDepth = Math.max(...Array.from(columns.keys()));
+
+  for (let d = 0; d <= maxDepth; d++) {
+    const col = columns.get(d) ?? [];
+    let y = 0;
+
+    for (const node of col) {
+      await area.translate(node.id, { x: d * (NODE_W + H_GAP), y });
+      y += node.height + V_GAP;
+    }
+
+    if (d === 0 && col.length === 1) {
+      const nextCol = columns.get(1) ?? [];
+      const nextH = nextCol.reduce((s, n) => s + n.height + V_GAP, -V_GAP);
+      await area.translate(col[0].id, {
+        x: 0,
+        y: Math.max(0, nextH / 2 - col[0].height / 2),
+      });
+    }
+  }
+
+  const BASE_GRID = 16;
+  const updateGrid = () => {
+    const { x, y, k } = area.area.transform;
+    const size = BASE_GRID * k;
+    container.style.backgroundSize = `${size}px ${size}px`;
+    container.style.backgroundPosition = `${x}px ${y}px`;
+  };
+
+  const fitView = async () => {
+    await AreaExtensions.zoomAt(area, editor.getNodes(), { scale: 0.85 });
+    updateGrid();
+  };
+  await fitView();
+
+  const zoomBy = async (delta: number) => {
+    const cx = container.clientWidth / 2;
+    const cy = container.clientHeight / 2;
+    const { k } = area.area.transform;
+    const nextK = k * (1 + delta);
+    if (nextK < 0.33 || nextK > 3) return;
+    await area.area.zoom(nextK, cx * delta, cy * delta);
+    updateGrid();
+  };
+
+  AreaExtensions.restrictor(area, {
+    translation: () => {
+      const { k } = area.area.transform;
+      const bb = AreaExtensions.getBoundingBox(area, editor.getNodes());
+      const rect = container.getBoundingClientRect();
+      const pad = 150;
+      return {
+        left: pad - bb.right * k,
+        right: rect.width - pad - bb.left * k,
+        top: pad - bb.bottom * k,
+        bottom: rect.height - pad - bb.top * k,
+      };
+    },
+  });
+
+  area.addPipe(ctx => {
+    if (ctx.type === 'zoom') {
+      if (ctx.data.source === 'dblclick') return undefined;
+      const nextK = ctx.data.zoom;
+      if (nextK < 0.33 || nextK > 3) return undefined;
+    }
+    if (ctx.type === 'nodetranslate') return undefined;
+    if (ctx.type === 'translated' || ctx.type === 'zoomed') {
+      updateGrid();
+    }
+    return ctx;
+  });
+
+  const highlightNodes = (query: string) => {
+    const q = query.toLowerCase();
+    const matching: DMNode[] = [];
+
+    for (const node of editor.getNodes()) {
+      const prev = { h: node.highlighted, d: node.dimmed };
+      node.highlighted = q !== '' && node.label.toLowerCase().includes(q);
+      node.dimmed = q !== '' && !node.highlighted;
+      if (node.highlighted) matching.push(node);
+      if (prev.h !== node.highlighted || prev.d !== node.dimmed) {
+        void area.update('node', node.id);
+      }
+    }
+
+    // Also update connections so they dim when both endpoints are dimmed
+    for (const conn of editor.getConnections()) {
+      void area.update('connection', conn.id);
+    }
+
+    if (matching.length > 0) {
+      void AreaExtensions.zoomAt(area, matching, { scale: 0.85 });
+    }
+  };
+
+  return {
+    destroy: () => {
+      area.destroy();
+    },
+    fitView,
+    zoomBy,
+    highlightNodes,
+  };
+}
+
+export function RelationshipCanvas({
+  dataMartId,
+  dataMartTitle,
+  dataMartDescription,
+  dataMartStatus,
+  relationships,
+  connectedFieldCounts,
+  searchQuery,
+  showTransient,
+  onRequestFullscreen,
+  className,
+  style,
+}: RelationshipCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<EditorHandle | null>(null);
+  const searchQueryRef = useRef(searchQuery);
+  searchQueryRef.current = searchQuery;
+
+  const handleOpenExternal = useCallback((targetId: string) => {
+    const basePath = window.location.pathname.replace(/\/data-marts\/.*/, '');
+    window.open(`${basePath}/data-marts/${targetId}/data-setup`, '_blank');
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || relationships.length === 0) return;
+
+    void setupEditor(
+      el,
+      dataMartId,
+      dataMartTitle,
+      dataMartDescription,
+      dataMartStatus,
+      relationships,
+      connectedFieldCounts,
+      handleOpenExternal,
+      showTransient
+    ).then(h => {
+      editorRef.current = h;
+      if (searchQueryRef.current) {
+        h.highlightNodes(searchQueryRef.current);
+      }
+    });
+
+    return () => {
+      editorRef.current?.destroy();
+      editorRef.current = null;
+      el.replaceChildren();
+    };
+  }, [
+    dataMartId,
+    dataMartTitle,
+    dataMartDescription,
+    dataMartStatus,
+    relationships,
+    connectedFieldCounts,
+    handleOpenExternal,
+    showTransient,
+  ]);
+
+  useEffect(() => {
+    editorRef.current?.highlightNodes(searchQuery);
+  }, [searchQuery]);
+
+  if (relationships.length === 0) return null;
+
+  return (
+    <div
+      className={`rel-canvas relative overflow-hidden rounded-lg border ${className ?? ''}`}
+      style={style ?? { height: 480 }}
+    >
+      <style>{`
+        .rel-canvas svg path { stroke-width: 1.5px !important; }
+        .rel-canvas [data-testid="minimap"] { transform: scale(0.5); transform-origin: bottom right; }
+        @keyframes node-pulse {
+          0%, 100% { box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25), 0 0 12px rgba(59, 130, 246, 0.4); }
+          50% { box-shadow: 0 0 0 6px rgba(59, 130, 246, 0.15), 0 0 20px rgba(59, 130, 246, 0.5); }
+        }
+      `}</style>
+      <div className='absolute top-3 right-3 z-10 flex items-start gap-2'>
+        <div className='flex flex-col gap-1.5'>
+          <Button
+            variant='outline'
+            size='icon'
+            className='h-12 w-12'
+            onClick={() => {
+              void editorRef.current?.fitView();
+            }}
+            aria-label='Fit to view'
+          >
+            <Locate className='h-6 w-6' />
+          </Button>
+          <Button
+            variant='outline'
+            size='icon'
+            className='h-12 w-12'
+            onClick={() => {
+              void editorRef.current?.zoomBy(0.25);
+            }}
+            aria-label='Zoom in'
+          >
+            <ZoomIn className='h-6 w-6' />
+          </Button>
+          <Button
+            variant='outline'
+            size='icon'
+            className='h-12 w-12'
+            onClick={() => {
+              void editorRef.current?.zoomBy(-0.25);
+            }}
+            aria-label='Zoom out'
+          >
+            <ZoomOut className='h-6 w-6' />
+          </Button>
+          {onRequestFullscreen && (
+            <Button
+              variant='outline'
+              size='icon'
+              className='h-12 w-12'
+              onClick={onRequestFullscreen}
+              aria-label='Expand diagram'
+            >
+              <Maximize2 className='h-6 w-6' />
+            </Button>
+          )}
+        </div>
+      </div>
+      <div
+        ref={containerRef}
+        style={{
+          width: '100%',
+          height: '100%',
+          backgroundImage:
+            'linear-gradient(rgba(0,0,0,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(0,0,0,0.06) 1px, transparent 1px)',
+          backgroundSize: '16px 16px',
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/TargetDataMartPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/TargetDataMartPicker.tsx
@@ -1,0 +1,93 @@
+import { X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { Button } from '../../../../../shared/components/Button';
+import { Combobox } from '../../../../../shared/components/Combobox/combobox';
+import { generateUniqueAlias, slugify } from '../../../../../utils/string-utils';
+import { dataMartService } from '../../../shared';
+import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
+import type { DataMartRelationship } from '../../../shared/types/relationship.types';
+
+interface TargetDataMartPickerProps {
+  dataMartId: string;
+  storageId: string;
+  existingRelationships: DataMartRelationship[];
+  onCreated: (relationship: DataMartRelationship) => void;
+  onCancel: () => void;
+}
+
+export function TargetDataMartPicker({
+  dataMartId,
+  storageId,
+  existingRelationships,
+  onCreated,
+  onCancel,
+}: TargetDataMartPickerProps) {
+  const [availableDMs, setAvailableDMs] = useState<{ id: string; title: string }[]>([]);
+  const [isLoadingDMs, setIsLoadingDMs] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+
+  useEffect(() => {
+    if (!dataMartId || !storageId) return;
+    setIsLoadingDMs(true);
+    void (async () => {
+      try {
+        const [allDMs, srcDM] = await Promise.all([
+          dataMartService.getDataMarts(),
+          dataMartService.getDataMartById(dataMartId),
+        ]);
+
+        const filtered = allDMs
+          .filter(dm => dm.id !== dataMartId && dm.storage.title === srcDM.storage.title)
+          .map(dm => ({ id: dm.id, title: dm.title }));
+
+        setAvailableDMs(filtered);
+      } finally {
+        setIsLoadingDMs(false);
+      }
+    })();
+  }, [dataMartId, storageId]);
+
+  const handleSelect = async (targetDMId: string) => {
+    if (isCreating) return;
+    const dm = availableDMs.find(d => d.id === targetDMId);
+    if (!dm) return;
+
+    setIsCreating(true);
+    try {
+      const takenAliases = new Set(existingRelationships.map(r => r.targetAlias));
+      const targetAlias = generateUniqueAlias(slugify(dm.title), takenAliases);
+
+      const created = await dataMartRelationshipService.createRelationship(dataMartId, {
+        targetDataMartId: targetDMId,
+        targetAlias,
+        joinConditions: [],
+      });
+      onCreated(created);
+    } catch {
+      toast.error('Failed to add relationship');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <div className='flex items-center gap-2 pt-2'>
+      <div className='w-72'>
+        <Combobox
+          options={availableDMs.map(dm => ({ value: dm.id, label: dm.title }))}
+          value=''
+          onValueChange={v => {
+            void handleSelect(v);
+          }}
+          placeholder={isLoadingDMs ? 'Loading...' : isCreating ? 'Adding...' : 'Search data mart'}
+          disabled={isLoadingDMs || isCreating}
+        />
+      </div>
+      <Button type='button' variant='ghost' size='sm' onClick={onCancel} aria-label='Cancel'>
+        <X className='h-4 w-4' />
+        Cancel
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/TargetDataMartPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/TargetDataMartPicker.tsx
@@ -56,7 +56,10 @@ export function TargetDataMartPicker({
     setIsCreating(true);
     try {
       const takenAliases = new Set(existingRelationships.map(r => r.targetAlias));
-      const targetAlias = generateUniqueAlias(slugify(dm.title), takenAliases);
+      // Non-ASCII titles (e.g. Cyrillic) slugify to empty, which fails the server-side
+      // alias regex. Fall back to the data-mart id so the relationship can be created.
+      const baseAlias = slugify(dm.title) || slugify(targetDMId);
+      const targetAlias = generateUniqueAlias(baseAlias, takenAliases);
 
       const created = await dataMartRelationshipService.createRelationship(dataMartId, {
         targetDataMartId: targetDMId,

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/useTransientRelationships.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/useTransientRelationships.ts
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react';
+import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
+import type {
+  DataMartRelationship,
+  TransientRelationshipRow,
+} from '../../../shared/types/relationship.types';
+
+const MAX_DEPTH = 5;
+
+export function useTransientRelationships(
+  dataMartId: string,
+  dataMartTitle: string,
+  dataMartStatus: string,
+  directRelationships: DataMartRelationship[],
+  showTransient: boolean
+): { rows: TransientRelationshipRow[]; isLoading: boolean } {
+  const [rows, setRows] = useState<TransientRelationshipRow[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const versionRef = useRef(0);
+  const lastDataMartIdRef = useRef<string>('');
+
+  useEffect(() => {
+    const directRows: TransientRelationshipRow[] = directRelationships.map(rel => ({
+      relationship: rel,
+      depth: 1,
+      parentDataMartTitle: dataMartTitle,
+      sourceDmId: dataMartId,
+      isBlocked: false,
+      aliasPath: rel.targetAlias,
+      rowKey: rel.id,
+    }));
+
+    if (!showTransient) {
+      setRows(directRows);
+      return;
+    }
+
+    const version = ++versionRef.current;
+    // Skeleton flashes are jarring during incremental edits (create/delete/edit).
+    // Only show the loader on the first load per data mart.
+    const isInitialLoad = lastDataMartIdRef.current !== dataMartId;
+    if (isInitialLoad) setIsLoading(true);
+    lastDataMartIdRef.current = dataMartId;
+
+    async function collectTransient(
+      parentDmId: string,
+      parentTitle: string,
+      parentAliasPath: string,
+      parentRowKey: string,
+      rels: DataMartRelationship[],
+      depth: number,
+      ancestorDmIds: Set<string>,
+      parentBlocked: boolean
+    ): Promise<TransientRelationshipRow[]> {
+      // Build a row plus recursively its subtree for every rel in parallel.
+      const subtrees = await Promise.all(
+        rels.map(async rel => {
+          const dmId = rel.targetDataMart.id;
+          const isDraft = rel.targetDataMart.status === 'DRAFT';
+          const isJoinNotConfigured = rel.joinConditions.length === 0;
+          const aliasPath = parentAliasPath
+            ? `${parentAliasPath}.${rel.targetAlias}`
+            : rel.targetAlias;
+          const rowKey = parentRowKey ? `${parentRowKey}/${rel.id}` : rel.id;
+
+          const row: TransientRelationshipRow = {
+            relationship: rel,
+            depth,
+            parentDataMartTitle: parentTitle,
+            sourceDmId: parentDmId,
+            isBlocked: parentBlocked,
+            aliasPath,
+            rowKey,
+          };
+
+          if (depth >= MAX_DEPTH || ancestorDmIds.has(dmId)) {
+            return [row];
+          }
+
+          try {
+            const childRels = await dataMartRelationshipService.getRelationships(dmId);
+            if (childRels.length === 0) return [row];
+
+            const newAncestors = new Set(ancestorDmIds);
+            newAncestors.add(dmId);
+            const children = await collectTransient(
+              dmId,
+              rel.targetDataMart.title,
+              aliasPath,
+              rowKey,
+              childRels,
+              depth + 1,
+              newAncestors,
+              parentBlocked || isDraft || isJoinNotConfigured
+            );
+            return [row, ...children];
+          } catch {
+            return [row];
+          }
+        })
+      );
+
+      return subtrees.flat();
+    }
+
+    const rootIsDraft = dataMartStatus === 'DRAFT';
+
+    void collectTransient(
+      dataMartId,
+      dataMartTitle,
+      '',
+      '',
+      directRelationships,
+      1,
+      new Set([dataMartId]),
+      rootIsDraft
+    ).then(collected => {
+      if (versionRef.current === version) {
+        setRows(collected);
+        setIsLoading(false);
+      }
+    });
+  }, [dataMartId, dataMartTitle, dataMartStatus, directRelationships, showTransient]);
+
+  return { rows, isLoading };
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SourceFieldsTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SourceFieldsTable.tsx
@@ -49,8 +49,14 @@ function FieldAliasInput({
   const [value, setValue] = useState(initialValue);
   const debouncedValue = useDebounce(value, 500);
   const lastSaved = useRef(initialValue);
+  // Hold the latest `onSave` in a ref so the debounced effect below only fires
+  // when `debouncedValue` actually changes — wiring `onSave` directly into the
+  // dep array would restart debounce on every parent render that passes an
+  // inline callback.
   const onSaveRef = useRef(onSave);
-  onSaveRef.current = onSave;
+  useEffect(() => {
+    onSaveRef.current = onSave;
+  }, [onSave]);
 
   useEffect(() => {
     if (debouncedValue !== lastSaved.current) {

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SourceFieldsTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SourceFieldsTable.tsx
@@ -1,0 +1,345 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { EyeOff, Info, MoreHorizontal, Eye, Search } from 'lucide-react';
+import { Button } from '@owox/ui/components/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@owox/ui/components/dropdown-menu';
+import { Input } from '@owox/ui/components/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@owox/ui/components/select';
+import { TableBody, TableCell, TableHead, TableHeader, TableRow } from '@owox/ui/components/table';
+import { Tabs, TabsList, TabsTrigger } from '@owox/ui/components/tabs';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import {
+  AGGREGATE_FUNCTIONS,
+  type AggregateFunction,
+  type BlendedField,
+  type BlendedFieldOverride,
+} from '../../../shared/types/relationship.types';
+import { useDebounce } from '../../../../../hooks/useDebounce';
+
+type FilterMode = 'all' | 'visible' | 'hidden';
+
+interface SourceFieldsTableProps {
+  fields: BlendedField[];
+  onFieldOverrideChange: (fieldName: string, override: Partial<BlendedFieldOverride>) => void;
+  /**
+   * Optional slot rendered to the left of the filtering block in the toolbar.
+   * Used by RelationshipAccordionItem to render the Output Alias input in the
+   * same row as the field filters, matching the Join Settings layout.
+   */
+  leadingToolbar?: ReactNode;
+}
+
+function FieldAliasInput({
+  initialValue,
+  onSave,
+}: {
+  initialValue: string;
+  onSave: (value: string) => void;
+}) {
+  const [value, setValue] = useState(initialValue);
+  const debouncedValue = useDebounce(value, 500);
+  const lastSaved = useRef(initialValue);
+  const onSaveRef = useRef(onSave);
+  onSaveRef.current = onSave;
+
+  useEffect(() => {
+    if (debouncedValue !== lastSaved.current) {
+      onSaveRef.current(debouncedValue);
+      lastSaved.current = debouncedValue;
+    }
+  }, [debouncedValue]);
+
+  return (
+    <Input
+      value={value}
+      onChange={e => {
+        setValue(e.target.value);
+      }}
+      onBlur={() => {
+        if (value !== lastSaved.current) {
+          onSave(value);
+          lastSaved.current = value;
+        }
+      }}
+      className='h-8 w-full'
+    />
+  );
+}
+
+const COLUMN_COUNT = 5;
+
+export function SourceFieldsTable({
+  fields,
+  onFieldOverrideChange,
+  leadingToolbar,
+}: SourceFieldsTableProps) {
+  const [searchValue, setSearchValue] = useState('');
+  // Re-run the filter on the debounced value so typing stays responsive on
+  // schemas with hundreds of fields (the input itself always reflects the
+  // latest keystroke).
+  const debouncedSearch = useDebounce(searchValue, 250);
+  const [filterMode, setFilterMode] = useState<FilterMode>('all');
+  const [hiddenOverrides, setHiddenOverrides] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    setHiddenOverrides({});
+  }, [fields]);
+
+  const isFieldHidden = useCallback(
+    (fieldName: string): boolean => {
+      if (fieldName in hiddenOverrides) return hiddenOverrides[fieldName];
+      const field = fields.find(f => f.originalFieldName === fieldName);
+      return field?.isHidden ?? false;
+    },
+    [fields, hiddenOverrides]
+  );
+
+  const filteredFields = useMemo(() => {
+    let result = fields;
+    if (debouncedSearch.trim()) {
+      const q = debouncedSearch.toLowerCase();
+      result = result.filter(
+        f =>
+          f.originalFieldName.toLowerCase().includes(q) ||
+          f.type.toLowerCase().includes(q) ||
+          f.alias.toLowerCase().includes(q) ||
+          f.description.toLowerCase().includes(q)
+      );
+    }
+    if (filterMode === 'visible') {
+      result = result.filter(f => !isFieldHidden(f.originalFieldName));
+    } else if (filterMode === 'hidden') {
+      result = result.filter(f => isFieldHidden(f.originalFieldName));
+    }
+    return result;
+  }, [fields, debouncedSearch, filterMode, isFieldHidden]);
+
+  const toggleHidden = (fieldName: string) => {
+    const newHidden = !isFieldHidden(fieldName);
+    setHiddenOverrides(prev => ({ ...prev, [fieldName]: newHidden }));
+    onFieldOverrideChange(fieldName, { isHidden: newHidden });
+  };
+
+  const totalCount = fields.length;
+  const hiddenCount = fields.filter(f => isFieldHidden(f.originalFieldName)).length;
+  const visibleCount = totalCount - hiddenCount;
+
+  const headCellClass = 'bg-secondary dark:bg-background sticky top-0 z-10';
+
+  const filteringBlock = (
+    <div className='bg-muted/50 flex flex-col gap-1.5 rounded-md p-3 dark:bg-white/5'>
+      <label className='flex items-center gap-1.5 text-sm font-medium'>
+        Fields filtering
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
+              <Info className='size-4 shrink-0' />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side='top' className='max-w-xs'>
+            Search and filter the fields exposed to reports from this data mart.
+          </TooltipContent>
+        </Tooltip>
+      </label>
+      <div className='flex items-center gap-2'>
+        <div className='relative flex-1'>
+          <Search className='text-muted-foreground pointer-events-none absolute top-1/2 left-2 h-3.5 w-3.5 -translate-y-1/2' />
+          <Input
+            placeholder='Search fields'
+            value={searchValue}
+            onChange={e => {
+              setSearchValue(e.target.value);
+            }}
+            className='bg-background h-8 pl-7 text-sm dark:bg-white/5'
+          />
+        </div>
+        <Tabs
+          value={filterMode}
+          onValueChange={v => {
+            setFilterMode(v as FilterMode);
+          }}
+        >
+          <TabsList>
+            <TabsTrigger value='all'>All ({totalCount})</TabsTrigger>
+            <TabsTrigger value='visible'>Visible ({visibleCount})</TabsTrigger>
+            <TabsTrigger value='hidden'>Hidden ({hiddenCount})</TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className='space-y-3 py-2'>
+      {leadingToolbar ? (
+        <div className='grid grid-cols-2 gap-3'>
+          {filteringBlock}
+          {leadingToolbar}
+        </div>
+      ) : (
+        filteringBlock
+      )}
+
+      <div className='relative max-h-[400px] w-full overflow-auto'>
+        <table className='w-full table-auto caption-bottom text-sm'>
+          <TableHeader className='bg-transparent'>
+            <TableRow className='hover:bg-transparent'>
+              <TableHead className={`${headCellClass} w-[30%]`}>
+                <Tooltip>
+                  <TooltipTrigger className='cursor-default'>Name</TooltipTrigger>
+                  <TooltipContent>Field name in the source data mart</TooltipContent>
+                </Tooltip>
+              </TableHead>
+              <TableHead className={`${headCellClass} w-[25%]`}>
+                <Tooltip>
+                  <TooltipTrigger className='cursor-default'>Alias</TooltipTrigger>
+                  <TooltipContent>Alternative name for the field</TooltipContent>
+                </Tooltip>
+              </TableHead>
+              <TableHead className={`${headCellClass} w-[15%]`}>
+                <Tooltip>
+                  <TooltipTrigger className='cursor-default'>Type</TooltipTrigger>
+                  <TooltipContent>Data type of the field</TooltipContent>
+                </Tooltip>
+              </TableHead>
+              <TableHead className={`${headCellClass} w-[25%]`}>
+                <Tooltip>
+                  <TooltipTrigger className='cursor-default'>Aggregation</TooltipTrigger>
+                  <TooltipContent>Function used to aggregate values when blending</TooltipContent>
+                </Tooltip>
+              </TableHead>
+              <TableHead className={`${headCellClass} w-[5%]`} />
+            </TableRow>
+          </TableHeader>
+          <TableBody className='border-b border-gray-200 bg-white dark:border-white/4 dark:bg-white/1'>
+            {filteredFields.map(field => {
+              const hidden = isFieldHidden(field.originalFieldName);
+              return (
+                <TableRow
+                  key={field.originalFieldName}
+                  className={`group ${hidden ? 'opacity-60' : ''}`}
+                >
+                  <TableCell style={{ paddingTop: 8, paddingBottom: 8 }}>
+                    <div className='flex items-center gap-1.5'>
+                      <span className='font-medium'>{field.originalFieldName}</span>
+                      {hidden && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <EyeOff className='text-muted-foreground h-3.5 w-3.5 shrink-0' />
+                          </TooltipTrigger>
+                          <TooltipContent>Hidden from reports</TooltipContent>
+                        </Tooltip>
+                      )}
+                      {field.description && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className='text-muted-foreground/50 hover:text-muted-foreground inline-flex shrink-0 opacity-0 transition-opacity group-hover:opacity-100'>
+                              <Info className='h-3.5 w-3.5' />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side='top' className='max-w-xs'>
+                            {field.description}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell style={{ paddingTop: 8, paddingBottom: 8 }}>
+                    <FieldAliasInput
+                      initialValue={field.alias}
+                      onSave={value => {
+                        onFieldOverrideChange(field.originalFieldName, { alias: value });
+                      }}
+                    />
+                  </TableCell>
+                  <TableCell
+                    className='text-muted-foreground'
+                    style={{ paddingTop: 8, paddingBottom: 8 }}
+                  >
+                    {field.type}
+                  </TableCell>
+                  <TableCell style={{ paddingTop: 8, paddingBottom: 8 }}>
+                    <Select
+                      value={field.aggregateFunction}
+                      onValueChange={value => {
+                        onFieldOverrideChange(field.originalFieldName, {
+                          aggregateFunction: value as AggregateFunction,
+                        });
+                      }}
+                    >
+                      <SelectTrigger size='sm' className='h-8 w-full'>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {AGGREGATE_FUNCTIONS.map(fn => (
+                          <SelectItem key={fn} value={fn}>
+                            {fn}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell className='text-right' style={{ paddingTop: 8, paddingBottom: 8 }}>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant='ghost'
+                          size='sm'
+                          className='h-8 w-8 p-0 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100'
+                          aria-label='Row actions'
+                        >
+                          <MoreHorizontal className='h-4 w-4' />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align='end'>
+                        <DropdownMenuItem
+                          className='cursor-pointer'
+                          onClick={() => {
+                            toggleHidden(field.originalFieldName);
+                          }}
+                        >
+                          {hidden ? (
+                            <>
+                              <Eye className='mr-2 h-4 w-4' />
+                              Show in reports
+                            </>
+                          ) : (
+                            <>
+                              <EyeOff className='mr-2 h-4 w-4' />
+                              Hide from reports
+                            </>
+                          )}
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+            {filteredFields.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={COLUMN_COUNT}
+                  className='text-center text-gray-400'
+                  style={{ whiteSpace: 'nowrap' }}
+                >
+                  No fields match the current filter
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/fields/SchemaFieldActionsButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/fields/SchemaFieldActionsButton.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger,
 } from '@owox/ui/components/dropdown-menu';
 import { type Row } from '@tanstack/react-table';
-import { MoreHorizontal, Plus, Trash2 } from 'lucide-react';
+import { Eye, EyeOff, MoreHorizontal, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { ConfirmationDialog } from '../../../../../../../shared/components/ConfirmationDialog';
 
@@ -23,6 +23,10 @@ interface SchemaFieldActionsButtonProps<TData> {
   onAddNestedField?: (index: number) => void;
   /** Function to check if a field is a record type */
   isRecordType?: (index: number) => boolean;
+  /** Whether the field is currently hidden from reports */
+  isHiddenForReporting?: boolean;
+  /** Callback to toggle the hidden-for-reporting state */
+  onToggleHiddenForReporting?: (index: number) => void;
 }
 
 /**
@@ -33,6 +37,8 @@ export function SchemaFieldActionsButton<TData>({
   onDeleteRow,
   onAddNestedField,
   isRecordType,
+  isHiddenForReporting,
+  onToggleHiddenForReporting,
 }: SchemaFieldActionsButtonProps<TData>) {
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
 
@@ -44,8 +50,9 @@ export function SchemaFieldActionsButton<TData>({
   };
 
   const showAddNestedField = isRecordType && onAddNestedField && isRecordType(row.index);
+  const showHideToggle = !!onToggleHiddenForReporting;
   const showDeleteField = !!onDeleteRow;
-  const showSeparator = showAddNestedField && showDeleteField;
+  const showSeparator = (!!showAddNestedField || showHideToggle) && showDeleteField;
 
   return (
     <div className='px-3 text-right'>
@@ -69,6 +76,27 @@ export function SchemaFieldActionsButton<TData>({
             >
               <Plus className='mr-2 h-4 w-4' />
               Add nested field
+            </DropdownMenuItem>
+          )}
+
+          {onToggleHiddenForReporting && (
+            <DropdownMenuItem
+              className='cursor-pointer'
+              onClick={() => {
+                onToggleHiddenForReporting(row.index);
+              }}
+            >
+              {isHiddenForReporting ? (
+                <>
+                  <Eye className='mr-2 h-4 w-4' />
+                  Show in reports
+                </>
+              ) : (
+                <>
+                  <EyeOff className='mr-2 h-4 w-4' />
+                  Hide from reports
+                </>
+              )}
             </DropdownMenuItem>
           )}
 

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
@@ -1,5 +1,6 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import type { ColumnDef, Row, Table } from '@tanstack/react-table';
+import { EyeOff } from 'lucide-react';
 import type { ComponentType } from 'react';
 import { useCallback, useMemo } from 'react';
 import type { SortingStrategy } from '@dnd-kit/sortable';
@@ -184,14 +185,24 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
             return nameColumnCell({ row, updateField });
           }
           return (
-            <EditableText
-              value={asString(row.getValue('name'))}
-              onValueChange={value => {
-                updateField(row.index, { name: value } as Partial<T>);
-              }}
-              placeholder={'Field name is required'}
-              isBold={true}
-            />
+            <div className='flex items-center gap-1'>
+              <EditableText
+                value={asString(row.getValue('name'))}
+                onValueChange={value => {
+                  updateField(row.index, { name: value } as Partial<T>);
+                }}
+                placeholder={'Field name is required'}
+                isBold={true}
+              />
+              {row.original.isHiddenForReporting && (
+                <Tooltip>
+                  <TooltipTrigger>
+                    <EyeOff className='text-muted-foreground h-3.5 w-3.5 flex-shrink-0' />
+                  </TooltipTrigger>
+                  <TooltipContent>Hidden from reports</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
           );
         },
         enableHiding: false,
@@ -282,6 +293,16 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
             <SchemaFieldActionsButton
               row={row}
               onDeleteRow={onFieldsChange ? handleDeleteRow : undefined}
+              isHiddenForReporting={!!row.original.isHiddenForReporting}
+              onToggleHiddenForReporting={
+                onFieldsChange
+                  ? (index: number) => {
+                      updateField(index, {
+                        isHiddenForReporting: !fields[index].isHiddenForReporting,
+                      } as Partial<T>);
+                    }
+                  : undefined
+              }
             />
           );
         },
@@ -291,6 +312,7 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
       },
     ],
     [
+      fields,
       updateField,
       handleDeleteRow,
       onFieldsChange,

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.tsx
@@ -6,6 +6,7 @@ import { ExpandButton } from '@owox/ui/components/common/expand-button';
 import { SortableTableRow } from '@owox/ui/components/common/sortable-table-row';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import type { Row, Table } from '@tanstack/react-table';
+import { EyeOff } from 'lucide-react';
 import { useCallback, useMemo } from 'react';
 import { DataStorageType } from '../../../../../data-storage';
 import type { BigQuerySchemaField } from '../../../../shared/types/data-mart-schema.types';
@@ -183,6 +184,14 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
             placeholder={'Field name is required'}
             isBold={true}
           />
+          {level === 0 && row.original.isHiddenForReporting && (
+            <Tooltip>
+              <TooltipTrigger>
+                <EyeOff className='text-muted-foreground h-3.5 w-3.5 flex-shrink-0' />
+              </TooltipTrigger>
+              <TooltipContent>Hidden from reports</TooltipContent>
+            </Tooltip>
+          )}
         </div>
       );
     },
@@ -261,15 +270,36 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
 
   // Custom actions column cell with add nested field option for record types
   const actionsColumnCell = useCallback(
-    ({ row }: { row: Row<BigQuerySchemaField>; table: Table<BigQuerySchemaField> }) => (
-      <SchemaFieldActionsButton
-        row={row}
-        onDeleteRow={onFieldsChange ? handleDeleteRow : undefined}
-        onAddNestedField={onFieldsChange ? handleAddNestedField : undefined}
-        isRecordType={isRecordType}
-      />
-    ),
-    [onFieldsChange, handleDeleteRow, handleAddNestedField, isRecordType]
+    ({ row }: { row: Row<BigQuerySchemaField>; table: Table<BigQuerySchemaField> }) => {
+      const field = flattenedFields[row.index];
+      const isTopLevel = (field.level ?? 0) === 0;
+      return (
+        <SchemaFieldActionsButton
+          row={row}
+          onDeleteRow={onFieldsChange ? handleDeleteRow : undefined}
+          onAddNestedField={onFieldsChange ? handleAddNestedField : undefined}
+          isRecordType={isRecordType}
+          isHiddenForReporting={isTopLevel ? !!row.original.isHiddenForReporting : undefined}
+          onToggleHiddenForReporting={
+            onFieldsChange && isTopLevel
+              ? (index: number) => {
+                  updateField(index, {
+                    isHiddenForReporting: !flattenedFields[index].isHiddenForReporting,
+                  });
+                }
+              : undefined
+          }
+        />
+      );
+    },
+    [
+      onFieldsChange,
+      handleDeleteRow,
+      handleAddNestedField,
+      isRecordType,
+      flattenedFields,
+      updateField,
+    ]
   );
 
   // Use the drag-and-drop hook

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/SchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/SchemaTable.tsx
@@ -196,7 +196,12 @@ export function SchemaTable<T extends BaseSchemaField>({
             {table.getRowModel().rows.length ? (
               <DragContext {...dragContextProps}>
                 {table.getRowModel().rows.map(row => (
-                  <RowComponent key={row.id} id={getRowId ? getRowId(row) : row.index} row={row}>
+                  <RowComponent
+                    key={row.id}
+                    id={getRowId ? getRowId(row) : row.index}
+                    row={row}
+                    className={row.original.isHiddenForReporting ? 'opacity-70' : undefined}
+                  >
                     {row.getVisibleCells().map(cell => (
                       <TableCell
                         key={cell.id}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldInfoTooltip.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldInfoTooltip.tsx
@@ -1,0 +1,32 @@
+import { Info } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { cn } from '@owox/ui/lib/utils';
+
+interface FieldInfoTooltipProps {
+  text: string | undefined;
+  compact?: boolean;
+}
+
+export function FieldInfoTooltip({ text, compact }: FieldInfoTooltipProps) {
+  if (!text) return null;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className='text-muted-foreground/50 hover:text-muted-foreground inline-flex shrink-0 opacity-0 transition-opacity group-hover:opacity-100'
+          onClick={e => {
+            // Prevent parent <label>/<button> from toggling the checkbox or
+            // collapsing the group when the user clicks the info icon.
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          <Info className={cn('shrink-0', compact ? 'size-3.5' : 'size-4')} aria-hidden='true' />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side='top' className='max-w-xs whitespace-pre-wrap'>
+        {text}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
@@ -1,0 +1,217 @@
+import { useState } from 'react';
+import { Editor } from '@monaco-editor/react';
+import { useTheme } from 'next-themes';
+import { Copy, Loader2, Network } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+import { Button } from '@owox/ui/components/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter,
+} from '@owox/ui/components/dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { Skeleton } from '@owox/ui/components/skeleton';
+import { reportService } from '../../../reports/shared/services/report.service';
+import { useProjectRoute } from '../../../../../shared/hooks';
+import SqlValidator from '../SqlValidator/SqlValidator';
+
+type GeneratedSqlViewerVariant = 'action-icon' | 'outline-button';
+
+interface GeneratedSqlViewerProps {
+  reportId: string;
+  /**
+   * Data mart ID the report belongs to. Required to run the SQL dry-run
+   * validation (size estimate + syntax check) against the correct storage.
+   */
+  dataMartId: string;
+  /**
+   * Visual variant of the trigger:
+   * - 'action-icon' (default): ghost icon button with tooltip, intended for
+   *   table row action cells. Uses hover-reveal styling that matches sibling
+   *   row actions.
+   * - 'outline-button': outline button with "View Blending SQL" text,
+   *   intended for use inside forms where a full button label makes sense.
+   */
+  variant?: GeneratedSqlViewerVariant;
+  /**
+   * Optional report title, used to build a descriptive aria-label for the
+   * action icon variant (e.g. "View Blending SQL: Test Blending").
+   */
+  reportTitle?: string;
+}
+
+/**
+ * Button that opens a dialog with the generated SQL for a report.
+ * Provides copy-to-clipboard and copy-as-data-mart actions.
+ */
+export function GeneratedSqlViewer({
+  reportId,
+  dataMartId,
+  variant = 'action-icon',
+  reportTitle,
+}: GeneratedSqlViewerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [sql, setSql] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isCopyingAsDataMart, setIsCopyingAsDataMart] = useState(false);
+  const { resolvedTheme } = useTheme();
+  const { scope } = useProjectRoute();
+
+  async function loadSql() {
+    setIsLoading(true);
+    try {
+      const result = await reportService.getGeneratedSql(reportId);
+      setSql(result.sql);
+    } catch {
+      toast.error('Failed to load generated SQL');
+      setSql('');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function handleOpenChange(open: boolean) {
+    setIsOpen(open);
+    if (open) {
+      // Always refetch on open — skip cache, show fresh SQL.
+      setSql(null);
+      void loadSql();
+    }
+  }
+
+  async function handleCopyToClipboard() {
+    if (!sql) return;
+    try {
+      await navigator.clipboard.writeText(sql);
+      toast.success('SQL copied to clipboard');
+    } catch {
+      toast.error('Failed to copy SQL');
+    }
+  }
+
+  async function handleCopyAsDataMart() {
+    setIsCopyingAsDataMart(true);
+    try {
+      const { dataMartId: newDataMartId } = await reportService.copyAsDataMart(reportId);
+      toast.success('Data Mart created from report');
+      setIsOpen(false);
+      window.open(
+        scope(`/data-marts/${newDataMartId}/data-setup`),
+        '_blank',
+        'noopener,noreferrer'
+      );
+    } catch {
+      toast.error('Failed to create Data Mart from report');
+    } finally {
+      setIsCopyingAsDataMart(false);
+    }
+  }
+
+  const ariaLabel = reportTitle ? `View Blending SQL: ${reportTitle}` : 'View Blending SQL';
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      {variant === 'action-icon' ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DialogTrigger asChild>
+              <Button
+                type='button'
+                variant='ghost'
+                className='dm-card-table-body-row-actionbtn opacity-0 transition-opacity group-hover:opacity-100'
+                aria-label={ariaLabel}
+                onClick={e => {
+                  e.stopPropagation();
+                }}
+              >
+                <Network className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
+              </Button>
+            </DialogTrigger>
+          </TooltipTrigger>
+          <TooltipContent side='bottom' role='tooltip'>
+            View Blending SQL
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <DialogTrigger asChild>
+          <Button type='button' variant='outline' size='sm'>
+            <Network className='mr-2 h-4 w-4' />
+            View Blending SQL
+          </Button>
+        </DialogTrigger>
+      )}
+
+      <DialogContent className='flex flex-col gap-4 sm:max-w-[80vw]'>
+        <DialogHeader>
+          <DialogTitle>Generated Blending SQL</DialogTitle>
+        </DialogHeader>
+
+        <div className='min-h-[600px]'>
+          {isLoading ? (
+            <div className='space-y-2'>
+              <Skeleton className='h-6 w-full' />
+              <Skeleton className='h-6 w-3/4' />
+              <Skeleton className='h-6 w-5/6' />
+              <Skeleton className='h-6 w-full' />
+              <Skeleton className='h-6 w-2/3' />
+            </div>
+          ) : (
+            <div className='overflow-hidden rounded-md border' style={{ height: '600px' }}>
+              <Editor
+                height='100%'
+                language='sql'
+                value={sql ?? ''}
+                theme={resolvedTheme === 'dark' ? 'vs-dark' : 'light'}
+                options={{
+                  readOnly: true,
+                  minimap: { enabled: false },
+                  scrollBeyondLastLine: false,
+                  automaticLayout: true,
+                  overviewRulerBorder: false,
+                  hideCursorInOverviewRuler: true,
+                  lineNumbers: 'on',
+                  wordWrap: 'on',
+                }}
+              />
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className='sm:items-center sm:justify-between'>
+          {isLoading || !sql ? (
+            <div className='inline-flex h-9 items-center px-3 py-2'>
+              <div className='flex h-5 items-center gap-2 text-gray-500'>
+                <Loader2 className='h-4 w-4 animate-spin' />
+                <span className='text-sm'>Generating blending SQL...</span>
+              </div>
+            </div>
+          ) : (
+            <SqlValidator sql={sql} dataMartId={dataMartId} />
+          )}
+          <div className='flex gap-2'>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => void handleCopyToClipboard()}
+              disabled={isLoading || !sql}
+            >
+              <Copy className='mr-2 h-4 w-4' />
+              Copy to Clipboard
+            </Button>
+            <Button
+              type='button'
+              variant='default'
+              onClick={() => void handleCopyAsDataMart()}
+              disabled={isLoading || isCopyingAsDataMart}
+            >
+              Copy as Data Mart
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
@@ -32,13 +32,13 @@ interface GeneratedSqlViewerProps {
    * - 'action-icon' (default): ghost icon button with tooltip, intended for
    *   table row action cells. Uses hover-reveal styling that matches sibling
    *   row actions.
-   * - 'outline-button': outline button with "View Blending SQL" text,
+   * - 'outline-button': outline button with "View joined Data Marts SQL" text,
    *   intended for use inside forms where a full button label makes sense.
    */
   variant?: GeneratedSqlViewerVariant;
   /**
    * Optional report title, used to build a descriptive aria-label for the
-   * action icon variant (e.g. "View Blending SQL: Test Blending").
+   * action icon variant (e.g. "View joined Data Marts SQL: Test Report").
    */
   reportTitle?: string;
 }
@@ -110,7 +110,9 @@ export function GeneratedSqlViewer({
     }
   }
 
-  const ariaLabel = reportTitle ? `View Blending SQL: ${reportTitle}` : 'View Blending SQL';
+  const ariaLabel = reportTitle
+    ? `View joined Data Marts SQL: ${reportTitle}`
+    : 'View joined Data Marts SQL';
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
@@ -132,21 +134,21 @@ export function GeneratedSqlViewer({
             </DialogTrigger>
           </TooltipTrigger>
           <TooltipContent side='bottom' role='tooltip'>
-            View Blending SQL
+            View joined Data Marts SQL
           </TooltipContent>
         </Tooltip>
       ) : (
         <DialogTrigger asChild>
           <Button type='button' variant='outline' size='sm'>
             <Network className='mr-2 h-4 w-4' />
-            View Blending SQL
+            View joined Data Marts SQL
           </Button>
         </DialogTrigger>
       )}
 
       <DialogContent className='flex flex-col gap-4 sm:max-w-[80vw]'>
         <DialogHeader>
-          <DialogTitle>Generated Blending SQL</DialogTitle>
+          <DialogTitle>Joined Data Marts SQL</DialogTitle>
         </DialogHeader>
 
         <div className='min-h-[600px]'>
@@ -185,7 +187,7 @@ export function GeneratedSqlViewer({
             <div className='inline-flex h-9 items-center px-3 py-2'>
               <div className='flex h-5 items-center gap-2 text-gray-500'>
                 <Loader2 className='h-4 w-4 animate-spin' />
-                <span className='text-sm'>Generating blending SQL...</span>
+                <span className='text-sm'>Generating SQL...</span>
               </div>
             </div>
           ) : (

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -134,7 +134,6 @@ interface BlendedGroupItemProps {
 }
 
 function BlendedGroupItem({ group, isChecked, onToggleField }: BlendedGroupItemProps) {
-  // Smart default: групи з уже вибраними полями стартують відкритими
   const [isOpen, setIsOpen] = useState(() => group.selectedCount > 0);
 
   const counterText = `${group.selectedCount} / ${group.totalCount}`;

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -1,0 +1,386 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { cn } from '@owox/ui/lib/utils';
+import { Checkbox } from '@owox/ui/components/checkbox';
+import { Collapsible, CollapsibleContent } from '@owox/ui/components/collapsible';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { Skeleton } from '@owox/ui/components/skeleton';
+import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
+import { BLENDABLE_SCHEMA_QUERY_KEY } from '../../../shared/hooks/useBlendedFieldNames';
+import type { BlendedField } from '../../../shared/types/relationship.types';
+import { FieldInfoTooltip } from './FieldInfoTooltip';
+
+interface NativeField {
+  name: string;
+  type?: string;
+  alias?: string;
+  description?: string;
+  fields?: NativeField[];
+}
+
+function flattenNativeFields(fields: NativeField[], prefix = ''): NativeField[] {
+  const result: NativeField[] = [];
+  for (const field of fields) {
+    const fullName = prefix ? `${prefix}.${field.name}` : field.name;
+    result.push({
+      name: fullName,
+      type: field.type,
+      alias: field.alias,
+      description: field.description,
+    });
+    if (field.fields && Array.isArray(field.fields)) {
+      result.push(...flattenNativeFields(field.fields, fullName));
+    }
+  }
+  return result;
+}
+
+interface BlendedGroup {
+  aliasPath: string;
+  title: string;
+  alias: string;
+  description?: string;
+  visibleFields: BlendedField[];
+  selectedCount: number;
+  totalCount: number;
+}
+
+export interface ReportColumnPickerProps {
+  dataMartId: string;
+  value: string[] | null;
+  onChange: (value: string[] | null) => void;
+  onBlendedSelectionChange?: (hasBlendedSelection: boolean) => void;
+}
+
+interface NativeFieldsGroupProps {
+  nativeFields: NativeField[];
+  description?: string;
+  selectedCount: number;
+  totalCount: number;
+  isChecked: (name: string) => boolean;
+  onToggleField: (name: string, checked: boolean) => void;
+}
+
+function NativeFieldsGroup({
+  nativeFields,
+  description,
+  selectedCount,
+  totalCount,
+  isChecked,
+  onToggleField,
+}: NativeFieldsGroupProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const counterText = `${selectedCount} / ${totalCount}`;
+  const fieldWord = totalCount === 1 ? 'field' : 'fields';
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <button
+        type='button'
+        aria-expanded={isOpen}
+        aria-label={`${isOpen ? 'Collapse' : 'Expand'} Default Data Mart Columns`}
+        className='group bg-secondary/50 dark:bg-muted/50 hover:bg-secondary/80 dark:hover:bg-muted/80 flex w-full cursor-pointer items-start gap-1.5 rounded px-1 py-1 text-left transition-colors'
+        onClick={() => {
+          setIsOpen(v => !v);
+        }}
+      >
+        {isOpen ? (
+          <ChevronDown className='text-muted-foreground mt-0.5 h-4 w-4 shrink-0' />
+        ) : (
+          <ChevronRight className='text-muted-foreground mt-0.5 h-4 w-4 shrink-0' />
+        )}
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-center justify-between gap-1.5'>
+            <div className='flex min-w-0 items-center gap-1.5'>
+              <span className='truncate text-xs font-semibold'>Default Data Mart Columns</span>
+              <FieldInfoTooltip text={description} />
+            </div>
+            <span className='text-muted-foreground shrink-0 text-xs'>
+              {counterText} {fieldWord}
+            </span>
+          </div>
+        </div>
+      </button>
+      <CollapsibleContent>
+        {nativeFields.length === 0 && (
+          <p className='text-muted-foreground px-1 text-xs'>No fields available.</p>
+        )}
+        {nativeFields.map(field => (
+          <label
+            key={field.name}
+            className='group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
+          >
+            <Checkbox
+              checked={isChecked(field.name)}
+              onCheckedChange={checked => {
+                onToggleField(field.name, checked === true);
+              }}
+            />
+            <span className='font-mono text-xs'>{field.alias ?? field.name}</span>
+            {field.type && <span className='text-muted-foreground text-xs'>({field.type})</span>}
+            <FieldInfoTooltip text={field.description} compact />
+          </label>
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+interface BlendedGroupItemProps {
+  group: BlendedGroup;
+  isChecked: (name: string) => boolean;
+  onToggleField: (name: string, checked: boolean) => void;
+}
+
+function BlendedGroupItem({ group, isChecked, onToggleField }: BlendedGroupItemProps) {
+  // Smart default: групи з уже вибраними полями стартують відкритими
+  const [isOpen, setIsOpen] = useState(() => group.selectedCount > 0);
+
+  const counterText = `${group.selectedCount} / ${group.totalCount}`;
+  const fieldWord = group.totalCount === 1 ? 'field' : 'fields';
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <button
+        type='button'
+        aria-expanded={isOpen}
+        aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${group.alias}`}
+        className='group bg-secondary/50 dark:bg-muted/50 hover:bg-secondary/80 dark:hover:bg-muted/80 flex w-full cursor-pointer items-start gap-1.5 rounded px-1 py-1 text-left transition-colors'
+        onClick={() => {
+          setIsOpen(v => !v);
+        }}
+      >
+        {isOpen ? (
+          <ChevronDown className='text-muted-foreground mt-0.5 h-4 w-4 shrink-0' />
+        ) : (
+          <ChevronRight className='text-muted-foreground mt-0.5 h-4 w-4 shrink-0' />
+        )}
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-center justify-between gap-1.5'>
+            <div className='flex min-w-0 items-center gap-1.5'>
+              <span className='truncate text-xs font-semibold' title={group.alias}>
+                {group.alias}
+              </span>
+              <FieldInfoTooltip text={group.description} />
+            </div>
+            <span className='text-muted-foreground shrink-0 text-xs'>
+              {counterText} {fieldWord}
+            </span>
+          </div>
+        </div>
+      </button>
+      <CollapsibleContent>
+        {group.visibleFields.map(field => (
+          <label
+            key={field.name}
+            className='group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
+          >
+            <Checkbox
+              checked={isChecked(field.name)}
+              onCheckedChange={checked => {
+                onToggleField(field.name, checked === true);
+              }}
+            />
+            <span className='font-mono text-xs'>{field.alias || field.originalFieldName}</span>
+            {field.type && <span className='text-muted-foreground text-xs'>({field.type})</span>}
+            <FieldInfoTooltip text={field.description} compact />
+          </label>
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export function ReportColumnPicker({
+  dataMartId,
+  value,
+  onChange,
+  onBlendedSelectionChange,
+}: ReportColumnPickerProps) {
+  const { data: schema, isLoading } = useQuery({
+    queryKey: [BLENDABLE_SCHEMA_QUERY_KEY, dataMartId],
+    queryFn: () => dataMartRelationshipService.getBlendableSchema(dataMartId),
+    enabled: !!dataMartId,
+  });
+
+  const nativeFields = useMemo<NativeField[]>(
+    () => (schema ? flattenNativeFields(schema.nativeFields as NativeField[]) : []),
+    [schema]
+  );
+
+  // Only show blended fields from included sources
+  const includedPaths = useMemo(() => {
+    if (!schema?.availableSources) return new Set<string>();
+    return new Set(schema.availableSources.filter(s => s.isIncluded).map(s => s.aliasPath));
+  }, [schema]);
+
+  const includedBlendedFields = useMemo(() => {
+    if (!schema) return [];
+    return schema.blendedFields.filter(f => includedPaths.has(f.aliasPath) && !f.isHidden);
+  }, [schema, includedPaths]);
+
+  // Legacy reports with columnConfig === null had the "all native fields, no blended"
+  // meaning. Treat them the same for display/toggle math — the picker stays a pure
+  // controlled component: it only calls onChange when the user actually toggles
+  // something, so simply opening such a report does not mark the form dirty.
+  const effectiveValue = useMemo<string[]>(() => {
+    if (value !== null) return value;
+    return nativeFields.map(f => f.name);
+  }, [value, nativeFields]);
+
+  const hasBlendedSelection = useMemo(() => {
+    if (!schema) return false;
+    const blendedNames = new Set(includedBlendedFields.map(f => f.name));
+    return effectiveValue.some(name => blendedNames.has(name));
+  }, [schema, effectiveValue, includedBlendedFields]);
+
+  useEffect(() => {
+    onBlendedSelectionChange?.(hasBlendedSelection);
+  }, [hasBlendedSelection, onBlendedSelectionChange]);
+
+  function isChecked(fieldName: string): boolean {
+    return effectiveValue.includes(fieldName);
+  }
+
+  function toggleField(fieldName: string, checked: boolean) {
+    if (checked) {
+      if (effectiveValue.includes(fieldName)) return;
+      onChange([...effectiveValue, fieldName]);
+    } else {
+      onChange(effectiveValue.filter(name => name !== fieldName));
+    }
+  }
+
+  function selectAllNative() {
+    if (!schema) return;
+    const nativeNames = nativeFields.map(f => f.name);
+    const currentBlended = effectiveValue.filter(name => !nativeNames.includes(name));
+    onChange([...nativeNames, ...currentBlended]);
+  }
+
+  function deselectAllNative() {
+    if (!schema) return;
+    const nativeNames = new Set(nativeFields.map(f => f.name));
+    onChange(effectiveValue.filter(name => !nativeNames.has(name)));
+  }
+
+  const selectedNativeCount = nativeFields.filter(f => isChecked(f.name)).length;
+
+  const [showSelectedOnly, setShowSelectedOnly] = useState(false);
+
+  const visibleNativeFields = showSelectedOnly
+    ? nativeFields.filter(f => isChecked(f.name))
+    : nativeFields;
+
+  const availableSourceDescriptionByPath = useMemo(() => {
+    const map = new Map<string, string | undefined>();
+    for (const source of schema?.availableSources ?? []) {
+      map.set(source.aliasPath, source.description);
+    }
+    return map;
+  }, [schema]);
+
+  const groupedBlendedFields = useMemo<BlendedGroup[]>(() => {
+    const selectedSet = new Set(effectiveValue);
+    const groupMap = new Map<string, BlendedGroup>();
+
+    for (const field of includedBlendedFields) {
+      let group = groupMap.get(field.aliasPath);
+      if (!group) {
+        group = {
+          aliasPath: field.aliasPath,
+          title: field.sourceDataMartTitle,
+          alias: field.outputPrefix,
+          description: availableSourceDescriptionByPath.get(field.aliasPath),
+          visibleFields: [],
+          selectedCount: 0,
+          totalCount: 0,
+        };
+        groupMap.set(field.aliasPath, group);
+      }
+      group.totalCount += 1;
+      const isSelected = selectedSet.has(field.name);
+      if (isSelected) group.selectedCount += 1;
+      if (!showSelectedOnly || isSelected) group.visibleFields.push(field);
+    }
+
+    // У режимі "Selected only" ховаємо групи, у яких немає жодного видимого поля
+    return Array.from(groupMap.values()).filter(g => g.visibleFields.length > 0);
+  }, [includedBlendedFields, showSelectedOnly, effectiveValue, availableSourceDescriptionByPath]);
+
+  if (isLoading) {
+    return (
+      <div className='space-y-2'>
+        <Skeleton className='h-4 w-32' />
+        <Skeleton className='h-6 w-full' />
+        <Skeleton className='h-6 w-full' />
+        <Skeleton className='h-6 w-full' />
+      </div>
+    );
+  }
+
+  return (
+    <div className='space-y-2'>
+      <div className='flex items-center justify-between'>
+        <label className='text-muted-foreground hover:text-foreground flex cursor-pointer items-center gap-2 text-xs transition-colors'>
+          <Checkbox
+            checked={showSelectedOnly}
+            onCheckedChange={checked => {
+              setShowSelectedOnly(checked === true);
+            }}
+          />
+          Selected only
+        </label>
+        <div className='flex gap-2'>
+          <button
+            type='button'
+            className='text-muted-foreground hover:text-foreground cursor-pointer text-xs transition-colors'
+            onClick={selectAllNative}
+          >
+            Select All
+          </button>
+          <span className='text-muted-foreground text-xs'>/</span>
+          <button
+            type='button'
+            className='text-muted-foreground hover:text-foreground cursor-pointer text-xs transition-colors'
+            onClick={deselectAllNative}
+          >
+            Deselect All
+          </button>
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          'max-h-[32rem] space-y-1 overflow-y-auto rounded-md border p-1',
+          selectedNativeCount === 0 ? 'border-destructive' : 'border-border'
+        )}
+      >
+        {/* Default Columns (native fields) */}
+        <NativeFieldsGroup
+          nativeFields={visibleNativeFields}
+          description={schema?.nativeDescription}
+          selectedCount={selectedNativeCount}
+          totalCount={nativeFields.length}
+          isChecked={isChecked}
+          onToggleField={toggleField}
+        />
+
+        {/* Blended field groups */}
+        {groupedBlendedFields.map(group => (
+          <BlendedGroupItem
+            key={group.aliasPath}
+            group={group}
+            isChecked={isChecked}
+            onToggleField={toggleField}
+          />
+        ))}
+      </div>
+
+      {selectedNativeCount === 0 && (
+        <p className='text-destructive text-xs'>At least one native field must be selected.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/model/mappers/data-mart.mapper.ts
+++ b/apps/web/src/features/data-marts/edit/model/mappers/data-mart.mapper.ts
@@ -20,6 +20,7 @@ export async function mapDataMartFromDto(dataMartDto: DataMartResponseDto): Prom
     definition: await mapDefinitionFromDto(dataMartDto.definitionType, dataMartDto.definition),
     schema: dataMartDto.schema,
     connectorState: dataMartDto.connectorState ?? null,
+    blendedFieldsConfig: dataMartDto.blendedFieldsConfig ?? null,
     createdByUser: dataMartDto.createdByUser,
     businessOwnerUsers: dataMartDto.businessOwnerUsers,
     technicalOwnerUsers: dataMartDto.technicalOwnerUsers,

--- a/apps/web/src/features/data-marts/edit/model/types/data-mart-model.ts
+++ b/apps/web/src/features/data-marts/edit/model/types/data-mart-model.ts
@@ -5,6 +5,7 @@ import type { DataMartDefinitionConfig } from './data-mart-definition-config.ts'
 import type { DataMartDefinitionType } from '../../../shared';
 import type { DataMartSchema } from '../../../shared/types/data-mart-schema.types';
 import type { ConnectorStateResponseDto } from '../../../shared/types/api/response/connector-state.response.dto';
+import type { BlendedFieldsConfig } from '../../../shared/types/relationship.types';
 
 /**
  * Data mart domain model
@@ -79,6 +80,11 @@ export interface DataMart {
    * Connector state (if Data Mart is CONNECTOR-based)
    */
   connectorState?: ConnectorStateResponseDto | null;
+
+  /**
+   * Blended fields configuration
+   */
+  blendedFieldsConfig?: BlendedFieldsConfig | null;
 
   /**
    * Created by user projection

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
@@ -71,6 +71,7 @@ import type { DataDestinationFormData } from '../../../../../data-destination';
 import { useReport } from '../../../shared';
 import { isEmailDestinationConfig } from '../../../shared/model/types/data-mart-report';
 import { ReportFormActions } from '../shared/ReportFormActions';
+import { ReportColumnPicker } from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
 
 export interface EmailReportEditFormProps {
   initialReport?: DataMartReport;
@@ -291,6 +292,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
           messageTemplate: prefill?.messageTemplate ?? defaultMessageTemplate,
           insightTemplateId: prefill?.insightTemplateId,
           templateSourceType,
+          columnConfig: null,
         });
       }
     }, [
@@ -890,6 +892,23 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
                     </FormItem>
                   )}
                 />
+              </FormSection>
+
+              <FormSection
+                title='Report Columns'
+                tooltip='Select which columns to include in the report'
+              >
+                {dataMart?.id && (
+                  <div className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
+                    <ReportColumnPicker
+                      dataMartId={dataMart.id}
+                      value={form.watch('columnConfig')}
+                      onChange={value => {
+                        form.setValue('columnConfig', value, { shouldDirty: true });
+                      }}
+                    />
+                  </div>
+                )}
               </FormSection>
 
               <FormSection title='Automate Report Runs'>

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -58,6 +58,7 @@ import { useReport } from '../../../shared';
 import { ReportFormActions } from '../shared/ReportFormActions';
 import { OwnersSection } from '../../../../../../shared/components/OwnersSection/OwnersSection';
 import type { UserProjectionDto } from '../../../../../../shared/types/api';
+import { ReportColumnPicker } from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
 
 interface GoogleSheetsReportEditFormProps {
   initialReport?: DataMartReport;
@@ -199,11 +200,12 @@ export const GoogleSheetsReportEditForm = forwardRef<
             initialReport.destinationConfig.sheetId
           ),
           dataDestinationId: initialReport.dataDestination.id,
+          columnConfig: initialReport.columnConfig ?? null,
         });
       } else if (mode === ReportFormMode.CREATE) {
         // Pre-select destination if provided
         const destinationId = preSelectedDestination?.id ?? '';
-        reset({ title: '', documentUrl: '', dataDestinationId: destinationId });
+        reset({ title: '', documentUrl: '', dataDestinationId: destinationId, columnConfig: null });
       }
     }, [initialReport, mode, reset, preSelectedDestination]);
 
@@ -409,6 +411,22 @@ export const GoogleSheetsReportEditForm = forwardRef<
                   </FormItem>
                 )}
               />
+            </FormSection>
+            <FormSection
+              title='Report Columns'
+              tooltip='Select which columns to include in the report'
+            >
+              {dataMart?.id && (
+                <div className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
+                  <ReportColumnPicker
+                    dataMartId={dataMart.id}
+                    value={form.watch('columnConfig')}
+                    onChange={value => {
+                      form.setValue('columnConfig', value, { shouldDirty: true });
+                    }}
+                  />
+                </div>
+              )}
             </FormSection>
             <FormSection title='Automate Report Runs'>
               {dataMart?.id ? (

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/types.ts
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/types.ts
@@ -1,4 +1,6 @@
 export interface GoogleSheetsReportEditFormValues {
   title: string;
   documentUrl: string;
+  dataDestinationId: string;
+  columnConfig: string[] | null;
 }

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import { useOwnerState } from '../../../../../../shared/hooks/useOwnerState';
 import { UserReference } from '../../../../../../shared/components/UserReference/UserReference';
 import { useUser } from '../../../../../idp/hooks/useAuthState';
@@ -36,6 +36,8 @@ import { Button } from '@owox/ui/components/button';
 import LookerStudioCacheLifetimeDescription from './LookerStudioCacheLifetimeDescription.tsx';
 import { OwnersSection } from '../../../../../../shared/components/OwnersSection/OwnersSection';
 import type { UserProjectionDto } from '../../../../../../shared/types/api';
+import { ReportColumnPicker } from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
+import { GeneratedSqlViewer } from '../../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
 
 interface LookerStudioReportEditFormProps {
   initialReport?: DataMartReport;
@@ -82,6 +84,7 @@ export const LookerStudioReportEditForm = forwardRef<
     const formId = 'looker-studio-edit-form';
 
     const { dataMart } = useOutletContext<DataMartContextType>();
+    const [hasBlendedSelection, setHasBlendedSelection] = useState(false);
 
     const currentUser = useUser();
     const initialOwnerUsers =
@@ -136,10 +139,11 @@ export const LookerStudioReportEditForm = forwardRef<
       ) {
         reset({
           cacheLifetime: initialReport.destinationConfig.cacheLifetime,
+          columnConfig: initialReport.columnConfig ?? null,
         });
       } else if (mode === ReportFormMode.CREATE) {
         // Pre-select destination if provided
-        reset({ cacheLifetime: 300 });
+        reset({ cacheLifetime: 300, columnConfig: null });
       }
     }, [initialReport, mode, reset]);
 
@@ -192,6 +196,36 @@ export const LookerStudioReportEditForm = forwardRef<
                   </FormItem>
                 )}
               />
+            </FormSection>
+
+            <FormSection
+              title='Report Columns'
+              tooltip='Select which columns to include in the report'
+            >
+              {dataMart?.id && (
+                <div className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
+                  <ReportColumnPicker
+                    dataMartId={dataMart.id}
+                    value={form.watch('columnConfig')}
+                    onChange={value => {
+                      form.setValue('columnConfig', value, { shouldDirty: true });
+                    }}
+                    onBlendedSelectionChange={setHasBlendedSelection}
+                  />
+                  {hasBlendedSelection &&
+                    mode === ReportFormMode.EDIT &&
+                    initialReport?.id &&
+                    dataMart.id && (
+                      <div className='pt-1'>
+                        <GeneratedSqlViewer
+                          reportId={initialReport.id}
+                          dataMartId={dataMart.id}
+                          variant='outline-button'
+                        />
+                      </div>
+                    )}
+                </div>
+              )}
             </FormSection>
 
             <FormSection title='Ownership'>

--- a/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useEmailReportForm.test.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useEmailReportForm.test.ts
@@ -12,6 +12,7 @@ function buildPayload(overrides: Partial<Record<string, unknown>> = {}) {
     messageTemplate: '## Summary',
     insightTemplateId: undefined,
     templateSourceType: TemplateSourceTypeEnum.CUSTOM_MESSAGE,
+    columnConfig: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useEmailReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useEmailReportForm.ts
@@ -28,6 +28,10 @@ export const EmailReportEditFormSchema = z
     insightTemplateId: z.string().optional(),
     // Track which template source type is selected
     templateSourceType: z.nativeEnum(TemplateSourceTypeEnum),
+    columnConfig: z
+      .array(z.string())
+      .nullable()
+      .refine(val => val === null || val.length > 0, 'At least one column must be selected'),
   })
   .superRefine((data, ctx) => {
     if (data.templateSourceType === TemplateSourceTypeEnum.CUSTOM_MESSAGE) {
@@ -121,6 +125,7 @@ export function useEmailReportForm({
         isEmailDestinationConfig(initialReport.destinationConfig)
           ? (initialReport.destinationConfig.templateSource.type as TemplateSourceTypeEnum)
           : TemplateSourceTypeEnum.CUSTOM_MESSAGE,
+      columnConfig: initialReport?.columnConfig ?? null,
     },
     mode: 'onTouched',
   });
@@ -168,6 +173,7 @@ export function useEmailReportForm({
             ...(pendingOwnerIdsRef?.current != null
               ? { ownerIds: pendingOwnerIdsRef.current }
               : {}),
+            columnConfig: data.columnConfig,
           });
         } else {
           if (!initialReport) {
@@ -181,6 +187,7 @@ export function useEmailReportForm({
             ...(pendingOwnerIdsRef?.current != null
               ? { ownerIds: pendingOwnerIdsRef.current }
               : {}),
+            columnConfig: data.columnConfig,
           });
         }
 

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useGoogleSheetsReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useGoogleSheetsReportForm.ts
@@ -17,6 +17,10 @@ export const GoogleSheetsReportEditFormSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   documentUrl: z.string().refine(isValidGoogleSheetsUrl, 'Enter a valid Google Sheets URL'),
   dataDestinationId: z.string().min(1, 'Destination is required'),
+  columnConfig: z
+    .array(z.string())
+    .nullable()
+    .refine(val => val === null || val.length > 0, 'At least one column must be selected'),
 });
 
 export type GoogleSheetsReportEditFormValues = z.infer<typeof GoogleSheetsReportEditFormSchema>;
@@ -61,6 +65,7 @@ export function useGoogleSheetsReportForm({
           ? `https://docs.google.com/spreadsheets/d/${initialReport.destinationConfig.spreadsheetId}/edit#gid=${initialReport.destinationConfig.sheetId}`
           : '',
       dataDestinationId: initialReport?.dataDestination.id ?? preSelectedDestination?.id ?? '', // Use preSelectedDestination here
+      columnConfig: initialReport?.columnConfig ?? null,
     },
     mode: 'onTouched',
   });
@@ -98,6 +103,7 @@ export function useGoogleSheetsReportForm({
             ...(pendingOwnerIdsRef?.current != null
               ? { ownerIds: pendingOwnerIdsRef.current }
               : {}),
+            columnConfig: data.columnConfig,
           });
         } else {
           if (!initialReport) {
@@ -115,6 +121,7 @@ export function useGoogleSheetsReportForm({
             ...(pendingOwnerIdsRef?.current != null
               ? { ownerIds: pendingOwnerIdsRef.current }
               : {}),
+            columnConfig: data.columnConfig,
           });
         }
 

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
@@ -13,6 +13,10 @@ import type { DataDestination } from '../../../../data-destination/shared/model/
 // Define the form schema - simplified for editing existing reports
 const lookerStudioReportFormSchema = z.object({
   cacheLifetime: z.number().min(300, 'Cache time must be at least 5 minutes (300 seconds)'),
+  columnConfig: z
+    .array(z.string())
+    .nullable()
+    .refine(val => val === null || val.length > 0, 'At least one column must be selected'),
 });
 
 // Define the form data type
@@ -44,6 +48,7 @@ export function useLookerStudioReportForm({
         isLookerStudioDestinationConfig(initialReport.destinationConfig)
           ? initialReport.destinationConfig.cacheLifetime
           : 300,
+      columnConfig: initialReport?.columnConfig ?? null,
     },
     mode: 'onTouched',
   });
@@ -65,6 +70,7 @@ export function useLookerStudioReportForm({
           dataDestinationId: initialReport.dataDestination.id, // Keep existing
           destinationConfig,
           ...(pendingOwnerIdsRef?.current != null ? { ownerIds: pendingOwnerIdsRef.current } : {}),
+          columnConfig: data.columnConfig,
         });
       } else {
         // This shouldn't happen in our use case, but keeping for compatibility
@@ -74,6 +80,7 @@ export function useLookerStudioReportForm({
           dataDestinationId: preSelectedDestination?.id ?? '',
           destinationConfig,
           ...(pendingOwnerIdsRef?.current != null ? { ownerIds: pendingOwnerIdsRef.current } : {}),
+          columnConfig: data.columnConfig,
         });
       }
       onSuccess?.();

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
@@ -17,7 +17,9 @@ import {
 import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
 import { ReportStatusEnum } from '../../../shared/enums';
-import { useReport } from '../../../shared';
+import { reportHasBlending, useReport } from '../../../shared';
+import { useBlendedFieldNames } from '../../../../shared/hooks/useBlendedFieldNames';
+import { GeneratedSqlViewer } from '../../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
 
 interface EmailActionsCellProps {
   row: { original: DataMartReport };
@@ -32,6 +34,11 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
   const [menuOpen, setMenuOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { deleteReport, fetchReportsByDataMartId, runReport } = useReport();
+
+  // Show the "View SQL" icon only when the report actually produces blended output.
+  // The hook is safe to call per-row: React Query dedupes concurrent requests by key.
+  const blendedFieldNames = useBlendedFieldNames(row.original.dataMart.id);
+  const hasBlending = reportHasBlending(row.original, blendedFieldNames);
 
   const actionsMenuId = `actions-menu-${row.original.id}`;
 
@@ -105,6 +112,15 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
             Run report
           </TooltipContent>
         </Tooltip>
+
+        {/* View SQL (only when report uses blending) */}
+        {hasBlending && (
+          <GeneratedSqlViewer
+            reportId={row.original.id}
+            dataMartId={row.original.dataMart.id}
+            reportTitle={row.original.title}
+          />
+        )}
 
         {/* More actions */}
         <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
@@ -15,13 +15,15 @@ import {
   TooltipTrigger,
 } from '@owox/ui/components/tooltip';
 import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
-import { getGoogleSheetTabUrl } from '../../../shared';
+import { getGoogleSheetTabUrl, reportHasBlending } from '../../../shared';
 import type {
   DataMartReport,
   GoogleSheetsDestinationConfig,
 } from '../../../shared/model/types/data-mart-report';
 import { ReportStatusEnum } from '../../../shared/enums';
 import { useReport } from '../../../shared';
+import { useBlendedFieldNames } from '../../../../shared/hooks/useBlendedFieldNames';
+import { GeneratedSqlViewer } from '../../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
 
 interface GoogleSheetsActionsCellProps {
   row: { original: DataMartReport };
@@ -40,6 +42,11 @@ export function GoogleSheetsActionsCell({
   const [menuOpen, setMenuOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { deleteReport, fetchReportsByDataMartId, runReport } = useReport();
+
+  // Show the "View SQL" icon only when the report actually produces blended output.
+  // The hook is safe to call per-row: React Query dedupes concurrent requests by key.
+  const blendedFieldNames = useBlendedFieldNames(row.original.dataMart.id);
+  const hasBlending = reportHasBlending(row.original, blendedFieldNames);
 
   // Generate unique ID for the actions menu
   const actionsMenuId = `actions-menu-${row.original.id}`;
@@ -138,6 +145,15 @@ export function GoogleSheetsActionsCell({
             Open document
           </TooltipContent>
         </Tooltip>
+
+        {/* View SQL (only when report uses blending) */}
+        {hasBlending && (
+          <GeneratedSqlViewer
+            reportId={row.original.id}
+            dataMartId={row.original.dataMart.id}
+            reportTitle={row.original.title}
+          />
+        )}
 
         {/* More actions */}
         <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>

--- a/apps/web/src/features/data-marts/reports/shared/model/mappers/report.mapper.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/mappers/report.mapper.ts
@@ -28,6 +28,7 @@ export function mapReportDtoToEntity(reportDto: ReportResponseDto): DataMartRepo
     dataMart: { id: reportDto.dataMart.id },
     dataDestination: mapDataDestinationFromDto(reportDto.dataDestinationAccess),
     destinationConfig,
+    columnConfig: reportDto.columnConfig ?? null,
     lastRunDate: reportDto.lastRunAt ? new Date(reportDto.lastRunAt) : null,
     lastRunStatus: reportDto.lastRunStatus,
     lastRunError: reportDto.lastRunError,

--- a/apps/web/src/features/data-marts/reports/shared/model/types/data-mart-report.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/types/data-mart-report.ts
@@ -98,6 +98,7 @@ export interface DataMartReport {
   dataMart: Pick<DataMart, 'id'>;
   dataDestination: DataDestination;
   destinationConfig: DestinationConfig;
+  columnConfig: string[] | null;
   lastRunDate: Date | null;
   lastRunStatus: ReportStatusEnum | null;
   lastRunError: string | null;

--- a/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
@@ -97,6 +97,24 @@ export class ReportService extends ApiService {
   async runReport(id: string): Promise<void> {
     return this.post(`/${id}/run`);
   }
+
+  /**
+   * Get the generated SQL for a report
+   * @param id Report ID
+   * @returns Object containing the generated SQL string
+   */
+  async getGeneratedSql(id: string): Promise<{ sql: string }> {
+    return this.get<{ sql: string }>(`/${id}/generated-sql`);
+  }
+
+  /**
+   * Copy a report as a new Data Mart
+   * @param id Report ID
+   * @returns Promise with the created data mart id
+   */
+  async copyAsDataMart(id: string): Promise<{ dataMartId: string }> {
+    return this.post<{ dataMartId: string }>(`/${id}/copy-as-data-mart`);
+  }
 }
 
 // Create a singleton instance

--- a/apps/web/src/features/data-marts/reports/shared/services/types/create-report.request.dto.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/types/create-report.request.dto.ts
@@ -9,4 +9,5 @@ export interface CreateReportRequestDto {
   dataDestinationId: string;
   destinationConfig: DestinationConfigDto;
   ownerIds?: string[];
+  columnConfig?: string[] | null;
 }

--- a/apps/web/src/features/data-marts/reports/shared/services/types/report-response.dto.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/types/report-response.dto.ts
@@ -13,6 +13,7 @@ export interface ReportResponseDto {
   dataMart: DataMartResponseDto;
   dataDestinationAccess: DataDestinationResponseDto;
   destinationConfig: DestinationConfigDto;
+  columnConfig?: string[] | null;
   lastRunAt: string | null;
   lastRunStatus: ReportStatusEnum | null;
   lastRunError: string | null;

--- a/apps/web/src/features/data-marts/reports/shared/services/types/update-report.request.dto.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/types/update-report.request.dto.ts
@@ -72,4 +72,5 @@ export interface UpdateReportRequestDto {
   dataDestinationId: string;
   destinationConfig: DestinationConfigDto;
   ownerIds?: string[];
+  columnConfig?: string[] | null;
 }

--- a/apps/web/src/features/data-marts/reports/shared/utils/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './google-sheets-url.utils';
+export * from './report-has-blending.utils';
 export * from './service-account.utils';

--- a/apps/web/src/features/data-marts/reports/shared/utils/report-has-blending.utils.ts
+++ b/apps/web/src/features/data-marts/reports/shared/utils/report-has-blending.utils.ts
@@ -1,0 +1,18 @@
+import type { DataMartReport } from '../model/types/data-mart-report';
+
+/**
+ * Returns true when at least one column in the report's columnConfig is
+ * a valid blended field (i.e. present in the provided set of blended
+ * field names).
+ *
+ * Used by reports list action cells to decide whether to render the
+ * "View SQL" icon — it is shown only when the report actually produces
+ * blended output.
+ */
+export function reportHasBlending(
+  report: DataMartReport,
+  validBlendedFieldNames: Set<string>
+): boolean {
+  if (validBlendedFieldNames.size === 0 || !report.columnConfig) return false;
+  return report.columnConfig.some(name => validBlendedFieldNames.has(name));
+}

--- a/apps/web/src/features/data-marts/shared/hooks/useBlendedFieldNames.ts
+++ b/apps/web/src/features/data-marts/shared/hooks/useBlendedFieldNames.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { dataMartRelationshipService } from '../services/data-mart-relationship.service';
+
+/**
+ * Shared query key for the blendable schema request.
+ * Exported so that any component fetching blendable schema uses the same
+ * React Query cache entry for a given data mart.
+ */
+export const BLENDABLE_SCHEMA_QUERY_KEY = 'blendable-schema';
+
+/**
+ * Fetches the blendable schema for a data mart and returns a memoized Set
+ * of valid blended field names — names of blended fields that belong to
+ * currently included sources and are not hidden.
+ *
+ * Mirrors the filtering logic in ReportColumnPicker to keep the action-cell
+ * "View SQL" visibility in sync with what the edit form considers "blended".
+ */
+export function useBlendedFieldNames(dataMartId: string | undefined): Set<string> {
+  const { data: schema } = useQuery({
+    queryKey: [BLENDABLE_SCHEMA_QUERY_KEY, dataMartId],
+    queryFn: () => {
+      if (!dataMartId) {
+        return Promise.reject(new Error('dataMartId is required'));
+      }
+      return dataMartRelationshipService.getBlendableSchema(dataMartId);
+    },
+    enabled: !!dataMartId,
+  });
+
+  return useMemo(() => {
+    if (!schema) return new Set<string>();
+    const includedPaths = new Set(
+      schema.availableSources.filter(s => s.isIncluded).map(s => s.aliasPath)
+    );
+    return new Set(
+      schema.blendedFields
+        .filter(f => includedPaths.has(f.aliasPath) && !f.isHidden)
+        .map(f => f.name)
+    );
+  }, [schema]);
+}

--- a/apps/web/src/features/data-marts/shared/services/data-mart-relationship.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart-relationship.service.ts
@@ -1,0 +1,103 @@
+import type { AxiosRequestConfig } from '../../../../app/api/apiClient';
+import { ApiService } from '../../../../services';
+import type {
+  BlendableSchema,
+  BlendedFieldsConfig,
+  CreateRelationshipRequest,
+  DataMartRelationship,
+  UpdateRelationshipRequest,
+} from '../types/relationship.types';
+
+/**
+ * Service for data mart relationship operations.
+ * Provides CRUD operations for relationships and blendable schema access.
+ */
+class DataMartRelationshipService extends ApiService {
+  /**
+   * Separate service instance for endpoints outside /data-marts base path.
+   */
+  private readonly storageApiService: ApiService;
+
+  constructor() {
+    super('/data-marts');
+    this.storageApiService = new ApiService('');
+  }
+
+  /**
+   * Get all relationships for a data mart.
+   * @param dataMartId Data mart ID
+   */
+  async getRelationships(dataMartId: string): Promise<DataMartRelationship[]> {
+    return this.get<DataMartRelationship[]>(`/${dataMartId}/relationships`);
+  }
+
+  /**
+   * Create a new relationship for a data mart.
+   * @param dataMartId Data mart ID
+   * @param request Relationship creation request
+   */
+  async createRelationship(
+    dataMartId: string,
+    request: CreateRelationshipRequest
+  ): Promise<DataMartRelationship> {
+    return this.post<DataMartRelationship>(`/${dataMartId}/relationships`, request);
+  }
+
+  /**
+   * Update an existing relationship.
+   * @param dataMartId Data mart ID
+   * @param relId Relationship ID
+   * @param request Relationship update request
+   */
+  async updateRelationship(
+    dataMartId: string,
+    relId: string,
+    request: UpdateRelationshipRequest,
+    config?: AxiosRequestConfig
+  ): Promise<DataMartRelationship> {
+    return this.patch<DataMartRelationship>(
+      `/${dataMartId}/relationships/${relId}`,
+      request,
+      config
+    );
+  }
+
+  /**
+   * Delete a relationship.
+   * @param dataMartId Data mart ID
+   * @param relId Relationship ID
+   */
+  async deleteRelationship(dataMartId: string, relId: string): Promise<void> {
+    return this.delete(`/${dataMartId}/relationships/${relId}`);
+  }
+
+  /**
+   * Get the blendable schema for a data mart.
+   * @param dataMartId Data mart ID
+   */
+  async getBlendableSchema(dataMartId: string): Promise<BlendableSchema> {
+    return this.get<BlendableSchema>(`/${dataMartId}/blendable-schema`);
+  }
+
+  /**
+   * Get all relationships for a data storage.
+   * Uses a different base path (/data-storages) than the primary service.
+   * @param storageId Data storage ID
+   */
+  async updateBlendedFieldsConfig(
+    dataMartId: string,
+    config: BlendedFieldsConfig | null
+  ): Promise<unknown> {
+    return this.put(`/${dataMartId}/blended-fields-config`, {
+      blendedFieldsConfig: config,
+    });
+  }
+
+  async getRelationshipsByStorage(storageId: string): Promise<DataMartRelationship[]> {
+    return this.storageApiService.get<DataMartRelationship[]>(
+      `/data-storages/${storageId}/relationships`
+    );
+  }
+}
+
+export const dataMartRelationshipService = new DataMartRelationshipService();

--- a/apps/web/src/features/data-marts/shared/services/data-mart-relationship.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart-relationship.service.ts
@@ -1,5 +1,6 @@
 import type { AxiosRequestConfig } from '../../../../app/api/apiClient';
 import { ApiService } from '../../../../services';
+import type { DataMartResponseDto } from '../types/api/response/data-mart.response.dto';
 import type {
   BlendableSchema,
   BlendedFieldsConfig,
@@ -80,19 +81,25 @@ class DataMartRelationshipService extends ApiService {
   }
 
   /**
-   * Get all relationships for a data storage.
-   * Uses a different base path (/data-storages) than the primary service.
-   * @param storageId Data storage ID
+   * Replace the data mart's blended fields configuration.
+   * @param dataMartId Data mart ID.
+   * @param config Full configuration to persist, or `null` to clear it.
+   * @returns The updated data mart as returned by the API.
    */
   async updateBlendedFieldsConfig(
     dataMartId: string,
     config: BlendedFieldsConfig | null
-  ): Promise<unknown> {
-    return this.put(`/${dataMartId}/blended-fields-config`, {
+  ): Promise<DataMartResponseDto> {
+    return this.put<DataMartResponseDto>(`/${dataMartId}/blended-fields-config`, {
       blendedFieldsConfig: config,
     });
   }
 
+  /**
+   * Get all relationships for a data storage.
+   * Uses a different base path (/data-storages) than the primary service.
+   * @param storageId Data storage ID
+   */
   async getRelationshipsByStorage(storageId: string): Promise<DataMartRelationship[]> {
     return this.storageApiService.get<DataMartRelationship[]>(
       `/data-storages/${storageId}/relationships`

--- a/apps/web/src/features/data-marts/shared/types/api/response/data-mart.response.dto.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/response/data-mart.response.dto.ts
@@ -5,6 +5,7 @@ import { DataMartDefinitionType } from '../../../enums';
 import type { DataMartDefinitionDto } from './data-mart-definition.dto';
 import type { DataMartSchema } from '../../data-mart-schema.types';
 import type { ConnectorStateResponseDto } from './connector-state.response.dto';
+import type { BlendedFieldsConfig } from '../../relationship.types';
 
 /**
  * Data mart response data transfer object
@@ -28,4 +29,5 @@ export interface DataMartResponseDto {
   connectorState?: ConnectorStateResponseDto | null;
   availableForReporting?: boolean;
   availableForMaintenance?: boolean;
+  blendedFieldsConfig?: BlendedFieldsConfig | null;
 }

--- a/apps/web/src/features/data-marts/shared/types/data-mart-schema.types.ts
+++ b/apps/web/src/features/data-marts/shared/types/data-mart-schema.types.ts
@@ -230,6 +230,7 @@ export interface BaseSchemaField {
   alias?: string;
   description?: string;
   isPrimaryKey: boolean;
+  isHiddenForReporting?: boolean;
   status: DataMartSchemaFieldStatus;
 }
 

--- a/apps/web/src/features/data-marts/shared/types/relationship.types.ts
+++ b/apps/web/src/features/data-marts/shared/types/relationship.types.ts
@@ -1,0 +1,117 @@
+import type { UserProjection } from '../../../../shared/types';
+
+export const AGGREGATE_FUNCTIONS = [
+  'STRING_AGG',
+  'MAX',
+  'MIN',
+  'SUM',
+  'COUNT',
+  'COUNT_DISTINCT',
+  'ANY_VALUE',
+] as const;
+export type AggregateFunction = (typeof AGGREGATE_FUNCTIONS)[number];
+
+export interface JoinCondition {
+  sourceFieldName: string;
+  targetFieldName: string;
+}
+
+export interface RelatedDataMart {
+  id: string;
+  title: string;
+  description?: string;
+  status: string;
+}
+
+export interface DataMartRelationship {
+  id: string;
+  dataStorageId: string;
+  sourceDataMart: RelatedDataMart;
+  targetDataMart: RelatedDataMart;
+  targetAlias: string;
+  joinConditions: JoinCondition[];
+  createdById: string;
+  createdAt: string;
+  modifiedAt: string;
+  createdByUser?: UserProjection | null;
+}
+
+export interface CreateRelationshipRequest {
+  targetDataMartId: string;
+  targetAlias: string;
+  joinConditions: JoinCondition[];
+}
+
+export interface UpdateRelationshipRequest {
+  targetAlias?: string;
+  joinConditions?: JoinCondition[];
+}
+
+export interface TransientRelationshipRow {
+  relationship: DataMartRelationship;
+  depth: number;
+  parentDataMartTitle: string;
+  sourceDmId: string;
+  isBlocked: boolean;
+  aliasPath: string;
+  /**
+   * Stable identifier encoding the full relationship path from the root.
+   * Unique across rows even when the same relationship is reached via
+   * multiple parents (e.g. two direct parents pointing at the same DM
+   * produce identical children — distinct rows, but same rel.id/depth).
+   */
+  rowKey: string;
+}
+
+export interface BlendedField {
+  name: string;
+  sourceRelationshipId: string;
+  sourceDataMartId: string;
+  sourceDataMartTitle: string;
+  targetAlias: string;
+  originalFieldName: string;
+  type: string;
+  alias: string;
+  description: string;
+  isHidden: boolean;
+  aggregateFunction: AggregateFunction;
+  transitiveDepth: number;
+  aliasPath: string;
+  outputPrefix: string;
+}
+
+export interface AvailableSource {
+  aliasPath: string;
+  title: string;
+  description?: string;
+  defaultAlias: string;
+  depth: number;
+  fieldCount: number;
+  isIncluded: boolean;
+  relationshipId: string;
+  dataMartId: string;
+}
+
+export interface BlendableSchema {
+  nativeFields: unknown[];
+  nativeDescription?: string;
+  blendedFields: BlendedField[];
+  availableSources: AvailableSource[];
+}
+
+export interface BlendedFieldOverride {
+  alias?: string;
+  isHidden?: boolean;
+  aggregateFunction?: AggregateFunction;
+}
+
+export interface BlendedSource {
+  path: string;
+  alias: string;
+  isExcluded?: boolean;
+  fields?: Record<string, BlendedFieldOverride>;
+}
+
+export interface BlendedFieldsConfig {
+  sources: BlendedSource[];
+}

--- a/apps/web/src/features/data-marts/shared/types/relationship.types.ts
+++ b/apps/web/src/features/data-marts/shared/types/relationship.types.ts
@@ -1,5 +1,9 @@
 import type { UserProjection } from '../../../../shared/types';
 
+// Keep this list in sync with `AGGREGATE_FUNCTIONS` on the backend side
+// (`apps/backend/src/data-marts/dto/schemas/relationship-schemas.ts`).
+// The two declarations mirror each other so the blended SQL builder and
+// the UI expose identical options.
 export const AGGREGATE_FUNCTIONS = [
   'STRING_AGG',
   'MAX',

--- a/apps/web/src/pages/data-marts/edit/DataMartDataSetupContent.tsx
+++ b/apps/web/src/pages/data-marts/edit/DataMartDataSetupContent.tsx
@@ -13,6 +13,7 @@ import {
   CollapsibleCardFooter,
 } from '../../../shared/components/CollapsibleCard';
 import { DatabaseIcon, CodeIcon, Columns3 } from 'lucide-react';
+import { DataMartRelationshipsContent } from '../../../features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent';
 import type { DataMartDefinitionType } from '../../../features/data-marts/shared';
 
 export default function DataMartDataSetupContent() {
@@ -88,6 +89,8 @@ export default function DataMartDataSetupContent() {
         </CollapsibleCardContent>
         <CollapsibleCardFooter></CollapsibleCardFooter>
       </CollapsibleCard>
+
+      <DataMartRelationshipsContent />
     </div>
   );
 }

--- a/apps/web/src/shared/components/Combobox/combobox.tsx
+++ b/apps/web/src/shared/components/Combobox/combobox.tsx
@@ -49,6 +49,18 @@ export function Combobox({
 }: ComboboxProps) {
   const [open, setOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState('');
+  const [activeValue, setActiveValue] = React.useState(value);
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (nextOpen) {
+        setActiveValue(value);
+        setSearchQuery('');
+      }
+    },
+    [value]
+  );
 
   const groupedOptions = React.useMemo(() => {
     const groups: Record<string, ComboboxOption[]> = {};
@@ -78,7 +90,7 @@ export function Combobox({
   );
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={true}>
+    <Popover open={open} onOpenChange={handleOpenChange} modal={true}>
       <PopoverTrigger asChild>
         <Button
           variant='outline'
@@ -87,9 +99,15 @@ export function Combobox({
           className={cn('w-full justify-between', !value && 'text-muted-foreground', className)}
           disabled={disabled}
         >
-          <span className='min-w-0 flex-1 truncate text-left'>
-            {selectedOption ? selectedOption.label : placeholder}
-          </span>
+          {selectedOption ? (
+            renderLabel ? (
+              <span className='min-w-0 flex-1 text-left'>{renderLabel(selectedOption)}</span>
+            ) : (
+              <span className='min-w-0 flex-1 truncate text-left'>{selectedOption.label}</span>
+            )
+          ) : (
+            <span className='min-w-0 flex-1 truncate text-left'>{placeholder}</span>
+          )}
           <ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
         </Button>
       </PopoverTrigger>
@@ -99,6 +117,8 @@ export function Combobox({
         sideOffset={5}
       >
         <Command
+          value={activeValue}
+          onValueChange={setActiveValue}
           filter={filterOptions}
           className='[&_[data-slot=command-input-wrapper]]:gap-3 [&_[data-slot=command-input-wrapper]]:px-4'
         >
@@ -107,7 +127,7 @@ export function Combobox({
             value={searchQuery}
             onValueChange={setSearchQuery}
           />
-          <CommandList className='max-h-[300px] overflow-auto'>
+          <CommandList className='max-h-[200px] overflow-auto'>
             <CommandEmpty>{emptyMessage}</CommandEmpty>
             {Object.entries(groupedOptions).map(([groupName, groupOptions]) => {
               return (

--- a/apps/web/src/utils/string-utils.ts
+++ b/apps/web/src/utils/string-utils.ts
@@ -12,3 +12,28 @@ export function capitalizeFirstLetter(str: string): string {
 
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
+
+/**
+ * Convert a human-readable label into a snake_case slug safe for use as an
+ * SQL alias (lowercase letters, digits and underscores only).
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * Return `base` if it is not in `taken`, otherwise append `_2`, `_3`, ... until
+ * a free variant is found. Used to guarantee unique aliases when multiple items
+ * share the same slugified title.
+ */
+export function generateUniqueAlias(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) return base;
+  let i = 2;
+  while (taken.has(`${base}_${i}`)) {
+    i += 1;
+  }
+  return `${base}_${i}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -562,6 +562,12 @@
         "react-hook-form": "^7.58.0",
         "react-hot-toast": "^2.5.2",
         "react-router-dom": "^7.6.2",
+        "rete": "^2.0.6",
+        "rete-area-plugin": "^2.1.5",
+        "rete-connection-plugin": "^2.0.5",
+        "rete-minimap-plugin": "^2.0.3",
+        "rete-react-plugin": "^2.1.0",
+        "styled-components": "^6.3.12",
         "tailwindcss": "^4.1.8"
       },
       "devDependencies": {
@@ -3567,6 +3573,27 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.50.2",
@@ -13132,6 +13159,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stylis": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.7.tgz",
+      "integrity": "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA==",
+      "license": "MIT"
+    },
     "node_modules/@types/superagent": {
       "version": "8.1.9",
       "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
@@ -16805,6 +16838,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001788",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
@@ -17924,6 +17966,15 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -17955,6 +18006,17 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -27195,6 +27257,12 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -31807,6 +31875,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -33701,6 +33775,86 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rete": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/rete/-/rete-2.0.6.tgz",
+      "integrity": "sha512-kPmlKCGFES2VWtY7Y7SCB8ZeXRMsgX5deza9cu4OwmfM/ZUimd461kC3hRyccoyVxE4POlHUx0gg2jcGfusHFg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      }
+    },
+    "node_modules/rete-area-plugin": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/rete-area-plugin/-/rete-area-plugin-2.1.5.tgz",
+      "integrity": "sha512-iquEvwkQlcsO4cmgM3Z37TG0AWaE536dfA+lCJAze5YJzVx4RBaViUCqdB4dUA/utSytpBCkiDC4D3ztM9akGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "peerDependencies": {
+        "rete": "^2.0.0"
+      }
+    },
+    "node_modules/rete-connection-plugin": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/rete-connection-plugin/-/rete-connection-plugin-2.0.5.tgz",
+      "integrity": "sha512-KFtlOyEJRc0y9STVgo2T+t+j9u5fxiTxbyzPbMCm0uqncb3b8d2ABDIzvWoNo5zQAh2Oz/OvlUovupbzrGzpSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "peerDependencies": {
+        "rete": "^2.0.1",
+        "rete-area-plugin": "^2.0.0"
+      }
+    },
+    "node_modules/rete-minimap-plugin": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/rete-minimap-plugin/-/rete-minimap-plugin-2.0.3.tgz",
+      "integrity": "sha512-4rLvN6ykTY4Q1k6GO6W80mUbs5BXmGNtSXDumCF+eKkCK2nX8CNZGppcOqjTiWxHmsQfbZaKFwvnWDNwou4HHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "peerDependencies": {
+        "rete": "^2.0.1",
+        "rete-area-plugin": "^2.0.0"
+      }
+    },
+    "node_modules/rete-react-plugin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rete-react-plugin/-/rete-react-plugin-2.1.0.tgz",
+      "integrity": "sha512-FXYhdb4FFL7S7Iie398nfyLTRRan+OT6Gdo5nZnF/3nq8R1xan6zKuWmpovUXjxEgm6pkVhY9BjCEV8XlAXWAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "usehooks-ts": "^3.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6 || ^17 || ^18 || ^19 ",
+        "react-dom": "^16.8.6 || ^17 || ^18 || ^19",
+        "rete": "^2.0.1",
+        "rete-area-plugin": "^2.0.0",
+        "rete-render-utils": "^2.0.0",
+        "styled-components": "^5.3.6 || ^6"
+      }
+    },
+    "node_modules/rete-render-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/rete-render-utils/-/rete-render-utils-2.0.3.tgz",
+      "integrity": "sha512-Oz4W2PNayHocRvlzadb5BCNf+tDzJ8RhTwB3ucBPCdCLKZ974wWDiTSCRfA287L2hmHVzRfBdyAwC03K9eP+4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "peerDependencies": {
+        "rete": "^2.0.0",
+        "rete-area-plugin": "^2.0.0"
+      }
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -34352,6 +34506,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.32.6",
@@ -35839,6 +35999,73 @@
       "dependencies": {
         "inline-style-parser": "0.2.7"
       }
+    },
+    "node_modules/styled-components": {
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.3.12.tgz",
+      "integrity": "sha512-hFR6xsVkVYbsdcUlzPYFvFfoc6o2KlV0VvgRIQwSYMtdThM7SCxnjX9efh/cWce2kTq16I/Kl3xM98xiLptsXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.4.0",
+        "@emotion/unitless": "0.10.0",
+        "@types/stylis": "4.2.7",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.6",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/styled-components/node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "10.3.0",
@@ -38227,6 +38454,21 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
+      "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/util-deprecate": {

--- a/packages/ui/src/components/common/sortable-table-row.tsx
+++ b/packages/ui/src/components/common/sortable-table-row.tsx
@@ -12,12 +12,14 @@ interface SortableTableRowProps<T = unknown> {
   row?: T;
   /** Table cells (first cell replaced with drag handle) */
   children: ReactNode;
+  /** Optional class name for the row */
+  className?: string;
 }
 
 /**
  * Sortable table row with drag-and-drop functionality
  */
-export function SortableTableRow<T>({ id, children }: SortableTableRowProps<T>) {
+export function SortableTableRow<T>({ id, children, className }: SortableTableRowProps<T>) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
   });
@@ -53,7 +55,7 @@ export function SortableTableRow<T>({ id, children }: SortableTableRowProps<T>) 
   ];
 
   return (
-    <TableRow ref={setNodeRef} style={style} className='group'>
+    <TableRow ref={setNodeRef} style={style} className={`group${className ? ` ${className}` : ''}`}>
       {updatedChildren}
     </TableRow>
   );

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -101,8 +101,8 @@ function FormItem({ className = '', variant = 'default', ...props }: FormItemPro
         data-slot='form-item'
         className={cn(
           variant === 'default' &&
-            'group border-border flex flex-col gap-2 rounded-md border-b bg-white px-4 py-3 transition-shadow duration-200 hover:shadow-sm dark:border-white/4 dark:bg-white/4',
-          variant === 'light' && '',
+            'group border-border flex flex-col gap-2 rounded-md border-b bg-white px-4 py-3 transition-shadow duration-200 hover:shadow-sm dark:border-transparent dark:bg-white/4',
+          variant === 'light' && 'flex flex-col gap-1.5',
           className
         )}
         {...props}
@@ -268,6 +268,8 @@ function FormActions({
  */
 interface FormSectionProps {
   title?: string;
+  description?: string;
+  tooltip?: React.ReactNode | string;
   children: React.ReactNode;
   defaultOpen?: boolean;
   collapsible?: boolean;
@@ -276,8 +278,33 @@ interface FormSectionProps {
 
 const SECTION_STORAGE_PREFIX = 'form-section-';
 
+function FormSectionTooltip({ tooltip }: { tooltip: React.ReactNode | string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type='button'
+          tabIndex={-1}
+          className='pointer-events-none opacity-0 transition group-hover:pointer-events-auto group-hover:opacity-100'
+          aria-label='Help information'
+        >
+          <Info
+            className='text-muted-foreground/50 hover:text-muted-foreground size-4 shrink-0 transition-colors'
+            aria-hidden='true'
+          />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side='top' align='center' role='tooltip'>
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function FormSection({
   title,
+  description,
+  tooltip,
   children,
   defaultOpen = true,
   collapsible = true,
@@ -318,10 +345,12 @@ function FormSection({
     return (
       <div data-slot='form-section' className='mb-4'>
         {title && (
-          <h3 className='text-muted-foreground/75 mb-2 text-xs font-semibold tracking-wide uppercase'>
-            {title}
-          </h3>
+          <div className='group border-border flex items-center justify-between rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
+            <h3 className='text-muted-foreground text-sm font-medium'>{title}</h3>
+            {tooltip && <FormSectionTooltip tooltip={tooltip} />}
+          </div>
         )}
+        {description && <p className='text-muted-foreground mt-2 mb-2 text-sm'>{description}</p>}
         {content}
       </div>
     );
@@ -335,22 +364,24 @@ function FormSection({
       className='mb-4 flex flex-col gap-2'
     >
       {title && (
-        <CollapsibleTrigger asChild>
-          <button type='button' className='flex cursor-pointer items-center gap-1'>
-            <span className='text-muted-foreground/75 text-xs font-semibold tracking-wide uppercase'>
-              {title}
-            </span>
-            <ChevronRight
-              className={cn(
-                'text-foreground/75 h-3.5 w-3.5 transition-transform duration-200',
-                isOpen && 'rotate-90'
-              )}
-            />
-          </button>
-        </CollapsibleTrigger>
+        <div className='group border-border flex items-center justify-between rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
+          <CollapsibleTrigger asChild>
+            <button type='button' className='flex cursor-pointer items-center gap-1'>
+              <ChevronRight
+                className={cn(
+                  'text-muted-foreground h-3.5 w-3.5 transition-transform duration-200',
+                  isOpen && 'rotate-90'
+                )}
+              />
+              <span className='text-muted-foreground text-sm font-medium'>{title}</span>
+            </button>
+          </CollapsibleTrigger>
+          {tooltip && <FormSectionTooltip tooltip={tooltip} />}
+        </div>
       )}
 
       <CollapsibleContent className='data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden'>
+        {description && <p className='text-muted-foreground text-sm'>{description}</p>}
         {content}
       </CollapsibleContent>
     </Collapsible>

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -31,7 +31,7 @@ function SelectTrigger({
       data-slot='select-trigger'
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:flex-1 *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -98,7 +98,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot='select-item'
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:flex-1 *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Lets users declare one data mart as **joinable** with another and build reports that combine columns from several joined data marts in a single output. Before this change a report could only consume columns from one data mart.

End-user flow:

1. On a data mart's **Data Setup** tab, the new **Joinable Data Marts** block (table + diagram view) lists joinable data marts and adds new ones via **Join Data Mart**. Each entry has **Join Settings** (conditions) and per-field overrides — alias, visibility, aggregate function.
2. In any report edit form, the **Report Columns** picker now shows fields of the report's data mart plus fields from joined data marts. Picking a joined field switches the report to a SQL path that joins the underlying data marts; otherwise the native fast path runs unchanged.
3. A **Generated SQL** viewer shows the effective SQL for any report. Any joined report can be promoted to a standalone data mart via **Copy as Data Mart**.

## Architecture

Backend pipeline for a report run:

```text
Report.columnConfig
   │
   ▼
BlendedReportDataService.resolveBlendingDecision(report)
   │  ├─ no columnConfig            → native path (unchanged)
   │  ├─ no joined columns selected → native path with column filter
   │  └─ at least one joined column → build joined SQL
   │
   ▼
BlendableSchemaService.computeBlendableSchema(dataMartId)
   │  transitive resolution via DataMartRelationshipService
   │  (cycle detection, MAX_TRANSITIVE_DEPTH, chain validation)
   │
   ▼
BlendedQueryBuilderFacade.buildBlendedQuery(storageType, request)
   │  per-storage AbstractBlendedQueryBuilder subclass builds
   │  bottom-up CTEs with per-data-mart pre-aggregation
   │
   ▼
storage-specific reader executes SQL; ReportRunLogger records it.
```

Internal code uses `relationship` / `blendable` / `blended`; user-facing terms are **joinable data marts** / **joined reports**.

Key services:

- `DataMartRelationshipService` — CRUD over joinable-data-mart links, cycle detection, join condition validation against both schemas, field type compatibility.
- `BlendableSchemaService` — transitive resolution of joinable sources/fields from a root data mart, bounded by `MAX_TRANSITIVE_DEPTH`.
- `BlendedReportDataService` — decision, chain construction, per-storage builder dispatch, run-history logging.
- `AbstractBlendedQueryBuilder` — shared join/pre-aggregation strategy; per-storage subclasses add identifier escaping and type casting.

All new use-cases go through `AccessDecisionService` for role-based access (editor for mutations, viewer for reads).

Frontend:

- `apps/web/src/features/data-marts/edit/components/DataMartRelationships/` — the **Joinable Data Marts** block with table/diagram views (`RelationshipCanvas.tsx`), **Join Data Mart** picker, per-entry accordion, **Join Settings** form. `RelationshipCanvas` is lazy-loaded (Rete.js).
- `apps/web/src/features/data-marts/edit/components/ReportColumnPicker/` — column picker wired into all three report forms (Email, Google Sheets, Looker Studio), plus `GeneratedSqlViewer` and `FieldInfoTooltip`.

## API changes

New endpoints:

- `GET /api/data-marts/:id/blendable-schema` — transitively resolved joinable sources and fields.
- `PUT /api/data-marts/:id/blended-fields-config` — saves per-field overrides (alias / hidden / aggregate).
- `POST|PATCH|DELETE|GET /api/data-marts/:dataMartId/relationships[/:id]` — CRUD over joinable data marts.
- `GET /api/data-storages/:storageId/relationships` — list relationships scoped to a storage.
- `GET /api/reports/:id/generated-sql` — SQL that would be executed (native or joined).
- `POST /api/reports/:id/copy-as-data-mart` — creates a new data mart from a joined report's effective query.

New optional fields on existing DTOs:

- `Report.columnConfig: string[] | null` — ordered output columns. `null` (all pre-existing rows) preserves legacy behaviour (all native columns, schema order).
- `DataMart.blendedFieldsConfig` — per-joinable-data-mart overrides.

OpenAPI specs updated under `apps/backend/src/data-marts/controllers/spec/`.

## Database migrations

Three backwards-compatible migrations under `apps/backend/src/migrations/`:

| File | Purpose |
| --- | --- |
| `1776616688331-add-data-mart-relationship.ts` | New `data_mart_relationship` table with FKs to `data_mart` / `data_storage` (all `ON DELETE CASCADE`), unique index on `(sourceDataMartId, targetAlias)`, plus indexes on `dataStorageId` and `targetDataMartId`. |
| `1776616688332-add-blended-fields-config-to-data-mart.ts` | Nullable `blendedFieldsConfig` JSON column on `data_mart`. |
| `1776616688333-add-column-config-to-report.ts` | Nullable `columnConfig` JSON column on `report`. |

Timestamps are higher than the latest main migration (`1776158335590`). All migrations are reversible; no existing data is mutated. On data mart deletion `DataMartRelationshipService.deleteAllByDataMartId` is invoked in the same transaction as the soft-delete (belt-and-braces alongside the FK cascades).


