### PR TITLE
feat(web): blending data mart UX updates

### DIFF
--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
@@ -588,7 +588,7 @@ export function DataMartRelationshipsContent({
         <CollapsibleCardHeader>
           <CollapsibleCardHeaderTitle
             icon={Link2}
-            tooltip='Joinable data marts connected to this one'
+            tooltip='Business users can add columns from joinable data marts directly into their spreadsheet reports. No hallucinations - row counts remain unchanged'
           >
             Joinable Data Marts
           </CollapsibleCardHeaderTitle>

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
@@ -153,7 +153,9 @@ export function DataMartRelationshipsContent({
     if (!dataMartId) return;
     setIsLoading(true);
     try {
-      const data = await dataMartRelationshipService.getRelationships(dataMartId);
+      const data = await dataMartRelationshipService.getRelationships(dataMartId, {
+        skipLoadingIndicator: true,
+      });
       // Sort by createdAt ASC — oldest on top, newest at bottom
       const sorted = [...data].sort(
         (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
@@ -182,7 +184,7 @@ export function DataMartRelationshipsContent({
       const requestId = ++schemaRequestIdRef.current;
       if (showLoading) setIsLoading(true);
       dataMartRelationshipService
-        .getBlendableSchema(dataMartId)
+        .getBlendableSchema(dataMartId, { skipLoadingIndicator: true })
         .then(data => {
           if (schemaRequestIdRef.current !== requestId) return;
           setBlendableSchema(data);
@@ -262,7 +264,9 @@ export function DataMartRelationshipsContent({
   const handleDelete = useCallback(
     async (id: string) => {
       try {
-        await dataMartRelationshipService.deleteRelationship(dataMartId, id);
+        await dataMartRelationshipService.deleteRelationship(dataMartId, id, {
+          skipLoadingIndicator: true,
+        });
         toast.success('Relationship deleted');
         setRelationships(prev => prev.filter(r => r.id !== id));
         invalidateBlendableSchema();
@@ -293,7 +297,7 @@ export function DataMartRelationshipsContent({
     (newConfig: BlendedFieldsConfig) => {
       setLocalConfig(newConfig);
       void dataMartRelationshipService
-        .updateBlendedFieldsConfig(dataMartId, newConfig)
+        .updateBlendedFieldsConfig(dataMartId, newConfig, { skipLoadingIndicator: true })
         .then(response => {
           void syncDataMartFromResponse(response);
           fetchBlendableSchema();

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
@@ -174,8 +174,10 @@ export function JoinSettingsForm({
     if (!sourceId || !relationship.targetDataMart.id) return;
     setIsLoadingSchemas(true);
     void Promise.all([
-      dataMartService.getDataMartById(sourceId),
-      dataMartService.getDataMartById(relationship.targetDataMart.id),
+      dataMartService.getDataMartById(sourceId, { skipLoadingIndicator: true }),
+      dataMartService.getDataMartById(relationship.targetDataMart.id, {
+        skipLoadingIndicator: true,
+      }),
     ])
       .then(([src, tgt]) => {
         setSourceDM(src);
@@ -254,7 +256,10 @@ export function JoinSettingsForm({
     setIsSaving(true);
 
     dataMartRelationshipService
-      .updateRelationship(dataMartId, relationship.id, payload, { skipErrorToast: true })
+      .updateRelationship(dataMartId, relationship.id, payload, {
+        skipErrorToast: true,
+        skipLoadingIndicator: true,
+      })
       .then(updated => {
         lastSavedRef.current = {
           targetAlias: updated.targetAlias,

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
@@ -11,6 +11,7 @@ import { Input } from '@owox/ui/components/input';
 import { Separator } from '@owox/ui/components/separator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { cn } from '@owox/ui/lib/utils';
+import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
 import { ExternalLink, Info, Plus, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
@@ -18,8 +19,10 @@ import { toast } from 'react-hot-toast';
 import { z } from 'zod';
 import { Button } from '../../../../../shared/components/Button';
 import { Combobox } from '../../../../../shared/components/Combobox/combobox';
+import { UserReference } from '../../../../../shared/components/UserReference';
 import { useProjectRoute } from '../../../../../shared/hooks/useProjectRoute';
 import { useDebounce } from '../../../../../hooks/useDebounce';
+import { formatDateShort } from '../../../../../utils/date-formatters';
 import type { DataMartResponseDto } from '../../../shared';
 import { dataMartService } from '../../../shared';
 import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
@@ -302,40 +305,76 @@ export function JoinSettingsForm({
         </div>
       )}
       <Form {...form}>
-        <FormField
-          control={form.control}
-          name='targetAlias'
-          render={({ field }) => (
-            <FormItem
-              variant='light'
-              className='bg-muted/50 flex flex-col gap-1.5 rounded-md p-3 dark:bg-white/5'
-            >
-              <label className='flex items-center gap-1.5 text-sm font-medium'>
-                SQL Alias
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
-                      <Info className='size-4 shrink-0' />
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side='top' className='max-w-xs'>
-                    Internal name used when building the SQL JOIN for this data mart (e.g.
-                    orders_customer_id). Not shown in the output.
-                  </TooltipContent>
-                </Tooltip>
-              </label>
-              <FormControl>
-                <Input
-                  {...field}
-                  placeholder='e.g. orders'
-                  disabled={readOnly}
-                  className='bg-background h-8 text-sm dark:bg-white/5'
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <div className='grid grid-cols-2 gap-3'>
+          <div className='bg-muted/50 flex flex-col gap-1.5 rounded-md p-3 dark:bg-white/5'>
+            <label className='flex items-center gap-1.5 text-sm font-medium'>
+              Joined Data Mart
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
+                    <Info className='size-4 shrink-0' />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side='top' className='max-w-xs'>
+                  The data mart linked here, plus who configured the join and when.
+                </TooltipContent>
+              </Tooltip>
+            </label>
+            <div className='text-muted-foreground flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm'>
+              <ExternalAnchor
+                href={scope(`/data-marts/${relationship.targetDataMart.id}/data-setup`)}
+                title={relationship.targetDataMart.title}
+                className='min-w-0'
+              >
+                <span className='max-w-[360px] truncate'>{relationship.targetDataMart.title}</span>
+              </ExternalAnchor>
+              <span className='flex shrink-0 items-center gap-1.5'>
+                <span>Joined {formatDateShort(relationship.createdAt)}</span>
+                {relationship.createdByUser && (
+                  <>
+                    <span>by</span>
+                    <UserReference userProjection={relationship.createdByUser} />
+                  </>
+                )}
+              </span>
+            </div>
+          </div>
+
+          <FormField
+            control={form.control}
+            name='targetAlias'
+            render={({ field }) => (
+              <FormItem
+                variant='light'
+                className='bg-muted/50 flex flex-col gap-1.5 rounded-md p-3 dark:bg-white/5'
+              >
+                <label className='flex items-center gap-1.5 text-sm font-medium'>
+                  SQL Alias
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
+                        <Info className='size-4 shrink-0' />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side='top' className='max-w-xs'>
+                      Internal name used when building the SQL JOIN for this data mart (e.g.
+                      orders_customer_id). Not shown in the output.
+                    </TooltipContent>
+                  </Tooltip>
+                </label>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder='e.g. orders'
+                    disabled={readOnly}
+                    className='bg-background h-8 text-sm dark:bg-white/5'
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
 
         <Separator />
 

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
@@ -325,7 +325,7 @@ export function JoinSettingsForm({
                 </TooltipContent>
               </Tooltip>
             </label>
-            <div className='text-muted-foreground flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm'>
+            <div className='text-muted-foreground flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-1 text-sm'>
               <ExternalAnchor
                 href={scope(`/data-marts/${relationship.targetDataMart.id}/data-setup`)}
                 title={relationship.targetDataMart.title}
@@ -333,15 +333,15 @@ export function JoinSettingsForm({
               >
                 <span className='max-w-[360px] truncate'>{relationship.targetDataMart.title}</span>
               </ExternalAnchor>
-              <span className='flex shrink-0 items-center gap-1.5'>
-                <span>Joined {formatDateShort(relationship.createdAt)}</span>
-                {relationship.createdByUser && (
-                  <>
-                    <span>by</span>
-                    <UserReference userProjection={relationship.createdByUser} />
-                  </>
-                )}
+              <span className='whitespace-nowrap'>
+                Joined {formatDateShort(relationship.createdAt)}
               </span>
+              {relationship.createdByUser && (
+                <span className='flex min-w-0 items-center gap-1.5'>
+                  <span>by</span>
+                  <UserReference userProjection={relationship.createdByUser} />
+                </span>
+              )}
             </div>
           </div>
 

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
@@ -95,6 +95,15 @@ function getInitialDefaults(relationship: DataMartRelationship): JoinSettingsFor
   };
 }
 
+function FieldOptionLabel({ label, type }: { label: string; type?: string }) {
+  return (
+    <span className='flex min-w-0 flex-1 items-center justify-between gap-2'>
+      <span className='truncate'>{label}</span>
+      {type && <span className='text-muted-foreground shrink-0 text-xs'>{type}</span>}
+    </span>
+  );
+}
+
 interface JoinSettingsFormProps {
   relationship: DataMartRelationship;
   dataMartId: string;
@@ -192,65 +201,58 @@ export function JoinSettingsForm({
   const targetFields = getSchemaFields(targetDM);
 
   const watchedValues = form.watch();
-  const watchedKey = JSON.stringify(watchedValues);
+  const watchedAlias = watchedValues.targetAlias;
+  const watchedJoinConditions = watchedValues.joinConditions;
+  const watchedJoinKey = JSON.stringify(watchedJoinConditions);
 
   const joinTypeMismatches = useMemo(
     () =>
-      watchedValues.joinConditions.map(jc => {
+      watchedJoinConditions.map(jc => {
         if (!jc.sourceFieldName || !jc.targetFieldName) return null;
         const sourceType = sourceFields.find(f => f.name === jc.sourceFieldName)?.type;
         const targetType = targetFields.find(f => f.name === jc.targetFieldName)?.type;
         if (!sourceType || !targetType) return null;
         return sourceType !== targetType ? { sourceType, targetType } : null;
       }),
-    [watchedValues.joinConditions, sourceFields, targetFields]
+    [watchedJoinConditions, sourceFields, targetFields]
   );
   const hasTypeMismatch = joinTypeMismatches.some(Boolean);
 
-  const debouncedKey = useDebounce(watchedKey, 800);
+  const debouncedAlias = useDebounce(watchedAlias, 800);
+  const debouncedJoinKey = useDebounce(watchedJoinKey, 800);
 
   useEffect(() => {
     if (readOnly || isSaving) return;
 
-    let parsed: JoinSettingsFormValues;
-    try {
-      parsed = JSON.parse(debouncedKey) as JoinSettingsFormValues;
-    } catch {
-      return;
-    }
-
-    const parsedJoinKey = JSON.stringify(parsed.joinConditions);
+    const joinConditions = form.getValues('joinConditions');
     const hasAliasError = !!form.formState.errors.targetAlias;
     const joinsAreComplete =
-      parsed.joinConditions.length > 0 &&
-      parsed.joinConditions.every(jc => jc.sourceFieldName && jc.targetFieldName);
+      joinConditions.length > 0 &&
+      joinConditions.every(jc => jc.sourceFieldName && jc.targetFieldName);
 
     const aliasIsNew =
-      parsed.targetAlias !== lastSavedRef.current.targetAlias &&
-      parsed.targetAlias !== lastAttemptedRef.current.targetAlias;
+      debouncedAlias !== lastSavedRef.current.targetAlias &&
+      debouncedAlias !== lastAttemptedRef.current.targetAlias;
     const joinsAreNew =
-      parsedJoinKey !== lastSavedRef.current.joinConditionsKey &&
-      parsedJoinKey !== lastAttemptedRef.current.joinConditionsKey;
+      debouncedJoinKey !== lastSavedRef.current.joinConditionsKey &&
+      debouncedJoinKey !== lastAttemptedRef.current.joinConditionsKey;
 
     const payload: {
       targetAlias?: string;
       joinConditions?: JoinSettingsFormValues['joinConditions'];
     } = {};
     if (aliasIsNew && !hasAliasError) {
-      payload.targetAlias = parsed.targetAlias;
+      payload.targetAlias = debouncedAlias;
     }
     if (joinsAreNew && joinsAreComplete && !hasTypeMismatch) {
-      payload.joinConditions = parsed.joinConditions;
+      payload.joinConditions = joinConditions;
     }
     if (Object.keys(payload).length === 0) return;
 
-    // Mirror the payload into attempted refs so a failed save cannot loop on the
-    // same value (see original guard), while leaving untouched fields intact so
-    // they still eligible for their own autosave path.
     lastAttemptedRef.current = {
       targetAlias: payload.targetAlias ?? lastAttemptedRef.current.targetAlias,
       joinConditionsKey: payload.joinConditions
-        ? parsedJoinKey
+        ? debouncedJoinKey
         : lastAttemptedRef.current.joinConditionsKey,
     };
     setIsSaving(true);
@@ -276,7 +278,8 @@ export function JoinSettingsForm({
         setIsSaving(false);
       });
   }, [
-    debouncedKey,
+    debouncedAlias,
+    debouncedJoinKey,
     hasTypeMismatch,
     readOnly,
     isSaving,
@@ -436,19 +439,12 @@ export function JoinSettingsForm({
                             placeholder='Select field...'
                             disabled={readOnly || isLoadingSchemas}
                             className={cn(mismatch && 'border-destructive')}
-                            renderLabel={option => {
-                              const f = sourceFields.find(sf => sf.name === option.value);
-                              return (
-                                <span className='flex min-w-0 flex-1 items-center justify-between gap-2'>
-                                  <span className='truncate'>{option.label}</span>
-                                  {f && (
-                                    <span className='text-muted-foreground shrink-0 text-xs'>
-                                      {f.type}
-                                    </span>
-                                  )}
-                                </span>
-                              );
-                            }}
+                            renderLabel={option => (
+                              <FieldOptionLabel
+                                label={option.label}
+                                type={sourceFields.find(sf => sf.name === option.value)?.type}
+                              />
+                            )}
                           />
                         </FormControl>
                         <FormMessage />
@@ -482,19 +478,12 @@ export function JoinSettingsForm({
                             placeholder='Select field...'
                             disabled={readOnly || isLoadingSchemas}
                             className={cn(mismatch && 'border-destructive')}
-                            renderLabel={option => {
-                              const f = targetFields.find(tf => tf.name === option.value);
-                              return (
-                                <span className='flex min-w-0 flex-1 items-center justify-between gap-2'>
-                                  <span className='truncate'>{option.label}</span>
-                                  {f && (
-                                    <span className='text-muted-foreground shrink-0 text-xs'>
-                                      {f.type}
-                                    </span>
-                                  )}
-                                </span>
-                              );
-                            }}
+                            renderLabel={option => (
+                              <FieldOptionLabel
+                                label={option.label}
+                                type={targetFields.find(tf => tf.name === option.value)?.type}
+                              />
+                            )}
                           />
                         </FormControl>
                         <FormMessage />

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
@@ -92,25 +92,35 @@ export function RelationshipAccordionItem({
   const [localAlias, setLocalAlias] = useState(displayAlias);
   const debouncedAlias = useDebounce(localAlias, 500);
   const lastSavedAlias = useRef(displayAlias);
+  const isDirtyRef = useRef(false);
 
   useEffect(() => {
     setLocalAlias(displayAlias);
     lastSavedAlias.current = displayAlias;
+    isDirtyRef.current = false;
   }, [displayAlias]);
 
   useEffect(() => {
     if (!source) return;
+    if (!isDirtyRef.current) return;
     if (debouncedAlias !== lastSavedAlias.current) {
       onAliasChange(source, debouncedAlias);
       lastSavedAlias.current = debouncedAlias;
+      isDirtyRef.current = false;
     }
   }, [debouncedAlias, source, onAliasChange]);
+
+  const handleAliasInput = (next: string) => {
+    setLocalAlias(next);
+    isDirtyRef.current = true;
+  };
 
   const handleAliasBlur = () => {
     if (!source) return;
     if (localAlias !== lastSavedAlias.current) {
       onAliasChange(source, localAlias);
       lastSavedAlias.current = localAlias;
+      isDirtyRef.current = false;
     }
   };
 
@@ -160,9 +170,10 @@ export function RelationshipAccordionItem({
   // Keep actions visible while the dropdown is open, otherwise they would
   // disappear as soon as the pointer leaves the row to reach the menu.
   const actionsVisible = isOpen || isMenuOpen;
-  const actionsVisibilityClass = actionsVisible
-    ? 'opacity-100'
-    : 'opacity-0 group-hover:opacity-100';
+  const actionsVisibilityClass = cn(
+    'transition-opacity',
+    actionsVisible ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+  );
 
   return (
     <>
@@ -242,10 +253,7 @@ export function RelationshipAccordionItem({
 
               {/* Allow for reporting — rendered for both direct and transient rows */}
               <div
-                className={cn(
-                  'flex shrink-0 items-center gap-1.5 transition-opacity',
-                  actionsVisibilityClass
-                )}
+                className={cn('flex shrink-0 items-center gap-1.5', actionsVisibilityClass)}
                 onClick={e => {
                   e.stopPropagation();
                 }}
@@ -269,7 +277,7 @@ export function RelationshipAccordionItem({
 
               {/* Dropdown menu — controlled so siblings stay visible while open */}
               <div
-                className={cn('shrink-0 transition-opacity', actionsVisibilityClass)}
+                className={cn('shrink-0', actionsVisibilityClass)}
                 onClick={e => {
                   e.stopPropagation();
                 }}
@@ -388,7 +396,7 @@ export function RelationshipAccordionItem({
                             <Input
                               value={localAlias}
                               onChange={e => {
-                                setLocalAlias(e.target.value);
+                                handleAliasInput(e.target.value);
                               }}
                               onBlur={handleAliasBlur}
                               placeholder='e.g. campaign_performance'

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
@@ -12,14 +12,12 @@ import { Switch } from '@owox/ui/components/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@owox/ui/components/tabs';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { cn } from '@owox/ui/lib/utils';
-import { Box, Columns3, ExternalLink, GitMerge, Info, MoreHorizontal, Trash2 } from 'lucide-react';
+import { Columns3, ExternalLink, GitMerge, Info, MoreHorizontal, Trash2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Button } from '../../../../../shared/components/Button';
 import { ConfirmationDialog } from '../../../../../shared/components/ConfirmationDialog';
-import { UserReference } from '../../../../../shared/components/UserReference';
 import { useProjectRoute } from '../../../../../shared/hooks/useProjectRoute';
 import { useDebounce } from '../../../../../hooks/useDebounce';
-import { formatDateShort } from '../../../../../utils/date-formatters';
 import type {
   BlendedField,
   BlendedFieldOverride,
@@ -357,51 +355,6 @@ export function RelationshipAccordionItem({
                         Join Settings
                       </TabsTrigger>
                     </TabsList>
-                    <div className='text-muted-foreground ml-auto flex min-w-0 items-center gap-1.5 text-sm'>
-                      <Box className='size-4 shrink-0' />
-                      <span
-                        className='text-foreground max-w-[240px] truncate font-medium'
-                        title={rel.targetDataMart.title}
-                      >
-                        {rel.targetDataMart.title}
-                      </span>
-                      {rel.targetDataMart.description && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
-                              <Info className='size-4 shrink-0' />
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side='top' className='max-w-xs'>
-                            {rel.targetDataMart.description}
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                      <Button
-                        type='button'
-                        variant='ghost'
-                        size='sm'
-                        className='text-muted-foreground/60 hover:text-muted-foreground h-5 w-5 shrink-0 p-0'
-                        onClick={() => {
-                          window.open(
-                            scope(`/data-marts/${rel.targetDataMart.id}/data-setup`),
-                            '_blank'
-                          );
-                        }}
-                        aria-label='Open target data mart in new tab'
-                      >
-                        <ExternalLink className='size-4' />
-                      </Button>
-                    </div>
-                    <div className='text-muted-foreground flex shrink-0 items-center gap-1.5 text-sm'>
-                      <span>Joined {formatDateShort(rel.createdAt)}</span>
-                      {rel.createdByUser && (
-                        <>
-                          <span>by</span>
-                          <UserReference userProjection={rel.createdByUser} />
-                        </>
-                      )}
-                    </div>
                   </div>
 
                   <TabsContent value='fields' className='px-4 pt-2 pb-2'>

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
@@ -470,7 +470,9 @@ async function setupEditor(
 
       if (showTransient && depth < MAX_DEPTH && !ancestorDmIds.has(dmId)) {
         try {
-          const childRels = await dataMartRelationshipService.getRelationships(dmId);
+          const childRels = await dataMartRelationshipService.getRelationships(dmId, {
+            skipLoadingIndicator: true,
+          });
           if (childRels.length > 0) {
             const newAncestors = new Set(ancestorDmIds);
             newAncestors.add(dmId);

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/TargetDataMartPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/TargetDataMartPicker.tsx
@@ -33,8 +33,8 @@ export function TargetDataMartPicker({
     void (async () => {
       try {
         const [allDMs, srcDM] = await Promise.all([
-          dataMartService.getDataMarts(),
-          dataMartService.getDataMartById(dataMartId),
+          dataMartService.getDataMarts({ skipLoadingIndicator: true }),
+          dataMartService.getDataMartById(dataMartId, { skipLoadingIndicator: true }),
         ]);
 
         const filtered = allDMs
@@ -61,11 +61,15 @@ export function TargetDataMartPicker({
       const baseAlias = slugify(dm.title) || slugify(targetDMId);
       const targetAlias = generateUniqueAlias(baseAlias, takenAliases);
 
-      const created = await dataMartRelationshipService.createRelationship(dataMartId, {
-        targetDataMartId: targetDMId,
-        targetAlias,
-        joinConditions: [],
-      });
+      const created = await dataMartRelationshipService.createRelationship(
+        dataMartId,
+        {
+          targetDataMartId: targetDMId,
+          targetAlias,
+          joinConditions: [],
+        },
+        { skipLoadingIndicator: true }
+      );
       onCreated(created);
     } catch {
       toast.error('Failed to add relationship');

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/useTransientRelationships.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/useTransientRelationships.ts
@@ -78,7 +78,9 @@ export function useTransientRelationships(
           }
 
           try {
-            const childRels = await dataMartRelationshipService.getRelationships(dmId);
+            const childRels = await dataMartRelationshipService.getRelationships(dmId, {
+              skipLoadingIndicator: true,
+            });
             if (childRels.length === 0) return [row];
 
             const newAncestors = new Set(ancestorDmIds);

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { cn } from '@owox/ui/lib/utils';
 import { Badge } from '@owox/ui/components/badge';
@@ -68,19 +68,25 @@ export interface ReportColumnPickerProps {
   onCountChange?: (count: ReportColumnSelectionCount) => void;
 }
 
+type ToggleFieldFn = (name: string, checked: boolean) => void;
+
 interface NativeFieldRowProps {
   field: NativeField;
-  isChecked: (name: string) => boolean;
-  onToggleField: (name: string, checked: boolean) => void;
+  checked: boolean;
+  onToggleField: ToggleFieldFn;
 }
 
-function NativeFieldRow({ field, isChecked, onToggleField }: NativeFieldRowProps) {
+const NativeFieldRow = memo(function NativeFieldRow({
+  field,
+  checked,
+  onToggleField,
+}: NativeFieldRowProps) {
   return (
     <label className='group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded px-1 py-1'>
       <Checkbox
-        checked={isChecked(field.name)}
-        onCheckedChange={checked => {
-          onToggleField(field.name, checked === true);
+        checked={checked}
+        onCheckedChange={c => {
+          onToggleField(field.name, c === true);
         }}
       />
       <span className='font-mono text-xs'>{field.alias ?? field.name}</span>
@@ -88,15 +94,41 @@ function NativeFieldRow({ field, isChecked, onToggleField }: NativeFieldRowProps
       <FieldInfoTooltip text={field.description} compact />
     </label>
   );
+});
+
+interface BlendedFieldRowProps {
+  field: BlendedField;
+  checked: boolean;
+  onToggleField: ToggleFieldFn;
 }
+
+const BlendedFieldRow = memo(function BlendedFieldRow({
+  field,
+  checked,
+  onToggleField,
+}: BlendedFieldRowProps) {
+  return (
+    <label className='group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded px-1 py-1'>
+      <Checkbox
+        checked={checked}
+        onCheckedChange={c => {
+          onToggleField(field.name, c === true);
+        }}
+      />
+      <span className='font-mono text-xs'>{field.alias || field.originalFieldName}</span>
+      {field.type && <span className='text-muted-foreground text-xs'>({field.type})</span>}
+      <FieldInfoTooltip text={field.description} compact />
+    </label>
+  );
+});
 
 interface BlendedGroupItemProps {
   group: BlendedGroup;
-  isChecked: (name: string) => boolean;
-  onToggleField: (name: string, checked: boolean) => void;
+  selectedSet: Set<string>;
+  onToggleField: ToggleFieldFn;
 }
 
-function BlendedGroupItem({ group, isChecked, onToggleField }: BlendedGroupItemProps) {
+function BlendedGroupItem({ group, selectedSet, onToggleField }: BlendedGroupItemProps) {
   const [isOpen, setIsOpen] = useState(() => group.selectedCount > 0);
 
   return (
@@ -126,20 +158,12 @@ function BlendedGroupItem({ group, isChecked, onToggleField }: BlendedGroupItemP
       </button>
       <CollapsibleContent>
         {group.visibleFields.map(field => (
-          <label
+          <BlendedFieldRow
             key={field.name}
-            className='group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
-          >
-            <Checkbox
-              checked={isChecked(field.name)}
-              onCheckedChange={checked => {
-                onToggleField(field.name, checked === true);
-              }}
-            />
-            <span className='font-mono text-xs'>{field.alias || field.originalFieldName}</span>
-            {field.type && <span className='text-muted-foreground text-xs'>({field.type})</span>}
-            <FieldInfoTooltip text={field.description} compact />
-          </label>
+            field={field}
+            checked={selectedSet.has(field.name)}
+            onToggleField={onToggleField}
+          />
         ))}
       </CollapsibleContent>
     </Collapsible>
@@ -200,18 +224,21 @@ export function ReportColumnPicker({
     onBlendedSelectionChange?.(hasBlendedSelection);
   }, [hasBlendedSelection, onBlendedSelectionChange]);
 
-  function isChecked(fieldName: string): boolean {
-    return effectiveValueSet.has(fieldName);
-  }
+  const valueRef = useRef(effectiveValue);
+  valueRef.current = effectiveValue;
 
-  function toggleField(fieldName: string, checked: boolean) {
-    if (checked) {
-      if (effectiveValueSet.has(fieldName)) return;
-      onChange([...effectiveValue, fieldName]);
-    } else {
-      onChange(effectiveValue.filter(name => name !== fieldName));
-    }
-  }
+  const toggleField = useCallback<ToggleFieldFn>(
+    (fieldName, checked) => {
+      const current = valueRef.current;
+      if (checked) {
+        if (current.includes(fieldName)) return;
+        onChange([...current, fieldName]);
+      } else {
+        onChange(current.filter(name => name !== fieldName));
+      }
+    },
+    [onChange]
+  );
 
   function selectAll() {
     if (!schema) return;
@@ -231,12 +258,12 @@ export function ReportColumnPicker({
     onChange(effectiveValue.filter(name => !known.has(name)));
   }
 
-  const selectedNativeCount = nativeFields.filter(f => isChecked(f.name)).length;
+  const selectedNativeCount = nativeFields.filter(f => effectiveValueSet.has(f.name)).length;
 
   const [showSelectedOnly, setShowSelectedOnly] = useState(false);
 
   const visibleNativeFields = showSelectedOnly
-    ? nativeFields.filter(f => isChecked(f.name))
+    ? nativeFields.filter(f => effectiveValueSet.has(f.name))
     : nativeFields;
 
   const totalFieldsCount = nativeFields.length + includedBlendedFields.length;
@@ -334,7 +361,7 @@ export function ReportColumnPicker({
           <NativeFieldRow
             key={field.name}
             field={field}
-            isChecked={isChecked}
+            checked={effectiveValueSet.has(field.name)}
             onToggleField={toggleField}
           />
         ))}
@@ -343,7 +370,7 @@ export function ReportColumnPicker({
           <BlendedGroupItem
             key={group.aliasPath}
             group={group}
-            isChecked={isChecked}
+            selectedSet={effectiveValueSet}
             onToggleField={toggleField}
           />
         ))}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -343,7 +343,7 @@ export function ReportColumnPicker({
           Select all
         </label>
         <label className={toggleLabelClass}>
-          Selected only
+          Show selected only
           <Switch checked={showSelectedOnly} onCheckedChange={setShowSelectedOnly} />
         </label>
       </div>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -4,6 +4,7 @@ import { cn } from '@owox/ui/lib/utils';
 import { Badge } from '@owox/ui/components/badge';
 import { Checkbox } from '@owox/ui/components/checkbox';
 import { Collapsible, CollapsibleContent } from '@owox/ui/components/collapsible';
+import { Switch } from '@owox/ui/components/switch';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { Skeleton } from '@owox/ui/components/skeleton';
 import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
@@ -296,35 +297,28 @@ export function ReportColumnPicker({
     );
   }
 
+  const allSelected = totalFieldsCount > 0 && selectedFieldsCount >= totalFieldsCount;
+  const toggleLabelClass =
+    'text-muted-foreground hover:text-foreground flex cursor-pointer items-center gap-2 text-xs transition-colors';
+
   return (
     <div className='space-y-2'>
       <div className='flex items-center justify-between px-2'>
-        <label className='text-muted-foreground hover:text-foreground flex cursor-pointer items-center gap-2 text-xs transition-colors'>
+        <label className={toggleLabelClass}>
           <Checkbox
-            checked={showSelectedOnly}
+            checked={allSelected}
             onCheckedChange={checked => {
-              setShowSelectedOnly(checked === true);
+              if (checked === true) selectAll();
+              else deselectAll();
             }}
+            aria-label={allSelected ? 'Deselect all fields' : 'Select all fields'}
           />
-          Selected only
+          Select all
         </label>
-        <div className='flex gap-2'>
-          <button
-            type='button'
-            className='text-muted-foreground hover:text-foreground cursor-pointer text-xs transition-colors'
-            onClick={selectAll}
-          >
-            Select All
-          </button>
-          <span className='text-muted-foreground text-xs'>/</span>
-          <button
-            type='button'
-            className='text-muted-foreground hover:text-foreground cursor-pointer text-xs transition-colors'
-            onClick={deselectAll}
-          >
-            Deselect All
-          </button>
-        </div>
+        <label className={toggleLabelClass}>
+          Selected only
+          <Switch checked={showSelectedOnly} onCheckedChange={setShowSelectedOnly} />
+        </label>
       </div>
 
       <div

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { cn } from '@owox/ui/lib/utils';
+import { Badge } from '@owox/ui/components/badge';
 import { Checkbox } from '@owox/ui/components/checkbox';
 import { Collapsible, CollapsibleContent } from '@owox/ui/components/collapsible';
 import { ChevronDown, ChevronRight } from 'lucide-react';
@@ -42,7 +43,20 @@ interface BlendedGroup {
   description?: string;
   visibleFields: BlendedField[];
   selectedCount: number;
-  totalCount: number;
+}
+
+export interface ReportColumnSelectionCount {
+  selected: number;
+  total: number;
+}
+
+export function ReportColumnsCountBadge({ count }: { count: ReportColumnSelectionCount }) {
+  if (count.total === 0) return null;
+  return (
+    <Badge className='border-transparent bg-zinc-200 font-mono text-zinc-600 opacity-50 dark:bg-zinc-700 dark:text-zinc-300'>
+      {count.selected}/{count.total}
+    </Badge>
+  );
 }
 
 export interface ReportColumnPickerProps {
@@ -50,80 +64,28 @@ export interface ReportColumnPickerProps {
   value: string[] | null;
   onChange: (value: string[] | null) => void;
   onBlendedSelectionChange?: (hasBlendedSelection: boolean) => void;
+  onCountChange?: (count: ReportColumnSelectionCount) => void;
 }
 
-interface NativeFieldsGroupProps {
-  nativeFields: NativeField[];
-  description?: string;
-  selectedCount: number;
-  totalCount: number;
+interface NativeFieldRowProps {
+  field: NativeField;
   isChecked: (name: string) => boolean;
   onToggleField: (name: string, checked: boolean) => void;
 }
 
-function NativeFieldsGroup({
-  nativeFields,
-  description,
-  selectedCount,
-  totalCount,
-  isChecked,
-  onToggleField,
-}: NativeFieldsGroupProps) {
-  const [isOpen, setIsOpen] = useState(true);
-
-  const counterText = `${selectedCount} / ${totalCount}`;
-  const fieldWord = totalCount === 1 ? 'field' : 'fields';
-
+function NativeFieldRow({ field, isChecked, onToggleField }: NativeFieldRowProps) {
   return (
-    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <button
-        type='button'
-        aria-expanded={isOpen}
-        aria-label={`${isOpen ? 'Collapse' : 'Expand'} Default Data Mart Columns`}
-        className='group bg-secondary/50 dark:bg-muted/50 hover:bg-secondary/80 dark:hover:bg-muted/80 flex w-full cursor-pointer items-start gap-1.5 rounded px-1 py-1 text-left transition-colors'
-        onClick={() => {
-          setIsOpen(v => !v);
+    <label className='group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded px-1 py-1'>
+      <Checkbox
+        checked={isChecked(field.name)}
+        onCheckedChange={checked => {
+          onToggleField(field.name, checked === true);
         }}
-      >
-        {isOpen ? (
-          <ChevronDown className='text-muted-foreground mt-0.5 h-4 w-4 shrink-0' />
-        ) : (
-          <ChevronRight className='text-muted-foreground mt-0.5 h-4 w-4 shrink-0' />
-        )}
-        <div className='min-w-0 flex-1'>
-          <div className='flex items-center justify-between gap-1.5'>
-            <div className='flex min-w-0 items-center gap-1.5'>
-              <span className='truncate text-xs font-semibold'>Default Data Mart Columns</span>
-              <FieldInfoTooltip text={description} />
-            </div>
-            <span className='text-muted-foreground shrink-0 text-xs'>
-              {counterText} {fieldWord}
-            </span>
-          </div>
-        </div>
-      </button>
-      <CollapsibleContent>
-        {nativeFields.length === 0 && (
-          <p className='text-muted-foreground px-1 text-xs'>No fields available.</p>
-        )}
-        {nativeFields.map(field => (
-          <label
-            key={field.name}
-            className='group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
-          >
-            <Checkbox
-              checked={isChecked(field.name)}
-              onCheckedChange={checked => {
-                onToggleField(field.name, checked === true);
-              }}
-            />
-            <span className='font-mono text-xs'>{field.alias ?? field.name}</span>
-            {field.type && <span className='text-muted-foreground text-xs'>({field.type})</span>}
-            <FieldInfoTooltip text={field.description} compact />
-          </label>
-        ))}
-      </CollapsibleContent>
-    </Collapsible>
+      />
+      <span className='font-mono text-xs'>{field.alias ?? field.name}</span>
+      {field.type && <span className='text-muted-foreground text-xs'>({field.type})</span>}
+      <FieldInfoTooltip text={field.description} compact />
+    </label>
   );
 }
 
@@ -135,9 +97,6 @@ interface BlendedGroupItemProps {
 
 function BlendedGroupItem({ group, isChecked, onToggleField }: BlendedGroupItemProps) {
   const [isOpen, setIsOpen] = useState(() => group.selectedCount > 0);
-
-  const counterText = `${group.selectedCount} / ${group.totalCount}`;
-  const fieldWord = group.totalCount === 1 ? 'field' : 'fields';
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -156,16 +115,11 @@ function BlendedGroupItem({ group, isChecked, onToggleField }: BlendedGroupItemP
           <ChevronRight className='text-muted-foreground mt-0.5 h-4 w-4 shrink-0' />
         )}
         <div className='min-w-0 flex-1'>
-          <div className='flex items-center justify-between gap-1.5'>
-            <div className='flex min-w-0 items-center gap-1.5'>
-              <span className='truncate text-xs font-semibold' title={group.alias}>
-                {group.alias}
-              </span>
-              <FieldInfoTooltip text={group.description} />
-            </div>
-            <span className='text-muted-foreground shrink-0 text-xs'>
-              {counterText} {fieldWord}
+          <div className='flex min-w-0 items-center gap-1.5'>
+            <span className='truncate text-xs font-semibold' title={group.alias}>
+              {group.alias}
             </span>
+            <FieldInfoTooltip text={group.description} />
           </div>
         </div>
       </button>
@@ -196,6 +150,7 @@ export function ReportColumnPicker({
   value,
   onChange,
   onBlendedSelectionChange,
+  onCountChange,
 }: ReportColumnPickerProps) {
   const { data: schema, isLoading } = useQuery({
     queryKey: [BLENDABLE_SCHEMA_QUERY_KEY, dataMartId],
@@ -228,40 +183,51 @@ export function ReportColumnPicker({
     return nativeFields.map(f => f.name);
   }, [value, nativeFields]);
 
+  const effectiveValueSet = useMemo(() => new Set(effectiveValue), [effectiveValue]);
+
+  const includedBlendedNamesSet = useMemo(
+    () => new Set(includedBlendedFields.map(f => f.name)),
+    [includedBlendedFields]
+  );
+
   const hasBlendedSelection = useMemo(() => {
     if (!schema) return false;
-    const blendedNames = new Set(includedBlendedFields.map(f => f.name));
-    return effectiveValue.some(name => blendedNames.has(name));
-  }, [schema, effectiveValue, includedBlendedFields]);
+    return effectiveValue.some(name => includedBlendedNamesSet.has(name));
+  }, [schema, effectiveValue, includedBlendedNamesSet]);
 
   useEffect(() => {
     onBlendedSelectionChange?.(hasBlendedSelection);
   }, [hasBlendedSelection, onBlendedSelectionChange]);
 
   function isChecked(fieldName: string): boolean {
-    return effectiveValue.includes(fieldName);
+    return effectiveValueSet.has(fieldName);
   }
 
   function toggleField(fieldName: string, checked: boolean) {
     if (checked) {
-      if (effectiveValue.includes(fieldName)) return;
+      if (effectiveValueSet.has(fieldName)) return;
       onChange([...effectiveValue, fieldName]);
     } else {
       onChange(effectiveValue.filter(name => name !== fieldName));
     }
   }
 
-  function selectAllNative() {
+  function selectAll() {
     if (!schema) return;
     const nativeNames = nativeFields.map(f => f.name);
-    const currentBlended = effectiveValue.filter(name => !nativeNames.includes(name));
-    onChange([...nativeNames, ...currentBlended]);
+    const blendedNames = includedBlendedFields.map(f => f.name);
+    const known = new Set([...nativeNames, ...blendedNames]);
+    const orphanSelections = effectiveValue.filter(name => !known.has(name));
+    onChange([...nativeNames, ...blendedNames, ...orphanSelections]);
   }
 
-  function deselectAllNative() {
+  function deselectAll() {
     if (!schema) return;
-    const nativeNames = new Set(nativeFields.map(f => f.name));
-    onChange(effectiveValue.filter(name => !nativeNames.has(name)));
+    const known = new Set([
+      ...nativeFields.map(f => f.name),
+      ...includedBlendedFields.map(f => f.name),
+    ]);
+    onChange(effectiveValue.filter(name => !known.has(name)));
   }
 
   const selectedNativeCount = nativeFields.filter(f => isChecked(f.name)).length;
@@ -272,6 +238,16 @@ export function ReportColumnPicker({
     ? nativeFields.filter(f => isChecked(f.name))
     : nativeFields;
 
+  const totalFieldsCount = nativeFields.length + includedBlendedFields.length;
+  const selectedBlendedCount = effectiveValue.filter(name =>
+    includedBlendedNamesSet.has(name)
+  ).length;
+  const selectedFieldsCount = selectedNativeCount + selectedBlendedCount;
+
+  useEffect(() => {
+    onCountChange?.({ selected: selectedFieldsCount, total: totalFieldsCount });
+  }, [selectedFieldsCount, totalFieldsCount, onCountChange]);
+
   const availableSourceDescriptionByPath = useMemo(() => {
     const map = new Map<string, string | undefined>();
     for (const source of schema?.availableSources ?? []) {
@@ -281,7 +257,6 @@ export function ReportColumnPicker({
   }, [schema]);
 
   const groupedBlendedFields = useMemo<BlendedGroup[]>(() => {
-    const selectedSet = new Set(effectiveValue);
     const groupMap = new Map<string, BlendedGroup>();
 
     for (const field of includedBlendedFields) {
@@ -294,19 +269,21 @@ export function ReportColumnPicker({
           description: availableSourceDescriptionByPath.get(field.aliasPath),
           visibleFields: [],
           selectedCount: 0,
-          totalCount: 0,
         };
         groupMap.set(field.aliasPath, group);
       }
-      group.totalCount += 1;
-      const isSelected = selectedSet.has(field.name);
+      const isSelected = effectiveValueSet.has(field.name);
       if (isSelected) group.selectedCount += 1;
       if (!showSelectedOnly || isSelected) group.visibleFields.push(field);
     }
 
-    // У режимі "Selected only" ховаємо групи, у яких немає жодного видимого поля
     return Array.from(groupMap.values()).filter(g => g.visibleFields.length > 0);
-  }, [includedBlendedFields, showSelectedOnly, effectiveValue, availableSourceDescriptionByPath]);
+  }, [
+    includedBlendedFields,
+    showSelectedOnly,
+    effectiveValueSet,
+    availableSourceDescriptionByPath,
+  ]);
 
   if (isLoading) {
     return (
@@ -321,7 +298,7 @@ export function ReportColumnPicker({
 
   return (
     <div className='space-y-2'>
-      <div className='flex items-center justify-between'>
+      <div className='flex items-center justify-between px-2'>
         <label className='text-muted-foreground hover:text-foreground flex cursor-pointer items-center gap-2 text-xs transition-colors'>
           <Checkbox
             checked={showSelectedOnly}
@@ -335,7 +312,7 @@ export function ReportColumnPicker({
           <button
             type='button'
             className='text-muted-foreground hover:text-foreground cursor-pointer text-xs transition-colors'
-            onClick={selectAllNative}
+            onClick={selectAll}
           >
             Select All
           </button>
@@ -343,7 +320,7 @@ export function ReportColumnPicker({
           <button
             type='button'
             className='text-muted-foreground hover:text-foreground cursor-pointer text-xs transition-colors'
-            onClick={deselectAllNative}
+            onClick={deselectAll}
           >
             Deselect All
           </button>
@@ -356,17 +333,18 @@ export function ReportColumnPicker({
           selectedNativeCount === 0 ? 'border-destructive' : 'border-border'
         )}
       >
-        {/* Default Columns (native fields) */}
-        <NativeFieldsGroup
-          nativeFields={visibleNativeFields}
-          description={schema?.nativeDescription}
-          selectedCount={selectedNativeCount}
-          totalCount={nativeFields.length}
-          isChecked={isChecked}
-          onToggleField={toggleField}
-        />
+        {visibleNativeFields.length === 0 && (
+          <p className='text-muted-foreground px-1 text-xs'>No fields available.</p>
+        )}
+        {visibleNativeFields.map(field => (
+          <NativeFieldRow
+            key={field.name}
+            field={field}
+            isChecked={isChecked}
+            onToggleField={toggleField}
+          />
+        ))}
 
-        {/* Blended field groups */}
         {groupedBlendedFields.map(group => (
           <BlendedGroupItem
             key={group.aliasPath}

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
@@ -71,7 +71,11 @@ import type { DataDestinationFormData } from '../../../../../data-destination';
 import { useReport } from '../../../shared';
 import { isEmailDestinationConfig } from '../../../shared/model/types/data-mart-report';
 import { ReportFormActions } from '../shared/ReportFormActions';
-import { ReportColumnPicker } from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
+import {
+  ReportColumnPicker,
+  ReportColumnsCountBadge,
+  type ReportColumnSelectionCount,
+} from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
 
 export interface EmailReportEditFormProps {
   initialReport?: DataMartReport;
@@ -134,6 +138,10 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
     const scheduleRef = useRef<ReportSchedulesInlineListHandle | null>(null);
     const runAfterSaveRef = useRef(false);
     const [triggersDirty, setTriggersDirty] = useState(false);
+    const [columnsCount, setColumnsCount] = useState<ReportColumnSelectionCount>({
+      selected: 0,
+      total: 0,
+    });
     const [isCreatingInsight, setIsCreatingInsight] = useState(false);
     const [useInsightTemplateMode, setUseInsightTemplateMode] = useState(isInsightContext);
     const [isDestinationSelectOpen, setIsDestinationSelectOpen] = useState(false);
@@ -897,6 +905,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
               <FormSection
                 title='Report Columns'
                 tooltip='Select which columns to include in the report'
+                titleAdornment={<ReportColumnsCountBadge count={columnsCount} />}
               >
                 {dataMart?.id && (
                   <div className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
@@ -906,6 +915,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
                       onChange={value => {
                         form.setValue('columnConfig', value, { shouldDirty: true });
                       }}
+                      onCountChange={setColumnsCount}
                     />
                   </div>
                 )}

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -58,7 +58,11 @@ import { useReport } from '../../../shared';
 import { ReportFormActions } from '../shared/ReportFormActions';
 import { OwnersSection } from '../../../../../../shared/components/OwnersSection/OwnersSection';
 import type { UserProjectionDto } from '../../../../../../shared/types/api';
-import { ReportColumnPicker } from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
+import {
+  ReportColumnPicker,
+  ReportColumnsCountBadge,
+  type ReportColumnSelectionCount,
+} from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
 
 interface GoogleSheetsReportEditFormProps {
   initialReport?: DataMartReport;
@@ -121,6 +125,10 @@ export const GoogleSheetsReportEditForm = forwardRef<
     const scheduleRef = useRef<ReportSchedulesInlineListHandle | null>(null);
     const runAfterSaveRef = useRef(false);
     const [triggersDirty, setTriggersDirty] = useState(false);
+    const [columnsCount, setColumnsCount] = useState<ReportColumnSelectionCount>({
+      selected: 0,
+      total: 0,
+    });
     const { runReport } = useReport();
 
     const currentUser = useUser();
@@ -415,6 +423,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
             <FormSection
               title='Report Columns'
               tooltip='Select which columns to include in the report'
+              titleAdornment={<ReportColumnsCountBadge count={columnsCount} />}
             >
               {dataMart?.id && (
                 <div className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
@@ -424,6 +433,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
                     onChange={value => {
                       form.setValue('columnConfig', value, { shouldDirty: true });
                     }}
+                    onCountChange={setColumnsCount}
                   />
                 </div>
               )}

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -36,7 +36,11 @@ import { Button } from '@owox/ui/components/button';
 import LookerStudioCacheLifetimeDescription from './LookerStudioCacheLifetimeDescription.tsx';
 import { OwnersSection } from '../../../../../../shared/components/OwnersSection/OwnersSection';
 import type { UserProjectionDto } from '../../../../../../shared/types/api';
-import { ReportColumnPicker } from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
+import {
+  ReportColumnPicker,
+  ReportColumnsCountBadge,
+  type ReportColumnSelectionCount,
+} from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
 import { GeneratedSqlViewer } from '../../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
 
 interface LookerStudioReportEditFormProps {
@@ -85,6 +89,10 @@ export const LookerStudioReportEditForm = forwardRef<
 
     const { dataMart } = useOutletContext<DataMartContextType>();
     const [hasBlendedSelection, setHasBlendedSelection] = useState(false);
+    const [columnsCount, setColumnsCount] = useState<ReportColumnSelectionCount>({
+      selected: 0,
+      total: 0,
+    });
 
     const currentUser = useUser();
     const initialOwnerUsers =
@@ -201,6 +209,7 @@ export const LookerStudioReportEditForm = forwardRef<
             <FormSection
               title='Report Columns'
               tooltip='Select which columns to include in the report'
+              titleAdornment={<ReportColumnsCountBadge count={columnsCount} />}
             >
               {dataMart?.id && (
                 <div className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
@@ -211,6 +220,7 @@ export const LookerStudioReportEditForm = forwardRef<
                       form.setValue('columnConfig', value, { shouldDirty: true });
                     }}
                     onBlendedSelectionChange={setHasBlendedSelection}
+                    onCountChange={setColumnsCount}
                   />
                   {hasBlendedSelection &&
                     mode === ReportFormMode.EDIT &&

--- a/apps/web/src/features/data-marts/shared/services/data-mart-relationship.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart-relationship.service.ts
@@ -27,21 +27,27 @@ class DataMartRelationshipService extends ApiService {
   /**
    * Get all relationships for a data mart.
    * @param dataMartId Data mart ID
+   * @param config Optional axios config (e.g. `skipLoadingIndicator` for silent refreshes)
    */
-  async getRelationships(dataMartId: string): Promise<DataMartRelationship[]> {
-    return this.get<DataMartRelationship[]>(`/${dataMartId}/relationships`);
+  async getRelationships(
+    dataMartId: string,
+    config?: AxiosRequestConfig
+  ): Promise<DataMartRelationship[]> {
+    return this.get<DataMartRelationship[]>(`/${dataMartId}/relationships`, undefined, config);
   }
 
   /**
    * Create a new relationship for a data mart.
    * @param dataMartId Data mart ID
    * @param request Relationship creation request
+   * @param config Optional axios config (e.g. `skipLoadingIndicator` for silent refreshes)
    */
   async createRelationship(
     dataMartId: string,
-    request: CreateRelationshipRequest
+    request: CreateRelationshipRequest,
+    config?: AxiosRequestConfig
   ): Promise<DataMartRelationship> {
-    return this.post<DataMartRelationship>(`/${dataMartId}/relationships`, request);
+    return this.post<DataMartRelationship>(`/${dataMartId}/relationships`, request, config);
   }
 
   /**
@@ -67,42 +73,61 @@ class DataMartRelationshipService extends ApiService {
    * Delete a relationship.
    * @param dataMartId Data mart ID
    * @param relId Relationship ID
+   * @param config Optional axios config (e.g. `skipLoadingIndicator` for silent refreshes)
    */
-  async deleteRelationship(dataMartId: string, relId: string): Promise<void> {
-    return this.delete(`/${dataMartId}/relationships/${relId}`);
+  async deleteRelationship(
+    dataMartId: string,
+    relId: string,
+    config?: AxiosRequestConfig
+  ): Promise<void> {
+    return this.delete(`/${dataMartId}/relationships/${relId}`, config);
   }
 
   /**
    * Get the blendable schema for a data mart.
    * @param dataMartId Data mart ID
+   * @param config Optional axios config (e.g. `skipLoadingIndicator` for silent refreshes)
    */
-  async getBlendableSchema(dataMartId: string): Promise<BlendableSchema> {
-    return this.get<BlendableSchema>(`/${dataMartId}/blendable-schema`);
+  async getBlendableSchema(
+    dataMartId: string,
+    config?: AxiosRequestConfig
+  ): Promise<BlendableSchema> {
+    return this.get<BlendableSchema>(`/${dataMartId}/blendable-schema`, undefined, config);
   }
 
   /**
    * Replace the data mart's blended fields configuration.
    * @param dataMartId Data mart ID.
-   * @param config Full configuration to persist, or `null` to clear it.
+   * @param blendedFieldsConfig Full configuration to persist, or `null` to clear it.
+   * @param config Optional axios config (e.g. `skipLoadingIndicator` for silent refreshes)
    * @returns The updated data mart as returned by the API.
    */
   async updateBlendedFieldsConfig(
     dataMartId: string,
-    config: BlendedFieldsConfig | null
+    blendedFieldsConfig: BlendedFieldsConfig | null,
+    config?: AxiosRequestConfig
   ): Promise<DataMartResponseDto> {
-    return this.put<DataMartResponseDto>(`/${dataMartId}/blended-fields-config`, {
-      blendedFieldsConfig: config,
-    });
+    return this.put<DataMartResponseDto>(
+      `/${dataMartId}/blended-fields-config`,
+      { blendedFieldsConfig },
+      config
+    );
   }
 
   /**
    * Get all relationships for a data storage.
    * Uses a different base path (/data-storages) than the primary service.
    * @param storageId Data storage ID
+   * @param config Optional axios config (e.g. `skipLoadingIndicator` for silent refreshes)
    */
-  async getRelationshipsByStorage(storageId: string): Promise<DataMartRelationship[]> {
+  async getRelationshipsByStorage(
+    storageId: string,
+    config?: AxiosRequestConfig
+  ): Promise<DataMartRelationship[]> {
     return this.storageApiService.get<DataMartRelationship[]>(
-      `/data-storages/${storageId}/relationships`
+      `/data-storages/${storageId}/relationships`,
+      undefined,
+      config
     );
   }
 }

--- a/apps/web/src/features/data-marts/shared/services/data-mart-relationship.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart-relationship.service.ts
@@ -14,14 +14,8 @@ import type {
  * Provides CRUD operations for relationships and blendable schema access.
  */
 class DataMartRelationshipService extends ApiService {
-  /**
-   * Separate service instance for endpoints outside /data-marts base path.
-   */
-  private readonly storageApiService: ApiService;
-
   constructor() {
     super('/data-marts');
-    this.storageApiService = new ApiService('');
   }
 
   /**
@@ -110,23 +104,6 @@ class DataMartRelationshipService extends ApiService {
     return this.put<DataMartResponseDto>(
       `/${dataMartId}/blended-fields-config`,
       { blendedFieldsConfig },
-      config
-    );
-  }
-
-  /**
-   * Get all relationships for a data storage.
-   * Uses a different base path (/data-storages) than the primary service.
-   * @param storageId Data storage ID
-   * @param config Optional axios config (e.g. `skipLoadingIndicator` for silent refreshes)
-   */
-  async getRelationshipsByStorage(
-    storageId: string,
-    config?: AxiosRequestConfig
-  ): Promise<DataMartRelationship[]> {
-    return this.storageApiService.get<DataMartRelationship[]>(
-      `/data-storages/${storageId}/relationships`,
-      undefined,
       config
     );
   }

--- a/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
@@ -35,7 +35,7 @@ export class DataMartService extends ApiService {
    * Pagination is handled internally — callers receive the full list.
    * @returns Promise with all data mart items
    */
-  async getDataMarts(): Promise<DataMartListItemResponseDto[]> {
+  async getDataMarts(config?: AxiosRequestConfig): Promise<DataMartListItemResponseDto[]> {
     const allItems: DataMartListItemResponseDto[] = [];
     let nextOffset: number | null = 0;
 
@@ -45,7 +45,7 @@ export class DataMartService extends ApiService {
         params.offset = nextOffset;
       }
 
-      const page = await this.get<DataMartListResponseDto>('/', params);
+      const page = await this.get<DataMartListResponseDto>('/', params, config);
 
       allItems.push(...page.items);
       nextOffset = page.nextOffset;

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -270,6 +270,7 @@ interface FormSectionProps {
   title?: string;
   description?: string;
   tooltip?: React.ReactNode | string;
+  titleAdornment?: React.ReactNode;
   children: React.ReactNode;
   defaultOpen?: boolean;
   collapsible?: boolean;
@@ -305,6 +306,7 @@ function FormSection({
   title,
   description,
   tooltip,
+  titleAdornment,
   children,
   defaultOpen = true,
   collapsible = true,
@@ -346,9 +348,12 @@ function FormSection({
       <div data-slot='form-section' className='mb-4'>
         {title && (
           <div className='group flex items-center justify-between'>
-            <h3 className='text-muted-foreground/75 text-xs font-semibold tracking-wide uppercase'>
-              {title}
-            </h3>
+            <div className='flex items-center gap-2'>
+              <h3 className='text-muted-foreground/75 text-xs font-semibold tracking-wide uppercase'>
+                {title}
+              </h3>
+              {titleAdornment}
+            </div>
             {tooltip && <FormSectionTooltip tooltip={tooltip} />}
           </div>
         )}
@@ -368,10 +373,14 @@ function FormSection({
       {title && (
         <div className='group flex items-center justify-between'>
           <CollapsibleTrigger asChild>
-            <button type='button' className='flex cursor-pointer items-center gap-1'>
+            <button
+              type='button'
+              className={cn('flex cursor-pointer items-center', titleAdornment ? 'gap-2' : 'gap-1')}
+            >
               <span className='text-muted-foreground/75 text-xs font-semibold tracking-wide uppercase'>
                 {title}
               </span>
+              {titleAdornment}
               <ChevronRight
                 className={cn(
                   'text-foreground/75 h-3.5 w-3.5 transition-transform duration-200',


### PR DESCRIPTION
## Summary

Three focused UX improvements to the data-mart blending flow, split across three commits so each layer can be reviewed in isolation. No backend changes, no API contract changes.

**1. Join settings layout refresh** — moves "Joined Data Mart" + author/timestamp from the accordion header into a dedicated card inside the Join Settings tab, side-by-side with SQL Alias.
<img width="1206" height="402" alt="CleanShot 2026-04-27 at 21 07 21" src="https://github.com/user-attachments/assets/06fb5254-263f-4991-a43c-78389a23dc81" />


**2. Report column picker UI** — removes the redundant "Default Data Mart Columns" header, drops per-section field counters, surfaces a single total counter badge inside the section accordion header and aligns the toolbar checkbox with the field rows.
<img width="614" height="412" alt="CleanShot 2026-04-27 at 21 09 20" src="https://github.com/user-attachments/assets/dc8a4fd4-b52d-4574-ad9d-3f486822cb74" />



**3. Silent saves for join settings** — relationship updates, schema fetches and target-data-mart loads no longer flash the global progress bar; saves happen invisibly without disrupting the user.