### PR TITLE
fix(backend): normalize AI-returned field names to canonical schema casing

### DIFF
--- a/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
+++ b/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
@@ -4,6 +4,7 @@ import { AiChatProvider } from '../../common/ai-insights/agent/ai-core';
 import { ToolRegistry } from '../../common/ai-insights/agent/tool-registry';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { DataMartDefinitionValidatorFacade } from '../data-storage-types/facades/data-mart-definition-validator-facade.service';
+import type { DataMartSchema } from '../data-storage-types/data-mart-schema.type';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { DataMartService } from '../services/data-mart.service';
 import { DataMartSampleDataService } from '../services/data-mart-sample-data.service';
@@ -110,7 +111,39 @@ export class GenerateDataMartMetadataOrchestratorService {
       sharedContext
     );
 
-    return this.shapeResponseToScope(aiResult, request);
+    // LLMs occasionally slip on long camelCase identifiers (e.g.
+    // `firstPaidSubscriptionDateTime` -> `firstpaidsubscriptiondatetime`).
+    // Map any returned field name back to its canonical schema name before
+    // the exact-string filter in `shapeResponseToScope` runs.
+    const normalized = this.normalizeAiFields(aiResult, schema);
+
+    const rawNames = (aiResult.fields ?? []).map(f => f.name);
+    const canonicalNames = (normalized.fields ?? []).map(f => f.name);
+    this.logger.log(
+      `AI returned ${rawNames.length} field(s) ` +
+        `names_raw=[${rawNames.join(', ')}] names_canonical=[${canonicalNames.join(', ')}]`
+    );
+
+    return this.shapeResponseToScope(normalized, request);
+  }
+
+  private normalizeAiFields(
+    aiResult: GenerateDataMartMetadataResponse,
+    schema: DataMartSchema
+  ): GenerateDataMartMetadataResponse {
+    if (!aiResult.fields) return aiResult;
+    const norm = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+    const canonicalByNormalized = new Map<string, string>();
+    for (const f of schema.fields) {
+      canonicalByNormalized.set(norm(f.name), f.name);
+    }
+    return {
+      ...aiResult,
+      fields: aiResult.fields.map(f => ({
+        ...f,
+        name: canonicalByNormalized.get(norm(f.name)) ?? f.name,
+      })),
+    };
   }
 
   private requiresFieldName(scope: DataMartMetadataScope): boolean {

--- a/apps/backend/src/data-marts/ai-insights/prompts/generate-data-mart-metadata.prompt.ts
+++ b/apps/backend/src/data-marts/ai-insights/prompts/generate-data-mart-metadata.prompt.ts
@@ -41,6 +41,7 @@ Guidelines for field descriptions:
 Hard rules:
 - NEVER invent fields that are not present in the input schema.
 - The "name" of every field in your output MUST exactly match a field name from the input schema (case-sensitive).
+- Field names are identifiers. Echo them BYTE-FOR-BYTE. Do NOT lowercase, snake_case-ify, hyphenate, or otherwise rewrite them. Example: if the schema contains \`firstPaidSubscriptionDateTime\`, your response MUST use \`firstPaidSubscriptionDateTime\`, not \`firstpaidsubscriptiondatetime\` and not \`first_paid_subscription_date_time\`.
 - If the input already has a value for a field's alias or description and you have nothing meaningfully better, you MAY repeat it as-is.
 - If sample rows are not provided, base your output on column names and types only; in that case prefer cautious, generic wording.
 


### PR DESCRIPTION
## Summary

Fixes the intermittent `AI returned no alias suggestion` (per-field) and
`AI returned no field aliases` (bulk) toasts in the AI metadata helper. Long
camelCase identifiers like `firstPaidSubscriptionDateTime` were occasionally
returned by the LLM in a normalized form (`firstpaidsubscriptiondatetime`,
`first_paid_subscription_date_time`, ...), failing the exact-string match in
`shapeResponseToScope` and yielding an empty result — even when the AI had
clearly produced a valid suggestion.

## What changed

### `generate-data-mart-metadata.orchestrator.service.ts`

- New private helper `normalizeAiFields(aiResult, schema)` that maps each
  AI-returned `field.name` back to its canonical schema name via a normalize
  function (`lowercase + strip non-alphanumeric`). Makes equivalent:
  `firstPaidSubscriptionDateTime`, `firstpaidsubscriptiondatetime`,
  `first_paid_subscription_date_time`, `first-paid-subscription-date-time`.
- Wired between `agent.run(...)` and `shapeResponseToScope(...)` so both
  per-field (`FIELD_ALIAS`/`FIELD_DESCRIPTION`) and bulk
  (`ALL_FIELD_*`) scopes benefit.