### PR TITLE
Fix npm package README publishing

### DIFF
--- a/apps/ctl/README.md
+++ b/apps/ctl/README.md
@@ -5,7 +5,8 @@ OWOX Data Marts Control CLI.
 `owox` runs and manages a local or self-managed OWOX Data Marts runtime.
 `owox-ctl` controls an existing OWOX Data Marts instance through the HTTP API.
 
-The full user documentation lives in [docs/api/owox-ctl.md](../../docs/api/owox-ctl.md).
+The full user documentation lives in
+[owox-ctl API documentation](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/owox-ctl.md).
 
 ## Install
 

--- a/apps/ctl/README.md
+++ b/apps/ctl/README.md
@@ -6,7 +6,7 @@ OWOX Data Marts Control CLI.
 `owox-ctl` controls an existing OWOX Data Marts instance through the HTTP API.
 
 The full user documentation lives in
-[owox-ctl API documentation](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/owox-ctl.md).
+[owox-ctl API documentation](https://docs.owox.com/docs/api/owox-ctl/).
 
 ## Install
 

--- a/apps/ctl/package.json
+++ b/apps/ctl/package.json
@@ -32,6 +32,7 @@
     "node": ">=22.16.0"
   },
   "files": [
+    "./README.md",
     "./bin",
     "./dist/**/*.d.ts",
     "./dist/**/*.js",

--- a/apps/ctl/src/package-readme.test.ts
+++ b/apps/ctl/src/package-readme.test.ts
@@ -4,9 +4,8 @@ describe('package README', () => {
   const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
 
   it('links to the full CLI documentation with a stable package-safe URL', () => {
-    expect(readme).toContain(
-      'https://github.com/OWOX/owox-data-marts/blob/main/docs/api/owox-ctl.md'
-    );
+    expect(readme).toContain('https://docs.owox.com/docs/api/owox-ctl/');
     expect(readme).not.toContain('../../docs/api/owox-ctl.md');
+    expect(readme).not.toContain('github.com/OWOX/owox-data-marts/blob/main/docs');
   });
 });

--- a/apps/ctl/src/package-readme.test.ts
+++ b/apps/ctl/src/package-readme.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+
+describe('package README', () => {
+  const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+
+  it('links to the full CLI documentation with a stable package-safe URL', () => {
+    expect(readme).toContain(
+      'https://github.com/OWOX/owox-data-marts/blob/main/docs/api/owox-ctl.md'
+    );
+    expect(readme).not.toContain('../../docs/api/owox-ctl.md');
+  });
+});

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -3,133 +3,14 @@
 TypeScript/JavaScript client for calling the OWOX Data Marts API from custom
 scripts, internal tools, automation, and local agent workflows.
 
-Use `owox-ctl` for terminal commands. Use `@owox/api-client` for code-level
-integrations.
-
-The full user documentation lives in
-[@owox/api-client API documentation](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/api-client.md).
-
 ## Install
 
 ```bash
 npm install @owox/api-client
 ```
 
-## Create an API key
+## Documentation
 
-Before using `@owox/api-client`, create an API key. See
-[API Keys](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/api-keys.md).
-
-## Basic usage
-
-Set credentials as environment variables:
-
-```bash
-export OWOX_API_ORIGIN=https://app.owox.com
-export OWOX_API_KEY_ID=pmk_xxx
-export OWOX_API_KEY_SECRET=your_api_key_secret
-```
-
-Then create a client:
-
-```ts
-import { OWOXApiClient } from '@owox/api-client';
-
-const client = new OWOXApiClient({
-  apiOrigin: process.env.OWOX_API_ORIGIN!,
-  apiKeyId: process.env.OWOX_API_KEY_ID!,
-  apiKeySecret: process.env.OWOX_API_KEY_SECRET!,
-});
-
-const dataMarts = await client.dataMarts.list();
-
-console.log(dataMarts);
-```
-
-## Common operations
-
-```ts
-const dataMarts = await client.dataMarts.list();
-const storages = await client.storages.list();
-const destinations = await client.destinations.list();
-```
-
-## Use in local agents and scripts
-
-Local agents can run scripts that use `@owox/api-client` when they need
-structured access to OWOX Data Marts from TypeScript or JavaScript.
-
-```ts
-import { OWOXApiClient } from '@owox/api-client';
-
-const client = new OWOXApiClient({
-  apiOrigin: process.env.OWOX_API_ORIGIN!,
-  apiKeyId: process.env.OWOX_API_KEY_ID!,
-  apiKeySecret: process.env.OWOX_API_KEY_SECRET!,
-});
-
-const [dataMarts, storages, destinations] = await Promise.all([
-  client.dataMarts.list(),
-  client.storages.list(),
-  client.destinations.list(),
-]);
-
-console.log(
-  JSON.stringify(
-    {
-      dataMarts,
-      storages,
-      destinations,
-    },
-    null,
-    2
-  )
-);
-```
-
-## Security notes
-
-- Do not hard-code API key secrets in source code.
-- Use environment variables or a secret manager.
-- Do not commit `.env` files containing API key secrets.
-- Avoid putting API key secrets in agent instructions or prompts.
-- Revoke keys that are no longer used.
-
-## Authentication behavior
-
-`@owox/api-client` uses the API key ID and API key secret to request a
-short-lived access token.
-
-The access token is kept in memory for the current process and is not persisted.
-
-## Error handling
-
-`@owox/api-client` exports typed errors for request and authentication failures.
-
-```ts
-import { OWOXApiError, OWOXAuthError } from '@owox/api-client';
-
-try {
-  const dataMarts = await client.dataMarts.list();
-  console.log(dataMarts);
-} catch (error) {
-  if (error instanceof OWOXAuthError) {
-    console.error('Authentication failed');
-  } else if (error instanceof OWOXApiError) {
-    console.error(`OWOX API request failed: ${error.message}`);
-  } else {
-    throw error;
-  }
-}
-```
-
-## Compatibility
-
-The same `@owox/api-client` and OWOX Data Marts server version is supported.
-Different versions are best effort.
-
-## Related docs
-
-- [API Keys](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/api-keys.md)
-- [owox-ctl](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/owox-ctl.md)
-- [OpenAPI and Swagger UI](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/openapi.md)
+- [@owox/api-client guide](https://docs.owox.com/docs/api/api-client/)
+- [API Keys](https://docs.owox.com/docs/api/api-keys/)
+- [OpenAPI and Swagger UI](https://docs.owox.com/docs/api/openapi/)

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -1,0 +1,135 @@
+# @owox/api-client
+
+TypeScript/JavaScript client for calling the OWOX Data Marts API from custom
+scripts, internal tools, automation, and local agent workflows.
+
+Use `owox-ctl` for terminal commands. Use `@owox/api-client` for code-level
+integrations.
+
+The full user documentation lives in
+[@owox/api-client API documentation](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/api-client.md).
+
+## Install
+
+```bash
+npm install @owox/api-client
+```
+
+## Create an API key
+
+Before using `@owox/api-client`, create an API key. See
+[API Keys](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/api-keys.md).
+
+## Basic usage
+
+Set credentials as environment variables:
+
+```bash
+export OWOX_API_ORIGIN=https://app.owox.com
+export OWOX_API_KEY_ID=pmk_xxx
+export OWOX_API_KEY_SECRET=your_api_key_secret
+```
+
+Then create a client:
+
+```ts
+import { OWOXApiClient } from '@owox/api-client';
+
+const client = new OWOXApiClient({
+  apiOrigin: process.env.OWOX_API_ORIGIN!,
+  apiKeyId: process.env.OWOX_API_KEY_ID!,
+  apiKeySecret: process.env.OWOX_API_KEY_SECRET!,
+});
+
+const dataMarts = await client.dataMarts.list();
+
+console.log(dataMarts);
+```
+
+## Common operations
+
+```ts
+const dataMarts = await client.dataMarts.list();
+const storages = await client.storages.list();
+const destinations = await client.destinations.list();
+```
+
+## Use in local agents and scripts
+
+Local agents can run scripts that use `@owox/api-client` when they need
+structured access to OWOX Data Marts from TypeScript or JavaScript.
+
+```ts
+import { OWOXApiClient } from '@owox/api-client';
+
+const client = new OWOXApiClient({
+  apiOrigin: process.env.OWOX_API_ORIGIN!,
+  apiKeyId: process.env.OWOX_API_KEY_ID!,
+  apiKeySecret: process.env.OWOX_API_KEY_SECRET!,
+});
+
+const [dataMarts, storages, destinations] = await Promise.all([
+  client.dataMarts.list(),
+  client.storages.list(),
+  client.destinations.list(),
+]);
+
+console.log(
+  JSON.stringify(
+    {
+      dataMarts,
+      storages,
+      destinations,
+    },
+    null,
+    2
+  )
+);
+```
+
+## Security notes
+
+- Do not hard-code API key secrets in source code.
+- Use environment variables or a secret manager.
+- Do not commit `.env` files containing API key secrets.
+- Avoid putting API key secrets in agent instructions or prompts.
+- Revoke keys that are no longer used.
+
+## Authentication behavior
+
+`@owox/api-client` uses the API key ID and API key secret to request a
+short-lived access token.
+
+The access token is kept in memory for the current process and is not persisted.
+
+## Error handling
+
+`@owox/api-client` exports typed errors for request and authentication failures.
+
+```ts
+import { OWOXApiError, OWOXAuthError } from '@owox/api-client';
+
+try {
+  const dataMarts = await client.dataMarts.list();
+  console.log(dataMarts);
+} catch (error) {
+  if (error instanceof OWOXAuthError) {
+    console.error('Authentication failed');
+  } else if (error instanceof OWOXApiError) {
+    console.error(`OWOX API request failed: ${error.message}`);
+  } else {
+    throw error;
+  }
+}
+```
+
+## Compatibility
+
+The same `@owox/api-client` and OWOX Data Marts server version is supported.
+Different versions are best effort.
+
+## Related docs
+
+- [API Keys](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/api-keys.md)
+- [owox-ctl](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/owox-ctl.md)
+- [OpenAPI and Swagger UI](https://github.com/OWOX/owox-data-marts/blob/main/docs/api/openapi.md)

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -44,6 +44,7 @@
     "ts-jest": "^29.4.6"
   },
   "files": [
+    "README.md",
     "dist"
   ],
   "exports": {

--- a/packages/api-client/src/package-readme.test.ts
+++ b/packages/api-client/src/package-readme.test.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 describe('package README', () => {
   const readmeUrl = new URL('../README.md', import.meta.url);
 
-  it('provides npm users with install, usage, and package-safe documentation links', () => {
+  it('provides npm users with install and package-safe documentation links', () => {
     if (!existsSync(readmeUrl)) {
       throw new Error('packages/api-client/README.md must exist for npm package publishing');
     }
@@ -12,13 +12,13 @@ describe('package README', () => {
 
     expect(readme).toContain('# @owox/api-client');
     expect(readme).toContain('npm install @owox/api-client');
-    expect(readme).toContain('new OWOXApiClient');
-    expect(readme).toContain(
-      'https://github.com/OWOX/owox-data-marts/blob/main/docs/api/api-client.md'
-    );
-    expect(readme).toContain(
-      'https://github.com/OWOX/owox-data-marts/blob/main/docs/api/api-keys.md'
-    );
+    expect(readme).toContain('https://docs.owox.com/docs/api/api-client/');
+    expect(readme).toContain('https://docs.owox.com/docs/api/api-keys/');
+    expect(readme).toContain('https://docs.owox.com/docs/api/openapi/');
+    expect(readme).not.toContain('github.com/OWOX/owox-data-marts/blob/main/docs');
+    expect(readme).not.toContain('new OWOXApiClient');
+    expect(readme).not.toContain('## Basic usage');
+    expect(readme).not.toContain('## Error handling');
     expect(readme).not.toContain('./api-keys/');
     expect(readme).not.toContain('./owox-ctl/');
     expect(readme).not.toContain('./openapi/');

--- a/packages/api-client/src/package-readme.test.ts
+++ b/packages/api-client/src/package-readme.test.ts
@@ -1,0 +1,26 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+describe('package README', () => {
+  const readmeUrl = new URL('../README.md', import.meta.url);
+
+  it('provides npm users with install, usage, and package-safe documentation links', () => {
+    if (!existsSync(readmeUrl)) {
+      throw new Error('packages/api-client/README.md must exist for npm package publishing');
+    }
+
+    const readme = readFileSync(readmeUrl, 'utf8');
+
+    expect(readme).toContain('# @owox/api-client');
+    expect(readme).toContain('npm install @owox/api-client');
+    expect(readme).toContain('new OWOXApiClient');
+    expect(readme).toContain(
+      'https://github.com/OWOX/owox-data-marts/blob/main/docs/api/api-client.md'
+    );
+    expect(readme).toContain(
+      'https://github.com/OWOX/owox-data-marts/blob/main/docs/api/api-keys.md'
+    );
+    expect(readme).not.toContain('./api-keys/');
+    expect(readme).not.toContain('./owox-ctl/');
+    expect(readme).not.toContain('./openapi/');
+  });
+});


### PR DESCRIPTION
## Summary

- Add a short package-root README for `@owox/api-client` so npm displays install guidance without duplicating the primary docs.
- Replace the package-external relative `@owox/ctl` docs link with a direct `docs.owox.com` URL.
- Explicitly include package READMEs in both npm `files` lists and add regression tests for package-safe README links/content.

## Root Cause

`@owox/api-client` did not have a `README.md` in its package directory, so the published npm package had no README. `@owox/ctl` shipped a README, but its documentation link pointed outside the package via `../../docs/api/owox-ctl.md`, which breaks when rendered on npm.

## Review Follow-up

The package READMEs now use public `docs.owox.com` documentation links. The `@owox/api-client` README is intentionally minimal and links to the canonical guide, API key docs, and OpenAPI docs instead of copying guide content into the npm package README.

## Validation

- `npm --cache /private/tmp/owox-npm-cache run test -w @owox/ctl`
- `npm --cache /private/tmp/owox-npm-cache run test -w @owox/api-client`
- `npm --cache /private/tmp/owox-npm-cache run lint -w @owox/ctl`
- `npm --cache /private/tmp/owox-npm-cache run lint -w @owox/api-client`
- `npm --cache /private/tmp/owox-npm-cache run format:check -w @owox/ctl`
- `npm --cache /private/tmp/owox-npm-cache run format:check -w @owox/api-client`
- `npm --cache /private/tmp/owox-npm-cache run lint:md:all -- apps/ctl/README.md packages/api-client/README.md`
- `npm pack --dry-run --json --ignore-scripts --cache /private/tmp/owox-npm-cache -w @owox/ctl`
- `npm pack --dry-run --json --ignore-scripts --cache /private/tmp/owox-npm-cache -w @owox/api-client`