### PR TITLE
fix(backend): preserve user column formats on Google Sheets refresh

### DIFF
--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
@@ -151,7 +151,7 @@ describe('GoogleSheetsApiAdapter (pure helpers)', () => {
     });
   });
 
-  describe('getColumnNumberFormats', () => {
+  describe('getColumnFormats', () => {
     /**
      * Builds a `spreadsheets.get` response whose `sheets` array lists a
      * decoy tab FIRST and the target tab second. This reproduces the real
@@ -159,7 +159,7 @@ describe('GoogleSheetsApiAdapter (pure helpers)', () => {
      * not reorder `sheets` so that the requested tab is `sheets[0]`. The
      * adapter must therefore select by `sheetId`, not by position.
      */
-    const buildGetMock = (rows: Array<{ numberFormat?: sheets_v4.Schema$NumberFormat }>) =>
+    const buildGetMock = (cells: Array<sheets_v4.Schema$CellFormat | undefined>) =>
       jest.fn().mockResolvedValue({
         data: {
           sheets: [
@@ -172,11 +172,7 @@ describe('GoogleSheetsApiAdapter (pure helpers)', () => {
                 {
                   rowData: [
                     {
-                      values: rows.map(r =>
-                        r.numberFormat
-                          ? { userEnteredFormat: { numberFormat: r.numberFormat } }
-                          : {}
-                      ),
+                      values: cells.map(fmt => (fmt ? { userEnteredFormat: fmt } : {})),
                     },
                   ],
                 },
@@ -194,15 +190,18 @@ describe('GoogleSheetsApiAdapter (pure helpers)', () => {
 
     it('selects the target tab by sheetId, not by array position', async () => {
       const adapter = buildAdapter();
-      const currency: sheets_v4.Schema$NumberFormat = { type: 'CURRENCY', pattern: '"$"#,##0.00' };
-      const getMock = buildGetMock([{}, { numberFormat: currency }, {}]);
+      const currency: sheets_v4.Schema$CellFormat = {
+        numberFormat: { type: 'CURRENCY', pattern: '"$"#,##0.00' },
+      };
+      const getMock = buildGetMock([undefined, currency, undefined]);
       withGetMock(adapter, getMock);
 
-      const formats = await adapter.getColumnNumberFormats('spread-1', 7, 'Sheet1', 2, 1, 3);
+      const formats = await adapter.getColumnFormats('spread-1', 7, 'Sheet1', 2, 2, 1, 3);
 
       // Despite the decoy tab being sheets[0], we read the sheetId=7 tab.
       expect(formats).toEqual([undefined, currency, undefined]);
-      // Sanity: the request scoped the fields to include sheetId for selection.
+      // Sanity: the request scoped the fields to include sheetId for selection
+      // and the full userEnteredFormat (not just numberFormat).
       expect(getMock).toHaveBeenCalledWith(
         expect.objectContaining({
           spreadsheetId: 'spread-1',
@@ -211,6 +210,67 @@ describe('GoogleSheetsApiAdapter (pure helpers)', () => {
           fields: expect.stringContaining('properties(sheetId)'),
         })
       );
+      const calledFields = getMock.mock.calls[0][0].fields as string;
+      expect(calledFields).toContain('userEnteredFormat');
+      expect(calledFields).not.toContain('numberFormat'); // whole-format mask, not numberFormat-only
+    });
+
+    it('captures the whole userEnteredFormat (background, text, alignment), not just numberFormat', async () => {
+      const adapter = buildAdapter();
+      const styled: sheets_v4.Schema$CellFormat = {
+        backgroundColor: { red: 1, green: 0.9, blue: 0.6 },
+        textFormat: { bold: true },
+        horizontalAlignment: 'RIGHT',
+      };
+      const getMock = buildGetMock([styled, undefined]);
+      withGetMock(adapter, getMock);
+
+      const formats = await adapter.getColumnFormats('spread-1', 7, 'Sheet1', 2, 2, 1, 2);
+
+      expect(formats).toEqual([styled, undefined]);
+    });
+
+    it('takes the first non-empty format per column when scanning a multi-row window', async () => {
+      // Column 0: row 2 unformatted, row 3 carries DATE → DATE must win.
+      // Column 1: never formatted across the window → undefined.
+      const adapter = buildAdapter();
+      const date: sheets_v4.Schema$CellFormat = {
+        numberFormat: { type: 'DATE', pattern: 'dd.mm.yyyy' },
+      };
+      const getMock = jest.fn().mockResolvedValue({
+        data: {
+          sheets: [
+            {
+              properties: { sheetId: 7 },
+              data: [
+                {
+                  rowData: [
+                    { values: [{}, {}] }, // row 2: both unformatted
+                    { values: [{ userEnteredFormat: date }, {}] }, // row 3
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+      withGetMock(adapter, getMock);
+
+      const formats = await adapter.getColumnFormats('spread-1', 7, 'Sheet1', 2, 3, 1, 2);
+
+      expect(formats).toEqual([date, undefined]);
+      expect(getMock).toHaveBeenCalledWith(expect.objectContaining({ ranges: ["'Sheet1'!A2:B3"] }));
+    });
+
+    it('treats an empty userEnteredFormat object as no format', async () => {
+      const adapter = buildAdapter();
+      // Cell carries an empty userEnteredFormat ({}) — must be ignored, not captured.
+      const getMock = buildGetMock([{}, undefined]);
+      withGetMock(adapter, getMock);
+
+      const formats = await adapter.getColumnFormats('spread-1', 7, 'Sheet1', 2, 2, 1, 2);
+
+      expect(formats).toEqual([undefined, undefined]);
     });
 
     it('returns all-undefined when the requested sheetId is absent from the response', async () => {
@@ -221,18 +281,30 @@ describe('GoogleSheetsApiAdapter (pure helpers)', () => {
       });
       withGetMock(adapter, getMock);
 
-      const formats = await adapter.getColumnNumberFormats('spread-1', 7, 'Sheet1', 2, 1, 3);
+      const formats = await adapter.getColumnFormats('spread-1', 7, 'Sheet1', 2, 2, 1, 3);
 
       expect(formats).toEqual([undefined, undefined, undefined]);
     });
 
-    it('returns an empty array without calling the API when the span is empty', async () => {
+    it('returns an empty array without calling the API when the column span is empty', async () => {
       const adapter = buildAdapter();
       const getMock = jest.fn();
       withGetMock(adapter, getMock);
 
       // toCol < fromCol → width <= 0.
-      const formats = await adapter.getColumnNumberFormats('spread-1', 7, 'Sheet1', 2, 3, 1);
+      const formats = await adapter.getColumnFormats('spread-1', 7, 'Sheet1', 2, 2, 3, 1);
+
+      expect(formats).toEqual([]);
+      expect(getMock).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty array without calling the API when the row window is empty', async () => {
+      const adapter = buildAdapter();
+      const getMock = jest.fn();
+      withGetMock(adapter, getMock);
+
+      // rowTo < rowFrom → no rows to sample (e.g. sheet has only the header row).
+      const formats = await adapter.getColumnFormats('spread-1', 7, 'Sheet1', 2, 1, 1, 3);
 
       expect(formats).toEqual([]);
       expect(getMock).not.toHaveBeenCalled();

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
@@ -151,6 +151,94 @@ describe('GoogleSheetsApiAdapter (pure helpers)', () => {
     });
   });
 
+  describe('getColumnNumberFormats', () => {
+    /**
+     * Builds a `spreadsheets.get` response whose `sheets` array lists a
+     * decoy tab FIRST and the target tab second. This reproduces the real
+     * failure mode: `ranges` only scopes which grid data is included, it does
+     * not reorder `sheets` so that the requested tab is `sheets[0]`. The
+     * adapter must therefore select by `sheetId`, not by position.
+     */
+    const buildGetMock = (rows: Array<{ numberFormat?: sheets_v4.Schema$NumberFormat }>) =>
+      jest.fn().mockResolvedValue({
+        data: {
+          sheets: [
+            // Decoy tab at index 0 with no grid data (would yield all-undefined).
+            { properties: { sheetId: 999 }, data: [{ rowData: [{ values: [] }] }] },
+            // Target tab at index 1 carrying the real formats.
+            {
+              properties: { sheetId: 7 },
+              data: [
+                {
+                  rowData: [
+                    {
+                      values: rows.map(r =>
+                        r.numberFormat
+                          ? { userEnteredFormat: { numberFormat: r.numberFormat } }
+                          : {}
+                      ),
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+    const withGetMock = (adapter: GoogleSheetsApiAdapter, getMock: jest.Mock) => {
+      (adapter as unknown as { service: { spreadsheets: { get: jest.Mock } } }).service = {
+        spreadsheets: { get: getMock },
+      };
+    };
+
+    it('selects the target tab by sheetId, not by array position', async () => {
+      const adapter = buildAdapter();
+      const currency: sheets_v4.Schema$NumberFormat = { type: 'CURRENCY', pattern: '"$"#,##0.00' };
+      const getMock = buildGetMock([{}, { numberFormat: currency }, {}]);
+      withGetMock(adapter, getMock);
+
+      const formats = await adapter.getColumnNumberFormats('spread-1', 7, 'Sheet1', 2, 1, 3);
+
+      // Despite the decoy tab being sheets[0], we read the sheetId=7 tab.
+      expect(formats).toEqual([undefined, currency, undefined]);
+      // Sanity: the request scoped the fields to include sheetId for selection.
+      expect(getMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spreadsheetId: 'spread-1',
+          ranges: ["'Sheet1'!A2:C2"],
+          includeGridData: true,
+          fields: expect.stringContaining('properties(sheetId)'),
+        })
+      );
+    });
+
+    it('returns all-undefined when the requested sheetId is absent from the response', async () => {
+      const adapter = buildAdapter();
+      // Response only carries the decoy tab (sheetId 999); target 7 is missing.
+      const getMock = jest.fn().mockResolvedValue({
+        data: { sheets: [{ properties: { sheetId: 999 }, data: [{ rowData: [{ values: [] }] }] }] },
+      });
+      withGetMock(adapter, getMock);
+
+      const formats = await adapter.getColumnNumberFormats('spread-1', 7, 'Sheet1', 2, 1, 3);
+
+      expect(formats).toEqual([undefined, undefined, undefined]);
+    });
+
+    it('returns an empty array without calling the API when the span is empty', async () => {
+      const adapter = buildAdapter();
+      const getMock = jest.fn();
+      withGetMock(adapter, getMock);
+
+      // toCol < fromCol → width <= 0.
+      const formats = await adapter.getColumnNumberFormats('spread-1', 7, 'Sheet1', 2, 3, 1);
+
+      expect(formats).toEqual([]);
+      expect(getMock).not.toHaveBeenCalled();
+    });
+  });
+
   describe('findOwoxColumnsMetadataForSheet', () => {
     /**
      * Build a typed metadata fixture quickly. The adapter's filter only

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
@@ -190,7 +190,14 @@ export class GoogleSheetsApiAdapter {
    * format (default / "Automatic" cell). Returns all-`undefined` (and never
    * throws) when the requested range lies outside the current grid.
    *
+   * The target sheet is selected by `sheetId`, not by position: `ranges` only
+   * limits which grid-data portions are included in the response, it does NOT
+   * guarantee that `sheets[0]` is the requested tab. Relying on `sheets[0]`
+   * would read empty/other-tab grid data for any destination that is not the
+   * first sheet, silently skipping the format restore.
+   *
    * @param spreadsheetId - ID of the spreadsheet
+   * @param sheetId - ID of the destination sheet to read from
    * @param sheetTitle - Title of the sheet (used in the A1 range)
    * @param row - 1-based row index to sample (typically the first data row)
    * @param fromCol - 1-based, inclusive
@@ -198,6 +205,7 @@ export class GoogleSheetsApiAdapter {
    */
   public async getColumnNumberFormats(
     spreadsheetId: string,
+    sheetId: number,
     sheetTitle: string,
     row: number,
     fromCol: number,
@@ -213,10 +221,12 @@ export class GoogleSheetsApiAdapter {
         spreadsheetId,
         ranges: [range],
         includeGridData: true,
-        fields: 'sheets(data(rowData(values(userEnteredFormat(numberFormat)))))',
+        fields:
+          'sheets(properties(sheetId),data(rowData(values(userEnteredFormat(numberFormat)))))',
       })
     );
-    const cells = resp.data.sheets?.[0]?.data?.[0]?.rowData?.[0]?.values ?? [];
+    const sheet = resp.data.sheets?.find(s => s.properties?.sheetId === sheetId);
+    const cells = sheet?.data?.[0]?.rowData?.[0]?.values ?? [];
     const formats: (sheets_v4.Schema$NumberFormat | undefined)[] = new Array(width).fill(undefined);
     for (let i = 0; i < width; i++) {
       formats[i] = cells[i]?.userEnteredFormat?.numberFormat ?? undefined;

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
@@ -178,17 +178,27 @@ export class GoogleSheetsApiAdapter {
   }
 
   /**
-   * Reads the user-entered number format of each cell in a single row across
-   * a column span. Used to capture the date/number/currency formats a user
-   * applied to the imported columns *before* the writer overwrites their
-   * values, so they can be restored afterwards (Sheets re-derives a cell's
-   * number format from the value on every `USER_ENTERED` write, which would
-   * otherwise discard the user's formatting on each refresh).
+   * Reads, for each column in a span, the first non-empty user-entered cell
+   * format found while scanning a window of data rows top-down. Used to
+   * capture the formatting a user applied to the imported columns *before* the
+   * writer overwrites their values, so it can be restored afterwards. This
+   * covers the full `userEnteredFormat` — number/date/currency format,
+   * background & text colors, bold/italic, alignment, borders, wrap — not just
+   * the number format (the `USER_ENTERED` value write re-derives the number
+   * format, and restoring the whole format keeps the contract consistent).
+   *
+   * Why a window and not a single row: a format applied to a whole column sits
+   * on every cell (including blank ones), so row 2 alone usually suffices. But
+   * when row 2 happens to be unformatted while the rest of the column carries
+   * the user's format (e.g. only the data rows were formatted, or row 2 was
+   * reset by a prior buggy run), a single-row sample would miss it. Scanning a
+   * bounded window and taking the first formatted cell per column recovers
+   * that case in one request.
    *
    * The returned array is positionally aligned with `[fromCol..toCol]`; a slot
-   * is `undefined` when the corresponding cell carries no explicit number
-   * format (default / "Automatic" cell). Returns all-`undefined` (and never
-   * throws) when the requested range lies outside the current grid.
+   * is `undefined` when no cell in the window carries an explicit format
+   * (default / "Automatic" column). Returns all-`undefined` (and never throws)
+   * when the requested range lies outside the current grid.
    *
    * The target sheet is selected by `sheetId`, not by position: `ranges` only
    * limits which grid-data portions are included in the response, it does NOT
@@ -199,57 +209,82 @@ export class GoogleSheetsApiAdapter {
    * @param spreadsheetId - ID of the spreadsheet
    * @param sheetId - ID of the destination sheet to read from
    * @param sheetTitle - Title of the sheet (used in the A1 range)
-   * @param row - 1-based row index to sample (typically the first data row)
+   * @param rowFrom - 1-based first row of the sample window, inclusive
+   * @param rowTo - 1-based last row of the sample window, inclusive
    * @param fromCol - 1-based, inclusive
    * @param toCol - 1-based, inclusive
    */
-  public async getColumnNumberFormats(
+  public async getColumnFormats(
     spreadsheetId: string,
     sheetId: number,
     sheetTitle: string,
-    row: number,
+    rowFrom: number,
+    rowTo: number,
     fromCol: number,
     toCol: number
-  ): Promise<(sheets_v4.Schema$NumberFormat | undefined)[]> {
+  ): Promise<(sheets_v4.Schema$CellFormat | undefined)[]> {
     const width = toCol - fromCol + 1;
-    if (width <= 0) {
+    if (width <= 0 || rowTo < rowFrom) {
       return [];
     }
-    const range = `'${sheetTitle}'!${GoogleSheetsApiAdapter.colToA1(fromCol)}${row}:${GoogleSheetsApiAdapter.colToA1(toCol)}${row}`;
+    const range = `'${sheetTitle}'!${GoogleSheetsApiAdapter.colToA1(fromCol)}${rowFrom}:${GoogleSheetsApiAdapter.colToA1(toCol)}${rowTo}`;
     const resp = await this.executeWithRetry(() =>
       this.service.spreadsheets.get({
         spreadsheetId,
         ranges: [range],
         includeGridData: true,
-        fields:
-          'sheets(properties(sheetId),data(rowData(values(userEnteredFormat(numberFormat)))))',
+        fields: 'sheets(properties(sheetId),data(rowData(values(userEnteredFormat))))',
       })
     );
     const sheet = resp.data.sheets?.find(s => s.properties?.sheetId === sheetId);
-    const cells = sheet?.data?.[0]?.rowData?.[0]?.values ?? [];
-    const formats: (sheets_v4.Schema$NumberFormat | undefined)[] = new Array(width).fill(undefined);
+    if (!sheet) {
+      // The destination tab was not present in the response — capture cannot
+      // proceed for this refresh. Surface it: silently returning all-undefined
+      // would be indistinguishable from "user set no formats".
+      GoogleSheetsApiAdapter.LOGGER.warn(
+        `getColumnFormats: sheetId ${sheetId} not found in spreadsheet ` +
+          `${spreadsheetId} response; column formats will not be restored this refresh.`
+      );
+      return new Array(width).fill(undefined);
+    }
+    const rowData = sheet.data?.[0]?.rowData ?? [];
+    const formats: (sheets_v4.Schema$CellFormat | undefined)[] = new Array(width).fill(undefined);
     for (let i = 0; i < width; i++) {
-      formats[i] = cells[i]?.userEnteredFormat?.numberFormat ?? undefined;
+      // First non-empty format wins, scanning the window top-down.
+      for (const row of rowData) {
+        const fmt = row.values?.[i]?.userEnteredFormat;
+        if (fmt && Object.keys(fmt).length > 0) {
+          formats[i] = fmt;
+          break;
+        }
+      }
     }
     return formats;
   }
 
   /**
-   * Builds a `repeatCell` request that applies a number format to every cell
-   * of a single column within a row span, touching only
-   * `userEnteredFormat.numberFormat` and leaving all other cell formatting
-   * intact. Used to restore a user's captured column format over the freshly
-   * written data rows after the value write.
+   * Builds a `repeatCell` request that applies a captured cell format to every
+   * cell of a single column within a row span. The field mask is the whole
+   * `userEnteredFormat`, so the full set of user-applied cell formatting is
+   * restored — number format, background/text colors, bold/italic, horizontal
+   * & vertical alignment, borders, wrap, padding, etc. — not just the number
+   * format. The provided `format` is treated as the source of truth for the
+   * range: subfields absent from it are reset to default (matching "copy this
+   * representative cell's formatting onto the column").
+   *
+   * Sheet-level constructs (conditional formatting, data validation) live
+   * outside `userEnteredFormat` and are intentionally NOT touched here — the
+   * value write does not affect them either.
    *
    * All indexes are 0-based; `startRowIndex` is inclusive, `endRowIndex`
    * exclusive (Sheets API GridRange contract).
    */
-  public buildSetColumnNumberFormatRequest(
+  public buildSetColumnFormatRequest(
     sheetId: number,
     columnIndex: number,
     startRowIndex: number,
     endRowIndex: number,
-    numberFormat: sheets_v4.Schema$NumberFormat
+    format: sheets_v4.Schema$CellFormat
   ): sheets_v4.Schema$Request {
     return {
       repeatCell: {
@@ -261,9 +296,9 @@ export class GoogleSheetsApiAdapter {
           endColumnIndex: columnIndex + 1,
         },
         cell: {
-          userEnteredFormat: { numberFormat },
+          userEnteredFormat: format,
         },
-        fields: 'userEnteredFormat.numberFormat',
+        fields: 'userEnteredFormat',
       },
     };
   }

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
@@ -178,6 +178,87 @@ export class GoogleSheetsApiAdapter {
   }
 
   /**
+   * Reads the user-entered number format of each cell in a single row across
+   * a column span. Used to capture the date/number/currency formats a user
+   * applied to the imported columns *before* the writer overwrites their
+   * values, so they can be restored afterwards (Sheets re-derives a cell's
+   * number format from the value on every `USER_ENTERED` write, which would
+   * otherwise discard the user's formatting on each refresh).
+   *
+   * The returned array is positionally aligned with `[fromCol..toCol]`; a slot
+   * is `undefined` when the corresponding cell carries no explicit number
+   * format (default / "Automatic" cell). Returns all-`undefined` (and never
+   * throws) when the requested range lies outside the current grid.
+   *
+   * @param spreadsheetId - ID of the spreadsheet
+   * @param sheetTitle - Title of the sheet (used in the A1 range)
+   * @param row - 1-based row index to sample (typically the first data row)
+   * @param fromCol - 1-based, inclusive
+   * @param toCol - 1-based, inclusive
+   */
+  public async getColumnNumberFormats(
+    spreadsheetId: string,
+    sheetTitle: string,
+    row: number,
+    fromCol: number,
+    toCol: number
+  ): Promise<(sheets_v4.Schema$NumberFormat | undefined)[]> {
+    const width = toCol - fromCol + 1;
+    if (width <= 0) {
+      return [];
+    }
+    const range = `'${sheetTitle}'!${GoogleSheetsApiAdapter.colToA1(fromCol)}${row}:${GoogleSheetsApiAdapter.colToA1(toCol)}${row}`;
+    const resp = await this.executeWithRetry(() =>
+      this.service.spreadsheets.get({
+        spreadsheetId,
+        ranges: [range],
+        includeGridData: true,
+        fields: 'sheets(data(rowData(values(userEnteredFormat(numberFormat)))))',
+      })
+    );
+    const cells = resp.data.sheets?.[0]?.data?.[0]?.rowData?.[0]?.values ?? [];
+    const formats: (sheets_v4.Schema$NumberFormat | undefined)[] = new Array(width).fill(undefined);
+    for (let i = 0; i < width; i++) {
+      formats[i] = cells[i]?.userEnteredFormat?.numberFormat ?? undefined;
+    }
+    return formats;
+  }
+
+  /**
+   * Builds a `repeatCell` request that applies a number format to every cell
+   * of a single column within a row span, touching only
+   * `userEnteredFormat.numberFormat` and leaving all other cell formatting
+   * intact. Used to restore a user's captured column format over the freshly
+   * written data rows after the value write.
+   *
+   * All indexes are 0-based; `startRowIndex` is inclusive, `endRowIndex`
+   * exclusive (Sheets API GridRange contract).
+   */
+  public buildSetColumnNumberFormatRequest(
+    sheetId: number,
+    columnIndex: number,
+    startRowIndex: number,
+    endRowIndex: number,
+    numberFormat: sheets_v4.Schema$NumberFormat
+  ): sheets_v4.Schema$Request {
+    return {
+      repeatCell: {
+        range: {
+          sheetId,
+          startRowIndex,
+          endRowIndex,
+          startColumnIndex: columnIndex,
+          endColumnIndex: columnIndex + 1,
+        },
+        cell: {
+          userEnteredFormat: { numberFormat },
+        },
+        fields: 'userEnteredFormat.numberFormat',
+      },
+    };
+  }
+
+  /**
    * Finds OWOX report metadata by key and sheet
    *
    * @param metadata - Array of developer metadata

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.spec.ts
@@ -59,6 +59,8 @@ describe('ColumnPlanBuilder', () => {
       expect(plan.nameToFinalIndex.get('a')).toBe(0);
       expect(plan.nameToFinalIndex.get('b')).toBe(1);
       expect(plan.nameToFinalIndex.get('c')).toBe(2);
+      // Nothing imported before the first run — no formats to capture.
+      expect(plan.currentImportedNames).toEqual([]);
     });
 
     it('overwrites stale row-1 content when metadata is missing', () => {
@@ -110,6 +112,21 @@ describe('ColumnPlanBuilder', () => {
       expect(plan.finalImportedNames).toEqual(['date', 'cost', 'campaign', 'clicks']);
       expect(plan.nameToFinalIndex.get('cost')).toBe(1);
       expect(plan.nameToFinalIndex.get('campaign')).toBe(2);
+      // `currentImportedNames` reflects the sheet's pre-write order so the
+      // writer can key captured column formats to the right canonical name.
+      expect(plan.currentImportedNames).toEqual(['date', 'cost', 'campaign', 'clicks']);
+    });
+
+    it('exposes currentImportedNames with aliases resolved back to canonical names', () => {
+      // Row 1 shows aliases; currentImportedNames must be the canonical names
+      // (keys the writer uses for the captured-format map).
+      const plan = builder.build(
+        ['Date', 'Cost'],
+        prevAliased('date|Date', 'cost|Cost'),
+        aliased('date|Date', 'cost|Cost')
+      );
+
+      expect(plan.currentImportedNames).toEqual(['date', 'cost']);
     });
 
     it('ignores user content right of the imported range', () => {

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/column-plan-builder.ts
@@ -73,7 +73,8 @@ export class ColumnPlanBuilder {
       [], // ops
       nameToFinalIndex,
       desiredNames.length - 1, // lastImportedColIndex (-1 if empty)
-      -1 // prevLastImportedColIndex
+      -1, // prevLastImportedColIndex
+      [] // currentImportedNames — nothing imported before the first run
     );
   }
 
@@ -188,7 +189,8 @@ export class ColumnPlanBuilder {
       ops,
       nameToFinalIndex,
       finalImportedNames.length - 1,
-      prevLastImportedColIndex
+      prevLastImportedColIndex,
+      currentImportedNames // canonical names at current row-1 positions
     );
   }
 }

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -489,9 +489,11 @@ describe('GoogleSheetsReportWriter — preserves user column number formats acro
       report as never,
       new ReportDataDescription(makeHeaders(...finalImportedNames), 2)
     );
-    // Capture samples row 2 across the imported width, before any write.
+    // Capture samples row 2 across the imported width, before any write —
+    // and targets the destination tab by sheetId (not by position).
     expect(adapter.getColumnNumberFormats).toHaveBeenCalledWith(
       SPREADSHEET_ID,
+      SHEET_ID,
       SHEET_TITLE,
       2,
       1,

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -639,17 +639,18 @@ describe('GoogleSheetsReportWriter — preserves user column formats across refr
     });
     adapter.getColumnFormats.mockRejectedValueOnce(new Error('Sheets get API blew up'));
 
-    // prepareToWriteReport must resolve despite the capture failure.
-    await expect(
-      writer.prepareToWriteReport(
-        report as never,
-        new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
-      )
-    ).resolves.toBeUndefined();
+    // prepareToWriteReport must NOT reject despite the capture failure — a
+    // plain await fails the test if it rejects. We intentionally do not assert
+    // the resolved value: the best-effort contract is about "does not throw",
+    // and finalize's resolved value is not part of it.
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
 
-    // The data write and finalize proceed normally...
+    // The data write and finalize proceed normally (must not reject).
     await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
-    await expect(writer.finalize()).resolves.toBeUndefined();
+    await writer.finalize();
 
     // ...but nothing is restored, since the capture never completed.
     expect(restoreMarkers(adapter)).toEqual([]);

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -44,8 +44,8 @@ interface AdapterMock {
   buildDeleteColumnRequest: jest.Mock;
   buildCopyPasteRequest: jest.Mock;
   clearValuesInRange: jest.Mock;
-  getColumnNumberFormats: jest.Mock;
-  buildSetColumnNumberFormatRequest: jest.Mock;
+  getColumnFormats: jest.Mock;
+  buildSetColumnFormatRequest: jest.Mock;
 }
 
 interface BuildOpts {
@@ -68,11 +68,11 @@ interface BuildOpts {
    */
   currentImportedNames?: string[];
   /**
-   * Number formats `adapter.getColumnNumberFormats` resolves to, positionally
-   * aligned with {@link currentImportedNames}. `undefined` slot == an
-   * unformatted ("Automatic") column. Defaults to all-`undefined`.
+   * Cell formats `adapter.getColumnFormats` resolves to, positionally aligned
+   * with {@link currentImportedNames}. `undefined` slot == an unformatted
+   * ("Automatic") column. Defaults to all-`undefined`.
    */
-  columnNumberFormats?: (sheets_v4.Schema$NumberFormat | undefined)[];
+  columnFormats?: (sheets_v4.Schema$CellFormat | undefined)[];
 }
 
 /**
@@ -116,14 +116,14 @@ function buildWriter(opts: BuildOpts) {
     buildDeleteColumnRequest: jest.fn().mockReturnValue({}),
     buildCopyPasteRequest: jest.fn().mockReturnValue({}),
     clearValuesInRange: jest.fn().mockResolvedValue(undefined),
-    getColumnNumberFormats: jest
+    getColumnFormats: jest
       .fn()
       .mockResolvedValue(
-        opts.columnNumberFormats ?? (opts.currentImportedNames ?? []).map(() => undefined)
+        opts.columnFormats ?? (opts.currentImportedNames ?? []).map(() => undefined)
       ),
     // Echo a tagged marker so tests can assert which (column, format) pairs
     // were scheduled for restore in the finalize batch.
-    buildSetColumnNumberFormatRequest: jest
+    buildSetColumnFormatRequest: jest
       .fn()
       .mockImplementation(
         (
@@ -131,9 +131,9 @@ function buildWriter(opts: BuildOpts) {
           columnIndex: number,
           startRowIndex: number,
           endRowIndex: number,
-          numberFormat: sheets_v4.Schema$NumberFormat
+          format: sheets_v4.Schema$CellFormat
         ) => ({
-          __restoreFormat: { columnIndex, startRowIndex, endRowIndex, numberFormat },
+          __restoreFormat: { columnIndex, startRowIndex, endRowIndex, format },
         })
       ),
   };
@@ -457,9 +457,20 @@ describe('GoogleSheetsReportWriter — pre-clear range invariants', () => {
   });
 });
 
-describe('GoogleSheetsReportWriter — preserves user column number formats across refresh', () => {
-  const CURRENCY: sheets_v4.Schema$NumberFormat = { type: 'CURRENCY', pattern: '"$"#,##0.00' };
-  const DATE: sheets_v4.Schema$NumberFormat = { type: 'DATE', pattern: 'dd.MM.yyyy' };
+describe('GoogleSheetsReportWriter — preserves user column formats across refresh', () => {
+  // Full userEnteredFormat shapes — number format AND non-number formatting.
+  const CURRENCY: sheets_v4.Schema$CellFormat = {
+    numberFormat: { type: 'CURRENCY', pattern: '"$"#,##0.00' },
+  };
+  const DATE: sheets_v4.Schema$CellFormat = {
+    numberFormat: { type: 'DATE', pattern: 'dd.MM.yyyy' },
+  };
+  // A non-number format: background + bold text + right alignment, no numberFormat.
+  const STYLED: sheets_v4.Schema$CellFormat = {
+    backgroundColor: { red: 1, green: 0.9, blue: 0.6 },
+    textFormat: { bold: true, foregroundColor: { red: 0.2, green: 0.2, blue: 0.2 } },
+    horizontalAlignment: 'RIGHT',
+  };
 
   /** Collects the restore-format markers scheduled into the finalize batch. */
   function restoreMarkers(adapter: AdapterMock) {
@@ -472,7 +483,7 @@ describe('GoogleSheetsReportWriter — preserves user column number formats acro
       columnIndex: number;
       startRowIndex: number;
       endRowIndex: number;
-      numberFormat: sheets_v4.Schema$NumberFormat;
+      format: sheets_v4.Schema$CellFormat;
     }>;
   }
 
@@ -482,20 +493,22 @@ describe('GoogleSheetsReportWriter — preserves user column number formats acro
     const { writer, adapter, report, finalImportedNames } = buildWriter({
       availableRowsCount: 11,
       currentImportedNames: ['country', 'clicks', 'cost'],
-      columnNumberFormats: [DATE, undefined, CURRENCY],
+      columnFormats: [DATE, undefined, CURRENCY],
     });
 
     await writer.prepareToWriteReport(
       report as never,
       new ReportDataDescription(makeHeaders(...finalImportedNames), 2)
     );
-    // Capture samples row 2 across the imported width, before any write —
-    // and targets the destination tab by sheetId (not by position).
-    expect(adapter.getColumnNumberFormats).toHaveBeenCalledWith(
+    // Capture samples a bounded row window starting at row 2 across the
+    // imported width, before any write — and targets the destination tab by
+    // sheetId (not by position). rowTo = min(availableRowsCount, 2+100-1) = 11.
+    expect(adapter.getColumnFormats).toHaveBeenCalledWith(
       SPREADSHEET_ID,
       SHEET_ID,
       SHEET_TITLE,
       2,
+      11,
       1,
       3
     );
@@ -509,19 +522,39 @@ describe('GoogleSheetsReportWriter — preserves user column number formats acro
     const markers = restoreMarkers(adapter);
     expect(markers).toEqual(
       expect.arrayContaining([
-        { columnIndex: 0, startRowIndex: 1, endRowIndex: 3, numberFormat: DATE },
-        { columnIndex: 2, startRowIndex: 1, endRowIndex: 3, numberFormat: CURRENCY },
+        { columnIndex: 0, startRowIndex: 1, endRowIndex: 3, format: DATE },
+        { columnIndex: 2, startRowIndex: 1, endRowIndex: 3, format: CURRENCY },
       ])
     );
     // The unformatted column is never restored — we must not impose a format.
     expect(markers.find(m => m.columnIndex === 1)).toBeUndefined();
   });
 
+  it('preserves non-number formatting (background, text color, alignment), not just numberFormat', async () => {
+    // The whole userEnteredFormat is captured and restored, so a column the
+    // user styled WITHOUT a number format still survives a refresh.
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+      currentImportedNames: ['country', 'clicks', 'cost'],
+      columnFormats: [STYLED, undefined, undefined],
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+    await writer.finalize();
+
+    const markers = restoreMarkers(adapter);
+    expect(markers).toEqual([{ columnIndex: 0, startRowIndex: 1, endRowIndex: 2, format: STYLED }]);
+  });
+
   it('restores the format AFTER the data write so it wins over USER_ENTERED inference', async () => {
     const { writer, adapter, report, finalImportedNames } = buildWriter({
       availableRowsCount: 11,
       currentImportedNames: ['country', 'clicks', 'cost'],
-      columnNumberFormats: [undefined, undefined, CURRENCY],
+      columnFormats: [undefined, undefined, CURRENCY],
     });
 
     await writer.prepareToWriteReport(
@@ -535,8 +568,7 @@ describe('GoogleSheetsReportWriter — preserves user column number formats acro
       range.includes('!A2:')
     );
     const dataWriteOrder = adapter.updateValues.mock.invocationCallOrder[dataWriteIdx]!;
-    const restoreBatchOrder =
-      adapter.buildSetColumnNumberFormatRequest.mock.invocationCallOrder[0]!;
+    const restoreBatchOrder = adapter.buildSetColumnFormatRequest.mock.invocationCallOrder[0]!;
     // The restore request is built as part of the finalize batch, which is
     // issued strictly after the data values were written.
     expect(restoreBatchOrder).toBeGreaterThan(dataWriteOrder);
@@ -555,15 +587,15 @@ describe('GoogleSheetsReportWriter — preserves user column number formats acro
     await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
     await writer.finalize();
 
-    expect(adapter.getColumnNumberFormats).not.toHaveBeenCalled();
-    expect(adapter.buildSetColumnNumberFormatRequest).not.toHaveBeenCalled();
+    expect(adapter.getColumnFormats).not.toHaveBeenCalled();
+    expect(adapter.buildSetColumnFormatRequest).not.toHaveBeenCalled();
   });
 
   it('does not restore formats when the refresh fails before any data is written', async () => {
     const { writer, adapter, report, finalImportedNames } = buildWriter({
       availableRowsCount: 11,
       currentImportedNames: ['country', 'clicks', 'cost'],
-      columnNumberFormats: [DATE, undefined, CURRENCY],
+      columnFormats: [DATE, undefined, CURRENCY],
     });
 
     await writer.prepareToWriteReport(
@@ -573,7 +605,7 @@ describe('GoogleSheetsReportWriter — preserves user column number formats acro
     // Reader failed before producing any batch.
     await writer.finalize(new Error('reader failed'));
 
-    expect(adapter.buildSetColumnNumberFormatRequest).not.toHaveBeenCalled();
+    expect(adapter.buildSetColumnFormatRequest).not.toHaveBeenCalled();
   });
 
   it('skips restoring a captured format for a column dropped from the export', async () => {
@@ -584,7 +616,7 @@ describe('GoogleSheetsReportWriter — preserves user column number formats acro
       availableRowsCount: 11,
       finalImportedNames: ['country', 'cost'],
       currentImportedNames: ['country', 'clicks', 'cost'],
-      columnNumberFormats: [undefined, CURRENCY, undefined],
+      columnFormats: [undefined, CURRENCY, undefined],
     });
 
     await writer.prepareToWriteReport(
@@ -595,6 +627,37 @@ describe('GoogleSheetsReportWriter — preserves user column number formats acro
     await writer.finalize();
 
     expect(restoreMarkers(adapter)).toEqual([]);
+  });
+
+  it('does not fail the report run when capturing formats throws (best-effort)', async () => {
+    // Capturing formats is cosmetic: a transient spreadsheets.get failure must
+    // NOT abort the export. The run proceeds and simply restores no formats.
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+      currentImportedNames: ['country', 'clicks', 'cost'],
+      columnFormats: [DATE, undefined, CURRENCY],
+    });
+    adapter.getColumnFormats.mockRejectedValueOnce(new Error('Sheets get API blew up'));
+
+    // prepareToWriteReport must resolve despite the capture failure.
+    await expect(
+      writer.prepareToWriteReport(
+        report as never,
+        new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+      )
+    ).resolves.toBeUndefined();
+
+    // The data write and finalize proceed normally...
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+    await expect(writer.finalize()).resolves.toBeUndefined();
+
+    // ...but nothing is restored, since the capture never completed.
+    expect(restoreMarkers(adapter)).toEqual([]);
+    // Data was still written — the export did its job.
+    const dataWrites = adapter.updateValues.mock.calls.filter(([, range]: [string, string]) =>
+      range.includes('!A2:')
+    );
+    expect(dataWrites.length).toBeGreaterThan(0);
   });
 });
 

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -1,3 +1,4 @@
+import { sheets_v4 } from 'googleapis';
 import { ColumnPlan } from '../../../dto/domain/column-plan.dto';
 import { ReportDataBatch } from '../../../dto/domain/report-data-batch.dto';
 import { ReportDataDescription } from '../../../dto/domain/report-data-description.dto';
@@ -43,6 +44,8 @@ interface AdapterMock {
   buildDeleteColumnRequest: jest.Mock;
   buildCopyPasteRequest: jest.Mock;
   clearValuesInRange: jest.Mock;
+  getColumnNumberFormats: jest.Mock;
+  buildSetColumnNumberFormatRequest: jest.Mock;
 }
 
 interface BuildOpts {
@@ -58,6 +61,18 @@ interface BuildOpts {
    * the right edge of the imported rectangle the writer pre-clears.
    */
   finalImportedNames?: string[];
+  /**
+   * Canonical names occupying the imported row-1 cells before the write.
+   * Drives the user-format capture (keyed by name). Defaults to `[]` (first
+   * run — nothing to capture).
+   */
+  currentImportedNames?: string[];
+  /**
+   * Number formats `adapter.getColumnNumberFormats` resolves to, positionally
+   * aligned with {@link currentImportedNames}. `undefined` slot == an
+   * unformatted ("Automatic") column. Defaults to all-`undefined`.
+   */
+  columnNumberFormats?: (sheets_v4.Schema$NumberFormat | undefined)[];
 }
 
 /**
@@ -101,21 +116,46 @@ function buildWriter(opts: BuildOpts) {
     buildDeleteColumnRequest: jest.fn().mockReturnValue({}),
     buildCopyPasteRequest: jest.fn().mockReturnValue({}),
     clearValuesInRange: jest.fn().mockResolvedValue(undefined),
+    getColumnNumberFormats: jest
+      .fn()
+      .mockResolvedValue(
+        opts.columnNumberFormats ?? (opts.currentImportedNames ?? []).map(() => undefined)
+      ),
+    // Echo a tagged marker so tests can assert which (column, format) pairs
+    // were scheduled for restore in the finalize batch.
+    buildSetColumnNumberFormatRequest: jest
+      .fn()
+      .mockImplementation(
+        (
+          _sheetId: number,
+          columnIndex: number,
+          startRowIndex: number,
+          endRowIndex: number,
+          numberFormat: sheets_v4.Schema$NumberFormat
+        ) => ({
+          __restoreFormat: { columnIndex, startRowIndex, endRowIndex, numberFormat },
+        })
+      ),
   };
 
   const adapterFactory = {
     createFromDestination: jest.fn().mockResolvedValue(adapter),
   };
 
-  // First-run column plan: no structural ops, names mapped 1:1 to indexes.
+  // Column plan: no structural ops, names mapped 1:1 to indexes. Defaults to
+  // a first-run plan (no imported columns yet) unless the test supplies
+  // `currentImportedNames` to exercise the capture/restore path.
+  const currentImportedNames = opts.currentImportedNames ?? [];
+  const isFirstRun = currentImportedNames.length === 0;
   const nameToFinalIndex = new Map(finalImportedNames.map((name, i) => [name, i]));
   const columnPlan = new ColumnPlan(
-    true,
+    isFirstRun,
     finalImportedNames,
     [],
     nameToFinalIndex,
     finalImportedNames.length - 1,
-    -1
+    isFirstRun ? -1 : currentImportedNames.length - 1,
+    currentImportedNames
   );
   const columnPlanBuilder = { build: jest.fn().mockReturnValue(columnPlan) };
 
@@ -414,6 +454,145 @@ describe('GoogleSheetsReportWriter — pre-clear range invariants', () => {
       range.includes('!A2:')
     );
     expect(dataWrites).toHaveLength(0);
+  });
+});
+
+describe('GoogleSheetsReportWriter — preserves user column number formats across refresh', () => {
+  const CURRENCY: sheets_v4.Schema$NumberFormat = { type: 'CURRENCY', pattern: '"$"#,##0.00' };
+  const DATE: sheets_v4.Schema$NumberFormat = { type: 'DATE', pattern: 'dd.MM.yyyy' };
+
+  /** Collects the restore-format markers scheduled into the finalize batch. */
+  function restoreMarkers(adapter: AdapterMock) {
+    return adapter.batchUpdate.mock.calls
+      .flatMap(
+        ([, requests]: [string, unknown[]]) => requests as Array<{ __restoreFormat?: unknown }>
+      )
+      .map(r => r.__restoreFormat)
+      .filter(Boolean) as Array<{
+      columnIndex: number;
+      startRowIndex: number;
+      endRowIndex: number;
+      numberFormat: sheets_v4.Schema$NumberFormat;
+    }>;
+  }
+
+  it('captures row-2 formats before the write and re-applies them over the written data rows', async () => {
+    // Subsequent run: user has applied a DATE format to col A (country... say a
+    // date column) and a CURRENCY format to col C (cost). Col B is unformatted.
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+      currentImportedNames: ['country', 'clicks', 'cost'],
+      columnNumberFormats: [DATE, undefined, CURRENCY],
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 2)
+    );
+    // Capture samples row 2 across the imported width, before any write.
+    expect(adapter.getColumnNumberFormats).toHaveBeenCalledWith(
+      SPREADSHEET_ID,
+      SHEET_TITLE,
+      2,
+      1,
+      3
+    );
+
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+    await writer.writeReportDataBatch(new ReportDataBatch([['B', '20', '5']]));
+    await writer.finalize();
+
+    // Two formatted columns → two restore requests, each over rows 2..3
+    // (writtenRowsCount = 1 header-marker + 2 data rows = 3 → endRowIndex 3).
+    const markers = restoreMarkers(adapter);
+    expect(markers).toEqual(
+      expect.arrayContaining([
+        { columnIndex: 0, startRowIndex: 1, endRowIndex: 3, numberFormat: DATE },
+        { columnIndex: 2, startRowIndex: 1, endRowIndex: 3, numberFormat: CURRENCY },
+      ])
+    );
+    // The unformatted column is never restored — we must not impose a format.
+    expect(markers.find(m => m.columnIndex === 1)).toBeUndefined();
+  });
+
+  it('restores the format AFTER the data write so it wins over USER_ENTERED inference', async () => {
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+      currentImportedNames: ['country', 'clicks', 'cost'],
+      columnNumberFormats: [undefined, undefined, CURRENCY],
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+    await writer.finalize();
+
+    const dataWriteIdx = adapter.updateValues.mock.calls.findIndex(([, range]: [string, string]) =>
+      range.includes('!A2:')
+    );
+    const dataWriteOrder = adapter.updateValues.mock.invocationCallOrder[dataWriteIdx]!;
+    const restoreBatchOrder =
+      adapter.buildSetColumnNumberFormatRequest.mock.invocationCallOrder[0]!;
+    // The restore request is built as part of the finalize batch, which is
+    // issued strictly after the data values were written.
+    expect(restoreBatchOrder).toBeGreaterThan(dataWriteOrder);
+  });
+
+  it('does not capture or restore anything on the first run', async () => {
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+      // currentImportedNames defaults to [] → first run.
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+    await writer.finalize();
+
+    expect(adapter.getColumnNumberFormats).not.toHaveBeenCalled();
+    expect(adapter.buildSetColumnNumberFormatRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not restore formats when the refresh fails before any data is written', async () => {
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+      currentImportedNames: ['country', 'clicks', 'cost'],
+      columnNumberFormats: [DATE, undefined, CURRENCY],
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    // Reader failed before producing any batch.
+    await writer.finalize(new Error('reader failed'));
+
+    expect(adapter.buildSetColumnNumberFormatRequest).not.toHaveBeenCalled();
+  });
+
+  it('skips restoring a captured format for a column dropped from the export', async () => {
+    // User had a CURRENCY format on `clicks`, but the new export omits it
+    // (finalImportedNames lacks `clicks`). The captured format must not be
+    // re-applied to whatever column now sits at that index.
+    const { writer, adapter, report } = buildWriter({
+      availableRowsCount: 11,
+      finalImportedNames: ['country', 'cost'],
+      currentImportedNames: ['country', 'clicks', 'cost'],
+      columnNumberFormats: [undefined, CURRENCY, undefined],
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders('country', 'cost'), 1)
+    );
+    await writer.writeReportDataBatch(new ReportDataBatch([['A', '2']]));
+    await writer.finalize();
+
+    expect(restoreMarkers(adapter)).toEqual([]);
   });
 });
 

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -65,15 +65,17 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
    */
   private structuralOpsApplied = false;
   /**
-   * User-applied number formats captured from the imported columns *before*
-   * the destructive write, keyed by canonical column name. Restored over the
-   * freshly written data rows in {@link finalize} so that the date / number /
-   * currency formats the user set in the Sheets UI survive a refresh — Sheets
-   * re-derives a cell's number format from the value on every `USER_ENTERED`
-   * write, which would otherwise discard them. Empty on the first run (nothing
-   * imported yet) and for columns the user never formatted.
+   * User-applied cell formats captured from the imported columns *before* the
+   * destructive write, keyed by canonical column name. Holds the full
+   * `userEnteredFormat` (number/date/currency format, background & text colors,
+   * bold/italic, alignment, borders, wrap), restored over the freshly written
+   * data rows in {@link finalize} so the formatting the user set in the Sheets
+   * UI survives a refresh — Sheets re-derives a cell's number format from the
+   * value on every `USER_ENTERED` write, which would otherwise discard it, and
+   * restoring the whole format keeps the contract consistent. Empty on the
+   * first run (nothing imported yet) and for columns the user never formatted.
    */
-  private capturedColumnFormats = new Map<string, sheets_v4.Schema$NumberFormat>();
+  private capturedColumnFormats = new Map<string, sheets_v4.Schema$CellFormat>();
   private spreadsheetTimeZone: string;
   private spreadsheetTitle: string;
   private sheetTitle: string;
@@ -192,21 +194,25 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
           `deletes=${this.columnPlan.ops.filter(op => op.kind === 'delete').length}`
       );
 
-      // Capture the user's per-column number formats while the previous
-      // refresh's data is still in place. Must run before any write mutates
-      // the imported rectangle (the writes themselves are deferred, but the
-      // read has to reflect the pre-write state regardless). Restored in
-      // `finalize` so dates / numbers / currencies keep the formatting the
-      // user set in the Sheets UI. No-op on the first run.
-      await this.captureUserColumnFormats();
-
-      // Pre-allocate row capacity. `appendDimension('ROWS')` only grows the
-      // grid at the bottom — it does not mutate the user's imported content
-      // or column structure, so it is safe to do here even though the
-      // destructive operations are deferred.
-      if (reportDataDescription.estimatedDataRowsCount) {
-        await this.ensureRowsAvailable(reportDataDescription.estimatedDataRowsCount + 1); // +1 for headers
-      }
+      // Run two independent prep steps concurrently:
+      //   - Capture the user's per-column cell formats while the previous
+      //     refresh's data is still in place (a read; restored in `finalize`
+      //     so dates / numbers / currencies keep the user's formatting). It
+      //     reads row 2..N, which `appendDimension('ROWS')` below never
+      //     touches (rows are added at the bottom), so the two cannot race.
+      //   - Pre-allocate row capacity. `appendDimension('ROWS')` only grows
+      //     the grid at the bottom — it does not mutate the user's imported
+      //     content or column structure, so it is safe here even though the
+      //     destructive operations are deferred.
+      // Overlapping them avoids an extra sequential round-trip on every
+      // refresh. Capture is best-effort and never rejects; only a row-
+      // allocation failure can reject this `Promise.all`.
+      await Promise.all([
+        this.captureUserColumnFormats(),
+        reportDataDescription.estimatedDataRowsCount
+          ? this.ensureRowsAvailable(reportDataDescription.estimatedDataRowsCount + 1) // +1 for headers
+          : Promise.resolve(),
+      ]);
     }, 'Preparing Google Sheets document for report');
   }
 
@@ -485,7 +491,7 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
           requests.push(...fillDownRequests);
         }
 
-        // Restore the user's per-column number formats over the freshly
+        // Restore the user's per-column cell formats over the freshly
         // written data rows, in the same atomic batch. This must come after
         // the value write (which `USER_ENTERED` may have re-derived a format
         // from) so the user's captured format is the one that sticks. See
@@ -685,54 +691,80 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
   }
 
   /**
-   * Captures the number format a user applied to each imported column so it
-   * can be restored after the value write (see {@link restoreUserColumnFormats}).
+   * Captures the cell formatting a user applied to each imported column so it
+   * can be restored after the value write (see
+   * {@link buildRestoreColumnFormatRequests}).
    *
    * Why this is needed: the data write uses `valueInputOption: 'USER_ENTERED'`,
    * which makes Sheets re-derive each cell's number format from the value it
    * parses — discarding any date / number / currency format the user set in
    * the UI on every refresh. The old OWOX Sheets extension never re-derived
    * formats (it wrote typed values via `setValues`); we reproduce that
-   * "preserve the user's column formatting" behaviour by snapshotting it here
-   * and re-applying it in `finalize`.
+   * "preserve the user's column formatting" behaviour by snapshotting the full
+   * `userEnteredFormat` (number format + background/text colors + alignment +
+   * borders + wrap) here and re-applying it in `finalize`.
    *
-   * Strategy: sample row 2 (the first data row) of each imported column. A
-   * format the user applies to a whole column is present on every cell —
-   * including blank ones — so a single representative cell is enough. The
-   * result is keyed by the column's canonical *name* (not position) so a
+   * Strategy: sample a bounded window of data rows (rows 2..N, capped) and
+   * take the first explicit format found per column. A format the user applies
+   * to a whole column sits on every cell — including blank ones — so row 2
+   * alone usually suffices; the window additionally recovers the case where
+   * row 2 is unformatted but the rest of the column carries the user's format.
+   * The result is keyed by the column's canonical *name* (not position) so a
    * later `delete` op that shifts the column to a new final index still
    * restores the right format. Columns the user never formatted, and the
    * first run (nothing imported yet), produce no entries.
+   *
+   * Best-effort by contract: capturing formats is cosmetic and must never fail
+   * the export. Any error (transient `spreadsheets.get` failure, malformed
+   * response) is logged and swallowed — the refresh proceeds and simply does
+   * not restore formats this run, rather than turning a successful data export
+   * into a failed run.
    */
   private async captureUserColumnFormats(): Promise<void> {
+    // Number of data rows to scan for an explicit per-column format. Bounded so
+    // the grid-data response stays small regardless of dataset size.
+    const SAMPLE_ROWS = 100;
+
     this.capturedColumnFormats.clear();
     const currentNames = this.columnPlan.currentImportedNames;
     if (currentNames.length === 0) {
       return;
     }
-    return this.executeWithErrorHandling(async () => {
-      const formats = await this.adapter.getColumnNumberFormats(
+    try {
+      const formats = await this.adapter.getColumnFormats(
         this.destination.spreadsheetId,
         this.destination.sheetId,
         this.sheetTitle,
         2, // first data row
+        Math.min(this.availableRowsCount, 2 + SAMPLE_ROWS - 1),
         1,
         currentNames.length
       );
       currentNames.forEach((name, idx) => {
         const fmt = formats[idx];
-        // Only capture an explicit, meaningful format. Default ("Automatic")
-        // cells report no numberFormat; treat `NUMBER_FORMAT_TYPE_UNSPECIFIED`
-        // the same so we never re-impose a non-format over the data.
-        if (name && fmt && fmt.type && fmt.type !== 'NUMBER_FORMAT_TYPE_UNSPECIFIED') {
+        // Capture any explicit, non-empty cell format. Default ("Automatic")
+        // cells report no userEnteredFormat, so we never re-impose a format
+        // on a column the user left untouched.
+        if (name && fmt && Object.keys(fmt).length > 0) {
           this.capturedColumnFormats.set(name, fmt);
         }
       });
-    }, 'Capturing user column number formats before write');
+      this.logger.debug(
+        `Captured ${this.capturedColumnFormats.size}/${currentNames.length} user column ` +
+          `formats on sheet ${this.destination.sheetId}`
+      );
+    } catch (error) {
+      // Cosmetic capture must not break the export — see method contract.
+      this.capturedColumnFormats.clear();
+      this.logger.warn(
+        `Capturing user column formats failed on sheet ${this.destination.sheetId}; ` +
+          `proceeding without restoring formats this refresh. Cause: ${(error as Error).message}`
+      );
+    }
   }
 
   /**
-   * Builds requests that re-apply the captured user number formats
+   * Builds requests that re-apply the captured user cell formats
    * ({@link capturedColumnFormats}) over the freshly written data rows
    * (`rows 2..writtenRowsCount`). Each captured column is mapped from its
    * canonical name to its final index in the post-ops layout; columns dropped
@@ -744,18 +776,18 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
       return [];
     }
     const requests: sheets_v4.Schema$Request[] = [];
-    for (const [name, numberFormat] of this.capturedColumnFormats) {
+    for (const [name, format] of this.capturedColumnFormats) {
       const finalIdx = this.columnPlan.nameToFinalIndex.get(name);
       if (finalIdx === undefined) {
         continue; // column was removed from the export — nothing to restore
       }
       requests.push(
-        this.adapter.buildSetColumnNumberFormatRequest(
+        this.adapter.buildSetColumnFormatRequest(
           this.destination.sheetId,
           finalIdx,
           1, // 0-based row 2 — first data row
           this.writtenRowsCount, // exclusive end == last written row
-          numberFormat
+          format
         )
       );
     }

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -64,6 +64,16 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
    * saw it. See {@link applyDeferredSheetMutations}.
    */
   private structuralOpsApplied = false;
+  /**
+   * User-applied number formats captured from the imported columns *before*
+   * the destructive write, keyed by canonical column name. Restored over the
+   * freshly written data rows in {@link finalize} so that the date / number /
+   * currency formats the user set in the Sheets UI survive a refresh — Sheets
+   * re-derives a cell's number format from the value on every `USER_ENTERED`
+   * write, which would otherwise discard them. Empty on the first run (nothing
+   * imported yet) and for columns the user never formatted.
+   */
+  private capturedColumnFormats = new Map<string, sheets_v4.Schema$NumberFormat>();
   private spreadsheetTimeZone: string;
   private spreadsheetTitle: string;
   private sheetTitle: string;
@@ -181,6 +191,14 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
           `inserts=${this.columnPlan.ops.filter(op => op.kind === 'insert').length} ` +
           `deletes=${this.columnPlan.ops.filter(op => op.kind === 'delete').length}`
       );
+
+      // Capture the user's per-column number formats while the previous
+      // refresh's data is still in place. Must run before any write mutates
+      // the imported rectangle (the writes themselves are deferred, but the
+      // read has to reflect the pre-write state regardless). Restored in
+      // `finalize` so dates / numbers / currencies keep the formatting the
+      // user set in the Sheets UI. No-op on the first run.
+      await this.captureUserColumnFormats();
 
       // Pre-allocate row capacity. `appendDimension('ROWS')` only grows the
       // grid at the bottom — it does not mutate the user's imported content
@@ -467,12 +485,23 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
           requests.push(...fillDownRequests);
         }
 
+        // Restore the user's per-column number formats over the freshly
+        // written data rows, in the same atomic batch. This must come after
+        // the value write (which `USER_ENTERED` may have re-derived a format
+        // from) so the user's captured format is the one that sticks. See
+        // `captureUserColumnFormats`.
+        const restoreFormatRequests = this.buildRestoreColumnFormatRequests();
+        if (restoreFormatRequests.length > 0) {
+          requests.push(...restoreFormatRequests);
+        }
+
         await this.adapter.batchUpdate(this.destination.spreadsheetId, requests);
 
         this.logger.debug(
           `Developer metadata written for report ${this.report.id} ` +
             `(project: ${dataMart.projectId}, datamart: ${dataMart.id}); ` +
-            `fillDownRequests=${fillDownRequests.length}`
+            `fillDownRequests=${fillDownRequests.length}; ` +
+            `restoreFormatRequests=${restoreFormatRequests.length}`
         );
       }
     }, 'Finalizing report with metadata and formatting');
@@ -653,6 +682,83 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
 
       return { existingHeaders, previousOwoxColumns };
     }, 'Reading sheet state for column diff');
+  }
+
+  /**
+   * Captures the number format a user applied to each imported column so it
+   * can be restored after the value write (see {@link restoreUserColumnFormats}).
+   *
+   * Why this is needed: the data write uses `valueInputOption: 'USER_ENTERED'`,
+   * which makes Sheets re-derive each cell's number format from the value it
+   * parses — discarding any date / number / currency format the user set in
+   * the UI on every refresh. The old OWOX Sheets extension never re-derived
+   * formats (it wrote typed values via `setValues`); we reproduce that
+   * "preserve the user's column formatting" behaviour by snapshotting it here
+   * and re-applying it in `finalize`.
+   *
+   * Strategy: sample row 2 (the first data row) of each imported column. A
+   * format the user applies to a whole column is present on every cell —
+   * including blank ones — so a single representative cell is enough. The
+   * result is keyed by the column's canonical *name* (not position) so a
+   * later `delete` op that shifts the column to a new final index still
+   * restores the right format. Columns the user never formatted, and the
+   * first run (nothing imported yet), produce no entries.
+   */
+  private async captureUserColumnFormats(): Promise<void> {
+    this.capturedColumnFormats.clear();
+    const currentNames = this.columnPlan.currentImportedNames;
+    if (currentNames.length === 0) {
+      return;
+    }
+    return this.executeWithErrorHandling(async () => {
+      const formats = await this.adapter.getColumnNumberFormats(
+        this.destination.spreadsheetId,
+        this.sheetTitle,
+        2, // first data row
+        1,
+        currentNames.length
+      );
+      currentNames.forEach((name, idx) => {
+        const fmt = formats[idx];
+        // Only capture an explicit, meaningful format. Default ("Automatic")
+        // cells report no numberFormat; treat `NUMBER_FORMAT_TYPE_UNSPECIFIED`
+        // the same so we never re-impose a non-format over the data.
+        if (name && fmt && fmt.type && fmt.type !== 'NUMBER_FORMAT_TYPE_UNSPECIFIED') {
+          this.capturedColumnFormats.set(name, fmt);
+        }
+      });
+    }, 'Capturing user column number formats before write');
+  }
+
+  /**
+   * Builds requests that re-apply the captured user number formats
+   * ({@link capturedColumnFormats}) over the freshly written data rows
+   * (`rows 2..writtenRowsCount`). Each captured column is mapped from its
+   * canonical name to its final index in the post-ops layout; columns dropped
+   * from the export (no longer in `nameToFinalIndex`) are skipped. Returns an
+   * empty array when there is nothing to restore or no data rows were written.
+   */
+  private buildRestoreColumnFormatRequests(): sheets_v4.Schema$Request[] {
+    if (this.capturedColumnFormats.size === 0 || this.writtenRowsCount < 2) {
+      return [];
+    }
+    const requests: sheets_v4.Schema$Request[] = [];
+    for (const [name, numberFormat] of this.capturedColumnFormats) {
+      const finalIdx = this.columnPlan.nameToFinalIndex.get(name);
+      if (finalIdx === undefined) {
+        continue; // column was removed from the export — nothing to restore
+      }
+      requests.push(
+        this.adapter.buildSetColumnNumberFormatRequest(
+          this.destination.sheetId,
+          finalIdx,
+          1, // 0-based row 2 — first data row
+          this.writtenRowsCount, // exclusive end == last written row
+          numberFormat
+        )
+      );
+    }
+    return requests;
   }
 
   /**

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -713,6 +713,7 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
     return this.executeWithErrorHandling(async () => {
       const formats = await this.adapter.getColumnNumberFormats(
         this.destination.spreadsheetId,
+        this.destination.sheetId,
         this.sheetTitle,
         2, // first data row
         1,

--- a/apps/backend/src/data-marts/dto/domain/column-plan.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/column-plan.dto.ts
@@ -106,6 +106,20 @@ export class ColumnPlan {
      * first run. Used to delineate "user content right of imported range"
      * for fill-down formula capture.
      */
-    public readonly prevLastImportedColIndex: number
+    public readonly prevLastImportedColIndex: number,
+
+    /**
+     * Canonical column names occupying the imported row-1 cells
+     * `[0..prevLastImportedColIndex]` BEFORE {@link ops} are applied, in their
+     * current sheet order (aliases already resolved back to names). Length
+     * equals `previousOwoxColumns.length`; empty on the first run.
+     *
+     * The writer uses this to key the per-column number formats it captures
+     * from the sheet before the write back to canonical names, so that a
+     * user's date/number/currency format is re-applied to the *same* logical
+     * column after the data write — even when a `delete` op shifts that column
+     * to a new final index. See `GoogleSheetsReportWriter.captureUserColumnFormats`.
+     */
+    public readonly currentImportedNames: string[] = []
   ) {}
 }

--- a/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
+++ b/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
@@ -263,10 +263,13 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
         `'${sheet.sheetTitle}'!${String.fromCharCode(65 + columnIndex)}${rowIndex + 1}:${String.fromCharCode(65 + columnIndex)}${rowIndex + 1}`,
       ],
       includeGridData: true,
-      fields: 'sheets(data(rowData(values(userEnteredFormat(numberFormat)))))',
+      fields: 'sheets(properties(sheetId),data(rowData(values(userEnteredFormat(numberFormat)))))',
     });
+    // Select the target tab by sheetId — `ranges` does not guarantee the
+    // requested sheet is `sheets[0]` (the test spreadsheet holds many tabs).
+    const targetSheet = res.data.sheets?.find(s => s.properties?.sheetId === sheet.sheetId);
     return (
-      res.data.sheets?.[0]?.data?.[0]?.rowData?.[0]?.values?.[0]?.userEnteredFormat?.numberFormat ??
+      targetSheet?.data?.[0]?.rowData?.[0]?.values?.[0]?.userEnteredFormat?.numberFormat ??
       undefined
     );
   }

--- a/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
+++ b/apps/backend/test/integration/google-sheets-column-preservation.integration.ts
@@ -221,6 +221,56 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
     });
   }
 
+  /**
+   * Applies a number format to a column's data rows (0-based `columnIndex`,
+   * rows 2..`endRow` inclusive) the way a user would via Format → Number.
+   */
+  async function setColumnNumberFormat(
+    columnIndex: number,
+    endRow: number,
+    numberFormat: sheets_v4.Schema$NumberFormat
+  ): Promise<void> {
+    await sheet.sheets.spreadsheets.batchUpdate({
+      spreadsheetId: sheet.spreadsheetId,
+      requestBody: {
+        requests: [
+          {
+            repeatCell: {
+              range: {
+                sheetId: sheet.sheetId,
+                startRowIndex: 1, // row 2 (0-based)
+                endRowIndex: endRow,
+                startColumnIndex: columnIndex,
+                endColumnIndex: columnIndex + 1,
+              },
+              cell: { userEnteredFormat: { numberFormat } },
+              fields: 'userEnteredFormat.numberFormat',
+            },
+          },
+        ],
+      },
+    });
+  }
+
+  /** Reads the `userEnteredFormat.numberFormat` of a single cell (0-based indexes). */
+  async function readCellNumberFormat(
+    rowIndex: number,
+    columnIndex: number
+  ): Promise<sheets_v4.Schema$NumberFormat | undefined> {
+    const res = await sheet.sheets.spreadsheets.get({
+      spreadsheetId: sheet.spreadsheetId,
+      ranges: [
+        `'${sheet.sheetTitle}'!${String.fromCharCode(65 + columnIndex)}${rowIndex + 1}:${String.fromCharCode(65 + columnIndex)}${rowIndex + 1}`,
+      ],
+      includeGridData: true,
+      fields: 'sheets(data(rowData(values(userEnteredFormat(numberFormat)))))',
+    });
+    return (
+      res.data.sheets?.[0]?.data?.[0]?.rowData?.[0]?.values?.[0]?.userEnteredFormat?.numberFormat ??
+      undefined
+    );
+  }
+
   // -------------------------------------------------------------------------
   // Test 1 — First run lays down SQL order + persists OWOX_COLUMNS metadata
   // -------------------------------------------------------------------------
@@ -664,4 +714,54 @@ describeIfConfigured('Google Sheets column preservation (diff-based writer)', ()
     expect((await readRange('K1:K1'))[0]?.[0]).toBe('ratio');
     expect((await readFormulas('K2:K2'))[0]?.[0]).toBe('=B2/C2');
   }, 150_000);
+
+  // -------------------------------------------------------------------------
+  // Test 11 — User column formatting survives a refresh.
+  //
+  // The user-visible regression: a user formats the imported data columns in
+  // the Sheets UI (currency, custom number, date) and on the next Report Run
+  // the formatting "flies off" — because the writer committed values with
+  // `valueInputOption: 'USER_ENTERED'`, which makes Sheets re-derive each
+  // cell's number format from the value. The writer now captures the user's
+  // per-column number format before the write and re-applies it over the
+  // written rows in finalize, reproducing the old extension's behaviour of
+  // never clobbering user formatting.
+  //
+  // We assert on BOTH a previously-existing data row (row 2) and a row that
+  // is freshly grown by this refresh (the format must extend down to every
+  // written row, not just the rows that carried the format before).
+  // -------------------------------------------------------------------------
+  it('preserves user-applied column number formats (currency / custom number) across refresh', async () => {
+    const { reportId } = await provisionFixture({ testName: 'preserve-number-format' });
+
+    // First run lays down country | clicks | cost into A | B | C, rows 2..4.
+    await runAndWait(reportId);
+
+    // User formats the imported columns:
+    //   B (clicks, index 1) — custom thousands integer.
+    //   C (cost,   index 2) — currency.
+    const CLICKS_FORMAT: sheets_v4.Schema$NumberFormat = { type: 'NUMBER', pattern: '#,##0' };
+    const COST_FORMAT: sheets_v4.Schema$NumberFormat = { type: 'CURRENCY', pattern: '"$"#,##0.00' };
+    await setColumnNumberFormat(1, 4, CLICKS_FORMAT);
+    await setColumnNumberFormat(2, 4, COST_FORMAT);
+
+    // Refresh again — without the fix, USER_ENTERED writes wipe these formats.
+    await runAndWait(reportId);
+
+    // Row 2 (existed before) keeps the user's formats.
+    expect(await readCellNumberFormat(1, 1)).toEqual(CLICKS_FORMAT);
+    expect(await readCellNumberFormat(1, 2)).toEqual(COST_FORMAT);
+
+    // Row 4 (also within the dataset) keeps them too — format is re-applied
+    // across the whole written range, not just the first data row.
+    expect(await readCellNumberFormat(3, 1)).toEqual(CLICKS_FORMAT);
+    expect(await readCellNumberFormat(3, 2)).toEqual(COST_FORMAT);
+
+    // The data itself is still correct (formatting did not corrupt values).
+    expect(await readRange('A2:C4')).toEqual([
+      ['A', '10', '$2.00'],
+      ['B', '20', '$5.00'],
+      ['C', '30', '$6.00'],
+    ]);
+  }, 120_000);
 });


### PR DESCRIPTION
## Problem

When a Report Run updates a Google Sheet, the column formatting a user set in
the Sheets UI (dates, numbers, currencies, custom/datetime formats) was reset
on every refresh. Expected behaviour — formatting is preserved, the way the old
OWOX Sheets extension worked.

## Root cause

The writer commits every data cell with `valueInputOption: 'USER_ENTERED'`
(`google-sheets-api.adapter.ts`). With `USER_ENTERED`, Sheets re-derives each
cell's number format from the parsed value and **overwrites** the user's
explicit format. It's worst for `TIMESTAMP` columns, which the writer itself
stringifies to `"yyyy-MM-dd HH:mm:ss"` (`sheet-values-formatter.ts`) — Sheets
reparses that to a datetime serial and stamps it with its **default** format —
and for `DATE` columns arriving as ISO strings. Plain integers usually survive,
which is why users mostly noticed it on date/currency columns.

Things that were _not_ the cause (ruled out): the header-row "clear format"
request only touches `textFormat`/`backgroundColor`, never `numberFormat`;
`values.clear` preserves formatting; and a stable schema produces zero
structural column ops.

## Fix — capture & restore (reconstructing the old extension's behaviour)

The old extension never re-derived formats. We reproduce that:

1. **Before** any write, capture each imported column's
   `userEnteredFormat.numberFormat` (sampled from the first data row), keyed by
   the column's **canonical name** so it survives reorder/delete.
2. **After** the data write, in the same atomic `finalize` `batchUpdate`,
   re-apply the captured formats over the written data rows. Re-applied format
   wins over whatever `USER_ENTERED` inferred.

Notable properties:
- Format is keyed by name → follows a column through user reorder and ODM
  delete ops (a dropped column's format is not re-applied to a neighbour).
- Columns the user never formatted are left untouched — we never _impose_ a
  format.
- First run captures/restores nothing; failed refreshes restore nothing
  (deferred-mutations contract preserved — the sheet is left exactly as it was).
- Bonus: the format now extends to rows that grew on this refresh.

## Changes

- `column-plan.dto.ts` / `column-plan-builder.ts` — expose
  `currentImportedNames` (canonical name per current row-1 position).
- `google-sheets-api.adapter.ts` — `getColumnNumberFormats()` (read) and
  `buildSetColumnNumberFormatRequest()` (a `repeatCell` touching only
  `userEnteredFormat.numberFormat`).
- `google-sheets-report-writer.ts` — `captureUserColumnFormats()` in
  `prepareToWriteReport`; restore requests appended to the `finalize` batch.
- `getColumnNumberFormats` selects the destination tab by `sheetId` (not
  `sheets[0]`) — `ranges` does not guarantee the requested tab is first, so a
  non-first destination sheet would otherwise read empty grid data and silently
  skip the format restore.

## Tests

- **Integration (real Google Sheets + BigQuery):** new `Test 11` in
  `google-sheets-column-preservation.integration.ts` — applies currency +
  custom number formats to data columns, runs the report twice, asserts
  `numberFormat` is preserved on both a pre-existing row and a freshly grown
  row. Verified passing against the live Sheets API (13/13 in the suite).
- **Unit:** 5 new cases in `google-sheets-report-writer.spec.ts` (capture
  before write, restore after write, first-run no-op, failed-refresh no-op,
  dropped-column skip) + `currentImportedNames` assertions in
  `column-plan-builder.spec.ts`.

## Verification

- Integration (real Sheets + BQ): 13/13 ✅
- Unit (writer / builder / adapter specs): 56/56 ✅
- `tsc` + ESLint on changed files: clean ✅

## Migration note

On the first refresh after deploy over an already-clobbered sheet, the writer
captures whatever format is currently present and preserves it. The user
re-applies their intended format once, and from then on it sticks across
refreshes.