### PR TITLE
Disambiguate email report config OpenAPI variants

### DIFF
--- a/apps/backend/src/data-marts/controllers/spec/report-openapi.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report-openapi.ts
@@ -198,7 +198,10 @@ const destinationConfigRequestProperty = {
   description: 'Configuration for the selected data destination.',
   oneOf: [
     { $ref: getSchemaPath(ReportEmailDestinationConfigApiDto) },
-    { $ref: getSchemaPath(ReportLegacyEmailDestinationConfigApiDto) },
+    {
+      allOf: [{ $ref: getSchemaPath(ReportLegacyEmailDestinationConfigApiDto) }],
+      not: { required: ['templateSource'] },
+    },
     { $ref: getSchemaPath(ReportGoogleSheetsDestinationConfigApiDto) },
     { $ref: getSchemaPath(ReportLookerStudioDestinationConfigApiDto) },
   ],

--- a/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
@@ -85,6 +85,10 @@ describe('ReportController OpenAPI', () => {
 
     const updateProperties = requestSchema('/api/reports/{id}', 'put').properties;
     expect(updateProperties.destinationConfig.oneOf).toHaveLength(4);
+    expect(updateProperties.destinationConfig.oneOf[1]).toMatchObject({
+      allOf: [{ $ref: expect.stringContaining('ReportLegacyEmailDestinationConfigApiDto') }],
+      not: { required: ['templateSource'] },
+    });
     expect(updateProperties.limitConfig).toMatchObject({ type: 'integer', nullable: true });
   });
 


### PR DESCRIPTION
## Summary

- Makes the legacy email `destinationConfig` OpenAPI variant mutually exclusive with the new `templateSource` email variant.
- Keeps the runtime-compatible legacy shape documented while avoiding ambiguous `oneOf` matching for validators and generated clients.
- Adds OpenAPI test coverage for the legacy email branch exclusion.

## Context

Follow-up to #1237 after review feedback on `destinationConfig.oneOf`: both email variants use `type: "email-config"`, so the legacy branch now explicitly excludes payloads that include `templateSource`.

## Verification

- `npx prettier --check apps/backend/src/data-marts/controllers/spec/report-openapi.ts apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts`
- `npx eslint apps/backend/src/data-marts/controllers/spec/report-openapi.ts apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts --config apps/backend/eslint.config.mjs`
- `npm test -w @owox/backend -- report.openapi.spec.ts --runInBand`
- `git diff --check origin/main...HEAD`