### PR TITLE
Fix relationship graph zoom controls after resize

### DIFF
--- a/.changeset/graph-zoom-controls.md
+++ b/.changeset/graph-zoom-controls.md
@@ -1,0 +1,7 @@
+---
+"owox": minor
+---
+
+# Data mart relationship graph zoom controls
+
+Fix graph zoom controls for deep relationship graphs after fit-to-view scales the graph below the previous fixed zoom floor.

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
@@ -19,6 +19,11 @@ import {
   getRelationshipWarningLabel,
   hasRelationshipWarning,
 } from './relationship-warning-state';
+import {
+  getGraphZoomRange,
+  getNextGraphZoom,
+  isGraphZoomAllowed,
+} from './relationship-canvas-zoom';
 
 interface RelationshipCanvasProps {
   dataMartId: string;
@@ -43,6 +48,7 @@ const V_GAP = 24;
 const NODE_BORDER = '#9ca3af'; // gray-400, visible in both themes
 const HIGHLIGHT_COLOR = '#3b82f6'; // blue-500
 const DRAFT_COLOR = '#f97316'; // orange-500
+const FIT_VIEW_SCALE = 0.85;
 
 class DMNode extends ClassicPreset.Node {
   width = NODE_W;
@@ -592,8 +598,22 @@ async function setupEditor(
     container.style.backgroundPosition = `${x}px ${y}px`;
   };
 
+  let zoomRange = getGraphZoomRange(area.area.transform.k);
+
+  const updateZoomRangeFromCurrentTransform = () => {
+    zoomRange = getGraphZoomRange(area.area.transform.k);
+  };
+
+  let isFittingView = false;
+
   const fitView = async () => {
-    await AreaExtensions.zoomAt(area, editor.getNodes(), { scale: 0.85 });
+    isFittingView = true;
+    try {
+      await AreaExtensions.zoomAt(area, editor.getNodes(), { scale: FIT_VIEW_SCALE });
+    } finally {
+      isFittingView = false;
+    }
+    updateZoomRangeFromCurrentTransform();
     updateGrid();
   };
   await fitView();
@@ -602,9 +622,9 @@ async function setupEditor(
     const cx = container.clientWidth / 2;
     const cy = container.clientHeight / 2;
     const { k } = area.area.transform;
-    const nextK = k * (1 + delta);
-    if (nextK < 0.33 || nextK > 3) return;
-    await area.area.zoom(nextK, cx * delta, cy * delta);
+    const next = getNextGraphZoom(k, delta, zoomRange);
+    if (!next) return;
+    await area.area.zoom(next.zoom, -cx * next.delta, -cy * next.delta);
     updateGrid();
   };
 
@@ -627,7 +647,9 @@ async function setupEditor(
     if (ctx.type === 'zoom') {
       if (ctx.data.source === 'dblclick') return undefined;
       const nextK = ctx.data.zoom;
-      if (nextK < 0.33 || nextK > 3) return undefined;
+      if (!isGraphZoomAllowed(nextK, zoomRange, { allowBelowMin: isFittingView })) {
+        return undefined;
+      }
     }
     if (ctx.type === 'nodetranslate') return undefined;
     if (ctx.type === 'translated' || ctx.type === 'zoomed') {
@@ -656,7 +678,8 @@ async function setupEditor(
     }
 
     if (matching.length > 0) {
-      void AreaExtensions.zoomAt(area, matching, { scale: 0.85 });
+      // Keep the full-graph fit as the zoom-out floor; search only focuses matching nodes.
+      void AreaExtensions.zoomAt(area, matching, { scale: FIT_VIEW_SCALE });
     }
   };
 

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GRAPH_ZOOM_MAX,
+  getGraphZoomRange,
+  getNextGraphZoom,
+  isGraphZoomAllowed,
+} from './relationship-canvas-zoom';
+
+describe('relationship canvas zoom', () => {
+  it('uses the fitted graph zoom as the minimum zoom', () => {
+    const fittedZoom = 0.206833;
+    const range = getGraphZoomRange(fittedZoom);
+
+    expect(range.min).toBe(fittedZoom);
+
+    const next = getNextGraphZoom(fittedZoom, 0.25, range);
+
+    expect(next).not.toBeNull();
+    expect(next?.zoom).toBeGreaterThan(fittedZoom);
+  });
+
+  it('does not zoom out below the fitted graph zoom', () => {
+    const range = getGraphZoomRange(1);
+
+    expect(getNextGraphZoom(1, -0.25, range)).toBeNull();
+  });
+
+  it('clamps zoom in to the maximum zoom', () => {
+    const next = getNextGraphZoom(2.9, 0.25, getGraphZoomRange(0.2));
+
+    expect(next?.zoom).toBe(GRAPH_ZOOM_MAX);
+    expect(next?.delta).toBeCloseTo(GRAPH_ZOOM_MAX / 2.9 - 1);
+  });
+
+  it('clamps an oversized fitted zoom to the maximum zoom', () => {
+    expect(getGraphZoomRange(GRAPH_ZOOM_MAX + 1).min).toBe(GRAPH_ZOOM_MAX);
+  });
+
+  it('returns null when the requested zoom is already on the range boundary', () => {
+    expect(getNextGraphZoom(GRAPH_ZOOM_MAX, 0.25, getGraphZoomRange(0.2))).toBeNull();
+  });
+
+  it('guards invalid current zoom values', () => {
+    expect(getNextGraphZoom(Number.NaN, 0.25, getGraphZoomRange(0.2))).toBeNull();
+    expect(getNextGraphZoom(0, 0.25, getGraphZoomRange(0.2))).toBeNull();
+  });
+
+  it('falls back to a valid minimum for invalid fitted zoom values', () => {
+    expect(getGraphZoomRange(Number.NaN).min).toBe(1);
+    expect(getGraphZoomRange(0).min).toBe(1);
+  });
+
+  it('checks whether a zoom value is inside the graph zoom range', () => {
+    const range = getGraphZoomRange(0.5);
+
+    expect(isGraphZoomAllowed(0.5, range)).toBe(true);
+    expect(isGraphZoomAllowed(0.49, range)).toBe(false);
+    expect(isGraphZoomAllowed(GRAPH_ZOOM_MAX + 0.01, range)).toBe(false);
+  });
+
+  it('allows programmatic fit zoom below the current range minimum', () => {
+    const range = getGraphZoomRange(1);
+
+    expect(isGraphZoomAllowed(0.25, range, { allowBelowMin: true })).toBe(true);
+    expect(isGraphZoomAllowed(GRAPH_ZOOM_MAX + 0.01, range, { allowBelowMin: true })).toBe(false);
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.ts
@@ -1,0 +1,52 @@
+export const GRAPH_ZOOM_MAX = 3;
+const GRAPH_ZOOM_EPSILON = 0.0001;
+const GRAPH_ZOOM_FALLBACK_MIN = 1;
+
+export interface GraphZoomRange {
+  min: number;
+  max: number;
+}
+
+interface GraphZoomAllowedOptions {
+  allowBelowMin?: boolean;
+}
+
+export function getGraphZoomRange(fittedZoom: number): GraphZoomRange {
+  const safeFittedZoom =
+    Number.isFinite(fittedZoom) && fittedZoom > 0
+      ? Math.min(fittedZoom, GRAPH_ZOOM_MAX)
+      : GRAPH_ZOOM_FALLBACK_MIN;
+
+  return {
+    min: safeFittedZoom,
+    max: GRAPH_ZOOM_MAX,
+  };
+}
+
+export function getNextGraphZoom(
+  currentZoom: number,
+  delta: number,
+  range: GraphZoomRange
+): { zoom: number; delta: number } | null {
+  if (!Number.isFinite(currentZoom) || currentZoom <= 0) return null;
+
+  const requestedZoom = currentZoom * (1 + delta);
+  const zoom = Math.min(Math.max(requestedZoom, range.min), range.max);
+
+  if (!Number.isFinite(zoom) || Math.abs(zoom - currentZoom) < GRAPH_ZOOM_EPSILON) return null;
+
+  return {
+    zoom,
+    delta: zoom / currentZoom - 1,
+  };
+}
+
+export function isGraphZoomAllowed(
+  zoom: number,
+  range: GraphZoomRange,
+  options: GraphZoomAllowedOptions = {}
+): boolean {
+  const min = options.allowBelowMin ? 0 : range.min - GRAPH_ZOOM_EPSILON;
+
+  return zoom >= min && zoom <= range.max + GRAPH_ZOOM_EPSILON;
+}


### PR DESCRIPTION
## Summary
- Keep relationship graph zoom controls usable when fit-to-view scales deep graphs below the previous fixed zoom floor.
- Derive the zoom floor from the actual fit-to-view transform and allow programmatic fit to bypass stale lower bounds after resize.
- Add focused tests for zoom range clamping and invalid zoom values.

## Test Plan
- `npm run test -- relationship-canvas-zoom.test.ts`
- `npm run type-check`
- `npx eslint src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.ts src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.test.ts --config ./eslint.config.js`