### PR TITLE
fix(backend): qualify WHERE/ORDER BY with CTE alias in blended SQL

### DIFF
--- a/.changeset/fix-blended-where-cte-qualification.md
+++ b/.changeset/fix-blended-where-cte-qualification.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Fix: ambiguous column errors in blended report filters and sorting
+
+Blended reports that filtered or sorted on a column whose name also existed in another joined data mart (for example, a shared `date` join key) failed with database errors like `Column name date is ambiguous`. The generated WHERE and ORDER BY clauses referenced bare column names while the rest of the query already qualified every column with its CTE alias.
+
+The query builder now qualifies every WHERE and ORDER BY reference with the correct CTE alias (`main.<col>` for native columns, `<subsidiary>.<alias>` for blended fields, including hidden ones referenced only by filters). Filtering or sorting on a native column that isn't selected for display also now correctly projects that column into the main CTE, so those queries no longer fail with "unknown column" errors.

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.spec.ts
@@ -1,4 +1,5 @@
 import { BigQueryClauseRenderer } from './bigquery-clause-renderer';
+import { ColumnRefResolver } from '../../utils/sql-clause-renderer';
 
 describe('BigQueryClauseRenderer', () => {
   const r = new BigQueryClauseRenderer();
@@ -154,5 +155,81 @@ describe('BigQueryClauseRenderer', () => {
   it('quotes dotted identifiers correctly', () => {
     const out = r.renderWhere([{ column: 'project.dataset.col', operator: 'eq', value: 1 }]);
     expect(out.sql).toBe('\nWHERE `project`.`dataset`.`col` = @p0');
+  });
+
+  describe('column qualification', () => {
+    const qualify: ColumnRefResolver = column => `main.\`${column}\``;
+
+    it('honours the resolver in scalar operators', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'eq', value: 1 }], qualify).sql).toBe(
+        '\nWHERE main.`a` = @p0'
+      );
+      expect(
+        r.renderWhere([{ column: 'a', operator: 'between', value: { from: 1, to: 2 } }], qualify)
+          .sql
+      ).toBe('\nWHERE main.`a` BETWEEN @p0 AND @p1');
+    });
+
+    it('honours the resolver in substring/regex operators', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'contains', value: 'x' }], qualify).sql).toBe(
+        '\nWHERE STRPOS(main.`a`, @p0) > 0'
+      );
+      expect(
+        r.renderWhere([{ column: 'a', operator: 'starts_with', value: 'x' }], qualify).sql
+      ).toBe('\nWHERE STARTS_WITH(main.`a`, @p0)');
+      expect(r.renderWhere([{ column: 'a', operator: 'regex', value: '^x' }], qualify).sql).toBe(
+        '\nWHERE REGEXP_CONTAINS(main.`a`, @p0)'
+      );
+    });
+
+    it('honours the resolver in no-value operators', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'is_null' }], qualify).sql).toBe(
+        '\nWHERE main.`a` IS NULL'
+      );
+      expect(r.renderWhere([{ column: 'a', operator: 'is_empty' }], qualify).sql).toBe(
+        "\nWHERE (main.`a` IS NULL OR main.`a` = '')"
+      );
+    });
+
+    it('honours the resolver in relative_date presets', () => {
+      expect(
+        r.renderWhere(
+          [{ column: 'd', operator: 'relative_date', value: { kind: 'today' } }],
+          qualify
+        ).sql
+      ).toBe('\nWHERE main.`d` = CURRENT_DATE()');
+    });
+
+    it('honours the resolver on both column references in last_month', () => {
+      const sql = r.renderWhere(
+        [{ column: 'd', operator: 'relative_date', value: { kind: 'last_month' } }],
+        qualify
+      ).sql;
+      expect(sql).toContain(
+        'main.`d` >= DATE_TRUNC(DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH), MONTH)'
+      );
+      expect(sql).toContain('main.`d` < DATE_TRUNC(CURRENT_DATE(), MONTH)');
+      expect(sql).not.toMatch(/\s`d`\s</);
+    });
+
+    it('honours the resolver in ORDER BY', () => {
+      expect(r.renderOrderBy([{ column: 'a', direction: 'asc' }], qualify).sql).toBe(
+        '\nORDER BY main.`a` ASC'
+      );
+    });
+
+    it('routes different columns to different CTE prefixes', () => {
+      const routed: ColumnRefResolver = column =>
+        column === 'b' ? `orders.\`${column}\`` : `main.\`${column}\``;
+      expect(
+        r.renderWhere(
+          [
+            { column: 'a', operator: 'eq', value: 1 },
+            { column: 'b', operator: 'gt', value: 2 },
+          ],
+          routed
+        ).sql
+      ).toBe('\nWHERE main.`a` = @p0 AND orders.`b` > @p1');
+    });
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.ts
@@ -9,9 +9,7 @@ export class BigQueryClauseRenderer extends SqlClauseRenderer {
     return escapeBigQueryIdentifier(name);
   }
 
-  protected renderFilterFragment(rule: FilterRule, paramName: string): RenderedClause {
-    const col = this.quoteIdentifier(rule.column);
-
+  protected renderFilterFragment(rule: FilterRule, paramName: string, col: string): RenderedClause {
     switch (rule.operator) {
       case 'eq':
         return { sql: `${col} = @${paramName}`, params: [{ name: paramName, value: rule.value }] };

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
@@ -1044,7 +1044,7 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
     builder = new TestBlendedWithRenderer();
   });
 
-  it('appends WHERE on final SELECT', () => {
+  it('qualifies WHERE on a native main column with the main alias', () => {
     const chain = makeChain({
       relationship: makeRelationship(),
       targetTableReference: 'orders_table',
@@ -1063,11 +1063,63 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
       filters: [{ column: 'customer_name', operator: 'eq', value: 'X' }],
     };
     const { sql, params } = builder.buildBlendedQuery(ctx);
-    expect(sql).toContain('WHERE `customer_name` = @p0');
+    expect(sql).toContain('WHERE main.customer_name = @p0');
     expect(params).toEqual([{ name: 'p0', value: 'X' }]);
   });
 
-  it('appends ORDER BY and LIMIT in correct order after WHERE', () => {
+  it('qualifies WHERE on a blended outputAlias with its root CTE alias', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: 'orders_table',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_name',
+          outputAlias: 'order_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+    const { sql } = builder.buildBlendedQuery({
+      ...buildContext([chain], ['customer_name', 'order_names']),
+      filters: [{ column: 'order_names', operator: 'eq', value: 'X' }],
+    });
+    expect(sql).toContain('WHERE orders.order_names = @p0');
+  });
+
+  it('qualifies WHERE on a hidden blended outputAlias and keeps it out of SELECT', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: 'orders_table',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_name',
+          outputAlias: 'order_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+        {
+          targetFieldName: 'total',
+          outputAlias: 'orders__total',
+          isHidden: true,
+          aggregateFunction: 'SUM',
+        },
+      ],
+    });
+    const { sql } = builder.buildBlendedQuery({
+      ...buildContext([chain], ['customer_name', 'order_names']),
+      filters: [{ column: 'orders__total', operator: 'gt', value: 100 }],
+    });
+    expect(sql).toContain('WHERE orders.orders__total > @p0');
+    expect(sql).toContain('SUM(total) AS orders__total');
+    const selectSection = sql.split('FROM main\n')[0];
+    expect(selectSection).not.toContain('orders.orders__total,');
+    expect(selectSection.match(/orders\.orders__total\b/g)).toBeNull();
+  });
+
+  it('appends ORDER BY and LIMIT in correct order after WHERE with qualified references', () => {
     const chain = makeChain({
       relationship: makeRelationship(),
       targetTableReference: 'orders_table',
@@ -1089,8 +1141,93 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
     });
     expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('ORDER BY'));
     expect(sql.indexOf('ORDER BY')).toBeLessThan(sql.indexOf('LIMIT'));
-    expect(sql).toContain('ORDER BY `customer_name` DESC');
+    expect(sql).toContain('ORDER BY main.customer_name DESC');
     expect(sql).toContain('LIMIT 50');
+  });
+
+  it('projects native main columns referenced only by filter/sort into the main raw CTE', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: 'orders_table',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_name',
+          outputAlias: 'order_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+    const { sql } = builder.buildBlendedQuery({
+      ...buildContext([chain], ['order_names']),
+      filters: [{ column: 'customer_name', operator: 'eq', value: 'X' }],
+      sort: [{ column: 'signup_date', direction: 'desc' }],
+    });
+    expect(sql).toMatch(
+      /main AS \(\s*SELECT\s+customer_name,\s+id,\s+signup_date\s+FROM main_table/
+    );
+    expect(sql).toContain('WHERE main.customer_name = @p0');
+    expect(sql).toContain('ORDER BY main.signup_date DESC');
+  });
+
+  it('routes a depth-2 blended outputAlias to its root CTE in WHERE', () => {
+    const ab = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-ab',
+        targetAlias: 'orders',
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'customer_id' }],
+      }),
+      targetTableReference: 'orders_table',
+      parentAlias: 'main',
+      blendedFields: [],
+    });
+    const bc = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-bc',
+        targetAlias: 'items',
+        joinConditions: [{ sourceFieldName: 'order_id', targetFieldName: 'order_id' }],
+      }),
+      targetTableReference: 'items_table',
+      parentAlias: 'orders',
+      blendedFields: [
+        {
+          targetFieldName: 'item_id',
+          outputAlias: 'orders_items__count',
+          isHidden: false,
+          aggregateFunction: 'COUNT',
+        },
+      ],
+    });
+    const { sql } = builder.buildBlendedQuery({
+      ...buildContext([ab, bc], ['customer_name', 'orders_items__count']),
+      filters: [{ column: 'orders_items__count', operator: 'gt', value: 0 }],
+    });
+    expect(sql).toContain('WHERE orders.orders_items__count > @p0');
+  });
+
+  it('emits segment-aware quoting for dotted native main columns', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: 'orders_table',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_name',
+          outputAlias: 'order_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+    const { sql } = builder.buildBlendedQuery({
+      ...buildContext([chain], ['order_names']),
+      filters: [{ column: 'user.email', operator: 'eq', value: 'a@b' }],
+      sort: [{ column: 'user.email', direction: 'asc' }],
+    });
+    expect(sql).toContain('WHERE main.user.email = @p0');
+    expect(sql).toContain('ORDER BY main.user.email ASC');
+    expect(sql).not.toContain('main.`user.email`');
   });
 
   it('returns empty params when no filters', () => {
@@ -1102,5 +1239,97 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
     });
     const { params } = builder.buildBlendedQuery(buildContext([chain], ['customer_name']));
     expect(params).toEqual([]);
+  });
+});
+
+describe('AbstractBlendedQueryBuilder — regression: ambiguous column in WHERE/ORDER BY', () => {
+  let builder: TestBlendedWithRenderer;
+
+  beforeEach(() => {
+    builder = new TestBlendedWithRenderer();
+  });
+
+  it('qualifies every WHERE / ORDER BY reference when columns are shared across CTEs', () => {
+    const visitors = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-visitors',
+        targetAlias: 'visitors_e_commerce',
+        joinConditions: [{ sourceFieldName: 'visitor_id', targetFieldName: 'visitor_id' }],
+      }),
+      targetTableReference: 'visitors_table',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'total_sessions',
+          outputAlias: 'visitors_e_commerce__total_sessions',
+          isHidden: true,
+          aggregateFunction: 'SUM',
+        },
+      ],
+    });
+    const unifiedAdSpend = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-ad-spend',
+        targetAlias: 'unified_ad_spend_e_commerce',
+        joinConditions: [
+          { sourceFieldName: 'date', targetFieldName: 'date' },
+          { sourceFieldName: 'source', targetFieldName: 'source' },
+          { sourceFieldName: 'medium', targetFieldName: 'medium' },
+        ],
+      }),
+      targetTableReference: 'unified_ad_spend_table',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'spend',
+          outputAlias: 'unified_ad_spend_e_commerce__spend',
+          isHidden: false,
+          aggregateFunction: 'SUM',
+        },
+      ],
+    });
+
+    const { sql, params } = builder.buildBlendedQuery({
+      ...buildContext(
+        [visitors, unifiedAdSpend],
+        [
+          'date',
+          'customer_id',
+          'device_category',
+          'is_conversion',
+          'source',
+          'medium',
+          'unified_ad_spend_e_commerce__spend',
+        ]
+      ),
+      filters: [
+        {
+          column: 'date',
+          operator: 'between',
+          value: { from: '2025-01-01', to: '2025-01-31' },
+        },
+        { column: 'visitors_e_commerce__total_sessions', operator: 'gt', value: 5 },
+      ],
+      sort: [{ column: 'source', direction: 'asc' }],
+      limit: 1000,
+    });
+
+    expect(sql).toContain('WHERE main.date BETWEEN @p0 AND @p1');
+    expect(sql).toContain('AND visitors_e_commerce.visitors_e_commerce__total_sessions > @p2');
+    expect(sql).toContain('ORDER BY main.source ASC');
+    expect(sql).toContain('LIMIT 1000');
+
+    const tail = sql.slice(sql.indexOf('\nWHERE'));
+    expect(tail).not.toMatch(/WHERE\s+`?date`?\s/);
+    expect(tail).not.toMatch(/AND\s+`?date`?\s/);
+    expect(tail).not.toMatch(/ORDER BY\s+`?source`?\s/);
+    expect(tail).not.toMatch(/AND\s+`?source`?\s/);
+    expect(tail).not.toMatch(/WHERE\s+`?visitors_e_commerce__total_sessions`?\s/);
+
+    expect(params).toEqual([
+      { name: 'p0', value: '2025-01-01' },
+      { name: 'p1', value: '2025-01-31' },
+      { name: 'p2', value: 5 },
+    ]);
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
@@ -5,7 +5,7 @@ import {
 } from './blended-query-builder.interface';
 import { DataStorageType } from '../enums/data-storage-type.enum';
 import { AggregateFunction } from '../../dto/schemas/aggregate-function.schema';
-import { SqlClauseRenderer, SqlParameter } from '../utils/sql-clause-renderer';
+import { ColumnRefResolver, SqlClauseRenderer, SqlParameter } from '../utils/sql-clause-renderer';
 
 interface BlendTreeNode {
   chain: ResolvedRelationshipChain;
@@ -91,12 +91,28 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
   buildBlendedQuery(context: BlendedQueryContext): { sql: string; params: SqlParameter[] } {
     const { mainTableReference, mainDataMartTitle, mainDataMartUrl, chains, columns } = context;
     const columnSet = new Set(columns);
+    const referencedColumns = new Set<string>([
+      ...columns,
+      ...(context.filters ?? []).map(f => f.column),
+      ...(context.sort ?? []).map(s => s.column),
+    ]);
+
+    const roots = this.buildTree(chains);
+
+    // Single walk over the chain forest: collect every blended outputAlias and
+    // its root CTE alias. Hidden aliases are included (filters legitimately
+    // reference them) but tracked separately so `buildSelectParts` can still
+    // keep them out of the final SELECT.
+    const outputAliasToRoot = new Map<string, string>();
+    const hiddenOutputAliases = new Set<string>();
+    for (const root of roots) {
+      this.mapOutputAliasesToRoot(root, root.chain.cteName, outputAliasToRoot, hiddenOutputAliases);
+    }
 
     const cteBlocks: string[] = [];
 
     // 1. Raw CTE for main data mart — projects only the columns actually referenced.
-    const roots = this.buildTree(chains);
-    const mainColumns = this.collectMainReferences(roots, columnSet);
+    const mainColumns = this.collectMainReferences(roots, referencedColumns, outputAliasToRoot);
     cteBlocks.push(
       this.buildRawCte('main', mainTableReference, mainDataMartTitle, mainDataMartUrl, mainColumns)
     );
@@ -110,7 +126,7 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
 
     const withClause = `WITH\n${cteBlocks.join(',\n\n')}`;
 
-    const selectParts = this.buildSelectParts(roots, columnSet);
+    const selectParts = this.buildSelectParts(columnSet, outputAliasToRoot, hiddenOutputAliases);
     const joinParts = this.buildJoinParts(roots);
     const selectClause = selectParts.length > 0 ? selectParts.join(',\n  ') : '*';
 
@@ -118,18 +134,35 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       `SELECT\n  ${selectClause}\nFROM main` +
       (joinParts.length > 0 ? '\n' + joinParts.join('\n') : '');
 
+    const qualifyColumn = this.buildColumnQualifier(outputAliasToRoot);
     const renderer = this.clauseRenderer;
     const where = renderer
-      ? renderer.renderWhere(context.filters ?? [])
+      ? renderer.renderWhere(context.filters ?? [], qualifyColumn)
       : { sql: '', params: [] as SqlParameter[] };
     const orderBy = renderer
-      ? renderer.renderOrderBy(context.sort ?? [])
+      ? renderer.renderOrderBy(context.sort ?? [], qualifyColumn)
       : { sql: '', params: [] as SqlParameter[] };
     const limit = renderer
       ? renderer.renderLimit(context.limit ?? null)
       : { sql: '', params: [] as SqlParameter[] };
     const sql = `${withClause}\n\n${body}${where.sql}${orderBy.sql}${limit.sql}`;
     return { sql, params: [...where.params, ...orderBy.params, ...limit.params] };
+  }
+
+  /**
+   * Returns a resolver that prefixes blended outputAliases with their root
+   * CTE alias and everything else with `main.`. Without this, WHERE/ORDER BY
+   * would emit bare names and fail with "column X is ambiguous" whenever a
+   * name lives in two CTEs (join keys are the typical trigger).
+   */
+  private buildColumnQualifier(outputAliasToRoot: Map<string, string>): ColumnRefResolver {
+    return (column: string) => {
+      const rootAlias = outputAliasToRoot.get(column);
+      if (rootAlias) {
+        return `${this.quoteIdentifier(rootAlias)}.${this.quoteIdentifier(column)}`;
+      }
+      return `main.${this.quoteFieldRef(column)}`;
+    };
   }
 
   /**
@@ -335,38 +368,24 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
 
   /**
    * Columns of the main DM that need to be projected in its raw CTE:
-   *  - native columns from the user's `columnConfig` (everything in `columnSet`
-   *    that is not the outputAlias of a non-hidden subsidiary blended field)
+   *  - referenced columns (columnConfig + filter columns + sort columns) that
+   *    are NOT blended outputAliases (hidden ones included — those flow
+   *    through subsidiary CTEs, not through main)
    *  - join keys used by root-level (direct children of main) chains
    */
-  private collectMainReferences(roots: BlendTreeNode[], columnSet: Set<string>): string[] {
-    const subsidiaryOutputAliases = this.collectAllOutputAliases(roots);
-
+  private collectMainReferences(
+    roots: BlendTreeNode[],
+    referencedColumns: Set<string>,
+    blendedAliases: Map<string, string>
+  ): string[] {
     const refs = new Set<string>();
-    for (const col of columnSet) {
-      if (!subsidiaryOutputAliases.has(col)) refs.add(col);
+    for (const col of referencedColumns) {
+      if (!blendedAliases.has(col)) refs.add(col);
     }
     for (const root of roots) {
       for (const jc of root.chain.relationship.joinConditions) refs.add(jc.sourceFieldName);
     }
     return Array.from(refs).sort();
-  }
-
-  /**
-   * Recursively collects all non-hidden outputAlias values from a tree.
-   * In bottom-up mode, deep blended fields are surfaced through root nodes,
-   * so we need to traverse the entire tree.
-   */
-  private collectAllOutputAliases(nodes: BlendTreeNode[]): Set<string> {
-    const result = new Set<string>();
-    for (const node of nodes) {
-      for (const field of node.chain.blendedFields) {
-        if (!field.isHidden) result.add(field.outputAlias);
-      }
-      const childAliases = this.collectAllOutputAliases(node.children);
-      for (const alias of childAliases) result.add(alias);
-    }
-    return result;
   }
 
   /**
@@ -446,44 +465,44 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
   /**
    * Final SELECT: references main columns and blended columns from root-level
    * aggregation CTEs only. Deep blended fields are surfaced through root nodes
-   * via re-aggregation.
+   * via re-aggregation. Hidden blended fields fall through to the `main.<col>`
+   * branch so they never appear in the final SELECT, even though they live in
+   * `outputAliasToRoot` (filters need them).
    */
-  private buildSelectParts(roots: BlendTreeNode[], columnSet: Set<string>): string[] {
+  private buildSelectParts(
+    columnSet: Set<string>,
+    outputAliasToRoot: Map<string, string>,
+    hiddenOutputAliases: Set<string>
+  ): string[] {
     const parts: string[] = [];
-
-    // Build a map: outputAlias → root alias that surfaces it.
-    // Non-hidden blended fields from any depth are routed to their root ancestor.
-    const outputAliasToRoot = new Map<string, string>();
-    for (const root of roots) {
-      this.mapOutputAliasesToRoot(root, root.chain.cteName, outputAliasToRoot);
-    }
-
     for (const col of columnSet) {
       const rootAlias = outputAliasToRoot.get(col);
-      if (rootAlias) {
+      if (rootAlias && !hiddenOutputAliases.has(col)) {
         parts.push(`${this.quoteIdentifier(rootAlias)}.${this.quoteIdentifier(col)}`);
       } else {
-        parts.push(`main.${this.quoteIdentifier(col)}`);
+        parts.push(`main.${this.quoteFieldRef(col)}`);
       }
     }
-
     return parts;
   }
 
   /**
-   * Recursively maps every non-hidden outputAlias in a subtree to the root
-   * alias that will surface it after bottom-up aggregation.
+   * Recursively maps every blended outputAlias in a subtree to the root alias
+   * that will surface it after bottom-up aggregation, also flagging hidden
+   * fields so callers can apply visibility rules without a second traversal.
    */
   private mapOutputAliasesToRoot(
     node: BlendTreeNode,
     rootAlias: string,
-    result: Map<string, string>
+    outputAliasToRoot: Map<string, string>,
+    hiddenOutputAliases: Set<string>
   ): void {
     for (const field of node.chain.blendedFields) {
-      if (!field.isHidden) result.set(field.outputAlias, rootAlias);
+      outputAliasToRoot.set(field.outputAlias, rootAlias);
+      if (field.isHidden) hiddenOutputAliases.add(field.outputAlias);
     }
     for (const child of node.children) {
-      this.mapOutputAliasesToRoot(child, rootAlias, result);
+      this.mapOutputAliasesToRoot(child, rootAlias, outputAliasToRoot, hiddenOutputAliases);
     }
   }
 

--- a/apps/backend/src/data-marts/data-storage-types/utils/sql-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/utils/sql-clause-renderer.spec.ts
@@ -1,4 +1,4 @@
-import { SqlClauseRenderer, RenderedClause } from './sql-clause-renderer';
+import { ColumnRefResolver, SqlClauseRenderer, RenderedClause } from './sql-clause-renderer';
 import { FilterRule } from '../../dto/schemas/filter-config.schema';
 import { SortRule } from '../../dto/schemas/sort-config.schema';
 
@@ -6,15 +6,19 @@ class StubRenderer extends SqlClauseRenderer {
   protected quoteIdentifier(name: string): string {
     return `"${name}"`;
   }
-  protected renderFilterFragment(rule: FilterRule, paramName: string): RenderedClause {
+  protected renderFilterFragment(
+    rule: FilterRule,
+    paramName: string,
+    columnRef: string
+  ): RenderedClause {
     if (rule.operator === 'eq') {
       return {
-        sql: `${this.quoteIdentifier(rule.column)} = @${paramName}`,
+        sql: `${columnRef} = @${paramName}`,
         params: [{ name: paramName, value: rule.value }],
       };
     }
     if (rule.operator === 'is_empty') {
-      return { sql: `${this.quoteIdentifier(rule.column)} IS NULL`, params: [] };
+      return { sql: `${columnRef} IS NULL`, params: [] };
     }
     return { sql: '1=1', params: [] };
   }
@@ -67,5 +71,44 @@ describe('SqlClauseRenderer', () => {
   it('omits LIMIT when null or undefined', () => {
     expect(r.renderLimit(null).sql).toBe('');
     expect(r.renderLimit(undefined).sql).toBe('');
+  });
+
+  describe('column qualification via ColumnRefResolver', () => {
+    const qualify: ColumnRefResolver = column => `main."${column}"`;
+
+    it('passes the resolved column reference into WHERE fragments', () => {
+      const out = r.renderWhere(
+        [
+          { column: 'a', operator: 'eq', value: 1 },
+          { column: 'b', operator: 'is_empty' },
+        ],
+        qualify
+      );
+      expect(out.sql).toBe('\nWHERE main."a" = @p0 AND main."b" IS NULL');
+    });
+
+    it('passes the resolved column reference into ORDER BY fragments', () => {
+      const out = r.renderOrderBy(
+        [
+          { column: 'date', direction: 'desc' },
+          { column: 'amount', direction: 'asc' },
+        ],
+        qualify
+      );
+      expect(out.sql).toBe('\nORDER BY main."date" DESC, main."amount" ASC');
+    });
+
+    it('lets the resolver route different columns to different prefixes', () => {
+      const routed: ColumnRefResolver = column =>
+        column === 'b' ? `orders."${column}"` : `main."${column}"`;
+      const out = r.renderWhere(
+        [
+          { column: 'a', operator: 'eq', value: 1 },
+          { column: 'b', operator: 'eq', value: 2 },
+        ],
+        routed
+      );
+      expect(out.sql).toBe('\nWHERE main."a" = @p0 AND orders."b" = @p1');
+    });
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/utils/sql-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/utils/sql-clause-renderer.ts
@@ -11,18 +11,34 @@ export interface RenderedClause {
   params: SqlParameter[];
 }
 
+/**
+ * Returns the SQL fragment for a column reference — fully quoted and, when
+ * needed, prefixed with a CTE alias. The renderer cannot derive the prefix
+ * from the column name alone, so the caller supplies one.
+ */
+export type ColumnRefResolver = (column: string) => string;
+
 export abstract class SqlClauseRenderer {
   protected abstract quoteIdentifier(name: string): string;
-  protected abstract renderFilterFragment(rule: FilterRule, paramName: string): RenderedClause;
+  protected abstract renderFilterFragment(
+    rule: FilterRule,
+    paramName: string,
+    columnRef: string
+  ): RenderedClause;
 
-  renderWhere(filters: FilterRule[]): RenderedClause {
+  private resolverOrFallback(qualifyColumn: ColumnRefResolver | undefined): ColumnRefResolver {
+    return qualifyColumn ?? (c => this.quoteIdentifier(c));
+  }
+
+  renderWhere(filters: FilterRule[], qualifyColumn?: ColumnRefResolver): RenderedClause {
     if (!filters.length) return { sql: '', params: [] };
+    const resolve = this.resolverOrFallback(qualifyColumn);
     const fragments: string[] = [];
     const params: SqlParameter[] = [];
     let nextIndex = 0;
     for (const rule of filters) {
       const paramName = `p${nextIndex}`;
-      const out = this.renderFilterFragment(rule, paramName);
+      const out = this.renderFilterFragment(rule, paramName, resolve(rule.column));
       fragments.push(out.sql);
       params.push(...out.params);
       nextIndex += out.params.length;
@@ -30,9 +46,10 @@ export abstract class SqlClauseRenderer {
     return { sql: `\nWHERE ${fragments.join(' AND ')}`, params };
   }
 
-  renderOrderBy(sort: SortRule[]): RenderedClause {
+  renderOrderBy(sort: SortRule[], qualifyColumn?: ColumnRefResolver): RenderedClause {
     if (!sort.length) return { sql: '', params: [] };
-    const parts = sort.map(r => `${this.quoteIdentifier(r.column)} ${r.direction.toUpperCase()}`);
+    const resolve = this.resolverOrFallback(qualifyColumn);
+    const parts = sort.map(r => `${resolve(r.column)} ${r.direction.toUpperCase()}`);
     return { sql: `\nORDER BY ${parts.join(', ')}`, params: [] };
   }
 

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -40,8 +40,11 @@ export class BlendedReportDataService {
     );
 
     const blendedFieldsByName = new Map(blendableSchema.blendedFields.map(f => [f.name, f]));
-    const filterColumns = (report.filterConfig ?? []).map(f => f.column);
-    const referencedColumns = new Set<string>([...columnConfig, ...filterColumns]);
+    const referencedColumns = new Set<string>([
+      ...columnConfig,
+      ...(report.filterConfig ?? []).map(f => f.column),
+      ...(report.sortConfig ?? []).map(s => s.column),
+    ]);
     const hasBlendedColumns = Array.from(referencedColumns).some(col =>
       blendedFieldsByName.has(col)
     );


### PR DESCRIPTION
## Summary

Blended reports that filtered or sorted on a column whose name also lived in another joined data mart (for example a shared `date` join key) failed with database errors like `Column name date is ambiguous`. The query builder qualified every column in `SELECT`, `FROM`, and `JOIN` with its CTE alias (`main.date`, `unified_ad_spend_e_commerce.date`, etc.) but emitted bare column names in `WHERE` and `ORDER BY`:

```sql
WHERE `date` BETWEEN @p0 AND @p1
  AND `visitors_e_commerce__total_sessions` > @p2
ORDER BY `source` ASC
```

The bare reference is ambiguous whenever the same identifier exists in two or more CTEs — always the case for join keys, common for any field a main and a subsidiary data mart share by name.

## Fix

- `SqlClauseRenderer` (`utils/sql-clause-renderer.ts`) now accepts an optional `ColumnRefResolver: (column: string) => string` on `renderWhere` and `renderOrderBy`. The resolver returns a fully-quoted, CTE-prefixed SQL fragment for a single column. When no resolver is passed, the renderer falls back to `this.quoteIdentifier(column)` — preserving the prior behaviour for the non-blended (single-table) query path.
- `BigQueryClauseRenderer` now takes the rendered column reference as a parameter instead of computing it locally, so every operator branch (scalar, substring, regex, between, no-value, relative-date) honours the resolver.
- `AbstractBlendedQueryBuilder` does a single recursive walk over the chain forest that builds an `outputAliasToRoot` map (including hidden blended aliases, which filters legitimately reference) and a `hiddenOutputAliases` set. The map drives both the final `SELECT` qualification and a new `buildColumnQualifier(outputAliasToRoot)` resolver that is passed into the clause renderer. The qualifier produces `main.<col>` for native main columns and `<rootAlias>.<outputAlias>` for blended fields.
- `collectMainReferences` now sees `columnConfig ∪ filterColumns ∪ sortColumns`, so a filter or sort on a native main column that is *not* in `columnConfig` is correctly projected into the `main` raw CTE — previously such queries would have failed with "unknown column" once the WHERE qualification was correct.

The two cases now produce, for example:

```sql
WHERE main.date BETWEEN @p0 AND @p1
  AND visitors_e_commerce.visitors_e_commerce__total_sessions > @p2
ORDER BY main.source ASC
```

## Dialect coverage

The fix lives in the abstract layer (`SqlClauseRenderer` + `AbstractBlendedQueryBuilder`), so it applies to any dialect that wires a clause renderer. BigQuery already does and is fixed. Snowflake / Redshift / Databricks / Athena still throw `NotImplementedException` on output controls today (unchanged); when any of them gets a `*ClauseRenderer`, it inherits the qualification mechanism for free.
