### PR TITLE
Clarify Microsoft Ads numeric IDs

### DIFF
--- a/.changeset/microsoft-ads-numeric-id-guidance.md
+++ b/.changeset/microsoft-ads-numeric-id-guidance.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Clarify Microsoft Ads account and customer IDs
+
+Microsoft Ads connector docs and in-product field tips now explain that Account ID and Customer ID must be the numeric API identifiers from the `aid` and `cid` URL parameters, not the alphanumeric account/customer numbers shown in parts of the Microsoft Ads UI.

--- a/apps/backend/test/connector-specification.e2e-spec.ts
+++ b/apps/backend/test/connector-specification.e2e-spec.ts
@@ -128,6 +128,33 @@ describe('Connector Specification (e2e)', () => {
         expect(typeof oauthVariant.value).toBe('string');
       }
     );
+
+    it('GET /api/connectors/MicrosoftAds/specification - explains numeric API identifiers', async () => {
+      const res = await agent.get('/api/connectors/MicrosoftAds/specification').set(AUTH_HEADER);
+
+      expect(res.status).toBe(200);
+
+      const accountIdsField = res.body.find(
+        (item: Record<string, unknown>) => item.name === 'AccountIDs'
+      );
+      const customerIdField = res.body.find(
+        (item: Record<string, unknown>) => item.name === 'CustomerID'
+      );
+
+      expect(accountIdsField?.description).toContain('numeric');
+      expect(accountIdsField?.description).toContain('aid');
+      expect(accountIdsField?.description).toContain('123456789');
+      expect(accountIdsField?.description).toContain('Do not use the alphanumeric account number');
+      expect(accountIdsField?.description).toContain('A00000A0AA');
+      expect(accountIdsField?.placeholder).toBe('000000000');
+
+      expect(customerIdField?.description).toContain('numeric');
+      expect(customerIdField?.description).toContain('cid');
+      expect(customerIdField?.description).toContain('987654321');
+      expect(customerIdField?.description).toContain('Do not use the alphanumeric customer number');
+      expect(customerIdField?.description).toContain('C00000C0CC');
+      expect(customerIdField?.placeholder).toBe('000000000');
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/docs/google-sheets-connectors/microsoft-ads.md
+++ b/docs/google-sheets-connectors/microsoft-ads.md
@@ -16,7 +16,12 @@ Once you have copied the template, fill in the required information:
 In your newly copied spreadsheet, navigate to the "Config" sheet.
 
 Log in to your Bing Ads account at [https://ads.microsoft.com/](https://ads.microsoft.com/).  
-Your **Account ID** and **Customer ID** can be found in the account URL.
+Switch to the account you want to import and open the Campaigns page. Copy the numeric IDs from the browser URL:
+
+- Use the `aid` value as **Account ID**.
+- Use the `cid` value as **Customer ID**.
+
+> Important: Microsoft Ads also shows account/customer numbers in some places. Those values can be alphanumeric, for example `A00000A0AA`, and should not be used here. The connector requires the numeric API IDs from `aid` and `cid`.
 
 ![Bing Add Account](./res/bing_addaccount.png)
 
@@ -45,7 +50,7 @@ Next, access the custom menu: **OWOX → Manage Credentials**.
 
 ![Bing Credentials](./res/bing_credentials.png)
 
-Enter your credentials obtained by following this guide: [**How to obtain the credentials for Bing Ads connector**](../../packages/connectors/src/Sources/BingAds/CREDENTIALS.md).
+Enter your credentials obtained by following this guide: [**How to obtain the credentials for Microsoft Ads connector**](../../packages/connectors/src/Sources/MicrosoftAds/CREDENTIALS.md).
 
 ![Bing Token](./res/bing_creds.png)
 

--- a/packages/connectors/src/Sources/MicrosoftAds/CREDENTIALS.md
+++ b/packages/connectors/src/Sources/MicrosoftAds/CREDENTIALS.md
@@ -60,7 +60,12 @@ At this point, you have:
 ## Step 3: Get Account ID and Customer ID
 
 1. Go to [https://ads.microsoft.com/](https://ads.microsoft.com/) and log in to your Microsoft Ads account.  
-2. Your **Account ID** and **Customer ID** can be found in the URL.
+2. Switch to the account you want to import and open the Campaigns page.
+3. Copy the numeric IDs from the browser URL:
+   - Use the `aid` value as **Account ID**.
+   - Use the `cid` value as **Customer ID**.
+
+> Important: Microsoft Ads also shows account/customer numbers in some places. Those values can be alphanumeric, for example `A00000A0AA`, and should not be used here. The connector requires the numeric API IDs from `aid` and `cid`.
 
 ![Microsoft Add Account](res/microsoft_addaccount.png)
 

--- a/packages/connectors/src/Sources/MicrosoftAds/Source.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Source.js
@@ -142,13 +142,15 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
         isRequired: true,
         requiredType: "string",
         label: "Account ID(s)",
-        description: "Your Microsoft Ads Account IDs (comma separated)"
+        description: "Use the numeric Account ID from the Microsoft Ads URL aid parameter, for example 123456789. Do not use the alphanumeric account number shown elsewhere, such as A00000A0AA. For multiple accounts, separate IDs with commas.",
+        placeholder: "000000000"
       },
       CustomerID: {
         isRequired: true,
         requiredType: "string",
         label: "Customer ID",
-        description: "Your Microsoft Ads Customer ID"
+        description: "Use the numeric Customer ID from the Microsoft Ads URL cid parameter, for example 987654321. Do not use the alphanumeric customer number shown elsewhere, such as C00000C0CC.",
+        placeholder: "000000000"
       },
       StartDate: {
         requiredType: "date",


### PR DESCRIPTION
## Summary

- Document that Microsoft Ads Account ID and Customer ID must be the numeric API IDs from the `aid` and `cid` URL parameters.
- Update Microsoft Ads connector field tips so the first examples are valid numeric IDs, with alphanumeric account/customer numbers shown only as values not to use.
- Add backend connector-spec coverage for the Microsoft Ads identifier guidance and add a changeset note.

## Why

Users can confuse Microsoft Ads alphanumeric account/customer numbers with the numeric API identifiers expected by the connector. This makes the expected values explicit in docs and in-product tips.

## Validation

- `npm run build`
- `npm run lint`
- `npm run lint:md`
- `npm run format:check`
- `npm run test` (rerun outside sandbox because Supertest local bind is blocked in sandbox)
- `npm run build -w @owox/connectors`
- `npm run test:e2e -w @owox/backend -- connector-specification.e2e-spec.ts --runInBand`
- `git diff --check`