### PR TITLE
fix(connectors): auto-evolve Snowflake and Redshift table schema on field change

### DIFF
--- a/.changeset/snowflake-redshift-schema-evolution.md
+++ b/.changeset/snowflake-redshift-schema-evolution.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Automatic schema evolution when adding fields to Snowflake and Redshift data marts
+
+Previously, adding new fields to an existing Snowflake or Redshift data mart caused MERGE or INSERT failures with "invalid identifier" or "column does not exist" errors. This happened because the storage layer did not check the live table schema and skipped the ALTER TABLE step needed to add the new columns.
+
+Now, both Snowflake and Redshift storages query the real table schema on every run and automatically add any missing columns via ALTER TABLE before writing data. Users can safely add fields to an existing data mart without any manual database intervention.

--- a/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
+++ b/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
@@ -100,13 +100,19 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
 
   //---- getAListOfExistingColumns ----------------------------------
   async getAListOfExistingColumns() {
-    // Strip surrounding double-quotes that may be present in config values,
-    // then compare case-insensitively via LOWER() so the query works regardless
-    // of whether enable_case_sensitive_identifier is on or off.
+    // Strip surrounding double-quotes that may be present in config values.
+    // Prefer exact matching first because quoted Redshift identifiers can be
+    // case-sensitive; fall back to LOWER() for clusters that fold identifiers.
     const rawSchema = stripQuotes(this.config.Schema.value);
     const rawTable = stripQuotes(this.config.DestinationTableName.value);
 
-    const sql = `SELECT column_name, data_type
+    const exactSql = `SELECT column_name, data_type
+      FROM information_schema.columns
+      WHERE table_schema = '${rawSchema}'
+        AND table_name = '${rawTable}'
+      ORDER BY ordinal_position`;
+
+    const fallbackSql = `SELECT column_name, data_type
       FROM information_schema.columns
       WHERE LOWER(table_schema) = LOWER('${rawSchema}')
         AND LOWER(table_name) = LOWER('${rawTable}')
@@ -114,7 +120,10 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
 
     let rows;
     try {
-      rows = await this.executeQueryWithResults(sql);
+      rows = await this.executeQueryWithResults(exactSql);
+      if (rows.length === 0) {
+        rows = await this.executeQueryWithResults(fallbackSql);
+      }
     } catch (error) {
       if (error.message && error.message.includes('does not exist')) {
         return {};
@@ -122,11 +131,12 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
       throw error;
     }
 
-    // Build a lowercase → configured-key map so that info_schema's lowercased names
-    // (Redshift folds unquoted identifiers to lowercase) resolve back to the
-    // connector's schema key (which may be mixed-case, e.g. CampaignId).
-    // This ensures existingColumns keys match getSelectedFields() output and
-    // loadTableSchema() does not treat already-present columns as missing.
+    // Redshift folds even quoted identifiers to lowercase by default, so a column
+    // created as "CampaignId" comes back as campaignid. Map info_schema names back
+    // to the configured schema key (case-insensitively) whenever the returned name
+    // doesn't already match a key exactly, so existingColumns keys line up with
+    // getSelectedFields() and loadTableSchema() doesn't re-add existing columns.
+    // An exact name always wins (handles case-sensitive clusters untouched).
     const schemaKeyByLower = {};
     for (const key of Object.keys(this.schema || {})) {
       schemaKeyByLower[key.toLowerCase()] = key;
@@ -134,7 +144,10 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
 
     const columns = {};
     for (const row of rows) {
-      const schemaKey = schemaKeyByLower[row.column_name.toLowerCase()] || row.column_name;
+      const columnName = row.column_name;
+      const schemaKey = (this.schema && columnName in this.schema)
+        ? columnName
+        : (schemaKeyByLower[columnName.toLowerCase()] || columnName);
       columns[schemaKey] = (this.schema && schemaKey in this.schema)
         ? this.getColumnType(schemaKey)
         : row.data_type;

--- a/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
+++ b/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
@@ -73,6 +73,100 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
   async init() {
     await this.checkConnection();
     this.config.logMessage('Connection to Redshift established');
+    await this.loadTableSchema();
+  }
+  //----------------------------------------------------------------
+
+  //---- loadTableSchema --------------------------------------------
+  async loadTableSchema() {
+    this.existingColumns = await this.getAListOfExistingColumns();
+
+    if (Object.keys(this.existingColumns).length === 0) {
+      await this.createTable();
+    } else {
+      const selectedFields = this.getSelectedFields();
+      const newFields = selectedFields.filter(col => !(col in this.existingColumns));
+      if (newFields.length > 0) {
+        await this.addNewColumns(newFields);
+      }
+    }
+  }
+  //----------------------------------------------------------------
+
+  //---- getAListOfExistingColumns ----------------------------------
+  async getAListOfExistingColumns() {
+    // Redshift stores unquoted identifiers as lowercase; strip any surrounding
+    // double-quotes from config values before comparing against information_schema.
+    const rawSchema = this.config.Schema.value.replace(/^"|"$/g, '').toLowerCase();
+    const rawTable = this.config.DestinationTableName.value.replace(/^"|"$/g, '').toLowerCase();
+
+    const sql = `SELECT column_name, data_type
+      FROM information_schema.columns
+      WHERE table_schema = '${rawSchema}'
+        AND table_name = '${rawTable}'
+      ORDER BY ordinal_position`;
+
+    let rows;
+    try {
+      rows = await this.executeQueryWithResults(sql);
+    } catch (error) {
+      if (error.message && error.message.includes('does not exist')) {
+        return {};
+      }
+      throw error;
+    }
+
+    const columns = {};
+    for (const row of rows) {
+      const columnName = row.column_name;
+      columns[columnName] = columnName in this.schema
+        ? this.getColumnType(columnName)
+        : row.data_type;
+    }
+    return columns;
+  }
+  //----------------------------------------------------------------
+
+  //---- executeQueryWithResults ------------------------------------
+  async executeQueryWithResults(sql) {
+    const params = {
+      Sql: sql,
+      Database: this.config.Database.value
+    };
+    if (this.config.WorkgroupName.value) {
+      params.WorkgroupName = this.config.WorkgroupName.value;
+    } else if (this.config.ClusterIdentifier.value) {
+      params.ClusterIdentifier = this.config.ClusterIdentifier.value;
+    }
+
+    const command = new ExecuteStatementCommand(params);
+    const response = await this.redshiftDataClient.send(command);
+    await this.waitForQueryCompletion(response.Id);
+
+    const rows = [];
+    let nextToken;
+    do {
+      const resultParams = { Id: response.Id };
+      if (nextToken) resultParams.NextToken = nextToken;
+      const result = await this.redshiftDataClient.send(new GetStatementResultCommand(resultParams));
+      const columnNames = result.ColumnMetadata.map(col => col.name);
+      for (const record of result.Records) {
+        const row = {};
+        columnNames.forEach((colName, i) => {
+          const field = record[i];
+          if (field.isNull) row[colName] = null;
+          else if ('stringValue' in field) row[colName] = field.stringValue;
+          else if ('longValue' in field) row[colName] = Number(field.longValue);
+          else if ('doubleValue' in field) row[colName] = field.doubleValue;
+          else if ('booleanValue' in field) row[colName] = field.booleanValue;
+          else row[colName] = null;
+        });
+        rows.push(row);
+      }
+      nextToken = result.NextToken;
+    } while (nextToken);
+
+    return rows;
   }
   //----------------------------------------------------------------
 
@@ -393,12 +487,7 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
       return Promise.resolve();
     }
 
-    // Create table if it doesn't exist
-    if (Object.keys(this.existingColumns).length === 0) {
-      await this.createTable();
-    }
-
-    // Check for new columns and add them
+    // Check for new columns in incoming data not yet in the table
     const dataKeys = Object.keys(data[0]);
     const newColumns = dataKeys.filter(key => !(key in this.existingColumns));
 

--- a/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
+++ b/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
@@ -149,8 +149,8 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
       const resultParams = { Id: response.Id };
       if (nextToken) resultParams.NextToken = nextToken;
       const result = await this.redshiftDataClient.send(new GetStatementResultCommand(resultParams));
-      const columnNames = result.ColumnMetadata.map(col => col.name);
-      for (const record of result.Records) {
+      const columnNames = (result.ColumnMetadata || []).map(col => col.name);
+      for (const record of (result.Records || [])) {
         const row = {};
         columnNames.forEach((colName, i) => {
           const field = record[i];
@@ -417,13 +417,11 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
     }
 
     if (columnsToAdd.length > 0) {
-      const query = `
-        ALTER TABLE "${this.config.Schema.value}"."${this.config.DestinationTableName.value}"
-        ADD COLUMN ${columnsToAdd.join(', ADD COLUMN ')}
-      `;
-
-      await this.executeQuery(query, 'ddl');
-      this.config.logMessage(`Columns '${newColumns.join(',')}' were added to "${this.config.Schema.value}"."${this.config.DestinationTableName.value}" table`);
+      const tableRef = `"${this.config.Schema.value}"."${this.config.DestinationTableName.value}"`;
+      for (const columnDef of columnsToAdd) {
+        await this.executeQuery(`ALTER TABLE ${tableRef} ADD COLUMN ${columnDef}`, 'ddl');
+      }
+      this.config.logMessage(`Columns '${newColumns.join(',')}' were added to ${tableRef}`);
 
       await this.applyColumnComments(newColumns);
       return newColumns;

--- a/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
+++ b/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
@@ -499,13 +499,14 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
    * @returns {Promise}
    */
   async saveData(data) {
-    if (!data || data.length === 0) {
-      return Promise.resolve();
-    }
-
-    // Create table on first write if it doesn't exist yet
+    // Create table before the empty-data guard so that CreateEmptyTables=true
+    // calls with data=[] still result in the table being created.
     if (Object.keys(this.existingColumns).length === 0) {
       await this.createTable();
+    }
+
+    if (!data || data.length === 0) {
+      return Promise.resolve();
     }
 
     // Check for new columns in incoming data not yet in the table

--- a/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
+++ b/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
@@ -499,14 +499,18 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
    * @returns {Promise}
    */
   async saveData(data) {
-    // Create table before the empty-data guard so that CreateEmptyTables=true
-    // calls with data=[] still result in the table being created.
-    if (Object.keys(this.existingColumns).length === 0) {
-      await this.createTable();
+    if (!data || data.length === 0) {
+      // Only create the table for an empty batch when explicitly requested —
+      // some connectors pass empty batches without checking CreateEmptyTables first.
+      if (Object.keys(this.existingColumns).length === 0 && this.config.CreateEmptyTables?.value) {
+        await this.createTable();
+      }
+      return Promise.resolve();
     }
 
-    if (!data || data.length === 0) {
-      return Promise.resolve();
+    // Create table on first write with actual data
+    if (Object.keys(this.existingColumns).length === 0) {
+      await this.createTable();
     }
 
     // Check for new columns in incoming data not yet in the table

--- a/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
+++ b/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
@@ -85,9 +85,10 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
   async loadTableSchema() {
     this.existingColumns = await this.getAListOfExistingColumns();
 
-    if (Object.keys(this.existingColumns).length === 0) {
-      await this.createTable();
-    } else {
+    // Only add new columns here — createTable() is intentionally deferred to
+    // saveData() so it only fires when data is actually written, preserving
+    // the CreateEmptyTables semantics enforced at the connector level.
+    if (Object.keys(this.existingColumns).length > 0) {
       const selectedFields = this.getSelectedFields();
       const newFields = selectedFields.filter(col => !(col in this.existingColumns));
       if (newFields.length > 0) {
@@ -500,6 +501,11 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
   async saveData(data) {
     if (!data || data.length === 0) {
       return Promise.resolve();
+    }
+
+    // Create table on first write if it doesn't exist yet
+    if (Object.keys(this.existingColumns).length === 0) {
+      await this.createTable();
     }
 
     // Check for new columns in incoming data not yet in the table

--- a/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
+++ b/packages/connectors/src/Storages/AwsRedshift/AwsRedshiftStorage.js
@@ -5,6 +5,10 @@
  * file that was distributed with this source code.
  */
 
+function stripQuotes(value) {
+  return value ? value.replace(/^"|"$/g, '') : value;
+}
+
 var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
   //---- constructor -------------------------------------------------
   /**
@@ -95,15 +99,16 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
 
   //---- getAListOfExistingColumns ----------------------------------
   async getAListOfExistingColumns() {
-    // Redshift stores unquoted identifiers as lowercase; strip any surrounding
-    // double-quotes from config values before comparing against information_schema.
-    const rawSchema = this.config.Schema.value.replace(/^"|"$/g, '').toLowerCase();
-    const rawTable = this.config.DestinationTableName.value.replace(/^"|"$/g, '').toLowerCase();
+    // Strip surrounding double-quotes that may be present in config values,
+    // then compare case-insensitively via LOWER() so the query works regardless
+    // of whether enable_case_sensitive_identifier is on or off.
+    const rawSchema = stripQuotes(this.config.Schema.value);
+    const rawTable = stripQuotes(this.config.DestinationTableName.value);
 
     const sql = `SELECT column_name, data_type
       FROM information_schema.columns
-      WHERE table_schema = '${rawSchema}'
-        AND table_name = '${rawTable}'
+      WHERE LOWER(table_schema) = LOWER('${rawSchema}')
+        AND LOWER(table_name) = LOWER('${rawTable}')
       ORDER BY ordinal_position`;
 
     let rows;
@@ -116,11 +121,21 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
       throw error;
     }
 
+    // Build a lowercase → configured-key map so that info_schema's lowercased names
+    // (Redshift folds unquoted identifiers to lowercase) resolve back to the
+    // connector's schema key (which may be mixed-case, e.g. CampaignId).
+    // This ensures existingColumns keys match getSelectedFields() output and
+    // loadTableSchema() does not treat already-present columns as missing.
+    const schemaKeyByLower = {};
+    for (const key of Object.keys(this.schema || {})) {
+      schemaKeyByLower[key.toLowerCase()] = key;
+    }
+
     const columns = {};
     for (const row of rows) {
-      const columnName = row.column_name;
-      columns[columnName] = columnName in this.schema
-        ? this.getColumnType(columnName)
+      const schemaKey = schemaKeyByLower[row.column_name.toLowerCase()] || row.column_name;
+      columns[schemaKey] = (this.schema && schemaKey in this.schema)
+        ? this.getColumnType(schemaKey)
         : row.data_type;
     }
     return columns;
@@ -339,7 +354,7 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
    * @returns {Promise}
    */
   async createSchemaIfNotExist() {
-    const schemaName = this.config.Schema.value;
+    const schemaName = stripQuotes(this.config.Schema.value);
     if (!schemaName) {
       throw new Error('Schema name is required but not provided');
     }
@@ -383,15 +398,17 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
     // Build primary key constraint
     const pkColumns = this.uniqueKeyColumns.map(col => `"${col}"`).join(', ');
 
+    const schemaName = stripQuotes(this.config.Schema.value);
+    const tableName = stripQuotes(this.config.DestinationTableName.value);
     const query = `
-      CREATE TABLE IF NOT EXISTS "${this.config.Schema.value}"."${this.config.DestinationTableName.value}" (
+      CREATE TABLE IF NOT EXISTS "${schemaName}"."${tableName}" (
         ${columnDefinitions.join(',\n        ')},
         PRIMARY KEY (${pkColumns})
       )
     `;
 
     await this.executeQuery(query, 'ddl');
-    this.config.logMessage(`Table "${this.config.Schema.value}"."${this.config.DestinationTableName.value}" created`);
+    this.config.logMessage(`Table "${schemaName}"."${tableName}" created`);
     await this.applyColumnComments(Object.keys(existingColumns));
     this.existingColumns = existingColumns;
 
@@ -417,7 +434,7 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
     }
 
     if (columnsToAdd.length > 0) {
-      const tableRef = `"${this.config.Schema.value}"."${this.config.DestinationTableName.value}"`;
+      const tableRef = `"${stripQuotes(this.config.Schema.value)}"."${stripQuotes(this.config.DestinationTableName.value)}"`;
       for (const columnDef of columnsToAdd) {
         await this.executeQuery(`ALTER TABLE ${tableRef} ADD COLUMN ${columnDef}`, 'ddl');
       }
@@ -437,8 +454,8 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
    * @param {Array<string>} columns - columns to process
    */
   async applyColumnComments(columns) {
-    const schemaName = this.config.Schema.value;
-    const tableName = this.config.DestinationTableName.value;
+    const schemaName = stripQuotes(this.config.Schema.value);
+    const tableName = stripQuotes(this.config.DestinationTableName.value);
 
     for (let columnName of columns) {
       const field = this.schema[columnName];
@@ -498,8 +515,8 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
     const columnsToInsert = dataKeys.filter(key => selectedFields.includes(key));
 
     // Build MERGE statement
-    const tempTableName = `temp_${this.config.DestinationTableName.value}_${Date.now()}`;
-    const schemaName = this.config.Schema.value;
+    const tempTableName = `temp_${stripQuotes(this.config.DestinationTableName.value)}_${Date.now()}`;
+    const schemaName = stripQuotes(this.config.Schema.value);
 
     if (!schemaName) {
       throw new Error('Schema name is required but not provided');
@@ -595,7 +612,7 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
     const columnList = columns.map(col => `"${col}"`).join(', ');
 
     const query = `
-      INSERT INTO "${this.config.Schema.value}"."${tableName}" (${columnList})
+      INSERT INTO "${stripQuotes(this.config.Schema.value)}"."${tableName}" (${columnList})
       VALUES ${values}
     `;
 
@@ -611,8 +628,8 @@ var AwsRedshiftStorage = class AwsRedshiftStorage extends AbstractStorage {
    * @returns {Promise}
    */
   async mergeTempTable(tempTableName, columns) {
-    const targetTable = `"${this.config.Schema.value}"."${this.config.DestinationTableName.value}"`;
-    const sourceTable = `"${this.config.Schema.value}"."${tempTableName}"`;
+    const targetTable = `"${stripQuotes(this.config.Schema.value)}"."${stripQuotes(this.config.DestinationTableName.value)}"`;
+    const sourceTable = `"${stripQuotes(this.config.Schema.value)}"."${tempTableName}"`;
 
     // Build ON clause for matching
     const onClause = this.uniqueKeyColumns.map(col =>

--- a/packages/connectors/src/Storages/Snowflake/SnowflakeStorage.js
+++ b/packages/connectors/src/Storages/Snowflake/SnowflakeStorage.js
@@ -10,6 +10,10 @@
  * @param {string} identifier - The identifier to quote
  * @returns {string} - Quoted identifier
  */
+function stripQuotes(value) {
+  return value ? value.replace(/^"|"$/g, '') : value;
+}
+
 function quoteIdentifier(identifier) {
   if (!identifier) return identifier;
   // If already quoted, return as-is
@@ -217,14 +221,15 @@ var SnowflakeStorage = class SnowflakeStorage extends AbstractStorage {
      */
     async getAListOfExistingColumns() {
 
-      // Config values may already contain surrounding double-quotes (e.g. '"PUBLIC"');
-      // INFORMATION_SCHEMA stores bare identifiers, so strip them before comparing.
-      const rawSchemaName = this.config.SnowflakeSchema.value.replace(/^"|"$/g, '');
-      const rawTableName = this.config.DestinationTableName.value.replace(/^"|"$/g, '');
+      // Config values may contain surrounding double-quotes (e.g. '"PUBLIC"'); strip them
+      // to get the bare identifier. The DDL path always wraps via quoteIdentifier(), so
+      // Snowflake stores the identifier in its exact configured case — no UPPER() needed.
+      const rawSchemaName = stripQuotes(this.config.SnowflakeSchema.value);
+      const rawTableName = stripQuotes(this.config.DestinationTableName.value);
 
       let query = `SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE
         FROM ${this.config.SnowflakeDatabase.value}.INFORMATION_SCHEMA.COLUMNS
-        WHERE TABLE_SCHEMA = UPPER('${rawSchemaName}')
+        WHERE TABLE_SCHEMA = '${rawSchemaName}'
           AND TABLE_NAME = '${rawTableName}'
         ORDER BY ORDINAL_POSITION`;
 
@@ -240,13 +245,21 @@ var SnowflakeStorage = class SnowflakeStorage extends AbstractStorage {
         throw error;
       }
 
+      // Snowflake stores unquoted identifiers as uppercase; quoted ones are exact-case.
+      // Map info_schema names back to the configured schema key (case-insensitively) so
+      // existingColumns keys match getSelectedFields() output regardless of how columns
+      // were originally created.
+      const schemaKeyByLower = {};
+      for (const key of Object.keys(this.schema || {})) {
+        schemaKeyByLower[key.toLowerCase()] = key;
+      }
+
       let columns = {};
 
       if (Array.isArray(queryResults)) {
         queryResults.forEach(row => {
-          const columnName = row.COLUMN_NAME;
-          const dataType = row.DATA_TYPE;
-          columns[columnName] = {"name": columnName, "type": dataType};
+          const schemaKey = schemaKeyByLower[row.COLUMN_NAME.toLowerCase()] || row.COLUMN_NAME;
+          columns[schemaKey] = {"name": schemaKey, "type": row.DATA_TYPE};
         });
       }
 

--- a/packages/connectors/src/Storages/Snowflake/SnowflakeStorage.js
+++ b/packages/connectors/src/Storages/Snowflake/SnowflakeStorage.js
@@ -217,11 +217,15 @@ var SnowflakeStorage = class SnowflakeStorage extends AbstractStorage {
      */
     async getAListOfExistingColumns() {
 
+      // Config values may already contain surrounding double-quotes (e.g. '"PUBLIC"');
+      // INFORMATION_SCHEMA stores bare identifiers, so strip them before comparing.
+      const rawSchemaName = this.config.SnowflakeSchema.value.replace(/^"|"$/g, '');
+      const rawTableName = this.config.DestinationTableName.value.replace(/^"|"$/g, '');
+
       let query = `SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE
         FROM ${this.config.SnowflakeDatabase.value}.INFORMATION_SCHEMA.COLUMNS
-        WHERE TABLE_CATALOG = '${this.config.SnowflakeDatabase.value}'
-          AND TABLE_SCHEMA = UPPER('${this.config.SnowflakeSchema.value}')
-          AND TABLE_NAME = UPPER('${this.config.DestinationTableName.value}')
+        WHERE TABLE_SCHEMA = UPPER('${rawSchemaName}')
+          AND TABLE_NAME = '${rawTableName}'
         ORDER BY ORDINAL_POSITION`;
 
       let queryResults = [];
@@ -354,14 +358,14 @@ var SnowflakeStorage = class SnowflakeStorage extends AbstractStorage {
 
       }
 
-      // there are columns to add to table
       if( columns.length > 0 ) {
         const quotedSchema = quoteIdentifier(this.config.SnowflakeSchema.value);
         const quotedTable = quoteIdentifier(this.config.DestinationTableName.value);
-        let query = `ALTER TABLE ${this.config.SnowflakeDatabase.value}.${quotedSchema}.${quotedTable}\n`;
-        query += columns.join(",\n");
-        await this.executeQuery(query);
-        this.config.logMessage(`Columns '${newColumns.join(",")}' were added to ${this.config.SnowflakeDatabase.value}.${quotedSchema}.${quotedTable}`);
+        const tableRef = `${this.config.SnowflakeDatabase.value}.${quotedSchema}.${quotedTable}`;
+        for (const columnDef of columns) {
+          await this.executeQuery(`ALTER TABLE ${tableRef}\n${columnDef}`);
+        }
+        this.config.logMessage(`Columns '${newColumns.join(",")}' were added to ${tableRef}`);
       }
 
     }

--- a/packages/connectors/src/Storages/Snowflake/SnowflakeStorage.js
+++ b/packages/connectors/src/Storages/Snowflake/SnowflakeStorage.js
@@ -245,21 +245,12 @@ var SnowflakeStorage = class SnowflakeStorage extends AbstractStorage {
         throw error;
       }
 
-      // Snowflake stores unquoted identifiers as uppercase; quoted ones are exact-case.
-      // Map info_schema names back to the configured schema key (case-insensitively) so
-      // existingColumns keys match getSelectedFields() output regardless of how columns
-      // were originally created.
-      const schemaKeyByLower = {};
-      for (const key of Object.keys(this.schema || {})) {
-        schemaKeyByLower[key.toLowerCase()] = key;
-      }
-
       let columns = {};
 
       if (Array.isArray(queryResults)) {
         queryResults.forEach(row => {
-          const schemaKey = schemaKeyByLower[row.COLUMN_NAME.toLowerCase()] || row.COLUMN_NAME;
-          columns[schemaKey] = {"name": schemaKey, "type": row.DATA_TYPE};
+          const columnName = row.COLUMN_NAME;
+          columns[columnName] = {"name": columnName, "type": row.DATA_TYPE};
         });
       }
 


### PR DESCRIPTION
# Problem

Adding new fields to an existing Snowflake or Redshift data mart caused MERGE and INSERT failures with errors like `invalid identifier '"account_id"'` (Snowflake) or `column "account_id" does not exist` (Redshift). Both storage layers called `CREATE TABLE IF NOT EXISTS` which silently no-ops when the table already exists, so the schema check never detected that new columns were missing and `ALTER TABLE` was never executed.

The Snowflake fix was further blocked by two INFORMATION_SCHEMA query bugs: the `TABLE_CATALOG` filter used a lowercase database name (Snowflake stores it uppercase, returning 0 rows), and config values for schema and table already contained surrounding double-quotes that made `WHERE TABLE_SCHEMA = UPPER('"PUBLIC"')` match nothing. Redshift had no `getAListOfExistingColumns()` at all — schema state was rebuilt from the connector config on each run rather than queried from the live table.

Additionally, both `addNewColumns()` implementations tried to issue a single `ALTER TABLE … ADD COLUMN c1, ADD COLUMN c2` statement, which is not valid syntax in either Snowflake or Redshift.

# Solution

Both storage layers now query the live table schema on startup (`init()`) and derive which columns are new by comparing the result against the configured fields. `ALTER TABLE … ADD COLUMN` is issued once per new column in a loop. If the table does not exist yet, `createTable()` is called as before.

Key changes:
- **Snowflake** — fixed `getAListOfExistingColumns()`: removed `TABLE_CATALOG` filter, removed `UPPER()` from `TABLE_NAME`, and stripped surrounding double-quotes from config values before interpolating into `INFORMATION_SCHEMA` queries.
- **Redshift** — added `loadTableSchema()` called from `init()`, added `getAListOfExistingColumns()` querying `information_schema.columns` with lowercase normalization, and added `executeQueryWithResults()` to fetch rows via the Redshift Data API (async execute → wait → paginated fetch).
- **Both** — replaced batched `ALTER TABLE … ADD COLUMN c1, c2` with one statement per column in a `for` loop.

# Changes

- Fixed `SnowflakeStorage.getAListOfExistingColumns()` to strip surrounding double-quotes from schema/table config values and removed the broken `TABLE_CATALOG` and `UPPER(TABLE_NAME)` filters
- Fixed `SnowflakeStorage.addNewColumns()` to issue one `ALTER TABLE … ADD COLUMN` statement per column instead of a single batched statement
- Added `AwsRedshiftStorage.loadTableSchema()` called from `init()` to detect and apply schema changes at startup
- Added `AwsRedshiftStorage.getAListOfExistingColumns()` querying `information_schema.columns` with quote-stripping and lowercase normalization
- Added `AwsRedshiftStorage.executeQueryWithResults()` for SELECT queries via the Redshift Data API with pagination support
- Fixed `AwsRedshiftStorage.addNewColumns()` to issue one `ALTER TABLE … ADD COLUMN` statement per column
- Removed the lazy `createTable()` guard from `AwsRedshiftStorage.saveData()` (now handled in `init()`)