### PR TITLE
fix(backend): prevent OOM on large BigQuery reports by streaming query results

### DIFF
--- a/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.ts
@@ -14,6 +14,13 @@ import type { SqlParameter } from '../../utils/sql-clause-renderer';
  * query execution, dry-run, and job management.
  */
 export class BigQueryApiAdapter {
+  /**
+   * Interval between query-job status polls in {@link waitForJobToComplete}.
+   * Large enough to keep the `jobs.get` call rate low on long-running jobs,
+   * small enough that fast jobs add negligible latency.
+   */
+  private static readonly JOB_POLL_INTERVAL_MS = 2000;
+
   private readonly logger = new Logger(BigQueryApiAdapter.name);
   private readonly bigQuery: BigQuery;
   private readonly authClient: JWT | OAuth2Client;
@@ -48,10 +55,27 @@ export class BigQueryApiAdapter {
   }
 
   /**
-   * Executes a SQL query.
-   * When params are provided, BigQuery named parameter mode is used (@paramName placeholders).
-   * The SDK infers types from JS values (string, number, boolean, Date).
-   * null values are accepted by the SDK but may require explicit typed params in some edge cases.
+   * Executes a SQL query as a BigQuery job and resolves once the job reaches
+   * the DONE state, returning only the job id. Callers resolve the job's
+   * anonymous destination table (via {@link getJob}) and stream rows from it
+   * page by page using `Table.getRows({ maxResults, autoPaginate: false })`.
+   *
+   * Implemented with `createQueryJob` + job-metadata polling, NOT
+   * `bigQuery.query()`. `bigQuery.query()` calls `getQueryResults` under the
+   * hood, which buffers the entire result set into the process heap before
+   * resolving — for a large VIEW or SQL result (millions of rows) that
+   * exhausts the worker's heap and OOM-kills it before a single row reaches
+   * the destination. Polling job metadata fetches job status only (no row
+   * data), so memory stays flat; the actual row streaming happens later, in
+   * bounded pages, in the reader.
+   *
+   * Behaviour is identical for a SQL-query data mart and a VIEW-backed one —
+   * both arrive here as a query string and only need the job to finish so
+   * the destination table is materialised.
+   *
+   * When params are provided, BigQuery named parameter mode is used
+   * (@paramName placeholders). The SDK infers types from JS values
+   * (string, number, boolean, Date).
    */
   public async executeQuery(query: string, params?: SqlParameter[]): Promise<{ jobId: string }> {
     const queryConfig: Query =
@@ -60,25 +84,45 @@ export class BigQueryApiAdapter {
             query,
             params: Object.fromEntries(params.map(p => [p.name, p.value])),
             parameterMode: 'NAMED',
-            maxResults: 0,
             ...this.getLocationOption(),
           }
         : {
             query,
-            maxResults: 0,
             ...this.getLocationOption(),
           };
-    // The Query-object overload is typed as SimpleQueryRowsResponse (2-tuple) but at runtime
-    // BigQuery always returns the raw API response as the third element when maxResults=0.
-    // Double-cast through unknown to satisfy the 3-tuple destructure.
-    const [, , res] = await (this.bigQuery.query(queryConfig) as unknown as Promise<
-      [unknown, unknown, { jobReference?: { jobId?: string; location?: string } }]
-    >);
-    if (!res || !res.jobReference || !res.jobReference.jobId) {
+
+    const [job] = await this.bigQuery.createQueryJob(queryConfig);
+    await this.waitForJobToComplete(job);
+    this.setLocationFromJob(job);
+
+    const jobId = job.id;
+    if (!jobId) {
       throw new Error('Unexpected error during getting sql result job id');
     }
-    this.setLocationFromJobReference(res.jobReference.location);
-    return { jobId: res.jobReference.jobId };
+    return { jobId };
+  }
+
+  /**
+   * Polls a query job's metadata until it reaches the DONE state. Issues
+   * `jobs.get` only (job status, no row data), so memory usage is constant
+   * regardless of result size. Throws when the job finished with an error
+   * (e.g. invalid SQL) so a bad query still surfaces as a thrown error from
+   * {@link executeQuery}, matching the previous `bigQuery.query()` behaviour.
+   */
+  private async waitForJobToComplete(job: Job): Promise<void> {
+    while (true) {
+      const [metadata] = await job.getMetadata();
+      if (metadata?.status?.state === 'DONE') {
+        const errorResult = metadata.status.errorResult;
+        if (errorResult) {
+          throw new Error(
+            errorResult.message ?? 'BigQuery query job failed without an error message'
+          );
+        }
+        return;
+      }
+      await new Promise(resolve => setTimeout(resolve, BigQueryApiAdapter.JOB_POLL_INTERVAL_MS));
+    }
   }
 
   /**

--- a/apps/backend/test/integration/bigquery.integration.ts
+++ b/apps/backend/test/integration/bigquery.integration.ts
@@ -142,4 +142,60 @@ describeIfCredentials('BigQuery Integration Tests', () => {
       }
     }, 30000);
   });
+
+  // Regression net for the `executeQuery` rewrite (createQueryJob + job-status
+  // polling instead of `bigQuery.query()`). These run against real BigQuery
+  // and lock the two contracts the rewrite changed:
+  //   1. executeQuery waits for the job to finish, then its jobId resolves to
+  //      a materialized anonymous destination table that streams rows — the
+  //      exact path the report reader and the SQL-run executor depend on.
+  //   2. an invalid query still surfaces as a thrown error (previously thrown
+  //      by `bigQuery.query()`, now from the job's error status).
+  // The DDL path (CREATE/DROP) is already exercised by beforeAll/afterAll.
+  describe('Query Execution (executeQuery → job → destination table)', () => {
+    it('runs a SELECT as a job and streams rows from the destination table', async () => {
+      const { jobId } = await adapter.executeQuery(
+        `SELECT n, label FROM UNNEST([
+          STRUCT(1 AS n, 'a' AS label),
+          STRUCT(2 AS n, 'b' AS label)
+        ]) ORDER BY n`
+      );
+      expect(jobId).toBeTruthy();
+
+      const job = await adapter.getJob(jobId);
+      const destinationTable = job.metadata.configuration.query.destinationTable;
+      expect(destinationTable).toBeDefined();
+
+      const table = adapter.createTableReference(
+        destinationTable.projectId,
+        destinationTable.datasetId,
+        destinationTable.tableId
+      );
+      const [rows] = await table.getRows({ maxResults: 5000, autoPaginate: false });
+
+      expect(rows).toHaveLength(2);
+      expect(rows.map((r: Record<string, unknown>) => String(r.label))).toEqual(['a', 'b']);
+      expect(rows.map((r: Record<string, unknown>) => Number(r.n))).toEqual([1, 2]);
+    }, 60000);
+
+    it('supports NAMED query parameters end-to-end', async () => {
+      const { jobId } = await adapter.executeQuery('SELECT @n AS n', [{ name: 'n', value: 42 }]);
+
+      const job = await adapter.getJob(jobId);
+      const destinationTable = job.metadata.configuration.query.destinationTable;
+      const table = adapter.createTableReference(
+        destinationTable.projectId,
+        destinationTable.datasetId,
+        destinationTable.tableId
+      );
+      const [rows] = await table.getRows({ maxResults: 10, autoPaginate: false });
+
+      expect(rows).toHaveLength(1);
+      expect(Number((rows[0] as Record<string, unknown>).n)).toBe(42);
+    }, 60000);
+
+    it('rejects when the query is invalid (error surfaces from job status)', async () => {
+      await expect(adapter.executeQuery('SELEKT * FORM nope')).rejects.toThrow();
+    }, 60000);
+  });
 });


### PR DESCRIPTION
## Problem

Reports backed by a large BigQuery **VIEW** or SQL query (millions of rows)
crashed the worker with an out-of-memory error. The user-visible symptoms:

- The report sat in `RUNNING` for many minutes, then the worker process died
  with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap
  out of memory`.
- Because the process was OOM-killed mid-flight, `markAsUnsuccessful` never
  ran — the report stayed stuck in `RUNNING` indefinitely instead of failing
  cleanly.
- **No data ever reached the destination.** With a `TABLE`-backed data mart
  you could watch rows append to Google Sheets batch by batch; with a `VIEW`
  nothing appeared, because the crash happened before the first batch was
  written.

This reproduced on a clean checkout with **no recent Google Sheets changes**,
which ruled out the diff-based writer and pointed at the read path.

## Root cause

`BigQueryApiAdapter.executeQuery` ran the query via `bigQuery.query()`:

```ts
const [, , res] = await this.bigQuery.query(queryConfig); // maxResults: 0
return { jobId: res.jobReference.jobId };
```

`bigQuery.query()` calls `getQueryResults` under the hood, which **buffers the
entire result set into the process heap** before resolving — even though we
only need the job id and never read the returned rows here (the reader
paginates the job's destination table separately). For a multi-million-row
result that buffer alone exhausts the worker heap.

The crash stack confirmed it: `ArrayMap` → `PromiseFulfillReactionJob` →
`CompressionStream<ZlibContext>::AfterThreadPoolWork` — i.e. gzipped query
results being decompressed, JSON-parsed and `.map()`-ed into memory inside the
BigQuery client.

## Fix

Run the query as a job and **wait for completion without fetching any rows**:

```ts
const [job] = await this.bigQuery.createQueryJob(queryConfig);
await this.waitForJobToComplete(job); // polls jobs.get — no row data
return { jobId: job.id };
```

`waitForJobToComplete` polls the job's metadata (`jobs.get`, status only) every
2s until the job reaches `DONE`, and throws if the job finished with an error.
Memory stays flat regardless of result size. The actual row streaming is
unchanged — it still happens later, page by page (`maxResults: 5000`,
`autoPaginate: false`), in the report reader / SQL-run executor against the
job's anonymous destination table.

This mirrors the pattern already used by `executeDryRunQuery` (`createQueryJob`)
and `bigquery-sql-run.executor` (`job.promise()` to await completion without
fetching rows), so it's consistent with existing code in this module.

## Scope / blast radius

`executeQuery` has four callers; the contract (`(query, params?) → { jobId }`,
job finished before returning, throws on bad query) is preserved for all:

| Caller | Path | Verified |
| --- | --- | --- |
| `bigquery-report-reader` | SELECT → destination table → rows (GS export & all BQ reports) | new integration test + full report integration suite |
| `bigquery-sql-run.executor` | ad-hoc Run / preview | smoke checklist |
| `bigquery-create-view.executor` (×2) | DDL `CREATE VIEW` / `CREATE SCHEMA` | already exercised by this suite's `beforeAll`/`afterAll` |

`checkAccess` (`SELECT 1`) is intentionally left on `bigQuery.query()` — tiny
result, no memory concern.

Behaviour is identical for SQL-query and VIEW-backed data marts; both arrive as
a query string and only need the job to finish so the destination table is
materialized.

## Tests

- **New integration tests** (`bigquery.integration.ts`, real BigQuery, gated by
  `BQ_*` credentials, skip cleanly without them) locking the contracts the
  rewrite changed:
  1. SELECT → job → destination table → `getRows` returns the expected rows
     (also exercises autodetect-location, since the suite runs with
     `BIGQUERY_AUTODETECT_LOCATION`).
  2. NAMED query parameters end-to-end (used by output controls / blended SQL).
  3. Invalid SQL rejects (error now surfaces from job status, not from
     `bigQuery.query()`).
- DDL execution is already covered by the suite's setup/teardown.
- The end-to-end report path is covered by
  `google-sheets-column-preservation.integration.ts`.
- `tsc --noEmit`, ESLint, Prettier: clean on changed files.
- **Manual production smoke (all green):** large VIEW (1M+ rows) → GS export
  streams with flat memory and finishes `SUCCESS`; normal SQL data mart;
  report with filter/sort/limit (NAMED params); blended data mart; VIEW
  creation (DDL); ad-hoc Run; invalid SQL → clean `ERROR` (no stuck
  `RUNNING`); empty result set.

## Why no unit test

The adapter constructs its `BigQuery` client internally, so a unit test would
require mocking `@google-cloud/bigquery` — and the behaviour this change
depends on (does `createQueryJob().id` resolve via `getJob`, is the
destination table materialized after `DONE`, what shape is `errorResult`) is
exactly the SDK behaviour a mock cannot verify. Real-BigQuery integration is
the only meaningful net here.

## Risk / notes

- The poll loop has no explicit timeout — it polls until the job reports `DONE`
  or an error. BigQuery jobs always terminate, and run-level cancellation is
  handled upstream via `AbortSignal`, so there is no new "hang forever" state.
  Wall-clock is unchanged vs. the old code, which also blocked until the job
  finished — only the buffering is gone.
- Polling interval (2s) keeps `jobs.get` call volume low on long jobs while
  adding negligible latency to fast ones (a fast job is already `DONE` on the
  first poll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)