### PR TITLE
fix(web): Fix inconsistent date formatting in ApiKeysTable

### DIFF
--- a/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
@@ -8,6 +8,7 @@ import {
 } from '@owox/ui/components/dropdown-menu';
 import { Copy, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import RelativeTime from '@owox/ui/components/common/relative-time';
+import { formatDateOnly } from '../../../../utils';
 import { SortableHeader, ToggleColumnsHeader } from '../../../../shared/components/Table';
 import type { ProjectMemberApiKey } from '../../types';
 import toast from 'react-hot-toast';
@@ -71,7 +72,7 @@ export const getApiKeysColumns = ({
       const expiring = isExpiringSoon(expiresAt);
       return (
         <span className={expiring ? 'font-medium text-amber-600' : ''}>
-          {new Date(expiresAt).toLocaleDateString()}
+          {formatDateOnly(expiresAt)}
         </span>
       );
     },

--- a/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
@@ -72,7 +72,7 @@ export const getApiKeysColumns = ({
       const expiring = isExpiringSoon(expiresAt);
       return (
         <span className={expiring ? 'font-medium text-amber-600' : ''}>
-          {formatDateOnly(expiresAt)}
+          {formatDateOnly(expiresAt, { timeZone: 'UTC' })}
         </span>
       );
     },

--- a/apps/web/src/utils/date-formatters.ts
+++ b/apps/web/src/utils/date-formatters.ts
@@ -28,7 +28,10 @@ export const formatDateShort = (date: Date | string | null): string => {
   }).format(d);
 };
 
-export const formatDateOnly = (date: Date | string | null): string => {
+export const formatDateOnly = (
+  date: Date | string | null,
+  options?: { timeZone?: string }
+): string => {
   if (!date) return '—';
 
   let d: Date;
@@ -44,6 +47,7 @@ export const formatDateOnly = (date: Date | string | null): string => {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
+    ...options,
   }).format(d);
 };
 


### PR DESCRIPTION
Replaced date formatting logic in `ApiKeysTable` with `formatDateOnly` function for consistency across the application.
