### PR TITLE
feat(web): enhance project setup to promote Google Sheets extension

### DIFF
--- a/.changeset/enable-google-sheets-extension-in-setup-checklist.md
+++ b/.changeset/enable-google-sheets-extension-in-setup-checklist.md
@@ -1,0 +1,31 @@
+---
+'owox': minor
+---
+
+# Add "Enable Google Sheets" conditional checklist group for users who selected Sheets-related use cases during onboarding
+
+**Problem**
+Data analysts who selected Google Sheets use cases during onboarding didn't understand:
+
+- That Sheets is a key workflow in OWOX
+- That they should share data with business users
+- That the Google Sheets Extension exists
+This led to low engagement, business users not being involved, and missed product value.
+
+**Solution**
+Replace the generic "Get data to your report" group with a Sheets-specific "Enable Google Sheets" group for targeted users.
+
+**Added new "Enable Google Sheets" group in the Setup Checklist**
+Shown to: Users with `onboarding.use_case` containing `sync_dwh_sheets` or `import_external_sheets`
+
+**Steps:**
+
+1. **Create Destination - Google Sheets** → Links to `/data-destinations`
+2. **Install Google Sheets Extension** → Opens [Google Workspace Marketplace](https://workspace.google.com/marketplace/app/owox_data_marts/94902851409)
+3. **Create & Run Report from Extension** → Opens `sheets.new`
+
+**Features:**
+
+- Non-blocking (doesn't prevent progress on other checklist items)
+- Auto-updates when user creates destination or runs report
+- Uses `refetchInterval` to sync status in real-time

--- a/apps/backend/src/data-marts/dto/domain/project-setup-steps.interface.ts
+++ b/apps/backend/src/data-marts/dto/domain/project-setup-steps.interface.ts
@@ -11,6 +11,9 @@ export interface ProjectSetupSteps {
   hasReport: StepState;
   hasReportRun: StepState;
   hasTeammatesInvited: StepState;
+  hasGoogleSheetsDestination: StepState;
+  hasGoogleSheetsExtension: StepState;
+  hasGoogleSheetsReportRun: StepState;
 }
 
 export type SetupStepKey = keyof ProjectSetupSteps;
@@ -23,10 +26,17 @@ export const SETUP_STEP_KEYS: SetupStepKey[] = [
   'hasReport',
   'hasReportRun',
   'hasTeammatesInvited',
+  'hasGoogleSheetsDestination',
+  'hasGoogleSheetsExtension',
+  'hasGoogleSheetsReportRun',
 ];
 
 /** Steps scoped to user + project (each user tracks independently) */
-export const USER_SCOPED_STEP_KEYS: SetupStepKey[] = ['hasReportRun'];
+export const USER_SCOPED_STEP_KEYS: SetupStepKey[] = [
+  'hasReportRun',
+  'hasGoogleSheetsExtension',
+  'hasGoogleSheetsReportRun',
+];
 
 /** Steps scoped to project only (shared across all users) */
 export const PROJECT_SCOPED_STEP_KEYS: SetupStepKey[] = [
@@ -36,6 +46,7 @@ export const PROJECT_SCOPED_STEP_KEYS: SetupStepKey[] = [
   'hasDestination',
   'hasReport',
   'hasTeammatesInvited',
+  'hasGoogleSheetsDestination',
 ];
 
 export function createEmptySteps(): ProjectSetupSteps {
@@ -47,5 +58,8 @@ export function createEmptySteps(): ProjectSetupSteps {
     hasReport: { done: false, completedAt: null },
     hasReportRun: { done: false, completedAt: null },
     hasTeammatesInvited: { done: false, completedAt: null },
+    hasGoogleSheetsDestination: { done: false, completedAt: null },
+    hasGoogleSheetsExtension: { done: false, completedAt: null },
+    hasGoogleSheetsReportRun: { done: false, completedAt: null },
   };
 }

--- a/apps/backend/src/data-marts/events/data-destination-created.event.ts
+++ b/apps/backend/src/data-marts/events/data-destination-created.event.ts
@@ -1,9 +1,11 @@
 import { BaseEvent } from '@owox/internal-helpers';
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
 
 export interface DataDestinationCreatedEventPayload {
   destinationId: string;
   projectId: string;
   createdById: string;
+  destinationType: DataDestinationType;
 }
 
 export class DataDestinationCreatedEvent extends BaseEvent<DataDestinationCreatedEventPayload> {
@@ -11,7 +13,12 @@ export class DataDestinationCreatedEvent extends BaseEvent<DataDestinationCreate
     return 'data-destination.created' as const;
   }
 
-  constructor(destinationId: string, projectId: string, createdById: string) {
-    super({ destinationId, projectId, createdById });
+  constructor(
+    destinationId: string,
+    projectId: string,
+    createdById: string,
+    destinationType: DataDestinationType
+  ) {
+    super({ destinationId, projectId, createdById, destinationType });
   }
 }

--- a/apps/backend/src/data-marts/events/report-run-completed-successfully.event.ts
+++ b/apps/backend/src/data-marts/events/report-run-completed-successfully.event.ts
@@ -1,10 +1,12 @@
 import { BaseEvent } from '@owox/internal-helpers';
+import type { DataMartRunType } from '../enums/data-mart-run-type.enum';
 
 export interface ReportRunCompletedSuccessfullyEventPayload {
   dataMartRunId: string;
   dataMartId: string;
   /** Owner of the run — used to mark user-scoped checklist steps. */
   userId: string;
+  runType: DataMartRunType;
 }
 
 export class ReportRunCompletedSuccessfullyEvent extends BaseEvent<ReportRunCompletedSuccessfullyEventPayload> {
@@ -12,7 +14,7 @@ export class ReportRunCompletedSuccessfullyEvent extends BaseEvent<ReportRunComp
     return 'report-run.completed.successfully' as const;
   }
 
-  constructor(dataMartRunId: string, dataMartId: string, userId: string) {
-    super({ dataMartRunId, dataMartId, userId });
+  constructor(dataMartRunId: string, dataMartId: string, userId: string, runType: DataMartRunType) {
+    super({ dataMartRunId, dataMartId, userId, runType });
   }
 }

--- a/apps/backend/src/data-marts/services/data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.ts
@@ -257,7 +257,8 @@ export class DataMartRunService {
         new ReportRunCompletedSuccessfullyEvent(
           dataMartRun.id,
           dataMartRun.dataMartId,
-          dataMartRun.createdById
+          dataMartRun.createdById,
+          dataMartRun.type
         )
       );
     }

--- a/apps/backend/src/data-marts/services/project-setup-progress-listener.service.ts
+++ b/apps/backend/src/data-marts/services/project-setup-progress-listener.service.ts
@@ -7,6 +7,8 @@ import { DataMartPublishedEvent } from '../events/data-mart-published.event';
 import { DataDestinationCreatedEvent } from '../events/data-destination-created.event';
 import { ReportCreatedEvent } from '../events/report-created.event';
 import { ReportRunCompletedSuccessfullyEvent } from '../events/report-run-completed-successfully.event';
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
+import { DataMartRunType } from '../enums/data-mart-run-type.enum';
 
 @Injectable()
 export class ProjectSetupProgressListenerService {
@@ -31,6 +33,12 @@ export class ProjectSetupProgressListenerService {
   @OnEvent('data-destination.created', { async: true })
   async onDestinationCreated(event: DataDestinationCreatedEvent): Promise<void> {
     await this.progressService.markProjectStepDone(event.payload.projectId, 'hasDestination');
+    if (event.payload.destinationType === DataDestinationType.GOOGLE_SHEETS) {
+      await this.progressService.markProjectStepDone(
+        event.payload.projectId,
+        'hasGoogleSheetsDestination'
+      );
+    }
   }
 
   @OnEvent('report.created', { async: true })
@@ -40,12 +48,17 @@ export class ProjectSetupProgressListenerService {
 
   @OnEvent('report-run.completed.successfully', { async: true })
   async onReportRunSuccess(event: ReportRunCompletedSuccessfullyEvent): Promise<void> {
-    const { dataMartId, userId } = event.payload;
+    const { dataMartId, userId, runType } = event.payload;
     if (!userId) return;
 
     const projectId = await this.progressService.resolveProjectIdByDataMartId(dataMartId);
-    if (projectId) {
-      await this.progressService.markUserStepDone(projectId, userId, 'hasReportRun');
+    if (!projectId) return;
+
+    await this.progressService.markUserStepDone(projectId, userId, 'hasReportRun');
+
+    if (runType === DataMartRunType.GOOGLE_SHEETS_EXPORT) {
+      await this.progressService.markUserStepDone(projectId, userId, 'hasGoogleSheetsExtension');
+      await this.progressService.markUserStepDone(projectId, userId, 'hasGoogleSheetsReportRun');
     }
   }
 }

--- a/apps/backend/src/data-marts/services/project-setup-progress.service.ts
+++ b/apps/backend/src/data-marts/services/project-setup-progress.service.ts
@@ -382,12 +382,13 @@ export class ProjectSetupProgressService {
     if (dataMarts.length === 0) return false;
 
     const dataMartIds = dataMarts.map(dm => dm.id);
-    const count = await this.reportRepository
+    const report = await this.reportRepository
       .createQueryBuilder('report')
+      .select('report.id')
       .where('report.dataMartId IN (:...dataMartIds)', { dataMartIds })
       .limit(1)
-      .getCount();
-    return count > 0;
+      .getOne();
+    return report !== null;
   }
 
   private async checkUserReportRunExists(projectId: string, userId: string): Promise<boolean> {
@@ -398,15 +399,16 @@ export class ProjectSetupProgressService {
     if (dataMarts.length === 0) return false;
 
     const dataMartIds = dataMarts.map(dm => dm.id);
-    const count = await this.dataMartRunRepository
+    const run = await this.dataMartRunRepository
       .createQueryBuilder('run')
+      .select('run.id')
       .where('run.dataMartId IN (:...dataMartIds)', { dataMartIds })
       .andWhere('run.status = :status', { status: DataMartRunStatus.SUCCESS })
       .andWhere('run.createdById = :userId', { userId })
       .andWhere('run.type IN (:...types)', { types: REPORT_RUN_TYPES })
       .limit(1)
-      .getCount();
-    return count > 0;
+      .getOne();
+    return run !== null;
   }
 
   private async checkTeammatesInvited(projectId: string): Promise<boolean> {
@@ -439,14 +441,15 @@ export class ProjectSetupProgressService {
     if (dataMarts.length === 0) return false;
 
     const dataMartIds = dataMarts.map(dm => dm.id);
-    const count = await this.dataMartRunRepository
+    const run = await this.dataMartRunRepository
       .createQueryBuilder('run')
+      .select('run.id')
       .where('run.dataMartId IN (:...dataMartIds)', { dataMartIds })
       .andWhere('run.status = :status', { status: DataMartRunStatus.SUCCESS })
       .andWhere('run.createdById = :userId', { userId })
       .andWhere('run.type = :type', { type: DataMartRunType.GOOGLE_SHEETS_EXPORT })
       .limit(1)
-      .getCount();
-    return count > 0;
+      .getOne();
+    return run !== null;
   }
 }

--- a/apps/backend/src/data-marts/services/project-setup-progress.service.ts
+++ b/apps/backend/src/data-marts/services/project-setup-progress.service.ts
@@ -317,27 +317,24 @@ export class ProjectSetupProgressService {
       hasGoogleSheetsReportRun: { done: false, completedAt: null },
     };
 
-    // Note: `hasGoogleSheetsExtension` intentionally reuses the same check as
-    // `hasGoogleSheetsReportRunExists()`. In the current onboarding logic,
+    const now = new Date().toISOString();
+
+    // Note: In the current onboarding logic,
     // "Google Sheets extension connected" is interpreted as
     // "user successfully ran a report via Google Sheets", not just extension installation.
     // Because of this, both setup steps become completed after the first successful report run.
-    const [hasReportRun, hasGoogleSheetsExtension, hasGoogleSheetsReportRun] = await Promise.all([
+    const [hasReportRun, hasGoogleSheetsRun] = await Promise.all([
       this.checkUserReportRunExists(projectId, userId),
-      this.checkGoogleSheetsReportRunExists(projectId, userId),
       this.checkGoogleSheetsReportRunExists(projectId, userId),
     ]);
 
     if (hasReportRun) {
-      steps.hasReportRun = { done: true, completedAt: new Date().toISOString() };
+      steps.hasReportRun = { done: true, completedAt: now };
     }
 
-    if (hasGoogleSheetsExtension) {
-      steps.hasGoogleSheetsExtension = { done: true, completedAt: new Date().toISOString() };
-    }
-
-    if (hasGoogleSheetsReportRun) {
-      steps.hasGoogleSheetsReportRun = { done: true, completedAt: new Date().toISOString() };
+    if (hasGoogleSheetsRun) {
+      steps.hasGoogleSheetsExtension = { done: true, completedAt: now };
+      steps.hasGoogleSheetsReportRun = { done: true, completedAt: now };
     }
 
     return steps;

--- a/apps/backend/src/data-marts/services/project-setup-progress.service.ts
+++ b/apps/backend/src/data-marts/services/project-setup-progress.service.ts
@@ -19,6 +19,7 @@ import { DataMartRun } from '../entities/data-mart-run.entity';
 import { DataMartStatus } from '../enums/data-mart-status.enum';
 import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
 import { DataMartRunType } from '../enums/data-mart-run-type.enum';
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
 import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
 
 const OPTIMISTIC_LOCK_MAX_ATTEMPTS = 5;
@@ -247,6 +248,7 @@ export class ProjectSetupProgressService {
       hasDestination,
       hasReport,
       hasTeammates,
+      hasGoogleSheetsDestination,
     ] = await Promise.all([
       this.checkStorageExists(projectId),
       this.checkDraftDataMartExists(projectId),
@@ -254,16 +256,21 @@ export class ProjectSetupProgressService {
       this.checkDestinationExists(projectId),
       this.checkReportExists(projectId),
       this.checkTeammatesInvited(projectId),
+      this.checkGoogleSheetsDestinationExists(projectId),
     ]);
 
     if (hasStorage) steps.hasStorage = { done: true, completedAt: now };
     if (hasDraftDataMart) steps.hasDraftDataMart = { done: true, completedAt: now };
     if (hasPublishedDataMart) steps.hasPublishedDataMart = { done: true, completedAt: now };
     if (hasDestination) steps.hasDestination = { done: true, completedAt: now };
+    if (hasGoogleSheetsDestination) {
+      steps.hasGoogleSheetsDestination = { done: true, completedAt: now };
+    }
     if (hasReport) steps.hasReport = { done: true, completedAt: now };
     if (hasTeammates) steps.hasTeammatesInvited = { done: true, completedAt: now };
 
-    // hasReportRun is user-scoped — stays false at project level
+    // hasReportRun, hasGoogleSheetsExtension and hasGoogleSheetsReportRun are user-scoped
+    // — stays false at project level
 
     return steps;
   }
@@ -306,11 +313,26 @@ export class ProjectSetupProgressService {
   ): Promise<Record<string, StepState>> {
     const steps: Record<string, StepState> = {
       hasReportRun: { done: false, completedAt: null },
+      hasGoogleSheetsExtension: { done: false, completedAt: null },
+      hasGoogleSheetsReportRun: { done: false, completedAt: null },
     };
 
-    const hasReportRun = await this.checkUserReportRunExists(projectId, userId);
+    const [hasReportRun, hasGoogleSheetsExtension, hasGoogleSheetsReportRun] = await Promise.all([
+      this.checkUserReportRunExists(projectId, userId),
+      this.checkGoogleSheetsReportRunExists(projectId, userId),
+      this.checkGoogleSheetsReportRunExists(projectId, userId),
+    ]);
+
     if (hasReportRun) {
       steps.hasReportRun = { done: true, completedAt: new Date().toISOString() };
+    }
+
+    if (hasGoogleSheetsExtension) {
+      steps.hasGoogleSheetsExtension = { done: true, completedAt: new Date().toISOString() };
+    }
+
+    if (hasGoogleSheetsReportRun) {
+      steps.hasGoogleSheetsReportRun = { done: true, completedAt: new Date().toISOString() };
     }
 
     return steps;
@@ -392,5 +414,37 @@ export class ProjectSetupProgressService {
     } catch {
       return false;
     }
+  }
+
+  // ── Google Sheets progress checks ──
+
+  private async checkGoogleSheetsDestinationExists(projectId: string): Promise<boolean> {
+    const count = await this.dataDestinationRepository.count({
+      where: { projectId, type: DataDestinationType.GOOGLE_SHEETS },
+      take: 1,
+    });
+    return count > 0;
+  }
+
+  private async checkGoogleSheetsReportRunExists(
+    projectId: string,
+    userId: string
+  ): Promise<boolean> {
+    const dataMarts = await this.dataMartRepository.find({
+      where: { projectId },
+      select: ['id'],
+    });
+    if (dataMarts.length === 0) return false;
+
+    const dataMartIds = dataMarts.map(dm => dm.id);
+    const count = await this.dataMartRunRepository
+      .createQueryBuilder('run')
+      .where('run.dataMartId IN (:...dataMartIds)', { dataMartIds })
+      .andWhere('run.status = :status', { status: DataMartRunStatus.SUCCESS })
+      .andWhere('run.createdById = :userId', { userId })
+      .andWhere('run.type = :type', { type: DataMartRunType.GOOGLE_SHEETS_EXPORT })
+      .limit(1)
+      .getCount();
+    return count > 0;
   }
 }

--- a/apps/backend/src/data-marts/services/project-setup-progress.service.ts
+++ b/apps/backend/src/data-marts/services/project-setup-progress.service.ts
@@ -317,6 +317,11 @@ export class ProjectSetupProgressService {
       hasGoogleSheetsReportRun: { done: false, completedAt: null },
     };
 
+    // Note: `hasGoogleSheetsExtension` intentionally reuses the same check as
+    // `hasGoogleSheetsReportRunExists()`. In the current onboarding logic,
+    // "Google Sheets extension connected" is interpreted as
+    // "user successfully ran a report via Google Sheets", not just extension installation.
+    // Because of this, both setup steps become completed after the first successful report run.
     const [hasReportRun, hasGoogleSheetsExtension, hasGoogleSheetsReportRun] = await Promise.all([
       this.checkUserReportRunExists(projectId, userId),
       this.checkGoogleSheetsReportRunExists(projectId, userId),

--- a/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
@@ -211,7 +211,12 @@ export class CreateDataDestinationService {
     command: CreateDataDestinationCommand
   ): Promise<DataDestinationDto> {
     this.eventDispatcher.publishLocalOnCommit(
-      new DataDestinationCreatedEvent(savedEntity.id, command.projectId, command.userId)
+      new DataDestinationCreatedEvent(
+        savedEntity.id,
+        command.projectId,
+        command.userId,
+        savedEntity.type
+      )
     );
 
     const ownerIdsToSave = command.ownerIds ?? [command.userId];

--- a/apps/web/src/components/AppSidebar/SetupChecklist/SetupGroupPopover.tsx
+++ b/apps/web/src/components/AppSidebar/SetupChecklist/SetupGroupPopover.tsx
@@ -7,6 +7,8 @@ import { SETUP_STEPS } from './items';
 import type { GroupProgress, ProjectSetupProgress } from './types';
 import { formatDateShort } from '../../../utils/date-formatters';
 import { GroupStatusType } from './types';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { Info } from 'lucide-react';
 
 interface SetupGroupPopoverProps {
   groupProgress: GroupProgress;
@@ -41,7 +43,17 @@ export function SetupGroupPopover({ groupProgress, progress }: SetupGroupPopover
         <div className='flex flex-col gap-4'>
           {/* Header */}
           <div className='flex flex-col gap-0.5'>
-            <h3 className='text-base font-semibold'>{group.title}</h3>
+            <div className='flex items-center justify-between gap-2'>
+              <h3 className='text-base font-semibold'>{group.title}</h3>
+              {group.description && status !== GroupStatusType.DONE && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className='text-muted-foreground/75 hover:text-muted-foreground size-4 shrink-0' />
+                  </TooltipTrigger>
+                  <TooltipContent>{group.description}</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
             {status === GroupStatusType.DONE && completedAt ? (
               <p className='text-muted-foreground text-xs'>
                 Completed on {formatDateShort(completedAt)}

--- a/apps/web/src/components/AppSidebar/SetupChecklist/SetupStepAccordion.tsx
+++ b/apps/web/src/components/AppSidebar/SetupChecklist/SetupStepAccordion.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { ArrowRight, CircleCheckBig, PartyPopper } from 'lucide-react';
+import { ArrowRight, CircleCheckBig, ExternalLink, PartyPopper } from 'lucide-react';
 import { AccordionContent, AccordionItem, AccordionTrigger } from '@owox/ui/components/accordion';
 import { Button } from '@owox/ui/components/button';
 import { useProjectRoute } from '../../../shared/hooks';
@@ -30,7 +30,24 @@ export function SetupStepAccordion({ step, stepProgress, onClose }: SetupStepAcc
   const actionNode = (() => {
     switch (step.action.type) {
       case StepActionType.LINK: {
+        if (step.action.openInNewTab) {
+          return (
+            <Button size='sm' asChild>
+              <a
+                href={step.action.href}
+                target='_blank'
+                rel='noopener noreferrer'
+                onClick={handleCtaClick}
+              >
+                {step.action.label}
+                <ExternalLink className='size-4' />
+              </a>
+            </Button>
+          );
+        }
+
         const targetUrl = scope(step.action.href);
+
         return (
           <Button size='sm' asChild>
             <Link to={targetUrl} onClick={handleCtaClick}>

--- a/apps/web/src/components/AppSidebar/SetupChecklist/items.tsx
+++ b/apps/web/src/components/AppSidebar/SetupChecklist/items.tsx
@@ -1,4 +1,5 @@
 import { InviteTeammatesCard } from '../../../shared/components/InviteTeammatesCard';
+import type { User } from '../../../features/idp/types';
 import {
   GroupId,
   ProgressKey,
@@ -7,6 +8,34 @@ import {
   type SetupGroup,
   type SetupStep,
 } from './types';
+
+// Onboarding constants (mirrored from packages/idp-owox-better-auth/src/core/onboarding-constants.ts)
+const ONBOARDING_QUESTION = {
+  USE_CASE: 'use_case',
+} as const;
+
+const USE_CASE_ANSWER = {
+  SYNC_DWH_SHEETS: 'sync_dwh_sheets',
+  IMPORT_EXTERNAL_SHEETS: 'import_external_sheets',
+} as const;
+
+const SHEETS_USE_CASES = [USE_CASE_ANSWER.SYNC_DWH_SHEETS, USE_CASE_ANSWER.IMPORT_EXTERNAL_SHEETS];
+
+/**
+ * Check if user has selected Google Sheets related use cases during onboarding
+ */
+function hasSheetsUseCase(user: User | null): boolean {
+  if (!user?.onboarding?.length) return false;
+  const useCaseAnswer = user.onboarding.find(a => a.questionId === ONBOARDING_QUESTION.USE_CASE);
+  if (!useCaseAnswer) return false;
+  const answerValue = useCaseAnswer.answerValue;
+  if (Array.isArray(answerValue)) {
+    return answerValue.some(uc =>
+      SHEETS_USE_CASES.includes(uc as (typeof SHEETS_USE_CASES)[number])
+    );
+  }
+  return SHEETS_USE_CASES.includes(answerValue as (typeof SHEETS_USE_CASES)[number]);
+}
 
 const ROUTES = {
   DATA_MARTS: '/data-marts',
@@ -102,6 +131,46 @@ export const SETUP_STEPS: SetupStep[] = [
     },
     progressKey: ProgressKey.HAS_TEAMMATES_INVITED,
   },
+  {
+    id: SetupStepId.CREATE_GOOGLE_SHEETS_DESTINATION,
+    stepTitle: 'Create Destination - Google Sheets',
+    stepDescription: 'Create a destination to deliver reports to Google Sheets.',
+    successMessage: 'Google Sheets destination created',
+    action: {
+      type: StepActionType.LINK,
+      href: ROUTES.DESTINATIONS,
+      label: 'Create Google Sheets destination',
+    },
+    progressKey: ProgressKey.HAS_GOOGLE_SHEETS_DESTINATION,
+  },
+  {
+    id: SetupStepId.INSTALL_GOOGLE_SHEETS_EXTENSION,
+    stepTitle: 'Install Google Sheets Extension',
+    stepDescription:
+      'Install the OWOX Data Marts extension from Google Workspace Marketplace to run reports directly in Sheets.',
+    successMessage: 'Extension installed',
+    action: {
+      type: StepActionType.LINK,
+      href: 'https://workspace.google.com/marketplace/app/owox_data_marts/94902851409',
+      label: 'Install extension',
+      openInNewTab: true,
+    },
+    progressKey: ProgressKey.HAS_GOOGLE_SHEETS_EXTENSION,
+  },
+  {
+    id: SetupStepId.CREATE_RUN_REPORT_FROM_EXTENSION,
+    stepTitle: 'Create & Run Report from Extension',
+    stepDescription:
+      'Open Google Sheets, launch the extension sidebar, create a report, and run it to see your data.',
+    successMessage: 'Report created and run from extension',
+    action: {
+      type: StepActionType.LINK,
+      href: 'https://sheets.new',
+      label: 'Go to Google Sheets',
+      openInNewTab: true,
+    },
+    progressKey: ProgressKey.HAS_GOOGLE_SHEETS_REPORT_RUN,
+  },
 ];
 
 export const SETUP_GROUPS: SetupGroup[] = [
@@ -122,6 +191,20 @@ export const SETUP_GROUPS: SetupGroup[] = [
     title: 'Get data to your report',
     description: 'Create a destination, report, and run it to get results.',
     stepIds: [SetupStepId.CREATE_DESTINATION, SetupStepId.CREATE_REPORT, SetupStepId.REPORT_RUN],
+    isConditional: true,
+    showCondition: (user: User | null) => !hasSheetsUseCase(user),
+  },
+  {
+    id: GroupId.ENABLE_GOOGLE_SHEETS,
+    title: 'Enable Google Sheets',
+    description: 'Let your team build reports and add columns in Google Sheets without SQL.',
+    stepIds: [
+      SetupStepId.CREATE_GOOGLE_SHEETS_DESTINATION,
+      SetupStepId.INSTALL_GOOGLE_SHEETS_EXTENSION,
+      SetupStepId.CREATE_RUN_REPORT_FROM_EXTENSION,
+    ],
+    isConditional: true,
+    showCondition: (user: User | null) => hasSheetsUseCase(user),
   },
   {
     id: GroupId.INVITE_TEAMMATES,

--- a/apps/web/src/components/AppSidebar/SetupChecklist/types.ts
+++ b/apps/web/src/components/AppSidebar/SetupChecklist/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { User } from '../../../features/idp/types';
 
 export interface ProjectSetupResponse {
   version: number;
@@ -20,6 +21,9 @@ export enum ProgressKey {
   HAS_REPORT = 'hasReport',
   HAS_REPORT_RUN = 'hasReportRun',
   HAS_TEAMMATES_INVITED = 'hasTeammatesInvited',
+  HAS_GOOGLE_SHEETS_DESTINATION = 'hasGoogleSheetsDestination',
+  HAS_GOOGLE_SHEETS_EXTENSION = 'hasGoogleSheetsExtension',
+  HAS_GOOGLE_SHEETS_REPORT_RUN = 'hasGoogleSheetsReportRun',
 }
 
 export type ProjectSetupProgress = Record<ProgressKey, SetupStepProgress>;
@@ -34,7 +38,7 @@ export interface StepActionRenderContext {
 }
 
 export type StepAction =
-  | { type: StepActionType.LINK; href: string; label: string }
+  | { type: StepActionType.LINK; href: string; label: string; openInNewTab?: boolean }
   | {
       type: StepActionType.COMPONENT;
       label?: string;
@@ -49,6 +53,9 @@ export enum SetupStepId {
   CREATE_REPORT = 'create_report',
   REPORT_RUN = 'report_run',
   INVITE_TEAMMATES = 'invite_teammates',
+  CREATE_GOOGLE_SHEETS_DESTINATION = 'create_google_sheets_destination',
+  INSTALL_GOOGLE_SHEETS_EXTENSION = 'install_google_sheets_extension',
+  CREATE_RUN_REPORT_FROM_EXTENSION = 'create_run_report_from_extension',
 }
 
 export interface SetupStep {
@@ -73,6 +80,7 @@ export enum GroupId {
   PUBLISH = 'group_publish',
   REPORT = 'group_report',
   INVITE_TEAMMATES = 'group_invite_teammates',
+  ENABLE_GOOGLE_SHEETS = 'group_enable_google_sheets',
 }
 
 export interface SetupGroup {
@@ -80,6 +88,8 @@ export interface SetupGroup {
   title: string;
   description: string;
   stepIds: SetupStepId[];
+  isConditional?: boolean;
+  showCondition?: (user: User | null) => boolean;
 }
 
 export interface GroupProgress {

--- a/apps/web/src/components/AppSidebar/SetupChecklist/useSetupProgress.ts
+++ b/apps/web/src/components/AppSidebar/SetupChecklist/useSetupProgress.ts
@@ -6,8 +6,12 @@ import {
   type GroupStatus,
   type GroupProgress,
   type ProjectSetupProgress,
+  type SetupGroup,
+  type SetupStep,
 } from './types';
 import { useProjectId } from '../../../shared/hooks/useProjectId';
+import { useUser } from '../../../features/idp/hooks/useAuthState';
+import type { User } from '../../../features/idp/types';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { setupProgressService } from './setup-progress.service';
 
@@ -31,10 +35,34 @@ const EMPTY_PROGRESS: ProjectSetupProgress = {
   [ProgressKey.HAS_REPORT]: { done: false, completedAt: null },
   [ProgressKey.HAS_REPORT_RUN]: { done: false, completedAt: null },
   [ProgressKey.HAS_TEAMMATES_INVITED]: { done: false, completedAt: null },
+  [ProgressKey.HAS_GOOGLE_SHEETS_DESTINATION]: { done: false, completedAt: null },
+  [ProgressKey.HAS_GOOGLE_SHEETS_EXTENSION]: { done: false, completedAt: null },
+  [ProgressKey.HAS_GOOGLE_SHEETS_REPORT_RUN]: { done: false, completedAt: null },
 };
 
-function calculateGroupProgress(progress: ProjectSetupProgress): GroupProgress[] {
-  return SETUP_GROUPS.map(group => {
+/**
+ * Filter groups based on their showCondition
+ */
+function getVisibleGroups(groups: SetupGroup[], user: User | null): SetupGroup[] {
+  return groups.filter(group => {
+    if (!group.isConditional || !group.showCondition) return true;
+    return group.showCondition(user);
+  });
+}
+
+/**
+ * Get steps that belong to visible groups
+ */
+function getVisibleSteps(steps: SetupStep[], visibleGroups: SetupGroup[]): SetupStep[] {
+  const visibleStepIds = new Set(visibleGroups.flatMap(g => g.stepIds));
+  return steps.filter(step => visibleStepIds.has(step.id));
+}
+
+function calculateGroupProgress(
+  progress: ProjectSetupProgress,
+  visibleGroups: SetupGroup[]
+): GroupProgress[] {
+  return visibleGroups.map(group => {
     const stepIdsSet = new Set(group.stepIds);
     const steps = SETUP_STEPS.filter(step => stepIdsSet.has(step.id));
     const completedSteps = steps.filter(step => progress[step.progressKey].done);
@@ -91,6 +119,7 @@ export async function fetchSetupProgress(): Promise<ProjectSetupProgress> {
  */
 export function useSetupProgress(): SetupProgressResult {
   const projectId = useProjectId();
+  const user = useUser();
 
   const {
     data: progress = EMPTY_PROGRESS,
@@ -103,18 +132,27 @@ export function useSetupProgress(): SetupProgressResult {
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 
+  // Filter groups based on user onboarding (conditional groups)
+  const visibleGroups = useMemo(() => getVisibleGroups(SETUP_GROUPS, user), [user]);
+
+  // Get steps that belong to visible groups
+  const visibleSteps = useMemo(() => getVisibleSteps(SETUP_STEPS, visibleGroups), [visibleGroups]);
+
   const completedStepIds: string[] = [];
 
-  for (const step of SETUP_STEPS) {
+  for (const step of visibleSteps) {
     if (progress[step.progressKey].done) {
       completedStepIds.push(step.id);
     }
   }
 
   const completedCount = completedStepIds.length;
-  const totalCount = SETUP_STEPS.length;
+  const totalCount = visibleSteps.length;
   const percentage = totalCount === 0 ? 0 : Math.round((completedCount / totalCount) * 100);
-  const groupProgresses = useMemo(() => calculateGroupProgress(progress), [progress]);
+  const groupProgresses = useMemo(
+    () => calculateGroupProgress(progress, visibleGroups),
+    [progress, visibleGroups]
+  );
   const isAllComplete = completedCount >= totalCount;
 
   return {

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/DestinationTypeField.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/DestinationTypeField.tsx
@@ -62,53 +62,49 @@ export function DestinationTypeField({
                     const isComingSoon = status === DataDestinationStatus.COMING_SOON;
                     const isCloudOnly =
                       status === DataDestinationStatus.CLOUD_ONLY && checkIsCommunityEdition(flags);
-                    return (
-                      <div key={type}>
-                        {isCloudOnly ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <div>
-                                <SelectItem key={type} value={type} disabled>
-                                  <div className='flex items-center gap-2'>
-                                    <Icon size={18} />
-                                    {displayName}
-                                    <Badge variant='secondary'>Cloud &amp; Enterprise</Badge>
-                                  </div>
-                                </SelectItem>
+                    return isCloudOnly ? (
+                      <Tooltip key={type}>
+                        <TooltipTrigger asChild>
+                          <div>
+                            <SelectItem value={type} disabled>
+                              <div className='flex items-center gap-2'>
+                                <Icon size={18} />
+                                {displayName}
+                                <Badge variant='secondary'>Cloud &amp; Enterprise</Badge>
                               </div>
-                            </TooltipTrigger>
-                            <TooltipContent side='left' align='start' className='w-[220px]'>
-                              Available only in{' '}
-                              <Link
-                                className='inline-flex items-center gap-1 underline'
-                                target='_blank'
-                                to='https://docs.owox.com/docs/editions/owox-cloud-editions/?utm_source=owox_data_marts&utm_medium=destination_entity&utm_campaign=unavailable_select_item_tooltip'
-                              >
-                                Cloud edition
-                                <ExternalLinkIcon className='h-3 w-3' />
-                              </Link>{' '}
-                              or with{' '}
-                              <Link
-                                className='inline-flex items-center gap-1 underline'
-                                target='_blank'
-                                to='https://docs.owox.com/docs/editions/self-managed-editions/?utm_source=owox_data_marts&utm_medium=destination_entity&utm_campaign=unavailable_select_item_tooltip'
-                              >
-                                an Enterprise plan
-                                <ExternalLinkIcon className='h-3 w-3' />
-                              </Link>
-                              .
-                            </TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          <SelectItem key={type} value={type} disabled={isComingSoon}>
-                            <div className='flex items-center gap-2'>
-                              <Icon size={18} />
-                              {displayName}
-                              {isComingSoon && <Badge variant='outline'>{status}</Badge>}
-                            </div>
-                          </SelectItem>
-                        )}
-                      </div>
+                            </SelectItem>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent side='left' align='start' className='w-[220px]'>
+                          Available only in{' '}
+                          <Link
+                            className='inline-flex items-center gap-1 underline'
+                            target='_blank'
+                            to='https://docs.owox.com/docs/editions/owox-cloud-editions/?utm_source=owox_data_marts&utm_medium=destination_entity&utm_campaign=unavailable_select_item_tooltip'
+                          >
+                            Cloud edition
+                            <ExternalLinkIcon className='h-3 w-3' />
+                          </Link>{' '}
+                          or with{' '}
+                          <Link
+                            className='inline-flex items-center gap-1 underline'
+                            target='_blank'
+                            to='https://docs.owox.com/docs/editions/self-managed-editions/?utm_source=owox_data_marts&utm_medium=destination_entity&utm_campaign=unavailable_select_item_tooltip'
+                          >
+                            an Enterprise plan
+                            <ExternalLinkIcon className='h-3 w-3' />
+                          </Link>
+                          .
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <SelectItem key={type} value={type} disabled={isComingSoon}>
+                        <div className='flex items-center gap-2'>
+                          <Icon size={18} />
+                          {displayName}
+                          {isComingSoon && <Badge variant='outline'>{status}</Badge>}
+                        </div>
+                      </SelectItem>
                     );
                   })}
               </SelectGroup>

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/DestinationTypeField.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/DestinationTypeField.tsx
@@ -63,7 +63,7 @@ export function DestinationTypeField({
                     const isCloudOnly =
                       status === DataDestinationStatus.CLOUD_ONLY && checkIsCommunityEdition(flags);
                     return (
-                      <>
+                      <div key={type}>
                         {isCloudOnly ? (
                           <Tooltip>
                             <TooltipTrigger asChild>
@@ -108,7 +108,7 @@ export function DestinationTypeField({
                             </div>
                           </SelectItem>
                         )}
-                      </>
+                      </div>
                     );
                   })}
               </SelectGroup>

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
@@ -212,7 +212,7 @@ export function DataMartDefinitionSettings({
             {/* SQL Validator for SQL definition type */}
             {definitionType === DataMartDefinitionType.SQL && sqlCode && (
               <>
-                <div className='h-6 w-px bg-gray-300'></div>
+                <div className='bg-muted h-6 w-px'></div>
                 <SqlValidator
                   // We remount validator by key when storage-change token increments,
                   // so SQL dry-run is re-triggered after storage edit sheet closes.

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/DataMartTable.tsx
@@ -112,6 +112,7 @@ export function DataMartTable<TData, TValue>({
             checked={table.getIsAllPageRowsSelected()}
             ariaLabel='Select all rows on this page'
             onClick={table.getToggleAllPageRowsSelectedHandler()}
+            extendedHitArea
           />
         ),
         cell: ({ row }) => (
@@ -119,6 +120,7 @@ export function DataMartTable<TData, TValue>({
             checked={row.getIsSelected()}
             ariaLabel='Select row'
             onClick={row.getToggleSelectedHandler()}
+            extendedHitArea
           />
         ),
         enableSorting: false,

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsReportsTable.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsReportsTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { getGoogleSheetsColumns } from './columns';
 import type { Row } from '@tanstack/react-table';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
@@ -53,12 +53,15 @@ export function GoogleSheetsReportsTable({
 
   // Refresh setup progress when a successful report is found
   const refreshSetupProgress = useRefreshSetupProgress();
+  const hasRefreshedRef = useRef(false);
   useEffect(() => {
+    if (hasRefreshedRef.current) return;
     const hasSuccessfulReport = googleSheetsReports.some(
       report => report.lastRunStatus === ReportStatusEnum.SUCCESS
     );
 
     if (hasSuccessfulReport) {
+      hasRefreshedRef.current = true;
       refreshSetupProgress();
     }
   }, [googleSheetsReports, refreshSetupProgress]);

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsReportsTable.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsReportsTable.tsx
@@ -9,6 +9,8 @@ import { useBaseTable } from '../../../../../../shared/hooks';
 import { BaseTable } from '../../../../../../shared/components/Table';
 import { AddReportButton } from '../DestinationCard/AddReportButton';
 import type { DataMartStatusInfo } from '../../../../shared/types/data-mart-status.model';
+import { useRefreshSetupProgress } from '../../../../../../components/AppSidebar/SetupChecklist/useSetupProgress';
+import { ReportStatusEnum } from '../../../shared/enums';
 
 interface GoogleSheetsReportsTableProps {
   destination: DataDestination;
@@ -48,6 +50,18 @@ export function GoogleSheetsReportsTable({
       regularPollingIntervalMs: 5000, // 5 seconds
     });
   }, [setPollingConfig]);
+
+  // Refresh setup progress when a successful report is found
+  const refreshSetupProgress = useRefreshSetupProgress();
+  useEffect(() => {
+    const hasSuccessfulReport = googleSheetsReports.some(
+      report => report.lastRunStatus === ReportStatusEnum.SUCCESS
+    );
+
+    if (hasSuccessfulReport) {
+      refreshSetupProgress();
+    }
+  }, [googleSheetsReports, refreshSetupProgress]);
 
   // Define table columns
   const columns = useMemo(

--- a/apps/web/src/features/idp/services/auth.service.ts
+++ b/apps/web/src/features/idp/services/auth.service.ts
@@ -12,6 +12,7 @@ export function tokenPayloadToUser(payload: TokenPayload): User {
     projectId: payload.projectId,
     projectTitle: payload.projectTitle,
     avatar: payload.avatar,
+    onboarding: payload.onboarding,
   };
 }
 

--- a/apps/web/src/features/idp/types/auth-api.types.ts
+++ b/apps/web/src/features/idp/types/auth-api.types.ts
@@ -1,4 +1,4 @@
-import type { Role } from './user.types.js';
+import type { OnboardingAnswer, Role } from './user.types.js';
 
 /**
  * Access token response
@@ -19,6 +19,7 @@ export interface TokenPayload {
   avatar?: string;
   roles?: Role[];
   projectTitle?: string;
+  onboarding?: OnboardingAnswer[];
 }
 
 /**

--- a/apps/web/src/features/idp/types/user.types.ts
+++ b/apps/web/src/features/idp/types/user.types.ts
@@ -1,6 +1,14 @@
 export type Role = 'admin' | 'editor' | 'viewer';
 
 /**
+ * Onboarding answer from the onboarding questionnaire
+ */
+export interface OnboardingAnswer {
+  questionId: string;
+  answerValue: string | string[];
+}
+
+/**
  * User information
  */
 export interface User {
@@ -11,6 +19,7 @@ export interface User {
   roles?: Role[];
   projectId: string;
   projectTitle?: string;
+  onboarding?: OnboardingAnswer[];
 }
 
 /**

--- a/apps/web/src/shared/components/Table/BaseTable.tsx
+++ b/apps/web/src/shared/components/Table/BaseTable.tsx
@@ -79,7 +79,7 @@ export function BaseTable<TData>({
   const isActionsColumn = (columnId: string) => columnId === ACTIONS_COLUMN_ID;
 
   const baseHeaderClass =
-    'relative [&:has([role=checkbox])]:pl-6 [&>[role=checkbox]]:translate-y-[2px]';
+    'relative [&:has([role=checkbox])]:pl-2 [&>[role=checkbox]]:translate-y-[1px]';
 
   const actionsHeaderClass = cn(
     'sticky right-0 z-20',
@@ -92,21 +92,22 @@ export function BaseTable<TData>({
   const isHealthStatus = (columnId: string) => columnId === 'healthStatus';
 
   const baseCellClass =
-    'px-6 pr-0 break-words whitespace-normal transition-colors duration-200 ease-out ' +
+    'px-6 [&:has([role=checkbox])]:pl-2 pr-0 break-words whitespace-normal transition-colors duration-200 ease-out ' +
     'after:transition-opacity after:duration-150 after:ease-out ' +
-    '[&>[role=checkbox]]:translate-y-[2px]';
+    '[&>[role=checkbox]]:translate-y-[1px]';
 
   const actionsCellClass = cn(
     'sticky right-0 z-10 px-2',
     'bg-table-tbody-sticky-bg group-hover:bg-table-tbody-sticky-hover-bg transition-colors duration-200 ease-out',
     'after:pointer-events-none after:absolute after:inset-y-0 after:left-[-24px] after:w-[24px]',
-    'after:bg-gradient-to-r after:from-transparent after:to-table-tbody-sticky-hover-bg',
-    'after:opacity-0 after:transition-opacity after:duration-200',
-    'group-hover:after:opacity-100'
+    'after:bg-gradient-to-r after:from-transparent after:to-table-tbody-sticky-bg',
+    'group-data-[state=selected]:bg-table-tbody-sticky-hover-bg group-data-[state=selected]:after:to-table-tbody-sticky-hover-bg',
+    'after:transition-colors after:duration-200',
+    'group-hover:after:to-table-tbody-sticky-hover-bg'
   );
 
   const createdAtClass = 'whitespace-nowrap';
-  const healthStatusClass = 'pl-5';
+  const healthStatusClass = 'pl-4';
 
   return (
     <>
@@ -115,7 +116,7 @@ export function BaseTable<TData>({
         <div className='mb-4 flex items-center justify-between gap-2 last:mb-0'>
           {/* LEFT Column */}
           {renderToolbarLeft && (
-            <div className='flex items-center gap-2'>{renderToolbarLeft(table)}</div>
+            <div className='flex min-w-0 flex-1 items-center gap-2'>{renderToolbarLeft(table)}</div>
           )}
 
           {/* RIGHT Column */}

--- a/apps/web/src/shared/components/Table/TableColumnSearch.tsx
+++ b/apps/web/src/shared/components/Table/TableColumnSearch.tsx
@@ -30,7 +30,7 @@ export function TableColumnSearch<TData>({
   }
 
   return (
-    <div className='relative w-full md:w-48 lg:w-62 xl:w-128'>
+    <div className='relative max-w-md min-w-0 flex-1'>
       <Search className='text-muted-foreground absolute top-2.5 left-2 h-4 w-4' />
       <Input
         placeholder={placeholder}

--- a/apps/web/src/shared/components/Table/TableSelectionCheckbox.tsx
+++ b/apps/web/src/shared/components/Table/TableSelectionCheckbox.tsx
@@ -13,6 +13,8 @@ export interface TableSelectionCheckboxProps {
   checkIconClassName?: string;
   /** Decorative checkbox inside another interactive element (e.g. tree row button). */
   presentationOnly?: boolean;
+  /** Extend the hit area of the checkbox to the parent element. */
+  extendedHitArea?: boolean;
 }
 
 const indicatorClassName =
@@ -29,18 +31,26 @@ export function TableSelectionCheckbox({
   disabled,
   className,
   presentationOnly = false,
+  extendedHitArea = false,
   checkIconClassName = 'size-3.5 text-white',
 }: TableSelectionCheckboxProps) {
   const boxClassName = cn(
-    'border-input data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border bg-white shadow-xs transition-shadow dark:bg-white/8',
-    presentationOnly && 'flex items-center justify-center',
-    !presentationOnly &&
-      'peer focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+    'border-input data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary size-4 shrink-0 rounded-[4px] border bg-white shadow-xs dark:bg-white/8',
+    'flex items-center justify-center',
+    !presentationOnly && 'pointer-events-none',
     className
+  );
+  const buttonClassName = cn(
+    'inline-flex items-center justify-center rounded-md',
+    extendedHitArea ? 'size-8' : 'size-5',
+    'transition-colors focus-visible:outline-none',
+    'hover:bg-black/4 dark:hover:bg-white/4',
+    'focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+    'disabled:cursor-not-allowed disabled:opacity-50'
   );
 
   const indicator = checked ? (
-    <span data-state='checked' data-slot='checkbox-indicator' className={indicatorClassName}>
+    <span data-slot='checkbox-indicator' className={indicatorClassName}>
       <Check className={checkIconClassName} />
     </span>
   ) : null;
@@ -60,11 +70,13 @@ export function TableSelectionCheckbox({
       aria-checked={checked}
       data-state={checked ? 'checked' : 'unchecked'}
       aria-label={ariaLabel}
-      className={boxClassName}
+      className={buttonClassName}
       onClick={onClick}
       disabled={disabled}
     >
-      {indicator}
+      <span data-state={checked ? 'checked' : 'unchecked'} className={boxClassName}>
+        {indicator}
+      </span>
     </button>
   );
 }


### PR DESCRIPTION
# Add "Enable Google Sheets" conditional checklist group for users who selected Sheets-related use cases during onboarding

## Summary

Add "Enable Google Sheets" conditional checklist group for users who selected Sheets-related use cases during onboarding.

## Problem

Data analysts who selected Google Sheets use cases during onboarding didn't understand:

- That Sheets is a key workflow in OWOX
- That they should share data with business users
- That the Google Sheets Extension exists

This led to low engagement, business users not being involved, and missed product value.

## Solution

<img width="2169" height="2120" alt="Frame 23137590" src="https://github.com/user-attachments/assets/8c59d2c5-2c72-4440-a14b-95fad5ce4903" />

Replace the generic "Get data to your report" group with a Sheets-specific "Enable Google Sheets" group for targeted users.

### New Group: "Enable Google Sheets"

**Shown to:** Users with `onboarding.use_case` containing `sync_dwh_sheets` or `import_external_sheets`

**Steps:**
1. **Create Destination - Google Sheets** → Links to `/data-destinations`
2. **Install Google Sheets Extension** → Opens [Google Workspace Marketplace](https://workspace.google.com/marketplace/app/owox_data_marts/94902851409)
3. **Create & Run Report from Extension** → Opens `sheets.new`

**Progress tracking:**
- `hasGoogleSheetsDestination` (project-scoped): Set when GS destination created
- `hasGoogleSheetsExtension` (user-scoped): Set when GS report run succeeds  
- `hasGoogleSheetsReportRun` (user-scoped): Set when GS report run succeeds

**Features:**
- Non-blocking (doesn't prevent progress on other checklist items)
- Auto-updates when user creates destination or runs report
- Uses `refetchInterval` to sync status in real-time
