### PR TITLE
feat(web): promo bulk data mart creation

### DIFF
--- a/.changeset/promo-block-bigquery-bulk-import.md
+++ b/.changeset/promo-block-bigquery-bulk-import.md
@@ -1,0 +1,13 @@
+---
+'owox': minor
+---
+
+# Discover BigQuery Bulk Import When You Need It
+
+**Contextual BigQuery Promo** — When you have exactly one BigQuery Data Mart, you'll now see a helpful prompt suggesting bulk import from your existing BigQuery tables and views. Perfect for quickly setting up multiple Data Marts from assets you already have in BigQuery.
+
+**Cleaner Empty State Layout** — Fixed visual structure in the "Use existing SQL" section for smoother rendering and improved accessibility.
+
+**More Flexible Dialogs** — Confirmation dialogs now support richer content structures for better information hierarchy.
+
+**Refined Compact Promo Design** — The compact promo variant features improved typography, better spacing, and optimized mobile display with hidden decorative elements on smaller screens.

--- a/.changeset/promo-block-bigquery-bulk-import.md
+++ b/.changeset/promo-block-bigquery-bulk-import.md
@@ -4,10 +4,10 @@
 
 # Discover BigQuery Bulk Import When You Need It
 
-**Contextual BigQuery Promo** — When you have exactly one BigQuery Data Mart, you'll now see a helpful prompt suggesting bulk import from your existing BigQuery tables and views. Perfect for quickly setting up multiple Data Marts from assets you already have in BigQuery.
+**Contextual BigQuery Promo** — When you have exactly one BigQuery Data Mart, you'll now see a helpful prompt suggesting bulk import from your existing BigQuery tables and views, plus a direct manual setup path.
 
-**Cleaner Empty State Layout** — Fixed visual structure in the "Use existing SQL" section for smoother rendering and improved accessibility.
+**Clearer Storage Health UX in Resource Pickers** — If a selected storage is not fully configured, resource browsers now show a consistent health-state block instead of raw loading errors, so it's obvious why tables or views cannot be listed yet.
 
-**More Flexible Dialogs** — Confirmation dialogs now support richer content structures for better information hierarchy.
+**Unified Behavior Across Bulk and Single Flows** — The same unhealthy-storage UI is now reused in both Bulk Create and single Data Mart table selection flows, giving users a predictable experience.
 
-**Refined Compact Promo Design** — The compact promo variant features improved typography, better spacing, and optimized mobile display with hidden decorative elements on smaller screens.
+**Refined Dialog Layout for Table Selection** — The table picker dialog now uses a cleaner, card-based content area that improves readability and keeps the error/health state visually structured.

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DataMartDefinitionForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DataMartDefinitionForm.tsx
@@ -28,12 +28,33 @@ export function DataMartDefinitionForm({
 }: DataMartDefinitionFormProps) {
   const { control } = useFormContext<DataMartDefinitionFormData>();
   const [shouldAutoOpenConnector, setShouldAutoOpenConnector] = useState(false);
+  const [shouldAutoOpenTable, setShouldAutoOpenTable] = useState(false);
+  const [shouldAutoOpenView, setShouldAutoOpenView] = useState(false);
+  const [shouldAutoOpenTablePattern, setShouldAutoOpenTablePattern] = useState(false);
 
   useEffect(() => {
     if (definitionType === DataMartDefinitionType.CONNECTOR && !preset) {
       setShouldAutoOpenConnector(true);
     } else {
       setShouldAutoOpenConnector(false);
+    }
+
+    if (definitionType === DataMartDefinitionType.TABLE && !preset) {
+      setShouldAutoOpenTable(true);
+    } else {
+      setShouldAutoOpenTable(false);
+    }
+
+    if (definitionType === DataMartDefinitionType.VIEW && !preset) {
+      setShouldAutoOpenView(true);
+    } else {
+      setShouldAutoOpenView(false);
+    }
+
+    if (definitionType === DataMartDefinitionType.TABLE_PATTERN && !preset) {
+      setShouldAutoOpenTablePattern(true);
+    } else {
+      setShouldAutoOpenTablePattern(false);
     }
   }, [definitionType, preset]);
 
@@ -48,6 +69,7 @@ export function DataMartDefinitionForm({
           storageId={storageId}
           storageConfig={storageConfig}
           mode='TABLE'
+          autoOpen={shouldAutoOpenTable}
         />
       )}
 
@@ -58,6 +80,7 @@ export function DataMartDefinitionForm({
           storageId={storageId}
           storageConfig={storageConfig}
           mode='VIEW'
+          autoOpen={shouldAutoOpenView}
         />
       )}
 
@@ -67,6 +90,7 @@ export function DataMartDefinitionForm({
           storageType={storageType}
           storageId={storageId}
           storageConfig={storageConfig}
+          autoOpen={shouldAutoOpenTablePattern}
         />
       )}
 

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DefinitionFqnField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DefinitionFqnField.tsx
@@ -33,6 +33,7 @@ interface DefinitionFqnFieldProps {
   storageConfig: DataStorageConfigDto | null;
   /** Controls the label text and the resource type shown in the picker. */
   mode: 'TABLE' | 'VIEW';
+  autoOpen?: boolean;
 }
 
 export function DefinitionFqnField({
@@ -41,6 +42,7 @@ export function DefinitionFqnField({
   storageId,
   storageConfig,
   mode,
+  autoOpen,
 }: DefinitionFqnFieldProps) {
   const placeholder = getFullyQualifiedNamePlaceholder(storageType);
   const helpText = getFullyQualifiedNameHelpText(storageType);
@@ -80,6 +82,7 @@ export function DefinitionFqnField({
                     resourceType={resourceType}
                     onSelect={handleSelect}
                     hasValue={Boolean(field.value)}
+                    autoOpen={autoOpen}
                   />
                 </InputGroupAddon>
                 <InputGroupInput

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/FillFromStorageButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/FillFromStorageButton.tsx
@@ -15,6 +15,9 @@ import type {
   StorageResourceFilter,
   StorageResourceLeafDto,
 } from '../../../../../../data-storage/shared/api/types';
+import { UnhealthyStorageBlock } from '../../../../../../data-storage/shared/components';
+import { useDataStorageHealthStatus } from '../../../../../../data-storage/shared/model/hooks/useDataStorageHealthStatus';
+import { DataStorageHealthStatus } from '../../../../../../data-storage/shared/services/data-storage-health-status.service';
 import { StorageResourceTree } from './StorageResourceTree';
 import { extractStorageResourceError } from './storage-resource-error.utils';
 
@@ -51,6 +54,15 @@ export function FillFromStorageButton({
   const [namespaces, setNamespaces] = useState<StorageNamespaceNodeDto[] | null>(null);
   const [namespacesError, setNamespacesError] = useState<string | null>(null);
   const [namespacesLoading, setNamespacesLoading] = useState(false);
+  const {
+    status: healthStatus,
+    errorMessage: healthErrorMessage,
+    isFetched: healthIsFetched,
+  } = useDataStorageHealthStatus(storageId);
+  const isUnhealthyStorage =
+    healthIsFetched &&
+    (healthStatus === DataStorageHealthStatus.UNCONFIGURED ||
+      healthStatus === DataStorageHealthStatus.INVALID);
 
   const loadNamespaces = useCallback(async () => {
     setNamespacesLoading(true);
@@ -67,10 +79,10 @@ export function FillFromStorageButton({
   }, [storageId]);
 
   useEffect(() => {
-    if (open && namespaces === null && !namespacesLoading) {
-      void loadNamespaces();
-    }
-  }, [open, namespaces, namespacesLoading, loadNamespaces]);
+    if (!open || namespaces !== null || namespacesLoading) return;
+    if (!healthIsFetched || isUnhealthyStorage) return;
+    void loadNamespaces();
+  }, [open, namespaces, namespacesLoading, loadNamespaces, healthIsFetched, isUnhealthyStorage]);
 
   const handleSelect = useCallback(
     (resource: StorageResourceLeafDto) => {
@@ -115,25 +127,35 @@ export function FillFromStorageButton({
         {!hasValue && <span className='text-xs'>Select...</span>}
       </InputGroupButton>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className='sm:max-w-4xl'>
-          <DialogHeader>
+        <DialogContent className='flex max-h-[90vh] flex-col gap-0 p-0 sm:max-w-4xl'>
+          <DialogHeader className='px-6 pt-6 pb-6'>
             <DialogTitle>Pick a {resourceLabel}</DialogTitle>
             <DialogDescription>
               Pick a namespace to see all {resourceLabelPlural} the storage has access to. Selecting
               one fills the Fully Qualified Name.
             </DialogDescription>
           </DialogHeader>
-          <StorageResourceTree
-            namespaces={namespaces}
-            namespacesLoading={namespacesLoading}
-            namespacesError={namespacesError}
-            onRetryNamespaces={() => {
-              void loadNamespaces();
-            }}
-            loadNamespaceResources={loadNamespaceResources}
-            onSelectResource={handleSelect}
-            resourceType={resourceType}
-          />
+          <div className='bg-muted dark:bg-sidebar flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto rounded-b-md border-t px-6 py-4'>
+            {isUnhealthyStorage ? (
+              <>
+                <UnhealthyStorageBlock status={healthStatus} errorMessage={healthErrorMessage} />
+              </>
+            ) : (
+              <section className='dm-card-block !gap-2'>
+                <StorageResourceTree
+                  namespaces={namespaces}
+                  namespacesLoading={namespacesLoading}
+                  namespacesError={namespacesError}
+                  onRetryNamespaces={() => {
+                    void loadNamespaces();
+                  }}
+                  loadNamespaceResources={loadNamespaceResources}
+                  onSelectResource={handleSelect}
+                  resourceType={resourceType}
+                />
+              </section>
+            )}
+          </div>
         </DialogContent>
       </Dialog>
     </>

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/FillFromStorageButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/FillFromStorageButton.tsx
@@ -29,6 +29,7 @@ interface FillFromStorageButtonProps {
   resourceType: StorageResourceFilter;
   onSelect: (fullyQualifiedName: string) => void;
   hasValue?: boolean;
+  autoOpen?: boolean;
 }
 
 export function FillFromStorageButton({
@@ -37,8 +38,16 @@ export function FillFromStorageButton({
   resourceType,
   onSelect,
   hasValue = false,
+  autoOpen = false,
 }: FillFromStorageButtonProps) {
   const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (autoOpen) {
+      setOpen(true);
+    }
+  }, [autoOpen]);
+
   const [namespaces, setNamespaces] = useState<StorageNamespaceNodeDto[] | null>(null);
   const [namespacesError, setNamespacesError] = useState<string | null>(null);
   const [namespacesLoading, setNamespacesLoading] = useState(false);

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/TablePatternDefinitionField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/TablePatternDefinitionField.tsx
@@ -31,6 +31,7 @@ interface TablePatternDefinitionFieldProps {
   storageType: DataStorageType;
   storageId: string;
   storageConfig: DataStorageConfigDto | null;
+  autoOpen?: boolean;
 }
 
 export function TablePatternDefinitionField({
@@ -38,6 +39,7 @@ export function TablePatternDefinitionField({
   storageType,
   storageId,
   storageConfig,
+  autoOpen,
 }: TablePatternDefinitionFieldProps) {
   const placeholder = getTablePatternPlaceholder(storageType);
   const helpText = getTablePatternHelpText(storageType);
@@ -77,6 +79,7 @@ export function TablePatternDefinitionField({
                     resourceType='TABLE_PATTERN'
                     onSelect={handleSelect}
                     hasValue={Boolean(field.value)}
+                    autoOpen={autoOpen}
                   />
                 </InputGroupAddon>
                 <InputGroupInput

--- a/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/BulkCreateFromStorageDialog.tsx
+++ b/apps/web/src/features/data-marts/list/components/BulkCreateFromStorageDialog/BulkCreateFromStorageDialog.tsx
@@ -21,7 +21,7 @@ import type {
   StorageNamespaceNodeDto,
   StorageResourceLeafDto,
 } from '../../../../data-storage/shared/api/types';
-import { DataStorageHealthStatusView } from '../../../../data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView';
+import { UnhealthyStorageBlock } from '../../../../data-storage/shared/components';
 import {
   DataStorageActionType,
   DataStorageProvider,
@@ -489,24 +489,5 @@ function BlockPlaceholder({ children }: { children: ReactNode }) {
     <div className='text-muted-foreground bg-muted/40 rounded-md p-3 text-xs dark:bg-white/4'>
       {children}
     </div>
-  );
-}
-
-/**
- * Block shown in place of "Browse resources" / "Selected resources" when the picked storage
- * is in a known-bad state (UNCONFIGURED or INVALID) per the front-end health cache. Reuses
- * {@link DataStorageHealthStatusView} so the wording matches the storages list page.
- */
-function UnhealthyStorageBlock({
-  status,
-  errorMessage,
-}: {
-  status: DataStorageHealthStatus;
-  errorMessage: string | undefined;
-}) {
-  return (
-    <section className='dm-card-block !gap-2 text-sm'>
-      <DataStorageHealthStatusView status={status} errorMessage={errorMessage} />
-    </section>
   );
 }

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
@@ -38,6 +38,8 @@ import {
   type DataMartFilterKey,
 } from './components/DataMartsTableFilters.config';
 import type { ConnectorListItem } from '../../../../connectors/shared/model/types/connector';
+import { PromoBlock } from '../../../../../shared/components/PromoBlock/PromoBlock';
+import { GoogleBigQueryIcon } from '../../../../../shared/icons/google-bigquery-icon';
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -261,160 +263,188 @@ export function DataMartTable<TData, TValue>({
     return <EmptyDataMartsState />;
   }
 
+  const isPromoImportFromBigQuery =
+    data.length === 1 &&
+    data.some(
+      (row: TData) => (row as DataMartListItem).storageType === DataStorageType.GOOGLE_BIGQUERY
+    );
+
   return (
-    <div className='dm-card' data-testid='datamartTable'>
-      <BaseTable
-        tableId={tableId}
-        table={table}
-        onRowClick={handleRowClick}
-        ariaLabel='Data Marts table'
-        renderToolbarLeft={table => (
-          <>
-            {/* BTNs for selected Rows */}
-            {hasSelectedRows && (
-              <div className='mr-2 flex items-center gap-2 border-r pr-4'>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  onClick={() => {
-                    setShowDeleteConfirmation(true);
-                  }}
-                  disabled={isDeleting}
-                  title='Delete selected data marts'
-                >
-                  <Trash2 className='h-4 w-4' />
-                  <span className='hidden md:block'>Delete</span>
-                </Button>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  onClick={() => {
-                    setShowPublishConfirmation(true);
-                  }}
-                  disabled={!hasSelectedDrafts || isPublishing}
-                  title='Publish selected data marts'
-                >
-                  <CircleCheckBig className='h-4 w-4' />
-                  <span className='hidden md:block'>Publish</span>
-                </Button>
+    <div className='flex flex-col gap-4'>
+      <div className='dm-card' data-testid='datamartTable'>
+        <BaseTable
+          tableId={tableId}
+          table={table}
+          onRowClick={handleRowClick}
+          ariaLabel='Data Marts table'
+          renderToolbarLeft={table => (
+            <>
+              {/* BTNs for selected Rows */}
+              {hasSelectedRows && (
+                <div className='mr-2 flex items-center gap-2 border-r pr-4'>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={() => {
+                      setShowDeleteConfirmation(true);
+                    }}
+                    disabled={isDeleting}
+                    title='Delete selected data marts'
+                  >
+                    <Trash2 className='h-4 w-4' />
+                    <span className='hidden md:block'>Delete</span>
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={() => {
+                      setShowPublishConfirmation(true);
+                    }}
+                    disabled={!hasSelectedDrafts || isPublishing}
+                    title='Publish selected data marts'
+                  >
+                    <CircleCheckBig className='h-4 w-4' />
+                    <span className='hidden md:block'>Publish</span>
+                  </Button>
+                </div>
+              )}
+              {/* Filters */}
+              <div data-testid='datamartStatusFilter'>
+                <DataMartsTableFilters
+                  appliedState={appliedState}
+                  config={filtersConfig}
+                  onApply={apply}
+                  onClear={clear}
+                />
               </div>
-            )}
-            {/* Filters */}
-            <div data-testid='datamartStatusFilter'>
-              <DataMartsTableFilters
-                appliedState={appliedState}
-                config={filtersConfig}
-                onApply={apply}
-                onClear={clear}
-              />
+              {/* Search */}
+              <div data-testid='datamartSearchInput'>
+                <TableColumnSearch
+                  table={table}
+                  columnId={DataMartColumnKey.TITLE}
+                  placeholder='Search'
+                />
+              </div>
+            </>
+          )}
+          renderToolbarRight={() => (
+            <div className='flex items-center gap-2'>
+              <Button
+                variant='outline'
+                onClick={() => {
+                  setShowBulkCreateFromStorage(true);
+                }}
+                title='Import data marts from storage resources'
+              >
+                <Import className='h-4 w-4' />
+                <span className='hidden lg:block'>Import…</span>
+              </Button>
+              <TableCTAButton asChild>
+                <Link to={scope('/data-marts/create')}>
+                  <Plus className='h-4 w-4' />
+                  <span className='hidden lg:block'>New Data Mart</span>
+                </Link>
+              </TableCTAButton>
             </div>
-            {/* Search */}
-            <div data-testid='datamartSearchInput'>
-              <TableColumnSearch
-                table={table}
-                columnId={DataMartColumnKey.TITLE}
-                placeholder='Search'
-              />
-            </div>
-          </>
-        )}
-        renderToolbarRight={() => (
-          <div className='flex items-center gap-2'>
-            <Button
-              variant='outline'
-              onClick={() => {
-                setShowBulkCreateFromStorage(true);
-              }}
-              title='Import data marts from storage resources'
-            >
-              <Import className='h-4 w-4' />
-              <span className='hidden lg:block'>Import…</span>
-            </Button>
-            <TableCTAButton asChild>
-              <Link to={scope('/data-marts/create')}>
-                <Plus className='h-4 w-4' />
-                <span className='hidden lg:block'>New Data Mart</span>
-              </Link>
-            </TableCTAButton>
-          </div>
-        )}
-      />
+          )}
+        />
 
-      <BulkCreateFromStorageDialog
-        open={showBulkCreateFromStorage}
-        onOpenChange={setShowBulkCreateFromStorage}
-        onCreated={() => {
-          void refetchDataMarts();
-        }}
-      />
+        <BulkCreateFromStorageDialog
+          open={showBulkCreateFromStorage}
+          onOpenChange={setShowBulkCreateFromStorage}
+          onCreated={() => {
+            void refetchDataMarts();
+          }}
+        />
 
-      {/* Delete Confirmation Dialog */}
-      <AlertDialog open={showDeleteConfirmation} onOpenChange={setShowDeleteConfirmation}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Are you sure?</AlertDialogTitle>
-            <AlertDialogDescription>
-              <span className='mt-2 block space-y-2'>
-                <span className='block'>
-                  You're about to delete{' '}
-                  <strong>
-                    {Object.keys(table.getState().rowSelection).length} selected data mart
-                    {Object.keys(table.getState().rowSelection).length !== 1 ? 's' : ''}
-                  </strong>
-                  . This action cannot be undone.
-                </span>
-                {selectedRows.some(
-                  row =>
-                    (row.original as DataMartListItem).storageType ===
-                    DataStorageType.LEGACY_GOOGLE_BIGQUERY
-                ) && (
-                  <span className='text-destructive block'>
-                    Some of the selected data marts will also become unavailable in the Google
-                    Sheets extension because they use legacy BigQuery storage.
+        {/* Delete Confirmation Dialog */}
+        <AlertDialog open={showDeleteConfirmation} onOpenChange={setShowDeleteConfirmation}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+              <AlertDialogDescription>
+                <span className='mt-2 block space-y-2'>
+                  <span className='block'>
+                    You're about to delete{' '}
+                    <strong>
+                      {Object.keys(table.getState().rowSelection).length} selected data mart
+                      {Object.keys(table.getState().rowSelection).length !== 1 ? 's' : ''}
+                    </strong>
+                    . This action cannot be undone.
                   </span>
-                )}
-              </span>
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                void handleBatchDelete();
-              }}
-              disabled={isDeleting}
-              className='bg-destructive hover:bg-destructive/90'
-            >
-              {isDeleting ? 'Deleting...' : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+                  {selectedRows.some(
+                    row =>
+                      (row.original as DataMartListItem).storageType ===
+                      DataStorageType.LEGACY_GOOGLE_BIGQUERY
+                  ) && (
+                    <span className='text-destructive block'>
+                      Some of the selected data marts will also become unavailable in the Google
+                      Sheets extension because they use legacy BigQuery storage.
+                    </span>
+                  )}
+                </span>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  void handleBatchDelete();
+                }}
+                disabled={isDeleting}
+                className='bg-destructive hover:bg-destructive/90'
+              >
+                {isDeleting ? 'Deleting...' : 'Delete'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
-      {/* Publish Confirmation Dialog */}
-      <AlertDialog open={showPublishConfirmation} onOpenChange={setShowPublishConfirmation}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Publish Draft Data Marts?</AlertDialogTitle>
-            <AlertDialogDescription>
-              You're about to publish {selectedDraftRows.length} draft data mart
-              {selectedDraftRows.length !== 1 ? 's' : ''}.<br />
-              Their schemas will be updated and they will become Published.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPublishing}>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                void handleBatchPublish();
-              }}
-              disabled={isPublishing}
-            >
-              {isPublishing ? 'Publishing...' : 'Publish'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        {/* Publish Confirmation Dialog */}
+        <AlertDialog open={showPublishConfirmation} onOpenChange={setShowPublishConfirmation}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Publish Draft Data Marts?</AlertDialogTitle>
+              <AlertDialogDescription>
+                You're about to publish {selectedDraftRows.length} draft data mart
+                {selectedDraftRows.length !== 1 ? 's' : ''}.<br />
+                Their schemas will be updated and they will become Published.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPublishing}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  void handleBatchPublish();
+                }}
+                disabled={isPublishing}
+              >
+                {isPublishing ? 'Publishing...' : 'Publish'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+
+      {/* Promo block for importing data marts from BigQuery */}
+      {isPromoImportFromBigQuery && (
+        <PromoBlock
+          icon={GoogleBigQueryIcon}
+          size='compact'
+          title='Use existing BigQuery tables or views'
+          description='Automatically create multiple Data Marts from your BigQuery assets in&nbsp;seconds'
+          primaryAction={{
+            label: 'Create Multiple Data Marts...',
+            onClick: () => {
+              setShowBulkCreateFromStorage(true);
+            },
+          }}
+          secondaryAction={{
+            label: 'Create from a Single Table',
+            href: scope('/data-marts/create?preset=table'),
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/components/EmptyDataMartsState.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/components/EmptyDataMartsState.tsx
@@ -67,22 +67,18 @@ export function EmptyDataMartsState() {
         {/* SQL-based and Blank */}
         <EmptyStateCardSection>
           <EmptyStateCardSectionTitle>
-            Use existing SQL or start from scratch
+            Use existing SQL, Table or start from scratch
           </EmptyStateCardSectionTitle>
           <EmptyStateCardSectionContent>
-            {otherPresets.map((preset, index) => (
-              <>
+            {otherPresets.map(preset => (
+              <div className='flex items-center gap-4' key={preset.key}>
                 <EmptyStateCardActionButton
-                  key={preset.key}
                   href={scope(`/data-marts/create?preset=${preset.key}`)}
                   icon={preset.icon && <preset.icon className='h-4 w-4' />}
                   title={preset.title}
                   variant='outline'
                 />
-                {index < otherPresets.length - 1 && (
-                  <span className='text-muted-foreground text-sm'>or</span>
-                )}
-              </>
+              </div>
             ))}
           </EmptyStateCardSectionContent>
         </EmptyStateCardSection>

--- a/apps/web/src/features/data-marts/shared/utils/data-mart-presets.ts
+++ b/apps/web/src/features/data-marts/shared/utils/data-mart-presets.ts
@@ -6,7 +6,7 @@ import {
   TikTokAdsIcon,
   MicrosoftAdsIcon,
 } from '../../../../shared';
-import { Code, Plug, Box } from 'lucide-react';
+import { Code, Plug, Box, Table } from 'lucide-react';
 
 // Keys list and type
 export const DATA_MART_PRESETS = [
@@ -16,6 +16,7 @@ export const DATA_MART_PRESETS = [
   'microsoft',
   'connector',
   'sql',
+  'table',
   'blank',
 ] as const;
 
@@ -71,6 +72,12 @@ export const dataMartPresetsMap: Record<DataMartPresetKey, DataMartPreset> = {
     datamartTitle: 'SQL-based Data Mart',
     definitionType: DataMartDefinitionType.SQL,
     icon: Code,
+  },
+  table: {
+    title: 'Existing Table',
+    datamartTitle: 'Table-based Data Mart',
+    definitionType: DataMartDefinitionType.TABLE,
+    icon: Table,
   },
   blank: {
     title: 'Blank Data Mart',

--- a/apps/web/src/features/data-storage/shared/components/UnhealthyStorageBlock/UnhealthyStorageBlock.tsx
+++ b/apps/web/src/features/data-storage/shared/components/UnhealthyStorageBlock/UnhealthyStorageBlock.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+import { DataStorageHealthStatus } from '../../services/data-storage-health-status.service';
+import { DataStorageHealthStatusView } from '../DataStorageHealthIndicator/DataStorageHealthStatusView';
+
+interface UnhealthyStorageBlockProps {
+  status: DataStorageHealthStatus;
+  errorMessage?: string;
+  footer?: ReactNode;
+}
+
+export function UnhealthyStorageBlock({
+  status,
+  errorMessage,
+  footer,
+}: UnhealthyStorageBlockProps) {
+  return (
+    <>
+      <section className='dm-card-block !gap-2 text-sm'>
+        <DataStorageHealthStatusView status={status} errorMessage={errorMessage} />
+      </section>
+      {footer}
+    </>
+  );
+}

--- a/apps/web/src/features/data-storage/shared/components/UnhealthyStorageBlock/index.ts
+++ b/apps/web/src/features/data-storage/shared/components/UnhealthyStorageBlock/index.ts
@@ -1,0 +1,1 @@
+export { UnhealthyStorageBlock } from './UnhealthyStorageBlock';

--- a/apps/web/src/features/data-storage/shared/components/index.ts
+++ b/apps/web/src/features/data-storage/shared/components/index.ts
@@ -2,3 +2,4 @@ export * from './DataStorageInfo';
 export * from './DataStorageInfo';
 export * from './DataStorageDetails';
 export * from './DataStorageHealthIndicator';
+export * from './UnhealthyStorageBlock';

--- a/apps/web/src/shared/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/apps/web/src/shared/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -44,7 +44,9 @@ export const ConfirmationDialog = ({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription>{description}</DialogDescription>
+          <DialogDescription asChild>
+            <div>{description}</div>
+          </DialogDescription>
         </DialogHeader>
         {children}
         <DialogFooter>

--- a/apps/web/src/shared/components/PromoBlock/PromoBlock.tsx
+++ b/apps/web/src/shared/components/PromoBlock/PromoBlock.tsx
@@ -136,7 +136,7 @@ export function PromoBlock({
     title: cn(
       'leading-tight font-semibold',
       isCompact
-        ? 'text-xl md:text-2xl lg:text-3xl mb-1 lg:mb-2'
+        ? 'text-lg md:text-xl lg:text-2xl mb-2 lg:mb-3'
         : 'text-3xl md:text-4xl xl:text-5xl mb-2 lg:mb-8'
     ),
 
@@ -207,7 +207,7 @@ export function PromoBlock({
             {/* Glow */}
             <div
               className={cn(
-                'absolute -bottom-8 -left-8 -z-10',
+                'absolute -bottom-8 -left-8 -z-10 hidden lg:block',
                 'h-4/5 w-4/5 blur-2xl',
                 'bg-gray-300/40 dark:bg-transparent'
               )}


### PR DESCRIPTION
# Discover BigQuery Bulk Import When You Need It

## Contextual BigQuery Promo

When you have exactly one BigQuery Data Mart, you'll now see a helpful prompt suggesting bulk import from your existing BigQuery tables and views, plus a direct manual setup path.

<img width="1720" height="2320" alt="Frame 23137585" src="https://github.com/user-attachments/assets/379b79c1-3126-4b2f-885d-2e8e902582de" />

## Clearer Storage Health UX in Resource Pickers

If a selected storage is not fully configured, resource browsers now show a consistent health-state block instead of raw loading errors, so it's obvious why tables or views cannot be listed yet.

<img width="1720" height="2173" alt="Frame 23137584" src="https://github.com/user-attachments/assets/3dfdc8f4-74d0-4702-a5ae-ca35c983a067" />

## Unified Behavior Across Bulk and Single Flows

- The same unhealthy-storage UI is now reused in both Bulk Create and single Data Mart table selection flows, giving users a predictable experience.
- The table picker dialog now uses a cleaner, card-based content area that improves readability and keeps the error/health state visually structured.

<img width="1720" height="3828" alt="Frame 23137586" src="https://github.com/user-attachments/assets/61ddc203-53b5-418e-93f8-3dbd010946fb" />
