### PR TITLE
feat(backend): AI helper for Data Mart metadata (title, description, field aliases & descriptions)

### DIFF
--- a/.changeset/nalsur-sparkles-protocol.md
+++ b/.changeset/nalsur-sparkles-protocol.md
@@ -1,0 +1,38 @@
+---
+'owox': minor
+---
+
+# AI helper for Data Mart metadata
+
+Filling in titles, descriptions, field aliases and field descriptions by hand
+is now optional. A Sparkles ✨ button appears next to each of those inputs and
+asks the AI to draft a value based on the data mart's schema and a 30-row
+sample of the actual data. You review the suggestion in the input and click
+Apply (or just edit it further) before anything is saved — nothing is changed
+behind your back.
+
+- **One-click title and description.** While editing the data mart title or
+  description, click the Sparkles button on the right of the field to get an
+  AI draft grounded in the real columns and sample values. Save or keep
+  editing — your call.
+- **Per-field alias and description.** Open the editor on any column's Alias
+  or Description in the Output Schema and the Sparkles button writes a
+  suggestion straight into the open textarea. Cancel discards it, Apply
+  commits it to the local schema so you can still review the whole change
+  before saving the schema.
+- **Bulk fill for the whole schema.** A new icon button next to *Refresh
+  schema* opens a menu with **Generate field descriptions** and **Generate
+  field aliases** — useful when you want to populate every column at once.
+  Generated values land in the editable schema, so you can tweak any row
+  before clicking Save.
+- **Grounded in your real data.** Each AI call runs the data mart, grabs up
+  to 30 sample rows, and feeds them to the model along with the schema so
+  aliases match the values you actually have (e.g. `cnt` → `Count`,
+  `event_ts` → `Event Timestamp, in UTC`).
+- **Not for connector-based data marts (yet).** AI suggestions are available
+  for SQL, Table, View and Table Pattern definitions. Connector data marts
+  still need their metadata filled by hand.
+- **Self-hosted? Bring your own AI key.** The Sparkles buttons appear only
+  when `AI_BASE_URL`, `AI_API_KEY` and `AI_MODEL` are configured on the
+  deployment. Add them to your environment and the buttons light up — no
+  re-deploy of the UI required.

--- a/apps/backend/src/data-marts/ai-insights/agent/generate-data-mart-metadata.agent.ts
+++ b/apps/backend/src/data-marts/ai-insights/agent/generate-data-mart-metadata.agent.ts
@@ -1,0 +1,60 @@
+import { Agent, SharedAgentContext } from '../ai-insights-types';
+import { Injectable, Logger } from '@nestjs/common';
+import { AiMessage, AiRole } from '../../../common/ai-insights/agent/ai-core';
+import {
+  GenerateDataMartMetadataAgentInput,
+  GenerateDataMartMetadataAgentResponse,
+  GenerateDataMartMetadataAgentResponseSchema,
+} from './types';
+import { runAgentLoop } from '../../../common/ai-insights/llm-tool-runner';
+import {
+  buildGenerateDataMartMetadataSystemPrompt,
+  buildGenerateDataMartMetadataUserPrompt,
+} from '../prompts/generate-data-mart-metadata.prompt';
+
+@Injectable()
+export class GenerateDataMartMetadataAgent implements Agent<
+  GenerateDataMartMetadataAgentInput,
+  GenerateDataMartMetadataAgentResponse
+> {
+  readonly name = 'GenerateDataMartMetadataAgent';
+  private readonly logger = new Logger(GenerateDataMartMetadataAgent.name);
+
+  async run(
+    input: GenerateDataMartMetadataAgentInput,
+    shared: SharedAgentContext
+  ): Promise<GenerateDataMartMetadataAgentResponse> {
+    const { aiProvider, toolRegistry, telemetry, budgets, projectId, dataMartId } = shared;
+
+    const system = buildGenerateDataMartMetadataSystemPrompt();
+    const user = buildGenerateDataMartMetadataUserPrompt(input);
+
+    const initialMessages: AiMessage[] = [
+      { role: AiRole.SYSTEM, content: system },
+      { role: AiRole.USER, content: user },
+    ];
+
+    const context = {
+      projectId,
+      dataMartId,
+      prompt: `generate data mart metadata: ${input.scope}`,
+      telemetry,
+      budgets,
+    };
+
+    const { result } = await runAgentLoop({
+      aiProvider,
+      toolRegistry,
+      context,
+      telemetry,
+      initialMessages,
+      tools: [],
+      maxTurns: 1,
+      temperature: 0.3,
+      resultSchema: GenerateDataMartMetadataAgentResponseSchema,
+      logger: this.logger,
+    });
+
+    return result;
+  }
+}

--- a/apps/backend/src/data-marts/ai-insights/agent/sql-context-prefetch.service.ts
+++ b/apps/backend/src/data-marts/ai-insights/agent/sql-context-prefetch.service.ts
@@ -8,13 +8,12 @@ import {
   measureExecutionTime,
   toMeasuredExecutionBaseResult,
 } from '../../../common/utils/measure-execution-time';
+import { AI_INSIGHTS_SCHEMA_EXPIRES_AFTER_MS } from '../ai-insights.constants';
 
 export interface SqlContextPrefetchInput {
   projectId: string;
   dataMartId: string;
 }
-// refresh metadata if it was loaded more than 30 minutes ago.
-const SCHEMA_EXPIRES_AFTER_MS = 30 * 60 * 1000;
 
 @Injectable()
 export class AiAssistantSqlContextPrefetchService {
@@ -65,7 +64,7 @@ export class AiAssistantSqlContextPrefetchService {
     const dataMart = await this.dataMartService.actualizeSchemaIfExpired(
       input.dataMartId,
       input.projectId,
-      SCHEMA_EXPIRES_AFTER_MS
+      AI_INSIGHTS_SCHEMA_EXPIRES_AFTER_MS
     );
 
     return {

--- a/apps/backend/src/data-marts/ai-insights/agent/types.ts
+++ b/apps/backend/src/data-marts/ai-insights/agent/types.ts
@@ -1,8 +1,15 @@
 import { z } from 'zod';
-import { GetMetadataOutput, QueryRow, SqlStepError } from '../ai-insights-types';
+import {
+  DataMartMetadataScope,
+  GetMetadataOutput,
+  QueryRow,
+  SqlStepError,
+} from '../ai-insights-types';
 import { DataMartSchema } from '../../data-storage-types/data-mart-schema.type';
 import { AiRole } from '../../../common/ai-insights/agent/ai-core';
 import type { AgentFlowConversationSnapshot } from '../agent-flow/conversation-snapshot.schema';
+
+export { DataMartMetadataScope };
 
 export function isFinalReasonAnswer(value: FinalReason) {
   return value === FinalReason.ANSWER;
@@ -532,6 +539,68 @@ export const InsightGenerationAgentResponseSchema = z.object({
 });
 
 export type InsightGenerationAgentResponse = z.infer<typeof InsightGenerationAgentResponseSchema>;
+
+// Data Mart Metadata Helper Agent Types
+export interface GenerateDataMartMetadataAgentInput {
+  scope: DataMartMetadataScope;
+  dataMartTitle: string | null;
+  dataMartDescription: string | null;
+  schema: DataMartSchema;
+  sampleColumns: string[] | null;
+  sampleRows: QueryRow[] | null;
+  fieldName?: string;
+}
+
+export const GeneratedFieldMetadataSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'name is required')
+    .describe('Exact field name as it appears in the source schema. Case-sensitive.'),
+  alias: z
+    .string()
+    .optional()
+    .describe(
+      'Business-friendly display name for the field (e.g. "Campaign Name"). ' +
+        'Use Title Case. Avoid technical jargon, abbreviations, and underscores.'
+    ),
+  description: z
+    .string()
+    .optional()
+    .describe(
+      'Short business-friendly description of the field, one sentence. ' +
+        'Start with a capital letter, end with a period. Explain what the value represents, not its type.'
+    ),
+});
+
+export const GenerateDataMartMetadataAgentResponseSchema = z.object({
+  title: z
+    .string()
+    .optional()
+    .describe(
+      'Concise business-friendly title for the data mart, 3-8 words. ' +
+        'Required when scope is "title" or "all".'
+    ),
+  description: z
+    .string()
+    .optional()
+    .describe(
+      'Short business-friendly description of the data mart, 1-3 sentences. ' +
+        'Explain what data it contains and a typical use case. ' +
+        'Required when scope is "description" or "all".'
+    ),
+  fields: z
+    .array(GeneratedFieldMetadataSchema)
+    .optional()
+    .describe(
+      'Per-field metadata suggestions. ' +
+        'For scope "schema" or "all": include every field from the input schema. ' +
+        'For scope "field_alias" or "field_description": include only the requested field.'
+    ),
+});
+
+export type GenerateDataMartMetadataAgentResponse = z.infer<
+  typeof GenerateDataMartMetadataAgentResponseSchema
+>;
 
 export type SqlErrorAdvisorInput = {
   prompt: string;

--- a/apps/backend/src/data-marts/ai-insights/ai-insights-providers.ts
+++ b/apps/backend/src/data-marts/ai-insights/ai-insights-providers.ts
@@ -28,6 +28,7 @@ import { SqlAgent } from './agent/sql.agent';
 import { SqlBuilderAgent } from './agent/sql-builder.agent';
 import { TriageAgent } from './agent/triage.agent';
 import { GenerateInsightAgent } from './agent/generate-insight.agent';
+import { GenerateDataMartMetadataAgent } from './agent/generate-data-mart-metadata.agent';
 import { SqlErrorAdvisorAgent } from './agent/sql-error-advisor.agent';
 import { QueryRepairAgent } from './agent/query-repair.agent';
 import { PromptProcessedEventsService } from './prompt-processed-events.service';
@@ -50,6 +51,7 @@ export const aiInsightsProviders = [
   SqlErrorAdvisorAgent,
   FinalizeAgent,
   GenerateInsightAgent,
+  GenerateDataMartMetadataAgent,
   PromptTagHandler,
   PromptProcessedEventsService,
   DataMartInsightTemplateFacadeImpl,

--- a/apps/backend/src/data-marts/ai-insights/ai-insights-providers.ts
+++ b/apps/backend/src/data-marts/ai-insights/ai-insights-providers.ts
@@ -22,6 +22,7 @@ import {
   normalizeAiProviderName,
 } from '../../common/ai-insights/services/ai-chat-provider.token';
 import { AiInsightsOrchestratorService } from './ai-insight-orchestrator.service';
+import { GenerateDataMartMetadataOrchestratorService } from './generate-data-mart-metadata.orchestrator.service';
 import { FinalizeAgent } from './agent/finalize.agent';
 import { PlanAgent } from './agent/plan.agent';
 import { SqlAgent } from './agent/sql.agent';
@@ -43,6 +44,7 @@ export const aiInsightsProviders = [
   StorageRelatedPromptResolver,
   AiInsightsFacadeImpl,
   AiInsightsOrchestratorService,
+  GenerateDataMartMetadataOrchestratorService,
   TriageAgent,
   PlanAgent,
   SqlBuilderAgent,

--- a/apps/backend/src/data-marts/ai-insights/ai-insights-types.ts
+++ b/apps/backend/src/data-marts/ai-insights/ai-insights-types.ts
@@ -160,3 +160,32 @@ export interface GenerateInsightResponse {
   template: string;
   prompts: DataMartPromptMetaEntry[];
 }
+
+export enum DataMartMetadataScope {
+  TITLE = 'title',
+  DESCRIPTION = 'description',
+  FIELD_ALIAS = 'field_alias',
+  FIELD_DESCRIPTION = 'field_description',
+  ALL_FIELD_DESCRIPTIONS = 'all_field_descriptions',
+  ALL_FIELD_ALIASES = 'all_field_aliases',
+}
+
+export interface GenerateDataMartMetadataRequest {
+  projectId: string;
+  dataMartId: string;
+  scope: DataMartMetadataScope;
+  useSample: boolean;
+  fieldName?: string;
+}
+
+export interface GeneratedFieldMetadata {
+  name: string;
+  alias?: string;
+  description?: string;
+}
+
+export interface GenerateDataMartMetadataResponse {
+  title?: string;
+  description?: string;
+  fields?: GeneratedFieldMetadata[];
+}

--- a/apps/backend/src/data-marts/ai-insights/ai-insights.constants.ts
+++ b/apps/backend/src/data-marts/ai-insights/ai-insights.constants.ts
@@ -1,0 +1,7 @@
+/**
+ * How long a Data Mart's output schema is considered fresh before AI flows
+ * re-actualize it against the warehouse. Shared by the AI Insights prefetch
+ * path and the AI metadata helper so both react to upstream schema changes
+ * (drops, renames, additions) within the same window.
+ */
+export const AI_INSIGHTS_SCHEMA_EXPIRES_AFTER_MS = 30 * 60 * 1000;

--- a/apps/backend/src/data-marts/ai-insights/data-mart-insights.types.ts
+++ b/apps/backend/src/data-marts/ai-insights/data-mart-insights.types.ts
@@ -11,7 +11,7 @@ export type DataMartAdditionalParams = {
 };
 
 export interface ConsumptionContext {
-  contextType: 'INSIGHT' | 'REPORT';
+  contextType: 'INSIGHT' | 'REPORT' | 'DATA_MART_HELPER';
   contextId: string;
   contextTitle: string;
   dataMart: DataMart;

--- a/apps/backend/src/data-marts/ai-insights/data-mart-insights.types.ts
+++ b/apps/backend/src/data-marts/ai-insights/data-mart-insights.types.ts
@@ -11,7 +11,7 @@ export type DataMartAdditionalParams = {
 };
 
 export interface ConsumptionContext {
-  contextType: 'INSIGHT' | 'REPORT' | 'DATA_MART_HELPER';
+  contextType: 'INSIGHT' | 'REPORT';
   contextId: string;
   contextTitle: string;
   dataMart: DataMart;

--- a/apps/backend/src/data-marts/ai-insights/facades/ai-insights.facade.impl.ts
+++ b/apps/backend/src/data-marts/ai-insights/facades/ai-insights.facade.impl.ts
@@ -4,13 +4,22 @@ import { AiInsightsFacade } from './ai-insights.facade';
 import {
   AnswerPromptRequest,
   AnswerPromptResponse,
+  DataMartMetadataScope,
+  GenerateDataMartMetadataRequest,
+  GenerateDataMartMetadataResponse,
   GenerateInsightRequest,
   GenerateInsightResponse,
+  QueryRow,
   SharedAgentContext,
 } from '../ai-insights-types';
 import { AiInsightsOrchestratorService } from '../ai-insight-orchestrator.service';
-import { DataMartPromptMetaEntry, PromptAnswer } from '../data-mart-insights.types';
+import {
+  ConsumptionContext,
+  DataMartPromptMetaEntry,
+  PromptAnswer,
+} from '../data-mart-insights.types';
 import { GenerateInsightAgent } from '../agent/generate-insight.agent';
+import { GenerateDataMartMetadataAgent } from '../agent/generate-data-mart-metadata.agent';
 import { AI_CHAT_PROVIDER } from '../../../common/ai-insights/services/ai-chat-provider.token';
 import { AiChatProvider } from '../../../common/ai-insights/agent/ai-core';
 import { ToolRegistry } from '../../../common/ai-insights/agent/tool-registry';
@@ -20,6 +29,15 @@ import {
   measureExecutionTime,
   toMeasuredExecutionBaseResult,
 } from '../../../common/utils/measure-execution-time';
+import { DataMartService } from '../../services/data-mart.service';
+import { DataMartSqlTableService } from '../../services/data-mart-sql-table.service';
+import { DataMartDefinitionValidatorFacade } from '../../data-storage-types/facades/data-mart-definition-validator-facade.service';
+import { ConsumptionTrackingService } from '../../services/consumption-tracking.service';
+import { DataMartDefinitionType } from '../../enums/data-mart-definition-type.enum';
+import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
+import { getPromptTotalUsage } from '../utils/compute-model-usage';
+
+const METADATA_SAMPLE_ROW_LIMIT = 30;
 
 @Injectable()
 export class AiInsightsFacadeImpl implements AiInsightsFacade {
@@ -28,6 +46,11 @@ export class AiInsightsFacadeImpl implements AiInsightsFacade {
   constructor(
     private readonly aiInsightsAgentService: AiInsightsOrchestratorService,
     private readonly generateInsightAgent: GenerateInsightAgent,
+    private readonly generateDataMartMetadataAgent: GenerateDataMartMetadataAgent,
+    private readonly dataMartService: DataMartService,
+    private readonly dataMartSqlTableService: DataMartSqlTableService,
+    private readonly definitionValidatorFacade: DataMartDefinitionValidatorFacade,
+    private readonly consumptionTracker: ConsumptionTrackingService,
     @Inject(AI_CHAT_PROVIDER)
     private readonly aiProvider: AiChatProvider,
     private readonly toolRegistry: ToolRegistry
@@ -133,6 +156,152 @@ export class AiInsightsFacadeImpl implements AiInsightsFacade {
     } catch (e: unknown) {
       this.logger.error(`Error generating insight for data mart ${request.dataMartId}`, e);
       throw e;
+    }
+  }
+
+  async generateDataMartMetadata(
+    request: GenerateDataMartMetadataRequest
+  ): Promise<GenerateDataMartMetadataResponse> {
+    this.logger.log(
+      `Generating data mart metadata for ${request.dataMartId} (scope=${request.scope}, useSample=${request.useSample})`
+    );
+
+    const dataMart = await this.dataMartService.getByIdAndProjectId(
+      request.dataMartId,
+      request.projectId
+    );
+
+    if (dataMart.definitionType === DataMartDefinitionType.CONNECTOR) {
+      throw new BusinessViolationException(
+        'AI metadata generation is not supported for connector-based data marts'
+      );
+    }
+
+    await this.definitionValidatorFacade.checkIsValid(dataMart);
+
+    const schema = dataMart.schema;
+    if (!schema) {
+      throw new BusinessViolationException(
+        'Data mart has no output schema yet. Actualize the schema before requesting AI metadata.'
+      );
+    }
+
+    if (this.requiresFieldName(request.scope) && !request.fieldName?.trim()) {
+      throw new BusinessViolationException(`fieldName is required for scope "${request.scope}"`);
+    }
+
+    let sampleColumns: string[] | null = null;
+    let sampleRows: QueryRow[] | null = null;
+    if (request.useSample) {
+      const sample = await this.dataMartSqlTableService.executeSqlToTable(dataMart, undefined, {
+        limit: METADATA_SAMPLE_ROW_LIMIT,
+      });
+      sampleColumns = sample.columns;
+      sampleRows = sample.rows.map(row => this.toQueryRow(sample.columns, row));
+    }
+
+    const sharedContext: SharedAgentContext = {
+      aiProvider: this.aiProvider,
+      toolRegistry: this.toolRegistry,
+      budgets: {},
+      telemetry: {
+        llmCalls: [],
+        toolCalls: [],
+        messageHistory: [],
+      },
+      projectId: request.projectId,
+      dataMartId: request.dataMartId,
+    };
+
+    const measured = await measureExecutionTime(
+      () =>
+        this.generateDataMartMetadataAgent.run(
+          {
+            scope: request.scope,
+            dataMartTitle: dataMart.title ?? null,
+            dataMartDescription: dataMart.description ?? null,
+            schema,
+            sampleColumns,
+            sampleRows,
+            fieldName: request.fieldName,
+          },
+          sharedContext
+        ),
+      {
+        onMeasured: measuredExecution => {
+          this.logger.log('AiGenerateDataMartMetadataTime', {
+            projectId: request.projectId,
+            dataMartId: request.dataMartId,
+            scope: request.scope,
+            measure: toMeasuredExecutionBaseResult(measuredExecution),
+          });
+        },
+      }
+    );
+
+    const aiResult = measured.result;
+
+    const consumptionContext: ConsumptionContext = {
+      contextType: 'DATA_MART_HELPER',
+      contextId: dataMart.id,
+      contextTitle: dataMart.title,
+      dataMart,
+    };
+    try {
+      const totalTokens = getPromptTotalUsage(sharedContext.telemetry.llmCalls).totalTokens;
+      void this.consumptionTracker.registerAiProcessRunConsumption(totalTokens, consumptionContext);
+    } catch (error) {
+      this.logger.error('Failed to register AI metadata helper consumption', error);
+    }
+
+    return this.shapeResponseToScope(aiResult, request);
+  }
+
+  private requiresFieldName(scope: DataMartMetadataScope): boolean {
+    return (
+      scope === DataMartMetadataScope.FIELD_ALIAS ||
+      scope === DataMartMetadataScope.FIELD_DESCRIPTION
+    );
+  }
+
+  private toQueryRow(columns: string[], row: unknown[]): QueryRow {
+    const result: QueryRow = {};
+    for (let i = 0; i < columns.length; i++) {
+      result[columns[i]] = row[i];
+    }
+    return result;
+  }
+
+  private shapeResponseToScope(
+    aiResult: GenerateDataMartMetadataResponse,
+    request: GenerateDataMartMetadataRequest
+  ): GenerateDataMartMetadataResponse {
+    const { scope, fieldName } = request;
+
+    switch (scope) {
+      case DataMartMetadataScope.TITLE:
+        return { title: aiResult.title };
+      case DataMartMetadataScope.DESCRIPTION:
+        return { description: aiResult.description };
+      case DataMartMetadataScope.FIELD_ALIAS: {
+        const match = aiResult.fields?.find(f => f.name === fieldName);
+        return { fields: match ? [{ name: match.name, alias: match.alias }] : [] };
+      }
+      case DataMartMetadataScope.FIELD_DESCRIPTION: {
+        const match = aiResult.fields?.find(f => f.name === fieldName);
+        return {
+          fields: match ? [{ name: match.name, description: match.description }] : [],
+        };
+      }
+      case DataMartMetadataScope.ALL_FIELD_ALIASES:
+        return {
+          fields: aiResult.fields?.map(f => ({ name: f.name, alias: f.alias })) ?? [],
+        };
+      case DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS:
+      default:
+        return {
+          fields: aiResult.fields?.map(f => ({ name: f.name, description: f.description })) ?? [],
+        };
     }
   }
 }

--- a/apps/backend/src/data-marts/ai-insights/facades/ai-insights.facade.impl.ts
+++ b/apps/backend/src/data-marts/ai-insights/facades/ai-insights.facade.impl.ts
@@ -4,22 +4,16 @@ import { AiInsightsFacade } from './ai-insights.facade';
 import {
   AnswerPromptRequest,
   AnswerPromptResponse,
-  DataMartMetadataScope,
   GenerateDataMartMetadataRequest,
   GenerateDataMartMetadataResponse,
   GenerateInsightRequest,
   GenerateInsightResponse,
-  QueryRow,
   SharedAgentContext,
 } from '../ai-insights-types';
 import { AiInsightsOrchestratorService } from '../ai-insight-orchestrator.service';
-import {
-  ConsumptionContext,
-  DataMartPromptMetaEntry,
-  PromptAnswer,
-} from '../data-mart-insights.types';
+import { DataMartPromptMetaEntry, PromptAnswer } from '../data-mart-insights.types';
 import { GenerateInsightAgent } from '../agent/generate-insight.agent';
-import { GenerateDataMartMetadataAgent } from '../agent/generate-data-mart-metadata.agent';
+import { GenerateDataMartMetadataOrchestratorService } from '../generate-data-mart-metadata.orchestrator.service';
 import { AI_CHAT_PROVIDER } from '../../../common/ai-insights/services/ai-chat-provider.token';
 import { AiChatProvider } from '../../../common/ai-insights/agent/ai-core';
 import { ToolRegistry } from '../../../common/ai-insights/agent/tool-registry';
@@ -29,15 +23,6 @@ import {
   measureExecutionTime,
   toMeasuredExecutionBaseResult,
 } from '../../../common/utils/measure-execution-time';
-import { DataMartService } from '../../services/data-mart.service';
-import { DataMartSqlTableService } from '../../services/data-mart-sql-table.service';
-import { DataMartDefinitionValidatorFacade } from '../../data-storage-types/facades/data-mart-definition-validator-facade.service';
-import { ConsumptionTrackingService } from '../../services/consumption-tracking.service';
-import { DataMartDefinitionType } from '../../enums/data-mart-definition-type.enum';
-import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
-import { getPromptTotalUsage } from '../utils/compute-model-usage';
-
-const METADATA_SAMPLE_ROW_LIMIT = 30;
 
 @Injectable()
 export class AiInsightsFacadeImpl implements AiInsightsFacade {
@@ -46,11 +31,7 @@ export class AiInsightsFacadeImpl implements AiInsightsFacade {
   constructor(
     private readonly aiInsightsAgentService: AiInsightsOrchestratorService,
     private readonly generateInsightAgent: GenerateInsightAgent,
-    private readonly generateDataMartMetadataAgent: GenerateDataMartMetadataAgent,
-    private readonly dataMartService: DataMartService,
-    private readonly dataMartSqlTableService: DataMartSqlTableService,
-    private readonly definitionValidatorFacade: DataMartDefinitionValidatorFacade,
-    private readonly consumptionTracker: ConsumptionTrackingService,
+    private readonly generateDataMartMetadataOrchestratorService: GenerateDataMartMetadataOrchestratorService,
     @Inject(AI_CHAT_PROVIDER)
     private readonly aiProvider: AiChatProvider,
     private readonly toolRegistry: ToolRegistry
@@ -162,146 +143,19 @@ export class AiInsightsFacadeImpl implements AiInsightsFacade {
   async generateDataMartMetadata(
     request: GenerateDataMartMetadataRequest
   ): Promise<GenerateDataMartMetadataResponse> {
-    this.logger.log(
-      `Generating data mart metadata for ${request.dataMartId} (scope=${request.scope}, useSample=${request.useSample})`
-    );
-
-    const dataMart = await this.dataMartService.getByIdAndProjectId(
-      request.dataMartId,
-      request.projectId
-    );
-
-    if (dataMart.definitionType === DataMartDefinitionType.CONNECTOR) {
-      throw new BusinessViolationException(
-        'AI metadata generation is not supported for connector-based data marts'
-      );
-    }
-
-    await this.definitionValidatorFacade.checkIsValid(dataMart);
-
-    const schema = dataMart.schema;
-    if (!schema) {
-      throw new BusinessViolationException(
-        'Data mart has no output schema yet. Actualize the schema before requesting AI metadata.'
-      );
-    }
-
-    if (this.requiresFieldName(request.scope) && !request.fieldName?.trim()) {
-      throw new BusinessViolationException(`fieldName is required for scope "${request.scope}"`);
-    }
-
-    let sampleColumns: string[] | null = null;
-    let sampleRows: QueryRow[] | null = null;
-    if (request.useSample) {
-      const sample = await this.dataMartSqlTableService.executeSqlToTable(dataMart, undefined, {
-        limit: METADATA_SAMPLE_ROW_LIMIT,
-      });
-      sampleColumns = sample.columns;
-      sampleRows = sample.rows.map(row => this.toQueryRow(sample.columns, row));
-    }
-
-    const sharedContext: SharedAgentContext = {
-      aiProvider: this.aiProvider,
-      toolRegistry: this.toolRegistry,
-      budgets: {},
-      telemetry: {
-        llmCalls: [],
-        toolCalls: [],
-        messageHistory: [],
-      },
-      projectId: request.projectId,
-      dataMartId: request.dataMartId,
-    };
-
     const measured = await measureExecutionTime(
-      () =>
-        this.generateDataMartMetadataAgent.run(
-          {
-            scope: request.scope,
-            dataMartTitle: dataMart.title ?? null,
-            dataMartDescription: dataMart.description ?? null,
-            schema,
-            sampleColumns,
-            sampleRows,
-            fieldName: request.fieldName,
-          },
-          sharedContext
-        ),
+      () => this.generateDataMartMetadataOrchestratorService.run(request),
       {
-        onMeasured: measuredExecution => {
+        onMeasured: m => {
           this.logger.log('AiGenerateDataMartMetadataTime', {
             projectId: request.projectId,
             dataMartId: request.dataMartId,
             scope: request.scope,
-            measure: toMeasuredExecutionBaseResult(measuredExecution),
+            measure: toMeasuredExecutionBaseResult(m),
           });
         },
       }
     );
-
-    const aiResult = measured.result;
-
-    const consumptionContext: ConsumptionContext = {
-      contextType: 'DATA_MART_HELPER',
-      contextId: dataMart.id,
-      contextTitle: dataMart.title,
-      dataMart,
-    };
-    try {
-      const totalTokens = getPromptTotalUsage(sharedContext.telemetry.llmCalls).totalTokens;
-      void this.consumptionTracker.registerAiProcessRunConsumption(totalTokens, consumptionContext);
-    } catch (error) {
-      this.logger.error('Failed to register AI metadata helper consumption', error);
-    }
-
-    return this.shapeResponseToScope(aiResult, request);
-  }
-
-  private requiresFieldName(scope: DataMartMetadataScope): boolean {
-    return (
-      scope === DataMartMetadataScope.FIELD_ALIAS ||
-      scope === DataMartMetadataScope.FIELD_DESCRIPTION
-    );
-  }
-
-  private toQueryRow(columns: string[], row: unknown[]): QueryRow {
-    const result: QueryRow = {};
-    for (let i = 0; i < columns.length; i++) {
-      result[columns[i]] = row[i];
-    }
-    return result;
-  }
-
-  private shapeResponseToScope(
-    aiResult: GenerateDataMartMetadataResponse,
-    request: GenerateDataMartMetadataRequest
-  ): GenerateDataMartMetadataResponse {
-    const { scope, fieldName } = request;
-
-    switch (scope) {
-      case DataMartMetadataScope.TITLE:
-        return { title: aiResult.title };
-      case DataMartMetadataScope.DESCRIPTION:
-        return { description: aiResult.description };
-      case DataMartMetadataScope.FIELD_ALIAS: {
-        const match = aiResult.fields?.find(f => f.name === fieldName);
-        return { fields: match ? [{ name: match.name, alias: match.alias }] : [] };
-      }
-      case DataMartMetadataScope.FIELD_DESCRIPTION: {
-        const match = aiResult.fields?.find(f => f.name === fieldName);
-        return {
-          fields: match ? [{ name: match.name, description: match.description }] : [],
-        };
-      }
-      case DataMartMetadataScope.ALL_FIELD_ALIASES:
-        return {
-          fields: aiResult.fields?.map(f => ({ name: f.name, alias: f.alias })) ?? [],
-        };
-      case DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS:
-      default:
-        return {
-          fields: aiResult.fields?.map(f => ({ name: f.name, description: f.description })) ?? [],
-        };
-    }
+    return measured.result;
   }
 }

--- a/apps/backend/src/data-marts/ai-insights/facades/ai-insights.facade.ts
+++ b/apps/backend/src/data-marts/ai-insights/facades/ai-insights.facade.ts
@@ -1,6 +1,8 @@
 import {
   AnswerPromptRequest,
   AnswerPromptResponse,
+  GenerateDataMartMetadataRequest,
+  GenerateDataMartMetadataResponse,
   GenerateInsightRequest,
   GenerateInsightResponse,
 } from '../ai-insights-types';
@@ -20,4 +22,14 @@ export interface AiInsightsFacade {
    * @param request
    */
   generateInsight(request: GenerateInsightRequest): Promise<GenerateInsightResponse>;
+
+  /**
+   * Generates business-friendly metadata suggestions for a data mart
+   * (title / description / per-field aliases / per-field descriptions).
+   * The result is a suggestion only — it is NOT persisted by this method.
+   * @param request
+   */
+  generateDataMartMetadata(
+    request: GenerateDataMartMetadataRequest
+  ): Promise<GenerateDataMartMetadataResponse>;
 }

--- a/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
+++ b/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
@@ -1,0 +1,156 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { AI_CHAT_PROVIDER } from '../../common/ai-insights/services/ai-chat-provider.token';
+import { AiChatProvider } from '../../common/ai-insights/agent/ai-core';
+import { ToolRegistry } from '../../common/ai-insights/agent/tool-registry';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { DataMartDefinitionValidatorFacade } from '../data-storage-types/facades/data-mart-definition-validator-facade.service';
+import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
+import { DataMartService } from '../services/data-mart.service';
+import { DataMartSqlTableService } from '../services/data-mart-sql-table.service';
+import { GenerateDataMartMetadataAgent } from './agent/generate-data-mart-metadata.agent';
+import {
+  DataMartMetadataScope,
+  GenerateDataMartMetadataRequest,
+  GenerateDataMartMetadataResponse,
+  QueryRow,
+  SharedAgentContext,
+} from './ai-insights-types';
+
+const METADATA_SAMPLE_ROW_LIMIT = 30;
+
+/**
+ * Orchestrates a single AI metadata generation request: validates the data mart,
+ * optionally fetches a 30-row sample, runs the agent, and shapes the response per scope.
+ *
+ * Does not emit consumption events — AI helper is a free editor convenience.
+ */
+@Injectable()
+export class GenerateDataMartMetadataOrchestratorService {
+  private readonly logger = new Logger(GenerateDataMartMetadataOrchestratorService.name);
+
+  constructor(
+    private readonly dataMartService: DataMartService,
+    private readonly dataMartSqlTableService: DataMartSqlTableService,
+    private readonly definitionValidatorFacade: DataMartDefinitionValidatorFacade,
+    private readonly generateDataMartMetadataAgent: GenerateDataMartMetadataAgent,
+    @Inject(AI_CHAT_PROVIDER)
+    private readonly aiProvider: AiChatProvider,
+    private readonly toolRegistry: ToolRegistry
+  ) {}
+
+  async run(request: GenerateDataMartMetadataRequest): Promise<GenerateDataMartMetadataResponse> {
+    this.logger.log(
+      `Generating data mart metadata for ${request.dataMartId} (scope=${request.scope}, useSample=${request.useSample})`
+    );
+
+    const dataMart = await this.dataMartService.getByIdAndProjectId(
+      request.dataMartId,
+      request.projectId
+    );
+
+    if (dataMart.definitionType === DataMartDefinitionType.CONNECTOR) {
+      throw new BusinessViolationException(
+        'AI metadata generation is not supported for connector-based data marts'
+      );
+    }
+
+    await this.definitionValidatorFacade.checkIsValid(dataMart);
+
+    const schema = dataMart.schema;
+    if (!schema) {
+      throw new BusinessViolationException(
+        'Data mart has no output schema yet. Actualize the schema before requesting AI metadata.'
+      );
+    }
+
+    if (this.requiresFieldName(request.scope) && !request.fieldName?.trim()) {
+      throw new BusinessViolationException(`fieldName is required for scope "${request.scope}"`);
+    }
+
+    let sampleColumns: string[] | null = null;
+    let sampleRows: QueryRow[] | null = null;
+    if (request.useSample) {
+      const sample = await this.dataMartSqlTableService.executeSqlToTable(dataMart, undefined, {
+        limit: METADATA_SAMPLE_ROW_LIMIT,
+      });
+      sampleColumns = sample.columns;
+      sampleRows = sample.rows.map(row => this.toQueryRow(sample.columns, row));
+    }
+
+    const sharedContext: SharedAgentContext = {
+      aiProvider: this.aiProvider,
+      toolRegistry: this.toolRegistry,
+      budgets: {},
+      telemetry: {
+        llmCalls: [],
+        toolCalls: [],
+        messageHistory: [],
+      },
+      projectId: request.projectId,
+      dataMartId: request.dataMartId,
+    };
+
+    const aiResult = await this.generateDataMartMetadataAgent.run(
+      {
+        scope: request.scope,
+        dataMartTitle: dataMart.title ?? null,
+        dataMartDescription: dataMart.description ?? null,
+        schema,
+        sampleColumns,
+        sampleRows,
+        fieldName: request.fieldName,
+      },
+      sharedContext
+    );
+
+    return this.shapeResponseToScope(aiResult, request);
+  }
+
+  private requiresFieldName(scope: DataMartMetadataScope): boolean {
+    return (
+      scope === DataMartMetadataScope.FIELD_ALIAS ||
+      scope === DataMartMetadataScope.FIELD_DESCRIPTION
+    );
+  }
+
+  private toQueryRow(columns: string[], row: unknown[]): QueryRow {
+    const result: QueryRow = {};
+    for (let i = 0; i < columns.length; i++) {
+      result[columns[i]] = row[i];
+    }
+    return result;
+  }
+
+  private shapeResponseToScope(
+    aiResult: GenerateDataMartMetadataResponse,
+    request: GenerateDataMartMetadataRequest
+  ): GenerateDataMartMetadataResponse {
+    const { scope, fieldName } = request;
+
+    switch (scope) {
+      case DataMartMetadataScope.TITLE:
+        return { title: aiResult.title };
+      case DataMartMetadataScope.DESCRIPTION:
+        return { description: aiResult.description };
+      case DataMartMetadataScope.FIELD_ALIAS: {
+        const match = aiResult.fields?.find(f => f.name === fieldName);
+        return { fields: match ? [{ name: match.name, alias: match.alias }] : [] };
+      }
+      case DataMartMetadataScope.FIELD_DESCRIPTION: {
+        const match = aiResult.fields?.find(f => f.name === fieldName);
+        return {
+          fields: match ? [{ name: match.name, description: match.description }] : [],
+        };
+      }
+      case DataMartMetadataScope.ALL_FIELD_ALIASES:
+        return {
+          fields: aiResult.fields?.map(f => ({ name: f.name, alias: f.alias })) ?? [],
+        };
+      case DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS:
+      default:
+        return {
+          fields: aiResult.fields?.map(f => ({ name: f.name, description: f.description })) ?? [],
+        };
+    }
+  }
+}

--- a/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
+++ b/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
@@ -15,6 +15,7 @@ import {
   QueryRow,
   SharedAgentContext,
 } from './ai-insights-types';
+import { AI_INSIGHTS_SCHEMA_EXPIRES_AFTER_MS } from './ai-insights.constants';
 
 const METADATA_SAMPLE_ROW_LIMIT = 30;
 
@@ -43,9 +44,10 @@ export class GenerateDataMartMetadataOrchestratorService {
       `Generating data mart metadata for ${request.dataMartId} (scope=${request.scope}, useSample=${request.useSample})`
     );
 
-    const dataMart = await this.dataMartService.getByIdAndProjectId(
+    const dataMart = await this.dataMartService.actualizeSchemaIfExpired(
       request.dataMartId,
-      request.projectId
+      request.projectId,
+      AI_INSIGHTS_SCHEMA_EXPIRES_AFTER_MS
     );
 
     if (dataMart.definitionType === DataMartDefinitionType.CONNECTOR) {

--- a/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
+++ b/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
@@ -6,7 +6,7 @@ import { BusinessViolationException } from '../../common/exceptions/business-vio
 import { DataMartDefinitionValidatorFacade } from '../data-storage-types/facades/data-mart-definition-validator-facade.service';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { DataMartService } from '../services/data-mart.service';
-import { DataMartSqlTableService } from '../services/data-mart-sql-table.service';
+import { DataMartSampleDataService } from '../services/data-mart-sample-data.service';
 import { GenerateDataMartMetadataAgent } from './agent/generate-data-mart-metadata.agent';
 import {
   DataMartMetadataScope,
@@ -30,7 +30,7 @@ export class GenerateDataMartMetadataOrchestratorService {
 
   constructor(
     private readonly dataMartService: DataMartService,
-    private readonly dataMartSqlTableService: DataMartSqlTableService,
+    private readonly dataMartSampleDataService: DataMartSampleDataService,
     private readonly definitionValidatorFacade: DataMartDefinitionValidatorFacade,
     private readonly generateDataMartMetadataAgent: GenerateDataMartMetadataAgent,
     @Inject(AI_CHAT_PROVIDER)
@@ -70,9 +70,11 @@ export class GenerateDataMartMetadataOrchestratorService {
     let sampleColumns: string[] | null = null;
     let sampleRows: QueryRow[] | null = null;
     if (request.useSample) {
-      const sample = await this.dataMartSqlTableService.executeSqlToTable(dataMart, undefined, {
-        limit: METADATA_SAMPLE_ROW_LIMIT,
-      });
+      const sample = await this.dataMartSampleDataService.sampleAllRows(
+        request.dataMartId,
+        request.projectId,
+        METADATA_SAMPLE_ROW_LIMIT
+      );
       sampleColumns = sample.columns;
       sampleRows = sample.rows.map(row => this.toQueryRow(sample.columns, row));
     }

--- a/apps/backend/src/data-marts/ai-insights/prompts/generate-data-mart-metadata.prompt.ts
+++ b/apps/backend/src/data-marts/ai-insights/prompts/generate-data-mart-metadata.prompt.ts
@@ -1,0 +1,121 @@
+import {
+  DataMartMetadataScope,
+  GenerateDataMartMetadataAgentInput,
+  GenerateDataMartMetadataAgentResponseSchema,
+} from '../agent/types';
+import { buildJsonFormatSection, buildOutputRules } from './json-format.prompt';
+import { prepareSchema } from '../utils/prepare-schema';
+
+export function buildGenerateDataMartMetadataSystemPrompt(): string {
+  return `
+You are an analytics assistant that writes business-friendly metadata for a data mart.
+
+Your role:
+- Read a data mart schema (and optionally a small sample of rows) and produce concise, accurate descriptive metadata that a non-technical business user can understand.
+- You may be asked for the data mart title, the data mart description, a business-friendly alias for a single field, a business-friendly description for a single field, or descriptions for every field at once. Each request is for exactly one of these.
+
+Guidelines for the data mart title:
+- 3-8 words. Title Case.
+- Describe the dataset's subject and grain (e.g. "Daily Campaign Performance", "User Sessions Overview").
+- Avoid generic words like "data", "table", "dataset" alone.
+
+Guidelines for the data mart description:
+- 1-3 short sentences in plain English.
+- Explain WHAT the dataset contains (entities, grain, time coverage if obvious from the data) and a typical use case.
+- Do not enumerate every column.
+
+Guidelines for field aliases:
+- Convert the technical column name into a clear human label (e.g. "camp_name" -> "Campaign Name", "imps" -> "Impressions").
+- Use Title Case. Expand common abbreviations. No underscores.
+- Keep it short (1-4 words). Do not invent meaning that is not implied by the column name and sample values.
+
+Guidelines for field descriptions:
+- One sentence, starts with a capital letter, ends with a period.
+- Explain WHAT the value represents in business terms, not its data type.
+- Use sample values (when provided) to ground the description, but do not quote specific sample values literally.
+- Examples:
+  - "campaign_id" -> "Unique identifier of the advertising campaign."
+  - "ctr" -> "Click-through rate measured as clicks divided by impressions."
+  - "event_ts" -> "Timestamp of when the event occurred, in UTC."
+
+Hard rules:
+- NEVER invent fields that are not present in the input schema.
+- The "name" of every field in your output MUST exactly match a field name from the input schema (case-sensitive).
+- If the input already has a value for a field's alias or description and you have nothing meaningfully better, you MAY repeat it as-is.
+- If sample rows are not provided, base your output on column names and types only; in that case prefer cautious, generic wording.
+
+${buildJsonFormatSection(GenerateDataMartMetadataAgentResponseSchema)}
+`.trim();
+}
+
+export function buildGenerateDataMartMetadataUserPrompt(
+  input: GenerateDataMartMetadataAgentInput
+): string {
+  const {
+    scope,
+    dataMartTitle,
+    dataMartDescription,
+    schema,
+    sampleColumns,
+    sampleRows,
+    fieldName,
+  } = input;
+
+  const sampleSection =
+    sampleRows && sampleRows.length > 0
+      ? `Sample rows (up to 30):\n${JSON.stringify({ columns: sampleColumns ?? [], rows: sampleRows }, null, 2)}`
+      : 'Sample rows: (not provided — base your output on the schema only)';
+
+  return `
+Current data mart metadata:
+- Title: ${dataMartTitle?.trim() || '(not provided)'}
+- Description: ${dataMartDescription?.trim() || '(not provided)'}
+
+Data mart schema:
+${JSON.stringify(prepareSchema(schema), null, 2)}
+
+${sampleSection}
+
+Requested scope: ${scope}
+${fieldName ? `Target field: ${fieldName}` : ''}
+
+What to return in the JSON response:
+${describeScopeRequirements(scope, fieldName)}
+
+${buildOutputRules()}
+`.trim();
+}
+
+function describeScopeRequirements(scope: DataMartMetadataScope, fieldName?: string): string {
+  switch (scope) {
+    case DataMartMetadataScope.TITLE:
+      return '- "title": REQUIRED.\n- "description": OMIT.\n- "fields": OMIT.';
+    case DataMartMetadataScope.DESCRIPTION:
+      return '- "title": OMIT.\n- "description": REQUIRED.\n- "fields": OMIT.';
+    case DataMartMetadataScope.FIELD_ALIAS:
+      return [
+        '- "title": OMIT.',
+        '- "description": OMIT.',
+        `- "fields": REQUIRED. Include EXACTLY ONE entry where "name" == "${fieldName ?? ''}". Populate "alias". OMIT "description".`,
+      ].join('\n');
+    case DataMartMetadataScope.FIELD_DESCRIPTION:
+      return [
+        '- "title": OMIT.',
+        '- "description": OMIT.',
+        `- "fields": REQUIRED. Include EXACTLY ONE entry where "name" == "${fieldName ?? ''}". Populate "description". OMIT "alias".`,
+      ].join('\n');
+    case DataMartMetadataScope.ALL_FIELD_ALIASES:
+      return [
+        '- "title": OMIT.',
+        '- "description": OMIT.',
+        '- "fields": REQUIRED. Include EVERY field from the input schema. Populate "alias" for each. OMIT "description" — descriptions are not generated by this scope.',
+      ].join('\n');
+    case DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS:
+    default:
+      return [
+        '- "title": OMIT.',
+        '- "description": OMIT.',
+        '- "fields": REQUIRED. Include EVERY field from the input schema. Populate "description" for each. OMIT "alias" — aliases are not generated by this scope.',
+      ].join('\n');
+  }
+}

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.ts
@@ -53,6 +53,11 @@ import { UpdateDataMartAvailabilityApiDto } from '../dto/presentation/update-ava
 import { MemberOwnershipWarningsService } from '../services/member-ownership-warnings.service';
 import { UpdateDataMartTitleService } from '../use-cases/update-data-mart-title.service';
 import { ValidateDataMartDefinitionService } from '../use-cases/validate-data-mart-definition.service';
+import { GenerateDataMartMetadataService } from '../use-cases/generate-data-mart-metadata.service';
+import { GenerateDataMartMetadataRequestApiDto } from '../dto/presentation/generate-data-mart-metadata-request-api.dto';
+import { GenerateDataMartMetadataResponseApiDto } from '../dto/presentation/generate-data-mart-metadata-response-api.dto';
+import { DataMartAiHelperAvailabilityResponseApiDto } from '../dto/presentation/data-mart-ai-helper-availability-response-api.dto';
+import { AiInsightsConfigService } from '../../common/ai-insights/services/ai-insights-config.service';
 import { ContextAccessService } from '../services/context/context-access.service';
 import { UpdateEntityContextsRequestApiDto } from '../dto/presentation/context-api.dto';
 import {
@@ -78,6 +83,8 @@ import {
   UpdateDataMartOwnersSpec,
   UpdateDataMartTitleSpec,
   ValidateDataMartDefinitionSpec,
+  GenerateDataMartMetadataSpec,
+  DataMartAiHelperAvailabilitySpec,
 } from './spec/data-mart.api';
 
 @Controller('data-marts')
@@ -106,7 +113,9 @@ export class DataMartController {
     private readonly memberOwnershipWarningsService: MemberOwnershipWarningsService,
     private readonly getBlendableSchemaService: GetBlendableSchemaService,
     private readonly updateBlendedFieldsConfigService: UpdateBlendedFieldsConfigService,
-    private readonly contextAccessService: ContextAccessService
+    private readonly contextAccessService: ContextAccessService,
+    private readonly generateDataMartMetadataService: GenerateDataMartMetadataService,
+    private readonly aiInsightsConfig: AiInsightsConfigService
   ) {}
 
   @Auth(Role.editor(Strategy.INTROSPECT))
@@ -152,6 +161,13 @@ export class DataMartController {
   @GetMemberOwnershipWarningsSpec()
   async getMemberOwnershipWarnings(@AuthContext() context: AuthorizationContext) {
     return this.memberOwnershipWarningsService.getWarnings(context.projectId);
+  }
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get('ai-helper/availability')
+  @DataMartAiHelperAvailabilitySpec()
+  getAiHelperAvailability(): DataMartAiHelperAvailabilityResponseApiDto {
+    return { enabled: this.aiInsightsConfig.isInsightsEnabled() };
   }
 
   @Auth(Role.viewer(Strategy.PARSE))
@@ -307,6 +323,19 @@ export class DataMartController {
     const command = this.mapper.toUpdateSchemaCommand(id, context, dto);
     const dataMart = await this.updateSchemaService.run(command);
     return this.mapper.toResponse(dataMart);
+  }
+
+  @Auth(Role.editor(Strategy.INTROSPECT))
+  @Post(':id/ai-helper/generate-metadata')
+  @GenerateDataMartMetadataSpec()
+  async generateMetadata(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string,
+    @Body() dto: GenerateDataMartMetadataRequestApiDto
+  ): Promise<GenerateDataMartMetadataResponseApiDto> {
+    const command = this.mapper.toGenerateMetadataCommand(id, context, dto);
+    const result = await this.generateDataMartMetadataService.run(command);
+    return this.mapper.toGenerateMetadataResponse(result);
   }
 
   @Auth(Role.editor(Strategy.INTROSPECT))

--- a/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
@@ -19,6 +19,9 @@ import { BlendableSchemaDto } from '../../dto/domain/blendable-schema.dto';
 import { UpdateBlendedFieldsConfigApiDto } from '../../dto/presentation/update-blended-fields-config-api.dto';
 import { UpdateDataMartDefinitionApiDto } from '../../dto/presentation/update-data-mart-definition-api.dto';
 import { UpdateDataMartSchemaApiDto } from '../../dto/presentation/update-data-mart-schema-api.dto';
+import { GenerateDataMartMetadataRequestApiDto } from '../../dto/presentation/generate-data-mart-metadata-request-api.dto';
+import { GenerateDataMartMetadataResponseApiDto } from '../../dto/presentation/generate-data-mart-metadata-response-api.dto';
+import { DataMartAiHelperAvailabilityResponseApiDto } from '../../dto/presentation/data-mart-ai-helper-availability-response-api.dto';
 import { DataMartValidationResponseApiDto } from '../../dto/presentation/data-mart-validation-response-api.dto';
 import { DataMartRunsResponseApiDto } from '../../dto/presentation/data-mart-runs-response-api.dto';
 import { DataMartRunResponseApiDto } from '../../dto/presentation/data-mart-run-response-api.dto';
@@ -286,5 +289,30 @@ export function GetBlendableSchemaSpec() {
     }),
     ApiParam({ name: 'id', description: 'DataMart ID' }),
     ApiOkResponse({ type: BlendableSchemaDto })
+  );
+}
+
+export function GenerateDataMartMetadataSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Generate AI-powered metadata suggestions for a DataMart',
+      description:
+        'Returns AI-generated suggestions for DataMart title, description, a single field alias, a single field description, or descriptions for every field at once. The result is a suggestion only — it is NOT persisted. Apply via PUT /:id/title, /:id/description, /:id/schema after user confirmation. Returns 503 when AI is not configured on this deployment.',
+    }),
+    ApiParam({ name: 'id', description: 'DataMart ID' }),
+    ApiBody({ type: GenerateDataMartMetadataRequestApiDto }),
+    ApiOkResponse({ type: GenerateDataMartMetadataResponseApiDto }),
+    ApiResponse({ status: 503, description: 'AI helper is not configured on this deployment' })
+  );
+}
+
+export function DataMartAiHelperAvailabilitySpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Check whether the AI helper is configured on this deployment',
+      description:
+        'Returns { enabled: true } when AI keys are present and metadata generation is available; { enabled: false } otherwise. Frontend uses this to decide whether to render AI-helper buttons.',
+    }),
+    ApiOkResponse({ type: DataMartAiHelperAvailabilityResponseApiDto })
   );
 }

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -121,6 +121,7 @@ import { CancelDataMartRunService } from './use-cases/cancel-data-mart-run.servi
 import { ValidateDataMartDefinitionService } from './use-cases/validate-data-mart-definition.service';
 import { ActualizeDataMartSchemaService } from './use-cases/actualize-data-mart-schema.service';
 import { UpdateDataMartSchemaService } from './use-cases/update-data-mart-schema.service';
+import { GenerateDataMartMetadataService } from './use-cases/generate-data-mart-metadata.service';
 import { SqlDryRunService } from './use-cases/sql-dry-run.service';
 import { DataMartSchemaParserFacade } from './data-storage-types/facades/data-mart-schema-parser-facade.service';
 import { DataMartScheduledTrigger } from './entities/data-mart-scheduled-trigger.entity';
@@ -554,6 +555,7 @@ import { SetContextMembersService } from './use-cases/contexts/set-context-membe
     CreateViewService,
     ActualizeDataMartSchemaService,
     UpdateDataMartSchemaService,
+    GenerateDataMartMetadataService,
     ScheduledTriggersHandlerService,
     SqlDryRunTriggerService,
     SqlDryRunTriggerHandlerService,

--- a/apps/backend/src/data-marts/dto/domain/generate-data-mart-metadata.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/generate-data-mart-metadata.command.ts
@@ -1,0 +1,13 @@
+import { DataMartMetadataScope } from '../../ai-insights/ai-insights-types';
+
+export class GenerateDataMartMetadataCommand {
+  constructor(
+    public readonly id: string,
+    public readonly projectId: string,
+    public readonly scope: DataMartMetadataScope,
+    public readonly useSample: boolean,
+    public readonly fieldName: string | undefined,
+    public readonly userId: string = '',
+    public readonly roles: string[] = []
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/presentation/data-mart-ai-helper-availability-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-mart-ai-helper-availability-response-api.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DataMartAiHelperAvailabilityResponseApiDto {
+  @ApiProperty({
+    description:
+      'Whether AI-powered metadata generation is configured on this deployment. ' +
+      'When false, frontend SHOULD hide the AI-helper buttons.',
+  })
+  enabled: boolean;
+}

--- a/apps/backend/src/data-marts/dto/presentation/generate-data-mart-metadata-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/generate-data-mart-metadata-request-api.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsEnum, IsNotEmpty, IsOptional, IsString, ValidateIf } from 'class-validator';
+import { DataMartMetadataScope } from '../../ai-insights/ai-insights-types';
+
+export class GenerateDataMartMetadataRequestApiDto {
+  @ApiProperty({
+    enum: DataMartMetadataScope,
+    description:
+      'What metadata to generate. Use "all" to populate every field; use "field_alias" or ' +
+      '"field_description" together with `fieldName` to generate a single field value.',
+  })
+  @IsEnum(DataMartMetadataScope)
+  scope: DataMartMetadataScope;
+
+  @ApiProperty({
+    type: Boolean,
+    description:
+      'When true, the data mart is run to fetch up to 30 sample rows that ground the AI in real values. ' +
+      'When false, generation uses only column names and types (lower quality).',
+    default: true,
+  })
+  @IsBoolean()
+  useSample: boolean;
+
+  @ApiPropertyOptional({
+    type: String,
+    description:
+      'Required when scope is "field_alias" or "field_description". Must match an existing field name in the data mart schema.',
+  })
+  @ValidateIf(
+    (o: GenerateDataMartMetadataRequestApiDto) =>
+      o.scope === DataMartMetadataScope.FIELD_ALIAS ||
+      o.scope === DataMartMetadataScope.FIELD_DESCRIPTION
+  )
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  fieldName?: string;
+}

--- a/apps/backend/src/data-marts/dto/presentation/generate-data-mart-metadata-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/generate-data-mart-metadata-response-api.dto.ts
@@ -1,0 +1,26 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class GeneratedFieldMetadataApiDto {
+  @ApiPropertyOptional({ description: 'Exact field name as in the data mart schema' })
+  name: string;
+
+  @ApiPropertyOptional({ description: 'Business-friendly display name' })
+  alias?: string;
+
+  @ApiPropertyOptional({ description: 'Business-friendly description, one sentence' })
+  description?: string;
+}
+
+export class GenerateDataMartMetadataResponseApiDto {
+  @ApiPropertyOptional({ description: 'Suggested data mart title' })
+  title?: string;
+
+  @ApiPropertyOptional({ description: 'Suggested data mart description' })
+  description?: string;
+
+  @ApiPropertyOptional({
+    type: () => [GeneratedFieldMetadataApiDto],
+    description: 'Per-field suggestions',
+  })
+  fields?: GeneratedFieldMetadataApiDto[];
+}

--- a/apps/backend/src/data-marts/events/data-mart-ai-helper-generated.event.ts
+++ b/apps/backend/src/data-marts/events/data-mart-ai-helper-generated.event.ts
@@ -1,0 +1,26 @@
+import { BaseEvent } from '@owox/internal-helpers';
+import { DataMartMetadataScope } from '../ai-insights/ai-insights-types';
+
+export interface DataMartAiHelperGeneratedEventPayload {
+  projectId: string;
+  dataMartId: string;
+  userId: string;
+  scope: DataMartMetadataScope;
+}
+
+/**
+ * Emitted once per successful AI metadata generation for a Data Mart.
+ * The event `name` varies by scope (e.g. `data-mart.ai-assistant.title.generated`).
+ */
+export class DataMartAiHelperGeneratedEvent extends BaseEvent<DataMartAiHelperGeneratedEventPayload> {
+  private readonly eventName: string;
+
+  constructor(payload: DataMartAiHelperGeneratedEventPayload) {
+    super(payload);
+    this.eventName = `data-mart.ai-assistant.${payload.scope}.generated`;
+  }
+
+  get name(): string {
+    return this.eventName;
+  }
+}

--- a/apps/backend/src/data-marts/events/data-mart-ai-helper-generated.event.ts
+++ b/apps/backend/src/data-marts/events/data-mart-ai-helper-generated.event.ts
@@ -13,14 +13,11 @@ export interface DataMartAiHelperGeneratedEventPayload {
  * The event `name` varies by scope (e.g. `data-mart.ai-assistant.title.generated`).
  */
 export class DataMartAiHelperGeneratedEvent extends BaseEvent<DataMartAiHelperGeneratedEventPayload> {
-  private readonly eventName: string;
-
   constructor(payload: DataMartAiHelperGeneratedEventPayload) {
     super(payload);
-    this.eventName = `data-mart.ai-assistant.${payload.scope}.generated`;
   }
 
   get name(): string {
-    return this.eventName;
+    return `data-mart.ai-assistant.${this.payload.scope}.generated`;
   }
 }

--- a/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
@@ -51,6 +51,13 @@ import { UpdateBlendedFieldsConfigApiDto } from '../dto/presentation/update-blen
 import { UpdateDataMartDescriptionApiDto } from '../dto/presentation/update-data-mart-description-api.dto';
 import { UpdateDataMartSchemaApiDto } from '../dto/presentation/update-data-mart-schema-api.dto';
 import { UpdateDataMartTitleApiDto } from '../dto/presentation/update-data-mart-title-api.dto';
+import { GenerateDataMartMetadataCommand } from '../dto/domain/generate-data-mart-metadata.command';
+import { GenerateDataMartMetadataRequestApiDto } from '../dto/presentation/generate-data-mart-metadata-request-api.dto';
+import {
+  GenerateDataMartMetadataResponseApiDto,
+  GeneratedFieldMetadataApiDto,
+} from '../dto/presentation/generate-data-mart-metadata-response-api.dto';
+import { GenerateDataMartMetadataResponse } from '../ai-insights/ai-insights-types';
 import { ConnectorDefinition } from '../dto/schemas/data-mart-table-definitions/connector-definition.schema';
 import { DataMartDefinition } from '../dto/schemas/data-mart-table-definitions/data-mart-definition';
 import { isConnectorDefinition } from '../dto/schemas/data-mart-table-definitions/data-mart-definition.guards';
@@ -358,6 +365,38 @@ export class DataMartMapper {
       context.userId,
       context.roles ?? []
     );
+  }
+
+  toGenerateMetadataCommand(
+    id: string,
+    context: AuthorizationContext,
+    dto: GenerateDataMartMetadataRequestApiDto
+  ): GenerateDataMartMetadataCommand {
+    return new GenerateDataMartMetadataCommand(
+      id,
+      context.projectId,
+      dto.scope,
+      dto.useSample,
+      dto.fieldName?.trim() ? dto.fieldName.trim() : undefined,
+      context.userId,
+      context.roles ?? []
+    );
+  }
+
+  toGenerateMetadataResponse(
+    domain: GenerateDataMartMetadataResponse
+  ): GenerateDataMartMetadataResponseApiDto {
+    const response = new GenerateDataMartMetadataResponseApiDto();
+    response.title = domain.title;
+    response.description = domain.description;
+    response.fields = domain.fields?.map(field => {
+      const item = new GeneratedFieldMetadataApiDto();
+      item.name = field.name;
+      item.alias = field.alias;
+      item.description = field.description;
+      return item;
+    });
+    return response;
   }
 
   toGetBlendableSchemaCommand(

--- a/apps/backend/src/data-marts/services/data-mart-sample-data.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-sample-data.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { DataMartService } from './data-mart.service';
 import { DataMartSqlTableService } from './data-mart-sql-table.service';
 import { DataMartTableReferenceService } from './data-mart-table-reference.service';
@@ -38,5 +39,27 @@ export class DataMartSampleDataService {
       columns: result.columns,
       rows: result.rows,
     };
+  }
+
+  async sampleAllRows(
+    dataMartId: string,
+    projectId: string,
+    limit = 30,
+    fullyQualifiedTableName?: string
+  ): Promise<SampleTableDataResult> {
+    const dataMart = await this.dataMartService.getByIdAndProjectId(dataMartId, projectId);
+    if (dataMart.storage.type === DataStorageType.AWS_REDSHIFT) {
+      const fqn =
+        fullyQualifiedTableName ??
+        (await this.dataMartTableReferenceService.resolveTableName(dataMartId, projectId));
+      const sql = `SELECT * FROM ${fqn} LIMIT ${limit}`;
+      const result = await this.dataMartSqlTableService.executeSqlToTable(dataMart, sql, { limit });
+      return { columns: result.columns, rows: result.rows };
+    }
+
+    const result = await this.dataMartSqlTableService.executeSqlToTable(dataMart, undefined, {
+      limit,
+    });
+    return { columns: result.columns, rows: result.rows };
   }
 }

--- a/apps/backend/src/data-marts/use-cases/generate-data-mart-metadata.service.ts
+++ b/apps/backend/src/data-marts/use-cases/generate-data-mart-metadata.service.ts
@@ -1,0 +1,63 @@
+import {
+  ForbiddenException,
+  Inject,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { AI_INSIGHTS_FACADE } from '../ai-insights/ai-insights-types';
+import { AiInsightsFacade } from '../ai-insights/facades/ai-insights.facade';
+import { GenerateDataMartMetadataResponse } from '../ai-insights/ai-insights-types';
+import { GenerateDataMartMetadataCommand } from '../dto/domain/generate-data-mart-metadata.command';
+import { DataMartService } from '../services/data-mart.service';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+import { AiInsightsConfigService } from '../../common/ai-insights/services/ai-insights-config.service';
+
+@Injectable()
+export class GenerateDataMartMetadataService {
+  private readonly logger = new Logger(GenerateDataMartMetadataService.name);
+
+  constructor(
+    private readonly dataMartService: DataMartService,
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly aiInsightsConfig: AiInsightsConfigService,
+    @Inject(AI_INSIGHTS_FACADE)
+    private readonly aiInsightsFacade: AiInsightsFacade
+  ) {}
+
+  async run(command: GenerateDataMartMetadataCommand): Promise<GenerateDataMartMetadataResponse> {
+    if (!this.aiInsightsConfig.isInsightsEnabled()) {
+      throw new ServiceUnavailableException(
+        'AI helper is not configured on this deployment. Add AI_BASE_URL, AI_API_KEY and AI_MODEL environment variables to enable it.'
+      );
+    }
+
+    await this.dataMartService.getByIdAndProjectId(command.id, command.projectId);
+
+    if (command.userId) {
+      const canEdit = await this.accessDecisionService.canAccess(
+        command.userId,
+        command.roles,
+        EntityType.DATA_MART,
+        command.id,
+        Action.EDIT,
+        command.projectId
+      );
+      if (!canEdit) {
+        throw new ForbiddenException('You do not have permission to edit this DataMart');
+      }
+    }
+
+    this.logger.debug(
+      `Generating metadata for data mart ${command.id} (scope=${command.scope}, useSample=${command.useSample})`
+    );
+
+    return this.aiInsightsFacade.generateDataMartMetadata({
+      projectId: command.projectId,
+      dataMartId: command.id,
+      scope: command.scope,
+      useSample: command.useSample,
+      fieldName: command.fieldName,
+    });
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/generate-data-mart-metadata.service.ts
+++ b/apps/backend/src/data-marts/use-cases/generate-data-mart-metadata.service.ts
@@ -12,6 +12,8 @@ import { GenerateDataMartMetadataCommand } from '../dto/domain/generate-data-mar
 import { DataMartService } from '../services/data-mart.service';
 import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
 import { AiInsightsConfigService } from '../../common/ai-insights/services/ai-insights-config.service';
+import { OwoxEventDispatcher } from '../../common/event-dispatcher/owox-event-dispatcher';
+import { DataMartAiHelperGeneratedEvent } from '../events/data-mart-ai-helper-generated.event';
 
 @Injectable()
 export class GenerateDataMartMetadataService {
@@ -21,6 +23,7 @@ export class GenerateDataMartMetadataService {
     private readonly dataMartService: DataMartService,
     private readonly accessDecisionService: AccessDecisionService,
     private readonly aiInsightsConfig: AiInsightsConfigService,
+    private readonly eventDispatcher: OwoxEventDispatcher,
     @Inject(AI_INSIGHTS_FACADE)
     private readonly aiInsightsFacade: AiInsightsFacade
   ) {}
@@ -52,12 +55,31 @@ export class GenerateDataMartMetadataService {
       `Generating metadata for data mart ${command.id} (scope=${command.scope}, useSample=${command.useSample})`
     );
 
-    return this.aiInsightsFacade.generateDataMartMetadata({
+    const result = await this.aiInsightsFacade.generateDataMartMetadata({
       projectId: command.projectId,
       dataMartId: command.id,
       scope: command.scope,
       useSample: command.useSample,
       fieldName: command.fieldName,
     });
+
+    // Fire-and-forget analytics — transport failures must not break the user response.
+    try {
+      await this.eventDispatcher.publishExternal(
+        new DataMartAiHelperGeneratedEvent({
+          projectId: command.projectId,
+          dataMartId: command.id,
+          userId: command.userId,
+          scope: command.scope,
+        })
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to publish DataMartAiHelperGeneratedEvent (scope=${command.scope})`,
+        error
+      );
+    }
+
+    return result;
   }
 }

--- a/apps/web/src/features/data-marts/edit/components/AiHelperButton/AiHelperButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/AiHelperButton/AiHelperButton.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@owox/ui/components/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { cn } from '@owox/ui/lib/utils';
+import { Loader2, Sparkles } from 'lucide-react';
+
+interface AiHelperButtonProps {
+  /** Triggered when the button is clicked. Component handles loading state for the caller. */
+  onClick: () => void;
+  /** Whether a generation is currently in-flight. */
+  isLoading?: boolean;
+  /** Whether the button is disabled for reasons other than loading (e.g. nothing to operate on). */
+  disabled?: boolean;
+  /** Tooltip shown on hover. */
+  tooltip: string;
+  /** Optional aria-label override. Falls back to `tooltip`. */
+  ariaLabel?: string;
+  /** Optional extra classes. */
+  className?: string;
+}
+
+/**
+ * Compact icon button for triggering AI metadata generation.
+ * Shows a spinner while generating, otherwise a Sparkles icon.
+ */
+export function AiHelperButton({
+  onClick,
+  isLoading = false,
+  disabled = false,
+  tooltip,
+  ariaLabel,
+  className,
+}: AiHelperButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type='button'
+          variant='ghost'
+          size='icon'
+          onClick={onClick}
+          disabled={disabled || isLoading}
+          aria-label={ariaLabel ?? tooltip}
+          className={cn('h-8 w-8 shrink-0', className)}
+        >
+          {isLoading ? (
+            <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
+          ) : (
+            <Sparkles className='h-4 w-4' aria-hidden='true' />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side='bottom'>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/AiHelperButton/index.ts
+++ b/apps/web/src/features/data-marts/edit/components/AiHelperButton/index.ts
@@ -1,0 +1,1 @@
+export { AiHelperButton } from './AiHelperButton';

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -33,6 +33,9 @@ import {
 import { useSchemaActualizeTrigger } from '../../shared/hooks/useSchemaActualizeTrigger';
 import { PromoStep, useDataMartNextStepPromo } from '../hooks/useDataMartNextStepPromo';
 import { useDataMart } from '../model';
+import { useAiHelper, useAiHelperAvailability } from '../model/hooks';
+import { DataMartMetadataScope } from '../../shared';
+import { AiHelperButton } from './AiHelperButton';
 import NotFound from '../../../../pages/NotFound.tsx';
 import NoAccess from '../../../../pages/NoAccess.tsx';
 
@@ -150,6 +153,21 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
     },
     [dataMartId, updateDataMartTitle]
   );
+
+  const { enabled: isAiHelperEnabled } = useAiHelperAvailability();
+  const { generateTitle, pendingScope: aiPendingScope } = useAiHelper();
+
+  const handleGenerateTitle = useCallback(() => {
+    if (!dataMartId) return;
+    void (async () => {
+      const suggested = await generateTitle(dataMartId);
+      if (suggested && suggested !== dataMartTitle) {
+        await updateDataMartTitle(dataMartId, suggested);
+      }
+    })();
+  }, [dataMartId, dataMartTitle, generateTitle, updateDataMartTitle]);
+
+  const isGeneratingTitle = aiPendingScope?.scope === DataMartMetadataScope.TITLE;
 
   const handlePublish = useCallback(async () => {
     if (!dataMartId) return;
@@ -309,6 +327,16 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
               title={dataMartTitle}
               onUpdate={handleTitleUpdate}
               className='text-2xl font-medium'
+              aiButton={
+                isAiHelperEnabled ? (
+                  <AiHelperButton
+                    onClick={handleGenerateTitle}
+                    isLoading={isGeneratingTitle}
+                    disabled={!dataMartId || aiPendingScope !== null}
+                    tooltip='Generate title with AI'
+                  />
+                ) : undefined
+              }
             />
           </div>
         </div>

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -156,18 +156,8 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
 
   const { enabled: isAiHelperEnabled } = useAiHelperAvailability();
   const { generateTitle, pendingScope: aiPendingScope } = useAiHelper();
-
-  const handleGenerateTitle = useCallback(() => {
-    if (!dataMartId) return;
-    void (async () => {
-      const suggested = await generateTitle(dataMartId);
-      if (suggested && suggested !== dataMartTitle) {
-        await updateDataMartTitle(dataMartId, suggested);
-      }
-    })();
-  }, [dataMartId, dataMartTitle, generateTitle, updateDataMartTitle]);
-
   const isGeneratingTitle = aiPendingScope?.scope === DataMartMetadataScope.TITLE;
+  const showAiTitleHelper = isAiHelperEnabled && !isConnector;
 
   const handlePublish = useCallback(async () => {
     if (!dataMartId) return;
@@ -328,14 +318,21 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
               onUpdate={handleTitleUpdate}
               className='text-2xl font-medium'
               aiButton={
-                isAiHelperEnabled ? (
-                  <AiHelperButton
-                    onClick={handleGenerateTitle}
-                    isLoading={isGeneratingTitle}
-                    disabled={!dataMartId || aiPendingScope !== null}
-                    tooltip='Generate title with AI'
-                  />
-                ) : undefined
+                showAiTitleHelper
+                  ? ({ setValue }) => (
+                      <AiHelperButton
+                        onClick={() => {
+                          void (async () => {
+                            const suggested = await generateTitle(dataMartId);
+                            if (suggested) setValue(suggested);
+                          })();
+                        }}
+                        isLoading={isGeneratingTitle}
+                        disabled={!dataMartId || aiPendingScope !== null}
+                        tooltip='Generate title with AI'
+                      />
+                    )
+                  : undefined
               }
             />
           </div>

--- a/apps/web/src/features/data-marts/edit/components/DataMartOverview.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartOverview.tsx
@@ -1,5 +1,9 @@
-import { InlineEditDescription } from '../../../../shared/components/InlineEditDescription';
+import { useCallback } from 'react';
 import { useOutletContext } from 'react-router-dom';
+import { InlineEditDescription } from '../../../../shared/components/InlineEditDescription';
+import { DataMartMetadataScope } from '../../shared';
+import { useAiHelper, useAiHelperAvailability } from '../model/hooks';
+import { AiHelperButton } from './AiHelperButton';
 
 interface DataMartContextType {
   dataMart: {
@@ -15,12 +19,37 @@ export function DataMartOverview() {
     await updateDataMartDescription(dataMart.id, newDescription);
   };
 
+  const { enabled: isAiHelperEnabled } = useAiHelperAvailability();
+  const { generateDescription, pendingScope } = useAiHelper();
+
+  const handleGenerateDescription = useCallback(() => {
+    if (!dataMart.id) return;
+    void (async () => {
+      const suggested = await generateDescription(dataMart.id);
+      if (suggested) {
+        await updateDataMartDescription(dataMart.id, suggested);
+      }
+    })();
+  }, [dataMart.id, generateDescription, updateDataMartDescription]);
+
+  const isGenerating = pendingScope?.scope === DataMartMetadataScope.DESCRIPTION;
+
   return (
     <div>
       <InlineEditDescription
         description={dataMart.description}
         onUpdate={handleDescriptionUpdate}
         placeholder='Add a description for this Data Mart...'
+        aiButton={
+          isAiHelperEnabled ? (
+            <AiHelperButton
+              onClick={handleGenerateDescription}
+              isLoading={isGenerating}
+              disabled={pendingScope !== null}
+              tooltip='Generate description with AI'
+            />
+          ) : undefined
+        }
       />
     </div>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartOverview.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartOverview.tsx
@@ -1,7 +1,6 @@
-import { useCallback } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import { InlineEditDescription } from '../../../../shared/components/InlineEditDescription';
-import { DataMartMetadataScope } from '../../shared';
+import { DataMartDefinitionType, DataMartMetadataScope } from '../../shared';
 import { useAiHelper, useAiHelperAvailability } from '../model/hooks';
 import { AiHelperButton } from './AiHelperButton';
 
@@ -9,6 +8,7 @@ interface DataMartContextType {
   dataMart: {
     description: string;
     id: string;
+    definitionType: DataMartDefinitionType | null;
   };
   updateDataMartDescription: (id: string, description: string | null) => Promise<void>;
 }
@@ -22,17 +22,9 @@ export function DataMartOverview() {
   const { enabled: isAiHelperEnabled } = useAiHelperAvailability();
   const { generateDescription, pendingScope } = useAiHelper();
 
-  const handleGenerateDescription = useCallback(() => {
-    if (!dataMart.id) return;
-    void (async () => {
-      const suggested = await generateDescription(dataMart.id);
-      if (suggested) {
-        await updateDataMartDescription(dataMart.id, suggested);
-      }
-    })();
-  }, [dataMart.id, generateDescription, updateDataMartDescription]);
-
   const isGenerating = pendingScope?.scope === DataMartMetadataScope.DESCRIPTION;
+  const isConnector = dataMart.definitionType === DataMartDefinitionType.CONNECTOR;
+  const showAiHelper = isAiHelperEnabled && !isConnector;
 
   return (
     <div>
@@ -41,14 +33,21 @@ export function DataMartOverview() {
         onUpdate={handleDescriptionUpdate}
         placeholder='Add a description for this Data Mart...'
         aiButton={
-          isAiHelperEnabled ? (
-            <AiHelperButton
-              onClick={handleGenerateDescription}
-              isLoading={isGenerating}
-              disabled={pendingScope !== null}
-              tooltip='Generate description with AI'
-            />
-          ) : undefined
+          showAiHelper
+            ? ({ setValue }) => (
+                <AiHelperButton
+                  onClick={() => {
+                    void (async () => {
+                      const suggested = await generateDescription(dataMart.id);
+                      if (suggested) setValue(suggested);
+                    })();
+                  }}
+                  isLoading={isGenerating}
+                  disabled={pendingScope !== null}
+                  tooltip='Generate description with AI'
+                />
+              )
+            : undefined
         }
       />
     </div>

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
@@ -1,4 +1,12 @@
 import { Button } from '@owox/ui/components/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@owox/ui/components/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { Loader2, Sparkles } from 'lucide-react';
 import { useCallback, useEffect } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import type {
@@ -11,7 +19,8 @@ import type {
 import type { DataMartContextType } from '../../model/context/types.ts';
 import { useOperationState, useSchemaState } from './hooks';
 import { SchemaContent } from './SchemaContent';
-import type { DataMartDefinitionType } from '../../../shared/index.ts';
+import { DataMartMetadataScope, type DataMartDefinitionType } from '../../../shared/index.ts';
+import { useAiHelper, useAiHelperAvailability } from '../../model/hooks';
 
 interface DataMartSchemaSettingsProps {
   definitionType: DataMartDefinitionType | null;
@@ -34,6 +43,15 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
 
   const { schema, isDirty, updateSchema, resetSchema } = useSchemaState(initialSchema);
   const { operationStatus, startSaveOperation } = useOperationState(isLoading, error);
+
+  const { enabled: isAiHelperEnabled } = useAiHelperAvailability();
+  const {
+    generateFieldAlias,
+    generateFieldDescription,
+    generateAllFieldDescriptions,
+    generateAllFieldAliases,
+    pendingScope: aiPendingScope,
+  } = useAiHelper();
 
   // Reset schema when operation is successful
   useEffect(() => {
@@ -77,8 +95,57 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
     resetSchema();
   }, [resetSchema]);
 
+  // Per-field AI handlers return the generated value WITHOUT mutating schema.
+  // The open EditableText popover writes the value into its local buffer via the
+  // `editorAction` render-fn so the user sees it in the textarea and must Apply or
+  // Cancel explicitly.
+  const handleGenerateFieldAlias = useCallback(
+    async (fieldName: string): Promise<string | undefined> => {
+      if (!dataMartId) return undefined;
+      return generateFieldAlias(dataMartId, fieldName);
+    },
+    [dataMartId, generateFieldAlias]
+  );
+
+  const handleGenerateFieldDescription = useCallback(
+    async (fieldName: string): Promise<string | undefined> => {
+      if (!dataMartId) return undefined;
+      return generateFieldDescription(dataMartId, fieldName);
+    },
+    [dataMartId, generateFieldDescription]
+  );
+
+  const handleGenerateAllFieldDescriptions = useCallback(async () => {
+    if (!dataMartId || !schema) return;
+    const generated = await generateAllFieldDescriptions(dataMartId);
+    if (!generated) return;
+    const byName = new Map(generated.map(field => [field.name, field.description]));
+    const updated = schema.fields.map(field => {
+      const description = byName.get(field.name);
+      return description ? { ...field, description } : field;
+    });
+    updateSchema(updated as typeof schema.fields);
+  }, [dataMartId, schema, generateAllFieldDescriptions, updateSchema]);
+
+  const handleGenerateAllFieldAliases = useCallback(async () => {
+    if (!dataMartId || !schema) return;
+    const generated = await generateAllFieldAliases(dataMartId);
+    if (!generated) return;
+    const byName = new Map(generated.map(field => [field.name, field.alias]));
+    const updated = schema.fields.map(field => {
+      const alias = byName.get(field.name);
+      return alias ? { ...field, alias } : field;
+    });
+    updateSchema(updated as typeof schema.fields);
+  }, [dataMartId, schema, generateAllFieldAliases, updateSchema]);
+
   // Disable buttons during schema operations (save or actualization)
   const isSchemaOperationInProgress = isLoading || isSchemaActualizationLoading;
+  const isAiBusy = aiPendingScope !== null;
+  const isBulkAiBusy =
+    aiPendingScope?.scope === DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS ||
+    aiPendingScope?.scope === DataMartMetadataScope.ALL_FIELD_ALIASES;
+  const hasFields = !!schema && schema.fields.length > 0;
 
   if (!dataMart) {
     return <div>Error: Data mart not found</div>;
@@ -90,6 +157,15 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
         schema={schema}
         storageType={dataMart.storage.type}
         onFieldsChange={handleSchemaFieldsChange}
+        aiHelper={
+          isAiHelperEnabled
+            ? {
+                pendingScope: aiPendingScope,
+                onGenerateFieldAlias: handleGenerateFieldAlias,
+                onGenerateFieldDescription: handleGenerateFieldDescription,
+              }
+            : undefined
+        }
       />
       <div className='align-items-center mt-4 flex justify-between'>
         <div className='flex items-center gap-2'>
@@ -110,14 +186,63 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
           </Button>
         </div>
 
-        <Button
-          type='button'
-          variant='outline'
-          onClick={handleActualize}
-          disabled={!definitionType || isSchemaOperationInProgress}
-        >
-          Refresh schema
-        </Button>
+        <div className='flex items-center gap-2'>
+          {isAiHelperEnabled && (
+            <DropdownMenu>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type='button'
+                      variant='outline'
+                      size='icon'
+                      disabled={!hasFields || Boolean(isSchemaOperationInProgress) || isAiBusy}
+                      aria-label='Generate field metadata with AI'
+                    >
+                      {isBulkAiBusy ? (
+                        <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
+                      ) : (
+                        <Sparkles className='h-4 w-4' aria-hidden='true' />
+                      )}
+                    </Button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side='bottom'>Generate field metadata with AI</TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent align='end'>
+                <DropdownMenuItem
+                  className='cursor-pointer'
+                  disabled={!hasFields || isAiBusy}
+                  onClick={() => {
+                    void handleGenerateAllFieldDescriptions();
+                  }}
+                >
+                  <Sparkles className='mr-2 h-4 w-4' />
+                  Generate field descriptions
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className='cursor-pointer'
+                  disabled={!hasFields || isAiBusy}
+                  onClick={() => {
+                    void handleGenerateAllFieldAliases();
+                  }}
+                >
+                  <Sparkles className='mr-2 h-4 w-4' />
+                  Generate field aliases
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+
+          <Button
+            type='button'
+            variant='outline'
+            onClick={handleActualize}
+            disabled={!definitionType || isSchemaOperationInProgress}
+          >
+            Refresh schema
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
@@ -19,7 +19,7 @@ import type {
 import type { DataMartContextType } from '../../model/context/types.ts';
 import { useOperationState, useSchemaState } from './hooks';
 import { SchemaContent } from './SchemaContent';
-import { DataMartMetadataScope, type DataMartDefinitionType } from '../../../shared/index.ts';
+import { DataMartDefinitionType, DataMartMetadataScope } from '../../../shared/index.ts';
 import { useAiHelper, useAiHelperAvailability } from '../../model/hooks';
 
 interface DataMartSchemaSettingsProps {
@@ -52,6 +52,10 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
     generateAllFieldAliases,
     pendingScope: aiPendingScope,
   } = useAiHelper();
+  // Backend rejects metadata generation for CONNECTOR data marts; hide the buttons
+  // so the user is never offered an action that's guaranteed to 422.
+  const isConnector = definitionType === DataMartDefinitionType.CONNECTOR;
+  const showAiHelper = isAiHelperEnabled && !isConnector;
 
   // Reset schema when operation is successful
   useEffect(() => {
@@ -158,7 +162,7 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
         storageType={dataMart.storage.type}
         onFieldsChange={handleSchemaFieldsChange}
         aiHelper={
-          isAiHelperEnabled
+          showAiHelper
             ? {
                 pendingScope: aiPendingScope,
                 onGenerateFieldAlias: handleGenerateFieldAlias,
@@ -187,7 +191,7 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
         </div>
 
         <div className='flex items-center gap-2'>
-          {isAiHelperEnabled && (
+          {showAiHelper && (
             <DropdownMenu>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SchemaContent.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SchemaContent.tsx
@@ -23,6 +23,7 @@ import {
   isRedshiftSchema,
   isSnowflakeSchema,
 } from './utils';
+import type { SchemaAiHelper } from './types/ai-helper';
 
 /**
  * Props for the SchemaContent component
@@ -41,13 +42,20 @@ interface SchemaContentProps {
       | RedshiftSchemaField[]
       | DatabricksSchemaField[]
   ) => void;
+  /** AI helper handlers; omit to hide AI buttons on this deployment. */
+  aiHelper?: SchemaAiHelper;
 }
 
 /**
  * Component that renders the appropriate schema table based on the schema type
  * Handles the conditional rendering logic that was previously in the DataMartSchemaSettings component
  */
-export function SchemaContent({ schema, storageType, onFieldsChange }: SchemaContentProps) {
+export function SchemaContent({
+  schema,
+  storageType,
+  onFieldsChange,
+  aiHelper,
+}: SchemaContentProps) {
   // If schema doesn't exist, create an initial schema based on storage type
   const initialSchema = useMemo(() => {
     if (!schema) {
@@ -61,15 +69,45 @@ export function SchemaContent({ schema, storageType, onFieldsChange }: SchemaCon
 
   // Render the appropriate table based on schema type
   if (isBigQuerySchema(initialSchema)) {
-    return <BigQuerySchemaTable fields={initialSchema.fields} onFieldsChange={onFieldsChange} />;
+    return (
+      <BigQuerySchemaTable
+        fields={initialSchema.fields}
+        onFieldsChange={onFieldsChange}
+        aiHelper={aiHelper}
+      />
+    );
   } else if (isAthenaSchema(initialSchema)) {
-    return <AthenaSchemaTable fields={initialSchema.fields} onFieldsChange={onFieldsChange} />;
+    return (
+      <AthenaSchemaTable
+        fields={initialSchema.fields}
+        onFieldsChange={onFieldsChange}
+        aiHelper={aiHelper}
+      />
+    );
   } else if (isSnowflakeSchema(initialSchema)) {
-    return <SnowflakeSchemaTable fields={initialSchema.fields} onFieldsChange={onFieldsChange} />;
+    return (
+      <SnowflakeSchemaTable
+        fields={initialSchema.fields}
+        onFieldsChange={onFieldsChange}
+        aiHelper={aiHelper}
+      />
+    );
   } else if (isRedshiftSchema(initialSchema)) {
-    return <RedshiftSchemaTable fields={initialSchema.fields} onFieldsChange={onFieldsChange} />;
+    return (
+      <RedshiftSchemaTable
+        fields={initialSchema.fields}
+        onFieldsChange={onFieldsChange}
+        aiHelper={aiHelper}
+      />
+    );
   } else if (isDatabricksSchema(initialSchema)) {
-    return <DatabricksSchemaTable fields={initialSchema.fields} onFieldsChange={onFieldsChange} />;
+    return (
+      <DatabricksSchemaTable
+        fields={initialSchema.fields}
+        onFieldsChange={onFieldsChange}
+        aiHelper={aiHelper}
+      />
+    );
   }
 
   // Fallback for unsupported schema types

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/fields/SchemaFieldActionsButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/fields/SchemaFieldActionsButton.tsx
@@ -52,7 +52,7 @@ export function SchemaFieldActionsButton<TData>({
   const showAddNestedField = isRecordType && onAddNestedField && isRecordType(row.index);
   const showHideToggle = !!onToggleHiddenForReporting;
   const showDeleteField = !!onDeleteRow;
-  const showSeparator = (!!showAddNestedField || showHideToggle) && showDeleteField;
+  const showSeparator = (Boolean(showAddNestedField) || showHideToggle) && showDeleteField;
 
   return (
     <div className='px-3 text-right'>

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/AthenaSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/AthenaSchemaTable.tsx
@@ -12,6 +12,7 @@ import {
 import { SchemaFieldTypeSelect } from '../components';
 import { useDragAndDrop } from '../hooks';
 import { BaseSchemaTable } from './BaseSchemaTable';
+import type { SchemaAiHelper } from '../types/ai-helper';
 
 /**
  * Props for the AthenaSchemaTable component
@@ -21,12 +22,14 @@ interface AthenaSchemaTableProps {
   fields: AthenaSchemaField[];
   /** Callback function to call when the fields change */
   onFieldsChange?: (fields: AthenaSchemaField[]) => void;
+  /** AI helper handlers; omit to hide AI buttons. */
+  aiHelper?: SchemaAiHelper;
 }
 
 /**
  * Component for displaying and editing Athena schema fields
  */
-export function AthenaSchemaTable({ fields, onFieldsChange }: AthenaSchemaTableProps) {
+export function AthenaSchemaTable({ fields, onFieldsChange, aiHelper }: AthenaSchemaTableProps) {
   // Function to create a new Athena field
   const createNewField = useCallback(() => {
     return {
@@ -82,6 +85,7 @@ export function AthenaSchemaTable({ fields, onFieldsChange }: AthenaSchemaTableP
           strategy: verticalListSortingStrategy,
         }}
         rowComponent={SortableTableRow}
+        aiHelper={aiHelper}
       />
     </DndContext>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
@@ -14,6 +14,8 @@ import {
 } from '../components';
 import { asString } from '../utils';
 import { SchemaTable } from './SchemaTable';
+import type { SchemaAiHelper } from '../types/ai-helper';
+import { renderFieldAliasAi, renderFieldDescriptionAi } from '../utils/render-field-ai';
 
 // Extended column definition with optional columnIndex property
 export type ExtendedColumnDef<T extends BaseSchemaField> = ColumnDef<T> & {
@@ -95,6 +97,8 @@ export interface BaseSchemaTableProps<T extends BaseSchemaField> {
   rowComponent?: ComponentType<RowComponentProps<Row<T>>>;
   /** Function to get the ID for a row */
   getRowId?: (row: Row<T>) => string | number;
+  /** AI helper handlers passed to per-field actions menu. Omit to hide AI options. */
+  aiHelper?: SchemaAiHelper;
 }
 
 /**
@@ -120,6 +124,7 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
   dragContextProps,
   rowComponent,
   getRowId,
+  aiHelper,
 }: BaseSchemaTableProps<T>) {
   // Handler to update a field
   const updateField = useCallback(
@@ -247,6 +252,7 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
           if (aliasColumnCell) {
             return aliasColumnCell({ row, updateField });
           }
+          const fname = fields[row.index]?.name;
           return (
             <EditableText
               value={row.getValue('alias')}
@@ -254,6 +260,7 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
                 updateField(row.index, { alias: value } as Partial<T>);
               }}
               placeholder='-'
+              editorAction={renderFieldAliasAi(aiHelper, fname)}
             />
           );
         },
@@ -270,6 +277,7 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
           if (descriptionColumnCell) {
             return descriptionColumnCell({ row, updateField });
           }
+          const fname = fields[row.index]?.name;
           return (
             <EditableText
               value={row.getValue('description')}
@@ -278,6 +286,7 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
               }}
               minRows={5}
               placeholder='-'
+              editorAction={renderFieldDescriptionAi(aiHelper, fname)}
             />
           );
         },
@@ -322,6 +331,7 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
       aliasColumnCell,
       descriptionColumnCell,
       actionsColumnCell,
+      aiHelper,
     ]
   );
 

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.tsx
@@ -24,6 +24,8 @@ import {
 import { useDragAndDrop, useNestedFieldOperations, useRecordExpansion } from '../hooks';
 import type { ExtendedColumnDef } from './BaseSchemaTable';
 import { BaseSchemaTable } from './BaseSchemaTable';
+import { renderFieldAliasAi, renderFieldDescriptionAi } from '../utils/render-field-ai';
+import type { SchemaAiHelper } from '../types/ai-helper';
 
 /**
  * Props for the BigQuerySchemaTable component
@@ -33,13 +35,19 @@ interface BigQuerySchemaTableProps {
   fields: BigQuerySchemaField[];
   /** Callback function to call when the fields change */
   onFieldsChange?: (fields: BigQuerySchemaField[]) => void;
+  /** AI helper handlers; omit to hide AI buttons. */
+  aiHelper?: SchemaAiHelper;
 }
 
 /**
  * Component for displaying and editing BigQuery schema fields
  * Handles nested record fields with expand/collapse functionality
  */
-export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTableProps) {
+export function BigQuerySchemaTable({
+  fields,
+  onFieldsChange,
+  aiHelper,
+}: BigQuerySchemaTableProps) {
   // Use the record expansion hook to manage expanded/collapsed state
   const {
     expandedRecords,
@@ -238,17 +246,22 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
     }: {
       row: Row<BigQuerySchemaField>;
       updateField: (index: number, updatedField: Partial<BigQuerySchemaField>) => void;
-    }) => (
-      <EditableText
-        value={row.getValue('description')}
-        onValueChange={value => {
-          updateField(row.index, { description: value });
-        }}
-        minRows={5}
-        placeholder='-'
-      />
-    ),
-    [updateField]
+    }) => {
+      const field = flattenedFields[row.index];
+      const isTopLevel = (field.level ?? 0) === 0;
+      return (
+        <EditableText
+          value={row.getValue('description')}
+          onValueChange={value => {
+            updateField(row.index, { description: value });
+          }}
+          minRows={5}
+          placeholder='-'
+          editorAction={isTopLevel ? renderFieldDescriptionAi(aiHelper, field.name) : undefined}
+        />
+      );
+    },
+    [updateField, flattenedFields, aiHelper]
   );
 
   // Custom alias column cell that uses updateField from useNestedFieldOperations
@@ -258,16 +271,21 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
     }: {
       row: Row<BigQuerySchemaField>;
       updateField: (index: number, updatedField: Partial<BigQuerySchemaField>) => void;
-    }) => (
-      <EditableText
-        value={row.getValue('alias')}
-        onValueChange={value => {
-          updateField(row.index, { alias: value });
-        }}
-        placeholder='-'
-      />
-    ),
-    [updateField]
+    }) => {
+      const field = flattenedFields[row.index];
+      const isTopLevel = (field.level ?? 0) === 0;
+      return (
+        <EditableText
+          value={row.getValue('alias')}
+          onValueChange={value => {
+            updateField(row.index, { alias: value });
+          }}
+          placeholder='-'
+          editorAction={isTopLevel ? renderFieldAliasAi(aiHelper, field.name) : undefined}
+        />
+      );
+    },
+    [updateField, flattenedFields, aiHelper]
   );
 
   // Custom actions column cell with add nested field option for record types
@@ -342,6 +360,7 @@ export function BigQuerySchemaTable({ fields, onFieldsChange }: BigQuerySchemaTa
         aliasColumnCell={aliasColumnCell}
         descriptionColumnCell={descriptionColumnCell}
         actionsColumnCell={actionsColumnCell}
+        aiHelper={aiHelper}
         dragContext={SortableContext}
         dragContextProps={{
           items: flattenedFields.map(f => f.path ?? String(flattenedFields.indexOf(f))),

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/DatabricksSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/DatabricksSchemaTable.tsx
@@ -12,6 +12,7 @@ import {
 import { SchemaFieldTypeSelect } from '../components';
 import { useDragAndDrop } from '../hooks';
 import { BaseSchemaTable } from './BaseSchemaTable';
+import type { SchemaAiHelper } from '../types/ai-helper';
 
 /**
  * Props for the DatabricksSchemaTable component
@@ -21,12 +22,18 @@ interface DatabricksSchemaTableProps {
   fields: DatabricksSchemaField[];
   /** Callback function to call when the fields change */
   onFieldsChange?: (fields: DatabricksSchemaField[]) => void;
+  /** AI helper handlers; omit to hide AI buttons. */
+  aiHelper?: SchemaAiHelper;
 }
 
 /**
  * Component for displaying and editing Databricks schema fields
  */
-export function DatabricksSchemaTable({ fields, onFieldsChange }: DatabricksSchemaTableProps) {
+export function DatabricksSchemaTable({
+  fields,
+  onFieldsChange,
+  aiHelper,
+}: DatabricksSchemaTableProps) {
   // Function to create a new Databricks field
   const createNewField = useCallback(() => {
     return {
@@ -82,6 +89,7 @@ export function DatabricksSchemaTable({ fields, onFieldsChange }: DatabricksSche
           strategy: verticalListSortingStrategy,
         }}
         rowComponent={SortableTableRow}
+        aiHelper={aiHelper}
       />
     </DndContext>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/RedshiftSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/RedshiftSchemaTable.tsx
@@ -12,6 +12,7 @@ import {
 import { SchemaFieldTypeSelect } from '../components';
 import { useDragAndDrop } from '../hooks';
 import { BaseSchemaTable } from './BaseSchemaTable';
+import type { SchemaAiHelper } from '../types/ai-helper';
 
 /**
  * Props for the RedshiftSchemaTable component
@@ -21,12 +22,18 @@ interface RedshiftSchemaTableProps {
   fields: RedshiftSchemaField[];
   /** Callback function to call when the fields change */
   onFieldsChange?: (fields: RedshiftSchemaField[]) => void;
+  /** AI helper handlers; omit to hide AI buttons. */
+  aiHelper?: SchemaAiHelper;
 }
 
 /**
  * Component for displaying and editing Redshift schema fields
  */
-export function RedshiftSchemaTable({ fields, onFieldsChange }: RedshiftSchemaTableProps) {
+export function RedshiftSchemaTable({
+  fields,
+  onFieldsChange,
+  aiHelper,
+}: RedshiftSchemaTableProps) {
   // Function to create a new Redshift field
   const createNewField = useCallback(() => {
     return {
@@ -82,6 +89,7 @@ export function RedshiftSchemaTable({ fields, onFieldsChange }: RedshiftSchemaTa
           strategy: verticalListSortingStrategy,
         }}
         rowComponent={SortableTableRow}
+        aiHelper={aiHelper}
       />
     </DndContext>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/SnowflakeSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/SnowflakeSchemaTable.tsx
@@ -12,6 +12,7 @@ import {
 import { SchemaFieldTypeSelect } from '../components';
 import { useDragAndDrop } from '../hooks';
 import { BaseSchemaTable } from './BaseSchemaTable';
+import type { SchemaAiHelper } from '../types/ai-helper';
 
 /**
  * Props for the SnowflakeSchemaTable component
@@ -21,12 +22,18 @@ interface SnowflakeSchemaTableProps {
   fields: SnowflakeSchemaField[];
   /** Callback function to call when the fields change */
   onFieldsChange?: (fields: SnowflakeSchemaField[]) => void;
+  /** AI helper handlers; omit to hide AI buttons. */
+  aiHelper?: SchemaAiHelper;
 }
 
 /**
  * Component for displaying and editing Snowflake schema fields
  */
-export function SnowflakeSchemaTable({ fields, onFieldsChange }: SnowflakeSchemaTableProps) {
+export function SnowflakeSchemaTable({
+  fields,
+  onFieldsChange,
+  aiHelper,
+}: SnowflakeSchemaTableProps) {
   // Function to create a new Snowflake field
   const createNewField = useCallback(() => {
     return {
@@ -82,6 +89,7 @@ export function SnowflakeSchemaTable({ fields, onFieldsChange }: SnowflakeSchema
           strategy: verticalListSortingStrategy,
         }}
         rowComponent={SortableTableRow}
+        aiHelper={aiHelper}
       />
     </DndContext>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/types/ai-helper.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/types/ai-helper.ts
@@ -1,0 +1,15 @@
+import type { PendingScope } from '../../../model/hooks';
+
+/**
+ * Per-field AI helper handlers passed down through the schema table tree.
+ * `undefined` => AI helper is unavailable on this deployment and buttons must be hidden.
+ *
+ * `onGenerateField*` returns the generated value WITHOUT persisting it. The caller
+ * (the open editor popover) is responsible for placing the value into its local
+ * buffer so the user can review and explicitly Apply or Cancel.
+ */
+export interface SchemaAiHelper {
+  pendingScope: PendingScope | null;
+  onGenerateFieldAlias: (fieldName: string) => Promise<string | undefined>;
+  onGenerateFieldDescription: (fieldName: string) => Promise<string | undefined>;
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/utils/render-field-ai.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/utils/render-field-ai.tsx
@@ -1,0 +1,73 @@
+import type { EditableTextAction } from '@owox/ui/components/common/editable-text';
+import { DataMartMetadataScope } from '../../../../shared';
+import { AiHelperButton } from '../../AiHelperButton';
+import type { SchemaAiHelper } from '../types/ai-helper';
+
+/**
+ * Renders the AI generate button inside a field's alias editor popover.
+ *
+ * Returns a render-function that receives a `setValue` helper from EditableText —
+ * when the AI returns a value we write it into the editor's local buffer so the user
+ * sees it in the open textarea and must explicitly Apply (or Cancel) to persist.
+ *
+ * Returns `undefined` when AI helper is unavailable or no field name is provided.
+ */
+export function renderFieldAliasAi(
+  aiHelper: SchemaAiHelper | undefined,
+  fieldName: string | undefined
+): EditableTextAction | undefined {
+  if (!aiHelper || !fieldName) return undefined;
+  return ({ setValue }) => {
+    const pending = aiHelper.pendingScope;
+    const isLoading =
+      pending !== null &&
+      pending.scope === DataMartMetadataScope.FIELD_ALIAS &&
+      pending.fieldName === fieldName;
+    return (
+      <AiHelperButton
+        onClick={() => {
+          void (async () => {
+            const value = await aiHelper.onGenerateFieldAlias(fieldName);
+            if (value) setValue(value);
+          })();
+        }}
+        isLoading={isLoading}
+        disabled={pending !== null && !isLoading}
+        tooltip='Generate alias with AI'
+      />
+    );
+  };
+}
+
+/**
+ * Renders the AI generate button inside a field's description editor popover.
+ *
+ * See `renderFieldAliasAi` for behavior — writes the generated value into the open
+ * editor's buffer instead of mutating schema state directly.
+ */
+export function renderFieldDescriptionAi(
+  aiHelper: SchemaAiHelper | undefined,
+  fieldName: string | undefined
+): EditableTextAction | undefined {
+  if (!aiHelper || !fieldName) return undefined;
+  return ({ setValue }) => {
+    const pending = aiHelper.pendingScope;
+    const isLoading =
+      pending !== null &&
+      pending.scope === DataMartMetadataScope.FIELD_DESCRIPTION &&
+      pending.fieldName === fieldName;
+    return (
+      <AiHelperButton
+        onClick={() => {
+          void (async () => {
+            const value = await aiHelper.onGenerateFieldDescription(fieldName);
+            if (value) setValue(value);
+          })();
+        }}
+        isLoading={isLoading}
+        disabled={pending !== null && !isLoading}
+        tooltip='Generate description with AI'
+      />
+    );
+  };
+}

--- a/apps/web/src/features/data-marts/edit/model/hooks/index.ts
+++ b/apps/web/src/features/data-marts/edit/model/hooks/index.ts
@@ -1,2 +1,5 @@
 export { useDataMartForm, dataMartSchema, type DataMartFormData } from './use-data-mart-form.ts';
 export { useDataMart } from './use-data-mart.ts';
+export { useAiHelperAvailability } from './use-ai-helper-availability.ts';
+export { useAiHelper } from './use-ai-helper.ts';
+export type { UseAiHelperResult, PendingScope } from './use-ai-helper.ts';

--- a/apps/web/src/features/data-marts/edit/model/hooks/use-ai-helper-availability.ts
+++ b/apps/web/src/features/data-marts/edit/model/hooks/use-ai-helper-availability.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { dataMartService } from '../../../shared';
+
+let cachedAvailability: boolean | null = null;
+let inflight: Promise<boolean> | null = null;
+
+/**
+ * Returns whether AI helper is configured on this deployment.
+ *
+ * The flag is global (env-var driven on the backend) and immutable for the
+ * session, so the result is cached process-wide after the first fetch.
+ *
+ * `null` while the first request is in flight — components should hide the
+ * AI buttons in that intermediate state to avoid a flash.
+ */
+export function useAiHelperAvailability(): { enabled: boolean | null } {
+  const [enabled, setEnabled] = useState<boolean | null>(cachedAvailability);
+
+  useEffect(() => {
+    if (cachedAvailability !== null) return;
+
+    let cancelled = false;
+    inflight ??= dataMartService
+      .getAiHelperAvailability()
+      .then(response => {
+        cachedAvailability = response.enabled;
+        return response.enabled;
+      })
+      .catch(() => {
+        cachedAvailability = false;
+        return false;
+      })
+      .finally(() => {
+        inflight = null;
+      });
+
+    void inflight.then(result => {
+      if (!cancelled) {
+        setEnabled(result);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { enabled };
+}

--- a/apps/web/src/features/data-marts/edit/model/hooks/use-ai-helper.ts
+++ b/apps/web/src/features/data-marts/edit/model/hooks/use-ai-helper.ts
@@ -1,0 +1,186 @@
+import { useCallback, useState } from 'react';
+import toast from 'react-hot-toast';
+import { extractApiError } from '../../../../../app/api';
+import { trackEvent } from '../../../../../utils';
+import { dataMartService, DataMartMetadataScope } from '../../../shared';
+import type {
+  GenerateDataMartMetadataResponseDto,
+  GeneratedFieldMetadataDto,
+} from '../../../shared/types/api';
+
+const DEFAULT_USE_SAMPLE = true;
+
+export interface UseAiHelperResult {
+  /** Which scope is currently being generated, or null. */
+  pendingScope: PendingScope | null;
+  generateTitle: (dataMartId: string) => Promise<string | undefined>;
+  generateDescription: (dataMartId: string) => Promise<string | undefined>;
+  generateFieldAlias: (dataMartId: string, fieldName: string) => Promise<string | undefined>;
+  generateFieldDescription: (dataMartId: string, fieldName: string) => Promise<string | undefined>;
+  generateAllFieldDescriptions: (
+    dataMartId: string
+  ) => Promise<GeneratedFieldMetadataDto[] | undefined>;
+  generateAllFieldAliases: (dataMartId: string) => Promise<GeneratedFieldMetadataDto[] | undefined>;
+}
+
+export type PendingScope =
+  | { scope: DataMartMetadataScope.TITLE }
+  | { scope: DataMartMetadataScope.DESCRIPTION }
+  | { scope: DataMartMetadataScope.FIELD_ALIAS; fieldName: string }
+  | { scope: DataMartMetadataScope.FIELD_DESCRIPTION; fieldName: string }
+  | { scope: DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS }
+  | { scope: DataMartMetadataScope.ALL_FIELD_ALIASES };
+
+function isFieldScopedPending(
+  pending: PendingScope
+): pending is Extract<
+  PendingScope,
+  { scope: DataMartMetadataScope.FIELD_ALIAS | DataMartMetadataScope.FIELD_DESCRIPTION }
+> {
+  return (
+    pending.scope === DataMartMetadataScope.FIELD_ALIAS ||
+    pending.scope === DataMartMetadataScope.FIELD_DESCRIPTION
+  );
+}
+
+/**
+ * Calls the AI helper backend endpoint and returns suggested metadata.
+ *
+ * This hook does NOT persist suggestions — callers apply them via the
+ * existing update endpoints (or push them into local schema state).
+ */
+export function useAiHelper(): UseAiHelperResult {
+  const [pendingScope, setPendingScope] = useState<PendingScope | null>(null);
+
+  const generate = useCallback(
+    async (
+      dataMartId: string,
+      pending: PendingScope
+    ): Promise<GenerateDataMartMetadataResponseDto | undefined> => {
+      setPendingScope(pending);
+      try {
+        const fieldName = isFieldScopedPending(pending) ? pending.fieldName : undefined;
+
+        const result = await dataMartService.generateDataMartMetadata(dataMartId, {
+          scope: pending.scope,
+          useSample: DEFAULT_USE_SAMPLE,
+          fieldName,
+        });
+
+        trackEvent({
+          event: 'data_mart_ai_metadata_generated',
+          category: 'DataMart',
+          action: 'GenerateMetadata',
+          label: pending.scope,
+          context: dataMartId,
+        });
+
+        return result;
+      } catch (error) {
+        const apiError = extractApiError(error);
+        trackEvent({
+          event: 'data_mart_error',
+          category: 'DataMart',
+          action: 'GenerateMetadataError',
+          label: pending.scope,
+          context: dataMartId,
+          error: apiError.message,
+        });
+        return undefined;
+      } finally {
+        setPendingScope(null);
+      }
+    },
+    []
+  );
+
+  const generateTitle = useCallback(
+    async (dataMartId: string) => {
+      const result = await generate(dataMartId, { scope: DataMartMetadataScope.TITLE });
+      return result?.title?.trim();
+    },
+    [generate]
+  );
+
+  const generateDescription = useCallback(
+    async (dataMartId: string) => {
+      const result = await generate(dataMartId, { scope: DataMartMetadataScope.DESCRIPTION });
+      return result?.description?.trim();
+    },
+    [generate]
+  );
+
+  const generateFieldAlias = useCallback(
+    async (dataMartId: string, fieldName: string) => {
+      const result = await generate(dataMartId, {
+        scope: DataMartMetadataScope.FIELD_ALIAS,
+        fieldName,
+      });
+      const match = result?.fields?.find(f => f.name === fieldName);
+      const alias = match?.alias?.trim();
+      if (!alias) {
+        toast.error('AI returned no alias suggestion. Try again or fill it in manually.');
+        return undefined;
+      }
+      return alias;
+    },
+    [generate]
+  );
+
+  const generateFieldDescription = useCallback(
+    async (dataMartId: string, fieldName: string) => {
+      const result = await generate(dataMartId, {
+        scope: DataMartMetadataScope.FIELD_DESCRIPTION,
+        fieldName,
+      });
+      const match = result?.fields?.find(f => f.name === fieldName);
+      const description = match?.description?.trim();
+      if (!description) {
+        toast.error('AI returned no description suggestion. Try again or fill it in manually.');
+        return undefined;
+      }
+      return description;
+    },
+    [generate]
+  );
+
+  const generateAllFieldDescriptions = useCallback(
+    async (dataMartId: string) => {
+      const result = await generate(dataMartId, {
+        scope: DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS,
+      });
+      const fields = result?.fields ?? [];
+      if (fields.length === 0) {
+        toast.error('AI returned no field descriptions. Try again or fill them in manually.');
+        return undefined;
+      }
+      return fields;
+    },
+    [generate]
+  );
+
+  const generateAllFieldAliases = useCallback(
+    async (dataMartId: string) => {
+      const result = await generate(dataMartId, {
+        scope: DataMartMetadataScope.ALL_FIELD_ALIASES,
+      });
+      const fields = result?.fields ?? [];
+      if (fields.length === 0) {
+        toast.error('AI returned no field aliases. Try again or fill them in manually.');
+        return undefined;
+      }
+      return fields;
+    },
+    [generate]
+  );
+
+  return {
+    pendingScope,
+    generateTitle,
+    generateDescription,
+    generateFieldAlias,
+    generateFieldDescription,
+    generateAllFieldDescriptions,
+    generateAllFieldAliases,
+  };
+}

--- a/apps/web/src/features/data-marts/shared/index.ts
+++ b/apps/web/src/features/data-marts/shared/index.ts
@@ -7,3 +7,4 @@ export * from './enums/data-mart-status.enum';
 export * from './enums/data-mart-definition-type.enum';
 export * from './enums/data-mart-validation-error.enum';
 export * from './utils/data-mart-validation';
+export { DataMartMetadataScope } from './types/api/shared/data-mart-metadata-scope.enum';

--- a/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
@@ -13,6 +13,9 @@ import type {
   UpdateDataMartRequestDto,
   UpdateDataMartSchemaRequestDto,
   BatchDataMartHealthStatusResponseDto,
+  GenerateDataMartMetadataRequestDto,
+  GenerateDataMartMetadataResponseDto,
+  DataMartAiHelperAvailabilityResponseDto,
 } from '../types/api';
 import type { CreateSqlDryRunTaskResponseDto } from '../types/api/response/create-sql-dry-run-task.response.dto.ts';
 import type { TaskStatusResponseDto } from '../types/api/response/task-status.response.dto.ts';
@@ -354,6 +357,36 @@ export class DataMartService extends ApiService {
    */
   async updateContexts(id: string, contextIds: string[]): Promise<void> {
     return this.put(`/${id}/contexts`, { contextIds });
+  }
+
+  /**
+   * Check whether the AI helper is configured on this deployment.
+   * Returns { enabled: false } on self-hosted instances that did not set AI_* env vars.
+   */
+  async getAiHelperAvailability(): Promise<DataMartAiHelperAvailabilityResponseDto> {
+    return this.get<DataMartAiHelperAvailabilityResponseDto>(`/ai-helper/availability`, undefined, {
+      skipLoadingIndicator: true,
+      skipErrorToast: true,
+    } as AxiosRequestConfig);
+  }
+
+  /**
+   * Request AI-generated metadata for a data mart.
+   * Returns a suggestion only — the caller must apply it via the appropriate update endpoint.
+   * @param id Data mart ID
+   * @param data Generation request (scope, useSample, optional fieldName)
+   */
+  async generateDataMartMetadata(
+    id: string,
+    data: GenerateDataMartMetadataRequestDto
+  ): Promise<GenerateDataMartMetadataResponseDto> {
+    return this.post<GenerateDataMartMetadataResponseDto>(
+      `/${id}/ai-helper/generate-metadata`,
+      data,
+      {
+        timeout: 120000,
+      }
+    );
   }
 }
 export const dataMartService = new DataMartService();

--- a/apps/web/src/features/data-marts/shared/types/api/request/generate-data-mart-metadata.request.dto.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/request/generate-data-mart-metadata.request.dto.ts
@@ -1,0 +1,7 @@
+import type { DataMartMetadataScope } from '../shared/data-mart-metadata-scope.enum';
+
+export interface GenerateDataMartMetadataRequestDto {
+  scope: DataMartMetadataScope;
+  useSample: boolean;
+  fieldName?: string;
+}

--- a/apps/web/src/features/data-marts/shared/types/api/request/index.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/request/index.ts
@@ -15,3 +15,5 @@ export * from './update-data-mart-connector-definition.request.dto';
 export * from './update-data-mart-schema.request.dto';
 export * from './sql-validation-request.dto';
 export * from './run-data-mart.request.dto';
+export * from './generate-data-mart-metadata.request.dto';
+export * from '../shared/data-mart-metadata-scope.enum';

--- a/apps/web/src/features/data-marts/shared/types/api/response/data-mart-ai-helper-availability.response.dto.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/response/data-mart-ai-helper-availability.response.dto.ts
@@ -1,0 +1,3 @@
+export interface DataMartAiHelperAvailabilityResponseDto {
+  enabled: boolean;
+}

--- a/apps/web/src/features/data-marts/shared/types/api/response/generate-data-mart-metadata.response.dto.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/response/generate-data-mart-metadata.response.dto.ts
@@ -1,0 +1,11 @@
+export interface GeneratedFieldMetadataDto {
+  name: string;
+  alias?: string;
+  description?: string;
+}
+
+export interface GenerateDataMartMetadataResponseDto {
+  title?: string;
+  description?: string;
+  fields?: GeneratedFieldMetadataDto[];
+}

--- a/apps/web/src/features/data-marts/shared/types/api/response/index.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/response/index.ts
@@ -7,3 +7,5 @@ export * from './sql-validation-response.dto';
 export * from './data-mart-run.response.dto';
 export * from './data-mart-run-list.response.dto';
 export * from './batch-data-mart-health-status.response.dto';
+export * from './generate-data-mart-metadata.response.dto';
+export * from './data-mart-ai-helper-availability.response.dto';

--- a/apps/web/src/features/data-marts/shared/types/api/shared/data-mart-metadata-scope.enum.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/shared/data-mart-metadata-scope.enum.ts
@@ -1,0 +1,12 @@
+/**
+ * Mirror of the backend `DataMartMetadataScope` enum.
+ * Keep values in sync with `apps/backend/src/data-marts/ai-insights/ai-insights-types.ts`.
+ */
+export enum DataMartMetadataScope {
+  TITLE = 'title',
+  DESCRIPTION = 'description',
+  FIELD_ALIAS = 'field_alias',
+  FIELD_DESCRIPTION = 'field_description',
+  ALL_FIELD_DESCRIPTIONS = 'all_field_descriptions',
+  ALL_FIELD_ALIASES = 'all_field_aliases',
+}

--- a/apps/web/src/shared/components/InlineEditDescription/InlineEditDescription.tsx
+++ b/apps/web/src/shared/components/InlineEditDescription/InlineEditDescription.tsx
@@ -2,6 +2,15 @@ import { useState, useEffect, type KeyboardEvent, type ReactNode, useRef } from 
 import { cn } from '@owox/ui/lib/utils';
 import { Textarea } from '@owox/ui/components/textarea';
 
+export interface InlineEditDescriptionAiContext {
+  /** Replace the current value in the open textarea. Does not persist on its own. */
+  setValue: (value: string) => void;
+}
+
+export type InlineEditDescriptionAi =
+  | ReactNode
+  | ((ctx: InlineEditDescriptionAiContext) => ReactNode);
+
 interface InlineEditDescriptionProps {
   description: string | null;
   onUpdate: (newDescription: string | null) => Promise<void>;
@@ -9,8 +18,12 @@ interface InlineEditDescriptionProps {
   placeholder?: string;
   minWidth?: string;
   minHeight?: string;
-  /** Optional action button rendered in the bottom-right of the textarea while editing. */
-  aiButton?: ReactNode;
+  /**
+   * Optional action button rendered inside the editor while editing. May be a
+   * render-function that receives `{ setValue }` so the action can write directly
+   * into the editor's local buffer (e.g. AI suggestion).
+   */
+  aiButton?: InlineEditDescriptionAi;
 }
 
 export function InlineEditDescription({
@@ -84,15 +97,13 @@ export function InlineEditDescription({
   };
 
   if (isEditing) {
+    const resolvedAiButton =
+      typeof aiButton === 'function' ? aiButton({ setValue: setEditedDescription }) : aiButton;
+
     const editor = aiButton ? (
       // Shell-style editor: wrapper mimics textarea look; real <textarea> is borderless
       // and shares the visual surface with the AI button on the right.
-      <div
-        className={cn(
-          'flex w-full items-start gap-2 rounded-md bg-white p-2 dark:bg-white/4',
-          'focus-within:ring-primary focus-within:ring-1'
-        )}
-      >
+      <div className={cn('flex w-full items-start gap-2 rounded-md bg-white p-2 dark:bg-white/4')}>
         <Textarea
           ref={textareaRef}
           value={editedDescription}
@@ -111,7 +122,7 @@ export function InlineEditDescription({
             fontSize: 'inherit',
             lineHeight: 'inherit',
             fontFamily: 'inherit',
-            resize: 'vertical',
+            resize: 'none',
             minHeight: minHeight,
             // Inside flex shell we must NOT force textarea width — otherwise the AI
             // button gets pushed off-screen. Let flex-1 + min-w-0 handle sizing.
@@ -127,7 +138,7 @@ export function InlineEditDescription({
           }}
           className='shrink-0'
         >
-          {aiButton}
+          {resolvedAiButton}
         </span>
       </div>
     ) : (
@@ -151,7 +162,7 @@ export function InlineEditDescription({
           fontSize: 'inherit',
           lineHeight: 'inherit',
           fontFamily: 'inherit',
-          resize: 'vertical',
+          resize: 'none',
           minHeight: minHeight,
           minWidth: minWidth,
         }}

--- a/apps/web/src/shared/components/InlineEditDescription/InlineEditDescription.tsx
+++ b/apps/web/src/shared/components/InlineEditDescription/InlineEditDescription.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type KeyboardEvent, useRef } from 'react';
+import { useState, useEffect, type KeyboardEvent, type ReactNode, useRef } from 'react';
 import { cn } from '@owox/ui/lib/utils';
 import { Textarea } from '@owox/ui/components/textarea';
 
@@ -9,6 +9,8 @@ interface InlineEditDescriptionProps {
   placeholder?: string;
   minWidth?: string;
   minHeight?: string;
+  /** Optional action button rendered in the bottom-right of the textarea while editing. */
+  aiButton?: ReactNode;
 }
 
 export function InlineEditDescription({
@@ -18,6 +20,7 @@ export function InlineEditDescription({
   placeholder = 'Add description...',
   minWidth = '100%',
   minHeight = '256px',
+  aiButton,
 }: InlineEditDescriptionProps) {
   const [editedDescription, setEditedDescription] = useState(description ?? '');
   const [isEditing, setIsEditing] = useState(false);
@@ -81,8 +84,15 @@ export function InlineEditDescription({
   };
 
   if (isEditing) {
-    return (
-      <div className='w-full'>
+    const editor = aiButton ? (
+      // Shell-style editor: wrapper mimics textarea look; real <textarea> is borderless
+      // and shares the visual surface with the AI button on the right.
+      <div
+        className={cn(
+          'flex w-full items-start gap-2 rounded-md bg-white p-2 dark:bg-white/4',
+          'focus-within:ring-primary focus-within:ring-1'
+        )}
+      >
         <Textarea
           ref={textareaRef}
           value={editedDescription}
@@ -91,8 +101,8 @@ export function InlineEditDescription({
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           className={cn(
-            'm-0 w-full border-0 bg-white p-2 shadow-none dark:bg-white/4',
-            'focus-visible:ring-primary focus-visible:ring-0',
+            'm-0 min-w-0 flex-1 border-0 bg-transparent p-0 shadow-none',
+            'focus-visible:border-0 focus-visible:ring-0 focus-visible:ring-offset-0',
             {
               'opacity-50': isLoading,
             }
@@ -103,10 +113,55 @@ export function InlineEditDescription({
             fontFamily: 'inherit',
             resize: 'vertical',
             minHeight: minHeight,
-            minWidth: minWidth,
+            // Inside flex shell we must NOT force textarea width — otherwise the AI
+            // button gets pushed off-screen. Let flex-1 + min-w-0 handle sizing.
           }}
           disabled={isLoading}
+          data-gramm='false'
+          data-gramm_editor='false'
+          data-enable-grammarly='false'
         />
+        <span
+          onMouseDown={e => {
+            e.preventDefault();
+          }}
+          className='shrink-0'
+        >
+          {aiButton}
+        </span>
+      </div>
+    ) : (
+      // Default editor (no AI button): preserves the original look so existing
+      // consumers without `aiButton` see no visual regression.
+      <Textarea
+        ref={textareaRef}
+        value={editedDescription}
+        onChange={handleTextareaChange}
+        onBlur={() => void handleSubmit()}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        className={cn(
+          'm-0 w-full border-0 bg-white p-2 shadow-none dark:bg-white/4',
+          'focus-visible:ring-primary focus-visible:ring-0',
+          {
+            'opacity-50': isLoading,
+          }
+        )}
+        style={{
+          fontSize: 'inherit',
+          lineHeight: 'inherit',
+          fontFamily: 'inherit',
+          resize: 'vertical',
+          minHeight: minHeight,
+          minWidth: minWidth,
+        }}
+        disabled={isLoading}
+      />
+    );
+
+    return (
+      <div className='w-full'>
+        {editor}
         <div className='mt-2 text-xs text-neutral-500'>
           <span>
             Press{' '}
@@ -134,8 +189,13 @@ export function InlineEditDescription({
           setIsEditing(true);
         }}
         className={cn(
-          'min-h-64 cursor-pointer rounded p-2 whitespace-pre-wrap',
+          'min-h-64 w-full cursor-pointer rounded whitespace-pre-wrap',
           'transition-colors duration-150',
+          // Reserve right space equal to the AI-button column in edit mode so the
+          // text wraps identically and doesn't shift when the user opens the editor.
+          // Edit-mode reserves 48px on the right: wrapper p-2 right (8px) +
+          // gap-2 (8px) + AI button width (32px). pl-2 mirrors edit's wrapper p-2 left.
+          aiButton ? 'py-2 pr-12 pl-2' : 'p-2',
           !description && 'text-muted-foreground/50',
           className
         )}

--- a/apps/web/src/shared/components/InlineEditTitle/InlineEditTitle.tsx
+++ b/apps/web/src/shared/components/InlineEditTitle/InlineEditTitle.tsx
@@ -3,6 +3,13 @@ import { cn } from '@owox/ui/lib/utils';
 import { Textarea } from '@owox/ui/components/textarea';
 import toast from 'react-hot-toast';
 
+export interface InlineEditTitleAiContext {
+  /** Replace the current value in the open input. Does not persist on its own. */
+  setValue: (value: string) => void;
+}
+
+export type InlineEditTitleAi = ReactNode | ((ctx: InlineEditTitleAiContext) => ReactNode);
+
 interface InlineEditTitleProps {
   title: string;
   onUpdate: (newTitle: string) => Promise<void>;
@@ -10,8 +17,12 @@ interface InlineEditTitleProps {
   errorMessage?: string;
   minWidth?: string;
   readOnly?: boolean;
-  /** Optional action button rendered absolute on the right of the input, visible only while the field is focused. */
-  aiButton?: ReactNode;
+  /**
+   * Optional action button rendered on the right of the input, visible only while
+   * focused. May be a render-function that receives `{ setValue }` so the action
+   * can write directly into the editor's local buffer (e.g. AI suggestion).
+   */
+  aiButton?: InlineEditTitleAi;
 }
 
 export function InlineEditTitle({
@@ -144,7 +155,7 @@ export function InlineEditTitle({
               }}
               className='shrink-0'
             >
-              {aiButton}
+              {typeof aiButton === 'function' ? aiButton({ setValue: setEditedTitle }) : aiButton}
             </span>
           )}
         </div>

--- a/apps/web/src/shared/components/InlineEditTitle/InlineEditTitle.tsx
+++ b/apps/web/src/shared/components/InlineEditTitle/InlineEditTitle.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type KeyboardEvent, useRef } from 'react';
+import { useState, useEffect, type KeyboardEvent, type ReactNode, useRef } from 'react';
 import { cn } from '@owox/ui/lib/utils';
 import { Textarea } from '@owox/ui/components/textarea';
 import toast from 'react-hot-toast';
@@ -10,6 +10,8 @@ interface InlineEditTitleProps {
   errorMessage?: string;
   minWidth?: string;
   readOnly?: boolean;
+  /** Optional action button rendered absolute on the right of the input, visible only while the field is focused. */
+  aiButton?: ReactNode;
 }
 
 export function InlineEditTitle({
@@ -19,9 +21,11 @@ export function InlineEditTitle({
   errorMessage = 'Title cannot be empty',
   minWidth = '100px',
   readOnly = false,
+  aiButton,
 }: InlineEditTitleProps) {
   const [editedTitle, setEditedTitle] = useState(title);
   const [isLoading, setIsLoading] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -71,48 +75,82 @@ export function InlineEditTitle({
     }
   };
 
+  const showAiButton = !!aiButton && !readOnly && isFocused;
+
+  const textareaEl = (
+    <Textarea
+      ref={textareaRef}
+      value={editedTitle}
+      readOnly={readOnly}
+      onChange={e => {
+        if (readOnly) return;
+        setEditedTitle(e.target.value);
+        const textarea = e.target;
+        textarea.style.height = 'auto';
+        textarea.style.height = `${String(textarea.scrollHeight)}px`;
+      }}
+      onFocus={() => {
+        setIsFocused(true);
+      }}
+      onBlur={() => {
+        setIsFocused(false);
+        if (!readOnly) void handleSubmit();
+      }}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'm-0 border-0 p-0 shadow-none',
+        'bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0',
+        'break-words whitespace-normal',
+        aiButton ? 'min-w-0 flex-1' : 'w-full',
+        {
+          'opacity-50': isLoading,
+          'cursor-default': readOnly,
+        }
+      )}
+      style={{
+        fontSize: 'inherit',
+        fontWeight: 'inherit',
+        lineHeight: 'inherit',
+        fontFamily: 'inherit',
+        color: 'inherit',
+        resize: 'none',
+        overflow: 'hidden',
+        minHeight: 'inherit',
+        height: 'auto',
+        // When the AI button takes part of the row we must let flex shrink the
+        // textarea below 100%; otherwise the button is pushed off-screen.
+        minWidth: aiButton ? 0 : minWidth,
+      }}
+      disabled={isLoading}
+      data-gramm='false'
+      data-gramm_editor='false'
+      data-enable-grammarly='false'
+    />
+  );
+
   return (
     <h2
       className={cn('m-0 min-w-0 p-0', className, {
         'cursor-pointer hover:opacity-80': !readOnly,
       })}
     >
-      <Textarea
-        ref={textareaRef}
-        value={editedTitle}
-        readOnly={readOnly}
-        onChange={e => {
-          if (readOnly) return;
-          setEditedTitle(e.target.value);
-          const textarea = e.target;
-          textarea.style.height = 'auto';
-          textarea.style.height = `${String(textarea.scrollHeight)}px`;
-        }}
-        onBlur={() => !readOnly && void handleSubmit()}
-        onKeyDown={handleKeyDown}
-        className={cn(
-          'm-0 w-full border-0 p-0 shadow-none',
-          'bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0',
-          'break-words whitespace-normal',
-          {
-            'opacity-50': isLoading,
-            'cursor-default': readOnly,
-          }
-        )}
-        style={{
-          fontSize: 'inherit',
-          fontWeight: 'inherit',
-          lineHeight: 'inherit',
-          fontFamily: 'inherit',
-          color: 'inherit',
-          resize: 'none',
-          overflow: 'hidden',
-          minHeight: 'inherit',
-          height: 'auto',
-          minWidth: minWidth,
-        }}
-        disabled={isLoading}
-      />
+      {aiButton ? (
+        <div className='flex min-w-0 items-start gap-1'>
+          {textareaEl}
+          {showAiButton && (
+            <span
+              onMouseDown={e => {
+                e.preventDefault();
+              }}
+              className='shrink-0'
+            >
+              {aiButton}
+            </span>
+          )}
+        </div>
+      ) : (
+        textareaEl
+      )}
     </h2>
   );
 }

--- a/packages/ui/src/components/common/editable-text.tsx
+++ b/packages/ui/src/components/common/editable-text.tsx
@@ -153,7 +153,7 @@ export function EditableText({
               onChange={handleChange}
               onKeyDown={handleKeyDown}
               className={cn(
-                'min-h-[24px] min-w-0 flex-1 resize-y border-0 bg-transparent p-0 shadow-none',
+                'min-h-[24px] min-w-0 flex-1 resize-none border-0 bg-transparent p-0 shadow-none',
                 'focus-visible:border-0 focus-visible:ring-0 focus-visible:ring-offset-0'
               )}
               style={{ minHeight: String(Math.max(minRows * 24, 24)) + 'px' }}

--- a/packages/ui/src/components/common/editable-text.tsx
+++ b/packages/ui/src/components/common/editable-text.tsx
@@ -5,6 +5,24 @@ import { cn } from '@owox/ui/lib/utils';
 import { type KeyboardEvent, type ReactNode, useRef, useState } from 'react';
 
 /**
+ * Helpers passed to a `editorAction` render-function so the action (e.g. AI generate)
+ * can write directly into the editor's local buffer without going through the parent
+ * state. Use this when the action should populate the textarea for user review before
+ * the user explicitly clicks Apply.
+ */
+export interface EditableTextActionContext {
+  /** Replace the current value in the open textarea. Does not persist on its own. */
+  setValue: (value: string) => void;
+}
+
+/**
+ * Slot for the in-editor action (e.g. AI generate). Either a static node, or a
+ * render-function that receives `EditableTextActionContext` and can write into the
+ * editor's local buffer.
+ */
+export type EditableTextAction = ReactNode | ((ctx: EditableTextActionContext) => ReactNode);
+
+/**
  * Props for the EditableText component
  */
 export interface EditableTextProps {
@@ -26,6 +44,12 @@ export interface EditableTextProps {
   cancelButtonText?: string;
   /** Optional slot rendered inline after the value (e.g., a status icon). Keeps the full-width click area for editing. */
   trailingContent?: ReactNode;
+  /**
+   * Optional in-editor action (e.g. AI generate). When provided, an inline shell is
+   * rendered around the textarea with the action on the right. May be a render-function
+   * that receives a `setValue` helper to write directly into the open textarea.
+   */
+  editorAction?: EditableTextAction;
 }
 
 /**
@@ -41,6 +65,7 @@ export function EditableText({
   saveButtonText = 'Apply',
   cancelButtonText = 'Cancel',
   trailingContent,
+  editorAction,
 }: EditableTextProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editedValue, setEditedValue] = useState(value);
@@ -111,15 +136,55 @@ export function EditableText({
         </div>
       </PopoverTrigger>
       <PopoverContent className='w-auto max-w-[600px] min-w-[300px] p-2' align='start'>
-        <Textarea
-          ref={textareaRef}
-          value={editedValue}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          className='min-h-[24px] resize-y'
-          style={{ minHeight: String(Math.max(minRows * 24, 24)) + 'px' }}
-          rows={minRows}
-        />
+        {editorAction ? (
+          // Shell-style editor: wrapper mimics a Textarea (border/ring/padding).
+          // The real <textarea> is borderless and shares the visible surface with the
+          // action button on the right. Only enabled when an action is provided so
+          // existing consumers without `editorAction` see no visual regression.
+          <div
+            className={cn(
+              'border-input dark:bg-input/30 flex items-start gap-2 rounded-md border bg-transparent px-3 py-2 shadow-xs',
+              'focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]'
+            )}
+          >
+            <Textarea
+              ref={textareaRef}
+              value={editedValue}
+              onChange={handleChange}
+              onKeyDown={handleKeyDown}
+              className={cn(
+                'min-h-[24px] min-w-0 flex-1 resize-y border-0 bg-transparent p-0 shadow-none',
+                'focus-visible:border-0 focus-visible:ring-0 focus-visible:ring-offset-0'
+              )}
+              style={{ minHeight: String(Math.max(minRows * 24, 24)) + 'px' }}
+              rows={minRows}
+              data-gramm='false'
+              data-gramm_editor='false'
+              data-enable-grammarly='false'
+            />
+            <span
+              onMouseDown={e => {
+                e.preventDefault();
+              }}
+              className='shrink-0'
+            >
+              {typeof editorAction === 'function'
+                ? editorAction({ setValue: setEditedValue })
+                : editorAction}
+            </span>
+          </div>
+        ) : (
+          // Default editor (no action): preserves the original Textarea look.
+          <Textarea
+            ref={textareaRef}
+            value={editedValue}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            className='min-h-[24px] resize-y'
+            style={{ minHeight: String(Math.max(minRows * 24, 24)) + 'px' }}
+            rows={minRows}
+          />
+        )}
         <div className='mt-3 flex justify-end gap-2'>
           <Button
             variant='outline'


### PR DESCRIPTION
## Preview

### Title
<img width="1020" height="230" alt="CleanShot 2026-05-13 at 08 40 46" src="https://github.com/user-attachments/assets/99b54213-e531-424f-84bb-3f0317f2c436" />

### Description
<img width="1020" height="548" alt="CleanShot 2026-05-13 at 08 41 37" src="https://github.com/user-attachments/assets/562107c8-01a6-4ff7-8a48-457be81ad354" />

### Schema Fields
<img width="990" height="790" alt="CleanShot 2026-05-13 at 08 43 22" src="https://github.com/user-attachments/assets/82e3f261-a6b9-4095-813e-a76ae05d90be" />

### Schema Decription
<img width="990" height="842" alt="CleanShot 2026-05-13 at 08 45 18" src="https://github.com/user-attachments/assets/a611b0ff-2c81-482d-89cb-86f3ac852a28" />

### Schema Aliases
<img width="990" height="842" alt="CleanShot 2026-05-13 at 08 46 20" src="https://github.com/user-attachments/assets/dba33832-4dc7-4948-87ea-d445c93922a2" />




## Summary

Adds an AI helper that drafts Data Mart **title**, **description**, **per-field alias**,
**per-field description**, and bulk **all field descriptions** / **all field aliases**,
grounded in the data mart's schema and a 30-row data sample. Suggestions appear in
the existing inline editors — the user reviews them and clicks Apply before
anything is persisted. The feature is **free** (no consumption events) and is hidden
when AI keys are not configured on the deployment.

## What's new

### Backend (`apps/backend`)

- New AI agent `GenerateDataMartMetadataAgent` and prompt
  (`prompts/generate-data-mart-metadata.prompt.ts`) — single agent that supports
  six scopes via `DataMartMetadataScope` enum:
  `TITLE | DESCRIPTION | FIELD_ALIAS | FIELD_DESCRIPTION |
  ALL_FIELD_DESCRIPTIONS | ALL_FIELD_ALIASES`.
- New `GenerateDataMartMetadataOrchestratorService` mirrors the existing
  `AiInsightsOrchestratorService` pattern: validates the data mart
  (non-connector + valid storage + schema present), optionally runs the data
  mart to grab a 30-row sample via `DataMartSqlTableService`, executes the
  agent with `temperature: 0.3` (stable across regenerations), and shapes the
  response per scope.
- `AiInsightsFacadeImpl.generateDataMartMetadata` is a thin delegate around the
  orchestrator — same shape as the existing `answerPrompt` (measure-execution-time
  + delegation), no business logic in the facade.
- New use-case `GenerateDataMartMetadataService` enforces editor permission,
  gates the call on `AiInsightsConfigService.isInsightsEnabled()` (`503` when
  AI keys are not configured), and after a successful generation publishes a
  `DataMartAiHelperGeneratedEvent` via `OwoxEventDispatcher.publishExternal()`
  (analytics only, transport errors are logged and swallowed).
- New event class `DataMartAiHelperGeneratedEvent` — **single class**, scope-driven
  event name: `data-mart.ai-assistant.<scope>.generated`
  (e.g. `data-mart.ai-assistant.title.generated`,
  `data-mart.ai-assistant.all_field_aliases.generated`).
- New endpoints on `DataMartController`:
  - `POST /data-marts/:id/ai-helper/generate-metadata` — generate a suggestion.
  - `GET  /data-marts/ai-helper/availability` — `{ enabled: boolean }`, used by
    the UI to decide whether to render the AI buttons.
- **No consumption / billing events.** The AI helper is intentionally free —
  it does not call `ConsumptionTrackingService.registerAiProcessRunConsumption`.
  INSIGHT and REPORT consumption flows are untouched.

### Frontend (`apps/web`)

- New hooks `useAiHelperAvailability` (process-wide cached `/availability`
  fetch) and `useAiHelper` (per-scope generation handlers + `pendingScope`).
- New `AiHelperButton` icon button with Sparkles/Loader2 + tooltip.
- AI buttons embedded into the existing editors **only when an AI prop is
  passed in**, so consumers without AI see no visual regression:
  - `InlineEditTitle` and `InlineEditDescription` get an optional `aiButton`
    slot. The button is visible only while the field is focused / being
    edited. Non-edit mode reserves the same right-side space so the text
    doesn't reflow when the editor opens.
  - `EditableText` (the per-field popover used for schema cells) gets an
    optional `editorAction` slot. The slot accepts a render-function that
    receives `setValue` — AI-generated values are written into the editor's
    local buffer, so the user reviews them in the textarea and only persists
    on **Apply**. Cancel discards them cleanly.
- Bulk AI button in `DataMartSchemaSettings` is an icon-only Sparkles
  dropdown with two options: *Generate field descriptions* /
  *Generate field aliases*. Generated values land in the local dirty schema —
  user reviews and clicks Save.
- Browser-extension friendliness: AI buttons live as flex siblings outside
  the `<textarea>` bounding rect, so DeepL/Grammarly icons can't overlay
  them. Editors also set `data-gramm="false"` / `data-enable-grammarly="false"`
  for Grammarly's official opt-out.

## Constraints (intentional)

- Connector-based data marts are rejected with 422 — only `SQL`, `TABLE`,
  `VIEW`, `TABLE_PATTERN` definition types are supported.
- A data mart without an actualized schema is rejected with 422.
- A 30-row sample query runs against the warehouse on each AI call. This
  counts towards the warehouse's own quotas but **does not** produce a
  Process Run consumption event in OWOX.

## Self-hosted / BYOK

The existing `AiInsightsConfigService` is the gate. When any of `AI_BASE_URL`,
`AI_API_KEY`, `AI_MODEL` is missing, `/availability` returns
`{ enabled: false }` and the UI hides every Sparkles button. Setting the env
vars and restarting the backend is enough — no UI rebuild needed.

## How the AI knows what to produce

All formatting rules live in `prompts/generate-data-mart-metadata.prompt.ts`:

- Per-scope `describeScopeRequirements()` tells the model which JSON fields
  to populate and which to omit.
- The system prompt has explicit guidelines + examples for alias style
  (Title Case, 1–4 words, expand abbreviations) and description style
  (one sentence, business framing, ends with period).
- The Zod result schema's `.describe(...)` annotations are echoed into the
  prompt via `buildJsonFormatSection(...)` so the model sees the contract
  twice.

To tune the output, edit those three sources. Temperature is `0.3` (stable
across regenerations); bump it to `0.6–0.7` if more variety on repeat clicks
is desired.

## Test plan

- [ ] Open a published BigQuery Data Mart, focus the title → Sparkles button
      appears on the right of the title row → click → title is replaced by
      AI suggestion.
- [ ] Open Description, focus the textarea → Sparkles button appears on the
      right → click → AI draft fills the textarea → click outside /
      Ctrl+Enter to save.
- [ ] On the *Output Schema* tab, click an empty *Alias* cell → popover
      opens → Sparkles button on the right of the textarea → click → AI
      value appears in the open textarea → **Apply** persists into local
      schema → click **Save** at the bottom to persist to backend. Repeat
      the flow with **Cancel** — local schema must NOT change.
- [ ] Same flow on the *Description* column.
- [ ] Use the Sparkles icon next to *Refresh schema* → menu opens →
      *Generate field descriptions* fills all descriptions in local schema
      → review → Save. Repeat with *Generate field aliases*.
- [ ] Open a connector-based data mart, hit any Sparkles button → 422
      `Connector data marts are not supported`.
- [ ] In a deployment with no `AI_*` env vars: no Sparkles buttons anywhere,
      `/data-marts/ai-helper/availability` returns `{ enabled: false }`.
- [ ] After any successful generation, the external bus receives
      `data-mart.ai-assistant.<scope>.generated` with payload
      `{ projectId, dataMartId, userId, scope }`. **No** AI process run
      consumption event is emitted for the helper.
- [ ] Smoke regressions: trigger an Insight prompt → confirm INSIGHT-side
      consumption events still fire. Run an Email/Sheets report → confirm
      REPORT-side consumption events still fire. (Both billing paths are
      intentionally untouched.)
- [ ] Focus → blur Description without clicking Sparkles → no layout shift
      between non-edit and edit text wrapping.
