### PR TITLE
feat: allow report runs and trigger CRUD for users who see the Data Mart

### DIFF
--- a/apps/backend/src/data-marts/controllers/report.controller.ts
+++ b/apps/backend/src/data-marts/controllers/report.controller.ts
@@ -38,7 +38,6 @@ import {
   GetReportGeneratedSqlSpec,
   CopyReportAsDataMartSpec,
 } from './spec/report.api';
-import { RunType } from '../../common/scheduler/shared/types';
 import { OwnerFilter } from '../enums/owner-filter.enum';
 
 @Controller('reports')
@@ -142,7 +141,7 @@ export class ReportController {
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string
   ): Promise<void> {
-    const command = this.mapper.toRunReportCommand(id, context, RunType.manual);
+    const command = this.mapper.toManualRunReportCommand(id, context);
     await this.runReportService.run(command);
   }
 

--- a/apps/backend/src/data-marts/controllers/scheduled-trigger.controller.ts
+++ b/apps/backend/src/data-marts/controllers/scheduled-trigger.controller.ts
@@ -15,6 +15,7 @@ import { CreateScheduledTriggerRequestApiDto } from '../dto/presentation/create-
 import { ScheduledTriggerResponseApiDto } from '../dto/presentation/scheduled-trigger-response-api.dto';
 import { UpdateScheduledTriggerRequestApiDto } from '../dto/presentation/update-scheduled-trigger-request-api.dto';
 import { ScheduledTriggerMapper } from '../mappers/scheduled-trigger.mapper';
+import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 import { CreateScheduledTriggerService } from '../use-cases/create-scheduled-trigger.service';
 import { DeleteScheduledTriggerService } from '../use-cases/delete-scheduled-trigger.service';
@@ -76,7 +77,9 @@ export class ScheduledTriggerController {
     @Param('dataMartId') dataMartId: string,
     @Body() dto: CreateScheduledTriggerRequestApiDto
   ): Promise<ScheduledTriggerResponseApiDto> {
-    await this.checkDataMartAccess(dataMartId, context, Action.MANAGE_TRIGGERS);
+    if (dto.type === ScheduledTriggerType.CONNECTOR_RUN) {
+      await this.checkDataMartAccess(dataMartId, context, Action.MANAGE_TRIGGERS);
+    }
     const command = this.mapper.toCreateCommand(dataMartId, context, dto);
     const trigger = await this.createService.run(command);
     return this.mapper.toResponse(trigger);
@@ -118,7 +121,7 @@ export class ScheduledTriggerController {
     @Param('id') id: string,
     @Body() dto: UpdateScheduledTriggerRequestApiDto
   ): Promise<ScheduledTriggerResponseApiDto> {
-    await this.checkDataMartAccess(dataMartId, context, Action.MANAGE_TRIGGERS);
+    await this.checkDataMartAccess(dataMartId, context, Action.SEE);
     const command = this.mapper.toUpdateCommand(id, dataMartId, context, dto);
     const trigger = await this.updateService.run(command);
     return this.mapper.toResponse(trigger);
@@ -132,7 +135,7 @@ export class ScheduledTriggerController {
     @Param('dataMartId') dataMartId: string,
     @Param('id') id: string
   ): Promise<void> {
-    await this.checkDataMartAccess(dataMartId, context, Action.MANAGE_TRIGGERS);
+    await this.checkDataMartAccess(dataMartId, context, Action.SEE);
     const command = this.mapper.toDeleteCommand(id, dataMartId, context);
     await this.deleteService.run(command);
   }

--- a/apps/backend/src/data-marts/dto/domain/list-reports-by-insight-template.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/list-reports-by-insight-template.command.ts
@@ -2,6 +2,8 @@ export class ListReportsByInsightTemplateCommand {
   constructor(
     public readonly dataMartId: string,
     public readonly insightTemplateId: string,
-    public readonly projectId: string
+    public readonly projectId: string,
+    public readonly userId: string,
+    public readonly roles: string[]
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/report.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/report.dto.ts
@@ -25,6 +25,9 @@ export class ReportDto {
     public readonly columnConfig?: ReportColumnConfig,
     public readonly filterConfig?: FilterConfig | null,
     public readonly sortConfig?: SortConfig | null,
-    public readonly limitConfig?: number | null
+    public readonly limitConfig?: number | null,
+    public readonly canRun: boolean = false,
+    public readonly canManageTriggers: boolean = false,
+    public readonly canEditConfig: boolean = false
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/run-report.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/run-report.command.ts
@@ -1,9 +1,18 @@
 import { RunType } from '../../../common/scheduler/shared/types';
 
-export interface RunReportCommand {
+interface BaseRunReportCommand {
   reportId: string;
   userId: string;
-  roles?: string[];
-  runType: RunType;
-  projectId?: string;
 }
+
+export interface ManualRunReportCommand extends BaseRunReportCommand {
+  runType: RunType.manual;
+  roles: string[];
+  projectId: string;
+}
+
+export interface ScheduledRunReportCommand extends BaseRunReportCommand {
+  runType: RunType.scheduled;
+}
+
+export type RunReportCommand = ManualRunReportCommand | ScheduledRunReportCommand;

--- a/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
@@ -65,7 +65,8 @@ export class ReportResponseApiDto {
 
   @ApiProperty({
     example: true,
-    description: 'Whether the caller can create / edit / delete report triggers',
+    description:
+      'Whether the caller can create / edit / delete report triggers. Equal to canRun today.',
   })
   canManageTriggers: boolean;
 

--- a/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
@@ -59,4 +59,20 @@ export class ReportResponseApiDto {
 
   @ApiProperty({ type: [UserProjectionDto] })
   ownerUsers: UserProjectionDto[];
+
+  @ApiProperty({ example: true, description: 'Whether the caller can manually run this report' })
+  canRun: boolean;
+
+  @ApiProperty({
+    example: true,
+    description: 'Whether the caller can create / edit / delete report triggers',
+  })
+  canManageTriggers: boolean;
+
+  @ApiProperty({
+    example: false,
+    description:
+      'Whether the caller can edit the report configuration (columns, filters, owners, destination)',
+  })
+  canEditConfig: boolean;
 }

--- a/apps/backend/src/data-marts/mappers/report.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.ts
@@ -19,9 +19,7 @@ import { DataMartMapper } from './data-mart.mapper';
 import { DataDestinationMapper } from './data-destination.mapper';
 import { RunType } from '../../common/scheduler/shared/types';
 import { UserProjectionDto } from '../../idp/dto/domain/user-projection.dto';
-import { UserProjectionsListDto } from '../../idp/dto/domain/user-projections-list.dto';
 import { OwnerFilter } from '../enums/owner-filter.enum';
-import { resolveOwnerUsers } from '../utils/resolve-owner-users';
 
 @Injectable()
 export class ReportMapper {
@@ -53,7 +51,12 @@ export class ReportMapper {
   toDomainDto(
     entity: Report,
     createdByUser: UserProjectionDto | null = null,
-    ownerUsers: UserProjectionDto[] = []
+    ownerUsers: UserProjectionDto[] = [],
+    capabilities: { canRun: boolean; canManageTriggers: boolean; canEditConfig: boolean } = {
+      canRun: false,
+      canManageTriggers: false,
+      canEditConfig: false,
+    }
   ): ReportDto {
     return new ReportDto(
       entity.id,
@@ -72,17 +75,10 @@ export class ReportMapper {
       entity.columnConfig,
       entity.filterConfig ?? null,
       entity.sortConfig ?? null,
-      entity.limitConfig ?? null
-    );
-  }
-
-  toDomainDtoList(entities: Report[], userProjectionsList?: UserProjectionsListDto): ReportDto[] {
-    return entities.map(entity =>
-      this.toDomainDto(
-        entity,
-        entity.createdById ? (userProjectionsList?.getByUserId(entity.createdById) ?? null) : null,
-        userProjectionsList ? resolveOwnerUsers(entity.ownerIds, userProjectionsList) : []
-      )
+      entity.limitConfig ?? null,
+      capabilities.canRun,
+      capabilities.canManageTriggers,
+      capabilities.canEditConfig
     );
   }
 
@@ -107,6 +103,9 @@ export class ReportMapper {
       modifiedAt: dto.modifiedAt,
       createdByUser: dto.createdByUser,
       ownerUsers: dto.ownerUsers,
+      canRun: dto.canRun,
+      canManageTriggers: dto.canManageTriggers,
+      canEditConfig: dto.canEditConfig,
     };
   }
 
@@ -142,7 +141,9 @@ export class ReportMapper {
     return new ListReportsByInsightTemplateCommand(
       dataMartId,
       insightTemplateId,
-      context.projectId
+      context.projectId,
+      context.userId,
+      context.roles ?? []
     );
   }
 

--- a/apps/backend/src/data-marts/mappers/report.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.ts
@@ -11,7 +11,7 @@ import { DeleteReportCommand } from '../dto/domain/delete-report.command';
 import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data-mart.command';
 import { ListReportsByProjectCommand } from '../dto/domain/list-reports-by-project.command';
 import { ListReportsByInsightTemplateCommand } from '../dto/domain/list-reports-by-insight-template.command';
-import { RunReportCommand } from '../dto/domain/run-report.command';
+import { ManualRunReportCommand } from '../dto/domain/run-report.command';
 import { CopyReportAsDataMartCommand } from '../dto/domain/copy-report-as-data-mart.command';
 import { GetReportGeneratedSqlCommand } from '../dto/domain/get-report-generated-sql.command';
 import { AuthorizationContext } from '../../idp';
@@ -159,16 +159,12 @@ export class ReportMapper {
     );
   }
 
-  toRunReportCommand(
-    id: string,
-    context: AuthorizationContext,
-    runType: RunType
-  ): RunReportCommand {
+  toManualRunReportCommand(id: string, context: AuthorizationContext): ManualRunReportCommand {
     return {
       reportId: id,
       userId: context.userId,
       roles: context.roles ?? [],
-      runType,
+      runType: RunType.manual,
       projectId: context.projectId,
     };
   }

--- a/apps/backend/src/data-marts/scheduled-trigger-types/scheduled-report-run/services/scheduled-report-run-processor.ts
+++ b/apps/backend/src/data-marts/scheduled-trigger-types/scheduled-report-run/services/scheduled-report-run-processor.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { RunReportCommand } from '../../../dto/domain/run-report.command';
+import { ScheduledRunReportCommand } from '../../../dto/domain/run-report.command';
 import { DataMartScheduledTrigger } from '../../../entities/data-mart-scheduled-trigger.entity';
 import { RunReportService } from '../../../use-cases/run-report.service';
 import { ScheduledTriggerType } from '../../enums/scheduled-trigger-type.enum';
@@ -25,11 +25,11 @@ export class ScheduledReportRunProcessor implements ScheduledTriggerProcessor {
       throw new Error(`Invalid trigger config`);
     }
 
-    const runReportCommand = {
+    const runReportCommand: ScheduledRunReportCommand = {
       reportId: trigger.triggerConfig.reportId,
       userId: trigger.createdById,
       runType: RunType.scheduled,
-    } as RunReportCommand;
+    };
 
     await this.runReportService.run(runReportCommand, signal);
     this.logger.log(`Trigger ${trigger.id} processed`);

--- a/apps/backend/src/data-marts/services/report-access.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-access.service.spec.ts
@@ -20,9 +20,7 @@ describe('ReportAccessService', () => {
     };
     const reportOwnerRepository = {
       count: jest.fn(),
-    };
-    const dataDestinationRepository = {
-      count: jest.fn(),
+      exist: jest.fn(),
     };
     const idpProjectionsFacade = {
       getProjectMembers: jest.fn(),
@@ -34,7 +32,6 @@ describe('ReportAccessService', () => {
     const service = new ReportAccessService(
       reportRepository as never,
       reportOwnerRepository as never,
-      dataDestinationRepository as never,
       idpProjectionsFacade as never,
       accessDecisionService as never
     );
@@ -43,7 +40,6 @@ describe('ReportAccessService', () => {
       service,
       reportRepository,
       reportOwnerRepository,
-      dataDestinationRepository,
       idpProjectionsFacade,
       accessDecisionService,
     };
@@ -90,7 +86,7 @@ describe('ReportAccessService', () => {
         .mockResolvedValueOnce(true) // SEE DM
         .mockResolvedValueOnce(false); // EDIT DM (no maintenance)
       // Not a report owner
-      reportOwnerRepository.count.mockResolvedValue(0);
+      reportOwnerRepository.exist.mockResolvedValue(false);
 
       const result = await service.canMutate('user-1', ['editor'], 'report-1', 'proj-1');
       expect(result).toBe(false);
@@ -104,7 +100,7 @@ describe('ReportAccessService', () => {
         .mockResolvedValueOnce(true) // SEE DM
         .mockResolvedValueOnce(false) // EDIT DM
         .mockResolvedValueOnce(true); // USE Destination (effective)
-      reportOwnerRepository.count.mockResolvedValue(1);
+      reportOwnerRepository.exist.mockResolvedValue(true);
 
       const result = await service.canMutate('user-1', ['viewer'], 'report-1', 'proj-1');
       expect(result).toBe(true);
@@ -118,7 +114,7 @@ describe('ReportAccessService', () => {
         .mockResolvedValueOnce(true) // SEE DM
         .mockResolvedValueOnce(false) // EDIT DM
         .mockResolvedValueOnce(false); // USE Destination (ineffective)
-      reportOwnerRepository.count.mockResolvedValue(1);
+      reportOwnerRepository.exist.mockResolvedValue(true);
 
       const result = await service.canMutate('user-1', ['viewer'], 'report-1', 'proj-1');
       expect(result).toBe(false);
@@ -271,7 +267,7 @@ describe('ReportAccessService', () => {
         createService();
       reportRepository.findOne.mockResolvedValue(mockReport);
       accessDecisionService.canAccess.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
-      reportOwnerRepository.count.mockResolvedValue(0);
+      reportOwnerRepository.exist.mockResolvedValue(false);
 
       await expect(
         service.checkMutateAccess('user-1', ['viewer'], 'report-1', 'proj-1')
@@ -280,7 +276,7 @@ describe('ReportAccessService', () => {
       // Reset mocks for second assertion
       reportRepository.findOne.mockResolvedValue(mockReport);
       accessDecisionService.canAccess.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
-      reportOwnerRepository.count.mockResolvedValue(0);
+      reportOwnerRepository.exist.mockResolvedValue(false);
 
       await expect(
         service.checkMutateAccess('user-1', ['viewer'], 'report-1', 'proj-1')
@@ -295,7 +291,7 @@ describe('ReportAccessService', () => {
         .mockResolvedValueOnce(true) // SEE DM
         .mockResolvedValueOnce(false) // EDIT DM
         .mockResolvedValueOnce(false); // USE Destination (ineffective)
-      reportOwnerRepository.count.mockResolvedValue(1);
+      reportOwnerRepository.exist.mockResolvedValue(true);
 
       await expect(
         service.checkMutateAccess('user-1', ['viewer'], 'report-1', 'proj-1')
@@ -306,7 +302,7 @@ describe('ReportAccessService', () => {
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(false)
         .mockResolvedValueOnce(false);
-      reportOwnerRepository.count.mockResolvedValue(1);
+      reportOwnerRepository.exist.mockResolvedValue(true);
 
       await expect(
         service.checkMutateAccess('user-1', ['viewer'], 'report-1', 'proj-1')

--- a/apps/backend/src/data-marts/services/report-access.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-access.service.spec.ts
@@ -97,38 +97,28 @@ describe('ReportAccessService', () => {
     });
 
     it('should return true for report owner who is effective', async () => {
-      const {
-        service,
-        reportRepository,
-        reportOwnerRepository,
-        dataDestinationRepository,
-        accessDecisionService,
-      } = createService();
+      const { service, reportRepository, reportOwnerRepository, accessDecisionService } =
+        createService();
       reportRepository.findOne.mockResolvedValue(mockReport);
       accessDecisionService.canAccess
         .mockResolvedValueOnce(true) // SEE DM
-        .mockResolvedValueOnce(false); // EDIT DM
+        .mockResolvedValueOnce(false) // EDIT DM
+        .mockResolvedValueOnce(true); // USE Destination (effective)
       reportOwnerRepository.count.mockResolvedValue(1);
-      dataDestinationRepository.count.mockResolvedValue(1);
 
       const result = await service.canMutate('user-1', ['viewer'], 'report-1', 'proj-1');
       expect(result).toBe(true);
     });
 
     it('should return false for report owner who is ineffective (destination deleted)', async () => {
-      const {
-        service,
-        reportRepository,
-        reportOwnerRepository,
-        dataDestinationRepository,
-        accessDecisionService,
-      } = createService();
+      const { service, reportRepository, reportOwnerRepository, accessDecisionService } =
+        createService();
       reportRepository.findOne.mockResolvedValue(mockReport);
       accessDecisionService.canAccess
         .mockResolvedValueOnce(true) // SEE DM
-        .mockResolvedValueOnce(false); // EDIT DM
+        .mockResolvedValueOnce(false) // EDIT DM
+        .mockResolvedValueOnce(false); // USE Destination (ineffective)
       reportOwnerRepository.count.mockResolvedValue(1);
-      dataDestinationRepository.count.mockResolvedValue(0);
 
       const result = await service.canMutate('user-1', ['viewer'], 'report-1', 'proj-1');
       expect(result).toBe(false);
@@ -155,28 +145,28 @@ describe('ReportAccessService', () => {
   });
 
   describe('isEffective', () => {
-    it('should return true when destination exists', async () => {
-      const { service, dataDestinationRepository } = createService();
-      dataDestinationRepository.count.mockResolvedValue(1);
+    it('should return true when user has USE access to destination', async () => {
+      const { service, accessDecisionService } = createService();
+      accessDecisionService.canAccess.mockResolvedValue(true);
 
       const report = { dataDestination: { id: 'dest-1' } } as never;
-      const result = await service.isEffective('user-1', report);
+      const result = await service.isEffective('user-1', report, ['viewer'], 'proj-1');
       expect(result).toBe(true);
     });
 
-    it('should return false when destination is soft-deleted', async () => {
-      const { service, dataDestinationRepository } = createService();
-      dataDestinationRepository.count.mockResolvedValue(0);
+    it('should return false when user lacks USE access to destination', async () => {
+      const { service, accessDecisionService } = createService();
+      accessDecisionService.canAccess.mockResolvedValue(false);
 
       const report = { dataDestination: { id: 'dest-1' } } as never;
-      const result = await service.isEffective('user-1', report);
+      const result = await service.isEffective('user-1', report, ['viewer'], 'proj-1');
       expect(result).toBe(false);
     });
 
     it('should return false when destination is null', async () => {
       const { service } = createService();
       const report = { dataDestination: null } as never;
-      const result = await service.isEffective('user-1', report);
+      const result = await service.isEffective('user-1', report, ['viewer'], 'proj-1');
       expect(result).toBe(false);
     });
   });
@@ -298,30 +288,123 @@ describe('ReportAccessService', () => {
     });
 
     it('should throw with "destination" message for ineffective owner', async () => {
-      const {
-        service,
-        reportRepository,
-        reportOwnerRepository,
-        dataDestinationRepository,
-        accessDecisionService,
-      } = createService();
+      const { service, reportRepository, reportOwnerRepository, accessDecisionService } =
+        createService();
       reportRepository.findOne.mockResolvedValue(mockReport);
-      accessDecisionService.canAccess.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+      accessDecisionService.canAccess
+        .mockResolvedValueOnce(true) // SEE DM
+        .mockResolvedValueOnce(false) // EDIT DM
+        .mockResolvedValueOnce(false); // USE Destination (ineffective)
       reportOwnerRepository.count.mockResolvedValue(1);
-      dataDestinationRepository.count.mockResolvedValue(0);
 
       await expect(
         service.checkMutateAccess('user-1', ['viewer'], 'report-1', 'proj-1')
       ).rejects.toThrow(ForbiddenException);
 
       reportRepository.findOne.mockResolvedValue(mockReport);
-      accessDecisionService.canAccess.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+      accessDecisionService.canAccess
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(false);
       reportOwnerRepository.count.mockResolvedValue(1);
-      dataDestinationRepository.count.mockResolvedValue(0);
 
       await expect(
         service.checkMutateAccess('user-1', ['viewer'], 'report-1', 'proj-1')
-      ).rejects.toThrow(/destination.*deleted/i);
+      ).rejects.toThrow(/destination.*not accessible/i);
+    });
+  });
+
+  describe('canOperate', () => {
+    const buildOperateMocks = (canSeeDm: boolean, canUseDest: boolean) => {
+      const { service, reportRepository, accessDecisionService } = createService();
+      reportRepository.findOne.mockResolvedValue(mockReport);
+      accessDecisionService.canAccess.mockImplementation(
+        async (
+          _userId: string,
+          _roles: string[],
+          entityType: string,
+          _entityId: string,
+          action: string,
+          _projectId: string
+        ) => {
+          if (entityType === 'DATA_MART' && action === 'SEE') return canSeeDm;
+          if (entityType === 'DESTINATION' && action === 'USE') return canUseDest;
+          return false;
+        }
+      );
+      return { service, accessDecisionService };
+    };
+
+    it('returns true when user can see DM and use Destination', async () => {
+      const { service } = buildOperateMocks(true, true);
+      await expect(service.canOperate('user-1', ['viewer'], 'report-1', 'proj-1')).resolves.toBe(
+        true
+      );
+    });
+
+    it('returns false when DM is invisible', async () => {
+      const { service } = buildOperateMocks(false, true);
+      await expect(service.canOperate('user-1', ['viewer'], 'report-1', 'proj-1')).resolves.toBe(
+        false
+      );
+    });
+
+    it('returns false when Destination is not usable', async () => {
+      const { service } = buildOperateMocks(true, false);
+      await expect(service.canOperate('user-1', ['viewer'], 'report-1', 'proj-1')).resolves.toBe(
+        false
+      );
+    });
+
+    it('returns false when report does not exist', async () => {
+      const { service, reportRepository } = createService();
+      reportRepository.findOne.mockResolvedValue(null);
+      await expect(service.canOperate('user-1', ['viewer'], 'report-1', 'proj-1')).resolves.toBe(
+        false
+      );
+    });
+
+    it('returns false when report has no destination assigned', async () => {
+      const { service, reportRepository, accessDecisionService } = createService();
+      reportRepository.findOne.mockResolvedValue({
+        ...mockReport,
+        dataDestination: null,
+      });
+      accessDecisionService.canAccess.mockResolvedValueOnce(true); // SEE DM
+      await expect(service.canOperate('user-1', ['viewer'], 'report-1', 'proj-1')).resolves.toBe(
+        false
+      );
+    });
+  });
+
+  describe('checkOperateAccess', () => {
+    it('throws ForbiddenException with dm-invisible reason', async () => {
+      const { service, reportRepository, accessDecisionService } = createService();
+      reportRepository.findOne.mockResolvedValue(mockReport);
+      accessDecisionService.canAccess.mockResolvedValueOnce(false); // SEE DM = false
+      await expect(
+        service.checkOperateAccess('user-1', ['viewer'], 'report-1', 'proj-1')
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('throws ForbiddenException with destination-unusable reason', async () => {
+      const { service, reportRepository, accessDecisionService } = createService();
+      reportRepository.findOne.mockResolvedValue(mockReport);
+      accessDecisionService.canAccess
+        .mockResolvedValueOnce(true) // SEE DM
+        .mockResolvedValueOnce(false); // USE Destination
+      await expect(
+        service.checkOperateAccess('user-1', ['viewer'], 'report-1', 'proj-1')
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('passes when both DM SEE and Destination USE are allowed', async () => {
+      const { service, reportRepository, accessDecisionService } = createService();
+      reportRepository.findOne.mockResolvedValue(mockReport);
+      accessDecisionService.canAccess.mockResolvedValue(true);
+      await expect(
+        service.checkOperateAccess('user-1', ['viewer'], 'report-1', 'proj-1')
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/apps/backend/src/data-marts/services/report-access.service.ts
+++ b/apps/backend/src/data-marts/services/report-access.service.ts
@@ -8,15 +8,23 @@ import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
 import { AccessDecisionService, EntityType, Action } from './access-decision';
 
 type MutateDeniedReason = 'not-owner' | 'ineffective' | 'not-found' | 'dm-invisible';
+type OperateDeniedReason = 'not-found' | 'dm-invisible' | 'destination-unusable';
 
 type MutateResult = { allowed: true } | { allowed: false; reason: MutateDeniedReason };
+type OperateResult = { allowed: true } | { allowed: false; reason: OperateDeniedReason };
 
 const MUTATE_DENIED_MESSAGES: Record<MutateDeniedReason, string> = {
   'not-owner': 'You are not an owner of this report. Only report owners can modify it.',
   'not-found': 'Report not found.',
   ineffective:
-    'The destination for this report has been deleted. The report cannot be modified or run until a Technical User updates the destination or reassigns ownership.',
+    'The destination for this report is not accessible to you. Ask a Technical User to share the destination or replace it.',
   'dm-invisible': 'You do not have access to the DataMart for this report.',
+};
+
+const OPERATE_DENIED_MESSAGES: Record<OperateDeniedReason, string> = {
+  'not-found': 'Report not found.',
+  'dm-invisible': 'You do not have access to the DataMart for this report.',
+  'destination-unusable': 'You do not have access to the destination configured for this report.',
 };
 
 @Injectable()
@@ -124,24 +132,108 @@ export class ReportAccessService {
   }
 
   /**
-   * Check if an owner is effective — can actually mutate/run the Report.
-   * Ineffective = Destination deleted or inaccessible.
+   * Evaluate whether a user can OPERATE a Report — manual run + CRUD report triggers.
+   * Decoupled from `canMutate` (which controls report config edits / owner changes).
+   *
+   * Operate = canSee(DataMart) AND canUse(Destination).
+   * No Report ownership requirement.
+   */
+  private async evaluateOperateAccess(
+    userId: string,
+    roles: string[],
+    reportId: string,
+    projectId: string
+  ): Promise<OperateResult> {
+    const report = await this.reportRepository.findOne({
+      where: { id: reportId, dataMart: { projectId } },
+      relations: ['dataMart', 'dataDestination'],
+    });
+
+    if (!report) {
+      return { allowed: false, reason: 'not-found' };
+    }
+
+    const canSeeDm = await this.accessDecisionService.canAccess(
+      userId,
+      roles,
+      EntityType.DATA_MART,
+      report.dataMart.id,
+      Action.SEE,
+      projectId
+    );
+    if (!canSeeDm) {
+      return { allowed: false, reason: 'dm-invisible' };
+    }
+
+    if (!report.dataDestination) {
+      return { allowed: false, reason: 'destination-unusable' };
+    }
+
+    const canUseDest = await this.accessDecisionService.canAccess(
+      userId,
+      roles,
+      EntityType.DESTINATION,
+      report.dataDestination.id,
+      Action.USE,
+      projectId
+    );
+    if (!canUseDest) {
+      return { allowed: false, reason: 'destination-unusable' };
+    }
+
+    return { allowed: true };
+  }
+
+  async canOperate(
+    userId: string,
+    roles: string[],
+    reportId: string,
+    projectId: string
+  ): Promise<boolean> {
+    const result = await this.evaluateOperateAccess(userId, roles, reportId, projectId);
+    return result.allowed;
+  }
+
+  async checkOperateAccess(
+    userId: string,
+    roles: string[],
+    reportId: string,
+    projectId: string
+  ): Promise<void> {
+    const result = await this.evaluateOperateAccess(userId, roles, reportId, projectId);
+    if (!result.allowed) {
+      this.logger.warn(`Operate access denied: ${result.reason}`, {
+        userId,
+        reportId,
+        projectId,
+      });
+      throw new ForbiddenException(OPERATE_DENIED_MESSAGES[result.reason]);
+    }
+  }
+
+  /**
+   * Check if a user is "effective" for this report — has USE access to its Destination.
+   * Per Stage 2 §76 of the permissions spec, an Owner who loses Destination accessibility
+   * becomes ineffective for mutation and running.
    */
   async isEffective(
-    _userId: string,
+    userId: string,
     report: Report,
-    _roles?: string[],
-    _projectId?: string
+    roles: string[],
+    projectId: string
   ): Promise<boolean> {
     if (!report.dataDestination) {
       return false;
     }
 
-    const destinationCount = await this.dataDestinationRepository.count({
-      where: { id: report.dataDestination.id },
-    });
-
-    return destinationCount > 0;
+    return this.accessDecisionService.canAccess(
+      userId,
+      roles,
+      EntityType.DESTINATION,
+      report.dataDestination.id,
+      Action.USE,
+      projectId
+    );
   }
 
   isTechnicalUser(roles: string[]): boolean {

--- a/apps/backend/src/data-marts/services/report-access.service.ts
+++ b/apps/backend/src/data-marts/services/report-access.service.ts
@@ -3,7 +3,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Report } from '../entities/report.entity';
 import { ReportOwner } from '../entities/report-owner.entity';
-import { DataDestination } from '../entities/data-destination.entity';
 import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
 import { AccessDecisionService, EntityType, Action } from './access-decision';
 
@@ -12,6 +11,23 @@ type OperateDeniedReason = 'not-found' | 'dm-invisible' | 'destination-unusable'
 
 type MutateResult = { allowed: true } | { allowed: false; reason: MutateDeniedReason };
 type OperateResult = { allowed: true } | { allowed: false; reason: OperateDeniedReason };
+
+/**
+ * Capability flags exposed on Report API responses. `canRun` and `canManageTriggers`
+ * are derived from the same `canOperate` predicate today; they are kept as separate
+ * fields so the contract can diverge later without breaking clients.
+ */
+export interface ReportCapabilities {
+  canRun: boolean;
+  canManageTriggers: boolean;
+  canEditConfig: boolean;
+}
+
+const EMPTY_CAPABILITIES: ReportCapabilities = Object.freeze({
+  canRun: false,
+  canManageTriggers: false,
+  canEditConfig: false,
+});
 
 const MUTATE_DENIED_MESSAGES: Record<MutateDeniedReason, string> = {
   'not-owner': 'You are not an owner of this report. Only report owners can modify it.',
@@ -36,11 +52,16 @@ export class ReportAccessService {
     private readonly reportRepository: Repository<Report>,
     @InjectRepository(ReportOwner)
     private readonly reportOwnerRepository: Repository<ReportOwner>,
-    @InjectRepository(DataDestination)
-    private readonly dataDestinationRepository: Repository<DataDestination>,
     private readonly idpProjectionsFacade: IdpProjectionsFacade,
     private readonly accessDecisionService: AccessDecisionService
   ) {}
+
+  private async loadReportForAccess(reportId: string, projectId: string): Promise<Report | null> {
+    return this.reportRepository.findOne({
+      where: { id: reportId, dataMart: { projectId } },
+      relations: ['dataMart', 'dataDestination'],
+    });
+  }
 
   /**
    * Evaluate whether a user can mutate a Report. Single source of truth for access logic.
@@ -54,15 +75,24 @@ export class ReportAccessService {
     reportId: string,
     projectId: string
   ): Promise<MutateResult> {
-    const report = await this.reportRepository.findOne({
-      where: { id: reportId, dataMart: { projectId } },
-      relations: ['dataMart', 'dataDestination'],
-    });
-
+    const report = await this.loadReportForAccess(reportId, projectId);
     if (!report) {
       return { allowed: false, reason: 'not-found' };
     }
+    return this.evaluateMutateAccessForReport(userId, roles, report, projectId);
+  }
 
+  /**
+   * Same as `evaluateMutateAccess`, but operates on an already-loaded `Report`
+   * to avoid an extra `findOne` round-trip (used by list endpoints to defeat N+1).
+   * Caller MUST ensure `report.dataMart` and `report.dataDestination` relations are loaded.
+   */
+  private async evaluateMutateAccessForReport(
+    userId: string,
+    roles: string[],
+    report: Report,
+    projectId: string
+  ): Promise<MutateResult> {
     // Permissions Model: DM must be visible to the user
     const canSeeDm = await this.accessDecisionService.canAccess(
       userId,
@@ -90,16 +120,27 @@ export class ReportAccessService {
     }
 
     // Otherwise: must be report owner + effective
-    const ownerCount = await this.reportOwnerRepository.count({
-      where: { reportId, userId },
+    const isOwner = await this.reportOwnerRepository.exist({
+      where: { reportId: report.id, userId },
     });
 
-    if (ownerCount === 0) {
+    if (!isOwner) {
       return { allowed: false, reason: 'not-owner' };
     }
 
-    const effective = await this.isEffective(userId, report, roles, projectId);
-    return effective ? { allowed: true } : { allowed: false, reason: 'ineffective' };
+    if (!report.dataDestination) {
+      return { allowed: false, reason: 'ineffective' };
+    }
+
+    const canUseDest = await this.accessDecisionService.canAccess(
+      userId,
+      roles,
+      EntityType.DESTINATION,
+      report.dataDestination.id,
+      Action.USE,
+      projectId
+    );
+    return canUseDest ? { allowed: true } : { allowed: false, reason: 'ineffective' };
   }
 
   /**
@@ -144,15 +185,24 @@ export class ReportAccessService {
     reportId: string,
     projectId: string
   ): Promise<OperateResult> {
-    const report = await this.reportRepository.findOne({
-      where: { id: reportId, dataMart: { projectId } },
-      relations: ['dataMart', 'dataDestination'],
-    });
-
+    const report = await this.loadReportForAccess(reportId, projectId);
     if (!report) {
       return { allowed: false, reason: 'not-found' };
     }
+    return this.evaluateOperateAccessForReport(userId, roles, report, projectId);
+  }
 
+  /**
+   * Same as `evaluateOperateAccess`, but operates on an already-loaded `Report`
+   * to avoid an extra `findOne` round-trip. Caller MUST ensure relations
+   * `dataMart` and `dataDestination` are loaded.
+   */
+  private async evaluateOperateAccessForReport(
+    userId: string,
+    roles: string[],
+    report: Report,
+    projectId: string
+  ): Promise<OperateResult> {
     const canSeeDm = await this.accessDecisionService.canAccess(
       userId,
       roles,
@@ -209,6 +259,38 @@ export class ReportAccessService {
       });
       throw new ForbiddenException(OPERATE_DENIED_MESSAGES[result.reason]);
     }
+  }
+
+  /**
+   * Capability flags exposed on Report responses. `canRun` and `canManageTriggers`
+   * are tied to `canOperate` today; `canEditConfig` is tied to `canMutate`.
+   * Computing both with `Promise.all` halves the latency on hot paths.
+   *
+   * Caller must supply an already-loaded `Report` with `dataMart` and `dataDestination`
+   * relations populated. This is the one method use cases should call when assembling
+   * `ReportDto` — do not duplicate the Promise.all + capability assembly elsewhere.
+   */
+  async computeCapabilitiesForReport(
+    userId: string | undefined,
+    roles: string[],
+    report: Report,
+    projectId: string
+  ): Promise<ReportCapabilities> {
+    if (!userId) {
+      return EMPTY_CAPABILITIES;
+    }
+
+    const [operateResult, mutateResult] = await Promise.all([
+      this.evaluateOperateAccessForReport(userId, roles, report, projectId),
+      this.evaluateMutateAccessForReport(userId, roles, report, projectId),
+    ]);
+
+    const canOperate = operateResult.allowed;
+    return {
+      canRun: canOperate,
+      canManageTriggers: canOperate,
+      canEditConfig: mutateResult.allowed,
+    };
   }
 
   /**

--- a/apps/backend/src/data-marts/use-cases/create-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-report.service.spec.ts
@@ -62,7 +62,21 @@ describe('CreateReportService', () => {
       checkAccess: jest.fn().mockResolvedValue(undefined),
     };
     const mapper = {
-      toDomainDto: jest.fn().mockReturnValue({ id: 'report-1' }),
+      toDomainDto: jest
+        .fn()
+        .mockImplementation(
+          (
+            _entity: unknown,
+            _createdByUser: unknown,
+            _ownerUsers: unknown,
+            capabilities?: { canRun: boolean; canManageTriggers: boolean; canEditConfig: boolean }
+          ) => ({
+            id: 'report-1',
+            canRun: capabilities?.canRun ?? false,
+            canManageTriggers: capabilities?.canManageTriggers ?? false,
+            canEditConfig: capabilities?.canEditConfig ?? false,
+          })
+        ),
     };
     const availableDestinationTypesService = {
       verifyIsAllowed: jest.fn(),
@@ -83,6 +97,10 @@ describe('CreateReportService', () => {
       validateForReport: jest.fn().mockResolvedValue(undefined),
       ...outputControlsValidatorOverride,
     };
+    const reportAccessService = {
+      canOperate: jest.fn().mockResolvedValue(true),
+      canMutate: jest.fn().mockResolvedValue(true),
+    };
 
     const service = new CreateReportService(
       reportRepository as never,
@@ -96,7 +114,8 @@ describe('CreateReportService', () => {
       idpProjectionsFacade as never,
       accessDecisionService as never,
       eventDispatcher as never,
-      outputControlsValidator as never
+      outputControlsValidator as never,
+      reportAccessService as never
     );
 
     return { service, reportRepository, outputControlsValidator };
@@ -229,5 +248,21 @@ describe('CreateReportService', () => {
         limitConfig: 50,
       })
     );
+  });
+
+  it('should return DTO carrying capabilities computed for the creator', async () => {
+    const { service } = createService();
+    const command = new CreateReportCommand('proj-1', 'user-0', 'Test', 'dm-1', 'dest-1', {
+      type: 'looker-studio-config',
+      cacheLifetime: 3600,
+    } as never);
+
+    const result = await service.run(command);
+
+    expect(result).toMatchObject({
+      canRun: true,
+      canManageTriggers: true,
+      canEditConfig: true,
+    });
   });
 });

--- a/apps/backend/src/data-marts/use-cases/create-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-report.service.spec.ts
@@ -100,6 +100,11 @@ describe('CreateReportService', () => {
     const reportAccessService = {
       canOperate: jest.fn().mockResolvedValue(true),
       canMutate: jest.fn().mockResolvedValue(true),
+      computeCapabilitiesForReport: jest.fn().mockResolvedValue({
+        canRun: true,
+        canManageTriggers: true,
+        canEditConfig: true,
+      }),
     };
 
     const service = new CreateReportService(

--- a/apps/backend/src/data-marts/use-cases/create-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-report.service.ts
@@ -163,32 +163,18 @@ export class CreateReportService {
       await this.userProjectionsFetcherService.fetchUserProjectionsList(allUserIds);
     const createdByUser = userProjections.getByUserId(command.userId) ?? null;
 
-    const [canOperate, canMutate] = command.userId
-      ? await Promise.all([
-          this.reportAccessService.canOperate(
-            command.userId,
-            command.roles,
-            newReport.id,
-            command.projectId
-          ),
-          this.reportAccessService.canMutate(
-            command.userId,
-            command.roles,
-            newReport.id,
-            command.projectId
-          ),
-        ])
-      : [false, false];
+    const capabilities = await this.reportAccessService.computeCapabilitiesForReport(
+      command.userId,
+      command.roles,
+      newReport,
+      command.projectId
+    );
 
     return this.mapper.toDomainDto(
       newReport,
       createdByUser,
       resolveOwnerUsers(ownerIdsToSave, userProjections),
-      {
-        canRun: canOperate,
-        canManageTriggers: canOperate,
-        canEditConfig: canMutate,
-      }
+      capabilities
     );
   }
 }

--- a/apps/backend/src/data-marts/use-cases/create-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-report.service.ts
@@ -22,6 +22,7 @@ import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
 import { ForbiddenException } from '@nestjs/common';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 import { OutputControlsValidatorService } from '../services/output-controls-validator.service';
+import { ReportAccessService } from '../services/report-access.service';
 
 @Injectable()
 export class CreateReportService {
@@ -39,7 +40,8 @@ export class CreateReportService {
     private readonly idpProjectionsFacade: IdpProjectionsFacade,
     private readonly accessDecisionService: AccessDecisionService,
     private readonly eventDispatcher: OwoxEventDispatcher,
-    private readonly outputControlsValidator: OutputControlsValidatorService
+    private readonly outputControlsValidator: OutputControlsValidatorService,
+    private readonly reportAccessService: ReportAccessService
   ) {}
 
   @Transactional()
@@ -161,10 +163,32 @@ export class CreateReportService {
       await this.userProjectionsFetcherService.fetchUserProjectionsList(allUserIds);
     const createdByUser = userProjections.getByUserId(command.userId) ?? null;
 
+    const [canOperate, canMutate] = command.userId
+      ? await Promise.all([
+          this.reportAccessService.canOperate(
+            command.userId,
+            command.roles,
+            newReport.id,
+            command.projectId
+          ),
+          this.reportAccessService.canMutate(
+            command.userId,
+            command.roles,
+            newReport.id,
+            command.projectId
+          ),
+        ])
+      : [false, false];
+
     return this.mapper.toDomainDto(
       newReport,
       createdByUser,
-      resolveOwnerUsers(ownerIdsToSave, userProjections)
+      resolveOwnerUsers(ownerIdsToSave, userProjections),
+      {
+        canRun: canOperate,
+        canManageTriggers: canOperate,
+        canEditConfig: canMutate,
+      }
     );
   }
 }

--- a/apps/backend/src/data-marts/use-cases/create-scheduled-trigger.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-scheduled-trigger.service.spec.ts
@@ -34,7 +34,7 @@ describe('CreateScheduledTriggerService', () => {
       toDomainDto: jest.fn().mockReturnValue({ id: 'trigger-1' }),
     };
     const reportAccessService = {
-      canMutate: jest.fn().mockResolvedValue(true),
+      checkOperateAccess: jest.fn().mockResolvedValue(undefined),
       isTechnicalUser: jest
         .fn()
         .mockImplementation(
@@ -60,9 +60,8 @@ describe('CreateScheduledTriggerService', () => {
     jest.clearAllMocks();
   });
 
-  it('should allow viewer to create REPORT_RUN trigger when they own the report', async () => {
+  it('should allow viewer to create REPORT_RUN trigger when they can operate the report', async () => {
     const { service, reportAccessService } = createService();
-    reportAccessService.canMutate.mockResolvedValue(true);
 
     const command = new CreateScheduledTriggerCommand(
       'proj-1',
@@ -78,7 +77,7 @@ describe('CreateScheduledTriggerService', () => {
 
     await service.run(command);
 
-    expect(reportAccessService.canMutate).toHaveBeenCalledWith(
+    expect(reportAccessService.checkOperateAccess).toHaveBeenCalledWith(
       'user-2',
       ['viewer'],
       'report-1',
@@ -86,9 +85,11 @@ describe('CreateScheduledTriggerService', () => {
     );
   });
 
-  it('should throw ForbiddenException when viewer does not own the report', async () => {
+  it('should throw ForbiddenException when viewer cannot operate the report', async () => {
     const { service, reportAccessService } = createService();
-    reportAccessService.canMutate.mockResolvedValue(false);
+    reportAccessService.checkOperateAccess.mockRejectedValueOnce(
+      new ForbiddenException('forbidden')
+    );
 
     const command = new CreateScheduledTriggerCommand(
       'proj-1',
@@ -139,5 +140,50 @@ describe('CreateScheduledTriggerService', () => {
     );
 
     await expect(service.run(command)).resolves.toBeDefined();
+  });
+
+  it('allows viewer who can operate the report (BO DM) to create REPORT_RUN trigger', async () => {
+    const { service, reportAccessService } = createService();
+
+    const command = new CreateScheduledTriggerCommand(
+      'proj-1',
+      'user-2',
+      'dm-1',
+      ScheduledTriggerType.REPORT_RUN,
+      '0 9 * * *',
+      'UTC',
+      true,
+      { type: 'scheduled-report-run-config', reportId: 'report-1' } as never,
+      ['viewer']
+    );
+
+    await expect(service.run(command)).resolves.toBeDefined();
+    expect(reportAccessService.checkOperateAccess).toHaveBeenCalledWith(
+      'user-2',
+      ['viewer'],
+      'report-1',
+      'proj-1'
+    );
+  });
+
+  it('rejects when checkOperateAccess throws for REPORT_RUN', async () => {
+    const { service, reportAccessService } = createService();
+    reportAccessService.checkOperateAccess.mockRejectedValueOnce(
+      new ForbiddenException('forbidden')
+    );
+
+    const command = new CreateScheduledTriggerCommand(
+      'proj-1',
+      'user-2',
+      'dm-1',
+      ScheduledTriggerType.REPORT_RUN,
+      '0 9 * * *',
+      'UTC',
+      true,
+      { type: 'scheduled-report-run-config', reportId: 'report-1' } as never,
+      ['viewer']
+    );
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(ForbiddenException);
   });
 });

--- a/apps/backend/src/data-marts/use-cases/create-scheduled-trigger.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-scheduled-trigger.service.ts
@@ -88,18 +88,12 @@ export class CreateScheduledTriggerService {
       }
       const reportId = command.triggerConfig.reportId;
 
-      const canMutate = await this.reportAccessService.canMutate(
+      await this.reportAccessService.checkOperateAccess(
         command.userId,
         command.roles,
         reportId,
         command.projectId
       );
-
-      if (!canMutate) {
-        throw new ForbiddenException(
-          'You do not have permission to create triggers for this report. Only report owners can manage report triggers.'
-        );
-      }
     } else {
       // CONNECTOR_RUN requires editor role
       if (!this.reportAccessService.isTechnicalUser(command.roles)) {

--- a/apps/backend/src/data-marts/use-cases/delete-scheduled-trigger.service.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-scheduled-trigger.service.ts
@@ -44,18 +44,12 @@ export class DeleteScheduledTriggerService {
         throw new BadRequestException('Report ID is required for REPORT_RUN triggers');
       }
 
-      const canMutate = await this.reportAccessService.canMutate(
+      await this.reportAccessService.checkOperateAccess(
         command.userId,
         command.roles,
         trigger.triggerConfig.reportId,
         command.projectId
       );
-
-      if (!canMutate) {
-        throw new ForbiddenException(
-          'You do not have permission to delete triggers for this report. Only report owners can manage report triggers.'
-        );
-      }
     } else {
       if (!this.reportAccessService.isTechnicalUser(command.roles)) {
         throw new ForbiddenException('Only Technical Users can delete connector run triggers.');

--- a/apps/backend/src/data-marts/use-cases/delete-scheduled-trigger.service.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-scheduled-trigger.service.ts
@@ -5,6 +5,7 @@ import { DeleteScheduledTriggerCommand } from '../dto/domain/delete-scheduled-tr
 import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
 import { ScheduledTriggerService } from '../services/scheduled-trigger.service';
 import { ReportAccessService } from '../services/report-access.service';
+import { ReportService } from '../services/report.service';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
 import { isScheduledReportRunConfig } from '../scheduled-trigger-types/scheduled-trigger-config.guards';
 
@@ -14,7 +15,8 @@ export class DeleteScheduledTriggerService {
     @InjectRepository(DataMartScheduledTrigger)
     private readonly triggerRepository: Repository<DataMartScheduledTrigger>,
     private readonly scheduledTriggerService: ScheduledTriggerService,
-    private readonly reportAccessService: ReportAccessService
+    private readonly reportAccessService: ReportAccessService,
+    private readonly reportService: ReportService
   ) {}
 
   async run(command: DeleteScheduledTriggerCommand): Promise<void> {
@@ -43,6 +45,12 @@ export class DeleteScheduledTriggerService {
       if (!isScheduledReportRunConfig(trigger.triggerConfig)) {
         throw new BadRequestException('Report ID is required for REPORT_RUN triggers');
       }
+
+      await this.reportService.getByIdAndDataMartIdAndProjectId(
+        trigger.triggerConfig.reportId,
+        command.dataMartId,
+        command.projectId
+      );
 
       await this.reportAccessService.checkOperateAccess(
         command.userId,

--- a/apps/backend/src/data-marts/use-cases/get-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report.service.ts
@@ -50,22 +50,12 @@ export class GetReportService {
       }
     }
 
-    const [canOperate, canMutate] = command.userId
-      ? await Promise.all([
-          this.reportAccessService.canOperate(
-            command.userId,
-            command.roles,
-            command.id,
-            command.projectId
-          ),
-          this.reportAccessService.canMutate(
-            command.userId,
-            command.roles,
-            command.id,
-            command.projectId
-          ),
-        ])
-      : [false, false];
+    const capabilities = await this.reportAccessService.computeCapabilitiesForReport(
+      command.userId,
+      command.roles,
+      report,
+      command.projectId
+    );
 
     const allUserIds = [...(report.createdById ? [report.createdById] : []), ...report.ownerIds];
     const userProjections =
@@ -77,11 +67,7 @@ export class GetReportService {
       report,
       createdByUser,
       resolveOwnerUsers(report.ownerIds, userProjections),
-      {
-        canRun: canOperate,
-        canManageTriggers: canOperate,
-        canEditConfig: canMutate,
-      }
+      capabilities
     );
   }
 }

--- a/apps/backend/src/data-marts/use-cases/get-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report.service.ts
@@ -8,6 +8,7 @@ import { ReportDto } from '../dto/domain/report.dto';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
 import { resolveOwnerUsers } from '../utils/resolve-owner-users';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import { ReportAccessService } from '../services/report-access.service';
 
 @Injectable()
 export class GetReportService {
@@ -16,7 +17,8 @@ export class GetReportService {
     private readonly reportRepository: Repository<Report>,
     private readonly mapper: ReportMapper,
     private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
-    private readonly accessDecisionService: AccessDecisionService
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly reportAccessService: ReportAccessService
   ) {}
 
   async run(command: GetReportCommand): Promise<ReportDto> {
@@ -48,6 +50,23 @@ export class GetReportService {
       }
     }
 
+    const [canOperate, canMutate] = command.userId
+      ? await Promise.all([
+          this.reportAccessService.canOperate(
+            command.userId,
+            command.roles,
+            command.id,
+            command.projectId
+          ),
+          this.reportAccessService.canMutate(
+            command.userId,
+            command.roles,
+            command.id,
+            command.projectId
+          ),
+        ])
+      : [false, false];
+
     const allUserIds = [...(report.createdById ? [report.createdById] : []), ...report.ownerIds];
     const userProjections =
       await this.userProjectionsFetcherService.fetchUserProjectionsList(allUserIds);
@@ -57,7 +76,12 @@ export class GetReportService {
     return this.mapper.toDomainDto(
       report,
       createdByUser,
-      resolveOwnerUsers(report.ownerIds, userProjections)
+      resolveOwnerUsers(report.ownerIds, userProjections),
+      {
+        canRun: canOperate,
+        canManageTriggers: canOperate,
+        canEditConfig: canMutate,
+      }
     );
   }
 }

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-data-mart.service.ts
@@ -7,6 +7,8 @@ import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data
 import { ReportDto } from '../dto/domain/report.dto';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import { ReportAccessService } from '../services/report-access.service';
+import { resolveOwnerUsers } from '../utils/resolve-owner-users';
 
 @Injectable()
 export class ListReportsByDataMartService {
@@ -15,7 +17,8 @@ export class ListReportsByDataMartService {
     private readonly reportRepository: Repository<Report>,
     private readonly mapper: ReportMapper,
     private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
-    private readonly accessDecisionService: AccessDecisionService
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly reportAccessService: ReportAccessService
   ) {}
 
   async run(command: ListReportsByDataMartCommand): Promise<ReportDto[]> {
@@ -49,6 +52,40 @@ export class ListReportsByDataMartService {
     const userProjectionsList =
       await this.userProjectionsFetcherService.fetchUserProjectionsList(allUserIds);
 
-    return this.mapper.toDomainDtoList(reports, userProjectionsList);
+    const reportsWithCaps = await Promise.all(
+      reports.map(async report => {
+        const [canOperate, canMutate] = command.userId
+          ? await Promise.all([
+              this.reportAccessService.canOperate(
+                command.userId,
+                command.roles,
+                report.id,
+                command.projectId
+              ),
+              this.reportAccessService.canMutate(
+                command.userId,
+                command.roles,
+                report.id,
+                command.projectId
+              ),
+            ])
+          : [false, false];
+
+        return this.mapper.toDomainDto(
+          report,
+          report.createdById
+            ? (userProjectionsList?.getByUserId(report.createdById) ?? null)
+            : null,
+          userProjectionsList ? resolveOwnerUsers(report.ownerIds, userProjectionsList) : [],
+          {
+            canRun: canOperate,
+            canManageTriggers: canOperate,
+            canEditConfig: canMutate,
+          }
+        );
+      })
+    );
+
+    return reportsWithCaps;
   }
 }

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-data-mart.service.ts
@@ -54,22 +54,12 @@ export class ListReportsByDataMartService {
 
     const reportsWithCaps = await Promise.all(
       reports.map(async report => {
-        const [canOperate, canMutate] = command.userId
-          ? await Promise.all([
-              this.reportAccessService.canOperate(
-                command.userId,
-                command.roles,
-                report.id,
-                command.projectId
-              ),
-              this.reportAccessService.canMutate(
-                command.userId,
-                command.roles,
-                report.id,
-                command.projectId
-              ),
-            ])
-          : [false, false];
+        const capabilities = await this.reportAccessService.computeCapabilitiesForReport(
+          command.userId,
+          command.roles,
+          report,
+          command.projectId
+        );
 
         return this.mapper.toDomainDto(
           report,
@@ -77,11 +67,7 @@ export class ListReportsByDataMartService {
             ? (userProjectionsList?.getByUserId(report.createdById) ?? null)
             : null,
           userProjectionsList ? resolveOwnerUsers(report.ownerIds, userProjectionsList) : [],
-          {
-            canRun: canOperate,
-            canManageTriggers: canOperate,
-            canEditConfig: canMutate,
-          }
+          capabilities
         );
       })
     );

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-insight-template.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-insight-template.service.ts
@@ -48,32 +48,18 @@ export class ListReportsByInsightTemplateService {
 
     return Promise.all(
       reports.map(async report => {
-        const [canOperate, canMutate] = command.userId
-          ? await Promise.all([
-              this.reportAccessService.canOperate(
-                command.userId,
-                command.roles,
-                report.id,
-                command.projectId
-              ),
-              this.reportAccessService.canMutate(
-                command.userId,
-                command.roles,
-                report.id,
-                command.projectId
-              ),
-            ])
-          : [false, false];
+        const capabilities = await this.reportAccessService.computeCapabilitiesForReport(
+          command.userId,
+          command.roles,
+          report,
+          command.projectId
+        );
 
         return this.mapper.toDomainDto(
           report,
           report.createdById ? (userProjectionsList.getByUserId(report.createdById) ?? null) : null,
           resolveOwnerUsers(report.ownerIds, userProjectionsList),
-          {
-            canRun: canOperate,
-            canManageTriggers: canOperate,
-            canEditConfig: canMutate,
-          }
+          capabilities
         );
       })
     );

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-insight-template.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-insight-template.service.ts
@@ -8,6 +8,8 @@ import { ListReportsByInsightTemplateCommand } from '../dto/domain/list-reports-
 import { EmailConfigType } from '../data-destination-types/ee/email/schemas/email-config.schema';
 import { TemplateSourceTypeEnum } from '../enums/template-source-type.enum';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+import { ReportAccessService } from '../services/report-access.service';
+import { resolveOwnerUsers } from '../utils/resolve-owner-users';
 
 @Injectable()
 export class ListReportsByInsightTemplateService {
@@ -15,7 +17,8 @@ export class ListReportsByInsightTemplateService {
     @InjectRepository(Report)
     private readonly reportRepository: Repository<Report>,
     private readonly mapper: ReportMapper,
-    private readonly userProjectionsFetcherService: UserProjectionsFetcherService
+    private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
+    private readonly reportAccessService: ReportAccessService
   ) {}
 
   async run(command: ListReportsByInsightTemplateCommand): Promise<ReportDto[]> {
@@ -43,6 +46,36 @@ export class ListReportsByInsightTemplateService {
     const userProjectionsList =
       await this.userProjectionsFetcherService.fetchRelevantUserProjections(reports);
 
-    return this.mapper.toDomainDtoList(reports, userProjectionsList);
+    return Promise.all(
+      reports.map(async report => {
+        const [canOperate, canMutate] = command.userId
+          ? await Promise.all([
+              this.reportAccessService.canOperate(
+                command.userId,
+                command.roles,
+                report.id,
+                command.projectId
+              ),
+              this.reportAccessService.canMutate(
+                command.userId,
+                command.roles,
+                report.id,
+                command.projectId
+              ),
+            ])
+          : [false, false];
+
+        return this.mapper.toDomainDto(
+          report,
+          report.createdById ? (userProjectionsList.getByUserId(report.createdById) ?? null) : null,
+          resolveOwnerUsers(report.ownerIds, userProjectionsList),
+          {
+            canRun: canOperate,
+            canManageTriggers: canOperate,
+            canEditConfig: canMutate,
+          }
+        );
+      })
+    );
   }
 }

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.ts
@@ -87,22 +87,12 @@ export class ListReportsByProjectService {
 
     const reportsWithCaps = await Promise.all(
       reports.map(async report => {
-        const [canOperate, canMutate] = command.userId
-          ? await Promise.all([
-              this.reportAccessService.canOperate(
-                command.userId,
-                command.roles,
-                report.id,
-                command.projectId
-              ),
-              this.reportAccessService.canMutate(
-                command.userId,
-                command.roles,
-                report.id,
-                command.projectId
-              ),
-            ])
-          : [false, false];
+        const capabilities = await this.reportAccessService.computeCapabilitiesForReport(
+          command.userId,
+          command.roles,
+          report,
+          command.projectId
+        );
 
         return this.mapper.toDomainDto(
           report,
@@ -110,11 +100,7 @@ export class ListReportsByProjectService {
             ? (userProjectionsList?.getByUserId(report.createdById) ?? null)
             : null,
           userProjectionsList ? resolveOwnerUsers(report.ownerIds, userProjectionsList) : [],
-          {
-            canRun: canOperate,
-            canManageTriggers: canOperate,
-            canEditConfig: canMutate,
-          }
+          capabilities
         );
       })
     );

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.ts
@@ -10,6 +10,8 @@ import { RoleScope } from '../enums/role-scope.enum';
 import { ContextAccessService } from '../services/context/context-access.service';
 import { buildContextGateSql } from '../utils/build-context-gate-sql';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+import { ReportAccessService } from '../services/report-access.service';
+import { resolveOwnerUsers } from '../utils/resolve-owner-users';
 
 @Injectable()
 export class ListReportsByProjectService {
@@ -18,7 +20,8 @@ export class ListReportsByProjectService {
     private readonly reportRepository: Repository<Report>,
     private readonly mapper: ReportMapper,
     private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
-    private readonly contextAccessService: ContextAccessService
+    private readonly contextAccessService: ContextAccessService,
+    private readonly reportAccessService: ReportAccessService
   ) {}
 
   async run(command: ListReportsByProjectCommand): Promise<ReportDto[]> {
@@ -82,6 +85,40 @@ export class ListReportsByProjectService {
     const userProjectionsList =
       await this.userProjectionsFetcherService.fetchUserProjectionsList(allUserIds);
 
-    return this.mapper.toDomainDtoList(reports, userProjectionsList);
+    const reportsWithCaps = await Promise.all(
+      reports.map(async report => {
+        const [canOperate, canMutate] = command.userId
+          ? await Promise.all([
+              this.reportAccessService.canOperate(
+                command.userId,
+                command.roles,
+                report.id,
+                command.projectId
+              ),
+              this.reportAccessService.canMutate(
+                command.userId,
+                command.roles,
+                report.id,
+                command.projectId
+              ),
+            ])
+          : [false, false];
+
+        return this.mapper.toDomainDto(
+          report,
+          report.createdById
+            ? (userProjectionsList?.getByUserId(report.createdById) ?? null)
+            : null,
+          userProjectionsList ? resolveOwnerUsers(report.ownerIds, userProjectionsList) : [],
+          {
+            canRun: canOperate,
+            canManageTriggers: canOperate,
+            canEditConfig: canMutate,
+          }
+        );
+      })
+    );
+
+    return reportsWithCaps;
   }
 }

--- a/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
@@ -2,6 +2,11 @@ jest.mock('../../idp/facades/idp-projections.facade', () => ({
   IdpProjectionsFacade: jest.fn(),
 }));
 
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
 jest.mock('../report-run-logging/log-blended-sql', () => ({
   logBlendedSqlIfNeeded: jest.fn(),
 }));
@@ -16,6 +21,7 @@ import { DataDestination } from '../entities/data-destination.entity';
 import { Report } from '../entities/report.entity';
 import { ReportExecutionPolicyResolver } from './report-execution-policy.resolver';
 import { RunReportService } from './run-report.service';
+import { RunType } from '../../common/scheduler/shared/types';
 
 jest.mock('../data-destination-types/data-destination-providers', () => ({
   DATA_DESTINATION_REPORT_WRITER_RESOLVER: 'DATA_DESTINATION_REPORT_WRITER_RESOLVER',
@@ -40,19 +46,32 @@ describe('RunReportService', () => {
       // Default: no columnConfig -> no blending, no filter.
       resolveBlendingDecision: jest.fn().mockResolvedValue({ needsBlending: false }),
     };
+    const reportRunService = {
+      createPending: jest.fn(),
+    };
+    const reportRunTriggerService = {
+      createTrigger: jest.fn().mockResolvedValue(undefined),
+    };
+    const reportAccessService = {
+      checkOperateAccess: jest.fn().mockResolvedValue(undefined),
+      checkMutateAccess: jest.fn().mockResolvedValue(undefined),
+    };
+    const gracefulShutdownService = {
+      isInShutdownMode: jest.fn().mockReturnValue(false),
+    };
 
     const service = new RunReportService(
       reportReaderResolver as never,
       reportWriterResolver as never,
       {} as never,
+      gracefulShutdownService as never,
       {} as never,
-      {} as never,
-      {} as never,
+      reportRunService as never,
       {} as never,
       projectBalanceService as never,
       new ReportExecutionPolicyResolver(),
-      {} as never,
-      { checkMutateAccess: jest.fn().mockResolvedValue(undefined) } as never,
+      reportRunTriggerService as never,
+      reportAccessService as never,
       blendedReportDataService as never,
       { compose: jest.fn().mockResolvedValue({ sql: 'SELECT 1' }) } as never
     );
@@ -63,6 +82,9 @@ describe('RunReportService', () => {
       reportWriterResolver,
       projectBalanceService,
       blendedReportDataService,
+      reportRunService,
+      reportRunTriggerService,
+      reportAccessService,
     };
   };
 
@@ -182,6 +204,34 @@ describe('RunReportService', () => {
     ).executeReport(report, undefined, mockLogger);
 
     expect(logBlendedSqlIfNeeded).toHaveBeenCalledWith(decision, mockLogger);
+  });
+
+  describe('manual runs', () => {
+    it('uses checkOperateAccess (not checkMutateAccess) for manual runs', async () => {
+      const { service, reportAccessService, reportRunService, reportRunTriggerService } =
+        createService();
+      reportRunService.createPending.mockResolvedValue({
+        getDataMart: () => ({ projectId: 'proj-1' }),
+        getDataMartRun: () => ({ id: 'dmr-1' }),
+      });
+
+      await service.run({
+        reportId: 'report-1',
+        userId: 'user-1',
+        roles: ['viewer'],
+        runType: RunType.manual,
+        projectId: 'proj-1',
+      });
+
+      expect(reportAccessService.checkOperateAccess).toHaveBeenCalledWith(
+        'user-1',
+        ['viewer'],
+        'report-1',
+        'proj-1'
+      );
+      expect(reportAccessService.checkMutateAccess).not.toHaveBeenCalled();
+      expect(reportRunTriggerService.createTrigger).toHaveBeenCalled();
+    });
   });
 
   it('keeps non-email destinations unchanged and reads all batches', async () => {

--- a/apps/backend/src/data-marts/use-cases/run-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.ts
@@ -112,7 +112,7 @@ export class RunReportService {
       if (!command.projectId) {
         throw new ForbiddenException('Manual report runs require project context');
       }
-      await this.reportAccessService.checkMutateAccess(
+      await this.reportAccessService.checkOperateAccess(
         command.userId,
         command.roles ?? [],
         command.reportId,

--- a/apps/backend/src/data-marts/use-cases/run-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger, ForbiddenException } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { TypeResolver } from '../../common/resolver/type-resolver';
@@ -99,27 +99,31 @@ export class RunReportService {
 
   /**
    * Creates a pending report run and enqueues it via trigger for worker processing.
-   * Both operations are wrapped in a transaction to ensure atomicity.
+   *
+   * Auth gating runs OUTSIDE the transactional boundary so a 403 doesn't open and
+   * roll back a database transaction. The actual createPending + createTrigger work
+   * stays atomic via `enqueueReportRun`.
    *
    * @param command - Report run command with reportId, userId, runType
    * @param signal - Unused, kept for backward compatibility with scheduled processors
    */
-  @Transactional()
   async run(command: RunReportCommand, _signal?: AbortSignal): Promise<void> {
     this.validateCanRun();
 
     if (command.runType === RunType.manual) {
-      if (!command.projectId) {
-        throw new ForbiddenException('Manual report runs require project context');
-      }
       await this.reportAccessService.checkOperateAccess(
         command.userId,
-        command.roles ?? [],
+        command.roles,
         command.reportId,
         command.projectId
       );
     }
 
+    await this.enqueueReportRun(command);
+  }
+
+  @Transactional()
+  private async enqueueReportRun(command: RunReportCommand): Promise<void> {
     this.logger.log(`Creating report run trigger for report ${command.reportId}`);
 
     const reportRun = await this.reportRunService.createPending(command);

--- a/apps/backend/src/data-marts/use-cases/update-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-report.service.spec.ts
@@ -98,6 +98,11 @@ describe('UpdateReportService', () => {
       canBeOwner: jest.fn().mockResolvedValue(true),
       canOperate: jest.fn().mockResolvedValue(true),
       canMutate: jest.fn().mockResolvedValue(true),
+      computeCapabilitiesForReport: jest.fn().mockResolvedValue({
+        canRun: true,
+        canManageTriggers: true,
+        canEditConfig: true,
+      }),
     };
     const accessDecisionService = {
       canAccess: jest.fn().mockResolvedValue(true),

--- a/apps/backend/src/data-marts/use-cases/update-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-report.service.spec.ts
@@ -67,7 +67,21 @@ describe('UpdateReportService', () => {
       checkAccess: jest.fn().mockResolvedValue(undefined),
     };
     const mapper = {
-      toDomainDto: jest.fn().mockReturnValue({ id: 'report-1' }),
+      toDomainDto: jest
+        .fn()
+        .mockImplementation(
+          (
+            _entity: unknown,
+            _createdByUser: unknown,
+            _ownerUsers: unknown,
+            capabilities?: { canRun: boolean; canManageTriggers: boolean; canEditConfig: boolean }
+          ) => ({
+            id: 'report-1',
+            canRun: capabilities?.canRun ?? false,
+            canManageTriggers: capabilities?.canManageTriggers ?? false,
+            canEditConfig: capabilities?.canEditConfig ?? false,
+          })
+        ),
     };
     const availableDestinationTypesService = {
       verifyIsAllowed: jest.fn(),
@@ -82,6 +96,11 @@ describe('UpdateReportService', () => {
     const reportAccessService = {
       checkMutateAccess: jest.fn().mockResolvedValue(undefined),
       canBeOwner: jest.fn().mockResolvedValue(true),
+      canOperate: jest.fn().mockResolvedValue(true),
+      canMutate: jest.fn().mockResolvedValue(true),
+    };
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(true),
     };
     const reportDataCacheService = {
       invalidateByReportId: jest.fn().mockResolvedValue(undefined),
@@ -102,12 +121,14 @@ describe('UpdateReportService', () => {
       reportOwnerRepository as never,
       reportAccessService as never,
       reportDataCacheService as never,
-      outputControlsValidator as never
+      outputControlsValidator as never,
+      accessDecisionService as never
     );
 
     return {
       service,
       reportAccessService,
+      accessDecisionService,
       reportRepository,
       reportDataCacheService,
       outputControlsValidator,
@@ -344,5 +365,27 @@ describe('UpdateReportService', () => {
     await service.run(command);
 
     expect(reportDataCacheService.invalidateByReportId).not.toHaveBeenCalled();
+  });
+
+  it('should return DTO carrying capabilities computed for the updater', async () => {
+    const { service } = createService();
+
+    const command = new UpdateReportCommand(
+      'report-1',
+      'proj-1',
+      'user-1',
+      ['editor'],
+      'New Title',
+      'dest-1',
+      {} as never
+    );
+
+    const result = await service.run(command);
+
+    expect(result).toMatchObject({
+      canRun: true,
+      canManageTriggers: true,
+      canEditConfig: true,
+    });
   });
 });

--- a/apps/backend/src/data-marts/use-cases/update-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-report.service.ts
@@ -1,6 +1,11 @@
 import { Repository } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AvailableDestinationTypesService } from '../data-destination-types/available-destination-types.service';
 import { Report } from '../entities/report.entity';
@@ -15,6 +20,7 @@ import { ReportOwner } from '../entities/report-owner.entity';
 import { resolveOwnerUsers } from '../utils/resolve-owner-users';
 import { syncOwners } from '../utils/sync-owners';
 import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
+import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 import { ReportAccessService } from '../services/report-access.service';
 import { ReportDataCacheService } from '../services/report-data-cache.service';
 import { OutputControlsValidatorService } from '../services/output-controls-validator.service';
@@ -34,7 +40,8 @@ export class UpdateReportService {
     private readonly reportOwnerRepository: Repository<ReportOwner>,
     private readonly reportAccessService: ReportAccessService,
     private readonly reportDataCacheService: ReportDataCacheService,
-    private readonly outputControlsValidator: OutputControlsValidatorService
+    private readonly outputControlsValidator: OutputControlsValidatorService,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   @Transactional()
@@ -61,13 +68,29 @@ export class UpdateReportService {
       command.projectId
     );
 
-    // Get the data destination if it's being changed
-    let dataDestination: DataDestination | null = report.dataDestination;
-    if (command.dataDestinationId !== dataDestination.id) {
+    // Get the data destination if it's being changed and verify caller can USE it
+    let dataDestination: DataDestination = report.dataDestination;
+    const destinationIsChanging = command.dataDestinationId !== dataDestination.id;
+    if (destinationIsChanging) {
       dataDestination = await this.dataDestinationService.getByIdAndProjectId(
         command.dataDestinationId,
         command.projectId
       );
+
+      // Permissions Model: caller must have USE on the new destination
+      if (command.userId) {
+        const canUseNewDest = await this.accessDecisionService.canAccess(
+          command.userId,
+          command.roles,
+          EntityType.DESTINATION,
+          dataDestination.id,
+          Action.USE,
+          command.projectId
+        );
+        if (!canUseNewDest) {
+          throw new ForbiddenException('You do not have access to the Destination for this report');
+        }
+      }
     }
 
     this.availableDestinationTypesService.verifyIsAllowed(dataDestination.type);
@@ -172,10 +195,32 @@ export class UpdateReportService {
       ? (userProjections.getByUserId(fresh.createdById) ?? null)
       : null;
 
+    const [canOperate, canMutate] = command.userId
+      ? await Promise.all([
+          this.reportAccessService.canOperate(
+            command.userId,
+            command.roles,
+            command.id,
+            command.projectId
+          ),
+          this.reportAccessService.canMutate(
+            command.userId,
+            command.roles,
+            command.id,
+            command.projectId
+          ),
+        ])
+      : [false, false];
+
     return this.mapper.toDomainDto(
       fresh,
       createdByUser,
-      resolveOwnerUsers(fresh.ownerIds, userProjections)
+      resolveOwnerUsers(fresh.ownerIds, userProjections),
+      {
+        canRun: canOperate,
+        canManageTriggers: canOperate,
+        canEditConfig: canMutate,
+      }
     );
   }
 }

--- a/apps/backend/src/data-marts/use-cases/update-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-report.service.ts
@@ -195,32 +195,18 @@ export class UpdateReportService {
       ? (userProjections.getByUserId(fresh.createdById) ?? null)
       : null;
 
-    const [canOperate, canMutate] = command.userId
-      ? await Promise.all([
-          this.reportAccessService.canOperate(
-            command.userId,
-            command.roles,
-            command.id,
-            command.projectId
-          ),
-          this.reportAccessService.canMutate(
-            command.userId,
-            command.roles,
-            command.id,
-            command.projectId
-          ),
-        ])
-      : [false, false];
+    const capabilities = await this.reportAccessService.computeCapabilitiesForReport(
+      command.userId,
+      command.roles,
+      fresh,
+      command.projectId
+    );
 
     return this.mapper.toDomainDto(
       fresh,
       createdByUser,
       resolveOwnerUsers(fresh.ownerIds, userProjections),
-      {
-        canRun: canOperate,
-        canManageTriggers: canOperate,
-        canEditConfig: canMutate,
-      }
+      capabilities
     );
   }
 }

--- a/apps/backend/src/data-marts/use-cases/update-scheduled-trigger.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-scheduled-trigger.service.ts
@@ -10,6 +10,7 @@ import { BusinessViolationException } from '../../common/exceptions/business-vio
 import { DataMartStatus } from '../enums/data-mart-status.enum';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
 import { ReportAccessService } from '../services/report-access.service';
+import { ReportService } from '../services/report.service';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
 import { isScheduledReportRunConfig } from '../scheduled-trigger-types/scheduled-trigger-config.guards';
 
@@ -21,7 +22,8 @@ export class UpdateScheduledTriggerService {
     private readonly scheduledTriggerService: ScheduledTriggerService,
     private readonly mapper: ScheduledTriggerMapper,
     private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
-    private readonly reportAccessService: ReportAccessService
+    private readonly reportAccessService: ReportAccessService,
+    private readonly reportService: ReportService
   ) {}
 
   async run(command: UpdateScheduledTriggerCommand): Promise<ScheduledTriggerDto> {
@@ -69,6 +71,12 @@ export class UpdateScheduledTriggerService {
       if (!isScheduledReportRunConfig(trigger.triggerConfig)) {
         throw new BadRequestException('Report ID is required for REPORT_RUN triggers');
       }
+
+      await this.reportService.getByIdAndDataMartIdAndProjectId(
+        trigger.triggerConfig.reportId,
+        command.dataMartId,
+        command.projectId
+      );
 
       await this.reportAccessService.checkOperateAccess(
         command.userId,

--- a/apps/backend/src/data-marts/use-cases/update-scheduled-trigger.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-scheduled-trigger.service.ts
@@ -70,18 +70,12 @@ export class UpdateScheduledTriggerService {
         throw new BadRequestException('Report ID is required for REPORT_RUN triggers');
       }
 
-      const canMutate = await this.reportAccessService.canMutate(
+      await this.reportAccessService.checkOperateAccess(
         command.userId,
         command.roles,
         trigger.triggerConfig.reportId,
         command.projectId
       );
-
-      if (!canMutate) {
-        throw new ForbiddenException(
-          'You do not have permission to update triggers for this report. Only report owners can manage report triggers.'
-        );
-      }
     } else {
       if (!this.reportAccessService.isTechnicalUser(command.roles)) {
         throw new ForbiddenException('Only Technical Users can update connector run triggers.');

--- a/apps/backend/test/report-operate-access.e2e-spec.ts
+++ b/apps/backend/test/report-operate-access.e2e-spec.ts
@@ -1,0 +1,1829 @@
+import { INestApplication } from '@nestjs/common';
+import * as supertest from 'supertest';
+import {
+  createTestApp,
+  closeTestApp,
+  setupReportPrerequisites,
+  setupConnectorDataMart,
+  ReportBuilder,
+  DataDestinationBuilder,
+  ScheduledTriggerBuilder,
+  AUTH_HEADER,
+} from '@owox/test-utils';
+import { DataDestinationType } from '../src/data-marts/data-destination-types/enums/data-destination-type.enum';
+import { ScheduledTriggerType } from '../src/data-marts/scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { IdpProjectionsFacade } from '../src/idp/facades/idp-projections.facade';
+import { ProjectMemberDto } from '../src/idp/dto/domain/project-member.dto';
+import type { IdpProvider, Payload } from '@owox/idp-protocol';
+
+const VIEWER_AUTH_HEADER = { 'x-owox-authorization': 'viewer-token' };
+const EDITOR_AUTH_HEADER = { 'x-owox-authorization': 'editor-token' };
+
+const ADMIN_PAYLOAD: Payload = {
+  userId: '0',
+  email: 'admin@localhost',
+  roles: ['admin'],
+  fullName: 'Admin',
+  projectId: '0',
+};
+const EDITOR_PAYLOAD: Payload = {
+  userId: '1',
+  email: 'editor@localhost',
+  roles: ['editor'],
+  fullName: 'Technical User',
+  projectId: '0',
+};
+const VIEWER_PAYLOAD: Payload = {
+  userId: '2',
+  email: 'viewer@localhost',
+  roles: ['viewer'],
+  fullName: 'Business User',
+  projectId: '0',
+};
+
+function resolvePayload(token: string): Payload {
+  if (token.startsWith('viewer')) return VIEWER_PAYLOAD;
+  if (token.startsWith('editor')) return EDITOR_PAYLOAD;
+  return ADMIN_PAYLOAD;
+}
+
+const REPORT_RUN_TYPE = ScheduledTriggerType.REPORT_RUN;
+const CONNECTOR_RUN_TYPE = ScheduledTriggerType.CONNECTOR_RUN;
+const REPORT_RUN_CONFIG_TYPE = 'scheduled-report-run-config' as const;
+
+function reportTriggerPayload(reportId: string, cron = '0 * * * *') {
+  return new ScheduledTriggerBuilder()
+    .withType(REPORT_RUN_TYPE)
+    .withCronExpression(cron)
+    .withTimeZone('UTC')
+    .withTriggerConfig({ type: REPORT_RUN_CONFIG_TYPE, reportId })
+    .build();
+}
+
+/**
+ * Permissions Model: report-operate-access (B1-B9 + edges).
+ *
+ * Admin (id=0), Editor (id=1, TU), Viewer (id=2, BU). Admin auto-becomes
+ * Tech Owner of every DM and owner of every entity it creates.
+ *
+ * canOperate(report) = canSee(DataMart) AND canUse(Destination).
+ * canMutate(report) = canSee(DataMart) AND (DM EDIT OR (Report Owner AND isEffective)).
+ */
+describe('Report Operate Access (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+  let dataMartId: string;
+  let dataDestinationId: string;
+  let adminReportId: string;
+
+  beforeAll(async () => {
+    const testApp = await createTestApp();
+    app = testApp.app;
+    agent = testApp.agent;
+
+    const expressApp = (
+      app.getHttpAdapter() as { getInstance(): Express.Application }
+    ).getInstance();
+    const idpProvider = expressApp.get('idp') as IdpProvider;
+    jest
+      .spyOn(idpProvider, 'introspectToken')
+      .mockImplementation(async token => resolvePayload(token));
+    jest.spyOn(idpProvider, 'parseToken').mockImplementation(async token => resolvePayload(token));
+
+    const facade = app.get(IdpProjectionsFacade);
+    jest
+      .spyOn(facade, 'getProjectMembers')
+      .mockResolvedValue([
+        new ProjectMemberDto('0', 'admin@localhost', 'Admin', undefined, 'admin', true, false),
+        new ProjectMemberDto(
+          '1',
+          'editor@localhost',
+          'Technical User',
+          undefined,
+          'editor',
+          true,
+          false
+        ),
+        new ProjectMemberDto(
+          '2',
+          'viewer@localhost',
+          'Business User',
+          undefined,
+          'viewer',
+          true,
+          false
+        ),
+      ]);
+
+    const prereqs = await setupReportPrerequisites(agent);
+    dataMartId = prereqs.dataMartId;
+    dataDestinationId = prereqs.dataDestinationId;
+
+    const adminReportRes = await agent
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send(
+        new ReportBuilder()
+          .withTitle('Admin-owned Report')
+          .withDataMartId(dataMartId)
+          .withDataDestinationId(dataDestinationId)
+          .build()
+      );
+    expect(adminReportRes.status).toBe(201);
+    adminReportId = adminReportRes.body.id;
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Manual run — POST /api/reports/:id/run
+  // ────────────────────────────────────────────────────────────────
+
+  describe('Manual run — POST /api/reports/:id/run', () => {
+    afterEach(async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: true });
+    });
+
+    // B1: BO of DM (Viewer role) runs report owned by someone else — 2xx
+    it('B1: viewer who is Business Owner of DM runs admin-owned report → 201', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: ['2'], technicalOwnerIds: ['0'] });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(201);
+    });
+
+    // B4: Viewer with no BO but DM SHARED_FOR_REPORTING and Destination SHARED_FOR_USE — 2xx
+    it('B4: viewer with DM shared-for-reporting + destination shared-for-use → 201', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(201);
+    });
+
+    // B5: Viewer with NOT_SHARED DM and not BO — 403 dm-invisible
+    it('B5: viewer with no path to DM (NOT_SHARED, not BO) → 403 dm-invisible', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+      expect(String(res.body.message ?? '')).toMatch(/DataMart/i);
+    });
+
+    // B6: Viewer can see DM (shared-for-reporting) but Destination NOT shared — 403 destination-unusable
+    it('B6: viewer sees DM but destination NOT shared → 403 destination-unusable', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: false, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+      expect(String(res.body.message ?? '')).toMatch(/destination/i);
+    });
+
+    // B8: Report owner who lost USE on the destination — 403 destination-unusable (per-user isEffective)
+    it('B8: report owner (viewer) loses destination USE → 403 destination-unusable', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+      const isolatedDmId = isolated.dataMartId;
+
+      const viewerDestRes = await agent
+        .post('/api/data-destinations')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new DataDestinationBuilder()
+            .withTitle('Viewer-owned dest for B8')
+            .withType(DataDestinationType.LOOKER_STUDIO)
+            .withCredentials({ type: 'looker-studio-credentials' })
+            .build()
+        );
+      expect(viewerDestRes.status).toBe(201);
+      const viewerDestId = viewerDestRes.body.id;
+
+      const reportRes = await agent
+        .post('/api/reports')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Viewer-owned report for B8')
+            .withDataMartId(isolatedDmId)
+            .withDataDestinationId(viewerDestId)
+            .build()
+        );
+      expect(reportRes.status).toBe(201);
+      const viewerReportId = reportRes.body.id;
+      expect(reportRes.body.ownerUsers.map((u: { userId: string }) => u.userId)).toContain('2');
+
+      const okRun = await agent.post(`/api/reports/${viewerReportId}/run`).set(VIEWER_AUTH_HEADER);
+      expect(okRun.status).toBe(201);
+
+      const { DataSource } = await import('typeorm');
+      const dataSource = app.get(DataSource);
+      await dataSource.query(`UPDATE data_destination SET "deletedAt" = ? WHERE id = ?`, [
+        new Date().toISOString(),
+        viewerDestId,
+      ]);
+
+      const failRun = await agent
+        .post(`/api/reports/${viewerReportId}/run`)
+        .set(VIEWER_AUTH_HEADER);
+      expect(failRun.status).toBe(403);
+      expect(String(failRun.body.message ?? '')).toMatch(/destination/i);
+
+      await dataSource.query(`DELETE FROM report WHERE id = ?`, [viewerReportId]);
+    });
+
+    // Edge: Tech Owner of DM (Editor role) runs an admin-owned report — 201
+    it('edge: editor as Tech Owner of DM runs admin-owned report → 201', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0', '1'] });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(EDITOR_AUTH_HEADER);
+
+      expect(res.status).toBe(201);
+    });
+
+    // Edge: Project Admin runs any report regardless of sharing — 201
+    it('edge: project admin runs report regardless of sharing → 201', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: false, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(AUTH_HEADER);
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // REPORT_RUN trigger CRUD — POST/PUT/DELETE /api/data-marts/:dmId/scheduled-triggers
+  // ────────────────────────────────────────────────────────────────
+
+  describe('REPORT_RUN trigger CRUD — /api/data-marts/:dmId/scheduled-triggers', () => {
+    afterEach(async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: true });
+    });
+
+    // B2: BO of DM creates REPORT_RUN trigger for someone else's report — 201, createdById = caller
+    it('B2: viewer-as-BO creates REPORT_RUN trigger for admin-owned report → 201', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: ['2'], technicalOwnerIds: ['0'] });
+
+      const res = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(VIEWER_AUTH_HEADER)
+        .send(reportTriggerPayload(adminReportId));
+
+      expect(res.status).toBe(201);
+      expect(res.body.id).toEqual(expect.any(String));
+      expect(res.body.type).toBe('REPORT_RUN');
+      expect(res.body.createdById).toBe('2');
+
+      await agent
+        .delete(`/api/data-marts/${dataMartId}/scheduled-triggers/${res.body.id}`)
+        .set(AUTH_HEADER);
+    });
+
+    // B3: BO of DM updates and deletes a REPORT_RUN trigger originally created by someone else — 200 for both
+    it('B3: viewer-as-BO updates and deletes admin-created REPORT_RUN trigger → 200/200', async () => {
+      const createRes = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(AUTH_HEADER)
+        .send(reportTriggerPayload(adminReportId, '0 1 * * *'));
+      expect(createRes.status).toBe(201);
+      expect(createRes.body.createdById).toBe('0');
+      const triggerId = createRes.body.id;
+
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: ['2'], technicalOwnerIds: ['0'] });
+
+      const updateRes = await agent
+        .put(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          cronExpression: '0 2 * * *',
+          timeZone: 'America/New_York',
+          isActive: false,
+        });
+      expect(updateRes.status).toBe(200);
+      expect(updateRes.body.cronExpression).toBe('0 2 * * *');
+
+      const deleteRes = await agent
+        .delete(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(VIEWER_AUTH_HEADER);
+      expect(deleteRes.status).toBe(200);
+    });
+
+    // Negative: viewer with no DM path tries to create REPORT_RUN trigger — 403
+    it('viewer with no DM access tries to create REPORT_RUN trigger → 403', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+
+      const res = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(VIEWER_AUTH_HEADER)
+        .send(reportTriggerPayload(adminReportId));
+
+      expect(res.status).toBe(403);
+    });
+
+    // Regression: editor (TU) without BO of DM but DM SHARED_FOR_BOTH — should still be 201 (no regression)
+    it('editor (non-owner TU) on DM shared-for-both creates REPORT_RUN trigger → 201', async () => {
+      const res = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(EDITOR_AUTH_HEADER)
+        .send(reportTriggerPayload(adminReportId));
+
+      expect(res.status).toBe(201);
+      expect(res.body.createdById).toBe('1');
+
+      await agent
+        .delete(`/api/data-marts/${dataMartId}/scheduled-triggers/${res.body.id}`)
+        .set(AUTH_HEADER);
+    });
+
+    // Cross-DM attack: trigger on dm-X with reportId belonging to a report on dm-Y — non-2xx (400)
+    it('cross-DM attack: REPORT_RUN trigger on dm-X with reportId from dm-Y → non-2xx', async () => {
+      const otherSetup = await setupReportPrerequisites(agent);
+      const otherDmId = otherSetup.dataMartId;
+
+      const reportOnOtherDmRes = await agent
+        .post('/api/reports')
+        .set(AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Report on other DM')
+            .withDataMartId(otherDmId)
+            .withDataDestinationId(otherSetup.dataDestinationId)
+            .build()
+        );
+      expect(reportOnOtherDmRes.status).toBe(201);
+      const otherReportId = reportOnOtherDmRes.body.id;
+
+      const res = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(AUTH_HEADER)
+        .send(reportTriggerPayload(otherReportId));
+
+      expect(res.status).not.toBe(201);
+      expect(res.status).not.toBe(200);
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+
+      await agent.delete(`/api/reports/${otherReportId}`).set(AUTH_HEADER);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // CONNECTOR_RUN sanity — must NOT regress
+  // ────────────────────────────────────────────────────────────────
+
+  describe('CONNECTOR_RUN sanity (no regression)', () => {
+    let connectorDmId: string;
+
+    beforeAll(async () => {
+      const cd = await setupConnectorDataMart(agent, app);
+      connectorDmId = cd.dataMartId;
+      await agent
+        .put(`/api/data-marts/${connectorDmId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+    }, 120_000);
+
+    it('admin (Tech Owner with maintenance) creates CONNECTOR_RUN trigger → 201', async () => {
+      const res = await agent
+        .post(`/api/data-marts/${connectorDmId}/scheduled-triggers`)
+        .set(AUTH_HEADER)
+        .send(new ScheduledTriggerBuilder().withType(CONNECTOR_RUN_TYPE).build());
+
+      expect(res.status).toBe(201);
+      expect(res.body.type).toBe('CONNECTOR_RUN');
+
+      await agent
+        .delete(`/api/data-marts/${connectorDmId}/scheduled-triggers/${res.body.id}`)
+        .set(AUTH_HEADER);
+    });
+
+    it('viewer-as-BO of DM tries to create CONNECTOR_RUN trigger → 403', async () => {
+      await agent
+        .put(`/api/data-marts/${connectorDmId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: ['2'], technicalOwnerIds: ['0'] });
+
+      const res = await agent
+        .post(`/api/data-marts/${connectorDmId}/scheduled-triggers`)
+        .set(VIEWER_AUTH_HEADER)
+        .send(new ScheduledTriggerBuilder().withType(CONNECTOR_RUN_TYPE).build());
+
+      expect(res.status).toBe(403);
+
+      await agent
+        .put(`/api/data-marts/${connectorDmId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Edit-config protection — canMutate path must NOT regress
+  // ────────────────────────────────────────────────────────────────
+
+  describe('Edit-config protection (canMutate, no regression)', () => {
+    afterEach(async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+    });
+
+    // B7: BO of DM (not Owner of report) tries to PUT report config — 403
+    it('B7: viewer-as-BO of DM tries PUT /api/reports/:id (edit config) → 403', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: ['2'], technicalOwnerIds: ['0'] });
+
+      const res = await agent
+        .put(`/api/reports/${adminReportId}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          title: 'BO Should Not Edit',
+          dataDestinationId,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('viewer-as-BO of DM tries DELETE /api/reports/:id → 403', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: ['2'], technicalOwnerIds: ['0'] });
+
+      const res = await agent.delete(`/api/reports/${adminReportId}`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // B9: Capability fields on responses
+  // ────────────────────────────────────────────────────────────────
+
+  describe('B9: capability fields canRun / canManageTriggers / canEditConfig', () => {
+    let archetypeReportId: string;
+    let archetypeDmId: string;
+    let archetypeDestId: string;
+
+    beforeAll(async () => {
+      const setup = await setupReportPrerequisites(agent);
+      archetypeDmId = setup.dataMartId;
+      archetypeDestId = setup.dataDestinationId;
+
+      const reportRes = await agent
+        .post('/api/reports')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Viewer-owned archetype report')
+            .withDataMartId(archetypeDmId)
+            .withDataDestinationId(archetypeDestId)
+            .build()
+        );
+      expect(reportRes.status).toBe(201);
+      archetypeReportId = reportRes.body.id;
+    }, 60_000);
+
+    afterAll(async () => {
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${archetypeDestId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+    });
+
+    it('Project Admin → canRun = canManageTriggers = canEditConfig = true', async () => {
+      const res = await agent.get(`/api/reports/${archetypeReportId}`).set(AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.canRun).toBe(true);
+      expect(res.body.canManageTriggers).toBe(true);
+      expect(res.body.canEditConfig).toBe(true);
+    });
+
+    it('Report Owner with effective Destination → all three true', async () => {
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${archetypeDestId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.get(`/api/reports/${archetypeReportId}`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.canRun).toBe(true);
+      expect(res.body.canManageTriggers).toBe(true);
+      expect(res.body.canEditConfig).toBe(true);
+    });
+
+    it('Report Owner who lost Destination USE → canRun=canManageTriggers=canEditConfig=false', async () => {
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${archetypeDestId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: false, availableForMaintenance: false });
+
+      const res = await agent.get(`/api/reports/${archetypeReportId}`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.canRun).toBe(false);
+      expect(res.body.canManageTriggers).toBe(false);
+      expect(res.body.canEditConfig).toBe(false);
+    });
+
+    it('BO of DM (not Owner) with usable destination → canRun=canManageTriggers=true, canEditConfig=false', async () => {
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${archetypeDestId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: ['1'], technicalOwnerIds: ['0'] });
+
+      const res = await agent.get(`/api/reports/${archetypeReportId}`).set(EDITOR_AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.canRun).toBe(true);
+      expect(res.body.canManageTriggers).toBe(true);
+      expect(res.body.canEditConfig).toBe(false);
+    });
+
+    it('TU shared-for-reporting + usable destination → canRun=canManageTriggers=true, canEditConfig=false', async () => {
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${archetypeDestId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.get(`/api/reports/${archetypeReportId}`).set(EDITOR_AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.canRun).toBe(true);
+      expect(res.body.canManageTriggers).toBe(true);
+      expect(res.body.canEditConfig).toBe(false);
+    });
+
+    it('Caller can SEE DM but destination not USE-able → all three false', async () => {
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${archetypeDestId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: false, availableForMaintenance: false });
+
+      const res = await agent.get(`/api/reports/${archetypeReportId}`).set(EDITOR_AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.canRun).toBe(false);
+      expect(res.body.canManageTriggers).toBe(false);
+      expect(res.body.canEditConfig).toBe(false);
+    });
+
+    it('Caller has no DM access → GET returns 403', async () => {
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${archetypeDmId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+
+      const res = await agent.get(`/api/reports/${archetypeReportId}`).set(EDITOR_AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // B9 (cont.) — capability fields exposed on list endpoints
+  // ────────────────────────────────────────────────────────────────
+
+  describe('B9: capability fields on list endpoints', () => {
+    afterEach(async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: true });
+    });
+
+    it('GET /api/reports/data-mart/:dmId carries capability flags for BO viewer', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: ['2'], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.get(`/api/reports/data-mart/${dataMartId}`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      const found = res.body.find((r: { id: string }) => r.id === adminReportId);
+      expect(found).toBeDefined();
+      expect(found.canRun).toBe(true);
+      expect(found.canManageTriggers).toBe(true);
+      expect(found.canEditConfig).toBe(false);
+    });
+
+    it('GET /api/reports (project list) carries capability flags for admin caller', async () => {
+      const res = await agent.get('/api/reports').set(AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      const found = res.body.find((r: { id: string }) => r.id === adminReportId);
+      expect(found).toBeDefined();
+      expect(found.canRun).toBe(true);
+      expect(found.canManageTriggers).toBe(true);
+      expect(found.canEditConfig).toBe(true);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // B9 (cont.) — capability fields on POST/PUT report responses (C1 regression)
+  // ────────────────────────────────────────────────────────────────
+
+  describe('B9: capability fields on POST/PUT report responses (C1 regression)', () => {
+    let isolatedDmId: string;
+    let isolatedDestId: string;
+
+    beforeAll(async () => {
+      const setup = await setupReportPrerequisites(agent);
+      isolatedDmId = setup.dataMartId;
+      isolatedDestId = setup.dataDestinationId;
+    }, 60_000);
+
+    it('POST /api/reports returns canRun/canManageTriggers/canEditConfig in body', async () => {
+      const res = await agent
+        .post('/api/reports')
+        .set(AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Capability-flag check')
+            .withDataMartId(isolatedDmId)
+            .withDataDestinationId(isolatedDestId)
+            .build()
+        );
+
+      expect(res.status).toBe(201);
+      expect(res.body).toHaveProperty('canRun');
+      expect(res.body).toHaveProperty('canManageTriggers');
+      expect(res.body).toHaveProperty('canEditConfig');
+      expect(res.body.canRun).toBe(true);
+      expect(res.body.canManageTriggers).toBe(true);
+      expect(res.body.canEditConfig).toBe(true);
+    });
+
+    it('PUT /api/reports/:id returns canRun/canManageTriggers/canEditConfig in body', async () => {
+      const getRes = await agent.get(`/api/reports/data-mart/${isolatedDmId}`).set(AUTH_HEADER);
+      expect(getRes.status).toBe(200);
+      const targetReportId = getRes.body[0]?.id;
+      expect(targetReportId).toBeDefined();
+
+      const res = await agent
+        .put(`/api/reports/${targetReportId}`)
+        .set(AUTH_HEADER)
+        .send({
+          title: 'Updated for cap check',
+          dataDestinationId: isolatedDestId,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('canRun');
+      expect(res.body).toHaveProperty('canManageTriggers');
+      expect(res.body).toHaveProperty('canEditConfig');
+      expect(res.body.canRun).toBe(true);
+      expect(res.body.canManageTriggers).toBe(true);
+      expect(res.body.canEditConfig).toBe(true);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Gap fill — Manual run (A1-A7)
+  // ────────────────────────────────────────────────────────────────
+
+  describe('Gap fill — Manual run (A1-A7)', () => {
+    afterEach(async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: true });
+    });
+
+    // A1: DM Tech Owner (Editor) on own DM, but Destination NOT shared / no USE → 403
+    it('A1: editor as DM Tech Owner with destination not USE-able → 403 destination-unusable', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0', '1'] });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: false, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(EDITOR_AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+      expect(String(res.body.message ?? '')).toMatch(/destination/i);
+    });
+
+    // A2: Editor (TU) non-owner + DM SHARED_FOR_REPORTING + Destination usable → 200
+    it('A2: editor non-owner + DM shared-for-reporting + destination usable → 201', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(EDITOR_AUTH_HEADER);
+
+      expect(res.status).toBe(201);
+    });
+
+    // A3: Editor (TU) non-owner + DM SHARED_FOR_MAINTENANCE + Destination usable → 200
+    it('A3: editor non-owner + DM shared-for-maintenance + destination usable → 201', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(EDITOR_AUTH_HEADER);
+
+      expect(res.status).toBe(201);
+    });
+
+    // A4: Editor (TU) non-owner + DM SHARED_FOR_BOTH + Destination usable → 200
+    it('A4: editor non-owner + DM shared-for-both + destination usable → 201', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(EDITOR_AUTH_HEADER);
+
+      expect(res.status).toBe(201);
+    });
+
+    // A5: Viewer non-owner non-BO + DM SHARED_FOR_BOTH + Destination usable → 200
+    it('A5: viewer non-owner non-BO + DM shared-for-both + destination usable → 201', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(201);
+    });
+
+    // A6: Viewer non-owner non-BO + DM SHARED_FOR_MAINTENANCE only → 403
+    // Per access matrix (apps/backend/src/data-marts/services/access-decision/access-matrix.config.ts):
+    // BU non-owner + SHARED_FOR_MAINTENANCE = no access (BU cannot do maintenance).
+    it('A6: viewer non-owner non-BO + DM shared-for-maintenance only → 403 dm-invisible', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.post(`/api/reports/${adminReportId}/run`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+      expect(String(res.body.message ?? '')).toMatch(/DataMart/i);
+    });
+
+    // A7: Report Owner with effective Destination runs own report → 200 (golden path)
+    it('A7: report owner with effective destination runs own report → 201', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+
+      const ownerDestRes = await agent
+        .post('/api/data-destinations')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new DataDestinationBuilder()
+            .withTitle('Viewer-owned dest for A7')
+            .withType(DataDestinationType.LOOKER_STUDIO)
+            .withCredentials({ type: 'looker-studio-credentials' })
+            .build()
+        );
+      expect(ownerDestRes.status).toBe(201);
+      const ownerDestId = ownerDestRes.body.id;
+
+      const ownerReportRes = await agent
+        .post('/api/reports')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Viewer-owned report for A7')
+            .withDataMartId(isolated.dataMartId)
+            .withDataDestinationId(ownerDestId)
+            .build()
+        );
+      expect(ownerReportRes.status).toBe(201);
+      const ownerReportId = ownerReportRes.body.id;
+
+      const res = await agent.post(`/api/reports/${ownerReportId}/run`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Gap fill — Trigger CRUD (B1-B8)
+  // ────────────────────────────────────────────────────────────────
+
+  describe('Gap fill — Trigger CRUD (B1-B8)', () => {
+    afterEach(async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: true });
+    });
+
+    // B1: DM Business Owner updates a trigger created by another Business Owner
+    it('B1: viewer-as-BO updates trigger created by editor-as-BO → 200', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: ['1', '2'], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const createRes = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(EDITOR_AUTH_HEADER)
+        .send(reportTriggerPayload(adminReportId, '0 3 * * *'));
+      expect(createRes.status).toBe(201);
+      expect(createRes.body.createdById).toBe('1');
+      const triggerId = createRes.body.id;
+
+      const updateRes = await agent
+        .put(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          cronExpression: '0 4 * * *',
+          timeZone: 'UTC',
+          isActive: true,
+        });
+
+      expect(updateRes.status).toBe(200);
+      expect(updateRes.body.cronExpression).toBe('0 4 * * *');
+
+      await agent
+        .delete(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(AUTH_HEADER);
+    });
+
+    // B2: Report Owner creates / updates / deletes their own REPORT_RUN trigger
+    it('B2: report owner creates/updates/deletes own REPORT_RUN trigger → 201/200/200', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+
+      const ownerDestRes = await agent
+        .post('/api/data-destinations')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new DataDestinationBuilder()
+            .withTitle('Viewer-owned dest for B2')
+            .withType(DataDestinationType.LOOKER_STUDIO)
+            .withCredentials({ type: 'looker-studio-credentials' })
+            .build()
+        );
+      expect(ownerDestRes.status).toBe(201);
+
+      const ownerReportRes = await agent
+        .post('/api/reports')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Viewer-owned report for B2')
+            .withDataMartId(isolated.dataMartId)
+            .withDataDestinationId(ownerDestRes.body.id)
+            .build()
+        );
+      expect(ownerReportRes.status).toBe(201);
+      const ownerReportId = ownerReportRes.body.id;
+
+      const createRes = await agent
+        .post(`/api/data-marts/${isolated.dataMartId}/scheduled-triggers`)
+        .set(VIEWER_AUTH_HEADER)
+        .send(reportTriggerPayload(ownerReportId, '0 5 * * *'));
+      expect(createRes.status).toBe(201);
+      expect(createRes.body.createdById).toBe('2');
+      const triggerId = createRes.body.id;
+
+      const updateRes = await agent
+        .put(`/api/data-marts/${isolated.dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          cronExpression: '0 6 * * *',
+          timeZone: 'UTC',
+          isActive: false,
+        });
+      expect(updateRes.status).toBe(200);
+      expect(updateRes.body.cronExpression).toBe('0 6 * * *');
+      expect(updateRes.body.isActive).toBe(false);
+
+      const deleteRes = await agent
+        .delete(`/api/data-marts/${isolated.dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(VIEWER_AUTH_HEADER);
+      expect(deleteRes.status).toBe(200);
+    });
+
+    // B3: Viewer + DM SHARED_FOR_REPORTING non-owner non-BO creates a REPORT_RUN trigger
+    it('B3: viewer non-owner non-BO + DM shared-for-reporting + dest usable → 201', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(VIEWER_AUTH_HEADER)
+        .send(reportTriggerPayload(adminReportId, '0 7 * * *'));
+
+      expect(res.status).toBe(201);
+      expect(res.body.createdById).toBe('2');
+
+      await agent
+        .delete(`/api/data-marts/${dataMartId}/scheduled-triggers/${res.body.id}`)
+        .set(AUTH_HEADER);
+    });
+
+    // B4: Same viewer updates and deletes a REPORT_RUN trigger created by someone else
+    it('B4: viewer non-owner non-BO updates and deletes admin-created REPORT_RUN trigger → 200/200', async () => {
+      const createRes = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(AUTH_HEADER)
+        .send(reportTriggerPayload(adminReportId, '0 8 * * *'));
+      expect(createRes.status).toBe(201);
+      const triggerId = createRes.body.id;
+
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const updateRes = await agent
+        .put(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          cronExpression: '0 9 * * *',
+          timeZone: 'UTC',
+          isActive: true,
+        });
+      expect(updateRes.status).toBe(200);
+      expect(updateRes.body.cronExpression).toBe('0 9 * * *');
+
+      const deleteRes = await agent
+        .delete(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(VIEWER_AUTH_HEADER);
+      expect(deleteRes.status).toBe(200);
+    });
+
+    // B5: Viewer with no DM access tries to UPDATE an existing trigger → 403
+    it('B5: viewer with no DM access updates existing trigger → 403', async () => {
+      const createRes = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(AUTH_HEADER)
+        .send(reportTriggerPayload(adminReportId, '0 10 * * *'));
+      expect(createRes.status).toBe(201);
+      const triggerId = createRes.body.id;
+
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+
+      const res = await agent
+        .put(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          cronExpression: '0 11 * * *',
+          timeZone: 'UTC',
+          isActive: false,
+        });
+
+      expect(res.status).toBe(403);
+
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .delete(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(AUTH_HEADER);
+    });
+
+    // B6: Viewer with no DM access tries to DELETE an existing trigger → 403
+    it('B6: viewer with no DM access deletes existing trigger → 403', async () => {
+      const createRes = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(AUTH_HEADER)
+        .send(reportTriggerPayload(adminReportId, '0 12 * * *'));
+      expect(createRes.status).toBe(201);
+      const triggerId = createRes.body.id;
+
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+
+      const res = await agent
+        .delete(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .delete(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(AUTH_HEADER);
+    });
+
+    // B7: Destination shared with one BO but not another → second BO cannot create trigger
+    // Simulates "Destination access revoked between report-create and trigger-create" by creating
+    // a fresh DM with two BOs and a destination that only the first BO can USE.
+    it('B7: BO whose destination is not USE-able fails trigger create → 403 destination-unusable', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+
+      // Make admin Tech Owner only; viewer is BO; editor is also BO (both can SEE the DM via BO).
+      await agent
+        .put(`/api/data-marts/${isolated.dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-marts/${isolated.dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: ['1', '2'], technicalOwnerIds: ['0'] });
+
+      // Destination usable for both initially → admin creates a report.
+      await agent
+        .put(`/api/data-destinations/${isolated.dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const reportRes = await agent
+        .post('/api/reports')
+        .set(AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Report for B7')
+            .withDataMartId(isolated.dataMartId)
+            .withDataDestinationId(isolated.dataDestinationId)
+            .build()
+        );
+      expect(reportRes.status).toBe(201);
+      const reportIdForB7 = reportRes.body.id;
+
+      // Now revoke destination availability for non-owners. Viewer (BU) is not a destination owner,
+      // so it loses USE; same for editor.
+      await agent
+        .put(`/api/data-destinations/${isolated.dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: false, availableForMaintenance: false });
+
+      const res = await agent
+        .post(`/api/data-marts/${isolated.dataMartId}/scheduled-triggers`)
+        .set(VIEWER_AUTH_HEADER)
+        .send(reportTriggerPayload(reportIdForB7, '0 13 * * *'));
+
+      expect(res.status).toBe(403);
+      expect(String(res.body.message ?? '')).toMatch(/destination/i);
+    });
+
+    // B8: Cross-DM attack on UPDATE — supply unknown triggerConfig field → 400 (validation)
+    it('B8: cross-DM attack on UPDATE with extra triggerConfig field → 4xx (validator rejects)', async () => {
+      const createRes = await agent
+        .post(`/api/data-marts/${dataMartId}/scheduled-triggers`)
+        .set(AUTH_HEADER)
+        .send(reportTriggerPayload(adminReportId, '0 14 * * *'));
+      expect(createRes.status).toBe(201);
+      const triggerId = createRes.body.id;
+
+      const otherSetup = await setupReportPrerequisites(agent);
+      const otherReportRes = await agent
+        .post('/api/reports')
+        .set(AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Report on other DM (B8)')
+            .withDataMartId(otherSetup.dataMartId)
+            .withDataDestinationId(otherSetup.dataDestinationId)
+            .build()
+        );
+      expect(otherReportRes.status).toBe(201);
+      const otherReportId = otherReportRes.body.id;
+
+      const res = await agent
+        .put(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(AUTH_HEADER)
+        .send({
+          cronExpression: '0 15 * * *',
+          timeZone: 'UTC',
+          isActive: true,
+          triggerConfig: { type: REPORT_RUN_CONFIG_TYPE, reportId: otherReportId },
+        });
+
+      expect(res.status).not.toBe(200);
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+
+      await agent
+        .delete(`/api/data-marts/${dataMartId}/scheduled-triggers/${triggerId}`)
+        .set(AUTH_HEADER);
+      await agent.delete(`/api/reports/${otherReportId}`).set(AUTH_HEADER);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Gap fill — Edit-config (C1-C12)
+  // ────────────────────────────────────────────────────────────────
+
+  describe('Gap fill — Edit-config (C1-C12)', () => {
+    afterEach(async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: true });
+    });
+
+    // C1: Viewer + DM SHARED_FOR_REPORTING non-owner non-BO tries PUT → 403
+    it('C1: viewer non-owner non-BO + DM shared-for-reporting tries PUT → 403', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent
+        .put(`/api/reports/${adminReportId}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          title: 'Viewer non-owner cannot edit',
+          dataDestinationId,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        });
+
+      expect(res.status).toBe(403);
+    });
+
+    // C2: Same Viewer tries DELETE → 403
+    it('C2: viewer non-owner non-BO + DM shared-for-reporting tries DELETE → 403', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.delete(`/api/reports/${adminReportId}`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+    });
+
+    // C3: Editor (TU) non-owner + DM SHARED_FOR_REPORTING (no maintenance) tries PUT → 403
+    it('C3: editor non-owner + DM shared-for-reporting tries PUT non-owned report → 403', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: false });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent
+        .put(`/api/reports/${adminReportId}`)
+        .set(EDITOR_AUTH_HEADER)
+        .send({
+          title: 'Editor non-owner reporting only cannot edit',
+          dataDestinationId,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        });
+
+      expect(res.status).toBe(403);
+    });
+
+    // C4: Editor (TU) non-owner + DM SHARED_FOR_MAINTENANCE → PUT non-owned report = 200 (DM bypass)
+    it('C4: editor non-owner + DM shared-for-maintenance tries PUT → 200 (DM maintenance bypass)', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent
+        .put(`/api/reports/${adminReportId}`)
+        .set(EDITOR_AUTH_HEADER)
+        .send({
+          title: 'Editor with DM maintenance edits',
+          dataDestinationId,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.title).toBe('Editor with DM maintenance edits');
+    });
+
+    // C5: DM Tech Owner (Editor on own DM) tries PUT non-owned report on own DM → 200
+    it('C5: editor as DM Tech Owner tries PUT non-owned report → 200', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0', '1'] });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent
+        .put(`/api/reports/${adminReportId}`)
+        .set(EDITOR_AUTH_HEADER)
+        .send({
+          title: 'DM Tech Owner edits',
+          dataDestinationId,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.title).toBe('DM Tech Owner edits');
+    });
+
+    // C6: Report Owner with effective Destination tries PUT (changing title) → 200 (golden path)
+    it('C6: report owner with effective destination tries PUT → 200', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+
+      const ownerDestRes = await agent
+        .post('/api/data-destinations')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new DataDestinationBuilder()
+            .withTitle('Viewer-owned dest for C6')
+            .withType(DataDestinationType.LOOKER_STUDIO)
+            .withCredentials({ type: 'looker-studio-credentials' })
+            .build()
+        );
+      expect(ownerDestRes.status).toBe(201);
+
+      const reportRes = await agent
+        .post('/api/reports')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Viewer-owned report for C6')
+            .withDataMartId(isolated.dataMartId)
+            .withDataDestinationId(ownerDestRes.body.id)
+            .build()
+        );
+      expect(reportRes.status).toBe(201);
+      const reportIdForC6 = reportRes.body.id;
+
+      const res = await agent
+        .put(`/api/reports/${reportIdForC6}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          title: 'Owner edits title',
+          dataDestinationId: ownerDestRes.body.id,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 7200 },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.title).toBe('Owner edits title');
+    });
+
+    // C7: Report Owner with effective Destination tries DELETE → 200 (golden path)
+    it('C7: report owner with effective destination tries DELETE → 200', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+
+      const ownerDestRes = await agent
+        .post('/api/data-destinations')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new DataDestinationBuilder()
+            .withTitle('Viewer-owned dest for C7')
+            .withType(DataDestinationType.LOOKER_STUDIO)
+            .withCredentials({ type: 'looker-studio-credentials' })
+            .build()
+        );
+      expect(ownerDestRes.status).toBe(201);
+
+      const reportRes = await agent
+        .post('/api/reports')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Viewer-owned report for C7')
+            .withDataMartId(isolated.dataMartId)
+            .withDataDestinationId(ownerDestRes.body.id)
+            .build()
+        );
+      expect(reportRes.status).toBe(201);
+      const reportIdForC7 = reportRes.body.id;
+
+      const res = await agent.delete(`/api/reports/${reportIdForC7}`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+    });
+
+    // C8: Report Owner who lost Destination USE tries PUT → 403 ineffective.
+    // Cleaner mechanism than soft-delete: admin owns the destination, viewer is added as
+    // report owner via admin-create with ownerIds=['2']. Then admin flips availableForUse=false.
+    // Viewer is non-owner on the destination (admin owns it), so loses USE.
+    it('C8: report owner who lost destination USE tries PUT → 403 ineffective', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+
+      const reportRes = await agent
+        .post('/api/reports')
+        .set(AUTH_HEADER)
+        .send({
+          ...new ReportBuilder()
+            .withTitle('Report for C8')
+            .withDataMartId(isolated.dataMartId)
+            .withDataDestinationId(isolated.dataDestinationId)
+            .build(),
+          ownerIds: ['2'],
+        });
+      expect(reportRes.status).toBe(201);
+      const reportIdForC8 = reportRes.body.id;
+
+      const okPut = await agent
+        .put(`/api/reports/${reportIdForC8}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          title: 'Owner edits while effective',
+          dataDestinationId: isolated.dataDestinationId,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        });
+      expect(okPut.status).toBe(200);
+
+      await agent
+        .put(`/api/data-destinations/${isolated.dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: false, availableForMaintenance: false });
+
+      const res = await agent
+        .put(`/api/reports/${reportIdForC8}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          title: 'Owner edits while ineffective',
+          dataDestinationId: isolated.dataDestinationId,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        });
+
+      expect(res.status).toBe(403);
+      expect(String(res.body.message ?? '')).toMatch(/destination/i);
+    });
+
+    // C9: Report Owner who lost Destination USE tries DELETE → 403 ineffective.
+    it('C9: report owner who lost destination USE tries DELETE → 403 ineffective', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+
+      const reportRes = await agent
+        .post('/api/reports')
+        .set(AUTH_HEADER)
+        .send({
+          ...new ReportBuilder()
+            .withTitle('Report for C9')
+            .withDataMartId(isolated.dataMartId)
+            .withDataDestinationId(isolated.dataDestinationId)
+            .build(),
+          ownerIds: ['2'],
+        });
+      expect(reportRes.status).toBe(201);
+      const reportIdForC9 = reportRes.body.id;
+
+      await agent
+        .put(`/api/data-destinations/${isolated.dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: false, availableForMaintenance: false });
+
+      const res = await agent.delete(`/api/reports/${reportIdForC9}`).set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+      expect(String(res.body.message ?? '')).toMatch(/destination/i);
+    });
+
+    // C10: Owner tries PUT with new dataDestinationId pointing to a Destination they can't USE → 4xx.
+    it('C10: owner tries PUT with non-USE-able dataDestinationId → 4xx', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+
+      const ownerDestRes = await agent
+        .post('/api/data-destinations')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new DataDestinationBuilder()
+            .withTitle('Viewer-owned dest for C10')
+            .withType(DataDestinationType.LOOKER_STUDIO)
+            .withCredentials({ type: 'looker-studio-credentials' })
+            .build()
+        );
+      expect(ownerDestRes.status).toBe(201);
+
+      const reportRes = await agent
+        .post('/api/reports')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Viewer-owned report for C10')
+            .withDataMartId(isolated.dataMartId)
+            .withDataDestinationId(ownerDestRes.body.id)
+            .build()
+        );
+      expect(reportRes.status).toBe(201);
+      const reportIdForC10 = reportRes.body.id;
+
+      // Admin-only destination (viewer is not owner).
+      const adminOnlyDestRes = await agent
+        .post('/api/data-destinations')
+        .set(AUTH_HEADER)
+        .send(
+          new DataDestinationBuilder()
+            .withTitle('Admin-only dest for C10')
+            .withType(DataDestinationType.LOOKER_STUDIO)
+            .withCredentials({ type: 'looker-studio-credentials' })
+            .build()
+        );
+      expect(adminOnlyDestRes.status).toBe(201);
+      await agent
+        .put(`/api/data-destinations/${adminOnlyDestRes.body.id}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: false, availableForMaintenance: false });
+
+      const res = await agent
+        .put(`/api/reports/${reportIdForC10}`)
+        .set(VIEWER_AUTH_HEADER)
+        .send({
+          title: 'Owner switches to non-USE dest',
+          dataDestinationId: adminOnlyDestRes.body.id,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        });
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+    });
+
+    // C11: Owner tries PUT adding a new ownerIds member who lacks DM SEE or Destination USE → 4xx
+    it('C11: owner tries PUT adding ownerIds member without DM SEE → 4xx (canBeOwner)', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+
+      // Admin owns dest and report; only admin BO + admin TU on the DM.
+      // Viewer (id=2) has no path to DM (NOT_SHARED + not BO + not TO).
+      const reportRes = await agent
+        .post('/api/reports')
+        .set(AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Report for C11')
+            .withDataMartId(isolated.dataMartId)
+            .withDataDestinationId(isolated.dataDestinationId)
+            .build()
+        );
+      expect(reportRes.status).toBe(201);
+      const reportIdForC11 = reportRes.body.id;
+
+      await agent
+        .put(`/api/data-marts/${isolated.dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+
+      const res = await agent
+        .put(`/api/reports/${reportIdForC11}`)
+        .set(AUTH_HEADER)
+        .send({
+          title: 'Adding invalid owner',
+          dataDestinationId: isolated.dataDestinationId,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+          ownerIds: ['0', '2'],
+        });
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBeLessThan(500);
+    });
+
+    // C12: Project Admin tries PUT and DELETE an admin-not-owned report → 200, 200 (admin bypass)
+    it('C12: admin tries PUT and DELETE viewer-owned report → 200/200', async () => {
+      const isolated = await setupReportPrerequisites(agent);
+
+      const ownerDestRes = await agent
+        .post('/api/data-destinations')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new DataDestinationBuilder()
+            .withTitle('Viewer-owned dest for C12')
+            .withType(DataDestinationType.LOOKER_STUDIO)
+            .withCredentials({ type: 'looker-studio-credentials' })
+            .build()
+        );
+      expect(ownerDestRes.status).toBe(201);
+
+      const reportRes = await agent
+        .post('/api/reports')
+        .set(VIEWER_AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withTitle('Viewer-owned report for C12')
+            .withDataMartId(isolated.dataMartId)
+            .withDataDestinationId(ownerDestRes.body.id)
+            .build()
+        );
+      expect(reportRes.status).toBe(201);
+      const reportIdForC12 = reportRes.body.id;
+      expect(reportRes.body.ownerUsers.map((u: { userId: string }) => u.userId)).not.toContain('0');
+
+      const putRes = await agent
+        .put(`/api/reports/${reportIdForC12}`)
+        .set(AUTH_HEADER)
+        .send({
+          title: 'Admin edits viewer-owned report',
+          dataDestinationId: ownerDestRes.body.id,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        });
+      expect(putRes.status).toBe(200);
+      expect(putRes.body.title).toBe('Admin edits viewer-owned report');
+
+      const delRes = await agent.delete(`/api/reports/${reportIdForC12}`).set(AUTH_HEADER);
+      expect(delRes.status).toBe(200);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────
+  // Gap fill — Capability fields (D1, D2)
+  // ────────────────────────────────────────────────────────────────
+
+  describe('Gap fill — Capability fields (D1, D2)', () => {
+    afterEach(async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0'] });
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: true, availableForMaintenance: true });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: true });
+    });
+
+    // D1: GET as DM Tech Owner (Editor) with maintenance, not Report Owner → all three true
+    it('D1: editor as DM Tech Owner with maintenance bypass → canRun/canManageTriggers/canEditConfig all true', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/owners`)
+        .set(AUTH_HEADER)
+        .send({ businessOwnerIds: [], technicalOwnerIds: ['0', '1'] });
+      await agent
+        .put(`/api/data-destinations/${dataDestinationId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForUse: true, availableForMaintenance: false });
+
+      const res = await agent.get(`/api/reports/${adminReportId}`).set(EDITOR_AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body.canRun).toBe(true);
+      expect(res.body.canManageTriggers).toBe(true);
+      expect(res.body.canEditConfig).toBe(true);
+    });
+
+    // D2a: insight-template list endpoint returns 200 + array for admin (no email reports exist).
+    it('D2a: GET insight-template list as admin returns 200 array', async () => {
+      const res = await agent
+        .get(
+          `/api/reports/data-mart/${dataMartId}/insight-template/00000000-0000-0000-0000-000000000000`
+        )
+        .set(AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    // D2b: insight-template list endpoint as viewer with no DM access.
+    // The endpoint filters by destinationConfig email/insight-template; existing test data uses
+    // LOOKER_STUDIO so the result is always [] regardless of DM visibility — confirm that semantics.
+    it('D2b: GET insight-template list as viewer without DM access returns 200 empty array', async () => {
+      await agent
+        .put(`/api/data-marts/${dataMartId}/availability`)
+        .set(AUTH_HEADER)
+        .send({ availableForReporting: false, availableForMaintenance: false });
+
+      const res = await agent
+        .get(
+          `/api/reports/data-mart/${dataMartId}/insight-template/00000000-0000-0000-0000-000000000000`
+        )
+        .set(VIEWER_AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body).toEqual([]);
+    });
+  });
+});

--- a/apps/web/src/features/data-marts/reports/shared/model/mappers/report.mapper.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/mappers/report.mapper.ts
@@ -40,5 +40,8 @@ export function mapReportDtoToEntity(reportDto: ReportResponseDto): DataMartRepo
     modifiedAt: new Date(reportDto.modifiedAt),
     createdByUser: reportDto.createdByUser ?? null,
     ownerUsers: reportDto.ownerUsers ?? [],
+    canRun: reportDto.canRun,
+    canManageTriggers: reportDto.canManageTriggers,
+    canEditConfig: reportDto.canEditConfig,
   };
 }

--- a/apps/web/src/features/data-marts/reports/shared/model/types/data-mart-report.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/types/data-mart-report.ts
@@ -111,4 +111,7 @@ export interface DataMartReport {
   modifiedAt: Date;
   createdByUser?: UserProjection | null;
   ownerUsers?: UserProjection[];
+  canRun: boolean;
+  canManageTriggers: boolean;
+  canEditConfig: boolean;
 }

--- a/apps/web/src/features/data-marts/reports/shared/services/types/report-response.dto.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/types/report-response.dto.ts
@@ -26,4 +26,7 @@ export interface ReportResponseDto {
   modifiedAt: string;
   createdByUser?: UserProjection | null;
   ownerUsers?: UserProjection[];
+  canRun: boolean;
+  canManageTriggers: boolean;
+  canEditConfig: boolean;
 }


### PR DESCRIPTION
Manual report runs and REPORT_RUN trigger CRUD now require canOperate(report) = canSee(DataMart) AND canUse(Destination) instead of Report Ownership. Project members who see the DM (Business Owner, Tech Owner, or non-owner via shared-for-reporting / for-maintenance / for-both) can run any report and manage its triggers regardless of report ownership. Cross-owner trigger management is an explicit trade-off per the DoD.

Editing report config (columns, filters, owners, destination) remains on the unchanged canMutate path: Owner with effective Destination, DM maintenance bypass for Tech Users, or Admin.

Backend
- ReportAccessService gains canOperate / checkOperateAccess; isEffective is now per-user (canAccess USE on Destination), aligning the code with Stage 2 §76 of the permissions spec — owners who lose Destination USE become ineffective.
- run-report and create / update / delete-scheduled-trigger services route REPORT_RUN through checkOperateAccess and surface reason-keyed errors from OPERATE_DENIED_MESSAGES (not-found / dm-invisible / destination- unusable) instead of one-size-fits-all 403.
- scheduled-trigger.controller drops DM MANAGE_TRIGGERS for REPORT_RUN create; update / delete keep coarse SEE and let the service apply the type-specific gate. CONNECTOR_RUN is unchanged.
- ReportResponseApiDto exposes canRun / canManageTriggers / canEditConfig, computed in get / list / create / update services so frontends can gate UI without recomputing the access matrix.
- ListReportsByInsightTemplateCommand extended with userId / roles to enable capability computation there too.
- UpdateReportService now validates caller's USE on a newly-supplied dataDestinationId, fixing a parity gap with CreateReportService.

Web
- DataMartReport and the FE response DTO carry the same three flags. UI gating is intentionally deferred to a follow-up.

Tests
- 27 unit cases for the canOperate / checkOperateAccess / per-user isEffective matrix in report-access.service.spec.
- 57 e2e cases in report-operate-access.e2e-spec covering DoD end-to-end: Manual Run (14, full role x sharing matrix + ineffective owner), REPORT_RUN trigger CRUD (16, including cross-owner ops, cross-DM attacks on create and update, CONNECTOR_RUN regression sanity), config protection (15, including DM maintenance bypass and admin bypass), and capability flags on GET / list / POST / PUT (12).