### PR TITLE
feat(data-marts): enforce per-user access across blended data marts

### DIFF
--- a/.changeset/access-aware-data-mart-blending.md
+++ b/.changeset/access-aware-data-mart-blending.md
@@ -1,0 +1,12 @@
+---
+'owox': minor
+---
+
+# Access-aware Data Mart blending — column picker and relationship graph now respect per-user permissions
+
+Reports and the relationship graph now enforce per-user `USE`/`SEE` access across the full join chain, so users can only build reports from Data Marts they are actually permitted to reach.
+
+- **Relationship graph**: Data Marts the current user cannot access are marked with a warning icon and the entire downstream chain is shown as blocked. Clicking an inaccessible node does nothing.
+- **Column picker**: If a saved report contains columns from Data Marts the user has since lost access to, those columns appear in a separate **Inaccessible columns** section (expanded by default) so they can be removed before running the report.
+- **Blocked runs**: Running a report with inaccessible columns now returns a clear error — this applies to manual runs, scheduled runs, and Looker Studio connector requests. If your report suddenly fails, check whether your access to a joined Data Mart has changed and remove the affected columns.
+- **UI capability flags**: The **View SQL** and **Copy as Data Mart** buttons are now hidden for users without Maintenance access on the source Data Mart.

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
 import { Report } from '../../../entities/report.entity';
 import { GetDataRequest } from '../schemas/get-data.schema';
+import { GetSchemaRequest } from '../schemas/get-schema.schema';
 
 // Mock external modules before importing service
 jest.mock('@owox/internal-helpers', () => ({
@@ -23,6 +24,8 @@ import { LookerStudioReportRunService } from '../../../services/looker-studio-re
 import { ProjectBalanceService } from '../../../services/project-balance.service';
 import { ReportDataCacheService } from '../../../services/report-data-cache.service';
 import { ReportService } from '../../../services/report.service';
+import { BusinessViolationException } from '../../../../common/exceptions/business-violation.exception';
+import { ReportRunAccessValidatorService } from '../../../services/report-run-access-validator.service';
 import { LookerStudioConnectorApiConfigService } from './looker-studio-connector-api-config.service';
 import { LookerStudioConnectorApiDataService } from './looker-studio-connector-api-data.service';
 import { LookerStudioConnectorApiSchemaService } from './looker-studio-connector-api-schema.service';
@@ -39,6 +42,7 @@ describe('LookerStudioConnectorApiService', () => {
   let eventDispatcher: jest.Mocked<{ publishExternal: jest.Mock }>;
   let blendedReportDataService: jest.Mocked<BlendedReportDataService>;
   let systemTimeService: jest.Mocked<SystemTimeService>;
+  let reportRunAccessValidatorService: jest.Mocked<ReportRunAccessValidatorService>;
 
   const originalEnv = process.env;
 
@@ -86,6 +90,10 @@ describe('LookerStudioConnectorApiService', () => {
       now: jest.fn().mockReturnValue(new Date('2026-04-17T00:00:00.000Z').toISOString()),
     } as unknown as jest.Mocked<SystemTimeService>;
 
+    reportRunAccessValidatorService = {
+      validate: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<ReportRunAccessValidatorService>;
+
     service = new LookerStudioConnectorApiService(
       {} as LookerStudioConnectorApiConfigService,
       {} as LookerStudioConnectorApiSchemaService,
@@ -97,7 +105,8 @@ describe('LookerStudioConnectorApiService', () => {
       reportRunService,
       projectBalanceService,
       blendedReportDataService,
-      systemTimeService
+      systemTimeService,
+      reportRunAccessValidatorService
     );
 
     (service as any).logger = {
@@ -141,6 +150,58 @@ describe('LookerStudioConnectorApiService', () => {
     headersSent: false,
   });
 
+  const createMockSchemaRequest = (): GetSchemaRequest =>
+    ({
+      connectionConfig: {
+        deploymentUrl: 'https://example.com',
+        destinationId: 'dest-1',
+        destinationSecretKey: 'secret',
+      },
+      request: {
+        configParams: { destinationId: 'dest-1', reportId: 'report-1' },
+      },
+    }) as GetSchemaRequest;
+
+  describe('getSchema', () => {
+    beforeEach(() => {
+      const mockReport = createMockReport();
+      reportService.getByIdAndLookerStudioSecret.mockResolvedValue(mockReport);
+    });
+
+    it('validates BEFORE creating cached reader', async () => {
+      reportRunAccessValidatorService.validate.mockRejectedValue(
+        new BusinessViolationException(
+          'Looker Studio request blocked: report creator is no longer a member of this project.'
+        )
+      );
+
+      await expect(service.getSchema(createMockSchemaRequest())).rejects.toThrow(
+        BusinessViolationException
+      );
+      expect(cacheService.getOrCreateCachedReader).not.toHaveBeenCalled();
+    });
+
+    it('validates and then creates cached reader on success', async () => {
+      const mockCachedReader = {
+        fromCache: true,
+        reader: {},
+        dataDescription: { dataHeaders: [] },
+      };
+      cacheService.getOrCreateCachedReader.mockResolvedValue(mockCachedReader as any);
+      (service as any).schemaService = { getSchema: jest.fn().mockResolvedValue({ schema: [] }) };
+
+      await service.getSchema(createMockSchemaRequest());
+
+      expect(reportRunAccessValidatorService.validate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'report-1' }),
+        'user-1',
+        'project-1',
+        'Looker Studio request'
+      );
+      expect(cacheService.getOrCreateCachedReader).toHaveBeenCalled();
+    });
+  });
+
   describe('getDataStreaming', () => {
     beforeEach(() => {
       const mockReport = createMockReport();
@@ -175,6 +236,85 @@ describe('LookerStudioConnectorApiService', () => {
 
         expect(res.json).toHaveBeenCalledWith(mockResult);
         expect(dataService.streamData).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('access validation', () => {
+      it('validates sample extraction the same as full extraction', async () => {
+        const request = createMockRequest(true);
+        const res = createMockResponse();
+
+        dataService.getData.mockResolvedValue({
+          response: { schema: [], rows: [], filtersApplied: [] },
+          meta: { limitExceeded: false, rowsSent: 0, bytesSent: undefined, limitReason: undefined },
+        } as any);
+
+        await service.getDataStreaming(request, res as Response);
+
+        expect(reportRunAccessValidatorService.validate).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'report-1' }),
+          'user-1',
+          'project-1',
+          'Looker Studio request'
+        );
+      });
+
+      it('validates using report creator id and project id for full extraction', async () => {
+        const request = createMockRequest(false);
+        const res = createMockResponse();
+        const mockReportRun = {
+          markAsSuccess: jest.fn(),
+          markAsUnsuccessful: jest.fn(),
+          getReport: jest.fn().mockReturnValue(createMockReport()),
+          getReportId: jest.fn().mockReturnValue('report-1'),
+        };
+
+        reportRunService.create.mockResolvedValue(mockReportRun as any);
+        dataService.getData.mockResolvedValue({
+          response: { schema: [], rows: [], filtersApplied: [] },
+          meta: { limitExceeded: false, rowsSent: 0, bytesSent: undefined, limitReason: undefined },
+        } as any);
+
+        await service.getDataStreaming(request, res as Response);
+
+        expect(reportRunAccessValidatorService.validate).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'report-1' }),
+          'user-1',
+          'project-1',
+          'Looker Studio request'
+        );
+      });
+
+      it('throws and does not create run when creator is offboarded', async () => {
+        const request = createMockRequest(false);
+        const res = createMockResponse();
+
+        reportRunAccessValidatorService.validate.mockRejectedValue(
+          new BusinessViolationException(
+            'Looker Studio request blocked: report creator is no longer a member of this project. Recreate the report with an active owner.'
+          )
+        );
+
+        await expect(service.getDataStreaming(request, res as Response)).rejects.toThrow(
+          BusinessViolationException
+        );
+        expect(reportRunService.create).not.toHaveBeenCalled();
+      });
+
+      it('throws and does not create run when creator has orphan columns', async () => {
+        const request = createMockRequest(false);
+        const res = createMockResponse();
+
+        reportRunAccessValidatorService.validate.mockRejectedValue(
+          new BusinessViolationException(
+            'Looker Studio request blocked: column(s) dm2__col reference DataMarts no longer accessible to the report creator.'
+          )
+        );
+
+        await expect(service.getDataStreaming(request, res as Response)).rejects.toThrow(
+          BusinessViolationException
+        );
+        expect(reportRunService.create).not.toHaveBeenCalled();
       });
     });
 
@@ -497,6 +637,73 @@ describe('LookerStudioConnectorApiService', () => {
         expect.anything(),
         expect.objectContaining({ logs: [], errors: [] })
       );
+    });
+  });
+
+  describe('getData access validation', () => {
+    beforeEach(() => {
+      const mockReport = createMockReport();
+      const mockCachedReader = {
+        fromCache: true,
+        reader: {},
+        dataDescription: { dataHeaders: [] },
+      };
+
+      reportService.getByIdAndLookerStudioSecret.mockResolvedValue(mockReport);
+      cacheService.getOrCreateCachedReader.mockResolvedValue(mockCachedReader as any);
+    });
+
+    it('validates sample extraction the same as full extraction', async () => {
+      dataService.getData.mockResolvedValue({
+        response: { schema: [], rows: [], filtersApplied: [] },
+        meta: { limitExceeded: false, rowsSent: 0, bytesSent: undefined, limitReason: undefined },
+      } as any);
+
+      await service.getData(createMockRequest(true));
+
+      expect(reportRunAccessValidatorService.validate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'report-1' }),
+        'user-1',
+        'project-1',
+        'Looker Studio request'
+      );
+    });
+
+    it('validates using report creator id and project id for full extraction', async () => {
+      const mockReportRun = {
+        markAsSuccess: jest.fn(),
+        markAsUnsuccessful: jest.fn(),
+        getReport: jest.fn().mockReturnValue(createMockReport()),
+        getReportId: jest.fn().mockReturnValue('report-1'),
+      };
+
+      reportRunService.create.mockResolvedValue(mockReportRun as any);
+      dataService.getData.mockResolvedValue({
+        response: { schema: [], rows: [], filtersApplied: [] },
+        meta: { limitExceeded: false, rowsSent: 0, bytesSent: undefined, limitReason: undefined },
+      } as any);
+
+      await service.getData(createMockRequest(false));
+
+      expect(reportRunAccessValidatorService.validate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'report-1' }),
+        'user-1',
+        'project-1',
+        'Looker Studio request'
+      );
+    });
+
+    it('throws and does not create run when creator is offboarded', async () => {
+      reportRunAccessValidatorService.validate.mockRejectedValue(
+        new BusinessViolationException(
+          'Looker Studio request blocked: report creator is no longer a member of this project. Recreate the report with an active owner.'
+        )
+      );
+
+      await expect(service.getData(createMockRequest(false))).rejects.toThrow(
+        BusinessViolationException
+      );
+      expect(reportRunService.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
@@ -27,6 +27,7 @@ import { GetSchemaRequest, GetSchemaResponse } from '../schemas/get-schema.schem
 import { LookerStudioConnectorApiConfigService } from './looker-studio-connector-api-config.service';
 import { LookerStudioConnectorApiDataService } from './looker-studio-connector-api-data.service';
 import { LookerStudioConnectorApiSchemaService } from './looker-studio-connector-api-schema.service';
+import { ReportRunAccessValidatorService } from '../../../services/report-run-access-validator.service';
 
 interface ValidatedRequestData {
   connectionConfig: { destinationSecretKey: string };
@@ -78,7 +79,8 @@ export class LookerStudioConnectorApiService {
     private readonly lookerStudioReportRunService: LookerStudioReportRunService,
     private readonly projectBalanceService: ProjectBalanceService,
     private readonly blendedReportDataService: BlendedReportDataService,
-    private readonly systemTimeService: SystemTimeService
+    private readonly systemTimeService: SystemTimeService,
+    private readonly reportRunAccessValidatorService: ReportRunAccessValidatorService
   ) {}
 
   /**
@@ -92,18 +94,17 @@ export class LookerStudioConnectorApiService {
     return this.configService.getConfig(request);
   }
 
-  /**
-   * Handles getSchema request from Looker Studio.
-   * Returns available fields (dimensions and metrics) for the report.
-   *
-   * @param request - Looker Studio getSchema request with authentication
-   * @returns Schema response with field definitions
-   */
   public async getSchema(request: GetSchemaRequest): Promise<GetSchemaResponse> {
-    // Get report and cached reader centrally
-    const { report, cachedReader } = await this.getReportAndCachedReader(request);
+    const report = await this.loadReport(request);
 
-    // Pass cached data to schema service
+    await this.reportRunAccessValidatorService.validate(
+      report,
+      report.createdById,
+      report.dataMart.projectId,
+      'Looker Studio request'
+    );
+
+    const cachedReader = await this.cacheService.getOrCreateCachedReader(report);
     return this.schemaService.getSchema(request, report, cachedReader);
   }
 
@@ -124,13 +125,22 @@ export class LookerStudioConnectorApiService {
    * @returns Data response with rows and schema
    */
   public async getData(request: GetDataRequest): Promise<GetDataResponse> {
-    // Get report and cached reader centrally
-    const { report, cachedReader } = await this.getReportAndCachedReader(request);
-    const isSampleExtraction = Boolean(request.request.scriptParams?.sampleExtraction);
+    const report = await this.loadReport(request);
 
-    return isSampleExtraction
-      ? await this.getSampleDataExtraction(request, report, cachedReader)
-      : await this.getFullDataExtraction(request, report, cachedReader);
+    await this.reportRunAccessValidatorService.validate(
+      report,
+      report.createdById,
+      report.dataMart.projectId,
+      'Looker Studio request'
+    );
+
+    const cachedReader = await this.cacheService.getOrCreateCachedReader(report);
+
+    const isSampleExtraction = Boolean(request.request.scriptParams?.sampleExtraction);
+    if (isSampleExtraction) {
+      return await this.getSampleDataExtraction(request, report, cachedReader);
+    }
+    return await this.getFullDataExtraction(request, report, cachedReader);
   }
 
   /**
@@ -154,22 +164,28 @@ export class LookerStudioConnectorApiService {
    * @param res - Express response object for streaming
    */
   public async getDataStreaming(request: GetDataRequest, res: Response): Promise<void> {
-    const { report, cachedReader } = await this.getReportAndCachedReader(request);
-    const isSampleExtraction = Boolean(request.request.scriptParams?.sampleExtraction);
+    const report = await this.loadReport(request);
 
-    // Sample extraction always uses non-streaming (only 100 rows)
+    await this.reportRunAccessValidatorService.validate(
+      report,
+      report.createdById,
+      report.dataMart.projectId,
+      'Looker Studio request'
+    );
+
+    const cachedReader = await this.cacheService.getOrCreateCachedReader(report);
+
+    const isSampleExtraction = Boolean(request.request.scriptParams?.sampleExtraction);
     if (isSampleExtraction) {
       const result = await this.getSampleDataExtraction(request, report, cachedReader);
       res.json(result);
       return;
     }
 
-    // Check feature flag for full extraction
     if (this.isStreamingEnabled()) {
       this.logger.log('Using streaming mode for getData (LOOKER_STREAMING_ENABLED=true)');
       await this.getFullDataExtractionStreaming(request, report, cachedReader, res);
     } else {
-      // Non-streaming mode (default)
       const result = await this.getFullDataExtraction(request, report, cachedReader);
       res.json(result);
     }
@@ -230,26 +246,9 @@ export class LookerStudioConnectorApiService {
     }
   }
 
-  /**
-   * Retrieves and validates report with cached data reader.
-   *
-   * Steps:
-   * 1. Validates request structure and authentication secret
-   * 2. Fetches report by ID and secret key
-   * 3. Gets or creates cached reader for the report
-   *
-   * @param request - getSchema or getData request with authentication
-   * @returns Report entity and cached reader data
-   * @throws BusinessViolationException if validation fails or report not found
-   */
-  private async getReportAndCachedReader(request: GetSchemaRequest | GetDataRequest): Promise<{
-    report: Report;
-    cachedReader: CachedReaderData;
-  }> {
-    // Validate and extract request data
+  private async loadReport(request: GetSchemaRequest | GetDataRequest): Promise<Report> {
     const { connectionConfig, requestConfig } = this.validateAndExtractRequestData(request);
 
-    // Get report by ID and secret
     const report = await this.reportService.getByIdAndLookerStudioSecret(
       requestConfig.reportId,
       connectionConfig.destinationSecretKey
@@ -259,10 +258,7 @@ export class LookerStudioConnectorApiService {
       throw new BusinessViolationException('No report found for the provided secret and reportId');
     }
 
-    // Get cached reader
-    const cachedReader = await this.cacheService.getOrCreateCachedReader(report);
-
-    return { report, cachedReader };
+    return report;
   }
 
   /**

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -352,6 +352,7 @@ import { ListMembershipRequestsService } from './use-cases/project-members/list-
 import { ApproveMembershipRequestService } from './use-cases/project-members/approve-membership-request.service';
 import { DeclineMembershipRequestService } from './use-cases/project-members/decline-membership-request.service';
 import { SetContextMembersService } from './use-cases/contexts/set-context-members.service';
+import { ReportRunAccessValidatorService } from './services/report-run-access-validator.service';
 
 @Module({
   imports: [
@@ -713,6 +714,7 @@ import { SetContextMembersService } from './use-cases/contexts/set-context-membe
     ApproveMembershipRequestService,
     DeclineMembershipRequestService,
     SetContextMembersService,
+    ReportRunAccessValidatorService,
   ],
 })
 export class DataMartsModule {

--- a/apps/backend/src/data-marts/dto/domain/relationship.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/relationship.dto.ts
@@ -2,11 +2,18 @@ import { JoinCondition } from '../schemas/join-condition.schema';
 import { DataMartStatus } from '../../enums/data-mart-status.enum';
 import { UserProjectionDto } from '../../../idp/dto/domain/user-projection.dto';
 
+export interface RelationshipDataMartAccess {
+  canSee: boolean;
+  canUse: boolean;
+  canEdit: boolean;
+}
+
 export interface RelationshipDataMartRef {
   id: string;
   title: string;
   description?: string;
   status: DataMartStatus;
+  access?: RelationshipDataMartAccess;
 }
 
 export interface RelationshipDto {

--- a/apps/backend/src/data-marts/dto/domain/report.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/report.dto.ts
@@ -28,6 +28,8 @@ export class ReportDto {
     public readonly limitConfig?: number | null,
     public readonly canRun: boolean = false,
     public readonly canManageTriggers: boolean = false,
-    public readonly canEditConfig: boolean = false
+    public readonly canEditConfig: boolean = false,
+    public readonly canViewSql: boolean = false,
+    public readonly canCopyAsDataMart: boolean = false
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/run-report.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/run-report.command.ts
@@ -13,6 +13,7 @@ export interface ManualRunReportCommand extends BaseRunReportCommand {
 
 export interface ScheduledRunReportCommand extends BaseRunReportCommand {
   runType: RunType.scheduled;
+  projectId: string;
 }
 
 export type RunReportCommand = ManualRunReportCommand | ScheduledRunReportCommand;

--- a/apps/backend/src/data-marts/dto/presentation/relationship-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/relationship-response-api.dto.ts
@@ -3,6 +3,17 @@ import { JoinCondition } from '../schemas/join-condition.schema';
 import { DataMartStatus } from '../../enums/data-mart-status.enum';
 import { UserProjectionDto } from '../../../idp/dto/domain/user-projection.dto';
 
+export class DataMartRefAccessApiDto {
+  @ApiProperty({ example: true })
+  canSee: boolean;
+
+  @ApiProperty({ example: true })
+  canUse: boolean;
+
+  @ApiProperty({ example: false })
+  canEdit: boolean;
+}
+
 export class DataMartRefApiDto {
   @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
   id: string;
@@ -15,6 +26,9 @@ export class DataMartRefApiDto {
 
   @ApiProperty({ enum: DataMartStatus, example: DataMartStatus.PUBLISHED })
   status: DataMartStatus;
+
+  @ApiProperty({ type: DataMartRefAccessApiDto, required: false })
+  access?: DataMartRefAccessApiDto;
 }
 
 export class RelationshipResponseApiDto {

--- a/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
@@ -76,4 +76,16 @@ export class ReportResponseApiDto {
       'Whether the caller can edit the report configuration (columns, filters, owners, destination)',
   })
   canEditConfig: boolean;
+
+  @ApiProperty({
+    example: true,
+    description: 'Whether the caller can view the generated SQL for this report',
+  })
+  canViewSql: boolean;
+
+  @ApiProperty({
+    example: false,
+    description: 'Whether the caller can copy this report as a new DataMart',
+  })
+  canCopyAsDataMart: boolean;
 }

--- a/apps/backend/src/data-marts/mappers/relationship.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/relationship.mapper.ts
@@ -7,7 +7,7 @@ import { GetRelationshipCommand } from '../dto/domain/get-relationship.command';
 import { DeleteRelationshipCommand } from '../dto/domain/delete-relationship.command';
 import { ListRelationshipsCommand } from '../dto/domain/list-relationships.command';
 import { ListRelationshipsByStorageCommand } from '../dto/domain/list-relationships-by-storage.command';
-import { RelationshipDto } from '../dto/domain/relationship.dto';
+import { RelationshipDataMartAccess, RelationshipDto } from '../dto/domain/relationship.dto';
 import {
   CreateRelationshipRequestApiDto,
   JoinConditionApiDto,
@@ -104,7 +104,8 @@ export class RelationshipMapper {
 
   toDomainDto(
     entity: DataMartRelationship,
-    createdByUser: UserProjectionDto | null = null
+    createdByUser: UserProjectionDto | null = null,
+    accessByDmId?: Map<string, RelationshipDataMartAccess>
   ): RelationshipDto {
     return {
       id: entity.id,
@@ -114,12 +115,14 @@ export class RelationshipMapper {
         title: entity.sourceDataMart.title,
         description: entity.sourceDataMart.description,
         status: entity.sourceDataMart.status,
+        access: accessByDmId?.get(entity.sourceDataMart.id),
       },
       targetDataMart: {
         id: entity.targetDataMart.id,
         title: entity.targetDataMart.title,
         description: entity.targetDataMart.description,
         status: entity.targetDataMart.status,
+        access: accessByDmId?.get(entity.targetDataMart.id),
       },
       targetAlias: entity.targetAlias,
       joinConditions: entity.joinConditions,
@@ -132,12 +135,14 @@ export class RelationshipMapper {
 
   toDomainDtoList(
     entities: DataMartRelationship[],
-    userProjectionsList?: UserProjectionsListDto
+    userProjectionsList?: UserProjectionsListDto,
+    accessByDmId?: Map<string, RelationshipDataMartAccess>
   ): RelationshipDto[] {
     return entities.map(entity =>
       this.toDomainDto(
         entity,
-        entity.createdById ? (userProjectionsList?.getByUserId(entity.createdById) ?? null) : null
+        entity.createdById ? (userProjectionsList?.getByUserId(entity.createdById) ?? null) : null,
+        accessByDmId
       )
     );
   }

--- a/apps/backend/src/data-marts/mappers/report.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.ts
@@ -15,6 +15,7 @@ import { ManualRunReportCommand } from '../dto/domain/run-report.command';
 import { CopyReportAsDataMartCommand } from '../dto/domain/copy-report-as-data-mart.command';
 import { GetReportGeneratedSqlCommand } from '../dto/domain/get-report-generated-sql.command';
 import { AuthorizationContext } from '../../idp';
+import { EMPTY_CAPABILITIES } from '../services/report-access.service';
 import { DataMartMapper } from './data-mart.mapper';
 import { DataDestinationMapper } from './data-destination.mapper';
 import { RunType } from '../../common/scheduler/shared/types';
@@ -52,11 +53,13 @@ export class ReportMapper {
     entity: Report,
     createdByUser: UserProjectionDto | null = null,
     ownerUsers: UserProjectionDto[] = [],
-    capabilities: { canRun: boolean; canManageTriggers: boolean; canEditConfig: boolean } = {
-      canRun: false,
-      canManageTriggers: false,
-      canEditConfig: false,
-    }
+    capabilities: {
+      canRun: boolean;
+      canManageTriggers: boolean;
+      canEditConfig: boolean;
+      canViewSql: boolean;
+      canCopyAsDataMart: boolean;
+    } = EMPTY_CAPABILITIES
   ): ReportDto {
     return new ReportDto(
       entity.id,
@@ -78,7 +81,9 @@ export class ReportMapper {
       entity.limitConfig ?? null,
       capabilities.canRun,
       capabilities.canManageTriggers,
-      capabilities.canEditConfig
+      capabilities.canEditConfig,
+      capabilities.canViewSql,
+      capabilities.canCopyAsDataMart
     );
   }
 
@@ -106,6 +111,8 @@ export class ReportMapper {
       canRun: dto.canRun,
       canManageTriggers: dto.canManageTriggers,
       canEditConfig: dto.canEditConfig,
+      canViewSql: dto.canViewSql,
+      canCopyAsDataMart: dto.canCopyAsDataMart,
     };
   }
 

--- a/apps/backend/src/data-marts/scheduled-trigger-types/scheduled-report-run/services/scheduled-report-run-processor.ts
+++ b/apps/backend/src/data-marts/scheduled-trigger-types/scheduled-report-run/services/scheduled-report-run-processor.ts
@@ -29,6 +29,7 @@ export class ScheduledReportRunProcessor implements ScheduledTriggerProcessor {
       reportId: trigger.triggerConfig.reportId,
       userId: trigger.createdById,
       runType: RunType.scheduled,
+      projectId: trigger.dataMart.projectId,
     };
 
     await this.runReportService.run(runReportCommand, signal);

--- a/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
@@ -827,4 +827,475 @@ describe('BlendableSchemaService', () => {
       expect(result.blendedFields[3].name).toBe('orders_v2__country');
     });
   });
+
+  describe('computeBlendableSchema — access filter', () => {
+    it('filters out target DM and its fields when accessFilter returns false', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+
+      const relAtoB = makeRelationship({
+        id: 'rel-ab',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-b',
+          schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+        }),
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([relAtoB]);
+
+      const accessFilter = jest.fn().mockResolvedValue(false);
+      const result = await service.computeBlendableSchema('dm-a', 'project-1', accessFilter);
+
+      expect(result.availableSources).toEqual([]);
+      expect(result.blendedFields).toEqual([]);
+      expect(accessFilter).toHaveBeenCalledWith('dm-b');
+    });
+
+    it('cuts entire branch when intermediate DM is inaccessible (A→B→C, B blocked)', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+
+      const relAtoB = makeRelationship({
+        id: 'rel-ab',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-b',
+          schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+        }),
+      });
+
+      const relBtoC = makeRelationship({
+        id: 'rel-bc',
+        targetAlias: 'c',
+        sourceDataMart: makeDataMart({ id: 'dm-b' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-c',
+          schema: makeSchema([{ name: 'c_field', type: 'INTEGER' }]),
+        }),
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([relAtoB, relBtoC]);
+
+      const accessFilter = jest.fn().mockImplementation(async (dmId: string) => dmId !== 'dm-b');
+      const result = await service.computeBlendableSchema('dm-a', 'project-1', accessFilter);
+
+      expect(result.availableSources).toEqual([]);
+      expect(result.blendedFields).toEqual([]);
+    });
+
+    it('does not call accessFilter when not provided (backward-compatible)', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+
+      const relAtoB = makeRelationship({
+        id: 'rel-ab',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-b',
+          schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+        }),
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([relAtoB]);
+
+      const result = await service.computeBlendableSchema('dm-a', 'project-1');
+
+      expect(result.availableSources).toHaveLength(1);
+      expect(result.blendedFields).toHaveLength(1);
+    });
+
+    it('accessible parallel branch still visible when sibling branch is blocked', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+
+      const relAtoB = makeRelationship({
+        id: 'rel-ab',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-b',
+          schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+        }),
+      });
+
+      const relAtoC = makeRelationship({
+        id: 'rel-ac',
+        targetAlias: 'c',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-c',
+          schema: makeSchema([{ name: 'c_field', type: 'INTEGER' }]),
+        }),
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([relAtoB, relAtoC]);
+
+      const accessFilter = jest.fn().mockImplementation(async (dmId: string) => dmId === 'dm-c');
+      const result = await service.computeBlendableSchema('dm-a', 'project-1', accessFilter);
+
+      expect(result.availableSources).toHaveLength(1);
+      expect(result.availableSources[0].aliasPath).toBe('c');
+      expect(result.blendedFields).toHaveLength(1);
+      expect(result.blendedFields[0].name).toBe('c__c_field');
+    });
+  });
+
+  describe('findInaccessibleColumnRefs', () => {
+    it('returns empty array when columnConfig is empty', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+      relationshipService.findByStorageId.mockResolvedValue([]);
+
+      const accessFilter = jest.fn().mockResolvedValue(true);
+      const result = await service.findInaccessibleColumnRefs(
+        [],
+        'dm-a',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual([]);
+      expect(accessFilter).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array when all column refs are native fields', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({
+          id: 'dm-a',
+          schema: makeSchema([{ name: 'native_col', type: 'STRING' }]),
+        })
+      );
+      relationshipService.findByStorageId.mockResolvedValue([]);
+
+      const accessFilter = jest.fn().mockResolvedValue(true);
+      const result = await service.findInaccessibleColumnRefs(
+        ['native_col'],
+        'dm-a',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns orphan when column references physically missing blended field', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+      relationshipService.findByStorageId.mockResolvedValue([]);
+
+      const accessFilter = jest.fn().mockResolvedValue(true);
+      const result = await service.findInaccessibleColumnRefs(
+        ['b__deleted_field'],
+        'dm-a',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual(['b__deleted_field']);
+    });
+
+    it('returns orphan when source DM has no USE access', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+
+      const relAtoB = makeRelationship({
+        id: 'rel-ab',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-b',
+          schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+        }),
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([relAtoB]);
+
+      const accessFilter = jest.fn().mockResolvedValue(false);
+      const result = await service.findInaccessibleColumnRefs(
+        ['b__b_field'],
+        'dm-a',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual(['b__b_field']);
+    });
+
+    it('returns empty when all blended columns have accessible source DMs', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-a' }));
+
+      const relAtoB = makeRelationship({
+        id: 'rel-ab',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-b',
+          schema: makeSchema([{ name: 'b_field', type: 'STRING' }]),
+        }),
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([relAtoB]);
+
+      const accessFilter = jest.fn().mockResolvedValue(true);
+      const result = await service.findInaccessibleColumnRefs(
+        ['b__b_field'],
+        'dm-a',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns sorted orphan list with mixed native, accessible blended, and inaccessible', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({
+          id: 'dm-a',
+          schema: makeSchema([{ name: 'native_col', type: 'STRING' }]),
+        })
+      );
+
+      const relAtoB = makeRelationship({
+        id: 'rel-ab',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-b',
+          schema: makeSchema([{ name: 'ok_field', type: 'STRING' }]),
+        }),
+      });
+
+      const relAtoC = makeRelationship({
+        id: 'rel-ac',
+        targetAlias: 'c',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-c',
+          schema: makeSchema([{ name: 'blocked_field', type: 'STRING' }]),
+        }),
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([relAtoB, relAtoC]);
+
+      const accessFilter = jest.fn().mockImplementation(async (dmId: string) => dmId === 'dm-b');
+      const result = await service.findInaccessibleColumnRefs(
+        ['native_col', 'b__ok_field', 'c__blocked_field', 'missing__orphan'],
+        'dm-a',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual(['c__blocked_field', 'missing__orphan']);
+    });
+
+    it('diamond graph: C reachable via accessible A is NOT orphan even if B (other path to C) is blocked', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-root' }));
+
+      const dmC = makeDataMart({
+        id: 'dm-c',
+        schema: makeSchema([{ name: 'c_field', type: 'STRING' }]),
+      });
+
+      const relRootToA = makeRelationship({
+        id: 'rel-root-a',
+        targetAlias: 'a',
+        sourceDataMart: makeDataMart({ id: 'dm-root' }),
+        targetDataMart: makeDataMart({ id: 'dm-a', schema: makeSchema([]) }),
+      });
+
+      const relRootToB = makeRelationship({
+        id: 'rel-root-b',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-root' }),
+        targetDataMart: makeDataMart({ id: 'dm-b', schema: makeSchema([]) }),
+      });
+
+      const relAtoC = makeRelationship({
+        id: 'rel-a-c',
+        targetAlias: 'c',
+        sourceDataMart: makeDataMart({ id: 'dm-a' }),
+        targetDataMart: dmC,
+      });
+
+      const relBtoC = makeRelationship({
+        id: 'rel-b-c',
+        targetAlias: 'c',
+        sourceDataMart: makeDataMart({ id: 'dm-b' }),
+        targetDataMart: dmC,
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([
+        relRootToA,
+        relRootToB,
+        relAtoC,
+        relBtoC,
+      ]);
+
+      const accessFilter = jest.fn().mockImplementation(async (dmId: string) => dmId !== 'dm-b');
+      const result = await service.findInaccessibleColumnRefs(
+        ['a_c__c_field'],
+        'dm-root',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('transitive path: b_c__field is orphan when intermediate B is inaccessible even if C is accessible', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-root' }));
+
+      const relRootToB = makeRelationship({
+        id: 'rel-root-b',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-root' }),
+        targetDataMart: makeDataMart({ id: 'dm-b', schema: makeSchema([]) }),
+      });
+
+      const relBtoC = makeRelationship({
+        id: 'rel-b-c',
+        targetAlias: 'c',
+        sourceDataMart: makeDataMart({ id: 'dm-b' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-c',
+          schema: makeSchema([{ name: 'c_field', type: 'STRING' }]),
+        }),
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([relRootToB, relBtoC]);
+
+      const accessFilter = jest.fn().mockImplementation(async (dmId: string) => dmId === 'dm-c');
+      const result = await service.findInaccessibleColumnRefs(
+        ['b_c__c_field'],
+        'dm-root',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual(['b_c__c_field']);
+    });
+
+    it('native nested struct field profile.city is not flagged as orphan', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({
+          id: 'dm-a',
+          schema: {
+            type: 'bigquery-data-mart-schema',
+            fields: [
+              {
+                name: 'profile',
+                type: 'RECORD',
+                fields: [{ name: 'city', type: 'STRING' }],
+              },
+            ],
+          } as unknown as DataMart['schema'],
+        })
+      );
+      relationshipService.findByStorageId.mockResolvedValue([]);
+
+      const accessFilter = jest.fn().mockResolvedValue(true);
+      const result = await service.findInaccessibleColumnRefs(
+        ['profile.city'],
+        'dm-a',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findInaccessibleReportRefs', () => {
+    it('groups orphans by config source (columns / filters / sorts)', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-root' }));
+
+      const relRootToX = makeRelationship({
+        id: 'rel-x',
+        targetAlias: 'x',
+        sourceDataMart: makeDataMart({ id: 'dm-root' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-x',
+          schema: makeSchema([{ name: 'a', type: 'STRING' }]),
+        }),
+      });
+      const relRootToY = makeRelationship({
+        id: 'rel-y',
+        targetAlias: 'y',
+        sourceDataMart: makeDataMart({ id: 'dm-root' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-y',
+          schema: makeSchema([{ name: 'b', type: 'STRING' }]),
+        }),
+      });
+      const relRootToZ = makeRelationship({
+        id: 'rel-z',
+        targetAlias: 'z',
+        sourceDataMart: makeDataMart({ id: 'dm-root' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-z',
+          schema: makeSchema([{ name: 'c', type: 'STRING' }]),
+        }),
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([relRootToX, relRootToY, relRootToZ]);
+
+      const accessFilter = jest.fn().mockImplementation(async (dmId: string) => dmId === 'dm-x');
+      const result = await service.findInaccessibleReportRefs(
+        {
+          columnConfig: ['x__a'],
+          filterConfig: [{ column: 'y__b', operator: 'EQUALS', values: ['1'] }],
+          sortConfig: [{ column: 'z__c', direction: 'ASC' }],
+        },
+        'dm-root',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result.columns).toEqual([]);
+      expect(result.filters).toEqual(['y__b']);
+      expect(result.sorts).toEqual(['z__c']);
+    });
+
+    it('returns all empty when all columns are accessible', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-root' }));
+
+      const relRootToB = makeRelationship({
+        id: 'rel-b',
+        targetAlias: 'b',
+        sourceDataMart: makeDataMart({ id: 'dm-root' }),
+        targetDataMart: makeDataMart({
+          id: 'dm-b',
+          schema: makeSchema([{ name: 'field', type: 'STRING' }]),
+        }),
+      });
+      relationshipService.findByStorageId.mockResolvedValue([relRootToB]);
+
+      const accessFilter = jest.fn().mockResolvedValue(true);
+      const result = await service.findInaccessibleReportRefs(
+        {
+          columnConfig: ['b__field'],
+          filterConfig: [{ column: 'b__field', operator: 'EQUALS', values: ['v'] }],
+          sortConfig: [{ column: 'b__field', direction: 'DESC' }],
+        },
+        'dm-root',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual({ columns: [], filters: [], sorts: [] });
+    });
+
+    it('returns empty object when all configs are empty', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(makeDataMart({ id: 'dm-root' }));
+      relationshipService.findByStorageId.mockResolvedValue([]);
+
+      const accessFilter = jest.fn().mockResolvedValue(false);
+      const result = await service.findInaccessibleReportRefs(
+        { columnConfig: [], filterConfig: [], sortConfig: [] },
+        'dm-root',
+        'project-1',
+        accessFilter
+      );
+
+      expect(result).toEqual({ columns: [], filters: [], sorts: [] });
+      expect(accessFilter).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/backend/src/data-marts/services/blendable-schema.service.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.ts
@@ -17,6 +17,8 @@ import { AggregateFunction } from '../dto/schemas/aggregate-function.schema';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
 import { DataMartStatus } from '../enums/data-mart-status.enum';
+import { FilterConfig } from '../dto/schemas/filter-config.schema';
+import { SortConfig } from '../dto/schemas/sort-config.schema';
 
 const DEFAULT_CONFIG: BlendedFieldsConfig = {
   sources: [],
@@ -63,6 +65,8 @@ export function flattenSchemaFields(fields: RawSchemaField[], prefix = ''): Flat
   return result;
 }
 
+export type AccessFilter = (dmId: string) => Promise<boolean>;
+
 interface CollectContext {
   sourceId: string;
   parentPath: string;
@@ -72,6 +76,9 @@ interface CollectContext {
   availableSources: AvailableSourceDto[];
   branchDmIds: Set<string>;
   depth: number;
+  accessFilter?: AccessFilter;
+  pathByFieldName?: Map<string, string[]>;
+  ancestorDmIds?: string[];
 }
 
 @Injectable()
@@ -81,7 +88,11 @@ export class BlendableSchemaService {
     private readonly dataMartService: DataMartService
   ) {}
 
-  async computeBlendableSchema(dataMartId: string, projectId: string): Promise<BlendableSchemaDto> {
+  async computeBlendableSchema(
+    dataMartId: string,
+    projectId: string,
+    accessFilter?: AccessFilter
+  ): Promise<BlendableSchemaDto> {
     const dataMart = await this.dataMartService.getByIdAndProjectId(dataMartId, projectId);
     const nativeFields = (dataMart.schema?.fields ?? []).filter(
       f => !f.isHiddenForReporting
@@ -105,7 +116,7 @@ export class BlendableSchemaService {
     const availableSources: AvailableSourceDto[] = [];
     const branchDmIds = new Set<string>([dataMartId]);
 
-    this.collectBlendedFields({
+    await this.collectBlendedFields({
       sourceId: dataMartId,
       parentPath: '',
       sourcesByPath,
@@ -114,6 +125,7 @@ export class BlendableSchemaService {
       availableSources,
       branchDmIds,
       depth: 1,
+      accessFilter,
     });
 
     return {
@@ -124,18 +136,140 @@ export class BlendableSchemaService {
     };
   }
 
-  private collectBlendedFields(ctx: CollectContext): void {
+  async findInaccessibleReportRefs(
+    report: {
+      columnConfig?: string[] | null;
+      filterConfig?: FilterConfig;
+      sortConfig?: SortConfig;
+    },
+    dataMartId: string,
+    projectId: string,
+    accessFilter: AccessFilter
+  ): Promise<{ columns: string[]; filters: string[]; sorts: string[] }> {
+    const columnColumns = report.columnConfig ?? [];
+    const filterColumns = (report.filterConfig ?? []).map(r => r.column);
+    const sortColumns = (report.sortConfig ?? []).map(r => r.column);
+
+    const allColumns = [...new Set([...columnColumns, ...filterColumns, ...sortColumns])];
+    if (!allColumns.length) return { columns: [], filters: [], sorts: [] };
+
+    const orphans = await this.findInaccessibleColumnRefs(
+      allColumns,
+      dataMartId,
+      projectId,
+      accessFilter
+    );
+
+    const orphanSet = new Set(orphans);
+    return {
+      columns: columnColumns.filter(c => orphanSet.has(c)).sort(),
+      filters: [...new Set(filterColumns.filter(c => orphanSet.has(c)))].sort(),
+      sorts: [...new Set(sortColumns.filter(c => orphanSet.has(c)))].sort(),
+    };
+  }
+
+  async assertNoInaccessibleReportRefs(
+    report: {
+      columnConfig?: string[] | null;
+      filterConfig?: FilterConfig;
+      sortConfig?: SortConfig;
+    },
+    dataMartId: string,
+    projectId: string,
+    accessFilter: AccessFilter,
+    contextLabel: string
+  ): Promise<void> {
+    const { columns, filters, sorts } = await this.findInaccessibleReportRefs(
+      report,
+      dataMartId,
+      projectId,
+      accessFilter
+    );
+
+    if (!columns.length && !filters.length && !sorts.length) return;
+
+    const parts: string[] = [];
+    if (columns.length)
+      parts.push(`columns reference inaccessible data marts: ${columns.join(', ')}`);
+    if (filters.length)
+      parts.push(`filters reference inaccessible data marts: ${filters.join(', ')}`);
+    if (sorts.length) parts.push(`sorts reference inaccessible data marts: ${sorts.join(', ')}`);
+
+    throw new BusinessViolationException(`${contextLabel}: ${parts.join('; ')}`);
+  }
+
+  async findInaccessibleColumnRefs(
+    columnConfig: string[],
+    dataMartId: string,
+    projectId: string,
+    accessFilter: AccessFilter
+  ): Promise<string[]> {
+    if (!columnConfig.length) return [];
+
+    const dataMart = await this.dataMartService.getByIdAndProjectId(dataMartId, projectId);
+
+    const nativeSchemaFields = (dataMart.schema?.fields ?? []).filter(f => !f.isHiddenForReporting);
+    const nativeFieldNames = new Set(
+      flattenSchemaFields(nativeSchemaFields as RawSchemaField[]).map(f => f.name)
+    );
+
+    const allStorageRelationships = await this.relationshipService.findByStorageId(
+      dataMart.storage.id,
+      projectId
+    );
+    const relationshipsBySource = new Map<string, DataMartRelationship[]>();
+    for (const rel of allStorageRelationships) {
+      const list = relationshipsBySource.get(rel.sourceDataMart.id);
+      if (list) list.push(rel);
+      else relationshipsBySource.set(rel.sourceDataMart.id, [rel]);
+    }
+
+    const pathByFieldName = new Map<string, string[]>();
+    await this.collectBlendedFields({
+      sourceId: dataMartId,
+      parentPath: '',
+      sourcesByPath: new Map(
+        (dataMart.blendedFieldsConfig ?? DEFAULT_CONFIG).sources.map(s => [s.path, s])
+      ),
+      relationshipsBySource,
+      result: [],
+      availableSources: [],
+      branchDmIds: new Set<string>([dataMartId]),
+      depth: 1,
+      pathByFieldName,
+      ancestorDmIds: [],
+    });
+
+    const orphans: string[] = [];
+    for (const col of columnConfig) {
+      if (nativeFieldNames.has(col)) continue;
+
+      const path = pathByFieldName.get(col);
+      if (!path) {
+        orphans.push(col);
+        continue;
+      }
+
+      let pathInaccessible = false;
+      for (const dmId of path) {
+        const accessible = await accessFilter(dmId);
+        if (!accessible) {
+          pathInaccessible = true;
+          break;
+        }
+      }
+      if (pathInaccessible) orphans.push(col);
+    }
+
+    return orphans.sort();
+  }
+
+  private async collectBlendedFields(ctx: CollectContext): Promise<void> {
     const relationships = ctx.relationshipsBySource.get(ctx.sourceId) ?? [];
 
     for (const rel of relationships) {
-      // Skip relationships that don't have join conditions configured yet. They — and any
-      // relationships they transitively expose — must not surface in the reporting column
-      // picker, since without a JOIN there is no valid SQL to produce their rows.
       if (!rel.joinConditions || rel.joinConditions.length === 0) continue;
 
-      // TypeORM eager join silently drops soft-deleted DMs, leaving targetDataMart undefined.
-      // Surface this as a clear, actionable error so report-run failures point to the broken
-      // relationship rather than collapsing into a generic "cannot read 'schema' of undefined".
       if (!rel.targetDataMart) {
         throw new BusinessViolationException(
           `Relationship "${rel.targetAlias ?? rel.id}" (id=${rel.id}) targets a data mart that has been deleted. ` +
@@ -144,11 +278,14 @@ export class BlendableSchemaService {
         );
       }
 
-      // Reports cannot join against an unfinalized schema, so a draft target — and any
-      // descendants reachable only through it — must not surface in the picker.
       if (rel.targetDataMart.status !== DataMartStatus.PUBLISHED) continue;
 
       if (ctx.branchDmIds.has(rel.targetDataMart.id)) continue;
+
+      if (ctx.accessFilter) {
+        const allowed = await ctx.accessFilter(rel.targetDataMart.id);
+        if (!allowed) continue;
+      }
 
       const currentPath = ctx.parentPath ? `${ctx.parentPath}.${rel.targetAlias}` : rel.targetAlias;
 
@@ -160,11 +297,8 @@ export class BlendableSchemaService {
       );
       const flatTargetFields = flattenSchemaFields(targetSchemaFields);
 
-      // `sqlPrefix` is SQL‑safe because each `targetAlias` segment in
-      // `currentPath` is validated against `^[a-z0-9_]+$` in the Join
-      // Settings form. `displayPrefix` is free‑form and must never flow
-      // into SQL identifiers.
       const sqlPrefix = currentPath.replace(/\./g, '_');
+      // SQL-safe: alias segments validated against ^[a-z0-9_]+$; displayPrefix is free-form and must never flow into SQL identifiers.
       const displayPrefix = sourceConfig?.alias ?? rel.targetDataMart.title;
 
       const availableSource = new AvailableSourceDto();
@@ -179,13 +313,18 @@ export class BlendableSchemaService {
       availableSource.dataMartId = rel.targetDataMart.id;
       ctx.availableSources.push(availableSource);
 
+      const fieldPath = [...(ctx.ancestorDmIds ?? []), rel.targetDataMart.id];
+
       for (const field of flatTargetFields) {
         const fieldOverride = sourceConfig?.fields?.[field.name];
+        const fieldName = `${sqlPrefix}__${field.name.replace(/\./g, '_')}`;
+
+        if (ctx.pathByFieldName) {
+          ctx.pathByFieldName.set(fieldName, fieldPath);
+        }
 
         const dto = new BlendedFieldDto();
-        // Replace dots in nested struct field paths (e.g. `struct.field`) with
-        // underscores so the resulting alias is a valid SQL identifier.
-        dto.name = `${sqlPrefix}__${field.name.replace(/\./g, '_')}`;
+        dto.name = fieldName;
         dto.aliasPath = currentPath;
         dto.outputPrefix = displayPrefix;
         dto.sourceRelationshipId = rel.id;
@@ -204,12 +343,13 @@ export class BlendableSchemaService {
         ctx.result.push(dto);
       }
 
-      this.collectBlendedFields({
+      await this.collectBlendedFields({
         ...ctx,
         sourceId: rel.targetDataMart.id,
         parentPath: currentPath,
         branchDmIds: new Set([...ctx.branchDmIds, rel.targetDataMart.id]),
         depth: ctx.depth + 1,
+        ancestorDmIds: fieldPath,
       });
     }
   }

--- a/apps/backend/src/data-marts/services/report-access.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-access.service.spec.ts
@@ -51,7 +51,7 @@ describe('ReportAccessService', () => {
 
   const mockReport = {
     id: 'report-1',
-    dataMart: { id: 'dm-1', projectId: 'proj-1' },
+    dataMart: { id: 'dm-1', projectId: 'proj-1', storage: { id: 'storage-1' } },
     dataDestination: { id: 'dest-1' },
   };
 
@@ -401,6 +401,89 @@ describe('ReportAccessService', () => {
       await expect(
         service.checkOperateAccess('user-1', ['viewer'], 'report-1', 'proj-1')
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('computeCapabilitiesForReport', () => {
+    it('returns EMPTY_CAPABILITIES when userId is undefined', async () => {
+      const { service } = createService();
+      const result = await service.computeCapabilitiesForReport(
+        undefined,
+        [],
+        mockReport as never,
+        'proj-1'
+      );
+      expect(result).toEqual({
+        canRun: false,
+        canManageTriggers: false,
+        canEditConfig: false,
+        canViewSql: false,
+        canCopyAsDataMart: false,
+      });
+    });
+
+    it('sets canViewSql=true only when user has EDIT on DM', async () => {
+      const { service, accessDecisionService } = createService();
+      accessDecisionService.canAccess.mockImplementation(
+        async (_userId, _roles, entityType, _entityId, action) => {
+          if (entityType === 'DATA_MART' && action === 'SEE') return true;
+          if (entityType === 'DATA_MART' && action === 'EDIT') return true;
+          if (entityType === 'DESTINATION' && action === 'USE') return true;
+          if (entityType === 'STORAGE' && action === 'USE') return false;
+          return false;
+        }
+      );
+      const result = await service.computeCapabilitiesForReport(
+        'user-1',
+        ['editor'],
+        mockReport as never,
+        'proj-1'
+      );
+      expect(result.canViewSql).toBe(true);
+      expect(result.canCopyAsDataMart).toBe(false);
+    });
+
+    it('sets canCopyAsDataMart=true only when user has both EDIT(DM) and USE(Storage)', async () => {
+      const { service, accessDecisionService } = createService();
+      accessDecisionService.canAccess.mockImplementation(
+        async (_userId, _roles, entityType, _entityId, action) => {
+          if (entityType === 'DATA_MART' && action === 'SEE') return true;
+          if (entityType === 'DATA_MART' && action === 'EDIT') return true;
+          if (entityType === 'DESTINATION' && action === 'USE') return true;
+          if (entityType === 'STORAGE' && action === 'USE') return true;
+          return false;
+        }
+      );
+      const result = await service.computeCapabilitiesForReport(
+        'user-1',
+        ['editor'],
+        mockReport as never,
+        'proj-1'
+      );
+      expect(result.canViewSql).toBe(true);
+      expect(result.canCopyAsDataMart).toBe(true);
+    });
+
+    it('sets canViewSql=false when user lacks EDIT on DM even if other flags are true', async () => {
+      const { service, reportOwnerRepository, accessDecisionService } = createService();
+      reportOwnerRepository.exist.mockResolvedValue(true);
+      accessDecisionService.canAccess.mockImplementation(
+        async (_userId, _roles, entityType, _entityId, action) => {
+          if (entityType === 'DATA_MART' && action === 'SEE') return true;
+          if (entityType === 'DATA_MART' && action === 'EDIT') return false;
+          if (entityType === 'DESTINATION' && action === 'USE') return true;
+          if (entityType === 'STORAGE' && action === 'USE') return true;
+          return false;
+        }
+      );
+      const result = await service.computeCapabilitiesForReport(
+        'user-1',
+        ['viewer'],
+        mockReport as never,
+        'proj-1'
+      );
+      expect(result.canViewSql).toBe(false);
+      expect(result.canCopyAsDataMart).toBe(false);
     });
   });
 });

--- a/apps/backend/src/data-marts/services/report-access.service.ts
+++ b/apps/backend/src/data-marts/services/report-access.service.ts
@@ -12,21 +12,20 @@ type OperateDeniedReason = 'not-found' | 'dm-invisible' | 'destination-unusable'
 type MutateResult = { allowed: true } | { allowed: false; reason: MutateDeniedReason };
 type OperateResult = { allowed: true } | { allowed: false; reason: OperateDeniedReason };
 
-/**
- * Capability flags exposed on Report API responses. `canRun` and `canManageTriggers`
- * are derived from the same `canOperate` predicate today; they are kept as separate
- * fields so the contract can diverge later without breaking clients.
- */
 export interface ReportCapabilities {
   canRun: boolean;
   canManageTriggers: boolean;
   canEditConfig: boolean;
+  canViewSql: boolean;
+  canCopyAsDataMart: boolean;
 }
 
-const EMPTY_CAPABILITIES: ReportCapabilities = Object.freeze({
+export const EMPTY_CAPABILITIES: ReportCapabilities = Object.freeze({
   canRun: false,
   canManageTriggers: false,
   canEditConfig: false,
+  canViewSql: false,
+  canCopyAsDataMart: false,
 });
 
 const MUTATE_DENIED_MESSAGES: Record<MutateDeniedReason, string> = {
@@ -59,16 +58,10 @@ export class ReportAccessService {
   private async loadReportForAccess(reportId: string, projectId: string): Promise<Report | null> {
     return this.reportRepository.findOne({
       where: { id: reportId, dataMart: { projectId } },
-      relations: ['dataMart', 'dataDestination'],
+      relations: ['dataMart', 'dataMart.storage', 'dataDestination'],
     });
   }
 
-  /**
-   * Evaluate whether a user can mutate a Report. Single source of truth for access logic.
-   *
-   * Permissions Model: Editor no longer has project-wide bypass.
-   * Access requires: DM visible + (DM maintenance access OR Report ownership with effective dest).
-   */
   private async evaluateMutateAccess(
     userId: string,
     roles: string[],
@@ -82,18 +75,12 @@ export class ReportAccessService {
     return this.evaluateMutateAccessForReport(userId, roles, report, projectId);
   }
 
-  /**
-   * Same as `evaluateMutateAccess`, but operates on an already-loaded `Report`
-   * to avoid an extra `findOne` round-trip (used by list endpoints to defeat N+1).
-   * Caller MUST ensure `report.dataMart` and `report.dataDestination` relations are loaded.
-   */
   private async evaluateMutateAccessForReport(
     userId: string,
     roles: string[],
     report: Report,
     projectId: string
   ): Promise<MutateResult> {
-    // Permissions Model: DM must be visible to the user
     const canSeeDm = await this.accessDecisionService.canAccess(
       userId,
       roles,
@@ -106,7 +93,6 @@ export class ReportAccessService {
       return { allowed: false, reason: 'dm-invisible' };
     }
 
-    // DM maintenance access = can mutate any report on this DM
     const hasDmMaintenance = await this.accessDecisionService.canAccess(
       userId,
       roles,
@@ -119,7 +105,6 @@ export class ReportAccessService {
       return { allowed: true };
     }
 
-    // Otherwise: must be report owner + effective
     const isOwner = await this.reportOwnerRepository.exist({
       where: { reportId: report.id, userId },
     });
@@ -143,9 +128,6 @@ export class ReportAccessService {
     return canUseDest ? { allowed: true } : { allowed: false, reason: 'ineffective' };
   }
 
-  /**
-   * Check if a user can mutate (edit/delete/run) a Report. Returns boolean.
-   */
   async canMutate(
     userId: string,
     roles: string[],
@@ -156,9 +138,6 @@ export class ReportAccessService {
     return result.allowed;
   }
 
-  /**
-   * Assert that a user can mutate a Report, throwing descriptive ForbiddenException if not.
-   */
   async checkMutateAccess(
     userId: string,
     roles: string[],
@@ -172,13 +151,6 @@ export class ReportAccessService {
     }
   }
 
-  /**
-   * Evaluate whether a user can OPERATE a Report — manual run + CRUD report triggers.
-   * Decoupled from `canMutate` (which controls report config edits / owner changes).
-   *
-   * Operate = canSee(DataMart) AND canUse(Destination).
-   * No Report ownership requirement.
-   */
   private async evaluateOperateAccess(
     userId: string,
     roles: string[],
@@ -192,11 +164,6 @@ export class ReportAccessService {
     return this.evaluateOperateAccessForReport(userId, roles, report, projectId);
   }
 
-  /**
-   * Same as `evaluateOperateAccess`, but operates on an already-loaded `Report`
-   * to avoid an extra `findOne` round-trip. Caller MUST ensure relations
-   * `dataMart` and `dataDestination` are loaded.
-   */
   private async evaluateOperateAccessForReport(
     userId: string,
     roles: string[],
@@ -261,15 +228,8 @@ export class ReportAccessService {
     }
   }
 
-  /**
-   * Capability flags exposed on Report responses. `canRun` and `canManageTriggers`
-   * are tied to `canOperate` today; `canEditConfig` is tied to `canMutate`.
-   * Computing both with `Promise.all` halves the latency on hot paths.
-   *
-   * Caller must supply an already-loaded `Report` with `dataMart` and `dataDestination`
-   * relations populated. This is the one method use cases should call when assembling
-   * `ReportDto` — do not duplicate the Promise.all + capability assembly elsewhere.
-   */
+  // Caller must supply an already-loaded `Report` with `dataMart`, `dataMart.storage`,
+  // and `dataDestination` relations populated.
   async computeCapabilitiesForReport(
     userId: string | undefined,
     roles: string[],
@@ -280,24 +240,36 @@ export class ReportAccessService {
       return EMPTY_CAPABILITIES;
     }
 
-    const [operateResult, mutateResult] = await Promise.all([
+    const [operateResult, mutateResult, canEditDm, canUseStorage] = await Promise.all([
       this.evaluateOperateAccessForReport(userId, roles, report, projectId),
       this.evaluateMutateAccessForReport(userId, roles, report, projectId),
+      this.accessDecisionService.canAccess(
+        userId,
+        roles,
+        EntityType.DATA_MART,
+        report.dataMart.id,
+        Action.EDIT,
+        projectId
+      ),
+      this.accessDecisionService.canAccess(
+        userId,
+        roles,
+        EntityType.STORAGE,
+        report.dataMart.storage.id,
+        Action.USE,
+        projectId
+      ),
     ]);
 
-    const canOperate = operateResult.allowed;
     return {
-      canRun: canOperate,
-      canManageTriggers: canOperate,
+      canRun: operateResult.allowed,
+      canManageTriggers: operateResult.allowed,
       canEditConfig: mutateResult.allowed,
+      canViewSql: canEditDm,
+      canCopyAsDataMart: canEditDm && canUseStorage,
     };
   }
 
-  /**
-   * Check if a user is "effective" for this report — has USE access to its Destination.
-   * Per Stage 2 §76 of the permissions spec, an Owner who loses Destination accessibility
-   * becomes ineffective for mutation and running.
-   */
   async isEffective(
     userId: string,
     report: Report,
@@ -322,10 +294,6 @@ export class ReportAccessService {
     return roles.includes('editor') || roles.includes('admin');
   }
 
-  /**
-   * Check if a user can be added as an owner of a Report.
-   * Must be an active project member with access to the Report's DataMart.
-   */
   async canBeOwner(userId: string, report: Report, projectId: string): Promise<boolean> {
     const members = await this.idpProjectionsFacade.getProjectMembers(projectId);
     const member = members.find(
@@ -336,7 +304,6 @@ export class ReportAccessService {
       return false;
     }
 
-    // Permissions Model: check DataMart visibility for this user
     if (report.dataMart) {
       const canSeeDm = await this.accessDecisionService.canAccess(
         userId,
@@ -351,7 +318,6 @@ export class ReportAccessService {
       }
     }
 
-    // Permissions Model: check Destination USE access for this user
     if (report.dataDestination) {
       const canUseDest = await this.accessDecisionService.canAccess(
         userId,

--- a/apps/backend/src/data-marts/services/report-run-access-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-run-access-validator.service.spec.ts
@@ -1,0 +1,299 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { Report } from '../entities/report.entity';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataDestination } from '../entities/data-destination.entity';
+import { AccessDecisionService, EntityType, Action } from './access-decision';
+import { BlendableSchemaService } from './blendable-schema.service';
+import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
+import { ReportRunAccessValidatorService, RunContext } from './report-run-access-validator.service';
+import { ProjectMemberDto } from '../../idp/dto/domain/project-member.dto';
+
+const PROJECT_ID = 'proj-1';
+const USER_ID = 'user-1';
+const DM_ID = 'dm-1';
+const DEST_ID = 'dest-1';
+
+function buildReport(overrides: Partial<Report> = {}): Report {
+  const report = new Report();
+  report.id = 'report-1';
+  report.createdById = USER_ID;
+  report.dataMart = { id: DM_ID, projectId: PROJECT_ID, title: 'My DM' } as DataMart;
+  report.dataDestination = { id: DEST_ID } as DataDestination;
+  report.columnConfig = [];
+  return Object.assign(report, overrides);
+}
+
+function buildMember(): ProjectMemberDto {
+  return new ProjectMemberDto(
+    USER_ID,
+    'user@example.com',
+    'User',
+    undefined,
+    'editor',
+    false,
+    false
+  );
+}
+
+describe('ReportRunAccessValidatorService', () => {
+  let idpFacade: jest.Mocked<IdpProjectionsFacade>;
+  let accessDecisionService: jest.Mocked<AccessDecisionService>;
+  let blendableSchemaService: jest.Mocked<BlendableSchemaService>;
+  let service: ReportRunAccessValidatorService;
+
+  beforeEach(() => {
+    idpFacade = {
+      getProjectMember: jest.fn(),
+    } as unknown as jest.Mocked<IdpProjectionsFacade>;
+
+    accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(true),
+    } as unknown as jest.Mocked<AccessDecisionService>;
+
+    blendableSchemaService = {
+      findInaccessibleReportRefs: jest
+        .fn()
+        .mockResolvedValue({ columns: [], filters: [], sorts: [] }),
+    } as unknown as jest.Mocked<BlendableSchemaService>;
+
+    service = new ReportRunAccessValidatorService(
+      idpFacade,
+      accessDecisionService,
+      blendableSchemaService
+    );
+  });
+
+  const contexts: RunContext[] = ['Scheduled run', 'Looker Studio request', 'Manual run'];
+
+  describe.each(contexts)('context: %s', context => {
+    it('passes when member is active, has DM access, dest access, and no orphans', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+
+      await expect(
+        service.validate(buildReport(), USER_ID, PROJECT_ID, context)
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws when user is not found in project', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(undefined);
+
+      await expect(service.validate(buildReport(), USER_ID, PROJECT_ID, context)).rejects.toThrow(
+        BusinessViolationException
+      );
+
+      const call = idpFacade.getProjectMember.mock.calls[0];
+      expect(call[0]).toBe(PROJECT_ID);
+      expect(call[1]).toBe(USER_ID);
+    });
+
+    it('throws when user is outbound', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(
+        new ProjectMemberDto(USER_ID, 'u@e.com', 'U', undefined, 'editor', false, true)
+      );
+
+      await expect(service.validate(buildReport(), USER_ID, PROJECT_ID, context)).rejects.toThrow(
+        BusinessViolationException
+      );
+    });
+
+    it('throws when user has no SEE access to DM', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      accessDecisionService.canAccess.mockImplementation((_u, _r, entity, _id, action) =>
+        Promise.resolve(!(entity === EntityType.DATA_MART && action === Action.SEE))
+      );
+
+      await expect(service.validate(buildReport(), USER_ID, PROJECT_ID, context)).rejects.toThrow(
+        BusinessViolationException
+      );
+    });
+
+    it('throws when user has no USE access to destination', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      accessDecisionService.canAccess.mockImplementation((_u, _r, entity, _id, action) =>
+        Promise.resolve(!(entity === EntityType.DESTINATION && action === Action.USE))
+      );
+
+      await expect(service.validate(buildReport(), USER_ID, PROJECT_ID, context)).rejects.toThrow(
+        BusinessViolationException
+      );
+    });
+
+    it('skips destination check when report has no dataDestination', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      const report = buildReport({ dataDestination: null as unknown as DataDestination });
+
+      await expect(service.validate(report, USER_ID, PROJECT_ID, context)).resolves.toBeUndefined();
+      expect(accessDecisionService.canAccess).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        EntityType.DESTINATION,
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('throws when orphan columns exist', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      const report = buildReport({
+        columnConfig: ['dm2__field_a', 'dm2__field_b'],
+      });
+      blendableSchemaService.findInaccessibleReportRefs.mockResolvedValue({
+        columns: ['dm2__field_a', 'dm2__field_b'],
+        filters: [],
+        sorts: [],
+      });
+
+      await expect(service.validate(report, USER_ID, PROJECT_ID, context)).rejects.toThrow(
+        BusinessViolationException
+      );
+    });
+
+    it('skips orphan check when columnConfig, filterConfig, and sortConfig are empty', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      const report = buildReport({ columnConfig: [] });
+
+      await expect(service.validate(report, USER_ID, PROJECT_ID, context)).resolves.toBeUndefined();
+      expect(blendableSchemaService.findInaccessibleReportRefs).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error message content', () => {
+    it('uses "schedule creator" actor for Scheduled run membership error', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(undefined);
+
+      await expect(
+        service.validate(buildReport(), USER_ID, PROJECT_ID, 'Scheduled run')
+      ).rejects.toThrow(
+        'Scheduled run blocked: schedule creator is no longer a member of this project. Reassign the schedule to continue.'
+      );
+    });
+
+    it('uses "report creator" actor for Looker Studio request membership error', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(undefined);
+
+      await expect(
+        service.validate(buildReport(), USER_ID, PROJECT_ID, 'Looker Studio request')
+      ).rejects.toThrow(
+        'Looker Studio request blocked: report creator is no longer a member of this project. Recreate the report with an active owner.'
+      );
+    });
+
+    it('uses "you" actor for Manual run membership error', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(undefined);
+
+      await expect(
+        service.validate(buildReport(), USER_ID, PROJECT_ID, 'Manual run')
+      ).rejects.toThrow(
+        'Manual run blocked: you are no longer a member of this project. Sign in with an account that has access.'
+      );
+    });
+
+    it('uses "schedule creator" actor for Scheduled run DM access error', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      accessDecisionService.canAccess.mockResolvedValue(false);
+
+      await expect(
+        service.validate(buildReport(), USER_ID, PROJECT_ID, 'Scheduled run')
+      ).rejects.toThrow(
+        'Scheduled run blocked: schedule creator no longer has access to DataMart "My DM".'
+      );
+    });
+
+    it('uses "report creator" actor for Looker Studio request DM access error', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      accessDecisionService.canAccess.mockResolvedValue(false);
+
+      await expect(
+        service.validate(buildReport(), USER_ID, PROJECT_ID, 'Looker Studio request')
+      ).rejects.toThrow(
+        'Looker Studio request blocked: report creator no longer has access to DataMart "My DM".'
+      );
+    });
+
+    it('includes orphan column names and "schedule creator" actor for Scheduled run', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      const report = buildReport({ columnConfig: ['x__col'] });
+      blendableSchemaService.findInaccessibleReportRefs.mockResolvedValue({
+        columns: ['x__col'],
+        filters: [],
+        sorts: [],
+      });
+
+      await expect(service.validate(report, USER_ID, PROJECT_ID, 'Scheduled run')).rejects.toThrow(
+        'Scheduled run blocked: columns x__col reference DataMarts no longer accessible to schedule creator.'
+      );
+    });
+
+    it('includes orphan column names and "report creator" actor for Looker Studio request', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      const report = buildReport({ columnConfig: ['x__col'] });
+      blendableSchemaService.findInaccessibleReportRefs.mockResolvedValue({
+        columns: ['x__col'],
+        filters: [],
+        sorts: [],
+      });
+
+      await expect(
+        service.validate(report, USER_ID, PROJECT_ID, 'Looker Studio request')
+      ).rejects.toThrow(
+        'Looker Studio request blocked: columns x__col reference DataMarts no longer accessible to report creator.'
+      );
+    });
+
+    it('uses "you" actor for Manual run DM access error', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      accessDecisionService.canAccess.mockResolvedValue(false);
+
+      await expect(
+        service.validate(buildReport(), USER_ID, PROJECT_ID, 'Manual run')
+      ).rejects.toThrow('Manual run blocked: you no longer have access to DataMart "My DM".');
+    });
+
+    it('uses "you" actor for Manual run destination USE error', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      accessDecisionService.canAccess.mockImplementation((_u, _r, entity, _id, action) =>
+        Promise.resolve(!(entity === EntityType.DESTINATION && action === Action.USE))
+      );
+
+      await expect(
+        service.validate(buildReport(), USER_ID, PROJECT_ID, 'Manual run')
+      ).rejects.toThrow(
+        'Manual run blocked: you no longer have access to the destination configured for this report.'
+      );
+    });
+
+    it('includes orphan column names and "you" actor for Manual run', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      const report = buildReport({ columnConfig: ['x__col'] });
+      blendableSchemaService.findInaccessibleReportRefs.mockResolvedValue({
+        columns: ['x__col'],
+        filters: [],
+        sorts: [],
+      });
+
+      await expect(service.validate(report, USER_ID, PROJECT_ID, 'Manual run')).rejects.toThrow(
+        'Manual run blocked: columns x__col reference DataMarts no longer accessible to you.'
+      );
+    });
+
+    it('includes filter and sort orphans with granular labels for Scheduled run', async () => {
+      idpFacade.getProjectMember.mockResolvedValue(buildMember());
+      const report = buildReport({ columnConfig: ['x__col'] });
+      blendableSchemaService.findInaccessibleReportRefs.mockResolvedValue({
+        columns: [],
+        filters: ['y__filter_col'],
+        sorts: ['z__sort_col'],
+      });
+
+      await expect(service.validate(report, USER_ID, PROJECT_ID, 'Scheduled run')).rejects.toThrow(
+        'Scheduled run blocked: filters y__filter_col; sorts z__sort_col reference DataMarts no longer accessible to schedule creator.'
+      );
+    });
+  });
+});

--- a/apps/backend/src/data-marts/services/report-run-access-validator.service.ts
+++ b/apps/backend/src/data-marts/services/report-run-access-validator.service.ts
@@ -1,0 +1,119 @@
+import { Injectable } from '@nestjs/common';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
+import { Report } from '../entities/report.entity';
+import { AccessDecisionService, EntityType, Action } from './access-decision';
+import { BlendableSchemaService } from './blendable-schema.service';
+import { createDataMartUseAccessFilter } from '../utils/create-dm-access-filter';
+
+export type RunContext = 'Scheduled run' | 'Looker Studio request' | 'Manual run';
+
+const ACTOR_BY_CONTEXT: Record<RunContext, string> = {
+  'Scheduled run': 'schedule creator',
+  'Looker Studio request': 'report creator',
+  'Manual run': 'you',
+};
+
+const HAS_ACCESS_VERB_BY_CONTEXT: Record<RunContext, string> = {
+  'Scheduled run': 'no longer has access',
+  'Looker Studio request': 'no longer has access',
+  'Manual run': 'no longer have access',
+};
+
+const MEMBERSHIP_ERROR_BY_CONTEXT: Record<RunContext, string> = {
+  'Scheduled run':
+    'schedule creator is no longer a member of this project. Reassign the schedule to continue.',
+  'Looker Studio request':
+    'report creator is no longer a member of this project. Recreate the report with an active owner.',
+  'Manual run':
+    'you are no longer a member of this project. Sign in with an account that has access.',
+};
+
+@Injectable()
+export class ReportRunAccessValidatorService {
+  constructor(
+    private readonly idpProjectionsFacade: IdpProjectionsFacade,
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly blendableSchemaService: BlendableSchemaService
+  ) {}
+
+  async validate(
+    report: Report,
+    userId: string,
+    projectId: string,
+    context: RunContext,
+    preResolvedRoles?: string[]
+  ): Promise<void> {
+    const actor = ACTOR_BY_CONTEXT[context];
+    const hasAccessVerb = HAS_ACCESS_VERB_BY_CONTEXT[context];
+
+    let roles: string[];
+
+    if (preResolvedRoles) {
+      roles = preResolvedRoles;
+    } else {
+      const member = await this.idpProjectionsFacade.getProjectMember(projectId, userId);
+      if (!member || member.isOutbound) {
+        throw new BusinessViolationException(
+          `${context} blocked: ${MEMBERSHIP_ERROR_BY_CONTEXT[context]}`
+        );
+      }
+      roles = [member.role ?? 'viewer'];
+    }
+
+    const canSeeDm = await this.accessDecisionService.canAccess(
+      userId,
+      roles,
+      EntityType.DATA_MART,
+      report.dataMart.id,
+      Action.SEE,
+      projectId
+    );
+    if (!canSeeDm) {
+      throw new BusinessViolationException(
+        `${context} blocked: ${actor} ${hasAccessVerb} to DataMart "${report.dataMart.title}".`
+      );
+    }
+
+    if (report.dataDestination) {
+      const canUseDest = await this.accessDecisionService.canAccess(
+        userId,
+        roles,
+        EntityType.DESTINATION,
+        report.dataDestination.id,
+        Action.USE,
+        projectId
+      );
+      if (!canUseDest) {
+        throw new BusinessViolationException(
+          `${context} blocked: ${actor} ${hasAccessVerb} to the destination configured for this report.`
+        );
+      }
+    }
+
+    if (report.columnConfig?.length || report.filterConfig?.length || report.sortConfig?.length) {
+      const accessFilter = createDataMartUseAccessFilter(
+        this.accessDecisionService,
+        userId,
+        roles,
+        projectId
+      );
+      const { columns, filters, sorts } =
+        await this.blendableSchemaService.findInaccessibleReportRefs(
+          report,
+          report.dataMart.id,
+          projectId,
+          accessFilter
+        );
+      const parts: string[] = [];
+      if (columns.length) parts.push(`columns ${columns.sort().join(', ')}`);
+      if (filters.length) parts.push(`filters ${filters.sort().join(', ')}`);
+      if (sorts.length) parts.push(`sorts ${sorts.sort().join(', ')}`);
+      if (parts.length) {
+        throw new BusinessViolationException(
+          `${context} blocked: ${parts.join('; ')} reference DataMarts no longer accessible to ${actor}.`
+        );
+      }
+    }
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.spec.ts
@@ -52,13 +52,17 @@ describe('CopyReportAsDataMartService', () => {
         return Promise.resolve(false);
       }),
     };
+    const blendableSchemaService = {
+      assertNoInaccessibleReportRefs: jest.fn().mockResolvedValue(undefined),
+    };
 
     const service = new CopyReportAsDataMartService(
       reportRepository as never,
       reportSqlComposerService as never,
       createDataMartService as never,
       updateDataMartDefinitionService as never,
-      accessDecisionService as never
+      accessDecisionService as never,
+      blendableSchemaService as never
     );
 
     return {
@@ -68,6 +72,7 @@ describe('CopyReportAsDataMartService', () => {
       createDataMartService,
       updateDataMartDefinitionService,
       accessDecisionService,
+      blendableSchemaService,
     };
   };
 
@@ -188,4 +193,21 @@ describe('CopyReportAsDataMartService', () => {
       expect(updateDataMartDefinitionService.run).not.toHaveBeenCalled();
     }
   );
+
+  it('throws BusinessViolationException when report has inaccessible column/filter/sort refs', async () => {
+    const { service, blendableSchemaService, createDataMartService } = createService();
+    blendableSchemaService.assertNoInaccessibleReportRefs.mockRejectedValue(
+      new BusinessViolationException(
+        'Cannot copy report: columns reference inaccessible data marts: dm2__field_a'
+      )
+    );
+
+    const command = new CopyReportAsDataMartCommand('report-1', 'user-1', 'proj-1', ['editor']);
+
+    await expect(service.run(command)).rejects.toThrow(BusinessViolationException);
+    await expect(service.run(command)).rejects.toThrow(
+      'Cannot copy report: columns reference inaccessible data marts: dm2__field_a'
+    );
+    expect(createDataMartService.run).not.toHaveBeenCalled();
+  });
 });

--- a/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.ts
@@ -16,7 +16,9 @@ import { SqlDefinition } from '../dto/schemas/data-mart-table-definitions/sql-de
 import { Report } from '../entities/report.entity';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+import { BlendableSchemaService } from '../services/blendable-schema.service';
 import { ReportSqlComposerService } from '../services/report-sql-composer.service';
+import { createDataMartUseAccessFilter } from '../utils/create-dm-access-filter';
 import { CreateDataMartService } from './create-data-mart.service';
 import { UpdateDataMartDefinitionService } from './update-data-mart-definition.service';
 
@@ -28,7 +30,8 @@ export class CopyReportAsDataMartService {
     private readonly reportSqlComposerService: ReportSqlComposerService,
     private readonly createDataMartService: CreateDataMartService,
     private readonly updateDataMartDefinitionService: UpdateDataMartDefinitionService,
-    private readonly accessDecisionService: AccessDecisionService
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly blendableSchemaService: BlendableSchemaService
   ) {}
 
   @Transactional()
@@ -77,6 +80,20 @@ export class CopyReportAsDataMartService {
         'You do not have permission to copy this report: use access to the source data storage is required.'
       );
     }
+
+    const accessFilter = createDataMartUseAccessFilter(
+      this.accessDecisionService,
+      command.userId,
+      command.roles,
+      command.projectId
+    );
+    await this.blendableSchemaService.assertNoInaccessibleReportRefs(
+      report,
+      report.dataMart.id,
+      command.projectId,
+      accessFilter,
+      'Cannot copy report'
+    );
 
     const { sql } = await this.reportSqlComposerService.compose(report);
 

--- a/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.spec.ts
@@ -27,7 +27,12 @@ describe('CreateDataMartRelationshipService', () => {
     storage: { id: 'storage-1', type: 'BIGQUERY' },
     schema: [],
   };
-  const relationship = { id: 'rel-1', createdById: 'user-1' };
+  const relationship = {
+    id: 'rel-1',
+    createdById: 'user-1',
+    sourceDataMart: { id: 'dm-source' },
+    targetDataMart: { id: 'dm-target' },
+  };
 
   const createService = (accessResults: [boolean, boolean] = [true, true]) => {
     const relationshipService = {
@@ -53,7 +58,8 @@ describe('CreateDataMartRelationshipService', () => {
       canAccess: jest
         .fn()
         .mockResolvedValueOnce(accessResults[0])
-        .mockResolvedValueOnce(accessResults[1]),
+        .mockResolvedValueOnce(accessResults[1])
+        .mockResolvedValue(true),
     };
 
     const service = new CreateDataMartRelationshipService(
@@ -84,7 +90,6 @@ describe('CreateDataMartRelationshipService', () => {
 
     await service.run(command);
 
-    expect(accessDecisionService.canAccess).toHaveBeenCalledTimes(2);
     expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
       'user-1',
       ['editor'],

--- a/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-mart-relationship.service.ts
@@ -7,6 +7,7 @@ import { DataMartRelationshipService } from '../services/data-mart-relationship.
 import { DataMartService } from '../services/data-mart.service';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import { buildDmAccessFlags } from '../utils/build-dm-access-flags';
 
 @Injectable()
 export class CreateDataMartRelationshipService {
@@ -53,8 +54,9 @@ export class CreateDataMartRelationshipService {
       ),
     ]);
     if (!canEditSource || !canEditTarget) {
+      const blockedTitle = !canEditSource ? sourceDataMart.title : targetDataMart.title;
       throw new ForbiddenException(
-        'You do not have permission to create relationship between these DataMarts'
+        `You do not have permission to create a relationship with "${blockedTitle}"`
       );
     }
 
@@ -79,7 +81,16 @@ export class CreateDataMartRelationshipService {
       sourceDataMart,
       targetDataMart
     );
-    const createdByUser = await this.userProjectionsFetcherService.fetchCreatedByUser(relationship);
-    return this.mapper.toDomainDto(relationship, createdByUser);
+    const [createdByUser, accessByDmId] = await Promise.all([
+      this.userProjectionsFetcherService.fetchCreatedByUser(relationship),
+      buildDmAccessFlags(
+        new Set([relationship.sourceDataMart.id, relationship.targetDataMart.id]),
+        command.userId,
+        command.roles,
+        command.projectId,
+        this.accessDecisionService
+      ),
+    ]);
+    return this.mapper.toDomainDto(relationship, createdByUser, accessByDmId);
   }
 }

--- a/apps/backend/src/data-marts/use-cases/create-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-report.service.spec.ts
@@ -28,6 +28,7 @@ jest.mock('../utils/resolve-owner-users', () => ({
 }));
 
 import { BadRequestException } from '@nestjs/common';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { CreateReportService } from './create-report.service';
 import { CreateReportCommand } from '../dto/domain/create-report.command';
 import { DataMartStatus } from '../enums/data-mart-status.enum';
@@ -107,6 +108,10 @@ describe('CreateReportService', () => {
       }),
     };
 
+    const blendableSchemaService = {
+      assertNoInaccessibleReportRefs: jest.fn().mockResolvedValue(undefined),
+    };
+
     const service = new CreateReportService(
       reportRepository as never,
       reportOwnerRepository as never,
@@ -120,10 +125,11 @@ describe('CreateReportService', () => {
       accessDecisionService as never,
       eventDispatcher as never,
       outputControlsValidator as never,
-      reportAccessService as never
+      reportAccessService as never,
+      blendableSchemaService as never
     );
 
-    return { service, reportRepository, outputControlsValidator };
+    return { service, reportRepository, outputControlsValidator, blendableSchemaService };
   };
 
   beforeEach(() => {
@@ -269,5 +275,31 @@ describe('CreateReportService', () => {
       canManageTriggers: true,
       canEditConfig: true,
     });
+  });
+
+  it('throws BusinessViolationException when report refs inaccessible data marts', async () => {
+    const { service, blendableSchemaService } = createService();
+    blendableSchemaService.assertNoInaccessibleReportRefs.mockRejectedValue(
+      new BusinessViolationException(
+        'Cannot create report: columns reference inaccessible data marts: b__orphan, c__missing'
+      )
+    );
+
+    const command = new CreateReportCommand(
+      'proj-1',
+      'user-0',
+      'Test',
+      'dm-1',
+      'dest-1',
+      { type: 'looker-studio-config', cacheLifetime: 3600 } as never,
+      undefined,
+      [],
+      [{ dataMartId: 'dm-2', fieldName: 'b__orphan', alias: 'b__orphan' }] as never
+    );
+
+    await expect(service.run(command)).rejects.toThrow(BusinessViolationException);
+    await expect(service.run(command)).rejects.toThrow(
+      /b__orphan.*c__missing|c__missing.*b__orphan/
+    );
   });
 });

--- a/apps/backend/src/data-marts/use-cases/create-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-report.service.ts
@@ -23,6 +23,8 @@ import { ForbiddenException } from '@nestjs/common';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 import { OutputControlsValidatorService } from '../services/output-controls-validator.service';
 import { ReportAccessService } from '../services/report-access.service';
+import { BlendableSchemaService } from '../services/blendable-schema.service';
+import { createDataMartUseAccessFilter } from '../utils/create-dm-access-filter';
 
 @Injectable()
 export class CreateReportService {
@@ -41,12 +43,12 @@ export class CreateReportService {
     private readonly accessDecisionService: AccessDecisionService,
     private readonly eventDispatcher: OwoxEventDispatcher,
     private readonly outputControlsValidator: OutputControlsValidatorService,
-    private readonly reportAccessService: ReportAccessService
+    private readonly reportAccessService: ReportAccessService,
+    private readonly blendableSchemaService: BlendableSchemaService
   ) {}
 
   @Transactional()
   async run(command: CreateReportCommand): Promise<ReportDto> {
-    // Get the data mart and verify it's in published status
     const dataMart = await this.dataMartService.getByIdAndProjectId(
       command.dataMartId,
       command.projectId
@@ -57,7 +59,6 @@ export class CreateReportService {
       );
     }
 
-    // Permissions Model: verify user has reporting access to this DataMart
     if (command.userId) {
       const canUseDm = await this.accessDecisionService.canAccess(
         command.userId,
@@ -70,9 +71,32 @@ export class CreateReportService {
       if (!canUseDm) {
         throw new ForbiddenException('You do not have access to the DataMart for this report');
       }
+
+      if (
+        command.columnConfig?.length ||
+        command.filterConfig?.length ||
+        command.sortConfig?.length
+      ) {
+        const accessFilter = createDataMartUseAccessFilter(
+          this.accessDecisionService,
+          command.userId,
+          command.roles,
+          command.projectId
+        );
+        await this.blendableSchemaService.assertNoInaccessibleReportRefs(
+          {
+            columnConfig: command.columnConfig,
+            filterConfig: command.filterConfig,
+            sortConfig: command.sortConfig,
+          },
+          command.dataMartId,
+          command.projectId,
+          accessFilter,
+          'Cannot save report'
+        );
+      }
     }
 
-    // Permissions Model: verify user has access to this Destination
     if (command.userId) {
       const canUseDest = await this.accessDecisionService.canAccess(
         command.userId,
@@ -87,7 +111,6 @@ export class CreateReportService {
       }
     }
 
-    // Get the data destination
     const dataDestination = await this.dataDestinationService.getByIdAndProjectId(
       command.dataDestinationId,
       command.projectId
@@ -110,7 +133,6 @@ export class CreateReportService {
       limitConfig: command.limitConfig ?? null,
     });
 
-    // Create and save the report
     const report = this.reportRepository.create({
       title: command.title,
       dataMart,

--- a/apps/backend/src/data-marts/use-cases/get-blendable-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-blendable-schema.service.spec.ts
@@ -43,7 +43,11 @@ describe('GetBlendableSchemaService', () => {
       Action.SEE,
       'proj-1'
     );
-    expect(blendableSchemaService.computeBlendableSchema).toHaveBeenCalledWith('dm-1', 'proj-1');
+    expect(blendableSchemaService.computeBlendableSchema).toHaveBeenCalledWith(
+      'dm-1',
+      'proj-1',
+      expect.any(Function)
+    );
     expect(result).toBe(blendableSchema);
   });
 

--- a/apps/backend/src/data-marts/use-cases/get-blendable-schema.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-blendable-schema.service.ts
@@ -4,6 +4,7 @@ import { GetBlendableSchemaCommand } from '../dto/domain/get-blendable-schema.co
 import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
 import { BlendableSchemaService } from '../services/blendable-schema.service';
 import { DataMartService } from '../services/data-mart.service';
+import { createDataMartUseAccessFilter } from '../utils/create-dm-access-filter';
 
 @Injectable()
 export class GetBlendableSchemaService {
@@ -32,9 +33,17 @@ export class GetBlendableSchemaService {
       throw new ForbiddenException('You do not have access to this DataMart');
     }
 
+    const accessFilter = createDataMartUseAccessFilter(
+      this.accessDecisionService,
+      command.userId,
+      command.roles,
+      command.projectId
+    );
+
     return this.blendableSchemaService.computeBlendableSchema(
       command.dataMartId,
-      command.projectId
+      command.projectId,
+      accessFilter
     );
   }
 }

--- a/apps/backend/src/data-marts/use-cases/get-data-mart-relationship.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-data-mart-relationship.service.spec.ts
@@ -14,6 +14,7 @@ describe('GetDataMartRelationshipService', () => {
   const relationship = {
     id: 'rel-1',
     sourceDataMart: { id: 'dm-source' },
+    targetDataMart: { id: 'dm-target' },
   };
 
   const createService = (canAccess = true, foundRelationship = relationship) => {

--- a/apps/backend/src/data-marts/use-cases/get-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-data-mart-relationship.service.ts
@@ -11,6 +11,7 @@ import { AccessDecisionService, Action, EntityType } from '../services/access-de
 import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
 import { DataMartService } from '../services/data-mart.service';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+import { buildDmAccessFlags } from '../utils/build-dm-access-flags';
 
 @Injectable()
 export class GetDataMartRelationshipService {
@@ -49,8 +50,17 @@ export class GetDataMartRelationshipService {
       );
     }
 
-    const createdByUser = await this.userProjectionsFetcherService.fetchCreatedByUser(relationship);
+    const [createdByUser, accessByDmId] = await Promise.all([
+      this.userProjectionsFetcherService.fetchCreatedByUser(relationship),
+      buildDmAccessFlags(
+        new Set([relationship.sourceDataMart.id, relationship.targetDataMart.id]),
+        command.userId,
+        command.roles,
+        command.projectId,
+        this.accessDecisionService
+      ),
+    ]);
 
-    return this.mapper.toDomainDto(relationship, createdByUser);
+    return this.mapper.toDomainDto(relationship, createdByUser, accessByDmId);
   }
 }

--- a/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.spec.ts
@@ -1,4 +1,5 @@
 import { ForbiddenException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { GetReportGeneratedSqlService } from './get-report-generated-sql.service';
 import { GetReportGeneratedSqlCommand } from '../dto/domain/get-report-generated-sql.command';
 import { EntityType, Action } from '../services/access-decision';
@@ -6,6 +7,9 @@ import { EntityType, Action } from '../services/access-decision';
 describe('GetReportGeneratedSqlService', () => {
   const report = {
     id: 'report-1',
+    columnConfig: null,
+    filterConfig: null,
+    sortConfig: null,
     dataMart: {
       id: 'dm-1',
       storage: { id: 'storage-1', type: 'BIGQUERY' },
@@ -23,14 +27,24 @@ describe('GetReportGeneratedSqlService', () => {
     const accessDecisionService = {
       canAccess: jest.fn().mockResolvedValue(canEditDataMart),
     };
+    const blendableSchemaService = {
+      assertNoInaccessibleReportRefs: jest.fn().mockResolvedValue(undefined),
+    };
 
     const service = new GetReportGeneratedSqlService(
       reportRepository as never,
       reportSqlComposerService as never,
-      accessDecisionService as never
+      accessDecisionService as never,
+      blendableSchemaService as never
     );
 
-    return { service, reportRepository, reportSqlComposerService, accessDecisionService };
+    return {
+      service,
+      reportRepository,
+      reportSqlComposerService,
+      accessDecisionService,
+      blendableSchemaService,
+    };
   };
 
   beforeEach(() => jest.clearAllMocks());
@@ -79,6 +93,23 @@ describe('GetReportGeneratedSqlService', () => {
     const command = new GetReportGeneratedSqlCommand('report-1', 'user-1', 'proj-1', ['viewer']);
 
     await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+    expect(reportSqlComposerService.compose).not.toHaveBeenCalled();
+  });
+
+  it('throws BusinessViolationException when report has inaccessible column/filter/sort refs', async () => {
+    const { service, blendableSchemaService, reportSqlComposerService } = createService(true);
+    blendableSchemaService.assertNoInaccessibleReportRefs.mockRejectedValue(
+      new BusinessViolationException(
+        'Cannot view SQL: columns reference inaccessible data marts: dm2__field_a'
+      )
+    );
+
+    const command = new GetReportGeneratedSqlCommand('report-1', 'user-1', 'proj-1', ['editor']);
+
+    await expect(service.run(command)).rejects.toThrow(BusinessViolationException);
+    await expect(service.run(command)).rejects.toThrow(
+      'Cannot view SQL: columns reference inaccessible data marts: dm2__field_a'
+    );
     expect(reportSqlComposerService.compose).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.ts
@@ -9,7 +9,9 @@ import { Repository } from 'typeorm';
 import { GetReportGeneratedSqlCommand } from '../dto/domain/get-report-generated-sql.command';
 import { Report } from '../entities/report.entity';
 import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+import { BlendableSchemaService } from '../services/blendable-schema.service';
 import { ReportSqlComposerService } from '../services/report-sql-composer.service';
+import { createDataMartUseAccessFilter } from '../utils/create-dm-access-filter';
 
 @Injectable()
 export class GetReportGeneratedSqlService {
@@ -17,7 +19,8 @@ export class GetReportGeneratedSqlService {
     @InjectRepository(Report)
     private readonly reportRepository: Repository<Report>,
     private readonly reportSqlComposerService: ReportSqlComposerService,
-    private readonly accessDecisionService: AccessDecisionService
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly blendableSchemaService: BlendableSchemaService
   ) {}
 
   async run(command: GetReportGeneratedSqlCommand): Promise<{ sql: string }> {
@@ -50,6 +53,20 @@ export class GetReportGeneratedSqlService {
         'You do not have permission to view the generated SQL of this report: edit access to the source data mart is required.'
       );
     }
+
+    const accessFilter = createDataMartUseAccessFilter(
+      this.accessDecisionService,
+      command.userId,
+      command.roles,
+      command.projectId
+    );
+    await this.blendableSchemaService.assertNoInaccessibleReportRefs(
+      report,
+      report.dataMart.id,
+      command.projectId,
+      accessFilter,
+      'Cannot view SQL'
+    );
 
     const { sql } = await this.reportSqlComposerService.compose(report);
     return { sql };

--- a/apps/backend/src/data-marts/use-cases/list-data-mart-relationships.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-data-mart-relationships.service.spec.ts
@@ -11,7 +11,10 @@ import { ListRelationshipsCommand } from '../dto/domain/list-relationships.comma
 import { EntityType, Action } from '../services/access-decision';
 
 describe('ListDataMartRelationshipsService', () => {
-  const relationships = [{ id: 'rel-1' }, { id: 'rel-2' }];
+  const relationships = [
+    { id: 'rel-1', sourceDataMart: { id: 'dm-1' }, targetDataMart: { id: 'dm-2' } },
+    { id: 'rel-2', sourceDataMart: { id: 'dm-1' }, targetDataMart: { id: 'dm-3' } },
+  ];
 
   const createService = (canAccess = true) => {
     const relationshipService = {
@@ -60,6 +63,49 @@ describe('ListDataMartRelationshipsService', () => {
     );
     expect(relationshipService.findBySourceDataMartId).toHaveBeenCalledWith('dm-1');
     expect(result).toHaveLength(2);
+  });
+
+  it('passes accessByDmId map with per-DM flags to mapper', async () => {
+    const { service, mapper } = createService(true);
+
+    const command = new ListRelationshipsCommand('dm-1', 'proj-1', 'user-1', ['viewer']);
+
+    await service.run(command);
+
+    const [, , accessByDmId] = mapper.toDomainDtoList.mock.calls[0] as [
+      unknown,
+      unknown,
+      Map<string, { canSee: boolean; canUse: boolean; canEdit: boolean }>,
+    ];
+    expect(accessByDmId).toBeInstanceOf(Map);
+    expect(accessByDmId.has('dm-1')).toBe(true);
+    expect(accessByDmId.has('dm-2')).toBe(true);
+    expect(accessByDmId.has('dm-3')).toBe(true);
+    expect(accessByDmId.get('dm-1')).toEqual({ canSee: true, canUse: true, canEdit: true });
+  });
+
+  it('passes per-DM asymmetric access flags from AccessDecisionService to mapper', async () => {
+    const { service, accessDecisionService, mapper } = createService(true);
+
+    accessDecisionService.canAccess.mockImplementation(
+      (_userId: string, _roles: string[], _entityType: string, dmId: string, action: string) => {
+        if (dmId === 'dm-2' && action !== Action.SEE) return Promise.resolve(false);
+        if (dmId === 'dm-3' && action !== Action.SEE) return Promise.resolve(false);
+        return Promise.resolve(true);
+      }
+    );
+
+    const command = new ListRelationshipsCommand('dm-1', 'proj-1', 'user-1', ['viewer']);
+
+    await service.run(command);
+
+    const [, , accessByDmId] = mapper.toDomainDtoList.mock.calls[0] as [
+      unknown,
+      unknown,
+      Map<string, { canSee: boolean; canUse: boolean; canEdit: boolean }>,
+    ];
+    expect(accessByDmId.get('dm-1')).toEqual({ canSee: true, canUse: true, canEdit: true });
+    expect(accessByDmId.get('dm-2')).toEqual({ canSee: true, canUse: false, canEdit: false });
   });
 
   it('throws ForbiddenException when user lacks SEE on DataMart', async () => {

--- a/apps/backend/src/data-marts/use-cases/list-data-mart-relationships.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-data-mart-relationships.service.ts
@@ -6,6 +6,7 @@ import { AccessDecisionService, Action, EntityType } from '../services/access-de
 import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
 import { DataMartService } from '../services/data-mart.service';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+import { buildDmAccessFlags } from '../utils/build-dm-access-flags';
 
 @Injectable()
 export class ListDataMartRelationshipsService {
@@ -41,6 +42,20 @@ export class ListDataMartRelationshipsService {
     const userProjectionsList =
       await this.userProjectionsFetcherService.fetchRelevantUserProjections(relationships);
 
-    return this.mapper.toDomainDtoList(relationships, userProjectionsList);
+    const uniqueDmIds = new Set<string>();
+    for (const rel of relationships) {
+      uniqueDmIds.add(rel.sourceDataMart.id);
+      uniqueDmIds.add(rel.targetDataMart.id);
+    }
+
+    const accessByDmId = await buildDmAccessFlags(
+      uniqueDmIds,
+      command.userId,
+      command.roles,
+      command.projectId,
+      this.accessDecisionService
+    );
+
+    return this.mapper.toDomainDtoList(relationships, userProjectionsList, accessByDmId);
   }
 }

--- a/apps/backend/src/data-marts/use-cases/list-relationships-by-storage.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-relationships-by-storage.service.spec.ts
@@ -11,7 +11,10 @@ import { ListRelationshipsByStorageCommand } from '../dto/domain/list-relationsh
 import { EntityType, Action } from '../services/access-decision';
 
 describe('ListRelationshipsByStorageService', () => {
-  const relationships = [{ id: 'rel-1' }, { id: 'rel-2' }];
+  const relationships = [
+    { id: 'rel-1', sourceDataMart: { id: 'dm-1' }, targetDataMart: { id: 'dm-2' } },
+    { id: 'rel-2', sourceDataMart: { id: 'dm-1' }, targetDataMart: { id: 'dm-3' } },
+  ];
 
   const createService = (canAccess = true) => {
     const relationshipService = {
@@ -62,6 +65,53 @@ describe('ListRelationshipsByStorageService', () => {
     );
     expect(relationshipService.findByStorageId).toHaveBeenCalledWith('storage-1', 'proj-1');
     expect(result).toHaveLength(2);
+  });
+
+  it('passes accessByDmId map with per-DM flags to mapper', async () => {
+    const { service, mapper } = createService(true);
+
+    const command = new ListRelationshipsByStorageCommand('storage-1', 'proj-1', 'user-1', [
+      'viewer',
+    ]);
+
+    await service.run(command);
+
+    const [, , accessByDmId] = mapper.toDomainDtoList.mock.calls[0] as [
+      unknown,
+      unknown,
+      Map<string, { canSee: boolean; canUse: boolean; canEdit: boolean }>,
+    ];
+    expect(accessByDmId).toBeInstanceOf(Map);
+    expect(accessByDmId.has('dm-1')).toBe(true);
+    expect(accessByDmId.has('dm-2')).toBe(true);
+    expect(accessByDmId.has('dm-3')).toBe(true);
+    expect(accessByDmId.get('dm-2')).toEqual({ canSee: true, canUse: true, canEdit: true });
+  });
+
+  it('passes per-DM asymmetric access flags from AccessDecisionService to mapper', async () => {
+    const { service, accessDecisionService, mapper } = createService(true);
+
+    accessDecisionService.canAccess.mockImplementation(
+      (_userId: string, _roles: string[], _entityType: string, dmId: string, action: string) => {
+        if (dmId === 'dm-2' && action !== Action.SEE) return Promise.resolve(false);
+        if (dmId === 'dm-3' && action !== Action.SEE) return Promise.resolve(false);
+        return Promise.resolve(true);
+      }
+    );
+
+    const command = new ListRelationshipsByStorageCommand('storage-1', 'proj-1', 'user-1', [
+      'viewer',
+    ]);
+
+    await service.run(command);
+
+    const [, , accessByDmId] = mapper.toDomainDtoList.mock.calls[0] as [
+      unknown,
+      unknown,
+      Map<string, { canSee: boolean; canUse: boolean; canEdit: boolean }>,
+    ];
+    expect(accessByDmId.get('dm-1')).toEqual({ canSee: true, canUse: true, canEdit: true });
+    expect(accessByDmId.get('dm-2')).toEqual({ canSee: true, canUse: false, canEdit: false });
   });
 
   it('throws ForbiddenException when user lacks SEE on storage', async () => {

--- a/apps/backend/src/data-marts/use-cases/list-relationships-by-storage.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-relationships-by-storage.service.ts
@@ -6,6 +6,7 @@ import { AccessDecisionService, Action, EntityType } from '../services/access-de
 import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
 import { DataStorageService } from '../services/data-storage.service';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+import { buildDmAccessFlags } from '../utils/build-dm-access-flags';
 
 @Injectable()
 export class ListRelationshipsByStorageService {
@@ -44,6 +45,20 @@ export class ListRelationshipsByStorageService {
     const userProjectionsList =
       await this.userProjectionsFetcherService.fetchRelevantUserProjections(relationships);
 
-    return this.mapper.toDomainDtoList(relationships, userProjectionsList);
+    const uniqueDmIds = new Set<string>();
+    for (const rel of relationships) {
+      uniqueDmIds.add(rel.sourceDataMart.id);
+      uniqueDmIds.add(rel.targetDataMart.id);
+    }
+
+    const accessByDmId = await buildDmAccessFlags(
+      uniqueDmIds,
+      command.userId,
+      command.roles,
+      command.projectId,
+      this.accessDecisionService
+    );
+
+    return this.mapper.toDomainDtoList(relationships, userProjectionsList, accessByDmId);
   }
 }

--- a/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
@@ -11,7 +11,9 @@ jest.mock('../report-run-logging/log-blended-sql', () => ({
   logBlendedSqlIfNeeded: jest.fn(),
 }));
 
+import { NotFoundException } from '@nestjs/common';
 import { logBlendedSqlIfNeeded } from '../report-run-logging/log-blended-sql';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { ReportDataBatch } from '../dto/domain/report-data-batch.dto';
@@ -22,6 +24,7 @@ import { Report } from '../entities/report.entity';
 import { ReportExecutionPolicyResolver } from './report-execution-policy.resolver';
 import { RunReportService } from './run-report.service';
 import { RunType } from '../../common/scheduler/shared/types';
+import { ScheduledRunReportCommand } from '../dto/domain/run-report.command';
 
 jest.mock('../data-destination-types/data-destination-providers', () => ({
   DATA_DESTINATION_REPORT_WRITER_RESOLVER: 'DATA_DESTINATION_REPORT_WRITER_RESOLVER',
@@ -52,12 +55,20 @@ describe('RunReportService', () => {
     const reportRunTriggerService = {
       createTrigger: jest.fn().mockResolvedValue(undefined),
     };
-    const reportAccessService = {
-      checkOperateAccess: jest.fn().mockResolvedValue(undefined),
-      checkMutateAccess: jest.fn().mockResolvedValue(undefined),
-    };
     const gracefulShutdownService = {
       isInShutdownMode: jest.fn().mockReturnValue(false),
+    };
+
+    const reportRepository = {
+      findOne: jest.fn().mockResolvedValue({
+        id: 'report-1',
+        columnConfig: null,
+        dataMart: { id: 'dm-1', projectId: 'proj-1' },
+      }),
+    };
+
+    const reportRunAccessValidatorService = {
+      validate: jest.fn().mockResolvedValue(undefined),
     };
 
     const service = new RunReportService(
@@ -71,9 +82,10 @@ describe('RunReportService', () => {
       projectBalanceService as never,
       new ReportExecutionPolicyResolver(),
       reportRunTriggerService as never,
-      reportAccessService as never,
       blendedReportDataService as never,
-      { compose: jest.fn().mockResolvedValue({ sql: 'SELECT 1' }) } as never
+      { compose: jest.fn().mockResolvedValue({ sql: 'SELECT 1' }) } as never,
+      reportRepository as never,
+      reportRunAccessValidatorService as never
     );
 
     return {
@@ -84,7 +96,8 @@ describe('RunReportService', () => {
       blendedReportDataService,
       reportRunService,
       reportRunTriggerService,
-      reportAccessService,
+      reportRepository,
+      reportRunAccessValidatorService,
     };
   };
 
@@ -207,9 +220,32 @@ describe('RunReportService', () => {
   });
 
   describe('manual runs', () => {
-    it('uses checkOperateAccess (not checkMutateAccess) for manual runs', async () => {
-      const { service, reportAccessService, reportRunService, reportRunTriggerService } =
-        createService();
+    it('throws BusinessViolationException when validator rejects for orphan columns', async () => {
+      const { service, reportRunAccessValidatorService } = createService();
+      reportRunAccessValidatorService.validate.mockRejectedValue(
+        new BusinessViolationException(
+          'Manual run blocked: column(s) b__orphan reference DataMarts no longer accessible to the report creator.'
+        )
+      );
+
+      await expect(
+        service.run({
+          reportId: 'report-1',
+          userId: 'user-1',
+          roles: ['editor'],
+          runType: RunType.manual,
+          projectId: 'proj-1',
+        })
+      ).rejects.toThrow(BusinessViolationException);
+    });
+
+    it('calls validator with pre-resolved roles for manual run', async () => {
+      const {
+        service,
+        reportRunAccessValidatorService,
+        reportRunService,
+        reportRunTriggerService,
+      } = createService();
       reportRunService.createPending.mockResolvedValue({
         getDataMart: () => ({ projectId: 'proj-1' }),
         getDataMartRun: () => ({ id: 'dmr-1' }),
@@ -218,19 +254,98 @@ describe('RunReportService', () => {
       await service.run({
         reportId: 'report-1',
         userId: 'user-1',
-        roles: ['viewer'],
+        roles: ['editor'],
         runType: RunType.manual,
         projectId: 'proj-1',
       });
 
-      expect(reportAccessService.checkOperateAccess).toHaveBeenCalledWith(
+      expect(reportRunAccessValidatorService.validate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'report-1' }),
         'user-1',
-        ['viewer'],
-        'report-1',
-        'proj-1'
+        'proj-1',
+        'Manual run',
+        ['editor']
       );
-      expect(reportAccessService.checkMutateAccess).not.toHaveBeenCalled();
       expect(reportRunTriggerService.createTrigger).toHaveBeenCalled();
+    });
+  });
+
+  describe('scheduled runs', () => {
+    const scheduledCommand: ScheduledRunReportCommand = {
+      reportId: 'report-1',
+      userId: 'user-1',
+      runType: RunType.scheduled,
+      projectId: 'proj-1',
+    };
+
+    it('validates access and enqueues when report exists and validator passes', async () => {
+      const {
+        service,
+        reportRunService,
+        reportRunTriggerService,
+        reportRunAccessValidatorService,
+      } = createService();
+      reportRunService.createPending.mockResolvedValue({
+        getDataMart: () => ({ projectId: 'proj-1' }),
+        getDataMartRun: () => ({ id: 'dmr-1' }),
+      });
+
+      await service.run(scheduledCommand);
+
+      expect(reportRunAccessValidatorService.validate).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'report-1' }),
+        'user-1',
+        'proj-1',
+        'Scheduled run',
+        undefined
+      );
+      expect(reportRunTriggerService.createTrigger).toHaveBeenCalled();
+    });
+
+    it('throws when report is not found', async () => {
+      const { service, reportRepository } = createService();
+      reportRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.run(scheduledCommand)).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws BusinessViolationException when creator is offboarded', async () => {
+      const { service, reportRunAccessValidatorService } = createService();
+      reportRunAccessValidatorService.validate.mockRejectedValue(
+        new BusinessViolationException(
+          'Scheduled run blocked: schedule creator is no longer a member of this project.'
+        )
+      );
+
+      await expect(service.run(scheduledCommand)).rejects.toThrow(BusinessViolationException);
+    });
+
+    it('throws BusinessViolationException when creator lost DM access', async () => {
+      const { service, reportRunAccessValidatorService } = createService();
+      reportRunAccessValidatorService.validate.mockRejectedValue(
+        new BusinessViolationException(
+          'Scheduled run blocked: schedule creator no longer has access to DataMart "My DM".'
+        )
+      );
+
+      await expect(service.run(scheduledCommand)).rejects.toThrow(BusinessViolationException);
+    });
+
+    it('throws BusinessViolationException when report has orphan columns', async () => {
+      const { service, reportRepository, reportRunAccessValidatorService } = createService();
+      reportRepository.findOne.mockResolvedValue({
+        id: 'report-1',
+        columnConfig: ['dm2__field_a'],
+        dataMart: { id: 'dm-1', projectId: 'proj-1' },
+        dataDestination: { id: 'dest-1' },
+      });
+      reportRunAccessValidatorService.validate.mockRejectedValue(
+        new BusinessViolationException(
+          'Scheduled run blocked: column(s) dm2__field_a reference DataMarts no longer accessible.'
+        )
+      );
+
+      await expect(service.run(scheduledCommand)).rejects.toThrow(BusinessViolationException);
     });
   });
 

--- a/apps/backend/src/data-marts/use-cases/run-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { TypeResolver } from '../../common/resolver/type-resolver';
@@ -27,51 +27,16 @@ import {
   ReportExecutionPolicy,
   ReportExecutionPolicyResolver,
 } from './report-execution-policy.resolver';
-import { ReportAccessService } from '../services/report-access.service';
 import { ReportSqlComposerService } from '../services/report-sql-composer.service';
 import { SqlParameter } from '../data-storage-types/utils/sql-clause-renderer';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ReportRunAccessValidatorService } from '../services/report-run-access-validator.service';
 
 const ERROR_NAMES = {
   ABORT: 'AbortError',
 } as const;
 
-/**
- * Use case for executing scheduled and manual report runs.
- *
- * This is the main orchestrator for report execution, coordinating multiple services
- * to read data from storage, transform it, and write to destination.
- *
- * Responsibilities:
- * - Managing complete report execution lifecycle
- * - Coordinating data readers and writers via resolver pattern
- * - Handling cancellation via AbortSignal
- * - Preventing new runs during graceful shutdown
- * - Actualizing data mart schema before execution
- * - Tracking active processes for graceful shutdown
- *
- * Execution flow:
- * 1. Validate system can run (not in shutdown)
- * 2. Create pending ReportRun with optimistic locking
- * 3. Register process for graceful shutdown tracking
- * 4. Actualize data mart schema
- * 5. Mark run as started
- * 6. Execute data extraction and writing in batches
- * 7. Handle success/failure/cancellation
- * 8. Persist final status in transaction
- * 9. Unregister process
- *
- * Concurrency handling:
- * - Returns early if report already running (null from createPending)
- * - Optimistic locking prevents concurrent runs of same report
- * - Multiple different reports can run concurrently
- *
- * Cancellation support:
- * - Accepts optional AbortSignal for user/system cancellation
- * - Checks signal before each batch operation
- * - Marks run as CANCELLED on AbortError
- *
- * @see ReportRun - Domain model for report run
- */
 @Injectable()
 export class RunReportService {
   private readonly logger = new Logger(RunReportService.name);
@@ -92,32 +57,32 @@ export class RunReportService {
     private readonly projectBalanceService: ProjectBalanceService,
     private readonly reportExecutionPolicyResolver: ReportExecutionPolicyResolver,
     private readonly reportRunTriggerService: ReportRunTriggerService,
-    private readonly reportAccessService: ReportAccessService,
     private readonly blendedReportDataService: BlendedReportDataService,
-    private readonly reportSqlComposerService: ReportSqlComposerService
+    private readonly reportSqlComposerService: ReportSqlComposerService,
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    private readonly reportRunAccessValidatorService: ReportRunAccessValidatorService
   ) {}
 
-  /**
-   * Creates a pending report run and enqueues it via trigger for worker processing.
-   *
-   * Auth gating runs OUTSIDE the transactional boundary so a 403 doesn't open and
-   * roll back a database transaction. The actual createPending + createTrigger work
-   * stays atomic via `enqueueReportRun`.
-   *
-   * @param command - Report run command with reportId, userId, runType
-   * @param signal - Unused, kept for backward compatibility with scheduled processors
-   */
   async run(command: RunReportCommand, _signal?: AbortSignal): Promise<void> {
     this.validateCanRun();
 
-    if (command.runType === RunType.manual) {
-      await this.reportAccessService.checkOperateAccess(
-        command.userId,
-        command.roles,
-        command.reportId,
-        command.projectId
-      );
+    const report = await this.reportRepository.findOne({
+      where: { id: command.reportId, dataMart: { projectId: command.projectId } },
+      relations: ['dataMart', 'dataDestination'],
+    });
+    if (!report) {
+      throw new NotFoundException(`Report ${command.reportId} not found`);
     }
+
+    const isManual = command.runType === RunType.manual;
+    await this.reportRunAccessValidatorService.validate(
+      report,
+      command.userId,
+      command.projectId,
+      isManual ? 'Manual run' : 'Scheduled run',
+      isManual ? command.roles : undefined
+    );
 
     await this.enqueueReportRun(command);
   }
@@ -143,13 +108,6 @@ export class RunReportService {
     });
   }
 
-  /**
-   * Execute a pre-created report run. Called by ReportRunTriggerHandler on worker.
-   *
-   * @param dataMartRunId - The ID of the DataMartRun to execute
-   * @param expectedProjectId - The projectId from the trigger, used to validate ownership
-   * @param signal - Optional AbortSignal for cancellation
-   */
   async executeExistingRun(
     dataMartRunId: string,
     expectedProjectId: string,
@@ -171,24 +129,6 @@ export class RunReportService {
     await this.executeReportRunWithCleanup(reportRun, signal);
   }
 
-  /**
-   * Executes core report data extraction and writing logic.
-   *
-   * Process:
-   * 1. Resolves reader for data storage type (BigQuery, Athena, etc.)
-   * 2. Resolves writer for destination type (Looker Studio, Google Sheets, etc.)
-   * 3. Prepares report data (gets metadata, row count, etc.)
-   * 4. Initializes writer for batch writing
-   * 5. Reads and writes data in batches until complete
-   * 6. Finalizes both reader and writer (cleanup resources)
-   *
-   * Cancellation: Checks AbortSignal before each batch operation.
-   *
-   * @param report - Report entity with storage and destination config
-   * @param signal - Optional AbortSignal for cancellation
-   * @param reportRunLogger - Optional run-scoped structured logger.
-   * @throws Error if read/write fails, propagated to caller
-   */
   private async executeReport(
     report: Report,
     signal?: AbortSignal,
@@ -221,8 +161,6 @@ export class RunReportService {
         (report.sortConfig?.length ?? 0) > 0 ||
         report.limitConfig != null
       ) {
-        // Non-blended report with output controls — compose the full SQL + params here so
-        // the reader doesn't need to know about output-controls semantics.
         const composed = await this.reportSqlComposerService.compose(report);
         sqlOverride = composed.sql;
         sqlOverrideParams = composed.params;
@@ -261,23 +199,6 @@ export class RunReportService {
     }
   }
 
-  /**
-   * Wraps report execution with lifecycle management and cleanup.
-   *
-   * Ensures proper resource cleanup and status persistence even if execution fails.
-   *
-   * Steps:
-   * 1. Generates unique process ID for tracking
-   * 2. Registers process for graceful shutdown
-   * 3. Actualizes data mart schema
-   * 4. Marks run as started
-   * 5. Executes report data extraction
-   * 6. Handles success/error/cancellation
-   * 7. Always unregisters process in finally block
-   *
-   * @param reportRun - Report run domain model
-   * @param signal - Optional AbortSignal for cancellation
-   */
   private async executeReportRunWithCleanup(
     reportRun: ReportRun,
     signal?: AbortSignal
@@ -304,10 +225,6 @@ export class RunReportService {
     }
   }
 
-  /**
-   * Validates that system can start new report runs.
-   * @throws BusinessViolationException if system is in shutdown mode
-   */
   private validateCanRun() {
     if (this.gracefulShutdownService.isInShutdownMode()) {
       throw new BusinessViolationException(
@@ -374,38 +291,17 @@ export class RunReportService {
     }
   }
 
-  /**
-   * Generates unique process ID for graceful shutdown tracking.
-   * Format: report-{reportId}-{timestamp}-{random}
-   *
-   * @param reportId - Report identifier
-   * @returns Unique process ID
-   */
   private generateProcessId(reportId: string): string {
     const timestamp = this.systemTimeService.now();
     const random = Math.random().toString(36).substring(2, 11);
     return `report-${reportId}-${timestamp}-${random}`;
   }
 
-  /**
-   * Actualizes (refreshes) data mart schema before execution.
-   * Ensures report reads from latest table structure.
-   *
-   * @param dataMart - DataMart entity to actualize
-   */
   private async actualizeSchemaInDataMart(dataMart: DataMart): Promise<void> {
     await this.dataMartService.actualizeSchemaInEntity(dataMart);
     await this.dataMartService.save(dataMart);
   }
 
-  /**
-   * Handles successful report run completion.
-   * Marks as success and persists results.
-   *
-   * @param reportRun - Completed report run
-   * @param logs - Structured logs collected during the run
-   * @param errors - Structured errors collected during the run
-   */
   private async handleReportRunSuccess(
     reportRun: ReportRun,
     logs: string[] = [],
@@ -419,18 +315,6 @@ export class RunReportService {
     }
   }
 
-  /**
-   * Handles report run error or cancellation.
-   *
-   * Distinguishes between:
-   * - AbortError: User/system cancellation -> marks as CANCELLED
-   * - Other errors: Execution failure -> marks as FAILED with error message
-   *
-   * @param reportRun - Failed or cancelled report run
-   * @param error - Error that occurred
-   * @param logs - Structured logs collected before failure
-   * @param errors - Structured errors including the failure reason
-   */
   private async handleReportRunError(
     reportRun: ReportRun,
     error: Error,
@@ -450,14 +334,7 @@ export class RunReportService {
     await this.saveReportRunResultSafely(reportRun, logs, errors);
   }
 
-  /**
-   * Attempts to save report run results to the database.
-   * If save fails, logs the error but does not throw to prevent losing the in-memory state.
-   *
-   * TODO: Implement proper error handling strategy (retry mechanism, dead letter queue, etc.)
-   *
-   * @returns true if saved successfully, false otherwise
-   */
+  // TODO: Implement proper error handling strategy (retry mechanism, dead letter queue, etc.)
   private async saveReportRunResultSafely(
     reportRun: ReportRun,
     logs: string[] = [],

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-relationship.service.ts
@@ -13,6 +13,7 @@ import { DataMartRelationshipService } from '../services/data-mart-relationship.
 import { DataMartService } from '../services/data-mart.service';
 import { ReportDataCacheService } from '../services/report-data-cache.service';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+import { buildDmAccessFlags } from '../utils/build-dm-access-flags';
 
 @Injectable()
 export class UpdateDataMartRelationshipService {
@@ -81,8 +82,17 @@ export class UpdateDataMartRelationshipService {
 
     await this.reportDataCacheService.invalidateByDataMartId(command.sourceDataMartId);
 
-    const createdByUser = await this.userProjectionsFetcherService.fetchCreatedByUser(updated);
-    return this.mapper.toDomainDto(updated, createdByUser);
+    const [createdByUser, accessByDmId] = await Promise.all([
+      this.userProjectionsFetcherService.fetchCreatedByUser(updated),
+      buildDmAccessFlags(
+        new Set([updated.sourceDataMart.id, updated.targetDataMart.id]),
+        command.userId,
+        command.roles,
+        command.projectId,
+        this.accessDecisionService
+      ),
+    ]);
+    return this.mapper.toDomainDto(updated, createdByUser, accessByDmId);
   }
 
   private async cascadeAliasRename(

--- a/apps/backend/src/data-marts/use-cases/update-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-report.service.spec.ts
@@ -28,6 +28,7 @@ jest.mock('../utils/resolve-owner-users', () => ({
 }));
 
 import { ForbiddenException, BadRequestException } from '@nestjs/common';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { UpdateReportService } from './update-report.service';
 import { UpdateReportCommand } from '../dto/domain/update-report.command';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
@@ -115,6 +116,10 @@ describe('UpdateReportService', () => {
       ...outputControlsValidatorOverride,
     };
 
+    const blendableSchemaService = {
+      assertNoInaccessibleReportRefs: jest.fn().mockResolvedValue(undefined),
+    };
+
     const service = new UpdateReportService(
       reportRepository as never,
       dataDestinationService as never,
@@ -127,7 +132,8 @@ describe('UpdateReportService', () => {
       reportAccessService as never,
       reportDataCacheService as never,
       outputControlsValidator as never,
-      accessDecisionService as never
+      accessDecisionService as never,
+      blendableSchemaService as never
     );
 
     return {
@@ -137,6 +143,7 @@ describe('UpdateReportService', () => {
       reportRepository,
       reportDataCacheService,
       outputControlsValidator,
+      blendableSchemaService,
     };
   };
 
@@ -392,5 +399,31 @@ describe('UpdateReportService', () => {
       canManageTriggers: true,
       canEditConfig: true,
     });
+  });
+
+  it('throws BusinessViolationException when report refs inaccessible data marts', async () => {
+    const { service, blendableSchemaService } = createService();
+    blendableSchemaService.assertNoInaccessibleReportRefs.mockRejectedValue(
+      new BusinessViolationException(
+        'Cannot update report: columns reference inaccessible data marts: b__orphan, c__missing'
+      )
+    );
+
+    const command = new UpdateReportCommand(
+      'report-1',
+      'proj-1',
+      'user-1',
+      ['editor'],
+      'New Title',
+      'dest-1',
+      {} as never,
+      undefined,
+      [{ dataMartId: 'dm-2', fieldName: 'b__orphan', alias: 'b__orphan' }] as never
+    );
+
+    await expect(service.run(command)).rejects.toThrow(BusinessViolationException);
+    await expect(service.run(command)).rejects.toThrow(
+      /b__orphan.*c__missing|c__missing.*b__orphan/
+    );
   });
 });

--- a/apps/backend/src/data-marts/use-cases/update-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-report.service.ts
@@ -24,6 +24,8 @@ import { AccessDecisionService, EntityType, Action } from '../services/access-de
 import { ReportAccessService } from '../services/report-access.service';
 import { ReportDataCacheService } from '../services/report-data-cache.service';
 import { OutputControlsValidatorService } from '../services/output-controls-validator.service';
+import { BlendableSchemaService } from '../services/blendable-schema.service';
+import { createDataMartUseAccessFilter } from '../utils/create-dm-access-filter';
 
 @Injectable()
 export class UpdateReportService {
@@ -41,12 +43,12 @@ export class UpdateReportService {
     private readonly reportAccessService: ReportAccessService,
     private readonly reportDataCacheService: ReportDataCacheService,
     private readonly outputControlsValidator: OutputControlsValidatorService,
-    private readonly accessDecisionService: AccessDecisionService
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly blendableSchemaService: BlendableSchemaService
   ) {}
 
   @Transactional()
   async run(command: UpdateReportCommand): Promise<ReportDto> {
-    // Find the existing report
     const report = await this.reportRepository.findOne({
       where: {
         id: command.id,
@@ -68,7 +70,29 @@ export class UpdateReportService {
       command.projectId
     );
 
-    // Get the data destination if it's being changed and verify caller can USE it
+    if (
+      command.userId &&
+      (command.columnConfig?.length || command.filterConfig?.length || command.sortConfig?.length)
+    ) {
+      const accessFilter = createDataMartUseAccessFilter(
+        this.accessDecisionService,
+        command.userId,
+        command.roles,
+        command.projectId
+      );
+      await this.blendableSchemaService.assertNoInaccessibleReportRefs(
+        {
+          columnConfig: command.columnConfig,
+          filterConfig: command.filterConfig,
+          sortConfig: command.sortConfig,
+        },
+        report.dataMart.id,
+        command.projectId,
+        accessFilter,
+        'Cannot save report'
+      );
+    }
+
     let dataDestination: DataDestination = report.dataDestination;
     const destinationIsChanging = command.dataDestinationId !== dataDestination.id;
     if (destinationIsChanging) {
@@ -77,7 +101,6 @@ export class UpdateReportService {
         command.projectId
       );
 
-      // Permissions Model: caller must have USE on the new destination
       if (command.userId) {
         const canUseNewDest = await this.accessDecisionService.canAccess(
           command.userId,
@@ -95,14 +118,12 @@ export class UpdateReportService {
 
     this.availableDestinationTypesService.verifyIsAllowed(dataDestination.type);
 
-    // Validate access to the data destination
     await this.dataDestinationAccessValidationFacade.checkAccess(
       dataDestination.type,
       command.destinationConfig,
       dataDestination
     );
 
-    // Validate owners BEFORE mutating
     if (command.ownerIds !== undefined) {
       for (const ownerId of command.ownerIds) {
         const canOwn = await this.reportAccessService.canBeOwner(
@@ -178,7 +199,6 @@ export class UpdateReportService {
       await this.reportDataCacheService.invalidateByReportId(updatedReport.id);
     }
 
-    // Reload to get fresh owners
     const fresh = await this.reportRepository.findOne({
       where: { id: updatedReport.id },
       relations: ['dataMart', 'dataDestination', 'owners'],

--- a/apps/backend/src/data-marts/utils/build-dm-access-flags.ts
+++ b/apps/backend/src/data-marts/utils/build-dm-access-flags.ts
@@ -1,0 +1,44 @@
+import { RelationshipDataMartAccess } from '../dto/domain/relationship.dto';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+
+export async function buildDmAccessFlags(
+  uniqueDmIds: Set<string>,
+  userId: string,
+  roles: string[],
+  projectId: string,
+  accessDecisionService: AccessDecisionService
+): Promise<Map<string, RelationshipDataMartAccess>> {
+  const accessByDmId = new Map<string, RelationshipDataMartAccess>();
+  await Promise.all(
+    [...uniqueDmIds].map(async dmId => {
+      const [canSee, canUse, canEdit] = await Promise.all([
+        accessDecisionService.canAccess(
+          userId,
+          roles,
+          EntityType.DATA_MART,
+          dmId,
+          Action.SEE,
+          projectId
+        ),
+        accessDecisionService.canAccess(
+          userId,
+          roles,
+          EntityType.DATA_MART,
+          dmId,
+          Action.USE,
+          projectId
+        ),
+        accessDecisionService.canAccess(
+          userId,
+          roles,
+          EntityType.DATA_MART,
+          dmId,
+          Action.EDIT,
+          projectId
+        ),
+      ]);
+      accessByDmId.set(dmId, { canSee, canUse, canEdit });
+    })
+  );
+  return accessByDmId;
+}

--- a/apps/backend/src/data-marts/utils/create-dm-access-filter.ts
+++ b/apps/backend/src/data-marts/utils/create-dm-access-filter.ts
@@ -1,0 +1,24 @@
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+
+export function createDataMartUseAccessFilter(
+  accessDecisionService: AccessDecisionService,
+  userId: string,
+  roles: string[],
+  projectId: string
+): (dmId: string) => Promise<boolean> {
+  const cache = new Map<string, boolean>();
+  return async (dmId: string): Promise<boolean> => {
+    const cached = cache.get(dmId);
+    if (cached !== undefined) return cached;
+    const result = await accessDecisionService.canAccess(
+      userId,
+      roles,
+      EntityType.DATA_MART,
+      dmId,
+      Action.USE,
+      projectId
+    );
+    cache.set(dmId, result);
+    return result;
+  };
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
@@ -1,5 +1,13 @@
 import { Badge } from '@owox/ui/components/badge';
-import { ExternalLink, Info, Locate, Maximize2, ZoomIn, ZoomOut } from 'lucide-react';
+import {
+  AlertTriangle,
+  ExternalLink,
+  Info,
+  Locate,
+  Maximize2,
+  ZoomIn,
+  ZoomOut,
+} from 'lucide-react';
 import { useCallback, useEffect, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { GetSchemes } from 'rete';
@@ -11,8 +19,10 @@ import { Presets as ReactPresets, type ReactArea2D, ReactPlugin } from 'rete-rea
 import { Button } from '../../../../../shared/components/Button';
 import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
 import type { DataMartRelationship } from '../../../shared/types/relationship.types';
+import { deriveTransientInaccessible } from './compute-graph-state';
 import {
   CYCLE_STUB_TOOLTIP,
+  INACCESSIBLE_TOOLTIP,
   getRelationshipWarningLabel,
   hasRelationshipWarning,
 } from './relationship-warning-state';
@@ -40,6 +50,7 @@ const V_GAP = 24;
 const NODE_BORDER = '#9ca3af'; // gray-400, visible in both themes
 const HIGHLIGHT_COLOR = '#3b82f6'; // blue-500
 const DRAFT_COLOR = '#f97316'; // orange-500
+const INACCESSIBLE_COLOR = '#9ca3af'; // gray-400
 
 class DMNode extends ClassicPreset.Node {
   width = NODE_W;
@@ -53,6 +64,7 @@ class DMNode extends ClassicPreset.Node {
   onOpenExternal?: () => void;
   isDraft: boolean;
   isBlocked: boolean;
+  isInaccessible: boolean;
   isJoinNotConfigured: boolean;
   isCycleStub: boolean;
   highlighted = false;
@@ -70,6 +82,7 @@ class DMNode extends ClassicPreset.Node {
       onOpenExternal?: () => void;
       isDraft?: boolean;
       isBlocked?: boolean;
+      isInaccessible?: boolean;
       isJoinNotConfigured?: boolean;
       isCycleStub?: boolean;
     }
@@ -84,6 +97,7 @@ class DMNode extends ClassicPreset.Node {
     this.onOpenExternal = opts?.onOpenExternal;
     this.isDraft = opts?.isDraft ?? false;
     this.isBlocked = opts?.isBlocked ?? false;
+    this.isInaccessible = opts?.isInaccessible ?? false;
     this.isJoinNotConfigured = opts?.isJoinNotConfigured ?? false;
     this.isCycleStub = opts?.isCycleStub ?? false;
     if (!isSource) this.height = TGT_H;
@@ -101,7 +115,9 @@ function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Sch
   function handleExtClick(e: React.MouseEvent) {
     e.stopPropagation();
     e.preventDefault();
-    n.onOpenExternal?.();
+    if (!n.isInaccessible) {
+      n.onOpenExternal?.();
+    }
   }
 
   const outputs = Object.entries(n.outputs);
@@ -168,10 +184,15 @@ function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Sch
 
   const borderColor = hasRelationshipWarning(n) ? DRAFT_COLOR : NODE_BORDER;
   const badgeLabel = getRelationshipWarningLabel(n);
+  const nodeTitle = n.isCycleStub
+    ? CYCLE_STUB_TOOLTIP
+    : n.isInaccessible
+      ? INACCESSIBLE_TOOLTIP
+      : undefined;
 
   return (
     <div
-      title={n.isCycleStub ? CYCLE_STUB_TOOLTIP : undefined}
+      title={nodeTitle}
       style={{
         width: n.width,
         height: n.height,
@@ -183,8 +204,8 @@ function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Sch
           : '0 1px 4px 0 rgba(0,0,0,0.12)',
         cursor: 'default',
         position: 'relative',
-        opacity: n.dimmed ? 0.15 : 1,
-        filter: n.dimmed ? 'grayscale(0.8)' : undefined,
+        opacity: n.dimmed ? 0.15 : n.isInaccessible ? 0.6 : 1,
+        filter: n.dimmed ? 'grayscale(0.8)' : n.isInaccessible ? 'grayscale(0.6)' : undefined,
         animation: n.highlighted ? 'node-pulse 1.5s ease-in-out infinite' : undefined,
         transition: 'opacity 0.2s, filter 0.2s',
       }}
@@ -236,7 +257,15 @@ function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Sch
           {n.label}
         </span>
         <div className='ml-2 flex shrink-0 items-center gap-0.5'>
-          {n.description && (
+          {n.isInaccessible && (
+            <span
+              className='text-muted-foreground inline-flex cursor-default rounded p-0.5'
+              title={INACCESSIBLE_TOOLTIP}
+            >
+              <AlertTriangle style={{ width: 14, height: 14 }} />
+            </span>
+          )}
+          {!n.isInaccessible && n.description && (
             <span
               className='text-muted-foreground hover:text-foreground inline-flex cursor-default rounded p-0.5 transition-colors'
               title={n.description}
@@ -244,17 +273,19 @@ function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Sch
               <Info style={{ width: 14, height: 14 }} />
             </span>
           )}
-          <button
-            className='text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded p-0.5 transition-colors'
-            onPointerDown={e => {
-              e.stopPropagation();
-            }}
-            onClick={handleExtClick}
-            title='Open in new tab'
-            aria-label='Open in new tab'
-          >
-            <ExternalLink style={{ width: 14, height: 14 }} />
-          </button>
+          {!n.isInaccessible && (
+            <button
+              className='text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded p-0.5 transition-colors'
+              onPointerDown={e => {
+                e.stopPropagation();
+              }}
+              onClick={handleExtClick}
+              title='Open in new tab'
+              aria-label='Open in new tab'
+            >
+              <ExternalLink style={{ width: 14, height: 14 }} />
+            </button>
+          )}
         </div>
       </div>
       <div
@@ -344,17 +375,22 @@ async function setupEditor(
     if (!path) return null;
     const src = editor.getNode(props.data.source);
     const tgt = editor.getNode(props.data.target);
+    const inaccessible = tgt?.isInaccessible === true;
     const orange =
-      src?.isDraft === true ||
-      src?.isBlocked === true ||
-      src?.isJoinNotConfigured === true ||
-      src?.isCycleStub === true ||
-      tgt?.isDraft === true ||
-      tgt?.isBlocked === true ||
-      tgt?.isJoinNotConfigured === true ||
-      tgt?.isCycleStub === true;
+      !inaccessible &&
+      (src?.isDraft === true ||
+        src?.isBlocked === true ||
+        src?.isJoinNotConfigured === true ||
+        src?.isCycleStub === true ||
+        tgt?.isDraft === true ||
+        tgt?.isBlocked === true ||
+        tgt?.isJoinNotConfigured === true ||
+        tgt?.isCycleStub === true);
     const bothDimmed =
       (src?.dimmed === true || src === undefined) && (tgt?.dimmed === true || tgt === undefined);
+
+    const strokeColor = inaccessible ? INACCESSIBLE_COLOR : orange ? DRAFT_COLOR : 'steelblue';
+    const strokeDash = inaccessible ? '4 4' : orange ? '8 4' : undefined;
 
     return (
       <svg
@@ -371,9 +407,9 @@ async function setupEditor(
           d={path}
           fill='none'
           strokeWidth='5px'
-          stroke={orange ? DRAFT_COLOR : 'steelblue'}
-          strokeDasharray={orange ? '8 4' : undefined}
-          opacity={bothDimmed ? 0.15 : 1}
+          stroke={strokeColor}
+          strokeDasharray={strokeDash}
+          opacity={bothDimmed ? 0.15 : inaccessible ? 0.5 : 1}
           style={{ pointerEvents: 'auto', transition: 'opacity 0.2s' }}
         />
       </svg>
@@ -414,6 +450,7 @@ async function setupEditor(
     fieldCount?: number;
     isDraft?: boolean;
     isBlocked?: boolean;
+    isInaccessible?: boolean;
     isJoinNotConfigured?: boolean;
     isCycleStub?: boolean;
   }
@@ -445,7 +482,8 @@ async function setupEditor(
     rels: DataMartRelationship[],
     depth: number,
     ancestorDmIds: Set<string>,
-    parentBlocked: boolean
+    parentBlocked: boolean,
+    parentInaccessible: boolean
   ) {
     if (rels.length > 0) hasOutgoing.add(parentNodeKey);
 
@@ -455,6 +493,10 @@ async function setupEditor(
       const isDraft = rel.targetDataMart.status === 'DRAFT';
       const isJoinNotConfigured = rel.joinConditions.length === 0;
       const isBlocked = parentBlocked;
+      const isInaccessible = deriveTransientInaccessible(
+        parentInaccessible,
+        rel.targetDataMart.access
+      );
       const isCycleStub = ancestorDmIds.has(dmId);
 
       edges.push({ sourceId: parentNodeKey, targetId: nodeKey });
@@ -470,11 +512,12 @@ async function setupEditor(
         fieldCount: fieldCounts?.get(rel.id) ?? 0,
         isDraft,
         isBlocked,
+        isInaccessible,
         isJoinNotConfigured,
         isCycleStub,
       });
 
-      if (showTransient && !isCycleStub) {
+      if (showTransient && !isCycleStub && !isInaccessible) {
         try {
           const childRels = await dataMartRelationshipService.getRelationships(dmId, {
             skipLoadingIndicator: true,
@@ -487,18 +530,25 @@ async function setupEditor(
               childRels,
               depth + 1,
               newAncestors,
-              parentBlocked || isDraft || isJoinNotConfigured
+              parentBlocked || isDraft || isJoinNotConfigured,
+              isInaccessible
             );
           }
         } catch {
-          // Render partial graph if a transitive child fetch fails
-          // (e.g. missing permission) rather than failing the canvas.
+          // intentional: partial graph is acceptable when a transitive fetch fails
         }
       }
     }
   }
 
-  await collectGraph(dataMartId, initialRelationships, 1, new Set([dataMartId]), rootIsDraft);
+  await collectGraph(
+    dataMartId,
+    initialRelationships,
+    1,
+    new Set([dataMartId]),
+    rootIsDraft,
+    false
+  );
 
   const nodeMap = new Map<string, DMNode>();
   const columns = new Map<number, DMNode[]>();
@@ -510,6 +560,7 @@ async function setupEditor(
       description: info.description,
       isDraft: info.isDraft,
       isBlocked: info.isBlocked,
+      isInaccessible: info.isInaccessible,
       isJoinNotConfigured: info.isJoinNotConfigured,
       isCycleStub: info.isCycleStub,
       onOpenExternal: () => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/TargetDataMartPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/TargetDataMartPicker.tsx
@@ -1,8 +1,8 @@
 import { X } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { toast } from 'react-hot-toast';
 import { Button } from '../../../../../shared/components/Button';
 import { Combobox } from '../../../../../shared/components/Combobox/combobox';
+import { showApiErrorToast } from '../../../../../shared/utils';
 import { generateUniqueAlias, slugify } from '../../../../../utils/string-utils';
 import { dataMartService } from '../../../shared';
 import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
@@ -42,6 +42,9 @@ export function TargetDataMartPicker({
           .map(dm => ({ id: dm.id, title: dm.title }));
 
         setAvailableDMs(filtered);
+      } catch (err) {
+        showApiErrorToast(err, 'Failed to load data marts');
+        setAvailableDMs([]);
       } finally {
         setIsLoadingDMs(false);
       }
@@ -68,11 +71,11 @@ export function TargetDataMartPicker({
           targetAlias,
           joinConditions: [],
         },
-        { skipLoadingIndicator: true }
+        { skipLoadingIndicator: true, skipErrorToast: true }
       );
       onCreated(created);
-    } catch {
-      toast.error('Failed to add relationship');
+    } catch (err) {
+      showApiErrorToast(err, 'Failed to add relationship');
     } finally {
       setIsCreating(false);
     }

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/__tests__/RelationshipCanvas.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/__tests__/RelationshipCanvas.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { deriveTransientInaccessible } from '../compute-graph-state';
+
+describe('deriveTransientInaccessible', () => {
+  it.each([
+    {
+      parentInaccessible: false,
+      access: { canSee: true, canUse: true, canEdit: true },
+      expected: false,
+    },
+    {
+      parentInaccessible: false,
+      access: { canSee: false, canUse: false, canEdit: false },
+      expected: true,
+    },
+    {
+      parentInaccessible: true,
+      access: { canSee: true, canUse: true, canEdit: true },
+      expected: true,
+    },
+    {
+      parentInaccessible: true,
+      access: { canSee: false, canUse: false, canEdit: false },
+      expected: true,
+    },
+    {
+      parentInaccessible: false,
+      access: undefined,
+      expected: false,
+    },
+    {
+      parentInaccessible: true,
+      access: undefined,
+      expected: true,
+    },
+  ])(
+    'parentInaccessible=$parentInaccessible access.canSee=$access.canSee → $expected',
+    ({ parentInaccessible, access, expected }) => {
+      expect(deriveTransientInaccessible(parentInaccessible, access)).toBe(expected);
+    }
+  );
+
+  it('returns inaccessible when parent is inaccessible even if own canSee=true', () => {
+    expect(deriveTransientInaccessible(true, { canSee: true, canUse: true, canEdit: true })).toBe(
+      true
+    );
+  });
+
+  it('diamond per-path: node under inaccessible parent is inaccessible regardless of accessible sibling path', () => {
+    const blockedParent = true;
+    const accessibleSelf = { canSee: true, canUse: true, canEdit: true };
+    expect(deriveTransientInaccessible(blockedParent, accessibleSelf)).toBe(true);
+
+    const accessibleParent = false;
+    expect(deriveTransientInaccessible(accessibleParent, accessibleSelf)).toBe(false);
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/__tests__/TargetDataMartPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/__tests__/TargetDataMartPicker.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { TargetDataMartPicker } from '../TargetDataMartPicker';
+
+vi.mock('../../../../../../shared/components/Combobox/combobox', () => ({
+  Combobox: ({
+    onValueChange,
+    placeholder,
+  }: {
+    onValueChange: (v: string) => void;
+    placeholder: string;
+  }) => (
+    <button
+      data-testid='combobox'
+      aria-label={placeholder}
+      onClick={() => {
+        onValueChange('dm-target');
+      }}
+    >
+      {placeholder}
+    </button>
+  ),
+}));
+
+vi.mock('../../../../shared', () => ({
+  dataMartService: {
+    getDataMarts: vi.fn(),
+    getDataMartById: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../shared/services/data-mart-relationship.service', () => ({
+  dataMartRelationshipService: {
+    createRelationship: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../../../shared/utils', () => ({
+  showApiErrorToast: vi.fn(),
+  generateUniqueAlias: vi.fn(() => 'target-dm'),
+  slugify: vi.fn((s: string) => s.toLowerCase().replace(/\s+/g, '-')),
+}));
+
+vi.mock('../../../../../../utils/string-utils', () => ({
+  generateUniqueAlias: vi.fn(() => 'target-dm'),
+  slugify: vi.fn((s: string) => s.toLowerCase().replace(/\s+/g, '-')),
+}));
+
+import { dataMartService } from '../../../../shared';
+import { dataMartRelationshipService } from '../../../../shared/services/data-mart-relationship.service';
+import { showApiErrorToast } from '../../../../../../shared/utils';
+
+const BASE_DM = { id: 'dm-source', title: 'Source DM', storage: { title: 'BQ' } };
+const TARGET_DM = { id: 'dm-target', title: 'Target DM', storage: { title: 'BQ' } };
+
+describe('TargetDataMartPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (dataMartService.getDataMarts as ReturnType<typeof vi.fn>).mockResolvedValue([
+      BASE_DM,
+      TARGET_DM,
+    ]);
+    (dataMartService.getDataMartById as ReturnType<typeof vi.fn>).mockResolvedValue(BASE_DM);
+  });
+
+  it('shows error toast and clears list when getDataMarts rejects', async () => {
+    const loadError = new Error('Network Error');
+    (dataMartService.getDataMarts as ReturnType<typeof vi.fn>).mockRejectedValue(loadError);
+
+    render(
+      <TargetDataMartPicker
+        dataMartId='dm-source'
+        storageId='s-1'
+        existingRelationships={[]}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(showApiErrorToast).toHaveBeenCalledWith(loadError, 'Failed to load data marts');
+    });
+
+    expect(screen.getByTestId('combobox')).toBeInTheDocument();
+  });
+
+  it('shows backend message toast on 403 from createRelationship', async () => {
+    const apiError = Object.assign(new Error('You do not have permission'), {
+      response: { status: 403, data: { message: 'You do not have permission' } },
+    });
+    (dataMartRelationshipService.createRelationship as ReturnType<typeof vi.fn>).mockRejectedValue(
+      apiError
+    );
+
+    render(
+      <TargetDataMartPicker
+        dataMartId='dm-source'
+        storageId='s-1'
+        existingRelationships={[]}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('combobox')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('combobox'));
+
+    await waitFor(() => {
+      expect(showApiErrorToast).toHaveBeenCalledWith(apiError, 'Failed to add relationship');
+    });
+  });
+
+  it('shows fallback message toast on network error from createRelationship', async () => {
+    const networkError = new Error('Network Error');
+    (dataMartRelationshipService.createRelationship as ReturnType<typeof vi.fn>).mockRejectedValue(
+      networkError
+    );
+
+    render(
+      <TargetDataMartPicker
+        dataMartId='dm-source'
+        storageId='s-1'
+        existingRelationships={[]}
+        onCreated={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('combobox')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('combobox'));
+
+    await waitFor(() => {
+      expect(showApiErrorToast).toHaveBeenCalledWith(networkError, 'Failed to add relationship');
+    });
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/compute-graph-state.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/compute-graph-state.ts
@@ -1,0 +1,9 @@
+import type { RelatedDataMartAccess } from '../../../shared/types/relationship.types';
+
+export function deriveTransientInaccessible(
+  parentInaccessible: boolean,
+  access: RelatedDataMartAccess | undefined
+): boolean {
+  const ownInaccessible = access !== undefined ? !access.canSee : false;
+  return parentInaccessible || ownInaccessible;
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-warning-state.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-warning-state.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getRelationshipWarningLabel,
+  hasRelationshipWarning,
+  INACCESSIBLE_TOOLTIP,
+  CYCLE_STUB_TOOLTIP,
+} from './relationship-warning-state';
+
+describe('relationship-warning-state', () => {
+  describe('getRelationshipWarningLabel', () => {
+    it('returns "No access" when isInaccessible', () => {
+      expect(getRelationshipWarningLabel({ isInaccessible: true })).toBe('No access');
+    });
+
+    it('returns "Loop" when isCycleStub, even if also inaccessible', () => {
+      expect(getRelationshipWarningLabel({ isCycleStub: true, isInaccessible: true })).toBe('Loop');
+    });
+
+    it('returns "Draft" when isDraft', () => {
+      expect(getRelationshipWarningLabel({ isDraft: true })).toBe('Draft');
+    });
+
+    it('returns "Join not configured" when isJoinNotConfigured', () => {
+      expect(getRelationshipWarningLabel({ isJoinNotConfigured: true })).toBe(
+        'Join not configured'
+      );
+    });
+
+    it('returns "Blocked" when isBlocked', () => {
+      expect(getRelationshipWarningLabel({ isBlocked: true })).toBe('Blocked');
+    });
+
+    it('returns null when no flags set', () => {
+      expect(getRelationshipWarningLabel({})).toBeNull();
+    });
+
+    it('inaccessible takes precedence over draft', () => {
+      expect(getRelationshipWarningLabel({ isInaccessible: true, isDraft: true })).toBe(
+        'No access'
+      );
+    });
+
+    it('inaccessible takes precedence over blocked', () => {
+      expect(getRelationshipWarningLabel({ isInaccessible: true, isBlocked: true })).toBe(
+        'No access'
+      );
+    });
+  });
+
+  describe('hasRelationshipWarning', () => {
+    it('returns true for inaccessible node', () => {
+      expect(hasRelationshipWarning({ isInaccessible: true })).toBe(true);
+    });
+
+    it('returns true for child of inaccessible node (parentInaccessible propagated)', () => {
+      expect(hasRelationshipWarning({ isInaccessible: true, isBlocked: false })).toBe(true);
+    });
+
+    it('returns false when no warning flags', () => {
+      expect(hasRelationshipWarning({})).toBe(false);
+    });
+  });
+
+  describe('chain propagation semantics', () => {
+    it('INACCESSIBLE_TOOLTIP is defined', () => {
+      expect(INACCESSIBLE_TOOLTIP).toBeTruthy();
+    });
+
+    it('CYCLE_STUB_TOOLTIP is defined', () => {
+      expect(CYCLE_STUB_TOOLTIP).toBeTruthy();
+    });
+
+    it.each([
+      { parentInaccessible: true, canSee: true, expected: true },
+      { parentInaccessible: false, canSee: true, expected: false },
+      { parentInaccessible: false, canSee: false, expected: true },
+      { parentInaccessible: true, canSee: false, expected: true },
+    ])(
+      'parentInaccessible=$parentInaccessible canSee=$canSee → isInaccessible=$expected',
+      ({ parentInaccessible, canSee, expected }) => {
+        const isInaccessible = parentInaccessible || !canSee;
+        expect(hasRelationshipWarning({ isInaccessible })).toBe(expected);
+        if (expected) {
+          expect(getRelationshipWarningLabel({ isInaccessible })).toBe('No access');
+        }
+      }
+    );
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-warning-state.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-warning-state.ts
@@ -1,15 +1,19 @@
 export const CYCLE_STUB_TOOLTIP =
   'This data mart is already joined earlier in this branch — stopping here to avoid a loop.';
 
+export const INACCESSIBLE_TOOLTIP = "You don't have access to this data mart.";
+
 interface RelationshipWarningFlags {
   isCycleStub?: boolean;
   isDraft?: boolean;
   isJoinNotConfigured?: boolean;
   isBlocked?: boolean;
+  isInaccessible?: boolean;
 }
 
 export function getRelationshipWarningLabel(flags: RelationshipWarningFlags): string | null {
   if (flags.isCycleStub) return 'Loop';
+  if (flags.isInaccessible) return 'No access';
   if (flags.isDraft) return 'Draft';
   if (flags.isJoinNotConfigured) return 'Join not configured';
   if (flags.isBlocked) return 'Blocked';

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { Editor } from '@monaco-editor/react';
 import { useTheme } from 'next-themes';
 import { Copy, Loader2, Network } from 'lucide-react';
-import { toast } from 'react-hot-toast';
 import { Button } from '@owox/ui/components/button';
 import {
   Dialog,
@@ -14,6 +13,8 @@ import {
 } from '@owox/ui/components/dialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { Skeleton } from '@owox/ui/components/skeleton';
+import { toast } from 'react-hot-toast';
+import { showApiErrorToast } from '../../../../../shared/utils';
 import { reportService } from '../../../reports/shared/services/report.service';
 import { useProjectRoute } from '../../../../../shared/hooks';
 import SqlValidator from '../SqlValidator/SqlValidator';
@@ -22,36 +23,20 @@ type GeneratedSqlViewerVariant = 'action-icon' | 'outline-button';
 
 interface GeneratedSqlViewerProps {
   reportId: string;
-  /**
-   * Data mart ID the report belongs to. Required to run the SQL dry-run
-   * validation (size estimate + syntax check) against the correct storage.
-   */
   dataMartId: string;
-  /**
-   * Visual variant of the trigger:
-   * - 'action-icon' (default): ghost icon button with tooltip, intended for
-   *   table row action cells. Uses hover-reveal styling that matches sibling
-   *   row actions.
-   * - 'outline-button': outline button with "View joined Data Marts SQL" text,
-   *   intended for use inside forms where a full button label makes sense.
-   */
   variant?: GeneratedSqlViewerVariant;
-  /**
-   * Optional report title, used to build a descriptive aria-label for the
-   * action icon variant (e.g. "View joined Data Marts SQL: Test Report").
-   */
   reportTitle?: string;
+  canViewSql: boolean;
+  canCopyAsDataMart: boolean;
 }
 
-/**
- * Button that opens a dialog with the generated SQL for a report.
- * Provides copy-to-clipboard and copy-as-data-mart actions.
- */
 export function GeneratedSqlViewer({
   reportId,
   dataMartId,
   variant = 'action-icon',
   reportTitle,
+  canViewSql,
+  canCopyAsDataMart,
 }: GeneratedSqlViewerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [sql, setSql] = useState<string | null>(null);
@@ -60,13 +45,17 @@ export function GeneratedSqlViewer({
   const { resolvedTheme } = useTheme();
   const { scope } = useProjectRoute();
 
+  if (!canViewSql) return null;
+
   async function loadSql() {
     setIsLoading(true);
     try {
-      const result = await reportService.getGeneratedSql(reportId);
+      const result = await reportService.getGeneratedSql(reportId, {
+        skipErrorToast: true,
+      });
       setSql(result.sql);
-    } catch {
-      toast.error('Failed to load generated SQL');
+    } catch (err) {
+      showApiErrorToast(err, 'Failed to load generated SQL');
       setSql('');
     } finally {
       setIsLoading(false);
@@ -76,7 +65,6 @@ export function GeneratedSqlViewer({
   function handleOpenChange(open: boolean) {
     setIsOpen(open);
     if (open) {
-      // Always refetch on open — skip cache, show fresh SQL.
       setSql(null);
       void loadSql();
     }
@@ -95,7 +83,9 @@ export function GeneratedSqlViewer({
   async function handleCopyAsDataMart() {
     setIsCopyingAsDataMart(true);
     try {
-      const { dataMartId: newDataMartId } = await reportService.copyAsDataMart(reportId);
+      const { dataMartId: newDataMartId } = await reportService.copyAsDataMart(reportId, {
+        skipErrorToast: true,
+      });
       toast.success('Data Mart created from report');
       setIsOpen(false);
       window.open(
@@ -103,8 +93,8 @@ export function GeneratedSqlViewer({
         '_blank',
         'noopener,noreferrer'
       );
-    } catch {
-      toast.error('Failed to create Data Mart from report');
+    } catch (err) {
+      showApiErrorToast(err, 'Failed to create Data Mart from report');
     } finally {
       setIsCopyingAsDataMart(false);
     }
@@ -203,14 +193,16 @@ export function GeneratedSqlViewer({
               <Copy className='mr-2 h-4 w-4' />
               Copy to Clipboard
             </Button>
-            <Button
-              type='button'
-              variant='default'
-              onClick={() => void handleCopyAsDataMart()}
-              disabled={isLoading || isCopyingAsDataMart}
-            >
-              Copy as Data Mart
-            </Button>
+            {canCopyAsDataMart && (
+              <Button
+                type='button'
+                variant='default'
+                onClick={() => void handleCopyAsDataMart()}
+                disabled={isLoading || isCopyingAsDataMart}
+              >
+                Copy as Data Mart
+              </Button>
+            )}
           </div>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -82,6 +82,7 @@ export interface ReportColumnPickerProps {
   onOutputConfigChange?: (config: OutputConfig) => void;
   onBlendedSelectionChange?: (hasBlendedSelection: boolean) => void;
   onCountChange?: (count: ReportColumnSelectionCount) => void;
+  onOrphanCountChange?: (count: number) => void;
 }
 
 type ToggleFieldFn = (name: string, checked: boolean) => void;
@@ -249,6 +250,67 @@ function BlendedGroupItem({
   );
 }
 
+interface OrphanFieldsSectionProps {
+  orphanNames: string[];
+  onRemove: (name: string) => void;
+}
+
+function OrphanFieldsSection({ orphanNames, onRemove }: OrphanFieldsSectionProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <button
+        type='button'
+        aria-expanded={isOpen}
+        aria-label={`${isOpen ? 'Collapse' : 'Expand'} inaccessible columns`}
+        className='group bg-destructive/10 hover:bg-destructive/15 flex w-full cursor-pointer items-start gap-1.5 rounded px-1 py-1 text-left transition-colors'
+        onClick={() => {
+          setIsOpen(v => !v);
+        }}
+      >
+        {isOpen ? (
+          <ChevronDown className='text-destructive mt-0.5 h-4 w-4 shrink-0' />
+        ) : (
+          <ChevronRight className='text-destructive mt-0.5 h-4 w-4 shrink-0' />
+        )}
+        <AlertTriangle className='text-destructive mt-0.5 h-4 w-4 shrink-0' />
+        <span className='text-destructive text-xs font-semibold'>
+          Inaccessible columns ({orphanNames.length})
+        </span>
+      </button>
+      <CollapsibleContent>
+        <p className='text-muted-foreground px-1 py-1 text-xs'>
+          You no longer have access to the data marts these columns come from. Remove them before
+          saving.
+        </p>
+        <div className='space-y-1'>
+          {orphanNames.map(name => (
+            <div key={name} className='flex items-center gap-2 rounded px-1 py-1'>
+              <Checkbox checked disabled aria-label={name} />
+              <span className='text-muted-foreground flex-1 truncate font-mono text-xs'>
+                {name}
+              </span>
+              <Button
+                type='button'
+                variant='ghost'
+                size='sm'
+                className='text-destructive hover:text-destructive h-5 px-1 text-xs'
+                onClick={() => {
+                  onRemove(name);
+                }}
+                aria-label={`Remove ${name}`}
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
 export function ReportColumnPicker({
   dataMartId,
   storageType,
@@ -258,6 +320,7 @@ export function ReportColumnPicker({
   onOutputConfigChange,
   onBlendedSelectionChange,
   onCountChange,
+  onOrphanCountChange,
 }: ReportColumnPickerProps) {
   const outputControlsSupported = storageType ? supportsOutputControls(storageType) : false;
   const outputControlsAvailable: boolean = outputControlsSupported && !!onOutputConfigChange;
@@ -274,7 +337,6 @@ export function ReportColumnPicker({
     [schema]
   );
 
-  // Only show blended fields from included sources
   const includedPaths = useMemo(() => {
     if (!schema?.availableSources) return new Set<string>();
     return new Set(schema.availableSources.filter(s => s.isIncluded).map(s => s.aliasPath));
@@ -285,10 +347,6 @@ export function ReportColumnPicker({
     return schema.blendedFields.filter(f => includedPaths.has(f.aliasPath) && !f.isHidden);
   }, [schema, includedPaths]);
 
-  // Legacy reports with columnConfig === null had the "all native fields, no blended"
-  // meaning. Treat them the same for display/toggle math — the picker stays a pure
-  // controlled component: it only calls onChange when the user actually toggles
-  // something, so simply opening such a report does not mark the form dirty.
   const effectiveValue = useMemo<string[]>(() => {
     if (value !== null) return value;
     return nativeFields.map(f => f.name);
@@ -300,6 +358,13 @@ export function ReportColumnPicker({
     () => new Set(includedBlendedFields.map(f => f.name)),
     [includedBlendedFields]
   );
+
+  const orphanNames = useMemo<string[]>(() => {
+    if (!schema) return [];
+    const nativeNames = new Set(nativeFields.map(f => f.name));
+    const allBlendedNames = new Set(schema.blendedFields.map(f => f.name));
+    return effectiveValue.filter(n => !nativeNames.has(n) && !allBlendedNames.has(n));
+  }, [schema, nativeFields, effectiveValue]);
 
   const hasBlendedSelection = useMemo(() => {
     if (!schema) return false;
@@ -361,6 +426,10 @@ export function ReportColumnPicker({
   useEffect(() => {
     onCountChange?.({ selected: selectedFieldsCount, total: totalFieldsCount });
   }, [selectedFieldsCount, totalFieldsCount, onCountChange]);
+
+  useEffect(() => {
+    onOrphanCountChange?.(orphanNames.length);
+  }, [orphanNames.length, onOrphanCountChange]);
 
   const availableSourceDescriptionByPath = useMemo(() => {
     const map = new Map<string, string | undefined>();
@@ -588,6 +657,15 @@ export function ReportColumnPicker({
             onRemoveFilterAt={outputControlsAvailable ? handleRemoveFilterAt : undefined}
           />
         ))}
+
+        {orphanNames.length > 0 && (
+          <OrphanFieldsSection
+            orphanNames={orphanNames}
+            onRemove={name => {
+              onChange(effectiveValue.filter(n => n !== name));
+            }}
+          />
+        )}
       </div>
 
       {selectedNativeCount === 0 && (

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/__tests__/GeneratedSqlViewer.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/__tests__/GeneratedSqlViewer.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { GeneratedSqlViewer } from '../GeneratedSqlViewer';
+import { showApiErrorToast } from '../../../../../../shared/utils';
+import { reportService } from '../../../../reports/shared/services/report.service';
+
+vi.mock('../../../../../../shared/hooks', () => ({
+  useProjectRoute: () => ({ scope: (path: string) => `/p/proj${path}` }),
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' }),
+}));
+
+vi.mock('../../../../reports/shared/services/report.service', () => ({
+  reportService: {
+    getGeneratedSql: vi.fn(),
+    copyAsDataMart: vi.fn(),
+  },
+}));
+
+vi.mock('../SqlValidator/SqlValidator', () => ({
+  default: () => <div data-testid='sql-validator' />,
+}));
+
+vi.mock('@monaco-editor/react', () => ({
+  Editor: () => <div data-testid='monaco-editor' />,
+}));
+
+vi.mock('../../../../../../shared/utils', () => ({
+  showApiErrorToast: vi.fn(),
+}));
+
+describe('GeneratedSqlViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when canViewSql is false', () => {
+    const { container } = render(
+      <GeneratedSqlViewer
+        reportId='r-1'
+        dataMartId='dm-1'
+        canViewSql={false}
+        canCopyAsDataMart={true}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders trigger button when canViewSql is true', () => {
+    render(
+      <GeneratedSqlViewer
+        reportId='r-1'
+        dataMartId='dm-1'
+        canViewSql={true}
+        canCopyAsDataMart={false}
+      />
+    );
+    expect(screen.getByLabelText('View joined Data Marts SQL')).toBeInTheDocument();
+  });
+
+  it('calls showApiErrorToast once with backend error when getGeneratedSql rejects', async () => {
+    const apiError = {
+      response: {
+        data: {
+          message: 'Forbidden',
+          statusCode: 403,
+          path: '/api/reports/r-1/generated-sql',
+          timestamp: '',
+        },
+      },
+    };
+    vi.mocked(reportService.getGeneratedSql).mockRejectedValueOnce(apiError);
+
+    render(
+      <GeneratedSqlViewer
+        reportId='r-1'
+        dataMartId='dm-1'
+        canViewSql={true}
+        canCopyAsDataMart={false}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('View joined Data Marts SQL'));
+
+    await waitFor(() => {
+      expect(showApiErrorToast).toHaveBeenCalledTimes(1);
+      expect(showApiErrorToast).toHaveBeenCalledWith(apiError, 'Failed to load generated SQL');
+    });
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/__tests__/ReportColumnPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/__tests__/ReportColumnPicker.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReportColumnPicker } from '../ReportColumnPicker';
+
+vi.mock('../../../../shared/services/data-mart-relationship.service', () => ({
+  dataMartRelationshipService: {
+    getBlendableSchema: vi.fn(),
+  },
+}));
+
+import { dataMartRelationshipService } from '../../../../shared/services/data-mart-relationship.service';
+
+const NATIVE_SCHEMA = {
+  nativeFields: [
+    { name: 'id', type: 'STRING' },
+    { name: 'name', type: 'STRING' },
+  ],
+  blendedFields: [],
+  availableSources: [],
+};
+
+function renderPicker(
+  value: string[] | null,
+  onChange = vi.fn(),
+  extraProps: Record<string, unknown> = {}
+) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ReportColumnPicker dataMartId='dm-1' value={value} onChange={onChange} {...extraProps} />
+    </QueryClientProvider>
+  );
+}
+
+describe('ReportColumnPicker — orphan section', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (dataMartRelationshipService.getBlendableSchema as ReturnType<typeof vi.fn>).mockResolvedValue(
+      NATIVE_SCHEMA
+    );
+  });
+
+  it('shows orphan section when value contains a name absent from schema', async () => {
+    renderPicker(['id', 'orphan_col']);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Inaccessible columns \(1\)/)).toBeInTheDocument();
+    });
+    expect(screen.getByText('orphan_col')).toBeInTheDocument();
+  });
+
+  it('orphan section is open by default', async () => {
+    renderPicker(['orphan_col']);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Inaccessible columns/)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/You no longer have access to the data marts these columns come from/)
+    ).toBeVisible();
+  });
+
+  it('Remove button calls onChange filtering out the orphan name', async () => {
+    const onChange = vi.fn();
+    renderPicker(['id', 'orphan_col'], onChange);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Remove orphan_col')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('Remove orphan_col'));
+
+    expect(onChange).toHaveBeenCalledWith(['id']);
+  });
+
+  it('onOrphanCountChange fires with correct count', async () => {
+    const onOrphanCountChange = vi.fn();
+    renderPicker(['id', 'ghost_a', 'ghost_b'], vi.fn(), { onOrphanCountChange });
+
+    await waitFor(() => {
+      expect(onOrphanCountChange).toHaveBeenCalledWith(2);
+    });
+  });
+
+  it('allSelected is false when only orphans are in value', async () => {
+    renderPicker(['orphan_only']);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Select all fields|Deselect all fields/)).toBeInTheDocument();
+    });
+
+    const masterCheckbox = screen.getByLabelText(/Select all fields|Deselect all fields/);
+    expect(masterCheckbox).not.toBeChecked();
+  });
+});

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
@@ -143,6 +143,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
       selected: 0,
       total: 0,
     });
+    const [orphanCount, setOrphanCount] = useState(0);
     const [isCreatingInsight, setIsCreatingInsight] = useState(false);
     const [useInsightTemplateMode, setUseInsightTemplateMode] = useState(isInsightContext);
     const [isDestinationSelectOpen, setIsDestinationSelectOpen] = useState(false);
@@ -932,6 +933,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
                         form.setValue('limitConfig', config.limitConfig, { shouldDirty: true });
                       }}
                       onCountChange={setColumnsCount}
+                      onOrphanCountChange={setOrphanCount}
                     />
                   </div>
                 )}
@@ -994,6 +996,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
               isValid={isValid}
               triggersDirty={triggersDirty}
               ownersDirty={ownersDirty}
+              hasOrphans={orphanCount > 0}
               runAfterSaveRef={runAfterSaveRef}
               onSubmit={() => void form.handleSubmit(handleFormSubmit)()}
               onCancel={onCancel}

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -130,6 +130,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
       selected: 0,
       total: 0,
     });
+    const [orphanCount, setOrphanCount] = useState(0);
     const { runReport } = useReport();
 
     const currentUser = useUser();
@@ -458,6 +459,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
                       form.setValue('limitConfig', config.limitConfig, { shouldDirty: true });
                     }}
                     onCountChange={setColumnsCount}
+                    onOrphanCountChange={setOrphanCount}
                   />
                 </div>
               )}
@@ -515,6 +517,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
             isValid={isValid}
             triggersDirty={triggersDirty}
             ownersDirty={ownersDirty}
+            hasOrphans={orphanCount > 0}
             runAfterSaveRef={runAfterSaveRef}
             onSubmit={() => void form.handleSubmit(handleFormSubmit)()}
             onCancel={onCancel}

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -33,6 +33,8 @@ import type { DataMartContextType } from '../../../../edit/model/context/types.t
 import { type DataDestination } from '../../../../../data-destination';
 import { ReportFormMode } from '../../../shared';
 import { Button } from '@owox/ui/components/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { useSaveDisabled } from '../../hooks/useSaveDisabled';
 import LookerStudioCacheLifetimeDescription from './LookerStudioCacheLifetimeDescription.tsx';
 import { OwnersSection } from '../../../../../../shared/components/OwnersSection/OwnersSection';
 import type { UserProjectionDto } from '../../../../../../shared/types/api';
@@ -93,6 +95,7 @@ export const LookerStudioReportEditForm = forwardRef<
       selected: 0,
       total: 0,
     });
+    const [orphanCount, setOrphanCount] = useState(0);
 
     const currentUser = useUser();
     const initialOwnerUsers =
@@ -154,7 +157,6 @@ export const LookerStudioReportEditForm = forwardRef<
           limitConfig: initialReport.limitConfig ?? null,
         });
       } else if (mode === ReportFormMode.CREATE) {
-        // Pre-select destination if provided
         reset({
           cacheLifetime: 300,
           columnConfig: null,
@@ -168,6 +170,15 @@ export const LookerStudioReportEditForm = forwardRef<
     useEffect(() => {
       onDirtyChange?.(isDirty || ownersDirty);
     }, [isDirty, ownersDirty, onDirtyChange]);
+
+    const saveDisabled = useSaveDisabled({
+      mode,
+      isSubmitting,
+      isValid,
+      isDirty,
+      ownersDirty,
+      hasOrphans: orphanCount > 0,
+    });
 
     return (
       <Form {...form}>
@@ -242,6 +253,7 @@ export const LookerStudioReportEditForm = forwardRef<
                     }}
                     onBlendedSelectionChange={setHasBlendedSelection}
                     onCountChange={setColumnsCount}
+                    onOrphanCountChange={setOrphanCount}
                   />
                   {hasBlendedSelection &&
                     mode === ReportFormMode.EDIT &&
@@ -252,6 +264,8 @@ export const LookerStudioReportEditForm = forwardRef<
                           reportId={initialReport.id}
                           dataMartId={dataMart.id}
                           variant='outline-button'
+                          canViewSql={initialReport.canViewSql}
+                          canCopyAsDataMart={initialReport.canCopyAsDataMart}
                         />
                       </div>
                     )}
@@ -292,25 +306,30 @@ export const LookerStudioReportEditForm = forwardRef<
             )}
           </FormLayout>
           <FormActions>
-            <Button
-              variant='default'
-              type='submit'
-              className='w-full'
-              aria-label={mode === ReportFormMode.CREATE ? 'Create' : 'Save changes'}
-              // `disabled` logic is duplicated intentionally and needs to be synchronized manually
-              disabled={
-                isSubmitting ||
-                (mode === ReportFormMode.CREATE ? !isValid : !isDirty && !ownersDirty)
-              }
-            >
-              {isSubmitting
-                ? mode === ReportFormMode.CREATE
-                  ? 'Creating...'
-                  : 'Saving...'
-                : mode === ReportFormMode.CREATE
-                  ? 'Create'
-                  : 'Save changes'}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className='w-full'>
+                  <Button
+                    variant='default'
+                    type='submit'
+                    className='w-full'
+                    aria-label={mode === ReportFormMode.CREATE ? 'Create' : 'Save changes'}
+                    disabled={saveDisabled}
+                  >
+                    {isSubmitting
+                      ? mode === ReportFormMode.CREATE
+                        ? 'Creating...'
+                        : 'Saving...'
+                      : mode === ReportFormMode.CREATE
+                        ? 'Create'
+                        : 'Save changes'}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {orphanCount > 0 && (
+                <TooltipContent>Remove inaccessible columns before saving</TooltipContent>
+              )}
+            </Tooltip>
             {onCancel && (
               <Button
                 variant='outline'

--- a/apps/web/src/features/data-marts/reports/edit/components/shared/ReportFormActions.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/shared/ReportFormActions.tsx
@@ -7,9 +7,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@owox/ui/components/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { ChevronDown } from 'lucide-react';
 import { ReportFormMode } from '../../../shared';
 import type { RefObject } from 'react';
+import { useSaveDisabled } from '../../hooks/useSaveDisabled';
 
 export interface ReportFormActionsProps {
   mode: ReportFormMode;
@@ -18,6 +20,7 @@ export interface ReportFormActionsProps {
   isValid: boolean;
   triggersDirty: boolean;
   ownersDirty?: boolean;
+  hasOrphans?: boolean;
   runAfterSaveRef: RefObject<boolean>;
   onSubmit: () => void;
   onCancel?: () => void;
@@ -30,13 +33,20 @@ export const ReportFormActions = ({
   isValid,
   triggersDirty,
   ownersDirty = false,
+  hasOrphans = false,
   runAfterSaveRef,
   onSubmit,
   onCancel,
 }: ReportFormActionsProps) => {
-  const disabledPrimary =
-    isSubmitting ||
-    (mode === ReportFormMode.CREATE ? !isValid : !(isDirty || triggersDirty || ownersDirty));
+  const disabledPrimary = useSaveDisabled({
+    mode,
+    isSubmitting,
+    isValid,
+    isDirty,
+    triggersDirty,
+    ownersDirty,
+    hasOrphans,
+  });
 
   const primaryLabel =
     mode === ReportFormMode.CREATE ? 'Create & Run report' : 'Save changes to report';
@@ -51,47 +61,59 @@ export const ReportFormActions = ({
   return (
     <FormActions>
       <ButtonGroup className='w-full'>
-        <Button
-          variant='default'
-          type='submit'
-          disabled={disabledPrimary}
-          className='flex-1'
-          onClick={() => {
-            // For CREATE: run after save. For EDIT: don't run
-            runAfterSaveRef.current = mode === ReportFormMode.CREATE;
-          }}
-        >
-          {primaryLabel}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className='flex-1'>
+              <Button
+                variant='default'
+                type='submit'
+                disabled={disabledPrimary}
+                className='w-full'
+                onClick={() => {
+                  runAfterSaveRef.current = mode === ReportFormMode.CREATE;
+                }}
+              >
+                {primaryLabel}
+              </Button>
+            </span>
+          </TooltipTrigger>
+          {hasOrphans && <TooltipContent>Remove inaccessible columns before saving</TooltipContent>}
+        </Tooltip>
 
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant='default'
-              type='button'
-              disabled={disabledPrimary}
-              aria-label='More actions'
-              className='group'
-            >
-              <ChevronDown
-                className='size-4 transition-transform duration-200 group-data-[state=open]:rotate-180'
-                aria-hidden='true'
-              />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align='end' side='top'>
-            <DropdownMenuItem
-              onClick={() => {
-                // For CREATE: don't run. For EDIT: run after save
-                runAfterSaveRef.current = mode === ReportFormMode.EDIT;
-                onSubmit();
-              }}
-              disabled={isSubmitting}
-            >
-              {dropdownItemLabel}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant='default'
+                    type='button'
+                    disabled={disabledPrimary}
+                    aria-label='More actions'
+                    className='group'
+                  >
+                    <ChevronDown
+                      className='size-4 transition-transform duration-200 group-data-[state=open]:rotate-180'
+                      aria-hidden='true'
+                    />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end' side='top'>
+                  <DropdownMenuItem
+                    onClick={() => {
+                      runAfterSaveRef.current = mode === ReportFormMode.EDIT;
+                      onSubmit();
+                    }}
+                    disabled={isSubmitting}
+                  >
+                    {dropdownItemLabel}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </span>
+          </TooltipTrigger>
+          {hasOrphans && <TooltipContent>Remove inaccessible columns before saving</TooltipContent>}
+        </Tooltip>
       </ButtonGroup>
 
       {onCancel && (

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useSaveDisabled.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useSaveDisabled.ts
@@ -1,0 +1,25 @@
+import { ReportFormMode } from '../../shared';
+
+interface UseSaveDisabledParams {
+  mode: ReportFormMode;
+  isSubmitting: boolean;
+  isValid: boolean;
+  isDirty: boolean;
+  triggersDirty?: boolean;
+  ownersDirty?: boolean;
+  hasOrphans?: boolean;
+}
+
+export function useSaveDisabled({
+  mode,
+  isSubmitting,
+  isValid,
+  isDirty,
+  triggersDirty = false,
+  ownersDirty = false,
+  hasOrphans = false,
+}: UseSaveDisabledParams): boolean {
+  if (isSubmitting || hasOrphans) return true;
+  if (mode === ReportFormMode.CREATE) return !isValid;
+  return !(isDirty || triggersDirty || ownersDirty);
+}

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
@@ -113,12 +113,13 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
           </TooltipContent>
         </Tooltip>
 
-        {/* View SQL (only when report uses blending) */}
-        {hasBlending && (
+        {hasBlending && row.original.canViewSql && (
           <GeneratedSqlViewer
             reportId={row.original.id}
             dataMartId={row.original.dataMart.id}
             reportTitle={row.original.title}
+            canViewSql={row.original.canViewSql}
+            canCopyAsDataMart={row.original.canCopyAsDataMart}
           />
         )}
 

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
@@ -146,12 +146,13 @@ export function GoogleSheetsActionsCell({
           </TooltipContent>
         </Tooltip>
 
-        {/* View SQL (only when report uses blending) */}
-        {hasBlending && (
+        {hasBlending && row.original.canViewSql && (
           <GeneratedSqlViewer
             reportId={row.original.id}
             dataMartId={row.original.dataMart.id}
             reportTitle={row.original.title}
+            canViewSql={row.original.canViewSql}
+            canCopyAsDataMart={row.original.canCopyAsDataMart}
           />
         )}
 

--- a/apps/web/src/features/data-marts/reports/shared/model/mappers/report.mapper.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/mappers/report.mapper.ts
@@ -43,5 +43,7 @@ export function mapReportDtoToEntity(reportDto: ReportResponseDto): DataMartRepo
     canRun: reportDto.canRun,
     canManageTriggers: reportDto.canManageTriggers,
     canEditConfig: reportDto.canEditConfig,
+    canViewSql: reportDto.canViewSql,
+    canCopyAsDataMart: reportDto.canCopyAsDataMart,
   };
 }

--- a/apps/web/src/features/data-marts/reports/shared/model/types/data-mart-report.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/types/data-mart-report.ts
@@ -114,4 +114,6 @@ export interface DataMartReport {
   canRun: boolean;
   canManageTriggers: boolean;
   canEditConfig: boolean;
+  canViewSql: boolean;
+  canCopyAsDataMart: boolean;
 }

--- a/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
@@ -98,22 +98,12 @@ export class ReportService extends ApiService {
     return this.post(`/${id}/run`);
   }
 
-  /**
-   * Get the generated SQL for a report
-   * @param id Report ID
-   * @returns Object containing the generated SQL string
-   */
-  async getGeneratedSql(id: string): Promise<{ sql: string }> {
-    return this.get<{ sql: string }>(`/${id}/generated-sql`);
+  async getGeneratedSql(id: string, config?: AxiosRequestConfig): Promise<{ sql: string }> {
+    return this.get<{ sql: string }>(`/${id}/generated-sql`, undefined, config);
   }
 
-  /**
-   * Copy a report as a new Data Mart
-   * @param id Report ID
-   * @returns Promise with the created data mart id
-   */
-  async copyAsDataMart(id: string): Promise<{ dataMartId: string }> {
-    return this.post<{ dataMartId: string }>(`/${id}/copy-as-data-mart`);
+  async copyAsDataMart(id: string, config?: AxiosRequestConfig): Promise<{ dataMartId: string }> {
+    return this.post<{ dataMartId: string }>(`/${id}/copy-as-data-mart`, undefined, config);
   }
 }
 

--- a/apps/web/src/features/data-marts/reports/shared/services/types/report-response.dto.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/types/report-response.dto.ts
@@ -29,4 +29,6 @@ export interface ReportResponseDto {
   canRun: boolean;
   canManageTriggers: boolean;
   canEditConfig: boolean;
+  canViewSql: boolean;
+  canCopyAsDataMart: boolean;
 }

--- a/apps/web/src/features/data-marts/shared/types/relationship.types.ts
+++ b/apps/web/src/features/data-marts/shared/types/relationship.types.ts
@@ -20,11 +20,18 @@ export interface JoinCondition {
   targetFieldName: string;
 }
 
+export interface RelatedDataMartAccess {
+  canSee: boolean;
+  canUse: boolean;
+  canEdit: boolean;
+}
+
 export interface RelatedDataMart {
   id: string;
   title: string;
   description?: string;
   status: string;
+  access?: RelatedDataMartAccess;
 }
 
 export interface DataMartRelationship {


### PR DESCRIPTION
## Summary

Reports and the relationship graph now enforce per-user access across the full join chain. Users can no longer see, query, or export columns from Data Marts they do not have access to — even through transitive joins, filters, sorts, or generated SQL.

## Why

The previous behavior of `BlendableSchemaService.collectBlendedFields` was to walk every relationship in a storage without checking per-user access on the joined Data Marts, so a user with `SEE` on the root Data Mart could see every joined Data Mart's fields in the column picker, in the composed SQL, in the Looker Studio Community Connector responses, and in the **View SQL** / **Copy as Data Mart** outputs. Save/run on existing reports also kept working after access was revoked downstream. This PR aligns the blending flow with the rest of the access model so reports respect access boundaries through the whole join chain.

## What changed

### Backend (`apps/backend/src/data-marts/`)

- **Access filter in BlendableSchema** — `collectBlendedFields` accepts an `AccessFilter` and stops recursion on any branch where the caller lacks `USE`. Inaccessible Data Marts and their descendants disappear from `availableSources` and `blendedFields`.
- **Path-based orphan validation** — new `findInaccessibleReportRefs(report, projectId, accessFilter)` walks the **full DM path** for every column/filter/sort reference (not just the leaf) and reports the columns whose chain crosses an inaccessible Data Mart. This also covers the case where an inaccessible intermediate DM in a transitive chain (`b_c__field`) would otherwise be missed. A single helper `assertNoInaccessibleReportRefs` is wired into `CreateReportService`, `UpdateReportService`, `RunReportService`, `GetReportGeneratedSqlService` (View SQL), and `CopyReportAsDataMartService`. All three configs (`columnConfig`, `filterConfig`, `sortConfig`) are validated.
- **Native nested fields** are flattened (`profile.city`) before the orphan check so legitimate struct-style columns are not false-flagged.
- **ReportRunAccessValidatorService** (new) — single gate for **manual**, **scheduled**, and **Looker Studio Community Connector** runs (both sample and full extractions, plus `getSchema`). Checks project membership via `IdpProjectionsFacade.getProjectMember`, `SEE` on DataMart, `USE` on destination, and orphan refs. Scheduled runs use the schedule creator's rights; Looker requests use the report creator's rights; manual runs use the active user's rights. Error messages name the responsible actor (`schedule creator` / `report creator` / `you`) and include a context-appropriate remediation hint. Looker `loadReport` runs before any cache or storage probe, so an offboarded creator can no longer populate the report data cache.
- **Capability flags on DTOs**:
  - `RelationshipDto.{source,target}DataMart.access = { canSee, canUse, canEdit }` — populated by all list and single-fetch relationship endpoints so the UI can grey out unreachable nodes in the graph.
  - `ReportDto.canViewSql` (= `EDIT` on parent DM) and `ReportDto.canCopyAsDataMart` (= `EDIT` on parent DM + `USE` on storage) — symmetric with the existing endpoint gating in `GetReportGeneratedSqlService` and `CopyReportAsDataMartService`.
- **Forbidden message** in `CreateDataMartRelationshipService` now names the data mart the caller cannot reach.
- New shared utilities: `utils/create-dm-access-filter.ts`, `utils/build-dm-access-flags.ts`.

### Frontend (`apps/web/src/features/data-marts/`)

- **Relationship graph** — inaccessible Data Marts render as a greyed node with a warning icon. The greyed state is computed per path-instance (not per `dmId`), so a node reached through a blocked parent is greyed even if the same DM is reachable through a parallel accessible path. Click on a blocked node is a no-op and its descendants are not fetched.
- **TargetDataMartPicker** surfaces the backend `ForbiddenException` message verbatim and shows an error toast if the data-mart list fails to load.
- **ReportColumnPicker** — dedicated **Inaccessible columns** section (expanded by default) for columns whose source DM the user can no longer reach. Orphan rows have a Remove action; the master selection count and `allSelected` math exclude orphans.
- **Save button** is disabled while orphan columns remain, with a tooltip explaining the requirement. A shared `useSaveDisabled` hook is used by all three report forms (Google Sheets, Looker Studio, Email).
- **SQL viewer / Copy as Data Mart** are hidden when `canViewSql` / `canCopyAsDataMart` are false. The viewer's failure paths flow through `showApiErrorToast`, so a backend 400 (e.g. an orphan filter that the picker can't surface) is propagated verbatim instead of becoming a generic "Failed to load" message.

## Access model

A user with `SEE` on a root Data Mart no longer automatically gets read/query/export access to transitively joined Data Marts through blending. Access is now resolved per joined DM along the whole path, and `filterConfig` / `sortConfig` references are validated alongside `columnConfig` so all three configs share the same gate.

## Breaking changes / migration

- Existing reports that select columns (or filter/sort by columns) from Data Marts the owner has since lost access to will fail to save, to run manually, to render generated SQL, or to be copied as a Data Mart. The backend throws `BusinessViolationException`, which `BaseExceptionFilter` maps to **HTTP 400** with a message listing the offending references grouped as `columns` / `filters` / `sorts`. Users must remove those references first; the column picker surfaces the column orphans in the **Inaccessible columns** section, and filter/sort orphans surface as a backend error toast at save/run time.
- **Scheduled runs** for these reports are rejected by `ReportRunAccessValidatorService` **before** `reportRunService.createPending()` is called, so no `data_mart_run` row is written and `report.lastRunError` is not updated. The blocked-message (`Scheduled run blocked: schedule creator …`) appears in backend logs only — this is intentional (fail-fast, no wasted writes for rejected runs). To rescue an orphaned schedule, either remove the inaccessible references from the report config or reassign the schedule's creator.
- Looker Studio Community Connector requests for reports whose creator is offboarded or has lost access return a descriptive error instead of serving data.
- No DB migrations, no new endpoints, no changes to `Action` enum or roles.