### PR TITLE
feat(web): enhance report creation and team collaboration features

### DIFF
--- a/.changeset/promote-report-creation-and-invite-teammates.md
+++ b/.changeset/promote-report-creation-and-invite-teammates.md
@@ -1,0 +1,15 @@
+---
+'owox': minor
+---
+
+# Make Report Creation More Visible and Encourage Team Collaboration
+
+**Smarter Empty States with Quick Actions** — When a destination has no reports yet, you now see a prominent "New Report" button right where you need it. No more hunting for the add button — it's right there in the empty state, ready to get you started immediately.
+
+**Consistent "New" Language** — We've standardized button labels across the app: "New Report" and "New Trigger" now replace the older "Add" terminology. Clearer, more direct, and consistent with industry standards.
+
+**Helpful Teammate Invites** — Working with Google Sheets destinations just got more collaborative. When you haven't set up any reports yet, you'll see gentle suggestions to invite colleagues who might have the right access. Perfect for teams where not everyone has Google Workspace admin permissions.
+
+**Cleaner Table Empty States** — Empty tables now display without distracting hover effects, keeping the focus on your next action. The improved styling makes the "New Report" button stand out as the clear path forward.
+
+**Better Visual Hierarchy** — Subtle spacing improvements around destinations and promo blocks create a more polished, breathable interface that guides your eye naturally to what matters most.

--- a/apps/web/e2e/specs/availability.spec.ts
+++ b/apps/web/e2e/specs/availability.spec.ts
@@ -83,6 +83,7 @@ test.describe('Storage Availability', () => {
 
     // Open edit sheet
     await page.getByRole('button', { name: 'Open menu' }).first().click();
+    await page.getByRole('menuitem', { name: 'Edit' }).waitFor({ state: 'visible' });
     await page.getByRole('menuitem', { name: 'Edit' }).click();
     const sheet = page.getByTestId(TESTIDS.storageConfigSheet);
     await expect(sheet).toBeVisible();

--- a/apps/web/e2e/specs/trigger.spec.ts
+++ b/apps/web/e2e/specs/trigger.spec.ts
@@ -12,7 +12,7 @@ test.describe('Triggers - Empty State', () => {
 
     // ScheduledTriggerTable renders empty state with triggerEmptyState testid
     await expect(page.getByTestId(TESTIDS.triggerEmptyState)).toBeVisible();
-    await expect(page.getByText('No scheduled triggers yet')).toBeVisible();
+    await expect(page.getByText('Create your first scheduled trigger')).toBeVisible();
   });
 });
 

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/AddReportButton.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/AddReportButton.tsx
@@ -27,9 +27,10 @@ export function AddReportButton({ dataMartStatus, onAddReport }: AddReportButton
             aria-label='Add new report'
             disabled={isDisabled}
             data-testid='reportCreateButton'
+            className='text-foreground'
           >
-            <PlusIcon className='h-4 w-4' />
-            Add Report
+            <PlusIcon className='text-foreground h-4 w-4' />
+            New Report
           </Button>
         </span>
       </TooltipTrigger>

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import {
   CollapsibleCard,
   CollapsibleCardHeader,
@@ -8,10 +9,12 @@ import {
 } from '../../../../../../shared/components/CollapsibleCard';
 import type { DataMartStatusInfo } from '../../../../shared';
 import type { DataDestination } from '../../../../../data-destination';
-import { useDataDestinationVisibility } from '../../../../../data-destination';
+import { useDataDestination, useDataDestinationVisibility } from '../../../../../data-destination';
 import { useReportSidesheet } from '../../model/hooks';
 import { AddReportButton, ReportEditSheetRenderer, ReportListRenderer } from './index';
 import { DataDestinationType } from '../../../../../data-destination';
+import { InviteTeammatesCard } from '../../../../../../shared/components/InviteTeammatesCard';
+import { useReport } from '../../../shared';
 
 interface DestinationCardProps {
   destination: DataDestination;
@@ -27,6 +30,22 @@ const reportDestinationTypes = [
 ];
 
 /**
+ * Returns stats for a destination: report count and total Google Sheets destinations.
+ */
+function useDestinationStats(destinationId: string) {
+  const { reports } = useReport();
+  const { dataDestinations } = useDataDestination();
+  return useMemo(
+    () => ({
+      reportsCount: reports.filter(r => r.dataDestination.id === destinationId).length,
+      googleSheetsCount: dataDestinations.filter(d => d.type === DataDestinationType.GOOGLE_SHEETS)
+        .length,
+    }),
+    [reports, dataDestinations, destinationId]
+  );
+}
+
+/**
  * DestinationCard component
  * - Displays a collapsible card for each Data Destination
  * - Allows adding and editing reports via a modal
@@ -39,6 +58,13 @@ export function DestinationCard({ destination, dataMartStatus }: DestinationCard
   const { isOpen, mode, editingReport, handleAddReport, handleEditReport, handleCloseModal } =
     useReportSidesheet();
 
+  // Condition to show InviteTeammatesCard
+  const { reportsCount, googleSheetsCount } = useDestinationStats(destination.id);
+  const shouldShowInviteCard =
+    destination.type === DataDestinationType.GOOGLE_SHEETS &&
+    reportsCount === 0 &&
+    googleSheetsCount === 1;
+
   // Skip rendering if destination is not active
   if (!isVisible) {
     return null;
@@ -47,7 +73,7 @@ export function DestinationCard({ destination, dataMartStatus }: DestinationCard
   return (
     <>
       {/* Collapsible card container for a single destination */}
-      <div data-testid='destCard'>
+      <div className='flex flex-col gap-0.5' data-testid='destCard'>
         <CollapsibleCard name={destination.id} collapsible defaultCollapsed={false}>
           <CollapsibleCardHeader>
             {/* Card title with destination icon */}
@@ -66,11 +92,23 @@ export function DestinationCard({ destination, dataMartStatus }: DestinationCard
 
           {/* Reports list table */}
           <CollapsibleCardContent>
-            <ReportListRenderer destination={destination} onEditReport={handleEditReport} />
+            <ReportListRenderer
+              destination={destination}
+              onEditReport={handleEditReport}
+              dataMartStatus={dataMartStatus}
+              onAddReport={handleAddReport}
+            />
           </CollapsibleCardContent>
 
           <CollapsibleCardFooter />
         </CollapsibleCard>
+        {shouldShowInviteCard && (
+          <InviteTeammatesCard
+            hint='— Give business users self-service access to reporting in Google Sheets'
+            docsLabel='Learn more about Google Sheets destination'
+            docsHref='https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/?utm_source=owox_data_marts&utm_medium=dm_page_destinations_tab&utm_campaign=no_reports_google_sheets_destination'
+          />
+        )}
       </div>
 
       {/* Single Report Modal (used for both Add and Edit modes) */}

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/ReportListRenderer.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/ReportListRenderer.tsx
@@ -4,16 +4,31 @@ import { EmailReportsTable } from '../EmailReportsTable';
 import { LookerStudioReportCard } from '../LookerStudioReportCard';
 import type { DataDestination } from '../../../../../data-destination';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
+import type { DataMartStatusInfo } from '../../../../shared/types/data-mart-status.model';
 
 interface ReportListRendererProps {
   destination: DataDestination;
   onEditReport: (report: DataMartReport) => void;
+  dataMartStatus?: DataMartStatusInfo;
+  onAddReport: () => void;
 }
 
-export function ReportListRenderer({ destination, onEditReport }: ReportListRendererProps) {
+export function ReportListRenderer({
+  destination,
+  onEditReport,
+  dataMartStatus,
+  onAddReport,
+}: ReportListRendererProps) {
   switch (destination.type) {
     case DataDestinationType.GOOGLE_SHEETS:
-      return <GoogleSheetsReportsTable destination={destination} onEditReport={onEditReport} />;
+      return (
+        <GoogleSheetsReportsTable
+          destination={destination}
+          onEditReport={onEditReport}
+          dataMartStatus={dataMartStatus}
+          onAddReport={onAddReport}
+        />
+      );
 
     case DataDestinationType.EMAIL:
     case DataDestinationType.SLACK:
@@ -24,6 +39,8 @@ export function ReportListRenderer({ destination, onEditReport }: ReportListRend
           destinationType={destination.type}
           destination={destination}
           onEditReport={onEditReport}
+          dataMartStatus={dataMartStatus}
+          onAddReport={onAddReport}
         />
       );
 

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailReportsTable.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailReportsTable.tsx
@@ -7,11 +7,15 @@ import { DataDestinationType } from '../../../../../data-destination';
 import type { DataDestination } from '../../../../../data-destination';
 import { useBaseTable } from '../../../../../../shared/hooks';
 import { BaseTable } from '../../../../../../shared/components/Table';
+import type { DataMartStatusInfo } from '../../../../shared/types/data-mart-status.model';
+import { AddReportButton } from '../DestinationCard/AddReportButton';
 
 interface EmailReportsTableProps {
   destinationType: DataDestinationType;
   destination: DataDestination;
   onEditReport: (report: DataMartReport) => void;
+  dataMartStatus?: DataMartStatusInfo;
+  onAddReport: () => void;
 }
 
 /**
@@ -24,6 +28,8 @@ export function EmailReportsTable({
   destinationType,
   destination,
   onEditReport,
+  dataMartStatus,
+  onAddReport,
 }: EmailReportsTableProps) {
   const { reports, setPollingConfig } = useReport();
 
@@ -84,9 +90,16 @@ export function EmailReportsTable({
       ariaLabel={`${destination.title} reports`}
       showPagination={false}
       renderEmptyState={() => (
-        <span role='status' aria-live='polite'>
-          No reports for this destination
-        </span>
+        <div
+          className='flex flex-col items-center justify-center gap-4 py-8 text-center'
+          role='status'
+          aria-live='polite'
+        >
+          <p className='text-muted-foreground text-sm font-medium'>
+            Create your first report for this destination
+          </p>
+          <AddReportButton dataMartStatus={dataMartStatus} onAddReport={onAddReport} />
+        </div>
       )}
     />
   );

--- a/apps/web/src/features/data-marts/reports/list/components/EmptyDataMartDestinationsState/EmptyDataMartDestinationsState.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmptyDataMartDestinationsState/EmptyDataMartDestinationsState.tsx
@@ -4,6 +4,7 @@ import { PromoBlock } from '../../../../../../shared/components/PromoBlock/Promo
 import { GoogleSheetsIcon } from '../../../../../../shared/icons/google-sheets-icon';
 import { Button } from '@owox/ui/components/button';
 import { ArchiveRestore, ChevronRight } from 'lucide-react';
+import { InviteTeammatesCard } from '../../../../../../shared/components/InviteTeammatesCard';
 
 interface Props {
   variant?: 'default' | 'promo';
@@ -19,49 +20,65 @@ export function EmptyDataMartDestinationsState({
   // Promo variant (show after data mart is published)
   if (variant === 'promo') {
     return (
-      <PromoBlock
-        icon={GoogleSheetsIcon}
-        title='Use your data in&nbsp;Google&nbsp;Sheets'
-        subtitle='Ready to start reporting?'
-        description='No SQL needed — add columns and analyze data directly in&nbsp;Sheets'
-        primaryAction={{
-          label: 'Add Google Sheets Destination',
-          ...(onOpenCreateDestination
-            ? {
-                onClick: onOpenCreateDestination,
-              }
-            : {
-                href: scope('/data-destinations'),
-              }),
-        }}
-        secondaryAction={{
-          label: 'Learn more',
-          href: 'https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/?utm_source=owox_data_marts&utm_medium=dm_page_destinations_tab&utm_campaign=empty_state',
-          external: true,
-        }}
-      />
+      <div className='flex flex-col gap-0.5'>
+        <PromoBlock
+          icon={GoogleSheetsIcon}
+          title='Use your data in&nbsp;Google&nbsp;Sheets'
+          subtitle='Ready to start reporting?'
+          description='No SQL needed — add columns and analyze data directly in&nbsp;Sheets'
+          primaryAction={{
+            label: 'Add Google Sheets Destination',
+            ...(onOpenCreateDestination
+              ? {
+                  onClick: onOpenCreateDestination,
+                }
+              : {
+                  href: scope('/data-destinations'),
+                }),
+          }}
+          secondaryAction={{
+            label: 'Learn more',
+            href: 'https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/?utm_source=owox_data_marts&utm_medium=dm_page_destinations_tab&utm_campaign=empty_state',
+            external: true,
+          }}
+        />
+        <InviteTeammatesCard
+          hint='— Ask colleagues to configure Google Sheets destination'
+          docsLabel='Learn more about Google Sheets destination'
+          docsHref='https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/?utm_source=owox_data_marts&utm_medium=dm_page_destinations_tab&utm_campaign=empty_state'
+        />
+      </div>
     );
   }
 
   // Default empty state (show before data mart is published)
   return (
-    <div className='dm-card'>
-      <div className='dm-empty-state'>
-        <ArchiveRestore className='dm-empty-state-ico' strokeWidth={1} />
+    <div className='flex flex-col gap-0.5'>
+      <div className='dm-card'>
+        <div className='dm-empty-state'>
+          <ArchiveRestore className='dm-empty-state-ico' strokeWidth={1} />
 
-        <h2 className='dm-empty-state-title'>Google Sheets, Looker Studio, Email… and friends!</h2>
+          <h2 className='dm-empty-state-title'>
+            Google Sheets, Looker Studio, Email… and friends!
+          </h2>
 
-        <p className='dm-empty-state-subtitle'>
-          To turn data into reports using your favorite tools, create a Destination first.
-        </p>
+          <p className='dm-empty-state-subtitle'>
+            To turn data into reports using your favorite tools, create a Destination first.
+          </p>
 
-        <Button variant='outline' asChild>
-          <Link to={scope('/data-destinations')} className='flex items-center gap-1'>
-            Go to Destinations
-            <ChevronRight className='h-4 w-4' />
-          </Link>
-        </Button>
+          <Button variant='outline' asChild>
+            <Link to={scope('/data-destinations')} className='flex items-center gap-1'>
+              Go to Destinations
+              <ChevronRight className='h-4 w-4' />
+            </Link>
+          </Button>
+        </div>
       </div>
+      <InviteTeammatesCard
+        hint='— Not sure which destination to connect? Ask someone with access to help you'
+        docsLabel='Learn more about Google Sheets destination'
+        docsHref='https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/?utm_source=owox_data_marts&utm_medium=dm_page_destinations_tab&utm_campaign=empty_state'
+      />
     </div>
   );
 }

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsReportsTable.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsReportsTable.tsx
@@ -7,10 +7,14 @@ import { DataDestinationType } from '../../../../../data-destination';
 import type { DataDestination } from '../../../../../data-destination';
 import { useBaseTable } from '../../../../../../shared/hooks';
 import { BaseTable } from '../../../../../../shared/components/Table';
+import { AddReportButton } from '../DestinationCard/AddReportButton';
+import type { DataMartStatusInfo } from '../../../../shared/types/data-mart-status.model';
 
 interface GoogleSheetsReportsTableProps {
   destination: DataDestination;
   onEditReport: (report: DataMartReport) => void;
+  dataMartStatus?: DataMartStatusInfo;
+  onAddReport: () => void;
 }
 
 /**
@@ -22,6 +26,8 @@ interface GoogleSheetsReportsTableProps {
 export function GoogleSheetsReportsTable({
   destination,
   onEditReport,
+  dataMartStatus,
+  onAddReport,
 }: GoogleSheetsReportsTableProps) {
   const { reports, setPollingConfig } = useReport();
 
@@ -82,9 +88,16 @@ export function GoogleSheetsReportsTable({
       ariaLabel={`${destination.title} reports`}
       showPagination={false}
       renderEmptyState={() => (
-        <span role='status' aria-live='polite'>
-          No reports for this destination
-        </span>
+        <div
+          className='flex flex-col items-center justify-center gap-4 py-8 text-center'
+          role='status'
+          aria-live='polite'
+        >
+          <p className='text-muted-foreground text-sm font-medium'>
+            Create your first report for this destination
+          </p>
+          <AddReportButton dataMartStatus={dataMartStatus} onAddReport={onAddReport} />
+        </div>
       )}
     />
   );

--- a/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerTable/ScheduledTriggerTable.tsx
+++ b/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerTable/ScheduledTriggerTable.tsx
@@ -73,11 +73,18 @@ export function ScheduledTriggerTable({
               aria-live='polite'
               data-testid='triggerEmptyState'
             >
-              <p className='text-muted-foreground text-sm font-medium'>No scheduled triggers yet</p>
+              <p className='text-muted-foreground text-sm font-medium'>
+                Create your first scheduled trigger
+              </p>
               {onRequestCreate && (
-                <Button variant='outline' size='sm' onClick={onRequestCreate}>
-                  <Plus className='h-3.5 w-3.5' />
-                  Add Trigger
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={onRequestCreate}
+                  className='text-foreground'
+                >
+                  <Plus className='text-foreground h-4 w-4' />
+                  New Trigger
                 </Button>
               )}
             </div>

--- a/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
+++ b/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
@@ -19,6 +19,7 @@ import { useOnboardingVideo } from '../../../shared/hooks/useOnboardingVideo';
 import { DataMartStatus } from '../../../features/data-marts/shared/enums';
 import { PromoBlock } from '../../../shared/components/PromoBlock/PromoBlock';
 import { GoogleSheetsIcon } from '../../../shared/icons/google-sheets-icon';
+import { InviteTeammatesCard } from '../../../shared/components/InviteTeammatesCard';
 
 function DataMartDestinationsContentInner() {
   const { dataMart } = useOutletContext<DataMartContextType>();
@@ -73,21 +74,28 @@ function DataMartDestinationsContentInner() {
             />
           ))}
           {showSheetsUpsellPromo && (
-            <PromoBlock
-              icon={GoogleSheetsIcon}
-              size='compact'
-              title='Use your data in&nbsp;Google&nbsp;Sheets'
-              description='No SQL needed — add columns and analyze data directly in&nbsp;Sheets'
-              primaryAction={{
-                label: 'Add Google Sheets Destination',
-                onClick: handleOpenCreateDestination,
-              }}
-              secondaryAction={{
-                label: 'Learn more',
-                href: 'https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/?utm_source=owox_data_marts&utm_medium=dm_page_destinations_tab&utm_campaign=no_sheets_destination',
-                external: true,
-              }}
-            />
+            <div className='flex flex-col gap-0.5'>
+              <PromoBlock
+                icon={GoogleSheetsIcon}
+                size='compact'
+                title='Use your data in&nbsp;Google&nbsp;Sheets'
+                description='No SQL needed — add columns and analyze data directly in&nbsp;Sheets'
+                primaryAction={{
+                  label: 'Add Google Sheets Destination',
+                  onClick: handleOpenCreateDestination,
+                }}
+                secondaryAction={{
+                  label: 'Learn more',
+                  href: 'https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/?utm_source=owox_data_marts&utm_medium=dm_page_destinations_tab&utm_campaign=no_sheets_destination_upsell_promo',
+                  external: true,
+                }}
+              />
+              <InviteTeammatesCard
+                hint='— Ask colleagues to configure Google Sheets destination'
+                docsLabel='Learn more about Google Sheets destination'
+                docsHref='https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/?utm_source=owox_data_marts&utm_medium=dm_page_destinations_tab&utm_campaign=no_sheets_destination_invite_teammates_card'
+              />
+            </div>
           )}
         </>
       )}

--- a/apps/web/src/pages/data-marts/edit/DataMartTriggersContent.tsx
+++ b/apps/web/src/pages/data-marts/edit/DataMartTriggersContent.tsx
@@ -50,7 +50,7 @@ export default function DataMartTriggersContent() {
               data-testid='triggerCreateButton'
             >
               <Plus className='h-4 w-4' aria-hidden='true' />
-              Add Trigger
+              New Trigger
             </Button>
           </CollapsibleCardHeaderActions>
         </CollapsibleCardHeader>

--- a/apps/web/src/shared/components/InviteTeammatesCard/InviteTeammatesCard.tsx
+++ b/apps/web/src/shared/components/InviteTeammatesCard/InviteTeammatesCard.tsx
@@ -1,9 +1,7 @@
-import { useMemo } from 'react';
 import { UserPlus, HelpCircle } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { cn } from '@owox/ui/lib/utils';
-import { useProject } from '../../../app/store/hooks/useProject';
-import { useFlags } from '../../../app/store/hooks/useFlags';
-import { checkVisible } from '../../../utils/check-visible';
+import { useProjectRoute } from '../../hooks';
 import { Tooltip, TooltipTrigger, TooltipContent } from '@owox/ui/components/tooltip';
 
 interface InviteTeammatesCardProps {
@@ -25,28 +23,15 @@ export function InviteTeammatesCard({
   variant = 'card',
   onClick,
 }: InviteTeammatesCardProps) {
-  const { id: projectId } = useProject();
-  const { flags } = useFlags();
-
-  const membersHref = useMemo(() => {
-    if (!projectId) {
-      return null;
-    }
-    if (checkVisible('IDP_PROVIDER', ['owox-better-auth'], flags)) {
-      return `https://platform.owox.com/ui/p/${projectId}/settings/members`;
-    }
-    if (checkVisible('IDP_PROVIDER', ['better-auth'], flags)) {
-      return '/auth';
-    }
-    return null;
-  }, [flags, projectId]);
+  const { scope } = useProjectRoute();
+  const membersHref = '/project-settings/members';
 
   const baseClasses = cn(
-    'flex items-center text-sm gap-4',
+    'flex items-center gap-4 text-sm',
     variant !== 'button' && 'justify-between'
   );
   const variantClasses = {
-    card: 'bg-muted/50 rounded-md border-b border-gray-200 px-4 py-3 dark:border-white/2 dark:bg-white/2 text-muted-foreground dark:text-muted-foreground/75',
+    card: 'bg-muted/50 rounded-md border-b border-gray-200 px-4 py-3 text-muted-foreground dark:border-white/2 dark:bg-white/2 dark:text-muted-foreground/75',
     inline: 'mt-4 border-t border-b border-border/50 py-4 text-muted-foreground/75',
     button: '',
   };
@@ -60,39 +45,30 @@ export function InviteTeammatesCard({
       'inline-flex w-full items-center justify-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm font-medium transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
   };
 
-  if (!membersHref && !docsHref) return null;
-
-  const isMembersExternal = membersHref?.startsWith('http');
-
   return (
     <div className={cn(baseClasses, variantClasses[variant], className)}>
-      {membersHref && (
-        <div
-          className={cn(
-            'flex min-w-0 items-center gap-2',
-            variant === 'button' && 'w-full justify-center'
-          )}
+      <div
+        className={cn(
+          'flex min-w-0 items-center gap-2',
+          variant === 'button' && 'w-full justify-center'
+        )}
+      >
+        <Link
+          to={scope(membersHref)}
+          className={cn(linkClasses[variant])}
+          aria-label={inviteLabel}
+          onClick={onClick}
         >
-          <a
-            href={membersHref}
-            target={isMembersExternal ? '_blank' : undefined}
-            rel={isMembersExternal ? 'noopener noreferrer' : undefined}
-            className={cn(linkClasses[variant])}
-            aria-label={inviteLabel}
-            onClick={() => {
-              onClick?.();
-            }}
-          >
-            <UserPlus className='h-4 w-4 shrink-0' />
-            <span className='truncate'>{inviteLabel}</span>
-          </a>
-          {hint && variant !== 'button' && (
-            <span className='text-muted-foreground/75 dark:text-muted-foreground/50 hidden truncate lg:inline'>
-              {hint}
-            </span>
-          )}
-        </div>
-      )}
+          <UserPlus className='h-4 w-4 shrink-0' />
+          <span className='truncate underline'>{inviteLabel}</span>
+        </Link>
+
+        {hint && variant !== 'button' && (
+          <span className='text-muted-foreground/75 dark:text-muted-foreground/50 hidden truncate lg:inline'>
+            {hint}
+          </span>
+        )}
+      </div>
       {docsHref && (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -100,7 +76,7 @@ export function InviteTeammatesCard({
               href={docsHref}
               target='_blank'
               rel='noopener noreferrer'
-              className='text-muted-foreground hover:text-foreground'
+              className='text-muted-foreground/75 dark:text-muted-foreground/50 hover:text-foreground'
             >
               <HelpCircle className='h-4 w-4 shrink-0' />
             </a>

--- a/apps/web/src/shared/components/Table/BaseTable.tsx
+++ b/apps/web/src/shared/components/Table/BaseTable.tsx
@@ -200,19 +200,19 @@ export function BaseTable<TData>({
                 </TableRow>
               ))
             ) : renderEmptyState ? (
-              <TableRow>
+              <TableRow className='cursor-default hover:bg-transparent'>
                 <TableCell
                   colSpan={table.getVisibleLeafColumns().length}
-                  className='text-muted-foreground h-32 text-center'
+                  className='text-muted-foreground min-h-32 text-center'
                 >
                   {renderEmptyState()}
                 </TableCell>
               </TableRow>
             ) : (
-              <TableRow>
+              <TableRow className='cursor-default hover:bg-transparent'>
                 <TableCell
                   colSpan={table.getVisibleLeafColumns().length}
-                  className='text-muted-foreground h-32 text-center'
+                  className='text-muted-foreground min-h-32 text-center'
                 >
                   Oops! No data found
                 </TableCell>


### PR DESCRIPTION
# Make Report Creation More Visible and Encourage Team Collaboration

**Smarter Empty States with Quick Actions** — When a destination has no reports yet, you now see a prominent "New Report" button right where you need it. No more hunting for the add button — it's right there in the empty state, ready to get you started immediately.
<img width="1453" height="530" alt="Screenshot 2026-05-08 at 09 59 35" src="https://github.com/user-attachments/assets/4b6eec72-6c0f-4cd4-9b63-6065aff70ad1" />

**Consistent "New" Language** — We've standardized button labels across the app: "New Report" and "New Trigger" now replace the older "Add" terminology. Clearer, more direct, and consistent with industry standards.

**Helpful Teammate Invites** — Working with Google Sheets destinations just got more collaborative. When you haven't set up any reports yet, you'll see gentle suggestions to invite colleagues who might have the right access. Perfect for teams where not everyone has Google Workspace admin permissions.

**Cleaner Table Empty States** — Empty tables now display without distracting hover effects, keeping the focus on your next action. The improved styling makes the "New Report" button stand out as the clear path forward.

**Better Visual Hierarchy** — Subtle spacing improvements around destinations and promo blocks create a more polished, breathable interface that guides your eye naturally to what matters most.