### PR TITLE
feat(web): bulk data mart creation from storage assets

### DIFF
--- a/.changeset/ruslan-and-his-20-friends.md
+++ b/.changeset/ruslan-and-his-20-friends.md
@@ -1,0 +1,22 @@
+---
+'owox': minor
+---
+
+# Import many data marts at once from BigQuery
+
+You can now create up to 20 data marts at a time directly from the Data Marts page,
+without going through the create wizard for each one.
+
+- A new **Import…** button on the Data Marts page opens a picker that lists every
+  table and view in your selected Google BigQuery storage.
+- Tick the resources you want, review them in the chips strip below, and click
+  **Create** — each pick becomes its own data mart, named after the resource.
+- Sharded tables (for example `events_20240101`, `events_20240102`, …) are
+  recognized automatically and shown as a single entry like `events_*`. Picking
+  one creates a Table Pattern data mart that covers all shards at once.
+- The same wildcard recognition now powers the **Fill from Storage** button on
+  the Table Pattern field — you no longer have to scroll through individual
+  shard entries to find the pattern you want.
+- If the chosen storage has broken credentials or missing permissions, the
+  dialog now tells you what's wrong and offers a one-click shortcut to finish
+  the storage setup, instead of failing silently.

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-sharded-tables.util.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-sharded-tables.util.spec.ts
@@ -1,0 +1,151 @@
+import {
+  applyResourceFilter,
+  buildWildcardRollups,
+  GBQ_SHARDED_TABLE_SUFFIX_RE,
+} from './bigquery-sharded-tables.util';
+import type { RawTableListing } from './bigquery-sharded-tables.util';
+
+const PROJECT = 'owox-alaskevych-d-358411';
+const DATASET = 'facebook_local';
+
+function table(id: string, type: 'TABLE' | 'VIEW' = 'TABLE'): RawTableListing {
+  return {
+    id,
+    datasetId: DATASET,
+    type,
+    fullyQualifiedName: `${PROJECT}.${DATASET}.${id}`,
+  };
+}
+
+describe('GBQ_SHARDED_TABLE_SUFFIX_RE', () => {
+  it.each([
+    ['test_sharded_table_20260404', 'test_sharded_table', '20260404'],
+    ['events_20240101', 'events', '20240101'],
+    ['hits_202401', 'hits', '202401'],
+    ['report_2024', 'report', '2024'],
+    ['multi_word_table_20240101', 'multi_word_table', '20240101'],
+  ])('matches %s as prefix=%s suffix=%s', (input, expectedPrefix, expectedSuffix) => {
+    const m = GBQ_SHARDED_TABLE_SUFFIX_RE.exec(input);
+    expect(m).not.toBeNull();
+    expect(m![1]).toBe(expectedPrefix);
+    expect(m![2]).toBe(expectedSuffix);
+  });
+
+  it.each([
+    'plain_table',
+    'no_digits_here',
+    'too_short_99',
+    'has_999999999_too_long',
+    'mixed_2024_v2',
+    'trailing_underscore_',
+  ])('does not match %s', input => {
+    expect(GBQ_SHARDED_TABLE_SUFFIX_RE.exec(input)).toBeNull();
+  });
+});
+
+describe('buildWildcardRollups', () => {
+  it('rolls up the user-reported pair into a single wildcard', () => {
+    // Exact case from the bug report.
+    const rawTables = [table('test_sharded_table_20260404'), table('test_sharded_table_20260405')];
+    const rollups = buildWildcardRollups(rawTables, PROJECT);
+
+    expect(rollups).toHaveLength(1);
+    expect(rollups[0].leaf).toEqual({
+      id: 'test_sharded_table_*',
+      groupId: DATASET,
+      type: 'TABLE',
+      fullyQualifiedName: `${PROJECT}.${DATASET}.test_sharded_table_*`,
+    });
+    expect(rollups[0].shardIds).toEqual([
+      `${DATASET}.test_sharded_table_20260404`,
+      `${DATASET}.test_sharded_table_20260405`,
+    ]);
+  });
+
+  it('does not roll up a singleton', () => {
+    const rollups = buildWildcardRollups([table('lonely_20240101')], PROJECT);
+    expect(rollups).toHaveLength(0);
+  });
+
+  it('rolls up several independent shard groups', () => {
+    const rollups = buildWildcardRollups(
+      [
+        table('events_20240101'),
+        table('events_20240102'),
+        table('hits_202401'),
+        table('hits_202402'),
+        table('plain_table'),
+      ],
+      PROJECT
+    );
+    const ids = rollups.map(r => r.leaf.id).sort();
+    expect(ids).toEqual(['events_*', 'hits_*']);
+  });
+
+  it('ignores VIEW entries even when their names look sharded', () => {
+    const rollups = buildWildcardRollups(
+      [table('view_20240101', 'VIEW'), table('view_20240102', 'VIEW')],
+      PROJECT
+    );
+    expect(rollups).toHaveLength(0);
+  });
+});
+
+describe('applyResourceFilter', () => {
+  const RAW: RawTableListing[] = [
+    table('test_sharded_table_20260404'),
+    table('test_sharded_table_20260405'),
+    table('plain_table'),
+    table('my_view', 'VIEW'),
+  ];
+
+  it('unfiltered: returns views + non-sharded tables + wildcards (no individual shards)', () => {
+    const result = applyResourceFilter(RAW, PROJECT);
+    const ids = result.map(r => r.id).sort();
+    expect(ids).toEqual(['my_view', 'plain_table', 'test_sharded_table_*']);
+    // Individual shards must be folded away entirely.
+    expect(result.some(r => r.id.endsWith('20260404'))).toBe(false);
+    expect(result.some(r => r.id.endsWith('20260405'))).toBe(false);
+  });
+
+  it('filter=TABLE_PATTERN: returns only the wildcard rollups', () => {
+    const result = applyResourceFilter(RAW, PROJECT, 'TABLE_PATTERN');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('test_sharded_table_*');
+    expect(result[0].fullyQualifiedName).toBe(`${PROJECT}.${DATASET}.test_sharded_table_*`);
+  });
+
+  it('filter=TABLE: returns non-sharded tables only (shards still folded)', () => {
+    const result = applyResourceFilter(RAW, PROJECT, 'TABLE');
+    const ids = result.map(r => r.id);
+    expect(ids).toEqual(['plain_table']);
+  });
+
+  it('filter=VIEW: returns only views', () => {
+    const result = applyResourceFilter(RAW, PROJECT, 'VIEW');
+    const ids = result.map(r => r.id);
+    expect(ids).toEqual(['my_view']);
+  });
+
+  it('handles an SDK that returned a fully-qualified id (project:dataset.table form)', () => {
+    // Defensive case: if a table.id ever comes through with the colon-prefixed form,
+    // the regex would still match the trailing digits but the `prefix` would carry the
+    // dataset path. The shard would still be folded into a wildcard rollup keyed by that
+    // stretched prefix, so the user would not see "missing tables".
+    const stretched: RawTableListing = {
+      id: `${PROJECT}:${DATASET}.test_sharded_table_20260404`,
+      datasetId: DATASET,
+      type: 'TABLE',
+      fullyQualifiedName: `${PROJECT}.${DATASET}.${PROJECT}:${DATASET}.test_sharded_table_20260404`,
+    };
+    const stretched2: RawTableListing = {
+      id: `${PROJECT}:${DATASET}.test_sharded_table_20260405`,
+      datasetId: DATASET,
+      type: 'TABLE',
+      fullyQualifiedName: `${PROJECT}.${DATASET}.${PROJECT}:${DATASET}.test_sharded_table_20260405`,
+    };
+    const result = applyResourceFilter([stretched, stretched2], PROJECT);
+    // Should still produce some output (either two singletons or one wildcard).
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-sharded-tables.util.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-sharded-tables.util.ts
@@ -1,0 +1,130 @@
+import type {
+  StorageResourceFilter,
+  StorageResourceLeaf,
+} from '../../interfaces/storage-resource-browser.interface';
+
+/**
+ * Raw table descriptor returned by the BigQuery listing helper, before any wildcard
+ * rollup is applied.
+ */
+export interface RawTableListing {
+  id: string;
+  datasetId: string;
+  type: 'TABLE' | 'VIEW';
+  fullyQualifiedName: string;
+}
+
+/**
+ * BigQuery sharded-table suffix detector.
+ *
+ * Matches names ending with `_<digits>` where the digit run is 4–8 characters long,
+ * covering the three documented BigQuery sharding suffixes: `_YYYY`, `_YYYYMM`, and
+ * `_YYYYMMDD`. Anything outside that range is treated as a regular table to keep false
+ * positives (e.g. `users_v2`, `report_2024_final`) out of the rollup.
+ *
+ * NOTE: `(.+)` is greedy so the regex consumes the longest possible prefix; the
+ * digits group anchors to `$` so we always pull the trailing shard suffix.
+ */
+export const GBQ_SHARDED_TABLE_SUFFIX_RE = /^(.+)_(\d{4,8})$/;
+
+/** A wildcard rollup must merge at least this many shards before we surface it. */
+export const GBQ_MIN_SHARDS_FOR_WILDCARD = 2;
+
+/**
+ * Detects sharded table sets and emits one wildcard rollup per `(dataset, prefix)`.
+ *
+ * A sharded set is a group of TABLE entries whose names match the
+ * {@link GBQ_SHARDED_TABLE_SUFFIX_RE} pattern. A set must contain at least
+ * {@link GBQ_MIN_SHARDS_FOR_WILDCARD} shards — a single date-suffixed table is not
+ * sufficient evidence of sharding.
+ *
+ * Each returned `shardIds` entry is the `${datasetId}.${tableId}` key, suitable for
+ * exclusion lookups in {@link applyResourceFilter}.
+ */
+export function buildWildcardRollups(
+  rawTables: ReadonlyArray<RawTableListing>,
+  projectId: string
+): { leaf: StorageResourceLeaf; shardIds: string[] }[] {
+  const groups = new Map<string, { datasetId: string; prefix: string; shardIds: string[] }>();
+  for (const t of rawTables) {
+    if (t.type !== 'TABLE') continue;
+    const match = GBQ_SHARDED_TABLE_SUFFIX_RE.exec(t.id);
+    if (!match) continue;
+    const prefix = match[1];
+    if (!prefix) continue;
+    const key = `${t.datasetId}\0${prefix}`;
+    const shardKey = `${t.datasetId}.${t.id}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.shardIds.push(shardKey);
+    } else {
+      groups.set(key, {
+        datasetId: t.datasetId,
+        prefix,
+        shardIds: [shardKey],
+      });
+    }
+  }
+
+  const rollups: { leaf: StorageResourceLeaf; shardIds: string[] }[] = [];
+  for (const { datasetId, prefix, shardIds } of groups.values()) {
+    if (shardIds.length < GBQ_MIN_SHARDS_FOR_WILDCARD) continue;
+    const wildcardId = `${prefix}_*`;
+    rollups.push({
+      leaf: {
+        id: wildcardId,
+        groupId: datasetId,
+        type: 'TABLE',
+        fullyQualifiedName: `${projectId}.${datasetId}.${wildcardId}`,
+      },
+      shardIds,
+    });
+  }
+  return rollups;
+}
+
+/**
+ * Applies the public {@link StorageResourceFilter} contract on top of the raw table
+ * listing. Sharded tables are detected by {@link buildWildcardRollups} and collapsed
+ * into a single wildcard entry per `(dataset, prefix)`; the individual shards never
+ * appear in the response.
+ *
+ * Filter semantics:
+ *  - `TABLE_PATTERN` → only wildcard rollups
+ *  - `TABLE`         → only non-sharded TABLEs (shards are folded away)
+ *  - `VIEW`          → only views
+ *  - undefined       → views + non-sharded tables + wildcard rollups
+ */
+export function applyResourceFilter(
+  rawTables: ReadonlyArray<RawTableListing>,
+  projectId: string,
+  filter?: StorageResourceFilter
+): StorageResourceLeaf[] {
+  const wildcards = buildWildcardRollups(rawTables, projectId);
+  const wildcardShardIds = new Set(wildcards.flatMap(w => w.shardIds));
+
+  if (filter === 'TABLE_PATTERN') {
+    return wildcards.map(w => w.leaf);
+  }
+
+  const tableLeaves: StorageResourceLeaf[] = [];
+  const viewLeaves: StorageResourceLeaf[] = [];
+  for (const t of rawTables) {
+    const leaf: StorageResourceLeaf = {
+      id: t.id,
+      groupId: t.datasetId,
+      type: t.type,
+      fullyQualifiedName: t.fullyQualifiedName,
+    };
+    if (t.type === 'VIEW') {
+      viewLeaves.push(leaf);
+      continue;
+    }
+    if (wildcardShardIds.has(`${t.datasetId}.${t.id}`)) continue;
+    tableLeaves.push(leaf);
+  }
+
+  if (filter === 'TABLE') return tableLeaves;
+  if (filter === 'VIEW') return viewLeaves;
+  return [...viewLeaves, ...tableLeaves, ...wildcards.map(w => w.leaf)];
+}

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-storage-resource-browser.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-storage-resource-browser.service.ts
@@ -22,6 +22,7 @@ import {
   BigQueryOAuthCredentialsSchema,
   BigQueryServiceAccountCredentialsSchema,
 } from '../schemas/bigquery-credentials.schema';
+import { applyResourceFilter, type RawTableListing } from './bigquery-sharded-tables.util';
 
 // Page size and result cap keep latency bounded on accounts with many datasets/tables.
 const GBQ_LIST_PAGE_SIZE = 500;
@@ -49,13 +50,18 @@ interface GbqDatasetListing {
   location?: string;
 }
 
-interface GbqTableListing {
-  id: string;
-  datasetId: string;
-  type: 'TABLE' | 'VIEW';
-  fullyQualifiedName: string;
-}
+/**
+ * Raw table descriptor used internally by the listing helpers.
+ * Re-exported as {@link RawTableListing} from the sharded-tables util for testability.
+ */
+type GbqTableListing = RawTableListing;
 
+/**
+ * Internal filter used by {@link BigQueryStorageResourceBrowser.listTablesInProject}.
+ * Note: this is the SDK-level filter (matches the underlying BigQuery `type` field) and
+ * therefore does not include `TABLE_PATTERN` — the wildcard rollup is computed after
+ * the listing call returns, in {@link applyResourceFilter}.
+ */
 type GbqTableTypeFilter = 'TABLE' | 'VIEW';
 
 interface BigQueryClients {
@@ -94,13 +100,19 @@ export class BigQueryStorageResourceBrowser implements IStorageResourceBrowserPr
     filter?: StorageResourceFilter
   ): Promise<StorageResourceLeaf[]> {
     const clients = await this.createClients(storage);
-    const tables = await this.listTablesInProject(clients, namespaceId, filter);
-    return tables.map(t => ({
-      id: t.id,
-      groupId: t.datasetId,
-      type: t.type,
-      fullyQualifiedName: t.fullyQualifiedName,
-    }));
+    // Always pull both tables and views so the wildcard rollup can group by dataset
+    // regardless of the caller filter. The filter is applied as a post-step.
+    const rawTables = await this.listTablesInProject(clients, namespaceId);
+    this.logger.debug?.(
+      `listLeafResources(${namespaceId}, ${filter ?? 'unfiltered'}): ` +
+        `${rawTables.length} raw rows from BQ`
+    );
+    const result = applyResourceFilter(rawTables, namespaceId, filter);
+    this.logger.debug?.(
+      `listLeafResources(${namespaceId}, ${filter ?? 'unfiltered'}): ` +
+        `${result.length} leaves after wildcard collapsing`
+    );
+    return result;
   }
 
   // ── Client creation ────────────────────────────────────────────────────────

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/storage-resource-browser.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/storage-resource-browser.interface.ts
@@ -27,7 +27,19 @@ export interface StorageResourceLeaf extends StorageResourceNode {
   fullyQualifiedName: string;
 }
 
-export type StorageResourceFilter = 'TABLE' | 'VIEW';
+/**
+ * Resource filter accepted by {@link IStorageResourceBrowserProvider.listLeafResources}.
+ *
+ * - `TABLE`         — concrete tables only (no views, no wildcard rollups).
+ * - `VIEW`          — concrete views only.
+ * - `TABLE_PATTERN` — wildcard rollups for sharded tables (e.g. BigQuery date-suffixed
+ *                    `events_YYYYMMDD` shards collapsed into a single `events_*` entry).
+ *                    No individual shards or non-sharded tables are included.
+ *
+ * When omitted, the result combines: all views, all non-sharded tables, and the wildcard
+ * rollups for sharded tables (the individual shards are folded into their wildcard).
+ */
+export type StorageResourceFilter = 'TABLE' | 'VIEW' | 'TABLE_PATTERN';
 
 /**
  * Capability interface for singleton provider services that support resource browsing.

--- a/apps/backend/src/data-marts/dto/domain/list-storage-resources.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/list-storage-resources.command.ts
@@ -13,6 +13,6 @@ export class ListStorageResourcesCommand {
     /** Top-level container ID (e.g. GCP project, Snowflake database). Required for level=resources. */
     public readonly namespaceId?: string,
     /** Optional type filter. Only meaningful for level=resources. */
-    public readonly resourceType?: 'TABLE' | 'VIEW'
+    public readonly resourceType?: 'TABLE' | 'VIEW' | 'TABLE_PATTERN'
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/presentation/storage-resources/list-storage-resources-query.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/storage-resources/list-storage-resources-query.dto.ts
@@ -21,10 +21,12 @@ export class ListStorageResourcesQueryDto {
   namespaceId?: string;
 
   @ApiPropertyOptional({
-    enum: ['TABLE', 'VIEW'],
-    description: 'Filter leaf resources by type. Only applies to level=resources.',
+    enum: ['TABLE', 'VIEW', 'TABLE_PATTERN'],
+    description:
+      'Filter leaf resources by type. Only applies to level=resources. ' +
+      'TABLE_PATTERN returns wildcard rollups for sharded tables (e.g. `events_*`).',
   })
   @IsOptional()
-  @IsIn(['TABLE', 'VIEW'])
-  resourceType?: 'TABLE' | 'VIEW';
+  @IsIn(['TABLE', 'VIEW', 'TABLE_PATTERN'])
+  resourceType?: 'TABLE' | 'VIEW' | 'TABLE_PATTERN';
 }

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/FillFromStorageButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/FillFromStorageButton.tsx
@@ -80,8 +80,14 @@ export function FillFromStorageButton({
     return null;
   }
 
-  const resourceLabel = resourceType === 'VIEW' ? 'view' : 'table';
-  const resourceLabelPlural = resourceType === 'VIEW' ? 'views' : 'tables';
+  const resourceLabel =
+    resourceType === 'VIEW' ? 'view' : resourceType === 'TABLE_PATTERN' ? 'table pattern' : 'table';
+  const resourceLabelPlural =
+    resourceType === 'VIEW'
+      ? 'views'
+      : resourceType === 'TABLE_PATTERN'
+        ? 'table patterns (sharded tables collapsed into a single wildcard entry)'
+        : 'tables';
 
   return (
     <>

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/StorageResourceTree.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/StorageResourceTree.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import {
   AlertCircle,
+  Check,
   ChevronDown,
   ChevronRight,
   Database,
@@ -19,14 +20,26 @@ import type {
 } from '../../../../../../data-storage/shared/api/types';
 import { extractStorageResourceError } from './storage-resource-error.utils';
 
+export type StorageResourceTreeSelectionMode = 'single' | 'multi';
+
 interface StorageResourceTreeProps {
   namespaces: StorageNamespaceNodeDto[] | null;
   namespacesLoading: boolean;
   namespacesError: string | null;
   onRetryNamespaces: () => void;
   loadNamespaceResources: (namespaceId: string) => Promise<StorageResourceLeafDto[]>;
-  onSelectResource: (resource: StorageResourceLeafDto) => void;
-  resourceType: StorageResourceFilter;
+  /** Fires when a resource is picked in single-select mode. */
+  onSelectResource?: (resource: StorageResourceLeafDto) => void;
+  /** Optional filter passed to label/copy. When undefined, both tables and views are shown. */
+  resourceType?: StorageResourceFilter;
+  /** Defaults to 'single'. In 'multi' mode, clicking a resource toggles its selection. */
+  selectionMode?: StorageResourceTreeSelectionMode;
+  /** Set of currently-selected FQNs. Required for visual state in multi mode. */
+  selectedFqns?: ReadonlySet<string>;
+  /** Fires when a resource is toggled in multi-select mode. */
+  onToggleResource?: (resource: StorageResourceLeafDto) => void;
+  /** When true and the row is not already selected, the toggle is disabled (selection cap reached). */
+  isSelectionFull?: boolean;
 }
 
 interface ResourcesState {
@@ -47,6 +60,10 @@ export function StorageResourceTree({
   loadNamespaceResources,
   onSelectResource,
   resourceType,
+  selectionMode = 'single',
+  selectedFqns,
+  onToggleResource,
+  isSelectionFull = false,
 }: StorageResourceTreeProps) {
   const [expandedNamespaces, setExpandedNamespaces] = useState<Set<string>>(new Set());
   const [resourcesByNamespace, setResourcesByNamespace] = useState<
@@ -119,12 +136,38 @@ export function StorageResourceTree({
     });
   }, []);
 
-  const emptyLabel = resourceType === 'VIEW' ? 'No views.' : 'No tables.';
-  const loadingLabel = resourceType === 'VIEW' ? 'Loading views…' : 'Loading tables…';
+  const emptyLabel =
+    resourceType === 'VIEW'
+      ? 'No views.'
+      : resourceType === 'TABLE'
+        ? 'No tables.'
+        : resourceType === 'TABLE_PATTERN'
+          ? 'No sharded tables found in this namespace.'
+          : 'No tables or views.';
+  const loadingLabel =
+    resourceType === 'VIEW'
+      ? 'Loading views…'
+      : resourceType === 'TABLE'
+        ? 'Loading tables…'
+        : resourceType === 'TABLE_PATTERN'
+          ? 'Loading table patterns…'
+          : 'Loading resources…';
   const resourceSearchPlaceholder =
     resourceType === 'VIEW'
       ? 'Search views (group or view name)…'
-      : 'Search tables (group or table name)…';
+      : resourceType === 'TABLE'
+        ? 'Search tables (group or table name)…'
+        : resourceType === 'TABLE_PATTERN'
+          ? 'Search table patterns (group or prefix)…'
+          : 'Search resources (group or name)…';
+  const resourceSearchAriaLabel =
+    resourceType === 'VIEW'
+      ? 'views'
+      : resourceType === 'TABLE'
+        ? 'tables'
+        : resourceType === 'TABLE_PATTERN'
+          ? 'table patterns'
+          : 'resources';
 
   const sortedNamespaces = useMemo(() => {
     if (!namespaces) return null;
@@ -257,7 +300,7 @@ export function StorageResourceTree({
                                   }));
                                 }}
                                 className='h-8 pl-7 text-xs'
-                                aria-label={`Search ${resourceType === 'VIEW' ? 'views' : 'tables'} in ${ns.id}`}
+                                aria-label={`Search ${resourceSearchAriaLabel} in ${ns.id}`}
                               />
                             </div>
                             <GroupedResources
@@ -267,6 +310,10 @@ export function StorageResourceTree({
                               expandedGroupKeys={expandedGroupKeys}
                               onToggleGroup={toggleGroup}
                               onSelectResource={onSelectResource}
+                              selectionMode={selectionMode}
+                              selectedFqns={selectedFqns}
+                              onToggleResource={onToggleResource}
+                              isSelectionFull={isSelectionFull}
                             />
                           </>
                         )}
@@ -288,7 +335,11 @@ interface GroupedResourcesProps {
   filter: string;
   expandedGroupKeys: Set<string>;
   onToggleGroup: (namespaceId: string, groupId: string) => void;
-  onSelectResource: (resource: StorageResourceLeafDto) => void;
+  onSelectResource?: (resource: StorageResourceLeafDto) => void;
+  selectionMode: StorageResourceTreeSelectionMode;
+  selectedFqns?: ReadonlySet<string>;
+  onToggleResource?: (resource: StorageResourceLeafDto) => void;
+  isSelectionFull: boolean;
 }
 
 // Memoized so that typing in the namespace search input does not re-render every
@@ -300,6 +351,10 @@ const GroupedResources = memo(function GroupedResources({
   expandedGroupKeys,
   onToggleGroup,
   onSelectResource,
+  selectionMode,
+  selectedFqns,
+  onToggleResource,
+  isSelectionFull,
 }: GroupedResourcesProps) {
   const normalizedFilter = filter.trim().toLowerCase();
   const isFiltering = normalizedFilter.length > 0;
@@ -375,27 +430,53 @@ const GroupedResources = memo(function GroupedResources({
               <span className='ml-auto shrink-0 text-[11px] tabular-nums'>{groupItems.length}</span>
             </button>
             {groupExpanded &&
-              groupItems.map(resource => (
-                <button
-                  key={resource.fullyQualifiedName}
-                  type='button'
-                  className='hover:bg-accent flex w-full items-center gap-2 rounded py-1 pr-2 pl-7 text-left'
-                  onClick={() => {
-                    onSelectResource(resource);
-                  }}
-                  title={resource.fullyQualifiedName}
-                >
-                  {resource.type === 'VIEW' ? (
-                    <Eye className='size-4 shrink-0' />
-                  ) : (
-                    <Table className='size-4 shrink-0' />
-                  )}
-                  <span className='truncate'>{resource.id}</span>
-                  <span className='text-muted-foreground ml-auto shrink-0 text-xs'>
-                    {resource.type}
-                  </span>
-                </button>
-              ))}
+              groupItems.map(resource => {
+                const isSelected = selectedFqns?.has(resource.fullyQualifiedName) ?? false;
+                const isMulti = selectionMode === 'multi';
+                const disabled = isMulti && !isSelected && isSelectionFull;
+                const handleClick = () => {
+                  if (isMulti) {
+                    if (disabled) return;
+                    onToggleResource?.(resource);
+                    return;
+                  }
+                  onSelectResource?.(resource);
+                };
+                return (
+                  <button
+                    key={resource.fullyQualifiedName}
+                    type='button'
+                    role={isMulti ? 'checkbox' : undefined}
+                    aria-checked={isMulti ? isSelected : undefined}
+                    aria-disabled={disabled || undefined}
+                    className={`hover:bg-accent flex w-full items-center gap-2 rounded py-1 pr-2 pl-7 text-left ${
+                      isMulti && isSelected ? 'bg-accent/50' : ''
+                    } ${disabled ? 'cursor-not-allowed opacity-50 hover:bg-transparent' : ''}`}
+                    onClick={handleClick}
+                    disabled={disabled}
+                    title={resource.fullyQualifiedName}
+                  >
+                    {isMulti && (
+                      <span
+                        aria-hidden='true'
+                        data-state={isSelected ? 'checked' : 'unchecked'}
+                        className='border-input data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-primary flex size-4 shrink-0 items-center justify-center rounded-[4px] border bg-white shadow-xs dark:bg-white/8'
+                      >
+                        {isSelected && <Check className='size-3 text-white' />}
+                      </span>
+                    )}
+                    {resource.type === 'VIEW' ? (
+                      <Eye className='size-4 shrink-0' />
+                    ) : (
+                      <Table className='size-4 shrink-0' />
+                    )}
+                    <span className='truncate'>{resource.id}</span>
+                    <span className='text-muted-foreground ml-auto shrink-0 text-xs'>
+                      {resource.type}
+                    </span>
+                  </button>
+                );
+              })}
           </div>
         );
       })}

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/StorageResourceTree.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/StorageResourceTree.tsx
@@ -40,6 +40,12 @@ interface StorageResourceTreeProps {
   onToggleResource?: (resource: StorageResourceLeafDto) => void;
   /** When true and the row is not already selected, the toggle is disabled (selection cap reached). */
   isSelectionFull?: boolean;
+  /**
+   * When true, the per-namespace resource search input is hidden and the top search input
+   * filters BOTH namespaces (by name) and resources (within already-loaded namespaces).
+   * Use this in flows where two search inputs add cognitive load.
+   */
+  singleSearchMode?: boolean;
 }
 
 interface ResourcesState {
@@ -64,6 +70,7 @@ export function StorageResourceTree({
   selectedFqns,
   onToggleResource,
   isSelectionFull = false,
+  singleSearchMode = false,
 }: StorageResourceTreeProps) {
   const [expandedNamespaces, setExpandedNamespaces] = useState<Set<string>>(new Set());
   const [resourcesByNamespace, setResourcesByNamespace] = useState<
@@ -181,9 +188,20 @@ export function StorageResourceTree({
     return sortedNamespaces.filter(ns => {
       const id = ns.id.toLowerCase();
       const label = ns.label?.toLowerCase() ?? '';
-      return id.includes(query) || label.includes(query);
+      if (id.includes(query) || label.includes(query)) return true;
+      // In single-search mode the top input also acts as a resource filter; keep a namespace
+      // visible if it has loaded resources whose names match the query — that way the user
+      // can find a table even when its parent namespace name doesn't contain the term.
+      if (!singleSearchMode) return false;
+      const loaded = resourcesByNamespace[ns.id]?.data;
+      if (!loaded) return false;
+      return loaded.some(resource => {
+        const rid = resource.id.toLowerCase();
+        const rgroup = resource.groupId.toLowerCase();
+        return rid.includes(query) || rgroup.includes(query) || `${rgroup}.${rid}`.includes(query);
+      });
     });
-  }, [sortedNamespaces, namespaceFilter]);
+  }, [sortedNamespaces, namespaceFilter, singleSearchMode, resourcesByNamespace]);
 
   const hasAnyNamespaces = (sortedNamespaces?.length ?? 0) > 0;
 
@@ -194,13 +212,17 @@ export function StorageResourceTree({
           <Search className='text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2' />
           <Input
             type='search'
-            placeholder={`Search namespaces (${String(sortedNamespaces?.length ?? 0)})…`}
+            placeholder={
+              singleSearchMode
+                ? 'Search projects, datasets, or tables…'
+                : `Search namespaces (${String(sortedNamespaces?.length ?? 0)})…`
+            }
             value={namespaceFilter}
             onChange={event => {
               setNamespaceFilter(event.target.value);
             }}
             className='pl-8'
-            aria-label='Search namespaces'
+            aria-label={singleSearchMode ? 'Search resources' : 'Search namespaces'}
           />
         </div>
       )}
@@ -241,14 +263,24 @@ export function StorageResourceTree({
           filteredNamespaces.length > 0 && (
             <ul className='space-y-0.5'>
               {filteredNamespaces.map(ns => {
-                const nsExpanded = expandedNamespaces.has(ns.id);
                 const resourcesState = resourcesByNamespace[ns.id];
-                const resourceFilter = resourceFilterByNamespace[ns.id] ?? '';
+                // In single-search mode, when the user is typing AND a namespace already has
+                // its resources loaded, auto-expand it so the matching tables become visible
+                // without another click. We deliberately do NOT trigger fetches on un-loaded
+                // namespaces (could fan out to many slow API calls); the user expands those
+                // explicitly to drill in.
+                const isFilteringGlobally = singleSearchMode && namespaceFilter.trim().length > 0;
+                const nsExpanded =
+                  expandedNamespaces.has(ns.id) ||
+                  (isFilteringGlobally && resourcesState?.data != null);
+                const resourceFilter = singleSearchMode
+                  ? namespaceFilter
+                  : (resourceFilterByNamespace[ns.id] ?? '');
                 return (
                   <li key={ns.id}>
                     <button
                       type='button'
-                      className='hover:bg-accent flex w-full items-center gap-2 rounded px-2 py-1 text-left'
+                      className='hover:bg-accent flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors'
                       onClick={() => {
                         toggleNamespace(ns.id);
                       }}
@@ -286,23 +318,25 @@ export function StorageResourceTree({
                         )}
                         {resourcesState?.data && resourcesState.data.length > 0 && (
                           <>
-                            <div className='relative my-1'>
-                              <Search className='text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2' />
-                              <Input
-                                type='search'
-                                placeholder={resourceSearchPlaceholder}
-                                value={resourceFilter}
-                                onChange={event => {
-                                  const value = event.target.value;
-                                  setResourceFilterByNamespace(prev => ({
-                                    ...prev,
-                                    [ns.id]: value,
-                                  }));
-                                }}
-                                className='h-8 pl-7 text-xs'
-                                aria-label={`Search ${resourceSearchAriaLabel} in ${ns.id}`}
-                              />
-                            </div>
+                            {!singleSearchMode && (
+                              <div className='relative my-1'>
+                                <Search className='text-muted-foreground pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2' />
+                                <Input
+                                  type='search'
+                                  placeholder={resourceSearchPlaceholder}
+                                  value={resourceFilter}
+                                  onChange={event => {
+                                    const value = event.target.value;
+                                    setResourceFilterByNamespace(prev => ({
+                                      ...prev,
+                                      [ns.id]: value,
+                                    }));
+                                  }}
+                                  className='h-8 pl-7 text-xs'
+                                  aria-label={`Search ${resourceSearchAriaLabel} in ${ns.id}`}
+                                />
+                              </div>
+                            )}
                             <GroupedResources
                               namespaceId={ns.id}
                               resources={resourcesState.data}
@@ -412,22 +446,24 @@ const GroupedResources = memo(function GroupedResources({
           <div key={groupId} className='mt-1 first:mt-0'>
             <button
               type='button'
-              className='hover:bg-accent text-muted-foreground flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs'
+              className='hover:bg-accent flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors'
               onClick={() => {
                 onToggleGroup(namespaceId, groupId);
               }}
               aria-expanded={groupExpanded}
             >
               {groupExpanded ? (
-                <ChevronDown className='size-3.5 shrink-0' />
+                <ChevronDown className='text-muted-foreground size-4 shrink-0' />
               ) : (
-                <ChevronRight className='size-3.5 shrink-0' />
+                <ChevronRight className='text-muted-foreground size-4 shrink-0' />
               )}
-              <FolderOpen className='size-3.5 shrink-0' />
+              <FolderOpen className='text-muted-foreground size-4 shrink-0' />
               <span className='truncate' title={groupId}>
                 {groupId}
               </span>
-              <span className='ml-auto shrink-0 text-[11px] tabular-nums'>{groupItems.length}</span>
+              <span className='text-muted-foreground ml-auto shrink-0 text-xs tabular-nums'>
+                {groupItems.length}
+              </span>
             </button>
             {groupExpanded &&
               groupItems.map(resource => {
@@ -449,9 +485,11 @@ const GroupedResources = memo(function GroupedResources({
                     role={isMulti ? 'checkbox' : undefined}
                     aria-checked={isMulti ? isSelected : undefined}
                     aria-disabled={disabled || undefined}
-                    className={`hover:bg-accent flex w-full items-center gap-2 rounded py-1 pr-2 pl-7 text-left ${
-                      isMulti && isSelected ? 'bg-accent/50' : ''
-                    } ${disabled ? 'cursor-not-allowed opacity-50 hover:bg-transparent' : ''}`}
+                    className={`hover:bg-accent flex w-full items-center gap-2.5 rounded text-left transition-colors ${
+                      isMulti ? 'py-1.5 pr-2 pl-7' : 'py-1 pr-2 pl-7'
+                    } ${isMulti && isSelected ? 'bg-accent/50' : ''} ${
+                      disabled ? 'cursor-not-allowed opacity-50 hover:bg-transparent' : ''
+                    }`}
                     onClick={handleClick}
                     disabled={disabled}
                     title={resource.fullyQualifiedName}

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/TablePatternDefinitionField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/TablePatternDefinitionField.tsx
@@ -13,7 +13,11 @@ import {
 import { Input } from '@owox/ui/components/input';
 import { DataStorageType } from '../../../../../data-storage';
 import type { DataStorageConfigDto } from '../../../../../data-storage/shared/api/types';
-import { getTablePatternPlaceholder, getTablePatternHelpText } from '../../../../shared';
+import {
+  getTablePatternPlaceholder,
+  getTablePatternHelpText,
+  patternFqnToStored,
+} from '../../../../shared';
 import { getStorageResourceUrlFromFqn } from '../../../../../data-storage/shared/utils/storage-url.utils';
 import { FillFromStorageButton } from './FillFromStorageButton';
 
@@ -36,7 +40,10 @@ export function TablePatternDefinitionField({
 
   const handleSelect = useCallback(
     (fqn: string) => {
-      setValue('definition.pattern', fqn, {
+      // Wildcard rollups arrive as `prefix_*`, but the stored TABLE_PATTERN convention is the
+      // bare prefix (the BigQuery query builder appends `*` itself at query time). Strip here
+      // so the input matches what gets persisted.
+      setValue('definition.pattern', patternFqnToStored(fqn), {
         shouldDirty: true,
         shouldValidate: true,
       });
@@ -61,7 +68,7 @@ export function TablePatternDefinitionField({
                 <FillFromStorageButton
                   storageId={storageId}
                   storageType={storageType}
-                  resourceType='TABLE'
+                  resourceType='TABLE_PATTERN'
                   onSelect={handleSelect}
                 />
                 <Input

--- a/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/BulkCreateFromStorageDialog.tsx
+++ b/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/BulkCreateFromStorageDialog.tsx
@@ -1,0 +1,415 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AlertCircle, Database, X } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { Badge } from '@owox/ui/components/badge';
+import { Button } from '@owox/ui/components/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@owox/ui/components/dialog';
+import { extractApiError } from '../../../../../app/api';
+import { Combobox } from '../../../../../shared/components/Combobox/combobox';
+import { useProjectRoute } from '../../../../../shared/hooks';
+import { DataStorageHealthIndicator, DataStorageType } from '../../../../data-storage';
+import { dataStorageApiService } from '../../../../data-storage/shared/api';
+import type {
+  StorageNamespaceNodeDto,
+  StorageResourceLeafDto,
+} from '../../../../data-storage/shared/api/types';
+import {
+  DataStorageActionType,
+  DataStorageProvider,
+  useDataStorageContext,
+} from '../../../../data-storage/shared/model/context';
+import { mapDataStorageListFromDto } from '../../../../data-storage/shared/model/mappers';
+import { DataStorageTypeModel } from '../../../../data-storage/shared/types/data-storage-type.model';
+import { extractStorageResourceError } from '../../../edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/storage-resource-error.utils';
+import { StorageResourceTree } from '../../../edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/StorageResourceTree';
+import { BULK_CREATE_SUPPORTED_STORAGE_TYPES, MAX_BULK_DATA_MART_COUNT } from './constants';
+import { useBulkCreateDataMarts } from './use-bulk-create-data-marts';
+
+interface BulkCreateFromStorageDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after the create flow finishes (success or partial), so the list can refresh. */
+  onCreated: () => void;
+}
+
+export function BulkCreateFromStorageDialog(props: BulkCreateFromStorageDialogProps) {
+  return (
+    <DataStorageProvider>
+      <BulkCreateFromStorageDialogInner {...props} />
+    </DataStorageProvider>
+  );
+}
+
+function BulkCreateFromStorageDialogInner({
+  open,
+  onOpenChange,
+  onCreated,
+}: BulkCreateFromStorageDialogProps) {
+  const { state, dispatch } = useDataStorageContext();
+  const { dataStorages, loading: loadingStorages } = state;
+  const { navigate } = useProjectRoute();
+
+  const [storageId, setStorageId] = useState<string>('');
+  const [namespaces, setNamespaces] = useState<StorageNamespaceNodeDto[] | null>(null);
+  const [namespacesLoading, setNamespacesLoading] = useState(false);
+  const [namespacesError, setNamespacesError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Map<string, StorageResourceLeafDto>>(new Map());
+  const autoSelectedRef = useRef(false);
+  const fetchedStoragesRef = useRef(false);
+
+  const { run, inFlight, progress, reset } = useBulkCreateDataMarts();
+
+  const eligibleStorages = useMemo(
+    () => dataStorages.filter(s => BULK_CREATE_SUPPORTED_STORAGE_TYPES.has(s.type)),
+    [dataStorages]
+  );
+
+  // Fetch storages on first open. We use the context's dispatch directly to avoid the
+  // toast/error noise the sibling hook publishes — the dialog renders its own empty state.
+  useEffect(() => {
+    if (!open) return;
+    if (fetchedStoragesRef.current) return;
+    fetchedStoragesRef.current = true;
+
+    dispatch({ type: DataStorageActionType.FETCH_STORAGES_START });
+    dataStorageApiService
+      .getDataStorages()
+      .then(response => {
+        dispatch({
+          type: DataStorageActionType.FETCH_STORAGES_SUCCESS,
+          payload: response.map(mapDataStorageListFromDto),
+        });
+      })
+      .catch((error: unknown) => {
+        dispatch({
+          type: DataStorageActionType.FETCH_STORAGES_ERROR,
+          payload: extractApiError(error),
+        });
+      });
+  }, [open, dispatch]);
+
+  // Auto-select when there is exactly one eligible storage — saves a click in the common case.
+  useEffect(() => {
+    if (!open) return;
+    if (loadingStorages) return;
+    if (autoSelectedRef.current) return;
+    if (storageId) return;
+    if (eligibleStorages.length !== 1) return;
+    autoSelectedRef.current = true;
+    setStorageId(eligibleStorages[0].id);
+  }, [open, loadingStorages, eligibleStorages, storageId]);
+
+  // Reset transient state on close so the next open starts fresh.
+  useEffect(() => {
+    if (open) return;
+    setStorageId('');
+    setNamespaces(null);
+    setNamespacesLoading(false);
+    setNamespacesError(null);
+    setSelected(new Map());
+    autoSelectedRef.current = false;
+    reset();
+  }, [open, reset]);
+
+  const loadNamespaces = useCallback(async (id: string) => {
+    setNamespacesLoading(true);
+    setNamespacesError(null);
+    try {
+      const result = await dataStorageApiService.listStorageNamespaces(id);
+      setNamespaces(result);
+    } catch (error) {
+      setNamespacesError(extractStorageResourceError(error));
+      setNamespaces([]);
+    } finally {
+      setNamespacesLoading(false);
+    }
+  }, []);
+
+  // Whenever the storage changes (including after auto-select), kick off the namespace fetch
+  // and clear any prior selections — selections from another storage are not portable.
+  useEffect(() => {
+    if (!open) return;
+    if (!storageId) return;
+    setSelected(new Map());
+    setNamespaces(null);
+    setNamespacesError(null);
+    void loadNamespaces(storageId);
+  }, [open, storageId, loadNamespaces]);
+
+  const loadNamespaceResources = useCallback(
+    async (namespaceId: string): Promise<StorageResourceLeafDto[]> => {
+      // No resourceType filter — we want both TABLE and VIEW leaves.
+      return dataStorageApiService.listStorageResources(storageId, namespaceId);
+    },
+    [storageId]
+  );
+
+  const selectedFqns = useMemo(() => new Set(selected.keys()), [selected]);
+  const isSelectionFull = selected.size >= MAX_BULK_DATA_MART_COUNT;
+
+  const handleToggle = useCallback((resource: StorageResourceLeafDto) => {
+    setSelected(prev => {
+      const next = new Map(prev);
+      if (next.has(resource.fullyQualifiedName)) {
+        next.delete(resource.fullyQualifiedName);
+      } else if (next.size < MAX_BULK_DATA_MART_COUNT) {
+        next.set(resource.fullyQualifiedName, resource);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleRemove = useCallback((fqn: string) => {
+    setSelected(prev => {
+      if (!prev.has(fqn)) return prev;
+      const next = new Map(prev);
+      next.delete(fqn);
+      return next;
+    });
+  }, []);
+
+  const storageOptions = useMemo(
+    () =>
+      [...eligibleStorages]
+        .sort((a, b) => a.title.localeCompare(b.title))
+        .map(storage => ({ value: storage.id, label: storage.title })),
+    [eligibleStorages]
+  );
+
+  const handleConfirm = async () => {
+    if (!storageId || selected.size === 0) return;
+    const leaves = Array.from(selected.values());
+    const result = await run({ storageId, leaves });
+    onCreated();
+
+    if (result.successCount > 0) {
+      toast.success(
+        `Created ${String(result.successCount)} data mart${result.successCount === 1 ? '' : 's'}`,
+        { duration: 6000 }
+      );
+    }
+    if (result.failures.length > 0) {
+      toast.error(
+        `Failed to create ${String(result.failures.length)} data mart${
+          result.failures.length === 1 ? '' : 's'
+        }. Check ${result.failures.length === 1 ? 'it' : 'them'} and retry.`,
+        { duration: 8000 }
+      );
+      // Keep the failed selections so the user can retry without rebuilding the list.
+      setSelected(prev => {
+        const next = new Map<string, StorageResourceLeafDto>();
+        for (const [fqn, leaf] of prev) {
+          if (!result.successfulFqns.includes(fqn)) {
+            next.set(fqn, leaf);
+          }
+        }
+        return next;
+      });
+      return;
+    }
+
+    onOpenChange(false);
+  };
+
+  const confirmLabel = inFlight
+    ? progress
+      ? `Creating ${String(progress.done)} / ${String(progress.total)}…`
+      : 'Creating…'
+    : selected.size > 0
+      ? `Create ${String(selected.size)} data mart${selected.size === 1 ? '' : 's'}`
+      : 'Create data marts';
+
+  // When namespace listing fails, the storage is effectively unusable from this dialog —
+  // typical causes are missing/invalid credentials or insufficient IAM permissions. Drop the
+  // selection UI and steer the user toward fixing the storage configuration.
+  const isInvalidStorage = Boolean(storageId) && !namespacesLoading && Boolean(namespacesError);
+
+  const handleFinishStorageSetup = () => {
+    if (!storageId) return;
+    onOpenChange(false);
+    navigate(`/data-storages?id=${storageId}`);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        if (inFlight) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className='sm:max-w-4xl'>
+        <DialogHeader>
+          <DialogTitle>Create data marts from storage</DialogTitle>
+          <DialogDescription>
+            Pick a Google BigQuery storage and select up to {MAX_BULK_DATA_MART_COUNT} tables or
+            views. Each selected resource becomes a new data mart with a definition derived from the
+            resource type.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className='flex flex-col gap-3'>
+          <div className='flex flex-col gap-1.5'>
+            <label className='text-sm font-medium' htmlFor='bulk-create-storage-select'>
+              Data storage
+            </label>
+            <Combobox
+              options={storageOptions}
+              value={storageId}
+              onValueChange={value => {
+                setStorageId(value);
+              }}
+              placeholder={
+                loadingStorages
+                  ? 'Loading…'
+                  : storageOptions.length === 0
+                    ? 'No Google BigQuery storages available'
+                    : 'Select a storage'
+              }
+              emptyMessage='No Google BigQuery storages available'
+              disabled={loadingStorages || storageOptions.length === 0 || inFlight}
+              className='w-full'
+              renderLabel={option => (
+                <div className='flex min-w-0 flex-1 items-center gap-2'>
+                  <div className='shrink-0'>
+                    <DataStorageHealthIndicator
+                      storageId={option.value}
+                      storageTitle={option.label}
+                      hovercardSide='left'
+                      variant='compact'
+                    />
+                  </div>
+                  <StorageTypeIcon
+                    storageType={eligibleStorages.find(s => s.id === option.value)?.type ?? null}
+                  />
+                  <span className='min-w-0 truncate'>{option.label}</span>
+                </div>
+              )}
+            />
+          </div>
+
+          {isInvalidStorage ? (
+            <div className='flex flex-col gap-2 rounded-md border border-dashed p-3 text-sm'>
+              <div className='text-destructive flex items-start gap-2'>
+                <AlertCircle className='mt-0.5 size-4 shrink-0' />
+                <span>
+                  The selected storage cannot list resources right now. Finish the storage setup —
+                  check credentials and IAM permissions — then try again.
+                </span>
+              </div>
+              <p className='text-muted-foreground pl-6 text-xs'>{namespacesError}</p>
+            </div>
+          ) : (
+            storageId && (
+              <StorageResourceTree
+                namespaces={namespaces}
+                namespacesLoading={namespacesLoading}
+                namespacesError={namespacesError}
+                onRetryNamespaces={() => {
+                  void loadNamespaces(storageId);
+                }}
+                loadNamespaceResources={loadNamespaceResources}
+                selectionMode='multi'
+                selectedFqns={selectedFqns}
+                onToggleResource={handleToggle}
+                isSelectionFull={isSelectionFull}
+              />
+            )
+          )}
+
+          {!isInvalidStorage && (
+            <div className='flex flex-col gap-1.5'>
+              <div className='flex items-center justify-between text-xs'>
+                <span className='text-muted-foreground'>
+                  {selected.size} of {MAX_BULK_DATA_MART_COUNT} selected
+                </span>
+                {isSelectionFull && (
+                  <span className='text-muted-foreground'>
+                    Limit reached — remove an item to pick another.
+                  </span>
+                )}
+              </div>
+              {selected.size === 0 ? (
+                <div className='text-muted-foreground rounded-md border border-dashed p-2 text-xs'>
+                  {storageId
+                    ? 'Tick resources in the tree above to add them here.'
+                    : 'Pick a data storage to start selecting resources.'}
+                </div>
+              ) : (
+                <ul className='flex flex-wrap gap-1'>
+                  {Array.from(selected.values()).map(leaf => (
+                    <li key={leaf.fullyQualifiedName}>
+                      <Badge variant='secondary' className='gap-1 text-xs'>
+                        {leaf.type === 'VIEW' ? 'V' : 'T'}: {leaf.id}
+                        <button
+                          type='button'
+                          aria-label={`Remove ${leaf.fullyQualifiedName}`}
+                          title={leaf.fullyQualifiedName}
+                          onClick={() => {
+                            handleRemove(leaf.fullyQualifiedName);
+                          }}
+                          disabled={inFlight}
+                          className='hover:text-destructive ml-0.5 inline-flex shrink-0 items-center justify-center rounded-sm disabled:opacity-50'
+                        >
+                          <X className='size-3' />
+                        </button>
+                      </Badge>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+        </div>
+
+        {isInvalidStorage ? (
+          <DialogFooter className='sm:justify-center'>
+            <Button
+              type='button'
+              onClick={handleFinishStorageSetup}
+              title='Open the storage configuration to fix credentials or permissions'
+            >
+              Finish storage setup
+            </Button>
+          </DialogFooter>
+        ) : (
+          <DialogFooter>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => {
+                onOpenChange(false);
+              }}
+              disabled={inFlight}
+            >
+              Cancel
+            </Button>
+            <Button
+              type='button'
+              onClick={() => {
+                void handleConfirm();
+              }}
+              disabled={inFlight || !storageId || selected.size === 0}
+            >
+              <Database className='size-4' />
+              {confirmLabel}
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function StorageTypeIcon({ storageType }: { storageType: DataStorageType | null }) {
+  if (!storageType) return null;
+  const Icon = DataStorageTypeModel.getInfo(storageType).icon;
+  return <Icon size={20} className='shrink-0' />;
+}

--- a/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/BulkCreateFromStorageDialog.tsx
+++ b/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/BulkCreateFromStorageDialog.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AlertCircle, Database, X } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Box, X } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { Badge } from '@owox/ui/components/badge';
 import { Button } from '@owox/ui/components/button';
@@ -20,12 +21,15 @@ import type {
   StorageNamespaceNodeDto,
   StorageResourceLeafDto,
 } from '../../../../data-storage/shared/api/types';
+import { DataStorageHealthStatusView } from '../../../../data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView';
 import {
   DataStorageActionType,
   DataStorageProvider,
   useDataStorageContext,
 } from '../../../../data-storage/shared/model/context';
+import { useDataStorageHealthStatus } from '../../../../data-storage/shared/model/hooks/useDataStorageHealthStatus';
 import { mapDataStorageListFromDto } from '../../../../data-storage/shared/model/mappers';
+import { DataStorageHealthStatus } from '../../../../data-storage/shared/services/data-storage-health-status.service';
 import { DataStorageTypeModel } from '../../../../data-storage/shared/types/data-storage-type.model';
 import { extractStorageResourceError } from '../../../edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/storage-resource-error.utils';
 import { StorageResourceTree } from '../../../edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/StorageResourceTree';
@@ -65,6 +69,20 @@ function BulkCreateFromStorageDialogInner({
   const fetchedStoragesRef = useRef(false);
 
   const { run, inFlight, progress, reset } = useBulkCreateDataMarts();
+
+  // Front-end health check for the picked storage. The hook is called unconditionally
+  // (rules of hooks) and returns a default state when the id is empty; we only react to
+  // its result once a real storage is selected.
+  const {
+    status: healthStatus,
+    errorMessage: healthErrorMessage,
+    isFetched: healthIsFetched,
+  } = useDataStorageHealthStatus(storageId);
+  const isHealthKnownForStorage = storageId !== '' && healthIsFetched;
+  const isUnhealthyStorage =
+    isHealthKnownForStorage &&
+    (healthStatus === DataStorageHealthStatus.UNCONFIGURED ||
+      healthStatus === DataStorageHealthStatus.INVALID);
 
   const eligibleStorages = useMemo(
     () => dataStorages.filter(s => BULK_CREATE_SUPPORTED_STORAGE_TYPES.has(s.type)),
@@ -132,16 +150,29 @@ function BulkCreateFromStorageDialogInner({
     }
   }, []);
 
-  // Whenever the storage changes (including after auto-select), kick off the namespace fetch
-  // and clear any prior selections — selections from another storage are not portable.
+  // Whenever the storage changes (including after auto-select), wait for the front-end
+  // health check before deciding whether to call the backend. Skip the backend call when the
+  // storage is unhealthy — that case is handled by rendering DataStorageHealthStatusView.
   useEffect(() => {
     if (!open) return;
     if (!storageId) return;
     setSelected(new Map());
     setNamespaces(null);
+    if (!isHealthKnownForStorage) {
+      // Show a loading state while the health check is in flight so the user sees activity.
+      setNamespacesLoading(true);
+      setNamespacesError(null);
+      return;
+    }
+    if (isUnhealthyStorage) {
+      // No backend call — the unhealthy block carries the message. Clear any prior error.
+      setNamespacesLoading(false);
+      setNamespacesError(null);
+      return;
+    }
     setNamespacesError(null);
     void loadNamespaces(storageId);
-  }, [open, storageId, loadNamespaces]);
+  }, [open, storageId, isHealthKnownForStorage, isUnhealthyStorage, loadNamespaces]);
 
   const loadNamespaceResources = useCallback(
     async (namespaceId: string): Promise<StorageResourceLeafDto[]> => {
@@ -226,11 +257,6 @@ function BulkCreateFromStorageDialogInner({
       ? `Create ${String(selected.size)} data mart${selected.size === 1 ? '' : 's'}`
       : 'Create data marts';
 
-  // When namespace listing fails, the storage is effectively unusable from this dialog —
-  // typical causes are missing/invalid credentials or insufficient IAM permissions. Drop the
-  // selection UI and steer the user toward fixing the storage configuration.
-  const isInvalidStorage = Boolean(storageId) && !namespacesLoading && Boolean(namespacesError);
-
   const handleFinishStorageSetup = () => {
     if (!storageId) return;
     onOpenChange(false);
@@ -245,21 +271,18 @@ function BulkCreateFromStorageDialogInner({
         onOpenChange(next);
       }}
     >
-      <DialogContent className='sm:max-w-4xl'>
-        <DialogHeader>
-          <DialogTitle>Create data marts from storage</DialogTitle>
+      <DialogContent className='flex max-h-[90vh] flex-col gap-0 p-0 sm:max-w-4xl'>
+        <DialogHeader className='px-6 pt-6 pb-6'>
+          <DialogTitle>Import data marts from storage</DialogTitle>
           <DialogDescription>
-            Pick a Google BigQuery storage and select up to {MAX_BULK_DATA_MART_COUNT} tables or
-            views. Each selected resource becomes a new data mart with a definition derived from the
-            resource type.
+            Pick up to {MAX_BULK_DATA_MART_COUNT} tables or views — each becomes a new data mart.
           </DialogDescription>
         </DialogHeader>
 
-        <div className='flex flex-col gap-3'>
-          <div className='flex flex-col gap-1.5'>
-            <label className='text-sm font-medium' htmlFor='bulk-create-storage-select'>
-              Data storage
-            </label>
+        <div className='bg-muted dark:bg-sidebar flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto border-t px-6 py-4'>
+          {/* ── Block 1 ──────────────────────────────────────────────────── */}
+          <section className='dm-card-block !gap-2'>
+            <BlockHeading step={1}>Storage</BlockHeading>
             <Combobox
               options={storageOptions}
               value={storageId}
@@ -293,84 +316,90 @@ function BulkCreateFromStorageDialogInner({
                 </div>
               )}
             />
-          </div>
+          </section>
 
-          {isInvalidStorage ? (
-            <div className='flex flex-col gap-2 rounded-md border border-dashed p-3 text-sm'>
-              <div className='text-destructive flex items-start gap-2'>
-                <AlertCircle className='mt-0.5 size-4 shrink-0' />
-                <span>
-                  The selected storage cannot list resources right now. Finish the storage setup —
-                  check credentials and IAM permissions — then try again.
-                </span>
-              </div>
-              <p className='text-muted-foreground pl-6 text-xs'>{namespacesError}</p>
-            </div>
+          {isUnhealthyStorage ? (
+            <UnhealthyStorageBlock status={healthStatus} errorMessage={healthErrorMessage} />
           ) : (
-            storageId && (
-              <StorageResourceTree
-                namespaces={namespaces}
-                namespacesLoading={namespacesLoading}
-                namespacesError={namespacesError}
-                onRetryNamespaces={() => {
-                  void loadNamespaces(storageId);
-                }}
-                loadNamespaceResources={loadNamespaceResources}
-                selectionMode='multi'
-                selectedFqns={selectedFqns}
-                onToggleResource={handleToggle}
-                isSelectionFull={isSelectionFull}
-              />
-            )
-          )}
-
-          {!isInvalidStorage && (
-            <div className='flex flex-col gap-1.5'>
-              <div className='flex items-center justify-between text-xs'>
-                <span className='text-muted-foreground'>
-                  {selected.size} of {MAX_BULK_DATA_MART_COUNT} selected
-                </span>
-                {isSelectionFull && (
-                  <span className='text-muted-foreground'>
-                    Limit reached — remove an item to pick another.
-                  </span>
+            <>
+              {/* ── Block 2 ────────────────────────────────────────────── */}
+              <section className='dm-card-block !gap-2'>
+                <BlockHeading step={2}>Browse resources</BlockHeading>
+                {storageId ? (
+                  <StorageResourceTree
+                    namespaces={namespaces}
+                    namespacesLoading={namespacesLoading}
+                    namespacesError={namespacesError}
+                    onRetryNamespaces={() => {
+                      void loadNamespaces(storageId);
+                    }}
+                    loadNamespaceResources={loadNamespaceResources}
+                    selectionMode='multi'
+                    selectedFqns={selectedFqns}
+                    onToggleResource={handleToggle}
+                    isSelectionFull={isSelectionFull}
+                    singleSearchMode
+                  />
+                ) : (
+                  <BlockPlaceholder>
+                    Pick a data storage above to browse its tables and views.
+                  </BlockPlaceholder>
                 )}
-              </div>
-              {selected.size === 0 ? (
-                <div className='text-muted-foreground rounded-md border border-dashed p-2 text-xs'>
-                  {storageId
-                    ? 'Tick resources in the tree above to add them here.'
-                    : 'Pick a data storage to start selecting resources.'}
-                </div>
-              ) : (
-                <ul className='flex flex-wrap gap-1'>
-                  {Array.from(selected.values()).map(leaf => (
-                    <li key={leaf.fullyQualifiedName}>
-                      <Badge variant='secondary' className='gap-1 text-xs'>
-                        {leaf.type === 'VIEW' ? 'V' : 'T'}: {leaf.id}
-                        <button
-                          type='button'
-                          aria-label={`Remove ${leaf.fullyQualifiedName}`}
-                          title={leaf.fullyQualifiedName}
-                          onClick={() => {
-                            handleRemove(leaf.fullyQualifiedName);
-                          }}
-                          disabled={inFlight}
-                          className='hover:text-destructive ml-0.5 inline-flex shrink-0 items-center justify-center rounded-sm disabled:opacity-50'
-                        >
-                          <X className='size-3' />
-                        </button>
-                      </Badge>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
+              </section>
+
+              {/* ── Block 3 ────────────────────────────────────────────── */}
+              <section className='dm-card-block !gap-2'>
+                <BlockHeading
+                  step={3}
+                  trailing={
+                    <span className='text-muted-foreground text-xs font-normal'>
+                      {selected.size} / {MAX_BULK_DATA_MART_COUNT}
+                      {isSelectionFull && (
+                        <span className='ml-2'>
+                          · Limit reached, remove an item to pick another
+                        </span>
+                      )}
+                    </span>
+                  }
+                >
+                  Selected resources
+                </BlockHeading>
+                {selected.size === 0 ? (
+                  <BlockPlaceholder>
+                    {storageId
+                      ? 'Tick resources in the tree above to add them here.'
+                      : 'Selections appear here once you start ticking resources.'}
+                  </BlockPlaceholder>
+                ) : (
+                  <ul className='flex flex-wrap gap-1.5'>
+                    {Array.from(selected.values()).map(leaf => (
+                      <li key={leaf.fullyQualifiedName}>
+                        <Badge variant='secondary' className='gap-1 text-xs'>
+                          {leaf.type === 'VIEW' ? 'V' : 'T'}: {leaf.id}
+                          <button
+                            type='button'
+                            aria-label={`Remove ${leaf.fullyQualifiedName}`}
+                            title={leaf.fullyQualifiedName}
+                            onClick={() => {
+                              handleRemove(leaf.fullyQualifiedName);
+                            }}
+                            disabled={inFlight}
+                            className='hover:text-destructive ml-0.5 inline-flex shrink-0 items-center justify-center rounded-sm disabled:opacity-50'
+                          >
+                            <X className='size-3' />
+                          </button>
+                        </Badge>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            </>
           )}
         </div>
 
-        {isInvalidStorage ? (
-          <DialogFooter className='sm:justify-center'>
+        {isUnhealthyStorage ? (
+          <DialogFooter className='border-t px-6 py-4 sm:justify-center'>
             <Button
               type='button'
               onClick={handleFinishStorageSetup}
@@ -380,7 +409,7 @@ function BulkCreateFromStorageDialogInner({
             </Button>
           </DialogFooter>
         ) : (
-          <DialogFooter>
+          <DialogFooter className='border-t px-6 py-4'>
             <Button
               type='button'
               variant='outline'
@@ -398,7 +427,7 @@ function BulkCreateFromStorageDialogInner({
               }}
               disabled={inFlight || !storageId || selected.size === 0}
             >
-              <Database className='size-4' />
+              <Box className='size-4' />
               {confirmLabel}
             </Button>
           </DialogFooter>
@@ -412,4 +441,59 @@ function StorageTypeIcon({ storageType }: { storageType: DataStorageType | null 
   if (!storageType) return null;
   const Icon = DataStorageTypeModel.getInfo(storageType).icon;
   return <Icon size={20} className='shrink-0' />;
+}
+
+/**
+ * Small heading used at the top of each step-block in the dialog body. The numbered badge
+ * makes the linear flow obvious without forcing the user to read prose.
+ */
+function BlockHeading({
+  step,
+  children,
+  trailing,
+}: {
+  step: number;
+  children: ReactNode;
+  trailing?: ReactNode;
+}) {
+  return (
+    <div className='flex items-center gap-2'>
+      <span
+        className='bg-muted text-muted-foreground flex size-5 shrink-0 items-center justify-center rounded-full text-xs font-semibold'
+        aria-hidden='true'
+      >
+        {step}
+      </span>
+      <h3 className='text-sm font-medium'>{children}</h3>
+      {trailing && <div className='ml-auto'>{trailing}</div>}
+    </div>
+  );
+}
+
+/** Subtle placeholder used when a step's content is not yet available. */
+function BlockPlaceholder({ children }: { children: ReactNode }) {
+  return (
+    <div className='text-muted-foreground bg-muted/40 rounded-md p-3 text-xs dark:bg-white/4'>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Block shown in place of "Browse resources" / "Selected resources" when the picked storage
+ * is in a known-bad state (UNCONFIGURED or INVALID) per the front-end health cache. Reuses
+ * {@link DataStorageHealthStatusView} so the wording matches the storages list page.
+ */
+function UnhealthyStorageBlock({
+  status,
+  errorMessage,
+}: {
+  status: DataStorageHealthStatus;
+  errorMessage: string | undefined;
+}) {
+  return (
+    <section className='dm-card-block !gap-2 text-sm'>
+      <DataStorageHealthStatusView status={status} errorMessage={errorMessage} />
+    </section>
+  );
 }

--- a/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/BulkCreateFromStorageDialog.tsx
+++ b/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/BulkCreateFromStorageDialog.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Box, X } from 'lucide-react';
+import { Box, Eye, Table, X } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { Badge } from '@owox/ui/components/badge';
 import { Button } from '@owox/ui/components/button';
@@ -375,7 +375,8 @@ function BulkCreateFromStorageDialogInner({
                     {Array.from(selected.values()).map(leaf => (
                       <li key={leaf.fullyQualifiedName}>
                         <Badge variant='secondary' className='gap-1 text-xs'>
-                          {leaf.type === 'VIEW' ? 'V' : 'T'}: {leaf.id}
+                          <StorageTypeIcon resourceType={leaf.type} />
+                          {leaf.id}
                           <button
                             type='button'
                             aria-label={`Remove ${leaf.fullyQualifiedName}`}
@@ -437,7 +438,19 @@ function BulkCreateFromStorageDialogInner({
   );
 }
 
-function StorageTypeIcon({ storageType }: { storageType: DataStorageType | null }) {
+function StorageTypeIcon({
+  storageType,
+  resourceType,
+}: {
+  storageType?: DataStorageType | null;
+  resourceType?: StorageResourceLeafDto['type'];
+}) {
+  if (resourceType != null) {
+    if (resourceType === 'VIEW') {
+      return <Eye className='size-3.5 shrink-0' aria-hidden />;
+    }
+    return <Table className='size-3.5 shrink-0' aria-hidden />;
+  }
   if (!storageType) return null;
   const Icon = DataStorageTypeModel.getInfo(storageType).icon;
   return <Icon size={20} className='shrink-0' />;

--- a/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/bulk-create.utils.ts
+++ b/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/bulk-create.utils.ts
@@ -1,0 +1,47 @@
+import type { StorageResourceLeafDto } from '../../../../data-storage/shared/api/types';
+import { DataMartDefinitionType } from '../../../shared/enums/data-mart-definition-type.enum';
+import type {
+  UpdateDataMartTableDefinitionRequestDto,
+  UpdateDataMartTablePatternDefinitionRequestDto,
+  UpdateDataMartViewDefinitionRequestDto,
+} from '../../../shared/types/api';
+import { isPatternFqn, patternFqnToStored } from '../../../shared/utils/table-pattern.utils';
+
+export type BulkDefinitionRequest =
+  | UpdateDataMartTableDefinitionRequestDto
+  | UpdateDataMartViewDefinitionRequestDto
+  | UpdateDataMartTablePatternDefinitionRequestDto;
+
+/**
+ * Derive the definition payload for a freshly-created data mart from a picked storage leaf.
+ *
+ * Rules:
+ *   • VIEW leaf                            → VIEW
+ *   • TABLE leaf with `*` in the FQN       → TABLE_PATTERN
+ *   • any other TABLE leaf                 → TABLE
+ */
+export function deriveDefinition(leaf: StorageResourceLeafDto): BulkDefinitionRequest {
+  if (leaf.type === 'VIEW') {
+    return {
+      definitionType: DataMartDefinitionType.VIEW,
+      definition: { fullyQualifiedName: leaf.fullyQualifiedName },
+    };
+  }
+  if (isPatternFqn(leaf.fullyQualifiedName)) {
+    return {
+      definitionType: DataMartDefinitionType.TABLE_PATTERN,
+      definition: { pattern: patternFqnToStored(leaf.fullyQualifiedName) },
+    };
+  }
+  return {
+    definitionType: DataMartDefinitionType.TABLE,
+    definition: { fullyQualifiedName: leaf.fullyQualifiedName },
+  };
+}
+
+/** Title used for a data mart spawned from a resource leaf. */
+export function extractDataMartTitle(leaf: StorageResourceLeafDto): string {
+  if (leaf.id && leaf.id.trim().length > 0) return leaf.id;
+  const segments = leaf.fullyQualifiedName.split('.');
+  return segments[segments.length - 1] || leaf.fullyQualifiedName;
+}

--- a/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/constants.ts
+++ b/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/constants.ts
@@ -1,0 +1,13 @@
+import { DataStorageType } from '../../../../data-storage';
+
+/** Maximum number of data marts the user can create in a single bulk operation. */
+export const MAX_BULK_DATA_MART_COUNT = 20;
+
+/**
+ * Storage types that are eligible to seed bulk data mart creation. Legacy BigQuery is
+ * deliberately excluded — those data marts must use SQL definition type and are produced
+ * automatically, so a bulk create-from-resource flow does not apply to them.
+ */
+export const BULK_CREATE_SUPPORTED_STORAGE_TYPES: ReadonlySet<DataStorageType> = new Set([
+  DataStorageType.GOOGLE_BIGQUERY,
+]);

--- a/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/index.ts
+++ b/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/index.ts
@@ -1,0 +1,2 @@
+export { BulkCreateFromStorageDialog } from './BulkCreateFromStorageDialog';
+export { MAX_BULK_DATA_MART_COUNT } from './constants';

--- a/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/use-bulk-create-data-marts.ts
+++ b/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/use-bulk-create-data-marts.ts
@@ -1,0 +1,91 @@
+import { useCallback, useState } from 'react';
+import type { StorageResourceLeafDto } from '../../../../data-storage/shared/api/types';
+import { dataMartService } from '../../../shared';
+import { trackEvent } from '../../../../../utils/data-layer';
+import { deriveDefinition, extractDataMartTitle } from './bulk-create.utils';
+
+export interface BulkCreateFailure {
+  fullyQualifiedName: string;
+  title: string;
+  message: string;
+}
+
+export interface BulkCreateResult {
+  successCount: number;
+  failures: BulkCreateFailure[];
+  successfulFqns: string[];
+}
+
+interface RunArgs {
+  storageId: string;
+  leaves: StorageResourceLeafDto[];
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const response = (error as { response?: { data?: { message?: string } } }).response;
+    if (response?.data?.message) return response.data.message;
+  }
+  if (error instanceof Error) return error.message;
+  return 'Failed to create data mart';
+}
+
+/**
+ * Sequentially creates one data mart per resource leaf and immediately sets its definition.
+ * Failures are captured per-item; successfully created marts remain even if a later item fails
+ * (matches the resilient pattern used by batch publish).
+ */
+export function useBulkCreateDataMarts() {
+  const [inFlight, setInFlight] = useState(false);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+
+  const run = useCallback(async ({ storageId, leaves }: RunArgs): Promise<BulkCreateResult> => {
+    setInFlight(true);
+    setProgress({ done: 0, total: leaves.length });
+
+    const failures: BulkCreateFailure[] = [];
+    const successfulFqns: string[] = [];
+
+    try {
+      for (let i = 0; i < leaves.length; i++) {
+        const leaf = leaves[i];
+        const title = extractDataMartTitle(leaf);
+        try {
+          const created = await dataMartService.createDataMart({ title, storageId });
+          await dataMartService.updateDataMartDefinition(created.id, deriveDefinition(leaf));
+          successfulFqns.push(leaf.fullyQualifiedName);
+          trackEvent({
+            event: 'data_mart_created',
+            category: 'DataMart',
+            action: 'BulkCreateFromStorage',
+            label: leaf.type,
+            context: created.id,
+          });
+        } catch (error) {
+          console.error(`Bulk create failed for resource ${leaf.fullyQualifiedName}:`, error);
+          failures.push({
+            fullyQualifiedName: leaf.fullyQualifiedName,
+            title,
+            message: extractErrorMessage(error),
+          });
+        } finally {
+          setProgress({ done: i + 1, total: leaves.length });
+        }
+      }
+
+      return {
+        successCount: successfulFqns.length,
+        failures,
+        successfulFqns,
+      };
+    } finally {
+      setInFlight(false);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    setProgress(null);
+  }, []);
+
+  return { run, inFlight, progress, reset };
+}

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
@@ -10,10 +10,11 @@ import {
 } from '@owox/ui/components/alert-dialog';
 import { Button } from '@owox/ui/components/button';
 import { type ColumnDef, type Row } from '@tanstack/react-table';
-import { Check, CircleCheckBig, Plus, Trash2 } from 'lucide-react';
+import { Check, CircleCheckBig, Database, Plus, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { Link, useParams } from 'react-router-dom';
+import { BulkCreateFromStorageDialog } from '../BulkCreateFromStorageDialog';
 import { CardSkeleton } from '../../../../../shared/components/CardSkeleton';
 import {
   BaseTable,
@@ -86,6 +87,7 @@ export function DataMartTable<TData, TValue>({
   const [isDeleting, setIsDeleting] = useState(false);
   const [showPublishConfirmation, setShowPublishConfirmation] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
+  const [showBulkCreateFromStorage, setShowBulkCreateFromStorage] = useState(false);
 
   // Show onboarding video if the user has not seen it yet
   const shouldShowOnboarding = !isLoading && data.length === 0;
@@ -334,13 +336,33 @@ export function DataMartTable<TData, TValue>({
           </>
         )}
         renderToolbarRight={() => (
-          <TableCTAButton asChild>
-            <Link to={scope('/data-marts/create')}>
-              <Plus className='h-4 w-4' />
-              <span className='hidden lg:block'>New Data Mart</span>
-            </Link>
-          </TableCTAButton>
+          <div className='flex items-center gap-2'>
+            <Button
+              variant='outline'
+              onClick={() => {
+                setShowBulkCreateFromStorage(true);
+              }}
+              title='Import data marts from storage resources'
+            >
+              <Database className='h-4 w-4' />
+              <span className='hidden lg:block'>Import…</span>
+            </Button>
+            <TableCTAButton asChild>
+              <Link to={scope('/data-marts/create')}>
+                <Plus className='h-4 w-4' />
+                <span className='hidden lg:block'>New Data Mart</span>
+              </Link>
+            </TableCTAButton>
+          </div>
         )}
+      />
+
+      <BulkCreateFromStorageDialog
+        open={showBulkCreateFromStorage}
+        onOpenChange={setShowBulkCreateFromStorage}
+        onCreated={() => {
+          void refetchDataMarts();
+        }}
       />
 
       {/* Delete Confirmation Dialog */}

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
@@ -10,7 +10,7 @@ import {
 } from '@owox/ui/components/alert-dialog';
 import { Button } from '@owox/ui/components/button';
 import { type ColumnDef, type Row } from '@tanstack/react-table';
-import { Check, CircleCheckBig, Database, Plus, Trash2 } from 'lucide-react';
+import { Check, CircleCheckBig, Import, Plus, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { Link, useParams } from 'react-router-dom';
@@ -344,7 +344,7 @@ export function DataMartTable<TData, TValue>({
               }}
               title='Import data marts from storage resources'
             >
-              <Database className='h-4 w-4' />
+              <Import className='h-4 w-4' />
               <span className='hidden lg:block'>Import…</span>
             </Button>
             <TableCTAButton asChild>

--- a/apps/web/src/features/data-marts/shared/utils/index.ts
+++ b/apps/web/src/features/data-marts/shared/utils/index.ts
@@ -2,3 +2,4 @@ export * from './bigquery-validation';
 export * from './athena-validation';
 export * from './validation';
 export * from './status.utils';
+export * from './table-pattern.utils';

--- a/apps/web/src/features/data-marts/shared/utils/table-pattern.utils.ts
+++ b/apps/web/src/features/data-marts/shared/utils/table-pattern.utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared helpers for working with TABLE_PATTERN data mart definitions.
+ */
+
+/** Returns true if the FQN looks like a wildcard pattern (e.g. `events_*`). */
+export function isPatternFqn(fqn: string): boolean {
+  return fqn.includes('*');
+}
+
+/**
+ * Convert a wildcard-rollup FQN (e.g. `project.dataset.events_*`) to the value stored in
+ * the `definition.pattern` field of a TABLE_PATTERN data mart.
+ *
+ * The backend BigQuery query builder appends the trailing `*` at query time (see
+ * `apps/backend/.../bigquery-query.builder.ts`: `definition.pattern + '*'`), so the
+ * stored value MUST NOT include it. Stripping here avoids producing `events_**` later.
+ */
+export function patternFqnToStored(fqn: string): string {
+  return fqn.endsWith('*') ? fqn.slice(0, -1) : fqn;
+}

--- a/apps/web/src/features/data-storage/shared/api/types/response/storage-resources.response.dto.ts
+++ b/apps/web/src/features/data-storage/shared/api/types/response/storage-resources.response.dto.ts
@@ -11,7 +11,19 @@ export interface StorageResourceLeafDto {
   fullyQualifiedName: string;
 }
 
-export type StorageResourceFilter = 'TABLE' | 'VIEW';
+/**
+ * Filter accepted by the storage-resources listing API.
+ *
+ * - `TABLE`         — concrete tables only (no views, no wildcard rollups).
+ * - `VIEW`          — concrete views only.
+ * - `TABLE_PATTERN` — wildcard rollups for sharded tables (e.g. `events_*`).
+ *                    Backend returns one entry per `(group, prefix)` whose
+ *                    `fullyQualifiedName` already contains the `*` wildcard.
+ *
+ * When omitted the response combines: views + non-sharded tables + wildcard rollups
+ * (the individual shards are folded into their wildcard).
+ */
+export type StorageResourceFilter = 'TABLE' | 'VIEW' | 'TABLE_PATTERN';
 
 export interface ListStorageResourcesResponseDto {
   namespaces?: StorageNamespaceNodeDto[];


### PR DESCRIPTION
## Preview
<img width="903" height="1066" alt="CleanShot 2026-05-01 at 15 23 00" src="https://github.com/user-attachments/assets/b9bd7c5a-d16d-4d57-9be2-5a00f2105e1b" />

<img width="903" height="369" alt="CleanShot 2026-05-01 at 15 22 17" src="https://github.com/user-attachments/assets/794d6b17-f2d0-4331-a555-db43f59f3672" />

<img width="903" height="369" alt="CleanShot 2026-05-01 at 15 22 21" src="https://github.com/user-attachments/assets/444aacee-03b7-49bd-9afb-8737c26e6f72" />


## Summary

Adds a new "Import…" CTA on the Data Marts list page that lets users pick multiple
BigQuery tables, views, or sharded-table patterns at once and creates one data mart
per pick. Limit is 20 per import (configurable). Sharded tables (e.g. `events_YYYYMMDD`)
are auto-collapsed into a single wildcard pattern entry on the backend, and selecting
one creates a `TABLE_PATTERN` data mart with the correct stored value.

The single-resource picker (`Fill from Storage`) used inside data mart definition forms
benefits too: the Table Pattern field now shows wildcard rollups instead of every
shard separately.

## Backend changes

- New `TABLE_PATTERN` value on the storage-resources query filter.
- BigQuery resource browser now post-processes its raw `tables.list` response:
  - Sharded tables matching `^(.+)_(\d{4,8})$` are grouped by `(dataset, prefix)`
    and emitted as a single wildcard leaf `prefix_*` (FQN includes the `*`).
  - At least 2 shards required per group — single date-suffixed tables are not
    folded (avoids false positives like `report_2024_final`).
  - Filter contract:
    - `TABLE_PATTERN` → only wildcard rollups
    - `TABLE` → only non-sharded tables
    - `VIEW` → only views
    - none → views + non-sharded tables + wildcards (individual shards never appear)
- Pure logic extracted to `bigquery-sharded-tables.util.ts` with **20 unit tests**
  covering the user-reported case, regex edge cases, and a defensive case where the
  SDK returns a colon-prefixed id.
- Debug logs added to `listLeafResources` showing raw row count vs. post-collapse count.

## Frontend changes

### List page

- New `Import…` button in the right toolbar, next to "New Data Mart".
- New `BulkCreateFromStorageDialog` composed of:
  - Google BigQuery storage `Combobox` (excludes `LEGACY_GOOGLE_BIGQUERY`).
  - Multi-select extension to the existing `StorageResourceTree` (added
    `selectionMode='single'|'multi'` + `selectedFqns` + `onToggleResource` props,
    backwards compatible with single-select callers).
  - Selected-items chip strip with per-item remove.
  - Hard cap at `MAX_BULK_DATA_MART_COUNT = 20` (constant).
- Sequential per-item creation (`POST /data-marts` + `PUT /data-marts/:id/definition`)
  with partial-failure isolation matching the existing batch-publish pattern.
- Auto-derives definition type per leaf:
  - `VIEW` leaf → VIEW data mart
  - FQN with `*` → TABLE_PATTERN data mart, pattern stored without trailing `*`
    (matches the convention enforced by the BQ query builder, which appends `*` itself)
  - else → TABLE data mart
- Invalid-storage state: when `listStorageNamespaces` fails, the dialog hides chips
  and Cancel/Create buttons, shows a red headline + raw API error, and surfaces a
  centered "Finish storage setup" CTA that deep-links to
  `/{projectId}/data-storages?id={storageId}` (existing edit-drawer auto-open).

### Single-resource picker

- `TablePatternDefinitionField` now requests `resourceType='TABLE_PATTERN'`,
  so the picker shows wildcard rollups instead of individual shards.
- Pattern stored without the trailing `*` (uses the new
  `patternFqnToStored` helper from `data-marts/shared/utils/table-pattern.utils.ts`).
- `FillFromStorageButton` and `StorageResourceTree` got copy/empty-state updates
  for the `TABLE_PATTERN` mode.

## Why no Scheduled Queries import?

Considered importing BigQuery Scheduled Queries as SQL data marts; rejected because:

- Different API (`bigquerydatatransfer.googleapis.com`), not in our current BQ client.
- Requires `bigquery.transfers.list` IAM permission, not in baseline `dataViewer`.
- API is region-scoped — reliable enumeration would need ~30 region calls per project.
- SQL data marts have a separate setup flow (editor + review) that bulk-import skips.

If revisited later, build it as a dedicated import flow, not as part of the resource
browser.

## Test plan

- [x] Open `/data-marts`, click `Import…`. With one GBQ storage, it auto-selects.
- [x] Pick a mix of TABLE / VIEW / wildcard-rollup leaves (up to 20). Confirm chips
      reflect selection and the limit hint appears at 20/20.
- [x] Confirm; verify N data marts appear in the list with the right
      `definitionType` (TABLE / VIEW / TABLE_PATTERN) and titles.
- [x] For TABLE_PATTERN result, verify `definition.pattern` does NOT end with `*`
      (the query builder appends it).
- [x] Break a storage's credentials, reopen the dialog with that storage selected →
      red headline + centered "Finish storage setup" → click → lands on
      `/data-storages?id={id}` with the edit drawer open.
- [x] Existing single-resource picker for TABLE / VIEW unchanged.
- [x] Single-resource picker for Table Pattern field shows wildcard entries; picking
      one fills the input without `*`.