### PR TITLE
docs: fix Microsoft Ads reference and bullet list in setup guides

### DIFF
--- a/docs/getting-started/setup-guide/connector-data-mart.md
+++ b/docs/getting-started/setup-guide/connector-data-mart.md
@@ -49,7 +49,7 @@ Each connector requires authentication. Here is how you can obtain the required 
 - [TikTok Ads](../../../packages/connectors/src/Sources/TikTokAds/CREDENTIALS.md)
 - [Linkedin Ads](../../../packages/connectors/src/Sources/LinkedInAds/CREDENTIALS.md)
 - [X Ads](../../../packages/connectors/src/Sources/XAds/CREDENTIALS.md)
-- [Bing Ads](../../../packages/connectors/src/Sources/BingAds/CREDENTIALS.md)
+- [Microsoft Ads](../../../packages/connectors/src/Sources/MicrosoftAds/CREDENTIALS.md)
 - [Reddit Ads](../../../packages/connectors/src/Sources/RedditAds/CREDENTIALS.md)
 - [Criteo Ads](../../../packages/connectors/src/Sources/CriteoAds/CREDENTIALS.md)
 - [Open Exchange Rates](../../../packages/connectors/src/Sources/OpenExchangeRates/CREDENTIALS.md)

--- a/docs/getting-started/setup-guide/extension-data-marts.md
+++ b/docs/getting-started/setup-guide/extension-data-marts.md
@@ -6,8 +6,8 @@ You already use the [OWOX Reports Google Sheets Extension](https://workspace.goo
 
 - get reusable Insights defined by SQL with AI assistance
 - unlock new delivery destinations like Looker Studio, Email, Slack, MS Teams or Google Chat for your data
-- simplify access and scheduling management at the organizational level—all
-- gain full visibility into run history.
+- simplify access and scheduling management at the organizational level
+- gain full visibility into run history
 
 > 💡 OWOX Data Marts detects your existing Extension Data Marts and automatically
 > creates a **system storage** named after your GCP project ID. The storage type is “Google BigQuery (used in OWOX extension)”.


### PR DESCRIPTION
# Problem

Two documentation issues were introduced or left unresolved in the setup guides. In `connector-data-mart.md`, the credentials link still pointed to the old `BingAds/` directory (which no longer exists) under the outdated name "Bing Ads". In `extension-data-marts.md`, a prior edit accidentally merged two list items into a single grammatically broken sentence: "simplify access and scheduling management at the organizational level—all gain full visibility into run history."

# Solution

- Updated the "Bing Ads" credentials entry to "Microsoft Ads" with the correct path (`MicrosoftAds/CREDENTIALS.md`), consistent with the connector's renamed source directory.
- Restored the two bullet points in `extension-data-marts.md` to separate, clean items without the stray em-dash and orphaned "all".

# Changes

- Replaced broken `[Bing Ads](…/BingAds/CREDENTIALS.md)` link with `[Microsoft Ads](…/MicrosoftAds/CREDENTIALS.md)` in `connector-data-mart.md`
- Split malformed merged bullet into two clean bullets in `extension-data-marts.md`