### PR TITLE
feat(backend): correct Looker Studio types and aggregations for blended fields

### DIFF
--- a/.changeset/looker-studio-blended-types-aggregations.md
+++ b/.changeset/looker-studio-blended-types-aggregations.md
@@ -1,0 +1,15 @@
+---
+'owox': minor
+---
+
+# Correct column types and aggregations for blended fields in Looker Studio
+
+When a Data Mart pulls in fields from joined Data Marts (blended fields), the Looker Studio connector now reports the right column types and respects the aggregation function you selected for each field.
+
+- `COUNT` and `COUNT_DISTINCT` blended fields appear as numeric metrics — no more text dimensions for counts.
+- `STRING_AGG` and `ANY_VALUE` blended fields appear as dimensions, so Looker Studio doesn't try to sum already-aggregated values.
+- `MIN` / `MAX` / `SUM` blended fields use the matching default aggregation in Looker Studio (`MIN`/`MAX`/`SUM`), instead of always defaulting to `SUM`.
+- `COUNT_DISTINCT` is no longer marked as re-aggregatable, preventing inflated totals when the field is used across filters or breakdowns.
+- The fix works consistently across BigQuery, Snowflake, Redshift, Athena, and Databricks.
+
+Native (non-blended) numeric fields continue to behave as before — they default to `SUM` and remain re-aggregatable.

--- a/apps/backend/src/data-marts/data-destination-types/data-destination-providers.ts
+++ b/apps/backend/src/data-marts/data-destination-types/data-destination-providers.ts
@@ -32,6 +32,7 @@ import { LookerStudioConnectorApiService } from './looker-studio-connector/servi
 import { LookerStudioConnectorCredentialsValidator } from './looker-studio-connector/services/looker-studio-connector-credentials-validator';
 import { LookerStudioConnectorCredentialsProcessor } from './looker-studio-connector/services/looker-studio-connector-credentials-processor';
 import { LookerStudioConnectorSecretKeyRotator } from './looker-studio-connector/services/looker-studio-connector-secret-key-rotator';
+import { LookerStudioAggregationMapperService } from './looker-studio-connector/services/looker-studio-aggregation-mapper.service';
 import { LookerStudioTypeMapperService } from './looker-studio-connector/services/looker-studio-type-mapper.service';
 import {
   EmailAccessValidator,
@@ -113,6 +114,7 @@ export const dataDestinationResolverProviders = [
   LookerStudioConnectorApiSchemaService,
   LookerStudioConnectorApiDataService,
   LookerStudioConnectorApiService,
+  LookerStudioAggregationMapperService,
   LookerStudioTypeMapperService,
   {
     provide: DATA_DESTINATION_ACCESS_VALIDATOR_RESOLVER,

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
@@ -3,16 +3,9 @@ import { DateTime } from 'luxon';
 import { AthenaFieldType } from '../../../../data-storage-types/athena/enums/athena-field-type.enum';
 import { BigQueryFieldType } from '../../../../data-storage-types/bigquery/enums/bigquery-field-type.enum';
 import { SnowflakeFieldType } from '../../../../data-storage-types/snowflake/enums/snowflake-field-type.enum';
-import { RedshiftFieldType } from '../../../../data-storage-types/redshift/enums/redshift-field-type.enum';
-import { DatabricksFieldType } from '../../../../data-storage-types/databricks/enums/databricks-field-type.enum';
 import { ReportDataHeader } from '../../../../dto/domain/report-data-header.dto';
+import { StorageFieldType } from '../../../../dto/domain/storage-field-type';
 
-type FieldType =
-  | BigQueryFieldType
-  | AthenaFieldType
-  | SnowflakeFieldType
-  | RedshiftFieldType
-  | DatabricksFieldType;
 type FormatterFunction = (value: unknown, sheetTimeZone: string) => unknown;
 
 /**
@@ -21,7 +14,7 @@ type FormatterFunction = (value: unknown, sheetTimeZone: string) => unknown;
  */
 @Injectable()
 export class SheetValuesFormatter {
-  private readonly formatters = new Map<FieldType, FormatterFunction>([
+  private readonly formatters = new Map<StorageFieldType, FormatterFunction>([
     [BigQueryFieldType.TIMESTAMP, this.formatTimestamp],
     [AthenaFieldType.TIMESTAMP, this.formatTimestamp],
     [AthenaFieldType.TIMESTAMP_WITH_TIME_ZONE, this.formatTimestamp],

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-aggregation-mapper.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-aggregation-mapper.service.spec.ts
@@ -1,0 +1,196 @@
+import { LookerStudioAggregationMapperService } from './looker-studio-aggregation-mapper.service';
+import { AggregationType } from '../enums/aggregation-type.enum';
+import { FieldConceptType } from '../enums/field-concept-type.enum';
+import { FieldDataType } from '../enums/field-data-type.enum';
+import { AggregateFunction } from '../../../dto/schemas/aggregate-function.schema';
+
+describe('LookerStudioAggregationMapperService', () => {
+  let service: LookerStudioAggregationMapperService;
+
+  beforeEach(() => {
+    service = new LookerStudioAggregationMapperService();
+  });
+
+  describe('undefined aggFunc (native field)', () => {
+    it('NUMBER -> METRIC + SUM + reagg=true', () => {
+      const result = service.mapAggregateFunctionToLookerType(undefined, FieldDataType.NUMBER);
+      expect(result.conceptType).toBe(FieldConceptType.METRIC);
+      expect(result.defaultAggregationType).toBe(AggregationType.SUM);
+      expect(result.isReaggregatable).toBe(true);
+    });
+
+    it('STRING -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType(undefined, FieldDataType.STRING);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+      expect(result.defaultAggregationType).toBeUndefined();
+    });
+
+    it('BOOLEAN -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType(undefined, FieldDataType.BOOLEAN);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+  });
+
+  describe('SUM', () => {
+    it('NUMBER -> METRIC + SUM + reagg=true', () => {
+      const result = service.mapAggregateFunctionToLookerType('SUM', FieldDataType.NUMBER);
+      expect(result.conceptType).toBe(FieldConceptType.METRIC);
+      expect(result.defaultAggregationType).toBe(AggregationType.SUM);
+      expect(result.isReaggregatable).toBe(true);
+    });
+
+    it('STRING -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('SUM', FieldDataType.STRING);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('BOOLEAN -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('SUM', FieldDataType.BOOLEAN);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+  });
+
+  describe('MIN', () => {
+    it('NUMBER -> METRIC + MIN + reagg=true', () => {
+      const result = service.mapAggregateFunctionToLookerType('MIN', FieldDataType.NUMBER);
+      expect(result.conceptType).toBe(FieldConceptType.METRIC);
+      expect(result.defaultAggregationType).toBe(AggregationType.MIN);
+      expect(result.isReaggregatable).toBe(true);
+    });
+
+    it('STRING -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('MIN', FieldDataType.STRING);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('BOOLEAN -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('MIN', FieldDataType.BOOLEAN);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+  });
+
+  describe('MAX', () => {
+    it('NUMBER -> METRIC + MAX + reagg=true', () => {
+      const result = service.mapAggregateFunctionToLookerType('MAX', FieldDataType.NUMBER);
+      expect(result.conceptType).toBe(FieldConceptType.METRIC);
+      expect(result.defaultAggregationType).toBe(AggregationType.MAX);
+      expect(result.isReaggregatable).toBe(true);
+    });
+
+    it('STRING -> DIMENSION (e.g. MAX(date) -> STRING in Looker)', () => {
+      const result = service.mapAggregateFunctionToLookerType('MAX', FieldDataType.STRING);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('BOOLEAN -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('MAX', FieldDataType.BOOLEAN);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+  });
+
+  describe('COUNT', () => {
+    it('NUMBER -> METRIC + SUM + reagg=true (counts sum correctly across groups)', () => {
+      const result = service.mapAggregateFunctionToLookerType('COUNT', FieldDataType.NUMBER);
+      expect(result.conceptType).toBe(FieldConceptType.METRIC);
+      expect(result.defaultAggregationType).toBe(AggregationType.SUM);
+      expect(result.isReaggregatable).toBe(true);
+    });
+
+    it('STRING -> METRIC + SUM + reagg=true (effective type is always INTEGER for COUNT)', () => {
+      const result = service.mapAggregateFunctionToLookerType('COUNT', FieldDataType.STRING);
+      expect(result.conceptType).toBe(FieldConceptType.METRIC);
+      expect(result.defaultAggregationType).toBe(AggregationType.SUM);
+      expect(result.isReaggregatable).toBe(true);
+    });
+
+    it('BOOLEAN -> METRIC + SUM + reagg=true', () => {
+      const result = service.mapAggregateFunctionToLookerType('COUNT', FieldDataType.BOOLEAN);
+      expect(result.conceptType).toBe(FieldConceptType.METRIC);
+      expect(result.defaultAggregationType).toBe(AggregationType.SUM);
+      expect(result.isReaggregatable).toBe(true);
+    });
+  });
+
+  describe('COUNT_DISTINCT', () => {
+    it('NUMBER -> METRIC + no defaultAgg + reagg=false', () => {
+      const result = service.mapAggregateFunctionToLookerType(
+        'COUNT_DISTINCT',
+        FieldDataType.NUMBER
+      );
+      expect(result.conceptType).toBe(FieldConceptType.METRIC);
+      expect(result.defaultAggregationType).toBeUndefined();
+      expect(result.isReaggregatable).toBe(false);
+    });
+
+    it('STRING -> METRIC + no defaultAgg + reagg=false', () => {
+      const result = service.mapAggregateFunctionToLookerType(
+        'COUNT_DISTINCT',
+        FieldDataType.STRING
+      );
+      expect(result.conceptType).toBe(FieldConceptType.METRIC);
+      expect(result.defaultAggregationType).toBeUndefined();
+      expect(result.isReaggregatable).toBe(false);
+    });
+
+    it('BOOLEAN -> METRIC + no defaultAgg + reagg=false', () => {
+      const result = service.mapAggregateFunctionToLookerType(
+        'COUNT_DISTINCT',
+        FieldDataType.BOOLEAN
+      );
+      expect(result.conceptType).toBe(FieldConceptType.METRIC);
+      expect(result.defaultAggregationType).toBeUndefined();
+      expect(result.isReaggregatable).toBe(false);
+    });
+  });
+
+  describe('STRING_AGG', () => {
+    it('NUMBER -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('STRING_AGG', FieldDataType.NUMBER);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('STRING -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('STRING_AGG', FieldDataType.STRING);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('BOOLEAN -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('STRING_AGG', FieldDataType.BOOLEAN);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+  });
+
+  describe('ANY_VALUE', () => {
+    it('NUMBER -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('ANY_VALUE', FieldDataType.NUMBER);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('STRING -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('ANY_VALUE', FieldDataType.STRING);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('BOOLEAN -> DIMENSION', () => {
+      const result = service.mapAggregateFunctionToLookerType('ANY_VALUE', FieldDataType.BOOLEAN);
+      expect(result.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+  });
+
+  it('covers all AggregateFunction values (exhaustive check)', () => {
+    const allFuncs: AggregateFunction[] = [
+      'STRING_AGG',
+      'MAX',
+      'MIN',
+      'SUM',
+      'COUNT',
+      'COUNT_DISTINCT',
+      'ANY_VALUE',
+    ];
+    for (const func of allFuncs) {
+      for (const dt of Object.values(FieldDataType)) {
+        expect(() => service.mapAggregateFunctionToLookerType(func, dt)).not.toThrow();
+      }
+    }
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-aggregation-mapper.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-aggregation-mapper.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@nestjs/common';
+import { AggregateFunction } from '../../../dto/schemas/aggregate-function.schema';
+import { AggregationType } from '../enums/aggregation-type.enum';
+import { FieldConceptType } from '../enums/field-concept-type.enum';
+import { FieldDataType } from '../enums/field-data-type.enum';
+
+export interface AggregationSemantics {
+  conceptType: FieldConceptType;
+  defaultAggregationType?: AggregationType;
+  isReaggregatable?: boolean;
+}
+
+@Injectable()
+export class LookerStudioAggregationMapperService {
+  mapAggregateFunctionToLookerType(
+    aggFunc: AggregateFunction | undefined,
+    dataType: FieldDataType
+  ): AggregationSemantics {
+    if (aggFunc === undefined) {
+      return dataType === FieldDataType.NUMBER
+        ? {
+            conceptType: FieldConceptType.METRIC,
+            defaultAggregationType: AggregationType.SUM,
+            isReaggregatable: true,
+          }
+        : { conceptType: FieldConceptType.DIMENSION };
+    }
+
+    switch (aggFunc) {
+      case 'SUM':
+        return dataType === FieldDataType.NUMBER
+          ? {
+              conceptType: FieldConceptType.METRIC,
+              defaultAggregationType: AggregationType.SUM,
+              isReaggregatable: true,
+            }
+          : { conceptType: FieldConceptType.DIMENSION };
+      case 'MIN':
+        return dataType === FieldDataType.NUMBER
+          ? {
+              conceptType: FieldConceptType.METRIC,
+              defaultAggregationType: AggregationType.MIN,
+              isReaggregatable: true,
+            }
+          : { conceptType: FieldConceptType.DIMENSION };
+      case 'MAX':
+        return dataType === FieldDataType.NUMBER
+          ? {
+              conceptType: FieldConceptType.METRIC,
+              defaultAggregationType: AggregationType.MAX,
+              isReaggregatable: true,
+            }
+          : { conceptType: FieldConceptType.DIMENSION };
+      case 'COUNT':
+        return {
+          conceptType: FieldConceptType.METRIC,
+          defaultAggregationType: AggregationType.SUM,
+          isReaggregatable: true,
+        };
+      case 'COUNT_DISTINCT':
+        return { conceptType: FieldConceptType.METRIC, isReaggregatable: false };
+      case 'STRING_AGG':
+      case 'ANY_VALUE':
+        return { conceptType: FieldConceptType.DIMENSION };
+      default: {
+        const _exhaustive: never = aggFunc;
+        return _exhaustive;
+      }
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.spec.ts
@@ -1,13 +1,19 @@
 import { Response } from 'express';
 import { PassThrough } from 'stream';
 import * as zlib from 'zlib';
+import { Test } from '@nestjs/testing';
+import { BigQueryFieldType } from '../../../data-storage-types/bigquery/enums/bigquery-field-type.enum';
 import { DataStorageType } from '../../../data-storage-types/enums/data-storage-type.enum';
+import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
 import { CachedReaderData } from '../../../dto/domain/cached-reader-data.dto';
 import { Report } from '../../../entities/report.entity';
+import { FieldConceptType } from '../enums/field-concept-type.enum';
 import { FieldDataType } from '../enums/field-data-type.enum';
+import { AggregationType } from '../enums/aggregation-type.enum';
 import { GetDataRequest } from '../schemas/get-data.schema';
 import { LookerStudioConnectorApiDataService } from './looker-studio-connector-api-data.service';
 import { LookerStudioTypeMapperService } from './looker-studio-type-mapper.service';
+import { LookerStudioAggregationMapperService } from './looker-studio-aggregation-mapper.service';
 
 describe('LookerStudioConnectorApiDataService', () => {
   let service: LookerStudioConnectorApiDataService;
@@ -16,6 +22,12 @@ describe('LookerStudioConnectorApiDataService', () => {
   beforeEach(() => {
     typeMapperService = {
       mapToLookerStudioDataType: jest.fn().mockReturnValue(FieldDataType.STRING),
+      buildSchemaField: jest.fn().mockImplementation((header: ReportDataHeader) => ({
+        name: header.name,
+        label: header.alias || header.name,
+        dataType: FieldDataType.STRING,
+        semantics: { conceptType: FieldConceptType.DIMENSION },
+      })),
     } as unknown as jest.Mocked<LookerStudioTypeMapperService>;
 
     service = new LookerStudioConnectorApiDataService(typeMapperService);
@@ -47,7 +59,7 @@ describe('LookerStudioConnectorApiDataService', () => {
     }) as GetDataRequest;
 
   const createMockCachedReader = (
-    headers: Array<{ name: string; storageFieldType: string }>,
+    headers: Array<{ name: string; storageFieldType: string; aggregateFunction?: string }>,
     batches: Array<{ rows: unknown[][]; nextBatchId?: string }>
   ): CachedReaderData => {
     let batchIndex = 0;
@@ -58,6 +70,7 @@ describe('LookerStudioConnectorApiDataService', () => {
         dataHeaders: headers.map(h => ({
           name: h.name,
           storageFieldType: h.storageFieldType,
+          aggregateFunction: h.aggregateFunction,
         })),
       },
       reader: {
@@ -327,6 +340,105 @@ describe('LookerStudioConnectorApiDataService', () => {
       expect(meta.limitExceeded).toBe(false);
       expect(meta.rowsSent).toBe(2);
       expect(meta.limitReason).toBeUndefined();
+    });
+
+    it('blended COUNT on STRING field → schema carries NUMBER (regression fix)', async () => {
+      typeMapperService.buildSchemaField.mockImplementation((header: ReportDataHeader) => ({
+        name: header.name,
+        label: header.alias || header.name,
+        dataType: FieldDataType.NUMBER,
+        semantics: { conceptType: FieldConceptType.METRIC, isReaggregatable: true },
+        defaultAggregationType: AggregationType.SUM,
+      }));
+
+      const report = createMockReport();
+      const request = createMockRequest(['b_count']);
+      const cachedReader = createMockCachedReader(
+        [{ name: 'b_count', storageFieldType: 'INTEGER', aggregateFunction: 'COUNT' }],
+        [{ rows: [[42]], nextBatchId: undefined }]
+      );
+
+      const { response } = await service.getData(request, report, cachedReader, false);
+
+      expect(response.schema[0].dataType).toBe(FieldDataType.NUMBER);
+    });
+  });
+
+  describe('getSchema ↔ getData dataType agreement', () => {
+    it('same headers → schema service and data service produce identical dataType per field', async () => {
+      const module = await Test.createTestingModule({
+        providers: [
+          LookerStudioTypeMapperService,
+          LookerStudioAggregationMapperService,
+          LookerStudioConnectorApiDataService,
+        ],
+      }).compile();
+
+      const realDataService = module.get(LookerStudioConnectorApiDataService);
+      const realTypeMapper = module.get(LookerStudioTypeMapperService);
+
+      (realDataService as any).logger = {
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      };
+
+      const storageType = DataStorageType.GOOGLE_BIGQUERY;
+
+      const headers: ReportDataHeader[] = [
+        new ReportDataHeader('native_str', 'Native Str', undefined, BigQueryFieldType.STRING),
+        new ReportDataHeader('native_int', 'Native Int', undefined, BigQueryFieldType.INTEGER),
+        new ReportDataHeader('b_count', 'B Count', undefined, BigQueryFieldType.INTEGER, 'COUNT'),
+        new ReportDataHeader(
+          'b_cnt_dist',
+          'B Cnt Dist',
+          undefined,
+          BigQueryFieldType.INTEGER,
+          'COUNT_DISTINCT'
+        ),
+        new ReportDataHeader(
+          'b_str_agg',
+          'B Str Agg',
+          undefined,
+          BigQueryFieldType.STRING,
+          'STRING_AGG'
+        ),
+        new ReportDataHeader('b_max_date', 'B Max Date', undefined, BigQueryFieldType.DATE, 'MAX'),
+        new ReportDataHeader('b_max_int', 'B Max Int', undefined, BigQueryFieldType.INTEGER, 'MAX'),
+        new ReportDataHeader(
+          'b_any_int',
+          'B Any Int',
+          undefined,
+          BigQueryFieldType.INTEGER,
+          'ANY_VALUE'
+        ),
+      ];
+
+      const schemaDataTypes = headers.map(
+        h => realTypeMapper.buildSchemaField(h, storageType).dataType
+      );
+
+      const report = createMockReport();
+      const request = createMockRequest(headers.map(h => h.name));
+      const cachedReader: CachedReaderData = {
+        fromCache: false,
+        dataDescription: { dataHeaders: headers },
+        reader: {
+          readReportDataBatch: jest.fn().mockResolvedValue({
+            dataRows: [headers.map(() => null)],
+            nextDataBatchId: null,
+          }),
+        },
+      } as unknown as CachedReaderData;
+
+      const { response } = await realDataService.getData(request, report, cachedReader, false);
+
+      const responseDataTypes = response.schema.map(
+        (s: { name: string; dataType: FieldDataType }) => s.dataType
+      );
+
+      expect(responseDataTypes).toEqual(schemaDataTypes);
     });
   });
 });

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.ts
@@ -15,6 +15,7 @@ import {
   GetDataResult,
   RequestField,
 } from '../schemas/get-data.schema';
+
 import { LookerStudioTypeMapperService } from './looker-studio-type-mapper.service';
 
 /**
@@ -186,13 +187,10 @@ export class LookerStudioConnectorApiDataService {
     filteredHeaders: ReportDataHeader[],
     storageType: DataStorageType
   ): Array<{ name: string; dataType: FieldDataType }> {
-    return filteredHeaders.map(header => ({
-      name: header.name,
-      dataType: this.typeMapperService.mapToLookerStudioDataType(
-        header.storageFieldType!,
-        storageType
-      ),
-    }));
+    return filteredHeaders.map(header => {
+      const field = this.typeMapperService.buildSchemaField(header, storageType);
+      return { name: field.name, dataType: field.dataType };
+    });
   }
 
   /**

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-schema.service.spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LookerStudioConnectorApiSchemaService } from './looker-studio-connector-api-schema.service';
+import { LookerStudioTypeMapperService } from './looker-studio-type-mapper.service';
+import { LookerStudioAggregationMapperService } from './looker-studio-aggregation-mapper.service';
+import { DataMartService } from '../../../services/data-mart.service';
+import { DataStorageType } from '../../../data-storage-types/enums/data-storage-type.enum';
+import { BigQueryFieldType } from '../../../data-storage-types/bigquery/enums/bigquery-field-type.enum';
+import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
+import { FieldDataType } from '../enums/field-data-type.enum';
+import { FieldConceptType } from '../enums/field-concept-type.enum';
+import { AggregationType } from '../enums/aggregation-type.enum';
+
+describe('LookerStudioConnectorApiSchemaService.getSchemaFields', () => {
+  let service: LookerStudioConnectorApiSchemaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LookerStudioConnectorApiSchemaService,
+        LookerStudioTypeMapperService,
+        LookerStudioAggregationMapperService,
+        {
+          provide: DataMartService,
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    service = module.get(LookerStudioConnectorApiSchemaService);
+  });
+
+  const storageType = DataStorageType.GOOGLE_BIGQUERY;
+
+  it('native NUMBER → METRIC + SUM + reaggregatable=true', () => {
+    const headers = [
+      new ReportDataHeader('revenue', 'Revenue', undefined, BigQueryFieldType.INTEGER),
+    ];
+    const [field] = service.getSchemaFields(headers, storageType);
+
+    expect(field.dataType).toBe(FieldDataType.NUMBER);
+    expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+    expect(field.defaultAggregationType).toBe(AggregationType.SUM);
+    expect(field.semantics?.isReaggregatable).toBe(true);
+  });
+
+  it('native STRING → DIMENSION, no defaultAggregationType', () => {
+    const headers = [
+      new ReportDataHeader('country', 'Country', undefined, BigQueryFieldType.STRING),
+    ];
+    const [field] = service.getSchemaFields(headers, storageType);
+
+    expect(field.dataType).toBe(FieldDataType.STRING);
+    expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+    expect(field.defaultAggregationType).toBeUndefined();
+  });
+
+  it('blended COUNT/STRING (effective type=INTEGER) → METRIC, NUMBER, defaultAgg=SUM, reagg=true', () => {
+    const headers = [
+      new ReportDataHeader('b_count', 'B Count', undefined, BigQueryFieldType.INTEGER, 'COUNT'),
+    ];
+    const [field] = service.getSchemaFields(headers, storageType);
+
+    expect(field.dataType).toBe(FieldDataType.NUMBER);
+    expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+    expect(field.defaultAggregationType).toBe(AggregationType.SUM);
+    expect(field.semantics?.isReaggregatable).toBe(true);
+  });
+
+  it('blended COUNT_DISTINCT/STRING (effective type=INTEGER) → METRIC, NUMBER, no defaultAgg, reagg=false', () => {
+    const headers = [
+      new ReportDataHeader(
+        'b_cnt_dist',
+        'B Cnt Dist',
+        undefined,
+        BigQueryFieldType.INTEGER,
+        'COUNT_DISTINCT'
+      ),
+    ];
+    const [field] = service.getSchemaFields(headers, storageType);
+
+    expect(field.dataType).toBe(FieldDataType.NUMBER);
+    expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+    expect(field.defaultAggregationType).toBeUndefined();
+    expect(field.semantics?.isReaggregatable).toBe(false);
+  });
+
+  it('blended STRING_AGG (effective type=STRING) → DIMENSION, STRING', () => {
+    const headers = [
+      new ReportDataHeader('b_tags', 'B Tags', undefined, BigQueryFieldType.STRING, 'STRING_AGG'),
+    ];
+    const [field] = service.getSchemaFields(headers, storageType);
+
+    expect(field.dataType).toBe(FieldDataType.STRING);
+    expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+  });
+
+  it('blended ANY_VALUE/INTEGER (effective type=INTEGER) → DIMENSION, NUMBER', () => {
+    const headers = [
+      new ReportDataHeader(
+        'b_any_id',
+        'B Any Id',
+        undefined,
+        BigQueryFieldType.INTEGER,
+        'ANY_VALUE'
+      ),
+    ];
+    const [field] = service.getSchemaFields(headers, storageType);
+
+    expect(field.dataType).toBe(FieldDataType.NUMBER);
+    expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+  });
+
+  it('blended MAX/DATE (effective type=DATE → STRING in Looker) → DIMENSION, STRING', () => {
+    const headers = [
+      new ReportDataHeader('b_max_date', 'B Max Date', undefined, BigQueryFieldType.DATE, 'MAX'),
+    ];
+    const [field] = service.getSchemaFields(headers, storageType);
+
+    expect(field.dataType).toBe(FieldDataType.STRING);
+    expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+  });
+
+  it('blended MAX/INTEGER → METRIC, NUMBER, defaultAgg=MAX', () => {
+    const headers = [
+      new ReportDataHeader('b_max_rev', 'B Max Rev', undefined, BigQueryFieldType.INTEGER, 'MAX'),
+    ];
+    const [field] = service.getSchemaFields(headers, storageType);
+
+    expect(field.dataType).toBe(FieldDataType.NUMBER);
+    expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+    expect(field.defaultAggregationType).toBe(AggregationType.MAX);
+  });
+
+  it('blended SUM/INTEGER → METRIC, NUMBER, defaultAgg=SUM, reagg=true', () => {
+    const headers = [
+      new ReportDataHeader('b_sum_rev', 'B Sum Rev', undefined, BigQueryFieldType.INTEGER, 'SUM'),
+    ];
+    const [field] = service.getSchemaFields(headers, storageType);
+
+    expect(field.dataType).toBe(FieldDataType.NUMBER);
+    expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+    expect(field.defaultAggregationType).toBe(AggregationType.SUM);
+    expect(field.semantics?.isReaggregatable).toBe(true);
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-schema.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-schema.service.ts
@@ -4,9 +4,6 @@ import { CachedReaderData } from '../../../dto/domain/cached-reader-data.dto';
 import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
 import { Report } from '../../../entities/report.entity';
 import { DataMartService } from '../../../services/data-mart.service';
-import { AggregationType } from '../enums/aggregation-type.enum';
-import { FieldConceptType } from '../enums/field-concept-type.enum';
-import { FieldDataType } from '../enums/field-data-type.enum';
 import { GetSchemaRequest, GetSchemaResponse, SchemaField } from '../schemas/get-schema.schema';
 import { LookerStudioTypeMapperService } from './looker-studio-type-mapper.service';
 
@@ -40,32 +37,12 @@ export class LookerStudioConnectorApiSchemaService {
     };
   }
 
-  private getSchemaFields(
+  getSchemaFields(
     reportDataHeaders: ReportDataHeader[],
     storageType: DataStorageType
   ): SchemaField[] {
-    return reportDataHeaders.map(header => {
-      const schemaField: SchemaField = {
-        name: header.name,
-        label: header.alias || header.name,
-        description: header.description,
-        dataType: this.typeMapperService.mapToLookerStudioDataType(
-          header.storageFieldType!,
-          storageType
-        ),
-      };
-      if (schemaField.dataType === FieldDataType.NUMBER) {
-        schemaField.semantics = {
-          conceptType: FieldConceptType.METRIC,
-          isReaggregatable: true,
-        };
-        schemaField.defaultAggregationType = AggregationType.SUM;
-      } else {
-        schemaField.semantics = {
-          conceptType: FieldConceptType.DIMENSION,
-        };
-      }
-      return schemaField;
-    });
+    return reportDataHeaders.map(header =>
+      this.typeMapperService.buildSchemaField(header, storageType)
+    );
   }
 }

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-type-mapper.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-type-mapper.service.spec.ts
@@ -1,0 +1,400 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LookerStudioTypeMapperService } from './looker-studio-type-mapper.service';
+import { LookerStudioAggregationMapperService } from './looker-studio-aggregation-mapper.service';
+import { DataStorageType } from '../../../data-storage-types/enums/data-storage-type.enum';
+import { AthenaFieldType } from '../../../data-storage-types/athena/enums/athena-field-type.enum';
+import { BigQueryFieldType } from '../../../data-storage-types/bigquery/enums/bigquery-field-type.enum';
+import { DatabricksFieldType } from '../../../data-storage-types/databricks/enums/databricks-field-type.enum';
+import { RedshiftFieldType } from '../../../data-storage-types/redshift/enums/redshift-field-type.enum';
+import { SnowflakeFieldType } from '../../../data-storage-types/snowflake/enums/snowflake-field-type.enum';
+import { FieldDataType } from '../enums/field-data-type.enum';
+import { FieldConceptType } from '../enums/field-concept-type.enum';
+import { AggregationType } from '../enums/aggregation-type.enum';
+import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
+import { StorageFieldType } from '../../../dto/domain/storage-field-type';
+
+describe('LookerStudioTypeMapperService', () => {
+  let service: LookerStudioTypeMapperService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LookerStudioTypeMapperService, LookerStudioAggregationMapperService],
+    }).compile();
+
+    service = module.get(LookerStudioTypeMapperService);
+  });
+
+  describe('mapToLookerStudioDataType — fallbacks', () => {
+    it('LEGACY_GOOGLE_BIGQUERY behaves as GOOGLE_BIGQUERY', () => {
+      expect(
+        service.mapToLookerStudioDataType(
+          BigQueryFieldType.INTEGER,
+          DataStorageType.LEGACY_GOOGLE_BIGQUERY
+        )
+      ).toBe(FieldDataType.NUMBER);
+      expect(
+        service.mapToLookerStudioDataType(
+          BigQueryFieldType.TIMESTAMP,
+          DataStorageType.LEGACY_GOOGLE_BIGQUERY
+        )
+      ).toBe(FieldDataType.STRING);
+    });
+  });
+
+  describe('mapToLookerStudioDataType — exhaustive storage-native coverage', () => {
+    type Case = [StorageFieldType, FieldDataType];
+
+    const bigQueryCases: Case[] = [
+      [BigQueryFieldType.INTEGER, FieldDataType.NUMBER],
+      [BigQueryFieldType.FLOAT, FieldDataType.NUMBER],
+      [BigQueryFieldType.NUMERIC, FieldDataType.NUMBER],
+      [BigQueryFieldType.BIGNUMERIC, FieldDataType.NUMBER],
+      [BigQueryFieldType.BOOLEAN, FieldDataType.BOOLEAN],
+      [BigQueryFieldType.STRING, FieldDataType.STRING],
+      [BigQueryFieldType.DATE, FieldDataType.STRING],
+      [BigQueryFieldType.TIME, FieldDataType.STRING],
+      [BigQueryFieldType.DATETIME, FieldDataType.STRING],
+      [BigQueryFieldType.TIMESTAMP, FieldDataType.STRING],
+      [BigQueryFieldType.BYTES, FieldDataType.STRING],
+      [BigQueryFieldType.GEOGRAPHY, FieldDataType.STRING],
+      [BigQueryFieldType.JSON, FieldDataType.STRING],
+      [BigQueryFieldType.RECORD, FieldDataType.STRING],
+      [BigQueryFieldType.STRUCT, FieldDataType.STRING],
+      [BigQueryFieldType.RANGE, FieldDataType.STRING],
+      [BigQueryFieldType.INTERVAL, FieldDataType.STRING],
+    ];
+
+    const snowflakeCases: Case[] = [
+      [SnowflakeFieldType.INTEGER, FieldDataType.NUMBER],
+      [SnowflakeFieldType.FLOAT, FieldDataType.NUMBER],
+      [SnowflakeFieldType.NUMERIC, FieldDataType.NUMBER],
+      [SnowflakeFieldType.BOOLEAN, FieldDataType.BOOLEAN],
+      [SnowflakeFieldType.STRING, FieldDataType.STRING],
+      [SnowflakeFieldType.BYTES, FieldDataType.STRING],
+      [SnowflakeFieldType.DATE, FieldDataType.STRING],
+      [SnowflakeFieldType.TIME, FieldDataType.STRING],
+      [SnowflakeFieldType.TIMESTAMP, FieldDataType.STRING],
+      [SnowflakeFieldType.GEOGRAPHY, FieldDataType.STRING],
+      [SnowflakeFieldType.VARIANT, FieldDataType.STRING],
+    ];
+
+    const redshiftCases: Case[] = [
+      [RedshiftFieldType.SMALLINT, FieldDataType.NUMBER],
+      [RedshiftFieldType.INTEGER, FieldDataType.NUMBER],
+      [RedshiftFieldType.BIGINT, FieldDataType.NUMBER],
+      [RedshiftFieldType.DECIMAL, FieldDataType.NUMBER],
+      [RedshiftFieldType.NUMERIC, FieldDataType.NUMBER],
+      [RedshiftFieldType.REAL, FieldDataType.NUMBER],
+      [RedshiftFieldType.DOUBLE_PRECISION, FieldDataType.NUMBER],
+      [RedshiftFieldType.BOOLEAN, FieldDataType.BOOLEAN],
+      [RedshiftFieldType.BOOL, FieldDataType.BOOLEAN],
+      [RedshiftFieldType.VARCHAR, FieldDataType.STRING],
+      [RedshiftFieldType.CHAR, FieldDataType.STRING],
+      [RedshiftFieldType.TEXT, FieldDataType.STRING],
+      [RedshiftFieldType.BPCHAR, FieldDataType.STRING],
+      [RedshiftFieldType.DATE, FieldDataType.STRING],
+      [RedshiftFieldType.TIMESTAMP, FieldDataType.STRING],
+      [RedshiftFieldType.TIMESTAMPTZ, FieldDataType.STRING],
+      [RedshiftFieldType.TIME, FieldDataType.STRING],
+      [RedshiftFieldType.TIMETZ, FieldDataType.STRING],
+      [RedshiftFieldType.BYTEA, FieldDataType.STRING],
+      [RedshiftFieldType.SUPER, FieldDataType.STRING],
+      [RedshiftFieldType.GEOMETRY, FieldDataType.STRING],
+      [RedshiftFieldType.GEOGRAPHY, FieldDataType.STRING],
+    ];
+
+    const athenaCases: Case[] = [
+      [AthenaFieldType.TINYINT, FieldDataType.NUMBER],
+      [AthenaFieldType.SMALLINT, FieldDataType.NUMBER],
+      [AthenaFieldType.INTEGER, FieldDataType.NUMBER],
+      [AthenaFieldType.BIGINT, FieldDataType.NUMBER],
+      [AthenaFieldType.FLOAT, FieldDataType.NUMBER],
+      [AthenaFieldType.REAL, FieldDataType.NUMBER],
+      [AthenaFieldType.DOUBLE, FieldDataType.NUMBER],
+      [AthenaFieldType.DECIMAL, FieldDataType.NUMBER],
+      [AthenaFieldType.BOOLEAN, FieldDataType.BOOLEAN],
+      [AthenaFieldType.CHAR, FieldDataType.STRING],
+      [AthenaFieldType.VARCHAR, FieldDataType.STRING],
+      [AthenaFieldType.STRING, FieldDataType.STRING],
+      [AthenaFieldType.BINARY, FieldDataType.STRING],
+      [AthenaFieldType.VARBINARY, FieldDataType.STRING],
+      [AthenaFieldType.DATE, FieldDataType.STRING],
+      [AthenaFieldType.TIME, FieldDataType.STRING],
+      [AthenaFieldType.TIMESTAMP, FieldDataType.STRING],
+      [AthenaFieldType.TIME_WITH_TIME_ZONE, FieldDataType.STRING],
+      [AthenaFieldType.TIMESTAMP_WITH_TIME_ZONE, FieldDataType.STRING],
+      [AthenaFieldType.INTERVAL_YEAR_TO_MONTH, FieldDataType.STRING],
+      [AthenaFieldType.INTERVAL_DAY_TO_SECOND, FieldDataType.STRING],
+      [AthenaFieldType.ARRAY, FieldDataType.STRING],
+      [AthenaFieldType.MAP, FieldDataType.STRING],
+      [AthenaFieldType.STRUCT, FieldDataType.STRING],
+      [AthenaFieldType.ROW, FieldDataType.STRING],
+      [AthenaFieldType.JSON, FieldDataType.STRING],
+    ];
+
+    const databricksCases: Case[] = [
+      [DatabricksFieldType.TINYINT, FieldDataType.NUMBER],
+      [DatabricksFieldType.SMALLINT, FieldDataType.NUMBER],
+      [DatabricksFieldType.INT, FieldDataType.NUMBER],
+      [DatabricksFieldType.BIGINT, FieldDataType.NUMBER],
+      [DatabricksFieldType.FLOAT, FieldDataType.NUMBER],
+      [DatabricksFieldType.DOUBLE, FieldDataType.NUMBER],
+      [DatabricksFieldType.DECIMAL, FieldDataType.NUMBER],
+      [DatabricksFieldType.BOOLEAN, FieldDataType.BOOLEAN],
+      [DatabricksFieldType.STRING, FieldDataType.STRING],
+      [DatabricksFieldType.VARCHAR, FieldDataType.STRING],
+      [DatabricksFieldType.CHAR, FieldDataType.STRING],
+      [DatabricksFieldType.BINARY, FieldDataType.STRING],
+      [DatabricksFieldType.DATE, FieldDataType.STRING],
+      [DatabricksFieldType.TIMESTAMP, FieldDataType.STRING],
+      [DatabricksFieldType.TIMESTAMP_NTZ, FieldDataType.STRING],
+      [DatabricksFieldType.INTERVAL, FieldDataType.STRING],
+      [DatabricksFieldType.ARRAY, FieldDataType.STRING],
+      [DatabricksFieldType.STRUCT, FieldDataType.STRING],
+      [DatabricksFieldType.MAP, FieldDataType.STRING],
+    ];
+
+    describe.each([
+      ['BigQuery', DataStorageType.GOOGLE_BIGQUERY, bigQueryCases],
+      ['Snowflake', DataStorageType.SNOWFLAKE, snowflakeCases],
+      ['Redshift', DataStorageType.AWS_REDSHIFT, redshiftCases],
+      ['Athena', DataStorageType.AWS_ATHENA, athenaCases],
+      ['Databricks', DataStorageType.DATABRICKS, databricksCases],
+    ] as const)('%s storage', (_label, storageType, cases) => {
+      it.each(cases)('%s → %s', (rawType, expected) => {
+        expect(service.mapToLookerStudioDataType(rawType, storageType)).toBe(expected);
+      });
+    });
+  });
+
+  describe('buildSchemaField — native fields (no aggregateFunction)', () => {
+    it('native NUMBER → METRIC + SUM + reaggregatable=true', () => {
+      const header = new ReportDataHeader(
+        'revenue',
+        'Revenue',
+        undefined,
+        BigQueryFieldType.INTEGER
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.NUMBER);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+      expect(field.defaultAggregationType).toBe(AggregationType.SUM);
+      expect(field.semantics?.isReaggregatable).toBe(true);
+    });
+
+    it('native STRING → DIMENSION, no defaultAggregationType', () => {
+      const header = new ReportDataHeader(
+        'country',
+        'Country',
+        undefined,
+        BigQueryFieldType.STRING
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.STRING);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+      expect(field.defaultAggregationType).toBeUndefined();
+    });
+
+    it('native BOOLEAN → DIMENSION', () => {
+      const header = new ReportDataHeader(
+        'is_active',
+        'Is Active',
+        undefined,
+        BigQueryFieldType.BOOLEAN
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.BOOLEAN);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('label falls back to name when alias is absent', () => {
+      const header = new ReportDataHeader('revenue');
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.name).toBe('revenue');
+      expect(field.label).toBe('revenue');
+    });
+
+    it('header without storageFieldType falls back to STRING/DIMENSION', () => {
+      const header = new ReportDataHeader('unknown_col', 'Unknown');
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.STRING);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+      expect(field.defaultAggregationType).toBeUndefined();
+    });
+
+    it('label uses alias when provided', () => {
+      const header = new ReportDataHeader('revenue', 'Total Revenue');
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.label).toBe('Total Revenue');
+    });
+
+    it('description is forwarded when set', () => {
+      const header = new ReportDataHeader(
+        'revenue',
+        undefined,
+        'Sum of sales',
+        BigQueryFieldType.INTEGER
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.description).toBe('Sum of sales');
+    });
+  });
+
+  describe('buildSchemaField — blended fields (with aggregateFunction)', () => {
+    it('SUM/INTEGER → METRIC, NUMBER, defaultAgg=SUM, reagg=true', () => {
+      const header = new ReportDataHeader(
+        'b_revenue',
+        'B Revenue',
+        undefined,
+        BigQueryFieldType.INTEGER,
+        'SUM'
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.NUMBER);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+      expect(field.defaultAggregationType).toBe(AggregationType.SUM);
+      expect(field.semantics?.isReaggregatable).toBe(true);
+    });
+
+    it('COUNT/INTEGER → METRIC, NUMBER, defaultAgg=SUM, reagg=true', () => {
+      const header = new ReportDataHeader(
+        'b_count',
+        'B Count',
+        undefined,
+        BigQueryFieldType.INTEGER,
+        'COUNT'
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.NUMBER);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+      expect(field.defaultAggregationType).toBe(AggregationType.SUM);
+      expect(field.semantics?.isReaggregatable).toBe(true);
+    });
+
+    it('COUNT_DISTINCT/INTEGER → METRIC, NUMBER, no defaultAgg, reagg=false', () => {
+      const header = new ReportDataHeader(
+        'b_cnt_dist',
+        'B Count Distinct',
+        undefined,
+        BigQueryFieldType.INTEGER,
+        'COUNT_DISTINCT'
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.NUMBER);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+      expect(field.defaultAggregationType).toBeUndefined();
+      expect(field.semantics?.isReaggregatable).toBe(false);
+    });
+
+    it('STRING_AGG/STRING → DIMENSION, STRING', () => {
+      const header = new ReportDataHeader(
+        'b_tags',
+        'B Tags',
+        undefined,
+        BigQueryFieldType.STRING,
+        'STRING_AGG'
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.STRING);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('ANY_VALUE/INTEGER → DIMENSION, NUMBER', () => {
+      const header = new ReportDataHeader(
+        'b_any_id',
+        'B Any ID',
+        undefined,
+        BigQueryFieldType.INTEGER,
+        'ANY_VALUE'
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.NUMBER);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('MAX/DATE → DIMENSION, STRING (Looker has no DATE)', () => {
+      const header = new ReportDataHeader(
+        'b_max_date',
+        'B Max Date',
+        undefined,
+        BigQueryFieldType.DATE,
+        'MAX'
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.STRING);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+
+    it('MAX/INTEGER → METRIC, NUMBER, defaultAgg=MAX', () => {
+      const header = new ReportDataHeader(
+        'b_max_revenue',
+        'B Max Revenue',
+        undefined,
+        BigQueryFieldType.INTEGER,
+        'MAX'
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.NUMBER);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+      expect(field.defaultAggregationType).toBe(AggregationType.MAX);
+      expect(field.semantics?.isReaggregatable).toBe(true);
+    });
+
+    it('MIN/INTEGER → METRIC, NUMBER, defaultAgg=MIN', () => {
+      const header = new ReportDataHeader(
+        'b_min_revenue',
+        'B Min Revenue',
+        undefined,
+        BigQueryFieldType.INTEGER,
+        'MIN'
+      );
+      const field = service.buildSchemaField(header, DataStorageType.GOOGLE_BIGQUERY);
+
+      expect(field.dataType).toBe(FieldDataType.NUMBER);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+      expect(field.defaultAggregationType).toBe(AggregationType.MIN);
+    });
+
+    it('Databricks COUNT — header carries DatabricksFieldType.INT, returns METRIC/NUMBER', () => {
+      const header = new ReportDataHeader(
+        'b_count',
+        'B Count',
+        undefined,
+        DatabricksFieldType.INT,
+        'COUNT'
+      );
+      const field = service.buildSchemaField(header, DataStorageType.DATABRICKS);
+
+      expect(field.dataType).toBe(FieldDataType.NUMBER);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.METRIC);
+    });
+
+    it('Redshift STRING_AGG — header carries RedshiftFieldType.VARCHAR, returns DIMENSION/STRING', () => {
+      const header = new ReportDataHeader(
+        'b_tags',
+        'B Tags',
+        undefined,
+        RedshiftFieldType.VARCHAR,
+        'STRING_AGG'
+      );
+      const field = service.buildSchemaField(header, DataStorageType.AWS_REDSHIFT);
+
+      expect(field.dataType).toBe(FieldDataType.STRING);
+      expect(field.semantics?.conceptType).toBe(FieldConceptType.DIMENSION);
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-type-mapper.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-type-mapper.service.ts
@@ -5,20 +5,21 @@ import { DatabricksFieldType } from '../../../data-storage-types/databricks/enum
 import { DataStorageType } from '../../../data-storage-types/enums/data-storage-type.enum';
 import { RedshiftFieldType } from '../../../data-storage-types/redshift/enums/redshift-field-type.enum';
 import { SnowflakeFieldType } from '../../../data-storage-types/snowflake/enums/snowflake-field-type.enum';
+import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
+import { StorageFieldType } from '../../../dto/domain/storage-field-type';
 import { FieldDataType } from '../enums/field-data-type.enum';
+import { SchemaField } from '../schemas/get-schema.schema';
+import { LookerStudioAggregationMapperService } from './looker-studio-aggregation-mapper.service';
 
 @Injectable()
 export class LookerStudioTypeMapperService {
+  constructor(private readonly aggregationMapper: LookerStudioAggregationMapperService) {}
+
   /**
    * Maps data types from storage types to Looker Studio types
    */
   mapToLookerStudioDataType(
-    fieldType:
-      | BigQueryFieldType
-      | AthenaFieldType
-      | SnowflakeFieldType
-      | RedshiftFieldType
-      | DatabricksFieldType,
+    fieldType: StorageFieldType,
     storageType: DataStorageType
   ): FieldDataType {
     if (
@@ -37,6 +38,31 @@ export class LookerStudioTypeMapperService {
     }
     // Fallback for unknown storage types
     return FieldDataType.STRING;
+  }
+
+  buildSchemaField(header: ReportDataHeader, storageType: DataStorageType): SchemaField {
+    const dataType = header.storageFieldType
+      ? this.mapToLookerStudioDataType(header.storageFieldType, storageType)
+      : FieldDataType.STRING;
+    const { conceptType, defaultAggregationType, isReaggregatable } =
+      this.aggregationMapper.mapAggregateFunctionToLookerType(header.aggregateFunction, dataType);
+
+    const field: SchemaField = {
+      name: header.name,
+      label: header.alias || header.name,
+      description: header.description,
+      dataType,
+      semantics: {
+        conceptType,
+        ...(isReaggregatable !== undefined && { isReaggregatable }),
+      },
+    };
+
+    if (defaultAggregationType !== undefined) {
+      field.defaultAggregationType = defaultAggregationType;
+    }
+
+    return field;
   }
 
   /**

--- a/apps/backend/src/data-marts/data-storage-types/field-aggregation.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/field-aggregation.spec.ts
@@ -1,0 +1,83 @@
+import { computeEffectiveType } from './field-aggregation';
+import { DataStorageType } from './enums/data-storage-type.enum';
+import { BigQueryFieldType } from './bigquery/enums/bigquery-field-type.enum';
+import { AthenaFieldType } from './athena/enums/athena-field-type.enum';
+import { SnowflakeFieldType } from './snowflake/enums/snowflake-field-type.enum';
+import { RedshiftFieldType } from './redshift/enums/redshift-field-type.enum';
+import { DatabricksFieldType } from './databricks/enums/databricks-field-type.enum';
+
+describe('computeEffectiveType', () => {
+  describe('passes raw type through when no aggregation', () => {
+    it('undefined aggFunc returns rawType as-is', () => {
+      expect(
+        computeEffectiveType(BigQueryFieldType.STRING, undefined, DataStorageType.GOOGLE_BIGQUERY)
+      ).toBe(BigQueryFieldType.STRING);
+      expect(
+        computeEffectiveType(SnowflakeFieldType.INTEGER, undefined, DataStorageType.SNOWFLAKE)
+      ).toBe(SnowflakeFieldType.INTEGER);
+    });
+  });
+
+  describe('passes raw type through for SUM/MIN/MAX/ANY_VALUE', () => {
+    it('SUM on INTEGER → INTEGER', () => {
+      expect(
+        computeEffectiveType(BigQueryFieldType.INTEGER, 'SUM', DataStorageType.GOOGLE_BIGQUERY)
+      ).toBe(BigQueryFieldType.INTEGER);
+    });
+
+    it('MAX on DATE → DATE', () => {
+      expect(
+        computeEffectiveType(BigQueryFieldType.DATE, 'MAX', DataStorageType.GOOGLE_BIGQUERY)
+      ).toBe(BigQueryFieldType.DATE);
+    });
+
+    it('MIN on FLOAT → FLOAT', () => {
+      expect(computeEffectiveType(SnowflakeFieldType.FLOAT, 'MIN', DataStorageType.SNOWFLAKE)).toBe(
+        SnowflakeFieldType.FLOAT
+      );
+    });
+
+    it('ANY_VALUE on INTEGER → INTEGER', () => {
+      expect(
+        computeEffectiveType(RedshiftFieldType.INTEGER, 'ANY_VALUE', DataStorageType.AWS_REDSHIFT)
+      ).toBe(RedshiftFieldType.INTEGER);
+    });
+  });
+
+  describe('COUNT and COUNT_DISTINCT yield storage-specific integer type', () => {
+    it.each([
+      [DataStorageType.GOOGLE_BIGQUERY, BigQueryFieldType.STRING, BigQueryFieldType.INTEGER],
+      [DataStorageType.LEGACY_GOOGLE_BIGQUERY, BigQueryFieldType.STRING, BigQueryFieldType.INTEGER],
+      [DataStorageType.AWS_ATHENA, AthenaFieldType.STRING, AthenaFieldType.INTEGER],
+      [DataStorageType.SNOWFLAKE, SnowflakeFieldType.STRING, SnowflakeFieldType.INTEGER],
+      [DataStorageType.AWS_REDSHIFT, RedshiftFieldType.VARCHAR, RedshiftFieldType.INTEGER],
+      [DataStorageType.DATABRICKS, DatabricksFieldType.STRING, DatabricksFieldType.INT],
+    ])('COUNT in %s → %s', (storageType, rawType, expected) => {
+      expect(computeEffectiveType(rawType, 'COUNT', storageType)).toBe(expected);
+    });
+
+    it.each([
+      [DataStorageType.GOOGLE_BIGQUERY, BigQueryFieldType.STRING, BigQueryFieldType.INTEGER],
+      [DataStorageType.LEGACY_GOOGLE_BIGQUERY, BigQueryFieldType.STRING, BigQueryFieldType.INTEGER],
+      [DataStorageType.AWS_ATHENA, AthenaFieldType.STRING, AthenaFieldType.INTEGER],
+      [DataStorageType.SNOWFLAKE, SnowflakeFieldType.STRING, SnowflakeFieldType.INTEGER],
+      [DataStorageType.AWS_REDSHIFT, RedshiftFieldType.VARCHAR, RedshiftFieldType.INTEGER],
+      [DataStorageType.DATABRICKS, DatabricksFieldType.STRING, DatabricksFieldType.INT],
+    ])('COUNT_DISTINCT in %s → %s', (storageType, rawType, expected) => {
+      expect(computeEffectiveType(rawType, 'COUNT_DISTINCT', storageType)).toBe(expected);
+    });
+  });
+
+  describe('STRING_AGG yields storage-specific string type', () => {
+    it.each([
+      [DataStorageType.GOOGLE_BIGQUERY, BigQueryFieldType.STRING, BigQueryFieldType.STRING],
+      [DataStorageType.LEGACY_GOOGLE_BIGQUERY, BigQueryFieldType.STRING, BigQueryFieldType.STRING],
+      [DataStorageType.AWS_ATHENA, AthenaFieldType.STRING, AthenaFieldType.STRING],
+      [DataStorageType.SNOWFLAKE, SnowflakeFieldType.STRING, SnowflakeFieldType.STRING],
+      [DataStorageType.AWS_REDSHIFT, RedshiftFieldType.VARCHAR, RedshiftFieldType.VARCHAR],
+      [DataStorageType.DATABRICKS, DatabricksFieldType.STRING, DatabricksFieldType.STRING],
+    ])('STRING_AGG in %s → %s', (storageType, rawType, expected) => {
+      expect(computeEffectiveType(rawType, 'STRING_AGG', storageType)).toBe(expected);
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/field-aggregation.ts
+++ b/apps/backend/src/data-marts/data-storage-types/field-aggregation.ts
@@ -1,0 +1,64 @@
+import { AthenaFieldType } from './athena/enums/athena-field-type.enum';
+import { BigQueryFieldType } from './bigquery/enums/bigquery-field-type.enum';
+import { DatabricksFieldType } from './databricks/enums/databricks-field-type.enum';
+import { DataStorageType } from './enums/data-storage-type.enum';
+import { RedshiftFieldType } from './redshift/enums/redshift-field-type.enum';
+import { SnowflakeFieldType } from './snowflake/enums/snowflake-field-type.enum';
+import { AggregateFunction } from '../dto/schemas/aggregate-function.schema';
+import { StorageFieldType } from '../dto/domain/storage-field-type';
+
+export function computeEffectiveType(
+  rawType: StorageFieldType,
+  aggFunc: AggregateFunction | undefined,
+  storageType: DataStorageType
+): StorageFieldType {
+  if (!aggFunc) return rawType;
+  switch (aggFunc) {
+    case 'COUNT':
+    case 'COUNT_DISTINCT':
+      return getIntegerType(storageType);
+    case 'STRING_AGG':
+      return getStringType(storageType);
+    case 'SUM':
+    case 'MIN':
+    case 'MAX':
+    case 'ANY_VALUE':
+      return rawType;
+    default: {
+      const _exhaustive: never = aggFunc;
+      return _exhaustive;
+    }
+  }
+}
+
+function getIntegerType(storageType: DataStorageType): StorageFieldType {
+  switch (storageType) {
+    case DataStorageType.GOOGLE_BIGQUERY:
+    case DataStorageType.LEGACY_GOOGLE_BIGQUERY:
+      return BigQueryFieldType.INTEGER;
+    case DataStorageType.AWS_ATHENA:
+      return AthenaFieldType.INTEGER;
+    case DataStorageType.SNOWFLAKE:
+      return SnowflakeFieldType.INTEGER;
+    case DataStorageType.AWS_REDSHIFT:
+      return RedshiftFieldType.INTEGER;
+    case DataStorageType.DATABRICKS:
+      return DatabricksFieldType.INT;
+  }
+}
+
+function getStringType(storageType: DataStorageType): StorageFieldType {
+  switch (storageType) {
+    case DataStorageType.GOOGLE_BIGQUERY:
+    case DataStorageType.LEGACY_GOOGLE_BIGQUERY:
+      return BigQueryFieldType.STRING;
+    case DataStorageType.AWS_ATHENA:
+      return AthenaFieldType.STRING;
+    case DataStorageType.SNOWFLAKE:
+      return SnowflakeFieldType.STRING;
+    case DataStorageType.AWS_REDSHIFT:
+      return RedshiftFieldType.VARCHAR;
+    case DataStorageType.DATABRICKS:
+      return DatabricksFieldType.STRING;
+  }
+}

--- a/apps/backend/src/data-marts/dto/domain/report-data-header.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/report-data-header.dto.ts
@@ -1,8 +1,5 @@
-import { BigQueryFieldType } from '../../data-storage-types/bigquery/enums/bigquery-field-type.enum';
-import { AthenaFieldType } from '../../data-storage-types/athena/enums/athena-field-type.enum';
-import { SnowflakeFieldType } from '../../data-storage-types/snowflake/enums/snowflake-field-type.enum';
-import { RedshiftFieldType } from '../../data-storage-types/redshift/enums/redshift-field-type.enum';
-import { DatabricksFieldType } from '../../data-storage-types/databricks/enums/databricks-field-type.enum';
+import { AggregateFunction } from '../schemas/aggregate-function.schema';
+import { StorageFieldType } from './storage-field-type';
 
 /**
  * Represents a single report data header with metadata
@@ -27,11 +24,11 @@ export class ReportDataHeader {
     /**
      * The storage field type
      */
-    public readonly storageFieldType?:
-      | BigQueryFieldType
-      | AthenaFieldType
-      | SnowflakeFieldType
-      | RedshiftFieldType
-      | DatabricksFieldType
+    public readonly storageFieldType?: StorageFieldType,
+
+    /**
+     * The aggregate function applied to the field (if any)
+     */
+    public readonly aggregateFunction?: AggregateFunction
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/storage-field-type.ts
+++ b/apps/backend/src/data-marts/dto/domain/storage-field-type.ts
@@ -1,0 +1,12 @@
+import { AthenaFieldType } from '../../data-storage-types/athena/enums/athena-field-type.enum';
+import { BigQueryFieldType } from '../../data-storage-types/bigquery/enums/bigquery-field-type.enum';
+import { DatabricksFieldType } from '../../data-storage-types/databricks/enums/databricks-field-type.enum';
+import { RedshiftFieldType } from '../../data-storage-types/redshift/enums/redshift-field-type.enum';
+import { SnowflakeFieldType } from '../../data-storage-types/snowflake/enums/snowflake-field-type.enum';
+
+export type StorageFieldType =
+  | BigQueryFieldType
+  | AthenaFieldType
+  | SnowflakeFieldType
+  | RedshiftFieldType
+  | DatabricksFieldType;

--- a/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
@@ -297,6 +297,94 @@ describe('BlendedReportDataService', () => {
       expect(result.columnFilter).toEqual(columnConfig);
     });
 
+    describe('blendedDataHeaders carry effective type and aggregateFunction', () => {
+      function makeSimpleSchema(
+        fieldName: string,
+        type: string,
+        agg: BlendedFieldDto['aggregateFunction']
+      ): BlendableSchemaDto {
+        const field = new BlendedFieldDto();
+        field.name = fieldName;
+        field.sourceRelationshipId = 'rel-1';
+        field.sourceDataMartId = 'dm-target';
+        field.sourceDataMartTitle = 'Target';
+        field.targetAlias = 'alias_1';
+        field.originalFieldName = fieldName;
+        field.type = type;
+        field.isHidden = false;
+        field.aggregateFunction = agg;
+        field.transitiveDepth = 1;
+        field.aliasPath = 'alias_1';
+        field.outputPrefix = 'alias_1';
+
+        return {
+          nativeFields: [],
+          availableSources: [
+            {
+              aliasPath: 'alias_1',
+              title: 'Target',
+              defaultAlias: 'alias_1',
+              depth: 1,
+              fieldCount: 1,
+              isIncluded: true,
+              relationshipId: 'rel-1',
+              dataMartId: 'dm-target',
+            },
+          ],
+          blendedFields: [field],
+        };
+      }
+
+      async function resolveHeader(
+        fieldName: string,
+        type: string,
+        agg: BlendedFieldDto['aggregateFunction']
+      ) {
+        blendableSchemaService.computeBlendableSchema.mockResolvedValue(
+          makeSimpleSchema(fieldName, type, agg)
+        );
+        relationshipService.findBySourceDataMartId.mockResolvedValue([
+          {
+            id: 'rel-1',
+            targetAlias: 'alias_1',
+            sourceDataMart: { id: 'dm-1' },
+            targetDataMart: { id: 'dm-target' },
+            joinConditions: [],
+          } as unknown as DataMartRelationship,
+        ]);
+        tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
+        blendedQueryBuilderFacade.buildBlendedQuery.mockResolvedValue('SELECT ...');
+
+        const report = makeReport({ columnConfig: [fieldName] });
+        const result = await service.resolveBlendingDecision(report);
+        return result.blendedDataHeaders?.[0];
+      }
+
+      it('SUM/INTEGER: effective storageFieldType=INTEGER, aggregateFunction=SUM', async () => {
+        const header = await resolveHeader('f', 'INTEGER', 'SUM');
+        expect(header?.storageFieldType).toBe('INTEGER');
+        expect(header?.aggregateFunction).toBe('SUM');
+      });
+
+      it('COUNT/STRING: effective storageFieldType=INTEGER, aggregateFunction=COUNT', async () => {
+        const header = await resolveHeader('f', 'STRING', 'COUNT');
+        expect(header?.storageFieldType).toBe('INTEGER');
+        expect(header?.aggregateFunction).toBe('COUNT');
+      });
+
+      it('STRING_AGG/STRING: effective storageFieldType=STRING, aggregateFunction=STRING_AGG', async () => {
+        const header = await resolveHeader('f', 'STRING', 'STRING_AGG');
+        expect(header?.storageFieldType).toBe('STRING');
+        expect(header?.aggregateFunction).toBe('STRING_AGG');
+      });
+
+      it('MAX/DATE: effective storageFieldType=DATE, aggregateFunction=MAX', async () => {
+        const header = await resolveHeader('f', 'DATE', 'MAX');
+        expect(header?.storageFieldType).toBe('DATE');
+        expect(header?.aggregateFunction).toBe('MAX');
+      });
+    });
+
     it('sets parentAlias to main for direct relationships (transitiveDepth=1)', async () => {
       const columnConfig = ['blended_field'];
       const report = makeReport({ columnConfig });

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -7,6 +7,9 @@ import { Report } from '../entities/report.entity';
 import { ResolvedRelationshipChain } from '../data-storage-types/interfaces/blended-query-builder.interface';
 import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
 import { AvailableSourceDto, BlendedFieldDto } from '../dto/domain/blendable-schema.dto';
+import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
+import { StorageFieldType } from '../dto/domain/storage-field-type';
+import { computeEffectiveType } from '../data-storage-types/field-aggregation';
 import { BlendingDecision } from '../dto/domain/blending-decision.dto';
 import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
 import { PublicOriginService } from '../../common/config/public-origin.service';
@@ -37,7 +40,11 @@ export class BlendedReportDataService {
 
     const blendedFieldsByName = new Map(blendableSchema.blendedFields.map(f => [f.name, f]));
     const hasBlendedColumns = columnConfig.some(col => blendedFieldsByName.has(col));
-    const blendedDataHeaders = this.buildBlendedDataHeaders(columnConfig, blendedFieldsByName);
+    const blendedDataHeaders = this.buildBlendedDataHeaders(
+      columnConfig,
+      blendedFieldsByName,
+      dataMart.storage.type
+    );
 
     if (!hasBlendedColumns) {
       return {
@@ -92,22 +99,25 @@ export class BlendedReportDataService {
 
   private buildBlendedDataHeaders(
     columnConfig: string[],
-    blendedFieldsByName: Map<string, BlendedFieldDto>
+    blendedFieldsByName: Map<string, BlendedFieldDto>,
+    storageType: DataStorageType
   ): ReportDataHeader[] {
     const headers: ReportDataHeader[] = [];
     for (const col of columnConfig) {
       const blendedField = blendedFieldsByName.get(col);
       if (blendedField) {
+        const effectiveType = computeEffectiveType(
+          blendedField.type as StorageFieldType,
+          blendedField.aggregateFunction,
+          storageType
+        );
         headers.push(
           new ReportDataHeader(
             blendedField.name,
             `${blendedField.outputPrefix} ${blendedField.alias || blendedField.originalFieldName}`,
             blendedField.description || undefined,
-            // Blended field types come from the target data mart schema.
-            // They are not typed as the concrete storage-type enum here,
-            // so we leave storageFieldType undefined — destinations only
-            // use it for formatting hints.
-            undefined
+            effectiveType,
+            blendedField.aggregateFunction
           )
         );
       }

--- a/apps/backend/test/looker-studio-connector.e2e-spec.ts
+++ b/apps/backend/test/looker-studio-connector.e2e-spec.ts
@@ -16,7 +16,12 @@ import { DataMartSchemaProviderFacade } from '../src/data-marts/data-storage-typ
 import { ReportDataHeader } from '../src/data-marts/dto/domain/report-data-header.dto';
 import { ReportDataBatch } from '../src/data-marts/dto/domain/report-data-batch.dto';
 import { ReportDataDescription } from '../src/data-marts/dto/domain/report-data-description.dto';
+import { BlendingDecision } from '../src/data-marts/dto/domain/blending-decision.dto';
 import { BigQueryFieldType } from '../src/data-marts/data-storage-types/bigquery/enums/bigquery-field-type.enum';
+import { AggregateFunction } from '../src/data-marts/dto/schemas/aggregate-function.schema';
+import { FieldDataType } from '../src/data-marts/data-destination-types/looker-studio-connector/enums/field-data-type.enum';
+import { FieldConceptType } from '../src/data-marts/data-destination-types/looker-studio-connector/enums/field-concept-type.enum';
+import { AggregationType } from '../src/data-marts/data-destination-types/looker-studio-connector/enums/aggregation-type.enum';
 
 // ---------------------------------------------------------------------------
 // Mock data for the in-memory reader
@@ -32,24 +37,37 @@ const MOCK_ROWS: unknown[][] = [
   ['2024-01-03', 75.25],
 ];
 
-const mockReader = {
-  prepareReportData: jest
-    .fn()
-    .mockResolvedValue(new ReportDataDescription(MOCK_HEADERS, MOCK_ROWS.length)),
-  readReportDataBatch: jest.fn().mockResolvedValue(new ReportDataBatch(MOCK_ROWS, null)),
-  finalize: jest.fn().mockResolvedValue(undefined),
-  getState: jest.fn().mockReturnValue(null),
-  initFromState: jest.fn().mockResolvedValue(undefined),
-  getType: jest.fn().mockReturnValue('GOOGLE_BIGQUERY'),
-};
+function buildMockReader(headers: ReportDataHeader[], rows: unknown[][]) {
+  return {
+    prepareReportData: jest.fn().mockResolvedValue(new ReportDataDescription(headers, rows.length)),
+    readReportDataBatch: jest.fn().mockResolvedValue(new ReportDataBatch(rows, null)),
+    finalize: jest.fn().mockResolvedValue(undefined),
+    getState: jest.fn().mockReturnValue(null),
+    initFromState: jest.fn().mockResolvedValue(undefined),
+    getType: jest.fn().mockReturnValue('GOOGLE_BIGQUERY'),
+  };
+}
+
+function buildMockCachedReader(
+  reader: ReturnType<typeof buildMockReader>,
+  headers: ReportDataHeader[],
+  rows: unknown[][],
+  blendingDecision: BlendingDecision = { needsBlending: false }
+) {
+  return {
+    reader,
+    dataDescription: new ReportDataDescription(headers, rows.length),
+    fromCache: false,
+    blendingDecision,
+  };
+}
+
+const mockReader = buildMockReader(MOCK_HEADERS, MOCK_ROWS);
 
 const mockCacheService = {
-  getOrCreateCachedReader: jest.fn().mockResolvedValue({
-    reader: mockReader,
-    dataDescription: new ReportDataDescription(MOCK_HEADERS, MOCK_ROWS.length),
-    fromCache: false,
-    blendingDecision: { needsBlending: false },
-  }),
+  getOrCreateCachedReader: jest
+    .fn()
+    .mockResolvedValue(buildMockCachedReader(mockReader, MOCK_HEADERS, MOCK_ROWS)),
 };
 
 const mockSchemaProviderFacade = {
@@ -132,12 +150,9 @@ describe('Looker Studio Connector (e2e)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Re-set default mock return values after clearAllMocks
-    mockCacheService.getOrCreateCachedReader.mockResolvedValue({
-      reader: mockReader,
-      dataDescription: new ReportDataDescription(MOCK_HEADERS, MOCK_ROWS.length),
-      fromCache: false,
-      blendingDecision: { needsBlending: false },
-    });
+    mockCacheService.getOrCreateCachedReader.mockResolvedValue(
+      buildMockCachedReader(mockReader, MOCK_HEADERS, MOCK_ROWS)
+    );
     mockReader.readReportDataBatch.mockResolvedValue(new ReportDataBatch(MOCK_ROWS, null));
     mockSchemaProviderFacade.getActualDataMartSchema.mockResolvedValue({
       type: 'bigquery-data-mart-schema',
@@ -500,6 +515,187 @@ describe('Looker Studio Connector (e2e)', () => {
         .send('invalid.jwt.token');
 
       expect(res.status).toBe(401);
+    });
+  });
+
+  describe('Blended data marts: types and aggregations', () => {
+    function seedReader(headers: ReportDataHeader[], rows: unknown[][]): void {
+      const reader = buildMockReader(headers, rows);
+      mockCacheService.getOrCreateCachedReader.mockResolvedValue(
+        buildMockCachedReader(reader, headers, rows, { needsBlending: true })
+      );
+    }
+
+    function getSchemaRequest() {
+      return postLooker('/api/external/looker/get-schema', {
+        connectionConfig: {
+          deploymentUrl: 'http://localhost',
+          destinationId,
+          destinationSecretKey,
+        },
+        request: { configParams: { destinationId, reportId } },
+      });
+    }
+
+    function getDataRequest(fieldNames: string[]) {
+      return postLooker('/api/external/looker/get-data', {
+        connectionConfig: {
+          deploymentUrl: 'http://localhost',
+          destinationId,
+          destinationSecretKey,
+        },
+        request: {
+          configParams: { destinationId, reportId },
+          fields: fieldNames.map(name => ({ name })),
+        },
+      });
+    }
+
+    type AggCase = {
+      label: string;
+      storageFieldType: BigQueryFieldType;
+      aggregateFunction?: AggregateFunction;
+      expectedDataType: FieldDataType;
+      expectedConceptType: FieldConceptType;
+      expectedDefaultAggregation?: AggregationType;
+      expectedIsReaggregatable?: boolean;
+    };
+
+    const aggCases: AggCase[] = [
+      {
+        label: 'native NUMBER',
+        storageFieldType: BigQueryFieldType.INTEGER,
+        expectedDataType: FieldDataType.NUMBER,
+        expectedConceptType: FieldConceptType.METRIC,
+        expectedDefaultAggregation: AggregationType.SUM,
+        expectedIsReaggregatable: true,
+      },
+      {
+        label: 'native STRING',
+        storageFieldType: BigQueryFieldType.STRING,
+        expectedDataType: FieldDataType.STRING,
+        expectedConceptType: FieldConceptType.DIMENSION,
+      },
+      {
+        label: 'COUNT/INTEGER',
+        storageFieldType: BigQueryFieldType.INTEGER,
+        aggregateFunction: 'COUNT',
+        expectedDataType: FieldDataType.NUMBER,
+        expectedConceptType: FieldConceptType.METRIC,
+        expectedDefaultAggregation: AggregationType.SUM,
+        expectedIsReaggregatable: true,
+      },
+      {
+        label: 'COUNT_DISTINCT/INTEGER',
+        storageFieldType: BigQueryFieldType.INTEGER,
+        aggregateFunction: 'COUNT_DISTINCT',
+        expectedDataType: FieldDataType.NUMBER,
+        expectedConceptType: FieldConceptType.METRIC,
+        expectedIsReaggregatable: false,
+      },
+      {
+        label: 'STRING_AGG',
+        storageFieldType: BigQueryFieldType.STRING,
+        aggregateFunction: 'STRING_AGG',
+        expectedDataType: FieldDataType.STRING,
+        expectedConceptType: FieldConceptType.DIMENSION,
+      },
+      {
+        label: 'ANY_VALUE/INTEGER',
+        storageFieldType: BigQueryFieldType.INTEGER,
+        aggregateFunction: 'ANY_VALUE',
+        expectedDataType: FieldDataType.NUMBER,
+        expectedConceptType: FieldConceptType.DIMENSION,
+      },
+      {
+        label: 'MAX/INTEGER',
+        storageFieldType: BigQueryFieldType.INTEGER,
+        aggregateFunction: 'MAX',
+        expectedDataType: FieldDataType.NUMBER,
+        expectedConceptType: FieldConceptType.METRIC,
+        expectedDefaultAggregation: AggregationType.MAX,
+        expectedIsReaggregatable: true,
+      },
+      {
+        label: 'MAX/DATE',
+        storageFieldType: BigQueryFieldType.DATE,
+        aggregateFunction: 'MAX',
+        expectedDataType: FieldDataType.STRING,
+        expectedConceptType: FieldConceptType.DIMENSION,
+      },
+      {
+        label: 'SUM/INTEGER',
+        storageFieldType: BigQueryFieldType.INTEGER,
+        aggregateFunction: 'SUM',
+        expectedDataType: FieldDataType.NUMBER,
+        expectedConceptType: FieldConceptType.METRIC,
+        expectedDefaultAggregation: AggregationType.SUM,
+        expectedIsReaggregatable: true,
+      },
+    ];
+
+    it.each(aggCases)('$label → schema reflects type and aggregation', async testCase => {
+      seedReader(
+        [
+          new ReportDataHeader(
+            'field',
+            'Field',
+            undefined,
+            testCase.storageFieldType,
+            testCase.aggregateFunction
+          ),
+        ],
+        [[null]]
+      );
+
+      const schemaRes = await getSchemaRequest();
+      expect(schemaRes.status).toBe(200);
+      const [field] = schemaRes.body.schema;
+
+      expect(field.dataType).toBe(testCase.expectedDataType);
+      expect(field.semantics.conceptType).toBe(testCase.expectedConceptType);
+      expect(field.defaultAggregationType).toBe(testCase.expectedDefaultAggregation);
+      expect(field.semantics.isReaggregatable).toBe(testCase.expectedIsReaggregatable);
+    });
+
+    it('getSchema and getData agree on { name, dataType } for the same headers', async () => {
+      const headers = [
+        new ReportDataHeader('country', 'Country', undefined, BigQueryFieldType.STRING),
+        new ReportDataHeader(
+          'orders_count',
+          'Orders Count',
+          undefined,
+          BigQueryFieldType.INTEGER,
+          'COUNT'
+        ),
+        new ReportDataHeader('tags', 'Tags', undefined, BigQueryFieldType.STRING, 'STRING_AGG'),
+        new ReportDataHeader('last_seen', 'Last Seen', undefined, BigQueryFieldType.DATE, 'MAX'),
+        new ReportDataHeader(
+          'max_revenue',
+          'Max Revenue',
+          undefined,
+          BigQueryFieldType.INTEGER,
+          'MAX'
+        ),
+      ];
+      seedReader(headers, [['US', 10, 'a,b', '2024-01-01', 999]]);
+
+      const schemaRes = await getSchemaRequest();
+      expect(schemaRes.status).toBe(200);
+
+      const dataRes = await getDataRequest(headers.map(h => h.name));
+      expect(dataRes.status).toBe(200);
+
+      const schemaPairs = schemaRes.body.schema.map((f: Record<string, unknown>) => ({
+        name: f.name,
+        dataType: f.dataType,
+      }));
+      const dataPairs = dataRes.body.schema.map((f: Record<string, unknown>) => ({
+        name: f.name,
+        dataType: f.dataType,
+      }));
+
+      expect(dataPairs).toEqual(schemaPairs);
     });
   });
 });

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
@@ -66,8 +66,8 @@ export function useLookerStudioReportForm({
       if (initialReport) {
         // Only update the destination config, keep existing title and destination
         await updateReport(initialReport.id, {
-          title: initialReport.title, // Keep existing
-          dataDestinationId: initialReport.dataDestination.id, // Keep existing
+          title: initialReport.title || DEFAULT_REPORT_TITLE,
+          dataDestinationId: initialReport.dataDestination.id,
           destinationConfig,
           ...(pendingOwnerIdsRef?.current != null ? { ownerIds: pendingOwnerIdsRef.current } : {}),
           columnConfig: data.columnConfig,


### PR DESCRIPTION
## Summary

When a Data Mart pulls fields from joined Data Marts (blended fields), the Looker Studio connector now reports correct column types and respects the user-selected aggregation function for each blended field.

Before this change:
- `COUNT(string_field)` arrived as **STRING / DIMENSION** (should be **NUMBER / METRIC**).
- `COUNT_DISTINCT(...)` was also **STRING / DIMENSION** and was marked re-aggregatable — Looker would sum per-group distincts and inflate totals.
- `MAX(integer)` always produced `defaultAggregationType=SUM` instead of `MAX`.
- `STRING_AGG(...)` / `ANY_VALUE(...)` tried to behave as metrics.
- `getSchema` and `getData` duplicated the type-mapping logic and could drift apart (two independent sources of truth).

After this change: a single source of truth + storage-aware effective type + explicit mapping of aggregation to Looker concept.

## Approach

**Hybrid: effective type on the produce side + aggregateFunction propagated separately.**

1. **`computeEffectiveType(rawType, aggFunc, storageType): StorageFieldType`** — pure function returning the storage-specific value type after aggregation:

   | `aggFunc` | Effective type |
   |---|---|
   | `undefined` | `rawType` |
   | `COUNT` / `COUNT_DISTINCT` | INTEGER (or `INT` for Databricks) |
   | `STRING_AGG` | STRING (or `VARCHAR` for Redshift) |
   | `SUM` / `MIN` / `MAX` / `ANY_VALUE` | `rawType` |

2. **`ReportDataHeader.aggregateFunction`** — new field, propagated alongside the type. Type alone is not enough: `MAX(int)`, `COUNT_DISTINCT`, `ANY_VALUE` all yield INTEGER but must behave differently in Looker.

3. **`LookerStudioAggregationMapperService.mapAggregateFunctionToLookerType(aggFunc, dataType)`** — exhaustive switch:

   | backend `AggregateFunction` | `defaultAggregationType` | `isReaggregatable` | conceptType |
   |---|---|---|---|
   | `SUM` | `SUM` | `true` | METRIC if NUMBER, otherwise DIMENSION |
   | `COUNT` | `SUM` | `true` | METRIC |
   | `COUNT_DISTINCT` | — | `false` | METRIC |
   | `MIN` / `MAX` | `MIN` / `MAX` | `true` | METRIC if NUMBER, otherwise DIMENSION |
   | `STRING_AGG` / `ANY_VALUE` | — | — | DIMENSION |

   ⃰ `COUNT → SUM` because summing counts across non-overlapping groups is correct. `COUNT_DISTINCT → reagg=false` because `SUM(COUNT_DISTINCT_per_group) ≠ COUNT_DISTINCT_overall`.

4. **`LookerStudioTypeMapperService.buildSchemaField(header, storageType)`** — single source of truth shared by `getSchemaFields` and `buildResponseSchema`. Guarantees `getSchema.dataType === getData.schema.dataType` (locked in by an e2e contract test).

5. **`StorageFieldType` union alias** — deduplicates the 5-member union previously copy-pasted in `report-data-header.dto.ts`, `sheet-values-formatter.ts`, and the `mapToLookerStudioDataType` signature.

Native (no `aggregateFunction`) behaviour is **unchanged**: `NUMBER → METRIC + SUM + reagg=true`, otherwise DIMENSION.