### PR TITLE
chore(web): rename "Available for" labels to "Shared for" across UI and docs

### DIFF
--- a/.changeset/availability-shared-for-rename.md
+++ b/.changeset/availability-shared-for-rename.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Availability labels renamed to "Shared for use / reporting / maintenance"
+
+The availability toggle labels throughout the product have been renamed from "Available for use", "Available for reporting", and "Available for maintenance" to "Shared for use", "Shared for reporting", and "Shared for maintenance". The filter option previously labelled "Not available" is now "Not shared". This change makes the language more consistent and better reflects the collaborative sharing intent behind the toggles.

--- a/apps/web/e2e/specs/availability.spec.ts
+++ b/apps/web/e2e/specs/availability.spec.ts
@@ -15,8 +15,8 @@ async function ensureSectionExpanded(container: Locator, sectionName: string): P
 /**
  * Get the two availability switches within a container.
  * Returns [primarySwitch, maintenanceSwitch] — the first switch is
- * "Available for use" (storage/destination) or "Available for reporting" (data-mart),
- * the second is always "Available for maintenance".
+ * "Shared for use" (storage/destination) or "Shared for reporting" (data-mart),
+ * the second is always "Shared for maintenance".
  */
 function getAvailabilitySwitches(container: Locator | Page): [Locator, Locator] {
   const switches = container.getByRole('switch');
@@ -46,8 +46,8 @@ test.describe('Storage Availability', () => {
     await ensureSectionExpanded(sheet, 'Availability');
 
     // Both labels should be visible
-    await expect(sheet.getByText('Available for use', { exact: true })).toBeVisible();
-    await expect(sheet.getByText('Available for maintenance', { exact: true })).toBeVisible();
+    await expect(sheet.getByText('Shared for use', { exact: true })).toBeVisible();
+    await expect(sheet.getByText('Shared for maintenance', { exact: true })).toBeVisible();
   });
 
   test('availability defaults to use=ON, maintenance=OFF for new storage (AVL-02)', async ({
@@ -76,7 +76,7 @@ test.describe('Storage Availability', () => {
 
   test('availability set via API is reflected in UI (AVL-03)', async ({ page, apiHelpers }) => {
     const storage = await apiHelpers.createStorage('GOOGLE_BIGQUERY');
-    // Set "Available for maintenance" to OFF via API
+    // Set "Shared for maintenance" to OFF via API
     await apiHelpers.setStorageAvailability(storage.id, true, false);
 
     await page.goto('/ui/0/data-storages');
@@ -92,7 +92,7 @@ test.describe('Storage Availability', () => {
     // Expand Availability section
     await ensureSectionExpanded(sheet, 'Availability');
 
-    // "Available for use" should be ON, "Available for maintenance" should be OFF
+    // "Shared for use" should be ON, "Shared for maintenance" should be OFF
     const [useSwitch, maintenanceSwitch] = getAvailabilitySwitches(sheet);
     await expect(useSwitch).toHaveAttribute('data-state', 'checked');
     await expect(maintenanceSwitch).toHaveAttribute('data-state', 'unchecked');
@@ -116,8 +116,8 @@ test.describe('Destination Availability', () => {
     // Expand Availability section
     await ensureSectionExpanded(sheet, 'Availability');
 
-    await expect(sheet.getByText('Available for use', { exact: true })).toBeVisible();
-    await expect(sheet.getByText('Available for maintenance', { exact: true })).toBeVisible();
+    await expect(sheet.getByText('Shared for use', { exact: true })).toBeVisible();
+    await expect(sheet.getByText('Shared for maintenance', { exact: true })).toBeVisible();
   });
 
   test('destination availability set via API is reflected in UI (AVL-05)', async ({
@@ -125,7 +125,7 @@ test.describe('Destination Availability', () => {
     apiHelpers,
   }) => {
     const dest = await apiHelpers.createDestination('LOOKER_STUDIO', 'Persist Dest');
-    // Set "Available for use" to OFF via API
+    // Set "Shared for use" to OFF via API
     await apiHelpers.setDestinationAvailability(dest.id, false, true);
 
     await page.goto('/ui/0/data-destinations');
@@ -139,7 +139,7 @@ test.describe('Destination Availability', () => {
     // Expand Availability section
     await ensureSectionExpanded(sheet, 'Availability');
 
-    // "Available for use" should be OFF, "Available for maintenance" should be ON
+    // "Shared for use" should be OFF, "Shared for maintenance" should be ON
     const [useSwitch, maintenanceSwitch] = getAvailabilitySwitches(sheet);
     await expect(useSwitch).toHaveAttribute('data-state', 'unchecked');
     await expect(maintenanceSwitch).toHaveAttribute('data-state', 'checked');
@@ -161,8 +161,8 @@ test.describe('DataMart Availability', () => {
     await expect(page.getByTestId(TESTIDS.datamartTabOverview)).toBeVisible();
 
     await expect(page.getByText('Availability')).toBeVisible();
-    await expect(page.getByText('Available for reporting', { exact: true })).toBeVisible();
-    await expect(page.getByText('Available for maintenance', { exact: true })).toBeVisible();
+    await expect(page.getByText('Shared for reporting', { exact: true })).toBeVisible();
+    await expect(page.getByText('Shared for maintenance', { exact: true })).toBeVisible();
   });
 
   test('DM availability toggle saves immediately without Save button (AVL-07)', async ({
@@ -176,7 +176,7 @@ test.describe('DataMart Availability', () => {
     await page.goto(`/ui/0/data-marts/${dm.id}/overview`);
     await expect(page.getByTestId(TESTIDS.datamartTabOverview)).toBeVisible();
 
-    // Toggle "Available for reporting" OFF (first switch)
+    // Toggle "Shared for reporting" OFF (first switch)
     const [reportingSwitch] = getAvailabilitySwitches(page);
     await reportingSwitch.click();
 
@@ -192,7 +192,7 @@ test.describe('DataMart Availability', () => {
     await page.goto(`/ui/0/data-marts/${dm.id}/overview`);
     await expect(page.getByTestId(TESTIDS.datamartTabOverview)).toBeVisible();
 
-    // Toggle "Available for maintenance" OFF (second switch)
+    // Toggle "Shared for maintenance" OFF (second switch)
     const [, maintenanceSwitch] = getAvailabilitySwitches(page);
     await maintenanceSwitch.click();
     await expect(page.getByText('Availability updated')).toBeVisible();
@@ -201,11 +201,11 @@ test.describe('DataMart Availability', () => {
     await page.reload();
     await expect(page.getByTestId(TESTIDS.datamartTabOverview)).toBeVisible();
 
-    // "Available for maintenance" should be OFF after reload
+    // "Shared for maintenance" should be OFF after reload
     const [reportingSwitchAfter, maintenanceSwitchAfter] = getAvailabilitySwitches(page);
     await expect(maintenanceSwitchAfter).toHaveAttribute('data-state', 'unchecked');
 
-    // "Available for reporting" should still be ON
+    // "Shared for reporting" should still be ON
     await expect(reportingSwitchAfter).toHaveAttribute('data-state', 'checked');
   });
 });

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/DataDestinationForm.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/DataDestinationForm.tsx
@@ -335,7 +335,7 @@ export function DataDestinationForm({
             <FormSection title='Availability' defaultOpen={false} name='destination-availability'>
               <FormItem>
                 <div className='flex items-center justify-between gap-4'>
-                  <FormLabel>Available for use</FormLabel>
+                  <FormLabel>Shared for use</FormLabel>
                   <Switch
                     checked={sharingState.availableForUse}
                     onCheckedChange={v => {
@@ -349,7 +349,7 @@ export function DataDestinationForm({
                 <FormDescription>
                   <Accordion variant='common' type='single' collapsible>
                     <AccordionItem value='sharing-use-help'>
-                      <AccordionTrigger>What does "Available for use" mean?</AccordionTrigger>
+                      <AccordionTrigger>What does "Shared for use" mean?</AccordionTrigger>
                       <AccordionContent>
                         <p>
                           When enabled, project members can select this destination when configuring
@@ -362,7 +362,7 @@ export function DataDestinationForm({
               </FormItem>
               <FormItem>
                 <div className='flex items-center justify-between gap-4'>
-                  <FormLabel>Available for maintenance</FormLabel>
+                  <FormLabel>Shared for maintenance</FormLabel>
                   <Switch
                     checked={sharingState.availableForMaintenance}
                     onCheckedChange={v => {
@@ -377,9 +377,7 @@ export function DataDestinationForm({
                 <FormDescription>
                   <Accordion variant='common' type='single' collapsible>
                     <AccordionItem value='sharing-maintenance-help'>
-                      <AccordionTrigger>
-                        What does "Available for maintenance" mean?
-                      </AccordionTrigger>
+                      <AccordionTrigger>What does "Shared for maintenance" mean?</AccordionTrigger>
                       <AccordionContent>
                         <p>
                           When enabled, project members can copy credentials from this destination,

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/columns/columnLabels.ts
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/columns/columnLabels.ts
@@ -13,6 +13,6 @@ export const dataMartColumnLabels: Record<DataMartColumnKey, string> = {
   [DataMartColumnKey.BUSINESS_OWNERS]: 'Business Owner',
   [DataMartColumnKey.TECHNICAL_OWNERS]: 'Technical Owner',
   [DataMartColumnKey.CONTEXTS]: 'Contexts',
-  [DataMartColumnKey.AVAILABLE_FOR_REPORTING]: 'Available for reporting',
-  [DataMartColumnKey.AVAILABLE_FOR_MAINTENANCE]: 'Available for maintenance',
+  [DataMartColumnKey.AVAILABLE_FOR_REPORTING]: 'Shared for reporting',
+  [DataMartColumnKey.AVAILABLE_FOR_MAINTENANCE]: 'Shared for maintenance',
 };

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/columns/columns.tsx
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/columns/columns.tsx
@@ -296,7 +296,7 @@ export const getDataMartColumns = ({
     ),
     cell: ({ row }) =>
       row.original.availableForReporting === true ? (
-        <Check className='text-muted-foreground h-4 w-4' aria-label='Available for reporting' />
+        <Check className='text-muted-foreground h-4 w-4' aria-label='Shared for reporting' />
       ) : (
         <div className='text-muted-foreground'>—</div>
       ),
@@ -317,7 +317,7 @@ export const getDataMartColumns = ({
     ),
     cell: ({ row }) =>
       row.original.availableForMaintenance === true ? (
-        <Check className='text-muted-foreground h-4 w-4' aria-label='Available for maintenance' />
+        <Check className='text-muted-foreground h-4 w-4' aria-label='Shared for maintenance' />
       ) : (
         <div className='text-muted-foreground'>—</div>
       ),

--- a/apps/web/src/features/data-marts/list/components/DataMartTable/components/DataMartsTableFilters.config.ts
+++ b/apps/web/src/features/data-marts/list/components/DataMartTable/components/DataMartsTableFilters.config.ts
@@ -274,10 +274,10 @@ export function buildDataMartsTableFilters(
     },
     buildAvailabilityFilter<DataMartFilterKey>({
       id: AdditionalFilterKeys.AVAILABILITY,
-      firstLabel: 'Available for reporting',
-      maintenanceLabel: 'Available for maintenance',
-      bothLabel: 'Available for reporting and maintenance',
-      noneLabel: 'Not available',
+      firstLabel: 'Shared for reporting',
+      maintenanceLabel: 'Shared for maintenance',
+      bothLabel: 'Shared for reporting and maintenance',
+      noneLabel: 'Not shared',
     }),
   ];
 }

--- a/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/DataStorageForm.tsx
+++ b/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/DataStorageForm.tsx
@@ -401,7 +401,7 @@ export function DataStorageForm({
             <FormSection title='Availability' defaultOpen={false} name='storage-availability'>
               <FormItem>
                 <div className='flex items-center justify-between gap-4'>
-                  <FormLabel>Available for use</FormLabel>
+                  <FormLabel>Shared for use</FormLabel>
                   <Switch
                     checked={sharingState.availableForUse}
                     onCheckedChange={v => {
@@ -416,7 +416,7 @@ export function DataStorageForm({
                   <Accordion variant='common' type='single' collapsible>
                     <AccordionItem value='sharing-use-help'>
                       <AccordionTrigger>
-                        What does &quot;Available for use&quot; mean?
+                        What does &quot;Shared for use&quot; mean?
                       </AccordionTrigger>
                       <AccordionContent>
                         <p>
@@ -431,7 +431,7 @@ export function DataStorageForm({
               </FormItem>
               <FormItem>
                 <div className='flex items-center justify-between gap-4'>
-                  <FormLabel>Available for maintenance</FormLabel>
+                  <FormLabel>Shared for maintenance</FormLabel>
                   <Switch
                     checked={sharingState.availableForMaintenance}
                     onCheckedChange={v => {
@@ -446,7 +446,7 @@ export function DataStorageForm({
                   <Accordion variant='common' type='single' collapsible>
                     <AccordionItem value='sharing-maintenance-help'>
                       <AccordionTrigger>
-                        What does &quot;Available for maintenance&quot; mean?
+                        What does &quot;Shared for maintenance&quot; mean?
                       </AccordionTrigger>
                       <AccordionContent>
                         <p>

--- a/apps/web/src/features/project-settings/members/components/MemberDetailsSheet/MemberDetailsSheet.tsx
+++ b/apps/web/src/features/project-settings/members/components/MemberDetailsSheet/MemberDetailsSheet.tsx
@@ -223,11 +223,11 @@ export function MemberDetailsSheet({
                               <AccordionContent>
                                 <p className='mb-2'>
                                   <strong>Business User</strong> — sees accessible Data Marts and
-                                  Reports, creates Reports for Data Marts available for reporting,
+                                  Reports, creates Reports for Data Marts shared for reporting,
                                   manages Reports they own (edit, delete, change owners), manages
-                                  Report Triggers under their Reports, and uses Destinations
-                                  available for use. Cannot create, edit, or delete Data Marts, Data
-                                  Mart Triggers, or Storages.
+                                  Report Triggers under their Reports, and uses Destinations shared
+                                  for use. Cannot create, edit, or delete Data Marts, Data Mart
+                                  Triggers, or Storages.
                                 </p>
                                 <p className='mb-2'>
                                   <strong>Technical User</strong> — everything a Business User may

--- a/apps/web/src/features/project-settings/members/components/MemberFormFields/MemberFormFields.tsx
+++ b/apps/web/src/features/project-settings/members/components/MemberFormFields/MemberFormFields.tsx
@@ -98,9 +98,9 @@ export function MemberFormFields({
                     <AccordionContent>
                       <p className='mb-2'>
                         <strong>Business User</strong> — sees accessible Data Marts and Reports,
-                        creates Reports for Data Marts available for reporting, manages Reports they
+                        creates Reports for Data Marts shared for reporting, manages Reports they
                         own (edit, delete, change owners), manages Report Triggers under their
-                        Reports, and uses Destinations available for use. Cannot create, edit, or
+                        Reports, and uses Destinations shared for use. Cannot create, edit, or
                         delete Data Marts, Data Mart Triggers, or Storages.
                       </p>
                       <p className='mb-2'>

--- a/apps/web/src/pages/data-marts/edit/DataMartOverviewContent.tsx
+++ b/apps/web/src/pages/data-marts/edit/DataMartOverviewContent.tsx
@@ -276,7 +276,7 @@ export default function DataMartOverviewContent() {
                   htmlFor='available-for-maintenance'
                   className='text-foreground cursor-pointer text-sm font-medium select-none'
                 >
-                  Available for maintenance
+                  Shared for maintenance
                 </label>
               </div>
               <p className='text-muted-foreground text-xs'>
@@ -285,7 +285,7 @@ export default function DataMartOverviewContent() {
               <Accordion variant='common' type='single' collapsible>
                 <AccordionItem value='maintenance-help'>
                   <AccordionTrigger>
-                    What does &quot;Available for maintenance&quot; mean?
+                    What does &quot;Shared for maintenance&quot; mean?
                   </AccordionTrigger>
                   <AccordionContent>
                     <p>
@@ -311,7 +311,7 @@ export default function DataMartOverviewContent() {
                   htmlFor='available-for-reporting'
                   className='text-foreground cursor-pointer text-sm font-medium select-none'
                 >
-                  Available for reporting
+                  Shared for reporting
                 </label>
               </div>
               <p className='text-muted-foreground text-xs'>
@@ -320,7 +320,7 @@ export default function DataMartOverviewContent() {
               <Accordion variant='common' type='single' collapsible>
                 <AccordionItem value='reporting-help'>
                   <AccordionTrigger>
-                    What does &quot;Available for reporting&quot; mean?
+                    What does &quot;Shared for reporting&quot; mean?
                   </AccordionTrigger>
                   <AccordionContent>
                     <p>

--- a/apps/web/src/shared/components/AvailabilitySheet/AvailabilitySheet.tsx
+++ b/apps/web/src/shared/components/AvailabilitySheet/AvailabilitySheet.tsx
@@ -49,18 +49,18 @@ function getAvailabilityFields(
       {
         key: 'availableForReporting',
         sectionTitle: 'Reporting',
-        label: 'Available for reporting',
+        label: 'Shared for reporting',
         description: 'All project members can see this Data Mart and build reports on it',
-        helpTitle: 'What does "Available for reporting" mean?',
+        helpTitle: 'What does "Shared for reporting" mean?',
         helpContent:
           'When enabled, all project members (both Technical and Business Users) can see this Data Mart in the catalog and use it to create reports. Owners always have access regardless of this setting. Disable this to restrict visibility to owners only.',
       },
       {
         key: 'availableForMaintenance',
         sectionTitle: 'Maintenance',
-        label: 'Available for maintenance',
+        label: 'Shared for maintenance',
         description: 'Technical users can edit, delete, and manage triggers for this Data Mart',
-        helpTitle: 'What does "Available for maintenance" mean?',
+        helpTitle: 'What does "Shared for maintenance" mean?',
         helpContent:
           'When enabled, Technical Users who are not owners can edit the Data Mart definition, delete it, and manage its scheduled triggers. Business Users are not affected by this setting — they cannot perform maintenance actions regardless. Use this when you want other Technical Users on your team to help manage this Data Mart.',
       },
@@ -73,12 +73,12 @@ function getAvailabilityFields(
     {
       key: 'availableForUse',
       sectionTitle: 'Usage',
-      label: 'Available for use',
+      label: 'Shared for use',
       description:
         entityType === 'storage'
           ? 'Technical users can use this storage when creating Data Marts'
           : 'Project members can use this destination in their reports',
-      helpTitle: `What does "Available for use" mean?`,
+      helpTitle: `What does "Shared for use" mean?`,
       helpContent:
         entityType === 'storage'
           ? 'When enabled, Technical Users who are not owners can select this storage when creating new Data Marts. Without this, only storage owners and admins can use it. Enable this when multiple team members need to build Data Marts on the same storage.'
@@ -87,9 +87,9 @@ function getAvailabilityFields(
     {
       key: 'availableForMaintenance',
       sectionTitle: 'Maintenance',
-      label: 'Available for maintenance',
+      label: 'Shared for maintenance',
       description: `Project members with access can copy credentials, edit, and delete this ${entityName}`,
-      helpTitle: 'What does "Available for maintenance" mean?',
+      helpTitle: 'What does "Shared for maintenance" mean?',
       helpContent: `When enabled, project members can copy credentials from this ${entityName}, edit its configuration, and delete it. This is useful when multiple team members need to manage shared infrastructure. Without this, only owners and admins can perform these actions.`,
     },
   ];

--- a/apps/web/src/shared/components/TableFilters/availability-filter.utils.ts
+++ b/apps/web/src/shared/components/TableFilters/availability-filter.utils.ts
@@ -31,7 +31,7 @@ export function classifyAvailability(
 
 interface BuildAvailabilityFilterArgs<K extends string> {
   id: K;
-  /** Label for the "first flag" only option (e.g. "Available for reporting"). */
+  /** Label for the "first flag" only option (e.g. "Shared for reporting"). */
   firstLabel: string;
   /** Label for the maintenance-only option. */
   maintenanceLabel?: string;
@@ -49,9 +49,9 @@ export function buildAvailabilityFilter<K extends string>(
   const {
     id,
     firstLabel,
-    maintenanceLabel = 'Available for maintenance',
+    maintenanceLabel = 'Shared for maintenance',
     bothLabel = `${firstLabel} + maintenance`,
-    noneLabel = 'Not available',
+    noneLabel = 'Not shared',
     label = 'Availability',
   } = args;
   return {

--- a/docs/project/contexts.md
+++ b/docs/project/contexts.md
@@ -97,7 +97,7 @@ Editing a resource's context attachments is more restricted than editing the res
 | **Storage** | Project Admin, or Owner with Technical User role |
 | **Destination** | Project Admin, or Owner (any role) |
 
-Members who can edit a resource for other reasons (for example, a non-owner Technical User editing a Data Mart that is *Available for maintenance*) cannot change its contexts unless they meet the rules above.
+Members who can edit a resource for other reasons (for example, a non-owner Technical User editing a Data Mart that is *Shared for maintenance*) cannot change its contexts unless they meet the rules above.
 
 ---
 

--- a/docs/project/ownership-and-availability.md
+++ b/docs/project/ownership-and-availability.md
@@ -10,7 +10,7 @@ Access to a specific resource is decided by combining several **paths**:
 
 - The member's **role** (Project Admin, Technical User, Business User).
 - Their **ownership status** for the resource (Technical Owner, Business Owner, Owner, or non-owner).
-- The resource's **availability** toggles (*Available for use* / *Available for reporting*, *Available for maintenance*).
+- The resource's **availability** toggles (*Shared for use* / *Shared for reporting*, *Shared for maintenance*).
 - The member's **role scope** and assigned **contexts** (for non-owners with `Selected contexts only`).
 
 **Permissions are additive.** When more than one path applies, the member receives the **union** of allowed actions from all valid paths. Being assigned as an owner can only add access — it never reduces what the member could already do without that assignment.
@@ -18,7 +18,7 @@ Access to a specific resource is decided by combining several **paths**:
 Two paths combine into the final decision:
 
 1. **Ownership floor** — what the ownership assignment alone grants (e.g. a Business Owner is guaranteed *See* and *Use* of the Data Mart). This path bypasses the context gate; ownership of a resource implies visibility of it.
-2. **Non-owner sharing path** — what any member of the same role would be able to do on the resource given its availability toggles (e.g. a Technical User on a Data Mart that is *Available for maintenance* can edit, delete, and manage triggers). This path is gated by role scope and contexts even for owners — being an owner of one resource does not lift the context restriction for actions that come from the shared sharing path.
+2. **Non-owner sharing path** — what any member of the same role would be able to do on the resource given its availability toggles (e.g. a Technical User on a Data Mart that is *Shared for maintenance* can edit, delete, and manage triggers). This path is gated by role scope and contexts even for owners — being an owner of one resource does not lift the context restriction for actions that come from the shared sharing path.
 
 The following restrictions still apply on top of the union:
 
@@ -74,10 +74,10 @@ Availability settings control what non-owners can do with a resource. Owners and
 
 Each resource has two independent availability toggles. The first toggle name differs by entity type:
 
-- **Data Mart** — first toggle is **Available for reporting**
-- **Storage, Destination** — first toggle is **Available for use**
+- **Data Mart** — first toggle is **Shared for reporting**
+- **Storage, Destination** — first toggle is **Shared for use**
 
-The second toggle is **Available for maintenance** for all resource types. The combination of the two toggles determines what non-owners can do:
+The second toggle is **Shared for maintenance** for all resource types. The combination of the two toggles determines what non-owners can do:
 
 | State | What non-owners can do |
 |---|---|
@@ -88,7 +88,7 @@ The second toggle is **Available for maintenance** for all resource types. The c
 
 > ☝️ New resources start with both toggles off. Existing resources were migrated to both toggles on to preserve previous access patterns. Owners can gradually reconfigure availability to match their intended access model.
 
-![Resource settings page with the Available for reporting and Available for maintenance toggles](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/f38e1fc6-5052-466c-3a03-19b2673fb000/public)
+![Resource settings page with the Shared for reporting and Shared for maintenance toggles](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/1fb39e7a-4e85-48c4-6758-9ac173b86b00/public)
 
 **Who can configure availability** depends on the entity type and the owner's role:
 
@@ -133,7 +133,7 @@ The following actions can be granted or restricted by the combination of ownersh
 
 ### Storage
 
-| Who | Not available | Available for use | Available for maintenance | Available for both |
+| Who | Not shared | Shared for use | Shared for maintenance | Shared for both |
 |---|---|---|---|---|
 | **Owner (Technical User)** | All actions | All actions | All actions | All actions |
 | **Non-owner Technical User** | No access | See, Use | See, Use, Copy Credentials, Edit, Delete | See, Use, Copy Credentials, Edit, Delete |
@@ -145,20 +145,20 @@ The following actions can be granted or restricted by the combination of ownersh
 
 ### Data Mart
 
-| Who | Not available | Available for reporting | Available for maintenance | Available for both |
+| Who | Not shared | Shared for reporting | Shared for maintenance | Shared for both |
 |---|---|---|---|---|
 | **Technical Owner (Technical User)** | All actions | All actions | All actions | All actions |
 | **Technical Owner (Business User)** | See, Use | See, Use | See, Use | See, Use |
-| **Business Owner (Technical User)** | See, Use | See, Use | See, Use; + Edit, Delete, Manage Triggers via non-owner path † | See, Use; + Edit, Delete, Manage Triggers via non-owner path † |
+| **Business Owner (Technical User)** | See, Use | See, Use | See, Use; + Edit, Delete, Manage Triggers via non-owner path [1] | See, Use; + Edit, Delete, Manage Triggers via non-owner path [1] |
 | **Business Owner (Business User)** | See, Use | See, Use | See, Use | See, Use |
-| **Non-owner Technical User** | No access ‡ | See, Use ‡ | See, Use, Edit, Delete, Manage Triggers ‡ | See, Use, Edit, Delete, Manage Triggers ‡ |
-| **Non-owner Business User** | No access ‡ | See, Use ‡ | No access ‡ | See, Use ‡ |
+| **Non-owner Technical User** | No access [2] | See, Use [2] | See, Use, Edit, Delete, Manage Triggers [2] | See, Use, Edit, Delete, Manage Triggers [2] |
+| **Non-owner Business User** | No access [2] | See, Use [2] | No access [2] | See, Use [2] |
 
-† The maintenance actions in the **Business Owner (Technical User)** row are granted through the non-owner sharing path. Under `Selected contexts only` scope they require a context overlap between the member and the Data Mart; the See + Use floor is still granted without overlap.
+[1] The maintenance actions in the **Business Owner (Technical User)** row are granted through the non-owner sharing path. Under `Selected contexts only` scope they require a context overlap between the member and the Data Mart; the See + Use floor is still granted without overlap.
 
-‡ Non-owner access is subject to the context gate: under `Selected contexts only` scope, all actions in these rows require a context overlap between the member and the Data Mart.
+[2] Non-owner access is subject to the context gate: under `Selected contexts only` scope, all actions in these rows require a context overlap between the member and the Data Mart.
 
-> ☝️ When a Data Mart is available for maintenance, Business Users who are not owners still cannot access it — maintenance access is reserved for Technical Users.
+> ☝️ When a Data Mart is shared for maintenance, Business Users who are not owners still cannot access it — maintenance access is reserved for Technical Users.
 
 ---
 
@@ -170,16 +170,16 @@ Data Mart Triggers have no dedicated ownership. Who can see them and who can man
 |---|---|---|
 | **Technical Owner (Technical User)** | Yes | Yes |
 | **Technical Owner (Business User)** | Yes | No |
-| **Business Owner (Technical User)** of parent Data Mart available for maintenance | Yes | Yes, via non-owner path † |
-| **Business Owner (Technical User)** of parent Data Mart not available for maintenance | Yes | No |
+| **Business Owner (Technical User)** of parent Data Mart shared for maintenance | Yes | Yes, via non-owner path [1] |
+| **Business Owner (Technical User)** of parent Data Mart not shared for maintenance | Yes | No |
 | **Business Owner (Business User)** of parent Data Mart | Yes | No |
-| **Non-owner Technical User** (DM available for maintenance) | Yes ‡ | Yes ‡ |
-| **Non-owner Technical User** (DM available for reporting only) | Yes ‡ | No |
-| **Non-owner Business User** (DM visible) | Yes ‡ | No |
+| **Non-owner Technical User** (DM shared for maintenance) | Yes [2] | Yes [2] |
+| **Non-owner Technical User** (DM shared for reporting only) | Yes [2] | No |
+| **Non-owner Business User** (DM visible) | Yes [2] | No |
 
-† Under `Selected contexts only` scope this requires a context overlap between the member and the parent Data Mart.
+[1] Under `Selected contexts only` scope this requires a context overlap between the member and the parent Data Mart.
 
-‡ Under `Selected contexts only` scope this requires a context overlap between the member and the parent Data Mart.
+[2] Under `Selected contexts only` scope this requires a context overlap between the member and the parent Data Mart.
 
 ---
 
@@ -187,7 +187,7 @@ Data Mart Triggers have no dedicated ownership. Who can see them and who can man
 
 The owner of a Destination has full control regardless of their role — even a Business User who created a Destination manages it completely.
 
-| Who | Not available | Available for use | Available for maintenance | Available for both |
+| Who | Not shared | Shared for use | Shared for maintenance | Shared for both |
 |---|---|---|---|---|
 | **Owner (any role)** | All actions | All actions | All actions | All actions |
 | **Non-owner Technical User** | No access | See, Use | See, Use, Copy Credentials, Edit, Delete | See, Use, Copy Credentials, Edit, Delete |
@@ -203,12 +203,12 @@ Access to edit, delete, or run a Report requires one of two conditions:
 
 | Who | Can see | Can edit, delete, or run |
 |---|---|---|
-| **Has Data Mart maintenance access** § | Yes | Yes — for all Reports on that Data Mart |
+| **Has Data Mart maintenance access** [1] | Yes | Yes — for all Reports on that Data Mart |
 | **Report Owner** (Destination exists) | Yes | Yes |
 | **Report Owner** (Destination deleted) | Yes | No — read-only until Destination is restored or replaced |
 | **DM visible without maintenance access** | Yes | No |
 
-§ "Has Data Mart maintenance access" means the user receives `Edit` on the parent Data Mart through any path defined in the [Data Mart access table](#data-mart) — that is, Technical Owner with Technical User role, or Technical User (including a Business Owner who is a Technical User) receiving maintenance through the non-owner sharing path on a Data Mart that is *Available for maintenance*. The non-owner sharing path is gated by role scope and contexts; the Report-level decision inherits that gate.
+[1] "Has Data Mart maintenance access" means the user receives `Edit` on the parent Data Mart through any path defined in the [Data Mart access table](#data-mart) — that is, Technical Owner with Technical User role, or Technical User (including a Business Owner who is a Technical User) receiving maintenance through the non-owner sharing path on a Data Mart that is *Shared for maintenance*. The non-owner sharing path is gated by role scope and contexts; the Report-level decision inherits that gate.
 
 > ☝️ A Report owner can edit, delete, and run the Report only while its Destination still exists. If the Destination is deleted, the owner can still see the Report but cannot edit, delete, or run it until the Destination is restored or ownership is reassigned by a Technical User.
 
@@ -220,9 +220,9 @@ Access to edit, delete, or run a Report requires one of two conditions:
 
 | Who | Can see | Can manage (create, edit, delete) |
 |---|---|---|
-| **Has Data Mart maintenance access** § | Yes | Yes — for all Report Triggers on that Data Mart |
+| **Has Data Mart maintenance access** [1] | Yes | Yes — for all Report Triggers on that Data Mart |
 | **Report Owner** (Destination exists) | Yes | Yes — for own Report's triggers only |
 | **Report Owner** (Destination deleted) | Yes | No |
 | **DM visible without maintenance access** | Yes | No |
 
-§ Defined under [Report](#report) above — includes any path that grants `Edit` on the parent Data Mart, with the same role scope / context gating.
+[1] Defined under [Report](#report) above — includes any path that grants `Edit` on the parent Data Mart, with the same role scope / context gating.

--- a/docs/project/roles-and-permissions.md
+++ b/docs/project/roles-and-permissions.md
@@ -54,7 +54,7 @@ Assigned to members who create and run reports on data prepared by Technical Use
 **Data access:**
 
 - View Data Marts and their scheduled triggers made available to them
-- Create Reports on Data Marts available for reporting, using Destinations they have access to
+- Create Reports on Data Marts shared for reporting, using Destinations they have access to
 - Edit, delete, and run Reports they own
 - Create and manage Destinations they own or have maintenance access to
 - Cannot create, edit, or delete Data Marts, Storages, or Data Mart scheduled triggers


### PR DESCRIPTION
# Problem

The availability toggles on Data Marts, Storages, and Destinations were labelled "Available for reporting", "Available for use", and "Available for maintenance". This phrasing was ambiguous — "available" reads as a state of the resource itself (e.g. uptime) rather than describing a sharing decision made by the owner. The filter option "Not available" compounded this, conflating "not shared" with "offline" or "broken".

# Solution

Renamed all user-visible strings to the "Shared for *" pattern, which makes the collaborative intent explicit: the owner is choosing to share the resource with other project members. No logic, data model, or API contract was changed — this is a pure copy/label update across every surface that renders these strings.

# Changes

- Renamed "Available for use" → "Shared for use" in `DataDestinationForm`, `DataStorageForm`, and `AvailabilitySheet`
- Renamed "Available for reporting" → "Shared for reporting" in `DataMartOverviewContent` and `AvailabilitySheet`
- Renamed "Available for maintenance" → "Shared for maintenance" in all form components and `AvailabilitySheet`
- Updated column labels and aria-labels in `columnLabels.ts` and `columns.tsx`
- Updated filter option strings in `DataMartsTableFilters.config.ts` and `availability-filter.utils.ts` (including defaults and the "Not available" → "Not shared" option)
- Updated member role description prose in `MemberDetailsSheet` and `MemberFormFields`
- Updated E2E text matchers and comments in `availability.spec.ts`
- Updated screenshot URL in `ownership-and-availability.md` to reflect renamed UI labels
- Updated label references in `contexts.md`, `roles-and-permissions.md`, and `ownership-and-availability.md`
- Added changeset: `.changeset/availability-shared-for-rename.md`

![Resource settings page with the Shared for reporting and Shared for maintenance toggles](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/1fb39e7a-4e85-48c4-6758-9ac173b86b00/public)