### PR TITLE
fix(backend): scope notification settings API to authenticated project

### DIFF
--- a/.changeset/scope-notification-settings-to-auth-project.md
+++ b/.changeset/scope-notification-settings-to-auth-project.md
@@ -1,0 +1,10 @@
+---
+'owox': minor
+---
+
+# Security: scope project notification settings API to the authenticated project
+
+Project notification settings endpoints are now scoped strictly to the project of the authenticated user.
+The previous routes (`projects/:projectId/notification-settings*`) trusted a caller-controlled URL segment for
+tenant access, while role checks were performed against the token's own project — this allowed an authenticated
+user from one project to read or modify another project's notification configuration.

--- a/apps/backend/src/idp/idp.module.ts
+++ b/apps/backend/src/idp/idp.module.ts
@@ -9,6 +9,7 @@ import { IdpExceptionFilter } from './filters/idp-exception.filter';
 import { ProjectionsMapper } from './mappers/projections.mapper';
 import { IdpProjectionsService } from './services/idp-projections.service';
 import { IdpProviderService } from './services/idp-provider.service';
+import { TenantGuardService } from './services/tenant-guard.service';
 import { IntercomController } from './controllers/intercom.controller';
 import { IssueIntercomJwtService } from './use-cases/issue-intercom-jwt.service';
 import { IntercomMapper } from './mappers/intercom.mapper';
@@ -22,6 +23,7 @@ import { IntercomMapper } from './mappers/intercom.mapper';
     IdpGuard,
     IssueIntercomJwtService,
     IntercomMapper,
+    TenantGuardService,
     {
       provide: APP_FILTER,
       useClass: IdpExceptionFilter,
@@ -29,6 +31,12 @@ import { IntercomMapper } from './mappers/intercom.mapper';
     ProjectionsMapper,
     IdpProjectionsFacade,
   ],
-  exports: [IdpProviderService, IdpProjectionsService, IdpGuard, IdpProjectionsFacade],
+  exports: [
+    IdpProviderService,
+    IdpProjectionsService,
+    IdpGuard,
+    IdpProjectionsFacade,
+    TenantGuardService,
+  ],
 })
 export class IdpModule {}

--- a/apps/backend/src/idp/index.ts
+++ b/apps/backend/src/idp/index.ts
@@ -1,5 +1,6 @@
 // Services
 export * from './services/idp-provider.service';
+export * from './services/tenant-guard.service';
 
 // Guards
 export * from './guards/index';

--- a/apps/backend/src/idp/services/tenant-guard.service.ts
+++ b/apps/backend/src/idp/services/tenant-guard.service.ts
@@ -1,0 +1,44 @@
+import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
+import { ClsService } from 'nestjs-cls';
+import { AUTH_CONTEXT } from '../guards/idp.guard';
+
+interface CachedAuthContext {
+  userId?: string;
+  projectId?: string;
+}
+
+/**
+ * Defense-in-depth tenant boundary check.
+ *
+ * Use-cases that act on tenant-owned data must call `assertProject(projectId)`
+ * with the project id derived from the request. The check compares it against
+ * the authenticated project id stored in CLS by `IdpGuard`, so even if a
+ * controller forgets to source the project id from the auth context (or a new
+ * entry point is added in the future), the use-case still refuses to operate
+ * on a different tenant.
+ *
+ * The check is a no-op when no CLS auth context is present — that path covers
+ * background workers (queue processors, scheduled jobs) which legitimately
+ * operate across projects without an HTTP request.
+ */
+@Injectable()
+export class TenantGuardService {
+  private readonly logger = new Logger(TenantGuardService.name);
+
+  constructor(private readonly cls: ClsService) {}
+
+  assertProject(projectId: string): void {
+    if (!this.cls.isActive()) return;
+
+    const authContext = this.cls.get<CachedAuthContext>(AUTH_CONTEXT);
+    if (!authContext || !authContext.projectId) return;
+
+    if (authContext.projectId !== projectId) {
+      this.logger.warn(
+        `Tenant boundary violation: auth projectId=${authContext.projectId} ` +
+          `requested projectId=${projectId} userId=${authContext.userId ?? 'unknown'}`
+      );
+      throw new ForbiddenException('Project mismatch');
+    }
+  }
+}

--- a/apps/backend/src/notifications/controllers/project-notification-settings.controller.ts
+++ b/apps/backend/src/notifications/controllers/project-notification-settings.controller.ts
@@ -21,7 +21,7 @@ import {
   TestWebhookSpec,
 } from './spec/notification-settings.api';
 
-@Controller('projects/:projectId/notification-settings')
+@Controller('projects/notification-settings')
 @ApiTags('ProjectNotificationSettings')
 export class ProjectNotificationSettingsController {
   constructor(
@@ -35,20 +35,20 @@ export class ProjectNotificationSettingsController {
   @Get()
   @GetNotificationSettingsSpec()
   async getSettings(
-    @AuthContext() _context: AuthorizationContext,
-    @Param('projectId') projectId: string
+    @AuthContext() context: AuthorizationContext
   ): Promise<NotificationSettingsResponseApiDto> {
-    return this.getNotificationSettingsService.run(new GetNotificationSettingsCommand(projectId));
+    return this.getNotificationSettingsService.run(
+      new GetNotificationSettingsCommand(context.projectId)
+    );
   }
 
   @Auth(Role.viewer(Strategy.PARSE))
   @Get('members')
   @GetProjectMembersSpec()
   async getProjectMembers(
-    @AuthContext() _context: AuthorizationContext,
-    @Param('projectId') projectId: string
+    @AuthContext() context: AuthorizationContext
   ): Promise<ProjectMembersResponseApiDto> {
-    const members = await this.getProjectMembersService.run(projectId);
+    const members = await this.getProjectMembersService.run(context.projectId);
     return { members };
   }
 
@@ -56,15 +56,14 @@ export class ProjectNotificationSettingsController {
   @Put(':notificationType')
   @UpdateNotificationSettingSpec()
   async updateSetting(
-    @AuthContext() _context: AuthorizationContext,
-    @Param('projectId') projectId: string,
+    @AuthContext() context: AuthorizationContext,
     @Param('notificationType', new ParseEnumPipe(NotificationType))
     notificationType: NotificationType,
     @Body() dto: UpdateNotificationSettingApiDto
   ): Promise<NotificationSettingsItemResponseApiDto> {
     return this.upsertNotificationSettingService.run(
       new UpsertNotificationSettingCommand(
-        projectId,
+        context.projectId,
         notificationType,
         dto.enabled,
         dto.receivers,
@@ -78,19 +77,18 @@ export class ProjectNotificationSettingsController {
   @Post(':notificationType/test-webhook')
   @TestWebhookSpec()
   async testWebhook(
-    @AuthContext() _context: AuthorizationContext,
-    @Param('projectId') projectId: string,
+    @AuthContext() context: AuthorizationContext,
     @Param('notificationType', new ParseEnumPipe(NotificationType))
     notificationType: NotificationType,
     @Body() body: { webhookUrl?: string }
   ): Promise<{ message: string }> {
     await this.testNotificationWebhookService.run(
       new TestNotificationWebhookCommand(
-        projectId,
+        context.projectId,
         notificationType,
         body.webhookUrl,
-        _context.userId,
-        _context.projectTitle
+        context.userId,
+        context.projectTitle
       )
     );
     return { message: 'Test webhook sent successfully' };

--- a/apps/backend/src/notifications/use-cases/get-notification-settings.service.ts
+++ b/apps/backend/src/notifications/use-cases/get-notification-settings.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
+import { TenantGuardService } from '../../idp/services/tenant-guard.service';
 import { ProjectNotificationSettingsService } from '../services/project-notification-settings.service';
 import { NotificationSettingsMapper } from '../mappers/notification-settings.mapper';
 import { GetNotificationSettingsCommand } from '../dto/domain/get-notification-settings.command';
@@ -11,10 +12,12 @@ export class GetNotificationSettingsService {
   constructor(
     private readonly settingsService: ProjectNotificationSettingsService,
     private readonly idpProjectionsFacade: IdpProjectionsFacade,
-    private readonly mapper: NotificationSettingsMapper
+    private readonly mapper: NotificationSettingsMapper,
+    private readonly tenantGuard: TenantGuardService
   ) {}
 
   async run(command: GetNotificationSettingsCommand): Promise<NotificationSettingsResponseApiDto> {
+    this.tenantGuard.assertProject(command.projectId);
     const allMembers = await this.idpProjectionsFacade.getProjectMembers(command.projectId);
     const activeMembers = allMembers.filter(m => !m.isOutbound);
 

--- a/apps/backend/src/notifications/use-cases/get-project-members.service.ts
+++ b/apps/backend/src/notifications/use-cases/get-project-members.service.ts
@@ -1,12 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
+import { TenantGuardService } from '../../idp/services/tenant-guard.service';
 import { ProjectMemberApiDto } from '../dto/presentation/project-member-api.dto';
 
 @Injectable()
 export class GetProjectMembersService {
-  constructor(private readonly idpProjectionsFacade: IdpProjectionsFacade) {}
+  constructor(
+    private readonly idpProjectionsFacade: IdpProjectionsFacade,
+    private readonly tenantGuard: TenantGuardService
+  ) {}
 
   async run(projectId: string): Promise<ProjectMemberApiDto[]> {
+    this.tenantGuard.assertProject(projectId);
     const members = await this.idpProjectionsFacade.getProjectMembers(projectId);
     return members.map(m => ({
       userId: m.userId,

--- a/apps/backend/src/notifications/use-cases/test-notification-webhook.service.ts
+++ b/apps/backend/src/notifications/use-cases/test-notification-webhook.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
+import { TenantGuardService } from '../../idp/services/tenant-guard.service';
 import { ProjectNotificationSettingsService } from '../services/project-notification-settings.service';
 import { NotificationWebhookService } from '../services/notification-webhook.service';
 import { TestNotificationWebhookCommand } from '../dto/domain/test-notification-webhook.command';
@@ -7,10 +8,12 @@ import { TestNotificationWebhookCommand } from '../dto/domain/test-notification-
 export class TestNotificationWebhookService {
   constructor(
     private readonly settingsService: ProjectNotificationSettingsService,
-    private readonly webhookService: NotificationWebhookService
+    private readonly webhookService: NotificationWebhookService,
+    private readonly tenantGuard: TenantGuardService
   ) {}
 
   async run(command: TestNotificationWebhookCommand): Promise<void> {
+    this.tenantGuard.assertProject(command.projectId);
     const resolvedUrl =
       command.webhookUrl ??
       (

--- a/apps/backend/src/notifications/use-cases/upsert-notification-setting.service.ts
+++ b/apps/backend/src/notifications/use-cases/upsert-notification-setting.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { IdpProjectionsService } from '../../idp/services/idp-projections.service';
+import { TenantGuardService } from '../../idp/services/tenant-guard.service';
 import { ProjectNotificationSettingsService } from '../services/project-notification-settings.service';
 import { NotificationSettingsMapper } from '../mappers/notification-settings.mapper';
 import { UpsertNotificationSettingCommand } from '../dto/domain/upsert-notification-setting.command';
@@ -10,12 +11,14 @@ export class UpsertNotificationSettingService {
   constructor(
     private readonly settingsService: ProjectNotificationSettingsService,
     private readonly idpProjectionsService: IdpProjectionsService,
-    private readonly mapper: NotificationSettingsMapper
+    private readonly mapper: NotificationSettingsMapper,
+    private readonly tenantGuard: TenantGuardService
   ) {}
 
   async run(
     command: UpsertNotificationSettingCommand
   ): Promise<NotificationSettingsItemResponseApiDto> {
+    this.tenantGuard.assertProject(command.projectId);
     const settings = await this.settingsService.upsert(
       command.projectId,
       command.notificationType,

--- a/apps/backend/test/notification-members.e2e-spec.ts
+++ b/apps/backend/test/notification-members.e2e-spec.ts
@@ -55,8 +55,7 @@ const mockIdpProjectionsFacade = {
 };
 
 // ---------------------------------------------------------------------------
-const PROJECT_ID = '0';
-const BASE_URL = `/api/projects/${PROJECT_ID}/notification-settings`;
+const BASE_URL = `/api/projects/notification-settings`;
 
 describe('Notification Settings — Multi-Member (e2e)', () => {
   let app: INestApplication;

--- a/apps/backend/test/notification-settings-cross-project.e2e-spec.ts
+++ b/apps/backend/test/notification-settings-cross-project.e2e-spec.ts
@@ -1,0 +1,247 @@
+import { INestApplication } from '@nestjs/common';
+import * as supertest from 'supertest';
+import { createTestApp, closeTestApp } from '@owox/test-utils';
+import { NullIdpProvider, Payload } from '@owox/idp-protocol';
+import { IdpProjectionsFacade } from '../src/idp/facades/idp-projections.facade';
+import { ProjectMemberDto } from '../src/idp/dto/domain/project-member.dto';
+
+// ---------------------------------------------------------------------------
+// Two distinct tenants, each with a valid token. We override the express-app
+// IDP provider so that `parseToken` / `introspectToken` resolve a token to a
+// project, mirroring how a real multi-tenant deployment behaves.
+// ---------------------------------------------------------------------------
+const TENANT_A: Payload = {
+  userId: 'user-a',
+  email: 'a@test.com',
+  roles: ['admin'],
+  fullName: 'User A',
+  projectId: 'project-a',
+};
+const TENANT_B: Payload = {
+  userId: 'user-b',
+  email: 'b@test.com',
+  roles: ['admin'],
+  fullName: 'User B',
+  projectId: 'project-b',
+};
+
+const TOKENS: Record<string, Payload> = {
+  'token-a': TENANT_A,
+  'token-b': TENANT_B,
+};
+
+class MultiTenantIdpProvider extends NullIdpProvider {
+  async parseToken(token: string): Promise<Payload | null> {
+    return TOKENS[token] ?? null;
+  }
+
+  async introspectToken(token: string): Promise<Payload | null> {
+    return TOKENS[token] ?? null;
+  }
+}
+
+const headerForTenant = (token: string): Record<string, string> => ({
+  'x-owox-authorization': token,
+});
+
+// IdpProjectionsFacade is bypassed for project-member lookups so that the
+// notifications use-cases see a deterministic, per-tenant member list. Without
+// this override, getProjectMembers would hit the real (Null) IDP which returns
+// the same hard-coded admin for every project — useless for an isolation test.
+const MEMBER_A = new ProjectMemberDto(
+  TENANT_A.userId,
+  TENANT_A.email!,
+  TENANT_A.fullName,
+  undefined,
+  'admin',
+  true,
+  false
+);
+const MEMBER_B = new ProjectMemberDto(
+  TENANT_B.userId,
+  TENANT_B.email!,
+  TENANT_B.fullName,
+  undefined,
+  'admin',
+  true,
+  false
+);
+
+const mockIdpProjectionsFacade = {
+  getProjectMembers: jest.fn(async (projectId: string) => {
+    if (projectId === TENANT_A.projectId) return [MEMBER_A];
+    if (projectId === TENANT_B.projectId) return [MEMBER_B];
+    return [];
+  }),
+  getUserProjectionList: jest.fn(async (userIds: string[]) => ({
+    projections: userIds.map(id => {
+      const tenant = id === TENANT_A.userId ? TENANT_A : id === TENANT_B.userId ? TENANT_B : null;
+      return tenant
+        ? {
+            userId: tenant.userId,
+            email: tenant.email,
+            fullName: tenant.fullName,
+            avatar: undefined,
+            hasNotificationsEnabled: true,
+          }
+        : { userId: id };
+    }),
+  })),
+  getProjectProjection: jest.fn().mockResolvedValue(undefined),
+  getUserProjection: jest.fn().mockResolvedValue(undefined),
+};
+
+const BASE_URL = '/api/projects/notification-settings';
+
+describe('Notification Settings — multi-tenant isolation (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+
+  beforeAll(async () => {
+    const testApp = await createTestApp([
+      { provide: IdpProjectionsFacade, useValue: mockIdpProjectionsFacade },
+    ]);
+    app = testApp.app;
+    agent = testApp.agent;
+
+    // Swap the IDP provider stored on the express app so guard-time
+    // parse/introspect maps tokens to distinct tenants.
+    const provider = new MultiTenantIdpProvider();
+    await provider.initialize();
+    (app.getHttpAdapter().getInstance() as { set(key: string, value: unknown): void }).set(
+      'idp',
+      provider
+    );
+
+    // Seed user projections so UpsertNotificationSettingService can enrich
+    // receivers via IdpProjectionsService.getUserProjectionList (which reads
+    // local DB, not the facade we mocked above).
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const backendRoot = require.resolve('@owox/backend/package.json');
+    const backendDir = require('path').dirname(backendRoot);
+    const { DataSource } = require(require.resolve('typeorm', { paths: [backendDir] }));
+    /* eslint-enable @typescript-eslint/no-require-imports */
+    const dataSource = app.get(DataSource);
+    for (const t of [TENANT_A, TENANT_B]) {
+      await dataSource.query(
+        `INSERT INTO user_projection (userId, email, fullName, avatar, createdAt, modifiedAt)
+         VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+        [t.userId, t.email, t.fullName, null]
+      );
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  // ---------------------------------------------------------------------------
+  // With :projectId removed from the URL, the request can only ever target the
+  // tenant baked into the authenticated token. Each tenant gets its own
+  // settings, and writes by one are invisible to the other.
+  // ---------------------------------------------------------------------------
+  describe('two tenants get isolated settings', () => {
+    it('each tenant initializes its own default settings', async () => {
+      const resA = await agent.get(BASE_URL).set(headerForTenant('token-a'));
+      const resB = await agent.get(BASE_URL).set(headerForTenant('token-b'));
+
+      expect(resA.status).toBe(200);
+      expect(resB.status).toBe(200);
+
+      // Each tenant only sees their own admin in the receiver list — proves
+      // settings were created under the auth-context project, not shared.
+      const failedA = resA.body.settings.find(
+        (s: Record<string, unknown>) => s.notificationType === 'FAILED_RUNS_ALL_DM'
+      );
+      const failedB = resB.body.settings.find(
+        (s: Record<string, unknown>) => s.notificationType === 'FAILED_RUNS_ALL_DM'
+      );
+      const receiversA = failedA.receivers.map((r: Record<string, unknown>) => r.userId);
+      const receiversB = failedB.receivers.map((r: Record<string, unknown>) => r.userId);
+      expect(receiversA).toEqual([TENANT_A.userId]);
+      expect(receiversB).toEqual([TENANT_B.userId]);
+    });
+
+    it('tenant A writes do not leak to tenant B', async () => {
+      const putA = await agent
+        .put(`${BASE_URL}/FAILED_RUNS_ALL_DM`)
+        .set(headerForTenant('token-a'))
+        .send({
+          enabled: false,
+          webhookUrl: 'https://hooks.example.com/tenant-a',
+          groupingDelayCron: '0 * * * *',
+        });
+      expect(putA.status).toBe(200);
+      expect(putA.body.webhookUrl).toBe('https://hooks.example.com/tenant-a');
+
+      // Tenant B re-reads and must NOT see tenant A's webhook or enabled flag.
+      const getB = await agent.get(BASE_URL).set(headerForTenant('token-b'));
+      const failedB = getB.body.settings.find(
+        (s: Record<string, unknown>) => s.notificationType === 'FAILED_RUNS_ALL_DM'
+      );
+      expect(failedB.webhookUrl).toBeNull();
+      expect(failedB.enabled).toBe(true); // tenant B still has default
+    });
+
+    it('GET /members returns the calling tenant only', async () => {
+      const resA = await agent.get(`${BASE_URL}/members`).set(headerForTenant('token-a'));
+      const resB = await agent.get(`${BASE_URL}/members`).set(headerForTenant('token-b'));
+
+      expect(resA.body.members.map((m: Record<string, unknown>) => m.userId)).toEqual([
+        TENANT_A.userId,
+      ]);
+      expect(resB.body.members.map((m: Record<string, unknown>) => m.userId)).toEqual([
+        TENANT_B.userId,
+      ]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unauthenticated / unknown-token requests must be rejected before reaching
+  // any tenant's data.
+  // ---------------------------------------------------------------------------
+  describe('unknown tokens are rejected', () => {
+    it('rejects request with an unknown token', async () => {
+      const res = await agent.get(BASE_URL).set('x-owox-authorization', 'totally-not-a-real-token');
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects request with no auth header', async () => {
+      const res = await agent.get(BASE_URL);
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Defense-in-depth: TenantGuardService verifies command.projectId against
+  // CLS. If a future controller or internal caller passes the wrong project
+  // id, the use-case must refuse — even though the controller currently
+  // sources the project from context.projectId directly.
+  // ---------------------------------------------------------------------------
+  describe('TenantGuardService blocks tampered use-case calls', () => {
+    it('forces 403 if a use-case is run with a projectId other than CLS', async () => {
+      const { ClsService } = await import('nestjs-cls');
+      const cls = app.get(ClsService);
+      const { GetNotificationSettingsService } =
+        await import('../src/notifications/use-cases/get-notification-settings.service');
+      const { GetNotificationSettingsCommand } =
+        await import('../src/notifications/dto/domain/get-notification-settings.command');
+      const { AUTH_CONTEXT } = await import('../src/idp/guards/idp.guard');
+
+      const service = app.get(GetNotificationSettingsService);
+
+      // Seed CLS as tenant A but call the use-case for tenant B — this is the
+      // exact bypass we are defending against.
+      await cls.run(async () => {
+        cls.set(AUTH_CONTEXT, {
+          userId: TENANT_A.userId,
+          projectId: TENANT_A.projectId,
+          roles: TENANT_A.roles,
+        });
+        await expect(
+          service.run(new GetNotificationSettingsCommand(TENANT_B.projectId))
+        ).rejects.toMatchObject({ status: 403 });
+      });
+    });
+  });
+});

--- a/apps/backend/test/notification-settings.e2e-spec.ts
+++ b/apps/backend/test/notification-settings.e2e-spec.ts
@@ -2,8 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import * as supertest from 'supertest';
 import { createTestApp, closeTestApp, AUTH_HEADER } from '@owox/test-utils';
 
-const PROJECT_ID = '0';
-const BASE_URL = `/api/projects/${PROJECT_ID}/notification-settings`;
+const BASE_URL = `/api/projects/notification-settings`;
 
 describe('Notification Settings (e2e)', () => {
   let app: INestApplication;

--- a/apps/web/src/features/project-settings/notifications/hooks/useNotificationSettings.ts
+++ b/apps/web/src/features/project-settings/notifications/hooks/useNotificationSettings.ts
@@ -33,7 +33,7 @@ export function useNotificationSettings(projectId: string | null): UseNotificati
     setError(null);
 
     try {
-      const response = await notificationSettingsService.getSettings(projectId);
+      const response = await notificationSettingsService.getSettings();
       setSettings(response.settings);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load notification settings');
@@ -48,11 +48,7 @@ export function useNotificationSettings(projectId: string | null): UseNotificati
         throw new Error('Project ID is required');
       }
 
-      const updatedItem = await notificationSettingsService.updateSetting(
-        projectId,
-        notificationType,
-        data
-      );
+      const updatedItem = await notificationSettingsService.updateSetting(notificationType, data);
       // Update only the changed setting in the array
       setSettings(prev =>
         prev.map(s => (s.notificationType === notificationType ? updatedItem : s))
@@ -96,7 +92,7 @@ export function useProjectMembers(projectId: string | null): UseProjectMembersRe
     setError(null);
 
     try {
-      const response = await notificationSettingsService.getProjectMembers(projectId);
+      const response = await notificationSettingsService.getProjectMembers();
       setMembers(response.members);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load project members');
@@ -133,7 +129,7 @@ export function useTestWebhook(projectId: string | null): UseTestWebhookReturn {
 
       setIsTesting(true);
       try {
-        await notificationSettingsService.testWebhook(projectId, notificationType, webhookUrl);
+        await notificationSettingsService.testWebhook(notificationType, webhookUrl);
       } finally {
         setIsTesting(false);
       }

--- a/apps/web/src/features/project-settings/notifications/services/notification-settings.service.ts
+++ b/apps/web/src/features/project-settings/notifications/services/notification-settings.service.ts
@@ -7,38 +7,30 @@ import type {
   NotificationType,
 } from '../types';
 
+// Endpoints are scoped to the authenticated project via AuthorizationContext on
+// the backend — the URL no longer carries a project id.
 export class NotificationSettingsService extends ApiService {
   constructor() {
-    super('/projects');
+    super('/projects/notification-settings');
   }
 
-  async getSettings(projectId: string): Promise<NotificationSettingsResponse> {
-    return this.get<NotificationSettingsResponse>(`/${projectId}/notification-settings`);
+  async getSettings(): Promise<NotificationSettingsResponse> {
+    return this.get<NotificationSettingsResponse>('');
   }
 
   async updateSetting(
-    projectId: string,
     notificationType: NotificationType,
     data: UpdateNotificationSettingsRequest
   ): Promise<NotificationSettingsItem> {
-    return this.put<NotificationSettingsItem>(
-      `/${projectId}/notification-settings/${notificationType}`,
-      data
-    );
+    return this.put<NotificationSettingsItem>(`/${notificationType}`, data);
   }
 
-  async getProjectMembers(projectId: string): Promise<ProjectMembersResponse> {
-    return this.get<ProjectMembersResponse>(`/${projectId}/notification-settings/members`);
+  async getProjectMembers(): Promise<ProjectMembersResponse> {
+    return this.get<ProjectMembersResponse>('/members');
   }
 
-  async testWebhook(
-    projectId: string,
-    notificationType: NotificationType,
-    webhookUrl: string
-  ): Promise<void> {
-    return this.post(`/${projectId}/notification-settings/${notificationType}/test-webhook`, {
-      webhookUrl,
-    });
+  async testWebhook(notificationType: NotificationType, webhookUrl: string): Promise<void> {
+    return this.post(`/${notificationType}/test-webhook`, { webhookUrl });
   }
 }
 


### PR DESCRIPTION
Notification settings endpoints used to trust the URL projectId for tenant access while role checks ran against the token's own project, allowing cross-project read/modify/test-webhook by any authenticated user.

- Route moved from projects/:projectId/notification-settings* to projects/notification-settings*; project derived solely from AuthorizationContext
- New TenantGuardService verifies command.projectId against the CLS-cached auth context in every notification use-case (defense-in-depth, audit log on mismatch)
- Multi-tenant e2e test covers two isolated tenants and the CLS-bypass guard