### PR TITLE
feat(data-marts): enforce non-BMP character validation for data marts titles with legacy BigQuery storage

### DIFF
--- a/apps/backend/src/data-marts/use-cases/create-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-mart.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ForbiddenException, Logger } from '@nestjs/common';
+import { Injectable, ForbiddenException, BadRequestException, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
@@ -16,6 +16,7 @@ import { DataMartService } from '../services/data-mart.service';
 import { DataStorageService } from '../services/data-storage.service';
 import { LegacyDataMartsService } from '../services/legacy-data-marts/legacy-data-marts.service';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import { containsNonBmpCharacters } from '../utils/contains-non-bmp-characters';
 
 const LEGACY_DATA_MART_INITIAL_QUERY = 'SELECT 1';
 
@@ -60,6 +61,11 @@ export class CreateDataMartService {
 
     let legacyDataMartId: string | undefined = undefined;
     const isLegacyDataMart = dataStorage.type === DataStorageType.LEGACY_GOOGLE_BIGQUERY;
+    if (isLegacyDataMart && containsNonBmpCharacters(command.title)) {
+      throw new BadRequestException(
+        'Title contains unsupported characters (e.g. emoji). Legacy BigQuery storage does not support these characters.'
+      );
+    }
     if (isLegacyDataMart) {
       const newLegacyDataMart = await this.legacyDataMartService.createDataMart({
         title: command.title,

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-title.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-title.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ForbiddenException } from '@nestjs/common';
+import { Injectable, ForbiddenException, BadRequestException } from '@nestjs/common';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { DataMartDto } from '../dto/domain/data-mart.dto';
 import { UpdateDataMartTitleCommand } from '../dto/domain/update-data-mart-title.command';
@@ -6,6 +6,7 @@ import { DataMartMapper } from '../mappers/data-mart.mapper';
 import { DataMartService } from '../services/data-mart.service';
 import { LegacyDataMartsService } from '../services/legacy-data-marts/legacy-data-marts.service';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import { containsNonBmpCharacters } from '../utils/contains-non-bmp-characters';
 
 @Injectable()
 export class UpdateDataMartTitleService {
@@ -34,6 +35,11 @@ export class UpdateDataMartTitleService {
     }
 
     if (dataMart.storage.type === DataStorageType.LEGACY_GOOGLE_BIGQUERY) {
+      if (containsNonBmpCharacters(command.title)) {
+        throw new BadRequestException(
+          'Title contains unsupported characters (e.g. emoji). Legacy BigQuery storage does not support these characters.'
+        );
+      }
       await this.legacyDataMartsService.updateTitle(dataMart.id, command.title);
     }
 

--- a/apps/backend/src/data-marts/utils/contains-non-bmp-characters.spec.ts
+++ b/apps/backend/src/data-marts/utils/contains-non-bmp-characters.spec.ts
@@ -1,0 +1,41 @@
+import { containsNonBmpCharacters } from './contains-non-bmp-characters';
+
+describe('containsNonBmpCharacters', () => {
+  it('returns false for an empty string', () => {
+    expect(containsNonBmpCharacters('')).toBe(false);
+  });
+
+  it('returns false for ASCII characters', () => {
+    expect(containsNonBmpCharacters('Hello World')).toBe(false);
+    expect(containsNonBmpCharacters('Test123!@#')).toBe(false);
+  });
+
+  it('returns false for BMP Unicode characters', () => {
+    expect(containsNonBmpCharacters('Café')).toBe(false);
+    expect(containsNonBmpCharacters('日本語')).toBe(false);
+    expect(containsNonBmpCharacters('Привіт')).toBe(false);
+    expect(containsNonBmpCharacters('中文字符')).toBe(false);
+  });
+
+  it('returns true for emoji (outside BMP)', () => {
+    expect(containsNonBmpCharacters('Hello 👋')).toBe(true);
+    expect(containsNonBmpCharacters('🚀')).toBe(true);
+    expect(containsNonBmpCharacters('😀😁😂')).toBe(true);
+  });
+
+  it('returns true for characters above U+FFFF', () => {
+    // Mathematical alphanumeric symbols, CJK extension B, musical symbols etc.
+    expect(containsNonBmpCharacters('𝕳𝖊𝖑𝖑𝖔')).toBe(true);
+    expect(containsNonBmpCharacters('𠀋')).toBe(true);
+    expect(containsNonBmpCharacters('𝄞')).toBe(true);
+  });
+
+  it('returns true for mixed BMP and non-BMP strings', () => {
+    expect(containsNonBmpCharacters('Test 🎉 party')).toBe(true);
+    expect(containsNonBmpCharacters('Hello 𝄞 world')).toBe(true);
+  });
+
+  it('returns false for strings with combining marks only (still BMP)', () => {
+    expect(containsNonBmpCharacters('e\u0301')).toBe(false); // é as e + combining acute
+  });
+});

--- a/apps/backend/src/data-marts/utils/contains-non-bmp-characters.ts
+++ b/apps/backend/src/data-marts/utils/contains-non-bmp-characters.ts
@@ -1,0 +1,13 @@
+/**
+ * Checks whether a string contains characters outside the Basic Multilingual Plane (BMP),
+ * i.e. Unicode code points above U+FFFF. These are encoded as 4-byte sequences in UTF-8
+ * and include emoji, some CJK ideographs, musical symbols, etc.
+ *
+ * Legacy systems using MySQL `utf8` (3-byte max) charset silently truncate strings
+ * at the first 4-byte character, which can cause data loss.
+ */
+const NON_BMP_REGEX = /[\u{10000}-\u{10FFFF}]/u;
+
+export function containsNonBmpCharacters(value: string): boolean {
+  return NON_BMP_REGEX.test(value);
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartCreateForm.tsx
@@ -22,6 +22,7 @@ import { useDataStorage } from '../../../data-storage/shared/model/hooks/useData
 import type { DataStorageList } from '../../../data-storage/shared/model/types/data-storage-list.ts';
 import { DataStorageTypeModel } from '../../../data-storage/shared/types/data-storage-type.model.ts';
 import { type DataMart, type DataMartFormData, dataMartSchema, useDataMartForm } from '../model';
+import { containsNonBmpCharacters, LEGACY_TITLE_ERROR } from '../../shared';
 
 interface DataMartFormProps {
   initialData?: {
@@ -85,6 +86,15 @@ export function DataMartCreateForm({ initialData, onSuccess }: DataMartFormProps
   }, [dataStorages, loadingStorages, form]);
 
   const onSubmit = async (data: DataMartFormData) => {
+    const selectedStorage = dataStorages.find(s => s.id === data.storageId);
+    if (
+      selectedStorage?.type === DataStorageType.LEGACY_GOOGLE_BIGQUERY &&
+      containsNonBmpCharacters(data.title)
+    ) {
+      form.setError('title', { message: LEGACY_TITLE_ERROR });
+      return;
+    }
+
     const response = await handleCreate(data);
     if (response && onSuccess) {
       onSuccess(response);

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -33,9 +33,10 @@ import {
 import { useSchemaActualizeTrigger } from '../../shared/hooks/useSchemaActualizeTrigger';
 import { PromoStep, useDataMartNextStepPromo } from '../hooks/useDataMartNextStepPromo';
 import { useDataMart } from '../model';
-import { useAiHelper, useAiHelperAvailability } from '../model/hooks';
+import { useAiHelper, useAiHelperAvailability } from '../model';
 import { DataMartMetadataScope } from '../../shared';
 import { AiHelperButton } from './AiHelperButton';
+import { containsNonBmpCharacters, LEGACY_TITLE_ERROR } from '../../shared';
 import NotFound from '../../../../pages/NotFound.tsx';
 import NoAccess from '../../../../pages/NoAccess.tsx';
 
@@ -150,9 +151,16 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
   const handleTitleUpdate = useCallback(
     async (newTitle: string) => {
       if (!dataMartId) return;
+      if (
+        dataMart?.storage.type === DataStorageType.LEGACY_GOOGLE_BIGQUERY &&
+        containsNonBmpCharacters(newTitle)
+      ) {
+        toast.error(LEGACY_TITLE_ERROR);
+        throw new Error(LEGACY_TITLE_ERROR);
+      }
       await updateDataMartTitle(dataMartId, newTitle);
     },
-    [dataMartId, updateDataMartTitle]
+    [dataMartId, dataMart?.storage.type, updateDataMartTitle]
   );
 
   const { enabled: isAiHelperEnabled } = useAiHelperAvailability();

--- a/apps/web/src/features/data-marts/shared/utils/index.ts
+++ b/apps/web/src/features/data-marts/shared/utils/index.ts
@@ -3,3 +3,4 @@ export * from './athena-validation';
 export * from './validation';
 export * from './status.utils';
 export * from './table-pattern.utils';
+export * from './title-validation';

--- a/apps/web/src/features/data-marts/shared/utils/title-validation.test.ts
+++ b/apps/web/src/features/data-marts/shared/utils/title-validation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { containsNonBmpCharacters, LEGACY_TITLE_ERROR } from './title-validation';
+
+describe('title-validation', () => {
+  describe('containsNonBmpCharacters', () => {
+    it('returns false for an empty string', () => {
+      expect(containsNonBmpCharacters('')).toBe(false);
+    });
+
+    it('returns false for ASCII characters', () => {
+      expect(containsNonBmpCharacters('Hello World')).toBe(false);
+      expect(containsNonBmpCharacters('Test123!@#')).toBe(false);
+    });
+
+    it('returns false for BMP Unicode characters', () => {
+      expect(containsNonBmpCharacters('Café')).toBe(false);
+      expect(containsNonBmpCharacters('日本語')).toBe(false);
+      expect(containsNonBmpCharacters('Привіт')).toBe(false);
+      expect(containsNonBmpCharacters('中文字符')).toBe(false);
+    });
+
+    it('returns true for emoji (outside BMP)', () => {
+      expect(containsNonBmpCharacters('Hello 👋')).toBe(true);
+      expect(containsNonBmpCharacters('🚀')).toBe(true);
+      expect(containsNonBmpCharacters('😀😁😂')).toBe(true);
+    });
+
+    it('returns true for characters above U+FFFF', () => {
+      expect(containsNonBmpCharacters('𝕳𝖊𝖑𝖑𝖔')).toBe(true);
+      expect(containsNonBmpCharacters('𠀋')).toBe(true);
+      expect(containsNonBmpCharacters('𝄞')).toBe(true);
+    });
+
+    it('returns true for mixed BMP and non-BMP strings', () => {
+      expect(containsNonBmpCharacters('Test 🎉 party')).toBe(true);
+      expect(containsNonBmpCharacters('Hello 𝄞 world')).toBe(true);
+    });
+
+    it('returns false for strings with combining marks only (still BMP)', () => {
+      expect(containsNonBmpCharacters('e\u0301')).toBe(false);
+    });
+  });
+
+  describe('LEGACY_TITLE_ERROR', () => {
+    it('contains a human-readable error message', () => {
+      expect(LEGACY_TITLE_ERROR).toContain('emoji');
+      expect(LEGACY_TITLE_ERROR).toContain('Legacy BigQuery');
+    });
+  });
+});

--- a/apps/web/src/features/data-marts/shared/utils/title-validation.ts
+++ b/apps/web/src/features/data-marts/shared/utils/title-validation.ts
@@ -1,0 +1,13 @@
+/**
+ * Regex matching characters outside the Basic Multilingual Plane (U+10000–U+10FFFF).
+ * These are 4-byte UTF-8 sequences (emoji, musical symbols, etc.) that legacy
+ * MySQL `utf8` (non-utf8mb4) columns silently truncate.
+ */
+const NON_BMP_REGEX = /[\u{10000}-\u{10FFFF}]/u;
+
+export const LEGACY_TITLE_ERROR =
+  'Title cannot contain emoji or special symbols. Legacy BigQuery storage does not support these characters.';
+
+export function containsNonBmpCharacters(value: string): boolean {
+  return NON_BMP_REGEX.test(value);
+}


### PR DESCRIPTION
Implement a validation mechanism to disallow non-BMP characters in datamart titles within legacy BigQuery storage. This enforces improved data consistency and compatibility.