### PR TITLE
feat(idp-owox-better-auth): add owox cloud, add domain normalization

### DIFF
--- a/packages/idp-owox-better-auth/src/core/onboarding-constants.ts
+++ b/packages/idp-owox-better-auth/src/core/onboarding-constants.ts
@@ -38,6 +38,8 @@ export const PRIMARY_STORAGE_ANSWER = {
   SNOWFLAKE: 'snowflake',
   DATABRICKS: 'databricks',
   AZURE_SYNAPSE: 'azure_synapse',
+  OWOX_CLOUD_EU: 'owox_cloud_eu',
+  OWOX_CLOUD_US: 'owox_cloud_us',
   DONT_KNOW: 'dont_know',
   OTHER: 'other',
 } as const;
@@ -83,6 +85,8 @@ export const PRIMARY_STORAGE_OPTIONS: OnboardingOption[] = [
   { value: PRIMARY_STORAGE_ANSWER.SNOWFLAKE, label: 'Snowflake' },
   { value: PRIMARY_STORAGE_ANSWER.DATABRICKS, label: 'Databricks' },
   { value: PRIMARY_STORAGE_ANSWER.AZURE_SYNAPSE, label: 'Azure Synapse' },
+  { value: PRIMARY_STORAGE_ANSWER.OWOX_CLOUD_EU, label: 'OWOX Cloud (EU)' },
+  { value: PRIMARY_STORAGE_ANSWER.OWOX_CLOUD_US, label: 'OWOX Cloud (US)' },
   { value: PRIMARY_STORAGE_ANSWER.DONT_KNOW, label: "Don't know" },
   { value: PRIMARY_STORAGE_ANSWER.OTHER, label: 'Other' },
 ];

--- a/packages/idp-owox-better-auth/src/resources/templates/pages/onboarding.ejs
+++ b/packages/idp-owox-better-auth/src/resources/templates/pages/onboarding.ejs
@@ -1,5 +1,6 @@
 <!-- Onboarding Questionnaire (TypeForm-style) -->
 <%
+const OWOX_LOGO_DATA_URL = "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDUiIGhlaWdodD0iMzYiIHZpZXdCb3g9IjAgMCA0NSAzNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzEwMjZfOSkiPgo8cGF0aCBkPSJNNDEuMDEyNCAyLjcwODA4QzQyLjU4NDEgNC4yODA4NiA0My4yMzA3IDYuOTMxMzQgNDMuMjMwNyA2LjkzMTM0QzQzLjIzMDcgNi45MzEzNCA0NC4xOTI0IDEyLjI2ODYgNDQuMTkyNCAxOS41MTUyQzQ0LjE5MjQgOS4yNTc3OCA0MC43MTI2IDcuNDk3MSAyOC42MTY5IDcuNDk3MUgxNy40NjIyQzExLjI3MDIgNy40OTcxIDExLjY4OSAxMy43MiAxMS4yNzAyIDE2LjY4MTVMMTAuNzYxNCAyMS4xNTZDMTAuNTE3MSAyNS44NjM1IDExLjMzNDUgMjguNzgwNSAxNi4xNjQ0IDI4Ljc4MDVDNi4wOTM3MiAyOC43ODA1IDAuNDk5OTg3IDMwLjQyOTQgMC41IDE2LjIzMjZDMC40OTk5OTQgOS44MDcwOCAxLjQ2ODkzIDYuOTMxMzQgMS40Njg5MyA2LjkzMTM0QzEuNDY4OTMgNi45MzEzNCAyLjExNTQ4IDQuMjgwODYgMy42OTA0OCAyLjcwODA4QzUuMjY1NDkgMS4xMzM0OSA3LjU5OTggMC45NzU0NTMgNy41OTk4IDAuOTc1NDUzQzcuNTk5OCAwLjk3NTQ1MyAxMi40MTk1IDAuMjUgMjEuOTQwMyAwLjI1QzMxLjQ2MTIgMC4yNSAzNi44NCAwLjk3NTQ1MyAzNi44NCAwLjk3NTQ1M0MzNi44NCAwLjk3NTQ1MyAzOS40MzU5IDEuMTMzNDkgNDEuMDEyNCAyLjcwODA4WiIgZmlsbD0idXJsKCNwYWludDBfbGluZWFyXzEwMjZfOSkiLz4KPHBhdGggZD0iTTQ0LjE5MDcgMTkuODQxMkM0NC4xOTEzIDE5Ljk2OTUgNDQuMTkxNiAyMC4wOTg5IDQ0LjE5MTYgMjAuMjI5NUM0NC4xOTE2IDI2LjM4MzcgNDMuMjc1NCAyOC43NzkgNDMuMjc1NCAyOC43NzlDNDMuMjc1NCAyOC43NzkgNDIuNTU4NCAzMS42ODA4IDQxLjMzNDMgMzIuOTM0M0MzOS4zOTE4IDM0LjkyMzMgMzcuMzE0NCAzNS4wMzQzIDM3LjMxNDQgMzUuMDM0M0MzNy4zMTQ0IDM1LjAzNDMgMzIuODQ1MyAzNS43NSAyMy4yMjkgMzUuNzVDMTQuMDAzMSAzNS43NSA3Ljg1OTIxIDM1LjAzODcgNy44NTkyMSAzNS4wMzg3QzcuODU5MjEgMzUuMDM4NyA1LjI2NTA0IDM0Ljg3OTUgMy42OTAwNCAzMy4zMDY0QzIuMTE1MDQgMzEuNzMwNyAxLjQ2ODQ5IDI4Ljc3OSAxLjQ2ODQ5IDI4Ljc3OUMxLjQ2ODQ5IDI4Ljc3OSAwLjUgMjIuNzE2MyAwLjUgMTYuMDc5NEMwLjQ5OTk4OCAyOC44NzUyIDUuMDQ0MiAyOC43OTg0IDEzLjMxNDkgMjguNjU4N0gxMy4zMTQ5QzE0LjIyMDQgMjguNjQzNCAxNS4xNzA2IDI4LjYyNzMgMTYuMTY0NCAyOC42MjczSDI3LjMxOEMzMi4yMDEzIDI4LjYyNzMgMzMuMzAzOSAyNS4wNzMxIDMzLjUxNjQgMjEuMDAyOEwzNC4wMjY3IDE0Ljc5MzRDMzQuMTYyNiAxMi4yNDA5IDMzLjgzMzcgMTAuNDI4NyAzMy4wMzM2IDkuMjYyNDFDMzIuMTYxMiA3Ljk5MDE2IDMwLjY3NDcgNy4zNDM5IDI4LjYxNjkgNy4zNDM5QzQxLjQyNTMgNy4zNDM5IDQ0LjEwMjIgOS4wNTk5OCA0NC4xOTA3IDE5Ljg0MTJaIiBmaWxsPSJ1cmwoI3BhaW50MV9saW5lYXJfMTAyNl85KSIvPgo8L2c+CjxkZWZzPgo8bGluZWFyR3JhZGllbnQgaWQ9InBhaW50MF9saW5lYXJfMTAyNl85IiB4MT0iMjIuMjg3OCIgeTE9IjAuMjUiIHgyPSIyMi40ODE4IiB5Mj0iMzAuNTc2OCIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgo8c3RvcCBzdG9wLWNvbG9yPSIjMDVEMkZGIi8+CjxzdG9wIG9mZnNldD0iMC4xNTYyMjciIHN0b3AtY29sb3I9IiMyMUExRjEiLz4KPHN0b3Agb2Zmc2V0PSIwLjQwNzExNCIgc3RvcC1jb2xvcj0iIzFFODhFNSIvPgo8c3RvcCBvZmZzZXQ9IjAuNzIyNDgiIHN0b3AtY29sb3I9IiMxRTZFRTUiLz4KPHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMTgyRkZGIi8+CjwvbGluZWFyR3JhZGllbnQ+CjxsaW5lYXJHcmFkaWVudCBpZD0icGFpbnQxX2xpbmVhcl8xMDI2XzkiIHgxPSIzLjE3NzgzIiB5MT0iMzUuNjkzNyIgeDI9IjM3LjkzODYiIHkyPSI1LjQxMDk1IiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+CjxzdG9wIHN0b3AtY29sb3I9IiMyNEQ4RkYiLz4KPHN0b3Agb2Zmc2V0PSIwLjE1NjIyNyIgc3RvcC1jb2xvcj0iIzIxQTFGMSIvPgo8c3RvcCBvZmZzZXQ9IjAuNDA3MTE0IiBzdG9wLWNvbG9yPSIjMUU4OEU1Ii8+CjxzdG9wIG9mZnNldD0iMC43NDkxMDYiIHN0b3AtY29sb3I9IiMxRTdBRTUiLz4KPHN0b3Agb2Zmc2V0PSIxIiBzdG9wLWNvbG9yPSIjMDA0NkY5Ii8+CjwvbGluZWFyR3JhZGllbnQ+CjxjbGlwUGF0aCBpZD0iY2xpcDBfMTAyNl85Ij4KPHJlY3Qgd2lkdGg9IjQ1IiBoZWlnaHQ9IjM2IiBmaWxsPSJ3aGl0ZSIvPgo8L2NsaXBQYXRoPgo8L2RlZnM+Cjwvc3ZnPgo=";
 const storageIcons = {
   gbq: '<svg width="24" height="24" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10.6842 44.2221L0.419465 26.278C-0.139822 25.3001 -0.139822 23.6999 0.419465 22.722L10.6842 4.77786C11.2435 3.79993 12.6166 3 13.7355 3H34.265C35.3838 3 36.7567 3.79993 37.3163 4.77786L47.5801 22.722C48.14 23.6999 48.14 25.3001 47.5801 26.278L37.3163 44.2221C36.7567 45.2001 35.3838 46 34.265 46H13.7355C12.6166 46 11.2435 45.2001 10.6842 44.2221Z" fill="#4486FA"></path><path d="M30.6154 18.3848L43.6923 32.8463L37.3828 43.85C36.8268 44.8118 35.4628 45.5986 34.3511 45.5986L17.5385 30.0771L30.6154 18.3848Z" fill="#3778ED"></path><path d="M24.1539 33.1537C28.997 33.1537 32.9231 29.2276 32.9231 24.3845C32.9231 19.5414 28.997 15.6152 24.1539 15.6152C19.3108 15.6152 15.3846 19.5414 15.3846 24.3845C15.3846 29.2276 19.3108 33.1537 24.1539 33.1537Z" fill="white"></path><path d="M31.2681 29.2331L34.3825 32.3476C34.7428 32.7079 34.7428 33.2925 34.3825 33.6528L33.7296 34.3057C33.3693 34.666 32.7847 34.666 32.4244 34.3057L29.3099 31.1913C28.9496 30.831 28.9496 30.2464 29.3099 29.886L29.9628 29.2331C30.3231 28.8728 30.9077 28.8728 31.2681 29.2331Z" fill="white"></path><path d="M24.1538 31.0003C27.8074 31.0003 30.7692 28.0385 30.7692 24.3849C30.7692 20.7313 27.8074 17.7695 24.1538 17.7695C20.5003 17.7695 17.5385 20.7313 17.5385 24.3849C17.5385 28.0385 20.5003 31.0003 24.1538 31.0003Z" fill="#4486FA"></path><path d="M24.1538 29.4615C26.9577 29.4615 29.2308 27.1884 29.2308 24.3845C29.2308 21.5806 26.9577 19.3076 24.1538 19.3076C21.3499 19.3076 19.0769 21.5806 19.0769 24.3845C19.0769 27.1884 21.3499 29.4615 24.1538 29.4615Z" fill="#4486FA"></path><path fill-rule="evenodd" clip-rule="evenodd" d="M23.3846 21.4619H25.2308V29.4619H23.3846V21.4619ZM26.4615 24.8465H28.3077V28.5388H26.4615V24.8465ZM21.8462 23.6158H20V28.5388H21.8462V23.6158Z" fill="white"></path></svg>',
   aws_athena: '<svg width="24" height="24" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M48 29.0142L24 26.0256L0 29.0142L24 48L48 29.0142Z" fill="#FCBF92"/><path d="M0 29.0142L24 36.2676V48L0 35.8398V29.0142Z" fill="#9D5025"/><path d="M48 29.0142L24 36.2676V48L48 35.8398V29.0142Z" fill="#F58534"/><path d="M3.099 18.7008H0V25.5978L3.099 26.1684L6.5436 22.4742L3.099 18.7014V18.7008Z" fill="#9D5025"/><path d="M6.54421 25.8828L3.09961 26.1678V18.7008H6.54421V25.8828Z" fill="#F58534"/><path d="M8.86613 10.0992L4.78613 10.8768V26.5248L8.86613 27.3804L12.6005 18.7002L8.86613 10.0986V10.0992Z" fill="#9D5025"/><path d="M12.6 26.9526L8.86621 27.3804V10.0992L12.6 10.527V26.9526Z" fill="#F58534"/><path d="M16.8213 13.5798L11.1885 14.1504V27.873L16.8213 29.0142L22.8003 21.261L16.8213 13.5798Z" fill="#9D5025"/><path d="M20.6187 28.3722L16.8213 29.0142V13.5798L20.6187 13.8648V28.3722Z" fill="#F58534"/><path d="M23.9995 1.134L20.2021 2.3466V29.6562L23.9995 30.4332L27.7969 15.7836L23.9995 1.134Z" fill="#9D5025"/><path d="M27.5156 28.3722L31.1792 29.0142L36.812 18.7008L31.1792 8.4588L27.5156 9.0294V28.3722Z" fill="#9D5025"/><path d="M36.812 18.7008L31.1792 8.4588L27.5156 9.0294" fill="#9D5025"/><path d="M35.3281 26.9532L39.1327 27.381L43.2127 14.3646L39.1327 1.4196L35.3281 2.3466V26.9532Z" fill="#9D5025"/><path d="M41.4551 25.8828L44.8997 26.1678L47.9987 13.2948L44.8997 0L41.4551 0.8556V25.8828Z" fill="#9D5025"/><path d="M24 1.134L27.7974 2.3466V29.6562L24 30.4332V1.134ZM36.8118 9.6L31.179 8.4588V29.0142L36.8118 27.873V9.6ZM43.2144 3.06L39.1344 1.4196V27.381L43.2144 26.5248V3.06ZM48 1.5618L44.901 0V26.1684L48 25.5978V1.5618Z" fill="#F58534"/></svg>',
@@ -7,6 +8,8 @@ const storageIcons = {
   snowflake: '<svg width="24" height="24" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M41.1492 36.5821L31.017 30.7288C29.5935 29.9092 27.7733 30.3966 26.9494 31.8201C26.6302 32.3808 26.5051 32.9976 26.5655 33.5972V45.0365C26.5655 46.6712 27.894 47.9998 29.5331 47.9998C31.1679 47.9998 32.4965 46.6712 32.4965 45.0365V38.4585L38.173 41.7367C39.5964 42.5605 41.421 42.0688 42.2405 40.6454C43.0644 39.2219 42.577 37.4017 41.1492 36.5821Z" fill="#29B5E8"/><path d="M15.949 24.039C15.9663 22.9822 15.4099 21.9987 14.4954 21.4682L4.36313 15.6192C3.92316 15.3647 3.41849 15.231 2.91381 15.231C1.87427 15.231 0.908061 15.7874 0.390448 16.6846C-0.411852 18.0735 0.0669408 19.855 1.45587 20.6573L7.29627 24.0261L1.45587 27.3992C0.782972 27.7874 0.299866 28.4128 0.101448 29.1634C-0.101284 29.9139 0.00223886 30.699 0.390448 31.3719C0.908061 32.2691 1.87427 32.8255 2.9095 32.8255C3.41849 32.8255 3.92316 32.6918 4.36313 32.4373L14.4954 26.5883C15.4012 26.062 15.9577 25.0872 15.949 24.039Z" fill="#29B5E8"/><path d="M6.6628 11.4738L16.7951 17.3228C17.977 18.0086 19.4349 17.7843 20.3666 16.8742C20.9576 16.3307 21.3242 15.5543 21.3242 14.6916V2.96765C21.3242 1.32854 19.9957 0 18.3609 0C16.7217 0 15.3932 1.32854 15.3932 2.96765V9.64054L9.63907 6.31919C8.21564 5.49532 6.39536 5.98274 5.5715 7.40618C4.74763 8.82962 5.23936 10.6499 6.6628 11.4738Z" fill="#29B5E8"/><path d="M29.4459 24.5131C29.4459 24.7374 29.3165 25.048 29.1569 25.2119L25.1411 29.2277C24.9815 29.3873 24.6666 29.5167 24.4423 29.5167H23.42C23.1957 29.5167 22.8808 29.3873 22.7212 29.2277L18.7011 25.2119C18.5415 25.048 18.4121 24.7374 18.4121 24.5131V23.4908C18.4121 23.2622 18.5415 22.9516 18.7011 22.792L22.7212 18.7719C22.8808 18.6123 23.1957 18.4829 23.42 18.4829H24.4423C24.6666 18.4829 24.9815 18.6123 25.1411 18.7719L29.1569 22.792C29.3165 22.9516 29.4459 23.2622 29.4459 23.4908V24.5131ZM25.8614 24.0214V23.9782C25.8614 23.8143 25.7665 23.5857 25.6501 23.4649L24.4639 22.2831C24.3474 22.1623 24.1188 22.0674 23.9506 22.0674H23.9074C23.7435 22.0674 23.5149 22.1623 23.3941 22.2831L22.2123 23.4649C22.0958 23.5814 22.0009 23.81 22.0009 23.9782V24.0214C22.0009 24.1896 22.0958 24.4182 22.2123 24.5347L23.3941 25.7209C23.5149 25.8373 23.7435 25.9322 23.9074 25.9322H23.9506C24.1188 25.9322 24.3474 25.8373 24.4639 25.7209L25.6501 24.5347C25.7665 24.4182 25.8614 24.1896 25.8614 24.0214Z" fill="#29B5E8"/><path d="M31.0158 17.3228L41.1481 11.4738C42.5715 10.6542 43.0632 8.82962 42.2394 7.40618C41.4155 5.98274 39.5952 5.49532 38.1718 6.31919L32.4953 9.59741V2.96765C32.4953 1.32854 31.1667 0 29.532 0C27.8928 0 26.5643 1.32854 26.5643 2.96765V14.4587C26.5082 15.0539 26.6247 15.675 26.9482 16.2358C27.7721 17.6592 29.5923 18.1467 31.0158 17.3228Z" fill="#29B5E8"/><path d="M18.8267 30.3841C18.1538 30.2546 17.4335 30.3625 16.7951 30.7291L6.6628 36.5825C5.23936 37.402 4.74763 39.2223 5.5715 40.6457C6.39536 42.0735 8.21564 42.5609 9.63907 41.737L15.3932 38.4157V45.0368C15.3932 46.6716 16.7217 48.0002 18.3609 48.0002C19.9957 48.0002 21.3242 46.6716 21.3242 45.0368V33.3129C21.3242 31.8334 20.2415 30.6083 18.8267 30.3841Z" fill="#29B5E8"/><path d="M47.4814 16.6501C46.6618 15.2223 44.8372 14.7349 43.4138 15.5588L33.2815 21.4078C32.311 21.9685 31.7761 22.9951 31.7934 24.039C31.7847 25.0785 32.3196 26.0922 33.2815 26.6443L43.4138 32.4977C44.8372 33.3172 46.6575 32.8298 47.4814 31.4064C48.3052 29.9829 47.8135 28.1626 46.3901 27.3388L40.6532 24.0261L46.3901 20.7133C47.8178 19.8938 48.3052 18.0735 47.4814 16.6501Z" fill="#29B5E8"/></svg>',
   databricks: '<svg width="24" height="24" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M45.8905 35.0619V26.9571L45.0149 26.4095L24 37.9095L4.0796 26.9571V22.2476L24 33.0905L46 21.1524V13.1571L45.1244 12.6095L24 24.219L4.84577 13.7048L24 3.19048L39.4328 11.6238L40.6368 10.9667V10.0905L24 1L2 12.9381V14.1429L24 26.1905L43.9204 15.2381V20.0571L24 31.0095L2.87562 19.4L2 19.9476V28.0524L24 39.9905L43.9204 29.1476V33.8571L24 44.8095L2.87562 33.3095L2 33.8571V35.0619L24 47L45.8905 35.0619Z" fill="#FF3621"/></svg>',
   azure_synapse: '<svg width="24" height="24" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M23.9333 0L3 11.9733V35.8933L23.9333 48L44.8667 36.0267V12.0267L23.9333 0ZM41 33.52L23.9333 43.3867L6.86667 33.624V14.3467L23.9333 4.48L41 14.3733V33.52Z" fill="#0078D4"/><path d="M23.9333 0L3 11.9733L6.86667 14.3467L23.9333 4.48L41 14.3467L44.8667 11.9733L23.9333 0Z" fill="url(#paint0_linear_storage_az)"/><path d="M33.9068 27.9336C33.7031 27.5984 33.4028 27.3325 33.0454 27.1709C31.9608 24.8031 30.2991 22.7454 28.2128 21.1865C26.1265 19.6276 23.6822 18.6173 21.1041 18.2482L38.3761 8.26689L34.3601 5.96289L14.6908 17.3336C14.3087 17.5535 14.0099 17.8936 13.8411 18.3009C13.6722 18.7082 13.6426 19.1598 13.757 19.5857C13.8714 20.0115 14.1232 20.3876 14.4734 20.6554C14.8236 20.9233 15.2525 21.068 15.6934 21.0669C15.7747 21.0519 15.8549 21.0314 15.9334 21.0056L16.2668 22.4002C18.7745 21.8089 21.4081 22.0755 23.7464 23.1574C26.0848 24.2393 27.9928 26.074 29.1654 28.3682L9.56812 39.6936L13.5681 42.0029L33.1761 30.6669C33.4376 30.5106 33.6586 30.295 33.8214 30.0376L34.0214 29.9896C34.0028 29.9122 33.9734 29.8429 33.9548 29.7656C34.0967 29.4794 34.1665 29.1629 34.1581 28.8436C34.1497 28.5243 34.0634 28.2119 33.9068 27.9336Z" fill="#50E6FF"/><path d="M32.176 24.0347C31.2003 24.0347 30.2465 24.3241 29.4352 24.8662C28.6239 25.4082 27.9916 26.1787 27.6182 27.0802C27.2448 27.9816 27.1471 28.9735 27.3375 29.9305C27.5278 30.8875 27.9977 31.7665 28.6876 32.4565C29.3775 33.1464 30.2566 33.6163 31.2135 33.8066C32.1705 33.997 33.1625 33.8993 34.0639 33.5259C34.9653 33.1525 35.7358 32.5202 36.2779 31.7089C36.82 30.8976 37.1093 29.9438 37.1093 28.9681C37.1093 27.6597 36.5896 26.4049 35.6644 25.4797C34.7392 24.5545 33.4844 24.0347 32.176 24.0347ZM15.6907 14.0454C14.7149 14.0454 13.7611 14.3347 12.9498 14.8768C12.1386 15.4189 11.5062 16.1894 11.1329 17.0908C10.7595 17.9923 10.6618 18.9842 10.8521 19.9412C11.0425 20.8982 11.5123 21.7772 12.2023 22.4671C12.8922 23.1571 13.7712 23.6269 14.7282 23.8173C15.6852 24.0076 16.6771 23.9099 17.5786 23.5365C18.48 23.1632 19.2505 22.5308 19.7926 21.7196C20.3347 20.9083 20.624 19.9545 20.624 18.9787C20.624 17.6703 20.1042 16.4155 19.1791 15.4904C18.2539 14.5652 16.9991 14.0454 15.6907 14.0454Z" fill="url(#paint1_linear_storage_az)"/><defs><linearGradient id="paint0_linear_storage_az" x1="23.9333" y1="14.3467" x2="23.9333" y2="0" gradientUnits="userSpaceOnUse"><stop offset="0.199" stop-color="#005BA1"/><stop offset="1" stop-color="#0078D4"/></linearGradient><linearGradient id="paint1_linear_storage_az" x1="23.9333" y1="33.9014" x2="23.9333" y2="14.0987" gradientUnits="userSpaceOnUse"><stop stop-color="#198AB3"/><stop offset="0.172" stop-color="#32BEDD"/><stop offset="0.5" stop-color="#198AB3"/><stop offset="0.662" stop-color="#32BEDD"/><stop offset="0.975" stop-color="#50E6FF"/></linearGradient></defs></svg>',
+  owox_cloud_eu: '<img src="' + OWOX_LOGO_DATA_URL + '" width="24" height="20" class="shrink-0 object-contain" alt="" />',
+  owox_cloud_us: '<img src="' + OWOX_LOGO_DATA_URL + '" width="24" height="20" class="shrink-0 object-contain" alt="" />',
 };
 %>
 <style>
@@ -129,8 +132,8 @@ const storageIcons = {
 
   <!-- Question 4: Primary Storage (single-select) -->
   <div class="question-slide slide-hidden" data-question="3">
-    <h2 class="text-xl font-semibold text-foreground mb-1">Your primary Storage (Data Warehouse)</h2>
-    <p class="text-sm text-muted-foreground mb-5">Where does your analytical data live?</p>
+    <h2 class="text-xl font-semibold text-foreground mb-1">Where should OWOX process your data?</h2>
+    <p class="text-sm text-muted-foreground mb-5">Pick your Data Warehouse — or let OWOX host it for you</p>
     <div class="space-y-2" id="q-primary-storage">
       <% primaryStorageOptions.forEach(function(opt) { %>
       <label class="option-card flex items-center gap-3 rounded-md border border-border px-4 py-3 text-sm text-foreground">
@@ -175,6 +178,36 @@ const storageIcons = {
   </div>
 </div>
 
+<div
+  id="owox-cloud-modal"
+  class="fixed inset-0 z-50 hidden items-center justify-center p-4 bg-black/50"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="owox-cloud-modal-title"
+  aria-hidden="true"
+>
+  <div class="bg-background border border-border rounded-lg shadow-lg max-w-md w-full p-6">
+    <div class="flex gap-3">
+      <svg class="shrink-0 w-8 h-8 mt-0.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <circle cx="12" cy="12" r="10" stroke="#199EE3" stroke-width="1.75" />
+        <path d="M12 8v5M12 16h.01" stroke="#199EE3" stroke-width="1.75" stroke-linecap="round" />
+      </svg>
+      <div class="min-w-0">
+        <h3 id="owox-cloud-modal-title" class="text-base font-semibold text-foreground">OWOX Cloud is coming soon</h3>
+        <p class="text-sm text-muted-foreground mt-3">We're still building our managed storage.</p>
+        <p class="text-sm text-muted-foreground mt-2">We'll reach out as soon as it's available. In the meantime, feel free to select one of the supported warehouses to get started.</p>
+      </div>
+    </div>
+    <button
+      type="button"
+      id="owox-cloud-modal-ok"
+      class="mt-6 w-full inline-flex justify-center items-center py-2.5 px-4 rounded-md text-sm font-medium text-primary-foreground bg-primary hover:bg-primary/90 transition-colors"
+    >
+      Got it
+    </button>
+  </div>
+</div>
+
 <script>
 (function () {
   const TOTAL_STEPS = 4;
@@ -183,12 +216,70 @@ const storageIcons = {
   // Domain validation pattern
   const ORG_DOMAIN_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}$/;
 
+  function stripLeadingWww(host) {
+    return host.replace(/^www\./i, '');
+  }
+
+  /** Hostname from pasted URL or plain domain (https://owox.com/demo → owox.com, strips www.). */
+  function normalizeOrgDomainInput(raw) {
+    const trimmed = raw.trim();
+    if (!trimmed) return '';
+    let candidate = trimmed;
+    if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(candidate)) {
+      candidate = 'https://' + candidate;
+    }
+    try {
+      const u = new URL(candidate);
+      if (u.hostname) return stripLeadingWww(u.hostname.toLowerCase());
+    } catch {
+      // ignore
+    }
+    return stripLeadingWww(
+      trimmed
+        .replace(/^https?:\/\//i, '')
+        .split('/')[0]
+        .split('?')[0]
+        .split('#')[0]
+        .toLowerCase()
+    );
+  }
+
   const slides = document.querySelectorAll('.question-slide');
   const dots = document.querySelectorAll('.progress-dot');
   const counter = document.getElementById('step-counter');
   const btnBack = document.getElementById('btn-back');
   const btnNext = document.getElementById('btn-next');
   const errorEl = document.getElementById('onboarding-error');
+  const owoxCloudModal = document.getElementById('owox-cloud-modal');
+  const owoxCloudModalOk = document.getElementById('owox-cloud-modal-ok');
+
+  const OWOX_CLOUD_STORAGE_VALUES = new Set(['owox_cloud_eu', 'owox_cloud_us']);
+  let owoxModalPreviousFocus = null;
+
+  function isOwoxCloudModalOpen() {
+    return owoxCloudModal && !owoxCloudModal.classList.contains('hidden');
+  }
+
+  function openOwoxCloudModal() {
+    if (!owoxCloudModal || !owoxCloudModalOk) return;
+    owoxModalPreviousFocus = document.activeElement;
+    owoxCloudModal.classList.remove('hidden');
+    owoxCloudModal.classList.add('flex');
+    owoxCloudModal.setAttribute('aria-hidden', 'false');
+    owoxCloudModalOk.focus();
+  }
+
+  function closeOwoxCloudModal() {
+    if (!owoxCloudModal) return;
+    owoxCloudModal.classList.add('hidden');
+    owoxCloudModal.classList.remove('flex');
+    owoxCloudModal.setAttribute('aria-hidden', 'true');
+    const prev = owoxModalPreviousFocus;
+    owoxModalPreviousFocus = null;
+    if (prev && typeof prev.focus === 'function') {
+      prev.focus();
+    }
+  }
 
   // Validate redirect is a safe relative path
   const urlParams = new URLSearchParams(window.location.search);
@@ -211,7 +302,7 @@ const storageIcons = {
     btnBack.classList.toggle('hidden', step === 0);
 
     if (step === TOTAL_STEPS - 1) {
-      btnNext.innerHTML = 'Finish';
+      btnNext.textContent = 'Complete';
     } else {
       btnNext.innerHTML = 'Next &rarr;';
     }
@@ -239,11 +330,15 @@ const storageIcons = {
       return true;
     }
     if (step === 1) {
-      // Org domain: must not be empty and match valid domain format (case-insensitive)
-      const val = document.getElementById('org-domain').value.trim().toLowerCase();
-      if (!val) {
+      const input = document.getElementById('org-domain');
+      const raw = input.value.trim();
+      if (!raw) {
         errorEl.textContent = 'Please enter your organization domain.';
         return false;
+      }
+      const val = normalizeOrgDomainInput(raw);
+      if (val !== input.value) {
+        input.value = val;
       }
       if (!ORG_DOMAIN_PATTERN.test(val)) {
         errorEl.textContent = 'Please enter a valid domain (e.g., example.com or sub.example.com).';
@@ -344,10 +439,13 @@ const storageIcons = {
       answers.push(item);
     }
 
-    // Q2: Org domain (normalized to lowercase)
+    // Q2: Org domain (hostname; URLs normalized with URL API)
     const domainInput = document.getElementById('org-domain');
     if (domainInput?.value?.trim()) {
-      answers.push({ questionId: 'org_domain', answerValue: domainInput.value.trim().toLowerCase() });
+      const host = normalizeOrgDomainInput(domainInput.value);
+      if (host) {
+        answers.push({ questionId: 'org_domain', answerValue: host });
+      }
     }
 
     // Q3: Primary role (single-select)
@@ -405,12 +503,29 @@ const storageIcons = {
     }
   }
 
+  if (owoxCloudModalOk) {
+    owoxCloudModalOk.addEventListener('click', () => {
+      closeOwoxCloudModal();
+      submitAnswers();
+    });
+  }
+
   btnNext.addEventListener('click', () => {
     if (!validateStep(currentStep)) return;
     if (currentStep < TOTAL_STEPS - 1) {
       showStep(currentStep + 1);
     } else {
-      submitAnswers();
+      const storageChecked = document.querySelector('#q-primary-storage input[type="radio"]:checked');
+      if (
+        storageChecked &&
+        OWOX_CLOUD_STORAGE_VALUES.has(storageChecked.value) &&
+        owoxCloudModal &&
+        owoxCloudModalOk
+      ) {
+        openOwoxCloudModal();
+      } else {
+        submitAnswers();
+      }
     }
   });
 
@@ -420,7 +535,13 @@ const storageIcons = {
 
   // Keyboard navigation — skip when focus is in a text input (let it behave normally)
   document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && isOwoxCloudModalOpen()) {
+      e.preventDefault();
+      closeOwoxCloudModal();
+      return;
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
+      if (isOwoxCloudModalOpen()) return;
       if (e.target && e.target.tagName === 'INPUT' && e.target.type === 'text') return;
       e.preventDefault();
       btnNext.click();
@@ -464,12 +585,75 @@ const storageIcons = {
     }
   }
 
+  // Shuffle primary storage: randomize DWH options; keep OWOX Cloud (EU→US) and Other fixed at end.
+  function shufflePrimaryStorageOptions() {
+    const container = document.getElementById('q-primary-storage');
+    if (!container) return;
+    const cards = Array.from(container.querySelectorAll(':scope > label.option-card'));
+    if (cards.length < 2) return;
+
+    const otherCard = cards.find(function (label) {
+      var input = label.querySelector('input');
+      return input && input.value === 'other';
+    });
+    const owoxEuCard = cards.find(function (label) {
+      var input = label.querySelector('input');
+      return input && input.value === 'owox_cloud_eu';
+    });
+    const owoxUsCard = cards.find(function (label) {
+      var input = label.querySelector('input');
+      return input && input.value === 'owox_cloud_us';
+    });
+    var pinned = new Set([otherCard, owoxEuCard, owoxUsCard].filter(Boolean));
+    var shuffleable = cards.filter(function (c) { return !pinned.has(c); });
+
+    for (var i = shuffleable.length - 1; i > 0; i--) {
+      var j = Math.floor(Math.random() * (i + 1));
+      var tmp = shuffleable[i];
+      shuffleable[i] = shuffleable[j];
+      shuffleable[j] = tmp;
+    }
+
+    cards.forEach(function (c) { container.removeChild(c); });
+
+    var otherWrap = container.querySelector('.other-text-input');
+    shuffleable.forEach(function (c) {
+      if (otherWrap) container.insertBefore(c, otherWrap);
+      else container.appendChild(c);
+    });
+    if (owoxEuCard) {
+      if (otherWrap) container.insertBefore(owoxEuCard, otherWrap);
+      else container.appendChild(owoxEuCard);
+    }
+    if (owoxUsCard) {
+      if (otherWrap) container.insertBefore(owoxUsCard, otherWrap);
+      else container.appendChild(owoxUsCard);
+    }
+    if (otherCard) {
+      if (otherWrap) container.insertBefore(otherCard, otherWrap);
+      else container.appendChild(otherCard);
+    }
+  }
+
   shuffleOptions('q-use-case');
   shuffleOptions('q-primary-role');
-  shuffleOptions('q-primary-storage');
+  shufflePrimaryStorageOptions();
 
   setupOptionCards();
   setupOtherToggles();
+
+  const orgDomainEl = document.getElementById('org-domain');
+  if (orgDomainEl) {
+    orgDomainEl.addEventListener('blur', () => {
+      const raw = orgDomainEl.value.trim();
+      if (!raw) return;
+      const host = normalizeOrgDomainInput(raw);
+      if (host && ORG_DOMAIN_PATTERN.test(host)) {
+        orgDomainEl.value = host;
+      }
+    });
+  }
+
   showStep(0);
 })();
 </script>

--- a/packages/idp-owox-better-auth/src/resources/templates/pages/onboarding.ejs
+++ b/packages/idp-owox-better-auth/src/resources/templates/pages/onboarding.ejs
@@ -302,7 +302,7 @@ const storageIcons = {
     btnBack.classList.toggle('hidden', step === 0);
 
     if (step === TOTAL_STEPS - 1) {
-      btnNext.textContent = 'Complete';
+      btnNext.textContent = 'Finish';
     } else {
       btnNext.innerHTML = 'Next &rarr;';
     }
@@ -585,7 +585,7 @@ const storageIcons = {
     }
   }
 
-  // Shuffle primary storage: randomize DWH options; keep OWOX Cloud (EU→US) and Other fixed at end.
+  // Shuffle primary storage: randomize DWH options only; fix OWOX (EU→US), "Don't know", then Other.
   function shufflePrimaryStorageOptions() {
     const container = document.getElementById('q-primary-storage');
     if (!container) return;
@@ -596,6 +596,10 @@ const storageIcons = {
       var input = label.querySelector('input');
       return input && input.value === 'other';
     });
+    const dontKnowCard = cards.find(function (label) {
+      var input = label.querySelector('input');
+      return input && input.value === 'dont_know';
+    });
     const owoxEuCard = cards.find(function (label) {
       var input = label.querySelector('input');
       return input && input.value === 'owox_cloud_eu';
@@ -604,7 +608,9 @@ const storageIcons = {
       var input = label.querySelector('input');
       return input && input.value === 'owox_cloud_us';
     });
-    var pinned = new Set([otherCard, owoxEuCard, owoxUsCard].filter(Boolean));
+    var pinned = new Set(
+      [otherCard, dontKnowCard, owoxEuCard, owoxUsCard].filter(Boolean)
+    );
     var shuffleable = cards.filter(function (c) { return !pinned.has(c); });
 
     for (var i = shuffleable.length - 1; i > 0; i--) {
@@ -617,22 +623,19 @@ const storageIcons = {
     cards.forEach(function (c) { container.removeChild(c); });
 
     var otherWrap = container.querySelector('.other-text-input');
+    function insertBeforeOther(node) {
+      if (node) {
+        if (otherWrap) container.insertBefore(node, otherWrap);
+        else container.appendChild(node);
+      }
+    }
     shuffleable.forEach(function (c) {
-      if (otherWrap) container.insertBefore(c, otherWrap);
-      else container.appendChild(c);
+      insertBeforeOther(c);
     });
-    if (owoxEuCard) {
-      if (otherWrap) container.insertBefore(owoxEuCard, otherWrap);
-      else container.appendChild(owoxEuCard);
-    }
-    if (owoxUsCard) {
-      if (otherWrap) container.insertBefore(owoxUsCard, otherWrap);
-      else container.appendChild(owoxUsCard);
-    }
-    if (otherCard) {
-      if (otherWrap) container.insertBefore(otherCard, otherWrap);
-      else container.appendChild(otherCard);
-    }
+    insertBeforeOther(owoxEuCard);
+    insertBeforeOther(owoxUsCard);
+    insertBeforeOther(dontKnowCard);
+    insertBeforeOther(otherCard);
   }
 
   shuffleOptions('q-use-case');

--- a/packages/idp-owox-better-auth/src/services/onboarding/onboarding-service.test.ts
+++ b/packages/idp-owox-better-auth/src/services/onboarding/onboarding-service.test.ts
@@ -363,6 +363,20 @@ describe('OnboardingService', () => {
       expect(saved[0]!.otherText!.length).toBeLessThanOrEqual(500);
     });
 
+    it('saves primary_storage with owox_cloud_eu', async () => {
+      await service.saveAnswers('user-1', 'project-1', 'bi-user-1', 'admin', {
+        answers: [{ questionId: 'primary_storage', answerValue: 'owox_cloud_eu' }],
+      });
+
+      const saved = jest.mocked(store.saveOnboardingAnswers).mock.calls[0]![0] as Array<{
+        questionId: string;
+        answerValue: string;
+      }>;
+      expect(saved).toHaveLength(1);
+      expect(saved[0]!.questionId).toBe('primary_storage');
+      expect(saved[0]!.answerValue).toBe('owox_cloud_eu');
+    });
+
     it('throws on invalid questionId', async () => {
       await expect(
         service.saveAnswers('user-1', 'project-1', 'bi-user-1', 'viewer', {
@@ -388,6 +402,28 @@ describe('OnboardingService', () => {
         answerValue: string;
       }>;
       expect(saved[0]!.answerValue).toBe('example.com');
+    });
+
+    it('normalizes org_domain from a full URL to hostname', async () => {
+      await service.saveAnswers('user-1', 'project-1', 'bi-user-1', 'admin', {
+        answers: [{ questionId: 'org_domain', answerValue: 'https://owox.com/demo' }],
+      });
+
+      const saved = jest.mocked(store.saveOnboardingAnswers).mock.calls[0]![0] as Array<{
+        answerValue: string;
+      }>;
+      expect(saved[0]!.answerValue).toBe('owox.com');
+    });
+
+    it('strips www. from org_domain', async () => {
+      await service.saveAnswers('user-1', 'project-1', 'bi-user-1', 'admin', {
+        answers: [{ questionId: 'org_domain', answerValue: 'https://www.owox.com/demo' }],
+      });
+
+      const saved = jest.mocked(store.saveOnboardingAnswers).mock.calls[0]![0] as Array<{
+        answerValue: string;
+      }>;
+      expect(saved[0]!.answerValue).toBe('owox.com');
     });
 
     it('throws on invalid org_domain format', async () => {

--- a/packages/idp-owox-better-auth/src/services/onboarding/onboarding-service.ts
+++ b/packages/idp-owox-better-auth/src/services/onboarding/onboarding-service.ts
@@ -160,6 +160,34 @@ export class OnboardingService {
     }
   }
 
+  /**
+   * Extracts registrable-style hostname from pasted URLs (e.g. https://owox.com/demo → owox.com).
+   * Strips a leading `www.` segment.
+   */
+  private normalizeOrgDomainAnswer(raw: string): string {
+    const trimmed = raw.trim();
+    if (!trimmed) return '';
+    let candidate = trimmed;
+    if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(candidate)) {
+      candidate = `https://${candidate}`;
+    }
+    const stripWww = (host: string) => host.replace(/^www\./i, '');
+    try {
+      const u = new URL(candidate);
+      if (u.hostname) return stripWww(u.hostname.toLowerCase());
+    } catch {
+      // fall through
+    }
+    return stripWww(
+      trimmed
+        .replace(/^https?:\/\//i, '')
+        .split('/')[0]!
+        .split('?')[0]!
+        .split('#')[0]!
+        .toLowerCase()
+    );
+  }
+
   private validateQuestionId(questionId: string): void {
     if (!QUESTION_IDS.has(questionId)) {
       throw new Error('Invalid question identifier');
@@ -171,7 +199,7 @@ export class OnboardingService {
     answerValue: string | string[]
   ): string {
     if (questionId === ONBOARDING_QUESTION.ORG_DOMAIN) {
-      const domain = String(answerValue).trim().toLowerCase();
+      const domain = this.normalizeOrgDomainAnswer(String(answerValue));
       if (domain && !ORG_DOMAIN_PATTERN.test(domain)) {
         throw new Error('Invalid organization domain format');
       }


### PR DESCRIPTION
## Preview
<img width="574" height="928" alt="CleanShot 2026-05-01 at 09 23 05" src="https://github.com/user-attachments/assets/4e7b33c3-4825-47a5-93be-881bb0696541" />

<img width="574" height="394" alt="CleanShot 2026-05-01 at 09 35 36" src="https://github.com/user-attachments/assets/8ebcfa6c-a8b6-4b92-9b76-3d0f57c1dcac" />


## Summary
- Question 4 (primary storage): Updated heading and helper text to focus on where OWOX processes data and framed DWH vs OWOX-hosted storage.
- New answers: Added OWOX Cloud (EU) and OWOX Cloud (US) (owox_cloud_eu / owox_cloud_us) to onboarding constants and server validation.
- UX: Last step CTA label is Complete. Choosing an OWOX Cloud option shows a “coming soon” dialog before submit; confirming still saves and redirects as before. Shuffled DWH list keeps OWOX EU → US → Other at the bottom.
- Company website: Accepts pasted URLs; normalizes to hostname in the field and in the payload. Strips www. and aligns client + OnboardingService normalization; added/extended unit tests.