### PR TITLE
feat(consumption): publish HTTP Data report run usage

### DIFF
--- a/apps/backend/src/data-marts/services/consumption-tracking.service.spec.ts
+++ b/apps/backend/src/data-marts/services/consumption-tracking.service.spec.ts
@@ -33,10 +33,10 @@ describe('ConsumptionTrackingService.registerHttpDataRunConsumption', () => {
     (PubSubService as unknown as jest.Mock).mockClear();
   });
 
-  it('publishes one consumption command with the run id as processRunId', async () => {
+  it('publishes one consumption command with the run id as reportRunId', async () => {
     const service = buildService({
       CONSUMPTION_PUBSUB_PROJECT_ID: 'consumption-project',
-      CONSUMPTION_HTTP_DATA_RUN_TOPIC: 'http-data-topic',
+      CONSUMPTION_HTTP_DATA_REPORT_RUN_TOPIC: 'http-data-topic',
     });
 
     await service.registerHttpDataRunConsumption(fakeDataMart(), 'run-1');
@@ -49,7 +49,7 @@ describe('ConsumptionTrackingService.registerHttpDataRunConsumption', () => {
         dataMartId: 'dm-1',
         dataStorageId: 'storage-1',
         dataStorageType: 'GOOGLE_BIGQUERY',
-        processRunId: 'run-1',
+        reportRunId: 'run-1',
       })
     );
   });
@@ -64,7 +64,7 @@ describe('ConsumptionTrackingService.registerHttpDataRunConsumption', () => {
   });
 
   it('skips silently when PubSub is not configured', async () => {
-    const service = buildService({ CONSUMPTION_HTTP_DATA_RUN_TOPIC: 'http-data-topic' });
+    const service = buildService({ CONSUMPTION_HTTP_DATA_REPORT_RUN_TOPIC: 'http-data-topic' });
 
     await expect(
       service.registerHttpDataRunConsumption(fakeDataMart(), 'run-1')

--- a/apps/backend/src/data-marts/services/consumption-tracking.service.ts
+++ b/apps/backend/src/data-marts/services/consumption-tracking.service.ts
@@ -104,7 +104,7 @@ export class ConsumptionTrackingService {
       }
 
       this.httpDataRunConsumptionTopic = configService.get<string>(
-        'CONSUMPTION_HTTP_DATA_RUN_TOPIC'
+        'CONSUMPTION_HTTP_DATA_REPORT_RUN_TOPIC'
       );
       if (this.httpDataRunConsumptionTopic) {
         this.logger.log(`Consumption HTTP Data Run topic: ${this.httpDataRunConsumptionTopic}`);
@@ -201,7 +201,7 @@ export class ConsumptionTrackingService {
     }
     await this.sendConsumptionCommand(this.httpDataRunConsumptionTopic, {
       ...this.baseDataMartConsumptionPayload(dataMart),
-      processRunId: runId,
+      reportRunId: runId,
     });
   }
 

--- a/docs/getting-started/billing/consumption-units.md
+++ b/docs/getting-started/billing/consumption-units.md
@@ -15,7 +15,7 @@
 
 ### **How Are Report Runs Calculated?**
 
-A **Report Run** means pushing or pulling data (stored in **Storage**) to a **Destination**. Read more about [core concepts](../core-concepts.md).
+A **Report Run** means pushing or pulling data (stored in **Storage**) to a **Destination**, or accessing data through the HTTP Data API. Read more about [core concepts](../core-concepts.md).
 
 - Each **successful** execution of a Data Mart counts as **1 Report Run**, regardless of the volume of processed data.
 - The Data Mart is executed on behalf of the customer's [Storage](../core-concepts.md#storage) within the dedicated OWOX BI Project, and processing costs are charged to the customer's Storage billing account.
@@ -32,6 +32,7 @@ For better transparency and flexibility, Report Runs are broken down into follow
 | Report Run           | Platform Report Run      | Represents Report Runs executed from the [OWOX BigQuery™️ Data Marts](https://workspace.google.com/marketplace/app/owox_bigquery_data_marts/263000453832?utm_source=docs.owox.com&utm_medium=owox-data-marts&utm_campaign=consumption_units_article) Extension. Data was pushed from a Data Mart to Google Sheets. |
 | Report Run           | Data Studio Report Run | Represents Report Runs executed in the OWOX Data Marts Cloud edition on [app.owox.com](https://app.owox.com). Data was pulled from a Data Mart to the [Data Studio Destination](../../destinations/supported-destinations/data-studio.md).                                                                     |
 | Report Run           | Google Sheets Report Run | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). Data was pushed from a Data Mart to the [Google Sheets Destination](../../destinations/supported-destinations/google-sheets.md).                                                                                     |
+| Report Run           | HTTP Data Report Run   | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). Data was pulled from a Data Mart through the HTTP Data API endpoint.                                                                                                                                              |
 | Report Run           | Email Report Run         | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). A message was pushed to the [Email Destination](../../destinations/supported-destinations/email.md).                                                                                                                 |
 | Report Run           | Google Chat Report Run   | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). A message was pushed to the [Google Chat Destination](../../destinations/supported-destinations/google-chat.md).                                                                                                     |
 | Report Run           | MS Teams Report Run      | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). A message was pushed to the [MS Teams Destination](../../destinations/supported-destinations/microsoft-teams.md).                                                                                                    |

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -122,7 +122,7 @@ Each Report has **Owners** — the team members responsible for its configuratio
 ### Run Types
 
 - **Connector Run** – import data from a **Source** into **Storage**.
-- **Report Runs** – push or pull data (stored in **Storage**) to a **Destination**.
+- **Report Runs** – push or pull data (stored in **Storage**) to a **Destination**, or access data through the HTTP Data API.
 
 ### Notification
 


### PR DESCRIPTION
## Summary
- Rename the HTTP Data consumption topic setting to the report-run unit name.
- Send `reportRunId` in HTTP Data consumption commands.
- Add the HTTP Data Report Run sub-unit to the billing docs.

## Test Plan
- `npm test -w @owox/backend -- consumption-tracking.service.spec.ts --runInBand`
- `npm run build -w @owox/docs`