### PR TITLE
fix(backend): overwrite GS imported cells when storage returns NULL

### DIFF
--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -3,6 +3,7 @@ import { ReportDataBatch } from '../../../dto/domain/report-data-batch.dto';
 import { ReportDataDescription } from '../../../dto/domain/report-data-description.dto';
 import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
 import { GoogleSheetsReportWriter } from './google-sheets-report-writer';
+import { SheetValuesFormatter } from './sheet-formatters/sheet-values-formatter';
 
 /**
  * Targeted unit spec for {@link GoogleSheetsReportWriter}'s row-truncation
@@ -54,6 +55,12 @@ interface BuildOpts {
    * the right edge of the imported rectangle the writer truncates.
    */
   finalImportedNames?: string[];
+  /**
+   * Override the default no-op `formatRowsValuesByName` mock with a real
+   * formatter instance. Used by the null-overwrite test to exercise the
+   * full path from `writeReportDataBatch` to `adapter.updateValues`.
+   */
+  valuesFormatter?: SheetValuesFormatter;
 }
 
 /**
@@ -128,7 +135,7 @@ function buildWriter(opts: BuildOpts) {
     createOwoxColumnsMetadataRequest: jest.fn().mockReturnValue({}),
     updateOwoxColumnsMetadataRequest: jest.fn().mockReturnValue({}),
   };
-  const valuesFormatter = {
+  const valuesFormatter = opts.valuesFormatter ?? {
     formatRowsValuesByName: jest.fn().mockImplementation((rows: unknown[][]) => rows),
   };
 
@@ -260,5 +267,40 @@ describe('GoogleSheetsReportWriter — truncates trailing rows below new data', 
     } else {
       expect(adapter.clearValuesInRange).not.toHaveBeenCalled();
     }
+  });
+});
+
+describe('GoogleSheetsReportWriter — never sends null cells inside imported rectangle', () => {
+  it('coerces null SQL cells to "" in the array passed to adapter.updateValues', async () => {
+    // Exercise the full path with the real formatter: SQL produces null for
+    // the middle column; the array that reaches the adapter must contain ""
+    // at that index — not null, not undefined, not a sparse-array hole.
+    // Sheets `values.update` interprets all three as "skip this cell" and
+    // would silently preserve a stale or manually-edited value.
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 10,
+      valuesFormatter: new SheetValuesFormatter(),
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', null, 2]]));
+    await writer.finalize();
+
+    // The header write targets row 1; the data write is the call into row 2.
+    const dataCall = adapter.updateValues.mock.calls.find(
+      ([, range]: [string, string, unknown[][]]) => range.includes('!A2:')
+    );
+    expect(dataCall).toBeDefined();
+    const sentValues = dataCall![2] as unknown[][];
+    expect(sentValues).toEqual([['A', '', 2]]);
+
+    // Anti-regression: no null / undefined / sparse hole anywhere in the row.
+    expect(sentValues[0].every(v => v !== null && v !== undefined)).toBe(true);
+    expect(0 in sentValues[0]).toBe(true);
+    expect(1 in sentValues[0]).toBe(true);
+    expect(2 in sentValues[0]).toBe(true);
   });
 });

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -811,8 +811,12 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
 
   private reorderRowsToFinalLayout(rows: unknown[][]): unknown[][] {
     const finalNames = this.columnPlan.finalImportedNames;
+    const width = finalNames.length;
     return rows.map(srcRow => {
-      const out: unknown[] = new Array(finalNames.length);
+      // Pre-fill with "" so any index left unassigned below stays a defined
+      // empty cell rather than a sparse-array hole — see the null-overwrite
+      // contract documented on `SheetValuesFormatter.formatRowsValuesByName`.
+      const out: unknown[] = new Array(width).fill('');
       for (let i = 0; i < this.reportDataHeaders.length; i++) {
         const finalIdx = this.columnPlan.nameToFinalIndex.get(this.reportDataHeaders[i].name)!;
         out[finalIdx] = srcRow[i];

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.spec.ts
@@ -1,0 +1,71 @@
+import { BigQueryFieldType } from '../../../../data-storage-types/bigquery/enums/bigquery-field-type.enum';
+import { ReportDataHeader } from '../../../../dto/domain/report-data-header.dto';
+import { SheetValuesFormatter } from './sheet-values-formatter';
+
+describe('SheetValuesFormatter', () => {
+  let formatter: SheetValuesFormatter;
+
+  beforeEach(() => {
+    formatter = new SheetValuesFormatter();
+  });
+
+  describe('formatRowsValuesByName', () => {
+    const finalNames = ['country', 'clicks', 'cost'];
+    const headersByName = new Map<string, ReportDataHeader>([
+      ['country', new ReportDataHeader('country', undefined, undefined, BigQueryFieldType.STRING)],
+      ['clicks', new ReportDataHeader('clicks', undefined, undefined, BigQueryFieldType.INTEGER)],
+      ['cost', new ReportDataHeader('cost', undefined, undefined, BigQueryFieldType.FLOAT)],
+    ]);
+    const tz = 'UTC';
+
+    it('normalizes null cells to empty string so the Sheets API actually clears them', () => {
+      const rows = [['A', null, 1.5]];
+      formatter.formatRowsValuesByName(rows, finalNames, headersByName, tz);
+      expect(rows).toEqual([['A', '', 1.5]]);
+    });
+
+    it('normalizes undefined cells to empty string', () => {
+      const rows = [['A', undefined, 1.5]];
+      formatter.formatRowsValuesByName(rows, finalNames, headersByName, tz);
+      expect(rows).toEqual([['A', '', 1.5]]);
+    });
+
+    it('normalizes sparse-array holes to empty string', () => {
+      // Build an array with a literal hole at index 1.
+      // eslint-disable-next-line no-sparse-arrays
+      const sparse: unknown[] = ['A', , 1.5];
+      expect(1 in sparse).toBe(false);
+
+      const rows = [sparse];
+      formatter.formatRowsValuesByName(rows, finalNames, headersByName, tz);
+
+      expect(rows).toEqual([['A', '', 1.5]]);
+      // Hole is gone — every index is now materialized.
+      expect(1 in rows[0]).toBe(true);
+    });
+
+    it('preserves 0, false, and empty string as-is (only nullish becomes "")', () => {
+      const rows = [[0, false, '']];
+      formatter.formatRowsValuesByName(rows, finalNames, headersByName, tz);
+      expect(rows).toEqual([[0, false, '']]);
+    });
+
+    it('formats TIMESTAMP cells and normalizes a null timestamp to ""', () => {
+      const tsHeaders = new Map<string, ReportDataHeader>([
+        ['ts', new ReportDataHeader('ts', undefined, undefined, BigQueryFieldType.TIMESTAMP)],
+      ]);
+      const rows: unknown[][] = [['2024-05-01T12:00:00Z'], [null]];
+
+      formatter.formatRowsValuesByName(rows, ['ts'], tsHeaders, 'UTC');
+
+      expect(rows[0][0]).toBe('2024-05-01 12:00:00');
+      expect(rows[1][0]).toBe('');
+    });
+
+    it('mutates the input array in place and returns the same reference', () => {
+      const rows = [['A', null, 1.5]];
+      const result = formatter.formatRowsValuesByName(rows, finalNames, headersByName, tz);
+      expect(result).toBe(rows);
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
@@ -58,6 +58,14 @@ export class SheetValuesFormatter {
    * the destination sheet, so positional alignment with the SQL output schema
    * no longer holds.
    *
+   * Also normalizes every cell to a concrete primitive: `null`, `undefined`,
+   * and sparse-array holes collapse to `""`. The Sheets `values.update` API
+   * treats those three as "skip this cell, preserve existing content", which
+   * would let manual user edits bleed across refreshes inside the imported
+   * rectangle. `""` explicitly clears the cell, matching the writer's
+   * contract that the imported rectangle is fully owned by ODM. Other falsy
+   * values (`0`, `false`, the literal empty string) pass through unchanged.
+   *
    * @param orderedRows - Rows already reordered to align with `finalNames`
    * @param finalNames - Column names in the order they appear in the sheet
    * @param headersByName - SQL output schema indexed by column name
@@ -69,23 +77,19 @@ export class SheetValuesFormatter {
     headersByName: ReadonlyMap<string, ReportDataHeader>,
     sheetTimeZone: string
   ): unknown[][] {
-    const columnsToFormat = finalNames
-      .map((name, index) => {
-        const header = headersByName.get(name);
-        return {
-          index,
-          formatter: header ? this.formatters.get(header.storageFieldType!) : undefined,
-        };
-      })
-      .filter(item => item.formatter);
+    const formatters = finalNames.map(name => {
+      const header = headersByName.get(name);
+      return header ? this.formatters.get(header.storageFieldType!) : undefined;
+    });
+    const width = finalNames.length;
 
-    if (columnsToFormat.length > 0) {
-      orderedRows.forEach(row => {
-        columnsToFormat.forEach(({ index, formatter }) => {
-          row[index] = formatter!(row[index], sheetTimeZone);
-        });
-      });
-    }
+    orderedRows.forEach(row => {
+      for (let i = 0; i < width; i++) {
+        const fmt = formatters[i];
+        const raw = fmt ? fmt(row[i], sheetTimeZone) : row[i];
+        row[i] = raw == null ? '' : raw;
+      }
+    });
 
     return orderedRows;
   }

--- a/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
+++ b/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
@@ -566,6 +566,44 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
   }, 120_000);
 
   // -------------------------------------------------------------------------
+  // Test 9b — Inside the imported rectangle, manual edits NEVER survive a
+  // refresh, even when SQL returns NULL for that cell.
+  //
+  // Pre-fix: `null` in the 2D array passed to Sheets `values.update` is
+  // treated as "skip this cell", so a user's manual edit on a cell that the
+  // new SQL produces NULL for would silently survive across refresh. The
+  // formatter now coerces nullish to "" so the cell is explicitly cleared.
+  // -------------------------------------------------------------------------
+  it('overwrites manual edits inside imported range even when SQL produces NULL', async () => {
+    // Row 2: clicks = NULL. Row 3: clicks = 20. Lets us assert both halves of
+    // the contract in one report run.
+    const SQL_WITH_NULL = `
+      SELECT 'A' AS country, CAST(NULL AS INT64) AS clicks, 2 AS cost UNION ALL
+      SELECT 'B' AS country, 20 AS clicks, 5 AS cost
+    `;
+    const { reportId } = await provisionFixture({
+      testName: 'null-overwrites-manual-edit',
+      sql: SQL_WITH_NULL,
+    });
+    await runAndWait(reportId);
+
+    // Seed manual edits inside the imported rectangle:
+    //   B2 — the cell that SQL will produce NULL for on next refresh
+    //   B3 — the cell that SQL will produce 20 for on next refresh (control)
+    await writeCell('B2', 'manual-keep-me');
+    await writeCell('B3', 'manual-also');
+
+    await runAndWait(reportId);
+
+    // B2: was NULL in SQL → must be cleared (pre-fix this kept "manual-keep-me").
+    // B3: was 20 in SQL → must be overwritten with "20".
+    expect(await readRange('A2:C3')).toEqual([
+      ['A', '', '2'],
+      ['B', '20', '5'],
+    ]);
+  }, 120_000);
+
+  // -------------------------------------------------------------------------
   // Test 10 — Output Controls × diff-based writer interaction:
   // shrinking the result set via Report `limitConfig` must clear stale rows
   // from the previous (larger) refresh inside the imported rectangle. User


### PR DESCRIPTION
## Summary

After PR #1191 (diff-based Google Sheets writer) shipped, a customer reported that
manually-edited cells inside the imported column rectangle were surviving across
refreshes — but only when the new SQL row produced `NULL` for that cell.
Cells where SQL produced a non-null value continued to overwrite manual edits
correctly. The customer paused all scheduled refreshes and manually refreshed
through the UI as a workaround.

This PR restores the design contract from PR #1191:

> Within the imported rectangle, every cell is fully owned by ODM. Manual edits
> never bleed across refreshes. User content **right** of the imported rectangle
> is what the diff-based writer was built to protect — not content inside it.

## Problem

Reproducible scenario (the one the customer hit):

1. Trigger a Google Sheets report — data lands in rows 2..N of imported columns.
2. In the sheet UI, type any value into a cell inside the imported rectangle.
3. Re-run the report.
4. **Expected**: cell is overwritten with the new SQL value (or cleared if SQL
   returns `NULL`).
5. **Actual** (pre-fix): cell is overwritten correctly _only if_ the new SQL row
   produces a non-null value at that position. If SQL produces `NULL`, the
   manual edit survives — silently and indistinguishably from "ODM ignored my
   refresh entirely".

The bug is asymmetric per data type and per row, so to a user it looks like
"sometimes the report works, sometimes it doesn't" — high-friction support
case.

## Root cause

Google Sheets API contract for `spreadsheets.values.update` (USER_ENTERED):

| Value in 2D array | Sheets behavior |
|---|---|
| `"A"` / `42` / `true` | Writes the value, overwrites prior cell content |
| `""` (empty string) | **Clears** the cell |
| `0`, `false` | Writes `0` / `FALSE`, overwrites |
| `null` | **Skips this cell, preserves existing content** |
| `undefined` / sparse-array hole | JSON-serializes as `null` → same as above |

Three independent code paths leaked `null` / `undefined` / holes into the
payload sent by `GoogleSheetsApiAdapter.updateValues`:

1. `GoogleSheetsReportWriter.reorderRowsToFinalLayout` allocated the output
   row with `new Array(finalNames.length)` — every index left unassigned
   stayed a sparse hole.
2. `SheetValuesFormatter.formatRowsValuesByName` only touched cells in columns
   with a TIMESTAMP formatter — other cells passed through unchanged.
3. The timestamp formatter itself returned `value` unchanged for non-string
   input, so a TIMESTAMP-typed `null` survived the formatter pass.

Pre-PR-#1191 the writer called `clearSheet()` before every refresh, which
masked the bug — the entire sheet was wiped before being repopulated, so any
`null` in the new payload landed on an already-empty cell. PR #1191 removed
`clearSheet()` (it would destroy user content right of the imported range —
that was the headline feature), but did not replace it with an equivalent
mechanism for the rectangle's interior.

The customer's pattern (manual edits inside the rectangle) had not been
exercised by the manual test plan in PR #1191. The fixture SQL produced
non-null values for every column, so the asymmetric bug stayed dormant.

## Solution

Normalize `null`, `undefined`, and sparse-array holes to `""` (the explicit
"clear cell" sentinel) inside the values-preparation layer. Other falsy values
(`0`, `false`, the literal empty string) pass through unchanged so currency
totals, boolean flags, and intentionally-empty strings from SQL continue to
work.

**Primary change** — extend `SheetValuesFormatter.formatRowsValuesByName` to
iterate every cell in every row (not just columns with a registered formatter)
and collapse nullish to `""`. The contract is now documented on the method
JSDoc, so future contributors see it at the call site.

**Secondary defense** — pre-fill the row buffer in
`GoogleSheetsReportWriter.reorderRowsToFinalLayout` with `""` instead of
allocating a sparse array. The formatter still re-normalizes anything that
SQL produced as `null`, but this eliminates the sparse-hole leak path at the
source so JSON-debug output of the row payload is unambiguous.

The Sheets API call stays `values.update` with USER_ENTERED. No switch to
`batchUpdate` / `UpdateCellsRequest`, no architecture change.

## Before / After

`writeReportDataBatch` for a SQL row that produces `clicks IS NULL`:

```diff
- // Payload sent to spreadsheets.values.update:
- // { values: [["A", null, 2]] }
- // Sheets receives: A2 → "A", B2 → SKIP (manual edit survives), C2 → 2

+ // Payload sent to spreadsheets.values.update:
+ // { values: [["A", "", 2]] }
+ // Sheets receives: A2 → "A", B2 → CLEAR, C2 → 2
```

## Files changed

### Modified
- `apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts` —
  extended `formatRowsValuesByName` to iterate every cell and coerce nullish
  to `""`; documented the contract on the method JSDoc.
- `apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts` —
  `reorderRowsToFinalLayout` now pre-fills the row buffer with `""` instead
  of leaving sparse holes.

### Modified (tests)
- `apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts` —
  added a new end-to-end case that wires a real `SheetValuesFormatter` into the
  writer, sends a row with `null`, and asserts the adapter receives `""` (no
  null, undefined, or hole anywhere in the payload). Extended `BuildOpts` so
  individual tests can opt into the real formatter without disturbing the
  existing truncation suite.

### New (tests)
- `apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.spec.ts` —
  6 unit cases covering `null` / `undefined` / sparse-hole → `""`, `0` /
  `false` / `""` preserved as-is, TIMESTAMP formatter still works (and a null
  timestamp becomes `""`), and the in-place-mutation contract.
- `apps/backend/test/integration/google-sheets-column-preservation.integration.ts` —
  added Test 9b: real Sheets API run, seeds a manual edit on a cell that the
  next SQL refresh produces NULL for, asserts the cell becomes empty after
  refresh (pre-fix this kept the manual edit).

## Manual verification

Use a BigQuery-backed data mart with this SQL fixture:

```sql
WITH rows AS (
  SELECT * FROM UNNEST([
    STRUCT('A' AS country, 10                    AS clicks, 2    AS cost),
    STRUCT('B' AS country, CAST(NULL AS INT64)   AS clicks, 5    AS cost),
    STRUCT('C' AS country, 30                    AS clicks, NULL AS cost)
  ])
)
SELECT * FROM rows
```

1. Connect to a fresh Google Sheets destination → trigger the report. Verify
   `B3` (clicks for `B`) and `C4` (cost for `C`) appear empty.
2. In the sheet UI, type `MY MANUAL EDIT` into `B3` and `999` into `C4`.
   Also set `K2 = =B2/C2` (right of imported range — must survive).
3. Trigger a second run. Expect:
   - `B3` is empty (not `MY MANUAL EDIT`) — this is the bug being fixed.
   - `C4` is empty (not `999`).
   - `K2` still reads `=B2/C2` and evaluates correctly — DoD A from #1191
     still holds.
4. Toggle SQL: replace `CAST(NULL AS INT64)` with `99` → re-run. `B3` now
   reads `99` (non-null overwrite still works).
5. Falsy-but-not-nullish sanity:
   `SELECT 0 AS zero_int, FALSE AS bool_false, '' AS empty_str` →
   row 2 reads `0`, `FALSE`, `` — verifying we normalize only nullish, not
   falsy.

The companion manual checklist in `coverage/gs-manual-test.md` has been
expanded with this test (T7) plus 9 additional cases for previously
under-covered risks (empty result set, user-inserted column/row inside
imported range, cell formatting preservation, failed refresh, multi-batch,
SQL rename, limit shrinks/grows).

## Risks / Out of scope

- **Other warehouse adapters (Athena, Snowflake)** — the fix normalizes
  JavaScript `null` and `undefined`, which is what every adapter we use
  currently produces for SQL NULL. If a future adapter ships a different
  nullish representation (e.g. an empty object), it would need its own
  normalization at the reader layer. Integration tests still cover BigQuery
  only.
- **User inserts a column or row inside the imported rectangle manually** —
  not changed by this fix. ColumnPlan handles row 1, but the case where a
  user inserts a column between two SQL columns is not explicitly covered by
  tests. Tracked separately in the expanded manual checklist (T11, T12).
- **Concurrent edits during refresh** — documented limitation in PR #1191,
  unchanged here.

## Why we missed this in PR #1191

The original manual test plan covered six scenarios (first run, fill-down,
new-column-cloning, user reorder, aliases, remove column) plus a
pivot/chart/named-range smoke. The fixture SQL produced non-null values for
every column in every row, so the asymmetric "null skips, non-null
overwrites" behavior of `values.update` never manifested. The writer's unit
tests mocked the formatter as `(rows) => rows` — a pass-through that hid the
fact that no test asserted on the actual payload reaching the adapter.