### PR TITLE
fix(ci): align publish workflow with changesets cli flags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Publish to "latest"
         run: |
-          npx changeset publish --access public
+          npx changeset publish
 
       - name: Extract "latest" version
         id: extract_latest_version
@@ -163,7 +163,7 @@ jobs:
       - name: Publish to "next"
         run: |
           npx changeset version --snapshot next
-          npx changeset publish --no-git-tag --snapshot --tag next
+          npx changeset publish --no-git-tag --tag next
 
       - name: Extract "next" version
         id: extract_next_version


### PR DESCRIPTION
## Summary

- Remove unsupported `--access public` from stable `changeset publish`
- Remove unsupported `--snapshot` from snapshot `changeset publish`
- Keep existing release outcomes: stable packages publish to `latest`, snapshot packages publish to `next`

## Why

`@changesets/cli@2.31.0` now validates command flags and fails on flags that older versions ignored. `--access` is handled by Changesets config / package `publishConfig`, and `--snapshot` belongs to `changeset version`, not `changeset publish`.