### PR TITLE
fix(web): enhance Data Mart UX with improved navigation and dialog handling

### DIFF
--- a/.changeset/improve-data-mart-ux-and-dialogs.md
+++ b/.changeset/improve-data-mart-ux-and-dialogs.md
@@ -1,0 +1,12 @@
+---
+'owox': minor
+---
+
+# Improve Data Mart interaction with better navigation and dialog handling
+
+Enhances Data Mart table interactions and strengthens delete confirmation dialogs for better user experience and accessibility.
+
+- **Data Mart Table**: Cmd/Ctrl+Click now opens the Data Mart in a new tab, matching standard browser behavior
+- **Delete Dialogs**: Long Data Mart and report titles now wrap correctly without breaking layout
+- **Sticky Actions**: Fixed transparent background on sticky action cells during scroll with smooth color transitions
+- **Semantic HTML**: Improved dialog structure with proper paragraph elements for better screen reader support

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -490,18 +490,20 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
         onOpenChange={setIsDeleteDialogOpen}
         title='Delete Data Mart'
         description={
-          <span className='mt-2 block space-y-2'>
-            <span className='block'>
-              Are you sure you want to delete <strong>"{dataMartTitle}"</strong>? This action cannot
-              be undone.
-            </span>
+          <div className='mt-2 space-y-3'>
+            <p className='break-words'>
+              Are you sure you want to delete "
+              <span className='font-semibold [overflow-wrap:anywhere]'>{dataMartTitle}</span>"? This
+              action cannot be undone.
+            </p>
+
             {dataMart.storage.type === DataStorageType.LEGACY_GOOGLE_BIGQUERY && (
-              <span className='text-destructive block'>
+              <p className='text-destructive text-sm'>
                 Deleting this data mart will also make it unavailable in the Google Sheets
                 extension.
-              </span>
+              </p>
             )}
-          </span>
+          </div>
         }
         confirmLabel='Delete'
         cancelLabel='Cancel'

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
@@ -228,7 +228,16 @@ export function DataMartTable<TData, TValue>({
       return;
     }
     const id = (row.original as { id: string }).id;
-    navigate(`/data-marts/${id}/data-setup`);
+    const url = `/data-marts/${id}/data-setup`;
+    const path = scope(url);
+
+    if (e.metaKey || e.ctrlKey) {
+      window.open(path, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    console.log('path clicked: ', path);
+
+    navigate(url);
   };
 
   /**

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
@@ -235,7 +235,6 @@ export function DataMartTable<TData, TValue>({
       window.open(path, '_blank', 'noopener,noreferrer');
       return;
     }
-    console.log('path clicked: ', path);
 
     navigate(url);
   };

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/components/DataMartActionsCell.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/components/DataMartActionsCell.tsx
@@ -76,18 +76,20 @@ export const DataMartActionsCell = ({ row, onDeleteSuccess }: DataMartActionsCel
         onOpenChange={setIsDeleteDialogOpen}
         title='Delete Data Mart'
         description={
-          <span className='mt-2 block space-y-2'>
-            <span className='block'>
-              Are you sure you want to delete <strong>{row.original.title}</strong>? This action
-              cannot be undone.
-            </span>
+          <div className='mt-2 space-y-3'>
+            <p className='break-words'>
+              Are you sure you want to delete "
+              <span className='font-semibold [overflow-wrap:anywhere]'>{row.original.title}</span>"?
+              This action cannot be undone.
+            </p>
+
             {row.original.storageType === DataStorageType.LEGACY_GOOGLE_BIGQUERY && (
-              <span className='text-destructive block'>
+              <p className='text-destructive text-sm'>
                 Deleting this data mart will also make it unavailable in the Google Sheets
                 extension.
-              </span>
+              </p>
             )}
-          </span>
+          </div>
         }
         confirmLabel='Delete'
         cancelLabel='Cancel'

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
@@ -174,7 +174,13 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
           open={isDeleteDialogOpen}
           onOpenChange={setIsDeleteDialogOpen}
           title='Delete Report'
-          description={`Are you sure you want to delete "${row.original.title}"? This action cannot be undone.`}
+          description={
+            <p className='break-words'>
+              Are you sure you want to delete "
+              <span className='font-semibold [overflow-wrap:anywhere]'>{row.original.title}</span>"?
+              This action cannot be undone.
+            </p>
+          }
           confirmLabel='Delete'
           cancelLabel='Cancel'
           onConfirm={() => {

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
@@ -202,7 +202,13 @@ export function GoogleSheetsActionsCell({
           open={isDeleteDialogOpen}
           onOpenChange={setIsDeleteDialogOpen}
           title='Delete Report'
-          description={`Are you sure you want to delete "${row.original.title}"? This action cannot be undone.`}
+          description={
+            <p className='break-words'>
+              Are you sure you want to delete "
+              <span className='font-semibold [overflow-wrap:anywhere]'>{row.original.title}</span>"?
+              This action cannot be undone.
+            </p>
+          }
           confirmLabel='Delete'
           cancelLabel='Cancel'
           onConfirm={() => {

--- a/apps/web/src/shared/components/Table/BaseTable.tsx
+++ b/apps/web/src/shared/components/Table/BaseTable.tsx
@@ -98,7 +98,7 @@ export function BaseTable<TData>({
 
   const actionsCellClass = cn(
     'sticky right-0 z-10 px-2',
-    'group-hover:bg-table-tbody-sticky-hover-bg',
+    'bg-table-tbody-sticky-bg group-hover:bg-table-tbody-sticky-hover-bg transition-colors duration-200 ease-out',
     'after:pointer-events-none after:absolute after:inset-y-0 after:left-[-24px] after:w-[24px]',
     'after:bg-gradient-to-r after:from-transparent after:to-table-tbody-sticky-hover-bg',
     'after:opacity-0 after:transition-opacity after:duration-200',

--- a/apps/web/src/shared/components/Table/TableColumnSearch.tsx
+++ b/apps/web/src/shared/components/Table/TableColumnSearch.tsx
@@ -30,7 +30,7 @@ export function TableColumnSearch<TData>({
   }
 
   return (
-    <div className='relative w-full md:w-48 lg:w-80 xl:w-128'>
+    <div className='relative w-full md:w-48 lg:w-62 xl:w-128'>
       <Search className='text-muted-foreground absolute top-2.5 left-2 h-4 w-4' />
       <Input
         placeholder={placeholder}

--- a/apps/web/src/shared/components/TableFilters/TableFiltersTrigger.tsx
+++ b/apps/web/src/shared/components/TableFilters/TableFiltersTrigger.tsx
@@ -23,7 +23,7 @@ export function TableFiltersTrigger({
     <PopoverTrigger asChild>
       <Button variant='outline' size='sm' className='h-9'>
         <Icon className='size-4' />
-        <span className='hidden md:block'>{label}</span>
+        <span className='hidden lg:block'>{label}</span>
         {isActive && (
           <Badge className='bg-brand-blue-500 rounded-full px-1.5 py-0 text-xs text-white'>
             {badgeCount}

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -46,6 +46,7 @@
   --sidebar-active-foreground: oklch(0.145 0 0);
   --table-thead-sticky-bg: oklch(0.98 0 0);
   --table-tbody-sticky-hover-bg: oklch(0.97 0 0);
+  --table-tbody-sticky-bg: oklch(1 0 0);
 
   /* Brand Blue Color Scale based on brand-blue-500: oklch(0.6179 0.2295 250.87) */
   --brand-blue-50: oklch(0.985 0.03 250.87);
@@ -108,6 +109,7 @@
   --sidebar-active-foreground: oklch(0.985 0 0);
   --table-thead-sticky-bg: oklch(0.242 0 0);
   --table-tbody-sticky-hover-bg: oklch(0.269 0 0);
+  --table-tbody-sticky-bg: oklch(0.252 0 0);
 
   /* Brand Blue Color Scale — Dark Theme */
   --brand-blue-50: oklch(0.36 0.17 250.87);
@@ -174,6 +176,7 @@
   --color-sidebar-active-foreground: var(--sidebar-active-foreground);
   --color-table-thead-sticky-bg: var(--table-thead-sticky-bg);
   --color-table-tbody-sticky-hover-bg: var(--table-tbody-sticky-hover-bg);
+  --color-table-tbody-sticky-bg: var(--table-tbody-sticky-bg);
   --color-brand-blue-50: var(--brand-blue-50);
   --color-brand-blue-100: var(--brand-blue-100);
   --color-brand-blue-200: var(--brand-blue-200);


### PR DESCRIPTION
<img width="1542" height="973" alt="image" src="https://github.com/user-attachments/assets/c3c9b76c-a2b8-4ea0-be80-f0f21b287cb8" />

## Summary

Improves Data Mart UX with better navigation, accessible dialogs, and polished table interactions.

## Changes

- **Navigation**: Cmd/Ctrl+Click on Data Mart rows opens in new tab
- **Dialogs**: Delete confirmations handle long titles gracefully with proper text wrapping
- **Table UI**: Sticky action cells get default background and smooth hover transitions
- **Accessibility**: Semantic HTML structure in delete dialogs

## Screenshots

Before #1:
<img width="916" height="288" alt="Screenshot 2026-05-06 at 16 37 45" src="https://github.com/user-attachments/assets/2450b74c-b187-4e42-83d7-ca090b423264" />

After 1:
<img width="650" height="266" alt="Screenshot 2026-05-06 at 20 09 29" src="https://github.com/user-attachments/assets/42177f4e-b6b3-4e83-85ad-a0e57815b12d" />

Before 2:
<img width="681" height="781" alt="Screenshot 2026-05-06 at 20 12 25" src="https://github.com/user-attachments/assets/932ffbad-00a2-4beb-9d2e-7d5a149fdbbf" />

After 2:
<img width="359" height="236" alt="image" src="https://github.com/user-attachments/assets/7cc44c50-f3f7-42a0-95e2-4e1b47642983" />

