### PR TITLE
fix(web): resolve React SVG attribute warnings in icons

### DIFF
--- a/.changeset/fix-icons-svg-attributes.md
+++ b/.changeset/fix-icons-svg-attributes.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Fix React SVG Attribute Warnings in Icons
+
+Fixed React SVG attribute warnings in Microsoft Teams and Azure Synapse icon components by replacing invalid SVG kebab-case properties with JSX-compatible camelCase attributes.

--- a/apps/web/src/shared/icons/azure-synapse-icon.tsx
+++ b/apps/web/src/shared/icons/azure-synapse-icon.tsx
@@ -39,8 +39,8 @@ export const AzureSynapseIcon = ({ className, size = 24 }: AzureSynapseIconProps
           y2='0'
           gradientUnits='userSpaceOnUse'
         >
-          <stop offset='0.199' stop-color='#005BA1' />
-          <stop offset='1' stop-color='#0078D4' />
+          <stop offset='0.199' stopColor='#005BA1' />
+          <stop offset='1' stopColor='#0078D4' />
         </linearGradient>
         <linearGradient
           id='paint1_linear_19_1262'
@@ -50,11 +50,11 @@ export const AzureSynapseIcon = ({ className, size = 24 }: AzureSynapseIconProps
           y2='14.0987'
           gradientUnits='userSpaceOnUse'
         >
-          <stop stop-color='#198AB3' />
-          <stop offset='0.172' stop-color='#32BEDD' />
-          <stop offset='0.5' stop-color='#198AB3' />
-          <stop offset='0.662' stop-color='#32BEDD' />
-          <stop offset='0.975' stop-color='#50E6FF' />
+          <stop stopColor='#198AB3' />
+          <stop offset='0.172' stopColor='#32BEDD' />
+          <stop offset='0.5' stopColor='#198AB3' />
+          <stop offset='0.662' stopColor='#32BEDD' />
+          <stop offset='0.975' stopColor='#50E6FF' />
         </linearGradient>
       </defs>
     </svg>

--- a/apps/web/src/shared/icons/microsoft-teams-icon.tsx
+++ b/apps/web/src/shared/icons/microsoft-teams-icon.tsx
@@ -88,9 +88,9 @@ export const MicrosoftTeamsIcon = ({ className, size = 24 }: MicrosoftTeamsIconP
           y2='18.837'
           gradientUnits='userSpaceOnUse'
         >
-          <stop stop-color='#5A62C3' />
-          <stop offset='0.5' stop-color='#4D55BD' />
-          <stop offset='1' stop-color='#3940AB' />
+          <stop stopColor='#5A62C3' />
+          <stop offset='0.5' stopColor='#4D55BD' />
+          <stop offset='1' stopColor='#3940AB' />
         </linearGradient>
         <clipPath id='clip0_377_3451'>
           <rect width='23.65' height='22' fill='white' transform='translate(0 1)' />


### PR DESCRIPTION

<img width="1290" height="1766" alt="image" src="https://github.com/user-attachments/assets/77dd9e8e-2b7d-4d76-9a4f-bade3a55b2e4" />


## Summary

Fixed React SVG attribute warnings in icon components by replacing invalid kebab-case SVG properties with JSX-compatible camelCase equivalents.

Updated icons:
- apps/web/src/shared/icons/microsoft-teams-icon.tsx
- apps/web/src/shared/icons/azure-synapse-icon.tsx