### PR TITLE
fix(backend): correct Input Source mapping in Data Marts list

### DIFF
--- a/.changeset/data-mart-list-input-source-mismatch.md
+++ b/.changeset/data-mart-list-input-source-mismatch.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Correct Input Source shown in Data Marts list
+
+Previously, the Data Marts list could display the wrong Input Source (a different connector's name and icon than the one actually configured) for some data marts. The mismatch appeared whenever any data mart in the same list had multiple business owners, technical owners, or contexts assigned. Now every row shows the Input Source of its own data mart, regardless of how owners or contexts are configured.

--- a/apps/backend/src/data-marts/services/data-mart.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart.service.ts
@@ -63,8 +63,12 @@ export class DataMartService {
       roleScope?: RoleScope;
     }
   ): Promise<{ items: DataMart[]; total: number }> {
+    const DM_ALIAS = 'dm';
+    const RAW_ID_COL = `${DM_ALIAS}_id`; // TypeORM raw alias for dm.id
+    const RAW_DEFINITION_COL = 'dm_definition'; // explicit alias in addSelect below
+
     const qb = this.dataMartRepository
-      .createQueryBuilder('dm')
+      .createQueryBuilder(DM_ALIAS)
       .leftJoin('dm.storage', 'storage')
       .leftJoinAndSelect('dm.businessOwners', 'businessOwners')
       .leftJoinAndSelect('dm.technicalOwners', 'technicalOwners')
@@ -91,7 +95,7 @@ export class DataMartService {
       ])
       .addSelect(
         'CASE WHEN dm.definitionType = :connectorDefinitionType THEN dm.definition ELSE NULL END',
-        'dm_definition'
+        RAW_DEFINITION_COL
       )
       .setParameter('connectorDefinitionType', DataMartDefinitionType.CONNECTOR)
       .where('dm.projectId = :projectId', { projectId })
@@ -151,11 +155,19 @@ export class DataMartService {
       countQb.getCount(),
       qb.getRawAndEntities(),
     ]);
-    const items = entities.map((item, index) => {
-      if (raw[index]?.dm_definition) {
+    // raw has one row per JOIN combination (multiple rows per entity when owners/contexts exist),
+    // so index-based matching is wrong. Build a map keyed by data mart ID instead.
+    const rawDefinitionById = new Map<string, unknown>();
+    for (const row of raw) {
+      if (row[RAW_ID_COL] && row[RAW_DEFINITION_COL] && !rawDefinitionById.has(row[RAW_ID_COL])) {
+        rawDefinitionById.set(row[RAW_ID_COL], row[RAW_DEFINITION_COL]);
+      }
+    }
+    const items = entities.map(item => {
+      const rawDefinition = rawDefinitionById.get(item.id);
+      if (rawDefinition) {
         try {
           // value can be returned as a string or as an object
-          const rawDefinition = raw[index].dm_definition;
           const parsed =
             typeof rawDefinition === 'string' ? JSON.parse(rawDefinition) : rawDefinition;
           const result = DataMartDefinitionSchema.safeParse(parsed);


### PR DESCRIPTION
# Problem

The Data Marts list could display the wrong "Input Source" for some rows — showing a different connector's name and icon than the one actually configured. The bug was triggered whenever any data mart in the list had multiple business owners, technical owners, or contexts. Root cause: in `DataMartService.findByProjectIdForList`, the connector definition was extracted from `getRawAndEntities()` by matching `entities[i]` to `raw[i]` by array index. Because the query uses three `leftJoinAndSelect` calls, raw rows are NOT 1-to-1 with entities — a data mart with N joined records produces N raw rows but only one entity, shifting every subsequent index lookup and assigning each entity the definition of a different data mart.

# Solution

Replaced index-based matching with an ID-keyed `Map<string, definition>` built from the raw rows. Each data mart now receives the definition keyed by its own `dm.id`, regardless of how many raw rows it produced. The query alias and the `addSelect` alias for the computed definition column are extracted into local constants so the raw column names update consistently if the query alias is ever renamed.

# Changes

- Replaced index-based `raw[i].dm_definition` lookup with a `Map` keyed by `dm.id` in `DataMartService.findByProjectIdForList`
- Extracted query and raw-column aliases (`DM_ALIAS`, `RAW_ID_COL`, `RAW_DEFINITION_COL`) as local constants to eliminate magic strings
- Added changeset entry describing the user-visible fix