### PR TITLE
feat(web): simplify joined data mart date display in Join Settings

### DIFF
--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinSettingsForm.tsx
@@ -22,7 +22,7 @@ import { Combobox } from '../../../../../shared/components/Combobox/combobox';
 import { UserReference } from '../../../../../shared/components/UserReference';
 import { useProjectRoute } from '../../../../../shared/hooks/useProjectRoute';
 import { useDebounce } from '../../../../../hooks/useDebounce';
-import { formatDateShort } from '../../../../../utils/date-formatters';
+import { formatDateOnly, formatDateShort } from '../../../../../utils/date-formatters';
 import type { DataMartResponseDto } from '../../../shared';
 import { dataMartService } from '../../../shared';
 import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
@@ -336,9 +336,16 @@ export function JoinSettingsForm({
               >
                 <span className='max-w-[360px] truncate'>{relationship.targetDataMart.title}</span>
               </ExternalAnchor>
-              <span className='whitespace-nowrap'>
-                Joined {formatDateShort(relationship.createdAt)}
-              </span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className='whitespace-nowrap'>
+                    {formatDateOnly(relationship.createdAt)}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side='top'>
+                  {formatDateShort(relationship.createdAt)}
+                </TooltipContent>
+              </Tooltip>
               {relationship.createdByUser && (
                 <span className='flex min-w-0 items-center gap-1.5'>
                   <span>by</span>

--- a/apps/web/src/utils/date-formatters.ts
+++ b/apps/web/src/utils/date-formatters.ts
@@ -28,6 +28,25 @@ export const formatDateShort = (date: Date | string | null): string => {
   }).format(d);
 };
 
+export const formatDateOnly = (date: Date | string | null): string => {
+  if (!date) return '—';
+
+  let d: Date;
+  if (typeof date === 'string') {
+    d = new Date(date);
+    if (isNaN(d.getTime())) return '—';
+  } else {
+    d = date;
+    if (isNaN(d.getTime())) return '—';
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(d);
+};
+
 /**
  * Format a date as a full timestamp string (e.g., "2024-03-15 14:30:00")
  * Uses browser's timezone for display


### PR DESCRIPTION
Drop the redundant "Joined" prefix (block is already labelled "Joined Data Mart") and show only the date inline; the full timestamp is available on hover via tooltip. Reduces line wrapping in the join metadata row when the linked data mart title is long.
<img width="579" height="101" alt="CleanShot 2026-04-30 at 10 24 31" src="https://github.com/user-attachments/assets/4385cd10-572f-429c-9e5e-57d22ddd5716" />
