### PR TITLE
feat(facebook): add default fields and improve endpoint UX for Facebook Ads

### DIFF
--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
@@ -38,6 +38,7 @@ export function FieldsSelectionStep({
   onSelectAllFields,
 }: FieldsSelectionStepProps) {
   const filterInputRef = useRef<HTMLInputElement>(null);
+  const defaultsInitializedForRef = useRef<string | null>(null);
   const [filterText, setFilterText] = useState('');
   const [sortOrder, setSortOrder] = useState<ConnectorFieldSortOrder>(
     ConnectorFieldSortOrder.ORIGINAL
@@ -99,21 +100,31 @@ export function FieldsSelectionStep({
       }
     });
 
-    const hasFieldsBeyondUniqueKeys = selectedFields.some(f => !uniqueKeysSet.has(f));
-    if (!hasFieldsBeyondUniqueKeys) {
-      const defaultFields = selectedFieldData?.defaultFields ?? [];
-      defaultFields.forEach(fieldName => {
-        if (availableFieldNamesSet.has(fieldName) && !selectedFieldsSet.has(fieldName)) {
-          fieldsToAutoSelect.add(fieldName);
-        }
-      });
+    if (defaultsInitializedForRef.current !== selectedField) {
+      const hasFieldsBeyondUniqueKeys = selectedFields.some(f => !uniqueKeysSet.has(f));
+      if (!hasFieldsBeyondUniqueKeys) {
+        const defaultFields = selectedFieldData?.defaultFields ?? [];
+        defaultFields.forEach(fieldName => {
+          if (availableFieldNamesSet.has(fieldName) && !selectedFieldsSet.has(fieldName)) {
+            fieldsToAutoSelect.add(fieldName);
+          }
+        });
+      }
+      defaultsInitializedForRef.current = selectedField;
     }
 
     if (fieldsToAutoSelect.size > 0) {
       const namesToAdd = Array.from(fieldsToAutoSelect);
       onSelectAllFields(namesToAdd, true);
     }
-  }, [availableFields, uniqueKeys, selectedFields, selectedFieldData, onSelectAllFields]);
+  }, [
+    availableFields,
+    uniqueKeys,
+    selectedFields,
+    selectedFieldData,
+    onSelectAllFields,
+    selectedField,
+  ]);
 
   // HotKey for Selecting/Unselecting all fields
   useEffect(() => {

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/NodesSelectionStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/NodesSelectionStep.tsx
@@ -63,6 +63,7 @@ export function NodesSelectionStep({
               name='selectedField'
               value={field.name}
               label={field.overview ?? field.name}
+              subtitle={field.description}
               checked={selectedField === field.name}
               onChange={value => {
                 onFieldSelect(value as string);

--- a/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
@@ -13,6 +13,7 @@ var FacebookMarketingFieldsSchema = {
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account-user",
         "fields": adAccountUserFields,
         'uniqueKeys': ["id"],
+        'defaultFields': ["name"],
         "isTimeSeries": false,
         "destinationName": "facebook_ads_ad_account_user"
     },
@@ -22,6 +23,7 @@ var FacebookMarketingFieldsSchema = {
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/",
         "fields": adAccountFields,
         'uniqueKeys': ["id", "account_id"],
+        'defaultFields': ["name", "account_status", "currency", "timezone_name", "business_name", "created_time"],
         "isTimeSeries": false,
         "destinationName": "facebook_ads_ad_account"
     },
@@ -30,6 +32,7 @@ var FacebookMarketingFieldsSchema = {
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/adcreatives",
         "fields": adAccountCreativesFields,
         'uniqueKeys': ["id"],
+        'defaultFields': ["name", "account_id", "status", "body", "title", "call_to_action_type", "object_type", "effective_object_story_id"],
         "isTimeSeries": false,
         "destinationName": "facebook_ads_ad_account_adcreatives"
     },

--- a/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
@@ -9,7 +9,7 @@
 var FacebookMarketingFieldsSchema = {
     "ad-account-user": {
         "overview": "Ad Account User",
-        "description": "Someone on Facebook who creates ads. Each ad user can have a role on several ad accounts",
+        "description": "Users with access to an ad account and their assigned roles.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account-user",
         "fields": adAccountUserFields,
         'uniqueKeys': ["id"],
@@ -19,7 +19,7 @@ var FacebookMarketingFieldsSchema = {
     },
     "ad-account": {
         "overview": "Ad Account",
-        "description": "Represents the business entity managing ads.",
+        "description": "Your ad account settings, status, currency, and billing details.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/",
         "fields": adAccountFields,
         'uniqueKeys': ["id", "account_id"],
@@ -28,7 +28,8 @@ var FacebookMarketingFieldsSchema = {
         "destinationName": "facebook_ads_ad_account"
     },
     "ad-account/adcreatives": {
-        "description": "Defines your ad's appearance and content.",
+        "overview": "Ad Creatives",
+        "description": "The images, videos, text, and other visual elements used in your ads.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/adcreatives",
         "fields": adAccountCreativesFields,
         'uniqueKeys': ["id"],
@@ -42,11 +43,12 @@ var FacebookMarketingFieldsSchema = {
     //     "destinationName": "facebook_ads_ad_account_adimages"
     // },
     "ad-account/ads": {
-        "description": "Data for an ad, such as creative elements and measurement information.",
+        "overview": "Ads",
+        "description": "Individual ads with their status, creative, and campaign hierarchy.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/ads",
         "fields": adAccountAdsFields,
         'uniqueKeys': ["id"],
-        'defaultFields': ["id", "name", "status", "effective_status", "adset_id", "campaign_id", "created_time", "updated_time"],
+        'defaultFields': ["name", "account_id", "status", "effective_status", "adset_id", "campaign_id", "creative_id", "created_time", "updated_time"],
         "isTimeSeries": false,
         "destinationName": "facebook_ads_ad_account_ads"
     },
@@ -71,82 +73,99 @@ var FacebookMarketingFieldsSchema = {
     //     "destinationName": "facebook_ads_ad_account_customaudiences"
     // },
     "ad-account/insights": {
-        "description": "Interface for insights. De-dupes results across child objects, provides sorting, and async reports.",
+        "overview": "Ad Insights",
+        "description": "Daily performance metrics for each ad — impressions, clicks, spend, and conversions.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights",
         "fields": adAccountInsightsFields,
         'uniqueKeys': ["ad_id", "date_start", "date_stop"],
+        'defaultFields': ["account_id", "account_name", "campaign_id", "campaign_name", "adset_id", "adset_name", "ad_name", "impressions", "reach", "clicks", "spend", "cpc", "cpm", "ctr", "frequency", "actions", "action_values"],
         "isTimeSeries": true,
         "destinationName": "facebook_ads_ad_account_insights"
     },
     "ad-account/insights-by-age-and-gender": {
-        "description": "Interface for insights with breakdown by age and gender.",
+        "overview": "Ad Insights by Age and Gender",
+        "description": "Daily ad performance broken down by audience age range and gender.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights",
         "fields": adAccountInsightsFieldsByAgeAndGender,
         "breakdowns": ["age", "gender"],
         'uniqueKeys': ["ad_id", "date_start", "date_stop", "age", "gender"],
+        'defaultFields': ["account_id", "account_name", "campaign_id", "campaign_name", "adset_id", "adset_name", "ad_name", "impressions", "reach", "clicks", "spend", "cpc", "cpm", "ctr", "frequency", "actions", "action_values"],
         "isTimeSeries": true,
         "destinationName": "facebook_ads_ad_account_insights_by_age_and_gender"
     },
     "ad-account/insights-by-country": {
-        "description": "Interface for insights with breakdown by country.",
+        "overview": "Ad Insights by Country",
+        "description": "Daily ad performance broken down by the country where your audience is located.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights",
         "fields": adAccountInsightsFieldsByCountry,
         "breakdowns": ["country"],
         'uniqueKeys': ["ad_id", "date_start", "date_stop", "country"],
+        'defaultFields': ["account_id", "account_name", "campaign_id", "campaign_name", "adset_id", "adset_name", "ad_name", "impressions", "reach", "clicks", "spend", "cpc", "cpm", "ctr", "frequency", "actions", "action_values"],
         "isTimeSeries": true,
         "destinationName": "facebook_ads_ad_account_insights_by_country"
     },
     "ad-account/insights-by-device-platform": {
-        "description": "Interface for insights with breakdown by device platform.",
+        "overview": "Ad Insights by Device Platform",
+        "description": "Daily ad performance broken down by the device type your audience used.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights",
         "fields": adAccountInsightsFieldsByDevicePlatform,
         "breakdowns": ["device_platform"],
         'uniqueKeys': ["ad_id", "date_start", "date_stop", "device_platform"],
+        'defaultFields': ["account_id", "account_name", "campaign_id", "campaign_name", "adset_id", "adset_name", "ad_name", "impressions", "reach", "clicks", "spend", "cpc", "cpm", "ctr", "frequency", "actions", "action_values"],
         "isTimeSeries": true,
         "destinationName": "facebook_ads_ad_account_insights_by_device_platform"
     },
     "ad-account/insights-by-link-url-asset": {
-        "description": "Interface for insights with breakdown by link URL asset.",
+        "overview": "Ad Insights by Link URL Asset",
+        "description": "Daily ad performance broken down by the link URL shown in your ads.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights",
         "fields": adAccountInsightsFieldsByLinkUrlAsset,
         "breakdowns": ["link_url_asset"],
         'uniqueKeys': ["ad_id", "date_start", "date_stop"],
+        'defaultFields': ["account_id", "account_name", "campaign_id", "campaign_name", "adset_id", "adset_name", "ad_name", "impressions", "reach", "clicks", "spend", "cpc", "cpm", "ctr", "frequency", "actions", "action_values"],
         "isTimeSeries": true,
         "destinationName": "facebook_ads_ad_account_insights_by_link_url_asset"
     },
     "ad-account/insights-by-product-id": {
-        "description": "Interface for insights with breakdown by product ID.",
+        "overview": "Ad Insights by Product ID",
+        "description": "Daily ad performance broken down by individual product from your catalog.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights",
         "fields": adAccountInsightsFieldsByProductId,
         "breakdowns": ["product_id"],
         'uniqueKeys': ["ad_id", "date_start", "date_stop", "product_id"],
+        'defaultFields': ["account_id", "account_name", "campaign_id", "campaign_name", "adset_id", "adset_name", "ad_name", "impressions", "reach", "clicks", "spend", "cpc", "cpm", "ctr", "frequency", "actions", "action_values"],
         "isTimeSeries": true,
         "destinationName": "facebook_ads_ad_account_insights_by_product_id"
     },
     "ad-account/insights-by-publisher-platform-and-position": {
-        "description": "Interface for insights with breakdown by publisher platform and position.",
+        "overview": "Ad Insights by Publisher Platform and Position",
+        "description": "Daily ad performance broken down by where your ads appeared — platform and placement position.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights",
         "fields": adAccountInsightsFieldsByPublisherPlatformAndPosition,
         "breakdowns": ["publisher_platform", "platform_position"],
         'uniqueKeys': ["ad_id", "date_start", "date_stop", "publisher_platform", "platform_position"],
+        'defaultFields': ["account_id", "account_name", "campaign_id", "campaign_name", "adset_id", "adset_name", "ad_name", "impressions", "reach", "clicks", "spend", "cpc", "cpm", "ctr", "frequency", "actions", "action_values"],
         "isTimeSeries": true,
         "destinationName": "facebook_ads_ad_account_insights_by_publisher_platform_and_position"
     },
     "ad-account/insights-by-region": {
-        "description": "Interface for insights with breakdown by region.",
+        "overview": "Ad Insights by Region",
+        "description": "Daily ad performance broken down by the region where your audience is located.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/ad-account/insights",
         "fields": adAccountInsightsFieldsByRegion,
         "breakdowns": ["region"],
         'uniqueKeys': ["ad_id", "date_start", "date_stop", "region"],
+        'defaultFields': ["account_id", "account_name", "campaign_id", "campaign_name", "adset_id", "adset_name", "ad_name", "impressions", "reach", "clicks", "spend", "cpc", "cpm", "ctr", "frequency", "actions", "action_values"],
         "isTimeSeries": true,
         "destinationName": "facebook_ads_ad_account_insights_by_region"
     },
     "ad-group": {
-        "overview": "Ad Object (formerly Ad Group)",
-        "description": "Represents an Ad object (historically called 'Ad Group'). This is the entity for individual ads in Facebook's API.",
+        "overview": "Ad",
+        "description": "Individual ads with their creative, status, and links to their campaign and ad set.",
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/",
         "fields": adGroupFields,
         'uniqueKeys': ["id"],
+        'defaultFields': ["name", "account_id", "status", "effective_status", "adset_id", "campaign_id", "creative_id", "created_time", "updated_time"],
         "isTimeSeries": false,
         "destinationName": "facebook_ads_ad_group"
     },

--- a/packages/ui/src/components/common/wizard.tsx
+++ b/packages/ui/src/components/common/wizard.tsx
@@ -515,6 +515,7 @@ type AppWizardStepCardItemProps = {
   name: string;
   value?: string;
   label?: React.ReactNode;
+  subtitle?: React.ReactNode;
   checked?: boolean;
   selected?: boolean;
   disabled?: boolean;
@@ -529,6 +530,7 @@ function AppWizardStepCardItem({
   name,
   value,
   label,
+  subtitle,
   checked,
   selected = false,
   disabled = false,
@@ -564,7 +566,8 @@ function AppWizardStepCardItem({
         }
       }}
       className={cn(
-        'group flex items-center gap-2 rounded-sm px-4 py-3 transition-shadow duration-200 select-none',
+        'group flex gap-2 rounded-sm px-4 py-3 transition-shadow duration-200 select-none',
+        subtitle ? 'items-start' : 'items-center',
         disabled ? 'cursor-not-allowed' : 'hover:bg-accent cursor-pointer dark:hover:bg-white/4',
         selected ? 'bg-primary/8 hover:bg-primary/8 dark:bg-white/8 dark:hover:bg-white/8' : '',
         className
@@ -585,19 +588,25 @@ function AppWizardStepCardItem({
           // Radios/checkboxes are compact, text inputs expand
           type === 'radio' || type === 'checkbox'
             ? 'accent-primary dark:accent-primary h-4 w-4'
-            : 'h-8 w-full rounded-md border px-2'
+            : 'h-8 w-full rounded-md border px-2',
+          subtitle && 'mt-0.5'
         )}
         {...props}
       />
 
-      {/* Label next to the input (uses AppWizardStepLabel for consistency) */}
-      {label && (
-        <AppWizardStepLabel
-          htmlFor={id}
-          className={cn('cursor-pointer', disabled && 'cursor-not-allowed')}
-        >
-          {label}
-        </AppWizardStepLabel>
+      {/* Label + optional subtitle */}
+      {(label || subtitle) && (
+        <div className='flex min-w-0 flex-1 flex-col'>
+          {label && (
+            <AppWizardStepLabel
+              htmlFor={id}
+              className={cn('cursor-pointer', disabled && 'cursor-not-allowed')}
+            >
+              {label}
+            </AppWizardStepLabel>
+          )}
+          {subtitle && <p className='text-muted-foreground text-xs font-normal'>{subtitle}</p>}
+        </div>
       )}
 
       {/* Right side container (tooltip + rightIcon) */}


### PR DESCRIPTION
# Problem

The Facebook Ads connector required users to manually select every field from scratch when setting up a data mart — there were no pre-selected defaults to guide them. Additionally, the "Select data" step showed raw internal endpoint names like `ad-account/insights-by-publisher-platform-and-position` as labels, with API-jargon descriptions hidden behind a hover tooltip. Users had no immediate way to understand what each endpoint contained or which one to choose for performance data like spend, clicks, or impressions.

A secondary bug existed in `FieldsSelectionStep`: endpoints with a single `defaultField` (e.g. `ad-account-user` with only `name`) could not be unchecked — the `useEffect` that applied defaults re-ran after every uncheck, saw no non-unique-key fields selected, and immediately re-added the field in a tight loop.

# Solution

Default fields were added to all 14 active Facebook Ads endpoints by populating the existing `defaultFields` schema property, which is already consumed end-to-end by the backend Zod schema and the `FieldsSelectionStep` UI.

The re-select loop was fixed by introducing a `useRef` that tracks which endpoint has already had its defaults initialized in the current component lifecycle. The defaults block is skipped on subsequent re-renders for the same endpoint, but re-applied when the user navigates to a different endpoint (intentional — switching back resets to defaults if no custom selection was made).

Endpoint discoverability was improved by adding `overview` labels and plain-language `description` text to all endpoints, and by surfacing the description as a visible subtitle below each card label in `NodesSelectionStep` (previously only shown on hover).

# Changes

**`FieldsSchema.js` — Facebook Marketing connector**
- Added `defaultFields` to all 14 active endpoints (`ad-account-user`, `ad-account`, `ad-account/adcreatives`, `ad-account/ads`, `ad-account/insights` and all 7 breakdown variants, `ad-group`)
- Added `overview` display labels to 10 endpoints that were missing them (previously showed raw API path as label)
- Rewrote all `description` strings from API-jargon to plain user-facing language
- Fixed `ad-account/ads` `defaultFields`: removed redundant `id` (already a locked unique key), added `account_id` and `creative_id`

**`FieldsSelectionStep.tsx`**
- Added `defaultsInitializedForRef` to track which endpoint has had defaults applied
- Wrapped the default-fields application block in a ref check to prevent re-selecting fields the user has explicitly unchecked
- Added `selectedField` to the `useEffect` dependency array (was implicitly covered before, now explicit)

**`wizard.tsx` — `AppWizardStepCardItem`**
- Added optional `subtitle` prop (`React.ReactNode`)
- When `subtitle` is present: switches container alignment to `items-start`, adds `mt-0.5` to the input for visual alignment, wraps label and subtitle in a `flex-col` container

**`NodesSelectionStep.tsx`**
- Passes `field.description` as `subtitle` to `AppWizardStepCardItem`, making endpoint descriptions always visible without requiring a hover