### PR TITLE
fix(backend): OOM during AI metadata generation

### DIFF
--- a/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
+++ b/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
@@ -73,9 +73,12 @@ export class GenerateDataMartMetadataOrchestratorService {
     let sampleColumns: string[] | null = null;
     let sampleRows: QueryRow[] | null = null;
     if (request.useSample) {
-      const sample = await this.dataMartSampleDataService.sampleAllRows(
+      const schemaColumns = schema.fields.map(f => f.name);
+      const sample = await this.dataMartSampleDataService.sampleColumns(
         request.dataMartId,
         request.projectId,
+        schemaColumns,
+        undefined,
         METADATA_SAMPLE_ROW_LIMIT
       );
       sampleColumns = sample.columns;

--- a/apps/backend/src/data-marts/services/data-mart-sample-data.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-sample-data.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { DataMartService } from './data-mart.service';
 import { DataMartSqlTableService } from './data-mart-sql-table.service';
 import { DataMartTableReferenceService } from './data-mart-table-reference.service';
@@ -39,27 +38,5 @@ export class DataMartSampleDataService {
       columns: result.columns,
       rows: result.rows,
     };
-  }
-
-  async sampleAllRows(
-    dataMartId: string,
-    projectId: string,
-    limit = 30,
-    fullyQualifiedTableName?: string
-  ): Promise<SampleTableDataResult> {
-    const dataMart = await this.dataMartService.getByIdAndProjectId(dataMartId, projectId);
-    if (dataMart.storage.type === DataStorageType.AWS_REDSHIFT) {
-      const fqn =
-        fullyQualifiedTableName ??
-        (await this.dataMartTableReferenceService.resolveTableName(dataMartId, projectId));
-      const sql = `SELECT * FROM ${fqn} LIMIT ${limit}`;
-      const result = await this.dataMartSqlTableService.executeSqlToTable(dataMart, sql, { limit });
-      return { columns: result.columns, rows: result.rows };
-    }
-
-    const result = await this.dataMartSqlTableService.executeSqlToTable(dataMart, undefined, {
-      limit,
-    });
-    return { columns: result.columns, rows: result.rows };
   }
 }


### PR DESCRIPTION
## Summary

- AI metadata generation no longer OOMs the Node process on wide BigQuery
  data marts. The 30-row sample now applies `LIMIT` at the SQL level, so
  the storage returns exactly 30 rows instead of a 5000-row page that the
  JS loop would only later truncate.
- Removes the redundant `sampleAllRows()` from `DataMartSampleDataService`;
  the orchestrator now reuses the existing `sampleColumns()` helper with
  the documented schema fields — the same method already used by other
  AI features.
- Side effect: BigQuery scans only the documented schema columns instead
  of `SELECT *`, which reduces bytes processed for wide tables and avoids
  exposing undocumented sibling columns to the prompt.

## Why

Production crash on a BigQuery data mart with 35 columns (including wide
STRUCT/JSON fields). Node aborted with
`FATAL ERROR: Ineffective mark-compacts near heap limit — Allocation failed`
roughly 67 seconds after the orchestrator started.

**Root cause.** `DataMartSampleDataService.sampleAllRows()` passed
`sql=undefined` for every non-Redshift storage. The BigQuery query
builder then returned the full data mart definition without any `LIMIT`,
BigQuery executed the full scan, and `table.getRows({maxResults: 5000,
autoPaginate: false})` streamed the first 5000-row page into the Node
heap. The downstream loop breaks after 30 rows, but the entire 5000-row
page is already parsed in memory before that check runs — and 5000 wide
rows with deeply nested STRUCT/REPEATED cells exceed the 4 GB Node heap.

**Why AI Insight is unaffected by the same `runRows({limit: 30})`
pattern.** AI Insight runs `SqlDryRunService` first and rejects queries
that exceed `budgets.maxBytesProcessed`, *and* the SQL it produces is
LLM-built with narrow column projection and explicit `LIMIT`. Metadata
generation had neither safeguard.

The Redshift branch in `sampleAllRows()` already built SQL-level `LIMIT`,
which is why this class of failure never reproduced on Redshift.

## What changed

**Backend**

- `DataMartSampleDataService.sampleAllRows()` removed. Only one caller
  existed (the metadata orchestrator), so consolidation is non-breaking.
- `GenerateDataMartMetadataOrchestratorService` now calls
  `sampleColumns(schema.fields.map(f => f.name), undefined, 30)`. This
  emits `SELECT <fields> FROM <fqn> LIMIT 30` uniformly across BigQuery,
  Snowflake, Athena, Redshift, and Postgres via the existing
  `DataMartTableReferenceService` resolution.
- Unused `DataStorageType` import dropped from `data-mart-sample-data.service.ts`.