### PR TITLE
docs(project): add Project Settings section with members, roles, and access docs

### DIFF
--- a/.changeset/project-settings-docs.md
+++ b/.changeset/project-settings-docs.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Project Settings documentation
+
+New documentation section covering how members, roles, and resource access work in OWOX Data Marts. Includes three pages under Project Settings: Members Management (Created By field, owner assignment on creation), Roles and Permissions (Admin, Technical User, Business User capabilities), and Ownership and Sharing (ownership model per entity, sharing states, and per-entity access tables for Storage, Data Mart, Destination, Report, and their Triggers).

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -93,6 +93,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           ],
         },
         {
+          label: 'Project Administration',
+          items: [
+            'docs/project/members',
+            'docs/project/roles-and-permissions',
+            'docs/project/access-rights',
+          ],
+        },
+        {
           label: 'Destinations',
           items: [
             'docs/destinations/manage-destinations',

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -74,30 +74,35 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 'docs/getting-started/setup-guide/connector-triggers',
                 'docs/getting-started/setup-guide/report-triggers',
                 {
-                  label: 'Members Management',
+                  label: 'Self-Managed Authentication',
                   autogenerate: {
                     directory: 'docs/getting-started/setup-guide/members-management',
                   },
                   collapsed: true,
-                },
-                {
-                  label: 'Notifications',
-                  items: [
-                    'docs/notifications/notification-settings',
-                    'docs/notifications/email',
-                    'docs/notifications/webhooks',
-                  ],
                 },
               ],
             },
           ],
         },
         {
-          label: 'Project Administration',
+          label: 'Project Settings',
           items: [
-            'docs/project/members',
-            'docs/project/roles-and-permissions',
-            'docs/project/access-rights',
+            {
+              label: 'Members Management',
+              items: [
+                'docs/project/members',
+                'docs/project/roles-and-permissions',
+                'docs/project/ownership-and-sharing',
+              ],
+            },
+            {
+              label: 'Notifications',
+              items: [
+                'docs/notifications/notification-settings',
+                'docs/notifications/email',
+                'docs/notifications/webhooks',
+              ],
+            },
           ],
         },
         {

--- a/docs/project/access-rights.md
+++ b/docs/project/access-rights.md
@@ -6,9 +6,7 @@ A member's [role](roles-and-permissions.md) defines their capabilities across th
 
 ## Ownership
 
-Every resource — Storage, Data Mart, Destination, Report — has owners. Owners always have full control over their resource, regardless of how it is shared.
-
-The member who creates a resource is automatically assigned as its owner. Owners can assign additional owners from the resource settings page.
+Every resource — Storage, Data Mart, Destination, Report — has owners. The member who creates a resource is automatically assigned as its owner. Owners can assign additional owners from the resource settings page.
 
 | Entity | Owner type | Who can be owner |
 |---|---|---|
@@ -25,7 +23,18 @@ The member who creates a resource is automatically assigned as its owner. Owners
 | **Technical Owner** | Data definition, schema, and source connections | Full control |
 | **Business Owner** | Business requirements and usage | View and use only |
 
-> ☝️ A Business Owner can be any project member regardless of their role. However, their access to the Data Mart is limited to viewing and running it — they cannot edit or delete it.
+> ☝️ A Business Owner can be any project member regardless of their role. Their access to the Data Mart is limited to viewing and running it — they cannot edit, delete, or configure sharing.
+
+**Effective ownership depends on role.** For Data Marts and Storages, owner-level maintenance access only activates when the owner's role is Technical User or Admin:
+
+| Entity | Owner type | Requires Technical User or Admin role? |
+|---|---|---|
+| Data Mart | Technical Owner | Yes — stored but inactive if Business User |
+| Storage | Owner | Yes — stored but inactive if Business User |
+| Destination | Owner | No — effective for any role |
+| Report | Owner | No — effective for any role |
+
+If a Business User is assigned as Technical Owner of a Data Mart or as Storage Owner, the assignment is stored but grants no maintenance access until the member's role changes to Technical User. The product shows a warning when this situation is detected.
 
 **Triggers do not have dedicated ownership.** Data Mart Triggers are managed under their parent Data Mart; Report Triggers are managed under their parent Report. Access to triggers follows the access rules of the parent entity.
 
@@ -33,17 +42,27 @@ The member who creates a resource is automatically assigned as its owner. Owners
 
 ## Sharing States
 
-By default, a new resource is **not shared** — only its owners and Admins can see it. An owner can change the sharing state to give other project members access.
+Sharing controls what non-owners can do with a resource. Owners and Admins always have full access regardless of sharing state.
 
-| Sharing state | What it enables |
+Each resource has two independent sharing toggles. The combination determines the effective sharing state:
+
+| Sharing state | What it enables for non-owners |
 |---|---|
 | **Not Shared** | Visible only to owners and Admins |
 | **Shared for Reporting** | Others can view and run the Data Mart *(Data Mart only)* |
 | **Shared for Use** | Others can view and use the resource — for example, link a shared Storage to their own Data Mart *(Storage, Destination)* |
 | **Shared for Maintenance** | Others can view, use, edit, and delete the resource |
-| **Shared for Both** | Combines reporting/use access with maintenance access |
+| **Shared for Both** | Both reporting/use and maintenance toggles are enabled |
 
-Only the resource's owner or an Admin can configure the sharing state.
+> ☝️ New resources start as **Not Shared**. Existing resources were migrated to **Shared for Both** to preserve previous access patterns. Owners can gradually reconfigure sharing to match their intended access model.
+
+**Who can configure sharing** depends on the entity type and the owner's role:
+
+| Entity | Can configure sharing |
+|---|---|
+| Data Mart | Technical Owner with Technical User or Admin role; Admin |
+| Storage | Owner with Technical User or Admin role; Admin |
+| Destination | Any Owner (including Business User); Admin |
 
 ---
 
@@ -58,10 +77,19 @@ The following actions can be granted or restricted by the combination of ownersh
 | **Edit** | Modify the resource configuration |
 | **Delete** | Remove the resource |
 | **Copy Credentials** | Access connection credentials *(Storage, Destination)* |
-| **Configure Sharing** | Change who can access the resource and how |
+| **Configure Sharing** | Change the sharing state of the resource |
 | **Manage Owners** | Assign or revoke ownership |
 | **Manage Triggers** | Create, edit, or delete triggers *(Data Mart)* |
 | **Run** | Execute the resource manually |
+
+**Who can manage owners** per entity type:
+
+| Entity | Can manage owners |
+|---|---|
+| Data Mart | Technical Owner with Technical User or Admin role; Admin |
+| Storage | Owner with Technical User or Admin role; Admin |
+| Destination | Any Owner (including Business User); Admin |
+| Report | Any member who can currently mutate the Report |
 
 ---
 
@@ -94,12 +122,57 @@ The following actions can be granted or restricted by the combination of ownersh
 
 ---
 
+### Data Mart Trigger
+
+Data Mart Triggers have no dedicated ownership. Visibility and mutation access follow the parent Data Mart.
+
+| Who | Can see | Can manage (create, edit, delete) |
+|---|---|---|
+| **Technical Owner of parent Data Mart** | Yes | Yes |
+| **Business Owner of parent Data Mart** | Yes | No |
+| **Non-owner Technical User** (DM shared for maintenance) | Yes | Yes |
+| **Non-owner Technical User** (DM shared for reporting only) | Yes | No |
+| **Non-owner Business User** (DM visible) | Yes | No |
+
+---
+
 ### Destination
 
-Destinations are the one exception to role-based restrictions: the **owner of a Destination has full control regardless of their role** — even a Business User who created a Destination manages it completely.
+The owner of a Destination has full control regardless of their role — even a Business User who created a Destination manages it completely.
 
 | Who | Not Shared | Shared for Use | Shared for Maintenance | Shared for Both |
 |---|---|---|---|---|
 | **Owner (any role)** | All actions | All actions | All actions | All actions |
 | **Non-owner Technical User** | No access | See, Use | See, Use, Copy Credentials, Edit, Delete | See, Use, Copy Credentials, Edit, Delete |
 | **Non-owner Business User** | No access | See, Use | See, Use, Copy Credentials, Edit, Delete | See, Use, Copy Credentials, Edit, Delete |
+
+---
+
+### Report
+
+Reports do not have sharing states. **Visibility follows the parent Data Mart** — if you can see a Data Mart, you can see all Reports built on it.
+
+Mutation access (edit, delete, run, manage owners, manage triggers) is governed by a two-path model:
+
+| Who | Can see | Can mutate |
+|---|---|---|
+| **Has Data Mart maintenance access** (Technical Owner, or DM shared for maintenance with a Technical User) | Yes | Yes — for all Reports on that Data Mart |
+| **Report Owner** (Destination exists) | Yes | Yes |
+| **Report Owner** (Destination deleted) | Yes | No — read-only until Destination is restored or replaced |
+| **Business Owner of parent Data Mart** | Yes | No |
+| **Non-owner without DM maintenance access** | Yes, if DM is visible | No |
+
+> ☝️ A Report owner is **effective** only when the Report's Destination still exists. An ineffective owner can still see the Report but cannot edit, delete, or run it. A Technical User can restore access by updating the Destination or reassigning Report ownership.
+
+---
+
+### Report Trigger
+
+Report Triggers have no dedicated ownership. Visibility and mutation access follow the parent Report.
+
+| Who | Can see | Can manage (create, edit, delete) |
+|---|---|---|
+| **Has Data Mart maintenance access** | Yes | Yes — for all Report Triggers on that Data Mart |
+| **Effective Report Owner** | Yes | Yes — for own Report's triggers only |
+| **Ineffective Report Owner** (Destination deleted) | Yes | No |
+| **Non-owner** (DM visible) | Yes | No |

--- a/docs/project/access-rights.md
+++ b/docs/project/access-rights.md
@@ -1,0 +1,105 @@
+# Access Rights
+
+A member's [role](roles-and-permissions.md) defines their capabilities across the whole project. **Access rights** go one level deeper: they control what a member can do with a specific resource, based on two factors — their **ownership status** and the resource's **sharing state**.
+
+---
+
+## Ownership
+
+Every resource — Storage, Data Mart, Destination, Report — has owners. Owners always have full control over their resource, regardless of how it is shared.
+
+The member who creates a resource is automatically assigned as its owner. Owners can assign additional owners from the resource settings page.
+
+| Entity | Owner type | Who can be owner |
+|---|---|---|
+| **Storage** | Owner | Technical Users |
+| **Data Mart** | Technical Owner | Technical Users |
+| **Data Mart** | Business Owner | Any role |
+| **Destination** | Owner | Any role |
+| **Report** | Owner | Any role |
+
+**Data Marts support two distinct owner types:**
+
+| Owner type | Responsibility | Access level |
+|---|---|---|
+| **Technical Owner** | Data definition, schema, and source connections | Full control |
+| **Business Owner** | Business requirements and usage | View and use only |
+
+> ☝️ A Business Owner can be any project member regardless of their role. However, their access to the Data Mart is limited to viewing and running it — they cannot edit or delete it.
+
+**Triggers do not have dedicated ownership.** Data Mart Triggers are managed under their parent Data Mart; Report Triggers are managed under their parent Report. Access to triggers follows the access rules of the parent entity.
+
+---
+
+## Sharing States
+
+By default, a new resource is **not shared** — only its owners and Admins can see it. An owner can change the sharing state to give other project members access.
+
+| Sharing state | What it enables |
+|---|---|
+| **Not Shared** | Visible only to owners and Admins |
+| **Shared for Reporting** | Others can view and run the Data Mart *(Data Mart only)* |
+| **Shared for Use** | Others can view and use the resource — for example, link a shared Storage to their own Data Mart *(Storage, Destination)* |
+| **Shared for Maintenance** | Others can view, use, edit, and delete the resource |
+| **Shared for Both** | Combines reporting/use access with maintenance access |
+
+Only the resource's owner or an Admin can configure the sharing state.
+
+---
+
+## Actions
+
+The following actions can be granted or restricted by the combination of ownership and sharing state:
+
+| Action | Description |
+|---|---|
+| **See** | View the resource in lists and open its detail page |
+| **Use** | Link the resource to other entities (e.g. attach a Storage to a Data Mart) |
+| **Edit** | Modify the resource configuration |
+| **Delete** | Remove the resource |
+| **Copy Credentials** | Access connection credentials *(Storage, Destination)* |
+| **Configure Sharing** | Change who can access the resource and how |
+| **Manage Owners** | Assign or revoke ownership |
+| **Manage Triggers** | Create, edit, or delete triggers *(Data Mart)* |
+| **Run** | Execute the resource manually |
+
+---
+
+## Access by Entity
+
+**Admin** always has full access to all actions on all resources and is not listed in the tables below.
+
+### Storage
+
+| Who | Not Shared | Shared for Use | Shared for Maintenance | Shared for Both |
+|---|---|---|---|---|
+| **Owner (Technical User)** | All actions | All actions | All actions | All actions |
+| **Non-owner Technical User** | No access | See, Use | See, Use, Copy Credentials, Edit, Delete | See, Use, Copy Credentials, Edit, Delete |
+| **Any Business User** | No access | No access | No access | No access |
+
+> ☝️ Business Users do not have direct access to Storages. They interact with data through shared Data Marts and Destinations.
+
+---
+
+### Data Mart
+
+| Who | Not Shared | Shared for Reporting | Shared for Maintenance | Shared for Both |
+|---|---|---|---|---|
+| **Technical Owner (Technical User)** | All actions | All actions | All actions | All actions |
+| **Business Owner (any role)** | See, Use | See, Use | See, Use | See, Use |
+| **Non-owner Technical User** | No access | See, Use | See, Use, Edit, Delete, Manage Triggers | See, Use, Edit, Delete, Manage Triggers |
+| **Non-owner Business User** | No access | See, Use | No access | See, Use |
+
+> ☝️ When a Data Mart is shared for maintenance, Business Users who are not owners still cannot access it — maintenance access is reserved for Technical Users.
+
+---
+
+### Destination
+
+Destinations are the one exception to role-based restrictions: the **owner of a Destination has full control regardless of their role** — even a Business User who created a Destination manages it completely.
+
+| Who | Not Shared | Shared for Use | Shared for Maintenance | Shared for Both |
+|---|---|---|---|---|
+| **Owner (any role)** | All actions | All actions | All actions | All actions |
+| **Non-owner Technical User** | No access | See, Use | See, Use, Copy Credentials, Edit, Delete | See, Use, Copy Credentials, Edit, Delete |
+| **Non-owner Business User** | No access | See, Use | See, Use, Copy Credentials, Edit, Delete | See, Use, Copy Credentials, Edit, Delete |

--- a/docs/project/members.md
+++ b/docs/project/members.md
@@ -10,16 +10,11 @@ To see who has access to your project, navigate to the **Admin Dashboard** at `/
 
 ## Inviting a New Member
 
-1. Open the **Admin Dashboard** at `/auth/dashboard`
-2. Click **Add User**
+1. Open the **Members Page**
+2. Click **Invite People**
 3. Enter the member's email address
 4. Select their role
-5. Click **Generate Magic Link**
-6. Share the generated link with the new member via email
-
-> ☝️ **Important:** Share magic links via email only. Messaging apps may auto-open the URL and invalidate it before the recipient uses it.
-
-The new member uses the link to set their password and sign in for the first time.
+5. Click **Send Invite**
 
 ## Changing a Member's Role
 

--- a/docs/project/members.md
+++ b/docs/project/members.md
@@ -18,28 +18,18 @@ To see who has access to your project, navigate to the **Admin Dashboard** at `/
 
 ## Changing a Member's Role
 
-1. Open the **Admin Dashboard** at `/auth/dashboard`
-2. Find the member and click **View**
-3. Update their role on the User Details page
+1. Open the **Members Page**
+2. Find the member
+3. Update their role
 4. Save the change
 
 > ☝️ Downgrading a member from **Technical User** to **Business User** automatically removes them from all notification receivers lists.
 
-## Resetting a Member's Password
-
-1. Open the **Admin Dashboard** at `/auth/dashboard`
-2. Find the member and click **View**
-3. On the User Details page, click one of:
-   - **Generate Magic Link** — if the member has not set a password yet
-   - **Reset Password** — if the member already has a password (signs them out of all active sessions)
-4. Copy the link from the green confirmation box
-5. Share it with the member via email
-
 ## Removing a Member
 
-1. Open the **Admin Dashboard** at `/auth/dashboard`
-2. Find the member and click **View**
-3. Click **Delete User** and confirm
+1. Open the **Members Page**
+2. Find the member
+3. Click **Remove member** and confirm
 
 Removing a member also cleans them up from all notification receivers lists.
 
@@ -64,15 +54,3 @@ Triggers do not have dedicated ownership — they are managed through their pare
 Ownership can be reassigned at any time from the resource settings page. The Created By record remains unchanged regardless.
 
 **When a member is removed,** the Created By field retains the original record internally, but the member's name is no longer displayed — the column shows "—" instead. Resources they created are not deleted and remain fully accessible to their current owners.
-
-## Command Line
-
-You can add a member directly from the CLI:
-
-```bash
-owox idp add-user user@example.com
-```
-
----
-
-For initial admin account setup, recovery scenarios, and identity provider configuration, see [Better Auth Setup](../getting-started/setup-guide/members-management/better-auth.md).

--- a/docs/project/members.md
+++ b/docs/project/members.md
@@ -1,0 +1,83 @@
+# Managing Project Members
+
+Project members are the people who have access to your OWOX Data Marts project. Each member is assigned a role that determines what they can see and do — see [Roles and Permissions](roles-and-permissions.md) for details.
+
+Only **Admins** can invite, edit, or remove members.
+
+## Viewing Members
+
+To see who has access to your project, navigate to the **Admin Dashboard** at `/auth/dashboard`. The list shows each member's name, email, role, and account status.
+
+## Inviting a New Member
+
+1. Open the **Admin Dashboard** at `/auth/dashboard`
+2. Click **Add User**
+3. Enter the member's email address
+4. Select their role
+5. Click **Generate Magic Link**
+6. Share the generated link with the new member via email
+
+> ☝️ **Important:** Share magic links via email only. Messaging apps may auto-open the URL and invalidate it before the recipient uses it.
+
+The new member uses the link to set their password and sign in for the first time.
+
+## Changing a Member's Role
+
+1. Open the **Admin Dashboard** at `/auth/dashboard`
+2. Find the member and click **View**
+3. Update their role on the User Details page
+4. Save the change
+
+> ☝️ Downgrading a member from **Technical User** to **Business User** automatically removes them from all notification receivers lists.
+
+## Resetting a Member's Password
+
+1. Open the **Admin Dashboard** at `/auth/dashboard`
+2. Find the member and click **View**
+3. On the User Details page, click one of:
+   - **Generate Magic Link** — if the member has not set a password yet
+   - **Reset Password** — if the member already has a password (signs them out of all active sessions)
+4. Copy the link from the green confirmation box
+5. Share it with the member via email
+
+## Removing a Member
+
+1. Open the **Admin Dashboard** at `/auth/dashboard`
+2. Find the member and click **View**
+3. Click **Delete User** and confirm
+
+Removing a member also cleans them up from all notification receivers lists.
+
+## Created By
+
+Every resource in OWOX Data Marts — Data Mart, Storage, Destination, Report, Trigger, Run — records who created it. This **Created By** field is permanent: it never changes, even if ownership is later transferred to someone else.
+
+**Where it appears:**
+
+- **Data Marts, Storages, Destinations, Reports** — displayed as a sortable column in each list view
+- **Run history** — shown inline as "by [member name]" for manually triggered runs
+
+**Creator becomes the initial owner.** When a member creates a resource, they are automatically assigned as its owner:
+
+- Data Mart → assigned as **Technical Owner**
+- Storage → assigned as **Owner**
+- Destination → assigned as **Owner**
+- Report → assigned as **Owner**
+
+Triggers do not have dedicated ownership — they are managed through their parent entity (Data Mart or Report).
+
+Ownership can be reassigned at any time from the resource settings page. The Created By record remains unchanged regardless.
+
+**When a member is removed,** the Created By field retains the original record internally, but the member's name is no longer displayed — the column shows "—" instead. Resources they created are not deleted and remain fully accessible to their current owners.
+
+## Command Line
+
+You can add a member directly from the CLI:
+
+```bash
+owox idp add-user user@example.com
+```
+
+---
+
+For initial admin account setup, recovery scenarios, and identity provider configuration, see [Better Auth Setup](../getting-started/setup-guide/members-management/better-auth.md).

--- a/docs/project/ownership-and-sharing.md
+++ b/docs/project/ownership-and-sharing.md
@@ -1,4 +1,4 @@
-# Access Rights
+# Ownership and Sharing
 
 A member's [role](roles-and-permissions.md) defines their capabilities across the whole project. **Access rights** go one level deeper: they control what a member can do with a specific resource, based on two factors — their **ownership status** and the resource's **sharing state**.
 

--- a/docs/project/roles-and-permissions.md
+++ b/docs/project/roles-and-permissions.md
@@ -1,0 +1,81 @@
+# Roles and Permissions
+
+Every project member has one of three roles. A role controls what a member can do across the entire project — from managing users to creating and editing resources.
+
+## Roles Overview
+
+| Role | Typical user | Access level |
+|---|---|---|
+| **Admin** | Data team lead, IT admin | Full access to everything |
+| **Technical User** | Data analyst, data engineer | Create and manage own resources |
+| **Business User** | Analyst, marketer, business stakeholder | View and use shared resources |
+
+---
+
+## Admin
+
+Admins have unrestricted access to the entire project.
+
+**Member management:**
+
+- Invite members with any role
+- Change any member's role
+- Reset passwords and generate magic links
+- Delete members
+
+**Data access:**
+
+- Create, edit, and delete any Data Mart, Storage, Destination, Report, Trigger, and Run — regardless of who created it
+
+**Notifications:**
+
+- Automatically subscribed to all project notification channels upon joining
+
+---
+
+## Technical User
+
+Technical Users build and manage data resources, and can share them with others.
+
+**Member management:**
+
+- Invite Technical Users and Business Users (cannot invite Admins)
+
+**Data access:**
+
+- Create, edit, and delete their own Data Marts, Storages, Destinations, Reports, Triggers, and Runs
+- Configure sharing and manage owners for their own resources
+- Access resources that other members have shared with them — the level of access depends on how the resource is shared (see [Access Rights](access-rights.md))
+
+**Notifications:**
+
+- Automatically subscribed to all project notification channels upon joining
+
+---
+
+## Business User
+
+Business Users consume data that has been prepared and shared for them. They cannot create or modify resources.
+
+**Member management:**
+
+- Invite Business Users only
+
+**Data access:**
+
+- View and use Data Marts, Storages, Destinations, Reports, Triggers, and Runs that are explicitly shared with them
+
+**Notifications:**
+
+- Not subscribed to notifications by default
+- Automatically removed from notification receivers if their role is downgraded from Technical User
+
+---
+
+## Who Can Invite Whom
+
+| Inviting as | Can invite Admin | Can invite Technical User | Can invite Business User |
+|---|---|---|---|
+| Admin | ✓ | ✓ | ✓ |
+| Technical User | — | ✓ | ✓ |
+| Business User | — | — | ✓ |

--- a/docs/project/roles-and-permissions.md
+++ b/docs/project/roles-and-permissions.md
@@ -10,8 +10,6 @@ Every project member has one of three roles. A role controls what a member can d
 | **Technical User** | Create and manage data resources; full control over all Reports |
 | **Business User** | Self-service reporting on shared Data Marts; manage own Reports and Destinations |
 
----
-
 ## Admin
 
 Admins have unrestricted access to the entire project.

--- a/docs/project/roles-and-permissions.md
+++ b/docs/project/roles-and-permissions.md
@@ -4,11 +4,11 @@ Every project member has one of three roles. A role controls what a member can d
 
 ## Roles Overview
 
-| Role | Typical user | Access level |
-|---|---|---|
-| **Admin** | Data team lead, IT admin | Full access to everything |
-| **Technical User** | Data analyst, data engineer | Create and manage own resources |
-| **Business User** | Analyst, marketer, business stakeholder | View and use shared resources |
+| Role | Access level |
+|---|---|
+| **Admin** | Full access to everything |
+| **Technical User** | Create and manage data resources; full control over all Reports |
+| **Business User** | Self-service reporting on shared Data Marts; manage own Reports and Destinations |
 
 ---
 
@@ -35,7 +35,7 @@ Admins have unrestricted access to the entire project.
 
 ## Technical User
 
-Technical Users build and manage data resources, and can share them with others.
+Technical Users build and manage data infrastructure, and retain project-wide control over reporting.
 
 **Member management:**
 
@@ -43,9 +43,13 @@ Technical Users build and manage data resources, and can share them with others.
 
 **Data access:**
 
-- Create, edit, and delete their own Data Marts, Storages, Destinations, Reports, Triggers, and Runs
-- Configure sharing and manage owners for their own resources
-- Access resources that other members have shared with them — the level of access depends on how the resource is shared (see [Access Rights](access-rights.md))
+- Create, edit, and delete their own Data Marts, Storages, and Destinations
+- Create, edit, delete, and manage Data Mart Triggers
+- Configure sharing and manage owners for their own Data Marts, Storages, and Destinations
+- Access Data Marts, Storages, and Destinations that other members have shared with them — the level of access depends on how the resource is shared (see [Access Rights](access-rights.md))
+- Edit and delete any Report in the project, regardless of ownership
+- Manage owners of any Report in the project
+- Create, edit, and delete Report Triggers on any Report in the project
 
 **Notifications:**
 
@@ -55,7 +59,7 @@ Technical Users build and manage data resources, and can share them with others.
 
 ## Business User
 
-Business Users consume data that has been prepared and shared for them. They cannot create or modify resources.
+Business Users build and manage their own reporting assets on top of Data Marts prepared by Technical Users.
 
 **Member management:**
 
@@ -63,7 +67,14 @@ Business Users consume data that has been prepared and shared for them. They can
 
 **Data access:**
 
-- View and use Data Marts, Storages, Destinations, Reports, Triggers, and Runs that are explicitly shared with them
+- View Data Marts and their Triggers that are shared with them
+- Create Reports on Data Marts that are available for reporting
+- Edit, delete, run, and manage owners of Reports they own
+- Create, edit, and delete Report Triggers on Reports they own
+- Create, edit, and delete Destinations
+- Access Destinations that other members have shared with them
+
+> ☝️ A Business User can only edit or run a Report as long as its Destination still exists. If the Destination is deleted, the Report becomes read-only for that owner until a Technical User restores the Destination or reassigns ownership.
 
 **Notifications:**
 


### PR DESCRIPTION
# Problem

There was no user-facing documentation covering how project members are managed, what each role can do, or how resource access is controlled in OWOX Data Marts. Users had no reference for understanding the ownership model, sharing states, or why access to a specific resource was granted or denied.

# Solution

Created a dedicated **Project Settings** top-level section in the docs sidebar with three new pages covering the full access control model as implemented in the codebase. The Notifications subsection, previously buried inside Setup Guide, was moved under Project Settings alongside Members Management.

# Changes

- Added `docs/project/members.md` — member operations (invite, role change, remove), immutable Created By field, creator-to-owner auto-assignment per entity type, and removed-member display behavior
- Added `docs/project/roles-and-permissions.md` — roles overview table, per-role capability sections (Admin, Technical User, Business User) covering member management, data access, and notifications; includes who-can-invite-whom matrix
- Added `docs/project/ownership-and-sharing.md` — ownership model with effective/ineffective ownership per entity, sharing states as two independent toggles, migration defaults note, configure-sharing and manage-owners governance tables, and per-entity access tables for Storage, Data Mart, DM Trigger, Destination, Report, and Report Trigger
- Updated `apps/docs/astro.config.mjs` — added top-level `Project Settings` section with `Members Management` (members, roles-and-permissions, ownership-and-sharing) and `Notifications` subsections; renamed Setup Guide entry from `Members Management` to `Self-Managed Authentication`