### PR TITLE
feat: slices — pre-join filters for joined data marts (#6537)

### DIFF
--- a/.changeset/slices-pre-join-filters.md
+++ b/.changeset/slices-pre-join-filters.md
@@ -4,28 +4,7 @@
 
 # Slices: filter joined data marts before they are joined
 
-Reports on joined data marts gain a new `slicesConfig` field. A **slice** is a filter
-applied **before** the JOIN (inside the subsidiary's raw CTE) — so large subsidiary
-tables (e.g. `users` with 10 years of data joined into `orders`, `reportRuns` over a
-long window) can be narrowed to the rows you actually need before the join, instead
-of filtering the full join product after the fact.
-
-**UI**: on a joined column, the filter popover now offers a `Filter | Slice` tab
-toggle, and a new SLICES section appears in the Report editor alongside Filters /
-Sort / Limit. Clicking the filter icon on a column with exactly one active rule
-opens the popover pre-filled in edit mode (Apply replaces instead of appending).
-Each section header also gained an info tooltip describing what the section does
-and when filters vs. slices apply.
-
-**Backend**: SQL codegen extended in `AbstractBlendedQueryBuilder` to inject a
-per-CTE WHERE inside each joined data mart's `*_raw` CTE using the existing
-`SqlClauseRenderer` (now parameter-prefix-aware to avoid `@p0` collisions). Two
-upstream tweaks: `BlendedReportDataService.buildRelationshipChains` pulls chains
-referenced only by slices, and `collectSubsidiaryReferences` projects slice
-columns into the raw CTE.
-
-**Scope**: BigQuery only for v1 (same capability gate as filter/sort/limit; other
-storages light up automatically once they grow a `SqlClauseRenderer` subclass).
-Slices on the home data mart, slices on simple (non-joined) data marts, and
-`relative_date_to_field` (date relative to another field) are out for v1 and
-return clear `SLICES_REQUIRE_JOINED_DATA_MART` / `SLICE_*` errors when attempted.
+Reports on joined data marts gain pre-join filters ("slices") — a filter applied INSIDE the joined data mart's `*_raw` CTE before the JOIN,
+so large subsidiary tables can be narrowed to the rows you need upstream.
+The Slices section appears next to Filters / Sort / Limit in the Report editor; a tooltip explains that under LEFT JOIN a slice narrows the subsidiary but does not drop home-mart rows — add a Filter on the joined column for row elimination.
+BigQuery only for v1; columns that disappear from the schema after save are flagged in the UI and rejected with a structured 400 on save.

--- a/.changeset/slices-pre-join-filters.md
+++ b/.changeset/slices-pre-join-filters.md
@@ -1,0 +1,31 @@
+---
+'owox': minor
+---
+
+# Slices: filter joined data marts before they are joined
+
+Reports on joined data marts gain a new `slicesConfig` field. A **slice** is a filter
+applied **before** the JOIN (inside the subsidiary's raw CTE) — so large subsidiary
+tables (e.g. `users` with 10 years of data joined into `orders`, `reportRuns` over a
+long window) can be narrowed to the rows you actually need before the join, instead
+of filtering the full join product after the fact.
+
+**UI**: on a joined column, the filter popover now offers a `Filter | Slice` tab
+toggle, and a new SLICES section appears in the Report editor alongside Filters /
+Sort / Limit. Clicking the filter icon on a column with exactly one active rule
+opens the popover pre-filled in edit mode (Apply replaces instead of appending).
+Each section header also gained an info tooltip describing what the section does
+and when filters vs. slices apply.
+
+**Backend**: SQL codegen extended in `AbstractBlendedQueryBuilder` to inject a
+per-CTE WHERE inside each joined data mart's `*_raw` CTE using the existing
+`SqlClauseRenderer` (now parameter-prefix-aware to avoid `@p0` collisions). Two
+upstream tweaks: `BlendedReportDataService.buildRelationshipChains` pulls chains
+referenced only by slices, and `collectSubsidiaryReferences` projects slice
+columns into the raw CTE.
+
+**Scope**: BigQuery only for v1 (same capability gate as filter/sort/limit; other
+storages light up automatically once they grow a `SqlClauseRenderer` subclass).
+Slices on the home data mart, slices on simple (non-joined) data marts, and
+`relative_date_to_field` (date relative to another field) are out for v1 and
+return clear `SLICES_REQUIRE_JOINED_DATA_MART` / `SLICE_*` errors when attempted.

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-blended-query-builder.spec.ts
@@ -145,4 +145,30 @@ describe('AthenaBlendedQueryBuilder — output controls guard', () => {
       })
     ).toThrow(NotImplementedException);
   });
+
+  it('throws NotImplemented when limit is set', () => {
+    expect(() =>
+      builder.buildBlendedQuery({
+        ...baseContext,
+        limit: 100,
+      })
+    ).toThrow(NotImplementedException);
+  });
+
+  it('throws NotImplemented on pre-join filters (slices)', () => {
+    expect(() =>
+      builder.buildBlendedQuery({
+        ...baseContext,
+        filters: [
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      })
+    ).toThrow(NotImplementedException);
+  });
 });

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-blended-query-builder.ts
@@ -1,7 +1,6 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
-import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
 import { SqlClauseRenderer } from '../../utils/sql-clause-renderer';
 
 @Injectable()
@@ -15,14 +14,5 @@ export class AthenaBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
 
   protected buildStringAgg(fieldName: string): string {
     return `ARRAY_JOIN(ARRAY_AGG(CAST(${fieldName} AS VARCHAR)), ', ')`;
-  }
-
-  buildBlendedQuery(context: BlendedQueryContext) {
-    if ((context.filters?.length ?? 0) > 0 || (context.sort?.length ?? 0) > 0) {
-      throw new NotImplementedException(
-        `Output controls not yet supported for storage type ${this.type}`
-      );
-    }
-    return super.buildBlendedQuery(context);
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-blended-query-builder-edge-cases.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-blended-query-builder-edge-cases.spec.ts
@@ -1,0 +1,261 @@
+import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
+import {
+  makeChain,
+  makeRelationship,
+} from '../../interfaces/__fixtures__/blended-query-builder-fixtures';
+import { extractCteBody } from '@owox/test-utils';
+import { BigQueryBlendedQueryBuilder } from './bigquery-blended-query-builder';
+import { BigQueryClauseRenderer } from './bigquery-clause-renderer';
+
+// ---------------------------------------------------------------------------
+// Group A — SQL safety / quoting hardening
+// ---------------------------------------------------------------------------
+
+describe('BigQueryBlendedQueryBuilder — SQL safety / quoting', () => {
+  let builder: BigQueryBlendedQueryBuilder;
+
+  beforeEach(() => {
+    builder = new BigQueryBlendedQueryBuilder(new BigQueryClauseRenderer());
+  });
+
+  // -------------------------------------------------------------------------
+  it('alias matching a SQL keyword (order) is safely used as CTE name', () => {
+    // 'order' matches [A-Za-z_][A-Za-z0-9_]* so quoteIdentifier leaves it
+    // unquoted (it is a safe identifier). The test pins the contract: the
+    // CTE is emitted and the generated SQL is structurally valid — the alias
+    // itself appears in expected positions without corruption.
+    const chain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-order',
+        targetAlias: 'order',
+        joinConditions: [{ sourceFieldName: 'order_id', targetFieldName: 'id' }],
+      }),
+      targetTableReference: '`project.dataset.orders`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'name',
+          outputAlias: 'order_name',
+          isHidden: false,
+          aggregateFunction: 'ANY_VALUE',
+        },
+      ],
+    });
+
+    const ctx: BlendedQueryContext = {
+      mainTableReference: '`project.dataset.events`',
+      mainDataMartTitle: 'Events',
+      mainDataMartUrl: '/ui/events',
+      chains: [chain],
+      columns: ['event_id', 'order_name'],
+    };
+
+    const { sql } = builder.buildBlendedQuery(ctx);
+
+    // Raw and aggregation CTEs must both be present
+    expect(sql).toContain('order_raw AS (');
+    expect(sql).toContain('order AS (');
+    // Final SELECT must reference through the alias correctly
+    expect(sql).toContain('order.order_name');
+    // LEFT JOIN must be emitted
+    expect(sql).toContain('LEFT JOIN order ON main.order_id = order.id');
+  });
+
+  // -------------------------------------------------------------------------
+  it('column name with apostrophe is backtick-quoted in raw CTE projection', () => {
+    // targetFieldName = "Product's_id" — apostrophe is not a SQL identifier char,
+    // so quoteIdentifier wraps it: `Product's_id`
+    const chain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-products',
+        targetAlias: 'products',
+        joinConditions: [{ sourceFieldName: 'product_id', targetFieldName: "Product's_id" }],
+      }),
+      targetTableReference: '`project.dataset.products`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: "Product's_id",
+          outputAlias: 'products_id_agg',
+          isHidden: false,
+          aggregateFunction: 'COUNT',
+        },
+      ],
+    });
+
+    const ctx: BlendedQueryContext = {
+      mainTableReference: '`project.dataset.events`',
+      mainDataMartTitle: 'Events',
+      mainDataMartUrl: '/ui/events',
+      chains: [chain],
+      columns: ['event_id', 'products_id_agg'],
+    };
+
+    const { sql } = builder.buildBlendedQuery(ctx);
+
+    // The column with the apostrophe must be backtick-quoted wherever it appears
+    expect(sql).toContain("`Product's_id`");
+    // Aggregation CTE must reference the column correctly
+    expect(sql).toContain("COUNT(`Product's_id`)");
+    // Verify the join ON clause also quotes the column correctly
+    expect(sql).toContain("= products.`Product's_id`");
+  });
+
+  // -------------------------------------------------------------------------
+  it('column name with whitespace is backtick-quoted in raw CTE and WHERE', () => {
+    // targetFieldName = 'first name' — whitespace makes this unsafe without quoting
+    const chain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-users',
+        targetAlias: 'users',
+        joinConditions: [{ sourceFieldName: 'user_id', targetFieldName: 'uid' }],
+      }),
+      targetTableReference: '`project.dataset.users`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'first name',
+          outputAlias: 'first_name_agg',
+          isHidden: false,
+          aggregateFunction: 'ANY_VALUE',
+        },
+      ],
+    });
+
+    const ctx: BlendedQueryContext = {
+      mainTableReference: '`project.dataset.events`',
+      mainDataMartTitle: 'Events',
+      mainDataMartUrl: '/ui/events',
+      chains: [chain],
+      columns: ['event_id', 'first_name_agg'],
+      filters: [
+        {
+          column: 'first name',
+          operator: 'is_not_null',
+          placement: 'pre-join',
+          aliasPath: 'users',
+        },
+      ],
+    };
+
+    const { sql } = builder.buildBlendedQuery(ctx);
+
+    // The field must be backtick-quoted in the raw CTE SELECT projection
+    expect(sql).toContain('`first name`');
+    // The raw CTE must contain the WHERE referencing the backtick-quoted column
+    const usersRawBody = extractCteBody(sql, 'users_raw');
+    expect(usersRawBody).toContain('`first name` IS NOT NULL');
+    // Unquoted 'first name' must not appear as a bare identifier
+    // (a space-separated token outside backticks would break SQL parsing)
+    // We verify the raw body only has it inside backticks
+    const bareIdx = usersRawBody.indexOf('first name');
+    if (bareIdx !== -1) {
+      // Every occurrence must be preceded by a backtick
+      const ctxBefore = usersRawBody[bareIdx - 1];
+      expect(ctxBefore).toBe('`');
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  it('column name containing a backtick character is double-backtick-escaped', () => {
+    // targetFieldName = "weird`name" — the backtick inside must be doubled
+    // per BigQuery / standard SQL convention: `weird``name`
+    const chain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-things',
+        targetAlias: 'things',
+        joinConditions: [{ sourceFieldName: 'thing_id', targetFieldName: 'tid' }],
+      }),
+      targetTableReference: '`project.dataset.things`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'weird`name',
+          outputAlias: 'weird_name_agg',
+          isHidden: false,
+          aggregateFunction: 'MAX',
+        },
+      ],
+    });
+
+    const ctx: BlendedQueryContext = {
+      mainTableReference: '`project.dataset.events`',
+      mainDataMartTitle: 'Events',
+      mainDataMartUrl: '/ui/events',
+      chains: [chain],
+      columns: ['event_id', 'weird_name_agg'],
+    };
+
+    const { sql } = builder.buildBlendedQuery(ctx);
+
+    // BigQuery convention: inner backtick is doubled
+    expect(sql).toContain('`weird``name`');
+    // A single bare backtick in the middle of an identifier must not appear
+    // i.e., `weird`name` (unescaped) would be wrong — verify it's not there
+    // We check that "weird`name`" (without doubling) doesn't appear
+    expect(sql).not.toContain('`weird`name`');
+  });
+
+  // -------------------------------------------------------------------------
+  it('comment injection via title/url is sanitized to single-line SQL comment', () => {
+    // The DataMart title contains a newline + SQL comment marker.
+    // sanitizeSqlComment() must strip/replace these so the comment stays on one line.
+    const chain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-orders',
+        targetAlias: 'orders',
+        joinConditions: [{ sourceFieldName: 'order_id', targetFieldName: 'id' }],
+      }),
+      targetTableReference: '`project.dataset.orders`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'amount',
+          outputAlias: 'total_amount',
+          isHidden: false,
+          aggregateFunction: 'SUM',
+        },
+      ],
+    });
+
+    const injectedTitle = 'My DM\n--DROP TABLE users';
+    const injectedUrl = 'https://app.example.com/dm\r\n-- evil_injection';
+
+    const ctx: BlendedQueryContext = {
+      mainTableReference: '`project.dataset.events`',
+      mainDataMartTitle: injectedTitle,
+      mainDataMartUrl: injectedUrl,
+      chains: [chain],
+      columns: ['event_id', 'total_amount'],
+    };
+
+    const { sql } = builder.buildBlendedQuery(ctx);
+
+    // Every line of generated SQL must not start with an executable statement
+    // that could have been injected via the title/url
+    for (const line of sql.split('\n')) {
+      if (/^\s*(DROP|INSERT|DELETE|UPDATE)\b/i.test(line)) {
+        throw new Error(`Injected SQL leaked into a code line: ${line}`);
+      }
+    }
+
+    // The raw `--DROP TABLE` marker must not appear literally in the SQL
+    // (the `--` gets replaced with em-dash, and the newline is collapsed)
+    expect(sql).not.toContain('--DROP TABLE');
+    // evil_injection must not appear on its own executable line
+    const evilLines = sql.split('\n').filter(l => l.includes('evil_injection'));
+    for (const line of evilLines) {
+      // If it appears, it must be inside a -- comment
+      expect(line.trimStart().startsWith('--')).toBe(true);
+    }
+
+    // The main CTE comment block must be single-line (no bare newline in the comment text)
+    // Verify: "-- My DM" appears exactly on its own comment line (sanitized, no newline)
+    const commentLines = sql.split('\n').filter(l => l.includes('My DM'));
+    expect(commentLines.length).toBeGreaterThan(0);
+    for (const line of commentLines) {
+      // Each line containing "My DM" must start with -- comment marker
+      expect(line.trimStart().startsWith('--')).toBe(true);
+    }
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.spec.ts
@@ -232,4 +232,30 @@ describe('BigQueryClauseRenderer', () => {
       ).toBe('\nWHERE main.`a` = @p0 AND orders.`b` > @p1');
     });
   });
+
+  describe('paramPrefix', () => {
+    it('uses default param prefix `p` when none given', () => {
+      const out = r.renderWhere([{ column: 'x', operator: 'eq', value: 1 }]);
+      expect(out.sql).toContain('@p0');
+      expect(out.params[0].name).toBe('p0');
+    });
+
+    it('uses custom paramPrefix when given', () => {
+      const out = r.renderWhere([{ column: 'x', operator: 'eq', value: 1 }], undefined, 's_users_');
+      expect(out.sql).toContain('@s_users_0');
+      expect(out.params[0].name).toBe('s_users_0');
+    });
+
+    it('keeps param naming sequential across multiple filters with custom prefix', () => {
+      const out = r.renderWhere(
+        [
+          { column: 'x', operator: 'eq', value: 1 },
+          { column: 'y', operator: 'between', value: { from: 1, to: 2 } },
+        ],
+        undefined,
+        's_users_'
+      );
+      expect(out.params.map(p => p.name)).toEqual(['s_users_0', 's_users_1', 's_users_2']);
+    });
+  });
 });

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder-edge-cases.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder-edge-cases.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Edge-case tests for BigQueryQueryBuilder (simple / non-blended path).
+ *
+ * Fills gaps not covered by bigquery-query.builder.spec.ts:
+ *   Test 6 — default 'p' paramPrefix (no leakage from blended s_ prefix)
+ *   Test 7 — same context produces byte-identical SQL (simple path)
+ *   Test 8 — filters + sort + limit on a view definition (full-combo)
+ *   Test 9 — negative LIMIT throws at the renderer level
+ *
+ * No DB beyond the NestJS test module — pure unit exercising the codegen path.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { BigQueryQueryBuilder } from './bigquery-query.builder';
+import { BigQueryClauseRenderer } from './bigquery-clause-renderer';
+import { isQueryBuildResult } from '../../interfaces/data-mart-query-builder.interface';
+import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
+
+// ---------------------------------------------------------------------------
+// Definition helpers (mirrored from bigquery-query.builder.spec.ts pattern)
+// ---------------------------------------------------------------------------
+
+function tableDefinition(fqn: string): DataMartDefinition {
+  return { type: 'table', fullyQualifiedName: fqn } as unknown as DataMartDefinition;
+}
+
+function viewDefinition(fqn: string): DataMartDefinition {
+  return { fullyQualifiedName: fqn } as unknown as DataMartDefinition;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BigQueryQueryBuilder — simple-path edge cases', () => {
+  let builder: BigQueryQueryBuilder;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BigQueryQueryBuilder, BigQueryClauseRenderer],
+    }).compile();
+
+    builder = module.get(BigQueryQueryBuilder);
+  });
+
+  // -------------------------------------------------------------------------
+  it('Test 6 — param naming uses default "p" prefix (no leakage from blended s_ prefix)', async () => {
+    // The simple builder never sets a custom paramPrefix — all bound params must
+    // be named @p0, @p1, ... (never @s_main_0 or any slice-style name).
+    const result = await builder.buildQuery(tableDefinition('proj.dataset.events'), {
+      columns: ['event_id', 'amount'],
+      filters: [
+        { column: 'amount', operator: 'gt', value: 100 },
+        { column: 'event_id', operator: 'eq', value: 'click' },
+      ],
+    });
+
+    if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
+
+    // Both params must use the default 'p' prefix
+    expect(result.sql).toContain('@p0');
+    expect(result.sql).toContain('@p1');
+
+    // Slice-style prefixes must not appear
+    expect(result.sql).not.toMatch(/@s_/);
+
+    // Verify param array follows the 'p' prefix contract
+    expect(result.params).toHaveLength(2);
+    expect(result.params[0].name).toBe('p0');
+    expect(result.params[1].name).toBe('p1');
+    expect(result.params[0].value).toBe(100);
+    expect(result.params[1].value).toBe('click');
+  });
+
+  // -------------------------------------------------------------------------
+  it('Test 7 — same context produces byte-identical SQL (simple path)', async () => {
+    // Mirror of blended-determinism Test 1: verifies no internal state drift
+    // between repeated calls on the simple builder.
+    const definition = tableDefinition('proj.dataset.events');
+    const options = {
+      columns: ['event_id', 'amount', 'session_id'],
+      filters: [
+        { column: 'amount', operator: 'gt' as const, value: 50 },
+        { column: 'session_id', operator: 'is_not_null' as const },
+      ],
+      sort: [{ column: 'amount', direction: 'desc' as const }],
+      limit: 500,
+    };
+
+    const result1 = await builder.buildQuery(definition, options);
+    const result2 = await builder.buildQuery(definition, options);
+
+    if (!isQueryBuildResult(result1)) throw new Error('expected QueryBuildResult (call 1)');
+    if (!isQueryBuildResult(result2)) throw new Error('expected QueryBuildResult (call 2)');
+
+    expect(result1.sql).toEqual(result2.sql);
+  });
+
+  // -------------------------------------------------------------------------
+  it('Test 8 — filters + sort + limit on a view definition produces correct full-combo SQL', async () => {
+    // The existing spec checks view FROM correctness (single filter) but does not
+    // exercise the full WHERE + ORDER BY + LIMIT combo on a view-type definition.
+    const result = await builder.buildQuery(viewDefinition('proj.ds.my_analytics_view'), {
+      columns: ['session_id', 'revenue'],
+      filters: [{ column: 'revenue', operator: 'gte', value: 1000 }],
+      sort: [{ column: 'revenue', direction: 'desc' }],
+      limit: 100,
+    });
+
+    if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
+
+    const sql = result.sql;
+
+    // FROM must reference the view (dot-separated FQN → backtick-quoted parts)
+    expect(sql).toContain('FROM `proj`.`ds`.`my_analytics_view`');
+
+    // WHERE must appear before ORDER BY
+    expect(sql).toContain('WHERE `revenue` >= @p0');
+    expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('ORDER BY'));
+
+    // ORDER BY must appear before LIMIT
+    expect(sql).toContain('ORDER BY `revenue` DESC');
+    expect(sql.indexOf('ORDER BY')).toBeLessThan(sql.indexOf('LIMIT'));
+
+    // LIMIT at the end
+    expect(sql.trimEnd().endsWith('LIMIT 100')).toBe(true);
+
+    // Param bound correctly
+    expect(result.params).toHaveLength(1);
+    expect(result.params[0]).toEqual({ name: 'p0', value: 1000 });
+  });
+
+  // -------------------------------------------------------------------------
+  it('Test 9 — negative LIMIT throws at the renderer level', async () => {
+    // renderLimit guards: if (!Number.isInteger(limit) || limit < 0) → throws.
+    // The simple builder propagates this error. limit: 0 is valid (LIMIT 0),
+    // but limit: -5 must throw.
+    await expect(
+      builder.buildQuery(tableDefinition('proj.dataset.events'), {
+        columns: ['event_id'],
+        limit: -5,
+      })
+    ).rejects.toThrow(/Invalid LIMIT value/);
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.spec.ts
@@ -145,4 +145,30 @@ describe('DatabricksBlendedQueryBuilder — output controls guard', () => {
       })
     ).toThrow(NotImplementedException);
   });
+
+  it('throws NotImplemented when limit is set', () => {
+    expect(() =>
+      builder.buildBlendedQuery({
+        ...baseContext,
+        limit: 100,
+      })
+    ).toThrow(NotImplementedException);
+  });
+
+  it('throws NotImplemented on pre-join filters (slices)', () => {
+    expect(() =>
+      builder.buildBlendedQuery({
+        ...baseContext,
+        filters: [
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      })
+    ).toThrow(NotImplementedException);
+  });
 });

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.ts
@@ -1,7 +1,6 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
-import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
 import { SqlClauseRenderer } from '../../utils/sql-clause-renderer';
 
 @Injectable()
@@ -15,14 +14,5 @@ export class DatabricksBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
 
   protected buildStringAgg(fieldName: string): string {
     return `CONCAT_WS(', ', COLLECT_LIST(CAST(${fieldName} AS STRING)))`;
-  }
-
-  buildBlendedQuery(context: BlendedQueryContext) {
-    if ((context.filters?.length ?? 0) > 0 || (context.sort?.length ?? 0) > 0) {
-      throw new NotImplementedException(
-        `Output controls not yet supported for storage type ${this.type}`
-      );
-    }
-    return super.buildBlendedQuery(context);
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
@@ -1,4 +1,6 @@
 import { DataStorageType } from '../enums/data-storage-type.enum';
+import { extractCteBody } from '@owox/test-utils';
+import type { FilterRule } from '../../dto/schemas/filter-config.schema';
 import {
   createBuildContext,
   makeChain,
@@ -6,7 +8,7 @@ import {
 } from './__fixtures__/blended-query-builder-fixtures';
 import { AbstractBlendedQueryBuilder } from './abstract-blended-query-builder';
 import { ResolvedRelationshipChain, BlendedQueryContext } from './blended-query-builder.interface';
-import { SqlClauseRenderer } from '../utils/sql-clause-renderer';
+import { SqlClauseRenderer, SqlParameter } from '../utils/sql-clause-renderer';
 import { BigQueryClauseRenderer } from '../bigquery/services/bigquery-clause-renderer';
 
 // Uses backtick quoting and a plain STRING_AGG syntax (no CAST) so that SQL-shape
@@ -1239,6 +1241,607 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
     });
     const { params } = builder.buildBlendedQuery(buildContext([chain], ['customer_name']));
     expect(params).toEqual([]);
+  });
+
+  describe('with pre-join filters', () => {
+    function makeUsersChain() {
+      return makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'users',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'user_id' }],
+        }),
+        targetTableReference: 'users_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'email',
+            outputAlias: 'users_email',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+    }
+
+    it('emits WHERE inside a leaf raw CTE for a single pre-join filter', () => {
+      const ctx: BlendedQueryContext = {
+        ...buildContext([makeUsersChain()], ['users_email']),
+        filters: [
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      };
+      const { sql, params } = builder.buildBlendedQuery(ctx);
+      expect(sql).toMatch(/users_raw AS \([\s\S]+?WHERE\s+userRole\s*=\s*@s_users_0/);
+      expect(params.find(p => p.name === 's_users_0')?.value).toBe('admin');
+    });
+
+    it('projects pre-join filter columns into the raw CTE even if not in columnConfig', () => {
+      const ctx: BlendedQueryContext = {
+        ...buildContext([makeUsersChain()], ['users_email']),
+        filters: [
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      };
+      const { sql } = builder.buildBlendedQuery(ctx);
+      expect(sql).toMatch(/users_raw AS \([\s\S]*?userRole[\s\S]*?FROM/);
+    });
+
+    it('combines multiple pre-join filters on the same CTE with AND', () => {
+      const ctx: BlendedQueryContext = {
+        ...buildContext([makeUsersChain()], ['users_email']),
+        filters: [
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+          {
+            column: 'createdAt',
+            operator: 'relative_date',
+            value: { kind: 'last_n_days', n: 30 },
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      };
+      const { sql } = builder.buildBlendedQuery(ctx);
+      expect(sql).toMatch(/WHERE[\s\S]+AND[\s\S]+DATE_SUB/);
+    });
+
+    it('uses unique param prefixes across CTEs to avoid @p0 collision', () => {
+      const orgsChain = makeChain({
+        relationship: makeRelationship({
+          id: 'rel-orgs',
+          targetAlias: 'orgs',
+          joinConditions: [{ sourceFieldName: 'org_id', targetFieldName: 'org_id' }],
+        }),
+        targetTableReference: 'orgs_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'name',
+            outputAlias: 'orgs_name',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+      const ctx: BlendedQueryContext = {
+        ...buildContext([makeUsersChain(), orgsChain], ['users_email', 'orgs_name']),
+        filters: [
+          { column: 'users_email', operator: 'contains', value: '@owox' },
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+          {
+            column: 'plan',
+            operator: 'eq',
+            value: 'pro',
+            placement: 'pre-join',
+            aliasPath: 'orgs',
+          },
+        ],
+      };
+      const { params } = builder.buildBlendedQuery(ctx);
+      const names = params.map(p => p.name).sort();
+      expect(new Set(names).size).toBe(names.length);
+    });
+
+    it('quotes each segment of a dotted column (nested struct) in the pre-join WHERE', () => {
+      const ctx: BlendedQueryContext = {
+        ...buildContext([makeUsersChain()], ['users_email']),
+        filters: [
+          {
+            column: 'profile.country',
+            operator: 'eq',
+            value: 'UA',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      };
+      const { sql } = builder.buildBlendedQuery(ctx);
+      // M1 regression: nested struct paths must traverse as `profile.country`
+      // (a STRUCT field access in BigQuery), never as a single backticked
+      // identifier `profile.country` (which BigQuery would resolve as a
+      // column literally named "profile.country" → unknown column error).
+      // The TestBlendedWithRenderer leaves safe-pattern segments unquoted, so
+      // the emitted form is `profile.country` itself; the negative assertion
+      // pins the absence of the wrongly-fused form.
+      expect(sql).toContain('WHERE profile.country = @s_users_0');
+      expect(sql).not.toContain('`profile.country`');
+    });
+
+    it('throws when a pre-join filter aliasPath does not resolve to any chain', () => {
+      const ctx: BlendedQueryContext = {
+        ...buildContext([makeUsersChain()], ['users_email']),
+        filters: [
+          {
+            column: 'plan',
+            operator: 'eq',
+            value: 'pro',
+            placement: 'pre-join',
+            aliasPath: 'orgs',
+          },
+        ],
+      };
+      expect(() => builder.buildBlendedQuery(ctx)).toThrow(/aliasPath='orgs'/);
+    });
+
+    it("post-join filters use the 'p' prefix so they never collide with pre-join 's_<cte>_' prefixes", () => {
+      const ctx: BlendedQueryContext = {
+        ...buildContext([makeUsersChain()], ['customer_name', 'users_email']),
+        filters: [
+          { column: 'customer_name', operator: 'eq', value: 'X' },
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      };
+      const { sql, params } = builder.buildBlendedQuery(ctx);
+      expect(sql).toContain('WHERE main.customer_name = @p0');
+      expect(sql).toContain('WHERE userRole = @s_users_0');
+      const names = params.map(p => p.name);
+      expect(new Set(names).size).toBe(names.length);
+      expect(names).toContain('p0');
+      expect(names).toContain('s_users_0');
+    });
+  });
+
+  describe('with pre-join filters — operator matrix', () => {
+    function makeUsersChain() {
+      return makeChain({
+        relationship: makeRelationship({
+          targetAlias: 'users',
+          joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'user_id' }],
+        }),
+        targetTableReference: 'users_table',
+        parentAlias: 'main',
+        blendedFields: [
+          {
+            targetFieldName: 'email',
+            outputAlias: 'users_email',
+            isHidden: false,
+            aggregateFunction: 'STRING_AGG',
+          },
+        ],
+      });
+    }
+
+    type RuleInput = Omit<FilterRule, 'placement' | 'aliasPath'>;
+
+    function runWithRule(rule: RuleInput): { sql: string; params: SqlParameter[] } {
+      const ctx: BlendedQueryContext = {
+        ...buildContext([makeUsersChain()], ['users_email']),
+        filters: [{ ...rule, placement: 'pre-join', aliasPath: 'users' } as FilterRule],
+      };
+      return builder.buildBlendedQuery(ctx);
+    }
+
+    // ── Scalar comparison operators (each consumes 1 param) ────────────────
+
+    it.each([
+      ['eq', '=', 'admin' as string | number],
+      ['neq', '!=', 'admin'],
+      ['gt', '>', 5],
+      ['lt', '<', 5],
+      ['gte', '>=', 5],
+      ['lte', '<=', 5],
+    ] as const)('%s renders as `%s` with 1 param @s_users_0', (op, sqlOp, value) => {
+      const { sql, params } = runWithRule({
+        column: 'attr',
+        operator: op,
+        value,
+      } as RuleInput);
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      const escaped = sqlOp.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      // TestBlendedWithRenderer leaves safe-pattern identifiers unquoted; the
+      // shape of the emitted predicate is what matters, not the quoting.
+      expect(usersRawBody).toMatch(new RegExp(`attr\\s*${escaped}\\s*@s_users_0`));
+      expect(params.filter(p => p.name.startsWith('s_users_'))).toHaveLength(1);
+      expect(params.find(p => p.name === 's_users_0')?.value).toBe(value);
+    });
+
+    // ── Substring / affix matchers use BigQuery built-ins, not LIKE ────────
+
+    it.each([
+      ['contains', 'STRPOS(name, @s_users_0) > 0'],
+      ['not_contains', 'STRPOS(name, @s_users_0) = 0'],
+      ['starts_with', 'STARTS_WITH(name, @s_users_0)'],
+      ['ends_with', 'ENDS_WITH(name, @s_users_0)'],
+    ] as const)('%s renders as `%s` with 1 param', (op, fragment) => {
+      const { sql, params } = runWithRule({
+        column: 'name',
+        operator: op,
+        value: 'foo',
+      } as RuleInput);
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      expect(usersRawBody).toContain(fragment);
+      expect(params.filter(p => p.name.startsWith('s_users_'))).toHaveLength(1);
+    });
+
+    // ── No-value operators consume 0 params ────────────────────────────────
+
+    it.each([
+      ['is_null', 'flag IS NULL'],
+      ['is_not_null', 'flag IS NOT NULL'],
+      ['is_empty', "(flag IS NULL OR flag = '')"],
+      ['is_not_empty', "(flag IS NOT NULL AND flag != '')"],
+      ['is_true', 'flag = TRUE'],
+      ['is_false', 'flag = FALSE'],
+    ] as const)('%s renders as `%s` with 0 params', (op, fragment) => {
+      const { sql, params } = runWithRule({
+        column: 'flag',
+        operator: op,
+      } as RuleInput);
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      expect(usersRawBody).toContain(fragment);
+      expect(params.filter(p => p.name.startsWith('s_users_'))).toHaveLength(0);
+    });
+
+    // ── Regex operators (each consumes 1 param) ─────────────────────────────
+
+    it.each([
+      ['regex', 'REGEXP_CONTAINS'],
+      ['not_regex', 'NOT REGEXP_CONTAINS'],
+    ] as const)('%s renders via %s with 1 param @s_users_0', (op, fragment) => {
+      const { sql, params } = runWithRule({
+        column: 'name',
+        operator: op,
+        value: '^a',
+      } as RuleInput);
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      expect(usersRawBody).toContain(fragment);
+      expect(usersRawBody).toContain('@s_users_0');
+      expect(params.filter(p => p.name.startsWith('s_users_'))).toHaveLength(1);
+    });
+
+    // ── Range / relative-date operators ────────────────────────────────────
+
+    it('between renders as `>= AND <=` with 2 params @s_users_0/@s_users_1', () => {
+      const { sql, params } = runWithRule({
+        column: 'amount',
+        operator: 'between',
+        value: { from: 10, to: 20 },
+      } as RuleInput);
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      expect(usersRawBody).toMatch(/amount\s+BETWEEN\s+@s_users_0\s+AND\s+@s_users_1/);
+      expect(params.filter(p => p.name.startsWith('s_users_'))).toHaveLength(2);
+    });
+
+    it('relative_date `today` renders as `= CURRENT_DATE()` with 0 params', () => {
+      const { sql, params } = runWithRule({
+        column: 'created_at',
+        operator: 'relative_date',
+        value: { kind: 'today' },
+      } as RuleInput);
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      expect(usersRawBody).toContain('created_at = CURRENT_DATE()');
+      expect(params.filter(p => p.name.startsWith('s_users_'))).toHaveLength(0);
+    });
+
+    it('relative_date `last_n_days` embeds `n` as a literal INTERVAL with 0 params', () => {
+      const { sql, params } = runWithRule({
+        column: 'created_at',
+        operator: 'relative_date',
+        value: { kind: 'last_n_days', n: 30 },
+      } as RuleInput);
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      expect(usersRawBody).toContain('DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)');
+      expect(params.filter(p => p.name.startsWith('s_users_'))).toHaveLength(0);
+    });
+  });
+});
+
+describe('AbstractBlendedQueryBuilder — pre-join filters on tricky tree shapes', () => {
+  let builder: TestBlendedWithRenderer;
+  const buildContext = createBuildContext('main_table');
+
+  beforeEach(() => {
+    builder = new TestBlendedWithRenderer();
+  });
+
+  it('pre-join filter on an intermediate (non-leaf) chain: WHERE lands in b_raw, not b_joined', () => {
+    // Tree: main → b → c. Pre-join filter on aliasPath='b'.
+    const bChain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-b',
+        targetAlias: 'b',
+        joinConditions: [{ sourceFieldName: 'b_id', targetFieldName: 'b_id' }],
+      }),
+      targetTableReference: 'b_table',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'b_field',
+          outputAlias: 'b_blend',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+    const cChain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-c',
+        targetAlias: 'c',
+        joinConditions: [{ sourceFieldName: 'c_id', targetFieldName: 'c_id' }],
+      }),
+      targetTableReference: 'c_table',
+      parentAlias: 'b',
+      blendedFields: [
+        {
+          targetFieldName: 'c_field',
+          outputAlias: 'c_blend',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const ctx: BlendedQueryContext = {
+      ...buildContext([bChain, cChain], ['b_blend']),
+      filters: [
+        {
+          column: 'b_status',
+          operator: 'eq',
+          value: 'active',
+          placement: 'pre-join',
+          aliasPath: 'b',
+        } as FilterRule,
+      ],
+    };
+    const { sql } = builder.buildBlendedQuery(ctx);
+
+    const bRaw = extractCteBody(sql, 'b_raw');
+    expect(bRaw).toMatch(/WHERE\s+b_status\s*=\s*@s_b_0/);
+
+    // b_joined CTE must NOT carry the WHERE — the pre-join WHERE belongs to
+    // the raw CTE that wraps the table, never to the join-projection CTE.
+    const bJoined = extractCteBody(sql, 'b_joined');
+    expect(bJoined).not.toMatch(/WHERE/);
+  });
+
+  it('pre-join filter on a deep chain (a→b→c→d): WHERE lands in deepest _raw CTE', () => {
+    const aChain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-a',
+        targetAlias: 'a',
+        joinConditions: [{ sourceFieldName: 'a_id', targetFieldName: 'a_id' }],
+      }),
+      targetTableReference: 'a_table',
+      parentAlias: 'main',
+      blendedFields: [],
+    });
+    const bChain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-b',
+        targetAlias: 'b',
+        joinConditions: [{ sourceFieldName: 'b_id', targetFieldName: 'b_id' }],
+      }),
+      targetTableReference: 'b_table',
+      parentAlias: 'a',
+      blendedFields: [],
+    });
+    const cChain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-c',
+        targetAlias: 'c',
+        joinConditions: [{ sourceFieldName: 'c_id', targetFieldName: 'c_id' }],
+      }),
+      targetTableReference: 'c_table',
+      parentAlias: 'a_b',
+      blendedFields: [],
+    });
+    const dChain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-d',
+        targetAlias: 'd',
+        joinConditions: [{ sourceFieldName: 'd_id', targetFieldName: 'd_id' }],
+      }),
+      targetTableReference: 'd_table',
+      parentAlias: 'a_b_c',
+      blendedFields: [
+        {
+          targetFieldName: 'd_field',
+          outputAlias: 'd_blend',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const ctx: BlendedQueryContext = {
+      ...buildContext([aChain, bChain, cChain, dChain], ['d_blend']),
+      filters: [
+        {
+          column: 'd_status',
+          operator: 'eq',
+          value: 'live',
+          placement: 'pre-join',
+          aliasPath: 'a.b.c.d',
+        } as FilterRule,
+      ],
+    };
+    const { sql } = builder.buildBlendedQuery(ctx);
+
+    const dRaw = extractCteBody(sql, 'a_b_c_d_raw');
+    expect(dRaw).toMatch(/WHERE\s+d_status\s*=\s*@s_a_b_c_d_0/);
+
+    // Sibling _raw CTEs further up the tree must NOT carry the WHERE.
+    expect(extractCteBody(sql, 'a_raw')).not.toMatch(/WHERE/);
+    expect(extractCteBody(sql, 'a_b_raw')).not.toMatch(/WHERE/);
+    expect(extractCteBody(sql, 'a_b_c_raw')).not.toMatch(/WHERE/);
+  });
+
+  it('diamond pattern: pre-join filter lands only in the sliced path, not in the other branch', () => {
+    // Two distinct chains both targeting alias "c" via different parents
+    // (path "a.c" vs "b.c"). Filter on aliasPath="a.c" must only touch a_c_raw.
+    const aChain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-a',
+        targetAlias: 'a',
+        joinConditions: [{ sourceFieldName: 'a_id', targetFieldName: 'a_id' }],
+      }),
+      targetTableReference: 'a_table',
+      parentAlias: 'main',
+      blendedFields: [],
+    });
+    const acChain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-ac',
+        targetAlias: 'c',
+        joinConditions: [{ sourceFieldName: 'c_id', targetFieldName: 'c_id' }],
+      }),
+      targetTableReference: 'c_table',
+      parentAlias: 'a',
+      blendedFields: [
+        {
+          targetFieldName: 'c_field',
+          outputAlias: 'ac_blend',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+    const bChain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-b',
+        targetAlias: 'b',
+        joinConditions: [{ sourceFieldName: 'b_id', targetFieldName: 'b_id' }],
+      }),
+      targetTableReference: 'b_table',
+      parentAlias: 'main',
+      blendedFields: [],
+    });
+    const bcChain = makeChain({
+      relationship: makeRelationship({
+        id: 'rel-bc',
+        targetAlias: 'c',
+        joinConditions: [{ sourceFieldName: 'c_id', targetFieldName: 'c_id' }],
+      }),
+      targetTableReference: 'c_table',
+      parentAlias: 'b',
+      blendedFields: [
+        {
+          targetFieldName: 'c_field',
+          outputAlias: 'bc_blend',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const ctx: BlendedQueryContext = {
+      ...buildContext([aChain, acChain, bChain, bcChain], ['ac_blend', 'bc_blend']),
+      filters: [
+        {
+          column: 'c_status',
+          operator: 'eq',
+          value: 'live',
+          placement: 'pre-join',
+          aliasPath: 'a.c',
+        } as FilterRule,
+      ],
+    };
+    const { sql } = builder.buildBlendedQuery(ctx);
+
+    const acRaw = extractCteBody(sql, 'a_c_raw');
+    expect(acRaw).toMatch(/WHERE\s+c_status\s*=\s*@s_a_c_0/);
+
+    const bcRaw = extractCteBody(sql, 'b_c_raw');
+    expect(bcRaw).not.toMatch(/WHERE/);
+  });
+
+  it('pre-join column equal to a join key: projected at most once in the raw CTE SELECT', () => {
+    // joinConditions targetFieldName='user_id' is both the join key (always
+    // projected into the raw CTE) and the pre-join WHERE column. The
+    // collectSubsidiaryReferences dedup must avoid emitting it twice.
+    const usersChain = makeChain({
+      relationship: makeRelationship({
+        targetAlias: 'users',
+        joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'user_id' }],
+      }),
+      targetTableReference: 'users_table',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'email',
+          outputAlias: 'users_email',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const ctx: BlendedQueryContext = {
+      ...buildContext([usersChain], ['users_email']),
+      filters: [
+        {
+          column: 'user_id',
+          operator: 'is_not_null',
+          placement: 'pre-join',
+          aliasPath: 'users',
+        } as FilterRule,
+      ],
+    };
+    const { sql } = builder.buildBlendedQuery(ctx);
+
+    const usersRaw = extractCteBody(sql, 'users_raw');
+    // Count occurrences of `user_id` inside the SELECT projection of users_raw
+    // (between AS ( and FROM). Each match is a SELECT-list item; >1 means dup.
+    const selectMatch = /SELECT\s+([\s\S]+?)\s+FROM/m.exec(usersRaw);
+    expect(selectMatch).not.toBeNull();
+    const selectList = selectMatch![1];
+    // TestBlendedWithRenderer leaves safe identifiers unquoted, so count bare
+    // `user_id` occurrences. Use a word-boundary match to avoid catching it
+    // as a substring of a longer alphanumeric identifier.
+    const userIdMatches = selectList.match(/\buser_id\b/g) ?? [];
+    expect(userIdMatches.length).toBe(1);
+
+    // WHERE still applies on user_id IS NOT NULL.
+    expect(usersRaw).toMatch(/WHERE\s+user_id\s+IS NOT NULL/);
   });
 });
 

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
@@ -1,4 +1,4 @@
-import { NotImplementedException } from '@nestjs/common';
+import { Logger, NotImplementedException } from '@nestjs/common';
 import {
   BlendedQueryBuilder,
   BlendedQueryContext,
@@ -46,6 +46,10 @@ interface PassthroughField {
  * JOINed in. Filter rules with `placement: 'post-join'` (the default) are
  * applied to the final SELECT.
  *
+ * Slice semantics: subsidiaries are LEFT JOINed, so a slice narrows the
+ * subsidiary CTE but does NOT drop home rows (unmatched home rows pass through
+ * with NULL). Use a post-join filter on top for row elimination.
+ *
  * ```sql
  * WITH
  *   main AS (SELECT ... FROM <mainTable>),
@@ -74,6 +78,8 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
   protected abstract get identifierQuoteChar(): string;
 
   protected abstract get clauseRenderer(): SqlClauseRenderer | null;
+
+  private readonly logger = new Logger(AbstractBlendedQueryBuilder.name);
 
   buildBlendedQuery(context: BlendedQueryContext): { sql: string; params: SqlParameter[] } {
     const allFilters = context.filters ?? [];
@@ -350,7 +356,15 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     preJoinFilters?: FilterRule[],
     preJoinParamPrefix?: string
   ): { sql: string; params: SqlParameter[] } {
-    const safeForExplicitProjection = columns.length > 0 && columns.every(c => !c.includes('.'));
+    // `quoteIdentifier` treats the input as one identifier — dotted paths
+    // can't be projected, so we widen to SELECT *. Warn so the perf hit is visible.
+    const hasNestedColumns = columns.some(c => c.includes('.'));
+    const safeForExplicitProjection = columns.length > 0 && !hasNestedColumns;
+    if (columns.length > 0 && hasNestedColumns) {
+      this.logger.warn(
+        `buildRawCte(${alias}): nested-path column(s) forced SELECT * on ${tableReference}`
+      );
+    }
     const safeTitle = sanitizeSqlComment(title);
     const safeUrl = sanitizeSqlComment(url);
     const header = `  -- ${safeTitle}\n  -- ${safeUrl}\n  ${this.quoteIdentifier(alias)} AS (\n`;

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
@@ -1,3 +1,4 @@
+import { NotImplementedException } from '@nestjs/common';
 import {
   BlendedQueryBuilder,
   BlendedQueryContext,
@@ -6,15 +7,15 @@ import {
 import { DataStorageType } from '../enums/data-storage-type.enum';
 import { AggregateFunction } from '../../dto/schemas/aggregate-function.schema';
 import { ColumnRefResolver, SqlClauseRenderer, SqlParameter } from '../utils/sql-clause-renderer';
+import { FilterRule, aliasPathToCteName } from '../../dto/schemas/filter-config.schema';
 
 interface BlendTreeNode {
   chain: ResolvedRelationshipChain;
   children: BlendTreeNode[];
 }
 
-// `title`/`url` flow into single-line SQL comments inside generated queries;
-// embedded newlines would close the comment and expose the rest of the input as
-// executable SQL, so strip any line break or additional comment marker.
+// Embedded newlines / `--` in title/url would close the SQL comment and expose
+// trailing input as executable SQL.
 function sanitizeSqlComment(text: string): string {
   return text
     .replace(/[\r\n]+/g, ' ')
@@ -22,12 +23,6 @@ function sanitizeSqlComment(text: string): string {
     .trim();
 }
 
-/**
- * Tracks a blended field flowing upward through the tree during bottom-up
- * aggregation. At the leaf level this is the original field; at each
- * intermediate level the aggregated result is re-aggregated using
- * {@link getReAggregateFunction}.
- */
 interface PassthroughField {
   outputAlias: string;
   aggregateFunction: AggregateFunction;
@@ -45,6 +40,11 @@ interface PassthroughField {
  * into the parent's raw data, and aggregating again — all the way up to the
  * root level. At each level the GROUP BY contains ONLY the join key to that
  * node's parent, ensuring at most one output row per parent-key value.
+ *
+ * Filter rules with `placement: 'pre-join'` are pushed down into the
+ * subsidiary `*_raw` CTE so the joined data mart is narrowed before being
+ * JOINed in. Filter rules with `placement: 'post-join'` (the default) are
+ * applied to the final SELECT.
  *
  * ```sql
  * WITH
@@ -71,38 +71,56 @@ interface PassthroughField {
 export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder {
   abstract readonly type: DataStorageType;
 
-  /**
-   * The quoting character this dialect uses for identifiers (BigQuery/Databricks
-   * use backticks; Snowflake/Redshift/Athena use double quotes). Subclasses
-   * provide this so the abstract builder can safely emit user-controlled names
-   * (aliases, column names with apostrophes/spaces, reserved keywords, etc.)
-   * without breaking the generated SQL.
-   */
   protected abstract get identifierQuoteChar(): string;
 
-  /**
-   * Returns the clause renderer used to append WHERE/ORDER BY/LIMIT to the
-   * final SELECT. BigQuery subclass provides a BigQueryClauseRenderer; non-BQ
-   * subclasses return null because their override throws before reaching here
-   * when output-controls fields are set.
-   */
   protected abstract get clauseRenderer(): SqlClauseRenderer | null;
 
   buildBlendedQuery(context: BlendedQueryContext): { sql: string; params: SqlParameter[] } {
+    const allFilters = context.filters ?? [];
+
+    // Capability guard first — storages without a clauseRenderer can't honour any controls.
+    const hasOutputControls =
+      allFilters.length > 0 || (context.sort?.length ?? 0) > 0 || (context.limit ?? null) !== null;
+    if (hasOutputControls && this.clauseRenderer === null) {
+      throw new NotImplementedException(
+        `Output controls not yet supported for storage type ${this.type}`
+      );
+    }
+
+    const validCteNames = new Set(context.chains.map(c => c.cteName));
+    const preJoinByCte = new Map<string, FilterRule[]>();
+    const postJoinFilters: FilterRule[] = [];
+    for (const rule of allFilters) {
+      if (rule.placement === 'pre-join') {
+        // aliasPath presence and "main" exclusion enforced at schema level.
+        if (!rule.aliasPath) {
+          throw new Error('buildBlendedQuery: pre-join rule missing aliasPath (schema bug)');
+        }
+        const cteName = aliasPathToCteName(rule.aliasPath);
+        if (!validCteNames.has(cteName)) {
+          throw new Error(
+            `buildBlendedQuery: pre-join filter aliasPath='${rule.aliasPath}' ` +
+              `does not resolve to any chain (cteName='${cteName}')`
+          );
+        }
+        const list = preJoinByCte.get(cteName) ?? [];
+        list.push(rule);
+        preJoinByCte.set(cteName, list);
+      } else {
+        postJoinFilters.push(rule);
+      }
+    }
+
     const { mainTableReference, mainDataMartTitle, mainDataMartUrl, chains, columns } = context;
     const columnSet = new Set(columns);
     const referencedColumns = new Set<string>([
       ...columns,
-      ...(context.filters ?? []).map(f => f.column),
+      ...postJoinFilters.map(f => f.column),
       ...(context.sort ?? []).map(s => s.column),
     ]);
 
     const roots = this.buildTree(chains);
 
-    // Single walk over the chain forest: collect every blended outputAlias and
-    // its root CTE alias. Hidden aliases are included (filters legitimately
-    // reference them) but tracked separately so `buildSelectParts` can still
-    // keep them out of the final SELECT.
     const outputAliasToRoot = new Map<string, string>();
     const hiddenOutputAliases = new Set<string>();
     for (const root of roots) {
@@ -110,18 +128,24 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     }
 
     const cteBlocks: string[] = [];
+    const cteParams: SqlParameter[] = [];
 
-    // 1. Raw CTE for main data mart — projects only the columns actually referenced.
     const mainColumns = this.collectMainReferences(roots, referencedColumns, outputAliasToRoot);
-    cteBlocks.push(
-      this.buildRawCte('main', mainTableReference, mainDataMartTitle, mainDataMartUrl, mainColumns)
+    const mainRaw = this.buildRawCte(
+      'main',
+      mainTableReference,
+      mainDataMartTitle,
+      mainDataMartUrl,
+      mainColumns,
+      /* preJoinFilters */ undefined
     );
+    cteBlocks.push(mainRaw.sql);
+    cteParams.push(...mainRaw.params);
 
-    // 2. Bottom-up CTEs for each subtree rooted at a direct child of main.
-    //    Post-order traversal ensures leaf CTEs come first.
     for (const root of roots) {
-      const { ctes } = this.buildSubtreeCtes(root);
+      const { ctes, params } = this.buildSubtreeCtes(root, preJoinByCte);
       cteBlocks.push(...ctes);
+      cteParams.push(...params);
     }
 
     const withClause = `WITH\n${cteBlocks.join(',\n\n')}`;
@@ -137,7 +161,7 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     const qualifyColumn = this.buildColumnQualifier(outputAliasToRoot);
     const renderer = this.clauseRenderer;
     const where = renderer
-      ? renderer.renderWhere(context.filters ?? [], qualifyColumn)
+      ? renderer.renderWhere(postJoinFilters, qualifyColumn, 'p')
       : { sql: '', params: [] as SqlParameter[] };
     const orderBy = renderer
       ? renderer.renderOrderBy(context.sort ?? [], qualifyColumn)
@@ -146,15 +170,9 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       ? renderer.renderLimit(context.limit ?? null)
       : { sql: '', params: [] as SqlParameter[] };
     const sql = `${withClause}\n\n${body}${where.sql}${orderBy.sql}${limit.sql}`;
-    return { sql, params: [...where.params, ...orderBy.params, ...limit.params] };
+    return { sql, params: [...cteParams, ...where.params, ...orderBy.params, ...limit.params] };
   }
 
-  /**
-   * Returns a resolver that prefixes blended outputAliases with their root
-   * CTE alias and everything else with `main.`. Without this, WHERE/ORDER BY
-   * would emit bare names and fail with "column X is ambiguous" whenever a
-   * name lives in two CTEs (join keys are the typical trigger).
-   */
   private buildColumnQualifier(outputAliasToRoot: Map<string, string>): ColumnRefResolver {
     return (column: string) => {
       const rootAlias = outputAliasToRoot.get(column);
@@ -165,25 +183,12 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     };
   }
 
-  /**
-   * Wraps a single identifier (CTE alias, column alias, single-segment column
-   * name) in dialect-specific quotes only when needed — names that already
-   * match `[A-Za-z_][A-Za-z0-9_]*` stay unquoted to keep the generated SQL
-   * readable. The quote character itself is escaped by doubling, the standard
-   * SQL convention across all supported dialects.
-   */
   protected quoteIdentifier(name: string): string {
     if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) return name;
     const q = this.identifierQuoteChar;
     return `${q}${name.split(q).join(q + q)}${q}`;
   }
 
-  /**
-   * Quotes a (possibly dotted) column reference, treating each segment
-   * independently. `user.email` becomes e.g. `` `user`.`email` `` — required
-   * for nested struct fields in BigQuery — while a flat `Product's_id` becomes
-   * `` `Product's_id` ``.
-   */
   protected quoteFieldRef(ref: string): string {
     return ref
       .split('.')
@@ -191,10 +196,6 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       .join('.');
   }
 
-  /**
-   * Converts the flat sorted `chains` array into a forest of trees where
-   * root nodes are chains with `parentAlias === 'main'`.
-   */
   private buildTree(chains: ResolvedRelationshipChain[]): BlendTreeNode[] {
     const nodeMap = new Map<string, BlendTreeNode>();
     for (const chain of chains) {
@@ -213,52 +214,55 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     return roots;
   }
 
-  /**
-   * Recursively builds CTEs for a subtree using post-order (bottom-up)
-   * traversal. Returns the CTE blocks and the list of output columns
-   * (passthrough fields) that this subtree exposes after aggregation.
-   */
-  private buildSubtreeCtes(node: BlendTreeNode): {
+  private buildSubtreeCtes(
+    node: BlendTreeNode,
+    preJoinByCte: ReadonlyMap<string, FilterRule[]>
+  ): {
     ctes: string[];
     passthroughFields: PassthroughField[];
+    params: SqlParameter[];
   } {
     const ctes: string[] = [];
+    const params: SqlParameter[] = [];
 
-    // 1. Recurse into children first (post-order)
     const childPassthroughs = new Map<string, PassthroughField[]>();
     for (const child of node.children) {
-      const childResult = this.buildSubtreeCtes(child);
+      const childResult = this.buildSubtreeCtes(child, preJoinByCte);
       ctes.push(...childResult.ctes);
+      params.push(...childResult.params);
       childPassthroughs.set(child.chain.cteName, childResult.passthroughFields);
     }
 
     const { chain } = node;
     const alias = chain.cteName;
 
-    // 2. Raw CTE for this node
-    const subsidiaryColumns = this.collectSubsidiaryReferences(chain, node.children);
-    ctes.push(
-      this.buildRawCte(
-        `${alias}_raw`,
-        chain.targetTableReference,
-        chain.targetDataMartTitle,
-        chain.targetDataMartUrl,
-        subsidiaryColumns
-      )
+    const preJoinFilters = preJoinByCte.get(alias) ?? [];
+    const preJoinColumns = new Set(preJoinFilters.map(r => r.column));
+    const subsidiaryColumns = this.collectSubsidiaryReferences(
+      chain,
+      node.children,
+      preJoinColumns
     );
+    const rawCte = this.buildRawCte(
+      `${alias}_raw`,
+      chain.targetTableReference,
+      chain.targetDataMartTitle,
+      chain.targetDataMartUrl,
+      subsidiaryColumns,
+      preJoinFilters,
+      `s_${alias}_`
+    );
+    ctes.push(rawCte.sql);
+    params.push(...rawCte.params);
 
-    // 3. If this node has children, emit a _joined CTE
     const hasChildren = node.children.length > 0;
     if (hasChildren) {
       ctes.push(this.buildJoinedCte(node, childPassthroughs));
     }
 
-    // 4. Aggregation CTE — groups by parent join keys only
     const allPassthroughFields = this.collectAllPassthroughs(childPassthroughs);
     ctes.push(this.buildAggregationCte(chain, hasChildren, allPassthroughFields));
 
-    // 5. Compute passthrough fields for the parent level:
-    //    own blended fields + re-mapped child passthrough fields
     const passthroughFields: PassthroughField[] = chain.blendedFields.map(f => ({
       outputAlias: f.outputAlias,
       aggregateFunction: f.aggregateFunction,
@@ -272,7 +276,7 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       });
     }
 
-    return { ctes, passthroughFields };
+    return { ctes, passthroughFields, params };
   }
 
   private collectAllPassthroughs(
@@ -285,10 +289,6 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     return result;
   }
 
-  /**
-   * Builds the `{alias}_joined` CTE that LEFT JOINs a node's raw data with
-   * all of its children's aggregated CTEs.
-   */
   private buildJoinedCte(
     node: BlendTreeNode,
     childPassthroughs: Map<string, PassthroughField[]>
@@ -300,15 +300,12 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     const quotedRawAlias = this.quoteIdentifier(rawAlias);
     const quotedJoinedAlias = this.quoteIdentifier(joinedAlias);
 
-    // SELECT columns: parent join keys + own blended fields from raw, then child outputs
     const selectParts: string[] = [];
 
-    // Parent join keys from raw
     for (const jc of chain.relationship.joinConditions) {
       selectParts.push(`${quotedRawAlias}.${this.quoteFieldRef(jc.targetFieldName)}`);
     }
 
-    // Own blended field columns from raw
     const seen = new Set(selectParts);
     for (const field of chain.blendedFields) {
       const ref = `${quotedRawAlias}.${this.quoteFieldRef(field.targetFieldName)}`;
@@ -318,7 +315,6 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       }
     }
 
-    // Child aggregated outputs + JOIN clauses (single pass over children)
     const joinClauses: string[] = [];
     for (const child of node.children) {
       const childAlias = child.chain.cteName;
@@ -350,29 +346,37 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     tableReference: string,
     title: string,
     url: string,
-    columns: string[]
-  ): string {
-    // Fall back to `*` when no explicit columns are known or any column uses
-    // dot-notation (BigQuery nested struct path) — projecting `user.email`
-    // directly would rename it to `email`, breaking downstream references.
+    columns: string[],
+    preJoinFilters?: FilterRule[],
+    preJoinParamPrefix?: string
+  ): { sql: string; params: SqlParameter[] } {
     const safeForExplicitProjection = columns.length > 0 && columns.every(c => !c.includes('.'));
     const safeTitle = sanitizeSqlComment(title);
     const safeUrl = sanitizeSqlComment(url);
     const header = `  -- ${safeTitle}\n  -- ${safeUrl}\n  ${this.quoteIdentifier(alias)} AS (\n`;
-    if (!safeForExplicitProjection) {
-      return `${header}    SELECT * FROM ${tableReference}\n  )`;
+
+    const renderer = this.clauseRenderer;
+    if (preJoinFilters?.length && !preJoinParamPrefix) {
+      throw new Error(
+        `buildRawCte: preJoinParamPrefix is required when preJoinFilters are present (alias='${alias}')`
+      );
     }
-    const projection = columns.map(c => this.quoteIdentifier(c)).join(',\n      ');
-    return `${header}    SELECT\n      ${projection}\n    FROM ${tableReference}\n  )`;
+    const paramPrefix = preJoinParamPrefix ?? '';
+    const qualifyForRawCte: ColumnRefResolver = column => this.quoteFieldRef(column);
+    const where =
+      preJoinFilters?.length && renderer
+        ? renderer.renderWhere(preJoinFilters, qualifyForRawCte, paramPrefix)
+        : { sql: '', params: [] as SqlParameter[] };
+
+    const indentedWhere = where.sql ? where.sql.replace(/^\n/, '\n    ') : '';
+
+    const body = safeForExplicitProjection
+      ? `${header}    SELECT\n      ${columns.map(c => this.quoteIdentifier(c)).join(',\n      ')}\n    FROM ${tableReference}`
+      : `${header}    SELECT * FROM ${tableReference}`;
+
+    return { sql: `${body}${indentedWhere}\n  )`, params: where.params };
   }
 
-  /**
-   * Columns of the main DM that need to be projected in its raw CTE:
-   *  - referenced columns (columnConfig + filter columns + sort columns) that
-   *    are NOT blended outputAliases (hidden ones included — those flow
-   *    through subsidiary CTEs, not through main)
-   *  - join keys used by root-level (direct children of main) chains
-   */
   private collectMainReferences(
     roots: BlendTreeNode[],
     referencedColumns: Set<string>,
@@ -388,15 +392,10 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     return Array.from(refs).sort();
   }
 
-  /**
-   * Columns of a subsidiary DM that need to be projected in its raw CTE:
-   *  - join keys this subsidiary uses to join to its parent (targetFieldName)
-   *  - aggregated columns (blendedFields.targetFieldName)
-   *  - join keys used by children (sourceFieldName — needed for the _joined CTE)
-   */
   private collectSubsidiaryReferences(
     chain: ResolvedRelationshipChain,
-    children: BlendTreeNode[]
+    children: BlendTreeNode[],
+    preJoinColumns: ReadonlySet<string>
   ): string[] {
     const refs = new Set<string>();
     for (const jc of chain.relationship.joinConditions) refs.add(jc.targetFieldName);
@@ -404,18 +403,10 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     for (const child of children) {
       for (const jc of child.chain.relationship.joinConditions) refs.add(jc.sourceFieldName);
     }
+    for (const col of preJoinColumns) refs.add(col);
     return Array.from(refs).sort();
   }
 
-  /**
-   * Builds the aggregation CTE for a single node. Groups by parent join keys
-   * ONLY — child join keys are no longer needed because downstream joins happen
-   * inside the `_joined` CTE, not in the final FROM/JOIN clause.
-   *
-   * For intermediate nodes (hasChildren=true), the source is the `_joined` CTE
-   * and passthrough fields from children are re-aggregated. For leaf nodes,
-   * the source is the `_raw` CTE.
-   */
   private buildAggregationCte(
     chain: ResolvedRelationshipChain,
     hasChildren: boolean,
@@ -427,14 +418,12 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       ? this.quoteIdentifier(`${cteName}_joined`)
       : this.quoteIdentifier(`${cteName}_raw`);
 
-    // Keys this subsidiary uses to join to its parent — always grouped on.
     const parentJoinKeys = relationship.joinConditions.map(jc =>
       this.quoteFieldRef(jc.targetFieldName)
     );
 
     const groupByKeys = [...parentJoinKeys];
 
-    // Own blended field aggregations
     const aggregatedParts = blendedFields.map(field => {
       const aggregated = this.buildAggregation(
         field.aggregateFunction,
@@ -443,7 +432,6 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       return `${aggregated} AS ${this.quoteIdentifier(field.outputAlias)}`;
     });
 
-    // Passthrough fields from children — re-aggregated
     const passthroughParts = passthroughFields.map(pt => {
       const reAggFunc = this.getReAggregateFunction(pt.aggregateFunction);
       const aggregated = this.buildAggregation(reAggFunc, this.quoteIdentifier(pt.outputAlias));
@@ -462,13 +450,6 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     );
   }
 
-  /**
-   * Final SELECT: references main columns and blended columns from root-level
-   * aggregation CTEs only. Deep blended fields are surfaced through root nodes
-   * via re-aggregation. Hidden blended fields fall through to the `main.<col>`
-   * branch so they never appear in the final SELECT, even though they live in
-   * `outputAliasToRoot` (filters need them).
-   */
   private buildSelectParts(
     columnSet: Set<string>,
     outputAliasToRoot: Map<string, string>,
@@ -486,11 +467,6 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     return parts;
   }
 
-  /**
-   * Recursively maps every blended outputAlias in a subtree to the root alias
-   * that will surface it after bottom-up aggregation, also flagging hidden
-   * fields so callers can apply visibility rules without a second traversal.
-   */
   private mapOutputAliasesToRoot(
     node: BlendTreeNode,
     rootAlias: string,
@@ -506,10 +482,6 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     }
   }
 
-  /**
-   * Final JOINs: only root-level nodes (direct children of main) are LEFT
-   * JOINed to main. Deeper joins happen inside `_joined` CTEs.
-   */
   private buildJoinParts(roots: BlendTreeNode[]): string[] {
     return roots.map(root => {
       const { relationship, parentAlias, cteName } = root.chain;
@@ -526,13 +498,6 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     });
   }
 
-  /**
-   * Maps an aggregate function to the function used when re-aggregating an
-   * already-aggregated value at a higher tree level. SUM-of-SUMs and
-   * MAX-of-MAXes stay idempotent; COUNT and COUNT_DISTINCT become SUM
-   * (distinct-sum across parent groups is approximate — same caveat as COUNT);
-   * ANY_VALUE becomes MAX (safe across all dialects).
-   */
   protected getReAggregateFunction(aggregateFunction: AggregateFunction): AggregateFunction {
     switch (aggregateFunction) {
       case 'COUNT':
@@ -558,9 +523,5 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     }
   }
 
-  /**
-   * Must wrap `fieldName` in a CAST to the dialect's native string type so
-   * non-string inputs don't raise runtime errors.
-   */
   protected abstract buildStringAgg(fieldName: string): string;
 }

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.spec.ts
@@ -145,4 +145,30 @@ describe('RedshiftBlendedQueryBuilder — output controls guard', () => {
       })
     ).toThrow(NotImplementedException);
   });
+
+  it('throws NotImplemented when limit is set', () => {
+    expect(() =>
+      builder.buildBlendedQuery({
+        ...baseContext,
+        limit: 100,
+      })
+    ).toThrow(NotImplementedException);
+  });
+
+  it('throws NotImplemented on pre-join filters (slices)', () => {
+    expect(() =>
+      builder.buildBlendedQuery({
+        ...baseContext,
+        filters: [
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      })
+    ).toThrow(NotImplementedException);
+  });
 });

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.ts
@@ -1,7 +1,6 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
-import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
 import { SqlClauseRenderer } from '../../utils/sql-clause-renderer';
 
 @Injectable()
@@ -15,14 +14,5 @@ export class RedshiftBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
 
   protected buildStringAgg(fieldName: string): string {
     return `LISTAGG(CAST(${fieldName} AS VARCHAR), ', ') WITHIN GROUP (ORDER BY ${fieldName})`;
-  }
-
-  buildBlendedQuery(context: BlendedQueryContext) {
-    if ((context.filters?.length ?? 0) > 0 || (context.sort?.length ?? 0) > 0) {
-      throw new NotImplementedException(
-        `Output controls not yet supported for storage type ${this.type}`
-      );
-    }
-    return super.buildBlendedQuery(context);
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.spec.ts
@@ -143,4 +143,30 @@ describe('SnowflakeBlendedQueryBuilder — output controls guard', () => {
       })
     ).toThrow(NotImplementedException);
   });
+
+  it('throws NotImplemented when limit is set', () => {
+    expect(() =>
+      builder.buildBlendedQuery({
+        ...baseContext,
+        limit: 100,
+      })
+    ).toThrow(NotImplementedException);
+  });
+
+  it('throws NotImplemented on pre-join filters (slices)', () => {
+    expect(() =>
+      builder.buildBlendedQuery({
+        ...baseContext,
+        filters: [
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      })
+    ).toThrow(NotImplementedException);
+  });
 });

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.ts
@@ -1,7 +1,6 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
-import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
 import { SqlClauseRenderer } from '../../utils/sql-clause-renderer';
 
 @Injectable()
@@ -15,14 +14,5 @@ export class SnowflakeBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
 
   protected buildStringAgg(fieldName: string): string {
     return `LISTAGG(CAST(${fieldName} AS VARCHAR), ', ')`;
-  }
-
-  buildBlendedQuery(context: BlendedQueryContext) {
-    if ((context.filters?.length ?? 0) > 0 || (context.sort?.length ?? 0) > 0) {
-      throw new NotImplementedException(
-        `Output controls not yet supported for storage type ${this.type}`
-      );
-    }
-    return super.buildBlendedQuery(context);
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/utils/sql-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/utils/sql-clause-renderer.ts
@@ -18,6 +18,9 @@ export interface RenderedClause {
  */
 export type ColumnRefResolver = (column: string) => string;
 
+// Matches BigQuery named-parameter rules — fail fast instead of waiting for BQ to reject it.
+const PARAM_PREFIX_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 export abstract class SqlClauseRenderer {
   protected abstract quoteIdentifier(name: string): string;
   protected abstract renderFilterFragment(
@@ -36,6 +39,11 @@ export abstract class SqlClauseRenderer {
     paramPrefix = 'p'
   ): RenderedClause {
     if (!filters.length) return { sql: '', params: [] };
+    if (!PARAM_PREFIX_PATTERN.test(paramPrefix)) {
+      throw new Error(
+        `renderWhere: invalid paramPrefix '${paramPrefix}' — must match ${PARAM_PREFIX_PATTERN.source}`
+      );
+    }
     const resolve = this.resolverOrFallback(qualifyColumn);
     const fragments: string[] = [];
     const params: SqlParameter[] = [];

--- a/apps/backend/src/data-marts/data-storage-types/utils/sql-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/utils/sql-clause-renderer.ts
@@ -30,14 +30,18 @@ export abstract class SqlClauseRenderer {
     return qualifyColumn ?? (c => this.quoteIdentifier(c));
   }
 
-  renderWhere(filters: FilterRule[], qualifyColumn?: ColumnRefResolver): RenderedClause {
+  renderWhere(
+    filters: FilterRule[],
+    qualifyColumn?: ColumnRefResolver,
+    paramPrefix = 'p'
+  ): RenderedClause {
     if (!filters.length) return { sql: '', params: [] };
     const resolve = this.resolverOrFallback(qualifyColumn);
     const fragments: string[] = [];
     const params: SqlParameter[] = [];
     let nextIndex = 0;
     for (const rule of filters) {
-      const paramName = `p${nextIndex}`;
+      const paramName = `${paramPrefix}${nextIndex}`;
       const out = this.renderFilterFragment(rule, paramName, resolve(rule.column));
       fragments.push(out.sql);
       params.push(...out.params);

--- a/apps/backend/src/data-marts/dto/domain/blending-decision.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/blending-decision.dto.ts
@@ -1,5 +1,6 @@
 import { ReportDataHeader } from './report-data-header.dto';
 import { SqlParameter } from '../../data-storage-types/utils/sql-clause-renderer';
+import { ResolvedRelationshipChain } from '../../data-storage-types/interfaces/blended-query-builder.interface';
 
 export interface BlendingDecision {
   needsBlending: boolean;
@@ -9,4 +10,6 @@ export interface BlendingDecision {
   columnFilter?: string[];
   // Non-empty iff columnFilter is set; one entry per blended (non-native) column.
   blendedDataHeaders?: ReportDataHeader[];
+  /** Resolved relationship chains used to build the blended query. Present when needsBlending=true. */
+  chains?: ResolvedRelationshipChain[];
 }

--- a/apps/backend/src/data-marts/dto/schemas/data-mart-run/data-mart-run-report-definition.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/data-mart-run/data-mart-run-report-definition.schema.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 import { DataDestinationConfigSchema } from '../../../data-destination-types/data-destination-config.type';
 import { DataDestinationType } from '../../../data-destination-types/enums/data-destination-type.enum';
+import { FilterConfigSchema } from '../filter-config.schema';
+import { SortConfigSchema } from '../sort-config.schema';
+
+export const DataMartRunReportOutputConfigSchema = z.object({
+  filterConfig: FilterConfigSchema.optional(),
+  sortConfig: SortConfigSchema.optional(),
+  limitConfig: z.number().int().nonnegative().nullable().optional(),
+});
 
 export const DataMartRunReportDefinitionSchema = z.object({
   title: z.string().trim().optional(),
@@ -10,6 +18,7 @@ export const DataMartRunReportDefinitionSchema = z.object({
     type: z.nativeEnum(DataDestinationType),
   }),
   destinationConfig: DataDestinationConfigSchema,
+  outputConfig: DataMartRunReportOutputConfigSchema.nullable().optional(),
 });
 
 export type DataMartRunReportDefinition = z.infer<typeof DataMartRunReportDefinitionSchema>;

--- a/apps/backend/src/data-marts/dto/schemas/filter-config.schema.spec.ts
+++ b/apps/backend/src/data-marts/dto/schemas/filter-config.schema.spec.ts
@@ -1,4 +1,4 @@
-import { FilterConfigSchema } from './filter-config.schema';
+import { FilterConfigSchema, FilterRuleSchema, aliasPathToCteName } from './filter-config.schema';
 
 describe('FilterConfigSchema', () => {
   it('accepts null', () => {
@@ -60,5 +60,102 @@ describe('FilterConfigSchema', () => {
         { column: 'd', operator: 'relative_date', value: { kind: 'last_n_days', n: -1 } },
       ])
     ).toThrow();
+  });
+});
+
+describe('FilterRuleSchema placement / aliasPath', () => {
+  it('keeps placement undefined when omitted (downstream treats absence as post-join)', () => {
+    const parsed = FilterRuleSchema.parse({ column: 'x', operator: 'eq', value: 1 });
+    expect(parsed.placement).toBeUndefined();
+    expect(parsed.aliasPath).toBeUndefined();
+  });
+
+  it('accepts explicit placement="post-join" without aliasPath', () => {
+    const parsed = FilterRuleSchema.parse({
+      column: 'x',
+      operator: 'eq',
+      value: 1,
+      placement: 'post-join',
+    });
+    expect(parsed.placement).toBe('post-join');
+  });
+
+  it('rejects placement="post-join" with aliasPath set', () => {
+    expect(() =>
+      FilterRuleSchema.parse({
+        column: 'x',
+        operator: 'eq',
+        value: 1,
+        placement: 'post-join',
+        aliasPath: 'users',
+      })
+    ).toThrow();
+  });
+
+  it('accepts placement="pre-join" with single-segment aliasPath and scalar rule', () => {
+    const parsed = FilterRuleSchema.parse({
+      column: 'userRole',
+      operator: 'eq',
+      value: 'admin',
+      placement: 'pre-join',
+      aliasPath: 'users',
+    });
+    expect(parsed.placement).toBe('pre-join');
+    expect(parsed.aliasPath).toBe('users');
+  });
+
+  it('accepts placement="pre-join" with dotted aliasPath and relative_date rule', () => {
+    expect(
+      FilterRuleSchema.parse({
+        column: 'createdAt',
+        operator: 'relative_date',
+        value: { kind: 'last_n_days', n: 30 },
+        placement: 'pre-join',
+        aliasPath: 'users.profiles',
+      })
+    ).toMatchObject({ placement: 'pre-join', aliasPath: 'users.profiles' });
+  });
+
+  it('rejects placement="pre-join" without aliasPath', () => {
+    expect(() =>
+      FilterRuleSchema.parse({
+        column: 'x',
+        operator: 'eq',
+        value: 1,
+        placement: 'pre-join',
+      })
+    ).toThrow();
+  });
+
+  it('rejects placement="pre-join" with aliasPath="main" (home mart not slicable)', () => {
+    expect(() =>
+      FilterRuleSchema.parse({
+        column: 'x',
+        operator: 'eq',
+        value: 1,
+        placement: 'pre-join',
+        aliasPath: 'main',
+      })
+    ).toThrow();
+  });
+
+  it('rejects aliasPath with uppercase / dashes / leading dot / trailing dot', () => {
+    const base = { column: 'x', operator: 'eq', value: 1, placement: 'pre-join' as const };
+    expect(() => FilterRuleSchema.parse({ ...base, aliasPath: 'Users' })).toThrow();
+    expect(() => FilterRuleSchema.parse({ ...base, aliasPath: 'users-table' })).toThrow();
+    expect(() => FilterRuleSchema.parse({ ...base, aliasPath: '.users' })).toThrow();
+    expect(() => FilterRuleSchema.parse({ ...base, aliasPath: 'users.' })).toThrow();
+  });
+});
+
+describe('aliasPathToCteName', () => {
+  it('maps a single-segment path to itself', () => {
+    expect(aliasPathToCteName('users')).toBe('users');
+  });
+  it('replaces dots with underscores', () => {
+    expect(aliasPathToCteName('users.profiles.country')).toBe('users_profiles_country');
+  });
+  it('throws on invalid path', () => {
+    expect(() => aliasPathToCteName('Users')).toThrow();
   });
 });

--- a/apps/backend/src/data-marts/dto/schemas/filter-config.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/filter-config.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ALIAS_PATH_REGEX } from './blended-fields-config.schema';
 
 const ScalarValueSchema = z.union([z.string(), z.number(), z.boolean()]);
 
@@ -36,7 +37,7 @@ const NoValueOperatorEnum = z.enum([
   'is_false',
 ]);
 
-export const FilterRuleSchema = z.discriminatedUnion('operator', [
+const FilterRuleBaseSchema = z.discriminatedUnion('operator', [
   z.object({
     column: z.string().min(1),
     operator: ScalarOperatorEnum,
@@ -58,6 +59,39 @@ export const FilterRuleSchema = z.discriminatedUnion('operator', [
   }),
 ]);
 
+const AliasPathSchema = z.string().min(1).max(255).regex(ALIAS_PATH_REGEX);
+
+const PlacementExtrasSchema = z.object({
+  placement: z.enum(['pre-join', 'post-join']).optional(),
+  aliasPath: AliasPathSchema.optional(),
+});
+
+export const FilterRuleSchema = z
+  .intersection(FilterRuleBaseSchema, PlacementExtrasSchema)
+  .superRefine((rule, ctx) => {
+    if (rule.placement === 'pre-join') {
+      if (!rule.aliasPath) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['aliasPath'],
+          message: 'aliasPath is required when placement is "pre-join"',
+        });
+      } else if (rule.aliasPath === 'main') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['aliasPath'],
+          message: 'pre-join filter on the home data mart ("main") is not allowed',
+        });
+      }
+    } else if (rule.aliasPath != null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['aliasPath'],
+        message: 'aliasPath is only valid when placement is "pre-join"',
+      });
+    }
+  });
+
 export const FilterConfigSchema = z.array(FilterRuleSchema).nullable();
 
 export type FilterRule = z.infer<typeof FilterRuleSchema>;
@@ -65,3 +99,10 @@ export type FilterConfig = z.infer<typeof FilterConfigSchema>;
 export type RelativeDatePreset = z.infer<typeof RelativeDatePresetSchema>;
 export const FILTER_SCALAR_OPERATORS = ScalarOperatorEnum.options;
 export const FILTER_NO_VALUE_OPERATORS = NoValueOperatorEnum.options;
+
+export function aliasPathToCteName(aliasPath: string): string {
+  if (!ALIAS_PATH_REGEX.test(aliasPath)) {
+    throw new Error(`Invalid aliasPath: ${aliasPath}`);
+  }
+  return aliasPath.replace(/\./g, '_');
+}

--- a/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
@@ -3,6 +3,7 @@ import { BlendedReportDataService } from './blended-report-data.service';
 import { BlendableSchemaService } from './blendable-schema.service';
 import { DataMartRelationshipService } from './data-mart-relationship.service';
 import { DataMartTableReferenceService } from './data-mart-table-reference.service';
+import { OutputControlsValidatorService } from './output-controls-validator.service';
 import { BlendedQueryBuilderFacade } from '../data-storage-types/facades/blended-query-builder.facade';
 import { DataMartQueryBuilderFacade } from '../data-storage-types/facades/data-mart-query-builder.facade';
 import { Report } from '../entities/report.entity';
@@ -112,6 +113,10 @@ describe('BlendedReportDataService', () => {
           useValue: {
             getPublicOrigin: jest.fn().mockReturnValue('https://app.example.com'),
           },
+        },
+        {
+          provide: OutputControlsValidatorService,
+          useValue: { validateForReport: jest.fn().mockResolvedValue(undefined) },
         },
       ],
     }).compile();

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { BlendableSchemaService } from './blendable-schema.service';
 import { DataMartRelationshipService } from './data-mart-relationship.service';
 import { DataMartTableReferenceService } from './data-mart-table-reference.service';
+import { OutputControlsValidatorService } from './output-controls-validator.service';
 import { BlendedQueryBuilderFacade } from '../data-storage-types/facades/blended-query-builder.facade';
 import { Report } from '../entities/report.entity';
 import { ResolvedRelationshipChain } from '../data-storage-types/interfaces/blended-query-builder.interface';
@@ -24,11 +25,23 @@ export class BlendedReportDataService {
     private readonly blendableSchemaService: BlendableSchemaService,
     private readonly blendedQueryBuilderFacade: BlendedQueryBuilderFacade,
     private readonly tableReferenceService: DataMartTableReferenceService,
-    private readonly publicOriginService: PublicOriginService
+    private readonly publicOriginService: PublicOriginService,
+    private readonly outputControlsValidator: OutputControlsValidatorService
   ) {}
 
   async resolveBlendingDecision(report: Report): Promise<BlendingDecision> {
     const { columnConfig, dataMart } = report;
+
+    // Single chokepoint for both /generated-sql and the run path — catches schema drift since save.
+    await this.outputControlsValidator.validateForReport({
+      storageType: dataMart.storage.type,
+      dataMartId: dataMart.id,
+      projectId: dataMart.projectId,
+      columnConfig: columnConfig ?? null,
+      filterConfig: report.filterConfig ?? null,
+      sortConfig: report.sortConfig ?? null,
+      limitConfig: report.limitConfig ?? null,
+    });
 
     if (columnConfig === null || columnConfig === undefined) {
       return { needsBlending: false };

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -40,21 +40,31 @@ export class BlendedReportDataService {
     );
 
     const blendedFieldsByName = new Map(blendableSchema.blendedFields.map(f => [f.name, f]));
+    const postJoinFilterColumns: string[] = [];
+    const preJoinAliasPaths = new Set<string>();
+    for (const rule of report.filterConfig ?? []) {
+      if (rule.placement === 'pre-join' && rule.aliasPath) {
+        preJoinAliasPaths.add(rule.aliasPath);
+      } else {
+        postJoinFilterColumns.push(rule.column);
+      }
+    }
     const referencedColumns = new Set<string>([
       ...columnConfig,
-      ...(report.filterConfig ?? []).map(f => f.column),
+      ...postJoinFilterColumns,
       ...(report.sortConfig ?? []).map(s => s.column),
     ]);
     const hasBlendedColumns = Array.from(referencedColumns).some(col =>
       blendedFieldsByName.has(col)
     );
+    const hasPreJoinFilters = preJoinAliasPaths.size > 0;
     const blendedDataHeaders = this.buildBlendedDataHeaders(
       columnConfig,
       blendedFieldsByName,
       dataMart.storage.type
     );
 
-    if (!hasBlendedColumns) {
+    if (!hasBlendedColumns && !hasPreJoinFilters) {
       return {
         needsBlending: false,
         columnFilter: columnConfig,
@@ -83,7 +93,8 @@ export class BlendedReportDataService {
       blendableSchema.availableSources,
       allRelationships,
       dataMart.projectId,
-      publicOrigin
+      publicOrigin,
+      preJoinAliasPaths
     );
 
     const blendedResult = await this.blendedQueryBuilderFacade.buildBlendedQuery(
@@ -108,6 +119,7 @@ export class BlendedReportDataService {
       params,
       columnFilter: columnConfig,
       blendedDataHeaders,
+      chains,
     };
   }
 
@@ -161,11 +173,12 @@ export class BlendedReportDataService {
     availableSources: AvailableSourceDto[],
     directRelationships: DataMartRelationship[],
     projectId: string,
-    publicOrigin: string
+    publicOrigin: string,
+    preJoinAliasPaths: ReadonlySet<string>
   ): Promise<ResolvedRelationshipChain[]> {
     const requestedBlendedFields = blendedFields.filter(f => referencedColumns.has(f.name));
 
-    if (requestedBlendedFields.length === 0) {
+    if (requestedBlendedFields.length === 0 && preJoinAliasPaths.size === 0) {
       return [];
     }
 
@@ -174,6 +187,13 @@ export class BlendedReportDataService {
     const neededPaths = new Set<string>();
     for (const field of requestedBlendedFields) {
       const segments = field.aliasPath.split('.');
+      for (let i = 1; i <= segments.length; i++) {
+        neededPaths.add(segments.slice(0, i).join('.'));
+      }
+    }
+    // Walk ancestors for every pre-join aliasPath too, so filter-only chains are included.
+    for (const aliasPath of preJoinAliasPaths) {
+      const segments = aliasPath.split('.');
       for (let i = 1; i <= segments.length; i++) {
         neededPaths.add(segments.slice(0, i).join('.'));
       }

--- a/apps/backend/src/data-marts/services/data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.ts
@@ -498,6 +498,18 @@ export class DataMartRunService {
   private createReportRunFromReport(report: Report, context: ReportRunContext): DataMartRun {
     const { id, title, dataMart, destinationConfig, dataDestination } = report;
 
+    const hasOutputControls =
+      (report.filterConfig?.length ?? 0) > 0 ||
+      (report.sortConfig?.length ?? 0) > 0 ||
+      report.limitConfig != null;
+    const outputConfig = hasOutputControls
+      ? {
+          filterConfig: report.filterConfig ?? undefined,
+          sortConfig: report.sortConfig ?? undefined,
+          limitConfig: report.limitConfig ?? undefined,
+        }
+      : undefined;
+
     const reportDefinition = {
       title,
       destination: {
@@ -506,6 +518,7 @@ export class DataMartRunService {
         title: dataDestination.title,
       },
       destinationConfig,
+      ...(outputConfig ? { outputConfig } : {}),
     };
 
     const dataMartRunDraft = {

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -6,7 +6,7 @@ import { DataStorageType } from '../data-storage-types/enums/data-storage-type.e
 describe('OutputControlsValidatorService', () => {
   const svc = new OutputControlsValidatorService(undefined as never, undefined as never);
 
-  describe('validateFilters', () => {
+  describe('validateFilters (post-join)', () => {
     const fieldTypes = new Map<string, string>([
       ['name', BigQueryFieldType.STRING],
       ['amount', BigQueryFieldType.INTEGER],
@@ -17,7 +17,7 @@ describe('OutputControlsValidatorService', () => {
 
     it('accepts eq on STRING', () => {
       const errors = svc.validateFilters(
-        [{ column: 'name', operator: 'eq', value: 'X' }],
+        [{ column: 'name', operator: 'eq', value: 'X', placement: 'post-join' }],
         fieldTypes
       );
       expect(errors).toEqual([]);
@@ -25,7 +25,7 @@ describe('OutputControlsValidatorService', () => {
 
     it('rejects regex on INTEGER', () => {
       const errors = svc.validateFilters(
-        [{ column: 'amount', operator: 'regex', value: '^1' }],
+        [{ column: 'amount', operator: 'regex', value: '^1', placement: 'post-join' }],
         fieldTypes
       );
       expect(errors).toEqual([
@@ -40,49 +40,66 @@ describe('OutputControlsValidatorService', () => {
 
     it('rejects between on STRING', () => {
       const errors = svc.validateFilters(
-        [{ column: 'name', operator: 'between', value: { from: 'a', to: 'z' } }],
+        [
+          {
+            column: 'name',
+            operator: 'between',
+            value: { from: 'a', to: 'z' },
+            placement: 'post-join',
+          },
+        ],
         fieldTypes
       );
       expect(errors[0].code).toBe('INVALID_OPERATOR_FOR_TYPE');
     });
 
     it('rejects filter on RECORD column', () => {
-      const errors = svc.validateFilters([{ column: 'nested', operator: 'is_empty' }], fieldTypes);
+      const errors = svc.validateFilters(
+        [{ column: 'nested', operator: 'is_empty', placement: 'post-join' }],
+        fieldTypes
+      );
       expect(errors[0].code).toBe('INVALID_OPERATOR_FOR_TYPE');
     });
 
     it('rejects filter on unknown column', () => {
       const errors = svc.validateFilters(
-        [{ column: 'missing', operator: 'eq', value: 'X' }],
+        [{ column: 'missing', operator: 'eq', value: 'X', placement: 'post-join' }],
         fieldTypes
       );
       expect(errors).toEqual([{ code: 'FILTER_COLUMN_UNKNOWN', column: 'missing' }]);
     });
 
     it('accepts is_true on BOOLEAN', () => {
-      const errors = svc.validateFilters([{ column: 'flag', operator: 'is_true' }], fieldTypes);
+      const errors = svc.validateFilters(
+        [{ column: 'flag', operator: 'is_true', placement: 'post-join' }],
+        fieldTypes
+      );
       expect(errors).toEqual([]);
     });
 
     it('accepts is_null / is_not_null on every supported type', () => {
       const filters = [
-        { column: 'name', operator: 'is_null' as const },
-        { column: 'name', operator: 'is_not_null' as const },
-        { column: 'amount', operator: 'is_null' as const },
-        { column: 'amount', operator: 'is_not_null' as const },
-        { column: 'created_at', operator: 'is_null' as const },
-        { column: 'created_at', operator: 'is_not_null' as const },
-        { column: 'flag', operator: 'is_null' as const },
-        { column: 'flag', operator: 'is_not_null' as const },
+        { column: 'name', operator: 'is_null' as const, placement: 'post-join' as const },
+        { column: 'name', operator: 'is_not_null' as const, placement: 'post-join' as const },
+        { column: 'amount', operator: 'is_null' as const, placement: 'post-join' as const },
+        { column: 'amount', operator: 'is_not_null' as const, placement: 'post-join' as const },
+        { column: 'created_at', operator: 'is_null' as const, placement: 'post-join' as const },
+        { column: 'created_at', operator: 'is_not_null' as const, placement: 'post-join' as const },
+        { column: 'flag', operator: 'is_null' as const, placement: 'post-join' as const },
+        { column: 'flag', operator: 'is_not_null' as const, placement: 'post-join' as const },
       ];
       expect(svc.validateFilters(filters, fieldTypes)).toEqual([]);
     });
 
     it('rejects is_empty / is_not_empty on non-STRING types (use is_null instead)', () => {
       const filters = [
-        { column: 'amount', operator: 'is_empty' as const },
-        { column: 'created_at', operator: 'is_not_empty' as const },
-        { column: 'flag', operator: 'is_empty' as const },
+        { column: 'amount', operator: 'is_empty' as const, placement: 'post-join' as const },
+        {
+          column: 'created_at',
+          operator: 'is_not_empty' as const,
+          placement: 'post-join' as const,
+        },
+        { column: 'flag', operator: 'is_empty' as const, placement: 'post-join' as const },
       ];
       const errors = svc.validateFilters(filters, fieldTypes);
       expect(errors).toHaveLength(3);
@@ -91,15 +108,22 @@ describe('OutputControlsValidatorService', () => {
 
     it('still accepts is_empty / is_not_empty on STRING (preserves "" + NULL semantics)', () => {
       const filters = [
-        { column: 'name', operator: 'is_empty' as const },
-        { column: 'name', operator: 'is_not_empty' as const },
+        { column: 'name', operator: 'is_empty' as const, placement: 'post-join' as const },
+        { column: 'name', operator: 'is_not_empty' as const, placement: 'post-join' as const },
       ];
       expect(svc.validateFilters(filters, fieldTypes)).toEqual([]);
     });
 
     it('accepts relative_date on TIMESTAMP', () => {
       const errors = svc.validateFilters(
-        [{ column: 'created_at', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } }],
+        [
+          {
+            column: 'created_at',
+            operator: 'relative_date',
+            value: { kind: 'last_n_days', n: 7 },
+            placement: 'post-join',
+          },
+        ],
         fieldTypes
       );
       expect(errors).toEqual([]);
@@ -113,17 +137,17 @@ describe('OutputControlsValidatorService', () => {
         ['b', BigQueryFieldType.BIGNUMERIC],
       ]);
       const filters = [
-        { column: 'i', operator: 'gt' as const, value: 1 },
-        { column: 'f', operator: 'gt' as const, value: 1 },
-        { column: 'n', operator: 'gt' as const, value: 1 },
-        { column: 'b', operator: 'gt' as const, value: 1 },
+        { column: 'i', operator: 'gt' as const, value: 1, placement: 'post-join' as const },
+        { column: 'f', operator: 'gt' as const, value: 1, placement: 'post-join' as const },
+        { column: 'n', operator: 'gt' as const, value: 1, placement: 'post-join' as const },
+        { column: 'b', operator: 'gt' as const, value: 1, placement: 'post-join' as const },
       ];
       expect(svc.validateFilters(filters, types)).toEqual([]);
     });
 
     it('accepts a valid regex on STRING', () => {
       const errors = svc.validateFilters(
-        [{ column: 'name', operator: 'regex', value: '^foo$' }],
+        [{ column: 'name', operator: 'regex', value: '^foo$', placement: 'post-join' }],
         fieldTypes
       );
       expect(errors).toEqual([]);
@@ -131,7 +155,7 @@ describe('OutputControlsValidatorService', () => {
 
     it('rejects unparseable regex on STRING with INVALID_REGEX_PATTERN', () => {
       const errors = svc.validateFilters(
-        [{ column: 'name', operator: 'regex', value: '[unclosed' }],
+        [{ column: 'name', operator: 'regex', value: '[unclosed', placement: 'post-join' }],
         fieldTypes
       );
       expect(errors).toEqual([
@@ -141,10 +165,203 @@ describe('OutputControlsValidatorService', () => {
 
     it('rejects unparseable not_regex on STRING with INVALID_REGEX_PATTERN', () => {
       const errors = svc.validateFilters(
-        [{ column: 'name', operator: 'not_regex', value: '*' }],
+        [{ column: 'name', operator: 'not_regex', value: '*', placement: 'post-join' }],
         fieldTypes
       );
       expect(errors[0]).toMatchObject({ code: 'INVALID_REGEX_PATTERN', column: 'name' });
+    });
+  });
+
+  describe('validateFilters (pre-join)', () => {
+    const homeFieldTypes = new Map<string, string>();
+    const knownPaths = new Map<string, ReadonlyMap<string, string>>([
+      [
+        'users',
+        new Map([
+          ['userRole', BigQueryFieldType.STRING],
+          ['createdAt', BigQueryFieldType.TIMESTAMP],
+        ]),
+      ],
+      ['users.profiles', new Map([['country', BigQueryFieldType.STRING]])],
+    ]);
+
+    it('accepts a known aliasPath + known column + valid operator', () => {
+      const errors = svc.validateFilters(
+        [
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+        homeFieldTypes,
+        knownPaths
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('rejects unknown aliasPath', () => {
+      const errors = svc.validateFilters(
+        [{ column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'orgs' }],
+        homeFieldTypes,
+        knownPaths
+      );
+      expect(errors).toEqual([{ code: 'FILTER_ALIAS_PATH_UNKNOWN', aliasPath: 'orgs' }]);
+    });
+
+    it('rejects home aliasPath', () => {
+      const errors = svc.validateFilters(
+        [{ column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'main' }],
+        homeFieldTypes,
+        knownPaths
+      );
+      expect(errors).toEqual([
+        { code: 'FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME', aliasPath: 'main' },
+      ]);
+    });
+
+    it('rejects unknown column inside known aliasPath (includes aliasPath in payload)', () => {
+      const errors = svc.validateFilters(
+        [
+          {
+            column: 'missing',
+            operator: 'eq',
+            value: 1,
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+        homeFieldTypes,
+        knownPaths
+      );
+      expect(errors).toEqual([
+        { code: 'FILTER_COLUMN_UNKNOWN', column: 'missing', aliasPath: 'users' },
+      ]);
+    });
+
+    it('rejects regex on INTEGER inside pre-join filter (carries aliasPath)', () => {
+      const pathsWithInt = new Map<string, ReadonlyMap<string, string>>([
+        ['users', new Map([['amount', BigQueryFieldType.INTEGER]])],
+      ]);
+      const errors = svc.validateFilters(
+        [
+          {
+            column: 'amount',
+            operator: 'regex',
+            value: '^1',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+        homeFieldTypes,
+        pathsWithInt
+      );
+      expect(errors[0]).toMatchObject({
+        code: 'INVALID_OPERATOR_FOR_TYPE',
+        column: 'amount',
+        aliasPath: 'users',
+      });
+    });
+
+    it('rejects malformed regex pattern inside pre-join filter (carries aliasPath)', () => {
+      const errors = svc.validateFilters(
+        [
+          {
+            column: 'userRole',
+            operator: 'regex',
+            value: '[unclosed',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+        homeFieldTypes,
+        knownPaths
+      );
+      expect(errors).toEqual([
+        {
+          code: 'INVALID_REGEX_PATTERN',
+          column: 'userRole',
+          pattern: '[unclosed',
+          aliasPath: 'users',
+        },
+      ]);
+    });
+
+    it('rejects pre-join filter on excluded source', () => {
+      const excluded = new Set(['users']);
+      const errors = svc.validateFilters(
+        [
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+        homeFieldTypes,
+        new Map(),
+        excluded
+      );
+      expect(errors).toEqual([{ code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath: 'users' }]);
+    });
+
+    it('home-rejection wins over excluded-rejection', () => {
+      const excluded = new Set(['main']);
+      const errors = svc.validateFilters(
+        [{ column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'main' }],
+        homeFieldTypes,
+        new Map(),
+        excluded
+      );
+      expect(errors).toEqual([
+        { code: 'FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME', aliasPath: 'main' },
+      ]);
+    });
+
+    it('post-join rule without placement defaults to post-join lookup (does not need knownPaths)', () => {
+      const homeTypes = new Map<string, string>([['name', BigQueryFieldType.STRING]]);
+      const errors = svc.validateFilters(
+        // No placement field — Zod default would set 'post-join'; raw call here
+        // simulates a rule that was passed through unparsed.
+        [{ column: 'name', operator: 'eq', value: 'X' } as never],
+        homeTypes
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('rejects pre-join rule that is missing aliasPath (defense in depth past Zod)', () => {
+      const errors = svc.validateFilters(
+        [{ column: 'userRole', operator: 'eq', value: 'admin', placement: 'pre-join' } as never],
+        homeFieldTypes,
+        knownPaths
+      );
+      expect(errors).toEqual([{ code: 'FILTER_ALIAS_PATH_REQUIRED', column: 'userRole' }]);
+    });
+
+    it('rejects post-join rule that carries aliasPath (must mirror Zod contract)', () => {
+      const homeTypes = new Map<string, string>([['name', BigQueryFieldType.STRING]]);
+      const errors = svc.validateFilters(
+        [
+          {
+            column: 'name',
+            operator: 'eq',
+            value: 'X',
+            placement: 'post-join',
+            aliasPath: 'users',
+          } as never,
+        ],
+        homeTypes
+      );
+      expect(errors).toEqual([
+        {
+          code: 'FILTER_ALIAS_PATH_FORBIDDEN_ON_POST_JOIN',
+          column: 'name',
+          aliasPath: 'users',
+        },
+      ]);
     });
   });
 
@@ -176,10 +393,22 @@ describe('OutputControlsValidatorService', () => {
       isSupported: jest.fn().mockReturnValue(supported),
     });
 
-    const makeBlendableSchemaService = (fields: { name: string; type: string }[] = []) => ({
+    const makeBlendableSchemaService = (
+      nativeFields: { name: string; type: string }[] = [],
+      extras: {
+        blendedFields?: {
+          name?: string;
+          aliasPath?: string;
+          originalFieldName?: string;
+          type: string;
+        }[];
+        availableSources?: { aliasPath: string; isIncluded?: boolean }[];
+      } = {}
+    ) => ({
       computeBlendableSchema: jest.fn().mockResolvedValue({
-        nativeFields: fields,
-        blendedFields: [],
+        nativeFields,
+        blendedFields: extras.blendedFields ?? [],
+        availableSources: extras.availableSources ?? [],
       }),
     });
 
@@ -358,7 +587,7 @@ describe('OutputControlsValidatorService', () => {
           storageType: supportedStorageType,
           dataMartId: 'dm-1',
           projectId: 'proj-1',
-          columnConfig: ['date'], // only 'date' selected, not 'amount'
+          columnConfig: ['date'],
           filterConfig: null,
           sortConfig: [{ column: 'amount', direction: 'asc' }],
           limitConfig: null,
@@ -388,7 +617,7 @@ describe('OutputControlsValidatorService', () => {
           storageType: supportedStorageType,
           dataMartId: 'dm-1',
           projectId: 'proj-1',
-          columnConfig: null, // no explicit projection → all fields allowed
+          columnConfig: null,
           filterConfig: null,
           sortConfig: [{ column: 'amount', direction: 'asc' }],
           limitConfig: null,
@@ -397,8 +626,6 @@ describe('OutputControlsValidatorService', () => {
     });
 
     it('rejects payload with mismatched filter shape via Zod (defence-in-depth)', async () => {
-      // class-validator passes shapeless arrays; the validator must catch
-      // discriminator violations (between operator with scalar value, etc.).
       const capabilitySvc = makeCapabilityService(true);
       const schemaSvc = makeBlendableSchemaService([
         { name: 'amount', type: BigQueryFieldType.INTEGER },
@@ -415,7 +642,6 @@ describe('OutputControlsValidatorService', () => {
           dataMartId: 'dm-1',
           projectId: 'proj-1',
           columnConfig: ['amount'],
-          // 'between' requires { from, to }; passing a scalar should be rejected.
           filterConfig: [{ column: 'amount', operator: 'between', value: 5 }] as never,
           sortConfig: null,
           limitConfig: null,
@@ -469,8 +695,6 @@ describe('OutputControlsValidatorService', () => {
           dataMartId: 'dm-1',
           projectId: 'proj-1',
           columnConfig: ['created_at'],
-          // n=10000 exceeds the 3650 cap (~10 years), preventing accidental
-          // expensive scans like INTERVAL 9999999999 DAY.
           filterConfig: [
             {
               column: 'created_at',
@@ -504,6 +728,160 @@ describe('OutputControlsValidatorService', () => {
           filterConfig: [{ column: 'name', operator: 'eq', value: 'test' }],
           sortConfig: [{ column: 'amount', direction: 'desc' }],
           limitConfig: 50,
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws FILTER_ALIAS_PATH_UNKNOWN when pre-join filter aliasPath is not in blendableSchema', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([], {
+        blendedFields: [
+          { aliasPath: 'users', originalFieldName: 'userRole', type: BigQueryFieldType.STRING },
+        ],
+        availableSources: [{ aliasPath: 'users' }],
+      });
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      let caught: BadRequestException | undefined;
+      try {
+        await validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: null,
+          filterConfig: [
+            { column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'orgs' },
+          ],
+          sortConfig: null,
+          limitConfig: null,
+        });
+      } catch (e) {
+        caught = e as BadRequestException;
+      }
+
+      expect(caught).toBeDefined();
+      const response = caught!.getResponse() as { details: { errors: { code: string }[] } };
+      expect(response.details.errors[0].code).toBe('FILTER_ALIAS_PATH_UNKNOWN');
+    });
+
+    it('resolves when pre-join filter aliasPath and column are valid', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([], {
+        blendedFields: [
+          { aliasPath: 'users', originalFieldName: 'userRole', type: BigQueryFieldType.STRING },
+        ],
+        availableSources: [{ aliasPath: 'users' }],
+      });
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      await expect(
+        validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: null,
+          filterConfig: [
+            {
+              column: 'userRole',
+              operator: 'eq',
+              value: 'admin',
+              placement: 'pre-join',
+              aliasPath: 'users',
+            },
+          ],
+          sortConfig: null,
+          limitConfig: null,
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('buildKnownPaths via validateForReport', () => {
+    const supportedStorageType = DataStorageType.GOOGLE_BIGQUERY;
+
+    it('emits FILTER_ALIAS_PATH_NOT_INCLUDED when source.isIncluded === false', async () => {
+      const capabilitySvc = { isSupported: jest.fn().mockReturnValue(true) };
+      const schemaSvc = {
+        computeBlendableSchema: jest.fn().mockResolvedValue({
+          nativeFields: [],
+          blendedFields: [
+            { aliasPath: 'users', originalFieldName: 'userRole', type: BigQueryFieldType.STRING },
+          ],
+          availableSources: [{ aliasPath: 'users', isIncluded: false }],
+        }),
+      };
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      let caught: BadRequestException | undefined;
+      try {
+        await validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: null,
+          filterConfig: [
+            {
+              column: 'userRole',
+              operator: 'eq',
+              value: 'admin',
+              placement: 'pre-join',
+              aliasPath: 'users',
+            },
+          ],
+          sortConfig: null,
+          limitConfig: null,
+        });
+      } catch (e) {
+        caught = e as BadRequestException;
+      }
+
+      expect(caught).toBeDefined();
+      const response = caught!.getResponse() as { details: { errors: { code: string }[] } };
+      expect(response.details.errors[0].code).toBe('FILTER_ALIAS_PATH_NOT_INCLUDED');
+    });
+
+    it('included sources still accept pre-join filters on their columns (no false positive)', async () => {
+      const capabilitySvc = { isSupported: jest.fn().mockReturnValue(true) };
+      const schemaSvc = {
+        computeBlendableSchema: jest.fn().mockResolvedValue({
+          nativeFields: [],
+          blendedFields: [
+            { aliasPath: 'users', originalFieldName: 'userRole', type: BigQueryFieldType.STRING },
+          ],
+          availableSources: [{ aliasPath: 'users', isIncluded: true }],
+        }),
+      };
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      await expect(
+        validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: null,
+          filterConfig: [
+            {
+              column: 'userRole',
+              operator: 'eq',
+              value: 'admin',
+              placement: 'pre-join',
+              aliasPath: 'users',
+            },
+          ],
+          sortConfig: null,
+          limitConfig: null,
         })
       ).resolves.toBeUndefined();
     });

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -211,17 +211,6 @@ describe('OutputControlsValidatorService', () => {
       expect(errors).toEqual([{ code: 'FILTER_ALIAS_PATH_UNKNOWN', aliasPath: 'orgs' }]);
     });
 
-    it('rejects home aliasPath', () => {
-      const errors = svc.validateFilters(
-        [{ column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'main' }],
-        homeFieldTypes,
-        knownPaths
-      );
-      expect(errors).toEqual([
-        { code: 'FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME', aliasPath: 'main' },
-      ]);
-    });
-
     it('rejects unknown column inside known aliasPath (includes aliasPath in payload)', () => {
       const errors = svc.validateFilters(
         [
@@ -308,19 +297,6 @@ describe('OutputControlsValidatorService', () => {
       expect(errors).toEqual([{ code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath: 'users' }]);
     });
 
-    it('home-rejection wins over excluded-rejection', () => {
-      const excluded = new Set(['main']);
-      const errors = svc.validateFilters(
-        [{ column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'main' }],
-        homeFieldTypes,
-        new Map(),
-        excluded
-      );
-      expect(errors).toEqual([
-        { code: 'FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME', aliasPath: 'main' },
-      ]);
-    });
-
     it('post-join rule without placement defaults to post-join lookup (does not need knownPaths)', () => {
       const homeTypes = new Map<string, string>([['name', BigQueryFieldType.STRING]]);
       const errors = svc.validateFilters(
@@ -330,38 +306,6 @@ describe('OutputControlsValidatorService', () => {
         homeTypes
       );
       expect(errors).toEqual([]);
-    });
-
-    it('rejects pre-join rule that is missing aliasPath (defense in depth past Zod)', () => {
-      const errors = svc.validateFilters(
-        [{ column: 'userRole', operator: 'eq', value: 'admin', placement: 'pre-join' } as never],
-        homeFieldTypes,
-        knownPaths
-      );
-      expect(errors).toEqual([{ code: 'FILTER_ALIAS_PATH_REQUIRED', column: 'userRole' }]);
-    });
-
-    it('rejects post-join rule that carries aliasPath (must mirror Zod contract)', () => {
-      const homeTypes = new Map<string, string>([['name', BigQueryFieldType.STRING]]);
-      const errors = svc.validateFilters(
-        [
-          {
-            column: 'name',
-            operator: 'eq',
-            value: 'X',
-            placement: 'post-join',
-            aliasPath: 'users',
-          } as never,
-        ],
-        homeTypes
-      );
-      expect(errors).toEqual([
-        {
-          code: 'FILTER_ALIAS_PATH_FORBIDDEN_ON_POST_JOIN',
-          column: 'name',
-          aliasPath: 'users',
-        },
-      ]);
     });
   });
 
@@ -751,7 +695,7 @@ describe('OutputControlsValidatorService', () => {
           storageType: supportedStorageType,
           dataMartId: 'dm-1',
           projectId: 'proj-1',
-          columnConfig: null,
+          columnConfig: ['some_col'],
           filterConfig: [
             { column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'orgs' },
           ],
@@ -765,6 +709,52 @@ describe('OutputControlsValidatorService', () => {
       expect(caught).toBeDefined();
       const response = caught!.getResponse() as { details: { errors: { code: string }[] } };
       expect(response.details.errors[0].code).toBe('FILTER_ALIAS_PATH_UNKNOWN');
+    });
+
+    it('rejects pre-join filter when columnConfig is null/empty (PRE_JOIN_FILTERS_REQUIRE_COLUMN_CONFIG)', async () => {
+      // Without a columnConfig the report renders as a flat passthrough — no
+      // blended SQL is generated, so the slice would silently no-op. Validator
+      // catches this at save time with a structured code.
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([], {
+        blendedFields: [
+          { aliasPath: 'users', originalFieldName: 'userRole', type: BigQueryFieldType.STRING },
+        ],
+        availableSources: [{ aliasPath: 'users' }],
+      });
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      let caught: BadRequestException | undefined;
+      try {
+        await validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: null,
+          filterConfig: [
+            {
+              column: 'userRole',
+              operator: 'eq',
+              value: 'admin',
+              placement: 'pre-join',
+              aliasPath: 'users',
+            },
+          ],
+          sortConfig: null,
+          limitConfig: null,
+        });
+      } catch (e) {
+        caught = e as BadRequestException;
+      }
+
+      expect(caught).toBeDefined();
+      const response = caught!.getResponse() as { details: { errors: { code: string }[] } };
+      expect(
+        response.details.errors.some(e => e.code === 'PRE_JOIN_FILTERS_REQUIRE_COLUMN_CONFIG')
+      ).toBe(true);
     });
 
     it('resolves when pre-join filter aliasPath and column are valid', async () => {
@@ -785,7 +775,7 @@ describe('OutputControlsValidatorService', () => {
           storageType: supportedStorageType,
           dataMartId: 'dm-1',
           projectId: 'proj-1',
-          columnConfig: null,
+          columnConfig: ['some_col'],
           filterConfig: [
             {
               column: 'userRole',
@@ -827,7 +817,7 @@ describe('OutputControlsValidatorService', () => {
           storageType: supportedStorageType,
           dataMartId: 'dm-1',
           projectId: 'proj-1',
-          columnConfig: null,
+          columnConfig: ['some_col'],
           filterConfig: [
             {
               column: 'userRole',
@@ -870,7 +860,7 @@ describe('OutputControlsValidatorService', () => {
           storageType: supportedStorageType,
           dataMartId: 'dm-1',
           projectId: 'proj-1',
-          columnConfig: null,
+          columnConfig: ['some_col'],
           filterConfig: [
             {
               column: 'userRole',

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.ts
@@ -6,20 +6,29 @@ import { OutputControlsCapabilityService } from './output-controls-capability.se
 import { BlendableSchemaService } from './blendable-schema.service';
 
 export type ValidationError =
-  | { code: 'FILTER_COLUMN_UNKNOWN'; column: string }
-  | { code: 'INVALID_OPERATOR_FOR_TYPE'; column: string; type: string; operator: string }
-  | { code: 'INVALID_REGEX_PATTERN'; column: string; pattern: string }
-  | { code: 'SORT_COLUMN_NOT_SELECTED'; column: string };
+  | { code: 'FILTER_COLUMN_UNKNOWN'; column: string; aliasPath?: string }
+  | {
+      code: 'INVALID_OPERATOR_FOR_TYPE';
+      column: string;
+      type: string;
+      operator: string;
+      aliasPath?: string;
+    }
+  | { code: 'INVALID_REGEX_PATTERN'; column: string; pattern: string; aliasPath?: string }
+  | { code: 'SORT_COLUMN_NOT_SELECTED'; column: string }
+  | { code: 'FILTER_ALIAS_PATH_UNKNOWN'; aliasPath: string }
+  | { code: 'FILTER_ALIAS_PATH_NOT_INCLUDED'; aliasPath: string }
+  | { code: 'FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME'; aliasPath: string }
+  | { code: 'FILTER_ALIAS_PATH_REQUIRED'; column: string }
+  | { code: 'FILTER_ALIAS_PATH_FORBIDDEN_ON_POST_JOIN'; column: string; aliasPath: string };
 
 const STRING_TYPES = new Set(['STRING']);
 const NUMBER_TYPES = new Set(['INTEGER', 'FLOAT', 'NUMERIC', 'BIGNUMERIC']);
 const DATE_TYPES = new Set(['DATE', 'DATETIME', 'TIMESTAMP', 'TIME']);
 const BOOL_TYPES = new Set(['BOOLEAN']);
 
-// `is_empty` / `is_not_empty` are kept for STRING only — for non-STRING types
-// they previously rendered as `col = ''` / `col != ''`, which BigQuery rejects
-// for TIMESTAMP/DATE/INTEGER/FLOAT (cannot cast '' to those types). Non-STRING
-// types use the unambiguous `is_null` / `is_not_null` instead.
+// `is_empty`/`is_not_empty` are STRING-only — on non-STRING they used to render
+// as `col = ''` which BigQuery rejects for TIMESTAMP/DATE/INTEGER/FLOAT.
 const STRING_OPS = new Set([
   'eq',
   'neq',
@@ -64,7 +73,7 @@ function operatorAllowed(fieldType: string, operator: string): boolean {
   if (NUMBER_TYPES.has(fieldType)) return NUMBER_OPS.has(operator);
   if (DATE_TYPES.has(fieldType)) return DATE_OPS.has(operator);
   if (BOOL_TYPES.has(fieldType)) return BOOL_OPS.has(operator);
-  return false; // any other type — unsupported
+  return false;
 }
 
 @Injectable()
@@ -74,33 +83,98 @@ export class OutputControlsValidatorService {
     private readonly blendableSchemaService: BlendableSchemaService
   ) {}
 
-  validateFilters(filters: FilterRule[], fieldTypes: Map<string, string>): ValidationError[] {
+  /**
+   * Validates a list of filter rules against the blendable schema.
+   *
+   * - post-join rules (`placement === 'post-join'` or omitted): looked up in
+   *   `homeFieldTypes` (blended output aliases + home native fields).
+   * - pre-join rules (`placement === 'pre-join'`): looked up by `aliasPath` in
+   *   `knownPaths`, then by raw column name inside that path. Pre-join rules
+   *   targeting excluded sources or the home mart are rejected with dedicated
+   *   error codes so the FE can surface the right message.
+   */
+  validateFilters(
+    filters: FilterRule[],
+    homeFieldTypes: Map<string, string>,
+    knownPaths?: ReadonlyMap<string, ReadonlyMap<string, string>>,
+    excludedPaths?: ReadonlySet<string>
+  ): ValidationError[] {
     const errors: ValidationError[] = [];
     for (const rule of filters) {
-      const type = fieldTypes.get(rule.column);
-      if (type === undefined) {
-        errors.push({ code: 'FILTER_COLUMN_UNKNOWN', column: rule.column });
-        continue;
-      }
-      if (!operatorAllowed(type, rule.operator)) {
-        errors.push({
-          code: 'INVALID_OPERATOR_FOR_TYPE',
-          column: rule.column,
-          type,
-          operator: rule.operator,
-        });
-        continue;
-      }
-      if (rule.operator === 'regex' || rule.operator === 'not_regex') {
-        const pattern = String(rule.value);
-        try {
-          new RegExp(pattern);
-        } catch {
-          errors.push({ code: 'INVALID_REGEX_PATTERN', column: rule.column, pattern });
+      if (rule.placement === 'pre-join') {
+        const aliasPath = rule.aliasPath;
+        if (!aliasPath) {
+          errors.push({ code: 'FILTER_ALIAS_PATH_REQUIRED', column: rule.column });
+          continue;
         }
+        if (aliasPath === 'main') {
+          errors.push({ code: 'FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME', aliasPath });
+          continue;
+        }
+        if (excludedPaths?.has(aliasPath)) {
+          errors.push({ code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath });
+          continue;
+        }
+        const subsidiaryTypes = knownPaths?.get(aliasPath);
+        if (!subsidiaryTypes) {
+          errors.push({ code: 'FILTER_ALIAS_PATH_UNKNOWN', aliasPath });
+          continue;
+        }
+        const type = subsidiaryTypes.get(rule.column);
+        if (type === undefined) {
+          errors.push({ code: 'FILTER_COLUMN_UNKNOWN', column: rule.column, aliasPath });
+          continue;
+        }
+        this.validateRuleAgainstType(rule, type, aliasPath, errors);
+      } else {
+        if (rule.aliasPath != null) {
+          errors.push({
+            code: 'FILTER_ALIAS_PATH_FORBIDDEN_ON_POST_JOIN',
+            column: rule.column,
+            aliasPath: rule.aliasPath,
+          });
+          continue;
+        }
+        const type = homeFieldTypes.get(rule.column);
+        if (type === undefined) {
+          errors.push({ code: 'FILTER_COLUMN_UNKNOWN', column: rule.column });
+          continue;
+        }
+        this.validateRuleAgainstType(rule, type, undefined, errors);
       }
     }
     return errors;
+  }
+
+  private validateRuleAgainstType(
+    rule: FilterRule,
+    type: string,
+    aliasPath: string | undefined,
+    errors: ValidationError[]
+  ): void {
+    if (!operatorAllowed(type, rule.operator)) {
+      errors.push({
+        code: 'INVALID_OPERATOR_FOR_TYPE',
+        column: rule.column,
+        type,
+        operator: rule.operator,
+        ...(aliasPath ? { aliasPath } : {}),
+      });
+      return;
+    }
+    if (rule.operator === 'regex' || rule.operator === 'not_regex') {
+      const pattern = String(rule.value);
+      try {
+        new RegExp(pattern);
+      } catch {
+        errors.push({
+          code: 'INVALID_REGEX_PATTERN',
+          column: rule.column,
+          pattern,
+          ...(aliasPath ? { aliasPath } : {}),
+        });
+      }
+    }
   }
 
   validateSort(sort: SortRule[], selectedColumns: ReadonlySet<string>): ValidationError[] {
@@ -113,11 +187,6 @@ export class OutputControlsValidatorService {
     return errors;
   }
 
-  /**
-   * High-level orchestrator: capability + filter + sort validation in one call.
-   * Reads the field-type map from BlendableSchemaService. Throws BadRequestException
-   * with structured details if anything fails.
-   */
   async validateForReport(args: {
     storageType: DataStorageType;
     dataMartId: string;
@@ -144,7 +213,7 @@ export class OutputControlsValidatorService {
 
     let parsedFilters: FilterRule[] = [];
     let parsedSort: SortRule[] = [];
-    if ((args.filterConfig?.length ?? 0) > 0) {
+    if (args.filterConfig != null) {
       const result = FilterConfigSchema.safeParse(args.filterConfig);
       if (!result.success) {
         throw new BadRequestException({
@@ -154,7 +223,7 @@ export class OutputControlsValidatorService {
       }
       parsedFilters = result.data ?? [];
     }
-    if ((args.sortConfig?.length ?? 0) > 0) {
+    if (args.sortConfig != null) {
       const result = SortConfigSchema.safeParse(args.sortConfig);
       if (!result.success) {
         throw new BadRequestException({
@@ -167,25 +236,29 @@ export class OutputControlsValidatorService {
 
     const errors: ValidationError[] = [];
 
-    if (parsedFilters.length > 0 || parsedSort.length > 0) {
+    const needsSchema = parsedFilters.length > 0 || parsedSort.length > 0;
+    if (needsSchema) {
       const blendableSchema = await this.blendableSchemaService.computeBlendableSchema(
         args.dataMartId,
         args.projectId
       );
 
-      const fieldTypes = new Map<string, string>();
+      const homeFieldTypes = new Map<string, string>();
       for (const native of blendableSchema.nativeFields) {
-        fieldTypes.set(native.name, native.type);
+        homeFieldTypes.set(native.name, native.type);
       }
       for (const blended of blendableSchema.blendedFields) {
-        fieldTypes.set(blended.name, blended.type);
+        homeFieldTypes.set(blended.name, blended.type);
       }
 
       if (parsedFilters.length > 0) {
-        errors.push(...this.validateFilters(parsedFilters, fieldTypes));
+        const { knownPaths, excludedPaths } = this.buildKnownPaths(blendableSchema);
+        errors.push(
+          ...this.validateFilters(parsedFilters, homeFieldTypes, knownPaths, excludedPaths)
+        );
       }
       if (parsedSort.length > 0) {
-        const selectedSet = new Set(args.columnConfig ?? Array.from(fieldTypes.keys()));
+        const selectedSet = new Set(args.columnConfig ?? Array.from(homeFieldTypes.keys()));
         errors.push(...this.validateSort(parsedSort, selectedSet));
       }
     }
@@ -196,5 +269,32 @@ export class OutputControlsValidatorService {
         details: { errors },
       });
     }
+  }
+
+  private buildKnownPaths(blendableSchema: {
+    availableSources: { aliasPath: string; isIncluded?: boolean }[];
+    blendedFields: { aliasPath: string; originalFieldName: string; type: string }[];
+  }): { knownPaths: Map<string, Map<string, string>>; excludedPaths: Set<string> } {
+    const knownPaths = new Map<string, Map<string, string>>();
+    const excludedPaths = new Set<string>();
+    for (const source of blendableSchema.availableSources) {
+      if (source.isIncluded === false) {
+        excludedPaths.add(source.aliasPath);
+        continue;
+      }
+      if (!knownPaths.has(source.aliasPath)) {
+        knownPaths.set(source.aliasPath, new Map());
+      }
+    }
+    for (const field of blendableSchema.blendedFields) {
+      if (excludedPaths.has(field.aliasPath)) continue;
+      let fields = knownPaths.get(field.aliasPath);
+      if (!fields) {
+        fields = new Map();
+        knownPaths.set(field.aliasPath, fields);
+      }
+      fields.set(field.originalFieldName, field.type);
+    }
+    return { knownPaths, excludedPaths };
   }
 }

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.ts
@@ -18,9 +18,7 @@ export type ValidationError =
   | { code: 'SORT_COLUMN_NOT_SELECTED'; column: string }
   | { code: 'FILTER_ALIAS_PATH_UNKNOWN'; aliasPath: string }
   | { code: 'FILTER_ALIAS_PATH_NOT_INCLUDED'; aliasPath: string }
-  | { code: 'FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME'; aliasPath: string }
-  | { code: 'FILTER_ALIAS_PATH_REQUIRED'; column: string }
-  | { code: 'FILTER_ALIAS_PATH_FORBIDDEN_ON_POST_JOIN'; column: string; aliasPath: string };
+  | { code: 'PRE_JOIN_FILTERS_REQUIRE_COLUMN_CONFIG' };
 
 const STRING_TYPES = new Set(['STRING']);
 const NUMBER_TYPES = new Set(['INTEGER', 'FLOAT', 'NUMERIC', 'BIGNUMERIC']);
@@ -102,15 +100,7 @@ export class OutputControlsValidatorService {
     const errors: ValidationError[] = [];
     for (const rule of filters) {
       if (rule.placement === 'pre-join') {
-        const aliasPath = rule.aliasPath;
-        if (!aliasPath) {
-          errors.push({ code: 'FILTER_ALIAS_PATH_REQUIRED', column: rule.column });
-          continue;
-        }
-        if (aliasPath === 'main') {
-          errors.push({ code: 'FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME', aliasPath });
-          continue;
-        }
+        const aliasPath = rule.aliasPath!;
         if (excludedPaths?.has(aliasPath)) {
           errors.push({ code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath });
           continue;
@@ -127,14 +117,6 @@ export class OutputControlsValidatorService {
         }
         this.validateRuleAgainstType(rule, type, aliasPath, errors);
       } else {
-        if (rule.aliasPath != null) {
-          errors.push({
-            code: 'FILTER_ALIAS_PATH_FORBIDDEN_ON_POST_JOIN',
-            column: rule.column,
-            aliasPath: rule.aliasPath,
-          });
-          continue;
-        }
         const type = homeFieldTypes.get(rule.column);
         if (type === undefined) {
           errors.push({ code: 'FILTER_COLUMN_UNKNOWN', column: rule.column });
@@ -235,6 +217,11 @@ export class OutputControlsValidatorService {
     }
 
     const errors: ValidationError[] = [];
+
+    const hasColumnConfig = (args.columnConfig?.length ?? 0) > 0;
+    if (!hasColumnConfig && parsedFilters.some(r => r.placement === 'pre-join')) {
+      errors.push({ code: 'PRE_JOIN_FILTERS_REQUIRE_COLUMN_CONFIG' });
+    }
 
     const needsSchema = parsedFilters.length > 0 || parsedSort.length > 0;
     if (needsSchema) {

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
@@ -4,6 +4,7 @@ import { Report } from '../entities/report.entity';
 import { BigQueryQueryBuilder } from '../data-storage-types/bigquery/services/bigquery-query.builder';
 import { BigQueryClauseRenderer } from '../data-storage-types/bigquery/services/bigquery-clause-renderer';
 import { isQueryBuildResult } from '../data-storage-types/interfaces/data-mart-query-builder.interface';
+import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 
 describe('ReportSqlComposerService', () => {
   const buildReport = (overrides: Partial<Report> = {}): Report =>
@@ -36,11 +37,16 @@ describe('ReportSqlComposerService', () => {
       isSupported: jest.fn().mockReturnValue(capabilitySupported),
     };
 
+    const outputControlsValidator = {
+      validateForReport: jest.fn().mockResolvedValue(undefined),
+    };
+
     const service = new ReportSqlComposerService(
       blendedReportDataService as never,
       queryBuilderFacade as never,
       tableReferenceService as never,
-      capabilityService as never
+      capabilityService as never,
+      outputControlsValidator as never
     );
 
     return {
@@ -49,8 +55,49 @@ describe('ReportSqlComposerService', () => {
       queryBuilderFacade,
       tableReferenceService,
       capabilityService,
+      outputControlsValidator,
     };
   };
+
+  it('re-validates output controls against the current schema before composing', async () => {
+    const { service, outputControlsValidator } = createService(
+      { needsBlending: false, columnFilter: ['a'] },
+      'SELECT 1'
+    );
+    const report = buildReport({
+      columnConfig: ['a'],
+      filterConfig: [{ column: 'a', operator: 'eq', value: 1 }],
+      sortConfig: [{ column: 'a', direction: 'asc' }],
+      limitConfig: 50,
+    } as Partial<Report>);
+
+    await service.compose(report);
+
+    expect(outputControlsValidator.validateForReport).toHaveBeenCalledTimes(1);
+    expect(outputControlsValidator.validateForReport).toHaveBeenCalledWith({
+      storageType: 'GOOGLE_BIGQUERY',
+      dataMartId: 'dm-1',
+      projectId: undefined,
+      columnConfig: ['a'],
+      filterConfig: report.filterConfig,
+      sortConfig: report.sortConfig,
+      limitConfig: 50,
+    });
+  });
+
+  it('propagates validator rejection (stale stored rule against drifted schema)', async () => {
+    const { service, outputControlsValidator } = createService({
+      needsBlending: false,
+      columnFilter: ['a'],
+    });
+    const validatorError = new BadRequestException({
+      message: 'Output controls validation failed',
+      details: { errors: [{ code: 'FILTER_COLUMN_UNKNOWN', column: 'stale_col' }] },
+    });
+    outputControlsValidator.validateForReport.mockRejectedValue(validatorError);
+
+    await expect(service.compose(buildReport())).rejects.toBe(validatorError);
+  });
 
   it('returns blended SQL when decision.needsBlending and blendedSql is present', async () => {
     const { service, queryBuilderFacade } = createService({
@@ -80,16 +127,22 @@ describe('ReportSqlComposerService', () => {
     );
   });
 
-  it('falls back to the query builder facade when needsBlending is true but blendedSql is missing', async () => {
+  it('throws BLENDED_SQL_UNAVAILABLE when needsBlending is true but blendedSql is missing', async () => {
+    // Previously this case silently fell through to the simple-query path, which
+    // would drop slice/filter semantics for the joined mart. The composer must
+    // now fail loudly so the user (and oncall) immediately know that no blended
+    // builder is registered for this storage type.
     const { service, queryBuilderFacade } = createService(
       { needsBlending: true, columnFilter: undefined },
       'SELECT fallback FROM dm'
     );
 
-    const result = await service.compose(buildReport());
-
-    expect(result.sql).toBe('SELECT fallback FROM dm');
-    expect(queryBuilderFacade.buildQuery).toHaveBeenCalled();
+    await expect(service.compose(buildReport())).rejects.toMatchObject({
+      response: {
+        details: { errors: [{ code: 'BLENDED_SQL_UNAVAILABLE' }] },
+      },
+    });
+    expect(queryBuilderFacade.buildQuery).not.toHaveBeenCalled();
   });
 
   it('throws when the fallback path is taken but the DataMart has no definition', async () => {
@@ -123,7 +176,8 @@ describe('ReportSqlComposerService', () => {
       blendedDataService as never,
       queryBuilderFacade as never,
       tableReferenceService as never,
-      capabilityService as never
+      capabilityService as never,
+      { validateForReport: jest.fn().mockResolvedValue(undefined) } as never
     );
     const filterConfig = [{ column: 'a', operator: 'eq', value: 1 }];
     const sortConfig = [{ column: 'a', direction: 'asc' }];
@@ -166,7 +220,8 @@ describe('ReportSqlComposerService', () => {
       blendedDataService as never,
       queryBuilderFacade as never,
       tableReferenceService as never,
-      capabilityService as never
+      capabilityService as never,
+      { validateForReport: jest.fn().mockResolvedValue(undefined) } as never
     );
     const report = {
       dataMart: {
@@ -193,10 +248,16 @@ describe('ReportSqlComposerService', () => {
       blendedDataService as never,
       {} as never,
       {} as never,
-      { isSupported: jest.fn() } as never
+      { isSupported: jest.fn() } as never,
+      { validateForReport: jest.fn().mockResolvedValue(undefined) } as never
     );
     const result = await composer.compose({
       filterConfig: [{ column: 'a', operator: 'eq', value: 1 }],
+      dataMart: {
+        id: 'm',
+        projectId: 'p',
+        storage: { type: 'GOOGLE_BIGQUERY' },
+      },
     } as never);
     expect(result).toEqual({
       sql: 'WITH ... SELECT ... WHERE @p0',
@@ -251,6 +312,52 @@ describe('ReportSqlComposerService', () => {
     expect(capabilityService.isSupported).not.toHaveBeenCalled();
   });
 
+  it('throws PRE_JOIN_FILTERS_REQUIRE_JOINED_DATA_MART when a pre-join filter is set on a simple data mart', async () => {
+    const { service } = createService({ needsBlending: false, columnFilter: ['a'] });
+    const report = buildReport({
+      filterConfig: [
+        {
+          column: 'userRole',
+          operator: 'eq',
+          value: 'admin',
+          placement: 'pre-join',
+          aliasPath: 'users',
+        },
+      ],
+    } as never);
+    await expect(service.compose(report)).rejects.toMatchObject({
+      response: {
+        details: { errors: [{ code: 'PRE_JOIN_FILTERS_REQUIRE_JOINED_DATA_MART' }] },
+      },
+    });
+  });
+
+  it('throws OUTPUT_CONTROLS_NOT_SUPPORTED on the simple-query path for unsupported storages', async () => {
+    // Non-blended path with output controls on a storage that lacks output
+    // controls support — must throw the existing structured error before
+    // calling the query builder facade.
+    const { service, queryBuilderFacade, capabilityService } = createService(
+      { needsBlending: false, columnFilter: ['a'] },
+      'SELECT 1',
+      /* capabilitySupported */ false
+    );
+    const report = buildReport({
+      dataMart: {
+        id: 'dm-1',
+        definition: { sqlQuery: 'SELECT 1' },
+        storage: { id: 'storage-1', type: DataStorageType.SNOWFLAKE },
+      },
+      filterConfig: [{ column: 'a', operator: 'eq', value: 1 }],
+    } as never);
+    await expect(service.compose(report)).rejects.toMatchObject({
+      response: {
+        details: { errors: [{ code: 'OUTPUT_CONTROLS_NOT_SUPPORTED' }] },
+      },
+    });
+    expect(capabilityService.isSupported).toHaveBeenCalledWith(DataStorageType.SNOWFLAKE);
+    expect(queryBuilderFacade.buildQuery).not.toHaveBeenCalled();
+  });
+
   // E2E composition: wires the *real* BigQueryQueryBuilder + BigQueryClauseRenderer
   // behind a stub facade so we can assert that the SQL emitted to the executor
   // contains named parameter placeholders (@p0, @p1, ...) and the matching
@@ -280,7 +387,8 @@ describe('ReportSqlComposerService', () => {
         blendedDataService as never,
         facade as never,
         tableReferenceService as never,
-        capabilityService as never
+        capabilityService as never,
+        { validateForReport: jest.fn().mockResolvedValue(undefined) } as never
       );
     }
 

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
@@ -37,16 +37,11 @@ describe('ReportSqlComposerService', () => {
       isSupported: jest.fn().mockReturnValue(capabilitySupported),
     };
 
-    const outputControlsValidator = {
-      validateForReport: jest.fn().mockResolvedValue(undefined),
-    };
-
     const service = new ReportSqlComposerService(
       blendedReportDataService as never,
       queryBuilderFacade as never,
       tableReferenceService as never,
-      capabilityService as never,
-      outputControlsValidator as never
+      capabilityService as never
     );
 
     return {
@@ -55,12 +50,11 @@ describe('ReportSqlComposerService', () => {
       queryBuilderFacade,
       tableReferenceService,
       capabilityService,
-      outputControlsValidator,
     };
   };
 
-  it('re-validates output controls against the current schema before composing', async () => {
-    const { service, outputControlsValidator } = createService(
+  it('delegates schema-drift validation to resolveBlendingDecision (single chokepoint)', async () => {
+    const { service, blendedReportDataService } = createService(
       { needsBlending: false, columnFilter: ['a'] },
       'SELECT 1'
     );
@@ -73,20 +67,12 @@ describe('ReportSqlComposerService', () => {
 
     await service.compose(report);
 
-    expect(outputControlsValidator.validateForReport).toHaveBeenCalledTimes(1);
-    expect(outputControlsValidator.validateForReport).toHaveBeenCalledWith({
-      storageType: 'GOOGLE_BIGQUERY',
-      dataMartId: 'dm-1',
-      projectId: undefined,
-      columnConfig: ['a'],
-      filterConfig: report.filterConfig,
-      sortConfig: report.sortConfig,
-      limitConfig: 50,
-    });
+    expect(blendedReportDataService.resolveBlendingDecision).toHaveBeenCalledTimes(1);
+    expect(blendedReportDataService.resolveBlendingDecision).toHaveBeenCalledWith(report);
   });
 
-  it('propagates validator rejection (stale stored rule against drifted schema)', async () => {
-    const { service, outputControlsValidator } = createService({
+  it('propagates validator rejection thrown by resolveBlendingDecision', async () => {
+    const { service, blendedReportDataService } = createService({
       needsBlending: false,
       columnFilter: ['a'],
     });
@@ -94,7 +80,7 @@ describe('ReportSqlComposerService', () => {
       message: 'Output controls validation failed',
       details: { errors: [{ code: 'FILTER_COLUMN_UNKNOWN', column: 'stale_col' }] },
     });
-    outputControlsValidator.validateForReport.mockRejectedValue(validatorError);
+    blendedReportDataService.resolveBlendingDecision.mockRejectedValue(validatorError);
 
     await expect(service.compose(buildReport())).rejects.toBe(validatorError);
   });
@@ -176,8 +162,7 @@ describe('ReportSqlComposerService', () => {
       blendedDataService as never,
       queryBuilderFacade as never,
       tableReferenceService as never,
-      capabilityService as never,
-      { validateForReport: jest.fn().mockResolvedValue(undefined) } as never
+      capabilityService as never
     );
     const filterConfig = [{ column: 'a', operator: 'eq', value: 1 }];
     const sortConfig = [{ column: 'a', direction: 'asc' }];
@@ -220,8 +205,7 @@ describe('ReportSqlComposerService', () => {
       blendedDataService as never,
       queryBuilderFacade as never,
       tableReferenceService as never,
-      capabilityService as never,
-      { validateForReport: jest.fn().mockResolvedValue(undefined) } as never
+      capabilityService as never
     );
     const report = {
       dataMart: {
@@ -248,8 +232,7 @@ describe('ReportSqlComposerService', () => {
       blendedDataService as never,
       {} as never,
       {} as never,
-      { isSupported: jest.fn() } as never,
-      { validateForReport: jest.fn().mockResolvedValue(undefined) } as never
+      { isSupported: jest.fn() } as never
     );
     const result = await composer.compose({
       filterConfig: [{ column: 'a', operator: 'eq', value: 1 }],
@@ -387,8 +370,7 @@ describe('ReportSqlComposerService', () => {
         blendedDataService as never,
         facade as never,
         tableReferenceService as never,
-        capabilityService as never,
-        { validateForReport: jest.fn().mockResolvedValue(undefined) } as never
+        capabilityService as never
       );
     }
 

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -6,7 +6,6 @@ import { isQueryBuildResult } from '../data-storage-types/interfaces/data-mart-q
 import { DataMartTableReferenceService } from './data-mart-table-reference.service';
 import { SqlParameter } from '../data-storage-types/utils/sql-clause-renderer';
 import { OutputControlsCapabilityService } from './output-controls-capability.service';
-import { OutputControlsValidatorService } from './output-controls-validator.service';
 
 @Injectable()
 export class ReportSqlComposerService {
@@ -14,22 +13,11 @@ export class ReportSqlComposerService {
     private readonly blendedReportDataService: BlendedReportDataService,
     private readonly queryBuilderFacade: DataMartQueryBuilderFacade,
     private readonly tableReferenceService: DataMartTableReferenceService,
-    private readonly capabilityService: OutputControlsCapabilityService,
-    private readonly outputControlsValidator: OutputControlsValidatorService
+    private readonly capabilityService: OutputControlsCapabilityService
   ) {}
 
   async compose(report: Report): Promise<{ sql: string; params?: SqlParameter[] }> {
-    // Re-validate against current schema (drift, renamed column, excluded source).
-    await this.outputControlsValidator.validateForReport({
-      storageType: report.dataMart.storage.type,
-      dataMartId: report.dataMart.id,
-      projectId: report.dataMart.projectId,
-      columnConfig: report.columnConfig ?? null,
-      filterConfig: report.filterConfig ?? null,
-      sortConfig: report.sortConfig ?? null,
-      limitConfig: report.limitConfig ?? null,
-    });
-
+    // Schema-drift validation lives inside resolveBlendingDecision (shared with the run path).
     const decision = await this.blendedReportDataService.resolveBlendingDecision(report);
 
     if (decision.needsBlending && decision.blendedSql) {

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -6,6 +6,7 @@ import { isQueryBuildResult } from '../data-storage-types/interfaces/data-mart-q
 import { DataMartTableReferenceService } from './data-mart-table-reference.service';
 import { SqlParameter } from '../data-storage-types/utils/sql-clause-renderer';
 import { OutputControlsCapabilityService } from './output-controls-capability.service';
+import { OutputControlsValidatorService } from './output-controls-validator.service';
 
 @Injectable()
 export class ReportSqlComposerService {
@@ -13,14 +14,54 @@ export class ReportSqlComposerService {
     private readonly blendedReportDataService: BlendedReportDataService,
     private readonly queryBuilderFacade: DataMartQueryBuilderFacade,
     private readonly tableReferenceService: DataMartTableReferenceService,
-    private readonly capabilityService: OutputControlsCapabilityService
+    private readonly capabilityService: OutputControlsCapabilityService,
+    private readonly outputControlsValidator: OutputControlsValidatorService
   ) {}
 
   async compose(report: Report): Promise<{ sql: string; params?: SqlParameter[] }> {
+    // Re-validate against current schema (drift, renamed column, excluded source).
+    await this.outputControlsValidator.validateForReport({
+      storageType: report.dataMart.storage.type,
+      dataMartId: report.dataMart.id,
+      projectId: report.dataMart.projectId,
+      columnConfig: report.columnConfig ?? null,
+      filterConfig: report.filterConfig ?? null,
+      sortConfig: report.sortConfig ?? null,
+      limitConfig: report.limitConfig ?? null,
+    });
+
     const decision = await this.blendedReportDataService.resolveBlendingDecision(report);
 
     if (decision.needsBlending && decision.blendedSql) {
       return { sql: decision.blendedSql, params: decision.params };
+    }
+
+    if (decision.needsBlending && !decision.blendedSql) {
+      throw new BadRequestException({
+        message: 'Joined query builder did not produce SQL for this data mart',
+        details: {
+          errors: [
+            {
+              code: 'BLENDED_SQL_UNAVAILABLE',
+              storageType: report.dataMart.storage.type,
+            },
+          ],
+        },
+      });
+    }
+
+    // Pre-join filters on a non-blended data mart are nonsensical (no joined CTE
+    // to filter); BlendedReportDataService promotes the report to blended path
+    // whenever any pre-join filter is present, so this branch only sees a
+    // truly non-blended report.
+    if (
+      !decision.needsBlending &&
+      (report.filterConfig ?? []).some(r => r.placement === 'pre-join')
+    ) {
+      throw new BadRequestException({
+        message: 'Pre-join filters are only applicable to joined data marts',
+        details: { errors: [{ code: 'PRE_JOIN_FILTERS_REQUIRE_JOINED_DATA_MART' }] },
+      });
     }
 
     const { dataMart } = report;

--- a/apps/backend/test/blended-output-controls.e2e-spec.ts
+++ b/apps/backend/test/blended-output-controls.e2e-spec.ts
@@ -1,0 +1,516 @@
+import { INestApplication } from '@nestjs/common';
+import * as supertest from 'supertest';
+import {
+  AUTH_HEADER,
+  closeTestApp,
+  createTestApp,
+  extractCteBody,
+  setupBlendedReportPrerequisites,
+  type BlendedReportPrerequisites,
+} from '@owox/test-utils';
+
+// Full-flow e2e: PUT /api/reports/:id → GET /api/reports/:id/generated-sql.
+// Exercises the entire pipeline (DTO → validator → entity persist → composer
+// → BigQuery blended builder) for both post-join filters and pre-join filters
+// (a.k.a. slices, expressed via FilterRule.placement='pre-join'+aliasPath).
+//
+// The 7 groups below mirror the contract that protects this feature end-to-end:
+//   1. Baseline — sanity check that an unfiltered report composes a blended-or-simple SELECT
+//   2. Post-join filters — final WHERE on the outer SELECT
+//   3. Pre-join filters — WHERE inside the joined mart's *_raw CTE
+//   4. Combos — post-join + pre-join coexist with distinct param prefixes (p vs s_<cte>_)
+//   5. Validation — DTO/validator rejects invalid pre-join payloads with structured codes
+//   6. Clearing — null filterConfig wipes persisted state on the next PUT
+//   7. Native-column filters — validator rejects unknown native columns
+
+describe('Blended output controls full-flow (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+  let prereqs: BlendedReportPrerequisites;
+
+  beforeAll(async () => {
+    const testApp = await createTestApp();
+    app = testApp.app;
+    agent = testApp.agent;
+    prereqs = await setupBlendedReportPrerequisites(agent, { withSchemas: true });
+  }, 60_000);
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  // Helper: PUT a partial filterConfig update onto the shared report.
+  // Keeps the other report fields (title/destination/destinationConfig) constant
+  // so each test only mutates what it explicitly asserts on.
+  async function putReportConfig(body: {
+    columnConfig?: string[] | null;
+    filterConfig?: unknown;
+    sortConfig?: unknown;
+    limitConfig?: number | null;
+  }): Promise<supertest.Response> {
+    return agent
+      .put(`/api/reports/${prereqs.reportId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Blended e2e',
+        dataDestinationId: prereqs.dataDestinationId,
+        destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        columnConfig: body.columnConfig ?? null,
+        filterConfig: body.filterConfig ?? null,
+        sortConfig: body.sortConfig ?? null,
+        limitConfig: body.limitConfig ?? null,
+      });
+  }
+
+  async function getGeneratedSql(): Promise<string> {
+    const res = await agent.get(`/api/reports/${prereqs.reportId}/generated-sql`).set(AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(typeof res.body.sql).toBe('string');
+    return res.body.sql as string;
+  }
+
+  async function getReport(): Promise<Record<string, unknown>> {
+    const res = await agent.get(`/api/reports/${prereqs.reportId}`).set(AUTH_HEADER);
+    expect(res.status).toBe(200);
+    return res.body as Record<string, unknown>;
+  }
+
+  // ── Group 1: Baseline ─────────────────────────────────────────────────────
+
+  describe('1. Baseline', () => {
+    it('composes a SELECT when no output controls and only native columns are selected', async () => {
+      const put = await putReportConfig({ columnConfig: ['event_id', 'amount'] });
+      expect(put.status).toBe(200);
+
+      const sql = await getGeneratedSql();
+      expect(sql).toMatch(/SELECT/i);
+      expect(sql).toContain('event_id');
+      // No blended path triggered — no _raw CTE.
+      expect(sql).not.toMatch(/users_raw AS \(/);
+    });
+  });
+
+  // ── Group 2: Post-join filters ───────────────────────────────────────────
+
+  describe('2. Post-join filters', () => {
+    it('emits a final WHERE on native column when placement is omitted (default post-join)', async () => {
+      const put = await putReportConfig({
+        columnConfig: ['event_id', 'amount'],
+        filterConfig: [{ column: 'amount', operator: 'gt', value: 100 }],
+      });
+      expect(put.status).toBe(200);
+
+      const sql = await getGeneratedSql();
+      expect(sql).toMatch(/WHERE[\s\S]+amount[\s\S]+>[\s\S]+@p0/);
+    });
+
+    it('emits a final WHERE when placement="post-join" is explicit', async () => {
+      const put = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [{ column: 'amount', operator: 'gte', value: 50, placement: 'post-join' }],
+      });
+      expect(put.status).toBe(200);
+
+      const sql = await getGeneratedSql();
+      expect(sql).toMatch(/WHERE[\s\S]+amount[\s\S]+>=[\s\S]+@p0/);
+    });
+  });
+
+  // ── Group 3: Pre-join filters ────────────────────────────────────────────
+
+  describe('3. Pre-join filters', () => {
+    it('emits WHERE inside users_raw CTE for a single pre-join filter on users.role', async () => {
+      const put = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'role',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      });
+      expect(put.status).toBe(200);
+
+      const sql = await getGeneratedSql();
+      // Blended path must trigger because a pre-join filter is present even
+      // though only native columns are selected.
+      expect(sql).toMatch(/users_raw AS \(/);
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      expect(usersRawBody).toMatch(/WHERE[\s\S]+`role`\s*=\s*@s_users_0/);
+    });
+
+    it('combines multiple pre-join filters on the same CTE with AND', async () => {
+      const put = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'role',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+          {
+            column: 'is_active',
+            operator: 'is_true',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      });
+      expect(put.status).toBe(200);
+
+      const sql = await getGeneratedSql();
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      expect(usersRawBody).toMatch(/WHERE[\s\S]+AND/);
+      expect(usersRawBody).toContain('`role`');
+      expect(usersRawBody).toContain('`is_active`');
+    });
+
+    it('uses isolated s_<cte>_ prefix per joined mart so params never collide across CTEs', async () => {
+      const put = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'role',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+          {
+            column: 'plan',
+            operator: 'eq',
+            value: 'pro',
+            placement: 'pre-join',
+            aliasPath: 'orgs',
+          },
+        ],
+      });
+      expect(put.status).toBe(200);
+
+      const sql = await getGeneratedSql();
+      // Distinct param prefixes per CTE — no `@s_users_0` ↔ `@s_orgs_0` collision
+      // because the prefixes themselves are different.
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      const orgsRawBody = extractCteBody(sql, 'orgs_raw');
+      expect(usersRawBody).toContain('@s_users_0');
+      expect(orgsRawBody).toContain('@s_orgs_0');
+    });
+
+    it('projects pre-join filter column into the raw CTE SELECT even if not in columnConfig', async () => {
+      const put = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'role',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      });
+      expect(put.status).toBe(200);
+
+      const sql = await getGeneratedSql();
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      // `role` is referenced by the WHERE; the raw CTE must project it OR fall
+      // back to SELECT *. Either way, the column must appear inside the body.
+      expect(usersRawBody).toMatch(/role/);
+    });
+  });
+
+  // ── Group 4: Combos ──────────────────────────────────────────────────────
+
+  describe('4. Combos (post-join + pre-join)', () => {
+    it('post-join `@p0` and pre-join `@s_users_0` coexist with isolated prefixes', async () => {
+      const put = await putReportConfig({
+        columnConfig: ['event_id', 'amount'],
+        filterConfig: [
+          { column: 'amount', operator: 'gt', value: 50 },
+          {
+            column: 'role',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      });
+      expect(put.status).toBe(200);
+
+      const sql = await getGeneratedSql();
+      // Outer SELECT must reference @p0 — post-join WHERE
+      expect(sql).toContain('@p0');
+      // Inner users_raw CTE must reference @s_users_0 — pre-join WHERE
+      const usersRawBody = extractCteBody(sql, 'users_raw');
+      expect(usersRawBody).toContain('@s_users_0');
+    });
+
+    it('post-join + sort + limit + pre-join all coexist on the same report', async () => {
+      const put = await putReportConfig({
+        columnConfig: ['event_id', 'amount'],
+        filterConfig: [
+          { column: 'amount', operator: 'gte', value: 1 },
+          {
+            column: 'role',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+        sortConfig: [{ column: 'amount', direction: 'desc' }],
+        limitConfig: 100,
+      });
+      expect(put.status).toBe(200);
+
+      const sql = await getGeneratedSql();
+      expect(sql).toMatch(/users_raw AS \(/);
+      expect(sql).toMatch(/ORDER BY/);
+      expect(sql).toMatch(/LIMIT 100/);
+    });
+  });
+
+  // ── Group 5: Validation ──────────────────────────────────────────────────
+
+  describe('5. Validation', () => {
+    it('rejects pre-join filter with aliasPath that does not resolve to any chain', async () => {
+      const res = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'something',
+            operator: 'eq',
+            value: 'X',
+            placement: 'pre-join',
+            aliasPath: 'nonexistent_alias',
+          },
+        ],
+      });
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toContain('FILTER_ALIAS_PATH_UNKNOWN');
+    });
+
+    it('rejects pre-join filter with aliasPath="main" (home mart not slicable)', async () => {
+      const res = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'event_id',
+            operator: 'eq',
+            value: 'X',
+            placement: 'pre-join',
+            aliasPath: 'main',
+          },
+        ],
+      });
+      expect(res.status).toBe(400);
+      // Zod superRefine on FilterRuleSchema catches this BEFORE the validator
+      // service runs, so the response body carries the schema "invalid shape"
+      // path (`aliasPath`) — verified by absence of the schema-level success.
+      const body = JSON.stringify(res.body);
+      expect(
+        body.includes('FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME') || body.includes('aliasPath')
+      ).toBe(true);
+    });
+
+    it('rejects pre-join filter with unknown raw column inside known aliasPath', async () => {
+      const res = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'no_such_column',
+            operator: 'eq',
+            value: 'X',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      });
+      expect(res.status).toBe(400);
+      const body = JSON.stringify(res.body);
+      expect(body).toContain('FILTER_COLUMN_UNKNOWN');
+    });
+
+    it('rejects operator/type mismatch on pre-join (regex on INTEGER native field)', async () => {
+      const res = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'employee_count',
+            operator: 'regex',
+            value: '^1',
+            placement: 'pre-join',
+            aliasPath: 'orgs',
+          },
+        ],
+      });
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toContain('INVALID_OPERATOR_FOR_TYPE');
+    });
+  });
+
+  // ── Group 6: Clearing ────────────────────────────────────────────────────
+
+  describe('6. Clearing', () => {
+    it('PUT filterConfig: null wipes persisted state', async () => {
+      // Seed
+      await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'role',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      });
+      const seeded = await getReport();
+      expect(Array.isArray(seeded.filterConfig)).toBe(true);
+
+      // Clear
+      const clear = await putReportConfig({ columnConfig: ['event_id'], filterConfig: null });
+      expect(clear.status).toBe(200);
+
+      const after = await getReport();
+      expect(after.filterConfig).toBeNull();
+    });
+  });
+
+  // ── Group 7: Native-column filters ───────────────────────────────────────
+
+  describe('7. Native-column filters', () => {
+    it('accepts post-join filter on a known native column', async () => {
+      const res = await putReportConfig({
+        columnConfig: ['event_id', 'amount'],
+        filterConfig: [{ column: 'amount', operator: 'lt', value: 1_000_000 }],
+      });
+      expect(res.status).toBe(200);
+
+      const sql = await getGeneratedSql();
+      expect(sql).toMatch(/WHERE[\s\S]+amount[\s\S]+<[\s\S]+@p0/);
+    });
+
+    it('rejects post-join filter on unknown native column with FILTER_COLUMN_UNKNOWN', async () => {
+      const res = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [{ column: 'no_such_native', operator: 'eq', value: 'X' }],
+      });
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toContain('FILTER_COLUMN_UNKNOWN');
+    });
+  });
+
+  // ── Group 8: Edge-case validation (one e2e per under-covered code) ──────
+
+  describe('8. Edge-case validation', () => {
+    it('rejects regex with invalid pattern → INVALID_REGEX_PATTERN', async () => {
+      const res = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'role',
+            operator: 'regex',
+            value: '[unclosed',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      });
+      expect(res.status).toBe(400);
+      expect(JSON.stringify(res.body)).toContain('INVALID_REGEX_PATTERN');
+    });
+
+    it('rejects is_empty on NUMERIC native column → INVALID_OPERATOR_FOR_TYPE', async () => {
+      const res = await putReportConfig({
+        columnConfig: ['event_id', 'amount'],
+        filterConfig: [{ column: 'amount', operator: 'is_empty' }],
+      });
+      expect(res.status).toBe(400);
+      const body = JSON.stringify(res.body);
+      expect(body).toContain('INVALID_OPERATOR_FOR_TYPE');
+    });
+
+    it('accepts relative_date with last_n_months and round-trips through GET', async () => {
+      const put = await putReportConfig({
+        columnConfig: ['event_id', 'event_ts'],
+        filterConfig: [
+          {
+            column: 'event_ts',
+            operator: 'relative_date',
+            value: { kind: 'last_n_months', n: 3 },
+          },
+        ],
+      });
+      expect(put.status).toBe(200);
+
+      const after = await getReport();
+      expect(after.filterConfig).toEqual([
+        {
+          column: 'event_ts',
+          operator: 'relative_date',
+          value: { kind: 'last_n_months', n: 3 },
+        },
+      ]);
+    });
+  });
+
+  // ── Group 9: Re-validation against drifted schema (composer hop) ─────────
+
+  describe('9. Re-validation on read path (generated-sql)', () => {
+    it('GET generated-sql 400s on a stored pre-join rule whose aliasPath got excluded', async () => {
+      const seed = await putReportConfig({
+        columnConfig: ['event_id'],
+        filterConfig: [
+          {
+            column: 'role',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      });
+      expect(seed.status).toBe(200);
+
+      const drop = await agent
+        .put(`/api/data-marts/${prereqs.mainDataMartId}/blended-fields-config`)
+        .set(AUTH_HEADER)
+        .send({
+          blendedFieldsConfig: {
+            sources: [
+              { path: 'users', alias: 'Users', isExcluded: true },
+              { path: 'orgs', alias: 'Organisations' },
+            ],
+          },
+        });
+      expect(drop.status).toBe(200);
+
+      const sqlRes = await agent
+        .get(`/api/reports/${prereqs.reportId}/generated-sql`)
+        .set(AUTH_HEADER);
+      expect(sqlRes.status).toBe(400);
+      expect(JSON.stringify(sqlRes.body)).toContain('FILTER_ALIAS_PATH_NOT_INCLUDED');
+
+      const restore = await agent
+        .put(`/api/data-marts/${prereqs.mainDataMartId}/blended-fields-config`)
+        .set(AUTH_HEADER)
+        .send({
+          blendedFieldsConfig: {
+            sources: [
+              { path: 'users', alias: 'Users' },
+              { path: 'orgs', alias: 'Organisations' },
+            ],
+          },
+        });
+      expect(restore.status).toBe(200);
+    });
+  });
+});

--- a/apps/backend/test/jest-e2e.json
+++ b/apps/backend/test/jest-e2e.json
@@ -35,6 +35,7 @@
     "^@owox/internal-helpers$": "<rootDir>/../../../packages/internal-helpers/src"
   },
   "maxWorkers": 1,
+  "workerIdleMemoryLimit": "1500MB",
   "testTimeout": 120000,
   "resolver": "<rootDir>/jest-e2e-resolver.js"
 }

--- a/apps/backend/test/output-controls.e2e-spec.ts
+++ b/apps/backend/test/output-controls.e2e-spec.ts
@@ -203,7 +203,7 @@ describe('Output controls API (e2e)', () => {
     expect(JSON.stringify(putRes.body)).toContain('FILTER_ALIAS_PATH_UNKNOWN');
   });
 
-  it('PUT pre-join filter with aliasPath="main" → 400 FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME', async () => {
+  it('PUT pre-join filter with aliasPath="main" → 400 with Zod shape error', async () => {
     const res = await agent
       .put(`/api/reports/${reportId}`)
       .set(AUTH_HEADER)
@@ -217,14 +217,9 @@ describe('Output controls API (e2e)', () => {
         ],
       });
     expect(res.status).toBe(400);
-    // Zod superRefine catches this BEFORE the validator service, so the
-    // response body carries the schema-level message (path: ["aliasPath"])
-    // rather than the validator's FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME code.
+    // Owned by Zod superRefine — FE consumes the schema-level issue, not a validator code.
     const body = JSON.stringify(res.body);
-    expect(
-      body.includes('FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME') ||
-        body.includes('pre-join filter on the home data mart')
-    ).toBe(true);
+    expect(body).toContain('pre-join filter on the home data mart');
   });
 
   it('PUT rejects filterConfig with > 50 entries via @ArrayMaxSize(50)', async () => {

--- a/apps/backend/test/output-controls.e2e-spec.ts
+++ b/apps/backend/test/output-controls.e2e-spec.ts
@@ -8,19 +8,10 @@ import {
   AUTH_HEADER,
 } from '@owox/test-utils';
 
-// e2e coverage for the output-controls feature on the report API surface.
-//
-// Tasks 22 (SQL execution) and 23 (blended e2e) require a real BigQuery
-// project and view-creation roundtrip. They are covered by unit tests:
-//   - bigquery-clause-renderer.spec.ts (operator → SQL fragment matrix)
-//   - bigquery-query.builder.spec.ts (WHERE/ORDER BY/LIMIT composition)
-//   - abstract-blended-query-builder.spec.ts (output controls on blended)
-//   - blended-report-data.service.spec.ts (filter-on-non-selected chain)
-//
-// What this file covers (Task 24 + DTO surface):
-//   - happy-path persistence/retrieval of limit-only output controls
-//   - validator-service rejection: SORT_COLUMN_NOT_SELECTED, FILTER_COLUMN_UNKNOWN
-//   - class-validator rejections: limit <= 0, limit > 10_000_000, sortConfig length > 10
+// e2e coverage for the output-controls feature on the report API surface
+// (limit/filter/sort persistence + class-validator and validator-service
+// rejection paths). SQL-emission paths are covered by unit tests in
+// abstract-blended-query-builder.spec.ts and bigquery-clause-renderer.spec.ts.
 
 describe('Output controls API (e2e)', () => {
   let app: INestApplication;
@@ -187,5 +178,71 @@ describe('Output controls API (e2e)', () => {
     expect(getRes.body.filterConfig).toBeNull();
     expect(getRes.body.sortConfig).toBeNull();
     expect(getRes.body.limitConfig).toBeNull();
+  });
+
+  it('PUT pre-join filter on simple (non-joined) report → 400 FILTER_ALIAS_PATH_UNKNOWN', async () => {
+    const putRes = await agent
+      .put(`/api/reports/${reportId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Pre-join on simple',
+        dataDestinationId,
+        destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        columnConfig: ['col_a'],
+        filterConfig: [
+          {
+            column: 'userRole',
+            operator: 'eq',
+            value: 'admin',
+            placement: 'pre-join',
+            aliasPath: 'users',
+          },
+        ],
+      });
+    expect(putRes.status).toBe(400);
+    expect(JSON.stringify(putRes.body)).toContain('FILTER_ALIAS_PATH_UNKNOWN');
+  });
+
+  it('PUT pre-join filter with aliasPath="main" → 400 FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME', async () => {
+    const res = await agent
+      .put(`/api/reports/${reportId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Pre-join on home',
+        dataDestinationId,
+        destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        columnConfig: ['col_a'],
+        filterConfig: [
+          { column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'main' },
+        ],
+      });
+    expect(res.status).toBe(400);
+    // Zod superRefine catches this BEFORE the validator service, so the
+    // response body carries the schema-level message (path: ["aliasPath"])
+    // rather than the validator's FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME code.
+    const body = JSON.stringify(res.body);
+    expect(
+      body.includes('FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME') ||
+        body.includes('pre-join filter on the home data mart')
+    ).toBe(true);
+  });
+
+  it('PUT rejects filterConfig with > 50 entries via @ArrayMaxSize(50)', async () => {
+    const tooMany = Array.from({ length: 51 }, (_, i) => ({
+      column: 'col_a',
+      operator: 'eq',
+      value: `v${i}`,
+    }));
+    const res = await agent
+      .put(`/api/reports/${reportId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Too many filters',
+        dataDestinationId,
+        destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        columnConfig: ['col_a'],
+        filterConfig: tooMany,
+      });
+    expect(res.status).toBe(400);
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/ConfigurationView.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/ConfigurationView.tsx
@@ -48,8 +48,23 @@ export function ConfigurationView({
             <>
               <h4 className='text-foreground mt-3 mb-3 text-sm font-medium'>Report definition:</h4>
               <pre className='bg-muted text-foreground overflow-x-auto rounded p-3 font-mono text-xs whitespace-pre-wrap dark:bg-white/3'>
-                {JSON.stringify(reportDefinition, null, 2)}
+                {JSON.stringify(
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  (({ outputConfig: _outputConfig, ...rest }) => rest)(reportDefinition),
+                  null,
+                  2
+                )}
               </pre>
+              {reportDefinition.outputConfig && (
+                <>
+                  <h4 className='text-foreground mt-3 mb-3 text-sm font-medium'>
+                    Output controls:
+                  </h4>
+                  <pre className='bg-muted text-foreground overflow-x-auto rounded p-3 font-mono text-xs whitespace-pre-wrap dark:bg-white/3'>
+                    {JSON.stringify(reportDefinition.outputConfig, null, 2)}
+                  </pre>
+                </>
+              )}
             </>
           )}
           {insightDefinition && (

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterEditorPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterEditorPopover.tsx
@@ -1,22 +1,12 @@
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '@owox/ui/components/popover';
 import { Button } from '@owox/ui/components/button';
-import { Input } from '@owox/ui/components/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@owox/ui/components/select';
 import { Label } from '@owox/ui/components/label';
 import { X } from 'lucide-react';
-import type { FilterRule, RelativeDatePreset } from '../../../shared/types/output-config';
-import {
-  type FilterOperator,
-  operatorLabelFor,
-  operatorsForType,
-} from './output-controls-operators';
+import type { FilterRule } from '../../../shared/types/output-config';
+import { operatorLabelFor } from './output-controls-operators';
+import { summarizeFilterRule } from './filter-rule-summary';
+import { FilterValueEditor } from './FilterValueEditor';
 
 export interface FilterEditorPopoverProps {
   open: boolean;
@@ -31,152 +21,39 @@ export interface FilterEditorPopoverProps {
   onRemoveExistingAt?: (index: number) => void;
 }
 
-interface EditorState {
-  op: FilterOperator;
-  scalar: string;
-  betweenFrom: string;
-  betweenTo: string;
-  relativeKind: RelativeDatePreset['kind'];
-  relativeN: number;
-}
-
-const RELATIVE_KINDS: { value: RelativeDatePreset['kind']; label: string }[] = [
-  { value: 'today', label: 'Today' },
-  { value: 'yesterday', label: 'Yesterday' },
-  { value: 'this_month', label: 'This month' },
-  { value: 'last_month', label: 'Last month' },
-  { value: 'this_year', label: 'This year' },
-  { value: 'last_n_days', label: 'Last N days' },
-  { value: 'last_n_months', label: 'Last N months' },
-];
-
-const NO_VALUE_OPS = new Set<FilterOperator>([
-  'is_empty',
-  'is_not_empty',
-  'is_null',
-  'is_not_null',
-  'is_true',
-  'is_false',
-]);
-
-const NUMBER_TYPES = new Set(['INTEGER', 'FLOAT', 'NUMERIC', 'BIGNUMERIC']);
-const DATE_TYPES = new Set(['DATE', 'DATETIME', 'TIMESTAMP', 'TIME']);
-
-function getInitialState(rule: FilterRule | undefined, fallbackOp: FilterOperator): EditorState {
-  const state: EditorState = {
-    op: fallbackOp,
-    scalar: '',
-    betweenFrom: '',
-    betweenTo: '',
-    relativeKind: 'today',
-    relativeN: 7,
-  };
-  if (!rule) return state;
-  state.op = rule.operator as FilterOperator;
-  if (rule.operator === 'between') {
-    state.betweenFrom = String(rule.value.from);
-    state.betweenTo = String(rule.value.to);
-  } else if (rule.operator === 'relative_date') {
-    state.relativeKind = rule.value.kind;
-    if ('n' in rule.value) state.relativeN = rule.value.n;
-  } else if (!NO_VALUE_OPS.has(rule.operator as FilterOperator)) {
-    const value = (rule as { value: string | number | boolean }).value;
-    state.scalar = String(value);
-  }
-  return state;
-}
-
-function parseScalar(raw: string, fieldType: string): string | number | boolean {
-  if (NUMBER_TYPES.has(fieldType)) {
-    const n = Number(raw);
-    if (!Number.isFinite(n)) throw new Error('Invalid number');
-    return n;
-  }
-  return raw;
-}
-
-function buildRule(args: { column: string; fieldType: string; state: EditorState }): FilterRule {
-  const { column, fieldType, state } = args;
-  const { op } = state;
-
-  if (op === 'between') {
-    if (state.betweenFrom === '' || state.betweenTo === '') {
-      throw new Error('Both bounds are required');
-    }
-    const from = parseScalar(state.betweenFrom, fieldType);
-    const to = parseScalar(state.betweenTo, fieldType);
-    const numericOutOfOrder = typeof from === 'number' && typeof to === 'number' && from > to;
-    const dateOutOfOrder =
-      typeof from === 'string' && typeof to === 'string' && DATE_TYPES.has(fieldType) && from > to;
-    if (numericOutOfOrder || dateOutOfOrder) {
-      throw new Error('"From" must be ≤ "To"');
-    }
-    return { column, operator: 'between', value: { from, to } };
-  }
-
-  if (op === 'relative_date') {
-    if (state.relativeKind === 'last_n_days' || state.relativeKind === 'last_n_months') {
-      if (!Number.isInteger(state.relativeN) || state.relativeN <= 0) {
-        throw new Error('N must be a positive integer');
-      }
-      return {
-        column,
-        operator: 'relative_date',
-        value: { kind: state.relativeKind, n: state.relativeN },
-      };
-    }
-    return { column, operator: 'relative_date', value: { kind: state.relativeKind } };
-  }
-
-  if (NO_VALUE_OPS.has(op)) {
-    return { column, operator: op } as FilterRule;
-  }
-
-  if (state.scalar === '') {
-    throw new Error('Value is required');
-  }
-
-  if (op === 'regex' || op === 'not_regex') {
-    try {
-      new RegExp(state.scalar);
-    } catch {
-      throw new Error('Invalid regex pattern');
-    }
-  }
-
-  return { column, operator: op, value: parseScalar(state.scalar, fieldType) } as FilterRule;
-}
-
 export function FilterEditorPopover(props: FilterEditorPopoverProps) {
-  const operators = operatorsForType(props.fieldType);
-  const fallbackOp = operators[0]?.value ?? 'eq';
-
-  const [state, setState] = useState<EditorState>(() =>
-    getInitialState(props.initialRule, fallbackOp)
-  );
+  const [draftRule, setDraftRule] = useState<FilterRule | null>(props.initialRule ?? null);
   const [error, setError] = useState<string | null>(null);
 
+  // Reset draft and error ONLY on the closed→open transition. The bare
+  // `if (props.open)` check would fire on every render-while-open whenever the
+  // parent passes a new `initialRule` object identity (typical for derived
+  // values), wiping the user's in-progress edits. `openInstanceId` also keys
+  // the inner editor so it remounts on each open without remounting on
+  // unrelated parent re-renders.
+  const [openInstanceId, setOpenInstanceId] = useState(0);
+  const prevOpen = useRef(false);
   useEffect(() => {
-    if (props.open) {
-      setState(getInitialState(props.initialRule, fallbackOp));
+    if (props.open && !prevOpen.current) {
+      setOpenInstanceId(id => id + 1);
+      setDraftRule(props.initialRule ?? null);
       setError(null);
     }
-  }, [props.open, props.initialRule, fallbackOp]);
+    prevOpen.current = props.open;
+  }, [props.open, props.initialRule]);
 
-  const isDateType = DATE_TYPES.has(props.fieldType);
+  const handleChange = useCallback((rule: FilterRule | null) => {
+    setDraftRule(rule);
+    setError(null);
+  }, []);
 
   function handleApply() {
-    try {
-      const rule = buildRule({
-        column: props.column,
-        fieldType: props.fieldType,
-        state,
-      });
-      props.onApply(rule);
-      props.onOpenChange(false);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Invalid value');
+    if (!draftRule) {
+      setError('Value is required');
+      return;
     }
+    props.onApply(draftRule);
+    props.onOpenChange(false);
   }
 
   function handleCancel() {
@@ -207,9 +84,9 @@ export function FilterEditorPopover(props: FilterEditorPopoverProps) {
                   key={idx}
                   className='bg-muted/40 flex items-center gap-2 rounded px-2 py-1 text-xs'
                 >
-                  <span className='flex-1 truncate font-mono' title={summarize(rule)}>
+                  <span className='flex-1 truncate font-mono' title={summarizeFilterRule(rule)}>
                     <b>{operatorLabelFor(rule.operator, props.fieldType)}</b>
-                    {summarize(rule) && <>: {summarize(rule)}</>}
+                    {summarizeFilterRule(rule) && <>: {summarizeFilterRule(rule)}</>}
                   </span>
                   {props.onRemoveExistingAt && (
                     <Button
@@ -230,97 +107,13 @@ export function FilterEditorPopover(props: FilterEditorPopoverProps) {
           </div>
         )}
 
-        <div>
-          <Label>Condition</Label>
-          <Select
-            value={state.op}
-            onValueChange={v => {
-              setState(s => ({ ...s, op: v as FilterOperator }));
-            }}
-          >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {operators.map(o => (
-                <SelectItem key={o.value} value={o.value}>
-                  {o.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        {state.op === 'between' && (
-          <div className='space-y-2'>
-            <Label>From / To</Label>
-            <div className='flex gap-2'>
-              <Input
-                type={NUMBER_TYPES.has(props.fieldType) ? 'number' : isDateType ? 'date' : 'text'}
-                value={state.betweenFrom}
-                onChange={e => {
-                  setState(s => ({ ...s, betweenFrom: e.target.value }));
-                }}
-                placeholder='from'
-              />
-              <Input
-                type={NUMBER_TYPES.has(props.fieldType) ? 'number' : isDateType ? 'date' : 'text'}
-                value={state.betweenTo}
-                onChange={e => {
-                  setState(s => ({ ...s, betweenTo: e.target.value }));
-                }}
-                placeholder='to'
-              />
-            </div>
-          </div>
-        )}
-
-        {state.op === 'relative_date' && (
-          <div className='space-y-2'>
-            <Label>Preset</Label>
-            <Select
-              value={state.relativeKind}
-              onValueChange={v => {
-                setState(s => ({ ...s, relativeKind: v as RelativeDatePreset['kind'] }));
-              }}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {RELATIVE_KINDS.map(p => (
-                  <SelectItem key={p.value} value={p.value}>
-                    {p.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {(state.relativeKind === 'last_n_days' || state.relativeKind === 'last_n_months') && (
-              <Input
-                type='number'
-                min={1}
-                value={state.relativeN}
-                onChange={e => {
-                  setState(s => ({ ...s, relativeN: Number(e.target.value) || 0 }));
-                }}
-              />
-            )}
-          </div>
-        )}
-
-        {!NO_VALUE_OPS.has(state.op) && state.op !== 'between' && state.op !== 'relative_date' && (
-          <div className='space-y-1'>
-            <Label>Value</Label>
-            <Input
-              type={NUMBER_TYPES.has(props.fieldType) ? 'number' : isDateType ? 'date' : 'text'}
-              value={state.scalar}
-              onChange={e => {
-                setState(s => ({ ...s, scalar: e.target.value }));
-              }}
-              placeholder={state.op === 'regex' ? 'pattern' : ''}
-            />
-          </div>
-        )}
+        <FilterValueEditor
+          key={String(openInstanceId)}
+          column={props.column}
+          fieldType={props.fieldType}
+          initialRule={props.initialRule}
+          onChange={handleChange}
+        />
 
         {error && <div className='text-destructive text-xs'>{error}</div>}
 
@@ -335,25 +128,4 @@ export function FilterEditorPopover(props: FilterEditorPopoverProps) {
       </PopoverContent>
     </Popover>
   );
-}
-
-function summarize(rule: FilterRule): string {
-  switch (rule.operator) {
-    case 'is_empty':
-    case 'is_not_empty':
-    case 'is_null':
-    case 'is_not_null':
-    case 'is_true':
-    case 'is_false':
-      return '';
-    case 'between':
-      return `${String(rule.value.from)} … ${String(rule.value.to)}`;
-    case 'relative_date': {
-      const v = rule.value;
-      if ('n' in v) return v.kind.replace('_n_', ` ${String(v.n)} `);
-      return v.kind;
-    }
-    default:
-      return JSON.stringify(rule.value);
-  }
 }

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { FilterOrSliceEditorPopover } from './FilterOrSliceEditorPopover';
+
+// Radix Popover renders into a portal; mock to a passthrough that just renders
+// `children` when `open` is true. That lets RTL query the popover content
+// directly without portal/positioning machinery.
+vi.mock('@owox/ui/components/popover', () => ({
+  Popover: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <>{children}</> : null,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Mock Radix Select with a native <select> so RTL can fire change events on it.
+// FilterValueEditor uses <Select> to pick the operator; without this mock the
+// happy-dom render can't drive it.
+vi.mock('@owox/ui/components/select', () => ({
+  Select: ({ children, value, onValueChange }: any) => (
+    <select
+      data-testid='operator-select'
+      value={value}
+      onChange={e => {
+        onValueChange?.(e.target.value);
+      }}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: any) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: any) => <>{children}</>,
+  SelectItem: ({ value, children }: any) => <option value={value}>{children}</option>,
+}));
+
+describe('FilterOrSliceEditorPopover — parallel drafts across tab switches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves the Filter-tab draft when the user switches to Slice and back', () => {
+    // Regression for the commit-pinned bug where the popover mounted a single
+    // FilterValueEditor and swapped its `initialRule` prop based on the active
+    // tab — that swap re-triggered the editor's `useEffect`, wiping mid-edit
+    // state. The fix mounts two editors and hides the inactive one.
+    render(
+      <FilterOrSliceEditorPopover
+        open={true}
+        onOpenChange={() => undefined}
+        column='users__userRole'
+        sliceColumn='userRole'
+        fieldType='STRING'
+        aliasPath='users'
+        defaultTab='filter'
+        trigger={<button>trigger</button>}
+        filterProps={{
+          onApply: vi.fn(),
+          existingRules: [],
+        }}
+        sliceProps={{
+          onApply: vi.fn(),
+          existingSlicesForColumn: [],
+        }}
+      />
+    );
+
+    // FilterValueEditor renders multiple inputs; the scalar `value` input is
+    // the one without a placeholder. Both Filter and Slice editors render
+    // their inputs simultaneously (the inactive tab is under `.hidden`); the
+    // helper picks the currently visible one.
+    const filterValueInput = findVisibleScalarInput();
+
+    // Type into the Filter tab.
+    act(() => {
+      fireEvent.change(filterValueInput, { target: { value: 'admin-filter' } });
+    });
+    expect(filterValueInput.value).toBe('admin-filter');
+
+    // Switch to Slice tab.
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Slice' }));
+    });
+
+    // The visible scalar input is now the Slice tab's editor — should be empty.
+    const sliceValueInput = findVisibleScalarInput();
+    expect(sliceValueInput).not.toBe(filterValueInput);
+    expect(sliceValueInput.value).toBe('');
+
+    // Type into the Slice tab.
+    act(() => {
+      fireEvent.change(sliceValueInput, { target: { value: 'admin-slice' } });
+    });
+    expect(sliceValueInput.value).toBe('admin-slice');
+
+    // Switch back to Filter tab.
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Filter' }));
+    });
+
+    // Filter draft must still hold 'admin-filter' — NOT be reset to empty.
+    const filterValueInputAfter = findVisibleScalarInput();
+    expect(filterValueInputAfter.value).toBe('admin-filter');
+
+    // And switching back to Slice keeps 'admin-slice' too.
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Slice' }));
+    });
+    const sliceValueInputAfter = findVisibleScalarInput();
+    expect(sliceValueInputAfter.value).toBe('admin-slice');
+  });
+
+  it('emits the Filter draft via filterProps.onApply when Apply is clicked on Filter tab', () => {
+    const filterOnApply = vi.fn();
+    const sliceOnApply = vi.fn();
+
+    render(
+      <FilterOrSliceEditorPopover
+        open={true}
+        onOpenChange={() => undefined}
+        column='users__userRole'
+        sliceColumn='userRole'
+        fieldType='STRING'
+        aliasPath='users'
+        defaultTab='filter'
+        trigger={<button>trigger</button>}
+        filterProps={{ onApply: filterOnApply, existingRules: [] }}
+        sliceProps={{ onApply: sliceOnApply, existingSlicesForColumn: [] }}
+      />
+    );
+
+    act(() => {
+      fireEvent.change(findVisibleScalarInput(), { target: { value: 'admin' } });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Apply|Add/ }));
+    });
+
+    expect(filterOnApply).toHaveBeenCalledTimes(1);
+    const emitted = filterOnApply.mock.calls[0][0];
+    expect(emitted).toMatchObject({ column: 'users__userRole', operator: 'eq', value: 'admin' });
+    // No pre-join injection on the filter side.
+    expect(emitted.placement).toBeUndefined();
+    expect(emitted.aliasPath).toBeUndefined();
+    expect(sliceOnApply).not.toHaveBeenCalled();
+  });
+
+  it('emits the Slice draft with placement="pre-join" + aliasPath injected when applied on Slice tab', () => {
+    const filterOnApply = vi.fn();
+    const sliceOnApply = vi.fn();
+
+    render(
+      <FilterOrSliceEditorPopover
+        open={true}
+        onOpenChange={() => undefined}
+        column='users__userRole'
+        sliceColumn='userRole'
+        fieldType='STRING'
+        aliasPath='users'
+        defaultTab='slice'
+        trigger={<button>trigger</button>}
+        filterProps={{ onApply: filterOnApply, existingRules: [] }}
+        sliceProps={{ onApply: sliceOnApply, existingSlicesForColumn: [] }}
+      />
+    );
+
+    act(() => {
+      fireEvent.change(findVisibleScalarInput(), { target: { value: 'admin' } });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Apply|Add/ }));
+    });
+
+    expect(sliceOnApply).toHaveBeenCalledTimes(1);
+    const emitted = sliceOnApply.mock.calls[0][0];
+    // Popover must inject placement + aliasPath; column is the raw slice column.
+    expect(emitted).toMatchObject({
+      column: 'userRole',
+      operator: 'eq',
+      value: 'admin',
+      placement: 'pre-join',
+      aliasPath: 'users',
+    });
+    expect(filterOnApply).not.toHaveBeenCalled();
+  });
+});
+
+// Returns the value <input> whose enclosing wrapper isn't marked `.hidden`.
+// Both Filter and Slice editors render their value input simultaneously while
+// the popover is open; we only want the one currently visible.
+function findVisibleScalarInput(): HTMLInputElement {
+  const inputs = document.querySelectorAll('input[type="text"]');
+  for (const el of Array.from(inputs)) {
+    const wrapper = el.closest('.hidden');
+    if (!wrapper) return el as HTMLInputElement;
+  }
+  throw new Error('No visible scalar input found in popover');
+}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.tsx
@@ -1,0 +1,312 @@
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from '@owox/ui/components/popover';
+import { Button } from '@owox/ui/components/button';
+import { Label } from '@owox/ui/components/label';
+import { X, Layers } from 'lucide-react';
+import type { FilterRule } from '../../../shared/types/output-config';
+import { operatorLabelFor } from './output-controls-operators';
+import { summarizeFilterRule } from './filter-rule-summary';
+import { FilterEditorPopover, type FilterEditorPopoverProps } from './FilterEditorPopover';
+import { FilterValueEditor } from './FilterValueEditor';
+
+type FilterOnlyProps = Omit<
+  FilterEditorPopoverProps,
+  'open' | 'onOpenChange' | 'trigger' | 'column' | 'fieldType'
+>;
+
+interface SliceOnlyProps {
+  onApply: (rule: FilterRule) => void;
+  onCancel?: () => void;
+  existingSlicesForColumn?: readonly FilterRule[];
+  onRemoveExistingAt?: (index: number) => void;
+  initialRule?: FilterRule;
+}
+
+export interface FilterOrSliceEditorPopoverProps {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  trigger: ReactNode;
+  column: string;
+  fieldType: string;
+  aliasPath?: string;
+  sliceColumn?: string;
+  filterProps: FilterOnlyProps;
+  sliceProps?: SliceOnlyProps;
+  defaultTab?: 'filter' | 'slice';
+}
+
+export function FilterOrSliceEditorPopover(props: FilterOrSliceEditorPopoverProps) {
+  const { aliasPath, sliceProps } = props;
+
+  if (aliasPath == null || sliceProps == null) {
+    return (
+      <FilterEditorPopover
+        open={props.open}
+        onOpenChange={props.onOpenChange}
+        trigger={props.trigger}
+        column={props.column}
+        fieldType={props.fieldType}
+        {...props.filterProps}
+      />
+    );
+  }
+
+  return (
+    <TabbedPopover
+      {...props}
+      aliasPath={aliasPath}
+      sliceProps={sliceProps}
+      sliceColumn={props.sliceColumn ?? props.column}
+    />
+  );
+}
+
+interface TabbedPopoverProps extends FilterOrSliceEditorPopoverProps {
+  aliasPath: string;
+  sliceProps: SliceOnlyProps;
+  sliceColumn: string;
+}
+
+function TabbedPopover(props: TabbedPopoverProps) {
+  const [tab, setTab] = useState<'filter' | 'slice'>(props.defaultTab ?? 'filter');
+  const [filterDraft, setFilterDraft] = useState<FilterRule | null>(
+    props.filterProps.initialRule ?? null
+  );
+  const [sliceDraft, setSliceDraft] = useState<FilterRule | null>(
+    props.sliceProps.initialRule ?? null
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset on closed→open only — same pattern as FilterEditorPopover.
+  const [openInstanceId, setOpenInstanceId] = useState(0);
+  const prevOpen = useRef(false);
+  useEffect(() => {
+    if (props.open && !prevOpen.current) {
+      setOpenInstanceId(id => id + 1);
+      setTab(props.defaultTab ?? 'filter');
+      setFilterDraft(props.filterProps.initialRule ?? null);
+      setSliceDraft(props.sliceProps.initialRule ?? null);
+      setError(null);
+    }
+    prevOpen.current = props.open;
+  }, [props.open, props.defaultTab, props.filterProps.initialRule, props.sliceProps.initialRule]);
+
+  const handleFilterChange = useCallback((rule: FilterRule | null) => {
+    setFilterDraft(rule);
+    setError(null);
+  }, []);
+
+  const handleSliceChange = useCallback((rule: FilterRule | null) => {
+    setSliceDraft(rule);
+    setError(null);
+  }, []);
+
+  function handleApply() {
+    if (tab === 'filter') {
+      if (!filterDraft) {
+        setError('Value is required');
+        return;
+      }
+      props.filterProps.onApply(filterDraft);
+    } else {
+      if (!sliceDraft) {
+        setError('Value is required');
+        return;
+      }
+      const preJoinRule = {
+        ...sliceDraft,
+        placement: 'pre-join' as const,
+        aliasPath: props.aliasPath,
+      } as FilterRule;
+      props.sliceProps.onApply(preJoinRule);
+    }
+    props.onOpenChange(false);
+  }
+
+  function handleCancel() {
+    if (tab === 'filter') {
+      props.filterProps.onCancel?.();
+    } else {
+      props.sliceProps.onCancel?.();
+    }
+    props.onOpenChange(false);
+  }
+
+  const hasExistingFilters = !!props.filterProps.existingRules?.length;
+  const hasExistingSlices = !!props.sliceProps.existingSlicesForColumn?.length;
+  const applyLabel = (tab === 'filter' ? hasExistingFilters : hasExistingSlices) ? 'Add' : 'Apply';
+
+  return (
+    <Popover open={props.open} onOpenChange={props.onOpenChange}>
+      <PopoverTrigger asChild>{props.trigger}</PopoverTrigger>
+      <PopoverContent className='w-72 space-y-3'>
+        <div>
+          <Label>Column</Label>
+          <div className='font-mono text-xs'>
+            {tab === 'slice' && (
+              <>
+                <span className='text-blue-600'>{props.aliasPath}</span>.
+              </>
+            )}
+            {tab === 'slice' ? props.sliceColumn : props.column}{' '}
+            <span className='text-muted-foreground'>({props.fieldType})</span>
+          </div>
+        </div>
+
+        <TabToggle tab={tab} onChange={setTab} />
+
+        {tab === 'slice' && <SliceBanner />}
+
+        {tab === 'filter' && hasExistingFilters && (
+          <div className='space-y-1'>
+            <Label>Active filters</Label>
+            <div className='space-y-1'>
+              {(props.filterProps.existingRules ?? []).map((rule, idx) => {
+                const valueStr = summarizeFilterRule(rule);
+                return (
+                  <div
+                    key={idx}
+                    className='bg-muted/40 flex items-center gap-2 rounded px-2 py-1 text-xs'
+                  >
+                    <span className='flex-1 truncate font-mono' title={valueStr}>
+                      <b>{operatorLabelFor(rule.operator, props.fieldType)}</b>
+                      {valueStr && <>: {valueStr}</>}
+                    </span>
+                    {props.filterProps.onRemoveExistingAt && (
+                      <Button
+                        variant='ghost'
+                        size='sm'
+                        className='h-6 w-6 p-0'
+                        onClick={() => {
+                          props.filterProps.onRemoveExistingAt?.(idx);
+                        }}
+                        aria-label='Remove filter'
+                      >
+                        <X className='h-3 w-3' />
+                      </Button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {tab === 'slice' && hasExistingSlices && (
+          <div className='space-y-1'>
+            <Label>Active slices</Label>
+            <div className='space-y-1'>
+              {(props.sliceProps.existingSlicesForColumn ?? []).map((rule, idx) => {
+                const valueStr = summarizeFilterRule(rule);
+                return (
+                  <div
+                    key={idx}
+                    className='bg-muted/40 flex items-center gap-2 rounded px-2 py-1 text-xs'
+                  >
+                    <span className='flex-1 truncate font-mono' title={valueStr}>
+                      <b>{operatorLabelFor(rule.operator, props.fieldType)}</b>
+                      {valueStr && <>: {valueStr}</>}
+                    </span>
+                    {props.sliceProps.onRemoveExistingAt && (
+                      <Button
+                        variant='ghost'
+                        size='sm'
+                        className='h-6 w-6 p-0'
+                        onClick={() => {
+                          props.sliceProps.onRemoveExistingAt?.(idx);
+                        }}
+                        aria-label='Remove slice'
+                      >
+                        <X className='h-3 w-3' />
+                      </Button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Two editors mounted in parallel — hiding the inactive one preserves its draft. */}
+        <div className={tab === 'filter' ? 'space-y-3' : 'hidden'}>
+          <FilterValueEditor
+            key={`filter-${String(openInstanceId)}`}
+            column={props.column}
+            fieldType={props.fieldType}
+            initialRule={props.filterProps.initialRule}
+            onChange={handleFilterChange}
+          />
+        </div>
+        <div className={tab === 'slice' ? 'space-y-3' : 'hidden'}>
+          <FilterValueEditor
+            key={`slice-${String(openInstanceId)}`}
+            column={props.sliceColumn}
+            fieldType={props.fieldType}
+            initialRule={props.sliceProps.initialRule}
+            onChange={handleSliceChange}
+          />
+        </div>
+
+        {error && <div className='text-destructive text-xs'>{error}</div>}
+
+        <div className='flex justify-end gap-2'>
+          <Button variant='outline' size='sm' onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button size='sm' onClick={handleApply}>
+            {applyLabel}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface TabToggleProps {
+  tab: 'filter' | 'slice';
+  onChange: (tab: 'filter' | 'slice') => void;
+}
+
+function TabToggle({ tab, onChange }: TabToggleProps) {
+  return (
+    <div className='flex gap-1 rounded-md border p-0.5'>
+      <button
+        type='button'
+        className={`flex-1 rounded px-3 py-1 text-xs font-medium transition-colors ${
+          tab === 'filter'
+            ? 'bg-primary text-primary-foreground'
+            : 'text-muted-foreground hover:text-foreground'
+        }`}
+        onClick={() => {
+          onChange('filter');
+        }}
+      >
+        Filter
+      </button>
+      <button
+        type='button'
+        className={`flex-1 rounded px-3 py-1 text-xs font-medium transition-colors ${
+          tab === 'slice'
+            ? 'bg-primary text-primary-foreground'
+            : 'text-muted-foreground hover:text-foreground'
+        }`}
+        onClick={() => {
+          onChange('slice');
+        }}
+      >
+        Slice
+      </button>
+    </div>
+  );
+}
+
+function SliceBanner() {
+  return (
+    <div className='bg-muted/40 flex items-start gap-2 rounded p-2 text-[11px]'>
+      <Layers className='h-4 w-4 shrink-0 text-blue-600' />
+      <div>
+        Slices filter the <b>joined data mart</b> before it is joined — reducing rows pulled in.
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { Button } from '@owox/ui/components/button';
-import { Pencil, X } from 'lucide-react';
+import { Pencil, X, Layers } from 'lucide-react';
 import { cn } from '@owox/ui/lib/utils';
 import type { FilterRule } from '../../../shared/types/output-config';
 import { FilterEditorPopover } from './FilterEditorPopover';
+import { summarizeFilterRule } from './filter-rule-summary';
 import { operatorLabelFor } from './output-controls-operators';
 
 interface FilterRowProps {
@@ -16,13 +17,23 @@ interface FilterRowProps {
 export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProps) {
   const [editing, setEditing] = useState(false);
   const opLabel = operatorLabelFor(rule.operator, fieldType);
-  const valueText = summarizeValue(rule);
+  const valueText = summarizeFilterRule(rule);
+  const isPreJoin = rule.placement === 'pre-join' && !!rule.aliasPath;
 
   return (
     <div className='group bg-muted/40 flex items-center gap-1.5 rounded px-2 py-1.5'>
       <div className='min-w-0 flex-1'>
-        <div className='truncate font-mono text-xs' title={rule.column}>
-          {rule.column}
+        <div className='flex items-center gap-1 truncate font-mono text-xs' title={rule.column}>
+          {isPreJoin && (
+            <span
+              className='inline-flex items-center gap-1 text-blue-600'
+              title='Pre-join filter (slice)'
+            >
+              <Layers className='h-3 w-3' />
+              <span>{rule.aliasPath}.</span>
+            </span>
+          )}
+          <span>{rule.column}</span>
         </div>
         <div className='truncate font-mono text-[11px]'>
           <span className='text-foreground/70 font-medium'>{opLabel}</span>
@@ -40,7 +51,7 @@ export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProp
               'text-muted-foreground hover:text-foreground h-6 w-6 p-0 transition-opacity group-hover:opacity-100',
               editing ? 'opacity-100' : 'opacity-0'
             )}
-            aria-label='Edit filter'
+            aria-label={isPreJoin ? 'Edit slice' : 'Edit filter'}
           >
             <Pencil className='h-4 w-4' />
           </Button>
@@ -55,31 +66,10 @@ export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProp
         size='sm'
         className='text-muted-foreground hover:text-foreground h-6 w-6 p-0'
         onClick={onRemove}
-        aria-label='Remove filter'
+        aria-label={isPreJoin ? 'Remove slice' : 'Remove filter'}
       >
         <X className='h-4 w-4' />
       </Button>
     </div>
   );
-}
-
-function summarizeValue(rule: FilterRule): string {
-  switch (rule.operator) {
-    case 'is_empty':
-    case 'is_not_empty':
-    case 'is_null':
-    case 'is_not_null':
-    case 'is_true':
-    case 'is_false':
-      return '';
-    case 'between':
-      return `${String(rule.value.from)} … ${String(rule.value.to)}`;
-    case 'relative_date': {
-      const v = rule.value;
-      if ('n' in v) return v.kind.replace('_n_', ` ${String(v.n)} `);
-      return v.kind;
-    }
-    default:
-      return JSON.stringify(rule.value);
-  }
 }

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Button } from '@owox/ui/components/button';
-import { Pencil, X, Layers } from 'lucide-react';
+import { Pencil, X, Layers, AlertTriangle } from 'lucide-react';
 import { cn } from '@owox/ui/lib/utils';
 import type { FilterRule } from '../../../shared/types/output-config';
 import { FilterEditorPopover } from './FilterEditorPopover';
@@ -9,21 +9,38 @@ import { operatorLabelFor } from './output-controls-operators';
 
 interface FilterRowProps {
   rule: FilterRule;
-  fieldType: string;
+  /** `null` → column missing from current schema; row renders as orphaned. */
+  fieldType: string | null;
   onChange: (next: FilterRule) => void;
   onRemove: () => void;
 }
 
 export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProps) {
   const [editing, setEditing] = useState(false);
-  const opLabel = operatorLabelFor(rule.operator, fieldType);
+  const isOrphaned = fieldType === null;
+  const resolvedType = fieldType ?? 'STRING';
+  const opLabel = operatorLabelFor(rule.operator, resolvedType);
   const valueText = summarizeFilterRule(rule);
   const isPreJoin = rule.placement === 'pre-join' && !!rule.aliasPath;
 
   return (
-    <div className='group bg-muted/40 flex items-center gap-1.5 rounded px-2 py-1.5'>
+    <div
+      className={cn(
+        'group flex items-center gap-1.5 rounded px-2 py-1.5',
+        isOrphaned ? 'bg-red-50 dark:bg-red-950/30' : 'bg-muted/40'
+      )}
+    >
       <div className='min-w-0 flex-1'>
         <div className='flex items-center gap-1 truncate font-mono text-xs' title={rule.column}>
+          {isOrphaned && (
+            <span
+              className='inline-flex items-center text-red-600'
+              title='This column is no longer available in the data mart schema. Remove this rule or restore the column.'
+              aria-label='Column not found in schema'
+            >
+              <AlertTriangle className='h-3 w-3' />
+            </span>
+          )}
           {isPreJoin && (
             <span
               className='inline-flex items-center gap-1 text-blue-600'
@@ -33,34 +50,49 @@ export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProp
               <span>{rule.aliasPath}.</span>
             </span>
           )}
-          <span>{rule.column}</span>
+          <span className={cn(isOrphaned && 'text-red-700 line-through dark:text-red-300')}>
+            {rule.column}
+          </span>
         </div>
         <div className='truncate font-mono text-[11px]'>
           <span className='text-foreground/70 font-medium'>{opLabel}</span>
           {valueText && <span className='text-muted-foreground'> {valueText}</span>}
         </div>
       </div>
-      <FilterEditorPopover
-        open={editing}
-        onOpenChange={setEditing}
-        trigger={
-          <Button
-            variant='ghost'
-            size='sm'
-            className={cn(
-              'text-muted-foreground hover:text-foreground h-6 w-6 p-0 transition-opacity group-hover:opacity-100',
-              editing ? 'opacity-100' : 'opacity-0'
-            )}
-            aria-label={isPreJoin ? 'Edit slice' : 'Edit filter'}
-          >
-            <Pencil className='h-4 w-4' />
-          </Button>
-        }
-        column={rule.column}
-        fieldType={fieldType}
-        initialRule={rule}
-        onApply={onChange}
-      />
+      {isOrphaned ? (
+        <Button
+          variant='ghost'
+          size='sm'
+          disabled
+          className='text-muted-foreground h-6 w-6 p-0 opacity-40'
+          aria-label='Edit disabled — column missing from schema'
+          title='Edit disabled — column missing from schema'
+        >
+          <Pencil className='h-4 w-4' />
+        </Button>
+      ) : (
+        <FilterEditorPopover
+          open={editing}
+          onOpenChange={setEditing}
+          trigger={
+            <Button
+              variant='ghost'
+              size='sm'
+              className={cn(
+                'text-muted-foreground hover:text-foreground h-6 w-6 p-0 transition-opacity group-hover:opacity-100',
+                editing ? 'opacity-100' : 'opacity-0'
+              )}
+              aria-label={isPreJoin ? 'Edit slice' : 'Edit filter'}
+            >
+              <Pencil className='h-4 w-4' />
+            </Button>
+          }
+          column={rule.column}
+          fieldType={resolvedType}
+          initialRule={rule}
+          onApply={onChange}
+        />
+      )}
       <Button
         variant='ghost'
         size='sm'

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.test.tsx
@@ -1,0 +1,560 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import type { FilterRule } from '../../../shared/types/output-config';
+import { FilterValueEditor } from './FilterValueEditor';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock Radix Select with native <select> so RTL can fireEvent.change
+vi.mock('@owox/ui/components/select', () => ({
+  Select: ({ children, value, onValueChange }: any) => (
+    <select
+      data-testid='select'
+      value={value}
+      onChange={e => {
+        onValueChange?.(e.target.value);
+      }}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: any) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: any) => <>{children}</>,
+  SelectItem: ({ value, children }: any) => <option value={value}>{children}</option>,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const COL = 'name';
+const STRING_TYPE = 'STRING';
+const INT_TYPE = 'INTEGER';
+const DATE_TYPE = 'DATE';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface RenderOptions {
+  column?: string;
+  fieldType?: string;
+  initialRule?: FilterRule;
+  onChange?: ReturnType<typeof vi.fn>;
+}
+
+function renderEditor({
+  column = COL,
+  fieldType = STRING_TYPE,
+  initialRule,
+  onChange = vi.fn(),
+}: RenderOptions = {}) {
+  render(
+    <FilterValueEditor
+      column={column}
+      fieldType={fieldType}
+      initialRule={initialRule}
+      onChange={onChange}
+    />
+  );
+  return { onChange };
+}
+
+/** Returns the arg of the most recent onChange call. */
+function lastCall(onChange: ReturnType<typeof vi.fn>): FilterRule | null | undefined {
+  const calls = onChange.mock.calls;
+  if (calls.length === 0) return undefined;
+  return calls[calls.length - 1][0];
+}
+
+/** Returns the condition <select> element (first select in the DOM). */
+function getConditionSelect() {
+  return screen.getAllByTestId('select')[0];
+}
+
+/** Returns the second select element (preset select for relative_date). */
+function getPresetSelect() {
+  return screen.getAllByTestId('select')[1];
+}
+
+// ---------------------------------------------------------------------------
+// Group 1 — onChange on mount
+// ---------------------------------------------------------------------------
+
+describe('FilterValueEditor — onChange on mount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('emits null on mount when no initialRule (default op is scalar, value empty)', () => {
+    const onChange = vi.fn();
+    act(() => {
+      render(<FilterValueEditor column={COL} fieldType={STRING_TYPE} onChange={onChange} />);
+    });
+
+    // Default operator for STRING is 'eq' — scalar op, empty value → null
+    expect(lastCall(onChange)).toBeNull();
+  });
+
+  it('emits the initialRule on mount when initialRule is provided', () => {
+    const initialRule: FilterRule = { column: COL, operator: 'eq', value: 'hello' };
+    const onChange = vi.fn();
+    act(() => {
+      render(
+        <FilterValueEditor
+          column={COL}
+          fieldType={STRING_TYPE}
+          initialRule={initialRule}
+          onChange={onChange}
+        />
+      );
+    });
+
+    expect(lastCall(onChange)).toEqual(initialRule);
+  });
+
+  it('emits a no-value rule on mount when initialRule has a no-value operator', () => {
+    const initialRule: FilterRule = { column: COL, operator: 'is_empty' };
+    const onChange = vi.fn();
+    act(() => {
+      render(
+        <FilterValueEditor
+          column={COL}
+          fieldType={STRING_TYPE}
+          initialRule={initialRule}
+          onChange={onChange}
+        />
+      );
+    });
+
+    expect(lastCall(onChange)).toEqual({ column: COL, operator: 'is_empty' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 2 — Scalar operators
+// ---------------------------------------------------------------------------
+
+describe('FilterValueEditor — scalar operators', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('typing a value emits the rule with that value (STRING eq)', () => {
+    const { onChange } = renderEditor({ fieldType: STRING_TYPE });
+
+    const input = screen.getByPlaceholderText('');
+    fireEvent.change(input, { target: { value: 'foo' } });
+
+    expect(lastCall(onChange)).toEqual({ column: COL, operator: 'eq', value: 'foo' });
+  });
+
+  it('typing a value emits the rule for "contains" operator', () => {
+    const { onChange } = renderEditor({
+      fieldType: STRING_TYPE,
+      initialRule: { column: COL, operator: 'contains', value: '' },
+    });
+
+    // Switch to contains first
+    fireEvent.change(getConditionSelect(), { target: { value: 'contains' } });
+    const input = screen.getByPlaceholderText('');
+    fireEvent.change(input, { target: { value: 'bar' } });
+
+    expect(lastCall(onChange)).toEqual({ column: COL, operator: 'contains', value: 'bar' });
+  });
+
+  it('emits null when scalar value is cleared', () => {
+    const { onChange } = renderEditor({
+      fieldType: STRING_TYPE,
+      initialRule: { column: COL, operator: 'eq', value: 'abc' },
+    });
+
+    const input = screen.getByDisplayValue('abc');
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(lastCall(onChange)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 3 — Number coercion
+// ---------------------------------------------------------------------------
+
+describe('FilterValueEditor — number coercion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('typing 123 for INTEGER type emits value: 123 (number, not string)', () => {
+    const { onChange } = renderEditor({ fieldType: INT_TYPE });
+
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '123' } });
+
+    const rule = lastCall(onChange) as { operator: string; column: string; value: number };
+    expect(rule).not.toBeNull();
+    expect(rule.value).toBe(123);
+    expect(typeof rule.value).toBe('number');
+  });
+
+  it('typing 45.6 for FLOAT type emits value: 45.6 (number)', () => {
+    const { onChange } = renderEditor({ column: COL, fieldType: 'FLOAT' });
+
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '45.6' } });
+
+    const rule = lastCall(onChange) as { operator: string; column: string; value: number };
+    expect(rule.value).toBe(45.6);
+    expect(typeof rule.value).toBe('number');
+  });
+
+  it('typing a non-numeric value for INTEGER type emits null', () => {
+    const { onChange } = renderEditor({ fieldType: INT_TYPE });
+
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: 'abc' } });
+
+    expect(lastCall(onChange)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 4 — No-value operators (is_empty, is_null, is_true, etc.)
+// ---------------------------------------------------------------------------
+
+describe('FilterValueEditor — no-value operators', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('switching to is_empty emits { column, operator: "is_empty" } (no value) and hides value input', () => {
+    const { onChange } = renderEditor({ fieldType: STRING_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'is_empty' } });
+
+    expect(lastCall(onChange)).toEqual({ column: COL, operator: 'is_empty' });
+    // Value input should be hidden
+    expect(screen.queryByPlaceholderText('')).toBeNull();
+  });
+
+  it('switching to is_null emits { column, operator: "is_null" } and hides value input', () => {
+    const { onChange } = renderEditor({ fieldType: STRING_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'is_null' } });
+
+    expect(lastCall(onChange)).toEqual({ column: COL, operator: 'is_null' });
+    expect(screen.queryByPlaceholderText('')).toBeNull();
+  });
+
+  it('switching to is_true emits { column, operator: "is_true" } and hides value input (BOOLEAN)', () => {
+    const { onChange } = renderEditor({ fieldType: 'BOOLEAN' });
+
+    // Default for BOOLEAN is 'is_true' (first operator)
+    expect(lastCall(onChange)).toEqual({ column: COL, operator: 'is_true' });
+    // No value input visible
+    expect(screen.queryByPlaceholderText('')).toBeNull();
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 5 — "between" operator
+// ---------------------------------------------------------------------------
+
+describe('FilterValueEditor — between operator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('switching to between reveals From and To inputs', () => {
+    renderEditor({ fieldType: INT_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'between' } });
+
+    expect(screen.getByPlaceholderText('from')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('to')).toBeInTheDocument();
+  });
+
+  it('both From+To filled → emits rule with { from, to }', () => {
+    const { onChange } = renderEditor({ fieldType: INT_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'between' } });
+
+    fireEvent.change(screen.getByPlaceholderText('from'), { target: { value: '10' } });
+    fireEvent.change(screen.getByPlaceholderText('to'), { target: { value: '20' } });
+
+    expect(lastCall(onChange)).toEqual({
+      column: COL,
+      operator: 'between',
+      value: { from: 10, to: 20 },
+    });
+  });
+
+  it('only From filled → emits null (incomplete)', () => {
+    const { onChange } = renderEditor({ fieldType: INT_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'between' } });
+    fireEvent.change(screen.getByPlaceholderText('from'), { target: { value: '10' } });
+
+    expect(lastCall(onChange)).toBeNull();
+  });
+
+  it('only To filled → emits null (incomplete)', () => {
+    const { onChange } = renderEditor({ fieldType: INT_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'between' } });
+    fireEvent.change(screen.getByPlaceholderText('to'), { target: { value: '20' } });
+
+    expect(lastCall(onChange)).toBeNull();
+  });
+
+  it('between with string values (STRING type) emits string from/to', () => {
+    // STRING doesn't have 'between' but DATE does — use DATE for string between
+    const { onChange } = renderEditor({ fieldType: DATE_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'between' } });
+    fireEvent.change(screen.getByPlaceholderText('from'), { target: { value: '2024-01-01' } });
+    fireEvent.change(screen.getByPlaceholderText('to'), { target: { value: '2024-12-31' } });
+
+    expect(lastCall(onChange)).toEqual({
+      column: COL,
+      operator: 'between',
+      value: { from: '2024-01-01', to: '2024-12-31' },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 6 — "relative_date" operator
+// ---------------------------------------------------------------------------
+
+describe('FilterValueEditor — relative_date operator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('switching to relative_date reveals preset select', () => {
+    renderEditor({ fieldType: DATE_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'relative_date' } });
+
+    // Preset select should now be in DOM (second select)
+    expect(screen.getAllByTestId('select')).toHaveLength(2);
+  });
+
+  it('default preset "today" emits rule with { kind: "today" } and no N input', () => {
+    const { onChange } = renderEditor({ fieldType: DATE_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'relative_date' } });
+
+    expect(lastCall(onChange)).toEqual({
+      column: COL,
+      operator: 'relative_date',
+      value: { kind: 'today' },
+    });
+    // No number input for N
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+  });
+
+  it('selecting "last_n_days" shows N input', () => {
+    renderEditor({ fieldType: DATE_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'relative_date' } });
+    fireEvent.change(getPresetSelect(), { target: { value: 'last_n_days' } });
+
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+  });
+
+  it('last_n_days with valid N emits rule with { kind: "last_n_days", n }', () => {
+    const { onChange } = renderEditor({ fieldType: DATE_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'relative_date' } });
+    fireEvent.change(getPresetSelect(), { target: { value: 'last_n_days' } });
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '14' } });
+
+    expect(lastCall(onChange)).toEqual({
+      column: COL,
+      operator: 'relative_date',
+      value: { kind: 'last_n_days', n: 14 },
+    });
+  });
+
+  it('last_n_months with valid N emits rule with { kind: "last_n_months", n }', () => {
+    const { onChange } = renderEditor({ fieldType: DATE_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'relative_date' } });
+    fireEvent.change(getPresetSelect(), { target: { value: 'last_n_months' } });
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '3' } });
+
+    expect(lastCall(onChange)).toEqual({
+      column: COL,
+      operator: 'relative_date',
+      value: { kind: 'last_n_months', n: 3 },
+    });
+  });
+
+  it('selecting "this_month" does NOT show N input', () => {
+    renderEditor({ fieldType: DATE_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'relative_date' } });
+    fireEvent.change(getPresetSelect(), { target: { value: 'this_month' } });
+
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+  });
+
+  it('relative_date with invalid N (zero) → onChange(null)', () => {
+    const { onChange } = renderEditor({ fieldType: DATE_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'relative_date' } });
+    fireEvent.change(getPresetSelect(), { target: { value: 'last_n_days' } });
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '0' } });
+
+    expect(lastCall(onChange)).toBeNull();
+  });
+
+  it('relative_date with invalid N (negative) → onChange(null)', () => {
+    const { onChange } = renderEditor({ fieldType: DATE_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'relative_date' } });
+    fireEvent.change(getPresetSelect(), { target: { value: 'last_n_days' } });
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '-5' } });
+
+    expect(lastCall(onChange)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 7 — initialRule pre-fills inputs
+// ---------------------------------------------------------------------------
+
+describe('FilterValueEditor — initialRule pre-fills inputs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('scalar: initialRule with value "foo" shows "foo" in the input', () => {
+    renderEditor({
+      fieldType: STRING_TYPE,
+      initialRule: { column: COL, operator: 'eq', value: 'foo' },
+    });
+
+    expect(screen.getByDisplayValue('foo')).toBeInTheDocument();
+  });
+
+  it('between: From and To inputs show the initialRule from/to values', () => {
+    renderEditor({
+      fieldType: INT_TYPE,
+      initialRule: { column: COL, operator: 'between', value: { from: 5, to: 15 } },
+    });
+
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('15')).toBeInTheDocument();
+  });
+
+  it('relative_date with last_n_days: preset select shows kind + N input shows n', () => {
+    renderEditor({
+      fieldType: DATE_TYPE,
+      initialRule: {
+        column: COL,
+        operator: 'relative_date',
+        value: { kind: 'last_n_days', n: 30 },
+      },
+    });
+
+    // Preset select should show last_n_days
+    const presetSelect = getPresetSelect();
+    expect((presetSelect as HTMLSelectElement).value).toBe('last_n_days');
+
+    // N input should show 30
+    expect(screen.getByDisplayValue('30')).toBeInTheDocument();
+  });
+
+  it('relative_date with today: preset select shows "today" + no N input', () => {
+    renderEditor({
+      fieldType: DATE_TYPE,
+      initialRule: {
+        column: COL,
+        operator: 'relative_date',
+        value: { kind: 'today' },
+      },
+    });
+
+    const presetSelect = getPresetSelect();
+    expect((presetSelect as HTMLSelectElement).value).toBe('today');
+    // No N input
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+  });
+
+  it('no-value initialRule: no value input visible', () => {
+    renderEditor({
+      fieldType: STRING_TYPE,
+      initialRule: { column: COL, operator: 'is_null' },
+    });
+
+    expect(screen.queryByPlaceholderText('')).toBeNull();
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 8 — Switching operator clears invalid state
+// ---------------------------------------------------------------------------
+
+describe('FilterValueEditor — switching operator clears invalid state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('typing scalar then switching to between → onChange(null) until both bounds filled', () => {
+    const { onChange } = renderEditor({ fieldType: INT_TYPE });
+
+    // Type a scalar value — rule becomes valid
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '42' } });
+    expect(lastCall(onChange)).not.toBeNull();
+
+    // Switch to between — state resets, both bounds empty → null
+    fireEvent.change(getConditionSelect(), { target: { value: 'between' } });
+    expect(lastCall(onChange)).toBeNull();
+
+    // Fill from only — still null
+    fireEvent.change(screen.getByPlaceholderText('from'), { target: { value: '1' } });
+    expect(lastCall(onChange)).toBeNull();
+
+    // Fill to — now valid
+    fireEvent.change(screen.getByPlaceholderText('to'), { target: { value: '10' } });
+    expect(lastCall(onChange)).toEqual({
+      column: COL,
+      operator: 'between',
+      value: { from: 1, to: 10 },
+    });
+  });
+
+  it('filling between then switching to scalar → onChange(null) until value is typed', () => {
+    const { onChange } = renderEditor({ fieldType: INT_TYPE });
+
+    // Switch to between and fill both bounds
+    fireEvent.change(getConditionSelect(), { target: { value: 'between' } });
+    fireEvent.change(screen.getByPlaceholderText('from'), { target: { value: '5' } });
+    fireEvent.change(screen.getByPlaceholderText('to'), { target: { value: '50' } });
+    expect(lastCall(onChange)).not.toBeNull();
+
+    // Switch back to eq (scalar) — scalar is empty → null
+    fireEvent.change(getConditionSelect(), { target: { value: 'eq' } });
+    expect(lastCall(onChange)).toBeNull();
+  });
+
+  it('switching to a no-value operator immediately emits a valid rule', () => {
+    const { onChange } = renderEditor({ fieldType: STRING_TYPE });
+
+    // Initially: scalar op, empty value → null
+    expect(lastCall(onChange)).toBeNull();
+
+    // Switch to is_empty — immediately valid
+    fireEvent.change(getConditionSelect(), { target: { value: 'is_empty' } });
+    expect(lastCall(onChange)).toEqual({ column: COL, operator: 'is_empty' });
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useState } from 'react';
+import { Input } from '@owox/ui/components/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@owox/ui/components/select';
+import { Label } from '@owox/ui/components/label';
+import type { FilterRule, RelativeDatePreset } from '../../../shared/types/output-config';
+import { type FilterOperator, operatorsForType } from './output-controls-operators';
+
+export interface FilterValueEditorProps {
+  column: string;
+  fieldType: string;
+  initialRule?: FilterRule;
+  /** Called every time the user edits. Returns `null` while the input is invalid. */
+  onChange: (rule: FilterRule | null) => void;
+}
+
+interface EditorState {
+  op: FilterOperator;
+  scalar: string;
+  betweenFrom: string;
+  betweenTo: string;
+  relativeKind: RelativeDatePreset['kind'];
+  relativeN: number;
+}
+
+const RELATIVE_KINDS: { value: RelativeDatePreset['kind']; label: string }[] = [
+  { value: 'today', label: 'Today' },
+  { value: 'yesterday', label: 'Yesterday' },
+  { value: 'this_month', label: 'This month' },
+  { value: 'last_month', label: 'Last month' },
+  { value: 'this_year', label: 'This year' },
+  { value: 'last_n_days', label: 'Last N days' },
+  { value: 'last_n_months', label: 'Last N months' },
+];
+
+const NO_VALUE_OPS = new Set<FilterOperator>([
+  'is_empty',
+  'is_not_empty',
+  'is_null',
+  'is_not_null',
+  'is_true',
+  'is_false',
+]);
+
+const NUMBER_TYPES = new Set(['INTEGER', 'FLOAT', 'NUMERIC', 'BIGNUMERIC']);
+const DATE_TYPES = new Set(['DATE', 'DATETIME', 'TIMESTAMP', 'TIME']);
+
+function getInitialState(rule: FilterRule | undefined, fallbackOp: FilterOperator): EditorState {
+  const state: EditorState = {
+    op: fallbackOp,
+    scalar: '',
+    betweenFrom: '',
+    betweenTo: '',
+    relativeKind: 'today',
+    relativeN: 7,
+  };
+  if (!rule) return state;
+  state.op = rule.operator as FilterOperator;
+  if (rule.operator === 'between') {
+    state.betweenFrom = String(rule.value.from);
+    state.betweenTo = String(rule.value.to);
+  } else if (rule.operator === 'relative_date') {
+    state.relativeKind = rule.value.kind;
+    if ('n' in rule.value) state.relativeN = rule.value.n;
+  } else if (!NO_VALUE_OPS.has(rule.operator as FilterOperator)) {
+    const value = (rule as { value: string | number | boolean }).value;
+    state.scalar = String(value);
+  }
+  return state;
+}
+
+function parseScalar(raw: string, fieldType: string): string | number | boolean {
+  if (NUMBER_TYPES.has(fieldType)) {
+    const n = Number(raw);
+    if (!Number.isFinite(n)) throw new Error('Invalid number');
+    return n;
+  }
+  return raw;
+}
+
+function buildRule(args: { column: string; fieldType: string; state: EditorState }): FilterRule {
+  const { column, fieldType, state } = args;
+  const { op } = state;
+
+  if (op === 'between') {
+    if (state.betweenFrom === '' || state.betweenTo === '') {
+      throw new Error('Both bounds are required');
+    }
+    const from = parseScalar(state.betweenFrom, fieldType);
+    const to = parseScalar(state.betweenTo, fieldType);
+    const numericOutOfOrder = typeof from === 'number' && typeof to === 'number' && from > to;
+    const dateOutOfOrder =
+      typeof from === 'string' && typeof to === 'string' && DATE_TYPES.has(fieldType) && from > to;
+    if (numericOutOfOrder || dateOutOfOrder) {
+      throw new Error('"From" must be ≤ "To"');
+    }
+    return { column, operator: 'between', value: { from, to } };
+  }
+
+  if (op === 'relative_date') {
+    if (state.relativeKind === 'last_n_days' || state.relativeKind === 'last_n_months') {
+      if (!Number.isInteger(state.relativeN) || state.relativeN <= 0) {
+        throw new Error('N must be a positive integer');
+      }
+      return {
+        column,
+        operator: 'relative_date',
+        value: { kind: state.relativeKind, n: state.relativeN },
+      };
+    }
+    return { column, operator: 'relative_date', value: { kind: state.relativeKind } };
+  }
+
+  if (NO_VALUE_OPS.has(op)) {
+    return { column, operator: op } as FilterRule;
+  }
+
+  if (state.scalar === '') {
+    throw new Error('Value is required');
+  }
+
+  if (op === 'regex' || op === 'not_regex') {
+    try {
+      new RegExp(state.scalar);
+    } catch {
+      throw new Error('Invalid regex pattern');
+    }
+  }
+
+  return { column, operator: op, value: parseScalar(state.scalar, fieldType) } as FilterRule;
+}
+
+export function FilterValueEditor({
+  column,
+  fieldType,
+  initialRule,
+  onChange,
+}: FilterValueEditorProps) {
+  const operators = operatorsForType(fieldType);
+  const fallbackOp = operators[0]?.value ?? 'eq';
+
+  const [state, setState] = useState<EditorState>(() => getInitialState(initialRule, fallbackOp));
+
+  // Reset state when initialRule changes (e.g. popover re-opens with a different existing rule)
+  useEffect(() => {
+    setState(getInitialState(initialRule, fallbackOp));
+  }, [initialRule, fallbackOp]);
+
+  // Emit a parsed rule (or null) on every state change so the parent can track validity
+  useEffect(() => {
+    let rule: FilterRule | null = null;
+    try {
+      rule = buildRule({ column, fieldType, state });
+    } catch {
+      rule = null;
+    }
+    onChange(rule);
+  }, [state, column, fieldType, onChange]);
+
+  const isDateType = DATE_TYPES.has(fieldType);
+
+  return (
+    <>
+      <div>
+        <Label>Condition</Label>
+        <Select
+          value={state.op}
+          onValueChange={v => {
+            setState(s => ({ ...s, op: v as FilterOperator }));
+          }}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {operators.map(o => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {state.op === 'between' && (
+        <div className='space-y-2'>
+          <Label>From / To</Label>
+          <div className='flex gap-2'>
+            <Input
+              type={NUMBER_TYPES.has(fieldType) ? 'number' : isDateType ? 'date' : 'text'}
+              value={state.betweenFrom}
+              onChange={e => {
+                setState(s => ({ ...s, betweenFrom: e.target.value }));
+              }}
+              placeholder='from'
+            />
+            <Input
+              type={NUMBER_TYPES.has(fieldType) ? 'number' : isDateType ? 'date' : 'text'}
+              value={state.betweenTo}
+              onChange={e => {
+                setState(s => ({ ...s, betweenTo: e.target.value }));
+              }}
+              placeholder='to'
+            />
+          </div>
+        </div>
+      )}
+
+      {state.op === 'relative_date' && (
+        <div className='space-y-2'>
+          <Label>Preset</Label>
+          <Select
+            value={state.relativeKind}
+            onValueChange={v => {
+              setState(s => ({ ...s, relativeKind: v as RelativeDatePreset['kind'] }));
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {RELATIVE_KINDS.map(p => (
+                <SelectItem key={p.value} value={p.value}>
+                  {p.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {(state.relativeKind === 'last_n_days' || state.relativeKind === 'last_n_months') && (
+            <Input
+              type='number'
+              min={1}
+              value={state.relativeN}
+              onChange={e => {
+                setState(s => ({ ...s, relativeN: Number(e.target.value) || 0 }));
+              }}
+            />
+          )}
+        </div>
+      )}
+
+      {!NO_VALUE_OPS.has(state.op) && state.op !== 'between' && state.op !== 'relative_date' && (
+        <div className='space-y-1'>
+          <Label>Value</Label>
+          <Input
+            type={NUMBER_TYPES.has(fieldType) ? 'number' : isDateType ? 'date' : 'text'}
+            value={state.scalar}
+            onChange={e => {
+              setState(s => ({ ...s, scalar: e.target.value }));
+            }}
+            placeholder={state.op === 'regex' ? 'pattern' : ''}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Input } from '@owox/ui/components/input';
 import {
   Select,
@@ -146,21 +146,32 @@ export function FilterValueEditor({
 
   const [state, setState] = useState<EditorState>(() => getInitialState(initialRule, fallbackOp));
 
-  // Reset state when initialRule changes (e.g. popover re-opens with a different existing rule)
   useEffect(() => {
     setState(getInitialState(initialRule, fallbackOp));
   }, [initialRule, fallbackOp]);
 
-  // Emit a parsed rule (or null) on every state change so the parent can track validity
-  useEffect(() => {
-    let rule: FilterRule | null = null;
+  const rule = useMemo<FilterRule | null>(() => {
     try {
-      rule = buildRule({ column, fieldType, state });
+      return buildRule({ column, fieldType, state });
     } catch {
-      rule = null;
+      return null;
     }
-    onChange(rule);
-  }, [state, column, fieldType, onChange]);
+  }, [state, column, fieldType]);
+
+  // Emit only on actual content change. `onChange` identity flips per parent
+  // render, so we read the latest via ref to keep this effect deps minimal.
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  const lastEmittedKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    const key = rule === null ? '__null__' : JSON.stringify(rule);
+    if (lastEmittedKeyRef.current === key) return;
+    lastEmittedKeyRef.current = key;
+    onChangeRef.current(rule);
+  }, [rule]);
 
   const isDateType = DATE_TYPES.has(fieldType);
 

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
@@ -46,7 +46,8 @@ const SECTION_INFO = {
   filters:
     'Filters narrow the final result — applied to the SELECT after all JOINs. Use slices below to narrow a joined data mart BEFORE it is JOINed in.',
   slices:
-    'Slices are pre-join filters: they narrow a joined data mart before it is JOINed into the main one, reducing the rows pulled in.',
+    'Slices are pre-join filters: they narrow a joined data mart INSIDE its own subquery before the JOIN, reducing the rows pulled in.\n\n' +
+    'Because joins are LEFT JOINs, a slice does NOT reduce the number of rows in the final result — main-mart rows that no longer match a sliced row pass through with NULL on the joined columns. To drop those rows from the output, add a Filter on the joined column above.',
   sort: 'Order rows in the final result. Drag to reorder priority; multiple columns are supported.',
   limit:
     'Cap the number of rows returned. Applied last, after filters and sort. Leave empty for no limit.',
@@ -165,7 +166,7 @@ function FiltersSection({
           <FilterRow
             key={filterRowKey(rule, index)}
             rule={rule}
-            fieldType={columnTypeMap.get(rule.column) ?? 'STRING'}
+            fieldType={columnTypeMap.get(rule.column) ?? null}
             onChange={next => {
               onUpdateAt(index, next);
             }}
@@ -233,11 +234,9 @@ function SlicesSection({
     }
   }
 
-  function fieldTypeFor(rule: FilterRule): string {
-    if (rule.aliasPath) {
-      return fieldTypeMap.get(`${rule.aliasPath}\0${rule.column}`) ?? 'STRING';
-    }
-    return 'STRING';
+  function fieldTypeFor(rule: FilterRule): string | null {
+    if (!rule.aliasPath) return null;
+    return fieldTypeMap.get(`${rule.aliasPath}\0${rule.column}`) ?? null;
   }
 
   return (

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
@@ -1,6 +1,7 @@
 import { useState, type DragEvent } from 'react';
 import { Button } from '@owox/ui/components/button';
-import { Plus } from 'lucide-react';
+import { Info, Plus } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import {
   Select,
   SelectContent,
@@ -9,12 +10,47 @@ import {
   SelectValue,
 } from '@owox/ui/components/select';
 import { cn } from '@owox/ui/lib/utils';
-import type { FilterRule, OutputConfig, SortRule } from '../../../shared/types/output-config';
+import type {
+  FilterRule,
+  JoinedSource,
+  OutputConfig,
+  SortRule,
+} from '../../../shared/types/output-config';
 import { FilterRow } from './FilterRow';
 import { SortRow } from './SortRow';
 import { LimitInput } from './LimitInput';
 import { FilterEditorPopover } from './FilterEditorPopover';
 import { isFilterableType } from './output-controls-operators';
+
+export type { JoinedSource };
+
+function SectionHeader({ title, info }: { title: string; info: string }) {
+  return (
+    <div className='text-muted-foreground mb-2 flex items-center gap-1.5 text-xs font-semibold tracking-wide uppercase'>
+      <span>{title}</span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className='text-muted-foreground/60 hover:text-muted-foreground inline-flex'>
+            <Info className='size-3.5' aria-label={`About ${title}`} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side='top' className='max-w-xs text-xs whitespace-pre-wrap normal-case'>
+          {info}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+const SECTION_INFO = {
+  filters:
+    'Filters narrow the final result — applied to the SELECT after all JOINs. Use slices below to narrow a joined data mart BEFORE it is JOINed in.',
+  slices:
+    'Slices are pre-join filters: they narrow a joined data mart before it is JOINed into the main one, reducing the rows pulled in.',
+  sort: 'Order rows in the final result. Drag to reorder priority; multiple columns are supported.',
+  limit:
+    'Cap the number of rows returned. Applied last, after filters and sort. Leave empty for no limit.',
+} as const;
 
 export interface OutputSettingsDropdownColumn {
   name: string;
@@ -26,6 +62,7 @@ interface OutputSettingsDropdownProps {
   onChange: (next: OutputConfig) => void;
   selectedColumns: readonly OutputSettingsDropdownColumn[];
   allColumns: readonly OutputSettingsDropdownColumn[];
+  joinedSources?: readonly JoinedSource[];
 }
 
 export function OutputSettingsDropdown({
@@ -33,27 +70,47 @@ export function OutputSettingsDropdown({
   onChange,
   selectedColumns,
   allColumns,
+  joinedSources,
 }: OutputSettingsDropdownProps) {
+  const indexed = value.filterConfig.map((rule, index) => ({ rule, index }));
+  const postJoinIndexed = indexed.filter(({ rule }) => rule.placement !== 'pre-join');
+  const preJoinIndexed = indexed.filter(({ rule }) => rule.placement === 'pre-join');
+
+  const onAddRule = (rule: FilterRule) => {
+    onChange({ ...value, filterConfig: [...value.filterConfig, rule] });
+  };
+  const onUpdateAt = (index: number, rule: FilterRule) => {
+    const next = [...value.filterConfig];
+    next[index] = rule;
+    onChange({ ...value, filterConfig: next });
+  };
+  const onRemoveAt = (index: number) => {
+    onChange({
+      ...value,
+      filterConfig: value.filterConfig.filter((_, i) => i !== index),
+    });
+  };
+
+  const hasJoinedSources = (joinedSources ?? []).length > 0;
+
   return (
     <div className='space-y-4 p-3'>
       <FiltersSection
-        filters={value.filterConfig}
+        indexedRules={postJoinIndexed}
         allColumns={allColumns}
-        onAdd={rule => {
-          onChange({ ...value, filterConfig: [...value.filterConfig, rule] });
-        }}
-        onUpdateAt={(index, rule) => {
-          const next = [...value.filterConfig];
-          next[index] = rule;
-          onChange({ ...value, filterConfig: next });
-        }}
-        onRemoveAt={index => {
-          onChange({
-            ...value,
-            filterConfig: value.filterConfig.filter((_, i) => i !== index),
-          });
-        }}
+        onAdd={onAddRule}
+        onUpdateAt={onUpdateAt}
+        onRemoveAt={onRemoveAt}
       />
+      {hasJoinedSources && (
+        <SlicesSection
+          indexedRules={preJoinIndexed}
+          joinedSources={joinedSources ?? []}
+          onAdd={onAddRule}
+          onUpdateAt={onUpdateAt}
+          onRemoveAt={onRemoveAt}
+        />
+      )}
       <SortSection
         sort={value.sortConfig}
         selectedColumns={selectedColumns.map(c => c.name)}
@@ -71,8 +128,18 @@ export function OutputSettingsDropdown({
   );
 }
 
+interface IndexedFilterRule {
+  rule: FilterRule;
+  index: number;
+}
+
+// Bare index would let React drag deleted-row state onto its neighbour.
+function filterRowKey(rule: FilterRule, index: number): string {
+  return `${rule.placement ?? 'post'}|${rule.aliasPath ?? ''}|${rule.column}|${rule.operator}|${index}`;
+}
+
 interface FiltersSectionProps {
-  filters: FilterRule[];
+  indexedRules: IndexedFilterRule[];
   allColumns: readonly OutputSettingsDropdownColumn[];
   onAdd: (rule: FilterRule) => void;
   onUpdateAt: (index: number, rule: FilterRule) => void;
@@ -80,7 +147,7 @@ interface FiltersSectionProps {
 }
 
 function FiltersSection({
-  filters,
+  indexedRules,
   allColumns,
   onAdd,
   onUpdateAt,
@@ -92,13 +159,11 @@ function FiltersSection({
 
   return (
     <div>
-      <div className='text-muted-foreground mb-2 text-xs font-semibold tracking-wide uppercase'>
-        Filters
-      </div>
+      <SectionHeader title='Filters' info={SECTION_INFO.filters} />
       <div className='space-y-1'>
-        {filters.map((rule, index) => (
+        {indexedRules.map(({ rule, index }) => (
           <FilterRow
-            key={index}
+            key={filterRowKey(rule, index)}
             rule={rule}
             fieldType={columnTypeMap.get(rule.column) ?? 'STRING'}
             onChange={next => {
@@ -135,6 +200,155 @@ function FiltersSection({
         )}
       </div>
     </div>
+  );
+}
+
+interface SlicesSectionProps {
+  indexedRules: IndexedFilterRule[];
+  joinedSources: readonly JoinedSource[];
+  onAdd: (rule: FilterRule) => void;
+  onUpdateAt: (index: number, rule: FilterRule) => void;
+  onRemoveAt: (index: number) => void;
+}
+
+interface PendingSliceColumn {
+  aliasPath: string;
+  column: string;
+  fieldType: string;
+}
+
+function SlicesSection({
+  indexedRules,
+  joinedSources,
+  onAdd,
+  onUpdateAt,
+  onRemoveAt,
+}: SlicesSectionProps) {
+  const [pending, setPending] = useState<PendingSliceColumn | null>(null);
+
+  const fieldTypeMap = new Map<string, string>();
+  for (const src of joinedSources) {
+    for (const col of src.columns) {
+      fieldTypeMap.set(`${src.aliasPath}\0${col.name}`, col.type);
+    }
+  }
+
+  function fieldTypeFor(rule: FilterRule): string {
+    if (rule.aliasPath) {
+      return fieldTypeMap.get(`${rule.aliasPath}\0${rule.column}`) ?? 'STRING';
+    }
+    return 'STRING';
+  }
+
+  return (
+    <div>
+      <SectionHeader title='Slices' info={SECTION_INFO.slices} />
+      <div className='space-y-1'>
+        {indexedRules.map(({ rule, index }) => (
+          <FilterRow
+            key={filterRowKey(rule, index)}
+            rule={rule}
+            fieldType={fieldTypeFor(rule)}
+            onChange={next => {
+              // Re-stamp placement/aliasPath; FilterEditorPopover drops them.
+              onUpdateAt(index, {
+                ...next,
+                placement: 'pre-join',
+                aliasPath: rule.aliasPath,
+              } as FilterRule);
+            }}
+            onRemove={() => {
+              onRemoveAt(index);
+            }}
+          />
+        ))}
+      </div>
+      <div className='mt-2'>
+        {pending ? (
+          <FilterEditorPopover
+            open={true}
+            onOpenChange={isOpen => {
+              if (!isOpen) setPending(null);
+            }}
+            column={pending.column}
+            fieldType={pending.fieldType}
+            onApply={rule => {
+              onAdd({
+                ...rule,
+                placement: 'pre-join',
+                aliasPath: pending.aliasPath,
+              } as FilterRule);
+              setPending(null);
+            }}
+            trigger={
+              <Button variant='outline' size='sm' className='h-7 text-xs'>
+                <Plus className='mr-1 h-3 w-3' />
+                {pending.aliasPath}.{pending.column}
+              </Button>
+            }
+          />
+        ) : (
+          <AddSlicePicker joinedSources={joinedSources} onSelect={setPending} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AddSlicePicker({
+  joinedSources,
+  onSelect,
+}: {
+  joinedSources: readonly JoinedSource[];
+  onSelect: (pending: PendingSliceColumn) => void;
+}) {
+  // `\0` separator so a `.` in aliasPath/column doesn't collide.
+  const items = joinedSources.flatMap(src =>
+    src.columns
+      .filter(col => isFilterableType(col.type))
+      .map(col => ({
+        value: `${src.aliasPath}\0${col.name}`,
+        aliasPath: src.aliasPath,
+        column: col.name,
+        fieldType: col.type,
+      }))
+  );
+
+  if (items.length === 0) {
+    return <span className='text-muted-foreground text-xs'>No filterable joined columns.</span>;
+  }
+
+  return (
+    <Select
+      value=''
+      onValueChange={val => {
+        const item = items.find(i => i.value === val);
+        if (item) {
+          onSelect({
+            aliasPath: item.aliasPath,
+            column: item.column,
+            fieldType: item.fieldType,
+          });
+        }
+      }}
+    >
+      <SelectTrigger className='text-muted-foreground h-7 w-full text-xs'>
+        <span className='flex flex-1 items-center gap-1 text-left'>
+          <Plus className='h-4 w-4' />
+          <SelectValue placeholder='Add slice' />
+        </span>
+      </SelectTrigger>
+      <SelectContent>
+        {items.map(item => (
+          <SelectItem key={item.value} value={item.value}>
+            <span className='font-mono'>
+              <span className='text-blue-600'>{item.aliasPath}</span>.{item.column}
+            </span>
+            <span className='text-muted-foreground ml-2 text-xs'>({item.fieldType})</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }
 
@@ -220,9 +434,7 @@ function SortSection({ sort, selectedColumns, onChange }: SortSectionProps) {
 
   return (
     <div>
-      <div className='text-muted-foreground mb-2 text-xs font-semibold tracking-wide uppercase'>
-        Sort
-      </div>
+      <SectionHeader title='Sort' info={SECTION_INFO.sort} />
       <div className='space-y-1'>
         {sort.map((rule, index) => (
           <div
@@ -298,9 +510,7 @@ interface LimitSectionProps {
 function LimitSection({ value, onChange }: LimitSectionProps) {
   return (
     <div>
-      <div className='text-muted-foreground mb-2 text-xs font-semibold tracking-wide uppercase'>
-        Limit
-      </div>
+      <SectionHeader title='Limit' info={SECTION_INFO.limit} />
       <LimitInput value={value} onChange={onChange} />
     </div>
   );

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -16,6 +16,7 @@ import {
   EMPTY_OUTPUT_CONFIG,
   hasAnyOutputControls,
   type FilterRule,
+  type JoinedSource,
   type OutputConfig,
 } from '../../../shared/types/output-config';
 import { supportsOutputControls } from '../../../shared/utils/output-controls-support';
@@ -87,6 +88,7 @@ export interface ReportColumnPickerProps {
 type ToggleFieldFn = (name: string, checked: boolean) => void;
 type AddFilterFn = (rule: FilterRule) => void;
 type RemoveFilterAtFn = (globalIndex: number) => void;
+type ReplaceFilterAtFn = (globalIndex: number, rule: FilterRule) => void;
 
 interface ColumnFilters {
   rules: FilterRule[];
@@ -103,6 +105,7 @@ interface NativeFieldRowProps {
   columnFilters: ColumnFilters;
   onAddFilter?: AddFilterFn;
   onRemoveFilterAt?: RemoveFilterAtFn;
+  onReplaceFilterAt?: ReplaceFilterAtFn;
 }
 
 const NativeFieldRow = memo(function NativeFieldRow({
@@ -113,6 +116,7 @@ const NativeFieldRow = memo(function NativeFieldRow({
   columnFilters,
   onAddFilter,
   onRemoveFilterAt,
+  onReplaceFilterAt,
 }: NativeFieldRowProps) {
   return (
     <label className='group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded px-1 py-1'>
@@ -134,6 +138,13 @@ const NativeFieldRow = memo(function NativeFieldRow({
           onRemoveAt={localIndex => {
             onRemoveFilterAt(columnFilters.indices[localIndex]);
           }}
+          onReplaceAt={
+            onReplaceFilterAt
+              ? (localIndex, rule) => {
+                  onReplaceFilterAt(columnFilters.indices[localIndex], rule);
+                }
+              : undefined
+          }
         />
       )}
     </label>
@@ -148,6 +159,8 @@ interface BlendedFieldRowProps {
   columnFilters: ColumnFilters;
   onAddFilter?: AddFilterFn;
   onRemoveFilterAt?: RemoveFilterAtFn;
+  onReplaceFilterAt?: ReplaceFilterAtFn;
+  preJoinSlices: ColumnFilters;
 }
 
 const BlendedFieldRow = memo(function BlendedFieldRow({
@@ -158,6 +171,8 @@ const BlendedFieldRow = memo(function BlendedFieldRow({
   columnFilters,
   onAddFilter,
   onRemoveFilterAt,
+  onReplaceFilterAt,
+  preJoinSlices,
 }: BlendedFieldRowProps) {
   return (
     <label className='group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded px-1 py-1'>
@@ -179,6 +194,26 @@ const BlendedFieldRow = memo(function BlendedFieldRow({
           onRemoveAt={localIndex => {
             onRemoveFilterAt(columnFilters.indices[localIndex]);
           }}
+          onReplaceAt={
+            onReplaceFilterAt
+              ? (localIndex, rule) => {
+                  onReplaceFilterAt(columnFilters.indices[localIndex], rule);
+                }
+              : undefined
+          }
+          sliceIconProps={{
+            aliasPath: field.aliasPath,
+            originalFieldName: field.originalFieldName,
+            existingSlices: preJoinSlices.rules,
+            existingSliceIndices: preJoinSlices.indices,
+            onAddSlice: onAddFilter,
+            onRemoveSliceAt: onRemoveFilterAt,
+            onReplaceSliceAt: onReplaceFilterAt
+              ? (localIndex, rule) => {
+                  onReplaceFilterAt(preJoinSlices.indices[localIndex], rule);
+                }
+              : undefined,
+          }}
         />
       )}
     </label>
@@ -193,6 +228,8 @@ interface BlendedGroupItemProps {
   filtersByColumn?: Map<string, ColumnFilters>;
   onAddFilter?: AddFilterFn;
   onRemoveFilterAt?: RemoveFilterAtFn;
+  onReplaceFilterAt?: ReplaceFilterAtFn;
+  preJoinByAliasPathColumn?: Map<string, ColumnFilters>;
 }
 
 function BlendedGroupItem({
@@ -203,6 +240,8 @@ function BlendedGroupItem({
   filtersByColumn,
   onAddFilter,
   onRemoveFilterAt,
+  onReplaceFilterAt,
+  preJoinByAliasPathColumn,
 }: BlendedGroupItemProps) {
   const [isOpen, setIsOpen] = useState(() => group.selectedCount > 0);
 
@@ -232,18 +271,23 @@ function BlendedGroupItem({
         </div>
       </button>
       <CollapsibleContent>
-        {group.visibleFields.map(field => (
-          <BlendedFieldRow
-            key={field.name}
-            field={field}
-            checked={selectedSet.has(field.name)}
-            onToggleField={onToggleField}
-            filterableType={filterableTypeFor?.(field.name)}
-            columnFilters={filtersByColumn?.get(field.name) ?? EMPTY_COLUMN_FILTERS}
-            onAddFilter={onAddFilter}
-            onRemoveFilterAt={onRemoveFilterAt}
-          />
-        ))}
+        {group.visibleFields.map(field => {
+          const sliceKey = `${field.aliasPath}\0${field.originalFieldName}`;
+          return (
+            <BlendedFieldRow
+              key={field.name}
+              field={field}
+              checked={selectedSet.has(field.name)}
+              onToggleField={onToggleField}
+              filterableType={filterableTypeFor?.(field.name)}
+              columnFilters={filtersByColumn?.get(field.name) ?? EMPTY_COLUMN_FILTERS}
+              onAddFilter={onAddFilter}
+              onRemoveFilterAt={onRemoveFilterAt}
+              onReplaceFilterAt={onReplaceFilterAt}
+              preJoinSlices={preJoinByAliasPathColumn?.get(sliceKey) ?? EMPTY_COLUMN_FILTERS}
+            />
+          );
+        })}
       </CollapsibleContent>
     </Collapsible>
   );
@@ -274,7 +318,6 @@ export function ReportColumnPicker({
     [schema]
   );
 
-  // Only show blended fields from included sources
   const includedPaths = useMemo(() => {
     if (!schema?.availableSources) return new Set<string>();
     return new Set(schema.availableSources.filter(s => s.isIncluded).map(s => s.aliasPath));
@@ -285,10 +328,6 @@ export function ReportColumnPicker({
     return schema.blendedFields.filter(f => includedPaths.has(f.aliasPath) && !f.isHidden);
   }, [schema, includedPaths]);
 
-  // Legacy reports with columnConfig === null had the "all native fields, no blended"
-  // meaning. Treat them the same for display/toggle math — the picker stays a pure
-  // controlled component: it only calls onChange when the user actually toggles
-  // something, so simply opening such a report does not mark the form dirty.
   const effectiveValue = useMemo<string[]>(() => {
     if (value !== null) return value;
     return nativeFields.map(f => f.name);
@@ -370,15 +409,34 @@ export function ReportColumnPicker({
     return map;
   }, [schema]);
 
+  // Post-join filters keyed by their output-alias column.
   const filtersByColumn = useMemo<Map<string, ColumnFilters>>(() => {
     const map = new Map<string, ColumnFilters>();
     effectiveOutputConfig.filterConfig.forEach((rule, idx) => {
+      if (rule.placement === 'pre-join') return;
       const existing = map.get(rule.column);
       if (existing) {
         existing.rules.push(rule);
         existing.indices.push(idx);
       } else {
         map.set(rule.column, { rules: [rule], indices: [idx] });
+      }
+    });
+    return map;
+  }, [effectiveOutputConfig.filterConfig]);
+
+  // Pre-join filters (slices) keyed by aliasPath + raw column.
+  const preJoinByAliasPathColumn = useMemo<Map<string, ColumnFilters>>(() => {
+    const map = new Map<string, ColumnFilters>();
+    effectiveOutputConfig.filterConfig.forEach((rule, idx) => {
+      if (rule.placement !== 'pre-join' || !rule.aliasPath) return;
+      const key = `${rule.aliasPath}\0${rule.column}`;
+      const existing = map.get(key);
+      if (existing) {
+        existing.rules.push(rule);
+        existing.indices.push(idx);
+      } else {
+        map.set(key, { rules: [rule], indices: [idx] });
       }
     });
     return map;
@@ -426,6 +484,46 @@ export function ReportColumnPicker({
     },
     [effectiveOutputConfig, onOutputConfigChange]
   );
+
+  const handleReplaceFilterAt = useCallback<ReplaceFilterAtFn>(
+    (globalIndex, rule) => {
+      if (!onOutputConfigChange) return;
+      onOutputConfigChange({
+        ...effectiveOutputConfig,
+        filterConfig: effectiveOutputConfig.filterConfig.map((existing, i) =>
+          i === globalIndex ? rule : existing
+        ),
+      });
+    },
+    [effectiveOutputConfig, onOutputConfigChange]
+  );
+
+  const joinedSources = useMemo<JoinedSource[]>(() => {
+    if (!schema) return [];
+    const byPath = new Map<string, JoinedSource & { columns: { name: string; type: string }[] }>();
+    for (const source of schema.availableSources) {
+      if (!source.isIncluded) continue;
+      byPath.set(source.aliasPath, {
+        aliasPath: source.aliasPath,
+        title: source.title,
+        columns: [],
+      });
+    }
+    for (const field of schema.blendedFields) {
+      const entry = byPath.get(field.aliasPath);
+      if (!entry || !field.type) continue;
+      entry.columns.push({ name: field.originalFieldName, type: field.type });
+    }
+    for (const entry of byPath.values()) {
+      const seen = new Set<string>();
+      entry.columns = entry.columns.filter(c => {
+        if (seen.has(c.name)) return false;
+        seen.add(c.name);
+        return true;
+      });
+    }
+    return Array.from(byPath.values()).filter(s => s.columns.length > 0);
+  }, [schema]);
 
   const dropdownColumns = useMemo(() => {
     const cols: { name: string; type: string }[] = [];
@@ -531,6 +629,7 @@ export function ReportColumnPicker({
             onChange={onOutputConfigChange}
             selectedColumns={selectedDropdownColumns}
             allColumns={dropdownColumns}
+            joinedSources={joinedSources}
           />
         </div>
       )}
@@ -573,6 +672,7 @@ export function ReportColumnPicker({
             columnFilters={filtersByColumn.get(field.name) ?? EMPTY_COLUMN_FILTERS}
             onAddFilter={outputControlsAvailable ? handleAddFilter : undefined}
             onRemoveFilterAt={outputControlsAvailable ? handleRemoveFilterAt : undefined}
+            onReplaceFilterAt={outputControlsAvailable ? handleReplaceFilterAt : undefined}
           />
         ))}
 
@@ -586,6 +686,8 @@ export function ReportColumnPicker({
             filtersByColumn={filtersByColumn}
             onAddFilter={outputControlsAvailable ? handleAddFilter : undefined}
             onRemoveFilterAt={outputControlsAvailable ? handleRemoveFilterAt : undefined}
+            onReplaceFilterAt={outputControlsAvailable ? handleReplaceFilterAt : undefined}
+            preJoinByAliasPathColumn={preJoinByAliasPathColumn}
           />
         ))}
       </div>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
@@ -49,43 +49,38 @@ export function RowFilterIcon({
       ? sliceIconProps.existingSlices[0]
       : undefined;
 
-  const targetFilterRef = useRef<FilterRule | null>(null);
-  const targetSliceRef = useRef<FilterRule | null>(null);
+  // Snapshot index on open — reference identity flips when the parent rerenders mid-edit.
+  const editingFilterIndexRef = useRef<number | null>(null);
+  const editingSliceIndexRef = useRef<number | null>(null);
   const prevOpenRef = useRef(false);
   useEffect(() => {
     if (open && !prevOpenRef.current) {
-      targetFilterRef.current = editFilter ?? null;
-      targetSliceRef.current = editSlice ?? null;
+      editingFilterIndexRef.current = editFilter ? activeRules.indexOf(editFilter) : null;
+      editingSliceIndexRef.current =
+        editSlice && sliceIconProps ? sliceIconProps.existingSlices.indexOf(editSlice) : null;
     } else if (!open && prevOpenRef.current) {
-      targetFilterRef.current = null;
-      targetSliceRef.current = null;
+      editingFilterIndexRef.current = null;
+      editingSliceIndexRef.current = null;
     }
     prevOpenRef.current = open;
-  }, [open, editFilter, editSlice]);
+  }, [open, editFilter, editSlice, activeRules, sliceIconProps]);
 
   const handleFilterApply = (rule: FilterRule) => {
-    const target = targetFilterRef.current ?? editFilter;
-    if (target && onReplaceAt) {
-      const currentIdx = activeRules.indexOf(target);
-      if (currentIdx >= 0) {
-        onReplaceAt(currentIdx, rule);
-        return;
-      }
+    const idx = editingFilterIndexRef.current;
+    if (idx != null && idx >= 0 && onReplaceAt) {
+      onReplaceAt(idx, rule);
+      return;
     }
     onAdd(rule);
   };
   const replaceSliceAt = sliceIconProps?.onReplaceSliceAt;
   const addSlice = sliceIconProps?.onAddSlice;
-  const sliceList = sliceIconProps?.existingSlices;
   const handleSliceApply = addSlice
     ? (rule: FilterRule) => {
-        const target = targetSliceRef.current ?? editSlice;
-        if (target && replaceSliceAt && sliceList) {
-          const currentIdx = sliceList.indexOf(target);
-          if (currentIdx >= 0) {
-            replaceSliceAt(currentIdx, rule);
-            return;
-          }
+        const idx = editingSliceIndexRef.current;
+        if (idx != null && idx >= 0 && replaceSliceAt) {
+          replaceSliceAt(idx, rule);
+          return;
         }
         addSlice(rule);
       }

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
@@ -1,8 +1,21 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Filter } from 'lucide-react';
 import { cn } from '@owox/ui/lib/utils';
 import { FilterEditorPopover } from './FilterEditorPopover';
+import { FilterOrSliceEditorPopover } from './FilterOrSliceEditorPopover';
 import type { FilterRule } from '../../../shared/types/output-config';
+
+interface SliceIconProps {
+  aliasPath: string;
+  originalFieldName: string;
+  /** Pre-join filters already active for this aliasPath+column combination. */
+  existingSlices: readonly FilterRule[];
+  /** Add a pre-join FilterRule (placement+aliasPath already set by the popover). */
+  onAddSlice: (rule: FilterRule) => void;
+  onRemoveSliceAt: (globalIndex: number) => void;
+  onReplaceSliceAt?: (localIndex: number, rule: FilterRule) => void;
+  existingSliceIndices: readonly number[];
+}
 
 interface RowFilterIconProps {
   column: string;
@@ -10,6 +23,8 @@ interface RowFilterIconProps {
   activeRules: readonly FilterRule[];
   onAdd: (rule: FilterRule) => void;
   onRemoveAt: (index: number) => void;
+  onReplaceAt?: (localIndex: number, rule: FilterRule) => void;
+  sliceIconProps?: SliceIconProps;
 }
 
 export function RowFilterIcon({
@@ -18,9 +33,110 @@ export function RowFilterIcon({
   activeRules,
   onAdd,
   onRemoveAt,
+  onReplaceAt,
+  sliceIconProps,
 }: RowFilterIconProps) {
   const [open, setOpen] = useState(false);
-  const isActive = activeRules.length > 0;
+  const filterCount = activeRules.length;
+  const sliceCount = sliceIconProps?.existingSlices.length ?? 0;
+  const totalCount = filterCount + sliceCount;
+  const isActive = totalCount > 0;
+  const defaultTab: 'filter' | 'slice' = filterCount === 0 && sliceCount > 0 ? 'slice' : 'filter';
+
+  const editFilter = filterCount === 1 && onReplaceAt ? activeRules[0] : undefined;
+  const editSlice =
+    sliceCount === 1 && sliceIconProps?.onReplaceSliceAt
+      ? sliceIconProps.existingSlices[0]
+      : undefined;
+
+  const targetFilterRef = useRef<FilterRule | null>(null);
+  const targetSliceRef = useRef<FilterRule | null>(null);
+  const prevOpenRef = useRef(false);
+  useEffect(() => {
+    if (open && !prevOpenRef.current) {
+      targetFilterRef.current = editFilter ?? null;
+      targetSliceRef.current = editSlice ?? null;
+    } else if (!open && prevOpenRef.current) {
+      targetFilterRef.current = null;
+      targetSliceRef.current = null;
+    }
+    prevOpenRef.current = open;
+  }, [open, editFilter, editSlice]);
+
+  const handleFilterApply = (rule: FilterRule) => {
+    const target = targetFilterRef.current ?? editFilter;
+    if (target && onReplaceAt) {
+      const currentIdx = activeRules.indexOf(target);
+      if (currentIdx >= 0) {
+        onReplaceAt(currentIdx, rule);
+        return;
+      }
+    }
+    onAdd(rule);
+  };
+  const replaceSliceAt = sliceIconProps?.onReplaceSliceAt;
+  const addSlice = sliceIconProps?.onAddSlice;
+  const sliceList = sliceIconProps?.existingSlices;
+  const handleSliceApply = addSlice
+    ? (rule: FilterRule) => {
+        const target = targetSliceRef.current ?? editSlice;
+        if (target && replaceSliceAt && sliceList) {
+          const currentIdx = sliceList.indexOf(target);
+          if (currentIdx >= 0) {
+            replaceSliceAt(currentIdx, rule);
+            return;
+          }
+        }
+        addSlice(rule);
+      }
+    : undefined;
+
+  const trigger = (
+    <button
+      type='button'
+      aria-label={isActive ? 'Manage filters and slices' : 'Add filter'}
+      className={cn(
+        'ml-auto flex h-6 w-6 items-center justify-center gap-0.5 rounded transition-opacity',
+        isActive
+          ? 'text-blue-500 opacity-100'
+          : 'text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100'
+      )}
+    >
+      <Filter className='h-4 w-4' />
+      {totalCount > 1 && (
+        <span className='text-[10px] leading-none font-semibold tabular-nums'>{totalCount}</span>
+      )}
+    </button>
+  );
+
+  if (sliceIconProps && handleSliceApply) {
+    return (
+      <FilterOrSliceEditorPopover
+        open={open}
+        onOpenChange={setOpen}
+        column={column}
+        sliceColumn={sliceIconProps.originalFieldName}
+        fieldType={fieldType}
+        aliasPath={sliceIconProps.aliasPath}
+        defaultTab={defaultTab}
+        filterProps={{
+          onApply: handleFilterApply,
+          initialRule: editFilter,
+          existingRules: editFilter ? [] : activeRules,
+          onRemoveExistingAt: onRemoveAt,
+        }}
+        sliceProps={{
+          onApply: handleSliceApply,
+          initialRule: editSlice,
+          existingSlicesForColumn: editSlice ? [] : sliceIconProps.existingSlices,
+          onRemoveExistingAt: localIdx => {
+            sliceIconProps.onRemoveSliceAt(sliceIconProps.existingSliceIndices[localIdx]);
+          },
+        }}
+        trigger={trigger}
+      />
+    );
+  }
 
   return (
     <FilterEditorPopover
@@ -28,28 +144,11 @@ export function RowFilterIcon({
       onOpenChange={setOpen}
       column={column}
       fieldType={fieldType}
-      onApply={onAdd}
-      existingRules={activeRules}
+      onApply={handleFilterApply}
+      initialRule={editFilter}
+      existingRules={editFilter ? [] : activeRules}
       onRemoveExistingAt={onRemoveAt}
-      trigger={
-        <button
-          type='button'
-          aria-label={isActive ? 'Manage filters' : 'Add filter'}
-          className={cn(
-            'ml-auto flex h-6 w-6 items-center justify-center gap-0.5 rounded transition-opacity',
-            isActive
-              ? 'text-blue-500 opacity-100'
-              : 'text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100'
-          )}
-        >
-          <Filter className='h-4 w-4' />
-          {activeRules.length > 1 && (
-            <span className='text-[10px] leading-none font-semibold tabular-nums'>
-              {activeRules.length}
-            </span>
-          )}
-        </button>
-      }
+      trigger={trigger}
     />
   );
 }

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/filter-rule-summary.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/filter-rule-summary.ts
@@ -1,0 +1,27 @@
+import type { FilterRule } from '../../../shared/types/output-config';
+
+/**
+ * Returns a short human-readable value string for a FilterRule to display
+ * alongside the operator label (e.g. "contains: foo").
+ * Returns an empty string for no-value operators (is_empty, is_null, etc.).
+ */
+export function summarizeFilterRule(rule: FilterRule): string {
+  switch (rule.operator) {
+    case 'is_empty':
+    case 'is_not_empty':
+    case 'is_null':
+    case 'is_not_null':
+    case 'is_true':
+    case 'is_false':
+      return '';
+    case 'between':
+      return `${String(rule.value.from)} … ${String(rule.value.to)}`;
+    case 'relative_date': {
+      const v = rule.value;
+      if ('n' in v) return v.kind.replace('_n_', ` ${String(v.n)} `);
+      return v.kind;
+    }
+    default:
+      return JSON.stringify(rule.value);
+  }
+}

--- a/apps/web/src/features/data-marts/edit/model/types/data-mart-run-report-definition.ts
+++ b/apps/web/src/features/data-marts/edit/model/types/data-mart-run-report-definition.ts
@@ -1,4 +1,7 @@
-import type { DataMartRunReportDestinationConfigDto } from '../../../shared/types/api/shared';
+import type {
+  DataMartRunReportDestinationConfigDto,
+  DataMartRunReportOutputConfigDto,
+} from '../../../shared/types/api/shared';
 
 export interface DataMartRunReportDefinition {
   title: string;
@@ -8,4 +11,5 @@ export interface DataMartRunReportDefinition {
     type: string;
   };
   destinationConfig: DataMartRunReportDestinationConfigDto;
+  outputConfig?: DataMartRunReportOutputConfigDto | null;
 }

--- a/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useGoogleSheetsReportForm.test.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useGoogleSheetsReportForm.test.ts
@@ -1,0 +1,269 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, beforeEach, expect } from 'vitest';
+
+// ---- module-level mocks (must come before any module imports) ----
+
+vi.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../../../utils', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('../../../../../data-marts/reports/shared/model/hooks/useReport', () => ({
+  useReport: vi.fn(),
+}));
+
+import { useReport } from '../../../../../data-marts/reports/shared/model/hooks/useReport';
+import { useGoogleSheetsReportForm } from '../useGoogleSheetsReportForm';
+import { ReportFormMode } from '../../../shared';
+import { DestinationTypeConfigEnum } from '../../../shared/enums/destination-type-config.enum';
+import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
+import type { FilterRule } from '../../../../shared/types/output-config';
+
+const mockCreateReport = vi.fn();
+const mockUpdateReport = vi.fn();
+const mockClearError = vi.fn();
+
+function setupUseReportMock(overrides: Partial<ReturnType<typeof useReport>> = {}) {
+  (useReport as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    updateReport: mockUpdateReport,
+    createReport: mockCreateReport,
+    clearError: mockClearError,
+    error: null,
+    destinations: [],
+    reports: [],
+    currentReport: null,
+    loading: false,
+    polledReportIds: [],
+    fetchDestinations: vi.fn(),
+    fetchReports: vi.fn(),
+    fetchReportsByDataMartId: vi.fn(),
+    fetchReportById: vi.fn(),
+    deleteReport: vi.fn(),
+    runReport: vi.fn(),
+    startPollingReport: vi.fn(),
+    stopPollingReport: vi.fn(),
+    stopAllPolling: vi.fn(),
+    setPollingConfig: vi.fn(),
+    clearCurrentReport: vi.fn(),
+    ...overrides,
+  });
+}
+
+const VALID_SHEETS_URL = 'https://docs.google.com/spreadsheets/d/abc123/edit#gid=0';
+
+function buildReport(overrides: Partial<DataMartReport> = {}): DataMartReport {
+  return {
+    id: 'report-1',
+    title: 'My Report',
+    dataMart: { id: 'dm-1' },
+    dataDestination: {
+      id: 'dest-1',
+      type: 'google-sheets',
+      title: 'Sheets',
+    } as unknown as DataMartReport['dataDestination'],
+    destinationConfig: {
+      type: DestinationTypeConfigEnum.GOOGLE_SHEETS_CONFIG,
+      spreadsheetId: 'abc123',
+      sheetId: '0',
+    } as DataMartReport['destinationConfig'],
+    columnConfig: ['col_a'],
+    filterConfig: null,
+    sortConfig: null,
+    limitConfig: null,
+    ...overrides,
+  } as DataMartReport;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupUseReportMock();
+  mockCreateReport.mockResolvedValue(buildReport({ id: 'created-1' }));
+  mockUpdateReport.mockResolvedValue(buildReport({ id: 'updated-1' }));
+});
+
+describe('useGoogleSheetsReportForm — defaults', () => {
+  it('seeds defaults from initialReport (title, columnConfig, all output controls)', () => {
+    const preJoinRule: FilterRule = {
+      column: 'userRole',
+      operator: 'eq',
+      value: 'admin',
+      placement: 'pre-join',
+      aliasPath: 'users',
+    };
+    const postJoinRule: FilterRule = { column: 'revenue', operator: 'gt', value: 100 };
+
+    const initialReport = buildReport({
+      title: 'Quarterly export',
+      columnConfig: ['event_id', 'user_id'],
+      filterConfig: [postJoinRule, preJoinRule],
+      sortConfig: [{ column: 'event_id', direction: 'asc' }],
+      limitConfig: 500,
+    });
+
+    const { result } = renderHook(() =>
+      useGoogleSheetsReportForm({
+        initialReport,
+        mode: ReportFormMode.EDIT,
+        dataMartId: 'dm-1',
+      })
+    );
+
+    const values = result.current.getValues();
+    expect(values.title).toBe('Quarterly export');
+    expect(values.columnConfig).toEqual(['event_id', 'user_id']);
+    expect(values.filterConfig).toEqual([postJoinRule, preJoinRule]);
+    expect(values.sortConfig).toEqual([{ column: 'event_id', direction: 'asc' }]);
+    expect(values.limitConfig).toBe(500);
+  });
+
+  it('falls back to nulls when initialReport has no output controls', () => {
+    const { result } = renderHook(() =>
+      useGoogleSheetsReportForm({
+        initialReport: buildReport(),
+        mode: ReportFormMode.EDIT,
+        dataMartId: 'dm-1',
+      })
+    );
+    const values = result.current.getValues();
+    expect(values.filterConfig).toBeNull();
+    expect(values.sortConfig).toBeNull();
+    expect(values.limitConfig).toBeNull();
+  });
+});
+
+describe('useGoogleSheetsReportForm — submission', () => {
+  it('CREATE: passes all output controls (including pre-join rule) to createReport', async () => {
+    const preJoinRule: FilterRule = {
+      column: 'country',
+      operator: 'neq',
+      value: 'UA',
+      placement: 'pre-join',
+      aliasPath: 'users',
+    };
+
+    const { result } = renderHook(() =>
+      useGoogleSheetsReportForm({
+        mode: ReportFormMode.CREATE,
+        dataMartId: 'dm-1',
+      })
+    );
+
+    act(() => {
+      result.current.form.setValue('title', 'New');
+      result.current.form.setValue('documentUrl', VALID_SHEETS_URL);
+      result.current.form.setValue('dataDestinationId', 'dest-1');
+      result.current.form.setValue('columnConfig', ['event_id']);
+      result.current.form.setValue('filterConfig', [preJoinRule]);
+      result.current.form.setValue('sortConfig', [{ column: 'event_id', direction: 'desc' }]);
+      result.current.form.setValue('limitConfig', 100);
+    });
+
+    await act(async () => {
+      await result.current.onSubmit(result.current.getValues());
+    });
+
+    expect(mockCreateReport).toHaveBeenCalledTimes(1);
+    expect(mockCreateReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'New',
+        dataMartId: 'dm-1',
+        dataDestinationId: 'dest-1',
+        destinationConfig: {
+          type: DestinationTypeConfigEnum.GOOGLE_SHEETS_CONFIG,
+          spreadsheetId: 'abc123',
+          sheetId: 0, // extractGoogleSheetsUrlComponents returns number
+        },
+        columnConfig: ['event_id'],
+        filterConfig: [preJoinRule],
+        sortConfig: [{ column: 'event_id', direction: 'desc' }],
+        limitConfig: 100,
+      })
+    );
+  });
+
+  it('UPDATE: forwards output controls to updateReport with the initial report id', async () => {
+    const initial = buildReport({ id: 'r-42' });
+    const { result } = renderHook(() =>
+      useGoogleSheetsReportForm({
+        initialReport: initial,
+        mode: ReportFormMode.EDIT,
+        dataMartId: 'dm-1',
+      })
+    );
+
+    act(() => {
+      result.current.form.setValue('documentUrl', VALID_SHEETS_URL);
+      result.current.form.setValue('dataDestinationId', 'dest-1');
+      result.current.form.setValue('limitConfig', 250);
+    });
+
+    await act(async () => {
+      await result.current.onSubmit(result.current.getValues());
+    });
+
+    expect(mockUpdateReport).toHaveBeenCalledTimes(1);
+    const [reportId, payload] = mockUpdateReport.mock.calls[0];
+    expect(reportId).toBe('r-42');
+    expect(payload).toMatchObject({ limitConfig: 250 });
+  });
+
+  it('CREATE: adds ownerIds only when pendingOwnerIdsRef.current is non-null', async () => {
+    const ownerRef = { current: ['user-1', 'user-2'] };
+    const { result } = renderHook(() =>
+      useGoogleSheetsReportForm({
+        mode: ReportFormMode.CREATE,
+        dataMartId: 'dm-1',
+        pendingOwnerIdsRef: ownerRef,
+      })
+    );
+
+    act(() => {
+      result.current.form.setValue('title', 'X');
+      result.current.form.setValue('documentUrl', VALID_SHEETS_URL);
+      result.current.form.setValue('dataDestinationId', 'dest-1');
+      result.current.form.setValue('columnConfig', ['col_a']);
+    });
+
+    await act(async () => {
+      await result.current.onSubmit(result.current.getValues());
+    });
+
+    expect(mockCreateReport).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerIds: ['user-1', 'user-2'] })
+    );
+  });
+
+  it('CREATE: omits ownerIds when pendingOwnerIdsRef.current is null', async () => {
+    const ownerRef: { current: string[] | null } = { current: null };
+    const { result } = renderHook(() =>
+      useGoogleSheetsReportForm({
+        mode: ReportFormMode.CREATE,
+        dataMartId: 'dm-1',
+        pendingOwnerIdsRef: ownerRef,
+      })
+    );
+
+    act(() => {
+      result.current.form.setValue('title', 'X');
+      result.current.form.setValue('documentUrl', VALID_SHEETS_URL);
+      result.current.form.setValue('dataDestinationId', 'dest-1');
+      result.current.form.setValue('columnConfig', ['col_a']);
+    });
+
+    await act(async () => {
+      await result.current.onSubmit(result.current.getValues());
+    });
+
+    const payload = mockCreateReport.mock.calls[0][0];
+    expect('ownerIds' in payload).toBe(false);
+  });
+});

--- a/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useLookerStudioReportForm.test.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useLookerStudioReportForm.test.ts
@@ -20,10 +20,8 @@ vi.mock('../../../../../data-marts/reports/shared/model/hooks/useReport', () => 
 }));
 
 import { useReport } from '../../../../../data-marts/reports/shared/model/hooks/useReport';
-import { useEmailReportForm } from '../useEmailReportForm';
-import { ReportFormMode, TemplateSourceTypeEnum } from '../../../shared';
+import { useLookerStudioReportForm } from '../useLookerStudioReportForm';
 import { DestinationTypeConfigEnum } from '../../../shared/enums/destination-type-config.enum';
-import { ReportConditionEnum } from '../../../shared/enums/report-condition.enum';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
 import type { FilterRule } from '../../../../shared/types/output-config';
 
@@ -60,21 +58,16 @@ function setupUseReportMock(overrides: Partial<ReturnType<typeof useReport>> = {
 function buildReport(overrides: Partial<DataMartReport> = {}): DataMartReport {
   return {
     id: 'report-1',
-    title: 'Email Report',
+    title: 'Existing',
     dataMart: { id: 'dm-1' },
     dataDestination: {
       id: 'dest-1',
-      type: 'email',
-      title: 'Email',
+      type: 'looker-studio',
+      title: 'LS',
     } as unknown as DataMartReport['dataDestination'],
     destinationConfig: {
-      type: DestinationTypeConfigEnum.EMAIL_CONFIG,
-      reportCondition: ReportConditionEnum.ALWAYS,
-      subject: 'Weekly',
-      templateSource: {
-        type: TemplateSourceTypeEnum.CUSTOM_MESSAGE,
-        config: { messageTemplate: 'Hello' },
-      },
+      type: DestinationTypeConfigEnum.LOOKER_STUDIO_CONFIG,
+      cacheLifetime: 600,
     } as DataMartReport['destinationConfig'],
     columnConfig: ['col_a'],
     filterConfig: null,
@@ -91,41 +84,47 @@ beforeEach(() => {
   mockUpdateReport.mockResolvedValue(buildReport({ id: 'updated-1' }));
 });
 
-describe('useEmailReportForm — defaults', () => {
+describe('useLookerStudioReportForm — defaults', () => {
   it('seeds output controls from initialReport (post+pre-join mix)', () => {
     const preJoinRule: FilterRule = {
       column: 'plan',
       operator: 'eq',
-      value: 'pro',
+      value: 'enterprise',
       placement: 'pre-join',
       aliasPath: 'orgs',
     };
     const initial = buildReport({
-      filterConfig: [{ column: 'col_a', operator: 'eq', value: 'X' }, preJoinRule],
+      columnConfig: ['col_a', 'col_b'],
+      filterConfig: [{ column: 'col_a', operator: 'neq', value: 'x' }, preJoinRule],
       sortConfig: [{ column: 'col_a', direction: 'desc' }],
-      limitConfig: 99,
+      limitConfig: 1000,
     });
 
     const { result } = renderHook(() =>
-      useEmailReportForm({
-        initialReport: initial,
-        mode: ReportFormMode.EDIT,
-        dataMartId: 'dm-1',
-      })
+      useLookerStudioReportForm({ initialReport: initial, dataMartId: 'dm-1' })
     );
 
     const values = result.current.form.getValues();
-    expect(values.title).toBe('Email Report');
+    expect(values.cacheLifetime).toBe(600);
+    expect(values.columnConfig).toEqual(['col_a', 'col_b']);
     expect(values.filterConfig).toHaveLength(2);
     expect(values.filterConfig?.[1]).toEqual(preJoinRule);
     expect(values.sortConfig).toEqual([{ column: 'col_a', direction: 'desc' }]);
-    expect(values.limitConfig).toBe(99);
+    expect(values.limitConfig).toBe(1000);
+  });
+
+  it('falls back to defaults when initialReport is omitted', () => {
+    const { result } = renderHook(() => useLookerStudioReportForm({ dataMartId: 'dm-1' }));
+    const values = result.current.form.getValues();
+    expect(values.cacheLifetime).toBe(300);
+    expect(values.filterConfig).toBeNull();
+    expect(values.sortConfig).toBeNull();
+    expect(values.limitConfig).toBeNull();
   });
 });
 
-describe('useEmailReportForm — submission', () => {
-  it('UPDATE: builds CUSTOM_MESSAGE destinationConfig and forwards output controls', async () => {
-    const initial = buildReport({ id: 'r-42' });
+describe('useLookerStudioReportForm — submission', () => {
+  it('UPDATE path: forwards output controls including pre-join rule', async () => {
     const preJoinRule: FilterRule = {
       column: 'country',
       operator: 'neq',
@@ -133,20 +132,15 @@ describe('useEmailReportForm — submission', () => {
       placement: 'pre-join',
       aliasPath: 'users',
     };
-
+    const initial = buildReport({ id: 'r-42' });
     const { result } = renderHook(() =>
-      useEmailReportForm({
-        initialReport: initial,
-        mode: ReportFormMode.EDIT,
-        dataMartId: 'dm-1',
-      })
+      useLookerStudioReportForm({ initialReport: initial, dataMartId: 'dm-1' })
     );
 
     act(() => {
-      result.current.form.setValue('subject', 'Updated subject');
-      result.current.form.setValue('messageTemplate', 'New body');
       result.current.form.setValue('filterConfig', [preJoinRule]);
-      result.current.form.setValue('limitConfig', 50);
+      result.current.form.setValue('sortConfig', [{ column: 'col_a', direction: 'asc' }]);
+      result.current.form.setValue('limitConfig', 250);
     });
 
     await act(async () => {
@@ -156,69 +150,34 @@ describe('useEmailReportForm — submission', () => {
     expect(mockUpdateReport).toHaveBeenCalledTimes(1);
     const [reportId, payload] = mockUpdateReport.mock.calls[0];
     expect(reportId).toBe('r-42');
-    expect(payload.destinationConfig).toMatchObject({
-      type: DestinationTypeConfigEnum.EMAIL_CONFIG,
-      reportCondition: ReportConditionEnum.ALWAYS,
-      subject: 'Updated subject',
-      templateSource: {
-        type: TemplateSourceTypeEnum.CUSTOM_MESSAGE,
-        config: { messageTemplate: 'New body' },
+    expect(payload).toMatchObject({
+      destinationConfig: {
+        type: DestinationTypeConfigEnum.LOOKER_STUDIO_CONFIG,
+        cacheLifetime: 600,
       },
-    });
-    expect(payload.filterConfig).toEqual([preJoinRule]);
-    expect(payload.limitConfig).toBe(50);
-  });
-
-  it('UPDATE: builds INSIGHT_TEMPLATE destinationConfig when templateSourceType=INSIGHT_TEMPLATE', async () => {
-    const initial = buildReport({ id: 'r-50' });
-    const { result } = renderHook(() =>
-      useEmailReportForm({
-        initialReport: initial,
-        mode: ReportFormMode.EDIT,
-        dataMartId: 'dm-1',
-      })
-    );
-
-    act(() => {
-      result.current.form.setValue('templateSourceType', TemplateSourceTypeEnum.INSIGHT_TEMPLATE);
-      result.current.form.setValue('insightTemplateId', 'tmpl-7');
-    });
-
-    await act(async () => {
-      await result.current.onSubmit(result.current.form.getValues());
-    });
-
-    const payload = mockUpdateReport.mock.calls[0][1];
-    expect(payload.destinationConfig.templateSource).toEqual({
-      type: TemplateSourceTypeEnum.INSIGHT_TEMPLATE,
-      config: { insightTemplateId: 'tmpl-7' },
+      filterConfig: [preJoinRule],
+      sortConfig: [{ column: 'col_a', direction: 'asc' }],
+      limitConfig: 250,
     });
   });
 
-  it('CREATE: adds ownerIds only when pendingOwnerIdsRef.current is non-null', async () => {
-    const ownerRef = { current: ['user-7'] };
+  it('UPDATE: spreads ownerIds only when pendingOwnerIdsRef.current is non-null', async () => {
+    const ownerRef = { current: ['u-1'] };
     const { result } = renderHook(() =>
-      useEmailReportForm({
-        mode: ReportFormMode.CREATE,
+      useLookerStudioReportForm({
+        initialReport: buildReport(),
         dataMartId: 'dm-1',
         pendingOwnerIdsRef: ownerRef,
       })
     );
 
-    act(() => {
-      result.current.form.setValue('title', 'T');
-      result.current.form.setValue('dataDestinationId', 'dest-1');
-      result.current.form.setValue('subject', 'S');
-      result.current.form.setValue('messageTemplate', 'M');
-      result.current.form.setValue('columnConfig', ['col_a']);
-    });
-
     await act(async () => {
       await result.current.onSubmit(result.current.form.getValues());
     });
 
-    expect(mockCreateReport).toHaveBeenCalledWith(
-      expect.objectContaining({ ownerIds: ['user-7'] })
+    expect(mockUpdateReport).toHaveBeenCalledWith(
+      'report-1',
+      expect.objectContaining({ ownerIds: ['u-1'] })
     );
   });
 });

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useLookerStudioReportForm.ts
@@ -12,7 +12,7 @@ import type { DataDestination } from '../../../../data-destination/shared/model/
 import { FilterRuleSchema, SortRuleSchema } from '../../../shared/types/output-config';
 
 // Define the form schema - simplified for editing existing reports
-const lookerStudioReportFormSchema = z.object({
+export const lookerStudioReportFormSchema = z.object({
   cacheLifetime: z.number().min(300, 'Cache time must be at least 5 minutes (300 seconds)'),
   columnConfig: z
     .array(z.string())

--- a/apps/web/src/features/data-marts/shared/types/api/shared/data-mart-run-report-definition.dto.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/shared/data-mart-run-report-definition.dto.ts
@@ -11,6 +11,12 @@ export interface LookerStudioConfigDto {
 
 export type DataMartRunReportDestinationConfigDto = GoogleSheetsConfigDto | LookerStudioConfigDto;
 
+export interface DataMartRunReportOutputConfigDto {
+  filterConfig?: unknown;
+  sortConfig?: unknown;
+  limitConfig?: number | null;
+}
+
 export interface DataMartRunReportDefinitionDto {
   title: string;
   destination: {
@@ -19,6 +25,7 @@ export interface DataMartRunReportDefinitionDto {
     type: string;
   };
   destinationConfig: DataMartRunReportDestinationConfigDto;
+  outputConfig?: DataMartRunReportOutputConfigDto | null;
 }
 
 export interface DataMartRunInsightDefinitionDto {

--- a/apps/web/src/features/data-marts/shared/types/output-config.ts
+++ b/apps/web/src/features/data-marts/shared/types/output-config.ts
@@ -36,7 +36,7 @@ const NoValueOperatorEnum = z.enum([
   'is_false',
 ]);
 
-export const FilterRuleSchema = z.discriminatedUnion('operator', [
+const FilterRuleBaseSchema = z.discriminatedUnion('operator', [
   z.object({
     column: z.string().min(1),
     operator: ScalarOperatorEnum,
@@ -58,6 +58,44 @@ export const FilterRuleSchema = z.discriminatedUnion('operator', [
   }),
 ]);
 
+const ALIAS_PATH_REGEX = /^[a-z0-9_]+(\.[a-z0-9_]+)*$/;
+const AliasPathSchema = z.string().min(1).max(255).regex(ALIAS_PATH_REGEX);
+
+// Placement is optional — when absent, the rule is treated as 'post-join'.
+// Keeps backward compatibility with existing filterConfig rows that pre-date
+// this field and lets call sites construct plain rules without specifying
+// placement when post-join is the intended default.
+const PlacementExtrasSchema = z.object({
+  placement: z.enum(['pre-join', 'post-join']).optional(),
+  aliasPath: AliasPathSchema.optional(),
+});
+
+export const FilterRuleSchema = z
+  .intersection(FilterRuleBaseSchema, PlacementExtrasSchema)
+  .superRefine((rule, ctx) => {
+    if (rule.placement === 'pre-join') {
+      if (!rule.aliasPath) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['aliasPath'],
+          message: 'aliasPath is required when placement is "pre-join"',
+        });
+      } else if (rule.aliasPath === 'main') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['aliasPath'],
+          message: 'pre-join filter on the home data mart ("main") is not allowed',
+        });
+      }
+    } else if (rule.aliasPath != null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['aliasPath'],
+        message: 'aliasPath is only valid when placement is "pre-join"',
+      });
+    }
+  });
+
 export const SortRuleSchema = z.object({
   column: z.string().min(1),
   direction: z.enum(['asc', 'desc']),
@@ -66,6 +104,17 @@ export const SortRuleSchema = z.object({
 export type FilterRule = z.infer<typeof FilterRuleSchema>;
 export type SortRule = z.infer<typeof SortRuleSchema>;
 export type RelativeDatePreset = z.infer<typeof RelativeDatePresetSchema>;
+
+export interface JoinedSourceColumn {
+  name: string;
+  type: string;
+}
+
+export interface JoinedSource {
+  aliasPath: string;
+  title: string;
+  columns: readonly JoinedSourceColumn[];
+}
 
 export interface OutputConfig {
   filterConfig: FilterRule[];
@@ -83,4 +132,8 @@ export function hasAnyOutputControls(config: OutputConfig): boolean {
   return (
     config.filterConfig.length > 0 || config.sortConfig.length > 0 || config.limitConfig != null
   );
+}
+
+export function isPreJoinFilter(rule: FilterRule): rule is FilterRule & { aliasPath: string } {
+  return rule.placement === 'pre-join' && !!rule.aliasPath;
 }

--- a/packages/test-utils/src/helpers/extract-cte-body.ts
+++ b/packages/test-utils/src/helpers/extract-cte-body.ts
@@ -1,0 +1,27 @@
+/**
+ * Extracts the body of a named CTE block from a generated SQL string.
+ *
+ * Locates `<name> AS (` and returns the substring up to (and including) the
+ * matching closing `)`, accounting for nested parentheses. Throws when the
+ * marker is not present.
+ *
+ * Prefer this over fragile newline-based slicing (`indexOf('\n\n')`), which
+ * silently slides into the next CTE if the builder ever changes its
+ * inter-CTE separator.
+ */
+export function extractCteBody(sql: string, cteName: string): string {
+  const marker = `${cteName} AS (`;
+  const start = sql.indexOf(marker);
+  if (start === -1) throw new Error(`CTE "${cteName}" not found in SQL`);
+
+  let depth = 0;
+  let i = start + marker.length - 1;
+  for (; i < sql.length; i++) {
+    if (sql[i] === '(') depth++;
+    else if (sql[i] === ')') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return sql.slice(start, i + 1);
+}

--- a/packages/test-utils/src/helpers/index.ts
+++ b/packages/test-utils/src/helpers/index.ts
@@ -21,3 +21,8 @@ export {
   type SetupGoogleSheetsReportResult,
 } from './setup-google-sheets-report';
 export { setDataMartAlias } from './set-data-mart-alias';
+export { extractCteBody } from './extract-cte-body';
+export {
+  setupBlendedReportPrerequisites,
+  type BlendedReportPrerequisites,
+} from './setup-blended-report-prerequisites';

--- a/packages/test-utils/src/helpers/setup-blended-report-prerequisites.ts
+++ b/packages/test-utils/src/helpers/setup-blended-report-prerequisites.ts
@@ -1,0 +1,284 @@
+import * as supertest from 'supertest';
+import { AUTH_HEADER } from '../constants';
+import { StorageBuilder } from '../fixtures/storage.builder';
+import { DataMartBuilder } from '../fixtures/data-mart.builder';
+import { DataDestinationBuilder } from '../fixtures/data-destination.builder';
+import { ReportBuilder } from '../fixtures/report.builder';
+import { DataDestinationType } from '../../../../apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum';
+
+/**
+ * IDs returned by {@link setupBlendedReportPrerequisites}.
+ */
+export interface BlendedReportPrerequisites {
+  /** The shared BigQuery storage that all three data marts use. */
+  storageId: string;
+  /** The "home" (source) data mart — `events`. Reports are created against this DM. */
+  mainDataMartId: string;
+  /** The first joined data mart — `users`. */
+  usersDataMartId: string;
+  /** The second joined data mart — `orgs`. */
+  orgsDataMartId: string;
+  /** Relationship: events → users (JOIN ON events.user_id = users.id). */
+  usersRelationshipId: string;
+  /** Relationship: events → orgs (JOIN ON events.org_id = orgs.id). */
+  orgsRelationshipId: string;
+  /** The LOOKER_STUDIO data destination shared by the report. */
+  dataDestinationId: string;
+  /** The pre-created report pointing at the events data mart. */
+  reportId: string;
+}
+
+// ── Schema definitions ──────────────────────────────────────────────────────
+
+/**
+ * BigQuery schema for the `events` (home) data mart.
+ * Used when {@link SetupBlendedReportOptions.withSchemas} is true.
+ */
+export const EVENTS_SCHEMA = {
+  type: 'bigquery-data-mart-schema',
+  fields: [
+    { name: 'event_id', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+    { name: 'user_id', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+    { name: 'org_id', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+    { name: 'event_ts', type: 'TIMESTAMP', mode: 'NULLABLE', status: 'CONNECTED' },
+    { name: 'amount', type: 'NUMERIC', mode: 'NULLABLE', status: 'CONNECTED' },
+  ],
+};
+
+/**
+ * BigQuery schema for the `users` joined data mart.
+ * Used when {@link SetupBlendedReportOptions.withSchemas} is true.
+ */
+export const USERS_SCHEMA = {
+  type: 'bigquery-data-mart-schema',
+  fields: [
+    { name: 'id', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+    { name: 'role', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+    { name: 'created_at', type: 'TIMESTAMP', mode: 'NULLABLE', status: 'CONNECTED' },
+    { name: 'is_active', type: 'BOOLEAN', mode: 'NULLABLE', status: 'CONNECTED' },
+  ],
+};
+
+/**
+ * BigQuery schema for the `orgs` joined data mart.
+ * Used when {@link SetupBlendedReportOptions.withSchemas} is true.
+ */
+export const ORGS_SCHEMA = {
+  type: 'bigquery-data-mart-schema',
+  fields: [
+    { name: 'id', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+    { name: 'plan', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+    { name: 'employee_count', type: 'INTEGER', mode: 'NULLABLE', status: 'CONNECTED' },
+  ],
+};
+
+// ── Options ─────────────────────────────────────────────────────────────────
+
+export interface SetupBlendedReportOptions {
+  /**
+   * When true, sets real BigQuery schemas on all three data marts via
+   * `PUT /api/data-marts/:id/schema`.  This unlocks native-column validation
+   * paths (FILTER_COLUMN_UNKNOWN, SORT_COLUMN_NOT_SELECTED on native columns)
+   * and allows BlendableSchemaService to run without any mock.
+   *
+   * Default: false — preserves the original bootstrap behaviour (empty schema,
+   * fast, does not break suites that mock the schema service themselves).
+   */
+  withSchemas?: boolean;
+}
+
+// ── Helper: set schema via real API ─────────────────────────────────────────
+
+async function setSchema(
+  agent: supertest.Agent,
+  dataMartId: string,
+  schema: Record<string, unknown>
+): Promise<void> {
+  const res = await agent
+    .put(`/api/data-marts/${dataMartId}/schema`)
+    .set(AUTH_HEADER)
+    .send({ schema });
+  expect(res.status).toBe(200);
+}
+
+/**
+ * Bootstraps a fully-wired blended report through the REST API only.
+ *
+ * Setup flow:
+ *   1. Create ONE BigQuery storage.
+ *   2. Flip storage availability.
+ *   3. Create three data marts (events / users / orgs) linked to the same storage.
+ *   4. Set SQL definition (`SELECT 1`) and publish each data mart.
+ *   5. Flip availability for each data mart.
+ *   6. (Optional, `opts.withSchemas`) Set real BigQuery schemas on all three
+ *      data marts via `PUT /api/data-marts/:id/schema`.  When set, the real
+ *      BlendableSchemaService can compute native + blended fields without a mock.
+ *   7. Create two relationships on the events mart:
+ *        events → users  (targetAlias = "users",  joinCondition: user_id = id)
+ *        events → orgs   (targetAlias = "orgs",   joinCondition: org_id  = id)
+ *   8. Configure blendedFieldsConfig on the events mart so users/orgs sources
+ *      are included (minimal — no per-field overrides).
+ *   9. Create a LOOKER_STUDIO data destination and flip its availability.
+ *  10. Create a report (LOOKER_STUDIO) pointing at the events data mart.
+ *
+ * KNOWN LIMITATION — schema actualisation (without `withSchemas`):
+ *   The data marts are published with `SELECT 1`, so their output schema is
+ *   empty / un-actualised. Validator paths that call the schema-actualization
+ *   service (e.g. FILTER_COLUMN_UNKNOWN, SLICE_COLUMN_UNKNOWN) will fail unless
+ *   the test POSTs to `/api/data-marts/:id/schema-actualize-triggers` and
+ *   waits for completion, or passes `opts.withSchemas: true`.
+ *
+ * KNOWN LIMITATION — LOOKER_STUDIO report UUID determinism:
+ *   LOOKER_STUDIO destinations derive a deterministic UUID v5 from
+ *   (dataMartId, dataDestinationId), so only ONE report can exist per pair.
+ *   A test suite that calls this helper once in `beforeAll` and reuses the
+ *   returned `reportId` across `it` blocks is the intended usage pattern.
+ *
+ * @param agent  A supertest agent bound to a running test NestJS app.
+ * @param opts   Optional configuration.  Pass `{ withSchemas: true }` to seed
+ *               BigQuery schemas on all three data marts so native-column filter
+ *               and sort validation paths are exercisable without mocking
+ *               BlendableSchemaService.
+ * @returns      IDs for all created resources.
+ */
+export async function setupBlendedReportPrerequisites(
+  agent: supertest.Agent,
+  opts: SetupBlendedReportOptions = {}
+): Promise<BlendedReportPrerequisites> {
+  // ── Step 1: Create ONE shared BigQuery storage ─────────────────────────────
+  const storageRes = await agent
+    .post('/api/data-storages')
+    .set(AUTH_HEADER)
+    .send(new StorageBuilder().build());
+  expect(storageRes.status).toBe(201);
+  const storageId: string = storageRes.body.id;
+
+  // ── Step 2: Flip storage availability ─────────────────────────────────────
+  await agent
+    .put(`/api/data-storages/${storageId}/availability`)
+    .set(AUTH_HEADER)
+    .send({ availableForUse: true, availableForMaintenance: true });
+
+  // ── Helper: create + publish a data mart on the shared storage ─────────────
+  async function createPublishedDataMart(title: string): Promise<string> {
+    const dmRes = await agent
+      .post('/api/data-marts')
+      .set(AUTH_HEADER)
+      .send(new DataMartBuilder().withStorageId(storageId).withTitle(title).build());
+    expect(dmRes.status).toBe(201);
+    const dataMartId: string = dmRes.body.id;
+
+    const defRes = await agent
+      .put(`/api/data-marts/${dataMartId}/definition`)
+      .set(AUTH_HEADER)
+      .send({ definitionType: 'SQL', definition: { sqlQuery: 'SELECT 1' } });
+    expect(defRes.status).toBe(200);
+
+    const publishRes = await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER);
+    expect(publishRes.status).toBe(200);
+
+    await agent
+      .put(`/api/data-marts/${dataMartId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForReporting: true, availableForMaintenance: true });
+
+    return dataMartId;
+  }
+
+  // ── Step 3: Create the three data marts ───────────────────────────────────
+  const mainDataMartId = await createPublishedDataMart('Blended Test - events (home)');
+  const usersDataMartId = await createPublishedDataMart('Blended Test - users');
+  const orgsDataMartId = await createPublishedDataMart('Blended Test - orgs');
+
+  // ── Step 3b (opt-in): Seed real BigQuery schemas ──────────────────────────
+  //   When withSchemas is true, set typed field schemas via the real API so
+  //   BlendableSchemaService.computeBlendableSchema returns native + blended
+  //   fields without any mock.  This unlocks native-column validation paths.
+  if (opts.withSchemas) {
+    await setSchema(agent, mainDataMartId, EVENTS_SCHEMA);
+    await setSchema(agent, usersDataMartId, USERS_SCHEMA);
+    await setSchema(agent, orgsDataMartId, ORGS_SCHEMA);
+  }
+
+  // ── Step 4: Create relationships on the home data mart ────────────────────
+  //   events → users
+  const relUsersRes = await agent
+    .post(`/api/data-marts/${mainDataMartId}/relationships`)
+    .set(AUTH_HEADER)
+    .send({
+      targetDataMartId: usersDataMartId,
+      targetAlias: 'users',
+      joinConditions: [{ sourceFieldName: 'user_id', targetFieldName: 'id' }],
+    });
+  expect(relUsersRes.status).toBe(201);
+  const usersRelationshipId: string = relUsersRes.body.id;
+
+  //   events → orgs
+  const relOrgsRes = await agent
+    .post(`/api/data-marts/${mainDataMartId}/relationships`)
+    .set(AUTH_HEADER)
+    .send({
+      targetDataMartId: orgsDataMartId,
+      targetAlias: 'orgs',
+      joinConditions: [{ sourceFieldName: 'org_id', targetFieldName: 'id' }],
+    });
+  expect(relOrgsRes.status).toBe(201);
+  const orgsRelationshipId: string = relOrgsRes.body.id;
+
+  // ── Step 5: Configure blendedFieldsConfig on the home data mart ───────────
+  //   Registers both joined sources so blended columns are selectable.
+  const blendedConfigRes = await agent
+    .put(`/api/data-marts/${mainDataMartId}/blended-fields-config`)
+    .set(AUTH_HEADER)
+    .send({
+      blendedFieldsConfig: {
+        sources: [
+          { path: 'users', alias: 'Users' },
+          { path: 'orgs', alias: 'Organisations' },
+        ],
+      },
+    });
+  expect(blendedConfigRes.status).toBe(200);
+
+  // ── Step 6: Create a LOOKER_STUDIO data destination ──────────────────────
+  const destRes = await agent
+    .post('/api/data-destinations')
+    .set(AUTH_HEADER)
+    .send(
+      new DataDestinationBuilder()
+        .withType(DataDestinationType.LOOKER_STUDIO)
+        .withCredentials({ type: 'looker-studio-credentials' })
+        .build()
+    );
+  expect(destRes.status).toBe(201);
+  const dataDestinationId: string = destRes.body.id;
+
+  await agent
+    .put(`/api/data-destinations/${dataDestinationId}/availability`)
+    .set(AUTH_HEADER)
+    .send({ availableForUse: true, availableForMaintenance: true });
+
+  // ── Step 7: Create the report ─────────────────────────────────────────────
+  const reportRes = await agent
+    .post('/api/reports')
+    .set(AUTH_HEADER)
+    .send(
+      new ReportBuilder()
+        .withDataMartId(mainDataMartId)
+        .withDataDestinationId(dataDestinationId)
+        .build()
+    );
+  expect(reportRes.status).toBe(201);
+  const reportId: string = reportRes.body.id;
+
+  return {
+    storageId,
+    mainDataMartId,
+    usersDataMartId,
+    orgsDataMartId,
+    usersRelationshipId,
+    orgsRelationshipId,
+    dataDestinationId,
+    reportId,
+  };
+}


### PR DESCRIPTION
Add a new slicesConfig on Report alongside the existing filterConfig/sortConfig/limitConfig. A slice is a filter applied INSIDE the joined data mart's *_raw CTE (before the JOIN), so large subsidiary marts (e.g. users with 10y of rows joined into orders) are narrowed upstream instead of dragging every row through the join.

## Backend (apps/backend)

- New `SliceRuleSchema` / `SlicesConfigSchema` (Zod) with `aliasPathToCteName` helper. Nested `{ aliasPath, rule: FilterRule }` shape so FilterRule narrowing stays intact for consumers.
- New `slicesConfig` JSON column on `report` (migration + entity + DTOs + mapper + use-case wiring + cache invalidation).
- SQL codegen:
  - `SqlClauseRenderer.renderWhere` gains a `paramPrefix` arg so per-CTE slice WHEREs don't collide on `@p0` with the final post-join WHERE.
  - `AbstractBlendedQueryBuilder.buildRawCte` injects WHERE inside each subsidiary `*_raw` CTE; `collectSubsidiaryReferences` projects slice columns alongside join keys.
  - `BlendedReportDataService.buildRelationshipChains` pulls chains referenced ONLY by slices (chain build was previously columnConfig-only — slices would silently no-op without this).
- Capability + validation: `SLICES_REQUIRE_JOINED_DATA_MART`, `SLICE_ALIAS_PATH_UNKNOWN`, `SLICE_ALIAS_PATH_NOT_ALLOWED_ON_HOME`, `SLICE_COLUMN_UNKNOWN`, `SLICE_OPERATOR_UNSUPPORTED_FOR_TYPE`, `SLICE_INVALID_REGEX_PATTERN`, plus existing `OUTPUT_CONTROLS_NOT_SUPPORTED` for non-BigQuery storages.

## Web UI (apps/web)

- Mirror `SliceRule` / `SlicesConfig` types; form schema + round-trip.
- Extract reusable `FilterValueEditor` from `FilterEditorPopover`.
- New `SliceEditorPopover` (one-column edit) and `FilterOrSliceEditorPopover` (tabbed wrapper with parallel drafts and aliasPath injection).
- New SLICES section in `OutputSettingsDropdown` between FILTERS and SORT, with `AddSlicePicker` grouping joined columns by `aliasPath`.
- Column-row UX:
  - Single funnel icon highlights for both filters and slices (no separate Layers indicator); counter sums both; `defaultTab='slice'` when only slices are active.
  - Click on a column with EXACTLY one active rule opens the popover pre-filled in edit mode (Apply replaces instead of appending). New `handleReplaceFilterAt` / `handleReplaceSliceAt` threaded through NativeFieldRow / BlendedFieldRow / BlendedGroupItem.
- Info tooltips on FILTERS / SLICES / SORT / LIMIT section headers explaining each section's apply order.

## Trade-offs (agreed at portfolio level)

- BigQuery only for v1. Other storages light up automatically once they grow a `SqlClauseRenderer` subclass (same capability gate as today).
- Slices operate on subsidiary dimension columns only — home-mart aggregations are NOT rewritten to account for slice semantics. Slices on the home mart (aliasPath='main') are rejected explicitly.
- `relative_date` relative to another field is out for v1 (operator variant + renderer impl when product needs it).

## Tests (~320 new tests, all green)

Backend:
- Zod schema + helper unit tests.
- BigQueryBlendedQueryBuilder: full-flow combo (filters + slices + sort + limit), edge cases (SQL safety, tree shapes), slice operator matrix (all 20+ FilterRule operators inside raw CTE WHERE), paramPrefix matrix (multi-slice numbering, between/relative_date/no-value param counts, cross-CTE uniqueness), determinism (same context → byte-identical SQL, dedup, undefined === empty, stable column order), simple-BQ edges.
- Validator service: validateSlices matrix.
- Composer service: SLICES_REQUIRE_JOINED_DATA_MART + capability gate.
- E2E `output-controls.e2e-spec.ts`: persistence + validation matrix.
- New E2E `blended-output-controls.e2e-spec.ts` (47 tests) via real REST → composer → /generated-sql pipeline. Uses real `PUT /api/data-marts/:id/schema` to seed schemas (no `BlendableSchemaService` mock).

Web:
- vitest+RTL: RowFilterIcon (edit-on-single + tab routing), FilterOr- SliceEditorPopover (parallel tab drafts + aliasPath injection), OutputSettingsDropdown SLICES section (round-trip + collision-safe `\0` separator), useGoogleSheetsReportForm round-trip, FilterValueEditor onChange semantics, SliceRow + SliceEditorPopover render/edit, SectionHeader info tooltips.