### PR TITLE
fix(tiktok): correctly request campaign_id and adgroup_id in Ad Insights

### DIFF
--- a/.changeset/tiktok-ads-campaign-id-null.md
+++ b/.changeset/tiktok-ads-campaign-id-null.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# TikTok Ads `campaign_id` and `adgroup_id` in Ad Insights
+
+Previously, the `campaign_id` and `adgroup_id` fields in the `tiktok_ads_ad_insights` table were always `null`. This happened because TikTok's API requires these parent-hierarchy IDs to be requested as metrics, not dimensions, at the ad data level — and they were missing from the request. Now both fields are correctly requested and populated, so users can join ad-level performance data back to their campaigns and ad groups.

--- a/packages/connectors/src/Sources/TikTokAds/TiktokMarketingApiProvider.js
+++ b/packages/connectors/src/Sources/TikTokAds/TiktokMarketingApiProvider.js
@@ -131,18 +131,22 @@ class TiktokMarketingApiProvider {
 
   getValidAdInsightsMetrics() {
     return [
+      // Parent-hierarchy IDs — at AUCTION_AD level TikTok returns these only when
+      // requested as `metrics`; passing them in `dimensions` is rejected at this level.
+      "campaign_id", "adgroup_id",
+
       // Cost metrics
-      "spend", "cpc", "cpm", "cpr", "cpa", "cost_per_conversion", "cost_per_1000_reached",
-      
+      "spend", "cpc", "cpm", "cpr", "cpa", "cost_per_1000_reached",
+
       // Performance metrics
-      "impressions", "clicks", "ctr", "reach", "frequency", "viewable_impression", 
+      "impressions", "clicks", "ctr", "reach", "frequency", "viewable_impression",
       "viewable_rate", "video_play_actions", "video_watched_2s", "video_watched_6s",
-      "average_video_play", "average_video_play_per_user", "video_views_p25", 
+      "average_video_play", "average_video_play_per_user", "video_views_p25",
       "video_views_p50", "video_views_p75", "video_views_p100", "profile_visits",
       "profile_visits_rate", "likes", "comments", "shares", "follows", "landing_page_views",
-      
+
       // Conversion metrics
-      "conversion", "cost_per_conversion", "conversion_rate", "conversion_1d_click", 
+      "conversion", "cost_per_conversion", "conversion_rate", "conversion_1d_click",
       "conversion_7d_click", "conversion_28d_click"
     ];
   }


### PR DESCRIPTION
# Problem

The `campaign_id` and `adgroup_id` fields in the `tiktok_ads_ad_insights` destination table were always `null`, making it impossible to join ad-level performance data back to campaigns or ad groups.

The root cause is a non-obvious convention in TikTok's `report/integrated/get` API: at the `AUCTION_AD` data level, parent-hierarchy IDs (`campaign_id`, `adgroup_id`) cannot be requested as `dimensions` — TikTok rejects that. They must be requested as `metrics` instead. The `getValidAdInsightsMetrics()` function only listed numeric performance fields, so these IDs were never included in any request and TikTok never returned them.

# Solution

Added `campaign_id` and `adgroup_id` to the `getValidAdInsightsMetrics()` allowlist in `TiktokMarketingApiProvider.js`. When a user selects either field, it now flows through `getFilteredMetrics()` into the API request's `metrics` parameter, and TikTok returns the values in the `record.metrics` block. The existing `castFields` flattening logic already handles merging `record.metrics` into the output row — no further changes were needed.

Also removed a duplicate `"cost_per_conversion"` entry that was present in both the cost and conversion sections of the same list.

# Changes

- Added `"campaign_id"` and `"adgroup_id"` to `getValidAdInsightsMetrics()` so they are requested as metrics at `AUCTION_AD` data level
- Removed duplicate `"cost_per_conversion"` from the cost metrics section (kept in conversion metrics where it belongs)