### PR TITLE
fix(backend): verify credential project ownership on destination create

### DIFF
--- a/.changeset/improved-security-for-destination-copying.md
+++ b/.changeset/improved-security-for-destination-copying.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Stricter project ownership check when linking an existing OAuth credential to a new destination
+
+Creating a Google Sheets destination with a pre-existing `credentialId` now requires that credential to belong to the same project as the destination being created. Requests that reference a credential from a different project are rejected with `403 Forbidden — Credential does not belong to this project`.

--- a/.changeset/improved-security-for-destination-copying.md
+++ b/.changeset/improved-security-for-destination-copying.md
@@ -2,6 +2,11 @@
 'owox': minor
 ---
 
-# Stricter project ownership check when linking an existing OAuth credential to a new destination
+# Stricter project ownership and copy-permission checks when linking an existing OAuth credential to a new destination
 
-Creating a Google Sheets destination with a pre-existing `credentialId` now requires that credential to belong to the same project as the destination being created. Requests that reference a credential from a different project are rejected with `403 Forbidden — Credential does not belong to this project`.
+Creating a Google Sheets destination with a pre-existing `credentialId` is now protected by the same two checks that already guarded credential copying from a source destination.
+
+- **Project ownership.** The credential must belong to the same project as the destination being created. Requests that reference a credential from a different project are rejected with `403 Forbidden — Credential does not belong to this project`. This brings the create endpoint in line with the destination update endpoint, which has always performed this check.
+- **Copy permission.** If the supplied credential is already linked to another destination in your project, creating a new destination with that same credential now requires explicit copy-credentials access on the existing destination — the same permission the **Copy from destination** flow has always required. If you do not have access, the request is rejected with `403 Forbidden — You do not have permission to copy credentials from this destination`.
+
+Legitimate flows are unaffected. When you finish the Google OAuth flow and the UI immediately creates a destination with the returned `credentialId`, the credential is fresh (not yet linked to any destination) and lives in your project, so both checks pass transparently. No database migration or configuration change is required, and existing destinations and credentials are not modified.

--- a/apps/backend/src/data-marts/use-cases/create-data-destination.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-destination.service.spec.ts
@@ -74,8 +74,13 @@ describe('CreateDataDestinationService', () => {
     };
     const dataDestinationCredentialService = {
       create: jest.fn().mockResolvedValue({ id: 'cred-1' }),
+      getById: jest.fn(),
     };
-    const googleOAuthClientService = {};
+    const googleOAuthClientService = {
+      getDestinationOAuth2ClientByCredentialId: jest.fn().mockResolvedValue({
+        getAccessToken: jest.fn().mockResolvedValue(undefined),
+      }),
+    };
     const dataDestinationService = {};
     const copyCredentialService = {};
     const userProjectionsFetcherService = {
@@ -108,7 +113,7 @@ describe('CreateDataDestinationService', () => {
       eventDispatcher as never
     );
 
-    return { service };
+    return { service, dataDestinationCredentialService, googleOAuthClientService };
   };
 
   beforeEach(() => {
@@ -183,5 +188,71 @@ describe('CreateDataDestinationService', () => {
       expect.anything(),
       expect.any(Function)
     );
+  });
+
+  describe('credentialId ownership check', () => {
+    it('throws ForbiddenException when credentialId belongs to a different project', async () => {
+      const { service, dataDestinationCredentialService } = createService();
+      dataDestinationCredentialService.getById.mockResolvedValue({
+        id: 'cred-1',
+        projectId: 'other-project',
+      });
+
+      const command = new CreateDataDestinationCommand(
+        'proj-1',
+        'Test',
+        DataDestinationType.GOOGLE_SHEETS,
+        'user-0',
+        undefined,
+        'cred-1'
+      );
+
+      await expect(service.run(command)).rejects.toThrow(
+        'Credential does not belong to this project'
+      );
+    });
+
+    it('throws ForbiddenException when credentialId does not exist', async () => {
+      const { service, dataDestinationCredentialService } = createService();
+      dataDestinationCredentialService.getById.mockResolvedValue(null);
+
+      const command = new CreateDataDestinationCommand(
+        'proj-1',
+        'Test',
+        DataDestinationType.GOOGLE_SHEETS,
+        'user-0',
+        undefined,
+        'cred-missing'
+      );
+
+      await expect(service.run(command)).rejects.toThrow(
+        'Credential does not belong to this project'
+      );
+    });
+
+    it('creates destination when credentialId belongs to the same project', async () => {
+      const { service, dataDestinationCredentialService, googleOAuthClientService } =
+        createService();
+      dataDestinationCredentialService.getById.mockResolvedValue({
+        id: 'cred-1',
+        projectId: 'proj-1',
+      });
+
+      const command = new CreateDataDestinationCommand(
+        'proj-1',
+        'Test',
+        DataDestinationType.GOOGLE_SHEETS,
+        'user-0',
+        undefined,
+        'cred-1'
+      );
+
+      const result = await service.run(command);
+
+      expect(
+        googleOAuthClientService.getDestinationOAuth2ClientByCredentialId
+      ).toHaveBeenCalledWith('cred-1');
+      expect(result).toEqual({ id: 'dest-1' });
+    });
   });
 });

--- a/apps/backend/src/data-marts/use-cases/create-data-destination.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-destination.service.spec.ts
@@ -59,6 +59,7 @@ describe('CreateDataDestinationService', () => {
     const repository = {
       create: jest.fn().mockReturnValue(savedEntity),
       save: jest.fn().mockResolvedValue(savedEntity),
+      findOne: jest.fn().mockResolvedValue(null),
     };
     const mapper = {
       toDomainDto: jest.fn().mockReturnValue({ id: 'dest-1' }),
@@ -113,7 +114,13 @@ describe('CreateDataDestinationService', () => {
       eventDispatcher as never
     );
 
-    return { service, dataDestinationCredentialService, googleOAuthClientService };
+    return {
+      service,
+      dataDestinationCredentialService,
+      googleOAuthClientService,
+      repository,
+      accessDecisionService,
+    };
   };
 
   beforeEach(() => {
@@ -230,13 +237,77 @@ describe('CreateDataDestinationService', () => {
       );
     });
 
-    it('creates destination when credentialId belongs to the same project', async () => {
+    it('creates destination when credentialId belongs to the same project and is not yet linked', async () => {
       const { service, dataDestinationCredentialService, googleOAuthClientService } =
         createService();
       dataDestinationCredentialService.getById.mockResolvedValue({
         id: 'cred-1',
         projectId: 'proj-1',
       });
+
+      const command = new CreateDataDestinationCommand(
+        'proj-1',
+        'Test',
+        DataDestinationType.GOOGLE_SHEETS,
+        'user-0',
+        undefined,
+        'cred-1'
+      );
+
+      const result = await service.run(command);
+
+      expect(
+        googleOAuthClientService.getDestinationOAuth2ClientByCredentialId
+      ).toHaveBeenCalledWith('cred-1');
+      expect(result).toEqual({ id: 'dest-1' });
+    });
+
+    it('rejects credential already linked to another destination when caller lacks COPY_CREDENTIALS', async () => {
+      const { service, dataDestinationCredentialService, repository, accessDecisionService } =
+        createService();
+      dataDestinationCredentialService.getById.mockResolvedValue({
+        id: 'cred-1',
+        projectId: 'proj-1',
+      });
+      repository.findOne.mockResolvedValue({ id: 'existing-dest', credentialId: 'cred-1' });
+      accessDecisionService.canAccess.mockResolvedValue(false);
+
+      const command = new CreateDataDestinationCommand(
+        'proj-1',
+        'Test',
+        DataDestinationType.GOOGLE_SHEETS,
+        'user-0',
+        undefined,
+        'cred-1'
+      );
+
+      await expect(service.run(command)).rejects.toThrow(
+        'You do not have permission to copy credentials from this destination'
+      );
+      expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+        'user-0',
+        [],
+        'DESTINATION',
+        'existing-dest',
+        'COPY_CREDENTIALS',
+        'proj-1'
+      );
+    });
+
+    it('accepts credential already linked to another destination when caller has COPY_CREDENTIALS', async () => {
+      const {
+        service,
+        dataDestinationCredentialService,
+        repository,
+        accessDecisionService,
+        googleOAuthClientService,
+      } = createService();
+      dataDestinationCredentialService.getById.mockResolvedValue({
+        id: 'cred-1',
+        projectId: 'proj-1',
+      });
+      repository.findOne.mockResolvedValue({ id: 'existing-dest', credentialId: 'cred-1' });
+      accessDecisionService.canAccess.mockResolvedValue(true);
 
       const command = new CreateDataDestinationCommand(
         'proj-1',

--- a/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
@@ -114,8 +114,12 @@ export class CreateDataDestinationService {
       return this.saveOwnersAndBuildResponse(savedEntity, command);
     }
 
-    // If a pre-created OAuth credential ID is provided, validate it by getting a fresh access token
+    // If a pre-created OAuth credential ID is provided, validate ownership and verify token
     if (command.credentialId) {
+      const credential = await this.dataDestinationCredentialService.getById(command.credentialId);
+      if (!credential || credential.projectId !== command.projectId) {
+        throw new ForbiddenException('Credential does not belong to this project');
+      }
       const oauth2Client =
         await this.googleOAuthClientService.getDestinationOAuth2ClientByCredentialId(
           command.credentialId

--- a/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
@@ -120,6 +120,28 @@ export class CreateDataDestinationService {
       if (!credential || credential.projectId !== command.projectId) {
         throw new ForbiddenException('Credential does not belong to this project');
       }
+
+      // If the credential is already linked to another destination, require COPY_CREDENTIALS
+      // on that destination — re-linking a credential is semantically a credential copy.
+      const existingDestination = await this.repository.findOne({
+        where: { credentialId: command.credentialId },
+      });
+      if (existingDestination) {
+        const canCopy = await this.accessDecisionService.canAccess(
+          command.userId,
+          command.roles,
+          EntityType.DESTINATION,
+          existingDestination.id,
+          Action.COPY_CREDENTIALS,
+          command.projectId
+        );
+        if (!canCopy) {
+          throw new ForbiddenException(
+            'You do not have permission to copy credentials from this destination'
+          );
+        }
+      }
+
       const oauth2Client =
         await this.googleOAuthClientService.getDestinationOAuth2ClientByCredentialId(
           command.credentialId


### PR DESCRIPTION
## Summary

`POST /api/data-destinations` accepted a caller-supplied `credentialId` and linked
it to a new destination after only verifying that Google returned an access token.
Two checks that the rest of the credential surface already enforced were missing
on this code path, so a caller could link a credential they should not be able to
use.

This PR closes both gaps and mirrors the existing checks from
`UpdateDataDestinationService` and the `sourceDestinationId` copy flow:

- **Project ownership.** Reject the request if the credential does not belong to
  the authenticated project (`403 Forbidden — Credential does not belong to this
  project`). Same wording and behavior as the destination update path.
- **Copy permission.** If the supplied credential is already linked to another
  destination in the project, require `Action.COPY_CREDENTIALS` on that existing
  destination via `AccessDecisionService.canAccess(...)`. Same check the
  `sourceDestinationId` branch already performs.

The COPY_CREDENTIALS gate fires only when the credential is already in use, so
the standard "complete OAuth flow → create destination with the returned
`credentialId`" UX path is unaffected (the credential is fresh, no existing
destination references it).

## What changed

- `apps/backend/src/data-marts/use-cases/create-data-destination.service.ts`:
  add ownership check + conditional `COPY_CREDENTIALS` check, before the OAuth
  token verification so cross-project credential UUIDs are not even probed
  against Google.
- `apps/backend/src/data-marts/use-cases/create-data-destination.service.spec.ts`:
  5 new Jest cases (cross-project reject, missing credential reject, same-project
  not-yet-linked accept, reused-without-permission reject, reused-with-permission
  accept).
- `.changeset/improved-security-for-destination-copying.md`: user-facing note
  describing both layers.

## Test plan

- [x] `npx jest src/data-marts/use-cases/create-data-destination.service.spec.ts`
      — 8/8 pass (3 existing + 5 new).
- [x] `npx jest src/data-marts/use-cases/update-data-destination.service.spec.ts`
      — 9/9 pass, no regression in the symmetric path.
- [x] `npx eslint` on changed files — clean.
- [ ] Manual smoke against a dev instance:
  - `POST /api/data-destinations` with a cross-project `credentialId` → expect
    `403 Forbidden — Credential does not belong to this project`.
  - Same-project `credentialId` from a fresh OAuth flow (not yet linked) →
    expect `201`.
  - Same-project `credentialId` already linked to another destination, caller
    lacks copy access → expect `403 Forbidden — You do not have permission to
    copy credentials from this destination`.
  - Same scenario, caller has copy access (e.g., destination owner or
    shared-for-maintenance) → expect `201`.