### PR TITLE
feat(web): improve report creation with consistent default title across all report types

### DIFF
--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
@@ -76,6 +76,7 @@ import {
   ReportColumnsCountBadge,
   type ReportColumnSelectionCount,
 } from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
+import { DEFAULT_REPORT_TITLE } from '../../../shared';
 
 export interface EmailReportEditFormProps {
   initialReport?: DataMartReport;
@@ -107,7 +108,7 @@ const MESSAGE_DESTINATION_TYPES: DataDestinationType[] = [
 
 function buildDefaultEmailReportLabel(dataMartTitle?: string | null): string {
   const normalizedTitle = dataMartTitle?.trim();
-  return normalizedTitle ? `Report: ${normalizedTitle}` : 'New report';
+  return normalizedTitle ? `Report: ${normalizedTitle}` : DEFAULT_REPORT_TITLE;
 }
 
 function buildDefaultEmailMessageTemplate(): string {

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -63,6 +63,7 @@ import {
   ReportColumnsCountBadge,
   type ReportColumnSelectionCount,
 } from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
+import { DEFAULT_REPORT_TITLE } from '../../../shared';
 
 interface GoogleSheetsReportEditFormProps {
   initialReport?: DataMartReport;
@@ -213,7 +214,12 @@ export const GoogleSheetsReportEditForm = forwardRef<
       } else if (mode === ReportFormMode.CREATE) {
         // Pre-select destination if provided
         const destinationId = preSelectedDestination?.id ?? '';
-        reset({ title: '', documentUrl: '', dataDestinationId: destinationId, columnConfig: null });
+        reset({
+          title: DEFAULT_REPORT_TITLE,
+          documentUrl: '',
+          dataDestinationId: destinationId,
+          columnConfig: null,
+        });
       }
     }, [initialReport, mode, reset, preSelectedDestination]);
 

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useEmailReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useEmailReportForm.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../shared/services/types/update-report.request.dto';
 import type { DataDestination } from '../../../../data-destination';
 import { ReportConditionEnum } from '../../shared/enums/report-condition.enum';
+import { DEFAULT_REPORT_TITLE } from '../../shared';
 
 export const EmailReportEditFormSchema = z
   .object({
@@ -89,7 +90,7 @@ export function useEmailReportForm({
   const form = useForm<EmailReportEditFormValues>({
     resolver: zodResolver(EmailReportEditFormSchema),
     defaultValues: {
-      title: initialReport?.title ?? '',
+      title: initialReport?.title ?? DEFAULT_REPORT_TITLE,
       dataDestinationId: initialReport?.dataDestination.id ?? preSelectedDestination?.id ?? '',
       reportCondition:
         initialReport?.destinationConfig &&

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useGoogleSheetsReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useGoogleSheetsReportForm.ts
@@ -12,6 +12,7 @@ import {
   useReport,
 } from '../../shared';
 import type { DataDestination } from '../../../../data-destination/shared/model/types';
+import { DEFAULT_REPORT_TITLE } from '../../shared';
 
 export const GoogleSheetsReportEditFormSchema = z.object({
   title: z.string().min(1, 'Title is required'),
@@ -58,7 +59,7 @@ export function useGoogleSheetsReportForm({
   const form = useForm<GoogleSheetsReportEditFormValues>({
     resolver: zodResolver(GoogleSheetsReportEditFormSchema),
     defaultValues: {
-      title: initialReport?.title ?? '',
+      title: initialReport?.title ?? DEFAULT_REPORT_TITLE,
       documentUrl:
         initialReport?.destinationConfig &&
         isGoogleSheetsDestinationConfig(initialReport.destinationConfig)

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
@@ -7,7 +7,7 @@ import type {
   DestinationConfig,
 } from '../../shared/model/types/data-mart-report.ts';
 import { isLookerStudioDestinationConfig } from '../../shared/model/types/data-mart-report.ts';
-import { DestinationTypeConfigEnum, useReport } from '../../shared';
+import { DEFAULT_REPORT_TITLE, DestinationTypeConfigEnum, useReport } from '../../shared';
 import type { DataDestination } from '../../../../data-destination/shared/model/types';
 
 // Define the form schema - simplified for editing existing reports
@@ -66,7 +66,7 @@ export function useLookerStudioReportForm({
       if (initialReport) {
         // Only update the destination config, keep existing title and destination
         await updateReport(initialReport.id, {
-          title: `Looker Studio Report`, // Keep existing
+          title: initialReport.title, // Keep existing
           dataDestinationId: initialReport.dataDestination.id, // Keep existing
           destinationConfig,
           ...(pendingOwnerIdsRef?.current != null ? { ownerIds: pendingOwnerIdsRef.current } : {}),
@@ -75,7 +75,7 @@ export function useLookerStudioReportForm({
       } else {
         // This shouldn't happen in our use case, but keeping for compatibility
         await createReport({
-          title: `Looker Studio Report`,
+          title: DEFAULT_REPORT_TITLE,
           dataMartId,
           dataDestinationId: preSelectedDestination?.id ?? '',
           destinationConfig,

--- a/apps/web/src/features/data-marts/reports/shared/constants.ts
+++ b/apps/web/src/features/data-marts/reports/shared/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_REPORT_TITLE = 'New report';

--- a/apps/web/src/features/data-marts/reports/shared/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/index.ts
@@ -4,3 +4,4 @@ export * from './services';
 export * from './enums';
 export * from './models';
 export * from './components';
+export * from './constants';


### PR DESCRIPTION
<img width="596" height="343" alt="image" src="https://github.com/user-attachments/assets/0ad4d210-c37f-4ffb-a5e4-c3a265cd9b1c" />

### What's new
New reports now come with a clear default title (`"New report"`), so users can save and continue working without extra steps. This makes report creation faster and more consistent across Google Sheets, Email, and Looker Studio.

### Improvements
- No more empty title field when creating a report
- Consistent experience across all report types
- Existing report titles are preserved correctly during updates (fixed issue in Looker Studio)