### PR TITLE
fix(backend): write full ODM note only on first column, short marker on the rest

### DIFF
--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -125,6 +125,7 @@ function buildWriter(opts: BuildOpts) {
   };
   const metadataFormatter = {
     buildImportedColumnNote: jest.fn().mockReturnValue('note'),
+    buildImportedColumnMarker: jest.fn().mockReturnValue('marker'),
     createNoteRequest: jest.fn().mockReturnValue({}),
     createTabColorAndFreezeHeaderRequest: jest.fn().mockReturnValue({}),
     createDeveloperMetadataRequest: jest.fn().mockReturnValue({}),
@@ -169,7 +170,7 @@ function buildWriter(opts: BuildOpts) {
     dataMart: { id: 'dm-1', projectId: 'proj-1', title: 'DM' },
   };
 
-  return { writer, adapter, report, finalImportedNames };
+  return { writer, adapter, report, finalImportedNames, metadataFormatter };
 }
 
 const makeHeaders = (...names: string[]): ReportDataHeader[] =>
@@ -413,5 +414,34 @@ describe('GoogleSheetsReportWriter — pre-clear range invariants', () => {
       range.includes('!A2:')
     );
     expect(dataWrites).toHaveLength(0);
+  });
+});
+
+describe('GoogleSheetsReportWriter — per-column header notes', () => {
+  it('writes the full ODM note only on the first column and the short marker on the rest', async () => {
+    const { writer, report, finalImportedNames, metadataFormatter } = buildWriter({
+      availableRowsCount: 11,
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+    await writer.finalize();
+
+    // Three imported columns → exactly one full note (A1) + two short markers.
+    expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledTimes(1);
+    expect(metadataFormatter.buildImportedColumnMarker).toHaveBeenCalledTimes(
+      finalImportedNames.length - 1
+    );
+    // The full note belongs to the first column's description ('country').
+    expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledWith(
+      undefined,
+      'DM',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Boolean)
+    );
   });
 });

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -758,9 +758,16 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
         headerRow,
       ]);
 
-      // Per-column note: description first, ODM info second. Every imported
-      // column carries the ODM provenance block so users can see ownership at
-      // a glance on any header — not just A1.
+      // Per-column note: only the FIRST column of the range (index 0, i.e. A1)
+      // carries the full provenance block — the user's column description plus
+      // the ODM metadata (import time, data mart title, link). Every other
+      // imported column gets just a short `--- Imported via OWOX Data Marts ---`
+      // marker, enough to show the column is ODM-managed without burying the
+      // user's content under the same metadata repeated in every header.
+      //
+      // `dataMart` is always the main/home data mart — columns pulled in from
+      // joinable data marts only change the column alias, never this note — so
+      // A1 already references the right (original) data mart for blended marts.
       const dateNow = DateTime.now().setZone(this.spreadsheetTimeZone);
       const dateNowFormatted = `${dateNow.toFormat('yyyy LLL d, HH:mm:ss')} ${dateNow.zoneName}`;
       const dataMart = this.report.dataMart;
@@ -775,13 +782,17 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
 
       const noteRequests = this.reportDataHeaders.map(header => {
         const idx = this.columnPlan.nameToFinalIndex.get(header.name)!;
-        const note = this.metadataFormatter.buildImportedColumnNote(
-          header.description,
-          this.dataMartTitle,
-          dataMartUrl,
-          dateNowFormatted,
-          isCommunityEdition
-        );
+        // The range always starts at column A, so index 0 is the first column.
+        const note =
+          idx === 0
+            ? this.metadataFormatter.buildImportedColumnNote(
+                header.description,
+                this.dataMartTitle,
+                dataMartUrl,
+                dateNowFormatted,
+                isCommunityEdition
+              )
+            : this.metadataFormatter.buildImportedColumnMarker(isCommunityEdition);
         return this.metadataFormatter.createNoteRequest(sheetId, note, 0, idx);
       });
 

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.spec.ts
@@ -107,6 +107,20 @@ describe('SheetMetadataFormatter', () => {
     });
   });
 
+  describe('buildImportedColumnMarker', () => {
+    it('returns only the short ODM ownership marker', () => {
+      expect(formatter.buildImportedColumnMarker(false)).toBe(
+        '--- Imported via OWOX Data Marts ---'
+      );
+    });
+
+    it('includes the Community Edition suffix inside the marker', () => {
+      expect(formatter.buildImportedColumnMarker(true)).toBe(
+        '--- Imported via OWOX Data Marts Community Edition ---'
+      );
+    });
+  });
+
   describe('buildImportedColumnNote', () => {
     const baseArgs = {
       title: 'Test Data Mart',
@@ -114,7 +128,7 @@ describe('SheetMetadataFormatter', () => {
       date: '2026-04-02 12:00:00 UTC',
     };
 
-    it('places description first followed by the ODM info block', () => {
+    it('places description first, separated by a blank line from the ODM info block', () => {
       const note = formatter.buildImportedColumnNote(
         'Total revenue per campaign per day',
         baseArgs.title,
@@ -124,16 +138,17 @@ describe('SheetMetadataFormatter', () => {
       );
 
       const lines = note.split('\n');
-      // Description on the first line; ODM info begins after the `---` separator.
+      // Description on the first line; ODM info begins after a blank line led
+      // by the `--- Imported via OWOX Data Marts ---` marker.
       expect(lines[0]).toBe('Total revenue per campaign per day');
-      expect(note).toContain('\n---\n');
-      expect(note).toContain('Imported via OWOX Data Marts at 2026-04-02 12:00:00 UTC');
+      expect(note).toContain('\n\n--- Imported via OWOX Data Marts ---\n');
+      expect(note).toContain('Imported at 2026-04-02 12:00:00 UTC');
       expect(note).toContain(`Data Mart: ${baseArgs.title}`);
       expect(note).toContain(`Data Mart page: ${baseArgs.url}`);
-      expect(note.indexOf('Imported via')).toBeGreaterThan(note.indexOf('---'));
+      expect(note.indexOf('Imported at')).toBeGreaterThan(note.indexOf('---'));
     });
 
-    it('omits description and separator when description is undefined', () => {
+    it('starts with the marker and omits the blank-line separator when description is undefined', () => {
       const note = formatter.buildImportedColumnNote(
         undefined,
         baseArgs.title,
@@ -142,11 +157,11 @@ describe('SheetMetadataFormatter', () => {
         false
       );
 
-      expect(note.startsWith('Imported via OWOX Data Marts')).toBe(true);
-      expect(note).not.toContain('---');
+      expect(note.startsWith('--- Imported via OWOX Data Marts ---')).toBe(true);
+      expect(note).not.toContain('\n\n');
     });
 
-    it('appends Community Edition suffix to ODM info', () => {
+    it('appends Community Edition suffix to the marker', () => {
       const note = formatter.buildImportedColumnNote(
         'desc',
         baseArgs.title,
@@ -154,7 +169,7 @@ describe('SheetMetadataFormatter', () => {
         baseArgs.date,
         true
       );
-      expect(note).toContain('OWOX Data Marts Community Edition');
+      expect(note).toContain('--- Imported via OWOX Data Marts Community Edition ---');
     });
 
     it('truncates oversize descriptions before composing the note', () => {
@@ -169,8 +184,8 @@ describe('SheetMetadataFormatter', () => {
 
       // Truncated to 45,000 chars + ellipsis; ODM info block still fits.
       expect(note.length).toBeLessThan(50_000);
-      expect(note).toContain('…\n---\n');
-      expect(note).toContain('Imported via OWOX Data Marts');
+      expect(note).toContain('…\n\n--- Imported via OWOX Data Marts ---');
+      expect(note).toContain('Imported at');
     });
 
     it('also truncates the assembled note when ODM info alone blows the size cap (H5)', () => {

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-metadata-formatter.ts
@@ -180,13 +180,40 @@ export class SheetMetadataFormatter {
   }
 
   /**
-   * Builds the cell-note text written into every header cell ODM owns.
+   * Builds the short ODM ownership marker written into every imported column
+   * *except* the first one in the range. It signals that the column is managed
+   * by OWOX Data Marts without repeating the full provenance block (timestamp,
+   * data mart title, link) that would otherwise be duplicated across every
+   * header and bury the user's own column descriptions.
+   *
+   * The first column of the range gets the full note from
+   * {@link buildImportedColumnNote}; non-first columns get only this marker.
+   */
+  public buildImportedColumnMarker(isCommunityEdition: boolean): string {
+    return this.buildOdmMarker(isCommunityEdition);
+  }
+
+  /**
+   * The single-line ODM ownership marker, shared by the full first-column note
+   * and the short marker written to the remaining columns so both read
+   * identically: `--- Imported via OWOX Data Marts ---`.
+   */
+  private buildOdmMarker(isCommunityEdition: boolean): string {
+    const editionSuffix = isCommunityEdition ? ' Community Edition' : '';
+    return `--- Imported via OWOX Data Marts${editionSuffix} ---`;
+  }
+
+  /**
+   * Builds the full cell-note text written into the FIRST imported column of
+   * the data mart range (A1 of the range). Non-first columns get the short
+   * marker from {@link buildImportedColumnMarker} instead.
    *
    * The column's own description is placed first (so users see the relevant
-   * context immediately), followed by ODM provenance info — date, data mart
-   * title, and link back to the OWOX UI. If the description is empty or
-   * exceeds {@link MAX_DESCRIPTION_LENGTH_IN_NOTE} characters, it is omitted
-   * or truncated with an ellipsis to stay within Sheets' note size limit.
+   * context immediately), separated by a blank line from the ODM provenance
+   * block — marker line, import date, data mart title, and link back to the
+   * OWOX UI. If the description is empty or exceeds
+   * {@link MAX_DESCRIPTION_LENGTH_IN_NOTE} characters, it is omitted or
+   * truncated with an ellipsis to stay within Sheets' note size limit.
    */
   public buildImportedColumnNote(
     description: string | undefined,
@@ -195,9 +222,9 @@ export class SheetMetadataFormatter {
     dateFormatted: string,
     isCommunityEdition: boolean
   ): string {
-    const editionSuffix = isCommunityEdition ? ' Community Edition' : '';
     const odmInfo =
-      `Imported via OWOX Data Marts${editionSuffix} at ${dateFormatted}\n` +
+      `${this.buildOdmMarker(isCommunityEdition)}\n` +
+      `Imported at ${dateFormatted}\n` +
       `Data Mart: ${dataMartTitle}\n` +
       `Data Mart page: ${dataMartUrl}`;
 
@@ -209,7 +236,9 @@ export class SheetMetadataFormatter {
       safeDescription = safeTruncate(safeDescription, MAX_DESCRIPTION_LENGTH_IN_NOTE);
     }
 
-    const assembled = safeDescription ? `${safeDescription}\n---\n${odmInfo}` : odmInfo;
+    // Blank line between the user's description and the ODM block so the two
+    // never read as one paragraph (the marker line provides the visual divider).
+    const assembled = safeDescription ? `${safeDescription}\n\n${odmInfo}` : odmInfo;
 
     // H5 — Even with description truncated, the ODM info block can blow the
     // limit when `dataMartTitle` (user-controlled, unbounded) is huge. Cap


### PR DESCRIPTION
## Preview
<img width="558" height="326" alt="CleanShot 2026-06-01 at 18 22 09" src="https://github.com/user-attachments/assets/887c0102-c754-4cd7-9421-5b7c9531b68d" />

## Summary

When a Data Mart is imported into a Google Sheet, the full "Imported via OWOX
Data Marts" provenance block (timestamp, Data Mart name, Data Mart page link)
was duplicated into the note of **every** column header. Combined with the
per-column description, this buried the user's own column descriptions under
repeated technical metadata.

This change keeps the ODM ownership signal on every imported column while
showing the full metadata block only once:

- **First column of the range (A1):** full note — the column description, a
  blank line, then the ODM metadata block (`--- Imported via OWOX Data Marts ---`,
  import timestamp, Data Mart name, Data Mart page link).
- **All other columns:** only the short marker `--- Imported via OWOX Data Marts ---`,
  enough to show the column is ODM-managed without repeating the metadata.
- **Joined / blended Data Marts:** A1 references only the main (Original/Home)
  Data Mart. This already held — `report.dataMart` is always the main mart, and
  joinable marts only affect the column alias, never the note — and is now
  documented in the writer.

## Changes

- `sheet-metadata-formatter.ts`
  - Add `buildImportedColumnMarker(isCommunityEdition)` returning the short marker.
  - Extract private `buildOdmMarker()` so the full note and the short marker
    read identically.
  - Restructure `buildImportedColumnNote()`: the marker is now the header line
    of the metadata block (`Imported at <timestamp>` instead of
    `Imported via OWOX Data Marts at <timestamp>`), and the description is
    separated from the block by a blank line so the two never read as one
    paragraph.
- `google-sheets-report-writer.ts`
  - In `writeHeaders()`, branch on `idx === 0`: the first column gets the full
    note, every other column gets the short marker.

## Notes

- The change only affects the **text** of the notes. ODM-owned-column
  detection and imported-range delineation rely on developer metadata
  (`OWOX_COLUMNS` / `OWOX_REPORT_META`), not on note text, so behavior is
  unaffected.
- Existing sheets keep their old per-column notes until the next refresh, which
  rewrites all header notes — they self-heal on the next import.

## Testing

- Updated `sheet-metadata-formatter.spec.ts` for the new note format and added
  coverage for `buildImportedColumnMarker`.
- Added a writer test asserting exactly one full note (A1) + N−1 short markers.
- All 29 tests pass; lint clean on the changed files.

## DoD

- [x] A1 of the Data Mart range carries the full note: column description + ODM
      metadata block (timestamp, Data Mart name, Data Mart page link)
- [x] Other columns of the range carry only the short marker
      (`--- Imported via OWOX Data Marts ---`)
- [x] For joined Data Marts, A1 references only the main (Original/Home) Data
      Mart, without joinable marts
- [x] Column description is visually separated from the ODM marker (blank line
      between them)