### PR TITLE
fix(data-marts): defer report consumption until run persists

### DIFF
--- a/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.spec.ts
@@ -38,9 +38,6 @@ describe('EmailReportWriter', () => {
         prompts: [],
       }),
     };
-    const consumptionTrackingService = {
-      registerEmailBasedReportRunConsumption: jest.fn().mockResolvedValue(undefined),
-    };
     const eventDispatcher = {
       publishExternal: jest.fn().mockResolvedValue(undefined),
     };
@@ -72,7 +69,6 @@ describe('EmailReportWriter', () => {
         markdownParser as never as MarkdownParser,
         publicOriginService as never,
         insightTemplateFacade as never as DataMartInsightTemplateFacadeImpl,
-        consumptionTrackingService as never,
         eventDispatcher as never,
         credentialsResolver as never as DataDestinationCredentialsResolver,
         sourceDataService as never as InsightTemplateSourceDataService,
@@ -86,7 +82,6 @@ describe('EmailReportWriter', () => {
       insightTemplateService,
       sourceUsageService,
       credentialsResolver,
-      consumptionTrackingService,
       eventDispatcher,
     };
   };
@@ -133,6 +128,30 @@ describe('EmailReportWriter', () => {
         },
       },
     }) as Report;
+
+  it('finalizes delivery without returning consumption metadata', async () => {
+    const { writer, emailProvider, eventDispatcher } = createWriter();
+    const report = createReport();
+
+    await writer.prepareToWriteReport(report, new ReportDataDescription([]));
+    const result = await writer.finalize();
+
+    expect(result).toBeUndefined();
+    expect(emailProvider.sendEmail).toHaveBeenCalledTimes(1);
+    expect(eventDispatcher.publishExternal).toHaveBeenCalledTimes(1);
+    const event = eventDispatcher.publishExternal.mock.calls[0][0] as {
+      name: string;
+      payload: unknown;
+    };
+    expect(event.name).toBe('email.report.run.successfully');
+    expect(event.payload).toEqual({
+      dataMartId: 'data-mart-1',
+      runId: 'report-1',
+      biProjectId: 'project-1',
+      userId: 'user-1',
+      status: 'successfully',
+    });
+  });
 
   it('passes preloaded main source to buildRenderContext for insight template reports', async () => {
     const { writer, sourceDataService, insightTemplateFacade, emailProvider, sourceUsageService } =

--- a/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.ts
@@ -31,7 +31,6 @@ import {
   ReportRunExecutionContext,
   ReportRunLogger,
 } from '../../../../report-run-logging/report-run-logger';
-import { ConsumptionTrackingService } from '../../../../services/consumption-tracking.service';
 import { InsightTemplateSourceDataService } from '../../../../services/insight-template-source-data.service';
 import { InsightTemplateService } from '../../../../services/insight-template.service';
 import { InsightTemplateSourceUsageService } from '../../../../services/insight-template-source-usage.service';
@@ -43,6 +42,7 @@ import { TemplateSourceTypeEnum } from '../../../../enums/template-source-type.e
 import { ReportCondition } from '../../../enums/report-condition.enum';
 import {
   DataDestinationReportWriter,
+  ReportWriteFinalizeResult,
   ReportWriteFinalizeMeta,
 } from '../../../interfaces/data-destination-report-writer.interface';
 import { RowsTruncationInfo } from '../../../../use-cases/report-execution-policy.resolver';
@@ -83,7 +83,6 @@ abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
     private readonly markdownParser: MarkdownParser,
     private readonly publicOriginService: PublicOriginService,
     private readonly insightTemplateFacade: DataMartInsightTemplateFacadeImpl,
-    private readonly consumptionTrackingService: ConsumptionTrackingService,
     private readonly eventDispatcher: OwoxEventDispatcher,
     private readonly credentialsResolver: DataDestinationCredentialsResolver,
     private readonly sourceDataService: InsightTemplateSourceDataService,
@@ -119,7 +118,10 @@ abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
     this.reportDataRows.push(...reportDataBatch.dataRows);
   }
 
-  public async finalize(processingError?: Error, meta?: ReportWriteFinalizeMeta): Promise<void> {
+  public async finalize(
+    processingError?: Error,
+    meta?: ReportWriteFinalizeMeta
+  ): Promise<ReportWriteFinalizeResult | void> {
     this.mainRowsTruncationInfo = meta?.mainRowsTruncationInfo ?? null;
 
     if (processingError) {
@@ -139,7 +141,6 @@ abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
       await this.sendEmail(emailHtml);
     }
 
-    await this.consumptionTrackingService.registerEmailBasedReportRunConsumption(this.report);
     await this.produceRunEvent('successfully');
   }
 
@@ -420,7 +421,6 @@ export class EmailReportWriter extends BaseEmailReportWriter {
     markdownParser: MarkdownParser,
     publicOriginService: PublicOriginService,
     insightTemplateFacade: DataMartInsightTemplateFacadeImpl,
-    consumptionTrackingService: ConsumptionTrackingService,
     eventDispatcher: OwoxEventDispatcher,
     credentialsResolver: DataDestinationCredentialsResolver,
     sourceDataService: InsightTemplateSourceDataService,
@@ -432,7 +432,6 @@ export class EmailReportWriter extends BaseEmailReportWriter {
       markdownParser,
       publicOriginService,
       insightTemplateFacade,
-      consumptionTrackingService,
       eventDispatcher,
       credentialsResolver,
       sourceDataService,
@@ -452,7 +451,6 @@ export class SlackReportWriter extends BaseEmailReportWriter {
     markdownParser: MarkdownParser,
     publicOriginService: PublicOriginService,
     insightTemplateFacade: DataMartInsightTemplateFacadeImpl,
-    consumptionTrackingService: ConsumptionTrackingService,
     eventDispatcher: OwoxEventDispatcher,
     credentialsResolver: DataDestinationCredentialsResolver,
     sourceDataService: InsightTemplateSourceDataService,
@@ -464,7 +462,6 @@ export class SlackReportWriter extends BaseEmailReportWriter {
       markdownParser,
       publicOriginService,
       insightTemplateFacade,
-      consumptionTrackingService,
       eventDispatcher,
       credentialsResolver,
       sourceDataService,
@@ -484,7 +481,6 @@ export class MsTeamsReportWriter extends BaseEmailReportWriter {
     markdownParser: MarkdownParser,
     publicOriginService: PublicOriginService,
     insightTemplateFacade: DataMartInsightTemplateFacadeImpl,
-    consumptionTrackingService: ConsumptionTrackingService,
     eventDispatcher: OwoxEventDispatcher,
     credentialsResolver: DataDestinationCredentialsResolver,
     sourceDataService: InsightTemplateSourceDataService,
@@ -496,7 +492,6 @@ export class MsTeamsReportWriter extends BaseEmailReportWriter {
       markdownParser,
       publicOriginService,
       insightTemplateFacade,
-      consumptionTrackingService,
       eventDispatcher,
       credentialsResolver,
       sourceDataService,
@@ -516,7 +511,6 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
     markdownParser: MarkdownParser,
     publicOriginService: PublicOriginService,
     insightTemplateFacade: DataMartInsightTemplateFacadeImpl,
-    consumptionTrackingService: ConsumptionTrackingService,
     eventDispatcher: OwoxEventDispatcher,
     credentialsResolver: DataDestinationCredentialsResolver,
     sourceDataService: InsightTemplateSourceDataService,
@@ -528,7 +522,6 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
       markdownParser,
       publicOriginService,
       insightTemplateFacade,
-      consumptionTrackingService,
       eventDispatcher,
       credentialsResolver,
       sourceDataService,

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -136,9 +136,6 @@ function buildWriter(opts: BuildOpts) {
     formatRowsValuesByName: jest.fn().mockImplementation((rows: unknown[][]) => rows),
   };
 
-  const consumptionTrackingService = {
-    registerSheetsReportRunConsumption: jest.fn().mockResolvedValue(undefined),
-  };
   const appEditionConfig = { isEnterpriseEdition: jest.fn().mockReturnValue(true) };
   const publicOriginService = {
     getPublicOrigin: jest.fn().mockReturnValue('https://example.test'),
@@ -151,7 +148,6 @@ function buildWriter(opts: BuildOpts) {
     valuesFormatter as never,
     columnPlanBuilder as never,
     adapterFactory as never,
-    consumptionTrackingService as never,
     appEditionConfig as never,
     publicOriginService as never,
     eventDispatcher as never
@@ -176,6 +172,29 @@ const makeHeaders = (...names: string[]): ReportDataHeader[] =>
   names.map(n => new ReportDataHeader(n));
 
 describe('GoogleSheetsReportWriter — pre-clears imported rectangle before writing', () => {
+  it('returns Sheets consumption metadata without registering consumption directly', async () => {
+    const { writer, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+
+    const result = await writer.finalize();
+
+    expect(result).toEqual({
+      consumption: {
+        googleSheets: {
+          googleSheetsDocumentTitle: 'Test Spreadsheet',
+          googleSheetsListTitle: SHEET_TITLE,
+        },
+      },
+    });
+  });
+
   it('pre-clears A2..lastImportedColA1:availableRows on the first batch', async () => {
     // Sheet had 11 rows from a previous (larger) refresh; this run will write
     // header (row 1) + a single data row (row 2). The pre-clear must wipe

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -1,9 +1,9 @@
 import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
 import { ColumnPlan, PreviousImportedColumn } from '../../../dto/domain/column-plan.dto';
-import { ConsumptionTrackingService } from '../../../services/consumption-tracking.service';
 import {
   DataDestinationReportWriter,
   ReportWriteFinalizeMeta,
+  ReportWriteFinalizeResult,
 } from '../../interfaces/data-destination-report-writer.interface';
 import { DataDestinationType } from '../../enums/data-destination-type.enum';
 import { Injectable, Logger, Scope } from '@nestjs/common';
@@ -78,7 +78,6 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
     private readonly valuesFormatter: SheetValuesFormatter,
     private readonly columnPlanBuilder: ColumnPlanBuilder,
     private readonly adapterFactory: GoogleSheetsApiAdapterFactory,
-    private readonly consumptionTrackingService: ConsumptionTrackingService,
     private readonly appEditionConfig: AppEditionConfig,
     private readonly publicOriginService: PublicOriginService,
     private readonly eventDispatcher: OwoxEventDispatcher
@@ -321,7 +320,10 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
    * data, and the design contract is that such failures must leave the
    * sheet exactly as the user last saw it.
    */
-  public async finalize(processingError?: Error, _meta?: ReportWriteFinalizeMeta): Promise<void> {
+  public async finalize(
+    processingError?: Error,
+    _meta?: ReportWriteFinalizeMeta
+  ): Promise<ReportWriteFinalizeResult | void> {
     await this.executeWithErrorHandling(async () => {
       // Zero-batch happy path: the reader finished cleanly but had nothing
       // to write. Bring the sheet layout up to date so column changes do
@@ -477,11 +479,6 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
       }
     }, 'Finalizing report with metadata and formatting');
     if (!processingError) {
-      await this.consumptionTrackingService.registerSheetsReportRunConsumption(this.report, {
-        googleSheetsDocumentTitle: this.spreadsheetTitle,
-        googleSheetsListTitle: this.sheetTitle,
-      });
-
       const dataMart = this.report.dataMart;
       await this.eventDispatcher.publishExternal(
         new SheetsReportRunEvent(
@@ -492,6 +489,14 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
           'successfully'
         )
       );
+      return {
+        consumption: {
+          googleSheets: {
+            googleSheetsDocumentTitle: this.spreadsheetTitle,
+            googleSheetsListTitle: this.sheetTitle,
+          },
+        },
+      };
     } else {
       const dataMart = this.report.dataMart;
       await this.eventDispatcher.publishExternal(

--- a/apps/backend/src/data-marts/data-destination-types/interfaces/data-destination-report-writer.interface.ts
+++ b/apps/backend/src/data-marts/data-destination-types/interfaces/data-destination-report-writer.interface.ts
@@ -10,6 +10,15 @@ export interface ReportWriteFinalizeMeta {
   mainRowsTruncationInfo?: RowsTruncationInfo | null;
 }
 
+export interface ReportWriteFinalizeResult {
+  consumption?: {
+    googleSheets?: {
+      googleSheetsDocumentTitle: string;
+      googleSheetsListTitle: string;
+    };
+  };
+}
+
 /**
  * Interface for writing reports to data destinations
  * Implementations handle the specifics of writing data to different destination types
@@ -42,5 +51,8 @@ export interface DataDestinationReportWriter extends TypedComponent<DataDestinat
    * @param processingError - Optional error that occurred during report processing
    * @param meta - Optional report-level metadata computed during execution
    */
-  finalize(processingError?: Error, meta?: ReportWriteFinalizeMeta): Promise<void>;
+  finalize(
+    processingError?: Error,
+    meta?: ReportWriteFinalizeMeta
+  ): Promise<ReportWriteFinalizeResult | void>;
 }

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
@@ -285,6 +285,40 @@ describe('LookerStudioConnectorApiService', () => {
         expect(consumptionTrackingService.registerLookerReportRunConsumption).toHaveBeenCalled();
         expect(eventDispatcher.publishExternal).toHaveBeenCalled();
       });
+
+      it('should not register consumption when final success is not persisted (non-streaming)', async () => {
+        delete process.env.LOOKER_STREAMING_ENABLED;
+        cacheService.getOrCreateCachedReader.mockResolvedValue({
+          fromCache: false,
+          reader: {},
+          dataDescription: { dataHeaders: [] },
+        } as any);
+        const request = createMockRequest(false);
+        const res = createMockResponse();
+        const mockResult = { schema: [], rows: [], filtersApplied: [] };
+        const mockReportRun = {
+          markAsSuccess: jest.fn(),
+          markAsUnsuccessful: jest.fn(),
+          getReport: jest.fn().mockReturnValue(createMockReport()),
+          getReportId: jest.fn().mockReturnValue('report-1'),
+        };
+
+        reportRunService.create.mockResolvedValue(mockReportRun as any);
+        reportRunService.finish.mockRejectedValueOnce(new Error('db unavailable'));
+        dataService.getData.mockResolvedValue({
+          response: mockResult,
+          meta: { limitExceeded: false, rowsSent: 0, bytesSent: undefined, limitReason: undefined },
+        } as any);
+
+        await service.getDataStreaming(request, res as Response);
+
+        expect(mockReportRun.markAsSuccess).toHaveBeenCalled();
+        expect(reportRunService.finish).toHaveBeenCalled();
+        expect(
+          consumptionTrackingService.registerLookerReportRunConsumption
+        ).not.toHaveBeenCalled();
+        expect(eventDispatcher.publishExternal).not.toHaveBeenCalled();
+      });
     });
 
     describe('full extraction with streaming enabled', () => {
@@ -378,6 +412,82 @@ describe('LookerStudioConnectorApiService', () => {
         expect(reportRunService.finish).toHaveBeenCalled();
         expect(consumptionTrackingService.registerLookerReportRunConsumption).toHaveBeenCalled();
         expect(eventDispatcher.publishExternal).toHaveBeenCalled();
+      });
+
+      it('should keep successful run when consumption registration fails', async () => {
+        process.env.LOOKER_STREAMING_ENABLED = 'true';
+        cacheService.getOrCreateCachedReader.mockResolvedValue({
+          fromCache: false,
+          reader: {},
+          dataDescription: { dataHeaders: [] },
+        } as any);
+        const request = createMockRequest(false);
+        const res = createMockResponse();
+        const mockReportRun = {
+          markAsSuccess: jest.fn(),
+          markAsUnsuccessful: jest.fn(),
+          getReport: jest.fn().mockReturnValue(createMockReport()),
+          getReportId: jest.fn().mockReturnValue('report-1'),
+        };
+
+        reportRunService.create.mockResolvedValue(mockReportRun as any);
+        dataService.prepareStreamingContext.mockResolvedValue({} as any);
+        dataService.streamData.mockResolvedValue({
+          rowCount: 100,
+          limitExceeded: false,
+          bytesWritten: 10,
+          limitReason: undefined,
+        } as any);
+        consumptionTrackingService.registerLookerReportRunConsumption.mockRejectedValueOnce(
+          new Error('pubsub unavailable')
+        );
+
+        await service.getDataStreaming(request, res as Response);
+
+        expect(mockReportRun.markAsSuccess).toHaveBeenCalled();
+        expect(mockReportRun.markAsUnsuccessful).not.toHaveBeenCalled();
+        expect(reportRunService.finish).toHaveBeenCalled();
+        expect(consumptionTrackingService.registerLookerReportRunConsumption).toHaveBeenCalled();
+        expect(eventDispatcher.publishExternal).toHaveBeenCalled();
+        expect((service as any).logger.warn).toHaveBeenCalledWith(
+          'Failed to register Looker report consumption for report-1: pubsub unavailable'
+        );
+      });
+
+      it('should not register consumption when final success is not persisted', async () => {
+        process.env.LOOKER_STREAMING_ENABLED = 'true';
+        cacheService.getOrCreateCachedReader.mockResolvedValue({
+          fromCache: false,
+          reader: {},
+          dataDescription: { dataHeaders: [] },
+        } as any);
+        const request = createMockRequest(false);
+        const res = createMockResponse();
+        const mockReportRun = {
+          markAsSuccess: jest.fn(),
+          markAsUnsuccessful: jest.fn(),
+          getReport: jest.fn().mockReturnValue(createMockReport()),
+          getReportId: jest.fn().mockReturnValue('report-1'),
+        };
+
+        reportRunService.create.mockResolvedValue(mockReportRun as any);
+        reportRunService.finish.mockRejectedValueOnce(new Error('db unavailable'));
+        dataService.prepareStreamingContext.mockResolvedValue({} as any);
+        dataService.streamData.mockResolvedValue({
+          rowCount: 100,
+          limitExceeded: false,
+          bytesWritten: 10,
+          limitReason: undefined,
+        } as any);
+
+        await service.getDataStreaming(request, res as Response);
+
+        expect(mockReportRun.markAsSuccess).toHaveBeenCalled();
+        expect(reportRunService.finish).toHaveBeenCalled();
+        expect(
+          consumptionTrackingService.registerLookerReportRunConsumption
+        ).not.toHaveBeenCalled();
+        expect(eventDispatcher.publishExternal).not.toHaveBeenCalled();
       });
 
       it('should handle errors before streaming starts', async () => {

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
@@ -415,13 +415,23 @@ export class LookerStudioConnectorApiService {
     reportRun.markAsSuccess();
 
     const saved = await this.saveReportRunResultSafely(reportRun, reportRunLogger);
-    if (saved) {
-      this.logger.log(`Report ${reportRun.getReportId()} completed successfully`);
+    if (!saved) {
+      return;
     }
+
+    this.logger.log(`Report ${reportRun.getReportId()} completed successfully`);
 
     const report = reportRun.getReport();
     if (!cachedReader.fromCache) {
-      await this.consumptionTrackingService.registerLookerReportRunConsumption(report);
+      try {
+        await this.consumptionTrackingService.registerLookerReportRunConsumption(report);
+      } catch (error) {
+        this.logger.warn(
+          `Failed to register Looker report consumption for ${report.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
     }
 
     const {

--- a/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
@@ -17,11 +17,15 @@ import { DataStorageType } from '../data-storage-types/enums/data-storage-type.e
 import { ReportDataBatch } from '../dto/domain/report-data-batch.dto';
 import { ReportDataDescription } from '../dto/domain/report-data-description.dto';
 import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
+import { DataMartRun } from '../entities/data-mart-run.entity';
 import { DataDestination } from '../entities/data-destination.entity';
 import { Report } from '../entities/report.entity';
+import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
+import { DataMartRunType } from '../enums/data-mart-run-type.enum';
 import { ReportExecutionPolicyResolver } from './report-execution-policy.resolver';
 import { RunReportService } from './run-report.service';
 import { RunType } from '../../common/scheduler/shared/types';
+import { ReportRun } from '../models/report-run.model';
 
 jest.mock('../data-destination-types/data-destination-providers', () => ({
   DATA_DESTINATION_REPORT_WRITER_RESOLVER: 'DATA_DESTINATION_REPORT_WRITER_RESOLVER',
@@ -46,8 +50,18 @@ describe('RunReportService', () => {
       // Default: no columnConfig -> no blending, no filter.
       resolveBlendingDecision: jest.fn().mockResolvedValue({ needsBlending: false }),
     };
+    const dataMartService = {
+      actualizeSchemaInEntity: jest.fn().mockResolvedValue(undefined),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    const availableDestinationTypesService = {
+      verifyIsAllowed: jest.fn(),
+    };
     const reportRunService = {
       createPending: jest.fn(),
+      loadByDataMartRunId: jest.fn(),
+      markAsStarted: jest.fn().mockResolvedValue(undefined),
+      finish: jest.fn().mockResolvedValue(undefined),
     };
     const reportRunTriggerService = {
       createTrigger: jest.fn().mockResolvedValue(undefined),
@@ -58,23 +72,33 @@ describe('RunReportService', () => {
     };
     const gracefulShutdownService = {
       isInShutdownMode: jest.fn().mockReturnValue(false),
+      registerActiveProcess: jest.fn(),
+      unregisterActiveProcess: jest.fn(),
+    };
+    const systemTimeService = {
+      now: jest.fn().mockReturnValue(new Date('2026-06-01T10:00:00.000Z')),
+    };
+    const consumptionTrackingService = {
+      registerSheetsReportRunConsumption: jest.fn().mockResolvedValue(undefined),
+      registerEmailBasedReportRunConsumption: jest.fn().mockResolvedValue(undefined),
     };
 
     const service = new RunReportService(
       reportReaderResolver as never,
       reportWriterResolver as never,
-      {} as never,
+      dataMartService as never,
       gracefulShutdownService as never,
-      {} as never,
+      systemTimeService as never,
       reportRunService as never,
-      {} as never,
+      availableDestinationTypesService as never,
       projectBalanceService as never,
       new ReportExecutionPolicyResolver(),
       reportRunTriggerService as never,
       reportAccessService as never,
       blendedReportDataService as never,
       { compose: jest.fn().mockResolvedValue({ sql: 'SELECT 1' }) } as never,
-      { getProjectMemberOrThrow: jest.fn().mockResolvedValue({ role: 'admin' }) } as never
+      { getProjectMemberOrThrow: jest.fn().mockResolvedValue({ role: 'admin' }) } as never,
+      consumptionTrackingService as never
     );
 
     return {
@@ -83,9 +107,13 @@ describe('RunReportService', () => {
       reportWriterResolver,
       projectBalanceService,
       blendedReportDataService,
+      dataMartService,
+      availableDestinationTypesService,
       reportRunService,
       reportRunTriggerService,
       reportAccessService,
+      gracefulShutdownService,
+      consumptionTrackingService,
     };
   };
 
@@ -105,6 +133,19 @@ describe('RunReportService', () => {
     dataDestination.type = destinationType;
     report.dataDestination = dataDestination;
     return report;
+  };
+
+  const createDataMartRun = (report: Report): DataMartRun => {
+    const dataMartRun = new DataMartRun();
+    dataMartRun.id = 'data-mart-run-1';
+    dataMartRun.dataMartId = report.dataMart.id;
+    dataMartRun.reportId = report.id;
+    dataMartRun.status = DataMartRunStatus.PENDING;
+    dataMartRun.type = DataMartRunType.GOOGLE_SHEETS_EXPORT;
+    dataMartRun.createdById = report.createdById;
+    dataMartRun.runType = RunType.manual;
+    dataMartRun.definitionRun = {} as never;
+    return dataMartRun;
   };
 
   const createReader = () => ({
@@ -216,6 +257,254 @@ describe('RunReportService', () => {
 
     expect(logBlendedSqlIfNeeded).toHaveBeenCalledWith(decision, mockLogger);
   });
+
+  it('registers Google Sheets consumption only after final report success is persisted', async () => {
+    const {
+      service,
+      reportReaderResolver,
+      reportWriterResolver,
+      reportRunService,
+      consumptionTrackingService,
+    } = createService();
+    const report = createReport(DataDestinationType.GOOGLE_SHEETS);
+    const reader = createReader();
+    const writer = createWriter(DataDestinationType.GOOGLE_SHEETS);
+    const reportRun = ReportRun.create(report, createDataMartRun(report));
+
+    reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], null));
+    writer.finalize.mockResolvedValue({
+      consumption: {
+        googleSheets: {
+          googleSheetsDocumentTitle: 'Test Spreadsheet',
+          googleSheetsListTitle: 'Sheet1',
+        },
+      },
+    });
+    reportReaderResolver.resolve.mockResolvedValue(reader);
+    reportWriterResolver.resolve.mockResolvedValue(writer);
+    reportRunService.loadByDataMartRunId.mockResolvedValue(reportRun);
+
+    await service.executeExistingRun('data-mart-run-1', 'project-1', 'user-1');
+
+    expect(reportRunService.finish).toHaveBeenCalled();
+    expect(consumptionTrackingService.registerSheetsReportRunConsumption).toHaveBeenCalledWith(
+      report,
+      {
+        googleSheetsDocumentTitle: 'Test Spreadsheet',
+        googleSheetsListTitle: 'Sheet1',
+      }
+    );
+    expect(reportRunService.finish.mock.invocationCallOrder[0]).toBeLessThan(
+      consumptionTrackingService.registerSheetsReportRunConsumption.mock.invocationCallOrder[0]
+    );
+  });
+
+  it.each([
+    DataDestinationType.EMAIL,
+    DataDestinationType.SLACK,
+    DataDestinationType.MS_TEAMS,
+    DataDestinationType.GOOGLE_CHAT,
+  ])(
+    'registers %s consumption only after final report success is persisted',
+    async destinationType => {
+      const {
+        service,
+        reportReaderResolver,
+        reportWriterResolver,
+        reportRunService,
+        consumptionTrackingService,
+      } = createService();
+      const report = createReport(destinationType);
+      const reader = createReader();
+      const writer = createWriter(destinationType);
+      const reportRun = ReportRun.create(report, createDataMartRun(report));
+
+      reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], null));
+      reportReaderResolver.resolve.mockResolvedValue(reader);
+      reportWriterResolver.resolve.mockResolvedValue(writer);
+      reportRunService.loadByDataMartRunId.mockResolvedValue(reportRun);
+
+      await service.executeExistingRun('data-mart-run-1', 'project-1', 'user-1');
+
+      expect(reportRunService.finish).toHaveBeenCalled();
+      expect(
+        consumptionTrackingService.registerEmailBasedReportRunConsumption
+      ).toHaveBeenCalledWith(report);
+      expect(reportRunService.finish.mock.invocationCallOrder[0]).toBeLessThan(
+        consumptionTrackingService.registerEmailBasedReportRunConsumption.mock
+          .invocationCallOrder[0]
+      );
+    }
+  );
+
+  it.each([
+    DataDestinationType.GOOGLE_SHEETS,
+    DataDestinationType.EMAIL,
+    DataDestinationType.SLACK,
+    DataDestinationType.MS_TEAMS,
+    DataDestinationType.GOOGLE_CHAT,
+  ])(
+    'keeps successful %s report status when consumption registration fails',
+    async destinationType => {
+      const {
+        service,
+        reportReaderResolver,
+        reportWriterResolver,
+        reportRunService,
+        consumptionTrackingService,
+      } = createService();
+      const report = createReport(destinationType);
+      const reader = createReader();
+      const writer = createWriter(destinationType);
+      const reportRun = ReportRun.create(report, createDataMartRun(report));
+
+      reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], null));
+      if (destinationType === DataDestinationType.GOOGLE_SHEETS) {
+        writer.finalize.mockResolvedValue({
+          consumption: {
+            googleSheets: {
+              googleSheetsDocumentTitle: 'Test Spreadsheet',
+              googleSheetsListTitle: 'Sheet1',
+            },
+          },
+        });
+        consumptionTrackingService.registerSheetsReportRunConsumption.mockRejectedValueOnce(
+          new Error('pubsub unavailable')
+        );
+      } else {
+        consumptionTrackingService.registerEmailBasedReportRunConsumption.mockRejectedValueOnce(
+          new Error('pubsub unavailable')
+        );
+      }
+      reportReaderResolver.resolve.mockResolvedValue(reader);
+      reportWriterResolver.resolve.mockResolvedValue(writer);
+      reportRunService.loadByDataMartRunId.mockResolvedValue(reportRun);
+
+      await service.executeExistingRun('data-mart-run-1', 'project-1', 'user-1');
+
+      expect(reportRunService.finish).toHaveBeenCalled();
+      if (destinationType === DataDestinationType.GOOGLE_SHEETS) {
+        expect(consumptionTrackingService.registerSheetsReportRunConsumption).toHaveBeenCalled();
+      } else {
+        expect(
+          consumptionTrackingService.registerEmailBasedReportRunConsumption
+        ).toHaveBeenCalledWith(report);
+      }
+      expect(reportRun.getDataMartRun().status).toBe(DataMartRunStatus.SUCCESS);
+    }
+  );
+
+  it('skips Google Sheets consumption when writer finalization returns no metadata', async () => {
+    const {
+      service,
+      reportReaderResolver,
+      reportWriterResolver,
+      reportRunService,
+      consumptionTrackingService,
+    } = createService();
+    const report = createReport(DataDestinationType.GOOGLE_SHEETS);
+    const reader = createReader();
+    const writer = createWriter(DataDestinationType.GOOGLE_SHEETS);
+    const reportRun = ReportRun.create(report, createDataMartRun(report));
+
+    reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], null));
+    reportReaderResolver.resolve.mockResolvedValue(reader);
+    reportWriterResolver.resolve.mockResolvedValue(writer);
+    reportRunService.loadByDataMartRunId.mockResolvedValue(reportRun);
+
+    await service.executeExistingRun('data-mart-run-1', 'project-1', 'user-1');
+
+    expect(reportRunService.finish).toHaveBeenCalled();
+    expect(consumptionTrackingService.registerSheetsReportRunConsumption).not.toHaveBeenCalled();
+    expect(reportRun.getDataMartRun().status).toBe(DataMartRunStatus.SUCCESS);
+  });
+
+  it('does not register Google Sheets consumption when reader finalization fails after writer finalization', async () => {
+    const {
+      service,
+      reportReaderResolver,
+      reportWriterResolver,
+      reportRunService,
+      consumptionTrackingService,
+    } = createService();
+    const report = createReport(DataDestinationType.GOOGLE_SHEETS);
+    const reader = createReader();
+    const writer = createWriter(DataDestinationType.GOOGLE_SHEETS);
+    const reportRun = ReportRun.create(report, createDataMartRun(report));
+
+    reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], null));
+    reader.finalize.mockRejectedValue(new Error('reader cleanup failed'));
+    writer.finalize.mockResolvedValue({
+      consumption: {
+        googleSheets: {
+          googleSheetsDocumentTitle: 'Test Spreadsheet',
+          googleSheetsListTitle: 'Sheet1',
+        },
+      },
+    });
+    reportReaderResolver.resolve.mockResolvedValue(reader);
+    reportWriterResolver.resolve.mockResolvedValue(writer);
+    reportRunService.loadByDataMartRunId.mockResolvedValue(reportRun);
+
+    await service.executeExistingRun('data-mart-run-1', 'project-1', 'user-1');
+
+    expect(writer.finalize).toHaveBeenCalled();
+    expect(reader.finalize).toHaveBeenCalled();
+    expect(reportRun.getDataMartRun().status).toBe(DataMartRunStatus.FAILED);
+    expect(consumptionTrackingService.registerSheetsReportRunConsumption).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    DataDestinationType.GOOGLE_SHEETS,
+    DataDestinationType.EMAIL,
+    DataDestinationType.SLACK,
+    DataDestinationType.MS_TEAMS,
+    DataDestinationType.GOOGLE_CHAT,
+  ])(
+    'does not register %s consumption when final report success is not persisted',
+    async destinationType => {
+      const {
+        service,
+        reportReaderResolver,
+        reportWriterResolver,
+        reportRunService,
+        consumptionTrackingService,
+      } = createService();
+      const report = createReport(destinationType);
+      const reader = createReader();
+      const writer = createWriter(destinationType);
+      const reportRun = ReportRun.create(report, createDataMartRun(report));
+
+      reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], null));
+      if (destinationType === DataDestinationType.GOOGLE_SHEETS) {
+        writer.finalize.mockResolvedValue({
+          consumption: {
+            googleSheets: {
+              googleSheetsDocumentTitle: 'Test Spreadsheet',
+              googleSheetsListTitle: 'Sheet1',
+            },
+          },
+        });
+      }
+      reportReaderResolver.resolve.mockResolvedValue(reader);
+      reportWriterResolver.resolve.mockResolvedValue(writer);
+      reportRunService.loadByDataMartRunId.mockResolvedValue(reportRun);
+      reportRunService.finish.mockRejectedValueOnce(new Error('db unavailable'));
+
+      await service.executeExistingRun('data-mart-run-1', 'project-1', 'user-1');
+
+      expect(reportRunService.finish).toHaveBeenCalled();
+      if (destinationType === DataDestinationType.GOOGLE_SHEETS) {
+        expect(
+          consumptionTrackingService.registerSheetsReportRunConsumption
+        ).not.toHaveBeenCalled();
+      } else {
+        expect(
+          consumptionTrackingService.registerEmailBasedReportRunConsumption
+        ).not.toHaveBeenCalled();
+      }
+    }
+  );
 
   describe('manual runs', () => {
     it('uses checkOperateAccess (not checkMutateAccess) for manual runs', async () => {

--- a/apps/backend/src/data-marts/use-cases/run-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.ts
@@ -6,8 +6,14 @@ import { GracefulShutdownService } from '../../common/scheduler/services/gracefu
 import { SystemTimeService } from '../../common/scheduler/services/system-time.service';
 import { AvailableDestinationTypesService } from '../data-destination-types/available-destination-types.service';
 import { DATA_DESTINATION_REPORT_WRITER_RESOLVER } from '../data-destination-types/data-destination-providers';
-import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
-import { DataDestinationReportWriter } from '../data-destination-types/interfaces/data-destination-report-writer.interface';
+import {
+  DataDestinationType,
+  isEmailBasedDataDestinationType,
+} from '../data-destination-types/enums/data-destination-type.enum';
+import {
+  DataDestinationReportWriter,
+  ReportWriteFinalizeResult,
+} from '../data-destination-types/interfaces/data-destination-report-writer.interface';
 import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../data-storage-types/data-storage-providers';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { DataStorageReportReader } from '../data-storage-types/interfaces/data-storage-report-reader.interface';
@@ -35,6 +41,7 @@ import {
 import { ReportAccessService } from '../services/report-access.service';
 import { ReportSqlComposerService } from '../services/report-sql-composer.service';
 import { SqlParameter } from '../data-storage-types/utils/sql-clause-renderer';
+import { ConsumptionTrackingService } from '../services/consumption-tracking.service';
 
 const ERROR_NAMES = {
   ABORT: 'AbortError',
@@ -100,7 +107,8 @@ export class RunReportService {
     private readonly reportAccessService: ReportAccessService,
     private readonly blendedReportDataService: BlendedReportDataService,
     private readonly reportSqlComposerService: ReportSqlComposerService,
-    private readonly idpProjectionsFacade: IdpProjectionsFacade
+    private readonly idpProjectionsFacade: IdpProjectionsFacade,
+    private readonly consumptionTrackingService: ConsumptionTrackingService
   ) {}
 
   /**
@@ -205,12 +213,13 @@ export class RunReportService {
     accessor: BlendableSchemaAccessor,
     signal?: AbortSignal,
     reportRunLogger?: ReportRunLogger
-  ): Promise<void> {
+  ): Promise<ReportWriteFinalizeResult | undefined> {
     signal?.throwIfAborted();
     const { dataMart, dataDestination } = report;
     const executionPolicy = this.reportExecutionPolicyResolver.resolve(report);
     let reportReader: DataStorageReportReader | null = null;
     let reportWriter: DataDestinationReportWriter | null = null;
+    let finalizeResult: ReportWriteFinalizeResult | undefined;
     let processingError: Error | undefined = undefined;
     try {
       signal?.throwIfAborted();
@@ -273,14 +282,16 @@ export class RunReportService {
       throw error;
     } finally {
       if (reportWriter) {
-        await reportWriter.finalize(processingError, {
-          mainRowsTruncationInfo: executionPolicy.getRowsTruncationInfo(),
-        });
+        finalizeResult =
+          (await reportWriter.finalize(processingError, {
+            mainRowsTruncationInfo: executionPolicy.getRowsTruncationInfo(),
+          })) ?? undefined;
       }
       if (reportReader) {
         await reportReader.finalize();
       }
     }
+    return finalizeResult;
   }
 
   /**
@@ -317,9 +328,14 @@ export class RunReportService {
       await this.actualizeSchemaInDataMart(reportRun.getDataMart());
       await this.reportRunService.markAsStarted(reportRun);
       this.logger.log(`Report ${reportRun.getReportId()} execution started`);
-      await this.executeReport(reportRun.getReport(), accessor, signal, reportRunLogger);
+      const finalizeResult = await this.executeReport(
+        reportRun.getReport(),
+        accessor,
+        signal,
+        reportRunLogger
+      );
       const { logs, errors } = reportRunLogger.asArrays();
-      await this.handleReportRunSuccess(reportRun, logs, errors);
+      await this.handleReportRunSuccess(reportRun, logs, errors, finalizeResult);
     } catch (error) {
       const { logs, errors } = reportRunLogger.asArrays();
       await this.handleReportRunError(reportRun, error as Error, logs, errors);
@@ -433,13 +449,50 @@ export class RunReportService {
   private async handleReportRunSuccess(
     reportRun: ReportRun,
     logs: string[] = [],
-    errors: string[] = []
+    errors: string[] = [],
+    finalizeResult?: ReportWriteFinalizeResult
   ): Promise<void> {
     reportRun.markAsSuccess();
 
     const saved = await this.saveReportRunResultSafely(reportRun, logs, errors);
-    if (saved) {
-      this.logger.log(`Report ${reportRun.getReportId()} completed successfully`);
+    if (!saved) {
+      return;
+    }
+
+    this.logger.log(`Report ${reportRun.getReportId()} completed successfully`);
+    await this.registerReportRunConsumption(reportRun.getReport(), finalizeResult);
+  }
+
+  private async registerReportRunConsumption(
+    report: Report,
+    finalizeResult?: ReportWriteFinalizeResult
+  ): Promise<void> {
+    try {
+      if (report.dataDestination.type === DataDestinationType.GOOGLE_SHEETS) {
+        const sheetsDetails = finalizeResult?.consumption?.googleSheets;
+        if (!sheetsDetails) {
+          this.logger.warn(
+            `Skipping Google Sheets report consumption for ${report.id}: missing finalize metadata`
+          );
+          return;
+        }
+
+        await this.consumptionTrackingService.registerSheetsReportRunConsumption(
+          report,
+          sheetsDetails
+        );
+        return;
+      }
+
+      if (isEmailBasedDataDestinationType(report.dataDestination.type)) {
+        await this.consumptionTrackingService.registerEmailBasedReportRunConsumption(report);
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Failed to register report consumption for ${report.id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Move report consumption registration out of destination writers and run it only after final status persistence succeeds.
- Return Google Sheets consumption metadata from writer finalization and swallow consumption tracking failures after a successful run.
- Add regression coverage for Sheets, Looker, and email-like destinations around ordering, persistence failures, and tracking failures.

## Test plan
- npm test -w @owox/backend -- run-report.service.spec.ts google-sheets-report-writer.spec.ts email-report-writer.spec.ts looker-studio-connector-api.service.spec.ts --runInBand
- npm run build -w @owox/backend
- git diff --check