### PR TITLE
Emoji picker to data mart title

### DIFF
--- a/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
@@ -15,6 +15,7 @@ import { Input } from '@owox/ui/components/input';
 import { Plus } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { EmojiPickerButton } from './EmojiPickerButton';
+import { prependEmoji } from './emoji-picker.constants';
 import { useForm } from 'react-hook-form';
 import { Combobox } from '../../../../shared/components/Combobox/combobox';
 import { DataStorageHealthIndicator, DataStorageType } from '../../../data-storage';
@@ -158,7 +159,7 @@ export function DataMartCreateForm({ initialData, onSuccess }: DataMartFormProps
                       />
                       <EmojiPickerButton
                         onSelect={emoji => {
-                          field.onChange(`${emoji} ${field.value}`);
+                          field.onChange(prependEmoji(emoji, field.value));
                         }}
                       />
                     </div>

--- a/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from '@owox/ui/components/input';
 import { Plus } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { EmojiPickerButton } from './EmojiPickerButton';
 import { useForm } from 'react-hook-form';
 import { Combobox } from '../../../../shared/components/Combobox/combobox';
 import { DataStorageHealthIndicator, DataStorageType } from '../../../data-storage';
@@ -148,12 +149,19 @@ export function DataMartCreateForm({ initialData, onSuccess }: DataMartFormProps
                 <FormItem>
                   <FormLabel>Title</FormLabel>
                   <FormControl>
-                    <Input
-                      id='title'
-                      placeholder='Enter title'
-                      {...field}
-                      disabled={isSubmitting}
-                    />
+                    <div className='flex items-center gap-1'>
+                      <Input
+                        id='title'
+                        placeholder='Enter title'
+                        {...field}
+                        disabled={isSubmitting}
+                      />
+                      <EmojiPickerButton
+                        onSelect={emoji => {
+                          field.onChange(`${emoji} ${field.value}`);
+                        }}
+                      />
+                    </div>
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -37,6 +37,7 @@ import { useAiHelper, useAiHelperAvailability } from '../model/hooks';
 import { DataMartMetadataScope } from '../../shared';
 import { AiHelperButton } from './AiHelperButton';
 import { EmojiPickerButton } from './EmojiPickerButton';
+import { prependEmoji } from './emoji-picker.constants';
 import NotFound from '../../../../pages/NotFound.tsx';
 import NoAccess from '../../../../pages/NoAccess.tsx';
 
@@ -318,11 +319,11 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
               title={dataMartTitle}
               onUpdate={handleTitleUpdate}
               className='text-2xl font-medium'
-              aiButton={({ value, setValue }) => (
+              aiButton={({ setValue }) => (
                 <>
                   <EmojiPickerButton
                     onSelect={emoji => {
-                      setValue(`${emoji} ${value}`);
+                      setValue(prev => prependEmoji(emoji, prev));
                     }}
                   />
                   {showAiTitleHelper && (

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -36,6 +36,7 @@ import { useDataMart } from '../model';
 import { useAiHelper, useAiHelperAvailability } from '../model/hooks';
 import { DataMartMetadataScope } from '../../shared';
 import { AiHelperButton } from './AiHelperButton';
+import { EmojiPickerButton } from './EmojiPickerButton';
 import NotFound from '../../../../pages/NotFound.tsx';
 import NoAccess from '../../../../pages/NoAccess.tsx';
 
@@ -317,23 +318,28 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
               title={dataMartTitle}
               onUpdate={handleTitleUpdate}
               className='text-2xl font-medium'
-              aiButton={
-                showAiTitleHelper
-                  ? ({ setValue }) => (
-                      <AiHelperButton
-                        onClick={() => {
-                          void (async () => {
-                            const suggested = await generateTitle(dataMartId);
-                            if (suggested) setValue(suggested);
-                          })();
-                        }}
-                        isLoading={isGeneratingTitle}
-                        disabled={!dataMartId || aiPendingScope !== null}
-                        tooltip='Generate title with AI'
-                      />
-                    )
-                  : undefined
-              }
+              aiButton={({ value, setValue }) => (
+                <>
+                  <EmojiPickerButton
+                    onSelect={emoji => {
+                      setValue(`${emoji} ${value}`);
+                    }}
+                  />
+                  {showAiTitleHelper && (
+                    <AiHelperButton
+                      onClick={() => {
+                        void (async () => {
+                          const suggested = await generateTitle(dataMartId);
+                          if (suggested) setValue(suggested);
+                        })();
+                      }}
+                      isLoading={isGeneratingTitle}
+                      disabled={!dataMartId || aiPendingScope !== null}
+                      tooltip='Generate title with AI'
+                    />
+                  )}
+                </>
+              )}
             />
           </div>
         </div>

--- a/apps/web/src/features/data-marts/edit/components/EmojiPickerButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/EmojiPickerButton.tsx
@@ -1,23 +1,9 @@
-import { Button } from '../../../../shared/components/Button';
+import { Button } from '@owox/ui/components/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@owox/ui/components/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { SmilePlus } from 'lucide-react';
 import { useState } from 'react';
-
-const EMOJI_GROUPS: { label: string; emojis: string[] }[] = [
-  {
-    label: 'Status',
-    emojis: ['🥇', '🥈', '🥉', '⭐', '🏆', '✅', '❌', '⚠️', '🔥', '💎', '🎯', '🚀'],
-  },
-  {
-    label: 'Category',
-    emojis: ['📊', '📈', '📉', '💰', '🛒', '👥', '🌍', '📦', '🔧', '📱', '🖥️', '🔍'],
-  },
-  {
-    label: 'Priority',
-    emojis: ['🔴', '🟠', '🟡', '🟢', '🔵', '🟣', '⚫', '⚪', '🟤', '💜', '💚', '💙'],
-  },
-];
+import { EMOJI_GROUPS } from './emoji-picker.constants';
 
 interface EmojiPickerButtonProps {
   onSelect: (emoji: string) => void;

--- a/apps/web/src/features/data-marts/edit/components/EmojiPickerButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/EmojiPickerButton.tsx
@@ -1,0 +1,83 @@
+import { Button } from '../../../../shared/components/Button';
+import { Popover, PopoverContent, PopoverTrigger } from '@owox/ui/components/popover';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { SmilePlus } from 'lucide-react';
+import { useState } from 'react';
+
+const EMOJI_GROUPS: { label: string; emojis: string[] }[] = [
+  {
+    label: 'Status',
+    emojis: ['🥇', '🥈', '🥉', '⭐', '🏆', '✅', '❌', '⚠️', '🔥', '💎', '🎯', '🚀'],
+  },
+  {
+    label: 'Category',
+    emojis: ['📊', '📈', '📉', '💰', '🛒', '👥', '🌍', '📦', '🔧', '📱', '🖥️', '🔍'],
+  },
+  {
+    label: 'Priority',
+    emojis: ['🔴', '🟠', '🟡', '🟢', '🔵', '🟣', '⚫', '⚪', '🟤', '💜', '💚', '💙'],
+  },
+];
+
+interface EmojiPickerButtonProps {
+  onSelect: (emoji: string) => void;
+}
+
+export function EmojiPickerButton({ onSelect }: EmojiPickerButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant='ghost'
+              className='size-7 p-0'
+              aria-label='Add emoji to title'
+              onMouseDown={e => {
+                e.preventDefault();
+              }}
+            >
+              <SmilePlus className='h-4 w-4 opacity-60' />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side='bottom'>Add emoji to title</TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        className='w-auto p-2'
+        side='bottom'
+        align='start'
+        onOpenAutoFocus={e => {
+          e.preventDefault();
+        }}
+      >
+        <div className='flex flex-col gap-2'>
+          {EMOJI_GROUPS.map(group => (
+            <div key={group.label}>
+              <p className='text-muted-foreground mb-1 px-1 text-[10px] font-medium uppercase'>
+                {group.label}
+              </p>
+              <div className='grid grid-cols-6 gap-0.5'>
+                {group.emojis.map(emoji => (
+                  <button
+                    key={emoji}
+                    type='button'
+                    className='hover:bg-accent rounded p-1 text-lg leading-none transition-colors'
+                    onClick={() => {
+                      onSelect(emoji);
+                      setOpen(false);
+                    }}
+                  >
+                    {emoji}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/emoji-picker.constants.ts
+++ b/apps/web/src/features/data-marts/edit/components/emoji-picker.constants.ts
@@ -1,0 +1,23 @@
+export interface EmojiGroup {
+  label: string;
+  emojis: string[];
+}
+
+export const EMOJI_GROUPS: EmojiGroup[] = [
+  {
+    label: 'Status',
+    emojis: ['🥇', '🥈', '🥉', '⭐', '🏆', '✅', '❌', '⚠️', '🔥', '💎', '🎯', '🚀'],
+  },
+  {
+    label: 'Category',
+    emojis: ['📊', '📈', '📉', '💰', '🛒', '👥', '🌍', '📦', '🔧', '📱', '🖥️', '🔍'],
+  },
+  {
+    label: 'Priority',
+    emojis: ['🔴', '🟠', '🟡', '🟢', '🔵', '🟣', '⚫', '⚪', '🟤', '💜', '💚', '💙'],
+  },
+];
+
+export function prependEmoji(emoji: string, title: string): string {
+  return `${emoji} ${title}`;
+}

--- a/apps/web/src/shared/components/InlineEditTitle/InlineEditTitle.tsx
+++ b/apps/web/src/shared/components/InlineEditTitle/InlineEditTitle.tsx
@@ -4,8 +4,10 @@ import { Textarea } from '@owox/ui/components/textarea';
 import toast from 'react-hot-toast';
 
 export interface InlineEditTitleAiContext {
+  /** Current value in the editor buffer. */
+  value: string;
   /** Replace the current value in the open input. Does not persist on its own. */
-  setValue: (value: string) => void;
+  setValue: (value: string | ((prev: string) => string)) => void;
 }
 
 export type InlineEditTitleAi = ReactNode | ((ctx: InlineEditTitleAiContext) => ReactNode);
@@ -155,7 +157,9 @@ export function InlineEditTitle({
               }}
               className='shrink-0'
             >
-              {typeof aiButton === 'function' ? aiButton({ setValue: setEditedTitle }) : aiButton}
+              {typeof aiButton === 'function'
+                ? aiButton({ value: editedTitle, setValue: setEditedTitle })
+                : aiButton}
             </span>
           )}
         </div>


### PR DESCRIPTION
Adds a quick-access emoji picker button next to the data mart title, both on the edit page and the create page. Selecting an emoji prepends it with a space to the current title, removing the need to copy-paste emojis manually.

## Changed files

- **New:** `EmojiPickerButton.tsx` — popover component with emoji grid
- `InlineEditTitle.tsx` — extended context to expose `value` alongside `setValue`
- `DataMartDetails.tsx` — wired emoji picker into the title area
- `DataMartCreateForm.tsx` — added emoji picker next to the title input

<img width="642" height="449" alt="emoji1" src="https://github.com/user-attachments/assets/5e60bea2-207f-4012-81d0-5c3f177801ac" />
<img width="498" height="326" alt="emoji2" src="https://github.com/user-attachments/assets/129522a1-0d24-4a42-bab0-b6c61e479c9d" />


## Test plan
- [ ] Open a data mart, focus the title — emoji picker icon appears
- [ ] Click an emoji — it prepends to the title
- [ ] Create a new data mart — emoji picker appears next to the title input
- [ ] AI title button still works alongside the emoji picker

@ikrasovytskyi 