### PR TITLE
fix(web): Output Schema hidden rows + Joinable DM save races

### DIFF
--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
@@ -104,7 +104,7 @@ function buildSourceList(
 export function DataMartRelationshipsContent({
   onRelationshipsChanged,
 }: DataMartRelationshipsContentProps) {
-  const { dataMart } = useDataMartContext();
+  const { dataMart, syncDataMartFromResponse, refreshDataMart } = useDataMartContext();
   const queryClient = useQueryClient();
 
   const invalidateBlendableSchema = useCallback(() => {
@@ -112,6 +112,7 @@ export function DataMartRelationshipsContent({
   }, [queryClient]);
 
   const [relationships, setRelationships] = useState<DataMartRelationship[]>([]);
+  const relationshipsRef = useRef<DataMartRelationship[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [newlyCreatedId, setNewlyCreatedId] = useState<string | null>(null);
@@ -131,10 +132,18 @@ export function DataMartRelationshipsContent({
   const localBlendedFieldsConfig: BlendedFieldsConfig =
     dataMart?.blendedFieldsConfig ?? DEFAULT_BLENDED_FIELDS_CONFIG;
   const [localConfig, setLocalConfig] = useState<BlendedFieldsConfig>(localBlendedFieldsConfig);
+  const localConfigRef = useRef(localConfig);
+  useEffect(() => {
+    localConfigRef.current = localConfig;
+  }, [localConfig]);
 
   useEffect(() => {
     setLocalConfig(dataMart?.blendedFieldsConfig ?? DEFAULT_BLENDED_FIELDS_CONFIG);
   }, [dataMart?.blendedFieldsConfig]);
+
+  useEffect(() => {
+    relationshipsRef.current = relationships;
+  }, [relationships]);
 
   useEffect(() => {
     localStorage.setItem(VIEW_MODE_KEY, viewMode);
@@ -268,22 +277,30 @@ export function DataMartRelationshipsContent({
   const handleRelationshipUpdated = useCallback(
     (updated: DataMartRelationship) => {
       toast.success('Relationship updated');
+      const prevTargetAlias = relationshipsRef.current.find(r => r.id === updated.id)?.targetAlias;
       setRelationships(prev => prev.map(r => (r.id === updated.id ? updated : r)));
+      // Rename cascades paths in blendedFieldsConfig server-side; refetch to avoid overwriting it on next save.
+      if (prevTargetAlias !== undefined && prevTargetAlias !== updated.targetAlias) {
+        void refreshDataMart(dataMartId);
+      }
       invalidateBlendableSchema();
       onRelationshipsChanged?.();
     },
-    [invalidateBlendableSchema, onRelationshipsChanged]
+    [dataMartId, refreshDataMart, invalidateBlendableSchema, onRelationshipsChanged]
   );
 
   const saveConfigAndRefresh = useCallback(
     (newConfig: BlendedFieldsConfig) => {
       setLocalConfig(newConfig);
-      void dataMartRelationshipService.updateBlendedFieldsConfig(dataMartId, newConfig).then(() => {
-        fetchBlendableSchema();
-        invalidateBlendableSchema();
-      });
+      void dataMartRelationshipService
+        .updateBlendedFieldsConfig(dataMartId, newConfig)
+        .then(response => {
+          void syncDataMartFromResponse(response);
+          fetchBlendableSchema();
+          invalidateBlendableSchema();
+        });
     },
-    [dataMartId, fetchBlendableSchema, invalidateBlendableSchema]
+    [dataMartId, fetchBlendableSchema, invalidateBlendableSchema, syncDataMartFromResponse]
   );
 
   const handleCreated = useCallback(
@@ -300,14 +317,15 @@ export function DataMartRelationshipsContent({
 
   const updateSourceConfig = useCallback(
     (path: string, updater: (current: BlendedSource | undefined) => BlendedSource) => {
-      const existingSources = localConfig.sources.filter(s => s.path !== path);
-      const currentSource = localConfig.sources.find(s => s.path === path);
+      const currentConfig = localConfigRef.current;
+      const existingSources = currentConfig.sources.filter(s => s.path !== path);
+      const currentSource = currentConfig.sources.find(s => s.path === path);
       saveConfigAndRefresh({
-        ...localConfig,
+        ...currentConfig,
         sources: [...existingSources, updater(currentSource)],
       });
     },
-    [localConfig, saveConfigAndRefresh]
+    [saveConfigAndRefresh]
   );
 
   const handleSourceAliasChange = useCallback(

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
@@ -185,24 +185,24 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
             return nameColumnCell({ row, updateField });
           }
           return (
-            <div className='flex items-center gap-1'>
-              <EditableText
-                value={asString(row.getValue('name'))}
-                onValueChange={value => {
-                  updateField(row.index, { name: value } as Partial<T>);
-                }}
-                placeholder={'Field name is required'}
-                isBold={true}
-              />
-              {row.original.isHiddenForReporting && (
-                <Tooltip>
-                  <TooltipTrigger>
-                    <EyeOff className='text-muted-foreground h-3.5 w-3.5 flex-shrink-0' />
-                  </TooltipTrigger>
-                  <TooltipContent>Hidden from reports</TooltipContent>
-                </Tooltip>
-              )}
-            </div>
+            <EditableText
+              value={asString(row.getValue('name'))}
+              onValueChange={value => {
+                updateField(row.index, { name: value } as Partial<T>);
+              }}
+              placeholder={'Field name is required'}
+              isBold={true}
+              trailingContent={
+                row.original.isHiddenForReporting ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <EyeOff className='text-muted-foreground h-3.5 w-3.5 shrink-0' />
+                    </TooltipTrigger>
+                    <TooltipContent>Hidden from reports</TooltipContent>
+                  </Tooltip>
+                ) : undefined
+              }
+            />
           );
         },
         enableHiding: false,

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.tsx
@@ -183,15 +183,17 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
             }}
             placeholder={'Field name is required'}
             isBold={true}
+            trailingContent={
+              level === 0 && row.original.isHiddenForReporting ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <EyeOff className='text-muted-foreground h-3.5 w-3.5 shrink-0' />
+                  </TooltipTrigger>
+                  <TooltipContent>Hidden from reports</TooltipContent>
+                </Tooltip>
+              ) : undefined
+            }
           />
-          {level === 0 && row.original.isHiddenForReporting && (
-            <Tooltip>
-              <TooltipTrigger>
-                <EyeOff className='text-muted-foreground h-3.5 w-3.5 flex-shrink-0' />
-              </TooltipTrigger>
-              <TooltipContent>Hidden from reports</TooltipContent>
-            </Tooltip>
-          )}
         </div>
       );
     },

--- a/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
+++ b/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
@@ -24,6 +24,7 @@ import type {
   UpdateDataMartTablePatternDefinitionRequestDto,
   UpdateDataMartViewDefinitionRequestDto,
 } from '../../../shared/types/api';
+import type { DataMartResponseDto } from '../../../shared/types/api/response/data-mart.response.dto';
 import type { DataStorage } from '../../../../data-storage/shared/model/types/data-storage';
 import type {
   ConnectorDefinitionConfig,
@@ -68,6 +69,25 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
       });
     }
   }, []);
+
+  const syncDataMartFromResponse = useCallback(async (response: DataMartResponseDto) => {
+    const dataMart = await mapDataMartFromDto(response);
+    dispatch({ type: 'UPDATE_DATA_MART_SUCCESS', payload: dataMart });
+  }, []);
+
+  const refreshDataMart = useCallback(
+    async (id: string) => {
+      try {
+        const response = await dataMartService.getDataMartById(id, {
+          skipLoadingIndicator: true,
+        });
+        await syncDataMartFromResponse(response);
+      } catch {
+        // apiClient surfaces the toast
+      }
+    },
+    [syncDataMartFromResponse]
+  );
 
   // Create a new data mart
   const createDataMart = useCallback(
@@ -639,6 +659,8 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
   const value = {
     ...state,
     getDataMart,
+    syncDataMartFromResponse,
+    refreshDataMart,
     createDataMart,
     updateDataMart,
     deleteDataMart,

--- a/apps/web/src/features/data-marts/edit/model/context/types.ts
+++ b/apps/web/src/features/data-marts/edit/model/context/types.ts
@@ -4,6 +4,7 @@ import type {
   RunDataMartRequestDto,
   UpdateDataMartRequestDto,
 } from '../../../shared/types/api';
+import type { DataMartResponseDto } from '../../../shared/types/api/response/data-mart.response.dto';
 import type { DataMartDefinitionType } from '../../../shared';
 import type { DataMartDefinitionConfig } from '../types';
 import type { ApiError } from '../../../../../app/api';
@@ -73,6 +74,8 @@ export type DataMartAction =
 
 export interface DataMartContextType extends DataMartState {
   getDataMart: (id: string) => Promise<void>;
+  syncDataMartFromResponse: (response: DataMartResponseDto) => Promise<void>;
+  refreshDataMart: (id: string) => Promise<void>;
   createDataMart: (data: CreateDataMartRequestDto) => Promise<Pick<DataMart, 'id' | 'title'>>;
   updateDataMart: (id: string, data: UpdateDataMartRequestDto) => Promise<void>;
   deleteDataMart: (id: string) => Promise<void>;

--- a/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
@@ -57,10 +57,11 @@ export class DataMartService extends ApiService {
   /**
    * Get a data mart by ID
    * @param id Data mart ID
+   * @param config Optional axios config (e.g. `skipLoadingIndicator` for silent refreshes)
    * @returns Promise with data mart response
    */
-  async getDataMartById(id: string): Promise<DataMartResponseDto> {
-    return this.get<DataMartResponseDto>(`/${id}`);
+  async getDataMartById(id: string, config?: AxiosRequestConfig): Promise<DataMartResponseDto> {
+    return this.get<DataMartResponseDto>(`/${id}`, undefined, config);
   }
 
   /**

--- a/packages/ui/src/components/common/editable-text.tsx
+++ b/packages/ui/src/components/common/editable-text.tsx
@@ -2,7 +2,7 @@ import { Button } from '@owox/ui/components/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@owox/ui/components/popover';
 import { Textarea } from '@owox/ui/components/textarea';
 import { cn } from '@owox/ui/lib/utils';
-import { type KeyboardEvent, useRef, useState } from 'react';
+import { type KeyboardEvent, type ReactNode, useRef, useState } from 'react';
 
 /**
  * Props for the EditableText component
@@ -24,6 +24,8 @@ export interface EditableTextProps {
   saveButtonText?: string;
   /** Custom cancel button text */
   cancelButtonText?: string;
+  /** Optional slot rendered inline after the value (e.g., a status icon). Keeps the full-width click area for editing. */
+  trailingContent?: ReactNode;
 }
 
 /**
@@ -38,6 +40,7 @@ export function EditableText({
   className,
   saveButtonText = 'Save',
   cancelButtonText = 'Discard',
+  trailingContent,
 }: EditableTextProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editedValue, setEditedValue] = useState(value);
@@ -99,10 +102,12 @@ export function EditableText({
             'cursor-edit w-full min-w-[100px]',
             !value && 'text-gray-400',
             isBold && 'font-medium',
+            trailingContent && 'flex items-center gap-1.5',
             className
           )}
         >
           {value || placeholder}
+          {trailingContent}
         </div>
       </PopoverTrigger>
       <PopoverContent className='w-auto max-w-[600px] min-w-[300px] p-2' align='start'>

--- a/packages/ui/src/components/common/sortable-table-row.tsx
+++ b/packages/ui/src/components/common/sortable-table-row.tsx
@@ -24,10 +24,10 @@ export function SortableTableRow<T>({ id, children, className }: SortableTableRo
     id,
   });
 
-  const style = {
+  const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.75 : 1,
+    ...(isDragging && { opacity: 0.75 }),
   };
 
   // Convert children to array to manipulate them


### PR DESCRIPTION
## Summary

Two independent bug fixes in the data marts edit flow:

1. **Output Schema — hidden fields now dim properly.** Rows with `isHiddenForReporting` were not dimmed because `SortableTableRow` was writing `opacity: 1` inline, overriding the `opacity-70` class from `SchemaTable`. The eye-off icon also floated to the right edge of the cell instead of sitting next to the field name, because `EditableText` stretched to `w-full` and pushed sibling elements out. The icon now renders through a new `trailingContent` slot on `EditableText`, keeping the full-width click area while sitting flush with the text. Visual behavior now matches the Joinable Data Marts panel.

2. **Joinable Data Marts — Output Alias edits no longer wipe sibling overrides.** Editing the Output Alias on one related data mart could intermittently roll back overrides (Output Alias, hidden fields, aggregation choices) on other relations in the same panel. Three issues contributed:
   - **Stale closure in `updateSourceConfig`** — the callback captured `localConfig` from render-time, so two rapid edits on neighboring rows could POST a config snapshot that was missing the first edit.
   - **SQL Alias rename cascade not rehydrated** — when a sibling relation's `targetAlias` changed, the backend cascaded paths in `blendedFieldsConfig` (`update-data-mart-relationship.service.ts`), but the frontend kept the pre-cascade paths. The next save would POST those pre-cascade paths and silently revert the cascade, orphaning overrides on other rows.
   - **`PUT /blended-fields-config` response discarded** — `DataMartContext.dataMart` stayed out of sync indefinitely. Any unrelated refetch (title edit, navigation) rehydrated `localConfig` from a stale DTO.

## Changes

### Output Schema (UI)
- `packages/ui/src/components/common/sortable-table-row.tsx` — only set inline `opacity` when dragging, so row className-driven dim takes effect.
- `packages/ui/src/components/common/editable-text.tsx` — new optional `trailingContent?: ReactNode` prop. When set, the trigger switches to `flex items-center gap-1.5` and renders the slot after the value.
- `apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx`, `BigQuerySchemaTable.tsx` — moved the `Tooltip` + `EyeOff` icon into `trailingContent` instead of rendering it as a sibling `<div>` wrapper.

### Joinable Data Marts (save races)
- `apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx`:
  - `updateSourceConfig` reads `localConfigRef.current` instead of the closure, so back-to-back edits on neighboring rows always use the latest saved state.
  - `handleRelationshipUpdated` captures `prevTargetAlias` before `setRelationships` and, if it changed, triggers a silent `refreshDataMart(dataMartId)` to rehydrate the cascaded paths.
  - `saveConfigAndRefresh` uses the `PUT /blended-fields-config` response to keep `DataMartContext` in sync via `syncDataMartFromResponse`.
- `apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx`, `types.ts` — two new context methods:
  - `syncDataMartFromResponse(response)` — maps DTO and dispatches `UPDATE_DATA_MART_SUCCESS` without a loading flash.
  - `refreshDataMart(id)` — silent refetch; passes `skipLoadingIndicator: true` so no global progress bar.
- `apps/web/src/features/data-marts/shared/services/data-mart.service.ts` — `getDataMartById(id, config?)` now accepts optional axios config so `refreshDataMart` can suppress the loading indicator.
