### PR TITLE
feat: HTTP Data API — optional column selectors (*/**) and no streaming caps

### DIFF
--- a/.changeset/http-data-api-ndjson-endpoint.md
+++ b/.changeset/http-data-api-ndjson-endpoint.md
@@ -4,9 +4,13 @@
 
 # Add the HTTP Data API — stream a published Data Mart's rows over HTTP as NDJSON
 
-A new `GET /api/external/http-data/data-marts/{id}.ndjson` endpoint streams the selected
-columns of a published Data Mart as newline-delimited JSON for project members
-authenticated with their ODM member token (`x-owox-authorization`). Callers explicitly
-choose columns and may pass optional base64-encoded `filter`/`sort` and a `limit`. Every
-pull is recorded as an `HTTP_DATA` Data Mart run (visible in run history) and counted for
+A new `GET /api/external/http-data/data-marts/{id}.ndjson` endpoint streams the columns
+of a published Data Mart as newline-delimited JSON for project members authenticated with
+their ODM member token (`x-owox-authorization`). Columns are selected via the repeated
+`column` parameter, or via reserved values: `*` (all native columns) and `**` (all native
+plus all reporting-visible blended columns); `*` may be combined with explicit columns, and
+omitting `column` is equivalent to `*`. Only reporting-visible columns are selectable —
+fields hidden from reporting and columns from excluded blend sources are rejected. Callers
+may also pass optional base64url-encoded `filter`/`sort` and a `limit`. Every pull is
+recorded as an `HTTP_DATA` Data Mart run (visible in run history) and counted for
 consumption; no persisted Report or Data Destination is created.

--- a/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
@@ -80,18 +80,11 @@ export function StreamHttpDataSpec() {
     ApiOkResponse({
       description:
         'NDJSON stream of row objects. Each line is a complete JSON object whose ' +
-        'keys match the requested columns. Response headers include `x-owox-run-id` ' +
-        'with the created DataMartRun ID and `x-owox-columns` with the requested ' +
-        'column list as a base64url-encoded JSON array.',
+        'keys match the requested columns, in the requested order. The response ' +
+        'includes the `x-owox-run-id` header with the created DataMartRun ID.',
       headers: {
         'x-owox-run-id': {
           description: 'ID of the created DataMartRun (HTTP_DATA) for traceability',
-          schema: { type: 'string' },
-        },
-        'x-owox-columns': {
-          description:
-            'Requested columns, in row-object order, as a base64url-encoded JSON array ' +
-            '(lets clients recover the column list even for an empty result stream)',
           schema: { type: 'string' },
         },
       },

--- a/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
@@ -15,11 +15,12 @@ export function StreamHttpDataSpec() {
       summary: 'Stream Data Mart data as NDJSON',
       description:
         'Streams rows of a published Data Mart as newline-delimited JSON ' +
-        '(one data row per line, no envelope). The caller must explicitly select ' +
-        'columns via the repeated `column` query parameter; row objects use those ' +
-        'column names as keys in the requested order. Authenticated with the ODM ' +
-        'member token via `x-owox-authorization`. Creates one DataMartRun of type ' +
-        'HTTP_DATA per request, available through the run history endpoint.',
+        '(one data row per line, no envelope). Columns are chosen via the repeated ' +
+        '`column` query parameter; row objects use those column names as keys in the ' +
+        'requested order. Omit `column` (or pass `*`) for all native columns, or pass ' +
+        '`**` for all native plus all reporting-visible blended columns. Authenticated ' +
+        'with the ODM member token via `x-owox-authorization`. Creates one DataMartRun ' +
+        'of type HTTP_DATA per request, available through the run history endpoint.',
     }),
     ApiHeader({
       name: 'x-owox-authorization',
@@ -35,8 +36,12 @@ export function StreamHttpDataSpec() {
       name: 'column',
       description:
         'Column to include in the output. Repeat the parameter to select multiple ' +
-        'columns; the order of repetition is preserved in row objects.',
-      required: true,
+        'columns; the order of repetition is preserved in row objects. Two reserved ' +
+        'values expand to column sets: `*` = all native columns, `**` = all native plus ' +
+        'all reporting-visible blended columns. `*` may be combined with explicit ' +
+        'columns (e.g. `column=*&column=orders__revenue` = all native plus that blended ' +
+        'field). Omitting the parameter is equivalent to `*`. Overlaps are de-duplicated.',
+      required: false,
       isArray: true,
       type: String,
       example: ['date', 'revenue'],
@@ -67,7 +72,7 @@ export function StreamHttpDataSpec() {
     }),
     ApiQuery({
       name: 'limit',
-      description: 'Optional row cap (1..10_000_000).',
+      description: 'Optional row cap (positive integer).',
       required: false,
       type: Number,
     }),
@@ -103,9 +108,8 @@ export function StreamHttpDataSpec() {
     ApiResponse({
       status: 400,
       description:
-        'Invalid request: missing or unknown column, duplicate columns, ' +
-        'forbidden pagination parameter (`pageToken`/`offset`), malformed filter/sort/limit, ' +
-        'or unsupported storage type.',
+        'Invalid request: unknown column, forbidden pagination parameter ' +
+        '(`pageToken`/`offset`), malformed filter/sort/limit, or unsupported storage type.',
     }),
     ApiResponse({ status: 401, description: 'Missing or invalid `x-owox-authorization` token.' }),
     ApiResponse({

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -13,6 +13,7 @@ import { HttpDataMapper } from './mappers/http-data.mapper';
 import { StreamHttpDataService } from './use-cases/stream-http-data.service';
 import { HttpDataStreamWriter } from './services/http-data/http-data-stream-writer.service';
 import { HttpDataRequestValidator } from './services/http-data/http-data-request-validator.service';
+import { HttpDataColumnResolver } from './services/http-data/http-data-column-resolver.service';
 import { HttpDataColumnValidator } from './services/http-data/http-data-column-validator.service';
 import { MarkdownParserController } from './controllers/markdown-parser.controller';
 import { ReportController } from './controllers/report.controller';
@@ -738,6 +739,7 @@ import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-m
     StreamHttpDataService,
     HttpDataStreamWriter,
     HttpDataRequestValidator,
+    HttpDataColumnResolver,
     HttpDataColumnValidator,
   ],
 })

--- a/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.ts
@@ -123,6 +123,13 @@ export const HttpDataQuerySchema = z
         });
       }
     }
+    if (value.column.includes(ALL_BLENDABLE_COLUMNS) && value.column.length > 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['column'],
+        message: `"${ALL_BLENDABLE_COLUMNS}" cannot be combined with other column values`,
+      });
+    }
   })
   .transform(value => ({
     columnSelector: toColumnSelector(value.column),

--- a/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.ts
@@ -2,11 +2,28 @@ import { z } from 'zod';
 import { FilterConfigSchema } from './filter-config.schema';
 import { SortConfigSchema } from './sort-config.schema';
 
-export const HTTP_DATA_MAX_COLUMNS = 100;
-export const HTTP_DATA_MAX_USER_LIMIT = 10_000_000;
 export const HTTP_DATA_MAX_ENCODED_PARAM_LENGTH = 8192;
 
+export const ALL_NATIVE_COLUMNS = '*';
+export const ALL_BLENDABLE_COLUMNS = '**';
+
+export type ColumnSelector =
+  | { mode: 'allNative'; explicit: string[] }
+  | { mode: 'allBlendable' }
+  | { mode: 'explicit'; explicit: string[] };
+
 const REJECTED_PAGINATION_KEYS = ['pageToken', 'offset'] as const;
+
+function toColumnSelector(tokens: string[]): ColumnSelector {
+  if (tokens.includes(ALL_BLENDABLE_COLUMNS)) {
+    return { mode: 'allBlendable' };
+  }
+  const explicit = tokens.filter(token => token !== ALL_NATIVE_COLUMNS);
+  if (tokens.includes(ALL_NATIVE_COLUMNS) || tokens.length === 0) {
+    return { mode: 'allNative', explicit };
+  }
+  return { mode: 'explicit', explicit };
+}
 
 function decodeBase64UrlJson(raw: string): unknown {
   let decoded: string;
@@ -77,21 +94,16 @@ const SortParamSchema = z
 const LimitParamSchema = z.coerce
   .number({ invalid_type_error: 'limit must be an integer' })
   .int('limit must be an integer')
-  .min(1, 'limit must be ≥ 1')
-  .max(HTTP_DATA_MAX_USER_LIMIT, `limit must be ≤ ${HTTP_DATA_MAX_USER_LIMIT}`);
+  .min(1, 'limit must be ≥ 1');
 
 const ColumnsParamSchema = z
   .union([z.string(), z.array(z.string())])
-  .transform(value => (Array.isArray(value) ? value : [value]))
-  .pipe(
-    z
-      .array(z.string().min(1, 'column value must not be empty'))
-      .min(1, 'at least one column is required')
-      .max(HTTP_DATA_MAX_COLUMNS, `at most ${HTTP_DATA_MAX_COLUMNS} columns are allowed`)
-      .refine(arr => new Set(arr).size === arr.length, {
-        message: 'duplicate column names are not allowed',
-      })
-  );
+  .optional()
+  .transform(value => {
+    if (value === undefined) return [];
+    return Array.isArray(value) ? value : [value];
+  })
+  .pipe(z.array(z.string().min(1, 'column value must not be empty')));
 
 export const HttpDataQuerySchema = z
   .object({
@@ -113,7 +125,7 @@ export const HttpDataQuerySchema = z
     }
   })
   .transform(value => ({
-    columns: value.column,
+    columnSelector: toColumnSelector(value.column),
     filter: value.filter,
     sort: value.sort,
     limit: value.limit,

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-resolver.service.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-resolver.service.spec.ts
@@ -1,0 +1,38 @@
+import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
+import { ColumnSelector } from '../../dto/schemas/http-data-query.schema';
+import { ReportingColumns } from './http-data-column-sets.util';
+import { HttpDataColumnResolver } from './http-data-column-resolver.service';
+
+describe('HttpDataColumnResolver', () => {
+  const resolver = new HttpDataColumnResolver();
+  const columns: ReportingColumns = { native: ['date', 'revenue'], blended: ['orders__cost'] };
+
+  it('expands "*" to all native columns', () => {
+    const selector: ColumnSelector = { mode: 'allNative', explicit: [] };
+    expect(resolver.resolve(selector, columns)).toEqual(['date', 'revenue']);
+  });
+
+  it('appends explicit columns to "*" and de-duplicates overlaps', () => {
+    const selector: ColumnSelector = { mode: 'allNative', explicit: ['orders__cost', 'date'] };
+    expect(resolver.resolve(selector, columns)).toEqual(['date', 'revenue', 'orders__cost']);
+  });
+
+  it('expands "**" to native plus reporting-visible blended columns', () => {
+    expect(resolver.resolve({ mode: 'allBlendable' }, columns)).toEqual([
+      'date',
+      'revenue',
+      'orders__cost',
+    ]);
+  });
+
+  it('returns explicit columns verbatim', () => {
+    const selector: ColumnSelector = { mode: 'explicit', explicit: ['revenue', 'orders__cost'] };
+    expect(resolver.resolve(selector, columns)).toEqual(['revenue', 'orders__cost']);
+  });
+
+  it('throws a business violation when the selection resolves to no columns', () => {
+    expect(() =>
+      resolver.resolve({ mode: 'allNative', explicit: [] }, { native: [], blended: [] })
+    ).toThrow(BusinessViolationException);
+  });
+});

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-resolver.service.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-resolver.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
+import { ColumnSelector } from '../../dto/schemas/http-data-query.schema';
+import { ReportingColumns } from './http-data-column-sets.util';
+
+@Injectable()
+export class HttpDataColumnResolver {
+  resolve(selector: ColumnSelector, columns: ReportingColumns): string[] {
+    const resolved = [...new Set(this.select(selector, columns))];
+    if (resolved.length === 0) {
+      throw new BusinessViolationException('No columns available for the requested Data Mart');
+    }
+    return resolved;
+  }
+
+  private select(selector: ColumnSelector, columns: ReportingColumns): string[] {
+    switch (selector.mode) {
+      case 'allBlendable':
+        return [...columns.native, ...columns.blended];
+      case 'allNative':
+        return [...columns.native, ...selector.explicit];
+      case 'explicit':
+        return selector.explicit;
+    }
+  }
+}

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-sets.util.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-sets.util.spec.ts
@@ -1,4 +1,5 @@
 import { BlendableSchemaDto } from '../../dto/domain/blendable-schema.dto';
+import { DataMartSchemaFieldStatus } from '../../data-storage-types/enums/data-mart-schema-field-status.enum';
 import { nativeColumnNames, visibleBlendedColumnNames } from './http-data-column-sets.util';
 
 function schemaOf(partial: Partial<BlendableSchemaDto>): BlendableSchemaDto {
@@ -32,6 +33,16 @@ describe('nativeColumnNames', () => {
       ] as never,
     });
     expect(nativeColumnNames(schema)).toEqual(['date', 'user', 'user.id']);
+  });
+
+  it('excludes fields with DISCONNECTED status', () => {
+    const schema = schemaOf({
+      nativeFields: [
+        { name: 'date', status: DataMartSchemaFieldStatus.CONNECTED },
+        { name: 'gone', status: DataMartSchemaFieldStatus.DISCONNECTED },
+      ] as never,
+    });
+    expect(nativeColumnNames(schema)).toEqual(['date']);
   });
 });
 

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-sets.util.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-sets.util.spec.ts
@@ -1,0 +1,54 @@
+import { BlendableSchemaDto } from '../../dto/domain/blendable-schema.dto';
+import { nativeColumnNames, visibleBlendedColumnNames } from './http-data-column-sets.util';
+
+function schemaOf(partial: Partial<BlendableSchemaDto>): BlendableSchemaDto {
+  return {
+    nativeFields: [],
+    blendedFields: [],
+    availableSources: [],
+    ...partial,
+  } as BlendableSchemaDto;
+}
+
+describe('nativeColumnNames', () => {
+  it('returns flat native field names', () => {
+    const schema = schemaOf({ nativeFields: [{ name: 'date' }, { name: 'revenue' }] as never });
+    expect(nativeColumnNames(schema)).toEqual(['date', 'revenue']);
+  });
+
+  it('flattens nested fields into parent and dotted leaf paths', () => {
+    const schema = schemaOf({
+      nativeFields: [{ name: 'user', fields: [{ name: 'id' }, { name: 'name' }] }] as never,
+    });
+    expect(nativeColumnNames(schema)).toEqual(['user', 'user.id', 'user.name']);
+  });
+
+  it('excludes fields hidden from reporting at any nesting level', () => {
+    const schema = schemaOf({
+      nativeFields: [
+        { name: 'date' },
+        { name: 'secret', isHiddenForReporting: true },
+        { name: 'user', fields: [{ name: 'id' }, { name: 'ssn', isHiddenForReporting: true }] },
+      ] as never,
+    });
+    expect(nativeColumnNames(schema)).toEqual(['date', 'user', 'user.id']);
+  });
+});
+
+describe('visibleBlendedColumnNames', () => {
+  const schema = schemaOf({
+    availableSources: [
+      { aliasPath: 'orders', isIncluded: true },
+      { aliasPath: 'archive', isIncluded: false },
+    ] as never,
+    blendedFields: [
+      { name: 'orders__cost', aliasPath: 'orders', isHidden: false } as never,
+      { name: 'orders__secret', aliasPath: 'orders', isHidden: true } as never,
+      { name: 'archive__old', aliasPath: 'archive', isHidden: false } as never,
+    ],
+  });
+
+  it('keeps only non-hidden fields from included sources', () => {
+    expect(visibleBlendedColumnNames(schema)).toEqual(['orders__cost']);
+  });
+});

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-sets.util.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-sets.util.ts
@@ -1,0 +1,39 @@
+import { BlendableSchemaDto } from '../../dto/domain/blendable-schema.dto';
+
+export interface ReportingColumns {
+  native: string[];
+  blended: string[];
+}
+
+interface NativeSchemaField {
+  name: string;
+  isHiddenForReporting?: boolean;
+  fields?: NativeSchemaField[];
+}
+
+export function nativeColumnNames(schema: BlendableSchemaDto): string[] {
+  return collectNative(schema.nativeFields as unknown as NativeSchemaField[]);
+}
+
+function collectNative(fields: NativeSchemaField[], prefix = ''): string[] {
+  const result: string[] = [];
+  for (const field of fields) {
+    if (field.isHiddenForReporting) continue;
+    const fullName = prefix ? `${prefix}.${field.name}` : field.name;
+    result.push(fullName);
+    if (field.fields && field.fields.length > 0) {
+      result.push(...collectNative(field.fields, fullName));
+    }
+  }
+  return result;
+}
+
+// Must stay in sync with the web ReportColumnPicker visibility predicate.
+export function visibleBlendedColumnNames(schema: BlendableSchemaDto): string[] {
+  const includedPaths = new Set(
+    schema.availableSources.filter(source => source.isIncluded).map(source => source.aliasPath)
+  );
+  return schema.blendedFields
+    .filter(field => includedPaths.has(field.aliasPath) && !field.isHidden)
+    .map(field => field.name);
+}

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-sets.util.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-sets.util.ts
@@ -1,4 +1,5 @@
 import { BlendableSchemaDto } from '../../dto/domain/blendable-schema.dto';
+import { DataMartSchemaFieldStatus } from '../../data-storage-types/enums/data-mart-schema-field-status.enum';
 
 export interface ReportingColumns {
   native: string[];
@@ -7,6 +8,7 @@ export interface ReportingColumns {
 
 interface NativeSchemaField {
   name: string;
+  status?: string;
   isHiddenForReporting?: boolean;
   fields?: NativeSchemaField[];
 }
@@ -19,6 +21,7 @@ function collectNative(fields: NativeSchemaField[], prefix = ''): string[] {
   const result: string[] = [];
   for (const field of fields) {
     if (field.isHiddenForReporting) continue;
+    if (field.status === DataMartSchemaFieldStatus.DISCONNECTED) continue;
     const fullName = prefix ? `${prefix}.${field.name}` : field.name;
     result.push(fullName);
     if (field.fields && field.fields.length > 0) {

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-validator.service.spec.ts
@@ -1,108 +1,65 @@
 import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
-import { BlendableSchemaService } from '../blendable-schema.service';
+import { ReportingColumns } from './http-data-column-sets.util';
 import { HttpDataColumnValidator } from './http-data-column-validator.service';
 
-function fakeDataMart() {
-  return { id: 'dm-main', projectId: 'proj-1' } as unknown as Parameters<
-    HttpDataColumnValidator['validate']
-  >[0];
-}
-
 describe('HttpDataColumnValidator', () => {
-  let blendable: jest.Mocked<BlendableSchemaService>;
-  let validator: HttpDataColumnValidator;
+  const validator = new HttpDataColumnValidator();
+  const columns: ReportingColumns = { native: ['date', 'revenue'], blended: ['orders__cost'] };
 
-  beforeEach(() => {
-    blendable = {
-      computeBlendableSchema: jest.fn(),
-    } as unknown as jest.Mocked<BlendableSchemaService>;
-
-    validator = new HttpDataColumnValidator(blendable);
+  it('accepts native and reporting-visible blended columns', () => {
+    expect(() =>
+      validator.validate({ selectedColumns: ['date', 'orders__cost'] }, columns)
+    ).not.toThrow();
   });
 
-  it('accepts native columns', async () => {
-    blendable.computeBlendableSchema.mockResolvedValue({
-      nativeFields: [{ name: 'date' }, { name: 'revenue' }] as never,
-      blendedFields: [],
-      availableSources: [],
-    });
-
-    await expect(
-      validator.validate(fakeDataMart(), { selectedColumns: ['date', 'revenue'] })
-    ).resolves.toBeUndefined();
+  it('rejects unknown selected columns with a business violation', () => {
+    expect(() => validator.validate({ selectedColumns: ['date', 'ghost'] }, columns)).toThrow(
+      BusinessViolationException
+    );
   });
 
-  it('accepts blended columns without checking access to their source Data Marts (authorized-view model)', async () => {
-    blendable.computeBlendableSchema.mockResolvedValue({
-      nativeFields: [{ name: 'date' }] as never,
-      blendedFields: [
-        { name: 'partner Revenue', sourceDataMartId: 'dm-partner' } as never,
-        { name: 'shared Field', sourceDataMartId: 'dm-shared' } as never,
-      ],
-      availableSources: [],
-    });
-
-    await expect(
-      validator.validate(fakeDataMart(), {
-        selectedColumns: ['date', 'partner Revenue', 'shared Field'],
-      })
-    ).resolves.toBeUndefined();
+  it('rejects columns outside the reporting-visible set (hidden or excluded-source)', () => {
+    expect(() => validator.validate({ selectedColumns: ['orders__secret'] }, columns)).toThrow(
+      BusinessViolationException
+    );
   });
 
-  it('rejects unknown selected columns with a business violation', async () => {
-    blendable.computeBlendableSchema.mockResolvedValue({
-      nativeFields: [{ name: 'date' }] as never,
-      blendedFields: [],
-      availableSources: [],
-    });
+  it('validates post-join filter and sort columns for existence', () => {
+    expect(() =>
+      validator.validate(
+        { selectedColumns: ['date'], sort: [{ column: 'ghost', direction: 'asc' }] },
+        columns
+      )
+    ).toThrow(BusinessViolationException);
 
-    await expect(
-      validator.validate(fakeDataMart(), { selectedColumns: ['date', 'ghost'] })
-    ).rejects.toBeInstanceOf(BusinessViolationException);
+    expect(() =>
+      validator.validate(
+        {
+          selectedColumns: ['date'],
+          filter: [{ column: 'ghost', operator: 'gt', value: 1 }] as never,
+        },
+        columns
+      )
+    ).toThrow(BusinessViolationException);
   });
 
-  it('validates post-join filter and sort columns for existence', async () => {
-    blendable.computeBlendableSchema.mockResolvedValue({
-      nativeFields: [{ name: 'date' }] as never,
-      blendedFields: [],
-      availableSources: [],
-    });
-
-    await expect(
-      validator.validate(fakeDataMart(), {
-        selectedColumns: ['date'],
-        sort: [{ column: 'ghost', direction: 'asc' }],
-      })
-    ).rejects.toBeInstanceOf(BusinessViolationException);
-
-    await expect(
-      validator.validate(fakeDataMart(), {
-        selectedColumns: ['date'],
-        filter: [{ column: 'ghost', operator: 'gt', value: 1 }] as never,
-      })
-    ).rejects.toBeInstanceOf(BusinessViolationException);
-  });
-
-  it('ignores pre-join filter columns (resolved by aliasPath downstream, not by name here)', async () => {
-    blendable.computeBlendableSchema.mockResolvedValue({
-      nativeFields: [{ name: 'date' }] as never,
-      blendedFields: [],
-      availableSources: [{ aliasPath: 'employees', dataMartId: 'dm-employees' }] as never,
-    });
-
-    await expect(
-      validator.validate(fakeDataMart(), {
-        selectedColumns: ['date'],
-        filter: [
-          {
-            column: 'employee_age',
-            operator: 'gt',
-            value: 18,
-            placement: 'pre-join',
-            aliasPath: 'employees',
-          },
-        ] as never,
-      })
-    ).resolves.toBeUndefined();
+  it('ignores pre-join filter columns (resolved by aliasPath downstream, not by name here)', () => {
+    expect(() =>
+      validator.validate(
+        {
+          selectedColumns: ['date'],
+          filter: [
+            {
+              column: 'employee_age',
+              operator: 'gt',
+              value: 18,
+              placement: 'pre-join',
+              aliasPath: 'employees',
+            },
+          ] as never,
+        },
+        columns
+      )
+    ).not.toThrow();
   });
 });

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-validator.service.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-validator.service.ts
@@ -2,8 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
 import { FilterConfig } from '../../dto/schemas/filter-config.schema';
 import { SortConfig } from '../../dto/schemas/sort-config.schema';
-import { DataMart } from '../../entities/data-mart.entity';
-import { BlendableSchemaService } from '../blendable-schema.service';
+import { ReportingColumns } from './http-data-column-sets.util';
 
 export interface HttpDataColumnValidationInput {
   selectedColumns: string[];
@@ -13,18 +12,8 @@ export interface HttpDataColumnValidationInput {
 
 @Injectable()
 export class HttpDataColumnValidator {
-  constructor(private readonly blendableSchemaService: BlendableSchemaService) {}
-
-  async validate(dataMart: DataMart, input: HttpDataColumnValidationInput): Promise<void> {
-    const schema = await this.blendableSchemaService.computeBlendableSchema(
-      dataMart.id,
-      dataMart.projectId
-    );
-
-    const knownColumns = new Set([
-      ...schema.nativeFields.map(field => field.name),
-      ...schema.blendedFields.map(field => field.name),
-    ]);
+  validate(input: HttpDataColumnValidationInput, columns: ReportingColumns): void {
+    const knownColumns = new Set([...columns.native, ...columns.blended]);
 
     const unknownColumns = Array.from(this.collectReferencedColumns(input)).filter(
       column => !knownColumns.has(column)

--- a/apps/backend/src/data-marts/services/http-data/http-data-request-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-request-validator.service.spec.ts
@@ -32,11 +32,15 @@ describe('HttpDataRequestValidator', () => {
     expect(result.columnSelector).toEqual({ mode: 'allNative', explicit: ['orders__revenue'] });
   });
 
-  it('treats "**" as all-blendable and lets it dominate other tokens', () => {
+  it('treats "**" as all-blendable', () => {
     expect(validator.validate({ column: '**' }).columnSelector).toEqual({ mode: 'allBlendable' });
-    expect(validator.validate({ column: ['**', 'date', '*'] }).columnSelector).toEqual({
-      mode: 'allBlendable',
-    });
+  });
+
+  it('rejects "**" combined with other column values', () => {
+    expect(() => validator.validate({ column: ['**', 'date'] })).toThrow(
+      BusinessViolationException
+    );
+    expect(() => validator.validate({ column: ['**', '*'] })).toThrow(BusinessViolationException);
   });
 
   it('rejects empty column value', () => {

--- a/apps/backend/src/data-marts/services/http-data/http-data-request-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-request-validator.service.spec.ts
@@ -4,32 +4,43 @@ import { HttpDataRequestValidator } from './http-data-request-validator.service'
 describe('HttpDataRequestValidator', () => {
   const validator = new HttpDataRequestValidator();
 
-  it('parses a single string column into an array of one', () => {
+  it('parses a single string column into an explicit selector', () => {
     const result = validator.validate({ column: 'date' });
-    expect(result.columns).toEqual(['date']);
+    expect(result.columnSelector).toEqual({ mode: 'explicit', explicit: ['date'] });
   });
 
-  it('preserves repeated column order', () => {
+  it('preserves repeated column order in an explicit selector', () => {
     const result = validator.validate({ column: ['date', 'Revenue Total', 'user_id'] });
-    expect(result.columns).toEqual(['date', 'Revenue Total', 'user_id']);
+    expect(result.columnSelector).toEqual({
+      mode: 'explicit',
+      explicit: ['date', 'Revenue Total', 'user_id'],
+    });
   });
 
-  it('rejects empty column list', () => {
-    expect(() => validator.validate({ column: [] })).toThrow(BusinessViolationException);
+  it('treats a missing column param as all-native', () => {
+    const result = validator.validate({});
+    expect(result.columnSelector).toEqual({ mode: 'allNative', explicit: [] });
   });
 
-  it('rejects missing column param', () => {
-    expect(() => validator.validate({})).toThrow(BusinessViolationException);
+  it('treats "*" as all-native', () => {
+    const result = validator.validate({ column: '*' });
+    expect(result.columnSelector).toEqual({ mode: 'allNative', explicit: [] });
+  });
+
+  it('keeps explicit columns alongside "*" as all-native additions', () => {
+    const result = validator.validate({ column: ['*', 'orders__revenue'] });
+    expect(result.columnSelector).toEqual({ mode: 'allNative', explicit: ['orders__revenue'] });
+  });
+
+  it('treats "**" as all-blendable and lets it dominate other tokens', () => {
+    expect(validator.validate({ column: '**' }).columnSelector).toEqual({ mode: 'allBlendable' });
+    expect(validator.validate({ column: ['**', 'date', '*'] }).columnSelector).toEqual({
+      mode: 'allBlendable',
+    });
   });
 
   it('rejects empty column value', () => {
     expect(() => validator.validate({ column: ['date', ''] })).toThrow(BusinessViolationException);
-  });
-
-  it('rejects duplicate columns', () => {
-    expect(() => validator.validate({ column: ['date', 'date'] })).toThrow(
-      BusinessViolationException
-    );
   });
 
   it('rejects forbidden pagination params', () => {
@@ -46,7 +57,7 @@ describe('HttpDataRequestValidator', () => {
     expect(result.limit).toBe(50);
   });
 
-  it('rejects non-integer / out-of-range limit', () => {
+  it('rejects non-integer or non-positive limit', () => {
     expect(() => validator.validate({ column: 'date', limit: '0' })).toThrow(
       BusinessViolationException
     );

--- a/apps/backend/src/data-marts/services/http-data/http-data-stream-writer.service.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-stream-writer.service.spec.ts
@@ -1,6 +1,6 @@
 import type { Response } from 'express';
 import { HttpDataStreamWriter } from './http-data-stream-writer.service';
-import { HTTP_DATA_COLUMNS_HEADER, HTTP_DATA_RUN_ID_HEADER } from './http-data.constants';
+import { HTTP_DATA_RUN_ID_HEADER } from './http-data.constants';
 
 type Mock = {
   res: Response;
@@ -74,26 +74,13 @@ function createMockResponse(
 describe('HttpDataStreamWriter', () => {
   const writer = new HttpDataStreamWriter();
 
-  it('initHeaders sets NDJSON content type, runId, base64url columns and flushes headers', () => {
+  it('initHeaders sets NDJSON content type, runId and flushes headers', () => {
     const mock = createMockResponse();
-    writer.initHeaders(mock.res, { runId: 'run-1', columns: ['date', 'Revenue Total'] });
+    writer.initHeaders(mock.res, { runId: 'run-1' });
     expect(mock.headers['Content-Type']).toBe('application/x-ndjson; charset=utf-8');
     expect(mock.headers['Cache-Control']).toBe('no-store');
     expect(mock.headers[HTTP_DATA_RUN_ID_HEADER]).toBe('run-1');
-    const decoded = Buffer.from(mock.headers[HTTP_DATA_COLUMNS_HEADER], 'base64url').toString(
-      'utf-8'
-    );
-    expect(JSON.parse(decoded)).toEqual(['date', 'Revenue Total']);
     expect(mock.flushHeadersCalls).toBe(1);
-  });
-
-  it('base64url-encodes non-ASCII column names (URL-safe alphabet, no padding)', () => {
-    const mock = createMockResponse();
-    writer.initHeaders(mock.res, { runId: 'run-2', columns: ['Доход', '📊'] });
-    const encoded = mock.headers[HTTP_DATA_COLUMNS_HEADER];
-    expect(/^[A-Za-z0-9_-]+$/.test(encoded)).toBe(true);
-    const decoded = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf-8'));
-    expect(decoded).toEqual(['Доход', '📊']);
   });
 
   it('serializeRow serializes JSON + newline as a buffer with the correct byte length', () => {

--- a/apps/backend/src/data-marts/services/http-data/http-data-stream-writer.service.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-stream-writer.service.ts
@@ -1,17 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import type { Response } from 'express';
-import { HTTP_DATA_COLUMNS_HEADER, HTTP_DATA_RUN_ID_HEADER } from './http-data.constants';
+import { HTTP_DATA_RUN_ID_HEADER } from './http-data.constants';
 
 @Injectable()
 export class HttpDataStreamWriter {
-  initHeaders(res: Response, meta: { runId: string; columns: string[] }): void {
+  initHeaders(res: Response, meta: { runId: string }): void {
     res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
     res.setHeader('Cache-Control', 'no-store');
     res.setHeader(HTTP_DATA_RUN_ID_HEADER, meta.runId);
-    res.setHeader(
-      HTTP_DATA_COLUMNS_HEADER,
-      Buffer.from(JSON.stringify(meta.columns), 'utf-8').toString('base64url')
-    );
     res.flushHeaders();
   }
 

--- a/apps/backend/src/data-marts/services/http-data/http-data.constants.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data.constants.ts
@@ -1,18 +1,5 @@
 export const STREAM_BATCH_SIZE = 5000;
 
-function envPositiveInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (raw === undefined || raw === '') return fallback;
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
-}
-
-export const HTTP_DATA_MAX_ROWS = envPositiveInt('HTTP_DATA_MAX_ROWS', 10_000_000);
-
-export const HTTP_DATA_MAX_BYTES = envPositiveInt('HTTP_DATA_MAX_BYTES', 1_073_741_824);
-
-export const HTTP_DATA_REQUEST_TIMEOUT_MS = envPositiveInt('HTTP_DATA_REQUEST_TIMEOUT_MS', 300_000);
-
 export const HTTP_DATA_RUN_ID_HEADER = 'x-owox-run-id';
 export const HTTP_DATA_COLUMNS_HEADER = 'x-owox-columns';
 

--- a/apps/backend/src/data-marts/services/http-data/http-data.constants.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data.constants.ts
@@ -1,7 +1,6 @@
 export const STREAM_BATCH_SIZE = 5000;
 
 export const HTTP_DATA_RUN_ID_HEADER = 'x-owox-run-id';
-export const HTTP_DATA_COLUMNS_HEADER = 'x-owox-columns';
 
 export const HTTP_DATA_PARAMS_KEY = 'httpData';
 

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.spec.ts
@@ -18,12 +18,14 @@ import { DataMart } from '../entities/data-mart.entity';
 import { DataMartStatus } from '../enums/data-mart-status.enum';
 import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
 import { AccessDecisionService } from '../services/access-decision/access-decision.service';
+import { BlendableSchemaService } from '../services/blendable-schema.service';
 import { BlendedReportDataService } from '../services/blended-report-data.service';
 import { ConsumptionTrackingService } from '../services/consumption-tracking.service';
 import { DataMartRunService } from '../services/data-mart-run.service';
 import { DataMartService } from '../services/data-mart.service';
 import { ProjectBalanceService } from '../services/project-balance.service';
 import { ReportSqlComposerService } from '../services/report-sql-composer.service';
+import { HttpDataColumnResolver } from '../services/http-data/http-data-column-resolver.service';
 import { HttpDataColumnValidator } from '../services/http-data/http-data-column-validator.service';
 import { HttpDataRequestValidator } from '../services/http-data/http-data-request-validator.service';
 import { HttpDataStreamWriter } from '../services/http-data/http-data-stream-writer.service';
@@ -117,11 +119,13 @@ function mockResponse(): MockResponse {
 
 describe('StreamHttpDataService', () => {
   let requestValidator: jest.Mocked<HttpDataRequestValidator>;
+  let columnResolver: jest.Mocked<HttpDataColumnResolver>;
   let columnValidator: jest.Mocked<HttpDataColumnValidator>;
   let streamWriter: HttpDataStreamWriter;
   let dataMartRunService: jest.Mocked<DataMartRunService>;
   let dataMartService: jest.Mocked<DataMartService>;
   let access: jest.Mocked<AccessDecisionService>;
+  let blendableSchema: jest.Mocked<BlendableSchemaService>;
   let blended: jest.Mocked<BlendedReportDataService>;
   let sqlComposer: jest.Mocked<ReportSqlComposerService>;
   let balance: jest.Mocked<ProjectBalanceService>;
@@ -135,16 +139,33 @@ describe('StreamHttpDataService', () => {
   beforeEach(() => {
     requestValidator = {
       validate: jest.fn(rawQuery => ({
-        columns: (rawQuery as { column: string[] }).column,
+        columnSelector: {
+          mode: 'explicit' as const,
+          explicit: (rawQuery as { column: string[] }).column,
+        },
         filter: undefined,
         sort: undefined,
         limit: undefined,
       })),
     } as unknown as jest.Mocked<HttpDataRequestValidator>;
 
+    columnResolver = {
+      resolve: jest.fn((selector, columns) =>
+        selector.mode === 'explicit' ? selector.explicit : columns.native
+      ),
+    } as unknown as jest.Mocked<HttpDataColumnResolver>;
+
     columnValidator = {
-      validate: jest.fn(async () => undefined),
+      validate: jest.fn(() => undefined),
     } as unknown as jest.Mocked<HttpDataColumnValidator>;
+
+    blendableSchema = {
+      computeBlendableSchema: jest.fn(async () => ({
+        nativeFields: [{ name: 'date' }, { name: 'revenue' }],
+        blendedFields: [],
+        availableSources: [],
+      })),
+    } as unknown as jest.Mocked<BlendableSchemaService>;
 
     streamWriter = new HttpDataStreamWriter();
 
@@ -213,11 +234,13 @@ describe('StreamHttpDataService', () => {
 
     service = new StreamHttpDataService(
       requestValidator,
+      columnResolver,
       columnValidator,
       streamWriter,
       dataMartRunService,
       dataMartService,
       access,
+      blendableSchema,
       blended,
       sqlComposer,
       balance,
@@ -478,9 +501,9 @@ describe('StreamHttpDataService', () => {
     );
   });
 
-  it('composes SQL with the capped limit when a limit is requested', async () => {
+  it('composes SQL with the requested limit', async () => {
     requestValidator.validate.mockReturnValueOnce({
-      columns: ['date', 'revenue'],
+      columnSelector: { mode: 'explicit' as const, explicit: ['date', 'revenue'] },
       filter: undefined,
       sort: undefined,
       limit: 5,
@@ -498,11 +521,11 @@ describe('StreamHttpDataService', () => {
     expect(sqlComposer.compose).not.toHaveBeenCalled();
   });
 
-  it('records decoded filter/sort/capped limit in the run metadata', async () => {
+  it('records decoded filter/sort/limit in the run metadata', async () => {
     const filter = [{ column: 'date', operator: 'gte', value: '2026-05-01' }];
     const sort = [{ column: 'date', direction: 'desc' }];
     requestValidator.validate.mockReturnValueOnce({
-      columns: ['date'],
+      columnSelector: { mode: 'explicit', explicit: ['date'] },
       filter,
       sort,
       limit: 5,
@@ -542,92 +565,35 @@ describe('StreamHttpDataService', () => {
     );
   });
 
-  it('records a FAILED run when the configured row limit is exceeded', async () => {
-    jest.resetModules();
-    process.env.HTTP_DATA_MAX_ROWS = '1';
-    try {
-      const { StreamHttpDataService: IsolatedStreamHttpDataService } =
-        await import('./stream-http-data.service');
-      const isolated = new IsolatedStreamHttpDataService(
-        requestValidator,
-        columnValidator,
-        streamWriter,
-        dataMartRunService,
-        dataMartService,
-        access,
-        blended,
-        sqlComposer,
-        balance,
-        consumption,
-        gracefulShutdown,
-        systemTime,
-        resolver
-      );
-      reader.readReportDataBatch.mockResolvedValueOnce(
-        new ReportDataBatch(
-          [
-            ['2026-05-01', 1],
-            ['2026-05-02', 2],
-          ],
-          null
-        )
-      );
-      const res = mockResponse();
+  it('resolves an all-blendable selector and streams every resolved column', async () => {
+    requestValidator.validate.mockReturnValueOnce({
+      columnSelector: { mode: 'allBlendable' as const },
+      filter: undefined,
+      sort: undefined,
+      limit: undefined,
+    });
+    columnResolver.resolve.mockReturnValueOnce(['date', 'revenue', 'orders__cost']);
+    reader.prepareReportData.mockResolvedValueOnce(
+      new ReportDataDescription([
+        new ReportDataHeader('date'),
+        new ReportDataHeader('revenue'),
+        new ReportDataHeader('orders__cost'),
+      ])
+    );
+    reader.readReportDataBatch.mockResolvedValueOnce(
+      new ReportDataBatch([['2026-05-01', 42, 7]], null)
+    );
+    const res = mockResponse();
 
-      await expect(isolated.stream(fakeCommand(), res)).resolves.toBeUndefined();
+    await service.stream(fakeCommand(), res);
 
-      expect(res._writes).toHaveLength(1);
-      expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: DataMartRunStatus.FAILED,
-          errors: expect.arrayContaining([expect.stringContaining('Row limit')]),
-        })
-      );
-    } finally {
-      delete process.env.HTTP_DATA_MAX_ROWS;
-      jest.resetModules();
-    }
-  });
-
-  it('records a FAILED run and does not write the row that would exceed the byte cap', async () => {
-    jest.resetModules();
-    process.env.HTTP_DATA_MAX_BYTES = '10';
-    try {
-      const { StreamHttpDataService: IsolatedStreamHttpDataService } =
-        await import('./stream-http-data.service');
-      const isolated = new IsolatedStreamHttpDataService(
-        requestValidator,
-        columnValidator,
-        streamWriter,
-        dataMartRunService,
-        dataMartService,
-        access,
-        blended,
-        sqlComposer,
-        balance,
-        consumption,
-        gracefulShutdown,
-        systemTime,
-        resolver
-      );
-      reader.readReportDataBatch.mockResolvedValueOnce(
-        new ReportDataBatch([['2026-05-01', 1]], null)
-      );
-      const res = mockResponse();
-
-      await expect(isolated.stream(fakeCommand(), res)).resolves.toBeUndefined();
-
-      expect(res._writes).toHaveLength(0);
-      expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: DataMartRunStatus.FAILED,
-          errors: expect.arrayContaining([expect.stringContaining('Byte limit')]),
-        })
-      );
-    } finally {
-      delete process.env.HTTP_DATA_MAX_BYTES;
-      jest.resetModules();
-    }
+    expect(res._writes).toEqual(['{"date":"2026-05-01","revenue":42,"orders__cost":7}\n']);
+    expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: DataMartRunStatus.SUCCESS,
+        metadata: expect.objectContaining({ columns: ['date', 'revenue', 'orders__cost'] }),
+      })
+    );
   });
 
   it('uses the blended SQL as sqlOverride when the decision needs blending', async () => {

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
@@ -316,7 +316,7 @@ export class StreamHttpDataService {
         const batch = await this.readBatchOrAbort(reader, nextBatchId, abortController.signal);
 
         if (!headersSent) {
-          this.streamWriter.initHeaders(res, { runId, columns: requestedColumns });
+          this.streamWriter.initHeaders(res, { runId });
           headersSent = true;
         }
 

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
@@ -26,15 +26,19 @@ import { ConsumptionTrackingService } from '../services/consumption-tracking.ser
 import { DataMartService } from '../services/data-mart.service';
 import { ProjectBalanceService } from '../services/project-balance.service';
 import { ReportSqlComposerService } from '../services/report-sql-composer.service';
+import { HttpDataColumnResolver } from '../services/http-data/http-data-column-resolver.service';
 import { HttpDataColumnValidator } from '../services/http-data/http-data-column-validator.service';
+import {
+  nativeColumnNames,
+  visibleBlendedColumnNames,
+  ReportingColumns,
+} from '../services/http-data/http-data-column-sets.util';
 import { HttpDataRequestValidator } from '../services/http-data/http-data-request-validator.service';
 import { HttpDataStreamWriter } from '../services/http-data/http-data-stream-writer.service';
+import { BlendableSchemaService } from '../services/blendable-schema.service';
 import { DataMartRunService } from '../services/data-mart-run.service';
 import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
 import {
-  HTTP_DATA_MAX_BYTES,
-  HTTP_DATA_MAX_ROWS,
-  HTTP_DATA_REQUEST_TIMEOUT_MS,
   HTTP_DATA_SCHEMA_EXPIRES_AFTER_MS,
   STREAM_BATCH_SIZE,
 } from '../services/http-data/http-data.constants';
@@ -55,11 +59,13 @@ export class StreamHttpDataService {
 
   constructor(
     private readonly requestValidator: HttpDataRequestValidator,
+    private readonly columnResolver: HttpDataColumnResolver,
     private readonly columnValidator: HttpDataColumnValidator,
     private readonly streamWriter: HttpDataStreamWriter,
     private readonly dataMartRunService: DataMartRunService,
     private readonly dataMartService: DataMartService,
     private readonly accessDecisionService: AccessDecisionService,
+    private readonly blendableSchemaService: BlendableSchemaService,
     private readonly blendedReportDataService: BlendedReportDataService,
     private readonly reportSqlComposerService: ReportSqlComposerService,
     private readonly projectBalanceService: ProjectBalanceService,
@@ -76,8 +82,7 @@ export class StreamHttpDataService {
     }
 
     const query = this.requestValidator.validate(command.rawQuery);
-    const effectiveLimit =
-      query.limit == null ? undefined : Math.min(query.limit, HTTP_DATA_MAX_ROWS);
+    const limit = query.limit;
     const ctx: AuthorizationContext = {
       userId: command.userId,
       projectId: command.projectId,
@@ -89,19 +94,27 @@ export class StreamHttpDataService {
       dataMart,
       HTTP_DATA_SCHEMA_EXPIRES_AFTER_MS
     );
-    await this.columnValidator.validate(dataMart, {
-      selectedColumns: query.columns,
-      filter: query.filter,
-      sort: query.sort,
-    });
+    const blendableSchema = await this.blendableSchemaService.computeBlendableSchema(
+      dataMart.id,
+      dataMart.projectId
+    );
+    const reportingColumns: ReportingColumns = {
+      native: nativeColumnNames(blendableSchema),
+      blended: visibleBlendedColumnNames(blendableSchema),
+    };
+    const columns = this.columnResolver.resolve(query.columnSelector, reportingColumns);
+    this.columnValidator.validate(
+      { selectedColumns: columns, filter: query.filter, sort: query.sort },
+      reportingColumns
+    );
     await this.projectBalanceService.verifyCanPerformOperations(dataMart.projectId);
 
     const readPlan: ReportLikeReadPlan = {
       dataMart,
-      columnConfig: query.columns,
+      columnConfig: columns,
       filterConfig: query.filter,
       sortConfig: query.sort,
-      limitConfig: effectiveLimit ?? null,
+      limitConfig: limit ?? null,
     };
 
     const decision = await this.blendedReportDataService.resolveBlendingDecision(readPlan);
@@ -113,7 +126,7 @@ export class StreamHttpDataService {
     let sqlOverride: string | undefined = decision.blendedSql;
     let sqlOverrideParams = decision.params;
     const hasOutputControls =
-      (query.filter?.length ?? 0) > 0 || (query.sort?.length ?? 0) > 0 || effectiveLimit != null;
+      (query.filter?.length ?? 0) > 0 || (query.sort?.length ?? 0) > 0 || limit != null;
     if (!decision.needsBlending && hasOutputControls) {
       const composed = await this.reportSqlComposerService.compose(readPlan, decision);
       sqlOverride = composed.sql;
@@ -124,10 +137,10 @@ export class StreamHttpDataService {
     const startedAt = this.systemTimeService.now();
     const baseMetadata: HttpDataRunMetadata = {
       format: HTTP_DATA_FORMAT,
-      columns: query.columns,
+      columns,
       filter: query.filter,
       sort: query.sort,
-      limit: effectiveLimit,
+      limit,
     };
 
     let reader: DataStorageReportReader | null = null;
@@ -145,7 +158,7 @@ export class StreamHttpDataService {
         res,
         reader,
         description.dataHeaders,
-        query.columns,
+        columns,
         runId
       );
 
@@ -278,12 +291,6 @@ export class StreamHttpDataService {
   ): Promise<{ rowCount: number; bytesWritten: number }> {
     const fieldIndexMap = this.buildFieldIndexMap(dataHeaders, requestedColumns);
     const abortController = new AbortController();
-    const timeoutHandle = setTimeout(() => {
-      abortController.abort(
-        new StreamCancelledError(`Stream timed out after ${HTTP_DATA_REQUEST_TIMEOUT_MS}ms`)
-      );
-    }, HTTP_DATA_REQUEST_TIMEOUT_MS);
-    timeoutHandle.unref?.();
     const onClose = () =>
       abortController.abort(
         new StreamCancelledError('Client disconnected before stream completion')
@@ -315,9 +322,6 @@ export class StreamHttpDataService {
 
         for (const row of batch.dataRows) {
           this.throwIfAborted(abortController.signal);
-          if (rowCount >= HTTP_DATA_MAX_ROWS) {
-            throw new Error(`Row limit reached (${HTTP_DATA_MAX_ROWS})`);
-          }
 
           const obj: Record<string, unknown> = {};
           for (let i = 0; i < requestedColumns.length; i++) {
@@ -326,9 +330,6 @@ export class StreamHttpDataService {
           }
 
           const chunk = this.streamWriter.serializeRow(obj);
-          if (bytesWritten + chunk.length > HTTP_DATA_MAX_BYTES) {
-            throw new Error(`Byte limit reached (${HTTP_DATA_MAX_BYTES})`);
-          }
           await this.streamWriter.writeChunk(res, chunk, abortController.signal);
           bytesWritten += chunk.length;
           rowCount += 1;
@@ -339,7 +340,6 @@ export class StreamHttpDataService {
 
       return { rowCount, bytesWritten };
     } finally {
-      clearTimeout(timeoutHandle);
       res.off('close', onClose);
       res.off('error', onError);
     }

--- a/apps/backend/test/http-data.e2e-spec.ts
+++ b/apps/backend/test/http-data.e2e-spec.ts
@@ -116,13 +116,6 @@ describe('HTTP Data API (e2e)', () => {
   // multi-tenant IdpProvider example if real 401 coverage is needed.
 
   describe('Request validation', () => {
-    it('returns 400 when column param is missing', async () => {
-      const res = await agent
-        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson`)
-        .set(AUTH_HEADER);
-      expect(res.status).toBe(400);
-    });
-
     it('returns 400 when column is empty string', async () => {
       const res = await agent
         .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=`)
@@ -130,9 +123,9 @@ describe('HTTP Data API (e2e)', () => {
       expect(res.status).toBe(400);
     });
 
-    it('returns 400 when columns are duplicated', async () => {
+    it('returns 400 when ** is combined with other columns', async () => {
       const res = await agent
-        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=date&column=date`)
+        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=**&column=date`)
         .set(AUTH_HEADER);
       expect(res.status).toBe(400);
     });
@@ -168,9 +161,7 @@ describe('HTTP Data API (e2e)', () => {
       expect(res.status).toBe(200);
       expect(res.headers['content-type']).toContain('application/x-ndjson');
       expect(res.headers['x-owox-run-id']).toBeDefined();
-      expect(
-        JSON.parse(Buffer.from(res.headers['x-owox-columns'], 'base64url').toString('utf-8'))
-      ).toEqual(['date', 'revenue']);
+      expect(res.headers['x-owox-columns']).toBeUndefined();
 
       const lines = parseNdjson(res.text);
       expect(lines).toEqual([
@@ -196,6 +187,38 @@ describe('HTTP Data API (e2e)', () => {
       expect(res.status).toBe(200);
       expect(res.text).not.toMatch(/"type"\s*:/);
       expect(res.text).not.toMatch(/"meta"|"done"/);
+    });
+
+    it('streams all native columns when column is omitted', async () => {
+      const res = await agent
+        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson`)
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(200);
+      expect(parseNdjson(res.text)).toEqual([
+        { date: '2026-05-01', revenue: 42.5 },
+        { date: '2026-05-02', revenue: 51.0 },
+        { date: '2026-05-03', revenue: 100.25 },
+      ]);
+    });
+
+    it('treats * as all native columns', async () => {
+      const res = await agent
+        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=*`)
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(200);
+      expect(parseNdjson(res.text)).toEqual([
+        { date: '2026-05-01', revenue: 42.5 },
+        { date: '2026-05-02', revenue: 51.0 },
+        { date: '2026-05-03', revenue: 100.25 },
+      ]);
+    });
+
+    it('de-duplicates repeated columns instead of rejecting them', async () => {
+      const res = await agent
+        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=date&column=date`)
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(200);
+      expect(res.text.split('\n')[0]).toBe('{"date":"2026-05-01"}');
     });
   });
 


### PR DESCRIPTION
# HTTP Data API — optional `column` with `*`/`**` selectors, no hard caps

Follow-up to the HTTP Data API NDJSON streaming endpoint. Removes the artificial streaming
limits and makes the `column` query parameter optional with two reserved expansion values,
while keeping column exposure aligned with the reporting column picker.

## What changed

### Removed limits

- **`HTTP_DATA_MAX_ROWS`**, **`HTTP_DATA_MAX_BYTES`**, **`HTTP_DATA_REQUEST_TIMEOUT_MS`** — the
  hard streaming caps and the request timeout are gone. Streams now run until the data is
  exhausted, the client disconnects, the response errors, or the server enters shutdown
  (the `AbortController` still guards a stalled backpressure drain).
- **100-column cap** (`HTTP_DATA_MAX_COLUMNS`) — removed.
- **`limit` upper bound** (`HTTP_DATA_MAX_USER_LIMIT`, 10,000,000) — removed; `limit` is now any
  positive integer.
- `bytesWritten`/`rowCount` are still tracked and recorded in the run metadata.

### Optional `column` with reserved selectors

- `column` is now optional. Two reserved values expand to column sets:
  - `*` — all native columns.
  - `**` — all native columns plus all reporting-visible blended columns.
- `*` can be combined with explicit columns (e.g. `column=*&column=orders__revenue` = all native
  plus that blended field). Omitting `column` is equivalent to `*`. Overlaps are de-duplicated.
- The previous hard rejection of duplicate `column` values is replaced by de-duplication, since
  `*` plus explicit columns legitimately overlap.

### Reporting-visibility is enforced (not just for `**`)

Column exposure now mirrors the reporting column picker, derived entirely from the existing
`BlendableSchemaDto` flags — both for sentinel expansion and for validating explicit selections:

- **Native**: fields flagged `isHiddenForReporting` (at every nesting level) and fields with
  `status === DISCONNECTED` are excluded — matching the report header generators.
- **Blended**: fields flagged `isHidden`, and any field belonging to an excluded source
  (`availableSources` with `isIncluded === false`), are excluded.

As a result, hidden/excluded columns are rejected with a `400` even when requested explicitly —
previously the validator accepted any blended field name.

## Implementation notes

- New `http-data-column-sets.util.ts` exposes `nativeColumnNames(schema)` and
  `visibleBlendedColumnNames(schema)` — the single source of truth shared by the resolver and the
  validator. The blended predicate must stay in sync with the web `ReportColumnPicker`.
- New `HttpDataColumnResolver` turns a parsed `ColumnSelector` (`allNative` / `allBlendable` /
  `explicit`) into a concrete, de-duplicated column list; an empty result is a `400`.
- `HttpDataColumnValidator` no longer recomputes the blendable schema — it takes the precomputed
  `BlendableSchemaDto` (computed once per request in the use-case) and validates against the
  reporting-visible column universe.
- The resolved concrete column list drives blending detection, the run metadata, and the NDJSON
  row keys.
- The `x-owox-columns` response header is removed: with the column cap gone, an unbounded selector
  could push that header past proxy/client header-size limits. Clients infer columns from the row
  keys; the resolved column list is still recorded in the run metadata. `x-owox-run-id` stays.

## Tests

- Updated `http-data-request-validator` specs: `column` optional, `*`/`**` parsing, `*` + explicit
  mixing, `**` dominance; removed the now-invalid "missing/empty/duplicate column" cases.
- New `http-data-column-resolver` specs: `*`/`**` expansion, nested-native flattening, hidden-native
  exclusion, blended visibility, mixing, de-duplication, empty-result `400`.
- Updated `http-data-column-validator` specs: reporting-visible validation; explicit hidden-native,
  hidden-blended, and excluded-source columns are rejected.
- `stream-http-data` specs: dropped the env-driven row/byte-cap tests; added an all-blendable
  selector wiring test.

## Swagger

`column` is documented as optional with the `*`/`**` semantics and mixing rules; the `limit`
description drops the upper bound; the operation summary no longer claims columns must be
explicitly selected.
