### PR TITLE
Refine report OpenAPI request and response schemas

### DIFF
--- a/apps/backend/src/data-marts/controllers/spec/report-openapi.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report-openapi.ts
@@ -1,0 +1,272 @@
+import { ApiProperty, ApiPropertyOptional, getSchemaPath } from '@nestjs/swagger';
+import { TemplateSourceTypeEnum } from '../../enums/template-source-type.enum';
+import { EmailConfigType } from '../../data-destination-types/ee/email/schemas/email-config.schema';
+import { ReportCondition } from '../../data-destination-types/enums/report-condition.enum';
+import { GoogleSheetsConfigType } from '../../data-destination-types/google-sheets/schemas/google-sheets-config.schema';
+import { LookerStudioConnectorConfigType } from '../../data-destination-types/looker-studio-connector/schemas/looker-studio-connector-config.schema';
+import {
+  FILTER_NO_VALUE_OPERATORS,
+  FILTER_SCALAR_OPERATORS,
+} from '../../dto/schemas/filter-config.schema';
+
+const primitiveValueSchema = {
+  oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }],
+};
+
+export class ReportCustomMessageTemplateSourceApiDto {
+  @ApiProperty({ enum: [TemplateSourceTypeEnum.CUSTOM_MESSAGE] })
+  type: TemplateSourceTypeEnum.CUSTOM_MESSAGE;
+
+  @ApiProperty({
+    type: 'object',
+    required: ['messageTemplate'],
+    properties: { messageTemplate: { type: 'string', minLength: 1 } },
+  })
+  config: { messageTemplate: string };
+}
+
+export class ReportInsightTemplateSourceApiDto {
+  @ApiProperty({ enum: [TemplateSourceTypeEnum.INSIGHT_TEMPLATE] })
+  type: TemplateSourceTypeEnum.INSIGHT_TEMPLATE;
+
+  @ApiProperty({
+    type: 'object',
+    required: ['insightTemplateId'],
+    properties: { insightTemplateId: { type: 'string', minLength: 1 } },
+  })
+  config: { insightTemplateId: string };
+}
+
+export class ReportEmailDestinationConfigApiDto {
+  @ApiProperty({ enum: [EmailConfigType] })
+  type: typeof EmailConfigType;
+
+  @ApiProperty({ minLength: 1 })
+  subject: string;
+
+  @ApiProperty({
+    oneOf: [
+      { $ref: getSchemaPath(ReportCustomMessageTemplateSourceApiDto) },
+      { $ref: getSchemaPath(ReportInsightTemplateSourceApiDto) },
+    ],
+  })
+  templateSource: ReportCustomMessageTemplateSourceApiDto | ReportInsightTemplateSourceApiDto;
+
+  @ApiProperty({ enum: ReportCondition })
+  reportCondition: ReportCondition;
+}
+
+export class ReportLegacyEmailDestinationConfigApiDto {
+  @ApiProperty({ enum: [EmailConfigType] })
+  type: typeof EmailConfigType;
+
+  @ApiProperty({ minLength: 1 })
+  subject: string;
+
+  @ApiProperty({ minLength: 1 })
+  messageTemplate: string;
+
+  @ApiProperty({ enum: ReportCondition })
+  reportCondition: ReportCondition;
+}
+
+export class ReportGoogleSheetsDestinationConfigApiDto {
+  @ApiProperty({ enum: [GoogleSheetsConfigType] })
+  type: typeof GoogleSheetsConfigType;
+
+  @ApiProperty({ minLength: 1 })
+  spreadsheetId: string;
+
+  @ApiProperty({ minimum: 0 })
+  sheetId: number;
+}
+
+export class ReportLookerStudioDestinationConfigApiDto {
+  @ApiProperty({ enum: [LookerStudioConnectorConfigType] })
+  type: typeof LookerStudioConnectorConfigType;
+
+  @ApiProperty({ minimum: 60 })
+  cacheLifetime: number;
+}
+
+export class ReportBetweenFilterValueApiDto {
+  @ApiProperty(primitiveValueSchema)
+  from: string | number | boolean;
+
+  @ApiProperty(primitiveValueSchema)
+  to: string | number | boolean;
+}
+
+export class ReportRelativeDateFilterValueApiDto {
+  @ApiProperty({
+    enum: [
+      'today',
+      'yesterday',
+      'this_month',
+      'last_month',
+      'this_year',
+      'last_n_days',
+      'last_n_months',
+    ],
+  })
+  kind:
+    | 'today'
+    | 'yesterday'
+    | 'this_month'
+    | 'last_month'
+    | 'this_year'
+    | 'last_n_days'
+    | 'last_n_months';
+
+  @ApiPropertyOptional({
+    description: 'Required when kind is last_n_days or last_n_months.',
+    minimum: 1,
+    maximum: 3650,
+  })
+  n?: number;
+}
+
+export class ReportFilterRuleApiDto {
+  @ApiProperty({ minLength: 1 })
+  column: string;
+
+  @ApiProperty({
+    enum: [...FILTER_SCALAR_OPERATORS, ...FILTER_NO_VALUE_OPERATORS, 'between', 'relative_date'],
+  })
+  operator: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Required for scalar, between, and relative_date operators. Omit for is_empty/is_null-style operators.',
+    oneOf: [
+      primitiveValueSchema,
+      { $ref: getSchemaPath(ReportBetweenFilterValueApiDto) },
+      { $ref: getSchemaPath(ReportRelativeDateFilterValueApiDto) },
+    ],
+  })
+  value?:
+    | string
+    | number
+    | boolean
+    | ReportBetweenFilterValueApiDto
+    | ReportRelativeDateFilterValueApiDto;
+
+  @ApiPropertyOptional({
+    enum: ['pre-join', 'post-join'],
+    description: 'Use pre-join for slice filters. Omit for normal output filters.',
+  })
+  placement?: 'pre-join' | 'post-join';
+
+  @ApiPropertyOptional({
+    minLength: 1,
+    maxLength: 255,
+    pattern: '^[a-z0-9_]+(\\.[a-z0-9_]+)*$',
+    description: 'Required for slice filters when placement is pre-join.',
+  })
+  aliasPath?: string;
+}
+
+export class ReportSortRuleApiDto {
+  @ApiProperty({
+    minLength: 1,
+    description: 'Output column name to sort by.',
+    example: 'date',
+  })
+  column: string;
+
+  @ApiProperty({
+    enum: ['asc', 'desc'],
+    description: 'Sort direction for this column.',
+  })
+  direction: 'asc' | 'desc';
+}
+
+export const REPORT_OPENAPI_MODELS = [
+  ReportBetweenFilterValueApiDto,
+  ReportCustomMessageTemplateSourceApiDto,
+  ReportEmailDestinationConfigApiDto,
+  ReportFilterRuleApiDto,
+  ReportGoogleSheetsDestinationConfigApiDto,
+  ReportInsightTemplateSourceApiDto,
+  ReportLegacyEmailDestinationConfigApiDto,
+  ReportLookerStudioDestinationConfigApiDto,
+  ReportRelativeDateFilterValueApiDto,
+  ReportSortRuleApiDto,
+];
+
+const destinationConfigRequestProperty = {
+  description: 'Configuration for the selected data destination.',
+  oneOf: [
+    { $ref: getSchemaPath(ReportEmailDestinationConfigApiDto) },
+    { $ref: getSchemaPath(ReportLegacyEmailDestinationConfigApiDto) },
+    { $ref: getSchemaPath(ReportGoogleSheetsDestinationConfigApiDto) },
+    { $ref: getSchemaPath(ReportLookerStudioDestinationConfigApiDto) },
+  ],
+};
+
+const commonReportRequestProperties = {
+  title: { type: 'string', example: 'My Report' },
+  dataDestinationId: { type: 'string', description: 'ID of the data destination' },
+  destinationConfig: destinationConfigRequestProperty,
+  ownerIds: {
+    type: 'array',
+    items: { type: 'string' },
+    maxItems: 100,
+  },
+  columnConfig: {
+    type: 'array',
+    nullable: true,
+    items: {
+      type: 'string',
+      minLength: 1,
+      description: 'Selected output column name.',
+    },
+    description: 'Ordered selected output column names. Set null to include all native columns.',
+    example: ['date', 'campaign_name', 'spend'],
+  },
+  filterConfig: {
+    type: 'array',
+    nullable: true,
+    maxItems: 50,
+    items: { $ref: getSchemaPath(ReportFilterRuleApiDto) },
+    description: 'Output filters. Use placement=pre-join and aliasPath for slice filters.',
+  },
+  sortConfig: {
+    type: 'array',
+    nullable: true,
+    maxItems: 10,
+    items: { $ref: getSchemaPath(ReportSortRuleApiDto) },
+    description: 'Ordered sort rules. Earlier rules take precedence.',
+    example: [{ column: 'date', direction: 'desc' }],
+  },
+  limitConfig: {
+    type: 'integer',
+    nullable: true,
+    minimum: 1,
+    maximum: 10_000_000,
+    description: 'Maximum number of rows to return. Set null to return without an explicit cap.',
+    example: 1000,
+  },
+};
+
+export const createReportRequestBodySchema = {
+  type: 'object',
+  required: ['title', 'dataMartId', 'dataDestinationId', 'destinationConfig'],
+  properties: {
+    title: commonReportRequestProperties.title,
+    dataMartId: { type: 'string', description: 'ID of the data mart' },
+    dataDestinationId: commonReportRequestProperties.dataDestinationId,
+    destinationConfig: commonReportRequestProperties.destinationConfig,
+    ownerIds: commonReportRequestProperties.ownerIds,
+    columnConfig: commonReportRequestProperties.columnConfig,
+    filterConfig: commonReportRequestProperties.filterConfig,
+    sortConfig: commonReportRequestProperties.sortConfig,
+    limitConfig: commonReportRequestProperties.limitConfig,
+  },
+};
+
+export const updateReportRequestBodySchema = {
+  type: 'object',
+  required: ['title', 'dataDestinationId', 'destinationConfig'],
+  properties: commonReportRequestProperties,
+};

--- a/apps/backend/src/data-marts/controllers/spec/report.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.api.ts
@@ -2,20 +2,25 @@ import { applyDecorators } from '@nestjs/common';
 import {
   ApiBody,
   ApiCreatedResponse,
+  ApiExtraModels,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
 } from '@nestjs/swagger';
 import { ReportResponseApiDto } from '../../dto/presentation/report-response-api.dto';
-import { CreateReportRequestApiDto } from '../../dto/presentation/create-report-request-api.dto';
-import { UpdateReportRequestApiDto } from '../../dto/presentation/update-report-request-api.dto';
 import { OwnerFilter } from '../../enums/owner-filter.enum';
+import {
+  createReportRequestBodySchema,
+  REPORT_OPENAPI_MODELS,
+  updateReportRequestBodySchema,
+} from './report-openapi';
 
 export function CreateReportSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Create a new report' }),
-    ApiBody({ type: CreateReportRequestApiDto }),
+    ApiExtraModels(...REPORT_OPENAPI_MODELS),
+    ApiBody({ schema: createReportRequestBodySchema }),
     ApiCreatedResponse({
       description: 'The report has been successfully created.',
       type: ReportResponseApiDto,
@@ -86,7 +91,8 @@ export function UpdateReportSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Update an existing report' }),
     ApiParam({ name: 'id', description: 'Report ID' }),
-    ApiBody({ type: UpdateReportRequestApiDto }),
+    ApiExtraModels(...REPORT_OPENAPI_MODELS),
+    ApiBody({ schema: updateReportRequestBodySchema }),
     ApiOkResponse({
       description: 'The report has been successfully updated.',
       type: ReportResponseApiDto,
@@ -112,7 +118,11 @@ export function GetReportGeneratedSqlSpec() {
     ApiParam({ name: 'id', description: 'Report ID' }),
     ApiOkResponse({
       description: 'The generated SQL query for the report.',
-      schema: { type: 'object', properties: { sql: { type: 'string' } } },
+      schema: {
+        type: 'object',
+        required: ['sql'],
+        properties: { sql: { type: 'string' } },
+      },
     })
   );
 }
@@ -123,7 +133,11 @@ export function CopyReportAsDataMartSpec() {
     ApiParam({ name: 'id', description: 'Report ID' }),
     ApiCreatedResponse({
       description: 'The new data mart has been successfully created.',
-      schema: { type: 'object', properties: { dataMartId: { type: 'string' } } },
+      schema: {
+        type: 'object',
+        required: ['dataMartId'],
+        properties: { dataMartId: { type: 'string', format: 'uuid' } },
+      },
     })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
@@ -1,0 +1,168 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
+
+jest.mock('../../../idp', () => ({
+  __esModule: true,
+  Auth: () => () => undefined,
+  AuthContext: () => () => undefined,
+}));
+
+import { ReportController } from '../report.controller';
+import { CopyReportAsDataMartService } from '../../use-cases/copy-report-as-data-mart.service';
+import { CreateReportService } from '../../use-cases/create-report.service';
+import { DeleteReportService } from '../../use-cases/delete-report.service';
+import { GetReportGeneratedSqlService } from '../../use-cases/get-report-generated-sql.service';
+import { GetReportService } from '../../use-cases/get-report.service';
+import { ListReportsByDataMartService } from '../../use-cases/list-reports-by-data-mart.service';
+import { ListReportsByInsightTemplateService } from '../../use-cases/list-reports-by-insight-template.service';
+import { ListReportsByProjectService } from '../../use-cases/list-reports-by-project.service';
+import { ReportMapper } from '../../mappers/report.mapper';
+import { RunReportService } from '../../use-cases/run-report.service';
+import { UpdateReportService } from '../../use-cases/update-report.service';
+
+describe('ReportController OpenAPI', () => {
+  let app: INestApplication;
+  let document: OpenAPIObject;
+
+  beforeAll(async () => {
+    const providers = [
+      CopyReportAsDataMartService,
+      CreateReportService,
+      DeleteReportService,
+      GetReportGeneratedSqlService,
+      GetReportService,
+      ListReportsByDataMartService,
+      ListReportsByInsightTemplateService,
+      ListReportsByProjectService,
+      ReportMapper,
+      RunReportService,
+      UpdateReportService,
+    ].map(provide => ({ provide, useValue: {} }));
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ReportController],
+      providers,
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    document = SwaggerModule.createDocument(
+      app,
+      new DocumentBuilder().setTitle('Test API').setVersion('1.0').build()
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  function requestSchema(path: string, method: 'post' | 'put'): Record<string, any> {
+    const requestBody = document.paths[path]?.[method]?.requestBody as Record<string, any>;
+    const schema = requestBody.content['application/json'].schema as Record<string, any>;
+    return schema.$ref ? resolveRef(schema.$ref as string) : schema;
+  }
+
+  function resolveRef(ref: string): Record<string, any> {
+    const schemaName = ref.split('/').at(-1)!;
+    return document.components?.schemas?.[schemaName] as Record<string, any>;
+  }
+
+  it('documents required report request fields and optional config fields', () => {
+    expect(requestSchema('/api/reports', 'post').required).toEqual([
+      'title',
+      'dataMartId',
+      'dataDestinationId',
+      'destinationConfig',
+    ]);
+    expect(requestSchema('/api/reports/{id}', 'put').required).toEqual([
+      'title',
+      'dataDestinationId',
+      'destinationConfig',
+    ]);
+
+    const updateProperties = requestSchema('/api/reports/{id}', 'put').properties;
+    expect(updateProperties.destinationConfig.oneOf).toHaveLength(4);
+    expect(updateProperties.limitConfig).toMatchObject({ type: 'integer', nullable: true });
+  });
+
+  it('documents output controls, including slice filter semantics', () => {
+    const updateProperties = requestSchema('/api/reports/{id}', 'put').properties;
+    const filterRule = resolveRef(updateProperties.filterConfig.items.$ref);
+    const sortRule = resolveRef(updateProperties.sortConfig.items.$ref);
+
+    expect(updateProperties.columnConfig).toMatchObject({
+      type: 'array',
+      nullable: true,
+      description: expect.stringContaining('output column names'),
+      items: {
+        type: 'string',
+        minLength: 1,
+        description: expect.stringContaining('output column'),
+      },
+      example: ['date', 'campaign_name', 'spend'],
+    });
+
+    expect(updateProperties.filterConfig).toMatchObject({
+      type: 'array',
+      nullable: true,
+      maxItems: 50,
+    });
+    expect(filterRule.required).toEqual(['column', 'operator']);
+    expect(filterRule.properties.operator.enum).toEqual(
+      expect.arrayContaining(['eq', 'is_empty', 'between', 'relative_date'])
+    );
+    expect(filterRule.properties.value.oneOf).toHaveLength(3);
+    expect(filterRule.properties.placement.enum).toEqual(['pre-join', 'post-join']);
+    expect(filterRule.properties.aliasPath.description).toContain('slice');
+
+    expect(updateProperties.sortConfig).toMatchObject({
+      type: 'array',
+      nullable: true,
+      maxItems: 10,
+      description: expect.stringContaining('Earlier rules take precedence'),
+      example: [{ column: 'date', direction: 'desc' }],
+    });
+    expect(sortRule.required).toEqual(['column', 'direction']);
+    expect(sortRule.properties.column.description).toContain('Output column');
+    expect(sortRule.properties.direction.enum).toEqual(['asc', 'desc']);
+
+    expect(updateProperties.limitConfig).toMatchObject({
+      type: 'integer',
+      nullable: true,
+      minimum: 1,
+      maximum: 10_000_000,
+      description: expect.stringContaining('Set null'),
+      example: 1000,
+    });
+  });
+
+  it('documents small object responses', () => {
+    expect(document.paths['/api/reports/{id}/generated-sql']?.get?.responses['200']).toMatchObject({
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['sql'],
+            properties: { sql: { type: 'string' } },
+          },
+        },
+      },
+    });
+    expect(
+      document.paths['/api/reports/{id}/copy-as-data-mart']?.post?.responses['201']
+    ).toMatchObject({
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['dataMartId'],
+            properties: { dataMartId: { type: 'string', format: 'uuid' } },
+          },
+        },
+      },
+    });
+  });
+});

--- a/apps/backend/src/data-marts/dto/presentation/create-report-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/create-report-request-api.dto.ts
@@ -31,7 +31,11 @@ export class CreateReportRequestApiDto {
   @IsNotEmpty()
   dataDestinationId: string;
 
-  @ApiProperty({ description: 'Configuration for the data destination' })
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: true,
+    description: 'Configuration for the data destination',
+  })
   @IsObject()
   @IsNotEmpty()
   destinationConfig: DataDestinationConfig;
@@ -59,6 +63,8 @@ export class CreateReportRequestApiDto {
     description: 'Filter rules applied to the final SELECT (output filters)',
     nullable: true,
     required: false,
+    type: 'array',
+    items: { type: 'object' },
   })
   @IsOptional()
   @IsArray()
@@ -69,6 +75,8 @@ export class CreateReportRequestApiDto {
     description: 'Sort rules (multi-column with order)',
     nullable: true,
     required: false,
+    type: 'array',
+    items: { type: 'object' },
   })
   @IsOptional()
   @IsArray()
@@ -79,7 +87,9 @@ export class CreateReportRequestApiDto {
     description: 'Row limit cap (no offset)',
     nullable: true,
     required: false,
-    type: Number,
+    type: 'integer',
+    minimum: 1,
+    maximum: 10_000_000,
   })
   @IsOptional()
   @IsInt()

--- a/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts
@@ -21,19 +21,40 @@ export class ReportResponseApiDto {
   @ApiProperty()
   dataDestinationAccess: DataDestinationResponseApiDto;
 
-  @ApiProperty()
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: true,
+    description: 'Configuration for the data destination',
+  })
   destinationConfig: DataDestinationConfig;
 
   @ApiProperty({ nullable: true, required: false, type: [String] })
   columnConfig?: ReportColumnConfig;
 
-  @ApiProperty({ nullable: true, required: false, description: 'Filter rules' })
+  @ApiProperty({
+    nullable: true,
+    required: false,
+    description: 'Filter rules',
+    type: 'array',
+    items: { type: 'object' },
+  })
   filterConfig?: FilterConfig | null;
 
-  @ApiProperty({ nullable: true, required: false, description: 'Sort rules' })
+  @ApiProperty({
+    nullable: true,
+    required: false,
+    description: 'Sort rules',
+    type: 'array',
+    items: { type: 'object' },
+  })
   sortConfig?: SortConfig | null;
 
-  @ApiProperty({ nullable: true, required: false, description: 'Row limit', type: Number })
+  @ApiProperty({
+    nullable: true,
+    required: false,
+    description: 'Row limit',
+    type: 'integer',
+  })
   limitConfig?: number | null;
 
   @ApiProperty({ nullable: true })

--- a/apps/backend/src/data-marts/dto/presentation/update-report-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-report-request-api.dto.ts
@@ -26,7 +26,11 @@ export class UpdateReportRequestApiDto {
   @IsNotEmpty()
   dataDestinationId: string;
 
-  @ApiProperty({ description: 'Configuration for the data destination' })
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: true,
+    description: 'Configuration for the data destination',
+  })
   @IsObject()
   @IsNotEmpty()
   destinationConfig: DataDestinationConfig;
@@ -54,6 +58,8 @@ export class UpdateReportRequestApiDto {
     description: 'Filter rules applied to the final SELECT (output filters)',
     nullable: true,
     required: false,
+    type: 'array',
+    items: { type: 'object' },
   })
   @IsOptional()
   @IsArray()
@@ -64,6 +70,8 @@ export class UpdateReportRequestApiDto {
     description: 'Sort rules (multi-column with order)',
     nullable: true,
     required: false,
+    type: 'array',
+    items: { type: 'object' },
   })
   @IsOptional()
   @IsArray()
@@ -74,7 +82,9 @@ export class UpdateReportRequestApiDto {
     description: 'Row limit cap (no offset)',
     nullable: true,
     required: false,
-    type: Number,
+    type: 'integer',
+    minimum: 1,
+    maximum: 10_000_000,
   })
   @IsOptional()
   @IsInt()


### PR DESCRIPTION
## Summary

- Adds explicit OpenAPI schemas for report create/update request bodies.
- Documents destination config variants for email, legacy email, Google Sheets, and Looker Studio.
- Improves report output-control docs for columns, filters, sorting, and limits.
- Adds OpenAPI coverage for report request schemas and small object responses.

## Verification

- `npx prettier --check apps/backend/src/data-marts/controllers/spec/report-openapi.ts apps/backend/src/data-marts/controllers/spec/report.api.ts apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts apps/backend/src/data-marts/dto/presentation/create-report-request-api.dto.ts apps/backend/src/data-marts/dto/presentation/update-report-request-api.dto.ts apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts`
- `npx eslint apps/backend/src/data-marts/controllers/spec/report-openapi.ts apps/backend/src/data-marts/controllers/spec/report.api.ts apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts apps/backend/src/data-marts/dto/presentation/create-report-request-api.dto.ts apps/backend/src/data-marts/dto/presentation/update-report-request-api.dto.ts apps/backend/src/data-marts/dto/presentation/report-response-api.dto.ts --config apps/backend/eslint.config.mjs`
- `npm test -w @owox/backend -- report.openapi.spec.ts --runInBand`
- `git diff --cached --check`

Note: full backend typecheck currently fails on unrelated existing files outside this change.