### PR TITLE
feat(backend): update gbq storage validation

### DIFF
--- a/apps/backend/src/data-marts/data-storage-types/bigquery/schemas/bigquery-config.schema.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/schemas/bigquery-config.schema.spec.ts
@@ -1,0 +1,31 @@
+import { BigQueryConfigSchema } from './bigquery-config.schema';
+
+describe('BigQueryConfigSchema.projectId', () => {
+  describe('valid project IDs', () => {
+    it.each([
+      'my-project',
+      'my-project-123',
+      'abcdef',
+      'a-cool-proj-30chars-still-fits',
+      'example.com:my-project',
+      'domain.co:abcdef',
+    ])('accepts %s', projectId => {
+      const result = BigQueryConfigSchema.safeParse({ projectId });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('invalid project IDs', () => {
+    it.each([
+      ['uppercase letters', 'GTM-NC4KR2JL'],
+      ['starts with a digit', '1my-project'],
+      ['too short', 'abc'],
+      ['ends with a hyphen', 'my-project-'],
+      ['underscore not allowed', 'my_project'],
+      ['empty string', ''],
+    ])('rejects %s (%s)', (_label, projectId) => {
+      const result = BigQueryConfigSchema.safeParse({ projectId });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/schemas/bigquery-config.schema.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/schemas/bigquery-config.schema.spec.ts
@@ -17,7 +17,7 @@ describe('BigQueryConfigSchema.projectId', () => {
 
   describe('invalid project IDs', () => {
     it.each([
-      ['uppercase letters', 'GTM-NC4KR2JL'],
+      ['uppercase letters', 'GTM-NC2077'],
       ['starts with a digit', '1my-project'],
       ['too short', 'abc'],
       ['ends with a hyphen', 'my-project-'],

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/schemas/bigquery-config.schema.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/schemas/bigquery-config.schema.ts
@@ -3,7 +3,13 @@ import { z } from 'zod';
 export const BIGQUERY_AUTODETECT_LOCATION = 'AUTODETECT';
 
 export const BigQueryConfigSchema = z.object({
-  projectId: z.string().min(1, 'projectId is required'),
+  projectId: z
+    .string()
+    .min(1, 'projectId is required')
+    .regex(
+      /^(?:[a-z][a-z0-9.-]*:)?[a-z][a-z0-9-]{4,28}[a-z0-9]$/,
+      'Invalid GCP project ID: 6-30 lowercase letters, numbers, or hyphens; must start with a letter and not end with a hyphen (optionally prefixed by a domain and colon, e.g. example.com:my-project)'
+    ),
   location: z
     .string()
     .nullish()

--- a/apps/backend/src/data-marts/use-cases/update-data-storage.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-storage.service.spec.ts
@@ -352,3 +352,114 @@ describe('UpdateDataStorageService - credential copy (sourceStorageId)', () => {
     );
   });
 });
+
+describe('UpdateDataStorageService - BigQuery projectId validation', () => {
+  const projectId = 'proj-1';
+  const targetId = 'storage-target';
+
+  const makeService = () => {
+    const dataStorageRepository = {
+      save: jest.fn(),
+    };
+    const dataStorageService = {
+      getByProjectIdAndId: jest.fn(),
+    };
+    const dataStorageMapper = {
+      toDomainDto: jest.fn().mockReturnValue({ id: targetId }),
+    };
+    const dataStorageAccessFacade = {
+      verifyAccess: jest.fn().mockResolvedValue(undefined),
+    };
+    const dataStorageCredentialService = {
+      create: jest.fn(),
+      update: jest.fn(),
+      softDelete: jest.fn(),
+    };
+    const copyCredentialService = new CopyCredentialService(
+      dataStorageCredentialService as never,
+      {} as never
+    );
+    const userProjectionsFetcherService = {
+      fetchUserProjectionsList: jest.fn().mockResolvedValue({
+        getByUserId: jest.fn().mockReturnValue(null),
+      }),
+    };
+    const storageOwnerRepository = {
+      delete: jest.fn().mockResolvedValue(undefined),
+      save: jest.fn().mockResolvedValue([]),
+    };
+    const idpProjectionsFacade = {
+      getProjectMembers: jest.fn().mockResolvedValue([]),
+    };
+    const eventDispatcher = {
+      publishExternal: jest.fn().mockResolvedValue(undefined),
+    };
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(true),
+    };
+
+    const service = new UpdateDataStorageService(
+      dataStorageRepository as never,
+      dataStorageService as never,
+      dataStorageMapper as never,
+      dataStorageAccessFacade as never,
+      dataStorageCredentialService as never,
+      copyCredentialService,
+      userProjectionsFetcherService as never,
+      idpProjectionsFacade as never,
+      storageOwnerRepository as never,
+      eventDispatcher as never,
+      accessDecisionService as never
+    );
+
+    return {
+      service,
+      dataStorageRepository,
+      dataStorageService,
+      dataStorageAccessFacade,
+    };
+  };
+
+  const makeCommand = (config: Record<string, unknown>): UpdateDataStorageCommand =>
+    new UpdateDataStorageCommand(targetId, projectId, config as never, 'Title');
+
+  const makeOAuthStorage = () => ({
+    id: targetId,
+    type: DataStorageType.GOOGLE_BIGQUERY,
+    projectId,
+    credentialId: 'cred-oauth',
+    credential: null,
+    config: { projectId: 'old-project' },
+    title: 'Title',
+    createdById: null,
+    ownerIds: [],
+  });
+
+  it('rejects OAuth update with invalid projectId before save', async () => {
+    const { service, dataStorageRepository, dataStorageService, dataStorageAccessFacade } =
+      makeService();
+
+    dataStorageService.getByProjectIdAndId.mockResolvedValue(makeOAuthStorage());
+
+    const command = makeCommand({ projectId: 'GTM-NC4KR2JL' });
+
+    await expect(service.run(command)).rejects.toThrow(/Invalid config — projectId: /);
+    expect(dataStorageRepository.save).not.toHaveBeenCalled();
+    expect(dataStorageAccessFacade.verifyAccess).not.toHaveBeenCalled();
+  });
+
+  it('passes validation for OAuth update with valid projectId', async () => {
+    const { service, dataStorageRepository, dataStorageService } = makeService();
+
+    const storage = makeOAuthStorage();
+    dataStorageService.getByProjectIdAndId
+      .mockResolvedValueOnce(storage)
+      .mockResolvedValueOnce(storage);
+    dataStorageRepository.save.mockResolvedValue(storage);
+
+    const command = makeCommand({ projectId: 'my-valid-project-1' });
+
+    await expect(service.run(command)).resolves.toBeDefined();
+    expect(dataStorageRepository.save).toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/update-data-storage.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-storage.service.spec.ts
@@ -441,7 +441,7 @@ describe('UpdateDataStorageService - BigQuery projectId validation', () => {
 
     dataStorageService.getByProjectIdAndId.mockResolvedValue(makeOAuthStorage());
 
-    const command = makeCommand({ projectId: 'GTM-NC4KR2JL' });
+    const command = makeCommand({ projectId: 'GTM-NC2077' });
 
     await expect(service.run(command)).rejects.toThrow(/Invalid config — projectId: /);
     expect(dataStorageRepository.save).not.toHaveBeenCalled();

--- a/apps/backend/src/data-marts/use-cases/update-data-storage.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-storage.service.ts
@@ -3,7 +3,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
 import { OwoxEventDispatcher } from '../../common/event-dispatcher/owox-event-dispatcher';
-import { BigQueryConfig } from '../data-storage-types/bigquery/schemas/bigquery-config.schema';
+import {
+  BigQueryConfig,
+  BigQueryConfigSchema,
+} from '../data-storage-types/bigquery/schemas/bigquery-config.schema';
 import { DataStorageCredentials } from '../data-storage-types/data-storage-credentials.type';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { DataStorageDto } from '../dto/domain/data-storage.dto';
@@ -209,6 +212,26 @@ export class UpdateDataStorageService {
       // Clear the eagerly-loaded relation so TypeORM save() does not
       // overwrite credentialId with the stale (soft-deleted) relation id.
       dataStorageEntity.credential = null;
+    }
+
+    // Validate BigQuery config format regardless of credential type.
+    // The full verifyAccess below is skipped for OAuth storages, so without this
+    // an invalid projectId would only surface during data mart execution.
+    if (
+      (dataStorageEntity.type === DataStorageType.GOOGLE_BIGQUERY ||
+        dataStorageEntity.type === DataStorageType.LEGACY_GOOGLE_BIGQUERY) &&
+      command.hasConfig()
+    ) {
+      const parsed = BigQueryConfigSchema.safeParse(command.config);
+      if (!parsed.success) {
+        const details = parsed.error.errors
+          .map(issue => {
+            const path = issue.path.join('.') || 'config';
+            return `${path}: ${issue.message}`;
+          })
+          .join('; ');
+        throw new BadRequestException(`Invalid config — ${details}`);
+      }
     }
 
     // Skip access validation for OAuth-configured storages (tokens are validated during OAuth exchange).


### PR DESCRIPTION
**Preview**
<img width="1362" height="474" alt="CleanShot 2026-04-21 at 18 13 44" src="https://github.com/user-attachments/assets/c9bb23fb-5df7-46cf-a6ff-c64bc7a4074a" />


**Summary**

BigQuery storages authenticated via OAuth bypassed `verifyAccess` on update, so invalid `projectId` values (e.g. `GTM-NC2077`) were persisted silently and only surfaced at data-mart runtime.

**Changes**

- `BigQueryConfigSchema.projectId` now enforces the official GCP format via regex (6–30 lowercase letters/numbers/hyphens, must start with a letter, not end with a hyphen, optional `domain:id` prefix).
- `UpdateDataStorageService` runs `BigQueryConfigSchema.safeParse` early for BigQuery/Legacy-BigQuery types — before the OAuth skip — and throws `BadRequestException` with a detailed message that survives `GlobalExceptionFilter` (uses a concatenated string instead of an object payload, which was dropped to `"Invalid config"`).
- Added unit tests: schema positive/negative cases (incl. `GTM-NC2077`) and update-flow tests for OAuth invalid/valid `projectId`.

**Out of scope**

- Live `checkAccess` API call for OAuth on save.
- Regex validation for other storage types (Athena, Snowflake, Databricks, Redshift).