### PR TITLE
feat(web): enhance report creation UX by enabling immediate button activation

### DIFF
--- a/.changeset/improve-report-creation-ux.md
+++ b/.changeset/improve-report-creation-ux.md
@@ -1,0 +1,13 @@
+---
+'owox': minor
+---
+
+# Improved Report Creation Experience
+
+When creating a new report, the "Create & Run report" button is now enabled as soon as all required fields are valid. Previously, you had to manually change the default report title to activate the button, even when all other fields were already correctly filled.
+
+- **Google Sheets Reports**: The create button is now immediately available when destination, document URL, and columns are selected
+- **Email Reports**: The create button activates once destination, subject, columns, and message template are provided
+- **Looker Studio Reports**: The create button is ready as soon as cache configuration and columns are set
+
+Faster report setup with fewer unnecessary clicks. You can now create a report immediately with the default title "New report" or any pre-filled values, without being forced to edit the title first just to unlock the button.

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
@@ -220,6 +220,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
 
     const {
       isDirty,
+      isValid,
       reset,
       form,
       isSubmitting,
@@ -976,6 +977,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
               mode={mode}
               isSubmitting={isSubmitting}
               isDirty={isDirty}
+              isValid={isValid}
               triggersDirty={triggersDirty}
               ownersDirty={ownersDirty}
               runAfterSaveRef={runAfterSaveRef}

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -155,6 +155,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
 
     const {
       isDirty,
+      isValid,
       reset,
       form,
       isSubmitting,
@@ -494,6 +495,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
             mode={mode}
             isSubmitting={isSubmitting}
             isDirty={isDirty}
+            isValid={isValid}
             triggersDirty={triggersDirty}
             ownersDirty={ownersDirty}
             runAfterSaveRef={runAfterSaveRef}

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -117,6 +117,7 @@ export const LookerStudioReportEditForm = forwardRef<
 
     const {
       isDirty,
+      isValid,
       reset,
       form,
       isSubmitting,
@@ -276,7 +277,11 @@ export const LookerStudioReportEditForm = forwardRef<
               type='submit'
               className='w-full'
               aria-label={mode === ReportFormMode.CREATE ? 'Create' : 'Save changes'}
-              disabled={(!isDirty && !ownersDirty) || isSubmitting}
+              // `disabled` logic is duplicated intentionally and needs to be synchronized manually
+              disabled={
+                isSubmitting ||
+                (mode === ReportFormMode.CREATE ? !isValid : !isDirty && !ownersDirty)
+              }
             >
               {isSubmitting
                 ? mode === ReportFormMode.CREATE

--- a/apps/web/src/features/data-marts/reports/edit/components/shared/ReportFormActions.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/shared/ReportFormActions.tsx
@@ -15,6 +15,7 @@ export interface ReportFormActionsProps {
   mode: ReportFormMode;
   isSubmitting: boolean;
   isDirty: boolean;
+  isValid: boolean;
   triggersDirty: boolean;
   ownersDirty?: boolean;
   runAfterSaveRef: RefObject<boolean>;
@@ -26,13 +27,16 @@ export const ReportFormActions = ({
   mode,
   isSubmitting,
   isDirty,
+  isValid,
   triggersDirty,
   ownersDirty = false,
   runAfterSaveRef,
   onSubmit,
   onCancel,
 }: ReportFormActionsProps) => {
-  const disabledPrimary = isSubmitting || !(isDirty || triggersDirty || ownersDirty);
+  const disabledPrimary =
+    isSubmitting ||
+    (mode === ReportFormMode.CREATE ? !isValid : !(isDirty || triggersDirty || ownersDirty));
 
   const primaryLabel =
     mode === ReportFormMode.CREATE ? 'Create & Run report' : 'Save changes to report';

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useEmailReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useEmailReportForm.ts
@@ -132,7 +132,7 @@ export function useEmailReportForm({
   });
 
   const { handleSubmit, formState, reset } = form;
-  const { isDirty, errors } = formState;
+  const { isDirty, errors, isValid } = formState;
 
   const onSubmit = useCallback(
     async (data: EmailReportEditFormValues) => {
@@ -228,6 +228,7 @@ export function useEmailReportForm({
     handleSubmit,
     errors,
     isDirty,
+    isValid,
     reset,
     formError,
     isSubmitting,

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useGoogleSheetsReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useGoogleSheetsReportForm.ts
@@ -72,7 +72,7 @@ export function useGoogleSheetsReportForm({
   });
 
   const { register, handleSubmit, formState, reset } = form;
-  const { errors, isDirty } = formState;
+  const { errors, isDirty, isValid } = formState;
 
   const onSubmit = useCallback(
     async (data: GoogleSheetsReportEditFormValues) => {
@@ -166,6 +166,7 @@ export function useGoogleSheetsReportForm({
     handleSubmit,
     errors,
     isDirty,
+    isValid,
     reset,
     formError,
     isSubmitting,

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
@@ -53,6 +53,9 @@ export function useLookerStudioReportForm({
     mode: 'onTouched',
   });
 
+  const { formState, reset } = form;
+  const { isDirty, isValid } = formState;
+
   const onSubmit = async (data: LookerStudioReportFormData) => {
     try {
       setFormError(null);
@@ -95,7 +98,8 @@ export function useLookerStudioReportForm({
     onSubmit,
     formError,
     isSubmitting: form.formState.isSubmitting,
-    isDirty: form.formState.isDirty,
-    reset: form.reset,
+    isDirty,
+    isValid,
+    reset,
   };
 }


### PR DESCRIPTION
## Improved Report Creation Experience

When creating a new report, the "Create & Run report" button is now enabled as soon as all required fields are valid. Previously, you had to manually change the default report title to activate the button, even when all other fields were already correctly filled.

### What changed

- **Google Sheets Reports**: The create button is now immediately available when destination, document URL, and columns are selected
- **Email Reports**: The create button activates once destination, subject, and message template are provided
- **Looker Studio Reports**: The create button is ready as soon as cache configuration and columns are set

### User benefit

Faster report setup with fewer unnecessary clicks. You can now create a report immediately with the default title "New report" or any pre-filled values, without being forced to edit the title first just to unlock the button.