### PR TITLE
feat(backend): add google sheet  columns adjustment

### DIFF
--- a/.changeset/columns-adjustment-ruslan-intelligence-report.md
+++ b/.changeset/columns-adjustment-ruslan-intelligence-report.md
@@ -32,3 +32,8 @@ named ranges — stays intact across refreshes.
 - **Every imported header carries provenance.** Hover any imported column
   header and you see its description followed by the OWOX Data Marts link
   back to the source data mart — not just on the first column anymore.
+- **A failed refresh no longer wipes your existing data.** If the warehouse
+  query fails or the connection drops before any new rows have been
+  produced, the sheet stays exactly as you last saw it. The data mart's
+  status flips to "failed" so you know to investigate, but you don't lose
+  the previous successful refresh.

--- a/.changeset/columns-adjustment-ruslan-intelligence-report.md
+++ b/.changeset/columns-adjustment-ruslan-intelligence-report.md
@@ -1,0 +1,34 @@
+---
+'owox': minor
+---
+
+# Google Sheets export now preserves your column layout and side-by-side formulas
+
+Refreshing an OWOX → Google Sheets report no longer wipes the entire tab.
+The exporter only touches the rectangle of cells it owns, so anything you
+keep in the same sheet — extra columns, formulas, pivot tables, charts,
+named ranges — stays intact across refreshes.
+
+- **Your column order wins.** Drag the imported columns into whatever order
+  fits your report; refresh keeps that order. Reordering the columns in the
+  data mart's Output Schema after the first refresh no longer rearranges
+  the sheet.
+- **New SQL columns are appended on the right.** A column added later in
+  the analyst's Output Schema lands at the right edge of the imported area
+  rather than displacing existing columns.
+- **Removed SQL columns disappear cleanly.** Any formula that depended on a
+  deleted column shows `#REF!` — the same honest signal Sheets gives when
+  you delete a column by hand, so you know immediately what to fix.
+- **Helper columns next to imported data are preserved.** Currency
+  conversions, `VLOOKUP` enrichments, calculated metrics — they keep
+  pointing at the right columns across refreshes, and a formula in the
+  first data row is automatically drag-filled down across all new rows.
+- **Output Schema aliases are respected.** Rename a column to a friendly
+  label in the data mart and the sheet header updates without rewriting
+  the whole tab.
+- **Pivots, charts and named ranges referencing the imported range keep
+  working.** Adding or removing SQL columns shifts these listeners the same
+  way a manual column insert/delete in Sheets would.
+- **Every imported header carries provenance.** Hover any imported column
+  header and you see its description followed by the OWOX Data Marts link
+  back to the source data mart — not just on the first column anymore.

--- a/apps/backend/src/data-marts/data-destination-types/data-destination-providers.ts
+++ b/apps/backend/src/data-marts/data-destination-types/data-destination-providers.ts
@@ -11,6 +11,7 @@ import { DataDestinationType } from './enums/data-destination-type.enum';
 import { GoogleSheetsApiAdapterFactory } from './google-sheets/adapters/google-sheets-api-adapter.factory';
 import { GoogleSheetsReportCreatedListener } from './google-sheets/listeners/google-sheets-report-created.listener';
 import { GoogleSheetsReportDeletedListener } from './google-sheets/listeners/google-sheets-report-deleted.listener';
+import { ColumnPlanBuilder } from './google-sheets/services/column-plan-builder';
 import { GoogleSheetsAccessValidator } from './google-sheets/services/google-sheets-access-validator';
 import { GoogleSheetsCredentialsValidator } from './google-sheets/services/google-sheets-credentials-validator';
 import { GoogleSheetsReportWriter } from './google-sheets/services/google-sheets-report-writer';
@@ -92,6 +93,7 @@ const googleSheetsUtilityProviders = [
   SheetHeaderFormatter,
   SheetMetadataFormatter,
   SheetValuesFormatter,
+  ColumnPlanBuilder,
   GoogleSheetsReportCreatedListener,
   GoogleSheetsReportDeletedListener,
 ];

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
@@ -1,0 +1,163 @@
+import { JWT } from 'google-auth-library';
+import { sheets_v4 } from 'googleapis';
+import { GoogleSheetsApiAdapter } from './google-sheets-api.adapter';
+
+describe('GoogleSheetsApiAdapter (pure helpers)', () => {
+  /**
+   * The adapter constructor wraps `google.sheets()` but does not perform any
+   * network I/O until a method is called. We pass a stub auth client so that
+   * the constructor's preconditions are satisfied and we can exercise the
+   * pure helpers (request builders, filter functions, A1 conversion).
+   */
+  const buildAdapter = () => new GoogleSheetsApiAdapter(undefined, {} as unknown as JWT);
+
+  describe('colToA1', () => {
+    it.each([
+      [1, 'A'],
+      [2, 'B'],
+      [26, 'Z'],
+      [27, 'AA'],
+      [52, 'AZ'],
+      [53, 'BA'],
+      [702, 'ZZ'],
+      [703, 'AAA'],
+    ])('converts column %i to %s', (col, expected) => {
+      expect(GoogleSheetsApiAdapter.colToA1(col)).toBe(expected);
+    });
+
+    it('rejects zero or negative column indexes', () => {
+      expect(() => GoogleSheetsApiAdapter.colToA1(0)).toThrow();
+      expect(() => GoogleSheetsApiAdapter.colToA1(-3)).toThrow();
+    });
+  });
+
+  describe('buildInsertColumnRequest', () => {
+    it('produces an insertDimension request for a single column with inheritFromBefore disabled', () => {
+      // inheritFromBefore must stay false: the writer is the sole owner of
+      // the new column's content and will populate header + data cells
+      // immediately after the insert. Inheriting would clone user formulas
+      // from the column to the left into row 2..N — see Bug 2 in DoD review.
+      const adapter = buildAdapter();
+      const req = adapter.buildInsertColumnRequest(7, 3);
+
+      expect(req).toEqual({
+        insertDimension: {
+          range: {
+            sheetId: 7,
+            dimension: 'COLUMNS',
+            startIndex: 3,
+            endIndex: 4,
+          },
+          inheritFromBefore: false,
+        },
+      });
+    });
+
+    it('keeps inheritFromBefore false even at the first column position', () => {
+      const adapter = buildAdapter();
+      const req = adapter.buildInsertColumnRequest(7, 0);
+      expect(req.insertDimension?.inheritFromBefore).toBe(false);
+    });
+  });
+
+  describe('buildCopyPasteRequest', () => {
+    it('builds a PASTE_FORMULA copy/paste request with both ranges expanded for fill-down', () => {
+      // Fill-down replays a formula sitting in row 2 across rows 3..N for
+      // every user column right of the imported range. Sheets shifts
+      // relative refs the same way drag-fill does.
+      const adapter = buildAdapter();
+      const req = adapter.buildCopyPasteRequest(
+        7,
+        { startRow: 1, endRow: 2, startCol: 10, endCol: 12 }, // row 2, cols K..L
+        { startRow: 2, endRow: 13, startCol: 10, endCol: 12 }, // rows 3..13, cols K..L
+        'PASTE_FORMULA'
+      );
+
+      expect(req).toEqual({
+        copyPaste: {
+          source: {
+            sheetId: 7,
+            startRowIndex: 1,
+            endRowIndex: 2,
+            startColumnIndex: 10,
+            endColumnIndex: 12,
+          },
+          destination: {
+            sheetId: 7,
+            startRowIndex: 2,
+            endRowIndex: 13,
+            startColumnIndex: 10,
+            endColumnIndex: 12,
+          },
+          pasteType: 'PASTE_FORMULA',
+          pasteOrientation: 'NORMAL',
+        },
+      });
+    });
+
+    it('respects the requested pasteType', () => {
+      const adapter = buildAdapter();
+      const req = adapter.buildCopyPasteRequest(
+        1,
+        { startRow: 0, endRow: 1, startCol: 0, endCol: 1 },
+        { startRow: 1, endRow: 2, startCol: 0, endCol: 1 },
+        'PASTE_VALUES'
+      );
+      expect(req.copyPaste?.pasteType).toBe('PASTE_VALUES');
+    });
+  });
+
+  describe('buildDeleteColumnRequest', () => {
+    it('produces a deleteDimension request for a single column', () => {
+      const adapter = buildAdapter();
+      const req = adapter.buildDeleteColumnRequest(7, 5);
+
+      expect(req).toEqual({
+        deleteDimension: {
+          range: {
+            sheetId: 7,
+            dimension: 'COLUMNS',
+            startIndex: 5,
+            endIndex: 6,
+          },
+        },
+      });
+    });
+  });
+
+  describe('findOwoxColumnsMetadataForSheet', () => {
+    /**
+     * Build a typed metadata fixture quickly. The adapter's filter only
+     * inspects `metadataKey` and `location.sheetId`, so other fields are
+     * irrelevant to these tests.
+     */
+    const meta = (
+      key: string,
+      sheetId: number | undefined
+    ): sheets_v4.Schema$DeveloperMetadata => ({
+      metadataKey: key,
+      metadataValue: '[]',
+      location: sheetId === undefined ? {} : { sheetId },
+    });
+
+    it('returns only OWOX_COLUMNS entries bound to the given sheet', () => {
+      const adapter = buildAdapter();
+      const all: sheets_v4.Schema$DeveloperMetadata[] = [
+        meta('OWOX_REPORT_META', 1),
+        meta('OWOX_COLUMNS', 1),
+        meta('OWOX_COLUMNS', 2),
+        meta('OWOX_COLUMNS', undefined),
+        meta('SOMETHING_ELSE', 1),
+      ];
+
+      const result = adapter.findOwoxColumnsMetadataForSheet(all, 1);
+
+      expect(result).toEqual([meta('OWOX_COLUMNS', 1)]);
+    });
+
+    it('returns an empty array when no entries match', () => {
+      const adapter = buildAdapter();
+      expect(adapter.findOwoxColumnsMetadataForSheet([], 1)).toEqual([]);
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
@@ -2,6 +2,7 @@ import { Logger } from '@nestjs/common';
 import { JWT, OAuth2Client } from 'google-auth-library';
 import { google, sheets_v4 } from 'googleapis';
 import { GoogleServiceAccountKey } from '../../../../common/schemas/google-service-account-key.schema';
+import { GOOGLE_SHEETS_METADATA_KEYS } from '../constants/google-sheets-metadata-keys.constants';
 import { GoogleSheetsCredentials } from '../schemas/google-sheets-credentials.schema';
 
 /**
@@ -112,6 +113,71 @@ export class GoogleSheetsApiAdapter {
   }
 
   /**
+   * Reads a single row from a sheet as formatted strings.
+   *
+   * Trailing empty cells are dropped by the Sheets API; callers that need the
+   * raw, position-aligned array should pass an explicit `toCol`.
+   *
+   * @param spreadsheetId - ID of the spreadsheet
+   * @param sheetTitle - Title of the sheet (used in the A1 range)
+   * @param row - 1-based row index
+   * @param fromCol - 1-based, inclusive (default `1`)
+   * @param toCol - 1-based, inclusive; omit to fetch the whole row
+   */
+  public async getRowValues(
+    spreadsheetId: string,
+    sheetTitle: string,
+    row: number,
+    fromCol: number = 1,
+    toCol?: number
+  ): Promise<string[]> {
+    const range =
+      toCol !== undefined
+        ? `'${sheetTitle}'!${GoogleSheetsApiAdapter.colToA1(fromCol)}${row}:${GoogleSheetsApiAdapter.colToA1(toCol)}${row}`
+        : `'${sheetTitle}'!${row}:${row}`;
+    const resp = await this.executeWithRetry(() =>
+      this.service.spreadsheets.values.get({
+        spreadsheetId,
+        range,
+        valueRenderOption: 'FORMATTED_VALUE',
+        majorDimension: 'ROWS',
+      })
+    );
+    return (resp.data.values?.[0] ?? []).map(v => (v == null ? '' : String(v)));
+  }
+
+  /**
+   * Reads formulas from a single row of a sheet.
+   *
+   * Cells without a formula return an empty string. The returned array is
+   * positionally aligned with `[fromCol..toCol]`.
+   *
+   * @param spreadsheetId - ID of the spreadsheet
+   * @param sheetTitle - Title of the sheet (used in the A1 range)
+   * @param row - 1-based row index
+   * @param fromCol - 1-based, inclusive
+   * @param toCol - 1-based, inclusive
+   */
+  public async getRowFormulas(
+    spreadsheetId: string,
+    sheetTitle: string,
+    row: number,
+    fromCol: number,
+    toCol: number
+  ): Promise<string[]> {
+    const range = `'${sheetTitle}'!${GoogleSheetsApiAdapter.colToA1(fromCol)}${row}:${GoogleSheetsApiAdapter.colToA1(toCol)}${row}`;
+    const resp = await this.executeWithRetry(() =>
+      this.service.spreadsheets.values.get({
+        spreadsheetId,
+        range,
+        valueRenderOption: 'FORMULA',
+        majorDimension: 'ROWS',
+      })
+    );
+    return (resp.data.values?.[0] ?? []).map(v => (typeof v === 'string' ? v : ''));
+  }
+
+  /**
    * Finds OWOX report metadata by key and sheet
    *
    * @param metadata - Array of developer metadata
@@ -120,7 +186,7 @@ export class GoogleSheetsApiAdapter {
   public findOwoxReportMetadata(
     metadata: sheets_v4.Schema$DeveloperMetadata[]
   ): sheets_v4.Schema$DeveloperMetadata | undefined {
-    return metadata.find(m => m.metadataKey === 'OWOX_REPORT_META');
+    return metadata.find(m => m.metadataKey === GOOGLE_SHEETS_METADATA_KEYS.REPORT_META);
   }
 
   /**
@@ -136,7 +202,26 @@ export class GoogleSheetsApiAdapter {
     sheetId: number
   ): sheets_v4.Schema$DeveloperMetadata[] {
     return metadata.filter(
-      m => m.metadataKey === 'OWOX_REPORT_META' && m.location?.sheetId === sheetId
+      m =>
+        m.metadataKey === GOOGLE_SHEETS_METADATA_KEYS.REPORT_META && m.location?.sheetId === sheetId
+    );
+  }
+
+  /**
+   * Finds OWOX column-list metadata entries for a specific sheet. The value is
+   * a JSON array of column names ODM wrote into the imported range on the
+   * previous refresh (see {@link GOOGLE_SHEETS_METADATA_KEYS.COLUMNS}).
+   *
+   * @param metadata - Array of developer metadata
+   * @param sheetId - Sheet ID to filter by
+   * @returns Array of OWOX_COLUMNS metadata entries for the specified sheet
+   */
+  public findOwoxColumnsMetadataForSheet(
+    metadata: sheets_v4.Schema$DeveloperMetadata[],
+    sheetId: number
+  ): sheets_v4.Schema$DeveloperMetadata[] {
+    return metadata.filter(
+      m => m.metadataKey === GOOGLE_SHEETS_METADATA_KEYS.COLUMNS && m.location?.sheetId === sheetId
     );
   }
 
@@ -219,6 +304,88 @@ export class GoogleSheetsApiAdapter {
   }
 
   /**
+   * Builds a `copyPaste` request that copies a single source range over a
+   * destination range with the chosen paste type. With `pasteType:
+   * 'PASTE_FORMULA'` Google Sheets shifts relative A1 references the same way
+   * as the manual drag-fill / paste-formula does — used by the writer to
+   * extend user formulas in row 2 down across freshly written data rows.
+   *
+   * All indexes are 0-based, end-exclusive, matching the Sheets API
+   * GridRange contract. Source area is typically a single cell or row;
+   * destination area is the wider rectangle to fill.
+   */
+  public buildCopyPasteRequest(
+    sheetId: number,
+    source: { startRow: number; endRow: number; startCol: number; endCol: number },
+    destination: { startRow: number; endRow: number; startCol: number; endCol: number },
+    pasteType: 'PASTE_FORMULA' | 'PASTE_NORMAL' | 'PASTE_VALUES' | 'PASTE_FORMAT'
+  ): sheets_v4.Schema$Request {
+    return {
+      copyPaste: {
+        source: {
+          sheetId,
+          startRowIndex: source.startRow,
+          endRowIndex: source.endRow,
+          startColumnIndex: source.startCol,
+          endColumnIndex: source.endCol,
+        },
+        destination: {
+          sheetId,
+          startRowIndex: destination.startRow,
+          endRowIndex: destination.endRow,
+          startColumnIndex: destination.startCol,
+          endColumnIndex: destination.endCol,
+        },
+        pasteType,
+        pasteOrientation: 'NORMAL',
+      },
+    };
+  }
+
+  /**
+   * Builds an `insertDimension` request that inserts a single empty column at
+   * the given 0-based position. Existing columns at and right of `atColIndex`
+   * shift right by one; A1 references in workbook formulas are recalculated
+   * automatically by Sheets.
+   *
+   * `inheritFromBefore` is forced to `false` so that the new column starts
+   * empty: the writer is the sole owner of its content and will populate the
+   * header + data cells immediately after. Setting it to `true` would
+   * accidentally clone user formulas/values from the column to the left.
+   */
+  public buildInsertColumnRequest(sheetId: number, atColIndex: number): sheets_v4.Schema$Request {
+    return {
+      insertDimension: {
+        range: {
+          sheetId,
+          dimension: 'COLUMNS',
+          startIndex: atColIndex,
+          endIndex: atColIndex + 1,
+        },
+        inheritFromBefore: false,
+      },
+    };
+  }
+
+  /**
+   * Builds a `deleteDimension` request that deletes a single column at the
+   * given 0-based position. Columns right of it shift left by one; formulas
+   * referencing the deleted column become `#REF!`.
+   */
+  public buildDeleteColumnRequest(sheetId: number, atColIndex: number): sheets_v4.Schema$Request {
+    return {
+      deleteDimension: {
+        range: {
+          sheetId,
+          dimension: 'COLUMNS',
+          startIndex: atColIndex,
+          endIndex: atColIndex + 1,
+        },
+      },
+    };
+  }
+
+  /**
    * Builds delete requests for developer metadata without executing them.
    * Use this to combine deletion with other operations in a single batchUpdate call.
    *
@@ -247,6 +414,24 @@ export class GoogleSheetsApiAdapter {
     metadataIds: number[]
   ): Promise<void> {
     await this.batchUpdate(spreadsheetId, this.buildDeleteDeveloperMetadataRequests(metadataIds));
+  }
+
+  /**
+   * Converts a 1-based column index to its A1 letter representation
+   * (1 → "A", 26 → "Z", 27 → "AA", …). Used internally to build A1 ranges.
+   */
+  public static colToA1(col: number): string {
+    if (col < 1 || !Number.isInteger(col)) {
+      throw new Error(`colToA1 expects a positive integer, received ${col}`);
+    }
+    let n = col;
+    let s = '';
+    while (n > 0) {
+      const rem = (n - 1) % 26;
+      s = String.fromCharCode(65 + rem) + s;
+      n = Math.floor((n - 1) / 26);
+    }
+    return s;
   }
 
   /**

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/constants/google-sheets-metadata-keys.constants.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/constants/google-sheets-metadata-keys.constants.ts
@@ -1,0 +1,24 @@
+/**
+ * Sheet-level developer metadata keys used by ODM in Google Sheets exports.
+ *
+ * These keys are written via `createDeveloperMetadata` requests and read back
+ * to determine prior export state and to keep multiple data marts isolated
+ * per sheet.
+ */
+export const GOOGLE_SHEETS_METADATA_KEYS = {
+  /**
+   * Single entry per sheet, value is JSON `{ reportId, dataMartId, projectId }`.
+   * Used to identify which OWOX report owns the imported range on a sheet.
+   */
+  REPORT_META: 'OWOX_REPORT_META',
+
+  /**
+   * JSON array of column names ODM has written into the imported range on the
+   * previous refresh. Used to delineate the imported rectangle on subsequent
+   * refreshes so that user content right of it stays untouched.
+   */
+  COLUMNS: 'OWOX_COLUMNS',
+} as const;
+
+export type GoogleSheetsMetadataKey =
+  (typeof GOOGLE_SHEETS_METADATA_KEYS)[keyof typeof GOOGLE_SHEETS_METADATA_KEYS];

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.spec.ts
@@ -267,4 +267,63 @@ describe('ColumnPlanBuilder', () => {
       expect(plan.finalImportedNames).toEqual(['date', 'cost']);
     });
   });
+
+  describe('alias↔name collision (C6)', () => {
+    it('logs a warning, ignores the second mapping, and does not crash on a collision', () => {
+      // Pathological-but-allowed shape: one column named `revenue` exposed
+      // as `Revenue`, another column literally named `Revenue` (no alias).
+      // Both compete for the display key `Revenue`. There is no clean
+      // recovery for "two row-1 cells share the same display string", but
+      // the builder MUST:
+      //   * detect the collision and emit an actionable warning, and
+      //   * still produce a finite plan without throwing.
+      // Operators rely on the log to find and rename one of the colliding
+      // columns. Downstream duplicate detection (C5 / data integrity) is
+      // expected to catch any residual degeneracy.
+      const warn = jest.spyOn(builder['logger'], 'warn').mockImplementation(() => undefined);
+
+      expect(() =>
+        builder.build(
+          ['Revenue', 'Revenue'],
+          [new PreviousImportedColumn('revenue', 'Revenue'), new PreviousImportedColumn('Revenue')],
+          headers('revenue', 'Revenue')
+        )
+      ).not.toThrow();
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Display string "Revenue" maps to multiple canonical names')
+      );
+      warn.mockRestore();
+    });
+  });
+
+  describe('empty cell in row 1 (H1)', () => {
+    it('substitutes the canonical name from the previous-run snapshot when a header is blank', () => {
+      const warn = jest.spyOn(builder['logger'], 'warn').mockImplementation(() => undefined);
+
+      // User accidentally cleared header `b` in the middle of the imported
+      // range. Without recovery, the diff would treat the column as
+      // "missing" and delete it, shifting data on the next refresh.
+      const plan = builder.build(['a', '', 'c'], prev('a', 'b', 'c'), headers('a', 'b', 'c'));
+
+      // No structural ops needed — the empty cell is recovered to `b` from
+      // the prior snapshot, and the diff is a no-op.
+      expect(plan.ops).toEqual([]);
+      expect(plan.finalImportedNames).toEqual(['a', 'b', 'c']);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Row 1 cell at column index 1 is empty')
+      );
+      warn.mockRestore();
+    });
+
+    it('treats an empty cell as nonexistent when the previous snapshot has no entry for it', () => {
+      // Edge case: prev shorter than existingHeaders width. Slicing keeps
+      // only the imported region, so this only matters when both are short.
+      const plan = builder.build(['a', ''], prev('a', 'b'), headers('a', 'b'));
+
+      // Prev has `b` at index 1 → recover; no structural op needed.
+      expect(plan.ops).toEqual([]);
+      expect(plan.finalImportedNames).toEqual(['a', 'b']);
+    });
+  });
 });

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.spec.ts
@@ -1,0 +1,270 @@
+import { PreviousImportedColumn } from '../../../dto/domain/column-plan.dto';
+import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
+import { ColumnPlanBuilder } from './column-plan-builder';
+
+describe('ColumnPlanBuilder', () => {
+  let builder: ColumnPlanBuilder;
+
+  beforeEach(() => {
+    builder = new ColumnPlanBuilder();
+  });
+
+  /**
+   * Convenience helper: build `ReportDataHeader[]` from a list of names so
+   * test cases stay focused on column ordering, not full DTO construction.
+   */
+  const headers = (...names: string[]): ReportDataHeader[] =>
+    names.map(name => new ReportDataHeader(name));
+
+  /**
+   * Build aliased headers when a test exercises alias-aware behavior.
+   * Items are written as `name|alias` for readability, e.g. `aliased('date|Date', 'cost')`.
+   */
+  const aliased = (...specs: string[]): ReportDataHeader[] =>
+    specs.map(spec => {
+      const [name, alias] = spec.split('|');
+      return new ReportDataHeader(name, alias);
+    });
+
+  /**
+   * Build `PreviousImportedColumn[]` with no aliases — covers the common
+   * case where the previous refresh wrote names directly into row 1.
+   */
+  const prev = (...names: string[]): PreviousImportedColumn[] =>
+    names.map(name => new PreviousImportedColumn(name));
+
+  /** Build `PreviousImportedColumn[]` from `name|alias` specs. */
+  const prevAliased = (...specs: string[]): PreviousImportedColumn[] =>
+    specs.map(spec => {
+      const [name, alias] = spec.split('|');
+      return new PreviousImportedColumn(name, alias);
+    });
+
+  /**
+   * Assert that a plan exposes the expected ops in the expected order.
+   * Compared as plain tuples to keep failure messages readable.
+   */
+  const opsTuples = (plan: ReturnType<ColumnPlanBuilder['build']>) =>
+    plan.ops.map(op => [op.kind, op.atIndex, op.name] as const);
+
+  describe('first run', () => {
+    it('writes desired columns in SQL order when no metadata and empty sheet', () => {
+      const plan = builder.build([], null, headers('a', 'b', 'c'));
+
+      expect(plan.isFirstRun).toBe(true);
+      expect(plan.finalImportedNames).toEqual(['a', 'b', 'c']);
+      expect(plan.ops).toEqual([]);
+      expect(plan.lastImportedColIndex).toBe(2);
+      expect(plan.prevLastImportedColIndex).toBe(-1);
+      expect(plan.nameToFinalIndex.get('a')).toBe(0);
+      expect(plan.nameToFinalIndex.get('b')).toBe(1);
+      expect(plan.nameToFinalIndex.get('c')).toBe(2);
+    });
+
+    it('overwrites stale row-1 content when metadata is missing', () => {
+      // User had unrelated headers but never linked the sheet to ODM before.
+      const plan = builder.build(['x', 'y'], null, headers('a', 'b'));
+
+      expect(plan.isFirstRun).toBe(true);
+      expect(plan.finalImportedNames).toEqual(['a', 'b']);
+      expect(plan.ops).toEqual([]);
+    });
+
+    it('treats wiped row 1 as first run even when OWOX_COLUMNS metadata exists', () => {
+      const plan = builder.build([], prev('a', 'b'), headers('a', 'b'));
+
+      expect(plan.isFirstRun).toBe(true);
+      expect(plan.finalImportedNames).toEqual(['a', 'b']);
+      expect(plan.ops).toEqual([]);
+    });
+
+    it('handles empty desired headers on first run', () => {
+      const plan = builder.build([], null, headers());
+
+      expect(plan.isFirstRun).toBe(true);
+      expect(plan.finalImportedNames).toEqual([]);
+      expect(plan.lastImportedColIndex).toBe(-1);
+    });
+  });
+
+  describe('subsequent run — no structural change', () => {
+    it('emits no ops when desired schema matches current row 1', () => {
+      const plan = builder.build(['a', 'b'], prev('a', 'b'), headers('a', 'b'));
+
+      expect(plan.isFirstRun).toBe(false);
+      expect(plan.ops).toEqual([]);
+      expect(plan.finalImportedNames).toEqual(['a', 'b']);
+      expect(plan.prevLastImportedColIndex).toBe(1);
+    });
+
+    it('keeps user-driven column reorder intact (row-1 order wins)', () => {
+      // ODM previously wrote [date, campaign, clicks, cost]; user dragged
+      // columns into a different order; SQL still asks for the same names.
+      const plan = builder.build(
+        ['date', 'cost', 'campaign', 'clicks'],
+        prev('date', 'campaign', 'clicks', 'cost'),
+        headers('date', 'campaign', 'clicks', 'cost')
+      );
+
+      expect(plan.ops).toEqual([]);
+      expect(plan.finalImportedNames).toEqual(['date', 'cost', 'campaign', 'clicks']);
+      expect(plan.nameToFinalIndex.get('cost')).toBe(1);
+      expect(plan.nameToFinalIndex.get('campaign')).toBe(2);
+    });
+
+    it('ignores user content right of the imported range', () => {
+      // `U` is a user-added column; ODM only owns indices 0..1.
+      const plan = builder.build(['a', 'b', 'U'], prev('a', 'b'), headers('a', 'b'));
+
+      expect(plan.ops).toEqual([]);
+      expect(plan.finalImportedNames).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('subsequent run — additions', () => {
+    it('appends a new SQL column at the right edge of the imported range', () => {
+      const plan = builder.build(['a', 'b', 'U'], prev('a', 'b'), headers('a', 'b', 'c'));
+
+      expect(opsTuples(plan)).toEqual([['insert', 2, 'c']]);
+      expect(plan.finalImportedNames).toEqual(['a', 'b', 'c']);
+      expect(plan.lastImportedColIndex).toBe(2);
+    });
+
+    it('appends multiple new columns in SQL order', () => {
+      const plan = builder.build(['a'], prev('a'), headers('a', 'b', 'c'));
+
+      expect(opsTuples(plan)).toEqual([
+        ['insert', 1, 'b'],
+        ['insert', 2, 'c'],
+      ]);
+      expect(plan.finalImportedNames).toEqual(['a', 'b', 'c']);
+    });
+  });
+
+  describe('subsequent run — deletions', () => {
+    it('deletes a removed column and shifts user content left', () => {
+      // ODM owned [c,a,b]; user added trailing column `U`. SQL drops `c`.
+      const plan = builder.build(['c', 'a', 'b', 'U'], prev('c', 'a', 'b'), headers('a', 'b'));
+
+      expect(opsTuples(plan)).toEqual([['delete', 0, 'c']]);
+      expect(plan.finalImportedNames).toEqual(['a', 'b']);
+      expect(plan.prevLastImportedColIndex).toBe(2);
+    });
+
+    it('deletes multiple removed columns from highest index first', () => {
+      const plan = builder.build(['a', 'b', 'c'], prev('a', 'b', 'c'), headers('b'));
+
+      // Both `a` (idx 0) and `c` (idx 2) are dropped; emit in descending order.
+      expect(opsTuples(plan)).toEqual([
+        ['delete', 2, 'c'],
+        ['delete', 0, 'a'],
+      ]);
+      expect(plan.finalImportedNames).toEqual(['b']);
+    });
+  });
+
+  describe('subsequent run — mixed add and remove', () => {
+    it('emits deletes before inserts and lands on the correct final layout', () => {
+      const plan = builder.build(['a', 'b', 'c', 'U'], prev('a', 'b', 'c'), headers('b', 'c', 'd'));
+
+      expect(opsTuples(plan)).toEqual([
+        ['delete', 0, 'a'],
+        ['insert', 2, 'd'],
+      ]);
+      expect(plan.finalImportedNames).toEqual(['b', 'c', 'd']);
+    });
+
+    it('honors user-driven reorder while adding a new column', () => {
+      const plan = builder.build(
+        ['c', 'a', 'b', 'U'],
+        prev('a', 'b', 'c'),
+        headers('a', 'b', 'c', 'd')
+      );
+
+      expect(opsTuples(plan)).toEqual([['insert', 3, 'd']]);
+      expect(plan.finalImportedNames).toEqual(['c', 'a', 'b', 'd']);
+    });
+  });
+
+  describe('rename in SQL', () => {
+    it('treats a renamed column as delete + insert (formulas referencing old name break with #REF!)', () => {
+      const plan = builder.build(['a', 'b'], prev('a', 'b'), headers('a', 'bb'));
+
+      expect(opsTuples(plan)).toEqual([
+        ['delete', 1, 'b'],
+        ['insert', 1, 'bb'],
+      ]);
+      expect(plan.finalImportedNames).toEqual(['a', 'bb']);
+    });
+  });
+
+  describe('alias-aware mapping (Output Schema aliases)', () => {
+    it('translates row-1 aliases back to canonical names — stable refresh', () => {
+      // Output Schema sets aliases "Date" and "Cost"; row 1 shows aliases.
+      // No structural change should be emitted.
+      const plan = builder.build(
+        ['Date', 'Cost'],
+        prevAliased('date|Date', 'cost|Cost'),
+        aliased('date|Date', 'cost|Cost')
+      );
+
+      expect(plan.ops).toEqual([]);
+      expect(plan.finalImportedNames).toEqual(['date', 'cost']);
+      expect(plan.nameToFinalIndex.get('date')).toBe(0);
+      expect(plan.nameToFinalIndex.get('cost')).toBe(1);
+    });
+
+    it('preserves user reorder when aliases are configured', () => {
+      // User dragged Cost in front of Date.
+      const plan = builder.build(
+        ['Cost', 'Date'],
+        prevAliased('date|Date', 'cost|Cost'),
+        aliased('date|Date', 'cost|Cost')
+      );
+
+      expect(plan.ops).toEqual([]);
+      expect(plan.finalImportedNames).toEqual(['cost', 'date']);
+    });
+
+    it('appends a new column with alias at the right edge of the imported range', () => {
+      const plan = builder.build(
+        ['Date', 'Cost'],
+        prevAliased('date|Date', 'cost|Cost'),
+        aliased('date|Date', 'cost|Cost', 'revenue|Revenue')
+      );
+
+      expect(opsTuples(plan)).toEqual([['insert', 2, 'revenue']]);
+      expect(plan.finalImportedNames).toEqual(['date', 'cost', 'revenue']);
+    });
+
+    it('handles the legacy metadata format (plain string names without aliases)', () => {
+      // Sheet exported before alias-aware metadata: previous snapshot is just
+      // names. Row 1 displays the names too. Expectation: behaves identically
+      // to a name-only diff.
+      const plan = builder.build(['a', 'b'], prev('a', 'b'), headers('a', 'b', 'c'));
+
+      expect(opsTuples(plan)).toEqual([['insert', 2, 'c']]);
+    });
+
+    it('falls back to treating an unknown row-1 string as the name itself', () => {
+      // User manually retyped a header in row 1 since the last refresh.
+      // The display string is not in the alias→name map; we trust it as the
+      // name and let the diff decide whether to keep, delete, or rename it.
+      const plan = builder.build(
+        ['date', 'manually_renamed_by_user'],
+        prevAliased('date|Date', 'cost|Cost'),
+        aliased('date|Date', 'cost|Cost')
+      );
+
+      // `cost` (with alias `Cost`) is no longer present in row 1, so it gets
+      // deleted; `manually_renamed_by_user` is foreign to desired schema, so
+      // it gets deleted too. (But desired set still contains `date` and
+      // `cost` — `cost` is not in current set, so it gets re-inserted.)
+      expect(opsTuples(plan)).toEqual([
+        ['delete', 1, 'manually_renamed_by_user'],
+        ['insert', 1, 'cost'],
+      ]);
+      expect(plan.finalImportedNames).toEqual(['date', 'cost']);
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.ts
@@ -100,19 +100,54 @@ export class ColumnPlanBuilder {
     const currentImportedDisplay = existingHeaders.slice(0, prevWidth);
 
     // Translate row-1 display strings (which can be aliases) to canonical
-    // names. Build the alias→name map from the previous-run snapshot:
-    // multiple aliases map to multiple names, but the same display string
-    // can never collide because Sheets headers are unique within imported
-    // range. If a display string is not found in the map, fall back to
-    // treating it as the name itself — handles the case where the user
-    // manually edited a row-1 cell since the last refresh.
+    // names. The alias→name map is built from the previous-run snapshot.
+    //
+    // Collision handling: two columns in the same imported range could
+    // (rarely, but in principle) share the same display string — e.g. one
+    // column with name=`revenue`, alias=`Revenue` and another with
+    // name=`Revenue` and no alias. In that case the first mapping wins and
+    // we emit a warning; the second column will fall through to the
+    // name-as-display fallback below, which is enough for the diff to
+    // recover without silently mis-routing data.
     const aliasToName = new Map<string, string>();
     for (const { name, alias } of previousOwoxColumns) {
-      aliasToName.set(alias ?? name, name);
+      const displayKey = alias ?? name;
+      const existing = aliasToName.get(displayKey);
+      if (existing !== undefined && existing !== name) {
+        this.logger.warn(
+          `Display string "${displayKey}" maps to multiple canonical names ` +
+            `("${existing}" and "${name}") in OWOX_COLUMNS — keeping the first. ` +
+            `Consider renaming one of the columns to avoid future ambiguity.`
+        );
+        continue;
+      }
+      aliasToName.set(displayKey, name);
     }
-    const currentImportedNames = currentImportedDisplay.map(display =>
-      display ? (aliasToName.get(display) ?? display) : ''
-    );
+
+    // Convert each row-1 cell to a canonical name:
+    //   * Non-empty + known display string → resolve via aliasToName.
+    //   * Non-empty + unknown display string → trust as canonical name
+    //     (handles the case where the user manually edited a header).
+    //   * Empty cell within imported region → substitute the canonical name
+    //     from the previous-run snapshot at the same index. This protects
+    //     against a user accidentally clearing a header: instead of
+    //     "phantom" the column out of the diff and silently shifting data
+    //     on the next refresh, we treat the column as if its header were
+    //     still there. Emit a warning so the operator sees the recovery.
+    const currentImportedNames = currentImportedDisplay.map((display, idx) => {
+      if (display) {
+        return aliasToName.get(display) ?? display;
+      }
+      const recovered = previousOwoxColumns[idx]?.name;
+      if (recovered) {
+        this.logger.warn(
+          `Row 1 cell at column index ${idx} is empty — recovering canonical ` +
+            `name "${recovered}" from OWOX_COLUMNS snapshot.`
+        );
+        return recovered;
+      }
+      return '';
+    });
 
     const desiredSet = new Set(desiredNames);
     const currentSet = new Set(currentImportedNames.filter(Boolean));

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.ts
@@ -1,0 +1,159 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  ColumnPlan,
+  PreviousImportedColumn,
+  StructuralColumnOp,
+} from '../../../dto/domain/column-plan.dto';
+import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
+
+/**
+ * Builds a {@link ColumnPlan} describing how to update the imported column range
+ * of a Google Sheet so that:
+ *   - existing user-driven column ordering in row 1 is preserved;
+ *   - new SQL columns are appended to the right edge of the imported range;
+ *   - SQL columns no longer present are removed;
+ *   - any content right of the imported range is left untouched.
+ *
+ * Stateless. Pure function exposed as `@Injectable()` to follow the existing
+ * pattern of formatter services in this folder
+ * (e.g. `SheetMetadataFormatter`, `SheetHeaderFormatter`).
+ */
+@Injectable()
+export class ColumnPlanBuilder {
+  private readonly logger = new Logger(ColumnPlanBuilder.name);
+
+  /**
+   * @param existingHeaders - row-1 values from the destination sheet
+   *   (FORMATTED_VALUE), trailing-empty cells already trimmed by the caller.
+   *   Each entry may be either a column `name` or its user-friendly `alias`,
+   *   depending on whether an alias was configured on the previous refresh.
+   * @param previousOwoxColumns - the (name, alias?) pairs ODM wrote into the
+   *   imported range on the previous refresh, parsed from `OWOX_COLUMNS`
+   *   developer metadata. `null` when metadata is absent (first refresh of
+   *   the sheet). Used to translate display strings in `existingHeaders`
+   *   back to canonical names so the diff is robust to aliasing.
+   * @param desiredHeaders - the column schema produced by the current SQL
+   *   output, in SQL declaration order.
+   */
+  public build(
+    existingHeaders: string[],
+    previousOwoxColumns: PreviousImportedColumn[] | null,
+    desiredHeaders: ReportDataHeader[]
+  ): ColumnPlan {
+    const desiredNames = desiredHeaders.map(h => h.name);
+
+    // First run: no prior ODM metadata, OR row 1 is empty (user wiped headers
+    // manually). Either way we treat the sheet as a blank canvas and lay down
+    // columns in SQL order without any structural ops.
+    const isFirstRun = previousOwoxColumns === null || existingHeaders.length === 0;
+    if (isFirstRun) {
+      if (previousOwoxColumns !== null && existingHeaders.length === 0) {
+        this.logger.warn(
+          'OWOX_COLUMNS metadata exists but row 1 is empty — treating as first run.'
+        );
+      }
+      return this.buildFirstRunPlan(desiredNames);
+    }
+
+    return this.buildDiffPlan(existingHeaders, previousOwoxColumns, desiredNames);
+  }
+
+  /**
+   * First-run path: write all desired columns into row 1 in SQL order, no
+   * insert/delete ops needed (the writer simply populates A1..Z1 with the
+   * header row).
+   */
+  private buildFirstRunPlan(desiredNames: string[]): ColumnPlan {
+    const nameToFinalIndex = new Map<string, number>();
+    desiredNames.forEach((name, idx) => nameToFinalIndex.set(name, idx));
+
+    return new ColumnPlan(
+      true, // isFirstRun
+      desiredNames,
+      [], // ops
+      nameToFinalIndex,
+      desiredNames.length - 1, // lastImportedColIndex (-1 if empty)
+      -1 // prevLastImportedColIndex
+    );
+  }
+
+  /**
+   * Subsequent-run path: diff the imported region (row-1 cells claimed by
+   * `OWOX_COLUMNS`) against the desired SQL schema and emit structural ops.
+   *
+   * Op ordering invariant: deletes first, sorted by `atIndex` descending so
+   * later deletes do not shift earlier ones. Inserts follow, each at the
+   * right edge of the (currently surviving) imported region. This keeps
+   * `atIndex` valid at the moment of application and ensures user content,
+   * which sits past the imported region, shifts predictably right with each
+   * insert.
+   */
+  private buildDiffPlan(
+    existingHeaders: string[],
+    previousOwoxColumns: PreviousImportedColumn[],
+    desiredNames: string[]
+  ): ColumnPlan {
+    const prevWidth = previousOwoxColumns.length;
+    const prevLastImportedColIndex = prevWidth - 1;
+
+    // Anything past `prevWidth` is user content; we never touch it.
+    const currentImportedDisplay = existingHeaders.slice(0, prevWidth);
+
+    // Translate row-1 display strings (which can be aliases) to canonical
+    // names. Build the alias→name map from the previous-run snapshot:
+    // multiple aliases map to multiple names, but the same display string
+    // can never collide because Sheets headers are unique within imported
+    // range. If a display string is not found in the map, fall back to
+    // treating it as the name itself — handles the case where the user
+    // manually edited a row-1 cell since the last refresh.
+    const aliasToName = new Map<string, string>();
+    for (const { name, alias } of previousOwoxColumns) {
+      aliasToName.set(alias ?? name, name);
+    }
+    const currentImportedNames = currentImportedDisplay.map(display =>
+      display ? (aliasToName.get(display) ?? display) : ''
+    );
+
+    const desiredSet = new Set(desiredNames);
+    const currentSet = new Set(currentImportedNames.filter(Boolean));
+
+    // Survivors keep their existing positions (preserves user ordering).
+    const survivors = currentImportedNames.filter(name => !!name && desiredSet.has(name));
+    // New names are appended in SQL order.
+    const toAdd = desiredNames.filter(name => !currentSet.has(name));
+
+    const ops: StructuralColumnOp[] = [];
+
+    // Deletes: emit by descending atIndex so subsequent indexes stay valid.
+    const deleteEntries: Array<{ index: number; name: string }> = [];
+    currentImportedNames.forEach((name, idx) => {
+      if (name && !desiredSet.has(name)) {
+        deleteEntries.push({ index: idx, name });
+      }
+    });
+    deleteEntries.sort((a, b) => b.index - a.index);
+    for (const { index, name } of deleteEntries) {
+      ops.push(new StructuralColumnOp('delete', index, name));
+    }
+
+    // Inserts: each at the right edge of the imported region as it grows.
+    let nextInsertIndex = survivors.length;
+    for (const name of toAdd) {
+      ops.push(new StructuralColumnOp('insert', nextInsertIndex, name));
+      nextInsertIndex++;
+    }
+
+    const finalImportedNames = [...survivors, ...toAdd];
+    const nameToFinalIndex = new Map<string, number>();
+    finalImportedNames.forEach((name, idx) => nameToFinalIndex.set(name, idx));
+
+    return new ColumnPlan(
+      false, // isFirstRun
+      finalImportedNames,
+      ops,
+      nameToFinalIndex,
+      finalImportedNames.length - 1,
+      prevLastImportedColIndex
+    );
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -47,6 +47,13 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
   private headersByName: Map<string, ReportDataHeader>;
   private columnPlan: ColumnPlan;
   private owoxColumnsMetadataId?: number;
+  /**
+   * Metadata IDs of any extra `OWOX_COLUMNS` entries beyond the canonical
+   * one (`owoxColumnsMetadataId`). Populated by {@link readSheetState};
+   * scheduled for atomic deletion in the finalize batchUpdate. Empty in the
+   * common case.
+   */
+  private duplicateOwoxColumnsMetadataIds: number[] = [];
   private spreadsheetTimeZone: string;
   private spreadsheetTitle: string;
   private sheetTitle: string;
@@ -88,6 +95,20 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
    * Auto fill-down for user formulas in row 2 right of the imported range is
    * replayed in {@link finalize} via a `PASTE_FORMULA` `copyPaste` request,
    * after data rows have been written — Sheets shifts relative refs there too.
+   *
+   * ### Concurrency
+   *
+   * There is a TOCTOU window between {@link readSheetState} and
+   * {@link applyStructuralColumnOps}: in the order of hundreds of
+   * milliseconds. If a user manually reorders columns in row 1 inside this
+   * window, the structural ops can act on the wrong indices and write data
+   * into the wrong cells for that one refresh. We accept this trade-off
+   * because (a) the window is small, (b) Sheets API does not expose
+   * optimistic-concurrency primitives like `If-Match`/`revisionId` on
+   * `batchUpdate`, and (c) the next refresh re-reads the layout and
+   * self-corrects — `OWOX_COLUMNS` is persisted in the same `batchUpdate`
+   * that runs at the end of this flow, so prior-state inconsistency cannot
+   * leak across refreshes. The risk is documented here rather than guarded.
    */
   public async prepareToWriteReport(
     report: Report,
@@ -102,6 +123,20 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
           'Cannot prepare report: Data mart has no connected fields. Please ensure at least one field is connected.'
         );
       }
+
+      // C5 — Reject duplicate column names from the SQL output up-front. The
+      // diff maps by name, so two columns sharing a name would collide in
+      // `headersByName` and `nameToFinalIndex`, silently dropping one column's
+      // values into another column on every refresh. We surface this as a
+      // business violation rather than logging it.
+      const duplicates = this.findDuplicateColumnNames(this.reportDataHeaders);
+      if (duplicates.length > 0) {
+        throw new BusinessViolationException(
+          `Duplicate column names in SQL output: ${duplicates.join(', ')}. ` +
+            `Rename one of the conflicting columns or apply an alias.`
+        );
+      }
+
       this.headersByName = new Map(this.reportDataHeaders.map(h => [h.name, h]));
 
       const { existingHeaders, previousOwoxColumns } = await this.readSheetState();
@@ -110,6 +145,22 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
         existingHeaders,
         previousOwoxColumns,
         this.reportDataHeaders
+      );
+
+      // C4 — Structured telemetry log for rollout observability. One line per
+      // refresh; lets us monitor first-run vs diff-run distribution, op
+      // counts, and tie any anomalies back to a specific data mart without a
+      // feature flag.
+      this.logger.log(
+        `gs-export.column-plan ` +
+          `dataMartId=${report.dataMart.id} ` +
+          `reportId=${report.id} ` +
+          `sheetId=${this.destination.sheetId} ` +
+          `isFirstRun=${this.columnPlan.isFirstRun} ` +
+          `prevColumns=${previousOwoxColumns?.length ?? 0} ` +
+          `desiredColumns=${this.reportDataHeaders.length} ` +
+          `inserts=${this.columnPlan.ops.filter(op => op.kind === 'insert').length} ` +
+          `deletes=${this.columnPlan.ops.filter(op => op.kind === 'delete').length}`
       );
 
       if (reportDataDescription.estimatedDataRowsCount) {
@@ -232,8 +283,11 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
                   `Overwriting with report ${this.report.id} as the new source of truth.`
               );
             }
-          } catch {
-            /* ignore parse error */
+          } catch (err) {
+            this.logger.debug(
+              `Failed to parse existing OWOX_REPORT_META on sheet ${this.destination.sheetId}; ` +
+                `treating as missing reportId. Cause: ${(err as Error).message}`
+            );
           }
           requests.push(
             this.metadataFormatter.updateDeveloperMetadataRequest(
@@ -279,14 +333,37 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
           );
         }
 
+        // H2 — atomically delete any extra OWOX_COLUMNS entries detected at
+        // read time, in the same batch as the canonical update. Mirrors the
+        // OWOX_REPORT_META dedup branch above.
+        if (this.duplicateOwoxColumnsMetadataIds.length > 0) {
+          requests.push(
+            ...this.adapter.buildDeleteDeveloperMetadataRequests(
+              this.duplicateOwoxColumnsMetadataIds
+            )
+          );
+          this.logger.debug(
+            `Scheduling deletion of ${this.duplicateOwoxColumnsMetadataIds.length} duplicate ` +
+              `OWOX_COLUMNS entries on sheet ${this.destination.sheetId}.`
+          );
+        }
+
+        // C1 + C2 + H4 — append fill-down `copyPaste` requests to the same
+        // batch so either both metadata persist AND fill-down replay land,
+        // or neither lands. Gates fill-down per-column on the presence of a
+        // formula in row 2 (no fill-down for static values / blank cells).
+        const fillDownRequests = await this.buildFillDownRequests();
+        if (fillDownRequests.length > 0) {
+          requests.push(...fillDownRequests);
+        }
+
         await this.adapter.batchUpdate(this.destination.spreadsheetId, requests);
 
         this.logger.debug(
           `Developer metadata written for report ${this.report.id} ` +
-            `(project: ${dataMart.projectId}, datamart: ${dataMart.id})`
+            `(project: ${dataMart.projectId}, datamart: ${dataMart.id}); ` +
+            `fillDownRequests=${fillDownRequests.length}`
         );
-
-        await this.replayFillDownFormulas();
       }
     }, 'Finalizing report with metadata and formatting');
     if (!processingError) {
@@ -447,6 +524,20 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
         const first = owoxColumnsEntries[0];
         this.owoxColumnsMetadataId = first.metadataId ?? undefined;
         previousOwoxColumns = this.parseOwoxColumnsMetadata(first.metadataValue ?? null);
+
+        // H2 — capture extra OWOX_COLUMNS entries for atomic cleanup in
+        // finalize. Mirrors the OWOX_REPORT_META dedup pattern below.
+        if (owoxColumnsEntries.length > 1) {
+          this.duplicateOwoxColumnsMetadataIds = owoxColumnsEntries
+            .slice(1)
+            .map(m => m.metadataId)
+            .filter((id): id is number => typeof id === 'number');
+          this.logger.warn(
+            `Found ${owoxColumnsEntries.length} OWOX_COLUMNS entries on sheet ` +
+              `${this.destination.sheetId} (dataMartId=${this.report.dataMart.id}). ` +
+              `Keeping the first and scheduling the rest for deletion in finalize.`
+          );
+        }
       }
 
       return { existingHeaders, previousOwoxColumns };
@@ -597,6 +688,24 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
    * order (i.e. SQL order); we move each value into the slot dictated by
    * `columnPlan.nameToFinalIndex`.
    */
+  /**
+   * Returns the list of column names that appear more than once in the
+   * input headers, with each duplicate listed only once. Empty array when
+   * all names are unique.
+   */
+  private findDuplicateColumnNames(headers: ReportDataHeader[]): string[] {
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const h of headers) {
+      if (seen.has(h.name)) {
+        duplicates.add(h.name);
+      } else {
+        seen.add(h.name);
+      }
+    }
+    return [...duplicates];
+  }
+
   private reorderRowsToFinalLayout(rows: unknown[][]): unknown[][] {
     const finalNames = this.columnPlan.finalImportedNames;
     return rows.map(srcRow => {
@@ -610,39 +719,78 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
   }
 
   /**
-   * Replays user fill-down formulas in row 2 across rows `[3..writtenRowsCount]`
-   * for every column right of the imported range.
+   * Builds fill-down `copyPaste` requests for user formulas sitting in row 2
+   * right of the imported range. The writer applies these requests as part
+   * of the finalize batchUpdate so that fill-down and metadata persist
+   * atomically — if either part fails, the whole batch is rejected and
+   * `OWOX_COLUMNS` is not advanced past a half-applied state.
    *
-   * Implemented as a single `copyPaste` request with `pasteType:
-   * 'PASTE_FORMULA'` — Google Sheets shifts relative A1 refs the same way
-   * drag-fill does. Cells in row 2 that hold static values (not formulas)
-   * are left untouched by `PASTE_FORMULA`.
+   * Strategy:
+   *   * Read row 2 of the user-content area (right of the imported range)
+   *     with `valueRenderOption: 'FORMULA'`.
+   *   * For each cell whose value starts with `=`, emit one narrow
+   *     `copyPaste` (source: row 2 of that column; destination: rows
+   *     3..writtenRowsCount of the same column; `pasteType: 'PASTE_FORMULA'`).
+   *   * Columns that hold a static value or are empty produce no request,
+   *     so the writer never overwrites a user lookup table in rows 3..N.
+   *
+   * Returns an empty array when there is nothing to fill (no user columns
+   * to the right, no data rows under the headers, or row 2 has no
+   * formulas).
    *
    * NOTE: writing the formula string directly via `values.update` /
    * `values.batchUpdate` would NOT shift refs — that API records formula
    * strings verbatim, regardless of destination row.
    */
-  private async replayFillDownFormulas(): Promise<void> {
-    const sourceCol = this.columnPlan.lastImportedColIndex + 1; // 0-based
-    const lastCol = this.availableColumnsCount; // 0-exclusive end
-    const sourceRow = 1; // 0-based row 2
-    const destStartRow = 2; // 0-based row 3
-    const destEndRow = this.writtenRowsCount; // 0-exclusive end
+  private async buildFillDownRequests(): Promise<sheets_v4.Schema$Request[]> {
+    const firstUserCol1 = this.columnPlan.lastImportedColIndex + 2; // 1-based first col right of imported
+    const lastCol1 = this.availableColumnsCount; // 1-based, inclusive
+    const dataRowFrom = 3; // 1-based; rows 3..writtenRowsCount get the fill-down
+    const dataRowTo = this.writtenRowsCount; // 1-based, inclusive
 
-    // Skip when there's nothing to fill (no rows below row 2, or no user
-    // columns right of imported range).
-    if (sourceCol >= lastCol || destStartRow >= destEndRow) {
-      return;
+    // Nothing to fill: no user columns, or no rows under row 2.
+    if (firstUserCol1 > lastCol1 || dataRowFrom > dataRowTo) {
+      return [];
     }
-    return this.executeWithErrorHandling(async () => {
-      const request = this.adapter.buildCopyPasteRequest(
-        this.destination.sheetId,
-        { startRow: sourceRow, endRow: sourceRow + 1, startCol: sourceCol, endCol: lastCol },
-        { startRow: destStartRow, endRow: destEndRow, startCol: sourceCol, endCol: lastCol },
-        'PASTE_FORMULA'
+
+    const formulas = await this.executeWithErrorHandling(
+      () =>
+        this.adapter.getRowFormulas(
+          this.destination.spreadsheetId,
+          this.sheetTitle,
+          2,
+          firstUserCol1,
+          lastCol1
+        ),
+      'Reading row-2 formulas for fill-down'
+    );
+
+    const requests: sheets_v4.Schema$Request[] = [];
+    formulas.forEach((cell, i) => {
+      if (!cell.startsWith('=')) {
+        return; // gate: skip static values and empties so we don't overwrite user content
+      }
+      const col0Based = firstUserCol1 - 1 + i;
+      requests.push(
+        this.adapter.buildCopyPasteRequest(
+          this.destination.sheetId,
+          {
+            startRow: 1, // 0-based row 2
+            endRow: 2, // exclusive
+            startCol: col0Based,
+            endCol: col0Based + 1,
+          },
+          {
+            startRow: dataRowFrom - 1, // 0-based row 3
+            endRow: dataRowTo, // exclusive end of writtenRowsCount
+            startCol: col0Based,
+            endCol: col0Based + 1,
+          },
+          'PASTE_FORMULA'
+        )
       );
-      await this.adapter.batchUpdate(this.destination.spreadsheetId, [request]);
-    }, 'Replaying user fill-down formulas');
+    });
+    return requests;
   }
 
   /**

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -54,6 +54,16 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
    * common case.
    */
   private duplicateOwoxColumnsMetadataIds: number[] = [];
+  /**
+   * Tracks whether the destructive part of the refresh — column
+   * insert/delete and header rewrite — has already been issued to the
+   * Sheets API. We defer those operations from `prepareToWriteReport`
+   * to the first successful `writeReportDataBatch` so that any failure
+   * upstream of the first batch (reader connection lost, SQL execution
+   * error, etc.) leaves the destination sheet exactly as the user last
+   * saw it. See {@link applyDeferredSheetMutations}.
+   */
+  private structuralOpsApplied = false;
   private spreadsheetTimeZone: string;
   private spreadsheetTitle: string;
   private sheetTitle: string;
@@ -87,10 +97,17 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
    *      - `OWOX_COLUMNS` developer metadata (the names + aliases ODM wrote
    *        last time).
    *   3. Build a `ColumnPlan` describing inserts/deletes to apply.
-   *   4. Allocate grid rows/columns, then apply structural ops in a single
-   *      `batchUpdate`. Sheets shifts A1 refs in user formulas automatically
-   *      across these structural changes.
-   *   5. Write headers + per-cell notes inside the imported rectangle only.
+   *
+   * **No sheet mutations happen here.** Column insert/delete and header
+   * rewrite are deferred to the first {@link writeReportDataBatch} call —
+   * see {@link applyDeferredSheetMutations}. The rationale is fault
+   * isolation: if the reader fails before producing the first batch
+   * (transient warehouse error, malformed SQL caught at execution, etc.),
+   * the destination sheet remains exactly as the user last saw it. We
+   * accept partial-data corruption mid-stream (some rows new, some old)
+   * because the alternative — destructive structural ops before data is
+   * known to be available — produces the much worse "headers updated but
+   * data gone" state that triggered this design.
    *
    * Auto fill-down for user formulas in row 2 right of the imported range is
    * replayed in {@link finalize} via a `PASTE_FORMULA` `copyPaste` request,
@@ -99,16 +116,18 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
    * ### Concurrency
    *
    * There is a TOCTOU window between {@link readSheetState} and
-   * {@link applyStructuralColumnOps}: in the order of hundreds of
-   * milliseconds. If a user manually reorders columns in row 1 inside this
-   * window, the structural ops can act on the wrong indices and write data
-   * into the wrong cells for that one refresh. We accept this trade-off
-   * because (a) the window is small, (b) Sheets API does not expose
-   * optimistic-concurrency primitives like `If-Match`/`revisionId` on
-   * `batchUpdate`, and (c) the next refresh re-reads the layout and
-   * self-corrects — `OWOX_COLUMNS` is persisted in the same `batchUpdate`
-   * that runs at the end of this flow, so prior-state inconsistency cannot
-   * leak across refreshes. The risk is documented here rather than guarded.
+   * {@link applyDeferredSheetMutations}: in the order of hundreds of
+   * milliseconds in the common case but can stretch longer when the reader
+   * is slow to produce its first batch. If a user manually reorders columns
+   * in row 1 inside this window, the structural ops can act on the wrong
+   * indices and write data into the wrong cells for that one refresh. We
+   * accept this trade-off because (a) the window is small in the happy
+   * path, (b) Sheets API does not expose optimistic-concurrency primitives
+   * like `If-Match`/`revisionId` on `batchUpdate`, and (c) the next refresh
+   * re-reads the layout and self-corrects — `OWOX_COLUMNS` is persisted in
+   * the same `batchUpdate` that runs at the end of this flow, so prior-state
+   * inconsistency cannot leak across refreshes. The risk is documented here
+   * rather than guarded.
    */
   public async prepareToWriteReport(
     report: Report,
@@ -163,15 +182,37 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
           `deletes=${this.columnPlan.ops.filter(op => op.kind === 'delete').length}`
       );
 
+      // Pre-allocate row capacity. `appendDimension('ROWS')` only grows the
+      // grid at the bottom — it does not mutate the user's imported content
+      // or column structure, so it is safe to do here even though the
+      // destructive operations are deferred.
       if (reportDataDescription.estimatedDataRowsCount) {
         await this.ensureRowsAvailable(reportDataDescription.estimatedDataRowsCount + 1); // +1 for headers
       }
-      await this.prepareSheetColumns(this.columnPlan.finalImportedNames.length);
-      await this.applyStructuralColumnOps();
-      await this.writeHeaders();
-
-      this.writtenRowsCount = 1;
     }, 'Preparing Google Sheets document for report');
+  }
+
+  /**
+   * Issues the destructive part of the refresh — grow column count,
+   * apply column insert/delete, write headers — as a one-shot block.
+   * Invoked lazily from the first {@link writeReportDataBatch} call so
+   * that any failure before data starts flowing leaves the sheet
+   * untouched. Subsequent batch calls return immediately because the
+   * `structuralOpsApplied` flag is already set.
+   *
+   * If the reader produces zero batches but completes without error,
+   * {@link finalize} calls this method itself to bring the sheet layout
+   * up to date even though no data rows were written.
+   */
+  private async applyDeferredSheetMutations(): Promise<void> {
+    if (this.structuralOpsApplied) {
+      return;
+    }
+    await this.prepareSheetColumns(this.columnPlan.finalImportedNames.length);
+    await this.applyStructuralColumnOps();
+    await this.writeHeaders();
+    this.writtenRowsCount = 1;
+    this.structuralOpsApplied = true;
   }
 
   /**
@@ -191,6 +232,12 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
       if (!rows.length) {
         return;
       }
+
+      // Lazily commit the structural changes and headers now that we have
+      // data to write. If the very first batch ever reaches us, this is the
+      // earliest point at which we know the reader has succeeded enough to
+      // produce something — before this, the sheet stays intact.
+      await this.applyDeferredSheetMutations();
 
       await this.ensureRowsAvailable(rows.length);
 
@@ -215,13 +262,28 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
 
   /**
    * Finalizes the report:
+   *   - if the reader completed successfully but produced zero batches,
+   *     applies the deferred structural ops + headers so the layout is
+   *     refreshed even on an empty result set;
    *   - sets tab color and freezes the header row;
    *   - persists `OWOX_REPORT_META` (one per sheet) and `OWOX_COLUMNS`
    *     (the imported-range column list for next refresh);
    *   - replays user fill-down formulas across all freshly written data rows.
+   *
+   * When `processingError` is set we **skip** the deferred-mutation
+   * fallback: the upstream pipeline failed before producing meaningful
+   * data, and the design contract is that such failures must leave the
+   * sheet exactly as the user last saw it.
    */
   public async finalize(processingError?: Error, _meta?: ReportWriteFinalizeMeta): Promise<void> {
     await this.executeWithErrorHandling(async () => {
+      // Zero-batch happy path: the reader finished cleanly but had nothing
+      // to write. Bring the sheet layout up to date so column changes do
+      // not stall indefinitely on legitimately empty data marts.
+      if (!processingError && !this.structuralOpsApplied && this.reportDataHeaders?.length > 0) {
+        await this.applyDeferredSheetMutations();
+      }
+
       if (this.writtenRowsCount > 0 && this.reportDataHeaders?.[0]) {
         const dataMart = this.report.dataMart;
 

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -1,4 +1,5 @@
 import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
+import { ColumnPlan, PreviousImportedColumn } from '../../../dto/domain/column-plan.dto';
 import { ConsumptionTrackingService } from '../../../services/consumption-tracking.service';
 import {
   DataDestinationReportWriter,
@@ -15,6 +16,7 @@ import { ReportDataDescription } from '../../../dto/domain/report-data-descripti
 import { ReportDataBatch } from '../../../dto/domain/report-data-batch.dto';
 import { SheetHeaderFormatter } from './sheet-formatters/sheet-header-formatter';
 import { SheetMetadataFormatter } from './sheet-formatters/sheet-metadata-formatter';
+import { ColumnPlanBuilder } from './column-plan-builder';
 import { GoogleSheetsApiAdapter } from '../adapters/google-sheets-api.adapter';
 import { GoogleSheetsApiAdapterFactory } from '../adapters/google-sheets-api-adapter.factory';
 import { SheetValuesFormatter } from './sheet-formatters/sheet-values-formatter';
@@ -42,6 +44,9 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
   // State for current write operation
   private destination: GoogleSheetsConfig;
   private reportDataHeaders: ReportDataHeader[];
+  private headersByName: Map<string, ReportDataHeader>;
+  private columnPlan: ColumnPlan;
+  private owoxColumnsMetadataId?: number;
   private spreadsheetTimeZone: string;
   private spreadsheetTitle: string;
   private sheetTitle: string;
@@ -54,6 +59,7 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
     private readonly headerFormatter: SheetHeaderFormatter,
     private readonly metadataFormatter: SheetMetadataFormatter,
     private readonly valuesFormatter: SheetValuesFormatter,
+    private readonly columnPlanBuilder: ColumnPlanBuilder,
     private readonly adapterFactory: GoogleSheetsApiAdapterFactory,
     private readonly consumptionTrackingService: ConsumptionTrackingService,
     private readonly appEditionConfig: AppEditionConfig,
@@ -62,8 +68,26 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
   ) {}
 
   /**
-   * Prepares the Google Sheets document for writing report data
-   * This method initializes the service, finds the sheet, prepares columns, clears the sheet, and writes headers
+   * Prepares the Google Sheets document for writing report data.
+   *
+   * Performs a *diff-based* update of the imported column range: the writer
+   * touches only the cells it owns and preserves any user-driven column
+   * ordering already present in the sheet. The flow is:
+   *
+   *   1. Initialize the Sheets service and read sheet metadata.
+   *   2. Read previous-run state in parallel:
+   *      - row 1 values (current header layout, source of truth for ordering);
+   *      - `OWOX_COLUMNS` developer metadata (the names + aliases ODM wrote
+   *        last time).
+   *   3. Build a `ColumnPlan` describing inserts/deletes to apply.
+   *   4. Allocate grid rows/columns, then apply structural ops in a single
+   *      `batchUpdate`. Sheets shifts A1 refs in user formulas automatically
+   *      across these structural changes.
+   *   5. Write headers + per-cell notes inside the imported rectangle only.
+   *
+   * Auto fill-down for user formulas in row 2 right of the imported range is
+   * replayed in {@link finalize} via a `PASTE_FORMULA` `copyPaste` request,
+   * after data rows have been written — Sheets shifts relative refs there too.
    */
   public async prepareToWriteReport(
     report: Report,
@@ -72,27 +96,40 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
     return this.executeWithErrorHandling(async () => {
       await this.initializeService(report);
 
-      await this.prepareSheetColumns(reportDataDescription.dataHeaders.length);
-
-      if (reportDataDescription.estimatedDataRowsCount) {
-        await this.ensureRowsAvailable(reportDataDescription.estimatedDataRowsCount + 1); // +1 for headers
-      }
-
       this.reportDataHeaders = reportDataDescription.dataHeaders;
-
       if (this.reportDataHeaders.length === 0) {
         throw new Error(
           'Cannot prepare report: Data mart has no connected fields. Please ensure at least one field is connected.'
         );
       }
+      this.headersByName = new Map(this.reportDataHeaders.map(h => [h.name, h]));
 
-      await this.clearSheet();
+      const { existingHeaders, previousOwoxColumns } = await this.readSheetState();
+
+      this.columnPlan = this.columnPlanBuilder.build(
+        existingHeaders,
+        previousOwoxColumns,
+        this.reportDataHeaders
+      );
+
+      if (reportDataDescription.estimatedDataRowsCount) {
+        await this.ensureRowsAvailable(reportDataDescription.estimatedDataRowsCount + 1); // +1 for headers
+      }
+      await this.prepareSheetColumns(this.columnPlan.finalImportedNames.length);
+      await this.applyStructuralColumnOps();
       await this.writeHeaders();
+
+      this.writtenRowsCount = 1;
     }, 'Preparing Google Sheets document for report');
   }
 
   /**
-   * Writes a batch of report data to the sheet
+   * Writes a batch of report data to the sheet.
+   *
+   * Each row is reordered up-front to match the user-driven column layout
+   * captured in `this.columnPlan.nameToFinalIndex`, then written into the
+   * imported rectangle (`A{rowFrom}:{lastA1}{rowTo}`). Cells outside this
+   * rectangle are not touched.
    *
    * @param reportDataBatch - Batch of data to write to the sheet
    * @throws Error if writing fails
@@ -106,13 +143,18 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
 
       await this.ensureRowsAvailable(rows.length);
 
-      const rowToWrite = this.writtenRowsCount + 1;
-      const range = `'${this.sheetTitle}'!${rowToWrite}:${rowToWrite + rows.length}`;
-      const formattedRows = this.valuesFormatter.formatRowsValues(
-        rows,
-        this.reportDataHeaders,
+      const orderedRows = this.reorderRowsToFinalLayout(rows);
+      const formattedRows = this.valuesFormatter.formatRowsValuesByName(
+        orderedRows,
+        this.columnPlan.finalImportedNames,
+        this.headersByName,
         this.spreadsheetTimeZone
       );
+
+      const rowFrom = this.writtenRowsCount + 1;
+      const rowTo = rowFrom + rows.length - 1;
+      const lastA1 = GoogleSheetsApiAdapter.colToA1(this.columnPlan.finalImportedNames.length);
+      const range = `'${this.sheetTitle}'!A${rowFrom}:${lastA1}${rowTo}`;
 
       await this.adapter.updateValues(this.destination.spreadsheetId, range, formattedRows);
 
@@ -121,24 +163,16 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
   }
 
   /**
-   * Finalizes the report by setting tab color, freezing header row, and adding metadata
+   * Finalizes the report:
+   *   - sets tab color and freezes the header row;
+   *   - persists `OWOX_REPORT_META` (one per sheet) and `OWOX_COLUMNS`
+   *     (the imported-range column list for next refresh);
+   *   - replays user fill-down formulas across all freshly written data rows.
    */
   public async finalize(processingError?: Error, _meta?: ReportWriteFinalizeMeta): Promise<void> {
     await this.executeWithErrorHandling(async () => {
       if (this.writtenRowsCount > 0 && this.reportDataHeaders?.[0]) {
-        const dateNow = DateTime.now().setZone(this.spreadsheetTimeZone);
-        const dateNowFormatted = `${dateNow.toFormat('yyyy LLL d, HH:mm:ss')} ${dateNow.zoneName}`;
-        const firstColumnDescription = this.reportDataHeaders[0].description;
-
         const dataMart = this.report.dataMart;
-        const isCommunityEdition = !this.appEditionConfig.isEnterpriseEdition();
-        const publicOrigin = this.publicOriginService.getPublicOrigin();
-        const dataMartUrl = buildDataMartUrl(
-          publicOrigin,
-          dataMart.projectId,
-          dataMart.id,
-          '/data-setup'
-        );
 
         // Check if developer metadata already exists for this sheet
         const existingMetadata = await this.adapter.getDeveloperMetadata(
@@ -158,14 +192,6 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
 
         const requests: sheets_v4.Schema$Request[] = [
           this.metadataFormatter.createTabColorAndFreezeHeaderRequest(this.destination.sheetId),
-          this.metadataFormatter.createMetadataNoteRequest(
-            this.destination.sheetId,
-            dateNowFormatted,
-            this.dataMartTitle,
-            dataMartUrl,
-            isCommunityEdition,
-            firstColumnDescription
-          ),
         ];
 
         if (allOwoxMetadataForSheet.length > 1) {
@@ -229,12 +255,38 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
           );
         }
 
+        // Persist the imported-range column list (with aliases) for the
+        // next refresh — the alias half lets the diff translate row-1
+        // headers back to canonical names even when Output Schema sets
+        // user-friendly aliases.
+        const importedColumnsSnapshot = this.columnPlan.finalImportedNames.map(name => {
+          const alias = this.headersByName.get(name)?.alias;
+          return alias ? { name, alias } : { name };
+        });
+        if (this.owoxColumnsMetadataId !== undefined) {
+          requests.push(
+            this.metadataFormatter.updateOwoxColumnsMetadataRequest(
+              this.owoxColumnsMetadataId,
+              importedColumnsSnapshot
+            )
+          );
+        } else {
+          requests.push(
+            this.metadataFormatter.createOwoxColumnsMetadataRequest(
+              this.destination.sheetId,
+              importedColumnsSnapshot
+            )
+          );
+        }
+
         await this.adapter.batchUpdate(this.destination.spreadsheetId, requests);
 
         this.logger.debug(
           `Developer metadata written for report ${this.report.id} ` +
             `(project: ${dataMart.projectId}, datamart: ${dataMart.id})`
         );
+
+        await this.replayFillDownFormulas();
       }
     }, 'Finalizing report with metadata and formatting');
     if (!processingError) {
@@ -367,44 +419,230 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
   }
 
   /**
-   * Clears all content from the sheet
+   * Reads the current state of the destination sheet that drives the diff:
+   *   - row 1 values (current header layout — source of truth for ordering);
+   *   - `OWOX_COLUMNS` developer metadata from the previous refresh.
+   *
+   * Both calls are issued in parallel since they are independent. Side-effect:
+   * caches the metadata id of the existing `OWOX_COLUMNS` entry (if any) so
+   * `finalize` can update instead of recreating it.
    */
-  private async clearSheet(): Promise<void> {
+  private async readSheetState(): Promise<{
+    existingHeaders: string[];
+    previousOwoxColumns: PreviousImportedColumn[] | null;
+  }> {
     return this.executeWithErrorHandling(async () => {
-      await this.adapter.clearSheet(this.destination.spreadsheetId, this.sheetTitle);
-    }, 'Clearing all content from sheet');
+      const [allMetadata, existingHeaders] = await Promise.all([
+        this.adapter.getDeveloperMetadata(this.destination.spreadsheetId, this.destination.sheetId),
+        this.adapter.getRowValues(this.destination.spreadsheetId, this.sheetTitle, 1),
+      ]);
+
+      const owoxColumnsEntries = this.adapter.findOwoxColumnsMetadataForSheet(
+        allMetadata,
+        this.destination.sheetId
+      );
+
+      let previousOwoxColumns: PreviousImportedColumn[] | null = null;
+      if (owoxColumnsEntries.length > 0) {
+        const first = owoxColumnsEntries[0];
+        this.owoxColumnsMetadataId = first.metadataId ?? undefined;
+        previousOwoxColumns = this.parseOwoxColumnsMetadata(first.metadataValue ?? null);
+      }
+
+      return { existingHeaders, previousOwoxColumns };
+    }, 'Reading sheet state for column diff');
   }
 
   /**
-   * Writes and formats the header row
+   * Parses the persisted `OWOX_COLUMNS` metadata payload, accepting both the
+   * current schema (`[{name, alias?}, …]`) and the legacy schema (a plain
+   * array of strings) for backward compatibility with sheets exported before
+   * alias-aware mapping landed. Returns `null` on malformed input — the
+   * caller treats that as "no prior state" and falls back to first-run path.
+   */
+  private parseOwoxColumnsMetadata(rawValue: string | null): PreviousImportedColumn[] | null {
+    if (!rawValue) {
+      return null;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawValue);
+    } catch {
+      this.logger.warn(
+        `Failed to parse OWOX_COLUMNS metadata on sheet ${this.destination.sheetId}; treating sheet as fresh.`
+      );
+      return null;
+    }
+    if (!Array.isArray(parsed)) {
+      this.logger.warn(
+        `OWOX_COLUMNS metadata on sheet ${this.destination.sheetId} is not an array; treating sheet as fresh.`
+      );
+      return null;
+    }
+
+    const result: PreviousImportedColumn[] = [];
+    for (const item of parsed) {
+      if (typeof item === 'string') {
+        // Legacy format: plain name string (no alias was tracked).
+        result.push(new PreviousImportedColumn(item));
+        continue;
+      }
+      if (
+        item &&
+        typeof item === 'object' &&
+        typeof (item as { name?: unknown }).name === 'string'
+      ) {
+        const obj = item as { name: string; alias?: unknown };
+        const alias = typeof obj.alias === 'string' ? obj.alias : undefined;
+        result.push(new PreviousImportedColumn(obj.name, alias));
+        continue;
+      }
+      this.logger.warn(
+        `OWOX_COLUMNS metadata on sheet ${this.destination.sheetId} contains an unrecognized entry; treating sheet as fresh.`
+      );
+      return null;
+    }
+    return result;
+  }
+
+  /**
+   * Applies structural column ops (`insertDimension`/`deleteDimension`) from
+   * the column plan in a single `batchUpdate`. No-op on first run or when the
+   * plan reports no changes.
+   */
+  private async applyStructuralColumnOps(): Promise<void> {
+    if (this.columnPlan.ops.length === 0) {
+      return;
+    }
+    return this.executeWithErrorHandling(async () => {
+      const requests = this.columnPlan.ops.map(op =>
+        op.kind === 'delete'
+          ? this.adapter.buildDeleteColumnRequest(this.destination.sheetId, op.atIndex)
+          : this.adapter.buildInsertColumnRequest(this.destination.sheetId, op.atIndex)
+      );
+      await this.adapter.batchUpdate(this.destination.spreadsheetId, requests);
+
+      const inserts = this.columnPlan.ops.filter(op => op.kind === 'insert').length;
+      const deletes = this.columnPlan.ops.length - inserts;
+      this.availableColumnsCount += inserts - deletes;
+    }, 'Applying structural column changes');
+  }
+
+  /**
+   * Writes header values + per-cell notes inside the imported rectangle, and
+   * resets/applies header formatting bounded to the same width. Format reset
+   * is **not** propagated to columns past the imported range so user content
+   * outside it keeps its styling.
    */
   private async writeHeaders(): Promise<void> {
     return this.executeWithErrorHandling(async () => {
       const { spreadsheetId, sheetId } = this.destination;
-      const headers = this.reportDataHeaders;
+      const finalNames = this.columnPlan.finalImportedNames;
 
-      // Write header values
-      await this.adapter.updateValues(spreadsheetId, `'${this.sheetTitle}'`, [
-        headers.map(h => h.alias || h.name),
+      // Build the row 1 array in final layout order. Each cell shows
+      // `alias || name`, looked up by name through the plan's index map.
+      const headerRow: string[] = new Array(finalNames.length);
+      for (const header of this.reportDataHeaders) {
+        const idx = this.columnPlan.nameToFinalIndex.get(header.name);
+        if (idx === undefined) {
+          // Defensive: should be unreachable given how the plan is built.
+          throw new Error(`ColumnPlan.nameToFinalIndex is missing entry for column ${header.name}`);
+        }
+        headerRow[idx] = header.alias || header.name;
+      }
+
+      const lastA1 = GoogleSheetsApiAdapter.colToA1(finalNames.length);
+      await this.adapter.updateValues(spreadsheetId, `'${this.sheetTitle}'!A1:${lastA1}1`, [
+        headerRow,
       ]);
 
-      // Format headers
-      const descriptions = headers.map((h, i) =>
-        this.metadataFormatter.createNoteRequest(sheetId, h.description, 0, i)
+      // Per-column note: description first, ODM info second. Every imported
+      // column carries the ODM provenance block so users can see ownership at
+      // a glance on any header — not just A1.
+      const dateNow = DateTime.now().setZone(this.spreadsheetTimeZone);
+      const dateNowFormatted = `${dateNow.toFormat('yyyy LLL d, HH:mm:ss')} ${dateNow.zoneName}`;
+      const dataMart = this.report.dataMart;
+      const isCommunityEdition = !this.appEditionConfig.isEnterpriseEdition();
+      const publicOrigin = this.publicOriginService.getPublicOrigin();
+      const dataMartUrl = buildDataMartUrl(
+        publicOrigin,
+        dataMart.projectId,
+        dataMart.id,
+        '/data-setup'
       );
 
-      // Reset header-row formatting across ALL columns first, then apply
-      // the new header format only to the columns we are about to write.
-      // Without this reset, columns that were part of a previous (wider)
-      // report keep the old gray header background on empty cells.
-      await this.adapter.batchUpdate(spreadsheetId, [
-        this.headerFormatter.createHeaderClearFormatRequest(sheetId, this.availableColumnsCount),
-        this.headerFormatter.createHeaderFormatRequest(sheetId, headers.length),
-        ...descriptions,
-      ]);
+      const noteRequests = this.reportDataHeaders.map(header => {
+        const idx = this.columnPlan.nameToFinalIndex.get(header.name)!;
+        const note = this.metadataFormatter.buildImportedColumnNote(
+          header.description,
+          this.dataMartTitle,
+          dataMartUrl,
+          dateNowFormatted,
+          isCommunityEdition
+        );
+        return this.metadataFormatter.createNoteRequest(sheetId, note, 0, idx);
+      });
 
-      this.writtenRowsCount++;
+      await this.adapter.batchUpdate(spreadsheetId, [
+        this.headerFormatter.createHeaderClearFormatRequest(sheetId, finalNames.length),
+        this.headerFormatter.createHeaderFormatRequest(sheetId, finalNames.length),
+        ...noteRequests,
+      ]);
     }, 'Writing and formatting column headers');
+  }
+
+  /**
+   * Reorders each row's fields so they line up with the user-driven column
+   * layout in the destination sheet. Inputs arrive in `reportDataHeaders`
+   * order (i.e. SQL order); we move each value into the slot dictated by
+   * `columnPlan.nameToFinalIndex`.
+   */
+  private reorderRowsToFinalLayout(rows: unknown[][]): unknown[][] {
+    const finalNames = this.columnPlan.finalImportedNames;
+    return rows.map(srcRow => {
+      const out: unknown[] = new Array(finalNames.length);
+      for (let i = 0; i < this.reportDataHeaders.length; i++) {
+        const finalIdx = this.columnPlan.nameToFinalIndex.get(this.reportDataHeaders[i].name)!;
+        out[finalIdx] = srcRow[i];
+      }
+      return out;
+    });
+  }
+
+  /**
+   * Replays user fill-down formulas in row 2 across rows `[3..writtenRowsCount]`
+   * for every column right of the imported range.
+   *
+   * Implemented as a single `copyPaste` request with `pasteType:
+   * 'PASTE_FORMULA'` — Google Sheets shifts relative A1 refs the same way
+   * drag-fill does. Cells in row 2 that hold static values (not formulas)
+   * are left untouched by `PASTE_FORMULA`.
+   *
+   * NOTE: writing the formula string directly via `values.update` /
+   * `values.batchUpdate` would NOT shift refs — that API records formula
+   * strings verbatim, regardless of destination row.
+   */
+  private async replayFillDownFormulas(): Promise<void> {
+    const sourceCol = this.columnPlan.lastImportedColIndex + 1; // 0-based
+    const lastCol = this.availableColumnsCount; // 0-exclusive end
+    const sourceRow = 1; // 0-based row 2
+    const destStartRow = 2; // 0-based row 3
+    const destEndRow = this.writtenRowsCount; // 0-exclusive end
+
+    // Skip when there's nothing to fill (no rows below row 2, or no user
+    // columns right of imported range).
+    if (sourceCol >= lastCol || destStartRow >= destEndRow) {
+      return;
+    }
+    return this.executeWithErrorHandling(async () => {
+      const request = this.adapter.buildCopyPasteRequest(
+        this.destination.sheetId,
+        { startRow: sourceRow, endRow: sourceRow + 1, startCol: sourceCol, endCol: lastCol },
+        { startRow: destStartRow, endRow: destEndRow, startCol: sourceCol, endCol: lastCol },
+        'PASTE_FORMULA'
+      );
+      await this.adapter.batchUpdate(this.destination.spreadsheetId, [request]);
+    }, 'Replaying user fill-down formulas');
   }
 
   /**

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.spec.ts
@@ -172,6 +172,55 @@ describe('SheetMetadataFormatter', () => {
       expect(note).toContain('…\n---\n');
       expect(note).toContain('Imported via OWOX Data Marts');
     });
+
+    it('also truncates the assembled note when ODM info alone blows the size cap (H5)', () => {
+      // The description-only guard is not enough on its own — `dataMartTitle`
+      // is user-controlled and unbounded. Here we make the title alone push
+      // the assembled note past the cap to verify the final-output truncation.
+      const oversizeTitle = 'T'.repeat(60_000);
+      const note = formatter.buildImportedColumnNote(
+        'short description',
+        oversizeTitle,
+        baseArgs.url,
+        baseArgs.date,
+        false
+      );
+
+      // Final assembled note must stay under the Sheets 50K cap (we use a
+      // 49.5K conservative limit).
+      expect(note.length).toBeLessThanOrEqual(49_500);
+      expect(note.endsWith('…')).toBe(true);
+    });
+
+    it('truncates on a Unicode code-point boundary, not in the middle of a surrogate pair (M8)', () => {
+      // Each "🚀" is one Unicode code point but two UTF-16 code units. A
+      // naïve `String.prototype.slice` could land between the high and low
+      // surrogates and produce an invalid string. We assert truncation
+      // never produces a lone surrogate.
+      const emojiHeavyDescription = '🚀'.repeat(30_000); // 30K code points = 60K UTF-16 units
+      const note = formatter.buildImportedColumnNote(
+        emojiHeavyDescription,
+        baseArgs.title,
+        baseArgs.url,
+        baseArgs.date,
+        false
+      );
+
+      for (let i = 0; i < note.length; i++) {
+        const code = note.charCodeAt(i);
+        const isHighSurrogate = code >= 0xd800 && code <= 0xdbff;
+        const isLowSurrogate = code >= 0xdc00 && code <= 0xdfff;
+        if (isHighSurrogate) {
+          // High surrogate must be immediately followed by a low surrogate.
+          const next = note.charCodeAt(i + 1);
+          expect(next >= 0xdc00 && next <= 0xdfff).toBe(true);
+          i++; // skip the paired low surrogate
+        } else if (isLowSurrogate) {
+          // A lone low surrogate would mean we sliced in the middle of a pair.
+          throw new Error(`Found lone low surrogate at index ${i}`);
+        }
+      }
+    });
   });
 
   describe('createOwoxColumnsMetadataRequest', () => {

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.spec.ts
@@ -21,58 +21,6 @@ describe('SheetMetadataFormatter', () => {
     });
   });
 
-  describe('createMetadataNoteRequest', () => {
-    it('should create valid metadata note request', () => {
-      const result = formatter.createMetadataNoteRequest(
-        123,
-        '2026-04-02 12:00:00 UTC',
-        'Test Data Mart',
-        'https://app.owox.com/ui/proj-123/dm-456',
-        false,
-        'First column description'
-      );
-
-      expect(result.repeatCell).toBeDefined();
-      expect(result.repeatCell?.range?.sheetId).toBe(123);
-      expect(result.repeatCell?.range?.startRowIndex).toBe(0);
-      expect(result.repeatCell?.range?.endRowIndex).toBe(1);
-      expect(result.repeatCell?.range?.startColumnIndex).toBe(0);
-      expect(result.repeatCell?.range?.endColumnIndex).toBe(1);
-
-      const note = result.repeatCell?.cell?.note;
-      expect(note).toContain('Imported via OWOX Data Marts at 2026-04-02 12:00:00 UTC');
-      expect(note).toContain('Data Mart: Test Data Mart');
-      expect(note).toContain('Data Mart page: https://app.owox.com/ui/proj-123/dm-456');
-      expect(note).toContain('First column description');
-    });
-
-    it('should add Community Edition suffix when isCommunityEdition is true', () => {
-      const result = formatter.createMetadataNoteRequest(
-        123,
-        '2026-04-02 12:00:00 UTC',
-        'Test Data Mart',
-        'https://app.owox.com/ui/proj-123/dm-456',
-        true
-      );
-
-      const note = result.repeatCell?.cell?.note;
-      expect(note).toContain('Imported via OWOX Data Marts Community Edition');
-    });
-
-    it('should omit first column description when not provided', () => {
-      const result = formatter.createMetadataNoteRequest(
-        123,
-        '2026-04-02 12:00:00 UTC',
-        'Test Data Mart',
-        'https://app.owox.com/ui/proj-123/dm-456',
-        false
-      );
-
-      const note = result.repeatCell?.cell?.note;
-      expect(note).not.toContain('---');
-    });
-  });
-
   describe('createDeveloperMetadataRequest', () => {
     it('should create valid developer metadata request per gas.md specification', () => {
       const result = formatter.createDeveloperMetadataRequest(
@@ -156,6 +104,121 @@ describe('SheetMetadataFormatter', () => {
       const result = formatter.createNoteRequest(123, null, 0, 0);
 
       expect(result.repeatCell?.cell?.note).toBeNull();
+    });
+  });
+
+  describe('buildImportedColumnNote', () => {
+    const baseArgs = {
+      title: 'Test Data Mart',
+      url: 'https://app.owox.com/ui/proj-1/dm-2',
+      date: '2026-04-02 12:00:00 UTC',
+    };
+
+    it('places description first followed by the ODM info block', () => {
+      const note = formatter.buildImportedColumnNote(
+        'Total revenue per campaign per day',
+        baseArgs.title,
+        baseArgs.url,
+        baseArgs.date,
+        false
+      );
+
+      const lines = note.split('\n');
+      // Description on the first line; ODM info begins after the `---` separator.
+      expect(lines[0]).toBe('Total revenue per campaign per day');
+      expect(note).toContain('\n---\n');
+      expect(note).toContain('Imported via OWOX Data Marts at 2026-04-02 12:00:00 UTC');
+      expect(note).toContain(`Data Mart: ${baseArgs.title}`);
+      expect(note).toContain(`Data Mart page: ${baseArgs.url}`);
+      expect(note.indexOf('Imported via')).toBeGreaterThan(note.indexOf('---'));
+    });
+
+    it('omits description and separator when description is undefined', () => {
+      const note = formatter.buildImportedColumnNote(
+        undefined,
+        baseArgs.title,
+        baseArgs.url,
+        baseArgs.date,
+        false
+      );
+
+      expect(note.startsWith('Imported via OWOX Data Marts')).toBe(true);
+      expect(note).not.toContain('---');
+    });
+
+    it('appends Community Edition suffix to ODM info', () => {
+      const note = formatter.buildImportedColumnNote(
+        'desc',
+        baseArgs.title,
+        baseArgs.url,
+        baseArgs.date,
+        true
+      );
+      expect(note).toContain('OWOX Data Marts Community Edition');
+    });
+
+    it('truncates oversize descriptions before composing the note', () => {
+      const oversize = 'x'.repeat(46_000);
+      const note = formatter.buildImportedColumnNote(
+        oversize,
+        baseArgs.title,
+        baseArgs.url,
+        baseArgs.date,
+        false
+      );
+
+      // Truncated to 45,000 chars + ellipsis; ODM info block still fits.
+      expect(note.length).toBeLessThan(50_000);
+      expect(note).toContain('…\n---\n');
+      expect(note).toContain('Imported via OWOX Data Marts');
+    });
+  });
+
+  describe('createOwoxColumnsMetadataRequest', () => {
+    it('serializes columns as a JSON array of {name, alias?} bound to the sheet', () => {
+      const result = formatter.createOwoxColumnsMetadataRequest(42, [
+        { name: 'date', alias: 'Date' },
+        { name: 'campaign' },
+        { name: 'cost', alias: 'Cost' },
+      ]);
+
+      expect(result.createDeveloperMetadata).toBeDefined();
+      const metadata = result.createDeveloperMetadata?.developerMetadata;
+      expect(metadata?.metadataKey).toBe('OWOX_COLUMNS');
+      expect(metadata?.visibility).toBe('DOCUMENT');
+      expect(metadata?.location?.sheetId).toBe(42);
+      expect(JSON.parse(metadata!.metadataValue!)).toEqual([
+        { name: 'date', alias: 'Date' },
+        { name: 'campaign' },
+        { name: 'cost', alias: 'Cost' },
+      ]);
+    });
+
+    it('omits the alias key entirely when no alias is provided', () => {
+      const result = formatter.createOwoxColumnsMetadataRequest(1, [{ name: 'a' }]);
+      const value = result.createDeveloperMetadata?.developerMetadata?.metadataValue;
+      // Stricter than `toEqual`: the persisted JSON must not carry
+      // `"alias":null` since downstream parsers treat null as a real value.
+      expect(value).toBe('[{"name":"a"}]');
+    });
+  });
+
+  describe('updateOwoxColumnsMetadataRequest', () => {
+    it('updates only metadataValue and uses dataFilters lookup by metadataId', () => {
+      const result = formatter.updateOwoxColumnsMetadataRequest(7, [
+        { name: 'a' },
+        { name: 'b', alias: 'Bee' },
+      ]);
+
+      const dataFilter = result.updateDeveloperMetadata?.dataFilters?.[0];
+      expect(dataFilter?.developerMetadataLookup?.metadataId).toBe(7);
+      expect(result.updateDeveloperMetadata?.fields).toBe('metadataValue');
+
+      const metadata = result.updateDeveloperMetadata?.developerMetadata;
+      expect(JSON.parse(metadata!.metadataValue!)).toEqual([
+        { name: 'a' },
+        { name: 'b', alias: 'Bee' },
+      ]);
     });
   });
 });

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.ts
@@ -1,5 +1,13 @@
+import { Injectable, Logger } from '@nestjs/common';
 import { sheets_v4 } from 'googleapis';
-import { Injectable } from '@nestjs/common';
+import { GOOGLE_SHEETS_METADATA_KEYS } from '../../constants/google-sheets-metadata-keys.constants';
+
+/**
+ * Maximum length of a column description embedded into a per-cell note before
+ * we truncate. Google Sheets caps cell notes at ~50,000 characters; the limit
+ * leaves room for the appended ODM info block.
+ */
+const MAX_DESCRIPTION_LENGTH_IN_NOTE = 45_000;
 
 /**
  * Service for formatting metadata in Google Sheets
@@ -7,6 +15,8 @@ import { Injectable } from '@nestjs/common';
  */
 @Injectable()
 export class SheetMetadataFormatter {
+  private readonly logger = new Logger(SheetMetadataFormatter.name);
+
   /**
    * Tab color for sheets
    * Blue color (RGB: 30, 136, 229)
@@ -39,39 +49,6 @@ export class SheetMetadataFormatter {
         fields: 'tabColorStyle,gridProperties.frozenRowCount',
       },
     };
-  }
-
-  /**
-   * Creates a request to add a metadata note to the first cell
-   *
-   * @param sheetId - ID of the sheet to add the note to
-   * @param dateFormatted - Formatted date string for the metadata note
-   * @param dataMartTitle - Title of the data mart
-   * @param dataMartUrl - URL to the data mart
-   * @param isCommunityEdition - Whether the app is running in Community Edition
-   * @param firstColumnDescription - Optional description for the first column
-   * @returns Google Sheets API request object for metadata note
-   */
-  public createMetadataNoteRequest(
-    sheetId: number,
-    dateFormatted: string,
-    dataMartTitle: string,
-    dataMartUrl: string,
-    isCommunityEdition: boolean,
-    firstColumnDescription?: string
-  ): sheets_v4.Schema$Request {
-    const editionSuffix = isCommunityEdition ? ' Community Edition' : '';
-
-    let metadataNote =
-      `Imported via OWOX Data Marts${editionSuffix} at ${dateFormatted}\n` +
-      `Data Mart: ${dataMartTitle}\n` +
-      `Data Mart page: ${dataMartUrl}`;
-
-    if (firstColumnDescription) {
-      metadataNote += `\n---\n${firstColumnDescription}`;
-    }
-
-    return this.createNoteRequest(sheetId, metadataNote, 0, 0);
   }
 
   /**
@@ -108,7 +85,7 @@ export class SheetMetadataFormatter {
   /**
    * Creates a request to add developer metadata to a specific sheet
    *
-   * - metadataKey: "OWOX_REPORT_META"
+   * - metadataKey: GOOGLE_SHEETS_METADATA_KEYS.REPORT_META
    * - metadataValue: JSON string with reportId, dataMartId, projectId
    * - visibility: DOCUMENT (accessible to all users with document access)
    * - location: Bound to specific sheet via sheetId
@@ -128,7 +105,7 @@ export class SheetMetadataFormatter {
     return {
       createDeveloperMetadata: {
         developerMetadata: {
-          metadataKey: 'OWOX_REPORT_META',
+          metadataKey: GOOGLE_SHEETS_METADATA_KEYS.REPORT_META,
           metadataValue: this.buildOwoxMetadataValue(reportId, dataMartId, projectId),
           visibility: 'DOCUMENT',
           location: {
@@ -169,6 +146,110 @@ export class SheetMetadataFormatter {
         fields: 'metadataValue',
       },
     };
+  }
+
+  /**
+   * Builds the cell-note text written into every header cell ODM owns.
+   *
+   * The column's own description is placed first (so users see the relevant
+   * context immediately), followed by ODM provenance info — date, data mart
+   * title, and link back to the OWOX UI. If the description is empty or
+   * exceeds {@link MAX_DESCRIPTION_LENGTH_IN_NOTE} characters, it is omitted
+   * or truncated with an ellipsis to stay within Sheets' note size limit.
+   */
+  public buildImportedColumnNote(
+    description: string | undefined,
+    dataMartTitle: string,
+    dataMartUrl: string,
+    dateFormatted: string,
+    isCommunityEdition: boolean
+  ): string {
+    const editionSuffix = isCommunityEdition ? ' Community Edition' : '';
+    const odmInfo =
+      `Imported via OWOX Data Marts${editionSuffix} at ${dateFormatted}\n` +
+      `Data Mart: ${dataMartTitle}\n` +
+      `Data Mart page: ${dataMartUrl}`;
+
+    if (!description) {
+      return odmInfo;
+    }
+
+    let safeDescription = description;
+    if (description.length > MAX_DESCRIPTION_LENGTH_IN_NOTE) {
+      this.logger.warn(
+        `Column description exceeds ${MAX_DESCRIPTION_LENGTH_IN_NOTE} chars; truncating before writing as cell note.`
+      );
+      safeDescription = description.slice(0, MAX_DESCRIPTION_LENGTH_IN_NOTE) + '…';
+    }
+
+    return `${safeDescription}\n---\n${odmInfo}`;
+  }
+
+  /**
+   * Creates a request that persists the (name, alias?) pairs ODM has written
+   * into the imported range. Read back on the next refresh to delineate the
+   * imported region and translate row-1 aliases back to canonical names so
+   * the column diff is robust to user-friendly aliases configured in Output
+   * Schema (see {@link GOOGLE_SHEETS_METADATA_KEYS.COLUMNS}).
+   *
+   * The serialized value is a JSON array of objects:
+   *   `[{"name":"date","alias":"Date"},{"name":"cost"},…]`
+   * `alias` is omitted when the column has no user-facing alias configured.
+   */
+  public createOwoxColumnsMetadataRequest(
+    sheetId: number,
+    columns: Array<{ name: string; alias?: string }>
+  ): sheets_v4.Schema$Request {
+    return {
+      createDeveloperMetadata: {
+        developerMetadata: {
+          metadataKey: GOOGLE_SHEETS_METADATA_KEYS.COLUMNS,
+          metadataValue: this.buildOwoxColumnsMetadataValue(columns),
+          visibility: 'DOCUMENT',
+          location: {
+            sheetId,
+          },
+        },
+      },
+    };
+  }
+
+  /**
+   * Creates a request that updates the existing column-list developer
+   * metadata for a sheet (see {@link createOwoxColumnsMetadataRequest}).
+   */
+  public updateOwoxColumnsMetadataRequest(
+    metadataId: number,
+    columns: Array<{ name: string; alias?: string }>
+  ): sheets_v4.Schema$Request {
+    return {
+      updateDeveloperMetadata: {
+        dataFilters: [
+          {
+            developerMetadataLookup: {
+              metadataId,
+            },
+          },
+        ],
+        developerMetadata: {
+          metadataValue: this.buildOwoxColumnsMetadataValue(columns),
+        },
+        fields: 'metadataValue',
+      },
+    };
+  }
+
+  /**
+   * Serializes the imported column list as a JSON array of `{ name, alias? }`
+   * objects. `alias` is omitted from the serialized form when not provided so
+   * the persisted payload stays minimal.
+   */
+  private buildOwoxColumnsMetadataValue(columns: Array<{ name: string; alias?: string }>): string {
+    return JSON.stringify(
+      columns.map(col =>
+        col.alias !== undefined ? { name: col.name, alias: col.alias } : { name: col.name }
+      )
+    );
   }
 
   private buildOwoxMetadataValue(reportId: string, dataMartId: string, projectId: string): string {

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.ts
@@ -10,6 +10,37 @@ import { GOOGLE_SHEETS_METADATA_KEYS } from '../../constants/google-sheets-metad
 const MAX_DESCRIPTION_LENGTH_IN_NOTE = 45_000;
 
 /**
+ * Conservative cap for the FINAL assembled note (description + separator +
+ * ODM info block). Set below the Sheets 50,000-character cap so we never
+ * hit "Cell note exceeds limit" rejections on the batchUpdate.
+ *
+ * The description-only guard above is not enough on its own: the ODM info
+ * block embeds `dataMartTitle`, which is user-controlled and unbounded in
+ * the DB schema. A pathologically-long title alone could push the note
+ * past the limit even with no description.
+ */
+const MAX_TOTAL_NOTE_LENGTH = 49_500;
+
+/**
+ * Truncates a string to `maxChars` *Unicode code points* (not UTF-16 code
+ * units), preserving surrogate-pair integrity so we never end up with a
+ * half-emoji at the boundary. Returns the original string when it fits.
+ */
+function safeTruncate(input: string, maxChars: number): string {
+  if (input.length <= maxChars) {
+    return input;
+  }
+  // Array.from splits by code point — slicing here never lands inside a
+  // surrogate pair. Always trim one extra character to reserve room for
+  // the ellipsis marker the caller appends.
+  return (
+    Array.from(input)
+      .slice(0, maxChars - 1)
+      .join('') + '…'
+  );
+}
+
+/**
  * Service for formatting metadata in Google Sheets
  * Provides methods to create metadata formatting requests
  */
@@ -170,19 +201,27 @@ export class SheetMetadataFormatter {
       `Data Mart: ${dataMartTitle}\n` +
       `Data Mart page: ${dataMartUrl}`;
 
-    if (!description) {
-      return odmInfo;
-    }
-
-    let safeDescription = description;
-    if (description.length > MAX_DESCRIPTION_LENGTH_IN_NOTE) {
+    let safeDescription = description ?? '';
+    if (safeDescription.length > MAX_DESCRIPTION_LENGTH_IN_NOTE) {
       this.logger.warn(
         `Column description exceeds ${MAX_DESCRIPTION_LENGTH_IN_NOTE} chars; truncating before writing as cell note.`
       );
-      safeDescription = description.slice(0, MAX_DESCRIPTION_LENGTH_IN_NOTE) + '…';
+      safeDescription = safeTruncate(safeDescription, MAX_DESCRIPTION_LENGTH_IN_NOTE);
     }
 
-    return `${safeDescription}\n---\n${odmInfo}`;
+    const assembled = safeDescription ? `${safeDescription}\n---\n${odmInfo}` : odmInfo;
+
+    // H5 — Even with description truncated, the ODM info block can blow the
+    // limit when `dataMartTitle` (user-controlled, unbounded) is huge. Cap
+    // the entire assembled string as a final safeguard.
+    if (assembled.length <= MAX_TOTAL_NOTE_LENGTH) {
+      return assembled;
+    }
+    this.logger.warn(
+      `Assembled imported-column note exceeds ${MAX_TOTAL_NOTE_LENGTH} chars ` +
+        `(actual: ${assembled.length}); truncating to stay under the Sheets cell-note size cap.`
+    );
+    return safeTruncate(assembled, MAX_TOTAL_NOTE_LENGTH);
   }
 
   /**

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
@@ -51,6 +51,45 @@ export class SheetValuesFormatter {
     return rows;
   }
 
+  /**
+   * Same as {@link formatRowsValues} but resolves the per-column formatter by
+   * column **name** instead of position. Used by the diff-based writer where
+   * each row has already been reordered to match the user's column layout in
+   * the destination sheet, so positional alignment with the SQL output schema
+   * no longer holds.
+   *
+   * @param orderedRows - Rows already reordered to align with `finalNames`
+   * @param finalNames - Column names in the order they appear in the sheet
+   * @param headersByName - SQL output schema indexed by column name
+   * @param sheetTimeZone - Time zone of the sheet
+   */
+  public formatRowsValuesByName(
+    orderedRows: unknown[][],
+    finalNames: string[],
+    headersByName: ReadonlyMap<string, ReportDataHeader>,
+    sheetTimeZone: string
+  ): unknown[][] {
+    const columnsToFormat = finalNames
+      .map((name, index) => {
+        const header = headersByName.get(name);
+        return {
+          index,
+          formatter: header ? this.formatters.get(header.storageFieldType!) : undefined,
+        };
+      })
+      .filter(item => item.formatter);
+
+    if (columnsToFormat.length > 0) {
+      orderedRows.forEach(row => {
+        columnsToFormat.forEach(({ index, formatter }) => {
+          row[index] = formatter!(row[index], sheetTimeZone);
+        });
+      });
+    }
+
+    return orderedRows;
+  }
+
   private formatTimestamp(value: unknown, sheetTimeZone: string): unknown {
     if (typeof value !== 'string' || !value) return value;
 

--- a/apps/backend/src/data-marts/dto/domain/column-plan.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/column-plan.dto.ts
@@ -1,0 +1,111 @@
+/**
+ * Snapshot entry describing a single column ODM owned in the imported range
+ * on the previous refresh. Persisted as part of the `OWOX_COLUMNS` developer
+ * metadata so the next refresh can recover the `name` of a column even when
+ * the sheet's row 1 displays a user-friendly `alias` (e.g. set in Output
+ * Schema). Columns are always matched by `name` — aliases are display-only.
+ */
+export class PreviousImportedColumn {
+  constructor(
+    /** Column name as defined in the SQL output / Output Schema. */
+    public readonly name: string,
+    /**
+     * Display alias rendered in row 1 on the previous refresh, when one was
+     * configured. `undefined` when row 1 displayed `name` itself.
+     */
+    public readonly alias?: string
+  ) {}
+}
+
+/**
+ * Single structural change to apply to the imported column range when refreshing
+ * a Google Sheets export. Operations are applied in the order produced by
+ * {@link ColumnPlan.ops}; indexes inside each op are valid at the moment of
+ * application (i.e. after preceding ops in the same plan).
+ */
+export class StructuralColumnOp {
+  constructor(
+    /**
+     * Kind of structural change.
+     * - `'delete'` removes the column at {@link atIndex} (e.g. removed from SQL).
+     * - `'insert'` adds a new empty column at {@link atIndex} that will be
+     *   populated by the writer with header + data values.
+     */
+    public readonly kind: 'insert' | 'delete',
+
+    /**
+     * 0-based column index at which the op is applied.
+     * Valid at the moment of application (after preceding ops in the plan).
+     */
+    public readonly atIndex: number,
+
+    /**
+     * Column `name` (matches `ReportDataHeader.name`) the op refers to.
+     * For `'delete'` — the name being removed; for `'insert'` — the name to be
+     * placed at {@link atIndex}.
+     */
+    public readonly name: string
+  ) {}
+}
+
+/**
+ * Plan describing how to update the imported column range on the destination
+ * Google Sheet so that:
+ *   - existing user column ordering is preserved;
+ *   - new SQL columns are appended to the right edge of the imported range;
+ *   - removed SQL columns are deleted from the imported range;
+ *   - user content right of the imported range is left untouched.
+ *
+ * Built by `ColumnPlanBuilder` from three inputs: row-1 of the sheet, the
+ * `OWOX_COLUMNS` developer metadata from the previous refresh, and the desired
+ * SQL output schema. The plan is purely declarative — it describes WHAT needs
+ * to change, not HOW to call the Sheets API.
+ */
+export class ColumnPlan {
+  constructor(
+    /**
+     * `true` when the plan is being built for a sheet that has not been
+     * exported to before (no `OWOX_COLUMNS` metadata, or row 1 is empty).
+     * In this case {@link ops} is empty and {@link finalImportedNames} is the
+     * SQL output order.
+     */
+    public readonly isFirstRun: boolean,
+
+    /**
+     * Ordered list of column names occupying row-1 cells
+     * `[0..lastImportedColIndex]` AFTER {@link ops} are applied.
+     * Used by the writer to (a) write header values, (b) place per-cell notes,
+     * (c) reorder data rows so they align with the user's column ordering.
+     */
+    public readonly finalImportedNames: string[],
+
+    /**
+     * Structural ops to apply, in execution order. Deletes are emitted first
+     * in descending `atIndex` order (so subsequent indexes stay valid), then
+     * inserts at the right edge of the imported region in SQL order.
+     * Empty on the first run.
+     */
+    public readonly ops: StructuralColumnOp[],
+
+    /**
+     * Map of column name → 0-based final column index in the post-ops layout.
+     * Aligned with {@link finalImportedNames}; provided as a precomputed map
+     * to avoid repeated `indexOf` calls in batch writes.
+     */
+    public readonly nameToFinalIndex: ReadonlyMap<string, number>,
+
+    /**
+     * 0-based final last imported column index; equals
+     * `finalImportedNames.length - 1`. Provided for convenience.
+     */
+    public readonly lastImportedColIndex: number,
+
+    /**
+     * 0-based last imported column index BEFORE ops are applied.
+     * Equals `previousOwoxColumns.length - 1` on subsequent runs; `-1` on
+     * first run. Used to delineate "user content right of imported range"
+     * for fill-down formula capture.
+     */
+    public readonly prevLastImportedColIndex: number
+  ) {}
+}

--- a/apps/backend/test/integration/README.md
+++ b/apps/backend/test/integration/README.md
@@ -6,11 +6,12 @@ Tests that validate cloud database adapters against real APIs. These catch SDK v
 
 ```text
 integration/
-├── README.md                      # This file
-├── setup-env.ts                   # Loads root .env.tests via dotenv (Jest setupFiles)
-├── bigquery.integration.ts        # Google BigQuery: 6 tests (access, dry run, schema)
-├── athena.integration.ts          # AWS Athena: 6 tests (access, dry run, schema)
-└── google-sheets.integration.ts   # Google Sheets: 4 tests (metadata CRUD operations) - [NOT WORKING, DO NOT ENABLE ON CI]
+├── README.md                                          # This file
+├── setup-env.ts                                       # Loads root .env.tests via dotenv (Jest setupFiles)
+├── bigquery.integration.ts                            # Google BigQuery: 6 tests (access, dry run, schema)
+├── athena.integration.ts                              # AWS Athena: 6 tests (access, dry run, schema)
+├── google-sheets.integration.ts                       # Google Sheets: 4 tests (metadata CRUD) - [NOT WORKING, DO NOT ENABLE ON CI]
+└── google-sheets-column-preservation.integration.ts   # Google Sheets diff-based writer: 8 tests (DoD A/B/C: imported-rectangle isolation, column-order preservation, fill-down)
 ```
 
 ## Running
@@ -172,12 +173,12 @@ Loaded by Jest via `setupFiles` in `jest-integration.json`. Runs before any test
 
 **Tests:**
 
-| #   | Test                                             | What It Validates                                                                                          |
-| --- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| 1   | Create developer metadata on report run          | Running a report creates `OWOX_REPORT_META` with correct `reportId`, `dataMartId`, `projectId`            |
-| 2   | Update metadata on re-run                        | Re-running the same report maintains metadata integrity                                                    |
-| 3   | Handle multiple reports on different sheets      | Multiple reports on different sheets create separate metadata entries with correct sheet IDs               |
-| 4   | Delete metadata when report is deleted           | Deleting a report removes its corresponding developer metadata from Google Sheets                          |
+| #   | Test                                        | What It Validates                                                                              |
+| --- | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1   | Create developer metadata on report run     | Running a report creates `OWOX_REPORT_META` with correct `reportId`, `dataMartId`, `projectId` |
+| 2   | Update metadata on re-run                   | Re-running the same report maintains metadata integrity                                        |
+| 3   | Handle multiple reports on different sheets | Multiple reports on different sheets create separate metadata entries with correct sheet IDs   |
+| 4   | Delete metadata when report is deleted      | Deleting a report removes its corresponding developer metadata from Google Sheets              |
 
 **Key patterns:**
 
@@ -186,6 +187,58 @@ Loaded by Jest via `setupFiles` in `jest-integration.json`. Runs before any test
 - **Sheet-specific metadata:** Each sheet has its own metadata entry identified by `location.sheetId`
 - **Automatic cleanup:** `afterAll` removes all test metadata to avoid accumulation
 - **Graceful skip:** If credentials not configured, entire suite skips with console message
+
+### `google-sheets-column-preservation.integration.ts` — 8 tests
+
+Validates the diff-based Google Sheets writer (DoD A/B/C of the
+column-preservation feature). Each test provisions an ephemeral sheet inside
+the shared test spreadsheet, a fresh BigQuery-backed data mart, and a Google
+Sheets report; cleanup deletes the sheet in `afterEach`.
+
+**Required env vars:**
+
+- `GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON`, `TEST_GOOGLE_SPREADSHEET_ID` — Sheets
+  destination; service account must have **Editor** access on the spreadsheet
+  (sheet add/delete needs Editor).
+- `BQ_SERVICE_ACCOUNT_KEY`, `BQ_PROJECT_ID` — backend storage for the data
+  mart. Tests use `SELECT … UNION ALL` literals, so no warehouse table is read
+  and `BQ_DATASET` is **not** required for this suite.
+
+**Setup (`beforeAll`, 60s):** boots an in-process NestJS test app via
+`createTestApp()` from `@owox/test-utils`. Each `beforeEach` (per-test) calls
+`createTestSheet`, `seedDataMartWithSql`, and `setupGoogleSheetsReport` from
+the same package.
+
+**Async wait policy:** `waitForReportCompletion()` polls
+`GET /api/reports/:id` and returns once `runsCount` increments and
+`lastRunStatus !== 'RUNNING'` (with backoff and a 45-second budget). Replaces
+the legacy `setTimeout(5000)` pattern.
+
+**Tests:**
+
+| #   | Group          | Test                                    | What It Validates                                                                                                                                  |
+| --- | -------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | First run      | Writes columns in SQL order             | Row 1 = SQL order; `OWOX_COLUMNS` metadata persisted as `[{name, alias?}, …]`                                                                      |
+| 2   | DoD A          | User content right of imported survives | `K1='ratio'` and `K2='=B2/C2'` stay in place (formula via `valueRenderOption: 'FORMULA'`); imported header row unchanged                           |
+| 3   | DoD B          | User-driven row-1 reorder wins          | `moveDimension` swap survives a refresh; data rows re-aligned with new header order; `OWOX_COLUMNS` reflects user order                            |
+| 4   | DoD B          | New SQL column appended at right edge   | Adding `conversion_rate` to a v2 data mart bound to the same sheet: column lands at the right edge; user marker shifted right by `insertDimension` |
+| 5   | DoD B          | Removed SQL column → `#REF!`            | Dropping `clicks` from SQL deletes the column; user formula referencing it surfaces `#REF!` (verified via FORMULA + EFFECTIVE value)               |
+| 6   | DoD B (alias)  | Output Schema alias propagates          | Setting `country` → `'Country'` updates row 1 and `OWOX_COLUMNS` without structural ops; clearing alias restores `'country'`                       |
+| 7   | DoD C          | Auto fill-down replicates row-2 formula | `K2='=B2/C2'` is replicated to `K3='=B3/C3'` and `K4='=B4/C4'` (Sheets `copyPaste` with `pasteType: 'PASTE_FORMULA'`)                              |
+| 8   | Report Columns | `columnConfig` filters the export       | `columnConfig: ['country', 'cost']` → only those two columns in row 1 and `OWOX_COLUMNS`                                                           |
+
+**Key patterns:**
+
+- **Per-test ephemeral sheets:** `createTestSheet` issues an `addSheet`
+  request with title `it-<timestamp>-<rand>-<slug>`; `afterEach` calls
+  `cleanup()` which sends a `deleteSheet` (idempotent, errors swallowed with
+  warn log).
+- **Fresh data mart per test:** once a data mart is published its SQL is
+  immutable, so tests that need a different SQL provision a brand-new data
+  mart via `seedDataMartWithSql`. Cheap: no warehouse tables created.
+- **Multiple reports on the same sheet (tests 4 and 5):** the writer reads
+  the existing `OWOX_COLUMNS` from the prior run and diffs against the new
+  schema, regardless of which `reportId` produced it.
 
 ## Adding a New Integration Test
 

--- a/apps/backend/test/integration/README.md
+++ b/apps/backend/test/integration/README.md
@@ -52,12 +52,12 @@ ATHENA_DATABASE=my_test_database
 
 # === Google Sheets ===
 # JSON string of a GCP service account key with Google Sheets API access
+# (Editor role on TEST_GOOGLE_SPREADSHEET_ID — sheet add/delete requires Editor).
 GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"...","private_key":"-----BEGIN PRIVATE KEY-----\n...","client_email":"...@...iam.gserviceaccount.com","token_uri":"https://oauth2.googleapis.com/token"}
-# Google Spreadsheet ID for testing (must be accessible by the service account)
+# Google Spreadsheet ID for testing (must be accessible by the service account).
+# The column-preservation suite creates and deletes its own tabs inside this
+# spreadsheet; no pre-existing tabs are required.
 TEST_GOOGLE_SPREADSHEET_ID=your_spreadsheet_id_here
-# Sheet IDs within the spreadsheet (typically 0, 1, 2, etc.)
-TEST_GOOGLE_SHEET_ID=0
-TEST_GOOGLE_SHEET_ID_2=1
 ```
 
 ### Minimum Cloud Permissions

--- a/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
+++ b/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
@@ -107,6 +107,35 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
     await waitForReportCompletion({ agent, reportId, runsCountBefore });
   }
 
+  /**
+   * Triggers a report run and expects it to finalize with `lastRunStatus =
+   * 'ERROR'`. Used by the "preserve data on failed refresh" test below —
+   * the helper rethrows any unexpected exception so the assertion is still
+   * tight when something other than an ERROR status surfaces.
+   */
+  async function runAndExpectFailure(reportId: string): Promise<void> {
+    const beforeRes = await agent.get(`/api/reports/${reportId}`).set(AUTH_HEADER);
+    expect(beforeRes.status).toBe(200);
+    const runsCountBefore = beforeRes.body.runsCount as number;
+
+    const triggerRes = await agent.post(`/api/reports/${reportId}/run`).set(AUTH_HEADER);
+    expect(triggerRes.status).toBe(201);
+
+    let succeeded = false;
+    try {
+      await waitForReportCompletion({ agent, reportId, runsCountBefore });
+      succeeded = true;
+    } catch (err) {
+      const msg = (err as Error).message ?? '';
+      if (!msg.includes('finished with status ERROR')) {
+        throw err;
+      }
+    }
+    if (succeeded) {
+      throw new Error('Expected report run to fail but it completed successfully');
+    }
+  }
+
   /** Provisions a fresh sheet, BQ-backed data mart, and Google Sheets report. */
   async function provisionFixture(opts: {
     testName: string;
@@ -477,4 +506,59 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
     expect(await readRow1()).toEqual(['country', 'cost']);
     expect((await readOwoxColumnsMetadata()).map(c => c.name)).toEqual(['country', 'cost']);
   }, 90_000);
+
+  // -------------------------------------------------------------------------
+  // Test 9 — Failed refresh leaves the sheet exactly as it was (no data loss)
+  //
+  // Covers the user-facing scenario the PM raised: refresh fails (warehouse
+  // error / connection drop / malformed SQL caught at execution) → user
+  // opens the sheet expecting their previous data and must NOT find an
+  // empty / half-updated state. The writer satisfies this by deferring all
+  // destructive operations (structural ops + writeHeaders) until the first
+  // successful `writeReportDataBatch`. If the reader fails before that, the
+  // writer issued zero mutations and the sheet is byte-for-byte the same as
+  // before the failed refresh.
+  // -------------------------------------------------------------------------
+  it('preserves the previous data when the refresh fails before producing any batch', async () => {
+    // 1. First refresh: succeeds with normal SQL and populates the sheet.
+    const { reportId: v1ReportId } = await provisionFixture({ testName: 'failed-refresh' });
+    await runAndWait(v1ReportId);
+    const row1Before = await readRow1();
+    const dataBefore = await readRange('A2:C4');
+    const metadataBefore = await readOwoxColumnsMetadata();
+    expect(row1Before.slice(0, 3)).toEqual(['country', 'clicks', 'cost']);
+
+    // Seed a user marker right of the imported range — must also survive.
+    await writeCell('K1', 'preserve_me');
+
+    // 2. Spin up a SECOND data mart whose SQL fails at runtime. Bind a new
+    //    report to the SAME sheet — when its refresh fails before the
+    //    first batch, the writer must leave the sheet exactly as it is.
+    const failingSql = `SELECT ERROR('intentional integration-test failure') AS x FROM UNNEST([1, 2, 3])`;
+    const { dataMartId: failingDmId } = await seedDataMartWithSql({
+      agent,
+      bigQueryServiceAccountJson: BQ_SERVICE_ACCOUNT_KEY!,
+      bigQueryProjectId: BQ_PROJECT_ID!,
+      sqlQuery: failingSql,
+      title: 'Integration Test DM failing',
+    });
+    const { reportId: failingReportId } = await setupGoogleSheetsReport({
+      agent,
+      dataMartId: failingDmId,
+      spreadsheetId: spreadsheetId!,
+      sheetId: sheet.sheetId,
+      serviceAccountJson: serviceAccountJson!,
+      reportTitle: 'Integration Test GS Report failing',
+    });
+
+    await runAndExpectFailure(failingReportId);
+
+    // 3. Sheet content is unchanged: row 1, data, user marker.
+    expect(await readRow1()).toEqual(row1Before);
+    expect(await readRange('A2:C4')).toEqual(dataBefore);
+    expect((await readRange('K1:K1'))[0]?.[0]).toBe('preserve_me');
+    // OWOX_COLUMNS metadata also stayed the same (failed refresh did not
+    // advance its layout pointer).
+    expect(await readOwoxColumnsMetadata()).toEqual(metadataBefore);
+  }, 120_000);
 });

--- a/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
+++ b/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
@@ -1,0 +1,443 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  AUTH_HEADER,
+  GOOGLE_SHEETS_TEST_CONFIG,
+  TestSheetHandle,
+  closeTestApp,
+  createTestApp,
+  createTestSheet,
+  seedDataMartWithSql,
+  setDataMartAlias,
+  setupGoogleSheetsReport,
+  waitForReportCompletion,
+} from '@owox/test-utils';
+import { sheets_v4 } from 'googleapis';
+import * as supertest from 'supertest';
+
+/**
+ * Level-4 real-Google-Sheets integration tests for the diff-based exporter.
+ *
+ * Validates the three DoD outcomes of the column-preservation refactor:
+ *   A. Touching only the imported rectangle — user content right of imported
+ *      survives a refresh.
+ *   B. Mapping by `name`, alias-aware via `OWOX_COLUMNS` metadata; user-driven
+ *      row-1 reorder wins; SQL add → append; SQL remove → delete + `#REF!`;
+ *      Output Schema alias propagates without structural ops.
+ *   C. Auto fill-down: a formula in row 2 right of the imported range is
+ *      replicated to every data row on refresh (Sheets API `copyPaste` with
+ *      `pasteType: 'PASTE_FORMULA'`).
+ *
+ * Required env vars (loaded by `setup-env.ts` from `.env.tests` locally, or
+ * GitHub Actions secrets in CI):
+ *   - GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON  (Editor on the test spreadsheet)
+ *   - TEST_GOOGLE_SPREADSHEET_ID
+ *   - BQ_SERVICE_ACCOUNT_KEY              (data mart storage credentials)
+ *   - BQ_PROJECT_ID
+ *
+ * BQ_DATASET is NOT required because tests use SELECT … UNION ALL literals
+ * — no real warehouse table is read.
+ */
+
+const {
+  isConfigured: SHEETS_CONFIGURED,
+  serviceAccountJson,
+  spreadsheetId,
+} = GOOGLE_SHEETS_TEST_CONFIG;
+const BQ_SERVICE_ACCOUNT_KEY = process.env.BQ_SERVICE_ACCOUNT_KEY;
+const BQ_PROJECT_ID = process.env.BQ_PROJECT_ID;
+
+const ALL_CREDS_AVAILABLE = !!(
+  SHEETS_CONFIGURED &&
+  serviceAccountJson &&
+  spreadsheetId &&
+  BQ_SERVICE_ACCOUNT_KEY &&
+  BQ_PROJECT_ID
+);
+
+if (!ALL_CREDS_AVAILABLE) {
+  console.log(
+    'Skipping google-sheets-column-preservation integration tests: credentials not configured'
+  );
+}
+
+const describeIfConfigured = ALL_CREDS_AVAILABLE ? describe : describe.skip;
+
+const BASE_SQL = `
+  SELECT 'A' AS country, 10 AS clicks, 2 AS cost UNION ALL
+  SELECT 'B' AS country, 20 AS clicks, 5 AS cost UNION ALL
+  SELECT 'C' AS country, 30 AS clicks, 6 AS cost
+`;
+
+describeIfConfigured('Google Sheets column preservation (diff-based writer)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+  /** Sheet provisioned in `beforeEach`, cleaned up in `afterEach`. */
+  let sheet: TestSheetHandle;
+
+  beforeAll(async () => {
+    const testApp = await createTestApp();
+    app = testApp.app;
+    agent = testApp.agent;
+  }, 60_000);
+
+  afterAll(async () => {
+    if (app) {
+      await closeTestApp(app);
+    }
+  }, 60_000);
+
+  afterEach(async () => {
+    if (sheet) {
+      await sheet.cleanup();
+    }
+  });
+
+  /**
+   * Triggers a report run and waits until it finalizes via backend status
+   * polling. Replaces the legacy `setTimeout(resolve, 5000)` pattern.
+   */
+  async function runAndWait(reportId: string): Promise<void> {
+    const beforeRes = await agent.get(`/api/reports/${reportId}`).set(AUTH_HEADER);
+    expect(beforeRes.status).toBe(200);
+    const runsCountBefore = beforeRes.body.runsCount as number;
+
+    const triggerRes = await agent.post(`/api/reports/${reportId}/run`).set(AUTH_HEADER);
+    expect(triggerRes.status).toBe(201);
+
+    await waitForReportCompletion({ agent, reportId, runsCountBefore });
+  }
+
+  /** Provisions a fresh sheet, BQ-backed data mart, and Google Sheets report. */
+  async function provisionFixture(opts: {
+    testName: string;
+    sql?: string;
+    columnConfig?: string[] | null;
+  }): Promise<{ dataMartId: string; reportId: string }> {
+    sheet = await createTestSheet(spreadsheetId!, serviceAccountJson!, opts.testName);
+    const { dataMartId } = await seedDataMartWithSql({
+      agent,
+      bigQueryServiceAccountJson: BQ_SERVICE_ACCOUNT_KEY!,
+      bigQueryProjectId: BQ_PROJECT_ID!,
+      sqlQuery: opts.sql ?? BASE_SQL,
+    });
+    const { reportId } = await setupGoogleSheetsReport({
+      agent,
+      dataMartId,
+      spreadsheetId: spreadsheetId!,
+      sheetId: sheet.sheetId,
+      serviceAccountJson: serviceAccountJson!,
+      columnConfig: opts.columnConfig,
+    });
+    return { dataMartId, reportId };
+  }
+
+  /** Reads row 1 of the current `sheet` as a string array (FORMATTED_VALUE). */
+  async function readRow1(): Promise<string[]> {
+    const res = await sheet.sheets.spreadsheets.values.get({
+      spreadsheetId: sheet.spreadsheetId,
+      range: `'${sheet.sheetTitle}'!1:1`,
+      valueRenderOption: 'FORMATTED_VALUE',
+    });
+    return (res.data.values?.[0] ?? []).map(v => (v == null ? '' : String(v)));
+  }
+
+  /** Reads a row range as raw string values. */
+  async function readRange(a1Range: string): Promise<string[][]> {
+    const res = await sheet.sheets.spreadsheets.values.get({
+      spreadsheetId: sheet.spreadsheetId,
+      range: `'${sheet.sheetTitle}'!${a1Range}`,
+      valueRenderOption: 'FORMATTED_VALUE',
+    });
+    return (res.data.values ?? []).map(row => row.map(v => (v == null ? '' : String(v))));
+  }
+
+  /** Reads a range with formulas preserved (PASTE_FORMULA assertions). */
+  async function readFormulas(a1Range: string): Promise<string[][]> {
+    const res = await sheet.sheets.spreadsheets.values.get({
+      spreadsheetId: sheet.spreadsheetId,
+      range: `'${sheet.sheetTitle}'!${a1Range}`,
+      valueRenderOption: 'FORMULA',
+    });
+    return (res.data.values ?? []).map(row => row.map(v => (typeof v === 'string' ? v : '')));
+  }
+
+  /** Returns the parsed `OWOX_COLUMNS` metadata payload bound to `sheet.sheetId`. */
+  async function readOwoxColumnsMetadata(): Promise<Array<{ name: string; alias?: string }>> {
+    const res = await sheet.sheets.spreadsheets.get({
+      spreadsheetId: sheet.spreadsheetId,
+      includeGridData: false,
+      fields:
+        'developerMetadata(metadataKey,metadataValue,location),sheets(properties.sheetId,developerMetadata(metadataKey,metadataValue,location))',
+    });
+    const allMetadata: sheets_v4.Schema$DeveloperMetadata[] = [
+      ...(res.data.developerMetadata ?? []),
+      ...(res.data.sheets ?? []).flatMap(s => s.developerMetadata ?? []),
+    ];
+    const owoxColumns = allMetadata.find(
+      m => m.metadataKey === 'OWOX_COLUMNS' && m.location?.sheetId === sheet.sheetId
+    );
+    if (!owoxColumns?.metadataValue) {
+      throw new Error(`OWOX_COLUMNS metadata missing on sheet ${sheet.sheetId}`);
+    }
+    return JSON.parse(owoxColumns.metadataValue) as Array<{ name: string; alias?: string }>;
+  }
+
+  /** Writes a single value/formula into a cell (used to seed user content). */
+  async function writeCell(a1: string, value: string): Promise<void> {
+    await sheet.sheets.spreadsheets.values.update({
+      spreadsheetId: sheet.spreadsheetId,
+      range: `'${sheet.sheetTitle}'!${a1}`,
+      valueInputOption: 'USER_ENTERED',
+      requestBody: { values: [[value]] },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Test 1 — First run lays down SQL order + persists OWOX_COLUMNS metadata
+  // -------------------------------------------------------------------------
+  it('first run writes columns in SQL order and persists OWOX_COLUMNS metadata', async () => {
+    const { reportId } = await provisionFixture({ testName: 'first-run' });
+    await runAndWait(reportId);
+
+    expect(await readRow1()).toEqual(['country', 'clicks', 'cost']);
+    expect(await readRange('A2:C4')).toEqual([
+      ['A', '10', '2'],
+      ['B', '20', '5'],
+      ['C', '30', '6'],
+    ]);
+    expect(await readOwoxColumnsMetadata()).toEqual([
+      { name: 'country' },
+      { name: 'clicks' },
+      { name: 'cost' },
+    ]);
+  }, 90_000);
+
+  // -------------------------------------------------------------------------
+  // Test 2 — DoD A: user content right of imported range survives refresh
+  // -------------------------------------------------------------------------
+  it('preserves user formulas and content right of the imported range across refresh', async () => {
+    const { reportId } = await provisionFixture({ testName: 'right-of-imported' });
+    await runAndWait(reportId);
+
+    await writeCell('K1', 'ratio');
+    await writeCell('K2', '=B2/C2');
+
+    await runAndWait(reportId);
+
+    const [k1Header] = (await readRange('K1:K1'))[0] ?? [];
+    expect(k1Header).toBe('ratio');
+
+    const [k2Formula] = (await readFormulas('K2:K2'))[0] ?? [];
+    expect(k2Formula).toBe('=B2/C2');
+
+    // Imported header row is unchanged.
+    expect(await readRow1()).toEqual(['country', 'clicks', 'cost']);
+  }, 90_000);
+
+  // -------------------------------------------------------------------------
+  // Test 3 — DoD B: user-driven column reorder wins over SQL order
+  // -------------------------------------------------------------------------
+  it('keeps user-driven row-1 reorder across refresh', async () => {
+    const { reportId } = await provisionFixture({ testName: 'user-reorder' });
+    await runAndWait(reportId);
+
+    // User drags column B (clicks) to be after column C (cost).
+    await sheet.sheets.spreadsheets.batchUpdate({
+      spreadsheetId: sheet.spreadsheetId,
+      requestBody: {
+        requests: [
+          {
+            moveDimension: {
+              source: {
+                sheetId: sheet.sheetId,
+                dimension: 'COLUMNS',
+                startIndex: 1,
+                endIndex: 2,
+              },
+              // moveDimension destination is interpreted as "before this index"
+              // in the original frame — index 3 = after column C.
+              destinationIndex: 3,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(await readRow1()).toEqual(['country', 'cost', 'clicks']);
+
+    await runAndWait(reportId);
+
+    expect(await readRow1()).toEqual(['country', 'cost', 'clicks']);
+    // Data rows realigned with the user-driven column order.
+    expect(await readRange('A2:C4')).toEqual([
+      ['A', '2', '10'],
+      ['B', '5', '20'],
+      ['C', '6', '30'],
+    ]);
+    expect(await readOwoxColumnsMetadata()).toEqual([
+      { name: 'country' },
+      { name: 'cost' },
+      { name: 'clicks' },
+    ]);
+  }, 90_000);
+
+  // -------------------------------------------------------------------------
+  // Test 4 — DoD B: new SQL column appended at the right edge of imported range
+  // -------------------------------------------------------------------------
+  it('appends a new SQL column at the right edge without disturbing user content', async () => {
+    // First report: 3-column SQL.
+    const v1 = await provisionFixture({ testName: 'add-column-v1' });
+    await runAndWait(v1.reportId);
+
+    // Place a marker user cell beyond the imported range.
+    await writeCell('F1', 'user_marker');
+
+    // Second report on the SAME sheet, using a 4-column data mart. The writer
+    // reads the existing OWOX_COLUMNS (`[country, clicks, cost]`) and diffs.
+    const SQL_V2 = `
+      SELECT 'A' AS country, 10 AS clicks, 2 AS cost, 1.5 AS conversion_rate UNION ALL
+      SELECT 'B' AS country, 20 AS clicks, 5 AS cost, 2.0 AS conversion_rate UNION ALL
+      SELECT 'C' AS country, 30 AS clicks, 6 AS cost, 1.8 AS conversion_rate
+    `;
+    const { dataMartId } = await seedDataMartWithSql({
+      agent,
+      bigQueryServiceAccountJson: BQ_SERVICE_ACCOUNT_KEY!,
+      bigQueryProjectId: BQ_PROJECT_ID!,
+      sqlQuery: SQL_V2,
+      title: 'Integration Test DM v2',
+    });
+    const { reportId: reportV2 } = await setupGoogleSheetsReport({
+      agent,
+      dataMartId,
+      spreadsheetId: spreadsheetId!,
+      sheetId: sheet.sheetId,
+      serviceAccountJson: serviceAccountJson!,
+      reportTitle: 'Integration Test GS Report v2',
+    });
+    await runAndWait(reportV2);
+
+    expect(await readRow1()).toEqual(['country', 'clicks', 'cost', 'conversion_rate']);
+    const cols = await readOwoxColumnsMetadata();
+    expect(cols.map(c => c.name)).toEqual(['country', 'clicks', 'cost', 'conversion_rate']);
+
+    // user_marker that lived in column F (index 5) is shifted by an
+    // insertDimension into column G — verify it survived.
+    expect((await readRange('G1:G1'))[0]?.[0]).toBe('user_marker');
+  }, 120_000);
+
+  // -------------------------------------------------------------------------
+  // Test 5 — DoD B: removed SQL column → user formula goes #REF!
+  // -------------------------------------------------------------------------
+  it('removes columns dropped from SQL; dependent user formulas become #REF!', async () => {
+    const v1 = await provisionFixture({ testName: 'remove-column-v1' });
+    await runAndWait(v1.reportId);
+
+    // User formula depends on the `clicks` column (currently column B).
+    await writeCell('E2', '=B2/C2');
+
+    const SQL_V2 = `
+      SELECT 'A' AS country, 2 AS cost UNION ALL
+      SELECT 'B' AS country, 5 AS cost UNION ALL
+      SELECT 'C' AS country, 6 AS cost
+    `;
+    const { dataMartId } = await seedDataMartWithSql({
+      agent,
+      bigQueryServiceAccountJson: BQ_SERVICE_ACCOUNT_KEY!,
+      bigQueryProjectId: BQ_PROJECT_ID!,
+      sqlQuery: SQL_V2,
+      title: 'Integration Test DM remove-v2',
+    });
+    const { reportId: reportV2 } = await setupGoogleSheetsReport({
+      agent,
+      dataMartId,
+      spreadsheetId: spreadsheetId!,
+      sheetId: sheet.sheetId,
+      serviceAccountJson: serviceAccountJson!,
+      reportTitle: 'Integration Test GS Report remove-v2',
+    });
+    await runAndWait(reportV2);
+
+    expect(await readRow1()).toEqual(['country', 'cost']);
+    expect((await readOwoxColumnsMetadata()).map(c => c.name)).toEqual(['country', 'cost']);
+
+    // The user formula was at E2; after `deleteDimension` shifted columns
+    // left by one, it is now at D2. Sheets rewrites the broken ref in place
+    // (#REF!) — surface it via FORMULA + FORMATTED value alternatives.
+    const [d2Formula] = (await readFormulas('D2:D2'))[0] ?? [];
+    const [d2Value] = (await readRange('D2:D2'))[0] ?? [];
+    expect((d2Formula ?? '') + ' ' + (d2Value ?? '')).toMatch(/#REF!/);
+  }, 120_000);
+
+  // -------------------------------------------------------------------------
+  // Test 6 — DoD B: alias-aware mapping (Output Schema alias)
+  // -------------------------------------------------------------------------
+  it('maps row-1 aliases back to canonical names without structural ops', async () => {
+    const { dataMartId, reportId } = await provisionFixture({ testName: 'alias-mapping' });
+    await runAndWait(reportId);
+
+    expect(await readRow1()).toEqual(['country', 'clicks', 'cost']);
+    expect(await readOwoxColumnsMetadata()).toEqual([
+      { name: 'country' },
+      { name: 'clicks' },
+      { name: 'cost' },
+    ]);
+
+    // Place a probe in user territory; if the writer accidentally re-runs
+    // structural ops it would shift this cell.
+    await writeCell('K1', 'probe');
+
+    // Action 1: set alias on `country`.
+    await setDataMartAlias(agent, dataMartId, 'country', 'Country');
+    await runAndWait(reportId);
+
+    expect(await readRow1()).toEqual(['Country', 'clicks', 'cost']);
+    expect(await readOwoxColumnsMetadata()).toEqual([
+      { name: 'country', alias: 'Country' },
+      { name: 'clicks' },
+      { name: 'cost' },
+    ]);
+    expect((await readRange('K1:K1'))[0]?.[0]).toBe('probe'); // no structural ops happened
+
+    // Action 2: drop the alias.
+    await setDataMartAlias(agent, dataMartId, 'country', null);
+    await runAndWait(reportId);
+
+    expect(await readRow1()).toEqual(['country', 'clicks', 'cost']);
+    expect(await readOwoxColumnsMetadata()).toEqual([
+      { name: 'country' },
+      { name: 'clicks' },
+      { name: 'cost' },
+    ]);
+    expect((await readRange('K1:K1'))[0]?.[0]).toBe('probe');
+  }, 120_000);
+
+  // -------------------------------------------------------------------------
+  // Test 7 — DoD C: auto fill-down replicates row-2 user formula
+  // -------------------------------------------------------------------------
+  it('replicates a user fill-down formula across data rows on refresh', async () => {
+    const { reportId } = await provisionFixture({ testName: 'auto-fill-down' });
+    await runAndWait(reportId);
+
+    // Seed a single formula in row 2; rows 3..N stay blank by default.
+    await writeCell('K2', '=B2/C2');
+
+    await runAndWait(reportId);
+
+    // Sheets shifts relative refs the same way drag-fill does.
+    expect((await readFormulas('K2:K4')).flat()).toEqual(['=B2/C2', '=B3/C3', '=B4/C4']);
+  }, 120_000);
+
+  // -------------------------------------------------------------------------
+  // Test 8 — Report Columns picker (`columnConfig`) filters the export
+  // -------------------------------------------------------------------------
+  it('honors the Report Columns picker (columnConfig) to omit columns from the export', async () => {
+    const { reportId } = await provisionFixture({
+      testName: 'column-picker',
+      columnConfig: ['country', 'cost'],
+    });
+    await runAndWait(reportId);
+
+    expect(await readRow1()).toEqual(['country', 'cost']);
+    expect((await readOwoxColumnsMetadata()).map(c => c.name)).toEqual(['country', 'cost']);
+  }, 90_000);
+});

--- a/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
+++ b/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
@@ -440,6 +440,31 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
   }, 120_000);
 
   // -------------------------------------------------------------------------
+  // Test 7b — Static values right of imported range are NOT overwritten by
+  // fill-down (C2 + H7). A user lookup table that sits in column K starting
+  // from row 5 must survive refresh untouched, even though row 2 of the
+  // same column holds a formula that should fill down across rows 3..N.
+  // -------------------------------------------------------------------------
+  it('does not overwrite static values right of imported range when only some rows hold formulas', async () => {
+    const { reportId } = await provisionFixture({ testName: 'fill-down-static-value' });
+    await runAndWait(reportId);
+
+    // Seed a formula in row 2 (should fill down) AND a static value in
+    // column L (no formula in row 2 → must NOT be touched).
+    await writeCell('K2', '=B2/C2');
+    await writeCell('L5', '999');
+
+    await runAndWait(reportId);
+
+    // Formula column: rows 2..4 carry shifted refs.
+    expect((await readFormulas('K2:K4')).flat()).toEqual(['=B2/C2', '=B3/C3', '=B4/C4']);
+    // Static-value column: row 5 still has the user value. If the writer
+    // blindly applied PASTE_FORMULA over the whole user block, this cell
+    // would have been cleared.
+    expect((await readRange('L5:L5'))[0]?.[0]).toBe('999');
+  }, 120_000);
+
+  // -------------------------------------------------------------------------
   // Test 8 — Report Columns picker (`columnConfig`) filters the export
   // -------------------------------------------------------------------------
   it('honors the Report Columns picker (columnConfig) to omit columns from the export', async () => {

--- a/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
+++ b/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
@@ -523,10 +523,9 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
     // 1. First refresh: succeeds with normal SQL and populates the sheet.
     const { reportId: v1ReportId } = await provisionFixture({ testName: 'failed-refresh' });
     await runAndWait(v1ReportId);
-    const row1Before = await readRow1();
     const dataBefore = await readRange('A2:C4');
     const metadataBefore = await readOwoxColumnsMetadata();
-    expect(row1Before.slice(0, 3)).toEqual(['country', 'clicks', 'cost']);
+    expect((await readRow1()).slice(0, 3)).toEqual(['country', 'clicks', 'cost']);
 
     // Seed a user marker right of the imported range — must also survive.
     await writeCell('K1', 'preserve_me');
@@ -553,12 +552,16 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
 
     await runAndExpectFailure(failingReportId);
 
-    // 3. Sheet content is unchanged: row 1, data, user marker.
-    expect(await readRow1()).toEqual(row1Before);
+    // 3. Sheet content is unchanged:
+    //   - imported portion of row 1 still holds the original headers
+    //     (cells past column C are blank up to K1, where the user marker
+    //     lives — sliced for readability),
+    //   - data rows untouched,
+    //   - user marker in K1 survived,
+    //   - OWOX_COLUMNS metadata did not advance its layout pointer.
+    expect((await readRow1()).slice(0, 3)).toEqual(['country', 'clicks', 'cost']);
     expect(await readRange('A2:C4')).toEqual(dataBefore);
     expect((await readRange('K1:K1'))[0]?.[0]).toBe('preserve_me');
-    // OWOX_COLUMNS metadata also stayed the same (failed refresh did not
-    // advance its layout pointer).
     expect(await readOwoxColumnsMetadata()).toEqual(metadataBefore);
   }, 120_000);
 });

--- a/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
+++ b/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
@@ -230,8 +230,10 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
     const [k2Formula] = (await readFormulas('K2:K2'))[0] ?? [];
     expect(k2Formula).toBe('=B2/C2');
 
-    // Imported header row is unchanged.
-    expect(await readRow1()).toEqual(['country', 'clicks', 'cost']);
+    // Imported header row is unchanged. We slice to the imported width
+    // because row 1 also holds the user header `K1='ratio'`, which must
+    // survive the refresh — that is exactly what we are verifying here.
+    expect((await readRow1()).slice(0, 3)).toEqual(['country', 'clicks', 'cost']);
   }, 90_000);
 
   // -------------------------------------------------------------------------
@@ -316,7 +318,15 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
     });
     await runAndWait(reportV2);
 
-    expect(await readRow1()).toEqual(['country', 'clicks', 'cost', 'conversion_rate']);
+    // Slice to the imported width — row 1 also still holds `user_marker`
+    // (now shifted from F1 to G1 by the structural insert), which must
+    // survive the refresh.
+    expect((await readRow1()).slice(0, 4)).toEqual([
+      'country',
+      'clicks',
+      'cost',
+      'conversion_rate',
+    ]);
     const cols = await readOwoxColumnsMetadata();
     expect(cols.map(c => c.name)).toEqual(['country', 'clicks', 'cost', 'conversion_rate']);
 
@@ -390,7 +400,9 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
     await setDataMartAlias(agent, dataMartId, 'country', 'Country');
     await runAndWait(reportId);
 
-    expect(await readRow1()).toEqual(['Country', 'clicks', 'cost']);
+    // Slice to the imported width — `K1='probe'` (user content) lives
+    // further right and must survive untouched.
+    expect((await readRow1()).slice(0, 3)).toEqual(['Country', 'clicks', 'cost']);
     expect(await readOwoxColumnsMetadata()).toEqual([
       { name: 'country', alias: 'Country' },
       { name: 'clicks' },
@@ -402,7 +414,7 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
     await setDataMartAlias(agent, dataMartId, 'country', null);
     await runAndWait(reportId);
 
-    expect(await readRow1()).toEqual(['country', 'clicks', 'cost']);
+    expect((await readRow1()).slice(0, 3)).toEqual(['country', 'clicks', 'cost']);
     expect(await readOwoxColumnsMetadata()).toEqual([
       { name: 'country' },
       { name: 'clicks' },

--- a/apps/backend/test/integration/google-sheets.integration.ts
+++ b/apps/backend/test/integration/google-sheets.integration.ts
@@ -9,8 +9,12 @@ import {
 } from '@owox/test-utils';
 import { google } from 'googleapis';
 
-const { spreadsheetId, sheetId, sheetId2, serviceAccountJson, isConfigured } =
-  GOOGLE_SHEETS_TEST_CONFIG;
+const { spreadsheetId, serviceAccountJson, isConfigured } = GOOGLE_SHEETS_TEST_CONFIG;
+// These sheet IDs are only consumed by this legacy (force-skipped) suite. We
+// read them inline rather than from shared config so other suites that
+// provision tabs on demand do not have to plumb optional env vars.
+const sheetId = parseInt(process.env.TEST_GOOGLE_SHEET_ID ?? '0', 10);
+const sheetId2 = parseInt(process.env.TEST_GOOGLE_SHEET_ID_2 ?? '1', 10);
 
 // @IMPORTANT: These tests are currently not in working condition and should not be enabled on CI.
 // They require additional setup and configuration.

--- a/packages/test-utils/src/constants.ts
+++ b/packages/test-utils/src/constants.ts
@@ -15,11 +15,25 @@ export const LOOKER_STUDIO_CREDENTIALS = {
 
 export const DEFAULT_CRON = '0 * * * *';
 
+/**
+ * Required env vars to enable any Google Sheets integration test against the
+ * real Sheets API:
+ *
+ *   - GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON — full service-account JSON; the
+ *     account must have **Editor** access on `TEST_GOOGLE_SPREADSHEET_ID`
+ *     (sheet add/delete needs Editor).
+ *   - TEST_GOOGLE_SPREADSHEET_ID — the shared test spreadsheet inside which
+ *     each test creates and deletes its own ephemeral tab.
+ *
+ * Suites that need a concrete pre-existing tab (e.g. the legacy
+ * `google-sheets.integration.ts`) read their own sheet IDs directly from
+ * `process.env` — we deliberately keep those out of this shared config so
+ * suites that provision sheets on demand (the column-preservation suite)
+ * stay decoupled from per-tab fixtures.
+ */
 export const GOOGLE_SHEETS_TEST_CONFIG = {
   serviceAccountJson: process.env.GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON,
   spreadsheetId: process.env.TEST_GOOGLE_SPREADSHEET_ID,
-  sheetId: parseInt(process.env.TEST_GOOGLE_SHEET_ID ?? '0', 10),
-  sheetId2: parseInt(process.env.TEST_GOOGLE_SHEET_ID_2 ?? '1', 10),
   isConfigured: !!(
     process.env.GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON && process.env.TEST_GOOGLE_SPREADSHEET_ID
   ),

--- a/packages/test-utils/src/helpers/google-sheets-test-sheet.ts
+++ b/packages/test-utils/src/helpers/google-sheets-test-sheet.ts
@@ -1,0 +1,101 @@
+import { randomBytes } from 'crypto';
+import { google, sheets_v4 } from 'googleapis';
+
+/**
+ * Handle returned by {@link createTestSheet}. Owns one ephemeral sheet inside
+ * a shared test spreadsheet plus an authed `googleapis` client that callers
+ * can reuse for direct sheet mutations (e.g. simulating user edits).
+ *
+ * `cleanup()` deletes the sheet and is idempotent — safe to call from
+ * `afterEach` even if the underlying request already happened. It swallows
+ * errors (with a warn log) so a teardown failure can never mask the test
+ * outcome.
+ */
+export interface TestSheetHandle {
+  sheetId: number;
+  sheetTitle: string;
+  spreadsheetId: string;
+  sheets: sheets_v4.Sheets;
+  cleanup(): Promise<void>;
+}
+
+const TITLE_MAX_LENGTH = 80;
+const RANDOM_SUFFIX_BYTES = 3;
+
+/**
+ * Provisions a brand-new ephemeral sheet inside the shared test spreadsheet.
+ *
+ * Title shape: `it-{Date.now()}-{rand}-{slug(baseName)}` — the timestamp +
+ * random suffix isolate parallel CI runs that target the same spreadsheet,
+ * the slug makes the sheet identifiable in the UI when debugging.
+ *
+ * @param spreadsheetId  the shared test spreadsheet ID (from env)
+ * @param serviceAccountJson  raw JSON string of a service account with Editor
+ *   access to the spreadsheet (sheet add/delete needs Editor)
+ * @param baseName  human-readable suffix; usually the test name. Sliced to
+ *   keep total title under Sheets' 100-character limit.
+ */
+export async function createTestSheet(
+  spreadsheetId: string,
+  serviceAccountJson: string,
+  baseName: string
+): Promise<TestSheetHandle> {
+  const credentials = JSON.parse(serviceAccountJson) as {
+    client_email: string;
+    private_key: string;
+  };
+  const auth = new google.auth.JWT({
+    email: credentials.client_email,
+    key: credentials.private_key,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
+  const sheets = google.sheets({ version: 'v4', auth });
+
+  const sheetTitle = buildSheetTitle(baseName);
+  const addRes = await sheets.spreadsheets.batchUpdate({
+    spreadsheetId,
+    requestBody: {
+      requests: [{ addSheet: { properties: { title: sheetTitle } } }],
+    },
+  });
+  const sheetId = addRes.data.replies?.[0]?.addSheet?.properties?.sheetId;
+  if (sheetId === undefined || sheetId === null) {
+    throw new Error(`Failed to obtain sheetId from addSheet reply for title "${sheetTitle}"`);
+  }
+
+  let cleanedUp = false;
+  return {
+    sheetId,
+    sheetTitle,
+    spreadsheetId,
+    sheets,
+    async cleanup(): Promise<void> {
+      if (cleanedUp) {
+        return;
+      }
+      cleanedUp = true;
+      try {
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: { requests: [{ deleteSheet: { sheetId } }] },
+        });
+      } catch (err) {
+        // Cleanup must never mask a test result — log and move on.
+        // eslint-disable-next-line no-console
+        console.warn(`Failed to delete test sheet ${sheetTitle} (id=${sheetId}):`, err);
+      }
+    },
+  };
+}
+
+function buildSheetTitle(baseName: string): string {
+  const rand = randomBytes(RANDOM_SUFFIX_BYTES).toString('hex');
+  const slug =
+    baseName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 32) || 'test';
+  const fullTitle = `it-${Date.now()}-${rand}-${slug}`;
+  return fullTitle.length > TITLE_MAX_LENGTH ? fullTitle.slice(0, TITLE_MAX_LENGTH) : fullTitle;
+}

--- a/packages/test-utils/src/helpers/index.ts
+++ b/packages/test-utils/src/helpers/index.ts
@@ -3,8 +3,21 @@ export { setupPublishedDataMart } from './setup-published-data-mart';
 export { setupConnectorDataMart } from './setup-connector-data-mart';
 export { setupReportPrerequisites } from './setup-report-prerequisites';
 export { truncateAllTables } from './truncate-all-tables';
+export { signLookerPayload, mockGoogleJwkFetch, restoreGoogleJwkFetch } from './create-looker-jwt';
+
 export {
-  signLookerPayload,
-  mockGoogleJwkFetch,
-  restoreGoogleJwkFetch,
-} from './create-looker-jwt';
+  waitForReportCompletion,
+  type WaitForReportCompletionOptions,
+} from './wait-for-report-completion';
+export { createTestSheet, type TestSheetHandle } from './google-sheets-test-sheet';
+export {
+  seedDataMartWithSql,
+  type SeedDataMartOptions,
+  type SeedDataMartResult,
+} from './seed-data-mart-with-sql';
+export {
+  setupGoogleSheetsReport,
+  type SetupGoogleSheetsReportOptions,
+  type SetupGoogleSheetsReportResult,
+} from './setup-google-sheets-report';
+export { setDataMartAlias } from './set-data-mart-alias';

--- a/packages/test-utils/src/helpers/seed-data-mart-with-sql.ts
+++ b/packages/test-utils/src/helpers/seed-data-mart-with-sql.ts
@@ -61,19 +61,22 @@ export async function seedDataMartWithSql(opts: SeedDataMartOptions): Promise<Se
   const storageId = storageRes.body.id;
 
   // Step 2: install BigQuery credentials + projectId config.
+  // Schema notes (see `bigquery-credentials.schema.ts` and
+  // `bigquery-config.schema.ts`):
+  //   - `credentials` IS the parsed service-account key object directly;
+  //     there is no wrapper with `type` / `serviceAccountKey`.
+  //   - `config` has only `{ projectId, location? }`. `location` is
+  //     optional; if omitted, it defaults to `AUTODETECT`. We pass it
+  //     uppercase to match `BIGQUERY_AUTODETECT_LOCATION`.
   const updateStorageRes = await agent
     .put(`/api/data-storages/${storageId}`)
     .set(AUTH_HEADER)
     .send({
       title: `Integration Test Storage ${Date.now()}`,
-      credentials: {
-        type: 'bigquery-service-account-credentials',
-        serviceAccountKey: JSON.parse(bigQueryServiceAccountJson),
-      },
+      credentials: JSON.parse(bigQueryServiceAccountJson),
       config: {
-        type: 'bigquery-config',
         projectId: bigQueryProjectId,
-        location: 'autodetect',
+        location: 'AUTODETECT',
       },
     });
   expect(updateStorageRes.status).toBe(200);

--- a/packages/test-utils/src/helpers/seed-data-mart-with-sql.ts
+++ b/packages/test-utils/src/helpers/seed-data-mart-with-sql.ts
@@ -1,0 +1,119 @@
+import * as supertest from 'supertest';
+import { AUTH_HEADER } from '../constants';
+import { DataMartBuilder } from '../fixtures/data-mart.builder';
+import { StorageBuilder } from '../fixtures/storage.builder';
+import { DataStorageType } from '../../../../apps/backend/src/data-marts/data-storage-types/enums/data-storage-type.enum';
+
+export interface SeedDataMartOptions {
+  agent: supertest.Agent;
+  /** Raw BigQuery service-account JSON (process.env.BQ_SERVICE_ACCOUNT_KEY). */
+  bigQueryServiceAccountJson: string;
+  /** GCP project ID for the BigQuery storage. */
+  bigQueryProjectId: string;
+  /** SQL the data mart will execute. Must be valid for BigQuery. */
+  sqlQuery: string;
+  /** Optional human-friendly title; defaults to `Integration Test DM <timestamp>`. */
+  title?: string;
+}
+
+export interface SeedDataMartResult {
+  storageId: string;
+  dataMartId: string;
+}
+
+/**
+ * Provisions a fully-published BigQuery-backed data mart with a custom SQL
+ * definition for use in Google Sheets export integration tests.
+ *
+ * Why BigQuery: the report-run pipeline executes the data mart's SQL through
+ * the storage adapter, so the storage must point at a real warehouse the
+ * test service account can reach. BigQuery is what the existing
+ * `bigquery.integration.ts` suite already exercises in CI, so the same
+ * `BQ_*` secrets work here without new infra.
+ *
+ * Steps:
+ *   1. POST /api/data-storages — create empty BigQuery storage.
+ *   2. PUT  /api/data-storages/:id — set credentials + projectId config.
+ *   3. PUT  /api/data-storages/:id/availability — flip flags (storage is
+ *      created "Not Available" by default; data marts cannot use it until
+ *      flipped).
+ *   4. POST /api/data-marts — create data mart linked to storage.
+ *   5. PUT  /api/data-marts/:id/definition — install the SQL.
+ *   6. POST /api/data-marts/:id/schema-actualize-triggers — refresh schema
+ *      so output schema reflects SQL columns.
+ *   7. PUT  /api/data-marts/:id/availability — flip availability flags.
+ *   8. PUT  /api/data-marts/:id/publish — publish so reports can run.
+ *
+ * Once a data mart is published its SQL definition becomes immutable. Tests
+ * that need a different SQL must call this helper again to provision a fresh
+ * data mart (cheap — no warehouse table is created).
+ */
+export async function seedDataMartWithSql(opts: SeedDataMartOptions): Promise<SeedDataMartResult> {
+  const { agent, bigQueryServiceAccountJson, bigQueryProjectId, sqlQuery } = opts;
+  const title = opts.title ?? `Integration Test DM ${Date.now()}`;
+
+  // Step 1: create empty BigQuery storage.
+  const storageRes = await agent
+    .post('/api/data-storages')
+    .set(AUTH_HEADER)
+    .send(new StorageBuilder().withType(DataStorageType.GOOGLE_BIGQUERY).build());
+  expect(storageRes.status).toBe(201);
+  const storageId = storageRes.body.id;
+
+  // Step 2: install BigQuery credentials + projectId config.
+  const updateStorageRes = await agent
+    .put(`/api/data-storages/${storageId}`)
+    .set(AUTH_HEADER)
+    .send({
+      title: `Integration Test Storage ${Date.now()}`,
+      credentials: {
+        type: 'bigquery-service-account-credentials',
+        serviceAccountKey: JSON.parse(bigQueryServiceAccountJson),
+      },
+      config: {
+        type: 'bigquery-config',
+        projectId: bigQueryProjectId,
+        location: 'autodetect',
+      },
+    });
+  expect(updateStorageRes.status).toBe(200);
+
+  // Step 3: flip availability flags on storage.
+  await agent
+    .put(`/api/data-storages/${storageId}/availability`)
+    .set(AUTH_HEADER)
+    .send({ availableForUse: true, availableForMaintenance: true });
+
+  // Step 4: create data mart linked to the storage.
+  const dataMartRes = await agent
+    .post('/api/data-marts')
+    .set(AUTH_HEADER)
+    .send(new DataMartBuilder().withStorageId(storageId).withTitle(title).build());
+  expect(dataMartRes.status).toBe(201);
+  const dataMartId = dataMartRes.body.id;
+
+  // Step 5: install SQL definition.
+  const defRes = await agent
+    .put(`/api/data-marts/${dataMartId}/definition`)
+    .set(AUTH_HEADER)
+    .send({ definitionType: 'SQL', definition: { sqlQuery } });
+  expect(defRes.status).toBe(200);
+
+  // Step 6: refresh schema so OutputSchema reflects SQL columns.
+  const actualizeRes = await agent
+    .post(`/api/data-marts/${dataMartId}/schema-actualize-triggers`)
+    .set(AUTH_HEADER);
+  expect([200, 201]).toContain(actualizeRes.status);
+
+  // Step 7: flip availability flags on data mart.
+  await agent
+    .put(`/api/data-marts/${dataMartId}/availability`)
+    .set(AUTH_HEADER)
+    .send({ availableForReporting: true, availableForMaintenance: true });
+
+  // Step 8: publish.
+  const publishRes = await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER);
+  expect(publishRes.status).toBe(200);
+
+  return { storageId, dataMartId };
+}

--- a/packages/test-utils/src/helpers/set-data-mart-alias.ts
+++ b/packages/test-utils/src/helpers/set-data-mart-alias.ts
@@ -1,0 +1,71 @@
+import * as supertest from 'supertest';
+import { AUTH_HEADER } from '../constants';
+
+interface DataMartSchemaField {
+  name: string;
+  alias?: string | null;
+  [key: string]: unknown;
+}
+
+interface DataMartSchemaPayload {
+  type?: string;
+  fields: DataMartSchemaField[];
+  [key: string]: unknown;
+}
+
+interface DataMartResponse {
+  id: string;
+  schema?: DataMartSchemaPayload;
+  [key: string]: unknown;
+}
+
+/**
+ * Sets (or clears) the alias on a single Output Schema field of a data mart.
+ *
+ * The backend exposes only a full-schema replace endpoint
+ * (`PUT /api/data-marts/:id/schema`), so we round-trip the entire schema
+ * payload, mutate just the targeted field, and put it back. No republish is
+ * required — alias is a presentation-layer field, not part of the SQL
+ * definition contract.
+ *
+ * @param fieldName  the canonical column `name` to mutate
+ * @param alias      new alias; pass `null` to clear an existing alias
+ */
+export async function setDataMartAlias(
+  agent: supertest.Agent,
+  dataMartId: string,
+  fieldName: string,
+  alias: string | null
+): Promise<void> {
+  const getRes = await agent.get(`/api/data-marts/${dataMartId}`).set(AUTH_HEADER);
+  expect(getRes.status).toBe(200);
+  const dataMart = getRes.body as DataMartResponse;
+
+  const schema = dataMart.schema;
+  if (!schema || !Array.isArray(schema.fields)) {
+    throw new Error(
+      `Data mart ${dataMartId} has no schema yet — cannot set alias on field "${fieldName}". ` +
+        `Make sure the schema is actualized (POST /schema-actualize-triggers) before calling this helper.`
+    );
+  }
+
+  const target = schema.fields.find(f => f.name === fieldName);
+  if (!target) {
+    const known = schema.fields.map(f => f.name).join(', ');
+    throw new Error(
+      `Field "${fieldName}" not found in data mart ${dataMartId} schema. Available: ${known}`
+    );
+  }
+
+  if (alias === null) {
+    delete target.alias;
+  } else {
+    target.alias = alias;
+  }
+
+  const putRes = await agent
+    .put(`/api/data-marts/${dataMartId}/schema`)
+    .set(AUTH_HEADER)
+    .send({ schema });
+  expect(putRes.status).toBe(200);
+}

--- a/packages/test-utils/src/helpers/setup-google-sheets-report.ts
+++ b/packages/test-utils/src/helpers/setup-google-sheets-report.ts
@@ -1,0 +1,92 @@
+import * as supertest from 'supertest';
+import { AUTH_HEADER } from '../constants';
+import { DataDestinationBuilder } from '../fixtures/data-destination.builder';
+import { DataDestinationType } from '../../../../apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum';
+
+export interface SetupGoogleSheetsReportOptions {
+  agent: supertest.Agent;
+  dataMartId: string;
+  spreadsheetId: string;
+  sheetId: number;
+  /** Raw service-account JSON string (process.env.GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON). */
+  serviceAccountJson: string;
+  destinationTitle?: string;
+  reportTitle?: string;
+  /**
+   * Optional Report-Columns picker config.
+   *   - `undefined` / `null` → use all native columns from output schema (default behavior).
+   *   - `string[]`           → only the listed column names land in the export.
+   * Schema: `apps/backend/src/data-marts/dto/schemas/report-column-config.schema.ts`.
+   */
+  columnConfig?: string[] | null;
+}
+
+export interface SetupGoogleSheetsReportResult {
+  dataDestinationId: string;
+  reportId: string;
+}
+
+/**
+ * Provisions a Google Sheets `DataDestination` + `Report` bound to a chosen
+ * sheet. Returns IDs the test can use to trigger runs and inspect state.
+ *
+ * Steps:
+ *   1. POST /api/data-destinations — create GOOGLE_SHEETS destination with the
+ *      service-account credentials.
+ *   2. PUT  /api/data-destinations/:id/availability — flip availability flags.
+ *   3. POST /api/reports — create report tied to the data mart and sheet,
+ *      with optional `columnConfig` for the picker.
+ */
+export async function setupGoogleSheetsReport(
+  opts: SetupGoogleSheetsReportOptions
+): Promise<SetupGoogleSheetsReportResult> {
+  const {
+    agent,
+    dataMartId,
+    spreadsheetId,
+    sheetId,
+    serviceAccountJson,
+    destinationTitle = `Integration Test GS Destination ${Date.now()}`,
+    reportTitle = `Integration Test GS Report ${Date.now()}`,
+    columnConfig,
+  } = opts;
+
+  // Step 1: create Google Sheets destination.
+  const destRes = await agent
+    .post('/api/data-destinations')
+    .set(AUTH_HEADER)
+    .send(
+      new DataDestinationBuilder()
+        .withType(DataDestinationType.GOOGLE_SHEETS)
+        .withTitle(destinationTitle)
+        .withCredentials({
+          type: 'google-sheets-credentials',
+          serviceAccountKey: JSON.parse(serviceAccountJson),
+        })
+        .build()
+    );
+  expect(destRes.status).toBe(201);
+  const dataDestinationId = destRes.body.id;
+
+  // Step 2: flip availability flags on destination.
+  await agent
+    .put(`/api/data-destinations/${dataDestinationId}/availability`)
+    .set(AUTH_HEADER)
+    .send({ availableForUse: true, availableForMaintenance: true });
+
+  // Step 3: create report.
+  const reportPayload: Record<string, unknown> = {
+    title: reportTitle,
+    dataMartId,
+    dataDestinationId,
+    destinationConfig: { type: 'google-sheets-config', spreadsheetId, sheetId },
+  };
+  if (columnConfig !== undefined) {
+    reportPayload.columnConfig = columnConfig;
+  }
+
+  const reportRes = await agent.post('/api/reports').set(AUTH_HEADER).send(reportPayload);
+  expect(reportRes.status).toBe(201);
+
+  return { dataDestinationId, reportId: reportRes.body.id };
+}

--- a/packages/test-utils/src/helpers/wait-for-report-completion.ts
+++ b/packages/test-utils/src/helpers/wait-for-report-completion.ts
@@ -1,0 +1,89 @@
+import * as supertest from 'supertest';
+import { AUTH_HEADER } from '../constants';
+
+/**
+ * Possible values exposed by `GET /api/reports/:id` in the `lastRunStatus`
+ * field. Mirrors the `ReportRunStatus` enum from
+ * `apps/backend/src/data-marts/enums/report-run-status.enum.ts`.
+ */
+type ReportLastRunStatus = 'SUCCESS' | 'ERROR' | 'RUNNING' | 'CANCELLED' | 'RESTRICTED';
+
+interface ReportSnapshot {
+  id: string;
+  runsCount: number;
+  lastRunStatus?: ReportLastRunStatus;
+  lastRunError?: string;
+  [key: string]: unknown;
+}
+
+export interface WaitForReportCompletionOptions {
+  agent: supertest.Agent;
+  reportId: string;
+  /** `runsCount` read BEFORE triggering the run. Helper waits until it increments. */
+  runsCountBefore: number;
+  /** Wall-clock budget in ms. Default 45 000 (Jest test timeout is 60 000). */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 45_000;
+const POLL_INTERVALS_MS = [300, 600, 1200, 2400] as const;
+const MAX_INTERVAL_MS = 3_000;
+
+/**
+ * Polls `GET /api/reports/:id` until a triggered report run finalizes.
+ *
+ * Replaces the legacy `setTimeout(resolve, 5000)` pattern so the test waits
+ * exactly as long as needed (typically 1–2 polling iterations given the
+ * 5-second `ReportRunTriggerHandlerService` cron) and surfaces clear failures
+ * — including the `lastRunError` payload — instead of asserting against a
+ * half-written sheet.
+ *
+ * Stop conditions:
+ *   - `runsCount > runsCountBefore` AND `lastRunStatus !== 'RUNNING'` → return.
+ *   - `lastRunStatus === 'ERROR'` → throw with `lastRunError` for loud failure.
+ *   - elapsed >= timeoutMs → throw with the final observed status.
+ */
+export async function waitForReportCompletion(
+  opts: WaitForReportCompletionOptions
+): Promise<ReportSnapshot> {
+  const { agent, reportId, runsCountBefore, timeoutMs = DEFAULT_TIMEOUT_MS } = opts;
+  const start = Date.now();
+  let attempt = 0;
+  let last: ReportSnapshot | undefined;
+
+  while (true) {
+    const elapsed = Date.now() - start;
+    if (elapsed >= timeoutMs) {
+      const tail = last
+        ? `last status=${last.lastRunStatus ?? 'undefined'}, runsCount=${last.runsCount}`
+        : 'no successful poll';
+      throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for report ${reportId} to finish (${tail}).`
+      );
+    }
+
+    const res = await agent.get(`/api/reports/${reportId}`).set(AUTH_HEADER);
+    if (res.status !== 200) {
+      throw new Error(
+        `GET /api/reports/${reportId} returned ${res.status}: ${JSON.stringify(res.body)}`
+      );
+    }
+    last = res.body as ReportSnapshot;
+
+    if (last.runsCount > runsCountBefore && last.lastRunStatus !== 'RUNNING') {
+      if (last.lastRunStatus === 'ERROR') {
+        const detail = last.lastRunError ? `: ${last.lastRunError}` : '';
+        throw new Error(`Report ${reportId} run finished with status ERROR${detail}`);
+      }
+      return last;
+    }
+
+    const delay = Math.min(POLL_INTERVALS_MS[attempt] ?? MAX_INTERVAL_MS, MAX_INTERVAL_MS);
+    attempt++;
+    await sleep(delay);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
# Preserve user customizations on Google Sheets export refresh

## Summary

Replaces the destructive `clearContents() + setValues()` flow in the Google
Sheets exporter with a **diff-based update** that touches only the imported
column rectangle. User content right of imported data, manually-reordered
columns, and Output Schema aliases are now preserved across refreshes;
formulas, pivots, charts, and named ranges that reference the imported range
keep working through Sheets-native `insertDimension` / `deleteDimension`
operations.

## Problem

Today every refresh of an OWOX → Google Sheets report wipes the entire tab
(`spreadsheets.values.clear` + `update`). Two user-visible consequences:

1. **Lost user content right of imported data.** Business users add
   currency-conversion formulas, `VLOOKUP`-enrichment columns, and pivot tables
   on the same tab; on the next refresh everything disappears.
2. **Broken formulas when SQL structure changes.** When the analyst adds or
   reorders columns, formulas that pointed at column `D = revenue` start
   pointing at whatever lands in `D` after the rewrite (e.g. `clicks`).

Customers work around this by `IMPORTRANGE`-ing the data into a second
workbook — at the cost of duplicated datasets and significant slow-down.

The root cause: the writer treats the entire sheet as its own scratch space
and does not distinguish "data we own" from "everything else."

## Solution

A column-aware diff between three inputs:

1. **Row 1 of the destination sheet** — the user's source-of-truth ordering.
2. **`OWOX_COLUMNS` developer metadata** — a snapshot of the names (and
   optional aliases) ODM wrote on the previous refresh. Persisted at sheet
   level via `createDeveloperMetadata`.
3. **Desired output schema** — the SQL columns produced by the current
   report run.

The new `ColumnPlanBuilder` produces a list of structural ops (insert/delete)
that are applied through `spreadsheets.batchUpdate`. Headers and data are
written only into the imported rectangle, and user formulas in row 2 to the
right of the imported range are auto-extended via a `copyPaste` request with
`pasteType: 'PASTE_FORMULA'` — Sheets shifts relative refs the same way the
manual drag-fill does.

### Why Sheets-native primitives matter

`insertDimension` / `deleteDimension` / `copyPaste` are exactly what Sheets
runs when a user inserts/deletes a column or drags a fill-handle. As a
result, the platform automatically updates A1 references in workbook
formulas, named ranges, charts, and pivot table source ranges — we do not
have to maintain those mappings ourselves.

### Column identity contract

- Columns are matched by `name` (the SQL field name). Display alias from
  Output Schema is treated as a presentation layer only — `OWOX_COLUMNS`
  stores both `name` and optional `alias` so the next refresh can translate
  user-friendly row-1 labels back to canonical names before diffing.
- Adding a SQL column → `insertDimension` at the right edge of the imported
  range. User content past the imported range shifts right automatically.
- Removing a SQL column → `deleteDimension`. User formulas referencing the
  deleted column become `#REF!`, an honest signal per DoD.
- Renaming a SQL column = delete old + insert new. Documented limitation.
- Reordering columns in SQL is ignored after the first run; row 1 wins.

### `OWOX_COLUMNS` metadata payload

```json
[
  { "name": "date" },
  { "name": "campaign" },
  { "name": "revenue", "alias": "Revenue" },
  { "name": "cost" }
]
```

`alias` is omitted when the column has no Output Schema alias configured.
The reader is backward-compatible with the legacy plain-string array
(`["date","campaign",…]`) just in case.

## Bugs found during manual smoke testing (and fixed in this PR)

While running the manual checklist, three issues surfaced. All three are
fixed and covered by tests:

1. **Fill-down wrote the literal formula on every row.** The first
   implementation used `spreadsheets.values.batchUpdate` (USER_ENTERED) to
   replicate row-2 formulas down — but that API stores the formula string
   verbatim, it does not shift relative refs. Replaced with a single
   `copyPaste` request (`pasteType: 'PASTE_FORMULA'`), which is the same
   operation Sheets runs for drag-fill.
2. **`insertDimension` cloned the neighbor column.** New columns in the
   imported range were arriving pre-filled with the formula from the column
   to the left. Cause: `inheritFromBefore: true`. Forced to `false` so the
   writer is the sole owner of the new column's content.
3. **Output Schema aliases caused a full delete + reinsert on every
   refresh.** Diff used row 1 strings as canonical names; with aliases set,
   row 1 stored `Revenue` while desired schema produced `revenue`, so the
   diff treated every aliased column as "delete + insert." Fixed by storing
   `{ name, alias? }` pairs in `OWOX_COLUMNS` and mapping aliases back to
   names before diffing.

## DoD coverage

### A. Keep content outside imported range

- [x] Refresh modifies only the imported rectangle (`A1:{lastA1}{rowN}`).
- [x] Content in columns right of the last imported column is untouched.
- [x] ODM provenance note is written on every imported column header
      (description first, then `--- / Imported via OWOX Data Marts at … /
      Data Mart: … / Data Mart page: …`).
- [x] Pivot tables, charts, and named ranges referencing the imported range
      keep working — automatic side-effect of using Sheets-native structural
      ops. See the "Pivot / Chart / Named range smoke" section under
      [Manual testing](#manual-testing) below.

### B. Preserve existing column order

- [x] New SQL column → appended at the right edge of the imported range
      (`insertDimension`).
- [x] Mapping by Column Name, alias-aware via `OWOX_COLUMNS`.
- [x] Existing column → position unchanged, only data updated.
- [x] Removed SQL column → `deleteDimension`; dependent user formulas →
      `#REF!`.
- [x] SQL reorder ignored after the first refresh; row-1 ordering wins.
- [x] Joined Data Marts mapped by `name` (already disambiguated upstream
      via `outputPrefix` in `BlendedReportDataService`).

### C. Auto fill-down

- [x] Formula in row 2 right of the imported range is replicated to every
      data row on refresh (`copyPaste` with `PASTE_FORMULA`).
- [x] Enabled by default, no UI toggle.

## Architecture

```
BEFORE (clear + full rewrite)         AFTER (diff-based)

prepareToWriteReport                  prepareToWriteReport
       │                                     │
       ▼                                     ▼
   clearSheet()                        readSheetState
       │                                • read row 1
       ▼                                • read OWOX_COLUMNS
   writeHeaders (all cols)                   │
       │                                     ▼
       ▼                              ColumnPlanBuilder.build()
   writeReportDataBatch×N                    │
       │                                     ▼
       ▼                              applyStructuralColumnOps
   finalize                            (insertDimension/deleteDimension)
   • A1 note                                 │
   • OWOX_REPORT_META                        ▼
                                        writeHeaders (imported cols only)
                                              │
                                              ▼
                                        writeReportDataBatch×N
                                        (imported rectangle only,
                                         per-row reorder)
                                              │
                                              ▼
                                        finalize
                                        • OWOX_REPORT_META
                                        • OWOX_COLUMNS [{name, alias?}]
                                        • replayFillDownFormulas
                                          (copyPaste PASTE_FORMULA)
```

## Files changed

### New

- `apps/backend/src/data-marts/dto/domain/column-plan.dto.ts` —
  `ColumnPlan`, `StructuralColumnOp`, `PreviousImportedColumn` value objects.
- `apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.ts`
  — pure planner (`@Injectable()`, stateless).
- `apps/backend/src/data-marts/data-destination-types/google-sheets/constants/google-sheets-metadata-keys.constants.ts`
  — central `OWOX_REPORT_META` + `OWOX_COLUMNS` keys (replaces magic strings).
- Spec files for the planner, the API adapter, and the metadata formatter.
- `apps/backend/test/integration/google-sheets-column-preservation.integration.ts`
  — 8 real-API integration tests.
- `packages/test-utils/src/helpers/{google-sheets-test-sheet,setup-google-sheets-report,seed-data-mart-with-sql,set-data-mart-alias,wait-for-report-completion}.ts`
  — reusable fixtures.

### Modified

- `apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts`
  — `prepareToWriteReport`, `writeHeaders`, `writeReportDataBatch`,
  `finalize` rewritten around the column plan; `clearSheet` removed.
- `apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts`
  — added `getRowValues`, `getRowFormulas`, `buildInsertColumnRequest`,
  `buildDeleteColumnRequest`, `buildCopyPasteRequest`,
  `findOwoxColumnsMetadataForSheet`, `colToA1`.
- `…/services/sheet-formatters/sheet-metadata-formatter.ts` — added
  `buildImportedColumnNote`, `createOwoxColumnsMetadataRequest`,
  `updateOwoxColumnsMetadataRequest`; removed legacy
  `createMetadataNoteRequest`.
- `…/services/sheet-formatters/sheet-values-formatter.ts` — added
  `formatRowsValuesByName` for name-keyed row formatting.
- `apps/backend/src/data-marts/data-destination-types/data-destination-providers.ts`
  — registered `ColumnPlanBuilder`.
- `apps/backend/test/integration/README.md` — section for the new suite.
- `packages/test-utils/src/helpers/index.ts` — re-exports.

## Tests

- **Unit**: 66 passing across 5 spec files (incl. 14 column-plan cases
  covering first-run, reorder, add, remove, mixed, rename, alias-aware
  mapping, legacy metadata format, manual rename fallback).
- **Integration** (Level 4, real Google Sheets + BigQuery — gated by
  credentials, skip-cleanly without): 8 cases — first run, user content
  survives refresh, user-driven reorder wins, add column, remove column with
  `#REF!`, alias-aware no-op, auto fill-down, Report Columns picker. See
  `apps/backend/test/integration/README.md` for the run instructions; CI
  workflow already wires the secrets.
- **Lint** + **Prettier** + `tsc --noEmit`: clean on all touched files.

## Manual testing

Run all six cases sequentially against a fresh tab — state from each case
carries into the next. Adds a Pivot / Chart / Named-range smoke at the end
to verify DoD A's "external listeners keep working" bullet.

### Test fixture

Use this SQL as the data mart definition (BigQuery):

```sql
WITH ad_performance AS (
    SELECT * FROM UNNEST([
        STRUCT(
            DATE '2026-04-01' AS date,
            'Brand Search'    AS campaign,
            'Google Ads'      AS channel,
            'acc_pro'         AS account,
            'US'              AS country,
            12500             AS impressions,
            450               AS clicks,
            320.50            AS cost,
            1280.75           AS revenue,
            11                AS conversions
            ),
        STRUCT(DATE '2026-04-01', 'Display Retargeting', 'Google Ads', 'acc_pro',  'US',  45000, 380, 210.00,  920.50,  5),
        STRUCT(DATE '2026-04-01', 'Performance Max',     'Google Ads', 'acc_pro',  'US',  22000, 510, 410.25, 1850.00, 15),
        STRUCT(DATE '2026-04-02', 'Brand Search',        'Google Ads', 'acc_pro',  'UK',  13200, 470, 335.10, 1340.00, 12),
        STRUCT(DATE '2026-04-02', 'Display Retargeting', 'Google Ads', 'acc_pro',  'UK',  47000, 395, 220.50,  950.20,  5),
        STRUCT(DATE '2026-04-02', 'Performance Max',     'Google Ads', 'acc_pro',  'UK',  23500, 520, 425.00, 1920.40, 16),
        STRUCT(DATE '2026-04-03', 'Awareness',           'Meta Ads',   'acc_main', 'DE',  60000, 420, 180.00,  540.00,  4),
        STRUCT(DATE '2026-04-03', 'Conversion',          'Meta Ads',   'acc_main', 'DE',  18000, 320, 290.50, 1180.00,  9),
        STRUCT(DATE '2026-04-04', 'Awareness',           'Meta Ads',   'acc_main', 'FR',  62000, 440, 185.50,  575.00,  4),
        STRUCT(DATE '2026-04-04', 'Conversion',          'Meta Ads',   'acc_main', 'FR',  19000, 340, 305.00, 1240.50, 10),
        STRUCT(DATE '2026-04-05', 'Brand Search',        'Google Ads', 'acc_pro',  'US',  14000, 490, 350.00, 1410.00, 13),
        STRUCT(DATE '2026-04-05', 'Display Retargeting', 'Google Ads', 'acc_pro',  'US',  48000, 410, 230.00,  990.00,  6)
        ])
)

SELECT
    date,
    campaign,
    channel,
    account,
    country,
    impressions,
    clicks,
    cost,
    revenue,
    conversions
FROM ad_performance
ORDER BY date, campaign;
```

Resulting layout: a clean sheet with 10 columns
(`A: date | B: campaign | C: channel | D: account | E: country |
F: impressions | G: clicks | H: cost | I: revenue | J: conversions`)
and 12 data rows.

User formulas to seed in row 2, right of the imported range:

| Cell | Formula |
|------|---------|
| `K2` | `=I2/H2` |
| `L2` | `=SUM(I2:I13)` |

### 1. First run (baseline)

- [ ] Clean sheet → run the report. Row 1 has SQL order, data underneath.
- [ ] Add `K2 = =I2/H2` and `L2 = =SUM(I2:I13)`.

### 2. Fill-down works (Fix #1: PASTE_FORMULA)

- [ ] Run the report again.
- [ ] **Expect**: column K now shows different numbers (not all the same).
      Click `K3` — formula should be `=I3/H3`; on `K7` → `=I7/H7`, and so on.
      This means Sheets shifted relative refs the same way drag-fill does.
- [ ] `L2` stays `=SUM(I2:I13)` — not shifted.

### 3. New column does not clone the neighbor formula (Fix #2: `inheritFromBefore=false`)

- [ ] Comment out `account` in the SQL → run the report. The column
      disappears.
- [ ] Uncomment `account` → run the report.
- [ ] **Expect**: `account` re-appears at the right edge of the imported
      range. Click the data row of the new column (e.g. `J2`) — it must
      hold the **value from SQL** (`acc_pro`), **not a formula** like
      `=H2/B2`. Previously this was the bug where Sheets cloned the
      formula from the column to the left.

### 4. User reorder wins (DoD B)

- [ ] Drag the `cost` column to the left of `campaign`.
- [ ] Run the report → user-driven order is preserved, data rows realign
      under the new headers.
- [ ] SQL reorder is ignored: shuffle the field order in the `SELECT`
      without add/remove → run → row 1 is unchanged.

### 5. Output Schema aliases (Fix #3)

- [ ] Set the alias `Revenue` for the `revenue` field in Output Schema →
      run the report.
- [ ] **Expect**: the cell with the `revenue` header now reads `Revenue`.
      **No structural change happens** — `K2`/`L2` formulas are alive, all
      other columns stay in place.
- [ ] Run the report once more **with no further changes** → row 1 and
      data do not "twitch" (previously, with aliases configured, every
      refresh produced a full delete + reinsert).
- [ ] Use the
      [Sheets API explorer](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get)
      to inspect `developerMetadata` — `OWOX_COLUMNS` should now contain
      a JSON object `{"name":"revenue","alias":"Revenue"}` (previously it
      was just the bare string `"revenue"`).
- [ ] Clear the alias → run → `revenue` is back in row 1, metadata entry
      drops the `alias` field.

### 6. Remove column → `#REF!` (DoD B)

- [ ] Comment out `revenue` in the SQL → run the report.
- [ ] **Expect**: the `revenue` column is removed from row 1; both `K2`
      (`=I2/H2`) and `L2` (`=SUM(I2:I13)`) become `#REF!` — the honest
      signal per DoD.

### Pivot / Chart / Named range smoke (DoD A)

One sheet with the data already imported (10 columns × 12 rows, i.e. the
state after the first refresh) is enough. We attach three "listeners" to
the imported range at once and verify them across three cases: stable
refresh, add column, remove column.

#### Setup (5 minutes, one-off)

**Pivot table.**

- Select `A1:J13`.
- **Insert → Pivot table → New sheet**.
- In the pivot editor:
    - **Rows**: `campaign`
    - **Columns**: `channel`
    - **Values**: `cost` → `SUM`
- Note (or screenshot) a few cells, e.g. `Brand Search × Google Ads = 1005.6`.

**Chart.**

- Back on the main tab. Select `A1:J13`.
- **Insert → Chart**.
- In the chart editor:
    - **Chart type**: Column chart.
    - **X-axis**: `date`.
    - **Series**: `cost`.
- Note the bar heights.

**Named range.**

- Select `A1:J13`.
- **Data → Named ranges → Add a range**.
- Name: `imported_data`. Apply.
- In any free cell (e.g. `P1`) put: `=SUM(INDEX(imported_data, 0, 8))`
  (sum of the 8th column = `cost`). Note the value.

#### Smoke 1 — stable refresh (sanity)

- Run the report **without any SQL change**.
- **Expect**:
    - Pivot table shows the same sums.
    - Chart bars have the same heights.
    - `=SUM(INDEX(imported_data, 0, 8))` returns the same number.

> If all three survive, proceed to smoke 2.

#### Smoke 2 — add column to SQL

- Comment out one field in SQL (e.g. `account`) → run. Column disappears.
- Uncomment it back → run again. Column reappears at the right edge of
  the imported range (as designed).
- **Expect**:
    - **Pivot**: data refreshed; the new `account` column may show up in
      the pivot editor's available-fields list (drag it into the pivot if
      you want to verify).
    - **Chart**: bar heights are unchanged (`cost` is still the series).
      If the chart was bound to a fixed range `A1:J13`, after adding the
      column it now binds to `A1:K13` because we used `insertDimension` —
      Sheets auto-extends the chart range the same way it does when a
      user manually inserts a column.
    - **Named range** `imported_data` now covers `A1:K13` (auto-extended
      by Sheets). `=SUM(INDEX(imported_data, 0, 8))` returns the same
      number (the 8th column is still `cost`).

#### Smoke 3 — remove column from SQL (expected breakage)

- Comment out a column **used** by pivot/chart/named-range — for example
  `cost`.
- Run the report.
- **Expect** (this is the DoD `#REF!` honest-signal contract):
    - **Pivot**: in the pivot editor, the `cost` field is flagged
      "Reference does not exist" or the pivot value column is empty. The
      pivot **does not crash** — Sheets just shows a warning and offers
      to remove the invalid field.
    - **Chart**: the `cost` series disappears or the chart is empty. The
      chart editor shows the data source as partially invalid.
    - **Named range**: `=SUM(INDEX(imported_data, 0, 8))` returns `#REF!`
      (or the value of the new 8th column if the imported range still
      has at least 8 columns) — Sheets shifted the named range when we
      called `deleteDimension`.

> This is **expected** behaviour. Pivot / chart / named-range are visibly
> broken **only when they referenced a column that was removed from the
> SQL** — exactly the same contract as direct formulas like `K2 = =I2/H2`.
> The user gets the honest "column was removed" signal and knows what to
> fix in the pivot/chart.

- Uncomment `cost` → run. **Expect**: data comes back, but the pivot /
  chart / named-range that broke do **not** auto-heal — Sheets persisted
  them in their broken state. This is also expected: the user has to
  restore the references manually (drop the broken field from the pivot,
  refresh the chart series). Same behaviour you would observe if a user
  manually deleted and re-inserted the column.

## Out of scope / follow-ups

- **Persistent column identity across SQL renames** — would require
  column-level developer metadata as a stable identifier. Separate ticket.
- **Smart handling of removed columns** (fallback to stale data, warning
  banner) — intentionally not done; `#REF!` is the honest signal.
- **UI toggle for Auto fill-down** — only if user feedback asks for it.
- **Re-enabling the legacy `google-sheets.integration.ts` suite** — the
  metadata-lifecycle tests are kept force-skipped (`describe.skip` on both
  branches of the conditional) per the existing `@IMPORTANT` comment;
  reactivation is its own ticket.

## Risks / things to watch in production

- **Concurrent edits race**: a user manually moving a column in row 1
  between our `getRowValues` read and the `batchUpdate` write would cause
  one refresh to write data into the wrong cells. Window is in the order of
  hundreds of milliseconds; acceptable per DoD, documented in code.
- **Note size limit**: cell notes cap at ~50 000 chars. Column descriptions
  longer than 45 000 chars are truncated with `…` and a warn log; in
  practice we have not seen anything close to this.
