### PR TITLE
refactor(web): update PromoBlock content and styling for Google Sheets banner

### DIFF
--- a/apps/web/src/features/data-marts/reports/list/components/EmptyDataMartDestinationsState/EmptyDataMartDestinationsState.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmptyDataMartDestinationsState/EmptyDataMartDestinationsState.tsx
@@ -16,18 +16,17 @@ export function EmptyDataMartDestinationsState({
   onOpenCreateDestination,
 }: Props) {
   const { scope } = useProjectRoute();
-
   // Promo variant (show after data mart is published)
   if (variant === 'promo') {
     return (
       <div className='flex flex-col gap-0.5'>
         <PromoBlock
           icon={GoogleSheetsIcon}
-          title='Use your data in&nbsp;Google&nbsp;Sheets'
+          title='Analyze your data in&nbsp;Google Sheets'
           subtitle='Ready to start reporting?'
-          description='No SQL needed — add columns and analyze data directly in&nbsp;Sheets'
+          description='Access live data directly in&nbsp;Sheets&nbsp;— choose columns and build reports without SQL or&nbsp;CSV&nbsp;exports.'
           primaryAction={{
-            label: 'Add Google Sheets Destination',
+            label: 'Connect Google Sheets',
             ...(onOpenCreateDestination
               ? {
                   onClick: onOpenCreateDestination,
@@ -37,9 +36,8 @@ export function EmptyDataMartDestinationsState({
                 }),
           }}
           secondaryAction={{
-            label: 'Learn more',
-            href: 'https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/?utm_source=owox_data_marts&utm_medium=dm_page_destinations_tab&utm_campaign=empty_state',
-            external: true,
+            label: 'View all destinations',
+            href: scope('/data-destinations'),
           }}
         />
         <InviteTeammatesCard

--- a/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
+++ b/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
@@ -20,12 +20,13 @@ import { DataMartStatus } from '../../../features/data-marts/shared/enums';
 import { PromoBlock } from '../../../shared/components/PromoBlock/PromoBlock';
 import { GoogleSheetsIcon } from '../../../shared/icons/google-sheets-icon';
 import { InviteTeammatesCard } from '../../../shared/components/InviteTeammatesCard';
+import { useProjectRoute } from '../../../shared/hooks/useProjectRoute';
 
 function DataMartDestinationsContentInner() {
   const { dataMart } = useOutletContext<DataMartContextType>();
   const { dataDestinations, isLoading, fetchDataDestinations } = useDataDestinationsWithReports();
   const [isCreateDestinationOpen, setIsCreateDestinationOpen] = useState(false);
-
+  const { scope } = useProjectRoute();
   const handleOpenCreateDestination = useCallback(() => {
     setIsCreateDestinationOpen(true);
   }, []);
@@ -78,16 +79,15 @@ function DataMartDestinationsContentInner() {
               <PromoBlock
                 icon={GoogleSheetsIcon}
                 size='compact'
-                title='Use your data in&nbsp;Google&nbsp;Sheets'
-                description='No SQL needed — add columns and analyze data directly in&nbsp;Sheets'
+                title='Analyze your data in&nbsp;Google Sheets'
+                description='Access live data directly in&nbsp;Sheets&nbsp;— choose columns and build reports without SQL or&nbsp;CSV&nbsp;exports.'
                 primaryAction={{
-                  label: 'Add Google Sheets Destination',
+                  label: 'Connect Google Sheets',
                   onClick: handleOpenCreateDestination,
                 }}
                 secondaryAction={{
-                  label: 'Learn more',
-                  href: 'https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/?utm_source=owox_data_marts&utm_medium=dm_page_destinations_tab&utm_campaign=no_sheets_destination_upsell_promo',
-                  external: true,
+                  label: 'View all destinations',
+                  href: scope('/data-destinations'),
                 }}
               />
               <InviteTeammatesCard

--- a/apps/web/src/shared/components/PromoBlock/PromoBlock.tsx
+++ b/apps/web/src/shared/components/PromoBlock/PromoBlock.tsx
@@ -134,9 +134,9 @@ export function PromoBlock({
     ),
 
     title: cn(
-      'leading-tight font-semibold',
+      'leading-tight font-medium',
       isCompact
-        ? 'text-lg md:text-xl lg:text-2xl mb-2 lg:mb-3'
+        ? 'text-xl lg:text-2xl mb-2 lg:mb-3'
         : 'text-3xl md:text-4xl xl:text-5xl mb-2 lg:mb-8'
     ),
 


### PR DESCRIPTION

<img width="1459" height="762" alt="Screenshot 2026-05-13 at 19 45 31" src="https://github.com/user-attachments/assets/73257ef5-a61b-4d7c-aa82-0f9accb50444" />


Updated the Google Sheets promo banner copy to better communicate the value of live data access and self-service reporting in Sheets. Replaced generic messaging with clearer user-focused benefits around choosing columns, building reports, and avoiding SQL or CSV exports.

Also replaced the secondary “Learn more” documentation link with a “View all destinations” action that navigates users to the full list of available reporting destinations and integrations.