### PR TITLE
fix(data-marts): duplicate CTE name + copy-report ownership

### DIFF
--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -210,6 +210,22 @@ describe('GoogleSheetsReportWriter — truncates trailing rows below new data', 
     expect(adapter.clearValuesInRange).not.toHaveBeenCalled();
   });
 
+  it('finalize emits an unsuccessful event when prepareToWriteReport failed before report was assigned', async () => {
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+    });
+    adapter.getSpreadsheet.mockRejectedValueOnce(new Error('spreadsheet unreachable'));
+
+    await expect(
+      writer.prepareToWriteReport(
+        report as never,
+        new ReportDataDescription(makeHeaders(...finalImportedNames), 0)
+      )
+    ).rejects.toThrow();
+
+    await expect(writer.finalize(new Error('original error'))).resolves.toBeUndefined();
+  });
+
   it('does not call clearValuesInRange when no data was written and structural ops were never applied', async () => {
     // Reader produced zero batches AND finalize was reached on the success
     // path. The writer's deferred mutations apply (so headers land on a

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -472,6 +472,8 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
    * Initializes the Google Sheets service with credentials and finds the target sheet
    */
   private async initializeService(report: Report): Promise<void> {
+    // Assign before any async work — `finalize(error)` reads `this.report.dataMart` on the failure path.
+    this.report = report;
     return this.executeWithErrorHandling(async () => {
       if (!isGoogleSheetsConfig(report.destinationConfig)) {
         throw new Error('Invalid Google Sheets destination configuration provided');
@@ -516,7 +518,6 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
       this.availableColumnsCount = sheet.properties?.gridProperties?.columnCount ?? 0;
       this.spreadsheetTimeZone = spreadsheet.properties?.timeZone ?? 'UTC';
       this.dataMartTitle = report.dataMart.title;
-      this.report = report;
     }, 'Initializing Google Sheets service and locating target sheet');
   }
 

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/__fixtures__/blended-query-builder-fixtures.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/__fixtures__/blended-query-builder-fixtures.ts
@@ -18,10 +18,21 @@ export function makeRelationship(
 }
 
 export function makeChain(
-  partial: Omit<ResolvedRelationshipChain, 'targetDataMartTitle' | 'targetDataMartUrl'>
+  partial: Omit<
+    ResolvedRelationshipChain,
+    'targetDataMartTitle' | 'targetDataMartUrl' | 'cteName'
+  > & {
+    cteName?: string;
+  }
 ): ResolvedRelationshipChain {
+  const cteName =
+    partial.cteName ??
+    (partial.parentAlias === 'main'
+      ? partial.relationship.targetAlias
+      : `${partial.parentAlias}_${partial.relationship.targetAlias}`);
   return {
     ...partial,
+    cteName,
     targetDataMartTitle: 'Test Subsidiary',
     targetDataMartUrl: '/ui/proj/data-marts/sub-1/data-setup',
   };

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
@@ -559,13 +559,13 @@ describe('AbstractBlendedQueryBuilder', () => {
         buildContext([ab, bc], ['campaign_id', 'b_c__product_name'])
       );
 
-      // C (leaf) aggregation
-      expect(sql).toContain('c AS (');
-      expect(sql).toContain('FROM c_raw');
+      // C (leaf) aggregation — CTE name is path-prefixed
+      expect(sql).toContain('b_c AS (');
+      expect(sql).toContain('FROM b_c_raw');
 
       // B has _joined CTE that LEFT JOINs with aggregated C
       expect(sql).toContain('b_joined AS (');
-      expect(sql).toContain('LEFT JOIN c ON b_raw.product_id = c.product_id');
+      expect(sql).toContain('LEFT JOIN b_c ON b_raw.product_id = b_c.product_id');
 
       // B aggregation reads from b_joined and groups by b_id ONLY
       expect(sql).toMatch(
@@ -575,7 +575,7 @@ describe('AbstractBlendedQueryBuilder', () => {
       // Final JOIN only to B, not C
       expect(sql).toContain('LEFT JOIN b ON main.b_id = b.b_id');
       const finalSection = sql.split('FROM main\n')[1];
-      expect(finalSection).not.toContain('LEFT JOIN c ON');
+      expect(finalSection).not.toContain('LEFT JOIN b_c ON');
 
       // b_c__product_name surfaced through B
       expect(sql).toContain('b.b_c__product_name');
@@ -616,7 +616,7 @@ describe('AbstractBlendedQueryBuilder', () => {
         /\n {2}b AS \(\s*SELECT\s+shared_id,\s+MAX\(c_val\) AS c_val\s+FROM b_joined\s+GROUP BY shared_id\s+\)/
       );
       expect(sql).toMatch(
-        /\n {2}c AS \(\s*SELECT\s+shared_id,\s+MAX\(val\) AS c_val\s+FROM c_raw\s+GROUP BY shared_id\s+\)/
+        /\n {2}b_c AS \(\s*SELECT\s+shared_id,\s+MAX\(val\) AS c_val\s+FROM b_c_raw\s+GROUP BY shared_id\s+\)/
       );
     });
 
@@ -648,7 +648,7 @@ describe('AbstractBlendedQueryBuilder', () => {
           joinConditions: [{ sourceFieldName: 'c_key', targetFieldName: 'c_key' }],
         }),
         targetTableReference: 'd_table',
-        parentAlias: 'c',
+        parentAlias: 'b_c',
         blendedFields: [
           {
             targetFieldName: 'value',
@@ -661,18 +661,18 @@ describe('AbstractBlendedQueryBuilder', () => {
 
       const { sql } = builder.buildBlendedQuery(buildContext([ab, bc, cd], ['col_a', 'd_value']));
 
-      // D (leaf) aggregates by c_key
-      expect(sql).toContain('FROM d_raw');
+      // D (leaf, cteName=b_c_d) aggregates by c_key
+      expect(sql).toContain('FROM b_c_d_raw');
       expect(sql).toContain('GROUP BY c_key');
 
-      // C (intermediate) has _joined CTE with D, aggregates by b_key
-      expect(sql).toContain('c_joined AS (');
-      expect(sql).toContain('LEFT JOIN d ON c_raw.c_key = d.c_key');
-      expect(sql).toMatch(/\n {2}c AS \([\s\S]*?FROM c_joined\s+GROUP BY b_key\s+\)/);
+      // C (intermediate, cteName=b_c) has _joined CTE with D, aggregates by b_key
+      expect(sql).toContain('b_c_joined AS (');
+      expect(sql).toContain('LEFT JOIN b_c_d ON b_c_raw.c_key = b_c_d.c_key');
+      expect(sql).toMatch(/\n {2}b_c AS \([\s\S]*?FROM b_c_joined\s+GROUP BY b_key\s+\)/);
 
       // B (intermediate) has _joined CTE with C, aggregates by a_key
       expect(sql).toContain('b_joined AS (');
-      expect(sql).toContain('LEFT JOIN c ON b_raw.b_key = c.b_key');
+      expect(sql).toContain('LEFT JOIN b_c ON b_raw.b_key = b_c.b_key');
       expect(sql).toMatch(/\n {2}b AS \([\s\S]*?FROM b_joined\s+GROUP BY a_key\s+\)/);
 
       // Final SELECT references only main and b
@@ -741,9 +741,11 @@ describe('AbstractBlendedQueryBuilder', () => {
       );
 
       expect(sql).toContain('orders_joined AS (');
-      expect(sql).toContain('LEFT JOIN products ON orders_raw.product_id = products.product_id');
       expect(sql).toContain(
-        'LEFT JOIN customers ON orders_raw.customer_id = customers.customer_id'
+        'LEFT JOIN orders_products ON orders_raw.product_id = orders_products.product_id'
+      );
+      expect(sql).toContain(
+        'LEFT JOIN orders_customers ON orders_raw.customer_id = orders_customers.customer_id'
       );
 
       expect(sql).toMatch(
@@ -756,8 +758,8 @@ describe('AbstractBlendedQueryBuilder', () => {
 
       const finalJoins = sql.split('FROM main\n')[1];
       expect(finalJoins).toContain('LEFT JOIN orders ON');
-      expect(finalJoins).not.toContain('LEFT JOIN products ON');
-      expect(finalJoins).not.toContain('LEFT JOIN customers ON');
+      expect(finalJoins).not.toContain('LEFT JOIN orders_products ON');
+      expect(finalJoins).not.toContain('LEFT JOIN orders_customers ON');
     });
 
     it('re-aggregation: COUNT becomes SUM at parent level', () => {
@@ -873,6 +875,81 @@ describe('AbstractBlendedQueryBuilder', () => {
       );
       expect(sql).toContain('STRING_AGG(item_skus) AS item_skus');
       expect(sql).toContain('orders.item_skus');
+    });
+
+    it('diamond pattern: two chains sharing targetAlias produce distinct path-prefixed CTEs', () => {
+      const left = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-main-left',
+          targetAlias: 'left',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+        }),
+        targetTableReference: 'left_table',
+        parentAlias: 'main',
+        blendedFields: [],
+      });
+      const right = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-main-right',
+          targetAlias: 'right',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+        }),
+        targetTableReference: 'right_table',
+        parentAlias: 'main',
+        blendedFields: [],
+      });
+      const leftShared = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-left-shared',
+          targetAlias: 'shared',
+          joinConditions: [{ sourceFieldName: 'left_id', targetFieldName: 'left_id' }],
+        }),
+        targetTableReference: 'shared_table',
+        parentAlias: 'left',
+        blendedFields: [
+          {
+            targetFieldName: 'value',
+            outputAlias: 'left_shared__value',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+      const rightShared = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-right-shared',
+          targetAlias: 'shared',
+          joinConditions: [{ sourceFieldName: 'right_id', targetFieldName: 'right_id' }],
+        }),
+        targetTableReference: 'shared_table',
+        parentAlias: 'right',
+        blendedFields: [
+          {
+            targetFieldName: 'value',
+            outputAlias: 'right_shared__value',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+
+      const { sql } = builder.buildBlendedQuery(
+        buildContext(
+          [left, right, leftShared, rightShared],
+          ['root_col', 'left_shared__value', 'right_shared__value']
+        )
+      );
+
+      expect(sql).toContain('left_shared AS (');
+      expect(sql).toContain('left_shared_raw AS (');
+      expect(sql).toContain('right_shared AS (');
+      expect(sql).toContain('right_shared_raw AS (');
+
+      expect(sql).toContain('LEFT JOIN left_shared ON left_raw.left_id = left_shared.left_id');
+      expect(sql).toContain('LEFT JOIN right_shared ON right_raw.right_id = right_shared.right_id');
+
+      expect(sql).toContain('left.left_shared__value');
+      expect(sql).toContain('right.right_shared__value');
     });
 
     it('row-count guarantee: only root-level LEFT JOINs in final FROM clause', () => {

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
@@ -165,11 +165,11 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
   private buildTree(chains: ResolvedRelationshipChain[]): BlendTreeNode[] {
     const nodeMap = new Map<string, BlendTreeNode>();
     for (const chain of chains) {
-      nodeMap.set(chain.relationship.targetAlias, { chain, children: [] });
+      nodeMap.set(chain.cteName, { chain, children: [] });
     }
     const roots: BlendTreeNode[] = [];
     for (const chain of chains) {
-      const node = nodeMap.get(chain.relationship.targetAlias)!;
+      const node = nodeMap.get(chain.cteName)!;
       if (chain.parentAlias === 'main') {
         roots.push(node);
       } else {
@@ -196,11 +196,11 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     for (const child of node.children) {
       const childResult = this.buildSubtreeCtes(child);
       ctes.push(...childResult.ctes);
-      childPassthroughs.set(child.chain.relationship.targetAlias, childResult.passthroughFields);
+      childPassthroughs.set(child.chain.cteName, childResult.passthroughFields);
     }
 
     const { chain } = node;
-    const alias = chain.relationship.targetAlias;
+    const alias = chain.cteName;
 
     // 2. Raw CTE for this node
     const subsidiaryColumns = this.collectSubsidiaryReferences(chain, node.children);
@@ -261,7 +261,7 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     childPassthroughs: Map<string, PassthroughField[]>
   ): string {
     const { chain } = node;
-    const alias = chain.relationship.targetAlias;
+    const alias = chain.cteName;
     const rawAlias = `${alias}_raw`;
     const joinedAlias = `${alias}_joined`;
     const quotedRawAlias = this.quoteIdentifier(rawAlias);
@@ -288,7 +288,7 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     // Child aggregated outputs + JOIN clauses (single pass over children)
     const joinClauses: string[] = [];
     for (const child of node.children) {
-      const childAlias = child.chain.relationship.targetAlias;
+      const childAlias = child.chain.cteName;
       const quotedChildAlias = this.quoteIdentifier(childAlias);
 
       for (const pt of childPassthroughs.get(childAlias) ?? []) {
@@ -402,11 +402,11 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     hasChildren: boolean,
     passthroughFields: PassthroughField[]
   ): string {
-    const { relationship, blendedFields } = chain;
-    const alias = this.quoteIdentifier(relationship.targetAlias);
+    const { relationship, blendedFields, cteName } = chain;
+    const alias = this.quoteIdentifier(cteName);
     const sourceAlias = hasChildren
-      ? this.quoteIdentifier(`${relationship.targetAlias}_joined`)
-      : this.quoteIdentifier(`${relationship.targetAlias}_raw`);
+      ? this.quoteIdentifier(`${cteName}_joined`)
+      : this.quoteIdentifier(`${cteName}_raw`);
 
     // Keys this subsidiary uses to join to its parent — always grouped on.
     const parentJoinKeys = relationship.joinConditions.map(jc =>
@@ -455,7 +455,7 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     // Non-hidden blended fields from any depth are routed to their root ancestor.
     const outputAliasToRoot = new Map<string, string>();
     for (const root of roots) {
-      this.mapOutputAliasesToRoot(root, root.chain.relationship.targetAlias, outputAliasToRoot);
+      this.mapOutputAliasesToRoot(root, root.chain.cteName, outputAliasToRoot);
     }
 
     for (const col of columnSet) {
@@ -493,8 +493,8 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
    */
   private buildJoinParts(roots: BlendTreeNode[]): string[] {
     return roots.map(root => {
-      const { relationship, parentAlias } = root.chain;
-      const alias = this.quoteIdentifier(relationship.targetAlias);
+      const { relationship, parentAlias, cteName } = root.chain;
+      const alias = this.quoteIdentifier(cteName);
       const parent = this.quoteIdentifier(parentAlias);
 
       const onParts = relationship.joinConditions.map(

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/blended-query-builder.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/blended-query-builder.interface.ts
@@ -16,6 +16,7 @@ export interface ResolvedRelationshipChain {
   relationship: DataMartRelationship;
   targetTableReference: string;
   parentAlias: string;
+  cteName: string;
   blendedFields: BlendedFieldConfig[];
   targetDataMartTitle: string;
   targetDataMartUrl: string;

--- a/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
@@ -517,9 +517,11 @@ describe('BlendedReportDataService', () => {
       );
     });
 
-    it('throws when two chains share the same targetAlias (CTE name collision)', async () => {
-      // A→B (alias="orders") and B→C (alias="orders") — both legit per-source but
-      // would produce duplicate CTE names in the generated SQL.
+    it('disambiguates CTE names with parent path when two chains share the same targetAlias', async () => {
+      // A→B (alias="orders") and B→C (alias="orders") — both legit per-source
+      // (the `(sourceDataMart, targetAlias)` unique constraint allows it). The
+      // builder must produce distinct CTE names ("orders" and "orders_orders")
+      // rather than rejecting the configuration.
       const columnConfig = ['b_orders__field', 'orders__field'];
       const report = makeReport({ columnConfig });
 
@@ -599,10 +601,268 @@ describe('BlendedReportDataService', () => {
         return ids.map(id => byId[id]).filter(Boolean);
       });
       tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
+      blendedQueryBuilderFacade.buildBlendedQuery.mockResolvedValue('SELECT ...');
+
+      await service.resolveBlendingDecision(report);
+
+      const [, context] = blendedQueryBuilderFacade.buildBlendedQuery.mock.calls[0];
+      expect(context!.chains).toHaveLength(2);
+
+      const abChain = context!.chains.find(c => c.relationship.id === 'rel-ab');
+      expect(abChain).toBeDefined();
+      expect(abChain!.parentAlias).toBe('main');
+      expect(abChain!.cteName).toBe('orders');
+
+      const bcChain = context!.chains.find(c => c.relationship.id === 'rel-bc');
+      expect(bcChain).toBeDefined();
+      expect(bcChain!.parentAlias).toBe('orders');
+      expect(bcChain!.cteName).toBe('orders_orders');
+    });
+
+    it('throws when two paths flatten to the same cteName (path-segment ambiguity safeguard)', async () => {
+      // Pathological: targetAlias "a_b" at depth 1 vs targetAlias "a" + "b" at depths 1/2
+      // both flatten to the cteName "a_b". The path-prefix scheme normally guarantees
+      // uniqueness, but with arbitrary underscores in targetAlias the flattening can
+      // collide — the safeguard surfaces this as a clear error instead of broken SQL.
+      const columnConfig = ['a_b__x', 'a_b__y'];
+      const report = makeReport({ columnConfig });
+
+      const fieldFromSingle = new BlendedFieldDto();
+      fieldFromSingle.name = 'a_b__x';
+      fieldFromSingle.sourceRelationshipId = 'rel-ab-direct';
+      fieldFromSingle.sourceDataMartId = 'dm-ab';
+      fieldFromSingle.targetAlias = 'a_b';
+      fieldFromSingle.originalFieldName = 'x';
+      fieldFromSingle.type = 'STRING';
+      fieldFromSingle.isHidden = false;
+      fieldFromSingle.aggregateFunction = 'STRING_AGG';
+      fieldFromSingle.transitiveDepth = 1;
+      fieldFromSingle.aliasPath = 'a_b';
+      fieldFromSingle.outputPrefix = 'a_b';
+
+      const fieldFromTwoStep = new BlendedFieldDto();
+      fieldFromTwoStep.name = 'a_b__y';
+      fieldFromTwoStep.sourceRelationshipId = 'rel-a-b';
+      fieldFromTwoStep.sourceDataMartId = 'dm-b';
+      fieldFromTwoStep.targetAlias = 'b';
+      fieldFromTwoStep.originalFieldName = 'y';
+      fieldFromTwoStep.type = 'STRING';
+      fieldFromTwoStep.isHidden = false;
+      fieldFromTwoStep.aggregateFunction = 'STRING_AGG';
+      fieldFromTwoStep.transitiveDepth = 2;
+      fieldFromTwoStep.aliasPath = 'a.b';
+      fieldFromTwoStep.outputPrefix = 'a_b';
+
+      blendableSchemaService.computeBlendableSchema.mockResolvedValue({
+        nativeFields: [],
+        availableSources: [
+          {
+            aliasPath: 'a_b',
+            title: 'AB',
+            defaultAlias: 'a_b',
+            depth: 1,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-ab-direct',
+            dataMartId: 'dm-ab',
+          },
+          {
+            aliasPath: 'a',
+            title: 'A',
+            defaultAlias: 'a',
+            depth: 1,
+            fieldCount: 0,
+            isIncluded: true,
+            relationshipId: 'rel-main-a',
+            dataMartId: 'dm-a',
+          },
+          {
+            aliasPath: 'a.b',
+            title: 'B',
+            defaultAlias: 'a_b',
+            depth: 2,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-a-b',
+            dataMartId: 'dm-b',
+          },
+        ],
+        blendedFields: [fieldFromSingle, fieldFromTwoStep],
+      });
+
+      const relAbDirect = {
+        id: 'rel-ab-direct',
+        targetAlias: 'a_b',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-ab', title: 'AB' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+      const relMainA = {
+        id: 'rel-main-a',
+        targetAlias: 'a',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-a', title: 'A' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+      const relAB = {
+        id: 'rel-a-b',
+        targetAlias: 'b',
+        sourceDataMart: { id: 'dm-a' },
+        targetDataMart: { id: 'dm-b', title: 'B' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+
+      relationshipService.findBySourceDataMartId.mockResolvedValue([relAbDirect, relMainA]);
+      relationshipService.findByIds.mockImplementation(async (ids: string[]) => {
+        const byId: Record<string, DataMartRelationship> = {
+          'rel-ab-direct': relAbDirect,
+          'rel-main-a': relMainA,
+          'rel-a-b': relAB,
+        };
+        return ids.map(id => byId[id]).filter(Boolean);
+      });
+      tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
 
       await expect(service.resolveBlendingDecision(report)).rejects.toThrow(
-        /targetAlias.+orders.+collision|duplicate.+CTE.+orders/i
+        /cteName "a_b" is produced by multiple/
       );
+    });
+
+    it('disambiguates CTE names in a diamond pattern (two paths reaching same target with same targetAlias)', async () => {
+      // Diamond: main→left→shared and main→right→shared, both with targetAlias="shared".
+      // Pre-fix this used to throw a "duplicate CTE name" error; now it must
+      // produce CTE names "left_shared" and "right_shared".
+      const columnConfig = ['left_shared__value', 'right_shared__value'];
+      const report = makeReport({ columnConfig });
+
+      const leftField = new BlendedFieldDto();
+      leftField.name = 'left_shared__value';
+      leftField.sourceRelationshipId = 'rel-left-shared';
+      leftField.sourceDataMartId = 'dm-shared';
+      leftField.targetAlias = 'shared';
+      leftField.originalFieldName = 'value';
+      leftField.type = 'STRING';
+      leftField.isHidden = false;
+      leftField.aggregateFunction = 'STRING_AGG';
+      leftField.transitiveDepth = 2;
+      leftField.aliasPath = 'left.shared';
+      leftField.outputPrefix = 'left_shared';
+
+      const rightField = new BlendedFieldDto();
+      rightField.name = 'right_shared__value';
+      rightField.sourceRelationshipId = 'rel-right-shared';
+      rightField.sourceDataMartId = 'dm-shared';
+      rightField.targetAlias = 'shared';
+      rightField.originalFieldName = 'value';
+      rightField.type = 'STRING';
+      rightField.isHidden = false;
+      rightField.aggregateFunction = 'STRING_AGG';
+      rightField.transitiveDepth = 2;
+      rightField.aliasPath = 'right.shared';
+      rightField.outputPrefix = 'right_shared';
+
+      blendableSchemaService.computeBlendableSchema.mockResolvedValue({
+        nativeFields: [],
+        availableSources: [
+          {
+            aliasPath: 'left',
+            title: 'Left',
+            defaultAlias: 'left',
+            depth: 1,
+            fieldCount: 0,
+            isIncluded: true,
+            relationshipId: 'rel-main-left',
+            dataMartId: 'dm-left',
+          },
+          {
+            aliasPath: 'right',
+            title: 'Right',
+            defaultAlias: 'right',
+            depth: 1,
+            fieldCount: 0,
+            isIncluded: true,
+            relationshipId: 'rel-main-right',
+            dataMartId: 'dm-right',
+          },
+          {
+            aliasPath: 'left.shared',
+            title: 'Shared',
+            defaultAlias: 'left_shared',
+            depth: 2,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-left-shared',
+            dataMartId: 'dm-shared',
+          },
+          {
+            aliasPath: 'right.shared',
+            title: 'Shared',
+            defaultAlias: 'right_shared',
+            depth: 2,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-right-shared',
+            dataMartId: 'dm-shared',
+          },
+        ],
+        blendedFields: [leftField, rightField],
+      });
+
+      const relMainLeft = {
+        id: 'rel-main-left',
+        targetAlias: 'left',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-left', title: 'Left' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+      const relMainRight = {
+        id: 'rel-main-right',
+        targetAlias: 'right',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-right', title: 'Right' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+      const relLeftShared = {
+        id: 'rel-left-shared',
+        targetAlias: 'shared',
+        sourceDataMart: { id: 'dm-left' },
+        targetDataMart: { id: 'dm-shared', title: 'Shared' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+      const relRightShared = {
+        id: 'rel-right-shared',
+        targetAlias: 'shared',
+        sourceDataMart: { id: 'dm-right' },
+        targetDataMart: { id: 'dm-shared', title: 'Shared' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+
+      relationshipService.findBySourceDataMartId.mockResolvedValue([relMainLeft, relMainRight]);
+      relationshipService.findByIds.mockImplementation(async (ids: string[]) => {
+        const byId: Record<string, DataMartRelationship> = {
+          'rel-main-left': relMainLeft,
+          'rel-main-right': relMainRight,
+          'rel-left-shared': relLeftShared,
+          'rel-right-shared': relRightShared,
+        };
+        return ids.map(id => byId[id]).filter(Boolean);
+      });
+      tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
+      blendedQueryBuilderFacade.buildBlendedQuery.mockResolvedValue('SELECT ...');
+
+      await service.resolveBlendingDecision(report);
+
+      const [, context] = blendedQueryBuilderFacade.buildBlendedQuery.mock.calls[0];
+      const cteNames = context!.chains.map(c => c.cteName).sort();
+      expect(cteNames).toEqual(['left', 'left_shared', 'right', 'right_shared']);
+
+      const leftShared = context!.chains.find(c => c.relationship.id === 'rel-left-shared')!;
+      expect(leftShared.cteName).toBe('left_shared');
+      expect(leftShared.parentAlias).toBe('left');
+
+      const rightShared = context!.chains.find(c => c.relationship.id === 'rel-right-shared')!;
+      expect(rightShared.cteName).toBe('right_shared');
+      expect(rightShared.parentAlias).toBe('right');
     });
 
     it('includes intermediate relationships when only a deep (transitiveDepth>1) field is selected', async () => {
@@ -720,6 +980,138 @@ describe('BlendedReportDataService', () => {
       // Sorted by transitiveDepth: A→B (depth 1) must come before B→C (depth 2).
       expect(context!.chains[0].relationship.id).toBe('rel-ab');
       expect(context!.chains[1].relationship.id).toBe('rel-bc');
+    });
+
+    it('routes blended fields to the chain matching their aliasPath when one relationship is reused by multiple paths', async () => {
+      const columnConfig = ['orders_products__product_price', 'orders_2_products__product_price'];
+      const report = makeReport({ columnConfig });
+
+      const ordersProductsField = new BlendedFieldDto();
+      ordersProductsField.name = 'orders_products__product_price';
+      ordersProductsField.sourceRelationshipId = 'rel-orders-products';
+      ordersProductsField.sourceDataMartId = 'dm-products';
+      ordersProductsField.targetAlias = 'products';
+      ordersProductsField.originalFieldName = 'product_price';
+      ordersProductsField.type = 'INTEGER';
+      ordersProductsField.isHidden = false;
+      ordersProductsField.aggregateFunction = 'SUM';
+      ordersProductsField.transitiveDepth = 2;
+      ordersProductsField.aliasPath = 'orders.products';
+      ordersProductsField.outputPrefix = 'orders_products';
+
+      const orders2ProductsField = new BlendedFieldDto();
+      orders2ProductsField.name = 'orders_2_products__product_price';
+      orders2ProductsField.sourceRelationshipId = 'rel-orders-products';
+      orders2ProductsField.sourceDataMartId = 'dm-products';
+      orders2ProductsField.targetAlias = 'products';
+      orders2ProductsField.originalFieldName = 'product_price';
+      orders2ProductsField.type = 'INTEGER';
+      orders2ProductsField.isHidden = false;
+      orders2ProductsField.aggregateFunction = 'SUM';
+      orders2ProductsField.transitiveDepth = 2;
+      orders2ProductsField.aliasPath = 'orders_2.products';
+      orders2ProductsField.outputPrefix = 'orders_2_products';
+
+      blendableSchemaService.computeBlendableSchema.mockResolvedValue({
+        nativeFields: [],
+        availableSources: [
+          {
+            aliasPath: 'orders',
+            title: 'Orders',
+            defaultAlias: 'orders',
+            depth: 1,
+            fieldCount: 0,
+            isIncluded: true,
+            relationshipId: 'rel-campaigns-orders',
+            dataMartId: 'dm-orders',
+          },
+          {
+            aliasPath: 'orders_2',
+            title: 'Orders',
+            defaultAlias: 'orders_2',
+            depth: 1,
+            fieldCount: 0,
+            isIncluded: true,
+            relationshipId: 'rel-campaigns-orders-2',
+            dataMartId: 'dm-orders',
+          },
+          {
+            aliasPath: 'orders.products',
+            title: 'Products',
+            defaultAlias: 'orders_products',
+            depth: 2,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-orders-products',
+            dataMartId: 'dm-products',
+          },
+          {
+            aliasPath: 'orders_2.products',
+            title: 'Products',
+            defaultAlias: 'orders_2_products',
+            depth: 2,
+            fieldCount: 1,
+            isIncluded: true,
+            relationshipId: 'rel-orders-products',
+            dataMartId: 'dm-products',
+          },
+        ],
+        blendedFields: [ordersProductsField, orders2ProductsField],
+      });
+
+      const relCampaignsOrders = {
+        id: 'rel-campaigns-orders',
+        targetAlias: 'orders',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-orders', title: 'Orders' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'campaign_id' }],
+      } as unknown as DataMartRelationship;
+      const relCampaignsOrders2 = {
+        id: 'rel-campaigns-orders-2',
+        targetAlias: 'orders_2',
+        sourceDataMart: { id: 'dm-1' },
+        targetDataMart: { id: 'dm-orders', title: 'Orders' },
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'campaign_id' }],
+      } as unknown as DataMartRelationship;
+      const relOrdersProducts = {
+        id: 'rel-orders-products',
+        targetAlias: 'products',
+        sourceDataMart: { id: 'dm-orders' },
+        targetDataMart: { id: 'dm-products', title: 'Products' },
+        joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: 'id' }],
+      } as unknown as DataMartRelationship;
+
+      relationshipService.findBySourceDataMartId.mockResolvedValue([
+        relCampaignsOrders,
+        relCampaignsOrders2,
+      ]);
+      relationshipService.findByIds.mockImplementation(async (ids: string[]) => {
+        const byId: Record<string, DataMartRelationship> = {
+          'rel-campaigns-orders': relCampaignsOrders,
+          'rel-campaigns-orders-2': relCampaignsOrders2,
+          'rel-orders-products': relOrdersProducts,
+        };
+        return ids.map(id => byId[id]).filter(Boolean);
+      });
+      tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
+      blendedQueryBuilderFacade.buildBlendedQuery.mockResolvedValue('SELECT ...');
+
+      await service.resolveBlendingDecision(report);
+
+      const [, context] = blendedQueryBuilderFacade.buildBlendedQuery.mock.calls[0];
+      expect(context!.chains).toHaveLength(4);
+
+      const ordersProductsChain = context!.chains.find(c => c.cteName === 'orders_products')!;
+      expect(ordersProductsChain.blendedFields).toHaveLength(1);
+      expect(ordersProductsChain.blendedFields[0].outputAlias).toBe(
+        'orders_products__product_price'
+      );
+
+      const orders2ProductsChain = context!.chains.find(c => c.cteName === 'orders_2_products')!;
+      expect(orders2ProductsChain.blendedFields).toHaveLength(1);
+      expect(orders2ProductsChain.blendedFields[0].outputAlias).toBe(
+        'orders_2_products__product_price'
+      );
     });
 
     describe('resolveBlendingDecision — filter on non-selected blended column', () => {

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -79,7 +79,6 @@ export class BlendedReportDataService {
       blendableSchema.blendedFields,
       blendableSchema.availableSources,
       allRelationships,
-      dataMart.id,
       dataMart.projectId,
       publicOrigin
     );
@@ -141,9 +140,11 @@ export class BlendedReportDataService {
    * Builds the minimal set of ResolvedRelationshipChain entries needed to satisfy
    * the columns requested in columnConfig.
    *
-   * For direct relationships (transitiveDepth === 1), parentAlias is 'main'.
-   * For transitive relationships (transitiveDepth > 1), parentAlias is the targetAlias
-   * of the preceding relationship in the chain.
+   * Each chain's `cteName` is derived from the full `aliasPath` (dots → underscores)
+   * and `parentAlias` is the parent's `cteName` ('main' at the root). The path-prefixed
+   * `cteName` is what guarantees CTE uniqueness when two relationships in the join
+   * tree share the same `targetAlias` (allowed under the
+   * `(sourceDataMart, targetAlias)` unique constraint).
    *
    * When a requested field lives at depth ≥ 2 (e.g. A→B→C, C-field requested), ALL
    * ancestor relationships along the aliasPath are also included — otherwise the
@@ -156,7 +157,6 @@ export class BlendedReportDataService {
     blendedFields: BlendedFieldDto[],
     availableSources: AvailableSourceDto[],
     directRelationships: DataMartRelationship[],
-    rootDataMartId: string,
     projectId: string,
     publicOrigin: string
   ): Promise<ResolvedRelationshipChain[]> {
@@ -195,19 +195,15 @@ export class BlendedReportDataService {
       }
     }
 
-    const fieldsByRelId = new Map<string, BlendedFieldDto[]>();
+    // Bucket by `aliasPath`, not `sourceRelationshipId` — one relationship can be the leaf of several paths when its parent is reachable via different aliases.
+    const fieldsByAliasPath = new Map<string, BlendedFieldDto[]>();
     for (const field of requestedBlendedFields) {
-      const bucket = fieldsByRelId.get(field.sourceRelationshipId) ?? [];
+      const bucket = fieldsByAliasPath.get(field.aliasPath) ?? [];
       bucket.push(field);
-      fieldsByRelId.set(field.sourceRelationshipId, bucket);
+      fieldsByAliasPath.set(field.aliasPath, bucket);
     }
 
-    // Parent-first order guarantees dataMartAliasMap has the parent's alias registered
-    // by the time we compute parentAlias for a child.
     const sortedSources = [...neededSources].sort((a, b) => a.depth - b.depth);
-
-    const dataMartAliasMap = new Map<string, string>();
-    dataMartAliasMap.set(rootDataMartId, 'main');
 
     const columnConfigSet = new Set(columnConfig);
     const chains: ResolvedRelationshipChain[] = [];
@@ -215,8 +211,9 @@ export class BlendedReportDataService {
       const rel = relationshipsById.get(src.relationshipId);
       if (!rel) continue;
 
-      const parentAlias =
-        src.depth === 1 ? 'main' : (dataMartAliasMap.get(rel.sourceDataMart.id) ?? 'main');
+      const segments = src.aliasPath.split('.');
+      const cteName = segments.join('_');
+      const parentAlias = segments.length === 1 ? 'main' : segments.slice(0, -1).join('_');
 
       const targetTableReference = await this.tableReferenceService.resolveTableName(
         rel.targetDataMart.id,
@@ -229,7 +226,7 @@ export class BlendedReportDataService {
         '/data-setup'
       );
 
-      const chainBlendedFields = (fieldsByRelId.get(rel.id) ?? []).map(f => ({
+      const chainBlendedFields = (fieldsByAliasPath.get(src.aliasPath) ?? []).map(f => ({
         targetFieldName: f.originalFieldName,
         outputAlias: f.name,
         // Hide fields referenced only by filterConfig — they flow through CTEs so
@@ -242,12 +239,11 @@ export class BlendedReportDataService {
         relationship: rel,
         targetTableReference,
         parentAlias,
+        cteName,
         blendedFields: chainBlendedFields,
         targetDataMartTitle: rel.targetDataMart.title,
         targetDataMartUrl,
       });
-
-      dataMartAliasMap.set(rel.targetDataMart.id, rel.targetAlias);
     }
 
     this.assertNoChainCollisions(chains);
@@ -256,29 +252,34 @@ export class BlendedReportDataService {
   }
 
   /**
-   * Verifies that all chains can co-exist in a single SQL query:
-   *  - `targetAlias` must be unique across chains (otherwise we emit two CTEs
-   *    with the same name).
-   *  - `outputAlias` of every blended field must be unique across all chains
-   *    (otherwise the final SELECT has two columns with the same alias).
+   * Defence-in-depth check that runs after `cteName`/`outputAlias` have been
+   * computed:
+   *  - `cteName` must be unique across chains. Path-prefixed names derived from
+   *    `aliasPath` should make this impossible, but a pathological mix of
+   *    `targetAlias` values (e.g. `"a_b"` at one level and `"a"` then `"b"` at
+   *    two levels) could still flatten to the same identifier — catch it here
+   *    instead of letting the database reject duplicate CTE names.
+   *  - `outputAlias` must be unique across all chains' blended fields, otherwise
+   *    the final SELECT would have two columns with the same name.
    *
-   * Both classes of conflict are user-fixable misconfigurations rather than
-   * platform bugs, so we surface them as `BusinessViolationException` with a
-   * pointer to the offending relationships.
+   * Both classes of conflict are user-fixable, so we surface them as
+   * `BusinessViolationException` with a pointer to the offending relationships.
    */
   private assertNoChainCollisions(chains: ResolvedRelationshipChain[]): void {
-    const aliasOwners = new Map<string, string[]>();
+    const cteNameOwners = new Map<string, string[]>();
     for (const chain of chains) {
-      const owners = aliasOwners.get(chain.relationship.targetAlias) ?? [];
+      const owners = cteNameOwners.get(chain.cteName) ?? [];
       owners.push(chain.relationship.id);
-      aliasOwners.set(chain.relationship.targetAlias, owners);
+      cteNameOwners.set(chain.cteName, owners);
     }
-    for (const [alias, owners] of aliasOwners) {
+    for (const [cteName, owners] of cteNameOwners) {
       if (owners.length > 1) {
         throw new BusinessViolationException(
-          `Duplicate CTE name: targetAlias "${alias}" is used by multiple relationships in the join chain. ` +
+          `Duplicate CTE name: cteName "${cteName}" is produced by multiple relationship chains. ` +
+            `This typically means two relationship targetAlias values flatten to the same identifier ` +
+            `(e.g. "a_b" at one level vs "a"+"b" at two levels). ` +
             `Rename the targetAlias on one of these relationships so each chain produces a unique CTE.`,
-          { targetAlias: alias, relationshipIds: owners }
+          { cteName, relationshipIds: owners }
         );
       }
     }

--- a/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.spec.ts
@@ -7,6 +7,9 @@ import { ForbiddenException, NotFoundException, UnauthorizedException } from '@n
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { CopyReportAsDataMartService } from './copy-report-as-data-mart.service';
 import { CopyReportAsDataMartCommand } from '../dto/domain/copy-report-as-data-mart.command';
+import { CreateDataMartCommand } from '../dto/domain/create-data-mart.command';
+import { UpdateDataMartDefinitionCommand } from '../dto/domain/update-data-mart-definition.command';
+import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { EntityType, Action } from '../services/access-decision';
 
 describe('CopyReportAsDataMartService', () => {
@@ -20,7 +23,8 @@ describe('CopyReportAsDataMartService', () => {
     dataDestination: { id: 'dest-1' },
   };
 
-  const newDataMart = { id: 'dm-new' };
+  const createdDataMart = { id: 'dm-new', title: 'Copy of My Report' };
+  const finalDataMart = { id: 'dm-new', title: 'Copy of My Report', definitionType: 'SQL' };
 
   const createService = (
     accessResults: { canEditDataMart: boolean; canUseStorage: boolean } = {
@@ -34,9 +38,11 @@ describe('CopyReportAsDataMartService', () => {
     const reportSqlComposerService = {
       compose: jest.fn().mockResolvedValue({ sql: 'SELECT 1' }),
     };
-    const dataMartService = {
-      create: jest.fn().mockReturnValue(newDataMart),
-      save: jest.fn().mockResolvedValue(newDataMart),
+    const createDataMartService = {
+      run: jest.fn().mockResolvedValue(createdDataMart),
+    };
+    const updateDataMartDefinitionService = {
+      run: jest.fn().mockResolvedValue(finalDataMart),
     };
     const accessDecisionService = {
       canAccess: jest.fn((_userId, _roles, entityType: EntityType) => {
@@ -50,7 +56,8 @@ describe('CopyReportAsDataMartService', () => {
     const service = new CopyReportAsDataMartService(
       reportRepository as never,
       reportSqlComposerService as never,
-      dataMartService as never,
+      createDataMartService as never,
+      updateDataMartDefinitionService as never,
       accessDecisionService as never
     );
 
@@ -58,15 +65,21 @@ describe('CopyReportAsDataMartService', () => {
       service,
       reportRepository,
       reportSqlComposerService,
-      dataMartService,
+      createDataMartService,
+      updateDataMartDefinitionService,
       accessDecisionService,
     };
   };
 
   beforeEach(() => jest.clearAllMocks());
 
-  it('should copy report when user has EDIT access on parent data mart and USE access on storage', async () => {
-    const { service, dataMartService, accessDecisionService } = createService();
+  it('delegates to CreateDataMartService and UpdateDataMartDefinitionService when user has EDIT on source DM and USE on storage', async () => {
+    const {
+      service,
+      createDataMartService,
+      updateDataMartDefinitionService,
+      accessDecisionService,
+    } = createService();
 
     const command = new CopyReportAsDataMartCommand('report-1', 'user-1', 'proj-1', ['editor']);
 
@@ -88,11 +101,38 @@ describe('CopyReportAsDataMartService', () => {
       Action.USE,
       'proj-1'
     );
-    expect(dataMartService.save).toHaveBeenCalled();
-    expect(result).toEqual(newDataMart);
+
+    expect(createDataMartService.run).toHaveBeenCalledWith(
+      new CreateDataMartCommand('proj-1', 'user-1', 'Copy of My Report', 'storage-1', ['editor'])
+    );
+    expect(updateDataMartDefinitionService.run).toHaveBeenCalledWith(
+      new UpdateDataMartDefinitionCommand(
+        'dm-new',
+        'proj-1',
+        DataMartDefinitionType.SQL,
+        { sqlQuery: 'SELECT 1' },
+        undefined,
+        undefined,
+        'user-1',
+        ['editor']
+      )
+    );
+
+    expect(result).toEqual(finalDataMart);
   });
 
-  it('should throw ForbiddenException when user lacks EDIT access on parent data mart', async () => {
+  it('runs the two use cases in the right order — create then update', async () => {
+    const { service, createDataMartService, updateDataMartDefinitionService } = createService();
+
+    const command = new CopyReportAsDataMartCommand('report-1', 'user-1', 'proj-1', ['editor']);
+    await service.run(command);
+
+    expect(createDataMartService.run.mock.invocationCallOrder[0]).toBeLessThan(
+      updateDataMartDefinitionService.run.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('throws ForbiddenException when user lacks EDIT access on the source data mart', async () => {
     const { service } = createService({ canEditDataMart: false, canUseStorage: true });
 
     const command = new CopyReportAsDataMartCommand('report-1', 'user-1', 'proj-1', ['viewer']);
@@ -100,7 +140,7 @@ describe('CopyReportAsDataMartService', () => {
     await expect(service.run(command)).rejects.toThrow(ForbiddenException);
   });
 
-  it('should throw ForbiddenException when user lacks USE access on storage', async () => {
+  it('throws ForbiddenException when user lacks USE access on the source storage', async () => {
     const { service } = createService({ canEditDataMart: true, canUseStorage: false });
 
     const command = new CopyReportAsDataMartCommand('report-1', 'user-1', 'proj-1', ['editor']);
@@ -108,7 +148,7 @@ describe('CopyReportAsDataMartService', () => {
     await expect(service.run(command)).rejects.toThrow(ForbiddenException);
   });
 
-  it('should throw NotFoundException when report not found', async () => {
+  it('throws NotFoundException when the report does not exist', async () => {
     const { service, reportRepository } = createService();
     reportRepository.findOne = jest.fn().mockResolvedValue(null);
 
@@ -131,15 +171,21 @@ describe('CopyReportAsDataMartService', () => {
   });
 
   it.each(['', '   ', '\n\t  '])(
-    'rejects empty/whitespace SQL from composer with a BusinessViolationException',
+    'rejects empty/whitespace SQL from composer with a BusinessViolationException and does not create a data mart',
     async emptySql => {
-      const { service, reportSqlComposerService, dataMartService } = createService();
+      const {
+        service,
+        reportSqlComposerService,
+        createDataMartService,
+        updateDataMartDefinitionService,
+      } = createService();
       reportSqlComposerService.compose = jest.fn().mockResolvedValue({ sql: emptySql });
 
       const command = new CopyReportAsDataMartCommand('report-1', 'user-1', 'proj-1', ['editor']);
 
       await expect(service.run(command)).rejects.toThrow(BusinessViolationException);
-      expect(dataMartService.save).not.toHaveBeenCalled();
+      expect(createDataMartService.run).not.toHaveBeenCalled();
+      expect(updateDataMartDefinitionService.run).not.toHaveBeenCalled();
     }
   );
 });

--- a/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.ts
@@ -1,22 +1,24 @@
 import {
+  ForbiddenException,
   Injectable,
   NotFoundException,
-  ForbiddenException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
-import { Report } from '../entities/report.entity';
-import { DataMart } from '../entities/data-mart.entity';
-import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
-import { DataMartStatus } from '../enums/data-mart-status.enum';
-import { DataMartService } from '../services/data-mart.service';
-import { ReportSqlComposerService } from '../services/report-sql-composer.service';
-import { SqlDefinition } from '../dto/schemas/data-mart-table-definitions/sql-definition.schema';
 import { CopyReportAsDataMartCommand } from '../dto/domain/copy-report-as-data-mart.command';
-import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import { CreateDataMartCommand } from '../dto/domain/create-data-mart.command';
+import { DataMartDto } from '../dto/domain/data-mart.dto';
+import { UpdateDataMartDefinitionCommand } from '../dto/domain/update-data-mart-definition.command';
+import { SqlDefinition } from '../dto/schemas/data-mart-table-definitions/sql-definition.schema';
+import { Report } from '../entities/report.entity';
+import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+import { ReportSqlComposerService } from '../services/report-sql-composer.service';
+import { CreateDataMartService } from './create-data-mart.service';
+import { UpdateDataMartDefinitionService } from './update-data-mart-definition.service';
 
 @Injectable()
 export class CopyReportAsDataMartService {
@@ -24,12 +26,13 @@ export class CopyReportAsDataMartService {
     @InjectRepository(Report)
     private readonly reportRepository: Repository<Report>,
     private readonly reportSqlComposerService: ReportSqlComposerService,
-    private readonly dataMartService: DataMartService,
+    private readonly createDataMartService: CreateDataMartService,
+    private readonly updateDataMartDefinitionService: UpdateDataMartDefinitionService,
     private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   @Transactional()
-  async run(command: CopyReportAsDataMartCommand): Promise<DataMart> {
+  async run(command: CopyReportAsDataMartCommand): Promise<DataMartDto> {
     if (!command.userId) {
       throw new UnauthorizedException('Authenticated user is required');
     }
@@ -84,21 +87,27 @@ export class CopyReportAsDataMartService {
       );
     }
 
-    const { dataMart: sourceDataMart } = report;
+    const createdDataMart = await this.createDataMartService.run(
+      new CreateDataMartCommand(
+        command.projectId,
+        command.userId,
+        `Copy of ${report.title}`,
+        report.dataMart.storage.id,
+        command.roles
+      )
+    );
 
-    const definition: SqlDefinition = { sqlQuery: sql };
-
-    const newDataMart = this.dataMartService.create({
-      title: `Copy of ${report.title}`,
-      projectId: command.projectId,
-      createdById: command.userId,
-      technicalOwnerIds: [command.userId],
-      storage: sourceDataMart.storage,
-      definitionType: DataMartDefinitionType.SQL,
-      definition,
-      status: DataMartStatus.DRAFT,
-    });
-
-    return this.dataMartService.save(newDataMart);
+    return this.updateDataMartDefinitionService.run(
+      new UpdateDataMartDefinitionCommand(
+        createdDataMart.id,
+        command.projectId,
+        DataMartDefinitionType.SQL,
+        { sqlQuery: sql } as SqlDefinition,
+        undefined,
+        undefined,
+        command.userId,
+        command.roles
+      )
+    );
   }
 }


### PR DESCRIPTION
## Summary

Two production fixes in the data-marts module:

- **Duplicate CTE name in blended reports.** Two relationships sharing the same `targetAlias` (legal — uniqueness is scoped to `sourceDataMart`) made the SQL builder emit two CTEs with the same name and the query failed at run / view-SQL / Looker-Studio time. CTE names are now derived from the full `aliasPath` (dots → underscores), so every chain gets a unique identifier. The previous targetAlias-collision validation is replaced by a defence-in-depth `cteName` check that surfaces the (rare) path-segment-flatten case with an actionable error.
- **Copy-report-as-data-mart skipped the technical-owner row.** `CopyReportAsDataMartService` called `DataMartService.create+save` directly, bypassing `DataMartTechnicalOwner` insertion and the `DataMartCreated` / `DataMartDefinitionSet` events. Users could create a data mart from a report and then not be able to open it. The copy now delegates to `CreateDataMartService` + `UpdateDataMartDefinitionService` under the same `@Transactional()` boundary, so it goes through the standard ownership/access flow.
