### PR TITLE
feat(web): add Live Run Indicator and manual run improvements for Data Mart

### DIFF
--- a/.changeset/live-run-indicator.md
+++ b/.changeset/live-run-indicator.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Data Mart Run Indicator and other improvements
+
+**Live Run Indicator** — When your Data Mart is actively processing data, a clear "Updating data" badge with an animated spinner now appears in the header. You'll always know when work is happening.
+
+**One-Click Run History** — The new indicator includes a "View runs" button that jumps straight to your run history — no navigation hunting required.
+
+**Conflict-Free Manual Runs** — Trying to start a manual run while another is in progress? The button is now smartly disabled with an explanation tooltip: "Please wait for the current run to complete." No more accidental overlapping runs.

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
@@ -224,8 +224,13 @@ export function ConnectorDefinitionField({
     }
   };
 
+  const normalizedDataMartStatus =
+    typeof datamartStatus === 'object' ? datamartStatus.code : datamartStatus;
+
+  const isManualRunDisabled = hasActiveRuns || normalizedDataMartStatus === DataMartStatus.DRAFT;
+
   const manualRunButton = (
-    <Button variant='outline' disabled={hasActiveRuns}>
+    <Button variant='outline' disabled={isManualRunDisabled}>
       <Play className='h-4 w-4' />
       <span>Manual Run...</span>
     </Button>
@@ -278,13 +283,16 @@ export function ConnectorDefinitionField({
                       <div className='flex items-center gap-2'>
                         {dataMart?.definitionType === DataMartDefinitionType.CONNECTOR && (
                           <>
-                            {hasActiveRuns ? (
+                            {isManualRunDisabled ? (
                               <Tooltip>
                                 <TooltipTrigger asChild>
                                   <div>{manualRunButton}</div>
                                 </TooltipTrigger>
+
                                 <TooltipContent>
-                                  Please wait for the current run to complete.
+                                  {hasActiveRuns
+                                    ? 'Please wait for the current run to complete.'
+                                    : 'Manual run is available only for published Data Marts.'}
                                 </TooltipContent>
                               </Tooltip>
                             ) : (
@@ -320,11 +328,7 @@ export function ConnectorDefinitionField({
                                     onUpdateConfiguration={configIndex =>
                                       updateConnectorConfiguration(configIndex)
                                     }
-                                    dataMartStatus={
-                                      typeof datamartStatus === 'object'
-                                        ? datamartStatus.code
-                                        : datamartStatus
-                                    }
+                                    dataMartStatus={normalizedDataMartStatus}
                                     totalConfigurations={
                                       connectorDef.connector.source.configuration.length
                                     }

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
@@ -28,6 +28,7 @@ import { ConnectorContextProvider } from '../../../../../connectors/shared/model
 import { ConnectorRunView } from '../../../../../connectors/edit/components/ConnectorRunSheet/ConnectorRunView';
 import type { ConnectorRunFormData } from '../../../../../connectors/shared/model/types/connector';
 import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog/ConfirmationDialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 
 interface ConnectorDefinitionFieldProps {
   control: Control<DataMartDefinitionFormData>;
@@ -44,7 +45,7 @@ export function ConnectorDefinitionField({
   autoOpen = false,
   saveDataMartDefinition,
 }: ConnectorDefinitionFieldProps) {
-  const { dataMart, runDataMart } = useOutletContext<DataMartContextType>();
+  const { dataMart, runDataMart, hasActiveRuns } = useOutletContext<DataMartContextType>();
   const { setValue, getValues, trigger } = useFormContext<DataMartDefinitionFormData>();
   const [isEditSheetOpen, setIsEditSheetOpen] = useState(false);
   const [isSetupSheetOpen, setIsSetupSheetOpen] = useState(false);
@@ -223,6 +224,13 @@ export function ConnectorDefinitionField({
     }
   };
 
+  const manualRunButton = (
+    <Button variant='outline' disabled={hasActiveRuns}>
+      <Play className='h-4 w-4' />
+      <span>Manual Run...</span>
+    </Button>
+  );
+
   return (
     <>
       <FormField
@@ -269,15 +277,25 @@ export function ConnectorDefinitionField({
                       </div>
                       <div className='flex items-center gap-2'>
                         {dataMart?.definitionType === DataMartDefinitionType.CONNECTOR && (
-                          <ConnectorRunView
-                            configuration={dataMart.definition as ConnectorDefinitionConfig}
-                            onManualRun={onManualRunHandler}
-                          >
-                            <Button variant='outline'>
-                              <Play className='h-4 w-4' />
-                              <span>Manual Run...</span>
-                            </Button>
-                          </ConnectorRunView>
+                          <>
+                            {hasActiveRuns ? (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <div>{manualRunButton}</div>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  Please wait for the current run to complete.
+                                </TooltipContent>
+                              </Tooltip>
+                            ) : (
+                              <ConnectorRunView
+                                configuration={dataMart.definition as ConnectorDefinitionConfig}
+                                onManualRun={onManualRunHandler}
+                              >
+                                {manualRunButton}
+                              </ConnectorRunView>
+                            )}
+                          </>
                         )}
                       </div>
                     </div>

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -8,7 +8,7 @@ import {
 import { Skeleton } from '@owox/ui/components/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { cn } from '@owox/ui/lib/utils';
-import { ArrowLeft, CircleCheckBig, MoreVertical, Play, Trash2 } from 'lucide-react';
+import { ArrowLeft, CircleCheckBig, Loader2, MoreVertical, Play, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { NavLink, Outlet } from 'react-router-dom';
@@ -77,6 +77,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
+  const [isConnectorRunSheetOpen, setIsConnectorRunSheetOpen] = useState(false);
   const lastRunIdRef = useRef<string | null>(null);
 
   const {
@@ -293,6 +294,21 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
       : 'Publish to enable reports and scheduled runs',
   };
 
+  // Config for connector run sheet
+  const connectorRunSheet = (
+    <ConnectorRunView
+      open={isConnectorRunSheetOpen}
+      onOpenChange={setIsConnectorRunSheetOpen}
+      configuration={dataMartDefinition ?? null}
+      onManualRun={data => {
+        void handleManualRun({
+          runType: data.runType,
+          data: data.data,
+        });
+      }}
+    />
+  );
+
   return (
     <div
       className='min-w-[600px] px-4 py-6 md:min-w-0 md:px-8 md:py-4 lg:px-12 xl:px-16'
@@ -346,23 +362,48 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
           )}
         >
           <div className='flex min-w-0 shrink-0 items-center gap-4'>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className={cn('shrink-0', !canPublish ? 'md:pt-1' : '')}>
-                  <StatusLabel
-                    type={isPublished ? StatusTypeEnum.SUCCESS : StatusTypeEnum.NEUTRAL}
-                    variant='subtle'
-                  >
-                    {dataMartStatus.displayName}
-                  </StatusLabel>
+            <div className={cn('flex shrink-0 items-center gap-4', !canPublish ? 'md:pt-1' : '')}>
+              <div
+                className={cn(
+                  'border-border flex items-center gap-2 overflow-hidden border-r motion-safe:transition-all motion-safe:duration-300 motion-safe:ease-out',
+                  hasActiveRuns
+                    ? 'max-w-[320px] pr-4 opacity-100'
+                    : 'max-w-0 border-r-0 pr-0 opacity-0'
+                )}
+              >
+                <div className='text-muted-foreground flex items-center gap-1 text-sm whitespace-nowrap'>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  <span>Updating data</span>
                 </div>
-              </TooltipTrigger>
-              <TooltipContent side='bottom'>
-                {isPublished
-                  ? 'Your published Data Mart is ready for scheduled runs'
-                  : 'Draft Data Mart is not available for scheduled runs. Publish it to activate scheduling.'}
-              </TooltipContent>
-            </Tooltip>
+
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={() => {
+                    navigate(`/data-marts/${dataMartId}/run-history`);
+                  }}
+                >
+                  View runs
+                </Button>
+              </div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    <StatusLabel
+                      type={isPublished ? StatusTypeEnum.SUCCESS : StatusTypeEnum.NEUTRAL}
+                      variant='subtle'
+                    >
+                      {dataMartStatus.displayName}
+                    </StatusLabel>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side='bottom'>
+                  {isPublished
+                    ? 'Your published Data Mart is ready for scheduled runs'
+                    : 'Draft Data Mart is not available for scheduled runs. Publish it to activate scheduling.'}
+                </TooltipContent>
+              </Tooltip>
+            </div>
             {isDraft && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -418,24 +459,28 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
             <DropdownMenuContent align='end'>
               {isConnector && (
                 <>
-                  <ConnectorRunView
-                    configuration={dataMartDefinition ?? null}
-                    onManualRun={data => {
-                      void handleManualRun({
-                        runType: data.runType,
-                        data: data.data,
-                      });
-                    }}
-                  >
+                  {hasActiveRuns ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div>
+                          <DropdownMenuItem disabled>
+                            <Play className='text-foreground h-4 w-4' />
+                            <span>Manual Run...</span>
+                          </DropdownMenuItem>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent side='left'>Already running. Please wait...</TooltipContent>
+                    </Tooltip>
+                  ) : (
                     <DropdownMenuItem
-                      onClick={e => {
-                        e.preventDefault();
+                      onClick={() => {
+                        setIsConnectorRunSheetOpen(true);
                       }}
                     >
                       <Play className='text-foreground h-4 w-4' />
                       <span>Manual Run...</span>
                     </DropdownMenuItem>
-                  </ConnectorRunView>
+                  )}
                   <DropdownMenuSeparator />
                 </>
               )}
@@ -509,6 +554,8 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
           }}
         />
       </div>
+
+      {connectorRunSheet}
 
       <ConfirmationDialog
         open={isDeleteDialogOpen}

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -168,6 +168,11 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
       await publishDataMart(dataMartId);
       void runSchemaActualization();
 
+      // Load runs for connector data marts
+      if (isConnector) {
+        void getDataMartRuns(dataMartId);
+      }
+
       // Show promo toast based on a data mart type
       showPromo({
         step: isConnector ? PromoStep.SCHEDULE_DATA : PromoStep.USE_DATA,
@@ -186,6 +191,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
     isConnector,
     publishDataMart,
     runSchemaActualization,
+    getDataMartRuns,
     showPromo,
     projectId,
     shouldShowInsights,
@@ -371,8 +377,12 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
                     : 'max-w-0 border-r-0 pr-0 opacity-0'
                 )}
               >
-                <div className='text-muted-foreground flex items-center gap-1 text-sm whitespace-nowrap'>
-                  <Loader2 className='h-4 w-4 animate-spin' />
+                <div
+                  role='status'
+                  aria-live='polite'
+                  className='text-muted-foreground flex items-center gap-1 text-sm whitespace-nowrap'
+                >
+                  <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
                   <span>Updating data</span>
                 </div>
 
@@ -459,28 +469,30 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
             <DropdownMenuContent align='end'>
               {isConnector && (
                 <>
-                  {hasActiveRuns ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <div>
-                          <DropdownMenuItem disabled>
-                            <Play className='text-foreground h-4 w-4' />
-                            <span>Manual Run...</span>
-                          </DropdownMenuItem>
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent side='left'>Already running. Please wait...</TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    <DropdownMenuItem
-                      onClick={() => {
-                        setIsConnectorRunSheetOpen(true);
-                      }}
-                    >
-                      <Play className='text-foreground h-4 w-4' />
-                      <span>Manual Run...</span>
-                    </DropdownMenuItem>
-                  )}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div>
+                        <DropdownMenuItem
+                          disabled={hasActiveRuns || isDraft}
+                          onClick={() => {
+                            if (hasActiveRuns || isDraft) return;
+
+                            setIsConnectorRunSheetOpen(true);
+                          }}
+                        >
+                          <Play className='text-foreground h-4 w-4' />
+                          <span>Manual Run...</span>
+                        </DropdownMenuItem>
+                      </div>
+                    </TooltipTrigger>
+                    {(hasActiveRuns || isDraft) && (
+                      <TooltipContent side='left'>
+                        {hasActiveRuns
+                          ? 'Please wait for the current run to complete.'
+                          : 'Manual run is available only for published Data Marts.'}
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
                   <DropdownMenuSeparator />
                 </>
               )}
@@ -555,7 +567,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
         />
       </div>
 
-      {connectorRunSheet}
+      {isConnector && connectorRunSheet}
 
       <ConfirmationDialog
         open={isDeleteDialogOpen}

--- a/apps/web/src/features/data-marts/shared/hooks/useSchemaActualizeTrigger.ts
+++ b/apps/web/src/features/data-marts/shared/hooks/useSchemaActualizeTrigger.ts
@@ -127,7 +127,7 @@ export function useSchemaActualizeTrigger(
     try {
       const { triggerId } = await dataMartService.createSchemaActualizeTrigger(dataMartId);
 
-      toast.loading('Synchronizing schema with the data storage state. This may take a while.', {
+      toast.loading('Synchronizing output schema with the storage state. Please wait...', {
         duration: Infinity,
         id: triggerId,
       });


### PR DESCRIPTION

<img width="1720" height="1220" alt="Frame 23137589" src="https://github.com/user-attachments/assets/279da032-e772-466b-b134-9e43c0c6b3c5" />


## Summary
Improves the Data Mart running experience by adding clear visual feedback when runs are in progress and preventing conflicting manual runs.

## Changes
- **Active Run Indicator** — When a Data Mart is actively running, you'll now see a live "Updating data" indicator with an animated spinner in the header. No more guessing whether your data is being processed.

- **Quick Access to Run History** — The new indicator includes a "View runs" button that takes you directly to the run history page to monitor progress.

- **Smarter Manual Run Button** — The "Manual Run" button is now disabled when a run is already in progress, with a helpful tooltip explaining why: "Please wait for the current run to complete."

- **Consistent UX Across Views** — Both the main header dropdown and the Data Setup tab now use the same logic for disabling manual runs during active operations.