### PR TITLE
feat(linkedin-ads): add default fields and improve endpoint UX for LinkedIn Ads

### DIFF
--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
@@ -38,7 +38,7 @@ export function FieldsSelectionStep({
   onSelectAllFields,
 }: FieldsSelectionStepProps) {
   const filterInputRef = useRef<HTMLInputElement>(null);
-  const defaultsInitializedForRef = useRef<string | null>(null);
+  const prevSelectedFieldRef = useRef<string | null>(null);
   const [filterText, setFilterText] = useState('');
   const [sortOrder, setSortOrder] = useState<ConnectorFieldSortOrder>(
     ConnectorFieldSortOrder.ORIGINAL
@@ -100,8 +100,12 @@ export function FieldsSelectionStep({
       }
     });
 
-    if (defaultsInitializedForRef.current !== selectedField) {
-      const hasFieldsBeyondUniqueKeys = selectedFields.some(f => !uniqueKeysSet.has(f));
+    const isEndpointSwitch = prevSelectedFieldRef.current !== selectedField;
+    if (isEndpointSwitch) {
+      prevSelectedFieldRef.current = selectedField;
+      const hasFieldsBeyondUniqueKeys = selectedFields.some(
+        f => !uniqueKeysSet.has(f) && availableFieldNamesSet.has(f)
+      );
       if (!hasFieldsBeyondUniqueKeys) {
         const defaultFields = selectedFieldData?.defaultFields ?? [];
         defaultFields.forEach(fieldName => {
@@ -110,7 +114,6 @@ export function FieldsSelectionStep({
           }
         });
       }
-      defaultsInitializedForRef.current = selectedField;
     }
 
     if (fieldsToAutoSelect.size > 0) {

--- a/packages/connectors/src/Sources/LinkedInAds/LinkedInAdsAPIReference/LinkedInAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/LinkedInAds/LinkedInAdsAPIReference/LinkedInAdsFieldsSchema.js
@@ -8,42 +8,47 @@
 var LinkedInAdsFieldsSchema = {
   "adAccounts": {
     "overview": "Ad Accounts",
-    "description": "Advertising accounts for an organization.",
+    "description": "Your ad account settings, billing details, currency, and account status.",
     "documentation": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts",
     "fields": adAccountFields,
     "uniqueKeys": ["id"],
+    "defaultFields": ["id", "name", "status", "currency", "type", "reference"],
     "destinationName": "linkedin_ads_ad_accounts"
   },
   "adCampaignGroups": {
     "overview": "Campaign Groups",
-    "description": "Group campaigns under an account.",
+    "description": "Top-level containers that group campaigns with shared objectives, budgets, and scheduling.",
     "documentation": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaign-groups",
     "fields": adCampaignGroupFields,
     "uniqueKeys": ["id"],
+    "defaultFields": ["id", "name", "status", "account", "objectiveType", "runSchedule", "totalBudget", "servingStatuses"],
     "destinationName": "linkedin_ads_ad_campaign_groups"
   },
   "adCampaigns": {
     "overview": "Campaigns",
-    "description": "Ad campaigns with scheduling, targeting, budgeting and other settings.",
+    "description": "Individual campaigns defining your targeting, ad format, bid strategy, and budget.",
     "documentation": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns",
     "fields": adCampaignFields,
     "uniqueKeys": ["id"],
+    "defaultFields": ["id", "name", "status", "account", "campaignGroup", "objectiveType", "type", "runSchedule"],
     "destinationName": "linkedin_ads_ad_campaigns"
   },
   "creatives": {
     "overview": "Creatives",
-    "description": "Ad creative objects.",
+    "description": "The visual and copy elements of your ads shown to members across LinkedIn.",
     "documentation": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives",
     "fields": creativesFields,
     "uniqueKeys": ["id"],
+    "defaultFields": ["id", "name", "intendedStatus", "account", "campaign", "isServing", "createdAt"],
     "destinationName": "linkedin_ads_creatives"
   },
   "adAnalytics": {
-    "overview": "LinkedIn Ads Analytics Report",
-    "description": "Provides analytics data for LinkedIn advertising campaigns",
+    "overview": "Ad Analytics",
+    "description": "Daily performance metrics for your campaigns — impressions, clicks, spend, and conversions.",
     "documentation": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting",
     "fields": adAnalyticsFields,
     "uniqueKeys": ["dateRangeStart", "dateRangeEnd", "pivotValues"],
+    "defaultFields": ["dateRangeStart", "dateRangeEnd", "pivotValues", "impressions", "clicks", "costInLocalCurrency", "costInUsd", "totalEngagements", "landingPageClicks", "externalWebsiteConversions"],
     "destinationName": "linkedin_ads_ad_analytics",
     "isTimeSeries": true
   }


### PR DESCRIPTION
# Problem

LinkedIn Ads connector endpoints had no default field selections, so users opening the field selection step for the first time saw all fields unselected and had to manually choose from scratch. Endpoint descriptions were also terse API-documentation text ("Ad creative objects.", "Group campaigns under an account.") rather than user-friendly labels. Additionally, the shared `FieldsSelectionStep` logic had a bug where deselecting all non-unique-key fields would immediately snap defaults back, making it impossible to intentionally reduce a selection to unique keys only.

# Solution

Added `defaultFields` arrays to all 5 LinkedIn Ads schema endpoints, choosing fields that cover the most common analysis needs without overwhelming the user. Endpoint descriptions were rewritten to match the conversational style established by the Facebook connector. The `FieldsSelectionStep` auto-selection logic was improved to only apply defaults when the user switches to an endpoint (not on every field toggle), so a user can deselect defaults and proceed — while returning to an endpoint after navigating away correctly re-applies defaults.

# Changes

- Added `defaultFields` to all 5 LinkedIn Ads endpoints: `adAccounts`, `adCampaignGroups`, `adCampaigns`, `creatives`, `adAnalytics`
- Rewrote endpoint `description` fields across all 5 endpoints to be user-facing and concise
- Renamed `adAnalytics` overview from "LinkedIn Ads Analytics Report" to "Ad Analytics"
- Replaced `defaultsInitializedForRef` with `prevSelectedFieldRef` in `FieldsSelectionStep` — defaults now re-apply only on endpoint switch, not on every field deselection
- Fixed `hasFieldsBeyondUniqueKeys` to filter by `availableFieldNamesSet`, preventing fields selected on other endpoints from suppressing defaults on the current one