### PR TITLE
Expose Data Mart data traversal with column controls in API client and owox-ctl

### DIFF
--- a/.changeset/add-api-control-cli.md
+++ b/.changeset/add-api-control-cli.md
@@ -11,5 +11,6 @@ This includes [`owox-ctl`](../docs/api/owox-ctl.md), the OWOX Data Marts Control
 
 - `owox-ctl status`
 - `owox-ctl data-marts list`
+- `owox-ctl data-marts stream`
 - `owox-ctl storages list`
 - `owox-ctl destinations list`

--- a/.changeset/http-data-api-ndjson-endpoint.md
+++ b/.changeset/http-data-api-ndjson-endpoint.md
@@ -6,11 +6,11 @@
 
 A new `GET /api/external/http-data/data-marts/{id}.ndjson` endpoint streams the columns
 of a published Data Mart as newline-delimited JSON for project members authenticated with
-their ODM member token (`x-owox-authorization`). Columns are selected via the repeated
-`column` parameter, or via reserved values: `*` (all native columns) and `**` (all native
-plus all reporting-visible blended columns); `*` may be combined with explicit columns, and
-omitting `column` is equivalent to `*`. Only reporting-visible columns are selectable —
-fields hidden from reporting and columns from excluded blend sources are rejected. Callers
-may also pass optional base64url-encoded `filter`/`sort` and a `limit`. Every pull is
-recorded as an `HTTP_DATA` Data Mart run (visible in run history) and counted for
-consumption; no persisted Report or Data Destination is created.
+their ODM member token (`x-owox-authorization`). Column-set selectors use `columns=*`
+for Data Mart output columns and `columns=**` for all report-available columns, including
+joined fields. Repeated `column` parameters select exact column names, so `column=*` and
+`column=**` mean literal columns named `*` and `**`. Only reporting-visible columns are
+selectable — fields hidden from reporting and columns from excluded blend sources are
+rejected. Callers may also pass optional base64url-encoded `filter`/`sort` and a `limit`.
+Every pull is recorded as an `HTTP_DATA` Data Mart run (visible in run history) and counted
+for consumption; no persisted Report or Data Destination is created.

--- a/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
@@ -15,10 +15,11 @@ export function StreamHttpDataSpec() {
       summary: 'Stream Data Mart data as NDJSON',
       description:
         'Streams rows of a published Data Mart as newline-delimited JSON ' +
-        '(one data row per line, no envelope). Columns are chosen via the repeated ' +
-        '`column` query parameter; row objects use those column names as keys in the ' +
-        'requested order. Omit `column` (or pass `*`) for all native columns, or pass ' +
-        '`**` for all native plus all reporting-visible blended columns. Authenticated ' +
+        '(one data row per line, no envelope). Output selectors use `columns=*` or ' +
+        '`columns=**`; exact column names use repeated `column` parameters. Row objects ' +
+        'use resolved column names as keys in the requested order. Omit both `columns` ' +
+        'and `column`, or pass `columns=*`, for all native columns. Pass `columns=**` ' +
+        'for all native plus all reporting-visible blended columns. Authenticated ' +
         'with the ODM member token via `x-owox-authorization`. Creates one DataMartRun ' +
         'of type HTTP_DATA per request, available through the run history endpoint.',
     }),
@@ -33,14 +34,25 @@ export function StreamHttpDataSpec() {
         'Data Mart identifier (UUID for native Data Marts, free-form string for legacy ones)',
     }),
     ApiQuery({
+      name: 'columns',
+      description:
+        'Optional column-set selector. `*` selects all current Data Mart output columns; ' +
+        '`**` selects all columns available to Reports, including joined fields. ' +
+        '`columns=*` may be combined with repeated `column` values. `columns=**` cannot ' +
+        'be combined with `column` or another `columns` value. Omit `columns` and ' +
+        '`column` to select all current Data Mart output columns.',
+      required: false,
+      enum: ['*', '**'],
+      example: '*',
+    }),
+    ApiQuery({
       name: 'column',
       description:
-        'Column to include in the output. Repeat the parameter to select multiple ' +
-        'columns; the order of repetition is preserved in row objects. Two reserved ' +
-        'values expand to column sets: `*` = all native columns, `**` = all native plus ' +
-        'all reporting-visible blended columns. `*` may be combined with explicit ' +
-        'columns (e.g. `column=*&column=orders__revenue` = all native plus that blended ' +
-        'field). Omitting the parameter is equivalent to `*`. Overlaps are de-duplicated.',
+        'Exact column name to include in the output. Repeat the parameter to select ' +
+        'multiple exact column names; the order of repetition is preserved in row ' +
+        'objects. Values are opaque strings. `column=*` and `column=**` refer to literal ' +
+        'columns named `*` and `**`; use `columns=*` or `columns=**` for selectors. ' +
+        'Overlaps are de-duplicated.',
       required: false,
       isArray: true,
       type: String,

--- a/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
@@ -124,6 +124,13 @@ export function StreamHttpDataSpec() {
     ApiResponse({
       status: 404,
       description: 'Data Mart not visible in the caller’s project, or not published.',
+    }),
+    ApiResponse({
+      status: 424,
+      description:
+        'Storage dependency failed while preparing or reading Data Mart data. ' +
+        'The response includes provider context such as storage type, provider message, ' +
+        'provider status code, and provider reason when available.',
     })
   );
 }

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-storage-error.mapper.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType, toHumanReadable } from '../../enums/data-storage-type.enum';
+import {
+  DataStorageErrorMapper,
+  StorageReadErrorMappingOptions,
+} from '../../interfaces/data-storage-error-mapper.interface';
+import { createStorageReadError, messageFromError } from '../../interfaces/storage-read-error';
+
+@Injectable()
+export class AthenaStorageErrorMapper implements DataStorageErrorMapper {
+  readonly type = DataStorageType.AWS_ATHENA;
+
+  toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown {
+    if (!options?.force) return error;
+
+    return createStorageReadError(
+      { storageType: this.type, providerName: toHumanReadable(this.type) },
+      { code: 'STORAGE_READ_FAILED', message: messageFromError(error) }
+    );
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-storage-error.mapper.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { DataStorageType, toHumanReadable } from '../../enums/data-storage-type.enum';
 import {
   DataStorageErrorMapper,
@@ -11,7 +11,7 @@ export class AthenaStorageErrorMapper implements DataStorageErrorMapper {
   readonly type = DataStorageType.AWS_ATHENA;
 
   toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown {
-    if (!options?.force) return error;
+    if (error instanceof HttpException || !options?.force) return error;
 
     return createStorageReadError(
       { storageType: this.type, providerName: toHumanReadable(this.type) },

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-storage-error.mapper.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-storage-error.mapper.spec.ts
@@ -1,0 +1,67 @@
+import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { BigQueryStorageErrorMapper } from './bigquery-storage-error.mapper';
+
+function bigQueryAccessDeniedError(): Error {
+  const message =
+    'Access Denied: Project test-project: User does not have bigquery.datasets.create permission in project test-project.';
+  const error = new Error(message) as Error & {
+    errors: Array<{ reason: string; message: string }>;
+    response: {
+      status: { errorResult: { reason: string; message: string } };
+    };
+  };
+  error.errors = [{ reason: 'accessDenied', message }];
+  error.response = {
+    status: { errorResult: { reason: 'accessDenied', message } },
+  };
+  return error;
+}
+
+function expectHttpException(error: unknown): HttpException {
+  expect(error).toBeInstanceOf(HttpException);
+  return error as HttpException;
+}
+
+describe('BigQueryStorageErrorMapper', () => {
+  const mapper = new BigQueryStorageErrorMapper();
+
+  it('maps raw BigQuery access denied errors before reader resolution', () => {
+    const mapped = expectHttpException(mapper.toStorageReadError(bigQueryAccessDeniedError()));
+
+    expect(mapped.getStatus()).toBe(HttpStatus.FAILED_DEPENDENCY);
+    expect(mapped.getResponse()).toMatchObject({
+      code: 'STORAGE_PERMISSION_DENIED',
+      message: expect.stringContaining('Google BigQuery returned 403 Forbidden'),
+      details: {
+        dependency: 'storage',
+        providerMessage: expect.stringContaining('bigquery.datasets.create'),
+        providerName: 'Google BigQuery',
+        providerReason: 'accessDenied',
+        providerStatusCode: 403,
+        storageType: DataStorageType.GOOGLE_BIGQUERY,
+      },
+    });
+  });
+
+  it('preserves app HttpExceptions', () => {
+    const original = new BadRequestException('Invalid request');
+    expect(mapper.toStorageReadError(original)).toBe(original);
+  });
+
+  it('maps plain storage read failures when already in storage-read scope', () => {
+    const mapped = expectHttpException(
+      mapper.toStorageReadError(new Error('Invalid cast at [57:23]'), { force: true })
+    );
+
+    expect(mapped.getStatus()).toBe(HttpStatus.FAILED_DEPENDENCY);
+    expect(mapped.getResponse()).toMatchObject({
+      code: 'STORAGE_READ_FAILED',
+      details: {
+        dependency: 'storage',
+        providerMessage: 'Invalid cast at [57:23]',
+        providerName: 'Google BigQuery',
+      },
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-storage-error.mapper.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-storage-error.mapper.spec.ts
@@ -49,6 +49,11 @@ describe('BigQueryStorageErrorMapper', () => {
     expect(mapper.toStorageReadError(original)).toBe(original);
   });
 
+  it('preserves app HttpExceptions when forced into storage-read scope', () => {
+    const original = new BadRequestException('Invalid request');
+    expect(mapper.toStorageReadError(original, { force: true })).toBe(original);
+  });
+
   it('maps plain storage read failures when already in storage-read scope', () => {
     const mapped = expectHttpException(
       mapper.toStorageReadError(new Error('Invalid cast at [57:23]'), { force: true })

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-storage-error.mapper.ts
@@ -60,6 +60,8 @@ export function mapBigQueryStorageReadError(
   error: unknown,
   options: StorageReadErrorMappingOptions = {}
 ): unknown {
+  if (error instanceof HttpException) return error;
+
   const context = {
     storageType: type,
     providerName: toHumanReadable(type),

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-storage-error.mapper.ts
@@ -1,0 +1,86 @@
+import { HttpException, Injectable } from '@nestjs/common';
+import { DataStorageType, toHumanReadable } from '../../enums/data-storage-type.enum';
+import {
+  createStorageReadError,
+  messageFromError,
+  StorageProviderReadError,
+} from '../../interfaces/storage-read-error';
+import {
+  DataStorageErrorMapper,
+  StorageReadErrorMappingOptions,
+} from '../../interfaces/data-storage-error-mapper.interface';
+
+type BigQueryErrorShape = {
+  errors?: Array<{ reason?: unknown; message?: unknown }>;
+  response?: {
+    status?: { errorResult?: { reason?: unknown; message?: unknown } };
+  };
+};
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function asBigQueryError(error: unknown): BigQueryErrorShape {
+  return typeof error === 'object' && error !== null ? (error as BigQueryErrorShape) : {};
+}
+
+function responseFieldsFor(
+  reason: string | undefined
+): Pick<StorageProviderReadError, 'code' | 'statusCode' | 'statusText'> {
+  if (reason === 'authError') {
+    return { code: 'STORAGE_UNAUTHORIZED', statusCode: 401, statusText: '401 Unauthorized' };
+  }
+  if (reason === 'accessDenied') {
+    return { code: 'STORAGE_PERMISSION_DENIED', statusCode: 403, statusText: '403 Forbidden' };
+  }
+  return { code: 'STORAGE_READ_FAILED' };
+}
+
+function extractBigQueryError(error: unknown): StorageProviderReadError | null {
+  if (error instanceof HttpException) return null;
+
+  const shaped = asBigQueryError(error);
+  const errorResult = shaped.response?.status?.errorResult;
+  const firstError = shaped.errors?.[0];
+  const reason = asString(errorResult?.reason) ?? asString(firstError?.reason);
+  const message = asString(errorResult?.message) ?? asString(firstError?.message);
+
+  if (!reason && !message) return null;
+
+  return {
+    ...responseFieldsFor(reason),
+    message: message ?? messageFromError(error),
+    ...(reason ? { reason } : {}),
+  };
+}
+
+export function mapBigQueryStorageReadError(
+  type: DataStorageType,
+  error: unknown,
+  options: StorageReadErrorMappingOptions = {}
+): unknown {
+  const context = {
+    storageType: type,
+    providerName: toHumanReadable(type),
+  };
+  const providerError = extractBigQueryError(error);
+
+  if (providerError) return createStorageReadError(context, providerError);
+  if (options.force) {
+    return createStorageReadError(context, {
+      code: 'STORAGE_READ_FAILED',
+      message: messageFromError(error),
+    });
+  }
+  return error;
+}
+
+@Injectable()
+export class BigQueryStorageErrorMapper implements DataStorageErrorMapper {
+  readonly type = DataStorageType.GOOGLE_BIGQUERY;
+
+  toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown {
+    return mapBigQueryStorageReadError(this.type, error, options);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-storage-error.mapper.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../../enums/data-storage-type.enum';
+import {
+  DataStorageErrorMapper,
+  StorageReadErrorMappingOptions,
+} from '../../../interfaces/data-storage-error-mapper.interface';
+import { mapBigQueryStorageReadError } from '../bigquery-storage-error.mapper';
+
+@Injectable()
+export class LegacyBigQueryStorageErrorMapper implements DataStorageErrorMapper {
+  readonly type = DataStorageType.LEGACY_GOOGLE_BIGQUERY;
+
+  toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown {
+    return mapBigQueryStorageReadError(this.type, error, options);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
@@ -14,6 +14,7 @@ import { AthenaSchemaMerger } from './athena/services/athena-schema-merger';
 import { AthenaSqlDryRunExecutor } from './athena/services/athena-sql-dry-run.executor';
 import { AthenaBlendedQueryBuilder } from './athena/services/athena-blended-query-builder';
 import { AthenaSqlRunExecutor } from './athena/services/athena-sql-run.executor';
+import { AthenaStorageErrorMapper } from './athena/services/athena-storage-error.mapper';
 import { BigQueryApiAdapterFactory } from './bigquery/adapters/bigquery-api-adapter.factory';
 import { BigQueryAccessValidator } from './bigquery/services/bigquery-access.validator';
 import { BigQueryBlendedQueryBuilder } from './bigquery/services/bigquery-blended-query-builder';
@@ -28,6 +29,7 @@ import { BigQueryReportReader } from './bigquery/services/bigquery-report-reader
 import { BigQuerySchemaMerger } from './bigquery/services/bigquery-schema-merger';
 import { BigquerySqlDryRunExecutor } from './bigquery/services/bigquery-sql-dry-run.executor';
 import { BigQuerySqlRunExecutor } from './bigquery/services/bigquery-sql-run.executor';
+import { BigQueryStorageErrorMapper } from './bigquery/services/bigquery-storage-error.mapper';
 import { LegacyBigQueryAccessValidator } from './bigquery/services/legacy/legacy-bigquery-access.validator';
 import { LegacyBigQueryCreateViewExecutor } from './bigquery/services/legacy/legacy-bigquery-create-view.executor';
 import { LegacyBigQueryDataMartSchemaParser } from './bigquery/services/legacy/legacy-bigquery-data-mart-schema.parser';
@@ -40,6 +42,7 @@ import { LegacyBigQuerySchemaMerger } from './bigquery/services/legacy/legacy-bi
 import { LegacyBigQuerySqlDryRunExecutor } from './bigquery/services/legacy/legacy-bigquery-sql-dry-run.executor';
 import { LegacyBigQuerySqlPreprocessor } from './bigquery/services/legacy/legacy-bigquery-sql-preprocessor.service';
 import { LegacyBigQuerySqlRunExecutor } from './bigquery/services/legacy/legacy-bigquery-sql-run.executor';
+import { LegacyBigQueryStorageErrorMapper } from './bigquery/services/legacy/legacy-bigquery-storage-error.mapper';
 import { BigQueryStorageResourceBrowser } from './bigquery/services/bigquery-storage-resource-browser.service';
 import { DataStorageCredentialsUtils } from './data-mart-schema.utils';
 import { DatabricksApiAdapterFactory } from './databricks/adapters/databricks-api-adapter.factory';
@@ -55,6 +58,7 @@ import { DatabricksSchemaMerger } from './databricks/services/databricks-schema-
 import { DatabricksSqlDryRunExecutor } from './databricks/services/databricks-sql-dry-run.executor';
 import { DatabricksBlendedQueryBuilder } from './databricks/services/databricks-blended-query-builder';
 import { DatabricksSqlRunExecutor } from './databricks/services/databricks-sql-run.executor';
+import { DatabricksStorageErrorMapper } from './databricks/services/databricks-storage-error.mapper';
 import { DataStorageType } from './enums/data-storage-type.enum';
 import { DataStoragePublicCredentialsFactory } from './factories/data-storage-public-credentials.factory';
 import { BlendedQueryBuilder } from './interfaces/blended-query-builder.interface';
@@ -69,6 +73,7 @@ import { DataMartSchemaParser } from './interfaces/data-mart-schema-parser.inter
 import { DataMartSchemaProvider } from './interfaces/data-mart-schema-provider.interface';
 import { DataMartValidator } from './interfaces/data-mart-validator.interface';
 import { DataStorageAccessValidator } from './interfaces/data-storage-access-validator.interface';
+import { DataStorageErrorMapper } from './interfaces/data-storage-error-mapper.interface';
 import { DataStorageReportReader } from './interfaces/data-storage-report-reader.interface';
 import { ReportHeadersGenerator } from './interfaces/report-headers-generator.interface';
 import { SqlDryRunExecutor } from './interfaces/sql-dry-run-executor.interface';
@@ -86,6 +91,7 @@ import { RedshiftSchemaMerger } from './redshift/services/redshift-schema-merger
 import { RedshiftSqlDryRunExecutor } from './redshift/services/redshift-sql-dry-run.executor';
 import { RedshiftBlendedQueryBuilder } from './redshift/services/redshift-blended-query-builder';
 import { RedshiftSqlRunExecutor } from './redshift/services/redshift-sql-run.executor';
+import { RedshiftStorageErrorMapper } from './redshift/services/redshift-storage-error.mapper';
 import { SnowflakeApiAdapterFactory } from './snowflake/adapters/snowflake-api-adapter.factory';
 import { SnowflakeAccessValidator } from './snowflake/services/snowflake-access.validator';
 import { SnowflakeCreateViewExecutor } from './snowflake/services/snowflake-create-view.executor';
@@ -99,6 +105,7 @@ import { SnowflakeSchemaMerger } from './snowflake/services/snowflake-schema-mer
 import { SnowflakeSqlDryRunExecutor } from './snowflake/services/snowflake-sql-dry-run.executor';
 import { SnowflakeBlendedQueryBuilder } from './snowflake/services/snowflake-blended-query-builder';
 import { SnowflakeSqlRunExecutor } from './snowflake/services/snowflake-sql-run.executor';
+import { SnowflakeStorageErrorMapper } from './snowflake/services/snowflake-storage-error.mapper';
 
 export const STORAGE_RESOURCE_BROWSER_RESOLVER = Symbol('STORAGE_RESOURCE_BROWSER_RESOLVER');
 export const BLENDED_QUERY_BUILDER_RESOLVER = Symbol('BLENDED_QUERY_BUILDER_RESOLVER');
@@ -106,6 +113,7 @@ export const DATA_STORAGE_ACCESS_VALIDATOR_RESOLVER = Symbol(
   'DATA_STORAGE_ACCESS_VALIDATOR_RESOLVER'
 );
 export const DATA_STORAGE_REPORT_READER_RESOLVER = Symbol('DATA_STORAGE_REPORT_READER_RESOLVER');
+export const DATA_STORAGE_ERROR_MAPPER_RESOLVER = Symbol('DATA_STORAGE_ERROR_MAPPER_RESOLVER');
 export const DATA_MART_VALIDATOR_RESOLVER = Symbol('DATA_MART_VALIDATOR_RESOLVER');
 export const DATA_MART_SCHEMA_PROVIDER_RESOLVER = Symbol('DATA_MART_SCHEMA_PROVIDER_RESOLVER');
 export const DATA_MART_SCHEMA_MERGER_RESOLVER = Symbol('DATA_MART_SCHEMA_MERGER_RESOLVER');
@@ -131,6 +139,14 @@ const storageDataProviders = [
   SnowflakeReportReader,
   RedshiftReportReader,
   DatabricksReportReader,
+];
+const storageErrorMapperProviders = [
+  BigQueryStorageErrorMapper,
+  LegacyBigQueryStorageErrorMapper,
+  AthenaStorageErrorMapper,
+  SnowflakeStorageErrorMapper,
+  RedshiftStorageErrorMapper,
+  DatabricksStorageErrorMapper,
 ];
 const adapterFactories = [
   BigQueryApiAdapterFactory,
@@ -230,6 +246,7 @@ const blendedQueryBuilderProviders = [
 export const dataStorageResolverProviders = [
   ...accessValidatorProviders,
   ...storageDataProviders,
+  ...storageErrorMapperProviders,
   ...adapterFactories,
   ...queryBuilderProviders,
   ...validatorProviders,
@@ -267,6 +284,12 @@ export const dataStorageResolverProviders = [
     useFactory: (moduleRef: ModuleRef, ...storageDataProviders: DataStorageReportReader[]) =>
       new TypeResolver<DataStorageType, DataStorageReportReader>(storageDataProviders, moduleRef),
     inject: [ModuleRef, ...storageDataProviders],
+  },
+  {
+    provide: DATA_STORAGE_ERROR_MAPPER_RESOLVER,
+    useFactory: (...mappers: DataStorageErrorMapper[]) =>
+      new TypeResolver<DataStorageType, DataStorageErrorMapper>(mappers),
+    inject: storageErrorMapperProviders,
   },
   {
     provide: DATA_MART_VALIDATOR_RESOLVER,

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-storage-error.mapper.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { DataStorageType, toHumanReadable } from '../../enums/data-storage-type.enum';
 import {
   DataStorageErrorMapper,
@@ -11,7 +11,7 @@ export class DatabricksStorageErrorMapper implements DataStorageErrorMapper {
   readonly type = DataStorageType.DATABRICKS;
 
   toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown {
-    if (!options?.force) return error;
+    if (error instanceof HttpException || !options?.force) return error;
 
     return createStorageReadError(
       { storageType: this.type, providerName: toHumanReadable(this.type) },

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-storage-error.mapper.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType, toHumanReadable } from '../../enums/data-storage-type.enum';
+import {
+  DataStorageErrorMapper,
+  StorageReadErrorMappingOptions,
+} from '../../interfaces/data-storage-error-mapper.interface';
+import { createStorageReadError, messageFromError } from '../../interfaces/storage-read-error';
+
+@Injectable()
+export class DatabricksStorageErrorMapper implements DataStorageErrorMapper {
+  readonly type = DataStorageType.DATABRICKS;
+
+  toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown {
+    if (!options?.force) return error;
+
+    return createStorageReadError(
+      { storageType: this.type, providerName: toHumanReadable(this.type) },
+      { code: 'STORAGE_READ_FAILED', message: messageFromError(error) }
+    );
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-error-mapper.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-error-mapper.interface.ts
@@ -1,0 +1,10 @@
+import { TypedComponent } from '../../../common/resolver/typed-component.resolver';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+
+export type StorageReadErrorMappingOptions = {
+  force?: boolean;
+};
+
+export interface DataStorageErrorMapper extends TypedComponent<DataStorageType> {
+  toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown;
+}

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/storage-read-error.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/storage-read-error.spec.ts
@@ -1,0 +1,44 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+import { createStorageReadError, messageFromError } from './storage-read-error';
+
+function expectHttpException(error: unknown): HttpException {
+  expect(error).toBeInstanceOf(HttpException);
+  return error as HttpException;
+}
+
+describe('storage read errors', () => {
+  it('creates a 424 failed dependency response from explicit provider details', () => {
+    const mapped = expectHttpException(
+      createStorageReadError(
+        { storageType: DataStorageType.SNOWFLAKE, providerName: 'Test storage' },
+        {
+          code: 'STORAGE_PERMISSION_DENIED',
+          message: 'Access Denied: missing storage permission.',
+          reason: 'accessDenied',
+          statusCode: 403,
+          statusText: '403 Forbidden',
+        }
+      )
+    );
+
+    expect(mapped.getStatus()).toBe(HttpStatus.FAILED_DEPENDENCY);
+    expect(mapped.getResponse()).toMatchObject({
+      code: 'STORAGE_PERMISSION_DENIED',
+      message: expect.stringContaining('Test storage returned 403 Forbidden'),
+      details: {
+        dependency: 'storage',
+        providerMessage: 'Access Denied: missing storage permission.',
+        providerName: 'Test storage',
+        providerReason: 'accessDenied',
+        providerStatusCode: 403,
+        storageType: DataStorageType.SNOWFLAKE,
+      },
+    });
+  });
+
+  it('extracts a short message from unknown errors without mapping them', () => {
+    expect(messageFromError(new Error('Invalid cast at [57:23]'))).toBe('Invalid cast at [57:23]');
+    expect(messageFromError('plain failure')).toBe('plain failure');
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/storage-read-error.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/storage-read-error.ts
@@ -1,0 +1,47 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+
+export type StorageReadErrorContext = {
+  storageType: DataStorageType;
+  providerName: string;
+};
+
+export type StorageProviderReadError = {
+  code: string;
+  message: string;
+  reason?: string;
+  statusCode?: number;
+  statusText?: string;
+};
+
+export function messageFromError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createStorageReadError(
+  context: StorageReadErrorContext,
+  providerError: StorageProviderReadError
+): HttpException {
+  let providerStatus = ' returned an error';
+  if (providerError.statusText) {
+    providerStatus = ` returned ${providerError.statusText}`;
+  } else if (providerError.statusCode) {
+    providerStatus = ` returned HTTP ${providerError.statusCode}`;
+  }
+
+  return new HttpException(
+    {
+      code: providerError.code,
+      message: `Storage dependency failed while reading this Data Mart data: ${context.providerName}${providerStatus}: ${providerError.message}`,
+      details: {
+        dependency: 'storage',
+        providerMessage: providerError.message,
+        providerName: context.providerName,
+        ...(providerError.reason ? { providerReason: providerError.reason } : {}),
+        ...(providerError.statusCode ? { providerStatusCode: providerError.statusCode } : {}),
+        storageType: context.storageType,
+      },
+    },
+    HttpStatus.FAILED_DEPENDENCY
+  );
+}

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-storage-error.mapper.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { DataStorageType, toHumanReadable } from '../../enums/data-storage-type.enum';
 import {
   DataStorageErrorMapper,
@@ -11,7 +11,7 @@ export class RedshiftStorageErrorMapper implements DataStorageErrorMapper {
   readonly type = DataStorageType.AWS_REDSHIFT;
 
   toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown {
-    if (!options?.force) return error;
+    if (error instanceof HttpException || !options?.force) return error;
 
     return createStorageReadError(
       { storageType: this.type, providerName: toHumanReadable(this.type) },

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-storage-error.mapper.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType, toHumanReadable } from '../../enums/data-storage-type.enum';
+import {
+  DataStorageErrorMapper,
+  StorageReadErrorMappingOptions,
+} from '../../interfaces/data-storage-error-mapper.interface';
+import { createStorageReadError, messageFromError } from '../../interfaces/storage-read-error';
+
+@Injectable()
+export class RedshiftStorageErrorMapper implements DataStorageErrorMapper {
+  readonly type = DataStorageType.AWS_REDSHIFT;
+
+  toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown {
+    if (!options?.force) return error;
+
+    return createStorageReadError(
+      { storageType: this.type, providerName: toHumanReadable(this.type) },
+      { code: 'STORAGE_READ_FAILED', message: messageFromError(error) }
+    );
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-storage-error.mapper.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType, toHumanReadable } from '../../enums/data-storage-type.enum';
+import {
+  DataStorageErrorMapper,
+  StorageReadErrorMappingOptions,
+} from '../../interfaces/data-storage-error-mapper.interface';
+import { createStorageReadError, messageFromError } from '../../interfaces/storage-read-error';
+
+@Injectable()
+export class SnowflakeStorageErrorMapper implements DataStorageErrorMapper {
+  readonly type = DataStorageType.SNOWFLAKE;
+
+  toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown {
+    if (!options?.force) return error;
+
+    return createStorageReadError(
+      { storageType: this.type, providerName: toHumanReadable(this.type) },
+      { code: 'STORAGE_READ_FAILED', message: messageFromError(error) }
+    );
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-storage-error.mapper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-storage-error.mapper.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { DataStorageType, toHumanReadable } from '../../enums/data-storage-type.enum';
 import {
   DataStorageErrorMapper,
@@ -11,7 +11,7 @@ export class SnowflakeStorageErrorMapper implements DataStorageErrorMapper {
   readonly type = DataStorageType.SNOWFLAKE;
 
   toStorageReadError(error: unknown, options?: StorageReadErrorMappingOptions): unknown {
-    if (!options?.force) return error;
+    if (error instanceof HttpException || !options?.force) return error;
 
     return createStorageReadError(
       { storageType: this.type, providerName: toHumanReadable(this.type) },

--- a/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.ts
@@ -14,15 +14,19 @@ export type ColumnSelector =
 
 const REJECTED_PAGINATION_KEYS = ['pageToken', 'offset'] as const;
 
-function toColumnSelector(tokens: string[]): ColumnSelector {
-  if (tokens.includes(ALL_BLENDABLE_COLUMNS)) {
+type ColumnSetSelector = typeof ALL_NATIVE_COLUMNS | typeof ALL_BLENDABLE_COLUMNS;
+
+function toColumnSelector(
+  columnsSelector: ColumnSetSelector | undefined,
+  exactColumns: string[]
+): ColumnSelector {
+  if (columnsSelector === ALL_BLENDABLE_COLUMNS) {
     return { mode: 'allBlendable' };
   }
-  const explicit = tokens.filter(token => token !== ALL_NATIVE_COLUMNS);
-  if (tokens.includes(ALL_NATIVE_COLUMNS) || tokens.length === 0) {
-    return { mode: 'allNative', explicit };
+  if (columnsSelector === ALL_NATIVE_COLUMNS || exactColumns.length === 0) {
+    return { mode: 'allNative', explicit: exactColumns };
   }
-  return { mode: 'explicit', explicit };
+  return { mode: 'explicit', explicit: exactColumns };
 }
 
 function decodeBase64UrlJson(raw: string): unknown {
@@ -96,7 +100,7 @@ const LimitParamSchema = z.coerce
   .int('limit must be an integer')
   .min(1, 'limit must be ≥ 1');
 
-const ColumnsParamSchema = z
+const ExactColumnParamSchema = z
   .union([z.string(), z.array(z.string())])
   .optional()
   .transform(value => {
@@ -105,9 +109,36 @@ const ColumnsParamSchema = z
   })
   .pipe(z.array(z.string().min(1, 'column value must not be empty')));
 
+const ColumnsSelectorParamSchema = z
+  .union([z.string(), z.array(z.string())])
+  .optional()
+  .transform((value, ctx): ColumnSetSelector | undefined => {
+    if (value === undefined) return undefined;
+    const values = Array.isArray(value) ? value : [value];
+    if (values.length > 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Parameter "columns" cannot be repeated',
+      });
+      return z.NEVER;
+    }
+
+    const selector = values[0];
+    if (selector !== ALL_NATIVE_COLUMNS && selector !== ALL_BLENDABLE_COLUMNS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `"columns" must be "${ALL_NATIVE_COLUMNS}" or "${ALL_BLENDABLE_COLUMNS}"`,
+      });
+      return z.NEVER;
+    }
+
+    return selector;
+  });
+
 export const HttpDataQuerySchema = z
   .object({
-    column: ColumnsParamSchema,
+    columns: ColumnsSelectorParamSchema,
+    column: ExactColumnParamSchema,
     filter: FilterParamSchema.optional(),
     sort: SortParamSchema.optional(),
     limit: LimitParamSchema.optional(),
@@ -123,16 +154,16 @@ export const HttpDataQuerySchema = z
         });
       }
     }
-    if (value.column.includes(ALL_BLENDABLE_COLUMNS) && value.column.length > 1) {
+    if (value.columns === ALL_BLENDABLE_COLUMNS && value.column.length > 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['column'],
-        message: `"${ALL_BLENDABLE_COLUMNS}" cannot be combined with other column values`,
+        path: ['columns'],
+        message: `"${ALL_BLENDABLE_COLUMNS}" cannot be combined with exact column values`,
       });
     }
   })
   .transform(value => ({
-    columnSelector: toColumnSelector(value.column),
+    columnSelector: toColumnSelector(value.columns, value.column),
     filter: value.filter,
     sort: value.sort,
     limit: value.limit,

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-resolver.service.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-resolver.service.spec.ts
@@ -26,8 +26,8 @@ describe('HttpDataColumnResolver', () => {
   });
 
   it('returns explicit columns verbatim', () => {
-    const selector: ColumnSelector = { mode: 'explicit', explicit: ['revenue', 'orders__cost'] };
-    expect(resolver.resolve(selector, columns)).toEqual(['revenue', 'orders__cost']);
+    const selector: ColumnSelector = { mode: 'explicit', explicit: ['revenue', '*', '**'] };
+    expect(resolver.resolve(selector, columns)).toEqual(['revenue', '*', '**']);
   });
 
   it('throws a business violation when the selection resolves to no columns', () => {

--- a/apps/backend/src/data-marts/services/http-data/http-data-request-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-request-validator.service.spec.ts
@@ -22,29 +22,40 @@ describe('HttpDataRequestValidator', () => {
     expect(result.columnSelector).toEqual({ mode: 'allNative', explicit: [] });
   });
 
-  it('treats "*" as all-native', () => {
-    const result = validator.validate({ column: '*' });
+  it('treats columns="*" as all-native', () => {
+    const result = validator.validate({ columns: '*' });
     expect(result.columnSelector).toEqual({ mode: 'allNative', explicit: [] });
   });
 
-  it('keeps explicit columns alongside "*" as all-native additions', () => {
-    const result = validator.validate({ column: ['*', 'orders__revenue'] });
-    expect(result.columnSelector).toEqual({ mode: 'allNative', explicit: ['orders__revenue'] });
+  it('keeps exact columns alongside columns="*" as all-native additions', () => {
+    const result = validator.validate({ columns: '*', column: ['*', 'orders__revenue'] });
+    expect(result.columnSelector).toEqual({
+      mode: 'allNative',
+      explicit: ['*', 'orders__revenue'],
+    });
   });
 
-  it('treats "**" as all-blendable', () => {
-    expect(validator.validate({ column: '**' }).columnSelector).toEqual({ mode: 'allBlendable' });
+  it('treats column="*" and column="**" as exact column names', () => {
+    const result = validator.validate({ column: ['*', '**'] });
+    expect(result.columnSelector).toEqual({ mode: 'explicit', explicit: ['*', '**'] });
   });
 
-  it('rejects "**" combined with other column values', () => {
-    expect(() => validator.validate({ column: ['**', 'date'] })).toThrow(
+  it('treats columns="**" as all-blendable', () => {
+    expect(validator.validate({ columns: '**' }).columnSelector).toEqual({ mode: 'allBlendable' });
+  });
+
+  it('rejects columns="**" combined with exact column values', () => {
+    expect(() => validator.validate({ columns: '**', column: 'date' })).toThrow(
       BusinessViolationException
     );
-    expect(() => validator.validate({ column: ['**', '*'] })).toThrow(BusinessViolationException);
   });
 
   it('rejects empty column value', () => {
     expect(() => validator.validate({ column: ['date', ''] })).toThrow(BusinessViolationException);
+  });
+
+  it('rejects repeated columns selector values', () => {
+    expect(() => validator.validate({ columns: ['*', '**'] })).toThrow(BusinessViolationException);
   });
 
   it('rejects forbidden pagination params', () => {

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.spec.ts
@@ -1,5 +1,7 @@
 import {
   ForbiddenException,
+  HttpException,
+  HttpStatus,
   InternalServerErrorException,
   NotFoundException,
   ServiceUnavailableException,
@@ -8,6 +10,7 @@ import type { Response } from 'express';
 import { GracefulShutdownService } from '../../common/scheduler/services/graceful-shutdown.service';
 import { SystemTimeService } from '../../common/scheduler/services/system-time.service';
 import { TypeResolver } from '../../common/resolver/type-resolver';
+import { DataStorageErrorMapper } from '../data-storage-types/interfaces/data-storage-error-mapper.interface';
 import { DataStorageReportReader } from '../data-storage-types/interfaces/data-storage-report-reader.interface';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { ReportDataDescription } from '../dto/domain/report-data-description.dto';
@@ -48,11 +51,56 @@ function fakeDataMart(overrides: Partial<DataMart> = {}): DataMart {
     id: 'dm-1',
     projectId: 'proj-1',
     status: DataMartStatus.PUBLISHED,
-    storage: { type: DataStorageType.GOOGLE_BIGQUERY, id: 'storage-1', title: 'bq' },
+    storage: { type: DataStorageType.SNOWFLAKE, id: 'storage-1', title: 'warehouse' },
     definition: { kind: 'sql', sql: 'SELECT 1' },
     title: 'My DM',
     ...overrides,
   } as unknown as DataMart;
+}
+
+function storageAccessDeniedError(): Error {
+  const message = 'Access Denied: missing storage.objects.read permission.';
+  const error = new Error(message) as Error & {
+    errors: Array<{ reason: string; message: string }>;
+    response: {
+      status: { errorResult: { reason: string; message: string } };
+    };
+  };
+  error.errors = [{ reason: 'accessDenied', message }];
+  error.response = {
+    status: { errorResult: { reason: 'accessDenied', message } },
+  };
+  return error;
+}
+
+function providerReason(error: unknown): string | undefined {
+  const shaped = error as {
+    errors?: Array<{ reason?: string }>;
+    response?: { status?: { errorResult?: { reason?: string } } };
+  };
+  return shaped.response?.status?.errorResult?.reason ?? shaped.errors?.[0]?.reason;
+}
+
+function storageReadFailure(error: unknown): HttpException {
+  const message = error instanceof Error ? error.message : String(error);
+  const reason = providerReason(error);
+  const providerStatusCode = reason === 'accessDenied' ? HttpStatus.FORBIDDEN : undefined;
+
+  return new HttpException(
+    {
+      code: reason === 'accessDenied' ? 'STORAGE_PERMISSION_DENIED' : 'STORAGE_READ_FAILED',
+      message: `Storage dependency failed while reading this Data Mart data: Test storage returned an error: ${message}`,
+      details: {
+        dependency: 'storage',
+        providerMessage: message,
+        providerName: 'Test storage',
+        ...(reason ? { providerReason: reason } : {}),
+        ...(providerStatusCode ? { providerStatusCode } : {}),
+        storageType: DataStorageType.SNOWFLAKE,
+      },
+    },
+    HttpStatus.FAILED_DEPENDENCY
+  );
 }
 
 type MockResponse = Response & {
@@ -133,7 +181,9 @@ describe('StreamHttpDataService', () => {
   let gracefulShutdown: jest.Mocked<GracefulShutdownService>;
   let systemTime: jest.Mocked<SystemTimeService>;
   let reader: jest.Mocked<DataStorageReportReader>;
-  let resolver: jest.Mocked<TypeResolver<DataStorageType, DataStorageReportReader>>;
+  let readerResolver: jest.Mocked<TypeResolver<DataStorageType, DataStorageReportReader>>;
+  let errorMapper: jest.Mocked<DataStorageErrorMapper>;
+  let errorMapperResolver: jest.Mocked<TypeResolver<DataStorageType, DataStorageErrorMapper>>;
   let service: StreamHttpDataService;
 
   beforeEach(() => {
@@ -225,12 +275,23 @@ describe('StreamHttpDataService', () => {
       finalize: jest.fn(async () => undefined),
       getState: jest.fn(() => null),
       initFromState: jest.fn(async () => undefined),
-      type: DataStorageType.GOOGLE_BIGQUERY,
+      type: DataStorageType.SNOWFLAKE,
     } as unknown as jest.Mocked<DataStorageReportReader>;
 
-    resolver = {
+    readerResolver = {
       resolve: jest.fn(async () => reader),
     } as unknown as jest.Mocked<TypeResolver<DataStorageType, DataStorageReportReader>>;
+
+    errorMapper = {
+      type: DataStorageType.SNOWFLAKE,
+      toStorageReadError: jest.fn(error =>
+        error instanceof HttpException ? error : storageReadFailure(error)
+      ),
+    } as unknown as jest.Mocked<DataStorageErrorMapper>;
+
+    errorMapperResolver = {
+      resolve: jest.fn(async () => errorMapper),
+    } as unknown as jest.Mocked<TypeResolver<DataStorageType, DataStorageErrorMapper>>;
 
     service = new StreamHttpDataService(
       requestValidator,
@@ -247,7 +308,8 @@ describe('StreamHttpDataService', () => {
       consumption,
       gracefulShutdown,
       systemTime,
-      resolver
+      readerResolver,
+      errorMapperResolver
     );
   });
 
@@ -300,29 +362,60 @@ describe('StreamHttpDataService', () => {
   it('records a FAILED run when prepareReportData fails before headers are sent', async () => {
     reader.prepareReportData.mockRejectedValueOnce(new Error('schema mismatch'));
     const res = mockResponse();
-    await expect(service.stream(fakeCommand(), res)).rejects.toThrow('schema mismatch');
+    await expect(service.stream(fakeCommand(), res)).rejects.toMatchObject({
+      status: HttpStatus.FAILED_DEPENDENCY,
+    });
     expect(res._writes).toHaveLength(0);
     expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledTimes(1);
     expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
       expect.objectContaining({
         status: DataMartRunStatus.FAILED,
         metadata: expect.objectContaining({ completed: false }),
-        errors: expect.arrayContaining([expect.stringContaining('schema mismatch')]),
+        errors: expect.arrayContaining([
+          expect.stringContaining('Storage dependency failed while reading this Data Mart data'),
+        ]),
       })
     );
+  });
+
+  it('maps storage provider failures before reader resolution to failed dependency', async () => {
+    dataMartService.actualizeSchemaInEntityIfExpired.mockRejectedValueOnce(
+      storageAccessDeniedError()
+    );
+    const res = mockResponse();
+
+    await expect(service.stream(fakeCommand(), res)).rejects.toMatchObject({
+      status: HttpStatus.FAILED_DEPENDENCY,
+      response: expect.objectContaining({
+        code: 'STORAGE_PERMISSION_DENIED',
+        details: expect.objectContaining({
+          dependency: 'storage',
+          providerReason: 'accessDenied',
+          providerStatusCode: 403,
+          storageType: DataStorageType.SNOWFLAKE,
+        }),
+      }),
+    });
+    expect(readerResolver.resolve).not.toHaveBeenCalled();
+    expect(errorMapperResolver.resolve).toHaveBeenCalledWith(DataStorageType.SNOWFLAKE);
+    expect(dataMartRunService.recordHttpDataRun).not.toHaveBeenCalled();
   });
 
   it('defers the 200 response until the first batch read succeeds', async () => {
     reader.readReportDataBatch.mockRejectedValueOnce(new Error('relation does not exist'));
     const res = mockResponse();
 
-    await expect(service.stream(fakeCommand(), res)).rejects.toThrow('relation does not exist');
+    await expect(service.stream(fakeCommand(), res)).rejects.toMatchObject({
+      status: HttpStatus.FAILED_DEPENDENCY,
+    });
     expect(res.flushHeaders).not.toHaveBeenCalled();
     expect(res._writes).toHaveLength(0);
     expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
       expect.objectContaining({
         status: DataMartRunStatus.FAILED,
-        errors: expect.arrayContaining([expect.stringContaining('relation does not exist')]),
+        errors: expect.arrayContaining([
+          expect.stringContaining('Storage dependency failed while reading this Data Mart data'),
+        ]),
       })
     );
   });

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.spec.ts
@@ -284,8 +284,8 @@ describe('StreamHttpDataService', () => {
 
     errorMapper = {
       type: DataStorageType.SNOWFLAKE,
-      toStorageReadError: jest.fn(error =>
-        error instanceof HttpException ? error : storageReadFailure(error)
+      toStorageReadError: jest.fn((error, options) =>
+        error instanceof HttpException || !options?.force ? error : storageReadFailure(error)
       ),
     } as unknown as jest.Mocked<DataStorageErrorMapper>;
 
@@ -398,6 +398,9 @@ describe('StreamHttpDataService', () => {
     });
     expect(readerResolver.resolve).not.toHaveBeenCalled();
     expect(errorMapperResolver.resolve).toHaveBeenCalledWith(DataStorageType.SNOWFLAKE);
+    expect(errorMapper.toStorageReadError).toHaveBeenCalledWith(expect.any(Error), {
+      force: true,
+    });
     expect(dataMartRunService.recordHttpDataRun).not.toHaveBeenCalled();
   });
 

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
@@ -106,12 +106,15 @@ export class StreamHttpDataService {
 
     let reader: DataStorageReportReader | null = null;
     let baseMetadata: HttpDataRunMetadata | null = null;
+    let schemaActualizationInProgress = false;
 
     try {
+      schemaActualizationInProgress = true;
       await this.dataMartService.actualizeSchemaInEntityIfExpired(
         dataMart,
         HTTP_DATA_SCHEMA_EXPIRES_AFTER_MS
       );
+      schemaActualizationInProgress = false;
       const blendableSchema = await this.blendableSchemaService.computeBlendableSchema(
         dataMart.id,
         dataMart.projectId,
@@ -189,7 +192,13 @@ export class StreamHttpDataService {
 
       res.end();
     } catch (error) {
-      const mappedError = await this.toClientFacingReadError(error, reader, dataMart, res);
+      const mappedError = await this.toClientFacingReadError(
+        error,
+        reader,
+        dataMart,
+        res,
+        schemaActualizationInProgress
+      );
       if (baseMetadata) {
         await this.recordFailedRun(
           dataMart,
@@ -210,14 +219,15 @@ export class StreamHttpDataService {
     error: unknown,
     reader: DataStorageReportReader | null,
     dataMart: DataMart,
-    res: Response
+    res: Response,
+    forceStorageReadError: boolean
   ): Promise<unknown> {
     if (res.headersSent || error instanceof StreamCancelledError) {
       return error;
     }
 
     const mapper = await this.errorMapperResolver.resolve(dataMart.storage.type);
-    return mapper.toStorageReadError(error, { force: reader !== null });
+    return mapper.toStorageReadError(error, { force: forceStorageReadError || reader !== null });
   }
 
   private async recordSuccessfulRun(

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
@@ -1,5 +1,6 @@
 import {
   ForbiddenException,
+  HttpException,
   Inject,
   Injectable,
   InternalServerErrorException,
@@ -11,8 +12,12 @@ import type { Response } from 'express';
 import { GracefulShutdownService } from '../../common/scheduler/services/graceful-shutdown.service';
 import { TypeResolver } from '../../common/resolver/type-resolver';
 import { AuthorizationContext } from '../../idp/types/auth.types';
-import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../data-storage-types/data-storage-providers';
+import {
+  DATA_STORAGE_ERROR_MAPPER_RESOLVER,
+  DATA_STORAGE_REPORT_READER_RESOLVER,
+} from '../data-storage-types/data-storage-providers';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
+import { DataStorageErrorMapper } from '../data-storage-types/interfaces/data-storage-error-mapper.interface';
 import { DataStorageReportReader } from '../data-storage-types/interfaces/data-storage-report-reader.interface';
 import { ReportLikeReadPlan } from '../dto/domain/report-like-read-plan';
 import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
@@ -76,7 +81,9 @@ export class StreamHttpDataService {
     private readonly gracefulShutdownService: GracefulShutdownService,
     private readonly systemTimeService: SystemTimeService,
     @Inject(DATA_STORAGE_REPORT_READER_RESOLVER)
-    private readonly readerResolver: TypeResolver<DataStorageType, DataStorageReportReader>
+    private readonly readerResolver: TypeResolver<DataStorageType, DataStorageReportReader>,
+    @Inject(DATA_STORAGE_ERROR_MAPPER_RESOLVER)
+    private readonly errorMapperResolver: TypeResolver<DataStorageType, DataStorageErrorMapper>
   ) {}
 
   async stream(command: StreamHttpDataCommand, res: Response): Promise<void> {
@@ -94,66 +101,68 @@ export class StreamHttpDataService {
     const accessor: BlendableSchemaAccessor = { userId: ctx.userId, roles: ctx.roles ?? [] };
 
     const dataMart = await this.loadAccessibleDataMart(command.dataMartId, ctx);
-    await this.dataMartService.actualizeSchemaInEntityIfExpired(
-      dataMart,
-      HTTP_DATA_SCHEMA_EXPIRES_AFTER_MS
-    );
-    const blendableSchema = await this.blendableSchemaService.computeBlendableSchema(
-      dataMart.id,
-      dataMart.projectId,
-      accessor
-    );
-    const reportingColumns: ReportingColumns = {
-      native: nativeColumnNames(blendableSchema),
-      blended: visibleBlendedColumnNames(blendableSchema),
-    };
-    const columns = this.columnResolver.resolve(query.columnSelector, reportingColumns);
-    this.columnValidator.validate(
-      { selectedColumns: columns, filter: query.filter, sort: query.sort },
-      reportingColumns
-    );
-    await this.projectBalanceService.verifyCanPerformOperations(dataMart.projectId);
-
-    const readPlan: ReportLikeReadPlan = {
-      dataMart,
-      columnConfig: columns,
-      filterConfig: query.filter,
-      sortConfig: query.sort,
-      limitConfig: limit ?? null,
-    };
-
-    const decision = await this.blendedReportDataService.resolveBlendingDecision(
-      readPlan,
-      accessor
-    );
-
-    if (decision.needsBlending && !decision.blendedSql) {
-      throw new InternalServerErrorException('Blended SQL was not produced for this Data Mart');
-    }
-
-    let sqlOverride: string | undefined = decision.blendedSql;
-    let sqlOverrideParams = decision.params;
-    const hasOutputControls =
-      (query.filter?.length ?? 0) > 0 || (query.sort?.length ?? 0) > 0 || limit != null;
-    if (!decision.needsBlending && hasOutputControls) {
-      const composed = await this.reportSqlComposerService.compose(readPlan, accessor, decision);
-      sqlOverride = composed.sql;
-      sqlOverrideParams = composed.params;
-    }
-
     const runId = randomUUID();
     const startedAt = this.systemTimeService.now();
-    const baseMetadata: HttpDataRunMetadata = {
-      format: HTTP_DATA_FORMAT,
-      columns,
-      filter: query.filter,
-      sort: query.sort,
-      limit,
-    };
 
     let reader: DataStorageReportReader | null = null;
+    let baseMetadata: HttpDataRunMetadata | null = null;
 
     try {
+      await this.dataMartService.actualizeSchemaInEntityIfExpired(
+        dataMart,
+        HTTP_DATA_SCHEMA_EXPIRES_AFTER_MS
+      );
+      const blendableSchema = await this.blendableSchemaService.computeBlendableSchema(
+        dataMart.id,
+        dataMart.projectId,
+        accessor
+      );
+      const reportingColumns: ReportingColumns = {
+        native: nativeColumnNames(blendableSchema),
+        blended: visibleBlendedColumnNames(blendableSchema),
+      };
+      const columns = this.columnResolver.resolve(query.columnSelector, reportingColumns);
+      this.columnValidator.validate(
+        { selectedColumns: columns, filter: query.filter, sort: query.sort },
+        reportingColumns
+      );
+      await this.projectBalanceService.verifyCanPerformOperations(dataMart.projectId);
+
+      const readPlan: ReportLikeReadPlan = {
+        dataMart,
+        columnConfig: columns,
+        filterConfig: query.filter,
+        sortConfig: query.sort,
+        limitConfig: limit ?? null,
+      };
+
+      const decision = await this.blendedReportDataService.resolveBlendingDecision(
+        readPlan,
+        accessor
+      );
+
+      if (decision.needsBlending && !decision.blendedSql) {
+        throw new InternalServerErrorException('Blended SQL was not produced for this Data Mart');
+      }
+
+      let sqlOverride: string | undefined = decision.blendedSql;
+      let sqlOverrideParams = decision.params;
+      const hasOutputControls =
+        (query.filter?.length ?? 0) > 0 || (query.sort?.length ?? 0) > 0 || limit != null;
+      if (!decision.needsBlending && hasOutputControls) {
+        const composed = await this.reportSqlComposerService.compose(readPlan, accessor, decision);
+        sqlOverride = composed.sql;
+        sqlOverrideParams = composed.params;
+      }
+
+      baseMetadata = {
+        format: HTTP_DATA_FORMAT,
+        columns,
+        filter: query.filter,
+        sort: query.sort,
+        limit,
+      };
+
       reader = await this.readerResolver.resolve(dataMart.storage.type);
       const description = await reader.prepareReportData(readPlan, {
         sqlOverride,
@@ -180,18 +189,35 @@ export class StreamHttpDataService {
 
       res.end();
     } catch (error) {
-      await this.recordFailedRun(
-        dataMart,
-        ctx.userId,
-        runId,
-        startedAt,
-        { ...baseMetadata, completed: false },
-        error
-      );
-      this.handleStreamFailure(res, error);
+      const mappedError = await this.toClientFacingReadError(error, reader, dataMart, res);
+      if (baseMetadata) {
+        await this.recordFailedRun(
+          dataMart,
+          ctx.userId,
+          runId,
+          startedAt,
+          { ...baseMetadata, completed: false },
+          mappedError
+        );
+      }
+      this.handleStreamFailure(res, mappedError);
     } finally {
       if (reader) await this.safelyFinalizeReader(reader);
     }
+  }
+
+  private async toClientFacingReadError(
+    error: unknown,
+    reader: DataStorageReportReader | null,
+    dataMart: DataMart,
+    res: Response
+  ): Promise<unknown> {
+    if (res.headersSent || error instanceof StreamCancelledError) {
+      return error;
+    }
+
+    const mapper = await this.errorMapperResolver.resolve(dataMart.storage.type);
+    return mapper.toStorageReadError(error, { force: reader !== null });
   }
 
   private async recordSuccessfulRun(
@@ -234,7 +260,7 @@ export class StreamHttpDataService {
     metadata: HttpDataRunMetadata,
     error: unknown
   ): Promise<void> {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = this.clientFacingErrorMessage(error);
     try {
       await this.dataMartRunService.recordHttpDataRun({
         runId,
@@ -250,6 +276,19 @@ export class StreamHttpDataService {
         `Failed to persist FAILED HTTP Data run ${runId}: ${err instanceof Error ? err.message : String(err)}`
       );
     }
+  }
+
+  private clientFacingErrorMessage(error: unknown): string {
+    if (error instanceof HttpException) {
+      const response = error.getResponse();
+      if (typeof response === 'string') return response;
+      if (typeof response === 'object' && response !== null && !Array.isArray(response)) {
+        const message = (response as { message?: unknown }).message;
+        if (typeof message === 'string' && message.length > 0) return message;
+      }
+    }
+
+    return error instanceof Error ? error.message : String(error);
   }
 
   private toMetadataDataDescription(

--- a/apps/backend/test/http-data.e2e-spec.ts
+++ b/apps/backend/test/http-data.e2e-spec.ts
@@ -85,6 +85,17 @@ function parseNdjson(body: string): unknown[] {
     .map(line => JSON.parse(line));
 }
 
+function buildStoragePermissionDeniedError(): Error {
+  const message = 'Access Denied: missing storage permission.';
+  const error = new Error(message) as Error & {
+    errors: Array<{ reason: string; message: string }>;
+    response: { status: { errorResult: { reason: string; message: string } } };
+  };
+  error.errors = [{ reason: 'accessDenied', message }];
+  error.response = { status: { errorResult: { reason: 'accessDenied', message } } };
+  return error;
+}
+
 describe('HTTP Data API (e2e)', () => {
   let app: INestApplication;
   let agent: supertest.Agent;
@@ -236,6 +247,46 @@ describe('HTTP Data API (e2e)', () => {
         .get(`/api/external/http-data/data-marts/${legacyId}.ndjson?column=date`)
         .set(AUTH_HEADER);
       expect(res.status).toBe(404);
+    });
+  });
+
+  describe('Storage error guidance', () => {
+    it('returns actionable guidance when storage credentials are denied by the provider', async () => {
+      jest
+        .mocked(mockReader.prepareReportData)
+        .mockRejectedValueOnce(buildStoragePermissionDeniedError());
+
+      const res = await agent
+        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=date`)
+        .set(AUTH_HEADER);
+
+      expect(res.status).toBe(424);
+      expect(res.body).toMatchObject({
+        code: 'STORAGE_PERMISSION_DENIED',
+        message: expect.stringContaining('returned 403 Forbidden'),
+        details: expect.objectContaining({
+          dependency: 'storage',
+          providerMessage: 'Access Denied: missing storage permission.',
+          providerReason: 'accessDenied',
+          providerStatusCode: 403,
+        }),
+      });
+    });
+
+    it('returns the provider message instead of an opaque 500 for storage read failures', async () => {
+      jest
+        .mocked(mockReader.prepareReportData)
+        .mockRejectedValueOnce(new Error('Invalid cast from ARRAY<STRING> to STRING at [57:23]'));
+
+      const res = await agent
+        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=date`)
+        .set(AUTH_HEADER);
+
+      expect(res.status).toBe(424);
+      expect(res.body).toMatchObject({
+        code: 'STORAGE_READ_FAILED',
+        message: expect.stringContaining('Invalid cast from ARRAY<STRING> to STRING'),
+      });
     });
   });
 

--- a/apps/backend/test/http-data.e2e-spec.ts
+++ b/apps/backend/test/http-data.e2e-spec.ts
@@ -123,9 +123,9 @@ describe('HTTP Data API (e2e)', () => {
       expect(res.status).toBe(400);
     });
 
-    it('returns 400 when ** is combined with other columns', async () => {
+    it('returns 400 when columns=** is combined with exact columns', async () => {
       const res = await agent
-        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=**&column=date`)
+        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?columns=**&column=date`)
         .set(AUTH_HEADER);
       expect(res.status).toBe(400);
     });
@@ -201,9 +201,9 @@ describe('HTTP Data API (e2e)', () => {
       ]);
     });
 
-    it('treats * as all native columns', async () => {
+    it('treats columns=* as all native columns', async () => {
       const res = await agent
-        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=*`)
+        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?columns=*`)
         .set(AUTH_HEADER);
       expect(res.status).toBe(200);
       expect(parseNdjson(res.text)).toEqual([
@@ -211,6 +211,13 @@ describe('HTTP Data API (e2e)', () => {
         { date: '2026-05-02', revenue: 51.0 },
         { date: '2026-05-03', revenue: 100.25 },
       ]);
+    });
+
+    it('treats column=* as a literal exact column name', async () => {
+      const res = await agent
+        .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=*`)
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(400);
     });
 
     it('de-duplicates repeated columns instead of rejecting them', async () => {

--- a/apps/ctl/src/base-command.test.ts
+++ b/apps/ctl/src/base-command.test.ts
@@ -1,10 +1,10 @@
 import { jest } from '@jest/globals';
-import { OWOXConfigError } from '@owox/api-client';
+import { OWOXApiError, OWOXConfigError } from '@owox/api-client';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { setupEnvironmentFromFlags } from './base-command.js';
+import { normalizeCliError, setupEnvironmentFromFlags } from './base-command.js';
 import DataMartsList from './commands/data-marts/list.js';
 
 describe('base command environment setup', () => {
@@ -94,5 +94,34 @@ describe('base command environment setup', () => {
       stderrWrite.mockRestore();
       process.exitCode = previousExitCode;
     }
+  });
+});
+
+describe('base command error normalization', () => {
+  it('preserves API error details for JSON output', () => {
+    const error = new OWOXApiError(
+      'OWOX API request failed with 424 Failed Dependency: Storage dependency failed',
+      {
+        status: 424,
+        code: 'STORAGE_PERMISSION_DENIED',
+        details: {
+          dependency: 'storage',
+          providerName: 'Google BigQuery',
+          providerStatusCode: 403,
+        },
+      }
+    );
+
+    expect(normalizeCliError(error)).toEqual({
+      message: 'OWOX API request failed with 424 Failed Dependency: Storage dependency failed',
+      status: 424,
+      code: 'STORAGE_PERMISSION_DENIED',
+      name: 'OWOXApiError',
+      details: {
+        dependency: 'storage',
+        providerName: 'Google BigQuery',
+        providerStatusCode: 403,
+      },
+    });
   });
 });

--- a/apps/ctl/src/base-command.ts
+++ b/apps/ctl/src/base-command.ts
@@ -17,6 +17,37 @@ type BaseFlags = {
 
 type SetupEnvironment = (config?: EnvSetupConfig) => EnvSetupResult;
 
+export type NormalizedCliError = {
+  message: string;
+  status?: number;
+  code?: string;
+  name?: string;
+  details?: unknown;
+};
+
+export function normalizeCliError(error: unknown): NormalizedCliError {
+  if (error instanceof OWOXApiError || error instanceof OWOXAuthError) {
+    return {
+      message: error.message,
+      status: error.status,
+      code: error.code,
+      name: error.name,
+      details: error.details,
+    };
+  }
+
+  if (error instanceof OWOXConfigError || error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+    };
+  }
+
+  return {
+    message: String(error),
+  };
+}
+
 export function setupEnvironmentFromFlags(
   flags: Pick<BaseFlags, 'env-file'>,
   setupEnvironment: SetupEnvironment = EnvManager.setupEnvironment.bind(EnvManager)
@@ -59,34 +90,7 @@ export abstract class BaseCommand extends Command {
   }
 
   protected handleCliError(error: unknown): never {
-    process.stderr.write(`${renderJson({ error: this.normalizeError(error) })}\n`);
+    process.stderr.write(`${renderJson({ error: normalizeCliError(error) })}\n`);
     this.exit(1);
-  }
-
-  private normalizeError(error: unknown): {
-    message: string;
-    status?: number;
-    code?: string;
-    name?: string;
-  } {
-    if (error instanceof OWOXApiError || error instanceof OWOXAuthError) {
-      return {
-        message: error.message,
-        status: error.status,
-        code: error.code,
-        name: error.name,
-      };
-    }
-
-    if (error instanceof OWOXConfigError || error instanceof Error) {
-      return {
-        message: error.message,
-        name: error.name,
-      };
-    }
-
-    return {
-      message: String(error),
-    };
   }
 }

--- a/apps/ctl/src/commands/data-marts/stream.test.ts
+++ b/apps/ctl/src/commands/data-marts/stream.test.ts
@@ -1,0 +1,85 @@
+import { Writable } from 'node:stream';
+
+import { buildTraverseDataOptions, streamDataMart } from './stream.js';
+
+function writableCollector() {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+
+  return { stream, chunks };
+}
+
+describe('data-marts stream', () => {
+  it('writes each streamed row chunk to stdout as NDJSON without buffering the whole result', async () => {
+    const receivedOptions: unknown[] = [];
+    const { stream, chunks } = writableCollector();
+
+    await streamDataMart(
+      {
+        dataMarts: {
+          traverseData: async (_dataMartId, options) => {
+            receivedOptions.push(options);
+            return {
+              runId: 'run-1',
+              async *rowChunks() {
+                yield [{ date: '2026-05-01' }, { date: '2026-05-02' }];
+                yield [{ date: '2026-05-02' }];
+              },
+            };
+          },
+        },
+      },
+      'dm-1',
+      {
+        columns: '*',
+        column: ['Event Date (local)', '*'],
+        limit: 1000,
+      },
+      stream
+    );
+
+    expect(chunks).toEqual([
+      '{"date":"2026-05-01"}\n{"date":"2026-05-02"}\n',
+      '{"date":"2026-05-02"}\n',
+    ]);
+    expect(receivedOptions).toEqual([
+      {
+        columns: '*',
+        column: ['Event Date (local)', '*'],
+        limit: 1000,
+      },
+    ]);
+  });
+
+  it('parses filter and sort flags as JSON arrays for traversal options', () => {
+    expect(
+      buildTraverseDataOptions({
+        columns: '*',
+        column: ['Event Date (local)'],
+        filter: '[{"column":"Event Date (local)","operator":"gte","value":"2026-01-01"}]',
+        sort: '[{"column":"Event Date (local)","direction":"desc"}]',
+        limit: 1000,
+      })
+    ).toEqual({
+      columns: '*',
+      column: ['Event Date (local)'],
+      filter: [{ column: 'Event Date (local)', operator: 'gte', value: '2026-01-01' }],
+      sort: [{ column: 'Event Date (local)', direction: 'desc' }],
+      limit: 1000,
+    });
+  });
+
+  it('rejects malformed filter and sort JSON flags before opening the stream', () => {
+    expect(() => buildTraverseDataOptions({ filter: '{"column":"date"}' })).toThrow(
+      '--filter must be a JSON array'
+    );
+    expect(() => buildTraverseDataOptions({ sort: 'not-json' })).toThrow(
+      '--sort must be valid JSON'
+    );
+  });
+});

--- a/apps/ctl/src/commands/data-marts/stream.ts
+++ b/apps/ctl/src/commands/data-marts/stream.ts
@@ -1,0 +1,125 @@
+import { once } from 'node:events';
+import type { Writable } from 'node:stream';
+
+import { Args, Flags } from '@oclif/core';
+import {
+  OWOXConfigError,
+  type OWOXApiClient,
+  type OWOXDataMartRow,
+  type TraverseDataOptions,
+} from '@owox/api-client';
+
+import { BaseCommand } from '../../base-command.js';
+
+export type DataMartsStreamClient = {
+  dataMarts: Pick<OWOXApiClient['dataMarts'], 'traverseData'>;
+};
+
+type DataMartsStreamFlags = {
+  columns?: string;
+  column?: string[];
+  filter?: string;
+  sort?: string;
+  limit?: number;
+};
+
+function parseJsonArrayFlag(
+  value: string | undefined,
+  flagName: '--filter' | '--sort'
+): unknown[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new OWOXConfigError(`${flagName} must be valid JSON`, { cause: error });
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new OWOXConfigError(`${flagName} must be a JSON array`);
+  }
+
+  return parsed;
+}
+
+export function buildTraverseDataOptions(flags: DataMartsStreamFlags): TraverseDataOptions {
+  return {
+    columns: flags.columns as TraverseDataOptions['columns'],
+    column: flags.column,
+    filter: parseJsonArrayFlag(flags.filter, '--filter'),
+    sort: parseJsonArrayFlag(flags.sort, '--sort'),
+    limit: flags.limit,
+  };
+}
+
+async function writeNdjsonRows(stream: Writable, rows: OWOXDataMartRow[]): Promise<void> {
+  if (rows.length === 0) {
+    return;
+  }
+
+  const chunk = `${rows.map(row => JSON.stringify(row)).join('\n')}\n`;
+  if (!stream.write(chunk)) {
+    await once(stream, 'drain');
+  }
+}
+
+export async function streamDataMart(
+  client: DataMartsStreamClient,
+  dataMartId: string,
+  options: TraverseDataOptions,
+  stdout: Writable = process.stdout
+): Promise<void> {
+  const data = await client.dataMarts.traverseData(dataMartId, options);
+  for await (const rows of data.rowChunks()) {
+    await writeNdjsonRows(stdout, rows);
+  }
+}
+
+export default class DataMartsStream extends BaseCommand {
+  static override description = 'Stream data mart rows as newline-delimited JSON';
+  static override args = {
+    dataMartId: Args.string({
+      required: true,
+      description: 'Data Mart ID',
+    }),
+  };
+  static override flags = {
+    ...BaseCommand.baseFlags,
+    columns: Flags.string({
+      description: 'Column-set selector. Quote "*" and "**" so the shell does not expand them.',
+      options: ['*', '**'],
+    }),
+    column: Flags.string({
+      description: 'Exact column name to include. Repeat for multiple columns.',
+      multiple: true,
+    }),
+    limit: Flags.integer({
+      description: 'Optional row cap',
+    }),
+    filter: Flags.string({
+      description: 'Filter config as a JSON array',
+    }),
+    sort: Flags.string({
+      description: 'Sort config as a JSON array',
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(DataMartsStream);
+
+    try {
+      this.loadEnvironment(flags);
+      await streamDataMart(
+        await this.getAuthenticatedClient(),
+        args.dataMartId,
+        buildTraverseDataOptions(flags),
+        process.stdout
+      );
+    } catch (error) {
+      this.handleCliError(error);
+    }
+  }
+}

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -67,6 +67,8 @@ for await (const rows of data.rowChunks()) {
 }
 ```
 
+Call `await data.cancel()` if you open a traversal and decide not to iterate `rowChunks()`.
+
 Column selection uses two separate fields:
 
 - `columns: '*'` selects all current Data Mart output columns.

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -46,6 +46,38 @@ console.log(dataMarts);
 const dataMarts = await client.dataMarts.list();
 ```
 
+## Stream Data Mart rows
+
+Use `dataMarts.traverseData()` to stream rows from a published Data Mart without direct storage credentials.
+The method returns stream metadata and exposes `rowChunks()` as the traversal primitive, so callers can append to a cache or write output without loading the full result into memory.
+
+```ts
+const data = await client.dataMarts.traverseData('dm_123', {
+  columns: '*',
+  column: ['Revenue: net = USD'],
+  filter: [{ column: 'Event Date (local)', operator: 'gte', value: '2026-01-01' }],
+  sort: [{ column: 'Event Date (local)', direction: 'asc' }],
+  limit: 1000,
+});
+
+console.log(data.runId);
+
+for await (const rows of data.rowChunks()) {
+  await cache.appendRows(rows);
+}
+```
+
+Column selection uses two separate fields:
+
+- `columns: '*'` selects all current Data Mart output columns.
+- `columns: '**'` selects all columns available to Reports, including joined fields.
+- `column: ['Event Date (local)', 'Revenue: net = USD']` selects exact column names.
+- `column: ['*', '**']` selects literal columns named `*` and `**`.
+
+Do not pass comma-separated column lists. Column names are opaque strings and may contain commas, equals signs, spaces, quotes, or other symbols.
+
+Use `filter` and `sort` arrays with the same rule shapes as report output controls. For normal filters on the streamed output, omit `placement` or use `placement: 'post-join'`. Use `placement: 'pre-join'` with `aliasPath` only when filtering a joined source before it is joined into the result.
+
 ## List storages
 
 ```ts

--- a/docs/api/owox-ctl.md
+++ b/docs/api/owox-ctl.md
@@ -107,12 +107,12 @@ owox-ctl storages list
 owox-ctl destinations list
 ```
 
-All commands emit JSON.
+Commands emit JSON unless noted; `data-marts stream` emits NDJSON rows.
 
 ## Stream Data Mart rows
 
 Use `data-marts stream` to write Data Mart rows to stdout as newline-delimited JSON.
-Rows are written as they arrive, so shell redirection and pipelines can handle file output without an `--output` flag.
+Rows are written as they arrive, so shell redirection and pipelines can handle file output.
 
 ```bash
 owox-ctl data-marts stream dm_123 --columns '*'

--- a/docs/api/owox-ctl.md
+++ b/docs/api/owox-ctl.md
@@ -102,15 +102,49 @@ When credentials are missing or invalid, `authenticated` is `false` and the comm
 
 ```bash
 owox-ctl data-marts list
+owox-ctl data-marts stream <dataMartId> --columns '*'
 owox-ctl storages list
 owox-ctl destinations list
 ```
 
 All commands emit JSON.
 
+## Stream Data Mart rows
+
+Use `data-marts stream` to write Data Mart rows to stdout as newline-delimited JSON.
+Rows are written as they arrive, so shell redirection and pipelines can handle file output without an `--output` flag.
+
+```bash
+owox-ctl data-marts stream dm_123 --columns '*'
+owox-ctl data-marts stream dm_123 --columns '**'
+owox-ctl data-marts stream dm_123 --column '*'
+owox-ctl data-marts stream dm_123 \
+  --column 'Event Date (local)' \
+  --column 'Revenue: net = USD' \
+  --filter '[{"column":"Event Date (local)","operator":"gte","value":"2026-01-01"}]' \
+  --sort '[{"column":"Event Date (local)","direction":"asc"}]' \
+  --limit 1000
+owox-ctl data-marts stream dm_123 \
+  --columns '**' \
+  --filter '[{"placement":"pre-join","aliasPath":"users","column":"country","operator":"eq","value":"US"}]' \
+  --limit 1000
+```
+
+Use `--columns '*'` or `--columns '**'` for column-set selectors. Quote `*` and `**` so your shell does not expand them.
+
+Use repeatable `--column` flags for exact column names. `--column '*'` and `--column '**'` mean literal columns named `*` and `**`.
+
+`--columns '**'` cannot be combined with `--column`. `--columns '*'` can be combined with explicit `--column` values, and overlaps are de-duplicated by the server.
+
+Use `--filter` and `--sort` with JSON arrays. Column names inside filter and sort rules are ordinary JSON string fields, so values can contain spaces, commas, equals signs, and other symbols.
+
+For normal filters on the streamed output, omit `placement` or use `"placement":"post-join"`.
+
+Use `"placement":"pre-join"` only when you need to filter a joined source before it is joined into the result. In that case `aliasPath` identifies which joined source path the filter applies to, for example `"users"` or `"users.profiles"`. Pre-join filters are advanced joined-field filters; they require `aliasPath`, and `aliasPath` is not valid for normal post-join filters.
+
 ## Use owox-ctl with AI agents
 
-AI agents can call `owox-ctl` as a regular terminal command. This lets AI agents inspect available data marts, storages, and destinations without building a direct integration with the OWOX Data Marts API.
+AI agents can call `owox-ctl` as a regular terminal command. This lets AI agents inspect available data marts, storages, destinations, and Data Mart rows without building a direct integration with the OWOX Data Marts API.
 
 Recommended setup:
 
@@ -124,6 +158,7 @@ Examples for AI agents:
 ```bash
 owox-ctl status
 owox-ctl data-marts list
+owox-ctl data-marts stream dm_123 --columns '*'
 owox-ctl storages list
 owox-ctl destinations list
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -38988,6 +38988,25 @@
         "prettier": "^3.0.0"
       }
     },
+    "packages/api-client": {
+      "name": "@owox/api-client",
+      "version": "0.26.0",
+      "license": "ELv2",
+      "dependencies": {
+        "undici": "^6.26.0"
+      },
+      "devDependencies": {
+        "@owox/eslint-config": "*",
+        "@owox/prettier-config": "*",
+        "@types/jest": "29.5.14",
+        "@types/node": "^22.10.7",
+        "jest": "^30.2.0",
+        "ts-jest": "^29.4.6"
+      },
+      "engines": {
+        "node": ">=22.16.0"
+      }
+    },
     "packages/test-utils": {
       "name": "@owox/test-utils",
       "version": "5.0.0",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -35,6 +35,9 @@
     "api-client",
     "http"
   ],
+  "dependencies": {
+    "undici": "^6.26.0"
+  },
   "devDependencies": {
     "@owox/eslint-config": "*",
     "@owox/prettier-config": "*",

--- a/packages/api-client/src/client.test.ts
+++ b/packages/api-client/src/client.test.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 import { OWOXApiClient, OWOXApiError, OWOXAuthError } from './index.js';
 
 type RecordedRequest = {
@@ -353,6 +355,47 @@ describe('OWOXApiClient', () => {
       { id: 'mart-2', title: 'Second Data Mart' },
     ]);
     expect(fetchMock.requests.map(request => request.url)).toContain('/api/data-marts?offset=1');
+  });
+
+  it('configures default stream requests without standard Undici streaming timeouts', async () => {
+    let streamRequestInit: RequestInit | undefined;
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+      const request = new Request(input, init);
+      const parsedUrl = new URL(request.url);
+
+      if (request.method === 'POST' && parsedUrl.pathname === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+
+      if (
+        request.method === 'GET' &&
+        parsedUrl.pathname === '/api/external/http-data/data-marts/dm-1.ndjson'
+      ) {
+        streamRequestInit = init;
+        return new Response('{"id":"row-1"}\n', {
+          status: 200,
+          headers: { 'content-type': 'application/x-ndjson' },
+        });
+      }
+
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+
+    try {
+      const client = new OWOXApiClient({
+        apiOrigin,
+        apiKeyId,
+        apiKeySecret,
+      });
+
+      await client.dataMarts.traverseData('dm-1');
+
+      expect(
+        (streamRequestInit as RequestInit & { dispatcher?: unknown }).dispatcher
+      ).toBeDefined();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it('storages.list calls the real list endpoint shape', async () => {

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -1,3 +1,5 @@
+import { Agent, type Dispatcher } from 'undici';
+
 import { exchangeAccessToken, normalizeApiOrigin, readResponseBody } from './auth.js';
 import { DataMartsApi } from './data-marts.js';
 import { DestinationsApi } from './destinations.js';
@@ -11,6 +13,11 @@ export type OWOXApiClientOptions = {
   apiKeySecret: string;
   fetchImpl?: typeof fetch;
 };
+
+type QueryParams = Record<string, string> | URLSearchParams;
+type FetchInit = RequestInit & { dispatcher?: Dispatcher };
+
+const streamFetchDispatcher = new Agent({ bodyTimeout: 0, headersTimeout: 0 });
 
 export class OWOXApiClient {
   readonly dataMarts: DataMartsApi;
@@ -39,30 +46,23 @@ export class OWOXApiClient {
   }
 
   async getJson<T>(path: string, query?: Record<string, string>): Promise<T> {
-    return this.getJsonWithAuth<T>(path, query, true);
+    return this.getJsonWithAuth<T>(path, query);
   }
 
-  private async getJsonWithAuth<T>(
-    path: string,
-    query: Record<string, string> | undefined,
-    retryOnUnauthorized: boolean
-  ): Promise<T> {
-    const accessToken = await this.getAccessToken();
-    const response = await requestApi({
-      apiOrigin: this.apiOrigin,
-      fetchImpl: this.fetchImpl,
-      path,
-      method: 'GET',
-      apiKeyId: this.apiKeyId,
-      accessToken,
-      query,
+  async getStream(path: string, query?: URLSearchParams): Promise<Response> {
+    const response = await this.requestWithAuth(path, query, 'application/x-ndjson', {
+      dispatcher: streamFetchDispatcher,
     });
-
-    if (response.status === 401 && retryOnUnauthorized) {
-      this.accessToken = undefined;
-      return this.getJsonWithAuth<T>(path, query, false);
+    if (!response.ok) {
+      const body = await readResponseBody(response);
+      throw createHttpError(response, body);
     }
 
+    return response;
+  }
+
+  private async getJsonWithAuth<T>(path: string, query: QueryParams | undefined): Promise<T> {
+    const response = await this.requestWithAuth(path, query, 'application/json');
     const body = await readResponseBody(response);
 
     if (!response.ok) {
@@ -70,6 +70,33 @@ export class OWOXApiClient {
     }
 
     return body as T;
+  }
+
+  private async requestWithAuth(
+    path: string,
+    query: QueryParams | undefined,
+    accept: string,
+    fetchInit?: FetchInit,
+    retryOnUnauthorized = true
+  ): Promise<Response> {
+    const response = await requestApi({
+      apiOrigin: this.apiOrigin,
+      fetchImpl: this.fetchImpl,
+      path,
+      method: 'GET',
+      apiKeyId: this.apiKeyId,
+      accessToken: await this.getAccessToken(),
+      query,
+      accept,
+      fetchInit,
+    });
+
+    if (response.status === 401 && retryOnUnauthorized) {
+      this.accessToken = undefined;
+      return this.requestWithAuth(path, query, accept, fetchInit, false);
+    }
+
+    return response;
   }
 
   private async getAccessToken(): Promise<string> {

--- a/packages/api-client/src/data-marts.test.ts
+++ b/packages/api-client/src/data-marts.test.ts
@@ -43,6 +43,29 @@ function createNdjsonResponse(chunks: string[], headers: Record<string, string> 
   });
 }
 
+function createOpenNdjsonResponse(chunk: string, onCancel: () => void): Response {
+  const encoder = new TextEncoder();
+  let pulled = false;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (!pulled) {
+        pulled = true;
+        controller.enqueue(encoder.encode(chunk));
+      }
+    },
+    cancel() {
+      onCancel();
+    },
+  });
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'content-type': 'application/x-ndjson',
+    },
+  });
+}
+
 async function readRequestBody(request: Request): Promise<unknown> {
   const text = await request.text();
   if (!text) {
@@ -177,17 +200,52 @@ describe('DataMartsApi.traverseData', () => {
 
     const data = await client.dataMarts.traverseData('dm-1');
 
-    await collectRows(data).catch(error => {
-      expect(error).toBeInstanceOf(OWOXApiError);
-      expect(error).toMatchObject({
-        name: 'OWOXApiError',
-        details: {
-          dataMartId: 'dm-1',
-          lineNumber: 2,
-          runId: 'run-bad',
-        },
-      });
+    const rows = collectRows(data);
+    await expect(rows).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(rows).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      details: {
+        dataMartId: 'dm-1',
+        lineNumber: 2,
+        runId: 'run-bad',
+      },
     });
+  });
+
+  it('cancels the NDJSON response body when traversal stops early', async () => {
+    let wasCancelled = false;
+    const fetchMock = createFetchMock(request => {
+      if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+
+      if (
+        request.method === 'GET' &&
+        request.url === '/api/external/http-data/data-marts/dm-1.ndjson'
+      ) {
+        return createOpenNdjsonResponse('{"date":"2026-05-01"}\n', () => {
+          wasCancelled = true;
+        });
+      }
+
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+
+    const client = new OWOXApiClient({
+      apiOrigin,
+      apiKeyId,
+      apiKeySecret,
+      fetchImpl: fetchMock.fetchImpl,
+    });
+
+    const data = await client.dataMarts.traverseData('dm-1');
+
+    for await (const rows of data.rowChunks()) {
+      expect(rows).toEqual([{ date: '2026-05-01' }]);
+      break;
+    }
+
+    expect(wasCancelled).toBe(true);
   });
 
   it('wraps network failures while opening the stream with data mart context', async () => {
@@ -213,11 +271,10 @@ describe('DataMartsApi.traverseData', () => {
       fetchImpl: fetchMock.fetchImpl,
     });
 
-    await client.dataMarts.traverseData('dm-1').catch(error => {
-      expect(error).toBeInstanceOf(OWOXApiError);
-      expect(error).toMatchObject({
-        details: { dataMartId: 'dm-1' },
-      });
+    const data = client.dataMarts.traverseData('dm-1');
+    await expect(data).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(data).rejects.toMatchObject({
+      details: { dataMartId: 'dm-1' },
     });
   });
 

--- a/packages/api-client/src/data-marts.test.ts
+++ b/packages/api-client/src/data-marts.test.ts
@@ -248,6 +248,41 @@ describe('DataMartsApi.traverseData', () => {
     expect(wasCancelled).toBe(true);
   });
 
+  it('can cancel an opened traversal without iterating it', async () => {
+    let wasCancelled = false;
+    const fetchMock = createFetchMock(request => {
+      if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+
+      if (
+        request.method === 'GET' &&
+        request.url === '/api/external/http-data/data-marts/dm-1.ndjson'
+      ) {
+        return createOpenNdjsonResponse('{"date":"2026-05-01"}\n', () => {
+          wasCancelled = true;
+        });
+      }
+
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+
+    const client = new OWOXApiClient({
+      apiOrigin,
+      apiKeyId,
+      apiKeySecret,
+      fetchImpl: fetchMock.fetchImpl,
+    });
+
+    const data = await client.dataMarts.traverseData('dm-1');
+    await data.cancel();
+
+    expect(wasCancelled).toBe(true);
+    await expect(collectRows(data)).rejects.toThrow(
+      'OWOX Data Mart data stream can only be traversed once'
+    );
+  });
+
   it('wraps network failures while opening the stream with data mart context', async () => {
     const fetchMock = createFetchMock(request => {
       if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {

--- a/packages/api-client/src/data-marts.test.ts
+++ b/packages/api-client/src/data-marts.test.ts
@@ -1,4 +1,4 @@
-import { OWOXApiClient, OWOXApiError } from './index.js';
+import { OWOXApiClient, OWOXApiError, OWOXAuthError } from './index.js';
 
 type RecordedRequest = {
   method: string;
@@ -309,6 +309,32 @@ describe('DataMartsApi.traverseData', () => {
     const data = client.dataMarts.traverseData('dm-1');
     await expect(data).rejects.toBeInstanceOf(OWOXApiError);
     await expect(data).rejects.toMatchObject({
+      details: { dataMartId: 'dm-1' },
+    });
+  });
+
+  it('preserves auth errors while opening the stream with data mart context', async () => {
+    const fetchMock = createFetchMock(request => {
+      if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(401, { code: 'INVALID_API_KEY', message: 'Unauthorized' });
+      }
+
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+
+    const client = new OWOXApiClient({
+      apiOrigin,
+      apiKeyId,
+      apiKeySecret,
+      fetchImpl: fetchMock.fetchImpl,
+    });
+
+    const data = client.dataMarts.traverseData('dm-1');
+    await expect(data).rejects.toBeInstanceOf(OWOXAuthError);
+    await expect(data).rejects.toMatchObject({
+      name: 'OWOXAuthError',
+      status: 401,
+      code: 'INVALID_API_KEY',
       details: { dataMartId: 'dm-1' },
     });
   });

--- a/packages/api-client/src/data-marts.test.ts
+++ b/packages/api-client/src/data-marts.test.ts
@@ -1,0 +1,238 @@
+import { OWOXApiClient, OWOXApiError } from './index.js';
+
+type RecordedRequest = {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+};
+
+type FetchMock = {
+  fetchImpl: typeof fetch;
+  requests: RecordedRequest[];
+};
+
+const apiOrigin = 'https://example.test';
+
+function createJsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+    },
+  });
+}
+
+function createNdjsonResponse(chunks: string[], headers: Record<string, string> = {}): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'content-type': 'application/x-ndjson',
+      ...headers,
+    },
+  });
+}
+
+async function readRequestBody(request: Request): Promise<unknown> {
+  const text = await request.text();
+  if (!text) {
+    return undefined;
+  }
+
+  return JSON.parse(text);
+}
+
+function createFetchMock(
+  handler: (request: RecordedRequest) => Response | Promise<Response>
+): FetchMock {
+  const requests: RecordedRequest[] = [];
+  const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const headers: Record<string, string> = {};
+    request.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+
+    const parsedUrl = new URL(request.url);
+    const recordedRequest: RecordedRequest = {
+      method: request.method,
+      url: `${parsedUrl.pathname}${parsedUrl.search}`,
+      headers,
+      body: await readRequestBody(request),
+    };
+    requests.push(recordedRequest);
+
+    return handler(recordedRequest);
+  };
+
+  return { fetchImpl: fetchImpl as typeof fetch, requests };
+}
+
+async function collectRows(data: {
+  rowChunks(): AsyncIterable<Record<string, unknown>[]>;
+}): Promise<Record<string, unknown>[]> {
+  const rows: Record<string, unknown>[] = [];
+  for await (const chunk of data.rowChunks()) {
+    rows.push(...chunk);
+  }
+  return rows;
+}
+
+describe('DataMartsApi.traverseData', () => {
+  const apiKeyId = 'pmk_AbCdEfGhIjKlMnOpQrStUv';
+  const apiKeySecret = 'secret-value-that-must-not-leak';
+
+  it('requests the NDJSON endpoint and exposes incremental row chunks with run metadata', async () => {
+    const filter = [{ column: 'Event Date (local)', operator: 'gte', value: '2026-01-01' }];
+    const sort = [{ column: 'Revenue: net = USD', direction: 'desc' }];
+    const fetchMock = createFetchMock(request => {
+      if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+
+      if (
+        request.method === 'GET' &&
+        request.url.startsWith('/api/external/http-data/data-marts/dm%20123.ndjson')
+      ) {
+        expect(request.headers.accept).toBe('application/x-ndjson');
+        expect(request.headers['x-owox-authorization']).toBe('Bearer access-token-1');
+        return createNdjsonResponse(['{"date":"2026-05-01"}\n', '{"date":"2026-05-02"}\n'], {
+          'x-owox-run-id': 'run-1',
+        });
+      }
+
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+
+    const client = new OWOXApiClient({
+      apiOrigin,
+      apiKeyId,
+      apiKeySecret,
+      fetchImpl: fetchMock.fetchImpl,
+    });
+
+    const data = await client.dataMarts.traverseData('dm 123', {
+      columns: '*',
+      column: ['Revenue: net = USD', '*'],
+      filter,
+      sort,
+      limit: 2,
+    });
+
+    expect(data.runId).toBe('run-1');
+    await expect(collectRows(data)).resolves.toEqual([
+      { date: '2026-05-01' },
+      { date: '2026-05-02' },
+    ]);
+
+    const request = fetchMock.requests.find(({ method }) => method === 'GET');
+    expect(request).toBeDefined();
+    const url = new URL(`${apiOrigin}${request?.url}`);
+    expect(url.pathname).toBe('/api/external/http-data/data-marts/dm%20123.ndjson');
+    expect(url.searchParams.get('columns')).toBe('*');
+    expect(url.searchParams.getAll('column')).toEqual(['Revenue: net = USD', '*']);
+    expect(url.searchParams.get('limit')).toBe('2');
+    expect(
+      JSON.parse(Buffer.from(url.searchParams.get('filter')!, 'base64url').toString('utf8'))
+    ).toEqual(filter);
+    expect(
+      JSON.parse(Buffer.from(url.searchParams.get('sort')!, 'base64url').toString('utf8'))
+    ).toEqual(sort);
+  });
+
+  it('reports malformed NDJSON lines with line and run context', async () => {
+    const fetchMock = createFetchMock(request => {
+      if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+
+      if (
+        request.method === 'GET' &&
+        request.url === '/api/external/http-data/data-marts/dm-1.ndjson'
+      ) {
+        return createNdjsonResponse(['{"date":"2026-05-01"}\n', '{bad json}\n'], {
+          'x-owox-run-id': 'run-bad',
+        });
+      }
+
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+
+    const client = new OWOXApiClient({
+      apiOrigin,
+      apiKeyId,
+      apiKeySecret,
+      fetchImpl: fetchMock.fetchImpl,
+    });
+
+    const data = await client.dataMarts.traverseData('dm-1');
+
+    await collectRows(data).catch(error => {
+      expect(error).toBeInstanceOf(OWOXApiError);
+      expect(error).toMatchObject({
+        name: 'OWOXApiError',
+        details: {
+          dataMartId: 'dm-1',
+          lineNumber: 2,
+          runId: 'run-bad',
+        },
+      });
+    });
+  });
+
+  it('wraps network failures while opening the stream with data mart context', async () => {
+    const fetchMock = createFetchMock(request => {
+      if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+
+      if (
+        request.method === 'GET' &&
+        request.url === '/api/external/http-data/data-marts/dm-1.ndjson'
+      ) {
+        throw new TypeError('network disconnected');
+      }
+
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+
+    const client = new OWOXApiClient({
+      apiOrigin,
+      apiKeyId,
+      apiKeySecret,
+      fetchImpl: fetchMock.fetchImpl,
+    });
+
+    await client.dataMarts.traverseData('dm-1').catch(error => {
+      expect(error).toBeInstanceOf(OWOXApiError);
+      expect(error).toMatchObject({
+        details: { dataMartId: 'dm-1' },
+      });
+    });
+  });
+
+  it('rejects columns="**" combined with exact column names before making a request', async () => {
+    const fetchMock = createFetchMock(() => createJsonResponse(500, { message: 'unexpected' }));
+    const client = new OWOXApiClient({
+      apiOrigin,
+      apiKeyId,
+      apiKeySecret,
+      fetchImpl: fetchMock.fetchImpl,
+    });
+
+    await expect(
+      client.dataMarts.traverseData('dm-1', { columns: '**', column: ['date'] })
+    ).rejects.toThrow('columns "**" cannot be combined with exact column values');
+    expect(fetchMock.requests).toHaveLength(0);
+  });
+});

--- a/packages/api-client/src/data-marts.ts
+++ b/packages/api-client/src/data-marts.ts
@@ -105,10 +105,12 @@ export class DataMartDataTraversal {
     const decoder = new TextDecoder();
     let pending = '';
     let lineNumber = 0;
+    let streamEnded = false;
 
     try {
       while (true) {
         const { done, value } = await reader.read();
+        streamEnded = done;
         pending += decoder.decode(value, { stream: !done });
 
         const lines = pending.split('\n');
@@ -146,6 +148,9 @@ export class DataMartDataTraversal {
         cause: error,
       });
     } finally {
+      if (!streamEnded) {
+        await reader.cancel().catch(() => undefined);
+      }
       reader.releaseLock();
     }
   }

--- a/packages/api-client/src/data-marts.ts
+++ b/packages/api-client/src/data-marts.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 
-import { OWOXApiError } from './errors.js';
+import { OWOXApiError, OWOXAuthError } from './errors.js';
 
 export type OWOXDataMart = Record<string, unknown> & {
   id: string;
@@ -83,8 +83,9 @@ function withDataMartContext(error: OWOXApiError, dataMartId: string): OWOXApiEr
         dataMartId,
         ...(error.details === undefined ? {} : { details: error.details }),
       };
+  const ErrorClass = error instanceof OWOXAuthError ? OWOXAuthError : OWOXApiError;
 
-  return new OWOXApiError(error.message, {
+  return new ErrorClass(error.message, {
     status: error.status,
     code: error.code,
     details,

--- a/packages/api-client/src/data-marts.ts
+++ b/packages/api-client/src/data-marts.ts
@@ -76,6 +76,22 @@ function buildTraverseDataQuery(options: TraverseDataOptions): URLSearchParams |
   return query.size === 0 ? undefined : query;
 }
 
+function withDataMartContext(error: OWOXApiError, dataMartId: string): OWOXApiError {
+  const details = isRecord(error.details)
+    ? { dataMartId, ...error.details }
+    : {
+        dataMartId,
+        ...(error.details === undefined ? {} : { details: error.details }),
+      };
+
+  return new OWOXApiError(error.message, {
+    status: error.status,
+    code: error.code,
+    details,
+    cause: error,
+  });
+}
+
 export class DataMartDataTraversal {
   readonly runId: string | undefined;
   private consumed = false;
@@ -237,7 +253,7 @@ export class DataMartsApi {
       );
     } catch (error) {
       if (error instanceof OWOXApiError) {
-        throw error;
+        throw withDataMartContext(error, dataMartId);
       }
 
       throw new OWOXApiError('Failed to open OWOX Data Mart data stream', {

--- a/packages/api-client/src/data-marts.ts
+++ b/packages/api-client/src/data-marts.ts
@@ -1,8 +1,20 @@
+import { Buffer } from 'node:buffer';
+
 import { OWOXApiError } from './errors.js';
 
 export type OWOXDataMart = Record<string, unknown> & {
   id: string;
   title: string;
+};
+
+export type OWOXDataMartRow = Record<string, unknown>;
+
+export type TraverseDataOptions = {
+  columns?: '*' | '**';
+  column?: string[];
+  filter?: unknown[] | null;
+  sort?: unknown[] | null;
+  limit?: number;
 };
 
 type DataMartsPage = {
@@ -13,6 +25,7 @@ type DataMartsPage = {
 
 export type JsonRequester = {
   getJson<T>(path: string, query?: Record<string, string>): Promise<T>;
+  getStream(path: string, query?: URLSearchParams): Promise<Response>;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -32,6 +45,144 @@ function parsePage(response: unknown): DataMartsPage {
   }
 
   return response as DataMartsPage;
+}
+
+function encodeBase64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+function buildTraverseDataQuery(options: TraverseDataOptions): URLSearchParams | undefined {
+  if (options.columns === '**' && (options.column?.length ?? 0) > 0) {
+    throw new OWOXApiError('columns "**" cannot be combined with exact column values');
+  }
+
+  const query = new URLSearchParams();
+  if (options.columns !== undefined) {
+    query.append('columns', options.columns);
+  }
+  for (const column of options.column ?? []) {
+    query.append('column', column);
+  }
+  if (options.filter != null) {
+    query.append('filter', encodeBase64UrlJson(options.filter));
+  }
+  if (options.sort != null) {
+    query.append('sort', encodeBase64UrlJson(options.sort));
+  }
+  if (options.limit !== undefined) {
+    query.append('limit', String(options.limit));
+  }
+
+  return query.size === 0 ? undefined : query;
+}
+
+export class DataMartDataTraversal {
+  readonly runId: string | undefined;
+  private consumed = false;
+
+  constructor(
+    private readonly response: Response,
+    private readonly dataMartId: string
+  ) {
+    this.runId = response.headers.get('x-owox-run-id') ?? undefined;
+  }
+
+  async *rowChunks(): AsyncIterable<OWOXDataMartRow[]> {
+    if (this.consumed) {
+      throw new OWOXApiError('OWOX Data Mart data stream can only be traversed once', {
+        details: this.contextDetails(),
+      });
+    }
+    this.consumed = true;
+
+    if (!this.response.body) {
+      throw new OWOXApiError('OWOX Data Mart data stream response did not include a body', {
+        details: this.contextDetails(),
+      });
+    }
+
+    const reader = this.response.body.getReader();
+    const decoder = new TextDecoder();
+    let pending = '';
+    let lineNumber = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        pending += decoder.decode(value, { stream: !done });
+
+        const lines = pending.split('\n');
+        pending = lines.pop() ?? '';
+
+        const rows: OWOXDataMartRow[] = [];
+        for (const line of lines) {
+          if (line.length === 0) {
+            continue;
+          }
+          lineNumber += 1;
+          rows.push(this.parseLine(line, lineNumber));
+        }
+
+        if (rows.length > 0) {
+          yield rows;
+        }
+
+        if (done) {
+          break;
+        }
+      }
+
+      if (pending.length > 0) {
+        lineNumber += 1;
+        yield [this.parseLine(pending, lineNumber)];
+      }
+    } catch (error) {
+      if (error instanceof OWOXApiError) {
+        throw error;
+      }
+
+      throw new OWOXApiError('Failed to read OWOX Data Mart data stream', {
+        details: this.contextDetails(),
+        cause: error,
+      });
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private parseLine(line: string, lineNumber: number): OWOXDataMartRow {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      throw new OWOXApiError(`Malformed NDJSON line ${lineNumber} in OWOX Data Mart data stream`, {
+        details: {
+          ...this.contextDetails(),
+          lineNumber,
+          linePreview: line.slice(0, 200),
+        },
+        cause: error,
+      });
+    }
+
+    if (!isRecord(parsed)) {
+      throw new OWOXApiError(`NDJSON line ${lineNumber} is not a JSON object`, {
+        details: {
+          ...this.contextDetails(),
+          lineNumber,
+        },
+      });
+    }
+
+    return parsed;
+  }
+
+  private contextDetails(): Record<string, string> {
+    return {
+      dataMartId: this.dataMartId,
+      ...(this.runId ? { runId: this.runId } : {}),
+    };
+  }
 }
 
 export class DataMartsApi {
@@ -66,5 +217,30 @@ export class DataMartsApi {
 
       offset = page.nextOffset;
     }
+  }
+
+  async traverseData(
+    dataMartId: string,
+    options: TraverseDataOptions = {}
+  ): Promise<DataMartDataTraversal> {
+    const query = buildTraverseDataQuery(options);
+    let response: Response;
+    try {
+      response = await this.requester.getStream(
+        `/api/external/http-data/data-marts/${encodeURIComponent(dataMartId)}.ndjson`,
+        query
+      );
+    } catch (error) {
+      if (error instanceof OWOXApiError) {
+        throw error;
+      }
+
+      throw new OWOXApiError('Failed to open OWOX Data Mart data stream', {
+        details: { dataMartId },
+        cause: error,
+      });
+    }
+
+    return new DataMartDataTraversal(response, dataMartId);
   }
 }

--- a/packages/api-client/src/data-marts.ts
+++ b/packages/api-client/src/data-marts.ts
@@ -95,6 +95,7 @@ function withDataMartContext(error: OWOXApiError, dataMartId: string): OWOXApiEr
 export class DataMartDataTraversal {
   readonly runId: string | undefined;
   private consumed = false;
+  private cancelled = false;
 
   constructor(
     private readonly response: Response,
@@ -103,8 +104,17 @@ export class DataMartDataTraversal {
     this.runId = response.headers.get('x-owox-run-id') ?? undefined;
   }
 
+  async cancel(): Promise<void> {
+    if (this.consumed || this.cancelled) {
+      return;
+    }
+
+    this.cancelled = true;
+    await this.response.body?.cancel().catch(() => undefined);
+  }
+
   async *rowChunks(): AsyncIterable<OWOXDataMartRow[]> {
-    if (this.consumed) {
+    if (this.consumed || this.cancelled) {
       throw new OWOXApiError('OWOX Data Mart data stream can only be traversed once', {
         details: this.contextDetails(),
       });

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,5 +1,10 @@
 export { OWOXApiClient, type OWOXApiClientOptions } from './client.js';
 export { OWOXApiError, OWOXAuthError, OWOXConfigError } from './errors.js';
-export { type OWOXDataMart } from './data-marts.js';
+export {
+  DataMartDataTraversal,
+  type OWOXDataMart,
+  type OWOXDataMartRow,
+  type TraverseDataOptions,
+} from './data-marts.js';
 export { type OWOXStorage } from './storages.js';
 export { type OWOXDestination } from './destinations.js';

--- a/packages/api-client/src/transport.ts
+++ b/packages/api-client/src/transport.ts
@@ -1,5 +1,8 @@
 import { createNetworkError } from './errors.js';
 
+type QueryParams = Record<string, string> | URLSearchParams;
+type FetchInit = RequestInit & { dispatcher?: unknown };
+
 type ApiRequestOptions = {
   apiOrigin: string;
   fetchImpl: typeof fetch;
@@ -7,16 +10,21 @@ type ApiRequestOptions = {
   method: 'GET' | 'POST';
   apiKeyId: string;
   accessToken?: string;
-  query?: Record<string, string>;
+  query?: QueryParams;
   jsonBody?: unknown;
+  accept?: string;
+  fetchInit?: FetchInit;
 };
 
-function buildApiUrl(
-  apiOrigin: string,
-  path: string,
-  query: Record<string, string> | undefined
-): URL {
+function buildApiUrl(apiOrigin: string, path: string, query: QueryParams | undefined): URL {
   const url = new URL(path, apiOrigin);
+
+  if (query instanceof URLSearchParams) {
+    query.forEach((value, key) => {
+      url.searchParams.append(key, value);
+    });
+    return url;
+  }
 
   for (const [key, value] of Object.entries(query ?? {})) {
     url.searchParams.set(key, value);
@@ -27,10 +35,11 @@ function buildApiUrl(
 
 export async function requestApi(options: ApiRequestOptions): Promise<Response> {
   const headers = new Headers({
-    accept: 'application/json',
+    accept: options.accept ?? 'application/json',
     'x-owox-api-key-id': options.apiKeyId,
   });
-  const init: RequestInit = {
+  const init: FetchInit = {
+    ...options.fetchInit,
     method: options.method,
     headers,
   };


### PR DESCRIPTION
## Summary

Adds API client and CLI support for reading rows from the existing HTTP Data API, with explicit column selection semantics for Data Mart output columns, report-available columns, and exact column names.

## Changes

- Introduces `dataMarts.traverseData()` in `@owox/api-client` for incremental NDJSON row traversal.
- Adds `DataMartDataTraversal.cancel()` so callers can close an opened traversal without iterating it.
- Adds `owox-ctl data-marts stream <dataMartId>` for writing streamed rows as newline-delimited JSON.
- Aligns `owox-ctl data-marts stream` with the automation-first JSON-only CLI surface introduced by #1266.
- Introduces the HTTP Data `columns` selector separately from repeated exact `column` values:
  - `columns=*` / `--columns '*'` selects Data Mart output columns.
  - `columns=**` / `--columns '**'` selects report-available columns, including joined fields.
  - repeated `column` values / `--column` select exact column names, so literal `*` and `**` remain addressable.
- Supports filter, sort, and limit controls through the client and CLI traversal path.
- Preserves stdout backpressure handling for CLI streaming.
- Aligns API client stream requests with authenticated JSON requests.
- Preserves Data Mart context on stream-open errors from the shared API transport.
- Maps storage-provider read failures to `424 Failed Dependency`, keeping OWOX authorization failures separate from third-party storage permission/read failures.
- Preserves app `HttpException`s before forced BigQuery storage-read mapping.
- Keeps storage-specific error parsing in storage-specific mappers, with a minimal shared helper only for building storage-read HTTP responses.
- Updates docs and release notes for NDJSON output and `columns=*` / `columns=**` selector semantics.

## Verification

- `npm run test -w @owox/backend -- storage-read-error.spec.ts bigquery-storage-error.mapper.spec.ts stream-http-data.service.spec.ts --runInBand`
- `npm run test -w @owox/ctl -- base-command.test.ts data-marts/stream.test.ts --runInBand`
- `npm run test -w @owox/api-client -- client.test.ts data-marts.test.ts --runInBand`
- `npm run test:e2e -w @owox/backend -- http-data.e2e-spec.ts --runInBand`
- `npm run typecheck -w @owox/api-client`
- `npm run typecheck -w @owox/ctl`
- `npm run lint -w @owox/backend`
- `npm run lint -w @owox/api-client`
- `npm run lint -w @owox/ctl`
- `npm run build -w @owox/backend`
- `npm run build -w @owox/ctl`
- `git diff --check`

Latest review update also re-ran:

- `npm run test -w @owox/api-client -- data-marts.test.ts --runInBand`
- `npm run test -w @owox/backend -- bigquery-storage-error.mapper.spec.ts --runInBand`
- `npm run typecheck -w @owox/api-client`
- `git diff --check`