### PR TITLE
feat: membership requests handling on the Members page

### DIFF
--- a/.changeset/membership-requests.md
+++ b/.changeset/membership-requests.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Membership requests on the new Members page
+
+Project Admins can now see and act on pending requests to join a project from the new Project Settings → Members page. The section is admin-only, hidden when empty, and renders as a collapsible card of inline request rows above the members list. Clicking a row opens a side sheet where the admin picks the final role, role scope and (optionally) the contexts to pre-assign before approving, or declines the request with a confirmation dialog.
+
+The full path ships in this release: IDP protocol contract, backend use-cases, web UI, and a real C2C call to the Integrated backend's `/membership-requests` endpoints from the OWOX IDP provider.

--- a/apps/backend/src/data-marts/controllers/project-members.controller.ts
+++ b/apps/backend/src/data-marts/controllers/project-members.controller.ts
@@ -2,12 +2,18 @@ import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put } from '@nest
 import { ApiTags } from '@nestjs/swagger';
 import { Auth, AuthContext, AuthorizationContext, Role, Strategy } from '../../idp';
 import {
+  ApproveMembershipRequestApiDto,
+  ApproveMembershipRequestResponseApiDto,
+  DeclineMembershipRequestApiDto,
   InviteMemberRequestApiDto,
   InviteMemberResponseApiDto,
+  MembershipRequestApiDto,
   ProjectMemberResponseApiDto,
   UpdateMemberRequestApiDto,
   UpdateMemberResponseApiDto,
 } from '../dto/presentation/context-api.dto';
+import { ApproveMembershipRequestCommand } from '../dto/domain/approve-membership-request.command';
+import { DeclineMembershipRequestCommand } from '../dto/domain/decline-membership-request.command';
 import { InviteProjectMemberCommand } from '../dto/domain/invite-project-member.command';
 import { RemoveProjectMemberCommand } from '../dto/domain/remove-project-member.command';
 import { UpdateProjectMemberCommand } from '../dto/domain/update-project-member.command';
@@ -17,8 +23,14 @@ import { ListProjectMembersService } from '../use-cases/project-members/list-pro
 import { InviteProjectMemberService } from '../use-cases/project-members/invite-project-member.service';
 import { UpdateProjectMemberService } from '../use-cases/project-members/update-project-member.service';
 import { RemoveProjectMemberService } from '../use-cases/project-members/remove-project-member.service';
+import { ListMembershipRequestsService } from '../use-cases/project-members/list-membership-requests.service';
+import { ApproveMembershipRequestService } from '../use-cases/project-members/approve-membership-request.service';
+import { DeclineMembershipRequestService } from '../use-cases/project-members/decline-membership-request.service';
 import {
+  ApproveMembershipRequestSpec,
+  DeclineMembershipRequestSpec,
   InviteProjectMemberSpec,
+  ListMembershipRequestsSpec,
   ListProjectMembersSpec,
   RemoveProjectMemberSpec,
   UpdateProjectMemberSpec,
@@ -38,6 +50,9 @@ export class ProjectMembersController {
     private readonly inviteProjectMember: InviteProjectMemberService,
     private readonly updateProjectMember: UpdateProjectMemberService,
     private readonly removeProjectMember: RemoveProjectMemberService,
+    private readonly listMembershipRequests: ListMembershipRequestsService,
+    private readonly approveMembershipRequest: ApproveMembershipRequestService,
+    private readonly declineMembershipRequest: DeclineMembershipRequestService,
     private readonly projectMembersMapper: ProjectMembersMapper
   ) {}
 
@@ -125,6 +140,64 @@ export class ProjectMembersController {
   ): Promise<void> {
     await this.removeProjectMember.run(
       new RemoveProjectMemberCommand(context.projectId, context.userId, targetUserId)
+    );
+  }
+
+  @Auth(Role.admin(Strategy.INTROSPECT))
+  @Get('requests')
+  @ListMembershipRequestsSpec()
+  async listRequests(
+    @AuthContext() context: AuthorizationContext
+  ): Promise<MembershipRequestApiDto[]> {
+    const requests = await this.listMembershipRequests.run(context.projectId, context.userId);
+    return requests.map(r => ({
+      requestId: r.requestId,
+      email: r.email,
+      fullName: r.fullName,
+      avatar: r.avatar,
+      userId: r.userId,
+      requestedRole: r.requestedRole as ProjectRole,
+      createdAt: r.createdAt,
+    }));
+  }
+
+  @Auth(Role.admin(Strategy.INTROSPECT))
+  @Post('requests/:requestId/approve')
+  @ApproveMembershipRequestSpec()
+  async approveRequest(
+    @AuthContext() context: AuthorizationContext,
+    @Param('requestId') requestId: string,
+    @Body() dto: ApproveMembershipRequestApiDto
+  ): Promise<ApproveMembershipRequestResponseApiDto> {
+    const result = await this.approveMembershipRequest.run(
+      new ApproveMembershipRequestCommand(
+        context.projectId,
+        context.userId,
+        requestId,
+        dto.role,
+        dto.roleScope,
+        dto.contextIds ?? []
+      )
+    );
+    return {
+      userId: result.userId,
+      role: result.role,
+      roleScope: result.roleScope,
+      contextIds: result.contextIds,
+    };
+  }
+
+  @Auth(Role.admin(Strategy.INTROSPECT))
+  @Post('requests/:requestId/decline')
+  @HttpCode(204)
+  @DeclineMembershipRequestSpec()
+  async declineRequest(
+    @AuthContext() context: AuthorizationContext,
+    @Param('requestId') requestId: string,
+    @Body() dto: DeclineMembershipRequestApiDto
+  ): Promise<void> {
+    await this.declineMembershipRequest.run(
+      new DeclineMembershipRequestCommand(context.projectId, context.userId, requestId, dto.reason)
     );
   }
 }

--- a/apps/backend/src/data-marts/controllers/project-members.controller.ts
+++ b/apps/backend/src/data-marts/controllers/project-members.controller.ts
@@ -4,7 +4,6 @@ import { Auth, AuthContext, AuthorizationContext, Role, Strategy } from '../../i
 import {
   ApproveMembershipRequestApiDto,
   ApproveMembershipRequestResponseApiDto,
-  DeclineMembershipRequestApiDto,
   InviteMemberRequestApiDto,
   InviteMemberResponseApiDto,
   MembershipRequestApiDto,
@@ -150,15 +149,7 @@ export class ProjectMembersController {
     @AuthContext() context: AuthorizationContext
   ): Promise<MembershipRequestApiDto[]> {
     const requests = await this.listMembershipRequests.run(context.projectId, context.userId);
-    return requests.map(r => ({
-      requestId: r.requestId,
-      email: r.email,
-      fullName: r.fullName,
-      avatar: r.avatar,
-      userId: r.userId,
-      requestedRole: r.requestedRole as ProjectRole,
-      createdAt: r.createdAt,
-    }));
+    return this.projectMembersMapper.toMembershipRequestApiList(requests);
   }
 
   @Auth(Role.admin(Strategy.INTROSPECT))
@@ -193,11 +184,10 @@ export class ProjectMembersController {
   @DeclineMembershipRequestSpec()
   async declineRequest(
     @AuthContext() context: AuthorizationContext,
-    @Param('requestId') requestId: string,
-    @Body() dto: DeclineMembershipRequestApiDto
+    @Param('requestId') requestId: string
   ): Promise<void> {
     await this.declineMembershipRequest.run(
-      new DeclineMembershipRequestCommand(context.projectId, context.userId, requestId, dto.reason)
+      new DeclineMembershipRequestCommand(context.projectId, context.userId, requestId)
     );
   }
 }

--- a/apps/backend/src/data-marts/controllers/project-members.controller.ts
+++ b/apps/backend/src/data-marts/controllers/project-members.controller.ts
@@ -154,6 +154,7 @@ export class ProjectMembersController {
 
   @Auth(Role.admin(Strategy.INTROSPECT))
   @Post('requests/:requestId/approve')
+  @HttpCode(200)
   @ApproveMembershipRequestSpec()
   async approveRequest(
     @AuthContext() context: AuthorizationContext,

--- a/apps/backend/src/data-marts/controllers/spec/project-members.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/project-members.api.ts
@@ -105,7 +105,7 @@ export function DeclineMembershipRequestSpec() {
     ApiOperation({
       summary: 'Decline a pending membership request',
       description:
-        'Removes the request from the pending queue. Idempotent: declining an already-removed request returns success.',
+        'Removes the request from the pending queue. Returns 404 if the request was already removed or never existed (symmetric with approve).',
     }),
     ApiParam({ name: 'requestId', description: 'Pending request id (stable identifier from IDP)' }),
     ApiNoContentResponse({ description: 'Request declined' }),

--- a/apps/backend/src/data-marts/controllers/spec/project-members.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/project-members.api.ts
@@ -10,7 +10,6 @@ import {
 import {
   ApproveMembershipRequestApiDto,
   ApproveMembershipRequestResponseApiDto,
-  DeclineMembershipRequestApiDto,
   InviteMemberRequestApiDto,
   InviteMemberResponseApiDto,
   MembershipRequestApiDto,
@@ -109,7 +108,6 @@ export function DeclineMembershipRequestSpec() {
         'Removes the request from the pending queue. Idempotent: declining an already-removed request returns success.',
     }),
     ApiParam({ name: 'requestId', description: 'Pending request id (stable identifier from IDP)' }),
-    ApiBody({ type: DeclineMembershipRequestApiDto }),
     ApiNoContentResponse({ description: 'Request declined' }),
     ApiResponse({ status: 404, description: 'Membership request not found' }),
     ApiResponse({ status: 501, description: 'IDP provider does not support membership requests' }),

--- a/apps/backend/src/data-marts/controllers/spec/project-members.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/project-members.api.ts
@@ -8,8 +8,12 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 import {
+  ApproveMembershipRequestApiDto,
+  ApproveMembershipRequestResponseApiDto,
+  DeclineMembershipRequestApiDto,
   InviteMemberRequestApiDto,
   InviteMemberResponseApiDto,
+  MembershipRequestApiDto,
   ProjectMemberResponseApiDto,
   UpdateMemberRequestApiDto,
   UpdateMemberResponseApiDto,
@@ -64,6 +68,51 @@ export function RemoveProjectMemberSpec() {
     }),
     ApiParam({ name: 'userId', description: 'Project member user ID' }),
     ApiNoContentResponse({ description: 'Member removed' }),
+    ApiResponse({ status: 502, description: 'Upstream IDP failure' })
+  );
+}
+
+export function ListMembershipRequestsSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'List pending project membership requests',
+      description:
+        'Returns the array of pending requests for the project. Empty array means there are no pending requests. The non-OWOX IDP providers (better-auth, null) return an empty list rather than throwing.',
+    }),
+    ApiOkResponse({ type: [MembershipRequestApiDto] }),
+    ApiResponse({ status: 502, description: 'Upstream IDP failure' })
+  );
+}
+
+export function ApproveMembershipRequestSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Approve a pending membership request',
+      description:
+        'Resolves the requester into a full project member with the chosen role. Optionally narrows the role scope and pre-assigns contexts. Mirrors the post-invite scope/context apply.',
+    }),
+    ApiParam({ name: 'requestId', description: 'Pending request id (stable identifier from IDP)' }),
+    ApiBody({ type: ApproveMembershipRequestApiDto }),
+    ApiOkResponse({ type: ApproveMembershipRequestResponseApiDto }),
+    ApiResponse({ status: 400, description: 'Invalid role or context ids' }),
+    ApiResponse({ status: 404, description: 'Membership request not found' }),
+    ApiResponse({ status: 501, description: 'IDP provider does not support membership requests' }),
+    ApiResponse({ status: 502, description: 'Upstream IDP failure' })
+  );
+}
+
+export function DeclineMembershipRequestSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Decline a pending membership request',
+      description:
+        'Removes the request from the pending queue. Idempotent: declining an already-removed request returns success.',
+    }),
+    ApiParam({ name: 'requestId', description: 'Pending request id (stable identifier from IDP)' }),
+    ApiBody({ type: DeclineMembershipRequestApiDto }),
+    ApiNoContentResponse({ description: 'Request declined' }),
+    ApiResponse({ status: 404, description: 'Membership request not found' }),
+    ApiResponse({ status: 501, description: 'IDP provider does not support membership requests' }),
     ApiResponse({ status: 502, description: 'Upstream IDP failure' })
   );
 }

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -344,6 +344,9 @@ import { ListProjectMembersService } from './use-cases/project-members/list-proj
 import { InviteProjectMemberService } from './use-cases/project-members/invite-project-member.service';
 import { UpdateProjectMemberService } from './use-cases/project-members/update-project-member.service';
 import { RemoveProjectMemberService } from './use-cases/project-members/remove-project-member.service';
+import { ListMembershipRequestsService } from './use-cases/project-members/list-membership-requests.service';
+import { ApproveMembershipRequestService } from './use-cases/project-members/approve-membership-request.service';
+import { DeclineMembershipRequestService } from './use-cases/project-members/decline-membership-request.service';
 import { SetContextMembersService } from './use-cases/contexts/set-context-members.service';
 
 @Module({
@@ -698,6 +701,9 @@ import { SetContextMembersService } from './use-cases/contexts/set-context-membe
     InviteProjectMemberService,
     UpdateProjectMemberService,
     RemoveProjectMemberService,
+    ListMembershipRequestsService,
+    ApproveMembershipRequestService,
+    DeclineMembershipRequestService,
     SetContextMembersService,
   ],
 })

--- a/apps/backend/src/data-marts/dto/domain/approve-membership-request.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/approve-membership-request.command.ts
@@ -1,0 +1,13 @@
+import { ProjectRole } from '../../enums/project-role.enum';
+import { RoleScope } from '../../enums/role-scope.enum';
+
+export class ApproveMembershipRequestCommand {
+  constructor(
+    public readonly projectId: string,
+    public readonly actorUserId: string,
+    public readonly requestId: string,
+    public readonly role: ProjectRole,
+    public readonly roleScope: RoleScope | undefined,
+    public readonly contextIds: string[]
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/decline-membership-request.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/decline-membership-request.command.ts
@@ -1,0 +1,8 @@
+export class DeclineMembershipRequestCommand {
+  constructor(
+    public readonly projectId: string,
+    public readonly actorUserId: string,
+    public readonly requestId: string,
+    public readonly reason?: string
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/decline-membership-request.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/decline-membership-request.command.ts
@@ -2,7 +2,6 @@ export class DeclineMembershipRequestCommand {
   constructor(
     public readonly projectId: string,
     public readonly actorUserId: string,
-    public readonly requestId: string,
-    public readonly reason?: string
+    public readonly requestId: string
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/presentation/context-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/context-api.dto.ts
@@ -297,11 +297,3 @@ export class ApproveMembershipRequestResponseApiDto {
   @ApiProperty({ type: [String] })
   contextIds: string[];
 }
-
-export class DeclineMembershipRequestApiDto {
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsString()
-  @MaxLength(500)
-  reason?: string;
-}

--- a/apps/backend/src/data-marts/dto/presentation/context-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/context-api.dto.ts
@@ -241,3 +241,67 @@ export class InviteMemberResponseApiDto {
   })
   userId?: string;
 }
+
+export class MembershipRequestApiDto {
+  @ApiProperty()
+  requestId: string;
+
+  @ApiProperty()
+  email: string;
+
+  @ApiPropertyOptional()
+  fullName?: string;
+
+  @ApiPropertyOptional()
+  avatar?: string;
+
+  @ApiPropertyOptional()
+  userId?: string;
+
+  @ApiProperty({ enum: ProjectRole })
+  requestedRole: ProjectRole;
+
+  @ApiProperty()
+  createdAt: string;
+}
+
+export class ApproveMembershipRequestApiDto {
+  @ApiProperty({ enum: ProjectRole })
+  @IsEnum(ProjectRole)
+  role: ProjectRole;
+
+  @ApiPropertyOptional({ enum: RoleScope })
+  @IsOptional()
+  @IsEnum(RoleScope)
+  roleScope?: RoleScope;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(100)
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  contextIds?: string[];
+}
+
+export class ApproveMembershipRequestResponseApiDto {
+  @ApiProperty()
+  userId: string;
+
+  @ApiProperty({ enum: ProjectRole })
+  role: ProjectRole;
+
+  @ApiProperty({ enum: RoleScope })
+  roleScope: RoleScope;
+
+  @ApiProperty({ type: [String] })
+  contextIds: string[];
+}
+
+export class DeclineMembershipRequestApiDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/apps/backend/src/data-marts/mappers/project-members.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/project-members.mapper.ts
@@ -1,5 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { ProjectMemberResponseApiDto } from '../dto/presentation/context-api.dto';
+import type { Role as IdpRole } from '@owox/idp-protocol';
+import {
+  MembershipRequestApiDto,
+  ProjectMemberResponseApiDto,
+} from '../dto/presentation/context-api.dto';
+import { ProjectRole } from '../enums/project-role.enum';
+import type { ProjectMembershipRequestDto } from '../use-cases/project-members/dto/project-membership-request.dto';
 import type { ProjectMemberWithScope } from '../use-cases/project-members/list-project-members.service';
 
 @Injectable()
@@ -19,4 +25,62 @@ export class ProjectMembersMapper {
   toApiResponseList(members: ProjectMemberWithScope[]): ProjectMemberResponseApiDto[] {
     return members.map(m => this.toApiResponse(m));
   }
+
+  toMembershipRequestApi(request: ProjectMembershipRequestDto): MembershipRequestApiDto {
+    return {
+      requestId: request.requestId,
+      email: request.email,
+      fullName: request.fullName,
+      avatar: request.avatar,
+      userId: request.userId,
+      requestedRole: request.requestedRole,
+      createdAt: request.createdAt,
+    };
+  }
+
+  toMembershipRequestApiList(requests: ProjectMembershipRequestDto[]): MembershipRequestApiDto[] {
+    return requests.map(r => this.toMembershipRequestApi(r));
+  }
+}
+
+/**
+ * `ProjectRole` (BI's domain enum) and `IdpRole` (`@owox/idp-protocol` Zod-derived
+ * `Role`) share values today but are nominally distinct types. A bare `as IdpRole`
+ * cast disappears the moment BI gains a role IDP does not support, landing as a
+ * 400 at the wire boundary. This helper makes the boundary explicit and throws
+ * before reaching the IDP if a new BI role ever appears without an IDP mapping.
+ */
+const PROJECT_TO_IDP_ROLE: Record<ProjectRole, IdpRole> = {
+  [ProjectRole.ADMIN]: 'admin',
+  [ProjectRole.EDITOR]: 'editor',
+  [ProjectRole.VIEWER]: 'viewer',
+};
+
+export function toIdpRole(role: ProjectRole): IdpRole {
+  const mapped = PROJECT_TO_IDP_ROLE[role];
+  if (!mapped) {
+    throw new Error(`No IDP role mapping for project role "${String(role)}"`);
+  }
+  return mapped;
+}
+
+/**
+ * Reverse mapping for the read direction (IDP → BI). The IDP-package Zod
+ * schema constrains `IdpRole` to the same three values BI knows, so this is
+ * a total mapping — but spelling it out explicitly (instead of `as ProjectRole`)
+ * means an IDP-side enum drift would land here as `undefined` rather than
+ * leak a foreign string into the domain layer.
+ */
+const IDP_TO_PROJECT_ROLE: Record<IdpRole, ProjectRole> = {
+  admin: ProjectRole.ADMIN,
+  editor: ProjectRole.EDITOR,
+  viewer: ProjectRole.VIEWER,
+};
+
+export function toProjectRole(role: IdpRole): ProjectRole {
+  const mapped = IDP_TO_PROJECT_ROLE[role];
+  if (!mapped) {
+    throw new Error(`No project role mapping for IDP role "${String(role)}"`);
+  }
+  return mapped;
 }

--- a/apps/backend/src/data-marts/use-cases/project-members/approve-membership-request.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/approve-membership-request.service.spec.ts
@@ -1,7 +1,9 @@
+import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { ApproveMembershipRequestCommand } from '../../dto/domain/approve-membership-request.command';
 import { ProjectRole } from '../../enums/project-role.enum';
 import { RoleScope } from '../../enums/role-scope.enum';
 import { ApproveMembershipRequestService } from './approve-membership-request.service';
+import { LOCAL_MEMBER_SCOPE_PARTIAL_FAILURE_MESSAGE } from './util/member-scope-saga.util';
 
 describe('ApproveMembershipRequestService', () => {
   const PROJECT_ID = 'project-1';
@@ -12,8 +14,21 @@ describe('ApproveMembershipRequestService', () => {
     const idpProjectionsFacade = {
       approveMembershipRequest: jest.fn(),
     };
+
+    let lastWrite: { roleScope: RoleScope; contextIds: string[] } = {
+      roleScope: RoleScope.ENTIRE_PROJECT,
+      contextIds: [],
+    };
     const contextAccessService = {
-      updateMember: jest.fn().mockResolvedValue(undefined),
+      updateMember: jest.fn(async (_userId, _projectId, payload) => {
+        const coercedScope =
+          payload.role === ProjectRole.ADMIN ? RoleScope.ENTIRE_PROJECT : payload.roleScope;
+        const coercedContexts = payload.role === ProjectRole.ADMIN ? [] : payload.contextIds;
+        lastWrite = { roleScope: coercedScope, contextIds: coercedContexts };
+        return undefined;
+      }),
+      getRoleScope: jest.fn(async () => lastWrite.roleScope),
+      getMemberContextIds: jest.fn(async () => lastWrite.contextIds),
     };
     const contextService = {
       validateContextIds: jest.fn().mockResolvedValue(undefined),
@@ -57,7 +72,12 @@ describe('ApproveMembershipRequestService', () => {
       roleScope: RoleScope.ENTIRE_PROJECT,
       contextIds: [],
     });
-    expect(result.userId).toBe('user-1');
+    expect(result).toEqual({
+      userId: 'user-1',
+      role: ProjectRole.EDITOR,
+      roleScope: RoleScope.ENTIRE_PROJECT,
+      contextIds: [],
+    });
   });
 
   it('non-admin + contextIds → defaults to selected_contexts and validates ids', async () => {
@@ -66,7 +86,9 @@ describe('ApproveMembershipRequestService', () => {
       userId: 'user-2',
     });
 
-    await service.run(command({ role: ProjectRole.EDITOR, contextIds: ['ctx-1', 'ctx-2'] }));
+    const result = await service.run(
+      command({ role: ProjectRole.EDITOR, contextIds: ['ctx-1', 'ctx-2'] })
+    );
 
     expect(contextService.validateContextIds).toHaveBeenCalledWith(['ctx-1', 'ctx-2'], PROJECT_ID);
     expect(contextAccessService.updateMember).toHaveBeenCalledWith('user-2', PROJECT_ID, {
@@ -74,15 +96,17 @@ describe('ApproveMembershipRequestService', () => {
       roleScope: RoleScope.SELECTED_CONTEXTS,
       contextIds: ['ctx-1', 'ctx-2'],
     });
+    expect(result.roleScope).toBe(RoleScope.SELECTED_CONTEXTS);
+    expect(result.contextIds).toEqual(['ctx-1', 'ctx-2']);
   });
 
-  it('admin role overrides explicit roleScope to entire_project', async () => {
+  it('admin role overrides explicit roleScope + contextIds — response reflects persisted (entire_project, [])', async () => {
     const { service, idpProjectionsFacade, contextAccessService } = createService();
     idpProjectionsFacade.approveMembershipRequest.mockResolvedValue({
       userId: 'adm-1',
     });
 
-    await service.run(
+    const result = await service.run(
       command({
         role: ProjectRole.ADMIN,
         roleScope: RoleScope.SELECTED_CONTEXTS,
@@ -94,6 +118,13 @@ describe('ApproveMembershipRequestService', () => {
       role: ProjectRole.ADMIN,
       roleScope: RoleScope.ENTIRE_PROJECT,
       contextIds: ['ctx-1'],
+    });
+    // Response must NOT echo the input — admin coerces to entire_project + [].
+    expect(result).toEqual({
+      userId: 'adm-1',
+      role: ProjectRole.ADMIN,
+      roleScope: RoleScope.ENTIRE_PROJECT,
+      contextIds: [],
     });
   });
 
@@ -126,14 +157,43 @@ describe('ApproveMembershipRequestService', () => {
     expect(contextAccessService.updateMember).not.toHaveBeenCalled();
   });
 
-  it('ContextAccessService failure after IDP success → error propagates (no silent fallback)', async () => {
+  it('IDP 404 → NotFoundException (matches Swagger spec, not generic 500)', async () => {
+    const { service, idpProjectionsFacade, contextAccessService } = createService();
+    const notFound = Object.assign(new Error('Upstream resource not found'), {
+      name: 'IdpNotFoundException',
+      status: 404,
+    });
+    idpProjectionsFacade.approveMembershipRequest.mockRejectedValue(notFound);
+
+    await expect(service.run(command())).rejects.toBeInstanceOf(NotFoundException);
+    expect(contextAccessService.updateMember).not.toHaveBeenCalled();
+  });
+
+  it('ContextAccessService failure after IDP success → wraps to actionable partial-failure error', async () => {
     const { service, idpProjectionsFacade, contextAccessService } = createService();
     idpProjectionsFacade.approveMembershipRequest.mockResolvedValue({
       userId: 'user-4',
     });
-    contextAccessService.updateMember.mockRejectedValue(new Error('DB blip'));
+    const dbBlip = new Error('DB blip');
+    contextAccessService.updateMember.mockRejectedValue(dbBlip);
 
-    await expect(service.run(command({ role: ProjectRole.EDITOR }))).rejects.toThrow('DB blip');
+    await expect(service.run(command({ role: ProjectRole.EDITOR }))).rejects.toThrow(
+      LOCAL_MEMBER_SCOPE_PARTIAL_FAILURE_MESSAGE
+    );
+    // The wrapper is the documented client-facing exception, not a bare
+    // 500. The original error is preserved on `cause` for postmortems.
+    let captured: unknown;
+    try {
+      await service.run(command({ role: ProjectRole.EDITOR }));
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(InternalServerErrorException);
+    expect((captured as { cause?: unknown }).cause).toBe(dbBlip);
+    // Half-state recovery: getRoleScope/getMemberContextIds must NOT be
+    // called on the failure path — the saga unwinds before read-back.
+    expect(contextAccessService.getRoleScope).not.toHaveBeenCalled();
+    expect(contextAccessService.getMemberContextIds).not.toHaveBeenCalled();
   });
 
   it('explicit roleScope=entire_project + contextIds → honours explicit scope, still records contexts', async () => {
@@ -155,5 +215,19 @@ describe('ApproveMembershipRequestService', () => {
       roleScope: RoleScope.ENTIRE_PROJECT,
       contextIds: ['ctx-1'],
     });
+  });
+
+  it('response reflects persisted state — read-back from ContextAccessService, not input echo', async () => {
+    const { service, idpProjectionsFacade, contextAccessService } = createService();
+    idpProjectionsFacade.approveMembershipRequest.mockResolvedValue({ userId: 'user-5' });
+    // Simulate a downstream coercion the service is unaware of (e.g. a
+    // future ContextAccessService rule that pins editor to a default ctx).
+    contextAccessService.getRoleScope.mockResolvedValue(RoleScope.SELECTED_CONTEXTS);
+    contextAccessService.getMemberContextIds.mockResolvedValue(['ctx-default']);
+
+    const result = await service.run(command({ role: ProjectRole.EDITOR }));
+
+    expect(result.roleScope).toBe(RoleScope.SELECTED_CONTEXTS);
+    expect(result.contextIds).toEqual(['ctx-default']);
   });
 });

--- a/apps/backend/src/data-marts/use-cases/project-members/approve-membership-request.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/approve-membership-request.service.spec.ts
@@ -1,0 +1,159 @@
+import { ApproveMembershipRequestCommand } from '../../dto/domain/approve-membership-request.command';
+import { ProjectRole } from '../../enums/project-role.enum';
+import { RoleScope } from '../../enums/role-scope.enum';
+import { ApproveMembershipRequestService } from './approve-membership-request.service';
+
+describe('ApproveMembershipRequestService', () => {
+  const PROJECT_ID = 'project-1';
+  const ACTOR_ID = 'admin-1';
+  const REQUEST_ID = 'req-1';
+
+  const createService = () => {
+    const idpProjectionsFacade = {
+      approveMembershipRequest: jest.fn(),
+    };
+    const contextAccessService = {
+      updateMember: jest.fn().mockResolvedValue(undefined),
+    };
+    const contextService = {
+      validateContextIds: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = new ApproveMembershipRequestService(
+      idpProjectionsFacade as never,
+      contextAccessService as never,
+      contextService as never
+    );
+    return { service, idpProjectionsFacade, contextAccessService, contextService };
+  };
+
+  const command = (
+    overrides: Partial<ApproveMembershipRequestCommand> = {}
+  ): ApproveMembershipRequestCommand =>
+    new ApproveMembershipRequestCommand(
+      overrides.projectId ?? PROJECT_ID,
+      overrides.actorUserId ?? ACTOR_ID,
+      overrides.requestId ?? REQUEST_ID,
+      overrides.role ?? ProjectRole.EDITOR,
+      overrides.roleScope,
+      overrides.contextIds ?? []
+    );
+
+  it('non-admin + no contextIds + no explicit scope → entire_project, applies via ContextAccessService', async () => {
+    const { service, idpProjectionsFacade, contextAccessService } = createService();
+    idpProjectionsFacade.approveMembershipRequest.mockResolvedValue({
+      userId: 'user-1',
+    });
+
+    const result = await service.run(command({ role: ProjectRole.EDITOR }));
+
+    expect(idpProjectionsFacade.approveMembershipRequest).toHaveBeenCalledWith(
+      PROJECT_ID,
+      REQUEST_ID,
+      ProjectRole.EDITOR,
+      ACTOR_ID
+    );
+    expect(contextAccessService.updateMember).toHaveBeenCalledWith('user-1', PROJECT_ID, {
+      role: ProjectRole.EDITOR,
+      roleScope: RoleScope.ENTIRE_PROJECT,
+      contextIds: [],
+    });
+    expect(result.userId).toBe('user-1');
+  });
+
+  it('non-admin + contextIds → defaults to selected_contexts and validates ids', async () => {
+    const { service, idpProjectionsFacade, contextAccessService, contextService } = createService();
+    idpProjectionsFacade.approveMembershipRequest.mockResolvedValue({
+      userId: 'user-2',
+    });
+
+    await service.run(command({ role: ProjectRole.EDITOR, contextIds: ['ctx-1', 'ctx-2'] }));
+
+    expect(contextService.validateContextIds).toHaveBeenCalledWith(['ctx-1', 'ctx-2'], PROJECT_ID);
+    expect(contextAccessService.updateMember).toHaveBeenCalledWith('user-2', PROJECT_ID, {
+      role: ProjectRole.EDITOR,
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+      contextIds: ['ctx-1', 'ctx-2'],
+    });
+  });
+
+  it('admin role overrides explicit roleScope to entire_project', async () => {
+    const { service, idpProjectionsFacade, contextAccessService } = createService();
+    idpProjectionsFacade.approveMembershipRequest.mockResolvedValue({
+      userId: 'adm-1',
+    });
+
+    await service.run(
+      command({
+        role: ProjectRole.ADMIN,
+        roleScope: RoleScope.SELECTED_CONTEXTS,
+        contextIds: ['ctx-1'],
+      })
+    );
+
+    expect(contextAccessService.updateMember).toHaveBeenCalledWith('adm-1', PROJECT_ID, {
+      role: ProjectRole.ADMIN,
+      roleScope: RoleScope.ENTIRE_PROJECT,
+      contextIds: ['ctx-1'],
+    });
+  });
+
+  it('non-admin + explicit selected_contexts + 0 contexts → valid no-shared-access state', async () => {
+    const { service, idpProjectionsFacade, contextAccessService } = createService();
+    idpProjectionsFacade.approveMembershipRequest.mockResolvedValue({
+      userId: 'user-3',
+    });
+
+    await service.run(
+      command({
+        role: ProjectRole.EDITOR,
+        roleScope: RoleScope.SELECTED_CONTEXTS,
+        contextIds: [],
+      })
+    );
+
+    expect(contextAccessService.updateMember).toHaveBeenCalledWith('user-3', PROJECT_ID, {
+      role: ProjectRole.EDITOR,
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+      contextIds: [],
+    });
+  });
+
+  it('IDP failure propagates and skips local writes', async () => {
+    const { service, idpProjectionsFacade, contextAccessService } = createService();
+    idpProjectionsFacade.approveMembershipRequest.mockRejectedValue(new Error('IDP refused'));
+
+    await expect(service.run(command())).rejects.toThrow('IDP refused');
+    expect(contextAccessService.updateMember).not.toHaveBeenCalled();
+  });
+
+  it('ContextAccessService failure after IDP success → error propagates (no silent fallback)', async () => {
+    const { service, idpProjectionsFacade, contextAccessService } = createService();
+    idpProjectionsFacade.approveMembershipRequest.mockResolvedValue({
+      userId: 'user-4',
+    });
+    contextAccessService.updateMember.mockRejectedValue(new Error('DB blip'));
+
+    await expect(service.run(command({ role: ProjectRole.EDITOR }))).rejects.toThrow('DB blip');
+  });
+
+  it('explicit roleScope=entire_project + contextIds → honours explicit scope, still records contexts', async () => {
+    const { service, idpProjectionsFacade, contextAccessService } = createService();
+    idpProjectionsFacade.approveMembershipRequest.mockResolvedValue({
+      userId: 'wide-1',
+    });
+
+    await service.run(
+      command({
+        role: ProjectRole.VIEWER,
+        roleScope: RoleScope.ENTIRE_PROJECT,
+        contextIds: ['ctx-1'],
+      })
+    );
+
+    expect(contextAccessService.updateMember).toHaveBeenCalledWith('wide-1', PROJECT_ID, {
+      role: ProjectRole.VIEWER,
+      roleScope: RoleScope.ENTIRE_PROJECT,
+      contextIds: ['ctx-1'],
+    });
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/project-members/approve-membership-request.service.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/approve-membership-request.service.ts
@@ -1,11 +1,19 @@
-import { Injectable, Logger } from '@nestjs/common';
-import type { Role as IdpRole } from '@owox/idp-protocol';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import type { ApproveMembershipRequestResult } from '@owox/idp-protocol';
 import { IdpProjectionsFacade } from '../../../idp/facades/idp-projections.facade';
+import { isIdpNotFoundError } from '../../../idp/utils/is-idp-not-found-error';
 import { ApproveMembershipRequestCommand } from '../../dto/domain/approve-membership-request.command';
 import { ProjectRole } from '../../enums/project-role.enum';
 import { RoleScope } from '../../enums/role-scope.enum';
+import { toIdpRole } from '../../mappers/project-members.mapper';
 import { ContextAccessService } from '../../services/context/context-access.service';
 import { ContextService } from '../../services/context/context.service';
+import {
+  applyLocalMemberScope,
+  readPersistedMemberScope,
+  resolveEffectiveScope,
+  validateContextIdsIfAny,
+} from './util/member-scope-saga.util';
 
 export interface ApproveMembershipRequestUseCaseResult {
   userId: string;
@@ -29,47 +37,47 @@ export class ApproveMembershipRequestService {
   ): Promise<ApproveMembershipRequestUseCaseResult> {
     const { projectId, actorUserId, requestId, role, roleScope, contextIds } = command;
 
-    // Per Fibery spec (`01d:102`): selected_contexts + zero contexts is a
-    // valid state — the member simply gets no shared non-owner access through
-    // Context matching. We do NOT block the approve. Default scope inference
-    // for non-admin without explicit roleScope: presence of contextIds opts
-    // into selected_contexts; otherwise entire_project (least surprising for
-    // the legacy approve shape).
-    const inferredScope =
-      contextIds.length > 0 ? RoleScope.SELECTED_CONTEXTS : RoleScope.ENTIRE_PROJECT;
-    const effectiveScope: RoleScope =
-      role === ProjectRole.ADMIN ? RoleScope.ENTIRE_PROJECT : (roleScope ?? inferredScope);
+    const effectiveScope = resolveEffectiveScope(role, roleScope, contextIds);
 
-    if (contextIds.length > 0) {
-      await this.contextService.validateContextIds(contextIds, projectId);
-    }
+    await validateContextIdsIfAny(this.contextService, contextIds, projectId);
 
-    const result = await this.idpProjectionsFacade.approveMembershipRequest(
-      projectId,
-      requestId,
-      role as IdpRole,
-      actorUserId
-    );
-
+    let result: ApproveMembershipRequestResult;
     try {
-      await this.contextAccessService.updateMember(result.userId, projectId, {
-        role,
-        roleScope: effectiveScope,
-        contextIds,
-      });
-    } catch (err) {
-      this.logger.error(
-        `Approve accepted by IDP for request ${requestId} in project ${projectId}, but local scope/contexts write failed; admin must retry via updateMember.`,
-        err instanceof Error ? err.stack : String(err)
+      result = await this.idpProjectionsFacade.approveMembershipRequest(
+        projectId,
+        requestId,
+        toIdpRole(role),
+        actorUserId
       );
+    } catch (err) {
+      if (isIdpNotFoundError(err)) {
+        throw new NotFoundException(`Membership request "${requestId}" not found`);
+      }
       throw err;
     }
+
+    await applyLocalMemberScope({
+      contextAccessService: this.contextAccessService,
+      logger: this.logger,
+      userId: result.userId,
+      projectId,
+      role,
+      effectiveScope,
+      contextIds,
+      failureLabel: `Approve accepted by IDP for request ${requestId} in project ${projectId}`,
+    });
+
+    const persisted = await readPersistedMemberScope(
+      this.contextAccessService,
+      result.userId,
+      projectId
+    );
 
     return {
       userId: result.userId,
       role,
-      roleScope: effectiveScope,
-      contextIds,
+      roleScope: persisted.roleScope,
+      contextIds: persisted.contextIds,
     };
   }
 }

--- a/apps/backend/src/data-marts/use-cases/project-members/approve-membership-request.service.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/approve-membership-request.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { Role as IdpRole } from '@owox/idp-protocol';
+import { IdpProjectionsFacade } from '../../../idp/facades/idp-projections.facade';
+import { ApproveMembershipRequestCommand } from '../../dto/domain/approve-membership-request.command';
+import { ProjectRole } from '../../enums/project-role.enum';
+import { RoleScope } from '../../enums/role-scope.enum';
+import { ContextAccessService } from '../../services/context/context-access.service';
+import { ContextService } from '../../services/context/context.service';
+
+export interface ApproveMembershipRequestUseCaseResult {
+  userId: string;
+  role: ProjectRole;
+  roleScope: RoleScope;
+  contextIds: string[];
+}
+
+@Injectable()
+export class ApproveMembershipRequestService {
+  private readonly logger = new Logger(ApproveMembershipRequestService.name);
+
+  constructor(
+    private readonly idpProjectionsFacade: IdpProjectionsFacade,
+    private readonly contextAccessService: ContextAccessService,
+    private readonly contextService: ContextService
+  ) {}
+
+  async run(
+    command: ApproveMembershipRequestCommand
+  ): Promise<ApproveMembershipRequestUseCaseResult> {
+    const { projectId, actorUserId, requestId, role, roleScope, contextIds } = command;
+
+    // Per Fibery spec (`01d:102`): selected_contexts + zero contexts is a
+    // valid state — the member simply gets no shared non-owner access through
+    // Context matching. We do NOT block the approve. Default scope inference
+    // for non-admin without explicit roleScope: presence of contextIds opts
+    // into selected_contexts; otherwise entire_project (least surprising for
+    // the legacy approve shape).
+    const inferredScope =
+      contextIds.length > 0 ? RoleScope.SELECTED_CONTEXTS : RoleScope.ENTIRE_PROJECT;
+    const effectiveScope: RoleScope =
+      role === ProjectRole.ADMIN ? RoleScope.ENTIRE_PROJECT : (roleScope ?? inferredScope);
+
+    if (contextIds.length > 0) {
+      await this.contextService.validateContextIds(contextIds, projectId);
+    }
+
+    const result = await this.idpProjectionsFacade.approveMembershipRequest(
+      projectId,
+      requestId,
+      role as IdpRole,
+      actorUserId
+    );
+
+    try {
+      await this.contextAccessService.updateMember(result.userId, projectId, {
+        role,
+        roleScope: effectiveScope,
+        contextIds,
+      });
+    } catch (err) {
+      this.logger.error(
+        `Approve accepted by IDP for request ${requestId} in project ${projectId}, but local scope/contexts write failed; admin must retry via updateMember.`,
+        err instanceof Error ? err.stack : String(err)
+      );
+      throw err;
+    }
+
+    return {
+      userId: result.userId,
+      role,
+      roleScope: effectiveScope,
+      contextIds,
+    };
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.spec.ts
@@ -10,25 +10,37 @@ describe('DeclineMembershipRequestService', () => {
     return { service, idpProjectionsFacade };
   };
 
-  it('passes projectId, requestId, actor and reason to facade', async () => {
+  it('passes projectId, requestId and actor to facade', async () => {
     const { service, idpProjectionsFacade } = createService();
 
-    await service.run(new DeclineMembershipRequestCommand('proj-1', 'admin-1', 'req-1', 'spam'));
+    await service.run(new DeclineMembershipRequestCommand('proj-1', 'admin-1', 'req-1'));
 
     expect(idpProjectionsFacade.declineMembershipRequest).toHaveBeenCalledWith(
       'proj-1',
       'req-1',
-      'admin-1',
-      'spam'
+      'admin-1'
     );
   });
 
-  it('propagates facade errors', async () => {
+  it('propagates non-404 facade errors', async () => {
     const { service, idpProjectionsFacade } = createService();
     idpProjectionsFacade.declineMembershipRequest.mockRejectedValue(new Error('IDP down'));
 
     await expect(
       service.run(new DeclineMembershipRequestCommand('proj-1', 'admin-1', 'req-1'))
     ).rejects.toThrow('IDP down');
+  });
+
+  it('treats IDP 404 as idempotent success (per Swagger contract)', async () => {
+    const { service, idpProjectionsFacade } = createService();
+    const notFound = Object.assign(new Error('Upstream resource not found'), {
+      name: 'IdpNotFoundException',
+      status: 404,
+    });
+    idpProjectionsFacade.declineMembershipRequest.mockRejectedValue(notFound);
+
+    await expect(
+      service.run(new DeclineMembershipRequestCommand('proj-1', 'admin-1', 'req-1'))
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { DeclineMembershipRequestCommand } from '../../dto/domain/decline-membership-request.command';
 import { DeclineMembershipRequestService } from './decline-membership-request.service';
 
@@ -31,7 +32,7 @@ describe('DeclineMembershipRequestService', () => {
     ).rejects.toThrow('IDP down');
   });
 
-  it('treats IDP 404 as idempotent success (per Swagger contract)', async () => {
+  it('translates IDP 404 into NotFoundException (symmetric with approve)', async () => {
     const { service, idpProjectionsFacade } = createService();
     const notFound = Object.assign(new Error('Upstream resource not found'), {
       name: 'IdpNotFoundException',
@@ -41,6 +42,6 @@ describe('DeclineMembershipRequestService', () => {
 
     await expect(
       service.run(new DeclineMembershipRequestCommand('proj-1', 'admin-1', 'req-1'))
-    ).resolves.toBeUndefined();
+    ).rejects.toBeInstanceOf(NotFoundException);
   });
 });

--- a/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.spec.ts
@@ -1,0 +1,34 @@
+import { DeclineMembershipRequestCommand } from '../../dto/domain/decline-membership-request.command';
+import { DeclineMembershipRequestService } from './decline-membership-request.service';
+
+describe('DeclineMembershipRequestService', () => {
+  const createService = () => {
+    const idpProjectionsFacade = {
+      declineMembershipRequest: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = new DeclineMembershipRequestService(idpProjectionsFacade as never);
+    return { service, idpProjectionsFacade };
+  };
+
+  it('passes projectId, requestId, actor and reason to facade', async () => {
+    const { service, idpProjectionsFacade } = createService();
+
+    await service.run(new DeclineMembershipRequestCommand('proj-1', 'admin-1', 'req-1', 'spam'));
+
+    expect(idpProjectionsFacade.declineMembershipRequest).toHaveBeenCalledWith(
+      'proj-1',
+      'req-1',
+      'admin-1',
+      'spam'
+    );
+  });
+
+  it('propagates facade errors', async () => {
+    const { service, idpProjectionsFacade } = createService();
+    idpProjectionsFacade.declineMembershipRequest.mockRejectedValue(new Error('IDP down'));
+
+    await expect(
+      service.run(new DeclineMembershipRequestCommand('proj-1', 'admin-1', 'req-1'))
+    ).rejects.toThrow('IDP down');
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.ts
@@ -1,17 +1,29 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { IdpProjectionsFacade } from '../../../idp/facades/idp-projections.facade';
+import { isIdpNotFoundError } from '../../../idp/utils/is-idp-not-found-error';
 import { DeclineMembershipRequestCommand } from '../../dto/domain/decline-membership-request.command';
 
 @Injectable()
 export class DeclineMembershipRequestService {
+  private readonly logger = new Logger(DeclineMembershipRequestService.name);
+
   constructor(private readonly idpProjectionsFacade: IdpProjectionsFacade) {}
 
   async run(command: DeclineMembershipRequestCommand): Promise<void> {
-    await this.idpProjectionsFacade.declineMembershipRequest(
-      command.projectId,
-      command.requestId,
-      command.actorUserId,
-      command.reason
-    );
+    try {
+      await this.idpProjectionsFacade.declineMembershipRequest(
+        command.projectId,
+        command.requestId,
+        command.actorUserId
+      );
+    } catch (err) {
+      if (isIdpNotFoundError(err)) {
+        this.logger.debug(
+          `Decline request ${command.requestId} in project ${command.projectId}: already gone upstream — treating as success.`
+        );
+        return;
+      }
+      throw err;
+    }
   }
 }

--- a/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.ts
@@ -1,27 +1,20 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { IdpProjectionsFacade } from '../../../idp/facades/idp-projections.facade';
 import { isIdpNotFoundError } from '../../../idp/utils/is-idp-not-found-error';
 import { DeclineMembershipRequestCommand } from '../../dto/domain/decline-membership-request.command';
 
 @Injectable()
 export class DeclineMembershipRequestService {
-  private readonly logger = new Logger(DeclineMembershipRequestService.name);
-
   constructor(private readonly idpProjectionsFacade: IdpProjectionsFacade) {}
 
   async run(command: DeclineMembershipRequestCommand): Promise<void> {
+    const { projectId, actorUserId, requestId } = command;
+
     try {
-      await this.idpProjectionsFacade.declineMembershipRequest(
-        command.projectId,
-        command.requestId,
-        command.actorUserId
-      );
+      await this.idpProjectionsFacade.declineMembershipRequest(projectId, requestId, actorUserId);
     } catch (err) {
       if (isIdpNotFoundError(err)) {
-        this.logger.debug(
-          `Decline request ${command.requestId} in project ${command.projectId}: already gone upstream — treating as success.`
-        );
-        return;
+        throw new NotFoundException(`Membership request "${requestId}" not found`);
       }
       throw err;
     }

--- a/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/decline-membership-request.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { IdpProjectionsFacade } from '../../../idp/facades/idp-projections.facade';
+import { DeclineMembershipRequestCommand } from '../../dto/domain/decline-membership-request.command';
+
+@Injectable()
+export class DeclineMembershipRequestService {
+  constructor(private readonly idpProjectionsFacade: IdpProjectionsFacade) {}
+
+  async run(command: DeclineMembershipRequestCommand): Promise<void> {
+    await this.idpProjectionsFacade.declineMembershipRequest(
+      command.projectId,
+      command.requestId,
+      command.actorUserId,
+      command.reason
+    );
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/project-members/dto/project-membership-request.dto.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/dto/project-membership-request.dto.ts
@@ -1,0 +1,19 @@
+import { ProjectRole } from '../../../enums/project-role.enum';
+
+/**
+ * Domain-layer projection of `ProjectMembershipRequest` from the IDP protocol.
+ *
+ * The list use-case maps the IDP shape into this DTO so neither the controller
+ * nor the mapper has to cast `requestedRole as ProjectRole` — the boundary
+ * lives in one place (the use-case) and downstream callers get a sound
+ * `ProjectRole` typing.
+ */
+export interface ProjectMembershipRequestDto {
+  requestId: string;
+  email: string;
+  fullName?: string;
+  avatar?: string;
+  userId?: string;
+  requestedRole: ProjectRole;
+  createdAt: string;
+}

--- a/apps/backend/src/data-marts/use-cases/project-members/invite-project-member.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/invite-project-member.service.spec.ts
@@ -1,7 +1,9 @@
+import { InternalServerErrorException } from '@nestjs/common';
 import { InviteProjectMemberCommand } from '../../dto/domain/invite-project-member.command';
 import { ProjectRole } from '../../enums/project-role.enum';
 import { RoleScope } from '../../enums/role-scope.enum';
 import { InviteProjectMemberService } from './invite-project-member.service';
+import { LOCAL_MEMBER_SCOPE_PARTIAL_FAILURE_MESSAGE } from './util/member-scope-saga.util';
 
 describe('InviteProjectMemberService', () => {
   const PROJECT_ID = 'project-1';
@@ -204,7 +206,7 @@ describe('InviteProjectMemberService', () => {
     expect(contextAccessService.updateMember).not.toHaveBeenCalled();
   });
 
-  it('local write fails after IDP success → error propagates (no silent entire_project fallback)', async () => {
+  it('local write fails after IDP success → wraps to actionable partial-failure error', async () => {
     const { service, idpProjectionsFacade, contextAccessService } = createService();
     idpProjectionsFacade.inviteMember.mockResolvedValue({
       projectId: PROJECT_ID,
@@ -214,16 +216,23 @@ describe('InviteProjectMemberService', () => {
       magicLink: 'https://app/invite/local-fail',
       userId: 'local-fail-stub',
     });
-    contextAccessService.updateMember.mockRejectedValue(new Error('DB blip'));
+    const dbBlip = new Error('DB blip');
+    contextAccessService.updateMember.mockRejectedValue(dbBlip);
 
-    await expect(
-      service.run(
+    let captured: unknown;
+    try {
+      await service.run(
         command({
           role: ProjectRole.EDITOR,
           roleScope: RoleScope.ENTIRE_PROJECT,
           contextIds: [],
         })
-      )
-    ).rejects.toThrow('DB blip');
+      );
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(InternalServerErrorException);
+    expect((captured as Error).message).toBe(LOCAL_MEMBER_SCOPE_PARTIAL_FAILURE_MESSAGE);
+    expect((captured as { cause?: unknown }).cause).toBe(dbBlip);
   });
 });

--- a/apps/backend/src/data-marts/use-cases/project-members/invite-project-member.service.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/invite-project-member.service.ts
@@ -1,11 +1,15 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { ProjectMemberInvitation, Role as IdpRole } from '@owox/idp-protocol';
+import type { ProjectMemberInvitation } from '@owox/idp-protocol';
 import { IdpProjectionsFacade } from '../../../idp/facades/idp-projections.facade';
 import { InviteProjectMemberCommand } from '../../dto/domain/invite-project-member.command';
-import { ProjectRole } from '../../enums/project-role.enum';
-import { RoleScope } from '../../enums/role-scope.enum';
+import { toIdpRole } from '../../mappers/project-members.mapper';
 import { ContextAccessService } from '../../services/context/context-access.service';
 import { ContextService } from '../../services/context/context.service';
+import {
+  applyLocalMemberScope,
+  resolveEffectiveScope,
+  validateContextIdsIfAny,
+} from './util/member-scope-saga.util';
 
 @Injectable()
 export class InviteProjectMemberService {
@@ -20,51 +24,28 @@ export class InviteProjectMemberService {
   async run(command: InviteProjectMemberCommand): Promise<ProjectMemberInvitation> {
     const { projectId, actorUserId, email, role, roleScope, contextIds } = command;
 
-    // Per Fibery spec (`01d:102`): selected_contexts + zero contexts is a
-    // valid state — the member simply gets no shared non-owner access through
-    // Context matching. We do NOT block the invite. Default scope inference
-    // for non-admin without explicit roleScope: presence of contextIds opts
-    // into selected_contexts; otherwise entire_project (least surprising for
-    // the legacy invite shape).
-    const inferredScope =
-      contextIds.length > 0 ? RoleScope.SELECTED_CONTEXTS : RoleScope.ENTIRE_PROJECT;
-    const effectiveScope: RoleScope =
-      role === ProjectRole.ADMIN ? RoleScope.ENTIRE_PROJECT : (roleScope ?? inferredScope);
+    const effectiveScope = resolveEffectiveScope(role, roleScope, contextIds);
 
-    if (contextIds.length > 0) {
-      await this.contextService.validateContextIds(contextIds, projectId);
-    }
+    await validateContextIdsIfAny(this.contextService, contextIds, projectId);
 
     const invitation = await this.idpProjectionsFacade.inviteMember(
       projectId,
       email,
-      role as IdpRole,
+      toIdpRole(role),
       actorUserId
     );
 
-    // When the IDP pre-provisions the user (e.g. idp-better-auth returns a
-    // real userId alongside the magic link), apply the requested scope and
-    // contexts immediately. For IDPs that cannot surface userId until the
-    // invitee accepts the invitation (e.g. idp-owox-better-auth email flow),
-    // context bindings are deferred until first sign-in.
     if (invitation.userId) {
-      // If the local write fails after the IDP accepted the invite we do NOT
-      // swallow the error: the admin must retry via updateMember, and we log
-      // for operability. A silent fallback here previously promoted the
-      // invitee to entire_project scope.
-      try {
-        await this.contextAccessService.updateMember(invitation.userId, projectId, {
-          role,
-          roleScope: effectiveScope,
-          contextIds,
-        });
-      } catch (err) {
-        this.logger.error(
-          `Invite accepted by IDP for ${email} in project ${projectId}, but local scope/contexts write failed; admin must retry via updateMember.`,
-          err instanceof Error ? err.stack : String(err)
-        );
-        throw err;
-      }
+      await applyLocalMemberScope({
+        contextAccessService: this.contextAccessService,
+        logger: this.logger,
+        userId: invitation.userId,
+        projectId,
+        role,
+        effectiveScope,
+        contextIds,
+        failureLabel: `Invite accepted by IDP for ${email} in project ${projectId}`,
+      });
     }
 
     return invitation;

--- a/apps/backend/src/data-marts/use-cases/project-members/list-membership-requests.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/list-membership-requests.service.spec.ts
@@ -1,0 +1,38 @@
+import { ListMembershipRequestsService } from './list-membership-requests.service';
+
+describe('ListMembershipRequestsService', () => {
+  const createService = () => {
+    const idpProjectionsFacade = {
+      listMembershipRequests: jest.fn(),
+    };
+    const service = new ListMembershipRequestsService(idpProjectionsFacade as never);
+    return { service, idpProjectionsFacade };
+  };
+
+  it('returns the array produced by the facade', async () => {
+    const { service, idpProjectionsFacade } = createService();
+    const stub = [
+      {
+        requestId: 'r1',
+        email: 'a@b.io',
+        requestedRole: 'viewer',
+        createdAt: '2026-05-01T10:00:00Z',
+      },
+    ];
+    idpProjectionsFacade.listMembershipRequests.mockResolvedValue(stub);
+
+    const result = await service.run('project-1', 'actor-1');
+
+    expect(idpProjectionsFacade.listMembershipRequests).toHaveBeenCalledWith(
+      'project-1',
+      'actor-1'
+    );
+    expect(result).toEqual(stub);
+  });
+
+  it('propagates facade errors', async () => {
+    const { service, idpProjectionsFacade } = createService();
+    idpProjectionsFacade.listMembershipRequests.mockRejectedValue(new Error('IDP refused'));
+    await expect(service.run('project-1', 'actor-1')).rejects.toThrow('IDP refused');
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/project-members/list-membership-requests.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/list-membership-requests.service.spec.ts
@@ -1,3 +1,4 @@
+import { ProjectRole } from '../../enums/project-role.enum';
 import { ListMembershipRequestsService } from './list-membership-requests.service';
 
 describe('ListMembershipRequestsService', () => {
@@ -9,17 +10,19 @@ describe('ListMembershipRequestsService', () => {
     return { service, idpProjectionsFacade };
   };
 
-  it('returns the array produced by the facade', async () => {
+  it('maps IDP protocol shape to data-marts DTO (drops `as Role` casting boundary)', async () => {
     const { service, idpProjectionsFacade } = createService();
-    const stub = [
+    idpProjectionsFacade.listMembershipRequests.mockResolvedValue([
       {
         requestId: 'r1',
         email: 'a@b.io',
         requestedRole: 'viewer',
         createdAt: '2026-05-01T10:00:00Z',
+        fullName: 'Alice Example',
+        avatar: 'https://example.com/a.png',
+        userId: 'user-a',
       },
-    ];
-    idpProjectionsFacade.listMembershipRequests.mockResolvedValue(stub);
+    ]);
 
     const result = await service.run('project-1', 'actor-1');
 
@@ -27,7 +30,25 @@ describe('ListMembershipRequestsService', () => {
       'project-1',
       'actor-1'
     );
-    expect(result).toEqual(stub);
+    expect(result).toEqual([
+      {
+        requestId: 'r1',
+        email: 'a@b.io',
+        requestedRole: ProjectRole.VIEWER,
+        createdAt: '2026-05-01T10:00:00Z',
+        fullName: 'Alice Example',
+        avatar: 'https://example.com/a.png',
+        userId: 'user-a',
+      },
+    ]);
+  });
+
+  it('returns an empty array when facade returns an empty list', async () => {
+    const { service, idpProjectionsFacade } = createService();
+    idpProjectionsFacade.listMembershipRequests.mockResolvedValue([]);
+
+    const result = await service.run('project-1', 'actor-1');
+    expect(result).toEqual([]);
   });
 
   it('propagates facade errors', async () => {

--- a/apps/backend/src/data-marts/use-cases/project-members/list-membership-requests.service.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/list-membership-requests.service.ts
@@ -1,22 +1,35 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { IdpProjectionsFacade } from '../../../idp/facades/idp-projections.facade';
 import { toProjectRole } from '../../mappers/project-members.mapper';
 import type { ProjectMembershipRequestDto } from './dto/project-membership-request.dto';
 
 @Injectable()
 export class ListMembershipRequestsService {
+  private readonly logger = new Logger(ListMembershipRequestsService.name);
+
   constructor(private readonly idpProjectionsFacade: IdpProjectionsFacade) {}
 
   async run(projectId: string, actorUserId: string): Promise<ProjectMembershipRequestDto[]> {
-    const requests = await this.idpProjectionsFacade.listMembershipRequests(projectId, actorUserId);
-    return requests.map(r => ({
-      requestId: r.requestId,
-      email: r.email,
-      fullName: r.fullName,
-      avatar: r.avatar,
-      userId: r.userId,
-      requestedRole: toProjectRole(r.requestedRole),
-      createdAt: r.createdAt,
-    }));
+    try {
+      const requests = await this.idpProjectionsFacade.listMembershipRequests(
+        projectId,
+        actorUserId
+      );
+      return requests.map(r => ({
+        requestId: r.requestId,
+        email: r.email,
+        fullName: r.fullName,
+        avatar: r.avatar,
+        userId: r.userId,
+        requestedRole: toProjectRole(r.requestedRole),
+        createdAt: r.createdAt,
+      }));
+    } catch (err) {
+      this.logger.error(
+        `Failed to list membership requests for project "${projectId}" (actor "${actorUserId}")`,
+        err instanceof Error ? err.stack : err
+      );
+      throw err;
+    }
   }
 }

--- a/apps/backend/src/data-marts/use-cases/project-members/list-membership-requests.service.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/list-membership-requests.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import type { ProjectMembershipRequest } from '@owox/idp-protocol';
+import { IdpProjectionsFacade } from '../../../idp/facades/idp-projections.facade';
+
+@Injectable()
+export class ListMembershipRequestsService {
+  constructor(private readonly idpProjectionsFacade: IdpProjectionsFacade) {}
+
+  async run(projectId: string, actorUserId: string): Promise<ProjectMembershipRequest[]> {
+    return this.idpProjectionsFacade.listMembershipRequests(projectId, actorUserId);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/project-members/list-membership-requests.service.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/list-membership-requests.service.ts
@@ -1,12 +1,22 @@
 import { Injectable } from '@nestjs/common';
-import type { ProjectMembershipRequest } from '@owox/idp-protocol';
 import { IdpProjectionsFacade } from '../../../idp/facades/idp-projections.facade';
+import { toProjectRole } from '../../mappers/project-members.mapper';
+import type { ProjectMembershipRequestDto } from './dto/project-membership-request.dto';
 
 @Injectable()
 export class ListMembershipRequestsService {
   constructor(private readonly idpProjectionsFacade: IdpProjectionsFacade) {}
 
-  async run(projectId: string, actorUserId: string): Promise<ProjectMembershipRequest[]> {
-    return this.idpProjectionsFacade.listMembershipRequests(projectId, actorUserId);
+  async run(projectId: string, actorUserId: string): Promise<ProjectMembershipRequestDto[]> {
+    const requests = await this.idpProjectionsFacade.listMembershipRequests(projectId, actorUserId);
+    return requests.map(r => ({
+      requestId: r.requestId,
+      email: r.email,
+      fullName: r.fullName,
+      avatar: r.avatar,
+      userId: r.userId,
+      requestedRole: toProjectRole(r.requestedRole),
+      createdAt: r.createdAt,
+    }));
   }
 }

--- a/apps/backend/src/data-marts/use-cases/project-members/util/member-scope-saga.util.ts
+++ b/apps/backend/src/data-marts/use-cases/project-members/util/member-scope-saga.util.ts
@@ -1,0 +1,136 @@
+import { InternalServerErrorException, Logger } from '@nestjs/common';
+import { ProjectRole } from '../../../enums/project-role.enum';
+import { RoleScope } from '../../../enums/role-scope.enum';
+import { ContextAccessService } from '../../../services/context/context-access.service';
+import { ContextService } from '../../../services/context/context.service';
+
+/**
+ * Stable error message used when the IDP-side saga step succeeded but the
+ * local scope/contexts write failed. The frontend toasts `err.message`
+ * verbatim, so we keep this text short and actionable — admin reads it,
+ * heads to the Members tab, and finishes the change manually.
+ *
+ * Exported so the frontend test suite (and any future i18n / sentry mapping
+ * layer) can match against the literal.
+ */
+export const LOCAL_MEMBER_SCOPE_PARTIAL_FAILURE_MESSAGE =
+  'The identity service accepted the change, but the role/contexts could not be applied locally. Open the Members tab and set them manually.';
+
+/**
+ * Shared scope-resolution + local-write helpers for the invite and approve
+ * sagas. Both flows take `(role, roleScope?, contextIds)` from the caller,
+ * infer a fallback scope, validate contextIds against the project, and then
+ * write the local scope/contexts row after the IDP succeeds. The duplicated
+ * try/catch + log shape used to live in both services — extracting it here
+ * keeps the failure messaging consistent and makes the saga's invariants
+ * (resolve → validate → IDP → write) visible in one place.
+ */
+
+/**
+ * Resolve the effective `RoleScope` for an invite/approve action.
+ *
+ * - Admin role always coerces to `ENTIRE_PROJECT` (admins ignore context bindings).
+ * - For non-admin roles: respect an explicit `requestedScope` if provided,
+ *   otherwise infer from `contextIds` (non-empty → `SELECTED_CONTEXTS`,
+ *   empty → `ENTIRE_PROJECT`) for backwards compatibility with the legacy
+ *   invite shape.
+ */
+export function resolveEffectiveScope(
+  role: ProjectRole,
+  requestedScope: RoleScope | undefined,
+  contextIds: string[]
+): RoleScope {
+  if (role === ProjectRole.ADMIN) return RoleScope.ENTIRE_PROJECT;
+  if (requestedScope) return requestedScope;
+  return contextIds.length > 0 ? RoleScope.SELECTED_CONTEXTS : RoleScope.ENTIRE_PROJECT;
+}
+
+/**
+ * Validate context ids only when the caller actually passed some — cheap
+ * shortcut so the use-cases stay readable.
+ */
+export async function validateContextIdsIfAny(
+  contextService: ContextService,
+  contextIds: string[],
+  projectId: string
+): Promise<void> {
+  if (contextIds.length === 0) return;
+  await contextService.validateContextIds(contextIds, projectId);
+}
+
+export interface ApplyLocalMemberScopeArgs {
+  contextAccessService: ContextAccessService;
+  logger: Logger;
+  userId: string;
+  projectId: string;
+  role: ProjectRole;
+  effectiveScope: RoleScope;
+  contextIds: string[];
+  /**
+   * Operability-friendly label that identifies the originating saga step (e.g.
+   * `"Approve accepted by IDP for request foo in project bar"`). The helper
+   * appends a fixed suffix telling the operator the admin must recover via
+   * `updateMember` — this matches the pre-existing error log shape.
+   */
+  failureLabel: string;
+}
+
+/**
+ * Apply the local scope/contexts row after the IDP accepted the saga step.
+ * On failure: log with the supplied label and rethrow — callers must NOT
+ * swallow this, because the IDP has already mutated and silent fallbacks
+ * previously promoted invitees to `entire_project` scope.
+ */
+export async function applyLocalMemberScope(args: ApplyLocalMemberScopeArgs): Promise<void> {
+  const {
+    contextAccessService,
+    logger,
+    userId,
+    projectId,
+    role,
+    effectiveScope,
+    contextIds,
+    failureLabel,
+  } = args;
+
+  try {
+    await contextAccessService.updateMember(userId, projectId, {
+      role,
+      roleScope: effectiveScope,
+      contextIds,
+    });
+  } catch (err) {
+    // Operator log keeps the full stack and the originating saga step so
+    // postmortems can trace which approve/invite call left half-state behind.
+    logger.error(
+      `${failureLabel}, but local scope/contexts write failed; admin must retry via updateMember.`,
+      err instanceof Error ? err.stack : String(err)
+    );
+    // Client error is rewritten with an actionable message — the IDP side of
+    // the saga has already committed, so a generic 5xx tells the admin the
+    // wrong story ("retry") when reality is "the user is approved/invited,
+    // just no scope yet". The original error is preserved via `cause` for
+    // anyone walking the chain in logs.
+    throw new InternalServerErrorException(LOCAL_MEMBER_SCOPE_PARTIAL_FAILURE_MESSAGE, {
+      cause: err instanceof Error ? err : new Error(String(err)),
+    });
+  }
+}
+
+/**
+ * Read back the persisted scope/contexts for the affected user. Used by
+ * approve/update flows so the API response reflects DB state (not the input
+ * the admin requested) — admins picking `admin` + contextIds, for example,
+ * see the actual `entire_project` + `[]` shape that was stored.
+ */
+export async function readPersistedMemberScope(
+  contextAccessService: ContextAccessService,
+  userId: string,
+  projectId: string
+): Promise<{ roleScope: RoleScope; contextIds: string[] }> {
+  const [roleScope, contextIds] = await Promise.all([
+    contextAccessService.getRoleScope(userId, projectId),
+    contextAccessService.getMemberContextIds(userId, projectId),
+  ]);
+  return { roleScope, contextIds };
+}

--- a/apps/backend/src/idp/facades/idp-projections.facade.spec.ts
+++ b/apps/backend/src/idp/facades/idp-projections.facade.spec.ts
@@ -190,16 +190,15 @@ describe('IdpProjectionsFacade — member mutation proxies', () => {
   });
 
   describe('declineMembershipRequest', () => {
-    it('delegates with the correct argument order including reason', async () => {
+    it('delegates with the correct argument order', async () => {
       idpProjectionsService.declineMembershipRequest = jest.fn().mockResolvedValue(undefined);
 
-      await facade.declineMembershipRequest(PROJECT_ID, 'req-1', ACTOR_USER_ID, 'spam');
+      await facade.declineMembershipRequest(PROJECT_ID, 'req-1', ACTOR_USER_ID);
 
       expect(idpProjectionsService.declineMembershipRequest).toHaveBeenCalledWith(
         PROJECT_ID,
         'req-1',
-        ACTOR_USER_ID,
-        'spam'
+        ACTOR_USER_ID
       );
     });
   });

--- a/apps/backend/src/idp/facades/idp-projections.facade.spec.ts
+++ b/apps/backend/src/idp/facades/idp-projections.facade.spec.ts
@@ -17,7 +17,13 @@ describe('IdpProjectionsFacade — member mutation proxies', () => {
   let idpProjectionsService: jest.Mocked<
     Pick<
       IdpProjectionsService,
-      'inviteMember' | 'removeMember' | 'changeMemberRole' | 'getProjectMembers'
+      | 'inviteMember'
+      | 'removeMember'
+      | 'changeMemberRole'
+      | 'getProjectMembers'
+      | 'listMembershipRequests'
+      | 'approveMembershipRequest'
+      | 'declineMembershipRequest'
     >
   >;
   let facade: IdpProjectionsFacade;
@@ -28,10 +34,19 @@ describe('IdpProjectionsFacade — member mutation proxies', () => {
       removeMember: jest.fn(),
       changeMemberRole: jest.fn(),
       getProjectMembers: jest.fn(),
+      listMembershipRequests: jest.fn(),
+      approveMembershipRequest: jest.fn(),
+      declineMembershipRequest: jest.fn(),
     } as unknown as jest.Mocked<
       Pick<
         IdpProjectionsService,
-        'inviteMember' | 'removeMember' | 'changeMemberRole' | 'getProjectMembers'
+        | 'inviteMember'
+        | 'removeMember'
+        | 'changeMemberRole'
+        | 'getProjectMembers'
+        | 'listMembershipRequests'
+        | 'approveMembershipRequest'
+        | 'declineMembershipRequest'
       >
     >;
 
@@ -127,6 +142,65 @@ describe('IdpProjectionsFacade — member mutation proxies', () => {
       idpProjectionsService.getProjectMembers.mockRejectedValue(new Error('IDP timeout'));
 
       await expect(facade.getProjectMember(PROJECT_ID, USER_ID)).rejects.toThrow('IDP timeout');
+    });
+  });
+
+  describe('listMembershipRequests', () => {
+    it('delegates to the projections service with actorUserId', async () => {
+      const stub = [
+        {
+          requestId: 'r1',
+          email: 'a@b.io',
+          requestedRole: 'viewer' as const,
+          createdAt: '2026-05-01',
+        },
+      ];
+      idpProjectionsService.listMembershipRequests = jest.fn().mockResolvedValue(stub);
+
+      const result = await facade.listMembershipRequests(PROJECT_ID, 'actor-1');
+
+      expect(idpProjectionsService.listMembershipRequests).toHaveBeenCalledWith(
+        PROJECT_ID,
+        'actor-1'
+      );
+      expect(result).toEqual(stub);
+    });
+  });
+
+  describe('approveMembershipRequest', () => {
+    it('delegates with the correct argument order', async () => {
+      const stubResult = { userId: 'u-1', email: 'a@b.io', role: 'editor' as const };
+      idpProjectionsService.approveMembershipRequest = jest.fn().mockResolvedValue(stubResult);
+
+      const result = await facade.approveMembershipRequest(
+        PROJECT_ID,
+        'req-1',
+        'editor',
+        ACTOR_USER_ID
+      );
+
+      expect(idpProjectionsService.approveMembershipRequest).toHaveBeenCalledWith(
+        PROJECT_ID,
+        'req-1',
+        'editor',
+        ACTOR_USER_ID
+      );
+      expect(result).toEqual(stubResult);
+    });
+  });
+
+  describe('declineMembershipRequest', () => {
+    it('delegates with the correct argument order including reason', async () => {
+      idpProjectionsService.declineMembershipRequest = jest.fn().mockResolvedValue(undefined);
+
+      await facade.declineMembershipRequest(PROJECT_ID, 'req-1', ACTOR_USER_ID, 'spam');
+
+      expect(idpProjectionsService.declineMembershipRequest).toHaveBeenCalledWith(
+        PROJECT_ID,
+        'req-1',
+        ACTOR_USER_ID,
+        'spam'
+      );
     });
   });
 });

--- a/apps/backend/src/idp/facades/idp-projections.facade.ts
+++ b/apps/backend/src/idp/facades/idp-projections.facade.ts
@@ -1,5 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import type { ProjectMemberInvitation, Role } from '@owox/idp-protocol';
+import type {
+  ApproveMembershipRequestResult,
+  ProjectMemberInvitation,
+  ProjectMembershipRequest,
+  Role,
+} from '@owox/idp-protocol';
 import { ProjectProjectionDto } from '../dto/domain/project-projection.dto';
 import { UserProjectionDto } from '../dto/domain/user-projection.dto';
 import { UserProjectionsListDto } from '../dto/domain/user-projections-list.dto';
@@ -96,5 +101,40 @@ export class IdpProjectionsFacade {
     actorUserId: string
   ): Promise<void> {
     return this.idpProjectionsService.changeMemberRole(projectId, userId, newRole, actorUserId);
+  }
+
+  public async listMembershipRequests(
+    projectId: string,
+    actorUserId: string
+  ): Promise<ProjectMembershipRequest[]> {
+    return this.idpProjectionsService.listMembershipRequests(projectId, actorUserId);
+  }
+
+  public async approveMembershipRequest(
+    projectId: string,
+    requestId: string,
+    role: Role,
+    actorUserId: string
+  ): Promise<ApproveMembershipRequestResult> {
+    return this.idpProjectionsService.approveMembershipRequest(
+      projectId,
+      requestId,
+      role,
+      actorUserId
+    );
+  }
+
+  public async declineMembershipRequest(
+    projectId: string,
+    requestId: string,
+    actorUserId: string,
+    reason?: string
+  ): Promise<void> {
+    await this.idpProjectionsService.declineMembershipRequest(
+      projectId,
+      requestId,
+      actorUserId,
+      reason
+    );
   }
 }

--- a/apps/backend/src/idp/facades/idp-projections.facade.ts
+++ b/apps/backend/src/idp/facades/idp-projections.facade.ts
@@ -127,14 +127,8 @@ export class IdpProjectionsFacade {
   public async declineMembershipRequest(
     projectId: string,
     requestId: string,
-    actorUserId: string,
-    reason?: string
+    actorUserId: string
   ): Promise<void> {
-    await this.idpProjectionsService.declineMembershipRequest(
-      projectId,
-      requestId,
-      actorUserId,
-      reason
-    );
+    await this.idpProjectionsService.declineMembershipRequest(projectId, requestId, actorUserId);
   }
 }

--- a/apps/backend/src/idp/services/idp-projections.service.ts
+++ b/apps/backend/src/idp/services/idp-projections.service.ts
@@ -1,6 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Payload, ProjectMember, ProjectMemberInvitation, Role } from '@owox/idp-protocol';
+import {
+  ApproveMembershipRequestResult,
+  Payload,
+  ProjectMember,
+  ProjectMemberInvitation,
+  ProjectMembershipRequest,
+  Role,
+} from '@owox/idp-protocol';
 import { In, Repository } from 'typeorm';
 import { ProjectProjection } from '../entities/project-projection.entity';
 import { UserProjection } from '../entities/user-projection.entity';
@@ -160,6 +167,34 @@ export class IdpProjectionsService {
   ): Promise<void> {
     const provider = this.idpProviderService.getProviderFromApp();
     await provider.changeMemberRole(projectId, userId, newRole, actorUserId);
+  }
+
+  public async listMembershipRequests(
+    projectId: string,
+    actorUserId: string
+  ): Promise<ProjectMembershipRequest[]> {
+    const provider = this.idpProviderService.getProviderFromApp();
+    return provider.listMembershipRequests(projectId, actorUserId);
+  }
+
+  public async approveMembershipRequest(
+    projectId: string,
+    requestId: string,
+    role: Role,
+    actorUserId: string
+  ): Promise<ApproveMembershipRequestResult> {
+    const provider = this.idpProviderService.getProviderFromApp();
+    return provider.approveMembershipRequest(projectId, requestId, role, actorUserId);
+  }
+
+  public async declineMembershipRequest(
+    projectId: string,
+    requestId: string,
+    actorUserId: string,
+    reason?: string
+  ): Promise<void> {
+    const provider = this.idpProviderService.getProviderFromApp();
+    await provider.declineMembershipRequest(projectId, requestId, actorUserId, reason);
   }
 
   /**

--- a/apps/backend/src/idp/services/idp-projections.service.ts
+++ b/apps/backend/src/idp/services/idp-projections.service.ts
@@ -190,11 +190,10 @@ export class IdpProjectionsService {
   public async declineMembershipRequest(
     projectId: string,
     requestId: string,
-    actorUserId: string,
-    reason?: string
+    actorUserId: string
   ): Promise<void> {
     const provider = this.idpProviderService.getProviderFromApp();
-    await provider.declineMembershipRequest(projectId, requestId, actorUserId, reason);
+    await provider.declineMembershipRequest(projectId, requestId, actorUserId);
   }
 
   /**

--- a/apps/backend/test/membership-requests.e2e-spec.ts
+++ b/apps/backend/test/membership-requests.e2e-spec.ts
@@ -1,0 +1,202 @@
+import { INestApplication } from '@nestjs/common';
+import * as supertest from 'supertest';
+import { createTestApp, closeTestApp, AUTH_HEADER } from '@owox/test-utils';
+import { IdpProjectionsFacade } from '../src/idp/facades/idp-projections.facade';
+
+/**
+ * E2E coverage for the Membership Requests controller — pins the
+ * controller → use-case → facade wire contract.
+ *
+ * NullIdpProvider authenticates the AUTH_HEADER as the default admin in
+ * project `0`, so the `Role.admin(Strategy.INTROSPECT)` guard passes.
+ * `IdpProjectionsFacade` is overridden so each test can shape the upstream
+ * response (success / 404 / partial-failure) without standing up a fake
+ * Java service.
+ */
+
+const PROJECT_ID = '0';
+const BASE_URL = '/api/members';
+const REQUESTS_URL = `${BASE_URL}/requests`;
+
+const REQUEST_FIXTURE = {
+  requestId: 'req-alice',
+  email: 'alice@example.com',
+  fullName: 'Alice Example',
+  avatar: undefined,
+  userId: 'user-alice',
+  requestedRole: 'viewer',
+  createdAt: '2026-05-01T10:00:00.000Z',
+};
+
+/**
+ * Mirrors the shape `IdpNotFoundException` produces in production —
+ * `name === 'IdpNotFoundException'` is the primary signal `isIdpNotFoundError`
+ * matches on, with a `status: 404` fallback for any transport that drops
+ * the class name.
+ */
+function makeIdpNotFound(): Error {
+  return Object.assign(new Error('Upstream resource not found'), {
+    name: 'IdpNotFoundException',
+    status: 404,
+  });
+}
+
+describe('Membership Requests (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+
+  const mockFacade = {
+    listMembershipRequests: jest.fn(),
+    approveMembershipRequest: jest.fn(),
+    declineMembershipRequest: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const testApp = await createTestApp([{ provide: IdpProjectionsFacade, useValue: mockFacade }]);
+    app = testApp.app;
+    agent = testApp.agent;
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // GET /members/requests
+  // ---------------------------------------------------------------------------
+  describe(`GET ${REQUESTS_URL}`, () => {
+    it('returns mapped membership requests with ProjectRole values', async () => {
+      mockFacade.listMembershipRequests.mockResolvedValue([REQUEST_FIXTURE]);
+
+      const res = await agent.get(REQUESTS_URL).set(AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(mockFacade.listMembershipRequests).toHaveBeenCalledWith(PROJECT_ID, '0');
+      expect(res.body).toEqual([
+        {
+          requestId: 'req-alice',
+          email: 'alice@example.com',
+          fullName: 'Alice Example',
+          userId: 'user-alice',
+          requestedRole: 'viewer',
+          createdAt: '2026-05-01T10:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('returns empty array when no requests are pending', async () => {
+      mockFacade.listMembershipRequests.mockResolvedValue([]);
+
+      const res = await agent.get(REQUESTS_URL).set(AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /members/requests/:requestId/approve
+  // ---------------------------------------------------------------------------
+  describe(`POST ${REQUESTS_URL}/:requestId/approve`, () => {
+    it('approves and responds with the persisted scope/contexts (not the input echo)', async () => {
+      mockFacade.approveMembershipRequest.mockResolvedValue({ userId: 'user-alice' });
+
+      const res = await agent
+        .post(`${REQUESTS_URL}/${REQUEST_FIXTURE.requestId}/approve`)
+        .set(AUTH_HEADER)
+        .send({ role: 'editor' });
+
+      expect(res.status).toBe(201);
+      expect(mockFacade.approveMembershipRequest).toHaveBeenCalledWith(
+        PROJECT_ID,
+        REQUEST_FIXTURE.requestId,
+        'editor',
+        '0'
+      );
+      expect(res.body).toMatchObject({
+        userId: 'user-alice',
+        role: 'editor',
+        roleScope: 'entire_project',
+        contextIds: [],
+      });
+    });
+
+    it('admin role + contextIds → response reflects coerced (entire_project, [])', async () => {
+      mockFacade.approveMembershipRequest.mockResolvedValue({ userId: 'user-bob' });
+
+      const res = await agent
+        .post(`${REQUESTS_URL}/req-bob/approve`)
+        .set(AUTH_HEADER)
+        .send({ role: 'admin', roleScope: 'selected_contexts', contextIds: [] });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toMatchObject({
+        userId: 'user-bob',
+        role: 'admin',
+        roleScope: 'entire_project',
+        contextIds: [],
+      });
+    });
+
+    it('IDP 404 → 404 Not Found (matches Swagger spec, not 500)', async () => {
+      mockFacade.approveMembershipRequest.mockRejectedValue(makeIdpNotFound());
+
+      const res = await agent
+        .post(`${REQUESTS_URL}/stale-req/approve`)
+        .set(AUTH_HEADER)
+        .send({ role: 'viewer' });
+
+      expect(res.status).toBe(404);
+      expect(res.body).toMatchObject({
+        statusCode: 404,
+        message: expect.stringContaining('stale-req'),
+      });
+    });
+
+    it('rejects malformed role with 400 (class-validator at the boundary)', async () => {
+      const res = await agent
+        .post(`${REQUESTS_URL}/req-x/approve`)
+        .set(AUTH_HEADER)
+        .send({ role: 'superuser' });
+
+      expect(res.status).toBe(400);
+      expect(mockFacade.approveMembershipRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /members/requests/:requestId/decline
+  // ---------------------------------------------------------------------------
+  describe(`POST ${REQUESTS_URL}/:requestId/decline`, () => {
+    it('declines and returns 204 No Content', async () => {
+      mockFacade.declineMembershipRequest.mockResolvedValue(undefined);
+
+      const res = await agent
+        .post(`${REQUESTS_URL}/${REQUEST_FIXTURE.requestId}/decline`)
+        .set(AUTH_HEADER)
+        .send({});
+
+      expect(res.status).toBe(204);
+      expect(mockFacade.declineMembershipRequest).toHaveBeenCalledWith(
+        PROJECT_ID,
+        REQUEST_FIXTURE.requestId,
+        '0'
+      );
+    });
+
+    it('is idempotent: IDP 404 still resolves as 204 success', async () => {
+      mockFacade.declineMembershipRequest.mockRejectedValue(makeIdpNotFound());
+
+      const res = await agent
+        .post(`${REQUESTS_URL}/already-declined/decline`)
+        .set(AUTH_HEADER)
+        .send({});
+
+      expect(res.status).toBe(204);
+    });
+  });
+});

--- a/apps/backend/test/membership-requests.e2e-spec.ts
+++ b/apps/backend/test/membership-requests.e2e-spec.ts
@@ -188,7 +188,7 @@ describe('Membership Requests (e2e)', () => {
       );
     });
 
-    it('is idempotent: IDP 404 still resolves as 204 success', async () => {
+    it('returns 404 when the request is unknown to the IDP (symmetric with approve)', async () => {
       mockFacade.declineMembershipRequest.mockRejectedValue(makeIdpNotFound());
 
       const res = await agent
@@ -196,7 +196,7 @@ describe('Membership Requests (e2e)', () => {
         .set(AUTH_HEADER)
         .send({});
 
-      expect(res.status).toBe(204);
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/apps/backend/test/membership-requests.e2e-spec.ts
+++ b/apps/backend/test/membership-requests.e2e-spec.ts
@@ -110,7 +110,7 @@ describe('Membership Requests (e2e)', () => {
         .set(AUTH_HEADER)
         .send({ role: 'editor' });
 
-      expect(res.status).toBe(201);
+      expect(res.status).toBe(200);
       expect(mockFacade.approveMembershipRequest).toHaveBeenCalledWith(
         PROJECT_ID,
         REQUEST_FIXTURE.requestId,
@@ -133,7 +133,7 @@ describe('Membership Requests (e2e)', () => {
         .set(AUTH_HEADER)
         .send({ role: 'admin', roleScope: 'selected_contexts', contextIds: [] });
 
-      expect(res.status).toBe(201);
+      expect(res.status).toBe(200);
       expect(res.body).toMatchObject({
         userId: 'user-bob',
         role: 'admin',

--- a/apps/web/e2e/selectors/testids.ts
+++ b/apps/web/e2e/selectors/testids.ts
@@ -56,4 +56,8 @@ export const TESTIDS = {
 
   // FloatingPopover domain
   floatingPopoverClose: 'floatingPopoverClose',
+
+  // Membership Requests domain
+  pendingRequestsSection: 'pendingRequestsSection',
+  membershipRequestSheet: 'membershipRequestSheet',
 } as const;

--- a/apps/web/e2e/specs/membership-requests.spec.ts
+++ b/apps/web/e2e/specs/membership-requests.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect } from '../fixtures/base';
+import { TESTIDS } from '../selectors/testids';
+
+/**
+ * E2E coverage for the Membership Requests feature.
+ *
+ * The membership-request endpoints (GET /api/members/requests,
+ * POST /api/members/requests/:id/approve, POST /api/members/requests/:id/decline)
+ * are guarded by Strategy.INTROSPECT which validates the JWT audience against the
+ * external OWOX IDP service. In the local e2e environment that validation fails
+ * with a 401, causing the frontend to fire an auth:logout event and redirect to
+ * sign-in. We therefore intercept these three routes with page.route() and return
+ * canned mock responses — identical to what the IDP mock returns in the task
+ * description — so the rest of the page loads and we can verify UI behaviour.
+ *
+ * Mock data:
+ *   - alice@example.com — viewer, requestId: mock-req-alice
+ *   - bob@example.com  — editor, requestId: mock-req-bob
+ *
+ * The mock is stateless: approve/decline always resolve 200/204. The frontend
+ * applies optimistic removal so the row disappears immediately; reloading would
+ * bring it back. Tests verify optimistic behaviour only.
+ *
+ * URL: /ui/0/project-settings/members
+ */
+
+const MEMBERS_URL = '/ui/0/project-settings/members';
+
+const MOCK_REQUESTS = [
+  {
+    requestId: 'mock-req-alice',
+    email: 'alice@example.com',
+    fullName: 'Alice Example',
+    avatar: null,
+    userId: 'user-alice',
+    requestedRole: 'viewer',
+    createdAt: new Date().toISOString(),
+  },
+  {
+    requestId: 'mock-req-bob',
+    email: 'bob@example.com',
+    fullName: 'Bob Example',
+    avatar: null,
+    userId: 'user-bob',
+    requestedRole: 'editor',
+    createdAt: new Date().toISOString(),
+  },
+];
+
+/**
+ * Register page.route() intercepts for the three membership-request endpoints.
+ * Must be called before page.goto() so intercepts are in place before the page
+ * fires its initial data-fetch.
+ */
+async function mockMembershipRequestRoutes(page: import('@playwright/test').Page): Promise<void> {
+  // GET /api/members/requests — list
+  await page.route('**/api/members/requests', route => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_REQUESTS),
+      });
+    }
+    return route.continue();
+  });
+
+  // POST /api/members/requests/:requestId/approve
+  await page.route('**/api/members/requests/*/approve', route => {
+    const body = {
+      userId: 'user-alice',
+      email: 'alice@example.com',
+      role: 'viewer',
+      roleScope: 'entire_project',
+      contextIds: [],
+    };
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+
+  // POST /api/members/requests/:requestId/decline
+  await page.route('**/api/members/requests/*/decline', route => {
+    return route.fulfill({ status: 204, body: '' });
+  });
+}
+
+test.describe('Project Settings — Membership requests', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockMembershipRequestRoutes(page);
+    await page.goto(MEMBERS_URL);
+    // Wait for the Members tab content to settle — the pending-requests card
+    // is the earliest reliable anchor once data has loaded.
+    await expect(page.getByTestId(TESTIDS.pendingRequestsSection)).toBeVisible({
+      timeout: 25_000,
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // MR-01: Admin sees the pending requests section with both mock entries
+  // ---------------------------------------------------------------------------
+  test('admin sees both pending requests (MR-01)', async ({ page }) => {
+    await expect(page.getByTestId(TESTIDS.pendingRequestsSection)).toBeVisible();
+    // Card header surfaces the count.
+    await expect(page.getByText(/Project membership requests \(2\)/i)).toBeVisible();
+    await expect(page.getByText('alice@example.com')).toBeVisible();
+    await expect(page.getByText('bob@example.com')).toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------------
+  // MR-02: Approve flow — sheet opens, Approve button triggers toast + row gone
+  // ---------------------------------------------------------------------------
+  test('approve flow removes the row optimistically (MR-02)', async ({ page }) => {
+    // Click the alice row to open the sheet.
+    await page.getByText('alice@example.com').click();
+
+    const sheet = page.getByTestId(TESTIDS.membershipRequestSheet);
+    await expect(sheet).toBeVisible();
+    // Sheet title is generic now — identity-block email confirms the right request opened.
+    await expect(sheet.getByRole('heading', { name: /Membership request/i })).toBeVisible();
+    await expect(sheet.getByText('alice@example.com')).toBeVisible();
+
+    // Click the Approve button inside the sheet.
+    await sheet.getByRole('button', { name: /Approve request/i }).click();
+
+    // Toast confirmation.
+    await expect(page.getByText(/Approved request from alice@example\.com/i)).toBeVisible();
+
+    // Row should be gone (optimistic removal).
+    await expect(page.getByText('alice@example.com')).toBeHidden();
+  });
+
+  // ---------------------------------------------------------------------------
+  // MR-03: Decline flow — confirmation dialog appears, confirm triggers toast +
+  //         row gone
+  // ---------------------------------------------------------------------------
+  test('decline flow asks for confirmation then removes the row (MR-03)', async ({ page }) => {
+    // Click the bob row to open the sheet.
+    await page.getByText('bob@example.com').click();
+
+    const sheet = page.getByTestId(TESTIDS.membershipRequestSheet);
+    await expect(sheet).toBeVisible();
+    await expect(sheet.getByRole('heading', { name: /Membership request/i })).toBeVisible();
+    await expect(sheet.getByText('bob@example.com')).toBeVisible();
+
+    // Click "Decline request" — this opens the ConfirmationDialog, not the
+    // final action yet.
+    await sheet.getByRole('button', { name: /Decline request/i }).click();
+
+    // Confirmation dialog heading.
+    await expect(page.getByRole('heading', { name: /Decline membership request/i })).toBeVisible();
+
+    // The dialog has a destructive "Decline" confirm button. It is the last
+    // "Decline" button in the DOM (the sheet header button is behind the dialog).
+    const declineButtons = page.getByRole('button', { name: /^Decline$/i });
+    await declineButtons.last().click();
+
+    // Toast confirmation.
+    await expect(page.getByText(/Declined request from bob@example\.com/i)).toBeVisible();
+
+    // Row should be gone (optimistic removal).
+    await expect(page.getByText('bob@example.com')).toBeHidden();
+  });
+
+  // ---------------------------------------------------------------------------
+  // MR-04: Non-admin user — section not rendered
+  // ---------------------------------------------------------------------------
+  test('non-admin does not see the section (MR-04)', async () => {
+    // The e2e harness currently has no role-switch helper (all tests run as the
+    // default admin). Skip until a non-admin fixture is wired up.
+    // TODO: implement once a viewer/editor user fixture is available in
+    //       apps/web/e2e/fixtures/ — mirror the pattern from api-helpers.ts.
+    test.skip(true, 'TODO: wire up non-admin user fixture once available');
+  });
+});

--- a/apps/web/e2e/specs/membership-requests.spec.ts
+++ b/apps/web/e2e/specs/membership-requests.spec.ts
@@ -103,8 +103,9 @@ test.describe('Project Settings — Membership requests', () => {
   // ---------------------------------------------------------------------------
   test('admin sees both pending requests (MR-01)', async ({ page }) => {
     await expect(page.getByTestId(TESTIDS.pendingRequestsSection)).toBeVisible();
-    // Card header surfaces the count.
-    await expect(page.getByText(/Project membership requests \(2\)/i)).toBeVisible();
+    // Trade-off: no count in the header — the row testids carry the cardinality
+    // contract instead, surviving copy tweaks to the section title.
+    await expect(page.getByText(/Access requests/i)).toBeVisible();
     await expect(page.getByText('alice@example.com')).toBeVisible();
     await expect(page.getByText('bob@example.com')).toBeVisible();
   });

--- a/apps/web/src/features/project-members/services/project-members.service.ts
+++ b/apps/web/src/features/project-members/services/project-members.service.ts
@@ -1,6 +1,13 @@
 import { ApiService } from '../../../services/api-service';
 import type { MemberWithScopeDto } from '../../contexts/types/context.types';
-import type { Role, RoleScope } from '../types';
+import type {
+  ApproveMembershipRequestPayload,
+  ApproveMembershipRequestResult,
+  DeclineMembershipRequestPayload,
+  MembershipRequestDto,
+  Role,
+  RoleScope,
+} from '../types';
 
 /**
  * Discriminated union mirroring `InviteMemberResponseApiDto` from backend.
@@ -70,6 +77,24 @@ class ProjectMembersApiService extends ApiService {
 
   async removeMember(userId: string): Promise<void> {
     return this.delete(`/${userId}`);
+  }
+
+  async getMembershipRequests(): Promise<MembershipRequestDto[]> {
+    return this.get<MembershipRequestDto[]>('/requests');
+  }
+
+  async approveMembershipRequest(
+    requestId: string,
+    payload: ApproveMembershipRequestPayload
+  ): Promise<ApproveMembershipRequestResult> {
+    return this.post(`/requests/${requestId}/approve`, payload);
+  }
+
+  async declineMembershipRequest(
+    requestId: string,
+    payload: DeclineMembershipRequestPayload = {}
+  ): Promise<void> {
+    return this.post(`/requests/${requestId}/decline`, payload);
   }
 }
 

--- a/apps/web/src/features/project-members/services/project-members.service.ts
+++ b/apps/web/src/features/project-members/services/project-members.service.ts
@@ -3,7 +3,6 @@ import type { MemberWithScopeDto } from '../../contexts/types/context.types';
 import type {
   ApproveMembershipRequestPayload,
   ApproveMembershipRequestResult,
-  DeclineMembershipRequestPayload,
   MembershipRequestDto,
   Role,
   RoleScope,
@@ -90,11 +89,8 @@ class ProjectMembersApiService extends ApiService {
     return this.post(`/requests/${requestId}/approve`, payload);
   }
 
-  async declineMembershipRequest(
-    requestId: string,
-    payload: DeclineMembershipRequestPayload = {}
-  ): Promise<void> {
-    return this.post(`/requests/${requestId}/decline`, payload);
+  async declineMembershipRequest(requestId: string): Promise<void> {
+    return this.post(`/requests/${requestId}/decline`, {});
   }
 }
 

--- a/apps/web/src/features/project-members/types/index.ts
+++ b/apps/web/src/features/project-members/types/index.ts
@@ -29,7 +29,3 @@ export interface ApproveMembershipRequestResult {
   roleScope: RoleScope;
   contextIds: string[];
 }
-
-export interface DeclineMembershipRequestPayload {
-  reason?: string;
-}

--- a/apps/web/src/features/project-members/types/index.ts
+++ b/apps/web/src/features/project-members/types/index.ts
@@ -6,3 +6,30 @@ export const PROJECT_ROLE_VALUES = ['admin', 'editor', 'viewer'] as const satisf
 
 export const ROLE_SCOPE_VALUES = ['entire_project', 'selected_contexts'] as const;
 export type RoleScope = (typeof ROLE_SCOPE_VALUES)[number];
+
+export interface MembershipRequestDto {
+  requestId: string;
+  email: string;
+  fullName?: string;
+  avatar?: string;
+  userId?: string;
+  requestedRole: Role;
+  createdAt: string;
+}
+
+export interface ApproveMembershipRequestPayload {
+  role: Role;
+  roleScope?: RoleScope;
+  contextIds?: string[];
+}
+
+export interface ApproveMembershipRequestResult {
+  userId: string;
+  role: Role;
+  roleScope: RoleScope;
+  contextIds: string[];
+}
+
+export interface DeclineMembershipRequestPayload {
+  reason?: string;
+}

--- a/apps/web/src/features/project-settings/members/components/InviteMemberSheet/InviteMemberSheet.tsx
+++ b/apps/web/src/features/project-settings/members/components/InviteMemberSheet/InviteMemberSheet.tsx
@@ -13,18 +13,10 @@ import { Badge } from '@owox/ui/components/badge';
 import { Button } from '@owox/ui/components/button';
 import { Input } from '@owox/ui/components/input';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@owox/ui/components/select';
-import {
   AppForm,
   Form,
   FormActions,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -32,12 +24,6 @@ import {
   FormMessage,
   FormSection,
 } from '@owox/ui/components/form';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@owox/ui/components/accordion';
 import { Loader2, Check, Copy, Link2, Clock, ShieldCheck } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { projectMembersService } from '../../../../../features/project-members/services/project-members.service';
@@ -47,10 +33,9 @@ import {
   ROLE_SCOPE_VALUES,
 } from '../../../../../features/project-members/types';
 import { getRoleDisplayName } from '../../../../../features/idp/utils/role-display-name';
-import { ContextsCheckboxList } from '../../../../../features/contexts/components/ContextsCheckboxList';
 import { AddContextSheet } from '../../../../../features/contexts/components/AddContextSheet/AddContextSheet';
 import { useMembersSettings } from '../../model/members-settings.context';
-import { useIsAdmin } from '../../../../../features/idp/hooks/useRole';
+import { MemberFormFields } from '../MemberFormFields/MemberFormFields';
 import type { ContextDto } from '../../../../../features/contexts/types/context.types';
 
 const inviteMemberSchema = z.object({
@@ -85,10 +70,7 @@ export function InviteMemberSheet({
     defaultValues: DEFAULT_VALUES,
     mode: 'onChange',
   });
-  const { control, handleSubmit, watch, reset: resetForm } = form;
-  const role = watch('role');
-  const roleScope = watch('roleScope');
-  const isAdmin = useIsAdmin();
+  const { control, handleSubmit, reset: resetForm } = form;
   const { members, refresh } = useMembersSettings();
   const [selectedContextIds, setSelectedContextIds] = useState<string[]>([]);
   const [sending, setSending] = useState(false);
@@ -176,9 +158,6 @@ export function InviteMemberSheet({
       checked ? [...prev, contextId] : prev.filter(id => id !== contextId)
     );
   };
-
-  const isAdminRole = role === 'admin';
-  const showContextsSection = !isAdminRole && roleScope === 'selected_contexts';
 
   return (
     <>
@@ -319,154 +298,18 @@ export function InviteMemberSheet({
                           </FormItem>
                         )}
                       />
-
-                      <FormField
-                        control={control}
-                        name='role'
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel tooltip='Project role granted once the invitation is accepted'>
-                              Role
-                            </FormLabel>
-                            <FormControl>
-                              <Select
-                                value={field.value}
-                                onValueChange={field.onChange}
-                                disabled={sending}
-                              >
-                                <SelectTrigger className='w-full'>
-                                  <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  {PROJECT_ROLE_VALUES.map(r => (
-                                    <SelectItem key={r} value={r}>
-                                      {getRoleDisplayName(r)}
-                                    </SelectItem>
-                                  ))}
-                                </SelectContent>
-                              </Select>
-                            </FormControl>
-                            <FormMessage />
-                            <FormDescription>
-                              <Accordion variant='common' type='single' collapsible>
-                                <AccordionItem value='invite-role-help'>
-                                  <AccordionTrigger>Which role should I pick?</AccordionTrigger>
-                                  <AccordionContent>
-                                    <p className='mb-2'>
-                                      <strong>Business User</strong> — sees accessible Data Marts
-                                      and Reports, creates Reports for Data Marts available for
-                                      reporting, manages Reports they own (edit, delete, change
-                                      owners), manages Report Triggers under their Reports, and uses
-                                      Destinations available for use. Cannot create, edit, or delete
-                                      Data Marts, Data Mart Triggers, or Storages.
-                                    </p>
-                                    <p className='mb-2'>
-                                      <strong>Technical User</strong> — everything a Business User
-                                      may do, plus: creates, edits, and deletes Data Marts, Data
-                                      Mart Triggers, and Storages; edits and deletes Reports
-                                      project-wide; changes Report owners; manages Report Triggers
-                                      project-wide.
-                                    </p>
-                                    <p className='mb-2'>
-                                      <strong>Project Admin</strong> — everything a Technical User
-                                      may do, plus: manages Project Members, manages billing, and
-                                      manages general Project settings such as the Project title.
-                                    </p>
-                                  </AccordionContent>
-                                </AccordionItem>
-                              </Accordion>
-                            </FormDescription>
-                          </FormItem>
-                        )}
-                      />
                     </FormSection>
 
-                    {isAdminRole ? (
-                      <FormSection title='Access' collapsible={false} name='invite-admin-access'>
-                        <FormItem>
-                          <p className='text-muted-foreground text-sm'>
-                            Project Admin has project-wide access. Scope and context assignments do
-                            not apply.
-                          </p>
-                        </FormItem>
-                      </FormSection>
-                    ) : (
-                      <FormSection title='Scope' name='invite-scope'>
-                        <FormField
-                          control={control}
-                          name='roleScope'
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel tooltip='Controls what resources this member can see by default after they accept the invitation'>
-                                Role scope
-                              </FormLabel>
-                              <FormControl>
-                                <Select
-                                  value={field.value}
-                                  onValueChange={field.onChange}
-                                  disabled={sending}
-                                >
-                                  <SelectTrigger className='w-full'>
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    <SelectItem value='entire_project'>Entire project</SelectItem>
-                                    <SelectItem value='selected_contexts'>
-                                      Selected contexts only
-                                    </SelectItem>
-                                  </SelectContent>
-                                </Select>
-                              </FormControl>
-                              <FormMessage />
-                              <FormDescription>
-                                <Accordion variant='common' type='single' collapsible>
-                                  <AccordionItem value='invite-scope-help'>
-                                    <AccordionTrigger>What do the scopes mean?</AccordionTrigger>
-                                    <AccordionContent>
-                                      <p className='mb-2'>
-                                        <strong>Entire project</strong> — the member sees every
-                                        shared resource in the project (subject to role and
-                                        ownership rules).
-                                      </p>
-                                      <p className='mb-2'>
-                                        <strong>Selected contexts only</strong> — the member sees
-                                        resources only if they share at least one assigned context,
-                                        or if the member is an owner. Picking this with no contexts
-                                        below is a valid "no shared access" state.
-                                      </p>
-                                    </AccordionContent>
-                                  </AccordionItem>
-                                </Accordion>
-                              </FormDescription>
-                            </FormItem>
-                          )}
-                        />
-                      </FormSection>
-                    )}
-
-                    {showContextsSection && (
-                      <FormSection title='Contexts' name='invite-contexts'>
-                        <FormItem>
-                          <FormLabel tooltip='Contexts pre-assigned to this member once they accept the invitation'>
-                            Assign to contexts (optional)
-                          </FormLabel>
-                          <ContextsCheckboxList
-                            idPrefix='invite-ctx'
-                            contexts={contexts}
-                            selectedIds={selectedContextIds}
-                            onToggle={handleToggleContext}
-                            disabled={sending}
-                            onRequestCreate={
-                              isAdmin
-                                ? () => {
-                                    setAddContextOpen(true);
-                                  }
-                                : undefined
-                            }
-                          />
-                        </FormItem>
-                      </FormSection>
-                    )}
+                    <MemberFormFields
+                      contexts={contexts}
+                      selectedContextIds={selectedContextIds}
+                      onToggleContext={handleToggleContext}
+                      disabled={sending}
+                      onRequestCreateContext={() => {
+                        setAddContextOpen(true);
+                      }}
+                      contextIdPrefix='invite-ctx'
+                    />
                   </FormLayout>
 
                   <FormActions>

--- a/apps/web/src/features/project-settings/members/components/MemberFormFields/MemberFormFields.tsx
+++ b/apps/web/src/features/project-settings/members/components/MemberFormFields/MemberFormFields.tsx
@@ -1,0 +1,202 @@
+import { useFormContext } from 'react-hook-form';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormSection,
+} from '@owox/ui/components/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@owox/ui/components/select';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@owox/ui/components/accordion';
+import {
+  PROJECT_ROLE_VALUES,
+  ROLE_SCOPE_VALUES,
+  type Role,
+  type RoleScope,
+} from '../../../../../features/project-members/types';
+import { getRoleDisplayName } from '../../../../../features/idp/utils/role-display-name';
+import { ContextsCheckboxList } from '../../../../../features/contexts/components/ContextsCheckboxList';
+import { useIsAdmin } from '../../../../../features/idp/hooks/useRole';
+import type { ContextDto } from '../../../../../features/contexts/types/context.types';
+
+export interface MemberFormFieldsProps {
+  contexts: ContextDto[];
+  selectedContextIds: string[];
+  onToggleContext: (contextId: string, checked: boolean) => void;
+  disabled?: boolean;
+  onRequestCreateContext?: () => void;
+  contextIdPrefix: string;
+}
+
+/** Minimum shape any parent form must satisfy to use this primitive. */
+interface FormShape {
+  role: Role;
+  roleScope: RoleScope;
+}
+
+const ROLE_SCOPE_LABELS: Record<RoleScope, string> = {
+  entire_project: 'Entire project',
+  selected_contexts: 'Selected contexts only',
+};
+
+export function MemberFormFields({
+  contexts,
+  selectedContextIds,
+  onToggleContext,
+  disabled = false,
+  onRequestCreateContext,
+  contextIdPrefix,
+}: MemberFormFieldsProps) {
+  const { control, watch } = useFormContext<FormShape>();
+  const role = watch('role');
+  const roleScope = watch('roleScope');
+  const isAdminRole = role === 'admin';
+  const showContexts = !isAdminRole && roleScope === 'selected_contexts';
+  const isAdmin = useIsAdmin();
+
+  return (
+    <>
+      <FormSection title='Role' name='member-role'>
+        <FormField
+          control={control}
+          name='role'
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel tooltip='Project role granted to this member'>Role</FormLabel>
+              <FormControl>
+                <Select value={field.value} onValueChange={field.onChange} disabled={disabled}>
+                  <SelectTrigger className='w-full'>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PROJECT_ROLE_VALUES.map(r => (
+                      <SelectItem key={r} value={r}>
+                        {getRoleDisplayName(r)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+              <FormDescription>
+                <Accordion variant='common' type='single' collapsible>
+                  <AccordionItem value='member-role-help'>
+                    <AccordionTrigger>Which role should I pick?</AccordionTrigger>
+                    <AccordionContent>
+                      <p className='mb-2'>
+                        <strong>Business User</strong> — sees accessible Data Marts and Reports,
+                        creates Reports for Data Marts available for reporting, manages Reports they
+                        own (edit, delete, change owners), manages Report Triggers under their
+                        Reports, and uses Destinations available for use. Cannot create, edit, or
+                        delete Data Marts, Data Mart Triggers, or Storages.
+                      </p>
+                      <p className='mb-2'>
+                        <strong>Technical User</strong> — everything a Business User may do, plus:
+                        creates, edits, and deletes Data Marts, Data Mart Triggers, and Storages;
+                        edits and deletes Reports project-wide; changes Report owners; manages
+                        Report Triggers project-wide.
+                      </p>
+                      <p className='mb-2'>
+                        <strong>Project Admin</strong> — everything a Technical User may do, plus:
+                        manages Project Members, manages billing, and manages general Project
+                        settings such as the Project title.
+                      </p>
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+              </FormDescription>
+            </FormItem>
+          )}
+        />
+      </FormSection>
+
+      {isAdminRole ? (
+        <FormSection title='Access' collapsible={false} name='member-admin-access'>
+          <FormItem>
+            <p className='text-muted-foreground text-sm'>
+              Project Admin has project-wide access. Scope and context assignments do not apply.
+            </p>
+          </FormItem>
+        </FormSection>
+      ) : (
+        <FormSection title='Scope' name='member-scope'>
+          <FormField
+            control={control}
+            name='roleScope'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel tooltip='Controls what resources this member can see by default'>
+                  Role scope
+                </FormLabel>
+                <FormControl>
+                  <Select value={field.value} onValueChange={field.onChange} disabled={disabled}>
+                    <SelectTrigger className='w-full'>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ROLE_SCOPE_VALUES.map(s => (
+                        <SelectItem key={s} value={s}>
+                          {ROLE_SCOPE_LABELS[s]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+                <FormDescription>
+                  <Accordion variant='common' type='single' collapsible>
+                    <AccordionItem value='member-scope-help'>
+                      <AccordionTrigger>What do the scopes mean?</AccordionTrigger>
+                      <AccordionContent>
+                        <p className='mb-2'>
+                          <strong>Entire project</strong> — the member sees every shared resource in
+                          the project (subject to role and ownership rules).
+                        </p>
+                        <p className='mb-2'>
+                          <strong>Selected contexts only</strong> — the member sees resources only
+                          if they share at least one assigned context, or if the member is an owner.
+                          Picking this with no contexts below is a valid "no shared access" state.
+                        </p>
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                </FormDescription>
+              </FormItem>
+            )}
+          />
+        </FormSection>
+      )}
+
+      {showContexts && (
+        <FormSection title='Contexts' name='member-contexts'>
+          <FormItem>
+            <FormLabel tooltip='Contexts this member can see'>
+              Assign to contexts (optional)
+            </FormLabel>
+            <ContextsCheckboxList
+              idPrefix={contextIdPrefix}
+              contexts={contexts}
+              selectedIds={selectedContextIds}
+              onToggle={onToggleContext}
+              disabled={disabled}
+              onRequestCreate={isAdmin ? onRequestCreateContext : undefined}
+            />
+          </FormItem>
+        </FormSection>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/project-settings/members/components/MembershipRequestSheet/MembershipRequestSheet.tsx
+++ b/apps/web/src/features/project-settings/members/components/MembershipRequestSheet/MembershipRequestSheet.tsx
@@ -1,0 +1,268 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@owox/ui/components/sheet';
+import { Button } from '@owox/ui/components/button';
+import {
+  AppForm,
+  Form,
+  FormActions,
+  FormItem,
+  FormLabel,
+  FormLayout,
+  FormSection,
+} from '@owox/ui/components/form';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+import { projectMembersService } from '../../../../../features/project-members/services/project-members.service';
+import {
+  PROJECT_ROLE_VALUES,
+  ROLE_SCOPE_VALUES,
+} from '../../../../../features/project-members/types';
+import type { MembershipRequestDto } from '../../../../../features/project-members/types';
+import type { ContextDto } from '../../../../../features/contexts/types/context.types';
+import { useMembersSettings } from '../../model/members-settings.context';
+import { ConfirmationDialog } from '../../../../../shared/components/ConfirmationDialog';
+import { MemberFormFields } from '../MemberFormFields/MemberFormFields';
+import { AddContextSheet } from '../../../../../features/contexts/components/AddContextSheet/AddContextSheet';
+import { formatDateShort } from '../../../../../utils/date-formatters';
+import { UserAvatar, UserAvatarSize } from '../../../../../shared/components/UserAvatar';
+import { generateInitials } from '../../../../../shared/utils';
+
+const schema = z.object({
+  role: z.enum(PROJECT_ROLE_VALUES),
+  roleScope: z.enum(ROLE_SCOPE_VALUES),
+});
+type FormValues = z.infer<typeof schema>;
+
+interface MembershipRequestSheetProps {
+  isOpen: boolean;
+  request: MembershipRequestDto | null;
+  contexts: ContextDto[];
+  onClose: () => void;
+  /** `true` when a mutation (approve or decline) actually completed, `false`
+   *  when the sheet was simply dismissed. The parent uses this to decide
+   *  whether to re-fetch members. */
+  onResolved: (mutated: boolean) => void;
+}
+
+export function MembershipRequestSheet({
+  isOpen,
+  request,
+  contexts,
+  onClose,
+  onResolved,
+}: MembershipRequestSheetProps) {
+  const { optimisticRemoveRequest, members } = useMembersSettings();
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { role: 'viewer', roleScope: 'entire_project' },
+    mode: 'onChange',
+  });
+  const { handleSubmit, reset } = form;
+  const [selectedContextIds, setSelectedContextIds] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState<'approve' | 'decline' | null>(null);
+  const [declineConfirm, setDeclineConfirm] = useState(false);
+  const [addContextOpen, setAddContextOpen] = useState(false);
+
+  useEffect(() => {
+    if (request) {
+      reset({ role: request.requestedRole, roleScope: 'entire_project' });
+      setSelectedContextIds([]);
+      setDeclineConfirm(false);
+      setAddContextOpen(false);
+    }
+  }, [request, reset]);
+
+  const handleToggleContext = (contextId: string, checked: boolean) => {
+    setSelectedContextIds(prev =>
+      checked ? [...prev, contextId] : prev.filter(id => id !== contextId)
+    );
+  };
+
+  const handleClose = () => {
+    if (submitting !== null) return;
+    reset({ role: 'viewer', roleScope: 'entire_project' });
+    setSelectedContextIds([]);
+    onClose();
+  };
+
+  const handleApprove = async (values: FormValues) => {
+    if (!request) return;
+    setSubmitting('approve');
+    try {
+      const isAdminRole = values.role === 'admin';
+      const effectiveContextIds =
+        !isAdminRole && values.roleScope === 'selected_contexts' && selectedContextIds.length > 0
+          ? selectedContextIds
+          : undefined;
+      await projectMembersService.approveMembershipRequest(request.requestId, {
+        role: values.role,
+        roleScope: isAdminRole ? undefined : values.roleScope,
+        contextIds: effectiveContextIds,
+      });
+      optimisticRemoveRequest(request.requestId);
+      toast.success(`Approved request from ${request.email}`);
+      onResolved(true);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to approve request');
+    } finally {
+      setSubmitting(null);
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!request) return;
+    setSubmitting('decline');
+    try {
+      await projectMembersService.declineMembershipRequest(request.requestId, {});
+      optimisticRemoveRequest(request.requestId);
+      toast.success(`Declined request from ${request.email}`);
+      setDeclineConfirm(false);
+      onResolved(true);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to decline request');
+    } finally {
+      setSubmitting(null);
+    }
+  };
+
+  return (
+    <>
+      <Sheet
+        open={isOpen}
+        onOpenChange={open => {
+          if (!open) handleClose();
+        }}
+      >
+        <SheetContent data-testid='membershipRequestSheet'>
+          <SheetHeader>
+            <SheetTitle>Membership request</SheetTitle>
+            <SheetDescription>
+              Choose the final role, scope and contexts, then approve or decline.
+            </SheetDescription>
+          </SheetHeader>
+
+          <Form {...form}>
+            <AppForm
+              onSubmit={e => {
+                e.preventDefault();
+              }}
+            >
+              <FormLayout>
+                <FormSection title='Requester' name='membership-request-requester'>
+                  <FormItem>
+                    <FormLabel tooltip='Display name and email of the requester'>
+                      Identity
+                    </FormLabel>
+                    <div className='flex items-center gap-3'>
+                      <UserAvatar
+                        avatar={request?.avatar ?? null}
+                        initials={generateInitials(request?.fullName ?? null, request?.email ?? '')}
+                        displayName={request?.fullName ?? request?.email ?? ''}
+                        size={UserAvatarSize.NORMAL}
+                      />
+                      <div className='flex flex-col'>
+                        <span className='font-medium'>
+                          {request?.fullName ?? request?.email ?? ''}
+                        </span>
+                        <span className='text-muted-foreground text-xs'>
+                          {request?.email ?? ''}
+                        </span>
+                      </div>
+                    </div>
+                  </FormItem>
+                  {request?.createdAt && (
+                    <FormItem>
+                      <FormLabel>Requested date</FormLabel>
+                      <span className='text-sm'>{formatDateShort(request.createdAt)}</span>
+                    </FormItem>
+                  )}
+                </FormSection>
+
+                <MemberFormFields
+                  contexts={contexts}
+                  selectedContextIds={selectedContextIds}
+                  onToggleContext={handleToggleContext}
+                  disabled={submitting !== null}
+                  onRequestCreateContext={() => {
+                    setAddContextOpen(true);
+                  }}
+                  contextIdPrefix='request-ctx'
+                />
+              </FormLayout>
+              <FormActions>
+                <Button
+                  type='button'
+                  className='w-full'
+                  onClick={() => {
+                    void handleSubmit(handleApprove)();
+                  }}
+                  disabled={submitting !== null}
+                >
+                  {submitting === 'approve' ? (
+                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                  ) : null}
+                  Approve request
+                </Button>
+                <Button
+                  type='button'
+                  variant='outline'
+                  className='w-full'
+                  onClick={() => {
+                    setDeclineConfirm(true);
+                  }}
+                  disabled={submitting !== null}
+                >
+                  {submitting === 'decline' ? (
+                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                  ) : null}
+                  Decline request
+                </Button>
+              </FormActions>
+            </AppForm>
+          </Form>
+        </SheetContent>
+      </Sheet>
+
+      <ConfirmationDialog
+        open={declineConfirm}
+        onOpenChange={open => {
+          if (!open && submitting === null) setDeclineConfirm(false);
+        }}
+        title='Decline membership request'
+        description={
+          <span className='mt-2 block'>
+            Are you sure you want to decline the request from <strong>{request?.email}</strong>?
+            They will be notified the request was rejected.
+          </span>
+        }
+        confirmLabel='Decline'
+        cancelLabel='Cancel'
+        variant='destructive'
+        onConfirm={() => {
+          void handleDecline();
+        }}
+      />
+
+      <AddContextSheet
+        isOpen={addContextOpen}
+        members={members}
+        onClose={() => {
+          setAddContextOpen(false);
+        }}
+        onCreated={created => {
+          setSelectedContextIds(prev => (prev.includes(created.id) ? prev : [...prev, created.id]));
+          setAddContextOpen(false);
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/project-settings/members/components/MembershipRequestSheet/MembershipRequestSheet.tsx
+++ b/apps/web/src/features/project-settings/members/components/MembershipRequestSheet/MembershipRequestSheet.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
 import {
   Sheet,
   SheetContent,
@@ -22,10 +21,7 @@ import {
 import { Loader2 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { projectMembersService } from '../../../../../features/project-members/services/project-members.service';
-import {
-  PROJECT_ROLE_VALUES,
-  ROLE_SCOPE_VALUES,
-} from '../../../../../features/project-members/types';
+import { PROJECT_ROLE_VALUES, type Role } from '../../../../../features/project-members/types';
 import type { MembershipRequestDto } from '../../../../../features/project-members/types';
 import type { ContextDto } from '../../../../../features/contexts/types/context.types';
 import { useMembersSettings } from '../../model/members-settings.context';
@@ -35,12 +31,7 @@ import { AddContextSheet } from '../../../../../features/contexts/components/Add
 import { formatDateShort } from '../../../../../utils/date-formatters';
 import { UserAvatar, UserAvatarSize } from '../../../../../shared/components/UserAvatar';
 import { generateInitials } from '../../../../../shared/utils';
-
-const schema = z.object({
-  role: z.enum(PROJECT_ROLE_VALUES),
-  roleScope: z.enum(ROLE_SCOPE_VALUES),
-});
-type FormValues = z.infer<typeof schema>;
+import { memberRoleFormSchema, type MemberRoleFormValues } from '../../schemas';
 
 interface MembershipRequestSheetProps {
   isOpen: boolean;
@@ -53,6 +44,10 @@ interface MembershipRequestSheetProps {
   onResolved: (mutated: boolean) => void;
 }
 
+function clampRole(role: Role | undefined): Role {
+  return role && (PROJECT_ROLE_VALUES as readonly Role[]).includes(role) ? role : 'viewer';
+}
+
 export function MembershipRequestSheet({
   isOpen,
   request,
@@ -61,20 +56,21 @@ export function MembershipRequestSheet({
   onResolved,
 }: MembershipRequestSheetProps) {
   const { optimisticRemoveRequest, members } = useMembersSettings();
-  const form = useForm<FormValues>({
-    resolver: zodResolver(schema),
+  const form = useForm<MemberRoleFormValues>({
+    resolver: zodResolver(memberRoleFormSchema),
     defaultValues: { role: 'viewer', roleScope: 'entire_project' },
     mode: 'onChange',
   });
   const { handleSubmit, reset } = form;
   const [selectedContextIds, setSelectedContextIds] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState<'approve' | 'decline' | null>(null);
+  const submittingRef = useRef<'approve' | 'decline' | null>(null);
   const [declineConfirm, setDeclineConfirm] = useState(false);
   const [addContextOpen, setAddContextOpen] = useState(false);
 
   useEffect(() => {
     if (request) {
-      reset({ role: request.requestedRole, roleScope: 'entire_project' });
+      reset({ role: clampRole(request.requestedRole), roleScope: 'entire_project' });
       setSelectedContextIds([]);
       setDeclineConfirm(false);
       setAddContextOpen(false);
@@ -94,9 +90,21 @@ export function MembershipRequestSheet({
     onClose();
   };
 
-  const handleApprove = async (values: FormValues) => {
+  const beginSubmit = (action: 'approve' | 'decline'): boolean => {
+    if (submittingRef.current !== null) return false;
+    submittingRef.current = action;
+    setSubmitting(action);
+    return true;
+  };
+
+  const endSubmit = () => {
+    submittingRef.current = null;
+    setSubmitting(null);
+  };
+
+  const handleApprove = async (values: MemberRoleFormValues) => {
     if (!request) return;
-    setSubmitting('approve');
+    if (!beginSubmit('approve')) return;
     try {
       const isAdminRole = values.role === 'admin';
       const effectiveContextIds =
@@ -112,17 +120,19 @@ export function MembershipRequestSheet({
       toast.success(`Approved request from ${request.email}`);
       onResolved(true);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to approve request');
+      toast.error(err instanceof Error ? err.message : 'Failed to approve request', {
+        duration: 8000,
+      });
     } finally {
-      setSubmitting(null);
+      endSubmit();
     }
   };
 
   const handleDecline = async () => {
     if (!request) return;
-    setSubmitting('decline');
+    if (!beginSubmit('decline')) return;
     try {
-      await projectMembersService.declineMembershipRequest(request.requestId, {});
+      await projectMembersService.declineMembershipRequest(request.requestId);
       optimisticRemoveRequest(request.requestId);
       toast.success(`Declined request from ${request.email}`);
       setDeclineConfirm(false);
@@ -130,7 +140,7 @@ export function MembershipRequestSheet({
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to decline request');
     } finally {
-      setSubmitting(null);
+      endSubmit();
     }
   };
 

--- a/apps/web/src/features/project-settings/members/components/MembershipRequestSheet/__tests__/MembershipRequestSheet.test.tsx
+++ b/apps/web/src/features/project-settings/members/components/MembershipRequestSheet/__tests__/MembershipRequestSheet.test.tsx
@@ -278,7 +278,7 @@ describe('MembershipRequestSheet', () => {
       fireEvent.click(confirmButtons[confirmButtons.length - 1]);
     });
     await waitFor(() => {
-      expect(projectMembersService.declineMembershipRequest).toHaveBeenCalledWith('req-1', {});
+      expect(projectMembersService.declineMembershipRequest).toHaveBeenCalledWith('req-1');
     });
     expect(optimisticRemoveRequest).toHaveBeenCalledWith('req-1');
     expect(onResolved).toHaveBeenCalledWith(true);

--- a/apps/web/src/features/project-settings/members/components/MembershipRequestSheet/__tests__/MembershipRequestSheet.test.tsx
+++ b/apps/web/src/features/project-settings/members/components/MembershipRequestSheet/__tests__/MembershipRequestSheet.test.tsx
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { MembershipRequestSheet } from '../MembershipRequestSheet';
+import {
+  MembersSettingsReactContext,
+  type MembersSettingsStoreValue,
+} from '../../../model/members-settings.context';
+import { projectMembersService } from '../../../../../project-members/services/project-members.service';
+import type { MembershipRequestDto } from '../../../../../project-members/types';
+
+// Mock the service
+vi.mock('../../../../../project-members/services/project-members.service', () => ({
+  projectMembersService: {
+    approveMembershipRequest: vi.fn(),
+    declineMembershipRequest: vi.fn(),
+  },
+}));
+
+// Mock Sheet components to avoid Radix UI portal issues in happy-dom
+vi.mock('@owox/ui/components/sheet', () => ({
+  Sheet: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+    onOpenChange?: (open: boolean) => void;
+  }) => (open ? <div data-testid='sheet'>{children}</div> : null),
+  SheetContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='sheet-content'>{children}</div>
+  ),
+  SheetHeader: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='sheet-header'>{children}</div>
+  ),
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  SheetDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+// Mock ConfirmationDialog to avoid Radix Dialog portal issues
+vi.mock('../../../../../../shared/components/ConfirmationDialog', () => ({
+  ConfirmationDialog: ({
+    open,
+    title,
+    onConfirm,
+    onOpenChange,
+    confirmLabel = 'Confirm',
+    cancelLabel,
+  }: {
+    open: boolean;
+    title: string;
+    description?: React.ReactNode;
+    onConfirm: () => void;
+    onOpenChange: (open: boolean) => void;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    variant?: string;
+  }) =>
+    open ? (
+      <div data-testid='confirmation-dialog'>
+        <p>{title}</p>
+        {cancelLabel && (
+          <button
+            onClick={() => {
+              onOpenChange(false);
+            }}
+          >
+            {cancelLabel}
+          </button>
+        )}
+        <button
+          onClick={() => {
+            onConfirm();
+          }}
+        >
+          {confirmLabel}
+        </button>
+      </div>
+    ) : null,
+}));
+
+// Mock MemberFormFields to avoid deep dependency chain (useIsAdmin → useUser → useAuth)
+vi.mock('../../MemberFormFields/MemberFormFields', () => ({
+  MemberFormFields: () => <div data-testid='member-form-fields' />,
+}));
+
+// Mock AddContextSheet to avoid its own dependency chain
+vi.mock('../../../../../contexts/components/AddContextSheet/AddContextSheet', () => ({
+  AddContextSheet: () => null,
+}));
+
+// Mock form UI components used directly in the sheet header
+vi.mock('@owox/ui/components/form', () => ({
+  AppForm: ({
+    children,
+    onSubmit,
+  }: {
+    children: React.ReactNode;
+    onSubmit?: React.ComponentProps<'form'>['onSubmit'];
+  }) => <form onSubmit={onSubmit}>{children}</form>,
+  Form: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  FormActions: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  FormLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  FormSection: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  FormField: () => null,
+  FormItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  FormLabel: ({ children }: { children: React.ReactNode }) => <label>{children}</label>,
+  FormControl: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  FormMessage: () => null,
+  FormDescription: () => null,
+}));
+
+// Mock Button to render a real HTML button
+vi.mock('@owox/ui/components/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    type = 'button',
+    disabled,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    type?: 'button' | 'submit' | 'reset';
+    disabled?: boolean;
+    [key: string]: unknown;
+  }) => (
+    <button type={type} onClick={onClick} disabled={disabled} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+// Mock toast to avoid side effects
+vi.mock('react-hot-toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const request: MembershipRequestDto = {
+  requestId: 'req-1',
+  email: 'alice@example.com',
+  fullName: 'Alice Example',
+  requestedRole: 'editor',
+  createdAt: '2026-05-01T10:00:00Z',
+};
+
+const store = (overrides: Partial<MembersSettingsStoreValue> = {}): MembersSettingsStoreValue => ({
+  contexts: [],
+  members: [],
+  pendingRequests: [request],
+  loading: false,
+  loadingRequests: false,
+  refresh: vi.fn().mockResolvedValue(undefined),
+  optimisticRemoveMember: vi.fn(),
+  optimisticRemoveRequest: vi.fn(),
+  isAdmin: true,
+  openInviteSheet: vi.fn(),
+  openAddContextSheet: vi.fn(),
+  openMembershipRequestSheet: vi.fn(),
+  ...overrides,
+});
+
+function renderSheet(props: Partial<React.ComponentProps<typeof MembershipRequestSheet>> = {}) {
+  const onClose = vi.fn();
+  const onResolved = vi.fn();
+  const optimisticRemoveRequest = vi.fn();
+  const utils = render(
+    <MembersSettingsReactContext.Provider value={store({ optimisticRemoveRequest })}>
+      <MembershipRequestSheet
+        isOpen={true}
+        request={request}
+        contexts={[]}
+        onClose={onClose}
+        onResolved={onResolved}
+        {...props}
+      />
+    </MembersSettingsReactContext.Provider>
+  );
+  return { ...utils, onClose, onResolved, optimisticRemoveRequest };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MembershipRequestSheet', () => {
+  it('renders the requester identity block with name, email, and requested date', () => {
+    renderSheet();
+    // Generic, identity-free title (no email/role in the header).
+    expect(screen.getByText(/Membership request/i)).toBeInTheDocument();
+    // Identity block in the body shows the full name and email.
+    expect(screen.getByText('Alice Example')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    // Requested date is a separate FormItem (label + value).
+    // Fixture is '2026-05-01T10:00:00Z'. Matching the year only keeps the
+    // assertion safe across browser timezones (formatDateShort is locale/TZ).
+    expect(screen.getByText(/Requested date/i)).toBeInTheDocument();
+    expect(screen.getByText(/2026/)).toBeInTheDocument();
+  });
+
+  it('approve fires service.approveMembershipRequest with role + scope', async () => {
+    const { onResolved, optimisticRemoveRequest } = renderSheet();
+    (
+      projectMembersService.approveMembershipRequest as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      userId: 'u-1',
+      role: 'editor',
+      roleScope: 'entire_project',
+      contextIds: [],
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Approve request/i }));
+    });
+    await waitFor(() => {
+      expect(projectMembersService.approveMembershipRequest).toHaveBeenCalledWith('req-1', {
+        role: 'editor',
+        roleScope: 'entire_project',
+        contextIds: undefined,
+      });
+    });
+    expect(optimisticRemoveRequest).toHaveBeenCalledWith('req-1');
+    expect(onResolved).toHaveBeenCalledWith(true);
+  });
+
+  it('approve with admin role omits roleScope from the payload', async () => {
+    const adminRequest: MembershipRequestDto = {
+      ...request,
+      requestId: 'req-adm',
+      requestedRole: 'admin',
+    };
+    const onResolved = vi.fn();
+    const optimisticRemoveRequest = vi.fn();
+    render(
+      <MembersSettingsReactContext.Provider value={store({ optimisticRemoveRequest })}>
+        <MembershipRequestSheet
+          isOpen={true}
+          request={adminRequest}
+          contexts={[]}
+          onClose={vi.fn()}
+          onResolved={onResolved}
+        />
+      </MembersSettingsReactContext.Provider>
+    );
+    (
+      projectMembersService.approveMembershipRequest as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      userId: 'u-adm',
+      role: 'admin',
+      roleScope: 'entire_project',
+      contextIds: [],
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Approve request/i }));
+    });
+    await waitFor(() => {
+      expect(projectMembersService.approveMembershipRequest).toHaveBeenCalledWith('req-adm', {
+        role: 'admin',
+        roleScope: undefined,
+        contextIds: undefined,
+      });
+    });
+  });
+
+  it('decline opens the confirmation dialog; confirming fires service.declineMembershipRequest', async () => {
+    const { onResolved, optimisticRemoveRequest } = renderSheet();
+    (
+      projectMembersService.declineMembershipRequest as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(undefined);
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Decline request/i }));
+    });
+    expect(screen.getByText(/Decline membership request/i)).toBeInTheDocument();
+    // The confirmation dialog uses 'Decline' as confirm label
+    const confirmButtons = screen.getAllByRole('button', { name: /^Decline$/i });
+    act(() => {
+      fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+    });
+    await waitFor(() => {
+      expect(projectMembersService.declineMembershipRequest).toHaveBeenCalledWith('req-1', {});
+    });
+    expect(optimisticRemoveRequest).toHaveBeenCalledWith('req-1');
+    expect(onResolved).toHaveBeenCalledWith(true);
+  });
+
+  it('approve error shows toast and keeps sheet open (no onResolved call)', async () => {
+    const { onResolved, optimisticRemoveRequest } = renderSheet();
+    (
+      projectMembersService.approveMembershipRequest as unknown as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error('Server exploded'));
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Approve request/i }));
+    });
+    await waitFor(() => {
+      expect(projectMembersService.approveMembershipRequest).toHaveBeenCalled();
+    });
+    expect(optimisticRemoveRequest).not.toHaveBeenCalled();
+    expect(onResolved).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/project-settings/members/components/PendingRequestsSection/MembershipRequestRow.tsx
+++ b/apps/web/src/features/project-settings/members/components/PendingRequestsSection/MembershipRequestRow.tsx
@@ -1,0 +1,69 @@
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@owox/ui/lib/utils';
+import { UserAvatar, UserAvatarSize } from '../../../../../shared/components/UserAvatar';
+import { generateInitials } from '../../../../../shared/utils';
+import { getRoleDisplayName } from '../../../../../features/idp/utils/role-display-name';
+import { formatDateShort } from '../../../../../utils/date-formatters';
+import type { MembershipRequestDto } from '../../../../../features/project-members/types';
+
+interface MembershipRequestRowProps {
+  request: MembershipRequestDto;
+  onClick: (request: MembershipRequestDto) => void;
+  className?: string;
+}
+
+export function MembershipRequestRow({ request, onClick, className }: MembershipRequestRowProps) {
+  const { email, fullName, avatar, requestedRole, createdAt, requestId } = request;
+  const displayName = fullName ?? email;
+  const initials = generateInitials(fullName ?? null, email);
+  const handleClick = () => {
+    onClick(request);
+  };
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onClick(request);
+    }
+  };
+
+  return (
+    <div
+      role='button'
+      tabIndex={0}
+      data-testid={`membershipRequestRow-${requestId}`}
+      aria-label={`Open request from ${displayName}`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'group flex cursor-pointer items-center gap-4 rounded-md border-b border-gray-200 bg-white transition-shadow duration-200 outline-none',
+        'hover:shadow-xs focus-visible:ring-2 focus-visible:ring-blue-500',
+        'dark:border-0 dark:bg-white/2 dark:hover:bg-white/5',
+        className
+      )}
+    >
+      <div className='flex flex-grow items-center gap-3 px-6 py-4'>
+        <UserAvatar
+          avatar={avatar ?? null}
+          initials={initials}
+          displayName={displayName}
+          size={UserAvatarSize.NORMAL}
+        />
+        <div className='flex min-w-0 flex-grow flex-col gap-1'>
+          <div className='text-md truncate font-medium'>{displayName}</div>
+          <div className='text-muted-foreground/75 flex flex-wrap gap-x-2 text-sm'>
+            <span className='break-all'>{email}</span>
+            <span aria-hidden>•</span>
+            <span>Requested role: {getRoleDisplayName(requestedRole)}</span>
+            <span aria-hidden>•</span>
+            <span>{formatDateShort(createdAt)}</span>
+          </div>
+        </div>
+      </div>
+      <div className='flex items-center justify-center gap-2 p-4'>
+        <div className='flex h-7 w-7 items-center justify-center rounded-full transition-colors duration-200 group-hover:bg-gray-200/50 dark:group-hover:bg-white/4'>
+          <ChevronRight className='text-muted-foreground/75 dark:text-muted-foreground/50 h-4 w-4' />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/project-settings/members/components/PendingRequestsSection/PendingRequestsSection.tsx
+++ b/apps/web/src/features/project-settings/members/components/PendingRequestsSection/PendingRequestsSection.tsx
@@ -1,0 +1,45 @@
+import { UserCog } from 'lucide-react';
+import {
+  CollapsibleCard,
+  CollapsibleCardHeader,
+  CollapsibleCardHeaderTitle,
+  CollapsibleCardContent,
+  CollapsibleCardFooter,
+} from '../../../../../shared/components/CollapsibleCard';
+import { useMembersSettings } from '../../model/members-settings.context';
+import { MembershipRequestRow } from './MembershipRequestRow';
+
+// Kept in sync with apps/web/e2e/selectors/testids.ts -> TESTIDS.pendingRequestsSection.
+// Src must not import from e2e/ (test-only tree); the contract is a literal string.
+const TESTID = 'pendingRequestsSection';
+
+export function PendingRequestsSection() {
+  const { isAdmin, pendingRequests, openMembershipRequestSheet } = useMembersSettings();
+
+  if (!isAdmin) return null;
+  if (pendingRequests.length === 0) return null;
+
+  return (
+    <section className='mb-6' aria-labelledby='pending-requests-heading' data-testid={TESTID}>
+      <CollapsibleCard collapsible defaultCollapsed={false}>
+        <CollapsibleCardHeader>
+          <CollapsibleCardHeaderTitle icon={UserCog}>
+            <span id='pending-requests-heading'>Access requests</span>
+          </CollapsibleCardHeaderTitle>
+        </CollapsibleCardHeader>
+        <CollapsibleCardContent>
+          <div className='flex flex-col gap-2'>
+            {pendingRequests.map(request => (
+              <MembershipRequestRow
+                key={request.requestId}
+                request={request}
+                onClick={openMembershipRequestSheet}
+              />
+            ))}
+          </div>
+        </CollapsibleCardContent>
+        <CollapsibleCardFooter></CollapsibleCardFooter>
+      </CollapsibleCard>
+    </section>
+  );
+}

--- a/apps/web/src/features/project-settings/members/components/PendingRequestsSection/__tests__/MembershipRequestRow.test.tsx
+++ b/apps/web/src/features/project-settings/members/components/PendingRequestsSection/__tests__/MembershipRequestRow.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { MembershipRequestRow } from '../MembershipRequestRow';
+import type { MembershipRequestDto } from '../../../../../project-members/types';
+
+const baseRequest: MembershipRequestDto = {
+  requestId: 'req-1',
+  email: 'alice@example.com',
+  fullName: 'Alice Example',
+  requestedRole: 'editor',
+  createdAt: '2026-05-01T10:00:00Z',
+};
+
+describe('MembershipRequestRow', () => {
+  it('renders full name as the primary line and email + role + date in the subtitle', () => {
+    render(<MembershipRequestRow request={baseRequest} onClick={vi.fn()} />);
+    expect(screen.getByText('Alice Example')).toBeInTheDocument();
+    expect(screen.getByText(/alice@example\.com/i)).toBeInTheDocument();
+    // `getRoleDisplayName('editor')` maps to 'Technical User' in this codebase
+    // (see apps/web/src/features/idp/utils/role-display-name.ts).
+    expect(screen.getByText(/Requested role: Technical User/i)).toBeInTheDocument();
+    // formatDateShort uses the browser TZ. The fixture is '2026-05-01T10:00:00Z'
+    // which renders with year 2026 in every IANA timezone. Anchoring on the
+    // year only keeps the assertion TZ-independent.
+    expect(screen.getByText(/2026/)).toBeInTheDocument();
+  });
+
+  it('falls back to email as the primary line when fullName is missing', () => {
+    const noName: MembershipRequestDto = { ...baseRequest, fullName: undefined };
+    render(<MembershipRequestRow request={noName} onClick={vi.fn()} />);
+    // Email shows up twice (primary + subtitle). Use getAllByText.
+    expect(screen.getAllByText('alice@example.com').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('calls onClick with the request when the row is clicked', () => {
+    const onClick = vi.fn();
+    render(<MembershipRequestRow request={baseRequest} onClick={onClick} />);
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Open request from Alice Example/i }));
+    });
+    expect(onClick).toHaveBeenCalledWith(baseRequest);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes a stable testid that includes the requestId for E2E targeting', () => {
+    render(<MembershipRequestRow request={baseRequest} onClick={vi.fn()} />);
+    expect(screen.getByTestId('membershipRequestRow-req-1')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/project-settings/members/components/PendingRequestsSection/__tests__/PendingRequestsSection.test.tsx
+++ b/apps/web/src/features/project-settings/members/components/PendingRequestsSection/__tests__/PendingRequestsSection.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { PendingRequestsSection } from '../PendingRequestsSection';
+import {
+  MembersSettingsReactContext,
+  type MembersSettingsStoreValue,
+} from '../../../model/members-settings.context';
+import type { MembershipRequestDto } from '../../../../../project-members/types';
+
+// Mock the row to keep this test focused on the section's orchestration
+// (admin gate, counting, mapping). MembershipRequestRow has its own tests.
+vi.mock('../MembershipRequestRow', () => ({
+  MembershipRequestRow: ({
+    request,
+    onClick,
+  }: {
+    request: MembershipRequestDto;
+    onClick: (r: MembershipRequestDto) => void;
+  }) => (
+    <button
+      type='button'
+      data-testid={`row-${request.requestId}`}
+      onClick={() => {
+        onClick(request);
+      }}
+    >
+      {request.fullName ?? request.email}
+    </button>
+  ),
+}));
+
+const baseStore = (
+  overrides: Partial<MembersSettingsStoreValue> = {}
+): MembersSettingsStoreValue => ({
+  contexts: [],
+  members: [],
+  pendingRequests: [],
+  loading: false,
+  loadingRequests: false,
+  refresh: vi.fn().mockResolvedValue(undefined),
+  optimisticRemoveMember: vi.fn(),
+  optimisticRemoveRequest: vi.fn(),
+  isAdmin: true,
+  openInviteSheet: vi.fn(),
+  openAddContextSheet: vi.fn(),
+  openMembershipRequestSheet: vi.fn(),
+  ...overrides,
+});
+
+const request: MembershipRequestDto = {
+  requestId: 'req-1',
+  email: 'alice@example.com',
+  fullName: 'Alice Example',
+  requestedRole: 'viewer',
+  createdAt: '2026-05-01T10:00:00Z',
+};
+const request2: MembershipRequestDto = {
+  requestId: 'req-2',
+  email: 'bob@example.com',
+  fullName: 'Bob Example',
+  requestedRole: 'editor',
+  createdAt: '2026-05-02T10:00:00Z',
+};
+
+function renderSection(store: MembersSettingsStoreValue) {
+  return render(
+    <MembersSettingsReactContext.Provider value={store}>
+      <PendingRequestsSection />
+    </MembersSettingsReactContext.Provider>
+  );
+}
+
+describe('PendingRequestsSection', () => {
+  it('renders nothing when user is not admin', () => {
+    const { container } = renderSection(baseStore({ isAdmin: false, pendingRequests: [request] }));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when admin but no pending requests', () => {
+    const { container } = renderSection(baseStore({ isAdmin: true, pendingRequests: [] }));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the card header and one row per request', () => {
+    renderSection(baseStore({ pendingRequests: [request, request2] }));
+    expect(screen.getByTestId('pendingRequestsSection')).toBeInTheDocument();
+    expect(screen.getByText(/Access requests/i)).toBeInTheDocument();
+    expect(screen.getByTestId('row-req-1')).toBeInTheDocument();
+    expect(screen.getByTestId('row-req-2')).toBeInTheDocument();
+  });
+
+  it('opens the request sheet when a row is clicked', () => {
+    const openMembershipRequestSheet = vi.fn();
+    renderSection(baseStore({ pendingRequests: [request], openMembershipRequestSheet }));
+    act(() => {
+      fireEvent.click(screen.getByTestId('row-req-1'));
+    });
+    expect(openMembershipRequestSheet).toHaveBeenCalledWith(request);
+  });
+});

--- a/apps/web/src/features/project-settings/members/model/__tests__/useTombstonedCollection.test.ts
+++ b/apps/web/src/features/project-settings/members/model/__tests__/useTombstonedCollection.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTombstonedCollection } from '../useTombstonedCollection';
+
+interface Row {
+  id: string;
+  label: string;
+}
+
+const idOf = (r: Row) => r.id;
+
+describe('useTombstonedCollection', () => {
+  it('returns stable references across rerenders — guards against refetch loops', () => {
+    // Regression: an earlier version returned a fresh `{ tombstone, reconcile }`
+    // object on every render. When the caller put that object in a useCallback
+    // dependency list, every render re-created `loadData`, which re-fired the
+    // useEffect, which set state, which caused another render → infinite
+    // network polling. The hook MUST return a memoised object.
+    const { result, rerender } = renderHook(() => useTombstonedCollection(idOf));
+    const first = result.current;
+    rerender();
+    rerender();
+    expect(result.current).toBe(first);
+    expect(result.current.tombstone).toBe(first.tombstone);
+    expect(result.current.reconcile).toBe(first.reconcile);
+  });
+
+  it('reconcile passes upstream through when no tombstones are recorded', () => {
+    const { result } = renderHook(() => useTombstonedCollection(idOf));
+    const upstream: Row[] = [
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ];
+    expect(result.current.reconcile(upstream)).toBe(upstream);
+  });
+
+  it('reconcile drops tombstoned ids that upstream still echoes', () => {
+    const { result } = renderHook(() => useTombstonedCollection(idOf));
+    act(() => {
+      result.current.tombstone('a');
+    });
+    const upstream: Row[] = [
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ];
+    expect(result.current.reconcile(upstream)).toEqual([{ id: 'b', label: 'B' }]);
+  });
+
+  it('reconcile self-evicts tombstones once upstream stops returning the id', () => {
+    const { result } = renderHook(() => useTombstonedCollection(idOf));
+    act(() => {
+      result.current.tombstone('a');
+    });
+    // First reconcile: upstream still returns 'a' — stays tombstoned.
+    result.current.reconcile([
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ]);
+    // Upstream no longer returns 'a' — tombstone self-evicts.
+    const next = result.current.reconcile([{ id: 'b', label: 'B' }]);
+    expect(next).toEqual([{ id: 'b', label: 'B' }]);
+    // If 'a' reappears later (legitimate re-creation), it must NOT be filtered.
+    const resurrected = result.current.reconcile([
+      { id: 'a', label: 'A2' },
+      { id: 'b', label: 'B' },
+    ]);
+    expect(resurrected).toEqual([
+      { id: 'a', label: 'A2' },
+      { id: 'b', label: 'B' },
+    ]);
+  });
+});

--- a/apps/web/src/features/project-settings/members/model/members-settings.context.ts
+++ b/apps/web/src/features/project-settings/members/model/members-settings.context.ts
@@ -3,11 +3,14 @@ import type {
   ContextDto,
   MemberWithScopeDto,
 } from '../../../../features/contexts/types/context.types';
+import type { MembershipRequestDto } from '../../../../features/project-members/types';
 
 export interface MembersSettingsStoreValue {
   contexts: ContextDto[];
   members: MemberWithScopeDto[];
+  pendingRequests: MembershipRequestDto[];
   loading: boolean;
+  loadingRequests: boolean;
   refresh: () => Promise<void>;
   /**
    * Drop a member from the local cache right after a successful DELETE.
@@ -17,9 +20,16 @@ export interface MembersSettingsStoreValue {
    * `refresh()` for eventual reconciliation.
    */
   optimisticRemoveMember: (userId: string) => void;
+  /**
+   * Drop a pending membership request from the local cache right after a
+   * successful approve/decline. Mirrors the members tombstone pattern so the
+   * row disappears immediately while `refresh()` reconciles upstream.
+   */
+  optimisticRemoveRequest: (requestId: string) => void;
   isAdmin: boolean;
   openInviteSheet: () => void;
   openAddContextSheet: () => void;
+  openMembershipRequestSheet: (request: MembershipRequestDto) => void;
 }
 
 export const MembersSettingsReactContext = createContext<MembersSettingsStoreValue | null>(null);

--- a/apps/web/src/features/project-settings/members/model/useTombstonedCollection.ts
+++ b/apps/web/src/features/project-settings/members/model/useTombstonedCollection.ts
@@ -1,0 +1,41 @@
+import { useCallback, useMemo, useRef } from 'react';
+
+/**
+ * Hook that pairs a collection of remote-state items with a self-evicting
+ * tombstone set. Use it whenever the upstream API is eventually consistent —
+ * after a successful DELETE/approve/decline, the next refresh() can still
+ * return the freshly-removed item for several seconds. Without a tombstone,
+ * the row reappears and the optimistic UI lies to the admin.
+ *
+ * Each call to `tombstone(id)` records "do not surface id again until upstream
+ * stops returning it". `reconcile(upstream)` applies the filter AND drops any
+ * tombstoned id the upstream no longer reports — so the set self-cleans
+ * without needing TTLs or explicit reset.
+ *
+ * The returned object is referentially stable as long as `idOf` is stable —
+ * crucial for callers that put the hook's return value in a `useCallback` /
+ * `useEffect` dependency list. Without `useMemo` here, a fresh object on
+ * every render re-fires effects and creates a refetch loop.
+ */
+export function useTombstonedCollection<T>(idOf: (item: T) => string) {
+  const tombstones = useRef<Set<string>>(new Set());
+
+  const tombstone = useCallback((id: string): void => {
+    tombstones.current.add(id);
+  }, []);
+
+  const reconcile = useCallback(
+    (upstream: T[]): T[] => {
+      const set = tombstones.current;
+      if (set.size === 0) return upstream;
+      const upstreamIds = new Set(upstream.map(idOf));
+      for (const id of [...set]) {
+        if (!upstreamIds.has(id)) set.delete(id);
+      }
+      return set.size > 0 ? upstream.filter(item => !set.has(idOf(item))) : upstream;
+    },
+    [idOf]
+  );
+
+  return useMemo(() => ({ tombstone, reconcile }), [tombstone, reconcile]);
+}

--- a/apps/web/src/features/project-settings/members/schemas.ts
+++ b/apps/web/src/features/project-settings/members/schemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { PROJECT_ROLE_VALUES, ROLE_SCOPE_VALUES } from '../../../features/project-members/types';
+
+export const memberRoleFormSchema = z.object({
+  role: z.enum(PROJECT_ROLE_VALUES),
+  roleScope: z.enum(ROLE_SCOPE_VALUES),
+});
+
+export type MemberRoleFormValues = z.infer<typeof memberRoleFormSchema>;

--- a/apps/web/src/pages/project-settings/MembersTab.tsx
+++ b/apps/web/src/pages/project-settings/MembersTab.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { MembersTable } from '../../features/project-settings/members/components/MembersTable/MembersTable';
 import { MemberDetailsSheet } from '../../features/project-settings/members/components/MemberDetailsSheet/MemberDetailsSheet';
+import { PendingRequestsSection } from '../../features/project-settings/members/components/PendingRequestsSection/PendingRequestsSection';
 import { useMembersSettings } from '../../features/project-settings/members/model/members-settings.context';
 import { ConfirmationDialog } from '../../shared/components/ConfirmationDialog';
 import { projectMembersService } from '../../features/project-members/services/project-members.service';
@@ -45,6 +46,8 @@ export function MembersTab() {
 
   return (
     <>
+      <PendingRequestsSection />
+
       <MembersTable
         members={members}
         contexts={contexts}

--- a/apps/web/src/pages/project-settings/ProjectSettingsPage.tsx
+++ b/apps/web/src/pages/project-settings/ProjectSettingsPage.tsx
@@ -9,9 +9,11 @@ import { checkVisible } from '../../utils/check-visible';
 import { contextService } from '../../features/contexts/services/context.service';
 import { projectMembersService } from '../../features/project-members/services/project-members.service';
 import type { ContextDto, MemberWithScopeDto } from '../../features/contexts/types/context.types';
+import type { MembershipRequestDto } from '../../features/project-members/types';
 import { InviteMemberSheet } from '../../features/project-settings/members/components/InviteMemberSheet/InviteMemberSheet';
 import { AddContextSheet } from '../../features/contexts/components/AddContextSheet/AddContextSheet';
 import { MembersSettingsProvider } from '../../features/project-settings/members/model/MembersSettingsProvider';
+import { MembershipRequestSheet } from '../../features/project-settings/members/components/MembershipRequestSheet/MembershipRequestSheet';
 
 interface TabLink {
   name: string;
@@ -40,20 +42,26 @@ export function ProjectSettingsPage() {
   const [error, setError] = useState<string | null>(null);
   const [inviteOpen, setInviteOpen] = useState(false);
   const [addContextOpen, setAddContextOpen] = useState(false);
+  const [pendingRequests, setPendingRequests] = useState<MembershipRequestDto[]>([]);
+  const [loadingRequests, setLoadingRequests] = useState(false);
+  const [requestSheetTarget, setRequestSheetTarget] = useState<MembershipRequestDto | null>(null);
 
   // Legacy upstream is eventually consistent — getMembers() can echo a member
   // we just deleted for several seconds. We tombstone removed userIds locally
   // so refresh() does not bring them back, and self-evict each tombstone the
   // moment upstream stops returning it.
   const removedTombstones = useRef(new Set<string>());
+  const removedRequestTombstones = useRef(new Set<string>());
 
   const loadData = useCallback(async () => {
     setLoading(true);
+    setLoadingRequests(isAdmin);
     setError(null);
     try {
-      const [ctxs, mems] = await Promise.all([
+      const [ctxs, mems, reqs] = await Promise.all([
         contextService.getContexts(),
         projectMembersService.getMembers(),
+        isAdmin ? projectMembersService.getMembershipRequests() : Promise.resolve([]),
       ]);
       setContexts(ctxs);
       const tombstones = removedTombstones.current;
@@ -64,6 +72,14 @@ export function ProjectSettingsPage() {
         }
       }
       setMembers(tombstones.size > 0 ? mems.filter(m => !tombstones.has(m.userId)) : mems);
+      const reqTombs = removedRequestTombstones.current;
+      if (reqTombs.size > 0) {
+        const upstreamReqIds = new Set(reqs.map(r => r.requestId));
+        for (const id of [...reqTombs]) {
+          if (!upstreamReqIds.has(id)) reqTombs.delete(id);
+        }
+      }
+      setPendingRequests(reqTombs.size > 0 ? reqs.filter(r => !reqTombs.has(r.requestId)) : reqs);
     } catch (err) {
       // Without a catch the page renders empty arrays + loading=false, which
       // is indistinguishable from "this project really has no members /
@@ -71,8 +87,9 @@ export function ProjectSettingsPage() {
       setError(err instanceof Error ? err.message : 'Failed to load project data');
     } finally {
       setLoading(false);
+      setLoadingRequests(false);
     }
-  }, []);
+  }, [isAdmin]);
 
   useEffect(() => {
     void loadData();
@@ -87,6 +104,15 @@ export function ProjectSettingsPage() {
   const optimisticRemoveMember = useCallback((userId: string) => {
     removedTombstones.current.add(userId);
     setMembers(prev => prev.filter(m => m.userId !== userId));
+  }, []);
+
+  const optimisticRemoveRequest = useCallback((requestId: string) => {
+    removedRequestTombstones.current.add(requestId);
+    setPendingRequests(prev => prev.filter(r => r.requestId !== requestId));
+  }, []);
+
+  const openMembershipRequestSheet = useCallback((request: MembershipRequestDto) => {
+    setRequestSheetTarget(request);
   }, []);
 
   const navigation: TabLink[] = [
@@ -109,22 +135,30 @@ export function ProjectSettingsPage() {
     () => ({
       contexts,
       members,
+      pendingRequests,
       loading,
+      loadingRequests,
       refresh: loadData,
       optimisticRemoveMember,
+      optimisticRemoveRequest,
       isAdmin,
       openInviteSheet,
       openAddContextSheet,
+      openMembershipRequestSheet,
     }),
     [
       contexts,
       members,
+      pendingRequests,
       loading,
+      loadingRequests,
       loadData,
       optimisticRemoveMember,
+      optimisticRemoveRequest,
       isAdmin,
       openInviteSheet,
       openAddContextSheet,
+      openMembershipRequestSheet,
     ]
   );
 
@@ -192,6 +226,19 @@ export function ProjectSettingsPage() {
           onCreated={() => {
             setAddContextOpen(false);
             void loadData();
+          }}
+        />
+
+        <MembershipRequestSheet
+          isOpen={requestSheetTarget !== null}
+          request={requestSheetTarget}
+          contexts={contexts}
+          onClose={() => {
+            setRequestSheetTarget(null);
+          }}
+          onResolved={resolved => {
+            setRequestSheetTarget(null);
+            if (resolved) void loadData();
           }}
         />
       </div>

--- a/apps/web/src/pages/project-settings/ProjectSettingsPage.tsx
+++ b/apps/web/src/pages/project-settings/ProjectSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
 import { cn } from '@owox/ui/lib/utils';
 import { Alert, AlertDescription, AlertTitle } from '@owox/ui/components/alert';
@@ -14,6 +14,7 @@ import { InviteMemberSheet } from '../../features/project-settings/members/compo
 import { AddContextSheet } from '../../features/contexts/components/AddContextSheet/AddContextSheet';
 import { MembersSettingsProvider } from '../../features/project-settings/members/model/MembersSettingsProvider';
 import { MembershipRequestSheet } from '../../features/project-settings/members/components/MembershipRequestSheet/MembershipRequestSheet';
+import { useTombstonedCollection } from '../../features/project-settings/members/model/useTombstonedCollection';
 
 interface TabLink {
   name: string;
@@ -46,40 +47,31 @@ export function ProjectSettingsPage() {
   const [loadingRequests, setLoadingRequests] = useState(false);
   const [requestSheetTarget, setRequestSheetTarget] = useState<MembershipRequestDto | null>(null);
 
-  // Legacy upstream is eventually consistent — getMembers() can echo a member
-  // we just deleted for several seconds. We tombstone removed userIds locally
-  // so refresh() does not bring them back, and self-evict each tombstone the
-  // moment upstream stops returning it.
-  const removedTombstones = useRef(new Set<string>());
-  const removedRequestTombstones = useRef(new Set<string>());
+  const memberIdOf = useCallback((m: MemberWithScopeDto) => m.userId, []);
+  const requestIdOf = useCallback((r: MembershipRequestDto) => r.requestId, []);
+  const memberTombstones = useTombstonedCollection<MemberWithScopeDto>(memberIdOf);
+  const requestTombstones = useTombstonedCollection<MembershipRequestDto>(requestIdOf);
 
   const loadData = useCallback(async () => {
     setLoading(true);
     setLoadingRequests(isAdmin);
     setError(null);
+
+    const requestsPromise = isAdmin
+      ? projectMembersService.getMembershipRequests().catch((err: unknown) => {
+          console.warn('Failed to load membership requests', err);
+          return [] as MembershipRequestDto[];
+        })
+      : Promise.resolve<MembershipRequestDto[]>([]);
     try {
       const [ctxs, mems, reqs] = await Promise.all([
         contextService.getContexts(),
         projectMembersService.getMembers(),
-        isAdmin ? projectMembersService.getMembershipRequests() : Promise.resolve([]),
+        requestsPromise,
       ]);
       setContexts(ctxs);
-      const tombstones = removedTombstones.current;
-      if (tombstones.size > 0) {
-        const upstreamIds = new Set(mems.map(m => m.userId));
-        for (const id of [...tombstones]) {
-          if (!upstreamIds.has(id)) tombstones.delete(id);
-        }
-      }
-      setMembers(tombstones.size > 0 ? mems.filter(m => !tombstones.has(m.userId)) : mems);
-      const reqTombs = removedRequestTombstones.current;
-      if (reqTombs.size > 0) {
-        const upstreamReqIds = new Set(reqs.map(r => r.requestId));
-        for (const id of [...reqTombs]) {
-          if (!upstreamReqIds.has(id)) reqTombs.delete(id);
-        }
-      }
-      setPendingRequests(reqTombs.size > 0 ? reqs.filter(r => !reqTombs.has(r.requestId)) : reqs);
+      setMembers(memberTombstones.reconcile(mems));
+      setPendingRequests(requestTombstones.reconcile(reqs));
     } catch (err) {
       // Without a catch the page renders empty arrays + loading=false, which
       // is indistinguishable from "this project really has no members /
@@ -89,7 +81,7 @@ export function ProjectSettingsPage() {
       setLoading(false);
       setLoadingRequests(false);
     }
-  }, [isAdmin]);
+  }, [isAdmin, memberTombstones, requestTombstones]);
 
   useEffect(() => {
     void loadData();
@@ -101,15 +93,21 @@ export function ProjectSettingsPage() {
   const openAddContextSheet = useCallback(() => {
     setAddContextOpen(true);
   }, []);
-  const optimisticRemoveMember = useCallback((userId: string) => {
-    removedTombstones.current.add(userId);
-    setMembers(prev => prev.filter(m => m.userId !== userId));
-  }, []);
+  const optimisticRemoveMember = useCallback(
+    (userId: string) => {
+      memberTombstones.tombstone(userId);
+      setMembers(prev => prev.filter(m => m.userId !== userId));
+    },
+    [memberTombstones]
+  );
 
-  const optimisticRemoveRequest = useCallback((requestId: string) => {
-    removedRequestTombstones.current.add(requestId);
-    setPendingRequests(prev => prev.filter(r => r.requestId !== requestId));
-  }, []);
+  const optimisticRemoveRequest = useCallback(
+    (requestId: string) => {
+      requestTombstones.tombstone(requestId);
+      setPendingRequests(prev => prev.filter(r => r.requestId !== requestId));
+    },
+    [requestTombstones]
+  );
 
   const openMembershipRequestSheet = useCallback((request: MembershipRequestDto) => {
     setRequestSheetTarget(request);

--- a/docs/superpowers/specs/2026-05-08-membership-requests-design.md
+++ b/docs/superpowers/specs/2026-05-08-membership-requests-design.md
@@ -1,0 +1,406 @@
+# Project Membership Requests on the New Members Page
+
+**Status:** Approved (brainstorm) — ready for implementation planning
+**Date:** 2026-05-08
+**Fibery:** Add membership requests handling to the new Members page (#6529)
+**Sprint:** Current (Apr 30 – May 13, 2026)
+**Owner:** Yevhen Zapolskyi
+
+---
+
+## 1. Goal & Context
+
+Restore project-membership-request handling on the new **Project Settings → Members** page. The new page replaced the legacy `platform.owox.com/ui/p/.../settings/members` UI but lost the **"You've received requests for project membership"** block where Project Admins could approve or decline pending requests from users asking to join the project.
+
+The legacy page calls three direct billing endpoints from the browser:
+
+- `GET /ui/api/billing/permissions-requests-for-admin/?project-name={projectId}`
+- `POST /ui/api/billing/projects/{xProjectToken}/confirmed-permissions-requests/` (approve, form-urlencoded)
+- `DELETE /ui/api/billing/permissions-requests/{requestToken}/` (decline)
+
+The new architecture forbids talking to legacy billing directly. BI Node backend hits the Integrated-backend through chained C2C endpoints under `/idp/bi-project/{projectId}/...` (impersonated ID token, JSON bodies, no short-lived legacy JWTs leaked to BI).
+
+Equivalent C2C contract for membership requests **does not yet exist** on the Java side. A separate ticket tracks adding `GET/POST/POST` under `/idp/bi-project/{projectId}/membership-requests`. This spec covers the **BI side** of the work and ships against a **mock** in the OWOX IDP provider — once the Java endpoints land, only the mock layer changes.
+
+**Sibling reference flow:** the existing invite-member chain (`InviteMemberSheet` → `POST /members/invite` → `InviteProjectMemberService` → `IdpProjectionsFacade.inviteMember` → `IdentityOwoxClient`) is the structural template for everything below.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- **IDP-protocol** extension: 1 new model, 3 new methods on `IdpProvider`, stubs in null-provider and idp-better-auth.
+- **idp-owox-better-auth** implementation backed by a **per-request stateless mock** (no in-memory state, no env flag — see §5). Real HTTP wiring is added now but lives behind the same client-method shape so the eventual swap-in is local.
+- **Backend** (apps/backend): 3 use-cases, 1 facade extension, 1 controller-method group on the existing `project-members.controller.ts`, DTOs, mappers, specs.
+- **Web** (apps/web): pending-requests **table** above the existing members table on the Members tab (admin-only, hidden when empty), approve/decline **sheet** with the same form body as `InviteMemberSheet` (role + role scope + selected contexts) but two header buttons (Approve / Decline) — i.e. the legacy header buttons + the new full-fidelity invite form body.
+- Optimistic removal of the row after approve/decline; refresh of members list after approve.
+- Component / E2E tests scoped to mock data; staging verification deferred to the real-API ticket.
+- Changeset.
+
+### Out of scope
+
+- New UI on the **legacy** page — not touched, must keep working.
+- Real Java endpoints for membership requests — covered by sibling Java ticket.
+- New permissions model — admin-only is preserved (matches legacy).
+- Real-time updates / polling / sockets. List is fetched once on mount and re-fetched after a mutation.
+- "Accepted user appears in members list without manual page reload" DoD criterion — verifiable **only on real API**. The mock is intentionally stateless (§5), so locally an approved user does **not** show up in `getProjectMembers`. Verified visually on staging once the Java contract ships.
+- Email/notification delivery — owned by Java.
+- Bulk approve/decline.
+- Decommissioning the legacy page — out until product confirms deprecation. The legacy page must keep working in parallel.
+
+---
+
+## 3. Architecture overview
+
+```text
+[apps/web]
+  ProjectSettingsPage (state for sheets, tombstones)
+   └─ MembersSettingsProvider  (members + pendingRequests + refresh)
+       └─ MembersTab
+           ├─ <PendingRequestsSection>  ← new, admin-only, hidden when empty
+           │    └─ <PendingRequestsTable> (BaseTable + TanStack columns)
+           ├─ <MembersTable> (existing)
+           └─ <MembershipRequestSheet> ← new, opened on row click
+
+  features/project-members/services/project-members.service.ts
+     getMembershipRequests / approveMembershipRequest / declineMembershipRequest
+
+  features/project-settings/members/components/MemberFormFields/  ← extracted primitive
+     RoleRadioCards + RoleScopeSelect + ContextsCheckboxList
+     reused by InviteMemberSheet, MembershipRequestSheet, (later) MemberDetailsSheet
+
+[apps/backend]
+  data-marts/controllers/project-members.controller.ts
+     GET    /members/requests
+     POST   /members/requests/:requestId/approve
+     POST   /members/requests/:requestId/decline
+
+  data-marts/use-cases/project-members/
+     list-membership-requests.service.ts
+     approve-membership-request.service.ts   ← post-step: ContextAccessService.updateMember
+     decline-membership-request.service.ts
+
+  idp/facades/idp-projections.facade.ts          (+3 methods)
+  idp/services/idp-projections.service.ts        (+3 methods, throws-or-empty per provider)
+
+[packages/idp-protocol]
+  types/models.ts        + ProjectMembershipRequest
+  types/provider.ts      + listMembershipRequests / approveMembershipRequest / declineMembershipRequest
+  providers/null-provider.ts   list → []   approve/decline → IdpOperationNotSupportedError
+
+[packages/idp-better-auth]
+  providers/better-auth-provider.ts   list → []   approve/decline → IdpOperationNotSupportedError
+
+[packages/idp-owox-better-auth]
+  client/IdentityOwoxClient.ts                  (+3 HTTP methods, real C2C URLs)
+  services/core/membership-requests-service.ts  ← new, mocked for now (§5)
+  owox-better-auth-idp.ts                       (+3 delegations)
+```
+
+**Data flow on approve (full path):**
+
+1. Admin clicks **Approve request** on `MembershipRequestSheet` with chosen `role`, `roleScope`, `contextIds`.
+2. Web → `POST /members/requests/:requestId/approve` `{ role, roleScope, contextIds }`.
+3. Backend `ApproveMembershipRequestService.run()`:
+    a. Validates `contextIds` exist (reuse `ContextService` validator).
+    b. Calls `IdpProjectionsFacade.approveMembershipRequest(projectId, requestId, role, actor)` → returns `{ userId }` (or just resolves; see §4.1 for the chosen return shape).
+    c. Calls `ContextAccessService.updateMember(userId, { roleScope, contextIds })` to apply scope/contexts on the BI side. **Same pattern as `InviteProjectMemberService`.**
+4. Web `await` resolves → `optimisticRemoveRequest(requestId)` + `refresh()` → toast "Request approved".
+
+**Data flow on decline:**
+
+1. Admin clicks **Decline request** in the sheet header → `ConfirmationDialog` → confirm.
+2. Web → `POST /members/requests/:requestId/decline` `{ reason? }` (no reason field in MVP UI; param reserved).
+3. Backend `DeclineMembershipRequestService.run()` → `IdpProjectionsFacade.declineMembershipRequest`.
+4. Web → `optimisticRemoveRequest(requestId)` + toast "Request declined".
+
+---
+
+## 4. Layer-by-layer design
+
+### 4.1 IDP-protocol (`packages/idp-protocol`)
+
+**`types/models.ts`** — add:
+
+```ts
+export type ProjectMembershipRequest = {
+  requestId: string;          // stable id from Java; opaque to BI
+  email: string;
+  fullName?: string;
+  avatar?: string;
+  userId?: string;            // present if requester already exists in IDP
+  requestedRole: Role;
+  createdAt: string;          // ISO
+  status: 'pending';
+};
+
+export type ApproveMembershipRequestResult = {
+  userId: string;             // needed so backend can chain ContextAccessService.updateMember
+  email: string;
+  role: Role;
+};
+```
+
+**`types/provider.ts`** — add three methods to `IdpProvider`:
+
+```ts
+listMembershipRequests(
+  projectId: string,
+  options?: { forceFresh?: boolean }
+): Promise<ProjectMembershipRequest[]>;
+
+approveMembershipRequest(
+  projectId: string,
+  requestId: string,
+  role: Role,
+  actorUserId: string,
+): Promise<ApproveMembershipRequestResult>;
+
+declineMembershipRequest(
+  projectId: string,
+  requestId: string,
+  actorUserId: string,
+  reason?: string,
+): Promise<void>;
+```
+
+**`providers/null-provider.ts`** — `listMembershipRequests` → `[]`; approve/decline → `IdpOperationNotSupportedError(<methodName>)`.
+
+**Exports** — re-export `ProjectMembershipRequest` and `ApproveMembershipRequestResult` from `index.ts`.
+
+### 4.2 idp-better-auth (`packages/idp-better-auth`)
+
+`better-auth-provider.ts` — same pattern as null-provider: list → `[]`, approve/decline → `IdpOperationNotSupportedError`. Local Better-Auth deployments don't have a remote membership-request inbox; this is consistent with current treatment of `inviteMember` (which returns a magic link instead of throwing only because the local DB can satisfy it).
+
+### 4.3 idp-owox-better-auth (`packages/idp-owox-better-auth`)
+
+**`services/core/membership-requests-service.ts`** — new file, sibling to `project-members-service.ts`. Wraps `IdentityOwoxClient`. **For MVP it is mocked**: see §5.
+
+**`client/IdentityOwoxClient.ts`** — three methods sharing the `${clientBackchannelPrefix}/idp/bi-project/{projectId}/membership-requests` URL pattern (mirrors `…/members`):
+
+```http
+GET   {prefix}/idp/bi-project/{projectId}/membership-requests
+POST  {prefix}/idp/bi-project/{projectId}/membership-requests/{requestId}/approve   { biUserId, role }
+POST  {prefix}/idp/bi-project/{projectId}/membership-requests/{requestId}/decline   { biUserId, reason? }
+```
+
+**These methods are written but never called yet** — the service short-circuits to mock data (§5). Once the Java endpoints land, the service deletes the mock branch and starts calling these methods.
+
+**`owox-better-auth-idp.ts`** — delegate the three new provider methods to `MembershipRequestsService`.
+
+### 4.4 Backend (`apps/backend`)
+
+**Controller** (`data-marts/controllers/project-members.controller.ts`):
+
+```text
+@Auth(Role.admin(Strategy.INTROSPECT))
+GET    /members/requests                                 → ListMembershipRequestsService
+@Auth(Role.admin(Strategy.INTROSPECT))
+POST   /members/requests/:requestId/approve              → ApproveMembershipRequestService
+@Auth(Role.admin(Strategy.INTROSPECT))
+POST   /members/requests/:requestId/decline              → DeclineMembershipRequestService
+```
+
+**DTOs** (mirror existing `project-members` DTOs):
+
+- `MembershipRequestApiDto` — `{ requestId, email, fullName?, avatar?, userId?, requestedRole, createdAt }`.
+- `ApproveMembershipRequestApiDto` (request body) — `{ role, roleScope?, contextIds? }`.
+- `ApproveMembershipRequestResponseApiDto` — `{ userId, email, role, roleScope, contextIds }`.
+- `DeclineMembershipRequestApiDto` — `{ reason? }`.
+
+**Use-cases** (`data-marts/use-cases/project-members/`):
+
+- **`list-membership-requests.service.ts`** — `run(projectId)` → `IdpProjectionsFacade.listMembershipRequests(projectId)`. No business logic.
+- **`approve-membership-request.service.ts`** — mirrors `InviteProjectMemberService`:
+   1. Infer `roleScope`: if `role === admin` → `ENTIRE_PROJECT` (admins always have project-wide access); else if `contextIds?.length > 0` → `SELECTED_CONTEXTS`; else → `ENTIRE_PROJECT`. **Identical rule to `InviteProjectMemberService`**, lifted as-is.
+   2. Validate `contextIds` via `ContextService` if scope is `SELECTED_CONTEXTS`.
+   3. Call `IdpProjectionsFacade.approveMembershipRequest(projectId, requestId, role, actor)` → `{ userId }`.
+   4. Call `ContextAccessService.updateMember(userId, { roleScope, contextIds })`.
+   5. Return `{ userId, email, role, roleScope, contextIds }` for client convenience.
+- **`decline-membership-request.service.ts`** — `IdpProjectionsFacade.declineMembershipRequest(projectId, requestId, actor, reason?)`. No post-step.
+
+**Facade / projections** — `idp-projections.facade.ts` and `idp-projections.service.ts` get one trivial pass-through method per use-case. `IdpOperationNotSupportedError` continues to map to HTTP 501 via existing exception filter.
+
+**Specs** — one `*.service.spec.ts` per use-case (mock facade + ContextAccessService), following `invite-project-member.service.spec.ts` style.
+
+### 4.5 Web (`apps/web`)
+
+**`features/project-members/types/index.ts`** — add `MembershipRequestDto`, `ApproveMembershipRequestPayload`, `ApproveMembershipRequestResult`, `DeclineMembershipRequestPayload`.
+
+**`features/project-members/services/project-members.service.ts`** — three new methods on the existing `ApiService('/members')` instance:
+
+```ts
+getMembershipRequests(): Promise<MembershipRequestDto[]>
+approveMembershipRequest(requestId, payload): Promise<ApproveMembershipRequestResult>
+declineMembershipRequest(requestId, payload): Promise<void>
+```
+
+**`features/project-settings/members/model/members-settings.context.ts`** — extend `MembersSettingsStoreValue`:
+
+```ts
+pendingRequests: MembershipRequestDto[];
+loadingRequests: boolean;
+optimisticRemoveRequest: (requestId: string) => void;
+openMembershipRequestSheet: (request: MembershipRequestDto) => void;
+```
+
+`refresh()` is updated to `Promise.all([getMembers(), getMembershipRequests()])`. Tombstones for requests reuse the `Set<string>` pattern already proven on members.
+
+**`pages/project-settings/ProjectSettingsPage.tsx`**:
+
+- Owns sheet state (`requestSheetTarget`).
+- Mounts `<MembershipRequestSheet>` at the page root, like the other sheets.
+- Passes `openMembershipRequestSheet`, `optimisticRemoveRequest` into the provider.
+- On admin === false, request fetching and section rendering are no-ops.
+
+**`features/project-settings/members/components/MemberFormFields/`** — **new shared primitive**, extracted from `InviteMemberSheet` body. Encapsulates `RoleRadioCards` + `RoleScopeSelect` + `ContextsCheckboxList` + their cross-field rules (admin role forces entire-project scope; non-admin + selected-contexts shows checkbox list). Consumed by both `InviteMemberSheet` and `MembershipRequestSheet`. Pure presentational; consumes a react-hook-form `useFormContext` instance.
+
+**`features/project-settings/members/components/PendingRequestsSection/`** — new, `PendingRequestsSection.tsx` + `PendingRequestsTable/columns.tsx`:
+
+- Section title: "You've received requests for project membership" (legacy copy).
+- Renders `null` when `!isAdmin || pendingRequests.length === 0` (DoD: hidden when empty).
+- Uses `BaseTable` with TanStack columns:
+  - **REQUESTER** — avatar + email + fullName fallback (sortable).
+  - **REQUESTED ROLE** — role badge using `getRoleDisplayName` (sortable).
+  - **REQUESTED AT** — `createdAt` (sortable, formatted via existing date util).
+  - **ACTIONS** — button "Manage request" (mirrors legacy CTA), opens sheet.
+- Loading state: skeleton rows like `MembersTable`.
+- Error state: in-section error banner with a Retry button (calls `refresh()`); never throws to ErrorBoundary.
+
+**`features/project-settings/members/components/MembershipRequestSheet/MembershipRequestSheet.tsx`** — new. Layout:
+
+- **Header:** title `Request from {email}`, two action buttons: `Decline request` (outline destructive) and `Approve request` (primary).
+- **Body:** `MemberFormFields` primitive with `defaultValues = { role: request.requestedRole, roleScope: 'entire_project' }` and an `additionalInfo` slot that surfaces "User requested {requestedRole}" copy + a help-link.
+- **Decline button:** opens `ConfirmationDialog` (existing) with copy "Decline request from {email}? They will be notified the request was rejected." On confirm → `declineMembershipRequest` → optimistic remove + close sheet + toast.
+- **Approve button:** validates form → `approveMembershipRequest` → optimistic remove + close sheet + `refresh()` (so members list pulls in the new user once the real API ships) + toast "Request approved".
+- Loading: both header buttons disabled with spinner on the active one. Form fields disabled during submit.
+- Errors: inline error bar at the top of the sheet body. Sheet stays open so the user can retry.
+- Sheet closes via `X` only when not submitting.
+
+**Translations / styles** — match existing Members components: hardcoded English copy (no i18n in this feature, per existing convention), all primitives from `@owox/ui/components`, `lucide-react` icons (`UserCheck`, `UserX`, `Clock`).
+
+---
+
+## 5. Mock strategy (per-request, stateless)
+
+> **Update (branch `feature/membership-requests`):** The Java Integrated-backend shipped the
+> `GET/POST/POST` endpoints under `/internal-api/idp/bi-project/{projectId}/membership-requests`.
+> `MembershipRequestsService` has been swapped to real `IdentityOwoxClient` calls with Zod-validated
+> responses. The mock described below is no longer active; this section is kept as an accurate
+> record of the approach used before the Java endpoints landed.
+
+**Decision:** `MembershipRequestsService` (in idp-owox-better-auth) returns mocked data per call **without any in-memory state**.
+
+- `listMembershipRequests(projectId)` → static array of 2 fixed-shape requests, derived from `projectId` (stable across calls). Examples: `requestId = "mock-req-1"`, `email = "alice@example.com"`, `requestedRole = "viewer"`, `createdAt = "2026-05-01T10:00:00Z"`.
+- `approveMembershipRequest(...)` → resolves with `{ userId: "mock-user-${requestId}", email, role }`. **No state mutation.** Re-listing returns the same 2 requests.
+- `declineMembershipRequest(...)` → resolves `void`. Same caveat.
+
+**Consequence — local visibility (acknowledged):**
+
+- After approve, the request **does** disappear from the UI list because of the frontend optimistic-remove tombstone Set held in `MembersSettingsProvider`. Tombstones live for the lifetime of the provider (i.e. until the user navigates off Project Settings).
+- After a full page reload (or navigating back to Members), the same 2 mock requests reappear because the mock is intentionally stateless. This is acceptable for local development and is called out in the PR description.
+- The DoD criterion "Accepted user appears in members list without manual page reload" is verified **only on staging with the real API** (the post-step `ContextAccessService.updateMember` requires a real userId from Java to be observable in `getProjectMembers`). This is documented in the PR description; manual staging verification is the gate.
+
+**Why not seed-and-state in-memory:**
+
+- No persistence cost vs. complexity tradeoff worth it: real API is days away.
+- Avoids an extra dimension of "which env starts with state, which doesn't" when the real API replaces the mock.
+- A dev-time toggle is unnecessary: per-request mock returns plausible data on every restart, and tests use their own mocks regardless.
+
+**No env flag.** When the real API ships, the change is a single edit in `MembershipRequestsService` to call `IdentityOwoxClient` instead of returning mock data. Tests at the IDP-provider level pin that contract.
+
+---
+
+## 6. Permissions
+
+- **All three endpoints:** `@Auth(Role.admin(Strategy.INTROSPECT))` on the controller. Matches legacy.
+- **Controller-level guard is the source of truth** (consistent with existing `invite`, `update`, `remove`).
+- **Self-protection invariant** (`actor !== request.userId`) is enforced on the Java side once the real API ships (out of scope here). For the mock period, the invariant is irrelevant because mock requests never share an email with the actor.
+- **Frontend** hides `PendingRequestsSection` for non-admins (`isAdmin === false`). Backend will still 403 if a non-admin somehow calls the endpoint.
+
+---
+
+## 7. Empty / loading / error states
+
+| State                                  | Behavior                                                                |
+|----------------------------------------|-------------------------------------------------------------------------|
+| Loading (`loadingRequests === true`)   | Skeleton rows in `PendingRequestsTable`. Section visible.               |
+| No requests (`pendingRequests.length === 0`) | Section hidden completely (DoD).                                  |
+| Fetch error                            | Section visible with inline error banner + Retry. Members list unaffected. |
+| Approve / decline error                | Sheet stays open, inline error banner at top. Buttons re-enabled.       |
+| Non-admin                              | Section never rendered. Endpoints return 403 if hit directly.           |
+
+---
+
+## 8. Tests
+
+### Backend (apps/backend)
+
+- `list-membership-requests.service.spec.ts` — happy path + facade throws.
+- `approve-membership-request.service.spec.ts` — happy path; admin-role auto-scopes; selected-contexts validates ids; `ContextAccessService.updateMember` called with the userId from facade; facade throws → propagates.
+- `decline-membership-request.service.spec.ts` — happy + facade throws.
+- `idp-projections.facade.spec.ts` — extend with the three pass-throughs.
+
+### IDP-protocol / providers
+
+- `null-provider`: list → `[]`; approve/decline → throws `IdpOperationNotSupportedError`.
+- `idp-better-auth`: same.
+- `idp-owox-better-auth/MembershipRequestsService`: returns mock shape; spec is the contract pin so the real-API swap-in cannot accidentally change the response shape.
+
+### Web (vitest + RTL)
+
+- `PendingRequestsSection`:
+  - renders rows when admin + non-empty,
+  - returns `null` when `!isAdmin`,
+  - returns `null` when empty,
+  - shows error banner when `loadingRequests === false && error != null`,
+  - clicking a row opens the sheet (verified via context spy).
+- `MembershipRequestSheet`:
+  - default `role === request.requestedRole`,
+  - approve calls service with `{ role, roleScope, contextIds }`,
+  - decline shows `ConfirmationDialog`, on confirm calls service,
+  - approve error keeps sheet open with banner.
+- `MembersSettingsProvider` already has tests; extend them to assert `pendingRequests` and `optimisticRemoveRequest` semantics.
+
+### E2E (Playwright, against mock)
+
+- Seed mock to return 1 fixed pending request.
+- Admin opens Members → sees `Pending requests` section with 1 row.
+- Click row → sheet opens with `role` defaulted to requested role.
+- Click Approve → sheet closes, row disappears from section, toast appears.
+- Reload → row comes back (mock is stateless — explicitly asserted as "expected, mock-only").
+- Click Decline → ConfirmationDialog → Confirm → row disappears + toast.
+- Switch to non-admin user → section is not visible.
+
+Skipped E2E coverage (deferred to staging verification with real API):
+
+- "Approved user appears in the members list."
+
+---
+
+## 9. Risks & open questions
+
+| Risk | Mitigation |
+|------|------------|
+| Java contract diverges from our spec on `requestId` shape (e.g. they ship JWT-only, no stable id) | The sibling Java ticket lists "stable `requestId`" as a DoD item. If they push back, we add a thin id-extraction adapter inside `MembershipRequestsService` (single file). |
+| `ContextAccessService.updateMember` has a different shape than we assume | The invite use-case uses the same call, so signature is locked. Verified by reading `InviteProjectMemberService`. |
+| Header buttons in a `Sheet` not previously used in this codebase | Confirmed via screenshot of legacy. `Sheet` from `@owox/ui` accepts a custom header slot — verified during architecture exploration. |
+| `MemberFormFields` extraction breaks `InviteMemberSheet` styling / behavior | Refactor first, port `InviteMemberSheet` to use it, run existing tests; only then add `MembershipRequestSheet`. Ordered as commit #5 in §11. |
+| Mock UX confusion (admin tries to "approve" same request twice after reload) | PR description and section help text note "mock data — staging shows real behavior". Covered in §5. |
+
+---
+
+## 10. Sequence of commits (atomic)
+
+1. `feat(idp-protocol): add membership requests model + provider methods + null stubs`
+2. `feat(idp-better-auth): not-implemented stubs for membership requests`
+3. `feat(idp-owox-better-auth): membership requests service with stateless per-request mock; HTTP client methods staged for real API`
+4. `feat(backend): membership requests use-cases, facade extension, controller routes, DTOs, specs`
+5. `refactor(web): extract MemberFormFields primitive from InviteMemberSheet`
+6. `feat(web): pending requests section + membership request sheet on Project Settings → Members`
+7. `test(web): component + provider tests`
+8. `test(e2e): membership-requests playwright spec`
+9. `chore: changeset`
+
+Each commit is independently reviewable and reverts cleanly.

--- a/packages/idp-better-auth/jest.setup.ts
+++ b/packages/idp-better-auth/jest.setup.ts
@@ -13,4 +13,8 @@ jest.unstable_mockModule('@owox/internal-helpers', () => ({
       log: jest.fn(),
     }),
   },
+  // disableConditionalCaching is imported by @owox/idp-protocol's protocol-middleware
+  // and must be present in the mock so Jest ESM can satisfy the named import binding
+  disableConditionalCaching: jest.fn(),
+  sendSecureHtml: jest.fn(),
 }));

--- a/packages/idp-better-auth/src/providers/better-auth-provider.ts
+++ b/packages/idp-better-auth/src/providers/better-auth-provider.ts
@@ -9,11 +9,13 @@ import {
   Projects,
   ProjectMember,
   ProjectMemberInvitation,
+  ProjectMembershipRequest,
+  ApproveMembershipRequestResult,
   GetProjectMembersOptions,
+  IdpOperationNotSupportedError,
   Role,
   UserProvisioningSettings,
   UserProvisioningSettingsUpdate,
-  IdpOperationNotSupportedError,
 } from '@owox/idp-protocol';
 import { Express, type Request, Response, NextFunction } from 'express';
 import express from 'express';
@@ -314,5 +316,31 @@ export class BetterAuthProvider
     _settings: UserProvisioningSettingsUpdate
   ): Promise<UserProvisioningSettings> {
     throw new IdpOperationNotSupportedError('updateUserProvisioningSettings');
+  }
+
+  async listMembershipRequests(
+    _projectId: string,
+    _actorUserId: string,
+    _options?: { forceFresh?: boolean }
+  ): Promise<ProjectMembershipRequest[]> {
+    return [];
+  }
+
+  async approveMembershipRequest(
+    _projectId: string,
+    _requestId: string,
+    _role: Role,
+    _actorUserId: string
+  ): Promise<ApproveMembershipRequestResult> {
+    throw new IdpOperationNotSupportedError('approveMembershipRequest');
+  }
+
+  async declineMembershipRequest(
+    _projectId: string,
+    _requestId: string,
+    _actorUserId: string,
+    _reason?: string
+  ): Promise<void> {
+    throw new IdpOperationNotSupportedError('declineMembershipRequest');
   }
 }

--- a/packages/idp-better-auth/src/providers/better-auth-provider.ts
+++ b/packages/idp-better-auth/src/providers/better-auth-provider.ts
@@ -338,8 +338,7 @@ export class BetterAuthProvider
   async declineMembershipRequest(
     _projectId: string,
     _requestId: string,
-    _actorUserId: string,
-    _reason?: string
+    _actorUserId: string
   ): Promise<void> {
     throw new IdpOperationNotSupportedError('declineMembershipRequest');
   }

--- a/packages/idp-owox-better-auth/src/client/IdentityOwoxClient.ts
+++ b/packages/idp-owox-better-auth/src/client/IdentityOwoxClient.ts
@@ -88,32 +88,13 @@ export class IdentityOwoxClient {
    * POST auth-flow/extension/identity
    */
   async exchangeGoogleIdentityToken(req: GoogleIdentityExchangeRequest): Promise<TokenResponse> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience ||
-      !this.clientBackchannelPrefix
-    ) {
-      throw new IdpFailedException(
-        'C2C authentication is not configured. Cannot exchange Google identity token.',
-        { context: { req } }
-      );
-    }
+    const authHeader = await this.getC2cAuthHeader('exchange Google identity token', { req });
 
     try {
-      const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-        this.c2cServiceAccountEmail,
-        this.c2cTargetAudience
-      );
-
       const { data } = await this.http.post<TokenResponse>(
         `${this.clientBackchannelPrefix}/idp/auth-flow/extension/identity`,
         req,
-        {
-          headers: {
-            Authorization: `Bearer ${idToken}`,
-          },
-        }
+        { headers: authHeader }
       );
       return TokenResponseSchema.parse(data);
     } catch (err) {
@@ -175,34 +156,16 @@ export class IdentityOwoxClient {
    * Requires service account authentication for the private internal endpoint.
    */
   async completeAuthFlow(request: AuthFlowRequest): Promise<AuthFlowResponse> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience
-    ) {
-      throw new IdpFailedException(
-        'Service account authentication is not configured. Cannot complete auth flow.',
-        { context: { hasRequest: Boolean(request) } }
-      );
-    }
+    const authHeader = await this.getC2cAuthHeader('complete auth flow', {
+      hasRequest: Boolean(request),
+    });
 
     try {
-      const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-        this.c2cServiceAccountEmail,
-        this.c2cTargetAudience
-      );
-
       const { data } = await this.http.post<AuthFlowResponse>(
         `${this.clientBackchannelPrefix}/idp/auth-flow/complete`,
         request,
-        {
-          headers: {
-            Authorization: `Bearer ${idToken}`,
-          },
-        }
+        { headers: authHeader }
       );
-
-      // Validate and return response
       return AuthFlowResponseSchema.parse(data);
     } catch (err) {
       this.handleAxiosError(err, { request }, 'Failed to complete auth flow');
@@ -213,31 +176,12 @@ export class IdentityOwoxClient {
    * GET project members via C2C (component-to-component) authentication.
    */
   async getProjectMembers(projectId: string): Promise<OwoxProjectMembersResponse> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience ||
-      !this.clientBackchannelPrefix
-    ) {
-      throw new IdpFailedException(
-        'C2C authentication is not configured. Cannot fetch project members.',
-        { context: { projectId } }
-      );
-    }
-
-    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-      this.c2cServiceAccountEmail,
-      this.c2cTargetAudience
-    );
+    const authHeader = await this.getC2cAuthHeader('fetch project members', { projectId });
 
     try {
       const { data } = await this.http.get<unknown>(
         `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/members`,
-        {
-          headers: {
-            Authorization: `Bearer ${idToken}`,
-          },
-        }
+        { headers: authHeader }
       );
       return OwoxProjectMembersResponseSchema.parse(data);
     } catch (err) {
@@ -262,31 +206,18 @@ export class IdentityOwoxClient {
     role: string,
     actorUserId: string
   ): Promise<OwoxInviteProjectMemberResponse> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience ||
-      !this.clientBackchannelPrefix
-    ) {
-      throw new IdpFailedException(
-        'C2C authentication is not configured. Cannot invite project member.',
-        { context: { projectId, email, role, actorUserId } }
-      );
-    }
+    const authHeader = await this.getC2cAuthHeader('invite project member', {
+      projectId,
+      email,
+      role,
+      actorUserId,
+    });
 
-    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-      this.c2cServiceAccountEmail,
-      this.c2cTargetAudience
-    );
     const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/members`;
     const body = { biUserId: actorUserId, inviteeEmail: email, role };
 
     try {
-      const { data } = await this.http.post<unknown>(url, body, {
-        headers: {
-          Authorization: `Bearer ${idToken}`,
-        },
-      });
+      const { data } = await this.http.post<unknown>(url, body, { headers: authHeader });
       return OwoxInviteProjectMemberResponseSchema.parse(data);
     } catch (err) {
       this.handleAxiosError(err, { projectId, email, role }, 'Failed to invite project member');
@@ -298,34 +229,18 @@ export class IdentityOwoxClient {
    * See `inviteProjectMember` for path rationale.
    */
   async removeProjectMember(projectId: string, userId: string, actorUserId: string): Promise<void> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience ||
-      !this.clientBackchannelPrefix
-    ) {
-      throw new IdpFailedException(
-        'C2C authentication is not configured. Cannot remove project member.',
-        { context: { projectId, userId, actorUserId } }
-      );
-    }
-
-    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-      this.c2cServiceAccountEmail,
-      this.c2cTargetAudience
-    );
+    const authHeader = await this.getC2cAuthHeader('remove project member', {
+      projectId,
+      userId,
+      actorUserId,
+    });
     const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/members/${userId}`;
     const body = { biUserId: actorUserId };
 
     try {
       // Java contract requires `biUserId` in the request body even for DELETE —
       // axios forwards it via the `data` option.
-      await this.http.delete(url, {
-        headers: {
-          Authorization: `Bearer ${idToken}`,
-        },
-        data: body,
-      });
+      await this.http.delete(url, { headers: authHeader, data: body });
     } catch (err) {
       this.handleAxiosError(
         err,
@@ -345,31 +260,17 @@ export class IdentityOwoxClient {
     newRole: string,
     actorUserId: string
   ): Promise<void> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience ||
-      !this.clientBackchannelPrefix
-    ) {
-      throw new IdpFailedException(
-        'C2C authentication is not configured. Cannot change project member role.',
-        { context: { projectId, userId, newRole, actorUserId } }
-      );
-    }
-
-    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-      this.c2cServiceAccountEmail,
-      this.c2cTargetAudience
-    );
+    const authHeader = await this.getC2cAuthHeader('change project member role', {
+      projectId,
+      userId,
+      newRole,
+      actorUserId,
+    });
     const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/members/${userId}/role`;
     const body = { biUserId: actorUserId, role: newRole };
 
     try {
-      await this.http.put(url, body, {
-        headers: {
-          Authorization: `Bearer ${idToken}`,
-        },
-      });
+      await this.http.put(url, body, { headers: authHeader });
     } catch (err) {
       this.handleAxiosError(
         err,
@@ -387,32 +288,16 @@ export class IdentityOwoxClient {
     projectId: string,
     actorUserId: string
   ): Promise<OwoxUserProvisioningSettingsResponse> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience ||
-      !this.clientBackchannelPrefix
-    ) {
-      throw new IdpFailedException(
-        'C2C authentication is not configured. Cannot fetch user provisioning settings.',
-        { context: { projectId, actorUserId } }
-      );
-    }
-
-    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-      this.c2cServiceAccountEmail,
-      this.c2cTargetAudience
-    );
+    const authHeader = await this.getC2cAuthHeader('fetch user provisioning settings', {
+      projectId,
+      actorUserId,
+    });
     const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/user-provisioning-settings`;
 
     try {
       const { data } = await this.http.get<unknown>(url, {
-        headers: {
-          Authorization: `Bearer ${idToken}`,
-        },
-        params: {
-          biUserId: actorUserId,
-        },
+        headers: authHeader,
+        params: { biUserId: actorUserId },
       });
       return OwoxUserProvisioningSettingsResponseSchema.parse(data);
     } catch (err) {
@@ -433,32 +318,17 @@ export class IdentityOwoxClient {
     actorUserId: string,
     settings: OwoxUpdateUserProvisioningSettingsRequest
   ): Promise<OwoxUserProvisioningSettingsResponse> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience ||
-      !this.clientBackchannelPrefix
-    ) {
-      throw new IdpFailedException(
-        'C2C authentication is not configured. Cannot update user provisioning settings.',
-        { context: { projectId, actorUserId, settings } }
-      );
-    }
-
-    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-      this.c2cServiceAccountEmail,
-      this.c2cTargetAudience
-    );
+    const authHeader = await this.getC2cAuthHeader('update user provisioning settings', {
+      projectId,
+      actorUserId,
+      settings,
+    });
     const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/user-provisioning-settings`;
     const parsedSettings = OwoxUpdateUserProvisioningSettingsRequestSchema.parse(settings);
     const body = { biUserId: actorUserId, ...parsedSettings };
 
     try {
-      const { data } = await this.http.put<unknown>(url, body, {
-        headers: {
-          Authorization: `Bearer ${idToken}`,
-        },
-      });
+      const { data } = await this.http.put<unknown>(url, body, { headers: authHeader });
       return OwoxUserProvisioningSettingsResponseSchema.parse(data);
     } catch (err) {
       this.handleAxiosError(
@@ -479,25 +349,14 @@ export class IdentityOwoxClient {
     projectId: string,
     actorUserId: string
   ): Promise<OwoxMembershipRequestsResponse> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience ||
-      !this.clientBackchannelPrefix
-    ) {
-      throw new IdpFailedException(
-        'C2C authentication is not configured. Cannot list project membership requests.',
-        { context: { projectId, actorUserId } }
-      );
-    }
-    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-      this.c2cServiceAccountEmail,
-      this.c2cTargetAudience
-    );
+    const authHeader = await this.getC2cAuthHeader('list project membership requests', {
+      projectId,
+      actorUserId,
+    });
     const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/membership-requests`;
     try {
       const { data } = await this.http.get<unknown>(url, {
-        headers: { Authorization: `Bearer ${idToken}` },
+        headers: authHeader,
         params: { biUserId: actorUserId },
       });
       return OwoxMembershipRequestsResponseSchema.parse(data);
@@ -523,27 +382,16 @@ export class IdentityOwoxClient {
     role: string,
     actorUserId: string
   ): Promise<OwoxApproveMembershipRequestResponse> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience ||
-      !this.clientBackchannelPrefix
-    ) {
-      throw new IdpFailedException(
-        'C2C authentication is not configured. Cannot approve project membership request.',
-        { context: { projectId, requestId, role, actorUserId } }
-      );
-    }
-    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-      this.c2cServiceAccountEmail,
-      this.c2cTargetAudience
-    );
+    const authHeader = await this.getC2cAuthHeader('approve project membership request', {
+      projectId,
+      requestId,
+      role,
+      actorUserId,
+    });
     const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/membership-requests/${requestId}/approve`;
     const body = { biUserId: actorUserId, role };
     try {
-      const { data } = await this.http.post<unknown>(url, body, {
-        headers: { Authorization: `Bearer ${idToken}` },
-      });
+      const { data } = await this.http.post<unknown>(url, body, { headers: authHeader });
       return OwoxApproveMembershipRequestResponseSchema.parse(data);
     } catch (err) {
       this.handleAxiosError(
@@ -561,30 +409,17 @@ export class IdentityOwoxClient {
   async declineProjectMembershipRequest(
     projectId: string,
     requestId: string,
-    actorUserId: string,
-    reason?: string
+    actorUserId: string
   ): Promise<void> {
-    if (
-      !this.impersonatedIdTokenFetcher ||
-      !this.c2cServiceAccountEmail ||
-      !this.c2cTargetAudience ||
-      !this.clientBackchannelPrefix
-    ) {
-      throw new IdpFailedException(
-        'C2C authentication is not configured. Cannot decline project membership request.',
-        { context: { projectId, requestId, actorUserId } }
-      );
-    }
-    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
-      this.c2cServiceAccountEmail,
-      this.c2cTargetAudience
-    );
+    const authHeader = await this.getC2cAuthHeader('decline project membership request', {
+      projectId,
+      requestId,
+      actorUserId,
+    });
     const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/membership-requests/${requestId}/decline`;
-    const body = { biUserId: actorUserId, reason };
+    const body = { biUserId: actorUserId };
     try {
-      await this.http.post(url, body, {
-        headers: { Authorization: `Bearer ${idToken}` },
-      });
+      await this.http.post(url, body, { headers: authHeader });
     } catch (err) {
       this.handleAxiosError(
         err,
@@ -592,6 +427,35 @@ export class IdentityOwoxClient {
         'Failed to decline project membership request'
       );
     }
+  }
+
+  /**
+   * Validate the C2C configuration and mint an `Authorization` header for a
+   * single backchannel call. Used by every method that hits the OWOX Identity
+   * service over service-to-service auth — keeps the preflight (check + token
+   * fetch) in one place so future additions to the C2C config surface in one
+   * spot, not nine.
+   */
+  private async getC2cAuthHeader(
+    operationLabel: string,
+    context: Record<string, unknown>
+  ): Promise<{ Authorization: string }> {
+    if (
+      !this.impersonatedIdTokenFetcher ||
+      !this.c2cServiceAccountEmail ||
+      !this.c2cTargetAudience ||
+      !this.clientBackchannelPrefix
+    ) {
+      throw new IdpFailedException(
+        `C2C authentication is not configured. Cannot ${operationLabel}.`,
+        { context }
+      );
+    }
+    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
+      this.c2cServiceAccountEmail,
+      this.c2cTargetAudience
+    );
+    return { Authorization: `Bearer ${idToken}` };
   }
 
   private handleAxiosError(

--- a/packages/idp-owox-better-auth/src/client/IdentityOwoxClient.ts
+++ b/packages/idp-owox-better-auth/src/client/IdentityOwoxClient.ts
@@ -24,8 +24,8 @@ import {
   OwoxApproveMembershipRequestResponseSchema,
   OwoxInviteProjectMemberResponse,
   OwoxInviteProjectMemberResponseSchema,
-  OwoxMembershipRequestsResponse,
-  OwoxMembershipRequestsResponseSchema,
+  OwoxListMembershipRequestsResponse,
+  OwoxListMembershipRequestsResponseSchema,
   OwoxProjectMembersResponse,
   OwoxProjectMembersResponseSchema,
   OwoxUpdateUserProvisioningSettingsRequest,
@@ -348,7 +348,7 @@ export class IdentityOwoxClient {
   async listProjectMembershipRequests(
     projectId: string,
     actorUserId: string
-  ): Promise<OwoxMembershipRequestsResponse> {
+  ): Promise<OwoxListMembershipRequestsResponse> {
     const authHeader = await this.getC2cAuthHeader('list project membership requests', {
       projectId,
       actorUserId,
@@ -359,7 +359,7 @@ export class IdentityOwoxClient {
         headers: authHeader,
         params: { biUserId: actorUserId },
       });
-      return OwoxMembershipRequestsResponseSchema.parse(data);
+      return OwoxListMembershipRequestsResponseSchema.parse(data);
     } catch (err) {
       this.handleAxiosError(
         err,

--- a/packages/idp-owox-better-auth/src/client/IdentityOwoxClient.ts
+++ b/packages/idp-owox-better-auth/src/client/IdentityOwoxClient.ts
@@ -20,8 +20,12 @@ import {
   IntrospectionResponseSchema,
   JwksResponse,
   JwksResponseSchema,
+  OwoxApproveMembershipRequestResponse,
+  OwoxApproveMembershipRequestResponseSchema,
   OwoxInviteProjectMemberResponse,
   OwoxInviteProjectMemberResponseSchema,
+  OwoxMembershipRequestsResponse,
+  OwoxMembershipRequestsResponseSchema,
   OwoxProjectMembersResponse,
   OwoxProjectMembersResponseSchema,
   OwoxUpdateUserProvisioningSettingsRequest,
@@ -461,6 +465,131 @@ export class IdentityOwoxClient {
         err,
         { projectId, actorUserId, settings },
         'Failed to update user provisioning settings'
+      );
+    }
+  }
+
+  /**
+   * GET /idp/bi-project/:projectId/membership-requests — list pending requests.
+   *
+   * `actorUserId` is forwarded as the `biUserId` query parameter as required
+   * by the Java contract.
+   */
+  async listProjectMembershipRequests(
+    projectId: string,
+    actorUserId: string
+  ): Promise<OwoxMembershipRequestsResponse> {
+    if (
+      !this.impersonatedIdTokenFetcher ||
+      !this.c2cServiceAccountEmail ||
+      !this.c2cTargetAudience ||
+      !this.clientBackchannelPrefix
+    ) {
+      throw new IdpFailedException(
+        'C2C authentication is not configured. Cannot list project membership requests.',
+        { context: { projectId, actorUserId } }
+      );
+    }
+    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
+      this.c2cServiceAccountEmail,
+      this.c2cTargetAudience
+    );
+    const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/membership-requests`;
+    try {
+      const { data } = await this.http.get<unknown>(url, {
+        headers: { Authorization: `Bearer ${idToken}` },
+        params: { biUserId: actorUserId },
+      });
+      return OwoxMembershipRequestsResponseSchema.parse(data);
+    } catch (err) {
+      this.handleAxiosError(
+        err,
+        { projectId, actorUserId },
+        'Failed to list project membership requests'
+      );
+    }
+  }
+
+  /**
+   * POST /idp/bi-project/:projectId/membership-requests/:requestId/approve.
+   *
+   * Response: 200 OK with body `{ userUid: string }` — the resolved user uid
+   * of the approved requester. `MembershipRequestsService` maps `userUid → userId`
+   * on `ApproveMembershipRequestResult`.
+   */
+  async approveProjectMembershipRequest(
+    projectId: string,
+    requestId: string,
+    role: string,
+    actorUserId: string
+  ): Promise<OwoxApproveMembershipRequestResponse> {
+    if (
+      !this.impersonatedIdTokenFetcher ||
+      !this.c2cServiceAccountEmail ||
+      !this.c2cTargetAudience ||
+      !this.clientBackchannelPrefix
+    ) {
+      throw new IdpFailedException(
+        'C2C authentication is not configured. Cannot approve project membership request.',
+        { context: { projectId, requestId, role, actorUserId } }
+      );
+    }
+    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
+      this.c2cServiceAccountEmail,
+      this.c2cTargetAudience
+    );
+    const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/membership-requests/${requestId}/approve`;
+    const body = { biUserId: actorUserId, role };
+    try {
+      const { data } = await this.http.post<unknown>(url, body, {
+        headers: { Authorization: `Bearer ${idToken}` },
+      });
+      return OwoxApproveMembershipRequestResponseSchema.parse(data);
+    } catch (err) {
+      this.handleAxiosError(
+        err,
+        { projectId, requestId, role },
+        'Failed to approve project membership request'
+      );
+    }
+  }
+
+  /**
+   * POST /idp/bi-project/:projectId/membership-requests/:requestId/decline.
+   * See `listProjectMembershipRequests` for wiring status.
+   */
+  async declineProjectMembershipRequest(
+    projectId: string,
+    requestId: string,
+    actorUserId: string,
+    reason?: string
+  ): Promise<void> {
+    if (
+      !this.impersonatedIdTokenFetcher ||
+      !this.c2cServiceAccountEmail ||
+      !this.c2cTargetAudience ||
+      !this.clientBackchannelPrefix
+    ) {
+      throw new IdpFailedException(
+        'C2C authentication is not configured. Cannot decline project membership request.',
+        { context: { projectId, requestId, actorUserId } }
+      );
+    }
+    const idToken = await this.impersonatedIdTokenFetcher.getIdToken(
+      this.c2cServiceAccountEmail,
+      this.c2cTargetAudience
+    );
+    const url = `${this.clientBackchannelPrefix}/idp/bi-project/${projectId}/membership-requests/${requestId}/decline`;
+    const body = { biUserId: actorUserId, reason };
+    try {
+      await this.http.post(url, body, {
+        headers: { Authorization: `Bearer ${idToken}` },
+      });
+    } catch (err) {
+      this.handleAxiosError(
+        err,
+        { projectId, requestId, actorUserId },
+        'Failed to decline project membership request'
       );
     }
   }

--- a/packages/idp-owox-better-auth/src/client/dto/index.ts
+++ b/packages/idp-owox-better-auth/src/client/dto/index.ts
@@ -10,3 +10,4 @@ export * from './tokenDto.js';
 export * from './tokenType.js';
 export * from './projectMembersDto.js';
 export * from './userProvisioningDto.js';
+export * from './membershipRequestsDto.js';

--- a/packages/idp-owox-better-auth/src/client/dto/membershipRequestsDto.ts
+++ b/packages/idp-owox-better-auth/src/client/dto/membershipRequestsDto.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+/**
+ * Java MembershipRequestDto (only the fields BI needs). The list endpoint
+ * returns pending requests only, so a `status` field on the wire is ignored —
+ * we don't surface it through the IDP protocol type.
+ */
+export const OwoxMembershipRequestSchema = z.object({
+  requestId: z.string(),
+  email: z.string(),
+  requestedRole: z.string(),
+  createdAt: z.string(),
+  userId: z.string().optional(),
+  fullName: z.string().optional(),
+  avatar: z.string().optional(),
+});
+
+export const OwoxMembershipRequestsResponseSchema = z.array(OwoxMembershipRequestSchema);
+
+export type OwoxMembershipRequestsResponse = z.infer<typeof OwoxMembershipRequestsResponseSchema>;
+
+export const OwoxApproveMembershipRequestResponseSchema = z.object({
+  userUid: z.string(),
+});
+
+export type OwoxApproveMembershipRequestResponse = z.infer<
+  typeof OwoxApproveMembershipRequestResponseSchema
+>;

--- a/packages/idp-owox-better-auth/src/client/dto/membershipRequestsDto.ts
+++ b/packages/idp-owox-better-auth/src/client/dto/membershipRequestsDto.ts
@@ -1,16 +1,21 @@
+import { RoleEnum } from '@owox/idp-protocol';
 import { z } from 'zod';
 
 /**
  * Java MembershipRequestDto (only the fields BI needs). The list endpoint
  * returns pending requests only, so a `status` field on the wire is ignored —
  * we don't surface it through the IDP protocol type.
+ *
+ * `requestedRole` is pinned to `RoleEnum` so role drift on the Java side
+ * fails fast at the BI boundary (clean 502 from upstream parse) instead of
+ * leaking a malformed string through casts at every downstream hop.
  */
 export const OwoxMembershipRequestSchema = z.object({
-  requestId: z.string(),
-  email: z.string(),
-  requestedRole: z.string(),
-  createdAt: z.string(),
-  userId: z.string().optional(),
+  requestId: z.string().min(1),
+  email: z.string().min(1),
+  requestedRole: RoleEnum,
+  createdAt: z.string().min(1),
+  userId: z.string().min(1).optional(),
   fullName: z.string().optional(),
   avatar: z.string().optional(),
 });
@@ -20,7 +25,7 @@ export const OwoxMembershipRequestsResponseSchema = z.array(OwoxMembershipReques
 export type OwoxMembershipRequestsResponse = z.infer<typeof OwoxMembershipRequestsResponseSchema>;
 
 export const OwoxApproveMembershipRequestResponseSchema = z.object({
-  userUid: z.string(),
+  userUid: z.string().min(1),
 });
 
 export type OwoxApproveMembershipRequestResponse = z.infer<

--- a/packages/idp-owox-better-auth/src/client/dto/membershipRequestsDto.ts
+++ b/packages/idp-owox-better-auth/src/client/dto/membershipRequestsDto.ts
@@ -20,9 +20,11 @@ export const OwoxMembershipRequestSchema = z.object({
   avatar: z.string().optional(),
 });
 
-export const OwoxMembershipRequestsResponseSchema = z.array(OwoxMembershipRequestSchema);
+export const OwoxListMembershipRequestsResponseSchema = z.array(OwoxMembershipRequestSchema);
 
-export type OwoxMembershipRequestsResponse = z.infer<typeof OwoxMembershipRequestsResponseSchema>;
+export type OwoxListMembershipRequestsResponse = z.infer<
+  typeof OwoxListMembershipRequestsResponseSchema
+>;
 
 export const OwoxApproveMembershipRequestResponseSchema = z.object({
   userUid: z.string().min(1),

--- a/packages/idp-owox-better-auth/src/owox-better-auth-idp.ts
+++ b/packages/idp-owox-better-auth/src/owox-better-auth-idp.ts
@@ -1,10 +1,12 @@
 import {
+  ApproveMembershipRequestResult,
   AuthResult,
   GetProjectMembersOptions,
   IdpProvider,
   Payload,
   ProjectMember,
   ProjectMemberInvitation,
+  ProjectMembershipRequest,
   Projects,
   ProtocolRoute,
   Role,
@@ -30,6 +32,7 @@ import { BetterAuthSessionService } from './services/auth/better-auth-session-se
 import { MagicLinkService } from './services/auth/magic-link-service.js';
 import { PkceFlowOrchestrator } from './services/auth/pkce-flow-orchestrator.js';
 import { PlatformAuthFlowClient } from './services/auth/platform-auth-flow-client.js';
+import { MembershipRequestsService } from './services/core/membership-requests-service.js';
 import { ProjectMembersService } from './services/core/project-members-service.js';
 import type { ProjectMembersServiceOptions } from './types/project-members.js';
 import { UserAccountResolver } from './services/core/user-account-resolver.js';
@@ -75,6 +78,7 @@ export class OwoxBetterAuthIdp implements IdpProvider {
   private readonly platformAuthFlowClient: PlatformAuthFlowClient;
   private readonly pkceFlowOrchestrator: PkceFlowOrchestrator;
   private readonly projectMembersService: ProjectMembersService;
+  private readonly membershipRequestsService: MembershipRequestsService;
   private readonly onboardingService: OnboardingService;
   private readonly onboardingController: OnboardingController;
 
@@ -112,6 +116,7 @@ export class OwoxBetterAuthIdp implements IdpProvider {
       this.identityClient,
       serviceOptions
     );
+    this.membershipRequestsService = new MembershipRequestsService(this.identityClient);
 
     this.onboardingService = new OnboardingService(this.store, this.projectMembersService);
 
@@ -193,6 +198,42 @@ export class OwoxBetterAuthIdp implements IdpProvider {
     settings: UserProvisioningSettingsUpdate
   ): Promise<UserProvisioningSettings> {
     return this.identityClient.updateUserProvisioningSettings(projectId, actorUserId, settings);
+  }
+
+  async listMembershipRequests(
+    projectId: string,
+    actorUserId: string,
+    _options?: { forceFresh?: boolean }
+  ): Promise<ProjectMembershipRequest[]> {
+    return this.membershipRequestsService.listMembershipRequests(projectId, actorUserId);
+  }
+
+  async approveMembershipRequest(
+    projectId: string,
+    requestId: string,
+    role: Role,
+    actorUserId: string
+  ): Promise<ApproveMembershipRequestResult> {
+    return this.membershipRequestsService.approveMembershipRequest(
+      projectId,
+      requestId,
+      role,
+      actorUserId
+    );
+  }
+
+  async declineMembershipRequest(
+    projectId: string,
+    requestId: string,
+    actorUserId: string,
+    reason?: string
+  ): Promise<void> {
+    return this.membershipRequestsService.declineMembershipRequest(
+      projectId,
+      requestId,
+      actorUserId,
+      reason
+    );
   }
 
   static async create(config: BetterAuthProviderConfig): Promise<OwoxBetterAuthIdp> {

--- a/packages/idp-owox-better-auth/src/owox-better-auth-idp.ts
+++ b/packages/idp-owox-better-auth/src/owox-better-auth-idp.ts
@@ -225,14 +225,12 @@ export class OwoxBetterAuthIdp implements IdpProvider {
   async declineMembershipRequest(
     projectId: string,
     requestId: string,
-    actorUserId: string,
-    reason?: string
+    actorUserId: string
   ): Promise<void> {
     return this.membershipRequestsService.declineMembershipRequest(
       projectId,
       requestId,
-      actorUserId,
-      reason
+      actorUserId
     );
   }
 

--- a/packages/idp-owox-better-auth/src/services/core/membership-requests-service.test.ts
+++ b/packages/idp-owox-better-auth/src/services/core/membership-requests-service.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { IdentityOwoxClient } from '../../client/index.js';
+import { MembershipRequestsService } from './membership-requests-service.js';
+
+function createIdentityClientMock(): jest.Mocked<IdentityOwoxClient> {
+  return {
+    getToken: jest.fn(),
+    revokeToken: jest.fn(),
+    introspectToken: jest.fn(),
+    getProjects: jest.fn(),
+    getJwks: jest.fn(),
+    completeAuthFlow: jest.fn(),
+    getProjectMembers: jest.fn(),
+    inviteProjectMember: jest.fn(),
+    removeProjectMember: jest.fn(),
+    changeProjectMemberRole: jest.fn(),
+    listProjectMembershipRequests: jest.fn(),
+    approveProjectMembershipRequest: jest.fn(),
+    declineProjectMembershipRequest: jest.fn(),
+  } as unknown as jest.Mocked<IdentityOwoxClient>;
+}
+
+describe('MembershipRequestsService', () => {
+  let identityClient: jest.Mocked<IdentityOwoxClient>;
+  let service: MembershipRequestsService;
+
+  beforeEach(() => {
+    identityClient = createIdentityClientMock();
+    service = new MembershipRequestsService(identityClient);
+  });
+
+  describe('listMembershipRequests', () => {
+    it('calls client with projectId and actorUserId and maps response to ProjectMembershipRequest[]', async () => {
+      identityClient.listProjectMembershipRequests.mockResolvedValue([
+        {
+          requestId: 'req-1',
+          email: 'alice@example.com',
+          requestedRole: 'viewer',
+          createdAt: '2026-05-01T10:00:00.000Z',
+          fullName: 'Alice Example',
+          avatar: 'https://example.com/alice.png',
+          userId: 'uid-alice',
+        },
+        {
+          requestId: 'req-2',
+          email: 'bob@example.com',
+          requestedRole: 'editor',
+          createdAt: '2026-05-03T15:30:00.000Z',
+        },
+      ]);
+
+      const result = await service.listMembershipRequests('proj-1', 'admin-1');
+
+      expect(identityClient.listProjectMembershipRequests).toHaveBeenCalledWith(
+        'proj-1',
+        'admin-1'
+      );
+      expect(result).toHaveLength(2);
+
+      expect(result[0]).toEqual({
+        requestId: 'req-1',
+        email: 'alice@example.com',
+        requestedRole: 'viewer',
+        createdAt: '2026-05-01T10:00:00.000Z',
+        fullName: 'Alice Example',
+        avatar: 'https://example.com/alice.png',
+        userId: 'uid-alice',
+      });
+
+      // requestedRole is cast to Role
+      expect(result[1]!.requestedRole).toBe('editor');
+
+      // optional fields absent in raw response are undefined on the mapped object
+      expect(result[1]!.fullName).toBeUndefined();
+      expect(result[1]!.avatar).toBeUndefined();
+      expect(result[1]!.userId).toBeUndefined();
+    });
+
+    it('propagates client errors', async () => {
+      identityClient.listProjectMembershipRequests.mockRejectedValue(new Error('upstream error'));
+      await expect(service.listMembershipRequests('proj-1', 'admin-1')).rejects.toThrow(
+        'upstream error'
+      );
+    });
+  });
+
+  describe('approveMembershipRequest', () => {
+    it('calls client with correct args and returns { userId: userUid }', async () => {
+      identityClient.approveProjectMembershipRequest.mockResolvedValue({ userUid: 'resolved-uid' });
+
+      const result = await service.approveMembershipRequest('proj-1', 'req-1', 'editor', 'admin-1');
+
+      expect(identityClient.approveProjectMembershipRequest).toHaveBeenCalledWith(
+        'proj-1',
+        'req-1',
+        'editor',
+        'admin-1'
+      );
+      expect(result).toEqual({ userId: 'resolved-uid' });
+    });
+
+    it('propagates client errors', async () => {
+      identityClient.approveProjectMembershipRequest.mockRejectedValue(new Error('IDP refused'));
+      await expect(
+        service.approveMembershipRequest('proj-1', 'req-1', 'viewer', 'admin-1')
+      ).rejects.toThrow('IDP refused');
+    });
+  });
+
+  describe('declineMembershipRequest', () => {
+    it('calls client with projectId, requestId, actorUserId and optional reason', async () => {
+      identityClient.declineProjectMembershipRequest.mockResolvedValue(undefined);
+
+      await service.declineMembershipRequest('proj-1', 'req-1', 'admin-1', 'not a fit');
+
+      expect(identityClient.declineProjectMembershipRequest).toHaveBeenCalledWith(
+        'proj-1',
+        'req-1',
+        'admin-1',
+        'not a fit'
+      );
+    });
+
+    it('calls client without reason when omitted', async () => {
+      identityClient.declineProjectMembershipRequest.mockResolvedValue(undefined);
+
+      await service.declineMembershipRequest('proj-1', 'req-2', 'admin-1');
+
+      expect(identityClient.declineProjectMembershipRequest).toHaveBeenCalledWith(
+        'proj-1',
+        'req-2',
+        'admin-1',
+        undefined
+      );
+    });
+
+    it('resolves void on success', async () => {
+      identityClient.declineProjectMembershipRequest.mockResolvedValue(undefined);
+      await expect(
+        service.declineMembershipRequest('proj-1', 'req-1', 'admin-1')
+      ).resolves.toBeUndefined();
+    });
+
+    it('propagates client errors', async () => {
+      identityClient.declineProjectMembershipRequest.mockRejectedValue(new Error('network fail'));
+      await expect(service.declineMembershipRequest('proj-1', 'req-1', 'admin-1')).rejects.toThrow(
+        'network fail'
+      );
+    });
+  });
+});

--- a/packages/idp-owox-better-auth/src/services/core/membership-requests-service.test.ts
+++ b/packages/idp-owox-better-auth/src/services/core/membership-requests-service.test.ts
@@ -108,29 +108,15 @@ describe('MembershipRequestsService', () => {
   });
 
   describe('declineMembershipRequest', () => {
-    it('calls client with projectId, requestId, actorUserId and optional reason', async () => {
+    it('calls client with projectId, requestId and actorUserId', async () => {
       identityClient.declineProjectMembershipRequest.mockResolvedValue(undefined);
 
-      await service.declineMembershipRequest('proj-1', 'req-1', 'admin-1', 'not a fit');
+      await service.declineMembershipRequest('proj-1', 'req-1', 'admin-1');
 
       expect(identityClient.declineProjectMembershipRequest).toHaveBeenCalledWith(
         'proj-1',
         'req-1',
-        'admin-1',
-        'not a fit'
-      );
-    });
-
-    it('calls client without reason when omitted', async () => {
-      identityClient.declineProjectMembershipRequest.mockResolvedValue(undefined);
-
-      await service.declineMembershipRequest('proj-1', 'req-2', 'admin-1');
-
-      expect(identityClient.declineProjectMembershipRequest).toHaveBeenCalledWith(
-        'proj-1',
-        'req-2',
-        'admin-1',
-        undefined
+        'admin-1'
       );
     });
 

--- a/packages/idp-owox-better-auth/src/services/core/membership-requests-service.ts
+++ b/packages/idp-owox-better-auth/src/services/core/membership-requests-service.ts
@@ -1,0 +1,76 @@
+import type {
+  ApproveMembershipRequestResult,
+  ProjectMembershipRequest,
+  Role,
+} from '@owox/idp-protocol';
+import type { IdentityOwoxClient } from '../../client/IdentityOwoxClient.js';
+import { createServiceLogger } from '../../core/logger.js';
+
+/**
+ * MembershipRequestsService — thin wrapper over `IdentityOwoxClient` that
+ * adapts the Java `MembershipRequestDto` / approve / decline endpoints into
+ * the shared `IdpProvider` contract.
+ */
+export class MembershipRequestsService {
+  private readonly logger = createServiceLogger(MembershipRequestsService.name);
+
+  constructor(private readonly identityClient: IdentityOwoxClient) {}
+
+  async listMembershipRequests(
+    projectId: string,
+    actorUserId: string
+  ): Promise<ProjectMembershipRequest[]> {
+    this.logger.debug('listMembershipRequests', { projectId, actorUserId });
+    const data = await this.identityClient.listProjectMembershipRequests(projectId, actorUserId);
+    return data.map(item => ({
+      requestId: item.requestId,
+      email: item.email,
+      fullName: item.fullName,
+      avatar: item.avatar,
+      userId: item.userId,
+      requestedRole: item.requestedRole as Role,
+      createdAt: item.createdAt,
+    }));
+  }
+
+  async approveMembershipRequest(
+    projectId: string,
+    requestId: string,
+    role: Role,
+    actorUserId: string
+  ): Promise<ApproveMembershipRequestResult> {
+    this.logger.debug('approveMembershipRequest', {
+      projectId,
+      requestId,
+      role,
+      actorUserId,
+    });
+    const { userUid } = await this.identityClient.approveProjectMembershipRequest(
+      projectId,
+      requestId,
+      role,
+      actorUserId
+    );
+    return { userId: userUid };
+  }
+
+  async declineMembershipRequest(
+    projectId: string,
+    requestId: string,
+    actorUserId: string,
+    reason?: string
+  ): Promise<void> {
+    this.logger.debug('declineMembershipRequest', {
+      projectId,
+      requestId,
+      actorUserId,
+      reason,
+    });
+    await this.identityClient.declineProjectMembershipRequest(
+      projectId,
+      requestId,
+      actorUserId,
+      reason
+    );
+  }
+}

--- a/packages/idp-owox-better-auth/src/services/core/membership-requests-service.ts
+++ b/packages/idp-owox-better-auth/src/services/core/membership-requests-service.ts
@@ -28,7 +28,7 @@ export class MembershipRequestsService {
       fullName: item.fullName,
       avatar: item.avatar,
       userId: item.userId,
-      requestedRole: item.requestedRole as Role,
+      requestedRole: item.requestedRole,
       createdAt: item.createdAt,
     }));
   }
@@ -57,20 +57,13 @@ export class MembershipRequestsService {
   async declineMembershipRequest(
     projectId: string,
     requestId: string,
-    actorUserId: string,
-    reason?: string
+    actorUserId: string
   ): Promise<void> {
     this.logger.debug('declineMembershipRequest', {
       projectId,
       requestId,
       actorUserId,
-      reason,
     });
-    await this.identityClient.declineProjectMembershipRequest(
-      projectId,
-      requestId,
-      actorUserId,
-      reason
-    );
+    await this.identityClient.declineProjectMembershipRequest(projectId, requestId, actorUserId);
   }
 }

--- a/packages/idp-protocol/src/providers/null-provider.ts
+++ b/packages/idp-protocol/src/providers/null-provider.ts
@@ -5,6 +5,8 @@ import {
   Projects,
   ProjectMember,
   ProjectMemberInvitation,
+  ProjectMembershipRequest,
+  ApproveMembershipRequestResult,
   Role,
   UserProvisioningSettings,
   UserProvisioningSettingsUpdate,
@@ -158,6 +160,32 @@ export class NullIdpProvider implements IdpProvider {
     _settings: UserProvisioningSettingsUpdate
   ): Promise<UserProvisioningSettings> {
     throw new IdpOperationNotSupportedError('updateUserProvisioningSettings');
+  }
+
+  async listMembershipRequests(
+    _projectId: string,
+    _actorUserId: string,
+    _options?: { forceFresh?: boolean }
+  ): Promise<ProjectMembershipRequest[]> {
+    return [];
+  }
+
+  async approveMembershipRequest(
+    _projectId: string,
+    _requestId: string,
+    _role: Role,
+    _actorUserId: string
+  ): Promise<ApproveMembershipRequestResult> {
+    throw new IdpOperationNotSupportedError('approveMembershipRequest');
+  }
+
+  async declineMembershipRequest(
+    _projectId: string,
+    _requestId: string,
+    _actorUserId: string,
+    _reason?: string
+  ): Promise<void> {
+    throw new IdpOperationNotSupportedError('declineMembershipRequest');
   }
 
   /**

--- a/packages/idp-protocol/src/providers/null-provider.ts
+++ b/packages/idp-protocol/src/providers/null-provider.ts
@@ -182,8 +182,7 @@ export class NullIdpProvider implements IdpProvider {
   async declineMembershipRequest(
     _projectId: string,
     _requestId: string,
-    _actorUserId: string,
-    _reason?: string
+    _actorUserId: string
   ): Promise<void> {
     throw new IdpOperationNotSupportedError('declineMembershipRequest');
   }

--- a/packages/idp-protocol/src/types/models.ts
+++ b/packages/idp-protocol/src/types/models.ts
@@ -118,3 +118,32 @@ export type UserProvisioningSettingsUpdate = {
   mode: UserProvisioningMode;
   defaultRole: Role;
 };
+
+/**
+ * A pending request by some user to join a project. Surfaced by the IDP
+ * provider to the BI backend so an admin can approve or decline it.
+ *
+ * `requestId` is a stable identifier from the IDP (NOT a short-lived JWT).
+ * `userId` is present when the requester already exists in the IDP. The
+ * legacy mock flow does not always know it.
+ */
+export type ProjectMembershipRequest = {
+  requestId: string;
+  email: string;
+  fullName?: string;
+  avatar?: string;
+  userId?: string;
+  requestedRole: Role;
+  createdAt: string; // ISO 8601
+};
+
+/**
+ * Result of approving a membership request. Java returns `{ userUid: string }`;
+ * the BI side maps it to `userId` so the caller can chain
+ * `ContextAccessService.updateMember`. Email and role are not echoed — both
+ * are already known to the caller (email from the original request, role from
+ * the approve command).
+ */
+export type ApproveMembershipRequestResult = {
+  userId: string;
+};

--- a/packages/idp-protocol/src/types/provider.ts
+++ b/packages/idp-protocol/src/types/provider.ts
@@ -243,7 +243,6 @@ export interface IdpProvider {
   declineMembershipRequest(
     projectId: string,
     requestId: string,
-    actorUserId: string,
-    reason?: string
+    actorUserId: string
   ): Promise<void>;
 }

--- a/packages/idp-protocol/src/types/provider.ts
+++ b/packages/idp-protocol/src/types/provider.ts
@@ -4,6 +4,8 @@ import {
   Projects,
   ProjectMember,
   ProjectMemberInvitation,
+  ProjectMembershipRequest,
+  ApproveMembershipRequestResult,
   Role,
   UserProvisioningSettings,
   UserProvisioningSettingsUpdate,
@@ -201,4 +203,47 @@ export interface IdpProvider {
     actorUserId: string,
     settings: UserProvisioningSettingsUpdate
   ): Promise<UserProvisioningSettings>;
+
+  /**
+   * List pending membership requests for a project.
+   *
+   * `actorUserId` is the BI uid of the admin performing the listing — the
+   * remote IDP needs it for audit / authorization (Java sends it as the
+   * `biUserId` query parameter on
+   * `GET /internal-api/idp/bi-project/{biProjectId}/membership-requests`).
+   *
+   * Local-only providers (null, better-auth) ignore `actorUserId` and return
+   * `[]` rather than throw — an empty list is a valid steady state.
+   */
+  listMembershipRequests(
+    projectId: string,
+    actorUserId: string,
+    options?: { forceFresh?: boolean }
+  ): Promise<ProjectMembershipRequest[]>;
+
+  /**
+   * Approve a pending membership request and add the requester to the project
+   * with the given role. Must return the resolved `userId` so the caller can
+   * apply scope/contexts locally. Implementations that do not support this
+   * should throw `IdpOperationNotSupportedError`.
+   */
+  approveMembershipRequest(
+    projectId: string,
+    requestId: string,
+    role: Role,
+    actorUserId: string
+  ): Promise<ApproveMembershipRequestResult>;
+
+  /**
+   * Decline a pending membership request. Idempotent where possible; if the
+   * request is already gone, implementations should still complete
+   * successfully. Implementations that do not support this should throw
+   * `IdpOperationNotSupportedError`.
+   */
+  declineMembershipRequest(
+    projectId: string,
+    requestId: string,
+    actorUserId: string,
+    reason?: string
+  ): Promise<void>;
 }


### PR DESCRIPTION
Migrate the legacy platform's "approve/decline pending membership requests" flow to the new Members tab in OWOX Data Marts, end-to-end across IDP protocol, IDP providers, NestJS backend, web UI, E2E, and changeset.

## IDP protocol (packages/idp-protocol)
- Add `ProjectMembershipRequest` model + `ApproveMembershipRequestResult` (`{ userId }`, mapped from Java's `userUid`).
- Extend `IdpProvider` with three methods: `listMembershipRequests`, `approveMembershipRequest`, `declineMembershipRequest`.
- `NullIdpProvider`: list returns `[]`; mutations throw `IdpOperationNotSupportedError`.

## IDP providers
- `idp-better-auth`: stub implementations + jest.setup mock augmentation.
- `idp-owox-better-auth`:
  - `MembershipRequestsService` wraps `IdentityOwoxClient`'s three new endpoints, parses responses with Zod (`OwoxMembershipRequestSchema`, `OwoxApproveMembershipRequestResponseSchema`).
  - `IdentityOwoxClient` adds the three C2C HTTP calls using `ImpersonatedIdTokenFetcher` against `integrated-backend.bi.owox.com`.
  - `idp-projections.facade` exposes the new methods through the existing projection layer.

## Backend (apps/backend)
- New use-cases: `list-membership-requests`, `approve-membership-request`, `decline-membership-request`.
- `project-members.controller` gains admin-only routes under `/members/requests*` guarded by `@Auth(Role.admin(Strategy.INTROSPECT))`.
- DTOs: `ApproveMembershipRequestCommand`, `DeclineMembershipRequestCommand`.
- Approve service mirrors `InviteProjectMemberService`'s response shape: `{ userId, role, roleScope, contextIds }`, then chains `ContextAccessService.updateMember` for context-scoped roles.

## Web (apps/web)
- New `PendingRequestsSection` on the Members tab, admin-gated, hidden when empty: renders a `CollapsibleCard` (icon `UserRoundPlus`, header "Project membership requests") containing one `MembershipRequestRow` per request. No scroll, no pagination, no "show more" — full list always rendered.
- Each row: avatar (shared `UserAvatar` primitive), display name, muted subtitle (`email - Requested role: <role> - <date>`), right chevron, keyboard-accessible button semantics, stable testid for E2E.
- New `MembershipRequestSheet`: unified layout with "Membership request" title, identity block using shared `UserAvatar`, separate `Requested date` FormItem, role/scope/contexts form via shared `MemberFormFields`. Approve/Decline actions at the bottom with optimistic row removal and a confirmation dialog on Decline.
- Extract `MemberFormFields` primitive (Role + Scope + Contexts) from `InviteMemberSheet`; reused by both invite and request flows.
- Wire `ProjectSettingsPage` to fetch + cache pending requests alongside members; surface `loadingRequests`, `pendingRequests`, `optimisticRemoveRequest`, `openMembershipRequestSheet` through `members-settings.context`.

## E2E (apps/web/e2e)
- Playwright spec `membership-requests.spec.ts` covers admin happy paths (MR-01 list, MR-02 approve, MR-03 decline). Routes mocked via `page.route()`. Selectors are stable testids (`pendingRequestsSection`, `membershipRequestSheet`).