### PR TITLE
feat(web): improve table and view selection UX by integrating picker button into input field

### DIFF
--- a/.changeset/improve-table-and-view-selection.md
+++ b/.changeset/improve-table-and-view-selection.md
@@ -1,0 +1,15 @@
+---
+'owox': minor
+---
+
+# Improve table and view selection UX by integrating picker button into input field
+
+Improves the visual design of table pattern and fully qualified name fields by moving the storage picker button inside the input. Creates a cleaner, more compact interface that guides users through the selection flow.
+
+- Button now appears inside the input field on the left side
+- When no value selected: shows "Select..." text with database icon
+- When value exists: shows compact icon-only button with "Change selection" tooltip
+- External link icon appears inside input on the right side when URL available
+- Focus state highlights entire input group for better visual feedback
+
+Improved visual hierarchy and space efficiency in Data Mart definition forms. No breaking changes. No migration required

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DefinitionFqnField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DefinitionFqnField.tsx
@@ -10,7 +10,12 @@ import {
   FormMessage,
   FormDescription,
 } from '@owox/ui/components/form';
-import { Input } from '@owox/ui/components/input';
+import {
+  InputGroup,
+  InputGroupInput,
+  InputGroupAddon,
+  InputGroupButton,
+} from '@owox/ui/components/input-group';
 import { DataStorageType } from '../../../../../data-storage';
 import type { DataStorageConfigDto } from '../../../../../data-storage/shared/api/types';
 import {
@@ -67,31 +72,36 @@ export function DefinitionFqnField({
           <FormItem className='dm-card-block'>
             <FormLabel>{label}</FormLabel>
             <FormControl>
-              <div className='flex items-center gap-2'>
-                <FillFromStorageButton
-                  storageId={storageId}
-                  storageType={storageType}
-                  resourceType={resourceType}
-                  onSelect={handleSelect}
-                />
-                <Input
+              <InputGroup className='dm-card-formcontrol'>
+                <InputGroupAddon align='inline-start'>
+                  <FillFromStorageButton
+                    storageId={storageId}
+                    storageType={storageType}
+                    resourceType={resourceType}
+                    onSelect={handleSelect}
+                    hasValue={Boolean(field.value)}
+                  />
+                </InputGroupAddon>
+                <InputGroupInput
                   placeholder={placeholder}
                   value={field.value}
                   onChange={field.onChange}
-                  className='dm-card-formcontrol'
                 />
                 {resourceUrl && (
-                  <a
-                    href={resourceUrl}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    title='Open in storage console'
-                    className='text-muted-foreground hover:text-primary shrink-0 p-1.5 transition-colors'
-                  >
-                    <ExternalLink className='h-4 w-4' />
-                  </a>
+                  <InputGroupAddon align='inline-end'>
+                    <InputGroupButton size='icon-xs' asChild variant='ghost'>
+                      <a
+                        href={resourceUrl}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        title='Open in storage console'
+                      >
+                        <ExternalLink className='!h-3.5 !w-3.5 shrink-0' />
+                      </a>
+                    </InputGroupButton>
+                  </InputGroupAddon>
                 )}
-              </div>
+              </InputGroup>
             </FormControl>
             <FormDescription className='text-muted-foreground/75'>{helpText}</FormDescription>
             <FormMessage />

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/FillFromStorageButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/FillFromStorageButton.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Database } from 'lucide-react';
-import { Button } from '@owox/ui/components/button';
 import {
   Dialog,
   DialogContent,
@@ -8,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@owox/ui/components/dialog';
+import { InputGroupButton } from '@owox/ui/components/input-group';
 import { DataStorageType } from '../../../../../../data-storage';
 import { dataStorageApiService } from '../../../../../../data-storage/shared/api';
 import type {
@@ -28,6 +28,7 @@ interface FillFromStorageButtonProps {
   storageType: DataStorageType;
   resourceType: StorageResourceFilter;
   onSelect: (fullyQualifiedName: string) => void;
+  hasValue?: boolean;
 }
 
 export function FillFromStorageButton({
@@ -35,6 +36,7 @@ export function FillFromStorageButton({
   storageType,
   resourceType,
   onSelect,
+  hasValue = false,
 }: FillFromStorageButtonProps) {
   const [open, setOpen] = useState(false);
   const [namespaces, setNamespaces] = useState<StorageNamespaceNodeDto[] | null>(null);
@@ -91,17 +93,18 @@ export function FillFromStorageButton({
 
   return (
     <>
-      <Button
-        type='button'
+      <InputGroupButton
+        size={hasValue ? 'icon-xs' : 'xs'}
         variant='outline'
-        size='sm'
         onClick={() => {
           setOpen(true);
         }}
+        title={hasValue ? 'Change selection' : 'Select from storage'}
+        aria-label={hasValue ? 'Change selection' : 'Select from storage'}
       >
-        <Database className='size-4' />
-        Fill from Storage
-      </Button>
+        <Database />
+        {!hasValue && <span className='text-xs'>Select...</span>}
+      </InputGroupButton>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className='sm:max-w-4xl'>
           <DialogHeader>

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/TablePatternDefinitionField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/TablePatternDefinitionField.tsx
@@ -10,7 +10,12 @@ import {
   FormMessage,
   FormDescription,
 } from '@owox/ui/components/form';
-import { Input } from '@owox/ui/components/input';
+import {
+  InputGroup,
+  InputGroupInput,
+  InputGroupAddon,
+  InputGroupButton,
+} from '@owox/ui/components/input-group';
 import { DataStorageType } from '../../../../../data-storage';
 import type { DataStorageConfigDto } from '../../../../../data-storage/shared/api/types';
 import {
@@ -64,31 +69,36 @@ export function TablePatternDefinitionField({
           <FormItem className='dm-card-block'>
             <FormLabel>Table Pattern</FormLabel>
             <FormControl>
-              <div className='flex items-center gap-2'>
-                <FillFromStorageButton
-                  storageId={storageId}
-                  storageType={storageType}
-                  resourceType='TABLE_PATTERN'
-                  onSelect={handleSelect}
-                />
-                <Input
+              <InputGroup className='dm-card-formcontrol'>
+                <InputGroupAddon align='inline-start'>
+                  <FillFromStorageButton
+                    storageId={storageId}
+                    storageType={storageType}
+                    resourceType='TABLE_PATTERN'
+                    onSelect={handleSelect}
+                    hasValue={Boolean(field.value)}
+                  />
+                </InputGroupAddon>
+                <InputGroupInput
                   placeholder={placeholder}
                   value={field.value}
                   onChange={field.onChange}
-                  className='dm-card-formcontrol'
                 />
                 {resourceUrl && (
-                  <a
-                    href={resourceUrl}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    title='Open in storage console'
-                    className='text-muted-foreground hover:text-primary shrink-0 p-1.5 transition-colors'
-                  >
-                    <ExternalLink className='h-4 w-4' />
-                  </a>
+                  <InputGroupAddon align='inline-end'>
+                    <InputGroupButton size='icon-xs' asChild variant='ghost'>
+                      <a
+                        href={resourceUrl}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        title='Open in storage console'
+                      >
+                        <ExternalLink className='!h-3.5 !w-3.5 shrink-0' />
+                      </a>
+                    </InputGroupButton>
+                  </InputGroupAddon>
                 )}
-              </div>
+              </InputGroup>
             </FormControl>
             <FormDescription className='text-muted-foreground/75'>{helpText}</FormDescription>
             <FormMessage />


### PR DESCRIPTION
Improves the visual design of table pattern and fully qualified name fields by moving the storage picker button inside the input. Creates a cleaner, more compact interface that guides users through the selection flow.

**New Data Mart – Empty field**
<img width="524" height="221" alt="Screenshot 2026-05-05 at 12 33 11" src="https://github.com/user-attachments/assets/68a7e872-e8ee-4933-9ff9-46509eae805f" />

**Selected Table Name**
<img width="711" height="306" alt="Screenshot 2026-05-05 at 11 32 45" src="https://github.com/user-attachments/assets/4790dec4-7ec4-4381-bcb0-c53318b485f2" />

**Selected View Name**
<img width="732" height="319" alt="Screenshot 2026-05-05 at 11 32 34" src="https://github.com/user-attachments/assets/b8b8ead7-b626-45e4-ba99-ab5a6abc8d3f" />

## Changes

- Replace separate button and input layout with unified InputGroup component
- Move FillFromStorageButton into InputGroupAddon for cohesive design
- Update button to use InputGroupButton with dynamic sizing based on selection state
- Add contextual button text that changes from "Select..." to icon-only when value exists
- Apply consistent styling to external link icon using InputGroupButton

## UI / UX

- Button now appears inside the input field on the left side
- When no value selected: shows "Select..." text with database icon
- When value exists: shows compact icon-only button with "Change selection" tooltip
- External link icon appears inside input on the right side when URL available
- Focus state highlights entire input group for better visual feedback

## Impact

- Improved visual hierarchy and space efficiency in Data Mart definition forms
- No breaking changes
- No migration required