### PR TITLE
docs: update screenshots and align "shared with" wording in project docs

### DIFF
--- a/docs/project/contexts.md
+++ b/docs/project/contexts.md
@@ -85,7 +85,7 @@ In each place, the **Contexts** picker shows every context defined in the projec
 
 Resource lists (Data Marts, Storages, Destinations) display attached contexts as badges, and the lists can be filtered by context.
 
-![Data Marts list showing context badges on each row and a context filter dropdown in the toolbar](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/ee9f757e-fa97-47ce-3361-86b031c3da00/public)
+![Data Marts list showing context badges on each row and a context filter dropdown in the toolbar](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/2a131338-482e-43c0-ded7-40fafe0b5000/public)
 
 ### Who Can Change a Resource's Contexts
 

--- a/docs/project/members.md
+++ b/docs/project/members.md
@@ -19,7 +19,7 @@ This applies to Data Marts, Storages, Destinations, Reports, Scheduled Triggers,
 - **Data Marts, Storages, Destinations, Reports**: sortable `Created By` column in list views, and in the **Details** section of each resource's page
 - **Run history**: inline `by [member name]` when a creator profile is available
 
-![Resource list view with a sortable Created By column showing which member created each resource](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/97cca939-e070-48d1-c874-cf3dda4bdc00/public)
+![Resource list view with a sortable Created By column showing which member created each resource](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/c53dcd3d-3bbd-4547-a5a3-f8dd2450de00/public)
 
 ## Initial Ownership
 
@@ -34,7 +34,7 @@ When creating a Storage, Destination, or Report, you can assign owners directly 
 
 Scheduled Triggers do not have dedicated ownership. Access to them follows the same rules as their parent Data Mart or Report.
 
-![Resource creation form with an Owners field for assigning initial owners during setup](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/e8b00bd7-8710-45df-1d3f-3685eddbe500/public)
+![Resource creation form with an Owners field for assigning initial owners during setup](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/7b347212-b2a0-42c5-fa6e-788a32833700/public)
 
 ## Member Removal Impact
 

--- a/docs/project/ownership-and-sharing.md
+++ b/docs/project/ownership-and-sharing.md
@@ -44,7 +44,7 @@ Most resources have a single **Owner** role. Data Marts are the exception — th
 
 A Data Mart may have multiple Technical Owners and multiple Business Owners. Ownership is additive — being assigned as an owner only adds access (guaranteed visibility, and, where the role permits, maintenance through the sharing toggle); it never reduces what the user could already do without the assignment.
 
-![Data Mart settings showing Technical Owner and Business Owner fields with assigned project members](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/c12de869-ff73-4a5e-16f6-5ff26fcee900/public)
+![Data Mart settings showing Technical Owner and Business Owner fields with assigned project members](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/3a8505f3-9bfc-445f-8679-36853567e900/public)
 
 **What an owner can do depends on their role.** For Destinations and Reports, owners have full control regardless of role. For Data Marts and Storages, full control requires Technical User or Project Admin:
 
@@ -139,7 +139,7 @@ The following actions can be granted or restricted by the combination of ownersh
 | **Non-owner Technical User** | No access | See, Use | See, Use, Copy Credentials, Edit, Delete | See, Use, Copy Credentials, Edit, Delete |
 | **Any Business User** | No access | No access | No access | No access |
 
-> ☝️ Business Users do not have direct access to Storages. They interact with data through Data Marts and Destinations available to them.
+> ☝️ Business Users do not have direct access to Storages. They interact with data through Data Marts and Destinations shared with them.
 
 ---
 

--- a/docs/project/roles-and-permissions.md
+++ b/docs/project/roles-and-permissions.md
@@ -8,7 +8,7 @@ Each project member has one of three roles.
 |---|---|
 | **Project Admin** | Full access across all entities |
 | **Technical User** | Build and maintain data resources; can edit any Report they have access to |
-| **Business User** | Self-service reporting on Data Marts available to them; manage own Reports and Destinations |
+| **Business User** | Self-service reporting on Data Marts shared with them; manage own Reports and Destinations |
 
 ## Project Admin
 
@@ -53,7 +53,7 @@ Assigned to members who create and run reports on data prepared by Technical Use
 
 **Data access:**
 
-- View Data Marts and their scheduled triggers made available to them
+- View Data Marts and their scheduled triggers shared with them
 - Create Reports on Data Marts shared for reporting, using Destinations they have access to
 - Edit, delete, and run Reports they own
 - Create and manage Destinations they own or have maintenance access to


### PR DESCRIPTION
# Problem

Several project documentation pages had stale screenshot URLs pointing to outdated CDN images, and two pages (`ownership-and-sharing.md` and `roles-and-permissions.md`) still used the old "available to them" phrasing for Business User access descriptions. This left the docs inconsistent with the "Shared for / Sharing" terminology introduced in the previous rename PR.

# Solution

Replaced stale CDN image URLs across three docs pages with updated ones reflecting the current UI. Updated the two remaining "available to them" phrases to "shared with them" to complete the terminology alignment. No logic, UI code, or API contracts were changed.

# Changes

- Replaced screenshot URL in `contexts.md` (Contexts list view)
- Replaced two screenshot URLs in `members.md` (Created By column and Owners field)
- Replaced screenshot URL in `ownership-and-sharing.md` (Data Mart ownership settings)
- Updated "available to them" → "shared with them" in `ownership-and-sharing.md` (Storage access callout)
- Updated "available to them" → "shared with them" in `roles-and-permissions.md` (Roles Overview table and Business User data access bullet)
