### PR TITLE
Disable proxy buffering on streaming HTTP responses (X-Accel-Buffering)

### DIFF
--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.spec.ts
@@ -189,6 +189,7 @@ describe('LookerStudioConnectorApiDataService', () => {
       expect(headers['Content-Type']).toBe('application/json');
       expect(headers['Content-Encoding']).toBe('gzip');
       expect(headers['Transfer-Encoding']).toBe('chunked');
+      expect(headers['X-Accel-Buffering']).toBe('no');
       expect(result.rowCount).toBe(2);
       expect(result.limitExceeded).toBe(false);
       expect(result.limitReason).toBeUndefined();

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api-data.service.ts
@@ -348,6 +348,7 @@ export class LookerStudioConnectorApiDataService {
     res.setHeader('Content-Type', 'application/json');
     res.setHeader('Content-Encoding', 'gzip');
     res.setHeader('Transfer-Encoding', 'chunked');
+    res.setHeader('X-Accel-Buffering', 'no');
 
     // Pipe gzip stream to response
     gzip.pipe(res);

--- a/apps/backend/src/data-marts/services/http-data/http-data-stream-writer.service.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-stream-writer.service.spec.ts
@@ -74,11 +74,12 @@ function createMockResponse(
 describe('HttpDataStreamWriter', () => {
   const writer = new HttpDataStreamWriter();
 
-  it('initHeaders sets NDJSON content type, runId and flushes headers', () => {
+  it('initHeaders sets NDJSON content type, runId, disables proxy buffering and flushes headers', () => {
     const mock = createMockResponse();
     writer.initHeaders(mock.res, { runId: 'run-1' });
     expect(mock.headers['Content-Type']).toBe('application/x-ndjson; charset=utf-8');
     expect(mock.headers['Cache-Control']).toBe('no-store');
+    expect(mock.headers['X-Accel-Buffering']).toBe('no');
     expect(mock.headers[HTTP_DATA_RUN_ID_HEADER]).toBe('run-1');
     expect(mock.flushHeadersCalls).toBe(1);
   });

--- a/apps/backend/src/data-marts/services/http-data/http-data-stream-writer.service.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-stream-writer.service.ts
@@ -7,6 +7,7 @@ export class HttpDataStreamWriter {
   initHeaders(res: Response, meta: { runId: string }): void {
     res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
     res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('X-Accel-Buffering', 'no');
     res.setHeader(HTTP_DATA_RUN_ID_HEADER, meta.runId);
     res.flushHeaders();
   }


### PR DESCRIPTION
## What

Add `X-Accel-Buffering: no` to both streaming HTTP responses:

- **HTTP Data API** NDJSON stream — `HttpDataStreamWriter.initHeaders()`
- **Looker Studio connector** `getData` stream — `LookerStudioConnectorApiDataService.streamData()`

## Why

By default nginx (and some CDNs/proxies) buffer proxied responses. For a streaming endpoint that withholds chunks until the upstream finishes, defeating incremental delivery. `X-Accel-Buffering: no` tells the proxy to pass bytes through as they arrive.

- **HTTP Data API** is a true incremental NDJSON stream (line-by-line `res.write()` + manual `flush()` + backpressure). The header is required here so the client receives rows as they are produced. It pairs with the existing `res.flush()` that drains the app-level `compression` middleware, so both buffering layers (app + proxy) are now handled.
- **Looker Studio** stream is gzipped and consumed whole by Apps Script `UrlFetchApp`, so the header is a defensive / consistency addition — it keeps large responses (up to ~49 MB) from being buffered to disk by the proxy. Harmless when no proxy is in front.

## Notes for reviewers

- The header is a no-op when the app isn't behind a buffering proxy, so it's safe for standalone `owox serve`.
- No changeset: this is a streaming-behavior fix, not a new user-facing feature; the HTTP Data API itself is already covered by an existing changeset.

## Tests

- `http-data-stream-writer.service.spec.ts` — asserts the header in `initHeaders` (test renamed to reflect proxy buffering).
- `looker-studio-connector-api-data.service.spec.ts` — extends the `streamData` header assertions with `X-Accel-Buffering: no`.
