### PR TITLE
feat(connectors): improve default fields for faster marketing connector setup

### DIFF
--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/CriteoAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/CriteoAdsFieldsSchema.js
@@ -12,7 +12,7 @@ var CriteoAdsFieldsSchema = {
     documentation: "https://developers.criteo.com/marketing-solutions/docs/campaign-statistics",
     fields: adStatisticsFields,
     uniqueKeys: ["CampaignId", "AdvertiserId", "AdsetId", "AdId", "Day"],
-    defaultFields: ["Day", "CampaignId", "Campaign", "AdvertiserId", "Advertiser", "AdsetId", "Adset", "AdId", "Ad", "Clicks", "Displays", "AdvertiserCost", "SalesClientAttribution", "RevenueGeneratedClientAttribution"],
+    defaultFields: ["Clicks", "Displays", "AdvertiserCost", "Campaign", "Advertiser", "Adset", "Ad", "Currency"],
     destinationName: "criteo_ads_statistics",
     isTimeSeries: true
   }

--- a/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
+++ b/packages/connectors/src/Sources/FacebookMarketing/MarketingAPIReference/FieldsSchema.js
@@ -100,7 +100,7 @@ var FacebookMarketingFieldsSchema = {
         "fields": adAccountInsightsFieldsByCountry,
         "breakdowns": ["country"],
         'uniqueKeys': ["ad_id", "date_start", "date_stop", "country"],
-        'defaultFields': ["account_id", "account_name", "campaign_id", "campaign_name", "adset_id", "adset_name", "ad_name", "impressions", "reach", "clicks", "spend", "cpc", "cpm", "ctr", "frequency", "actions", "action_values"],
+        'defaultFields': ["account_currency", "account_id", "account_name", "ad_name", "adset_id", "adset_name", "campaign_id", "campaign_name", "clicks", "impressions", "inline_link_clicks", "reach", "spend"],
         "isTimeSeries": true,
         "destinationName": "facebook_ads_ad_account_insights_by_country"
     },
@@ -165,7 +165,7 @@ var FacebookMarketingFieldsSchema = {
         "documentation": "https://developers.facebook.com/docs/marketing-api/reference/adgroup/",
         "fields": adGroupFields,
         'uniqueKeys': ["id"],
-        'defaultFields': ["name", "account_id", "status", "effective_status", "adset_id", "campaign_id", "creative_id", "created_time", "updated_time"],
+        'defaultFields': ["account_id", "creative_effective_object_story_id", "creative_name", "creative_object_story_spec", "creative_url_tags", "creative_asset_groups_spec", "name"],
         "isTimeSeries": false,
         "destinationName": "facebook_ads_ad_group"
     },

--- a/packages/connectors/src/Sources/LinkedInAds/LinkedInAdsAPIReference/LinkedInAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/LinkedInAds/LinkedInAdsAPIReference/LinkedInAdsFieldsSchema.js
@@ -12,7 +12,7 @@ var LinkedInAdsFieldsSchema = {
     "documentation": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts",
     "fields": adAccountFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "status", "currency", "type", "reference"],
+    "defaultFields": ["name", "currency"],
     "destinationName": "linkedin_ads_ad_accounts"
   },
   "adCampaignGroups": {
@@ -21,7 +21,7 @@ var LinkedInAdsFieldsSchema = {
     "documentation": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaign-groups",
     "fields": adCampaignGroupFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "status", "account", "objectiveType", "runSchedule", "totalBudget", "servingStatuses"],
+    "defaultFields": ["name", "status", "account"],
     "destinationName": "linkedin_ads_ad_campaign_groups"
   },
   "adCampaigns": {
@@ -30,7 +30,7 @@ var LinkedInAdsFieldsSchema = {
     "documentation": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns",
     "fields": adCampaignFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "status", "account", "campaignGroup", "objectiveType", "type", "runSchedule"],
+    "defaultFields": ["account", "costType", "dailyBudget", "locale", "name", "objectiveType", "totalBudget", "type", "unitCost", "status", "format"],
     "destinationName": "linkedin_ads_ad_campaigns"
   },
   "creatives": {
@@ -39,7 +39,7 @@ var LinkedInAdsFieldsSchema = {
     "documentation": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-creatives",
     "fields": creativesFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "intendedStatus", "account", "campaign", "isServing", "createdAt"],
+    "defaultFields": ["account", "intendedStatus", "name"],
     "destinationName": "linkedin_ads_creatives"
   },
   "adAnalytics": {
@@ -48,7 +48,7 @@ var LinkedInAdsFieldsSchema = {
     "documentation": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting",
     "fields": adAnalyticsFields,
     "uniqueKeys": ["dateRangeStart", "dateRangeEnd", "pivotValues"],
-    "defaultFields": ["dateRangeStart", "dateRangeEnd", "pivotValues", "impressions", "clicks", "costInLocalCurrency", "costInUsd", "totalEngagements", "landingPageClicks", "externalWebsiteConversions"],
+    "defaultFields": ["actionClicks", "adUnitClicks", "approximateMemberReach", "clicks", "commentLikes", "comments", "companyPageClicks", "conversionValueInLocalCurrency", "costInLocalCurrency", "costInUsd", "externalWebsiteConversions", "externalWebsitePostClickConversions", "externalWebsitePostViewConversions", "follows", "impressions", "landingPageClicks", "leadGenerationMailContactInfoShares", "leadGenerationMailInterestedClicks", "likes", "oneClickLeadFormOpens", "oneClickLeads", "opens", "otherEngagements", "reactions", "sends", "shares", "textUrlClicks", "totalEngagements", "viralClicks", "viralCommentLikes", "viralComments", "viralCompanyPageClicks", "viralExternalWebsiteConversions", "viralExternalWebsitePostClickConversions", "viralFollows", "viralImpressions", "viralLandingPageClicks", "viralLikes", "viralOneClickLeadFormOpens", "viralOneClickLeads", "viralOtherEngagements", "viralReactions", "viralShares", "viralTotalEngagements"],
     "destinationName": "linkedin_ads_ad_analytics",
     "isTimeSeries": true
   }

--- a/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/FieldsSchema.js
+++ b/packages/connectors/src/Sources/RedditAds/RedditAdsAPIReference/FieldsSchema.js
@@ -12,7 +12,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/Get%20Me",
     "fields": adAccountUserFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "email", "firstname", "lastname", "reddit_user_id", "reddit_username"],
+    "defaultFields": ["email", "firstname", "lastname", "reddit_user_id", "reddit_username"],
     "destinationName": "reddit_ads_ad_account_user"
   },
   "ad-account": {
@@ -21,7 +21,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/Get%20Ad%20Account",
     "fields": adAccountFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "type", "currency", "attribution_type", "click_attribution_window", "view_attribution_window", "created_at", "modified_at"],
+    "defaultFields": ["name", "type", "currency", "attribution_type", "click_attribution_window", "view_attribution_window", "created_at", "modified_at"],
     "destinationName": "reddit_ads_ad_account"
   },
   "ad-group": {
@@ -30,7 +30,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Groups",
     "fields": adGroupFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "ad_account_id", "campaign_id", "configured_status", "effective_status", "bid_strategy", "bid_type", "goal_type", "start_time", "end_time", "is_campaign_budget_optimization"],
+    "defaultFields": ["name", "ad_account_id", "campaign_id", "configured_status", "effective_status", "bid_strategy", "bid_type", "goal_type", "start_time", "end_time", "is_campaign_budget_optimization"],
     "destinationName": "reddit_ads_ad_group",
     "parameters": {
       "pageSize": {
@@ -46,7 +46,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ads",
     "fields": adsFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "type", "ad_account_id", "ad_group_id", "campaign_id", "configured_status", "effective_status", "post_id"],
+    "defaultFields": ["ad_account_id", "campaign_id", "name"],
     "destinationName": "reddit_ads_ads"
   },
   "campaigns": {
@@ -55,7 +55,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Campaigns",
     "fields": campaignsFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "objective", "ad_account_id", "configured_status", "effective_status", "spend_cap", "created_at"],
+    "defaultFields": ["ad_account_id", "name"],
     "destinationName": "reddit_ads_campaigns"
   },
   "user-custom-audience": {
@@ -64,7 +64,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20User%20Custom%20Audiences",
     "fields": userCustomAudienceFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "type", "status", "ad_account_id", "size_range_lower", "size_range_upper"],
+    "defaultFields": ["name", "type", "status", "ad_account_id", "size_range_lower", "size_range_upper"],
     "destinationName": "reddit_ads_user_custom_audience"
   },
   "funding-instruments": {
@@ -73,7 +73,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Funding%20Instruments",
     "fields": fundingInstrumentFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "currency", "credit_limit", "billable_amount", "is_servable"],
+    "defaultFields": ["name", "currency", "credit_limit", "billable_amount", "is_servable"],
     "destinationName": "reddit_ads_funding_instruments"
   },
   "lead-gen-form": {
@@ -82,7 +82,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Lead%20Gen%20Forms",
     "fields": leadGenFormFields,
     "uniqueKeys": ["id"],
-    "defaultFields": ["id", "name", "ad_account_id", "prompt", "created_at"],
+    "defaultFields": ["name", "ad_account_id", "prompt", "created_at"],
     "destinationName": "reddit_ads_lead_gen_form"
   },
   "report": {
@@ -91,7 +91,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
     "fields": reportFields,
     "uniqueKeys": ["ad_id", "date"],
-    "defaultFields": ["ad_id", "date", "impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
+    "defaultFields": ["impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
     "destinationName": "reddit_ads_report",
     "isTimeSeries": true
   },
@@ -101,7 +101,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
     "fields": reportCountryFields,
     "uniqueKeys": ["ad_id", "date", "country"],
-    "defaultFields": ["ad_id", "date", "country", "impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
+    "defaultFields": ["clicks", "hour", "impressions", "post_id", "spend"],
     "destinationName": "reddit_ads_report_by_COUNTRY",
     "isTimeSeries": true
   },
@@ -111,7 +111,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
     "fields": reportAdGroupIdFields,
     "uniqueKeys": ["ad_id", "date", "ad_group_id"],
-    "defaultFields": ["ad_id", "date", "ad_group_id", "impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
+    "defaultFields": ["impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
     "destinationName": "reddit_ads_report_by_AD_GROUP_ID",
     "isTimeSeries": true
   },
@@ -121,7 +121,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
     "fields": reportCampaignIdFields,
     "uniqueKeys": ["ad_id", "date", "campaign_id"],
-    "defaultFields": ["ad_id", "date", "campaign_id", "impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
+    "defaultFields": ["impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
     "destinationName": "reddit_ads_report_by_CAMPAIGN_ID",
     "isTimeSeries": true
   },
@@ -131,7 +131,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
     "fields": reportDmaBasedFields,
     "uniqueKeys": ["ad_id", "date", "dma"],
-    "defaultFields": ["ad_id", "date", "dma", "impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
+    "defaultFields": ["impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
     "destinationName": "reddit_ads_report_by_DMA",
     "isTimeSeries": true
   },
@@ -141,7 +141,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
     "fields": reportInterestFields,
     "uniqueKeys": ["ad_id", "date", "interest"],
-    "defaultFields": ["ad_id", "date", "interest", "impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
+    "defaultFields": ["impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
     "destinationName": "reddit_ads_report_by_INTEREST",
     "isTimeSeries": true
   },
@@ -151,7 +151,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
     "fields": reportKeywordFields,
     "uniqueKeys": ["ad_id", "date", "keyword"],
-    "defaultFields": ["ad_id", "date", "keyword", "impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
+    "defaultFields": ["impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
     "destinationName": "reddit_ads_report_by_KEYWORD",
     "isTimeSeries": true
   },
@@ -161,7 +161,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
     "fields": reportPlacementFields,
     "uniqueKeys": ["ad_id", "date", "placement"],
-    "defaultFields": ["ad_id", "date", "placement", "impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
+    "defaultFields": ["impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
     "destinationName": "reddit_ads_report_by_PLACEMENT",
     "isTimeSeries": true
   },
@@ -171,7 +171,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
     "fields": reportAdAccountIdFields,
     "uniqueKeys": ["ad_id", "date", "account_id"],
-    "defaultFields": ["ad_id", "date", "account_id", "impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
+    "defaultFields": ["impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
     "destinationName": "reddit_ads_report_by_AD_ACCOUNT_ID",
     "isTimeSeries": true
   },
@@ -181,7 +181,7 @@ var RedditFieldsSchema = {
     "documentation": "https://ads-api.reddit.com/docs/v3/operations/List%20Ad%20Metrics",
     "fields": reportCommunityFields,
     "uniqueKeys": ["ad_id", "date", "community"],
-    "defaultFields": ["ad_id", "date", "community", "impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
+    "defaultFields": ["impressions", "clicks", "spend", "ctr", "cpc", "ecpm", "reach", "frequency", "key_conversion_total_count", "key_conversion_ecpa", "conversion_purchase_clicks", "conversion_purchase_total_value", "conversion_roas"],
     "destinationName": "reddit_ads_report_by_COMMUNITY",
     "isTimeSeries": true
   }

--- a/packages/connectors/src/Sources/TikTokAds/TikTokAdsAPIReference/TikTokAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/TikTokAds/TikTokAdsAPIReference/TikTokAdsFieldsSchema.js
@@ -12,7 +12,7 @@ var TikTokAdsFieldsSchema = {
     "documentation": "https://ads.tiktok.com/marketing_api/docs",
     "fields": advertiserFields,
     "uniqueKeys": ["advertiser_id"],
-    "defaultFields": ["advertiser_id", "advertiser_name", "company_name", "currency"],
+    "defaultFields": ["advertiser_name", "currency"],
     "destinationName": "tiktok_ads_advertiser"
   },
   "campaigns": {
@@ -21,7 +21,7 @@ var TikTokAdsFieldsSchema = {
     "documentation": "https://ads.tiktok.com/marketing_api/docs?id=1739318962329602",
     "fields": campaignsFields,
     "uniqueKeys": ["campaign_id"],
-    "defaultFields": ["campaign_id", "campaign_name", "advertiser_id", "objective_type", "campaign_type", "operation_status", "secondary_status", "budget_mode", "budget", "create_time", "modify_time"],
+    "defaultFields": ["campaign_name", "advertiser_id", "objective_type", "campaign_type", "operation_status", "secondary_status", "budget_mode", "budget", "create_time", "modify_time"],
     "destinationName": "tiktok_ads_campaigns"
   },
   "ad_groups": {
@@ -30,7 +30,7 @@ var TikTokAdsFieldsSchema = {
     "documentation": "https://ads.tiktok.com/marketing_api/docs?id=1739314558673922",
     "fields": adGroupsFields,
     "uniqueKeys": ["adgroup_id"],
-    "defaultFields": ["adgroup_id", "adgroup_name", "advertiser_id", "campaign_id", "campaign_name", "operation_status", "budget_mode", "budget", "bid_type", "optimization_goal", "placement_type", "schedule_start_time", "schedule_end_time", "create_time", "modify_time"],
+    "defaultFields": ["adgroup_name", "advertiser_id", "campaign_id", "campaign_name", "operation_status", "budget_mode", "budget", "bid_type", "optimization_goal", "placement_type", "schedule_start_time", "schedule_end_time", "create_time", "modify_time"],
     "destinationName": "tiktok_ads_ad_groups"
   },
   "ads": {
@@ -39,7 +39,7 @@ var TikTokAdsFieldsSchema = {
     "documentation": "https://ads.tiktok.com/marketing_api/docs?id=1735735588640770",
     "fields": adsFields,
     "uniqueKeys": ["ad_id"],
-    "defaultFields": ["ad_id", "ad_name", "advertiser_id", "campaign_id", "campaign_name", "adgroup_id", "adgroup_name", "operation_status", "secondary_status", "creative_type", "ad_format", "call_to_action", "create_time", "modify_time"],
+    "defaultFields": ["ad_name", "advertiser_id", "campaign_id", "campaign_name", "adgroup_id", "adgroup_name"],
     "destinationName": "tiktok_ads_ads"
   },
   "ad_insights": {
@@ -48,7 +48,7 @@ var TikTokAdsFieldsSchema = {
     "documentation": "https://ads.tiktok.com/marketing_api/docs?id=1738864915188737",
     "fields": adInsightsFields,
     "uniqueKeys": ["ad_id", "stat_time_day"],
-    "defaultFields": ["ad_id", "stat_time_day", "advertiser_id", "campaign_id", "adgroup_id", "impressions", "clicks", "spend", "ctr", "cpc", "cpm", "reach", "conversion", "cost_per_conversion", "video_views", "video_completion"],
+    "defaultFields": ["advertiser_id", "date_start", "date_end", "impressions", "clicks", "spend"],
     "destinationName": "tiktok_ads_ad_insights",
     "isTimeSeries": true
   },
@@ -58,7 +58,7 @@ var TikTokAdsFieldsSchema = {
     "documentation": "https://ads.tiktok.com/marketing_api/docs?id=1738864915188737",
     "fields": adInsightsByCountryFields,
     "uniqueKeys": ["ad_id", "stat_time_day", "country_code"],
-    "defaultFields": ["ad_id", "stat_time_day", "country_code", "advertiser_id", "campaign_id", "adgroup_id", "impressions", "clicks", "spend", "ctr", "cpc", "cpm", "reach", "conversion", "cost_per_conversion", "video_views", "video_completion"],
+    "defaultFields": ["advertiser_id", "date_start", "date_end", "impressions", "clicks", "spend"],
     "destinationName": "tiktok_ads_ad_insights_by_country",
     "isTimeSeries": true
   },
@@ -68,7 +68,7 @@ var TikTokAdsFieldsSchema = {
     "documentation": "https://ads.tiktok.com/marketing_api/docs?id=1739314536665090",
     "fields": audiencesFields,
     "uniqueKeys": ["audience_id"],
-    "defaultFields": ["audience_id", "advertiser_id", "name", "audience_type", "cover_num", "is_valid", "is_expiring", "create_time"],
+    "defaultFields": ["advertiser_id", "name", "audience_type", "cover_num", "is_valid", "is_expiring", "create_time"],
     "destinationName": "tiktok_ads_audiences"
   }
 };

--- a/packages/connectors/src/Sources/XAds/XAdsAPIReference/XAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/XAds/XAdsAPIReference/XAdsFieldsSchema.js
@@ -12,7 +12,7 @@ var XAdsFieldsSchema = {
     documentation: "https://developer.twitter.com/en/docs/twitter-ads-api/account-structure",
     fields: accountFields,
     uniqueKeys: ["id"],
-    defaultFields: ["id", "name", "business_name", "country_code", "timezone", "industry_type", "approval_status", "created_at", "updated_at"],
+    defaultFields: ["name", "business_name"],
     destinationName: "x_ads_accounts"
   },
   campaigns: {
@@ -21,7 +21,7 @@ var XAdsFieldsSchema = {
     documentation: "https://developer.twitter.com/en/docs/twitter-ads-api/campaign-management",
     fields: campaignFields,
     uniqueKeys: ["id"],
-    defaultFields: ["id", "name", "account_id", "entity_status", "effective_status", "budget_optimization", "daily_budget_amount_local_micro", "total_budget_amount_local_micro", "currency", "created_at", "updated_at"],
+    defaultFields: ["name", "currency", "account_id"],
     destinationName: "x_ads_campaigns"
   },
   line_items: {
@@ -30,7 +30,7 @@ var XAdsFieldsSchema = {
     documentation: "https://developer.twitter.com/en/docs/twitter-ads-api/line-items",
     fields: lineItemFields,
     uniqueKeys: ["id"],
-    defaultFields: ["id", "name", "campaign_id", "entity_status", "product_type", "objective", "goal", "bid_strategy", "bid_amount_local_micro", "daily_budget_amount_local_micro", "total_budget_amount_local_micro", "start_time", "end_time", "created_at", "updated_at"],
+    defaultFields: ["name", "campaign_id"],
     destinationName: "x_ads_line_items"
   },
   promoted_tweets: {
@@ -39,7 +39,7 @@ var XAdsFieldsSchema = {
     documentation: "https://developer.twitter.com/en/docs/twitter-ads-api/promoted-tweets",
     fields: promotedTweetFields,
     uniqueKeys: ["id"],
-    defaultFields: ["id", "tweet_id", "line_item_id", "entity_status", "approval_status", "created_at", "updated_at"],
+    defaultFields: ["tweet_id", "line_item_id"],
     destinationName: "x_ads_promoted_tweets",
     requiredFields: ["id"]
   },
@@ -49,7 +49,7 @@ var XAdsFieldsSchema = {
     documentation: "https://developer.twitter.com/en/docs/twitter-ads-api/tweets",
     fields: tweetFields,
     uniqueKeys: ["id"],
-    defaultFields: ["id", "id_str", "full_text", "tweet_type", "lang", "created_at", "favorite_count", "retweet_count", "nullcast", "card_uri"],
+    defaultFields: ["name", "id_str", "card_uri"],
     destinationName: "x_ads_tweets",
     requiredFields: ["card_uri"]
   },
@@ -59,7 +59,7 @@ var XAdsFieldsSchema = {
     documentation: "https://developer.twitter.com/en/docs/twitter-ads-api/stats",
     fields: statsFields,
     uniqueKeys: ["id", "date", "placement"],
-    defaultFields: ["id", "date", "placement", "impressions", "clicks", "url_clicks", "engagements", "billed_charge_local_micro", "likes", "retweets", "replies", "follows"],
+    defaultFields: ["impressions", "billed_charge_local_micro", "url_clicks"],
     destinationName: "x_ads_stats",
     isTimeSeries: true
   },
@@ -69,7 +69,7 @@ var XAdsFieldsSchema = {
     documentation: "https://developer.x.com/en/docs/x-ads-api/analytics/api-reference/asynchronous",
     fields: statsByCountryFields,
     uniqueKeys: ["id", "date", "placement", "country"],
-    defaultFields: ["id", "date", "placement", "country", "impressions", "clicks", "url_clicks", "engagements", "billed_charge_local_micro", "likes", "retweets", "replies", "follows"],
+    defaultFields: ["impressions", "clicks", "url_clicks", "engagements", "billed_charge_local_micro", "likes", "retweets", "replies", "follows"],
     destinationName: "x_ads_stats_by_country",
     isTimeSeries: true,
     // asyncTimeSeries: uses the X Ads async jobs API (submit → poll → download
@@ -89,7 +89,7 @@ var XAdsFieldsSchema = {
     documentation: "https://developer.x.com/en/docs/x-ads-api/campaign-management/api-reference/targeting-criteria",
     fields: targetingLocationsFields,
     uniqueKeys: ["targeting_value"],
-    defaultFields: ["targeting_value", "name", "location_type", "country_code"],
+    defaultFields: ["name", "location_type", "country_code"],
     destinationName: "x_ads_targeting_locations"
   },
   cards: {
@@ -98,7 +98,7 @@ var XAdsFieldsSchema = {
     documentation: "https://developer.twitter.com/en/docs/twitter-ads-api/cards",
     fields: cardFields,
     uniqueKeys: ["id"],
-    defaultFields: ["id", "name", "card_type", "card_uri", "created_at", "updated_at"],
+    defaultFields: ["name", "card_uri", "components"],
     destinationName: "x_ads_cards"
   },
   cards_all: {
@@ -107,7 +107,7 @@ var XAdsFieldsSchema = {
     documentation: "https://developer.twitter.com/en/docs/twitter-ads-api/cards",
     fields: cardAllFields,
     uniqueKeys: ["id"],
-    defaultFields: ["id", "name", "card_type", "card_uri", "title", "website_url", "app_cta", "country_code", "created_at", "updated_at"],
+    defaultFields: ["name", "card_type", "card_uri", "title", "website_url", "app_cta", "country_code", "created_at", "updated_at"],
     destinationName: "x_ads_cards_all"
   }
 };


### PR DESCRIPTION
# Problem

The default field selections across CriteoAds, FacebookMarketing, LinkedInAds, RedditAds, TikTokAds, and XAds were either too minimal or outdated, or included uniqueKey fields that are already auto-checked by the system — creating redundant selections and a noisy setup experience. 

# Solution

Updated `defaultFields` across all 6 connectors to include the fields most useful to marketing analysts out of the box. Removed all fields that duplicate `uniqueKeys`, since those are already pre-selected automatically. 