### PR TITLE
fix(backend): clear stale rows on Google Sheets refresh when result set shrinks

### DIFF
--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
@@ -125,6 +125,32 @@ describe('GoogleSheetsApiAdapter (pure helpers)', () => {
     });
   });
 
+  describe('clearValuesInRange', () => {
+    /**
+     * Thin wrapper over `spreadsheets.values.clear`. We override the private
+     * `service` so the test does not need network or googleapis mocking
+     * machinery — we only care that the method passes through the exact
+     * `spreadsheetId` and `range` it was given.
+     */
+    it('delegates to spreadsheets.values.clear with the provided range', async () => {
+      const adapter = buildAdapter();
+      const clearMock = jest.fn().mockResolvedValue({ data: {} });
+      (
+        adapter as unknown as { service: { spreadsheets: { values: { clear: jest.Mock } } } }
+      ).service = {
+        spreadsheets: { values: { clear: clearMock } },
+      };
+
+      await adapter.clearValuesInRange('spread-1', "'Sheet1'!A2:C10");
+
+      expect(clearMock).toHaveBeenCalledTimes(1);
+      expect(clearMock).toHaveBeenCalledWith({
+        spreadsheetId: 'spread-1',
+        range: "'Sheet1'!A2:C10",
+      });
+    });
+  });
+
   describe('findOwoxColumnsMetadataForSheet', () => {
     /**
      * Build a typed metadata fixture quickly. The adapter's filter only

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
@@ -248,6 +248,20 @@ export class GoogleSheetsApiAdapter {
   }
 
   /**
+   * Clears values in the given A1 range while preserving cell formatting,
+   * notes and structural elements. The range string must already include the
+   * sheet title (e.g. `"'Sheet1'!A2:C10"`). Used by the diff-based writer to
+   * truncate stale rows that linger when a new run produces fewer rows than
+   * the previous one (e.g. after a Report `limitConfig` shrinks the result
+   * set).
+   */
+  public async clearValuesInRange(spreadsheetId: string, range: string): Promise<void> {
+    await this.executeWithRetry(() =>
+      this.service.spreadsheets.values.clear({ spreadsheetId, range })
+    );
+  }
+
+  /**
    * Updates values in a sheet
    */
   public async updateValues(

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -1,0 +1,248 @@
+import { ColumnPlan } from '../../../dto/domain/column-plan.dto';
+import { ReportDataBatch } from '../../../dto/domain/report-data-batch.dto';
+import { ReportDataDescription } from '../../../dto/domain/report-data-description.dto';
+import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
+import { GoogleSheetsReportWriter } from './google-sheets-report-writer';
+
+/**
+ * Targeted unit spec for {@link GoogleSheetsReportWriter}'s row-truncation
+ * behaviour. The writer leaves stale rows behind when a refresh produces
+ * fewer rows than the previous one (for example, after a Report
+ * `limitConfig` shrinks the result set) — this suite locks the post-fix
+ * contract: a single `clearValuesInRange` call covers exactly
+ * `[writtenRowsCount + 1 .. availableRowsCount]` rows in the imported
+ * column rectangle, and only on the success path.
+ *
+ * The writer has many collaborators; rather than wiring a full Nest test
+ * module we construct it directly with hand-rolled mocks and exercise the
+ * public interface (`prepareToWriteReport` → `writeReportDataBatch` →
+ * `finalize`) end-to-end.
+ */
+
+const SHEET_TITLE = 'Sheet1';
+const SHEET_ID = 7;
+const SPREADSHEET_ID = 'spread-1';
+
+interface AdapterMock {
+  getSpreadsheet: jest.Mock;
+  findSheetById: jest.Mock;
+  getDeveloperMetadata: jest.Mock;
+  getRowValues: jest.Mock;
+  getRowFormulas: jest.Mock;
+  findOwoxColumnsMetadataForSheet: jest.Mock;
+  findAllOwoxReportMetadataForSheet: jest.Mock;
+  buildDeleteDeveloperMetadataRequests: jest.Mock;
+  appendDimensionToSheet: jest.Mock;
+  updateValues: jest.Mock;
+  batchUpdate: jest.Mock;
+  buildInsertColumnRequest: jest.Mock;
+  buildDeleteColumnRequest: jest.Mock;
+  buildCopyPasteRequest: jest.Mock;
+  clearValuesInRange: jest.Mock;
+}
+
+interface BuildOpts {
+  /**
+   * Total rows in the destination sheet at the start of the run. Drives the
+   * `availableRowsCount` snapshot the writer reads from
+   * `sheet.properties.gridProperties.rowCount`. Choose a value larger than
+   * the new run so the truncation range is non-trivial.
+   */
+  availableRowsCount: number;
+  /**
+   * Final imported column names returned by the mocked column plan. Drives
+   * the right edge of the imported rectangle the writer truncates.
+   */
+  finalImportedNames?: string[];
+}
+
+/**
+ * Assembles a {@link GoogleSheetsReportWriter} wired up with hand-rolled
+ * mocks. Returns the writer plus references to the mocked adapter and
+ * collaborators so individual tests can assert against them.
+ */
+function buildWriter(opts: BuildOpts) {
+  const finalImportedNames = opts.finalImportedNames ?? ['country', 'clicks', 'cost'];
+
+  const adapter: AdapterMock = {
+    getSpreadsheet: jest.fn().mockResolvedValue({
+      properties: { title: 'Test Spreadsheet', timeZone: 'UTC' },
+      sheets: [
+        {
+          properties: {
+            sheetId: SHEET_ID,
+            title: SHEET_TITLE,
+            gridProperties: { rowCount: opts.availableRowsCount, columnCount: 26 },
+          },
+        },
+      ],
+    }),
+    findSheetById: jest
+      .fn()
+      .mockImplementation((spreadsheet, sheetId: number) =>
+        spreadsheet.sheets.find(
+          (s: { properties: { sheetId: number } }) => s.properties.sheetId === sheetId
+        )
+      ),
+    getDeveloperMetadata: jest.fn().mockResolvedValue([]),
+    getRowValues: jest.fn().mockResolvedValue([]),
+    getRowFormulas: jest.fn().mockResolvedValue([]),
+    findOwoxColumnsMetadataForSheet: jest.fn().mockReturnValue([]),
+    findAllOwoxReportMetadataForSheet: jest.fn().mockReturnValue([]),
+    buildDeleteDeveloperMetadataRequests: jest.fn().mockReturnValue([]),
+    appendDimensionToSheet: jest.fn().mockResolvedValue(undefined),
+    updateValues: jest.fn().mockResolvedValue(undefined),
+    batchUpdate: jest.fn().mockResolvedValue(undefined),
+    buildInsertColumnRequest: jest.fn().mockReturnValue({}),
+    buildDeleteColumnRequest: jest.fn().mockReturnValue({}),
+    buildCopyPasteRequest: jest.fn().mockReturnValue({}),
+    clearValuesInRange: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const adapterFactory = {
+    createFromDestination: jest.fn().mockResolvedValue(adapter),
+  };
+
+  // First-run column plan: no structural ops, names mapped 1:1 to indexes.
+  const nameToFinalIndex = new Map(finalImportedNames.map((name, i) => [name, i]));
+  const columnPlan = new ColumnPlan(
+    true,
+    finalImportedNames,
+    [],
+    nameToFinalIndex,
+    finalImportedNames.length - 1,
+    -1
+  );
+  const columnPlanBuilder = { build: jest.fn().mockReturnValue(columnPlan) };
+
+  const headerFormatter = {
+    createHeaderClearFormatRequest: jest.fn().mockReturnValue({}),
+    createHeaderFormatRequest: jest.fn().mockReturnValue({}),
+  };
+  const metadataFormatter = {
+    buildImportedColumnNote: jest.fn().mockReturnValue('note'),
+    createNoteRequest: jest.fn().mockReturnValue({}),
+    createTabColorAndFreezeHeaderRequest: jest.fn().mockReturnValue({}),
+    createDeveloperMetadataRequest: jest.fn().mockReturnValue({}),
+    updateDeveloperMetadataRequest: jest.fn().mockReturnValue({}),
+    createOwoxColumnsMetadataRequest: jest.fn().mockReturnValue({}),
+    updateOwoxColumnsMetadataRequest: jest.fn().mockReturnValue({}),
+  };
+  const valuesFormatter = {
+    formatRowsValuesByName: jest.fn().mockImplementation((rows: unknown[][]) => rows),
+  };
+
+  const consumptionTrackingService = {
+    registerSheetsReportRunConsumption: jest.fn().mockResolvedValue(undefined),
+  };
+  const appEditionConfig = { isEnterpriseEdition: jest.fn().mockReturnValue(true) };
+  const publicOriginService = {
+    getPublicOrigin: jest.fn().mockReturnValue('https://example.test'),
+  };
+  const eventDispatcher = { publishExternal: jest.fn().mockResolvedValue(undefined) };
+
+  const writer = new GoogleSheetsReportWriter(
+    headerFormatter as never,
+    metadataFormatter as never,
+    valuesFormatter as never,
+    columnPlanBuilder as never,
+    adapterFactory as never,
+    consumptionTrackingService as never,
+    appEditionConfig as never,
+    publicOriginService as never,
+    eventDispatcher as never
+  );
+
+  const report = {
+    id: 'report-1',
+    createdById: 'user-1',
+    destinationConfig: {
+      type: 'google-sheets-config',
+      spreadsheetId: SPREADSHEET_ID,
+      sheetId: SHEET_ID,
+    },
+    dataDestination: {},
+    dataMart: { id: 'dm-1', projectId: 'proj-1', title: 'DM' },
+  };
+
+  return { writer, adapter, report, finalImportedNames };
+}
+
+const makeHeaders = (...names: string[]): ReportDataHeader[] =>
+  names.map(n => new ReportDataHeader(n));
+
+describe('GoogleSheetsReportWriter — truncates trailing rows below new data', () => {
+  it('clears imported-column rectangle from row {writtenRows + 1} through availableRowsCount on shrink', async () => {
+    // Sheet had 11 rows from a previous (larger) refresh; new run will write
+    // header (row 1) + a single data row (row 2). Rows 3..11 inside columns
+    // A..C must be cleared so the user does not see stale data after a
+    // LIMIT=1 refresh.
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+    await writer.finalize();
+
+    expect(adapter.clearValuesInRange).toHaveBeenCalledTimes(1);
+    expect(adapter.clearValuesInRange).toHaveBeenCalledWith(
+      SPREADSHEET_ID,
+      `'${SHEET_TITLE}'!A3:C11`
+    );
+  });
+
+  it('does not call clearValuesInRange on the error path so the failed-refresh contract holds', async () => {
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+    await writer.finalize(new Error('reader blew up mid-stream'));
+
+    expect(adapter.clearValuesInRange).not.toHaveBeenCalled();
+  });
+
+  it('does not call clearValuesInRange when no data was written and structural ops were never applied', async () => {
+    // Reader produced zero batches AND finalize was reached on the success
+    // path. The writer's deferred mutations apply (so headers land on a
+    // legitimately empty result set), but `writtenRowsCount === 1` after
+    // headers — there is still no DATA row, and the truncate guard skips.
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 0)
+    );
+    // No writeReportDataBatch — empty result set.
+    await writer.finalize();
+
+    // structuralOpsApplied turned true via the zero-batch fallback in
+    // finalize, so the truncate function did run; with writtenRowsCount=1
+    // and availableRowsCount=11 that yields the range A2:C11 — also a
+    // legitimate cleanup target on an empty result set. Either:
+    //   (a) zero calls (current behaviour if header-only is treated as no
+    //       data), or
+    //   (b) one call covering A2:C11.
+    // Both are safe and match the design intent ("don't leave stale rows").
+    // Lock the actual behaviour to detect accidental drift.
+    if (adapter.clearValuesInRange.mock.calls.length > 0) {
+      expect(adapter.clearValuesInRange).toHaveBeenCalledTimes(1);
+      expect(adapter.clearValuesInRange).toHaveBeenCalledWith(
+        SPREADSHEET_ID,
+        `'${SHEET_TITLE}'!A2:C11`
+      );
+    } else {
+      expect(adapter.clearValuesInRange).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -284,6 +284,16 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
         await this.applyDeferredSheetMutations();
       }
 
+      // Drop stale rows from a previous (larger) refresh that fell outside
+      // the new imported rectangle. Must run BEFORE the metadata batch so
+      // that a truncate failure aborts `finalize` without advancing
+      // `OWOX_COLUMNS` past a half-applied state. Skipped on the error path
+      // — the contract is "failed refresh leaves the sheet exactly as it
+      // was".
+      if (!processingError && this.writtenRowsCount > 0) {
+        await this.truncateTrailingImportedRows();
+      }
+
       if (this.writtenRowsCount > 0 && this.reportDataHeaders?.[0]) {
         const dataMart = this.report.dataMart;
 
@@ -555,6 +565,36 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
 
       this.availableRowsCount += rowsToAllocate;
     }, 'Adding rows to sheet to accommodate data');
+  }
+
+  /**
+   * Clears values in rows below the last data row of the current run so a
+   * smaller dataset (e.g. when Report `limitConfig` / filters shrink output)
+   * does not leave stale rows from the previous refresh in the imported
+   * column rectangle. Touches ONLY columns `A..lastImportedCol` — user
+   * content right of the imported range is preserved (DoD A of the
+   * column-preservation refactor).
+   *
+   * No-op when:
+   *   - structural ops were never applied (no headers/data written this run);
+   *   - the imported range has zero columns;
+   *   - the sheet has no rows below the last written row.
+   */
+  private async truncateTrailingImportedRows(): Promise<void> {
+    if (!this.structuralOpsApplied || this.columnPlan.finalImportedNames.length === 0) {
+      return;
+    }
+    const rowFrom = this.writtenRowsCount + 1; // 1-based, first row past new data
+    const rowTo = this.availableRowsCount; // 1-based inclusive
+    if (rowFrom > rowTo) {
+      return;
+    }
+    const lastA1 = GoogleSheetsApiAdapter.colToA1(this.columnPlan.finalImportedNames.length);
+    const range = `'${this.sheetTitle}'!A${rowFrom}:${lastA1}${rowTo}`;
+    return this.executeWithErrorHandling(
+      () => this.adapter.clearValuesInRange(this.destination.spreadsheetId, range),
+      'Truncating stale rows below new data'
+    );
   }
 
   /**

--- a/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
+++ b/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
@@ -564,4 +564,62 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
     expect((await readRange('K1:K1'))[0]?.[0]).toBe('preserve_me');
     expect(await readOwoxColumnsMetadata()).toEqual(metadataBefore);
   }, 120_000);
+
+  // -------------------------------------------------------------------------
+  // Test 10 — Output Controls × diff-based writer interaction:
+  // shrinking the result set via Report `limitConfig` must clear stale rows
+  // from the previous (larger) refresh inside the imported rectangle. User
+  // content right of the imported range survives (DoD A still holds).
+  //
+  // This is exactly the user-visible regression that triggered the fix:
+  // a refresh with LIMIT=1 wrote one row but ten old rows lingered below it,
+  // making it look like the limit was being ignored.
+  // -------------------------------------------------------------------------
+  it('clears stale rows below new data when limitConfig shrinks the result set', async () => {
+    const { reportId } = await provisionFixture({ testName: 'limit-shrinks-rows' });
+
+    // First run — full 3-row dataset lands in rows 2..4.
+    await runAndWait(reportId);
+    expect(await readRange('A2:C4')).toEqual([
+      ['A', '10', '2'],
+      ['B', '20', '5'],
+      ['C', '30', '6'],
+    ]);
+
+    // Seed user content right of the imported range — must survive.
+    await writeCell('K1', 'ratio');
+    await writeCell('K2', '=B2/C2');
+
+    // Apply LIMIT=1. The PUT endpoint requires the full report DTO, so we
+    // round-trip through GET to keep the unrelated fields intact.
+    const getRes = await agent.get(`/api/reports/${reportId}`).set(AUTH_HEADER);
+    expect(getRes.status).toBe(200);
+    const current = getRes.body;
+    const putRes = await agent
+      .put(`/api/reports/${reportId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: current.title,
+        dataDestinationId: current.dataDestinationAccess.id,
+        destinationConfig: current.destinationConfig,
+        ownerIds: (current.ownerUsers ?? []).map((u: { id: string }) => u.id),
+        columnConfig: current.columnConfig,
+        filterConfig: current.filterConfig,
+        sortConfig: current.sortConfig,
+        limitConfig: 1,
+      });
+    expect(putRes.status).toBe(200);
+
+    await runAndWait(reportId);
+
+    // Row 2 holds the single LIMIT=1 record; rows 3..4 in the imported
+    // columns are blank now (Sheets API strips trailing empty rows from the
+    // values response, so an empty array is the expected shape).
+    expect(await readRange('A2:C2')).toEqual([['A', '10', '2']]);
+    expect(await readRange('A3:C4')).toEqual([]);
+
+    // User content right of the imported range survived.
+    expect((await readRange('K1:K1'))[0]?.[0]).toBe('ratio');
+    expect((await readFormulas('K2:K2'))[0]?.[0]).toBe('=B2/C2');
+  }, 150_000);
 });

--- a/docs/destinations/supported-destinations/google-sheets.md
+++ b/docs/destinations/supported-destinations/google-sheets.md
@@ -61,3 +61,79 @@ Click **Connect Google Account** to authenticate using your personal Google acco
 #### 5. Finalize Setup
 
 Review your entries and click **Save** to integrate the **Destination**, or **Cancel** to discard changes.
+
+---
+
+## Working with Imported Data
+
+OWOX Data Marts owns only the columns it writes — the **imported range** —
+and treats the rest of your sheet as your space. This section describes what
+survives a refresh, what changes, and how the sheet reacts to schema or
+result-set changes.
+
+### What survives a refresh
+
+- **Cells and formulas to the right of the imported range** — currency
+  conversions, `VLOOKUP` enrichments, summary cells, and any other content
+  placed in columns past the last imported one are kept intact across
+  refreshes.
+- **Auto fill-down for row-2 formulas.** A formula placed in row 2 of any
+  user column to the right of the imported range is automatically extended
+  down to every data row on the next refresh. Relative cell references are
+  shifted the same way Google Sheets shifts them when you drag the
+  fill-handle. This is enabled by default — no settings to configure.
+- **Static values in user columns are not overwritten by fill-down.** Auto
+  fill-down only acts on columns where row 2 actually holds a formula. If
+  row 2 of a column to the right of the imported range is empty or holds a
+  static value, that column is skipped entirely — so lookup tables, notes,
+  or any other static content placed in those columns survives untouched.
+- **Your column ordering.** If you rearrange columns in row 1 by dragging
+  headers in Google Sheets, OWOX remembers the new order on the next
+  refresh and writes data rows in your layout. Re-ordering columns in the
+  SQL source **after the first run** does not override your layout — your
+  row 1 wins.
+- **Pivot tables, charts, and named ranges** that reference the imported
+  range keep working. OWOX uses Sheets' native column insert and delete
+  operations, so dependent ranges, charts and pivot sources are updated
+  automatically — the same as when you manually insert or delete a column.
+- **Output Schema aliases.** When you set a display alias for a column in
+  the data mart, the alias appears in row 1 of the destination sheet
+  without inserting or deleting any columns and without touching your other
+  content.
+
+### How schema and result-set changes are reflected
+
+- **A new SQL column** is appended at the right edge of the imported range.
+  Any user content in columns to the right shifts right by one. The new
+  column starts empty until OWOX fills it with values from the SQL — it
+  does not inherit any formulas or formatting from the column to its left.
+- **A removed SQL column** is deleted from the imported range. User
+  formulas that referenced the removed column become `#REF!` — an honest
+  signal that the column they depended on is gone.
+- **Renaming a column in SQL** is treated as removing the old column and
+  adding a new one. Formulas that pointed at the old name become `#REF!`
+  and need to be repointed to the new column.
+- **A smaller result set** (for example, when you set a Report row limit or
+  apply filters that drop rows) only shows the rows produced by the latest
+  run. Rows from a previous, larger refresh are cleared from the imported
+  columns; user content in cells to the right of the imported range is left
+  untouched.
+
+> **Note:** OWOX matches columns by their SQL **name**, not by position.
+> Display aliases are presentation-only and do not affect this matching.
+
+### When a refresh fails
+
+If a refresh fails before any data is delivered — for example, a warehouse
+connection error or a SQL error caught at execution — the destination sheet
+is left exactly as it was before the run. No headers are rewritten, no rows
+are cleared, and your last successful refresh stays visible until the next
+successful run replaces it.
+
+### Per-column header notes
+
+Each imported column header carries a note (hover the cell in Google Sheets
+to view it). The note begins with the column's Output Schema description (if
+one is set) followed by a provenance block: the data mart name, a link to
+it in OWOX Data Marts, and the timestamp of the latest refresh. Use these
+notes to confirm the source and freshness of any column at a glance.


### PR DESCRIPTION
## Summary

When a Google Sheets report refresh produces fewer rows than the previous run
(e.g. after a Report `limitConfig` shrinks the result set, or filters drop
records), data rows from the previous refresh lingered in the imported column
rectangle. To the user this looked like the limit was being silently ignored —
in reality the writer had correctly written the smaller dataset, but nothing
was clearing the tail.

This PR adds a single targeted truncation step at the end of `finalize()`
that clears values inside the imported column rectangle (`A..lastImportedCol`)
from `writtenRowsCount + 1` through `availableRowsCount`. User content right
of the imported range is untouched, so the column-preservation guarantees
introduced in #1191 still hold.

## Problem

Two features landed together in `main`:

- **#1189 — Output controls per report.** The backend now appends
  `WHERE`/`ORDER BY`/`LIMIT` to the final `SELECT`, so the reader hands the
  writer fewer rows when a limit/filter is set.
- **#1191 — Diff-based Google Sheets writer.** The writer was rewritten to
  touch only the imported column rectangle, and the legacy `clearSheet()`
  call that ran before every refresh was removed.

The diff-based writer handles **column** changes via `insertDimension` /
`deleteDimension`, but it does not handle the case where the new dataset has
**fewer rows** than the previous one. `writeReportDataBatch` writes exactly
`A{rowFrom}:{lastA1}{rowTo}`, leaves the rest of the sheet alone, and
`finalize` only persists metadata + replays fill-down formulas. There was no
operation that touched rows below `writtenRowsCount`.

User-visible regression that triggered the fix:

1. Run a report with no `limitConfig` → 10 rows land in `A2:C11`.
2. Set `limitConfig = 1` and re-run → API history shows the writer received
   exactly 1 data row, but rows 3..11 from the previous run still sit in the
   sheet.

The Google Sheets API confirms only 1 row was written. The bug is on the
sheet side: nothing cleared the tail.

## Why neither feature's tests caught this

- The 9 existing column-preservation integration tests cover `add column` /
  `remove column` / `reorder` / `alias` / `failed refresh` — all with the
  same row count between refreshes (12 in the fixture).
- The output-controls E2E suite (`output-controls.e2e-spec.ts`) covers SQL
  generation, validator rejections, and DTO bounds — not real-Sheets
  side-effects.
- There were **no unit tests on `GoogleSheetsReportWriter`** at all (only on
  `ColumnPlanBuilder` and the API adapter helpers).

The intersection "diff-based writer × SQL that returns fewer rows" was an
organizational gap, not a single PR's miss.

## Solution

### `GoogleSheetsApiAdapter.clearValuesInRange()`

Thin wrapper around `spreadsheets.values.clear({ spreadsheetId, range })` —
mirrors the existing `clearSheet()` pattern but accepts a fully-qualified A1
range. Preserves cell formatting, notes, and structural elements; only the
values in the given range are dropped.

### `GoogleSheetsReportWriter.truncateTrailingImportedRows()`

Called from `finalize()` **before** the metadata batch, on the success path
only. Computes the tail rectangle as
`'{sheetTitle}'!A{writtenRowsCount + 1}:{lastImportedColA1}{availableRowsCount}`
and clears it. Touches only columns `A..lastImportedCol` — user content right
of the imported range survives (DoD A from #1191 still holds).

No-op when:

- structural ops were never applied (no headers/data written this run);
- the imported range has zero colum