### PR TITLE
fix(web): add initialDefinitionType prop to DataMartDefinitionForm and update logic for auto-opening sections based on definition type

### DIFF
--- a/.changeset/promo-block-bigquery-bulk-import.md
+++ b/.changeset/promo-block-bigquery-bulk-import.md
@@ -2,9 +2,9 @@
 'owox': minor
 ---
 
-# Discover BigQuery Bulk Import When You Need It
+# Introduce Promo for Multi Data Mart Creation from Connected BigQuery Storage
 
-**Contextual BigQuery Promo** — When you have exactly one BigQuery Data Mart, you'll now see a helpful prompt suggesting bulk import from your existing BigQuery tables and views, plus a direct manual setup path.
+**Contextual Promo** — When you have exactly one Data Mart with BigQuery storage configured, you’ll now see a prompt to bulk-create Data Marts from existing BigQuery tables and views, with an optional manual setup path.
 
 **Clearer Storage Health UX in Resource Pickers** — If a selected storage is not fully configured, resource browsers now show a consistent health-state block instead of raw loading errors, so it's obvious why tables or views cannot be listed yet.
 

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
@@ -197,6 +197,7 @@ export function DataMartDefinitionSettings({
           storageId={storageId}
           storageConfig={storageConfig}
           preset={preset?.connectorSourceTitle}
+          initialDefinitionType={initialDefinitionType}
           saveDataMartDefinition={handleFormSubmit}
         />
         {definitionType !== DataMartDefinitionType.CONNECTOR && (

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DataMartDefinitionForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DataMartDefinitionForm.tsx
@@ -15,6 +15,7 @@ interface DataMartDefinitionFormProps {
   storageId: string;
   storageConfig: DataStorageConfigDto | null;
   preset?: string;
+  initialDefinitionType?: DataMartDefinitionType | null;
   saveDataMartDefinition?: (e?: React.SyntheticEvent<HTMLFormElement>) => void;
 }
 
@@ -24,6 +25,7 @@ export function DataMartDefinitionForm({
   storageId,
   storageConfig,
   preset,
+  initialDefinitionType,
   saveDataMartDefinition,
 }: DataMartDefinitionFormProps) {
   const { control } = useFormContext<DataMartDefinitionFormData>();
@@ -33,30 +35,20 @@ export function DataMartDefinitionForm({
   const [shouldAutoOpenTablePattern, setShouldAutoOpenTablePattern] = useState(false);
 
   useEffect(() => {
-    if (definitionType === DataMartDefinitionType.CONNECTOR && !preset) {
-      setShouldAutoOpenConnector(true);
-    } else {
-      setShouldAutoOpenConnector(false);
-    }
+    const isDifferentFromInitial = initialDefinitionType !== definitionType;
 
-    if (definitionType === DataMartDefinitionType.TABLE && !preset) {
-      setShouldAutoOpenTable(true);
-    } else {
-      setShouldAutoOpenTable(false);
-    }
+    setShouldAutoOpenTable(
+      definitionType === DataMartDefinitionType.TABLE && isDifferentFromInitial
+    );
 
-    if (definitionType === DataMartDefinitionType.VIEW && !preset) {
-      setShouldAutoOpenView(true);
-    } else {
-      setShouldAutoOpenView(false);
-    }
+    setShouldAutoOpenView(definitionType === DataMartDefinitionType.VIEW && isDifferentFromInitial);
 
-    if (definitionType === DataMartDefinitionType.TABLE_PATTERN && !preset) {
-      setShouldAutoOpenTablePattern(true);
-    } else {
-      setShouldAutoOpenTablePattern(false);
-    }
-  }, [definitionType, preset]);
+    setShouldAutoOpenTablePattern(
+      definitionType === DataMartDefinitionType.TABLE_PATTERN && isDifferentFromInitial
+    );
+
+    setShouldAutoOpenConnector(definitionType === DataMartDefinitionType.CONNECTOR && !preset);
+  }, [definitionType, initialDefinitionType, preset]);
 
   return (
     <div className='space-y-2'>


### PR DESCRIPTION
Fixed incorrect auto-opening behavior of Fill From Storage dialogs for TABLE/VIEW/TABLE_PATTERN definitions.

Result
- Existing Data Marts with TABLE/VIEW/TABLE_PATTERN no longer auto-open dialogs on page load.
- New dialogs open only after explicit type selection (or matching preset in URL).
- All targeted scenarios now behave consistently and predictably.