### PR TITLE
feat(backend): added project id to triggers

### DIFF
--- a/apps/backend/src/common/scheduler/shared/entities/ui-trigger.entity.ts
+++ b/apps/backend/src/common/scheduler/shared/entities/ui-trigger.entity.ts
@@ -11,6 +11,15 @@ export abstract class UiTrigger<UiResponseType> extends Trigger {
   @Column()
   userId: string;
 
+  /**
+   * ID of the project the trigger belongs to.
+   *
+   * Defined on the base class so tenant-scoped lookups (status / result / abort)
+   * can filter by project regardless of the concrete trigger type.
+   */
+  @Column()
+  projectId: string;
+
   @Column({ type: 'json', nullable: true })
   uiResponse: UiResponseType;
 }

--- a/apps/backend/src/common/scheduler/shared/ui-trigger-controller.ts
+++ b/apps/backend/src/common/scheduler/shared/ui-trigger-controller.ts
@@ -21,16 +21,20 @@ export abstract class UiTriggerController<UiResponseType> {
   @Auth(Role.viewer(Strategy.PARSE))
   @Get('/:triggerId/status')
   public async getTriggerStatus(
-    @Param('triggerId') triggerId: string
+    @Param('triggerId') triggerId: string,
+    @AuthContext() context: AuthorizationContext
   ): Promise<{ status: TriggerStatus }> {
-    const status = await this.triggerService.getTriggerStatus(triggerId);
+    const status = await this.triggerService.getTriggerStatus(triggerId, context.projectId);
     return { status };
   }
 
   @Auth(Role.viewer(Strategy.PARSE))
   @Get('/:triggerId')
-  public async getTriggerResponse(@Param('triggerId') triggerId: string): Promise<UiResponseType> {
-    return this.triggerService.getTriggerResponse(triggerId);
+  public async getTriggerResponse(
+    @Param('triggerId') triggerId: string,
+    @AuthContext() context: AuthorizationContext
+  ): Promise<UiResponseType> {
+    return this.triggerService.getTriggerResponse(triggerId, context.projectId);
   }
 
   @Auth(Role.viewer(Strategy.PARSE))
@@ -39,6 +43,6 @@ export abstract class UiTriggerController<UiResponseType> {
     @Param('triggerId') triggerId: string,
     @AuthContext() context: AuthorizationContext
   ): Promise<void> {
-    return this.triggerService.abortTriggerRun(triggerId, context.userId);
+    return this.triggerService.abortTriggerRun(triggerId, context.userId, context.projectId);
   }
 }

--- a/apps/backend/src/common/scheduler/shared/ui-trigger.service.spec.ts
+++ b/apps/backend/src/common/scheduler/shared/ui-trigger.service.spec.ts
@@ -65,6 +65,17 @@ describe('UiTriggerService tenant scoping', () => {
         NotFoundException
       );
     });
+
+    it('fails closed without querying when projectId is missing', async () => {
+      const { service, repository } = createService();
+
+      await expect(
+        service.getTriggerStatus('trigger-1', undefined as unknown as string)
+      ).rejects.toThrow(NotFoundException);
+      // An undefined projectId must never reach the repository, where TypeORM
+      // would drop it from the where clause and disable the tenant filter.
+      expect(repository.findOne).not.toHaveBeenCalled();
+    });
   });
 
   describe('getTriggerResponse', () => {

--- a/apps/backend/src/common/scheduler/shared/ui-trigger.service.spec.ts
+++ b/apps/backend/src/common/scheduler/shared/ui-trigger.service.spec.ts
@@ -1,0 +1,128 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { TriggerStatus } from './entities/trigger-status';
+import { UiTrigger } from './entities/ui-trigger.entity';
+import { UiTriggerService } from './ui-trigger.service';
+
+interface TestResponse {
+  value: string;
+}
+
+/**
+ * Concrete subclass to exercise the abstract base service.
+ */
+class TestUiTriggerService extends UiTriggerService<TestResponse> {
+  constructor(repository: Repository<UiTrigger<TestResponse>>) {
+    super(repository);
+  }
+}
+
+describe('UiTriggerService tenant scoping', () => {
+  const PROJECT = 'proj-1';
+  const OTHER_PROJECT = 'proj-2';
+  const USER = 'user-1';
+
+  const createService = (overrides: Partial<UiTrigger<TestResponse>> = {}) => {
+    const stored = {
+      id: 'trigger-1',
+      projectId: PROJECT,
+      userId: USER,
+      status: TriggerStatus.SUCCESS,
+      uiResponse: { value: 'ok' },
+      ...overrides,
+    } as UiTrigger<TestResponse>;
+
+    const repository = {
+      // Mirror the real query: a trigger is only visible when both id and
+      // projectId match, so cross-project lookups resolve to null.
+      findOne: jest.fn(({ where }: { where: { id: string; projectId: string } }) => {
+        if (stored.id === where.id && stored.projectId === where.projectId) {
+          return Promise.resolve(stored);
+        }
+        return Promise.resolve(null);
+      }),
+      remove: jest.fn().mockResolvedValue(undefined),
+      save: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Repository<UiTrigger<TestResponse>>;
+
+    const service = new TestUiTriggerService(repository);
+    return { service, repository, stored };
+  };
+
+  describe('getTriggerStatus', () => {
+    it('returns the status for a trigger in the authenticated project', async () => {
+      const { service } = createService({ status: TriggerStatus.PROCESSING });
+
+      await expect(service.getTriggerStatus('trigger-1', PROJECT)).resolves.toBe(
+        TriggerStatus.PROCESSING
+      );
+    });
+
+    it('rejects a trigger from another project as not found', async () => {
+      const { service } = createService();
+
+      await expect(service.getTriggerStatus('trigger-1', OTHER_PROJECT)).rejects.toThrow(
+        NotFoundException
+      );
+    });
+  });
+
+  describe('getTriggerResponse', () => {
+    it('returns and removes the response for a trigger in the authenticated project', async () => {
+      const { service, repository, stored } = createService({ status: TriggerStatus.SUCCESS });
+
+      await expect(service.getTriggerResponse('trigger-1', PROJECT)).resolves.toEqual({
+        value: 'ok',
+      });
+      expect(repository.remove).toHaveBeenCalledWith(stored);
+    });
+
+    it('does not return or remove a trigger from another project', async () => {
+      const { service, repository } = createService({ status: TriggerStatus.SUCCESS });
+
+      await expect(service.getTriggerResponse('trigger-1', OTHER_PROJECT)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(repository.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('abortTriggerRun', () => {
+    it('aborts a trigger owned by the user within the authenticated project', async () => {
+      const { service, repository, stored } = createService({ status: TriggerStatus.IDLE });
+
+      await service.abortTriggerRun('trigger-1', USER, PROJECT);
+
+      expect(repository.remove).toHaveBeenCalledWith(stored);
+    });
+
+    it('does not abort a trigger from another project', async () => {
+      const { service, repository } = createService({ status: TriggerStatus.IDLE });
+
+      await expect(service.abortTriggerRun('trigger-1', USER, OTHER_PROJECT)).rejects.toThrow(
+        NotFoundException
+      );
+      expect(repository.remove).not.toHaveBeenCalled();
+    });
+
+    it('forbids aborting another user trigger even within the same project', async () => {
+      const { service, repository } = createService({
+        status: TriggerStatus.IDLE,
+        userId: 'someone-else',
+      });
+
+      await expect(service.abortTriggerRun('trigger-1', USER, PROJECT)).rejects.toThrow(
+        ForbiddenException
+      );
+      expect(repository.remove).not.toHaveBeenCalled();
+    });
+
+    it('rejects aborting a processing trigger that cannot transition', async () => {
+      const { service } = createService({ status: TriggerStatus.CANCELLED });
+
+      await expect(service.abortTriggerRun('trigger-1', USER, PROJECT)).rejects.toThrow(
+        BadRequestException
+      );
+    });
+  });
+});

--- a/apps/backend/src/common/scheduler/shared/ui-trigger.service.ts
+++ b/apps/backend/src/common/scheduler/shared/ui-trigger.service.ts
@@ -108,6 +108,13 @@ export abstract class UiTriggerService<UiResponseType> {
     id: string,
     projectId: string
   ): Promise<UiTrigger<UiResponseType>> {
+    // Fail closed when projectId is missing: TypeORM drops `undefined` keys from
+    // the where clause, which would otherwise collapse the query to `{ id }` and
+    // silently disable the tenant boundary.
+    if (!projectId) {
+      throw new NotFoundException(`Trigger with id ${id} not found`);
+    }
+
     const trigger = await this.triggerRepository.findOne({
       where: { id, projectId },
     });

--- a/apps/backend/src/common/scheduler/shared/ui-trigger.service.ts
+++ b/apps/backend/src/common/scheduler/shared/ui-trigger.service.ts
@@ -29,20 +29,20 @@ export abstract class UiTriggerService<UiResponseType> {
   }
 
   /**
-   * Get trigger status by ID
+   * Get trigger status by ID, scoped to the authenticated project.
    */
-  async getTriggerStatus(triggerId: string): Promise<TriggerStatus> {
+  async getTriggerStatus(triggerId: string, projectId: string): Promise<TriggerStatus> {
     this.logger.debug(`Checking trigger status for trigger ${triggerId}`);
-    const trigger = await this.getTriggerById(triggerId);
+    const trigger = await this.getTriggerById(triggerId, projectId);
     return trigger.status;
   }
 
   /**
-   * Get trigger response and handle different status cases
+   * Get trigger response and handle different status cases, scoped to the authenticated project.
    */
-  async getTriggerResponse(triggerId: string): Promise<UiResponseType> {
+  async getTriggerResponse(triggerId: string, projectId: string): Promise<UiResponseType> {
     this.logger.debug(`Getting trigger response for trigger ${triggerId}`);
-    const trigger = await this.getTriggerById(triggerId);
+    const trigger = await this.getTriggerById(triggerId, projectId);
 
     if (trigger.status === TriggerStatus.SUCCESS) {
       const response = trigger.uiResponse;
@@ -65,11 +65,11 @@ export abstract class UiTriggerService<UiResponseType> {
   }
 
   /**
-   * Abort trigger run
+   * Abort trigger run, scoped to the authenticated project and user.
    */
-  async abortTriggerRun(triggerId: string, userId: string): Promise<void> {
+  async abortTriggerRun(triggerId: string, userId: string, projectId: string): Promise<void> {
     this.logger.debug(`Aborting trigger run for trigger ${triggerId}`);
-    const trigger = await this.getTriggerById(triggerId);
+    const trigger = await this.getTriggerById(triggerId, projectId);
 
     if (trigger.userId !== userId) {
       throw new ForbiddenException('You are not allowed to cancel this trigger');
@@ -98,11 +98,18 @@ export abstract class UiTriggerService<UiResponseType> {
   }
 
   /**
-   * Get trigger by ID
+   * Get trigger by ID, scoped to the authenticated project.
+   *
+   * The `projectId` filter is the tenant boundary: a trigger that belongs to a
+   * different project is treated as non-existent so callers cannot read, remove,
+   * or abort triggers outside their project.
    */
-  protected async getTriggerById(id: string): Promise<UiTrigger<UiResponseType>> {
+  protected async getTriggerById(
+    id: string,
+    projectId: string
+  ): Promise<UiTrigger<UiResponseType>> {
     const trigger = await this.triggerRepository.findOne({
-      where: { id },
+      where: { id, projectId },
     });
     if (!trigger) {
       throw new NotFoundException(`Trigger with id ${id} not found`);

--- a/apps/backend/src/data-marts/controllers/ai-helper-trigger.controller.ts
+++ b/apps/backend/src/data-marts/controllers/ai-helper-trigger.controller.ts
@@ -100,18 +100,20 @@ export class AiHelperTriggerController extends UiTriggerController<AiHelperUiRes
   @Auth(Role.viewer(Strategy.PARSE))
   @Get('/:triggerId/status')
   public override async getTriggerStatus(
-    @Param('triggerId') triggerId: string
+    @Param('triggerId') triggerId: string,
+    @AuthContext() context: AuthorizationContext
   ): Promise<{ status: TriggerStatus }> {
-    return super.getTriggerStatus(triggerId);
+    return super.getTriggerStatus(triggerId, context);
   }
 
   @GetAiHelperTriggerResponseSpec()
   @Auth(Role.viewer(Strategy.PARSE))
   @Get('/:triggerId')
   public override async getTriggerResponse(
-    @Param('triggerId') triggerId: string
+    @Param('triggerId') triggerId: string,
+    @AuthContext() context: AuthorizationContext
   ): Promise<AiHelperUiResponse> {
-    return super.getTriggerResponse(triggerId);
+    return super.getTriggerResponse(triggerId, context);
   }
 
   @CancelAiHelperTriggerSpec()

--- a/apps/backend/src/data-marts/controllers/connector.controller.ts
+++ b/apps/backend/src/data-marts/controllers/connector.controller.ts
@@ -96,12 +96,14 @@ export class ConnectorController {
   @Get(':connectorName/oauth/status/:credentialId')
   @GetConnectorOAuthStatusSpec()
   async getConnectorOAuthStatus(
+    @AuthContext() context: AuthorizationContext,
     @Param('connectorName') connectorName: string,
     @Param('credentialId') credentialId: string
   ): Promise<ConnectorOAuthStatusResponseApiDto> {
     const status = await this.connectorOauthService.getCredentialStatus(
       connectorName,
-      credentialId
+      credentialId,
+      context.projectId
     );
     return this.mapper.toStatusResponse(status);
   }

--- a/apps/backend/src/data-marts/controllers/sql-dry-run-trigger.controller.ts
+++ b/apps/backend/src/data-marts/controllers/sql-dry-run-trigger.controller.ts
@@ -75,18 +75,20 @@ export class SqlDryRunTriggerController extends UiTriggerController<SqlDryRunRes
   @Auth(Role.viewer(Strategy.PARSE))
   @Get('/:triggerId/status')
   public override async getTriggerStatus(
-    @Param('triggerId') triggerId: string
+    @Param('triggerId') triggerId: string,
+    @AuthContext() context: AuthorizationContext
   ): Promise<{ status: TriggerStatus }> {
-    return super.getTriggerStatus(triggerId);
+    return super.getTriggerStatus(triggerId, context);
   }
 
   @GetSqlDryRunTriggerResponseSpec()
   @Auth(Role.viewer(Strategy.PARSE))
   @Get('/:triggerId')
   public override async getTriggerResponse(
-    @Param('triggerId') triggerId: string
+    @Param('triggerId') triggerId: string,
+    @AuthContext() context: AuthorizationContext
   ): Promise<SqlDryRunResponseApiDto> {
-    return super.getTriggerResponse(triggerId);
+    return super.getTriggerResponse(triggerId, context);
   }
 
   @CancelSqlDryRunTriggerSpec()

--- a/apps/backend/src/data-marts/entities/ai-assistant-run-trigger.entity.ts
+++ b/apps/backend/src/data-marts/entities/ai-assistant-run-trigger.entity.ts
@@ -8,9 +8,6 @@ export class AiAssistantRunTrigger extends UiTrigger<AiRunTriggerResponseApiDto>
   dataMartId: string;
 
   @Column()
-  projectId: string;
-
-  @Column()
   sessionId: string;
 
   @Column()

--- a/apps/backend/src/data-marts/entities/ai-helper-trigger.entity.ts
+++ b/apps/backend/src/data-marts/entities/ai-helper-trigger.entity.ts
@@ -26,12 +26,6 @@ export interface AiHelperUiResponse {
 @Entity('ai_helper_triggers')
 export class AiHelperTrigger extends UiTrigger<AiHelperUiResponse> {
   /**
-   * ID of the user's project.
-   */
-  @Column()
-  projectId: string;
-
-  /**
    * ID of the data mart for which metadata is generated.
    */
   @Column()

--- a/apps/backend/src/data-marts/entities/insight-artifact-sql-preview-trigger.entity.ts
+++ b/apps/backend/src/data-marts/entities/insight-artifact-sql-preview-trigger.entity.ts
@@ -8,9 +8,6 @@ export class InsightArtifactSqlPreviewTrigger extends UiTrigger<InsightArtifactS
   dataMartId: string;
 
   @Column()
-  projectId: string;
-
-  @Column()
   insightArtifactId: string;
 
   @Column({ type: 'text', nullable: true })

--- a/apps/backend/src/data-marts/entities/insight-run-trigger.entity.ts
+++ b/apps/backend/src/data-marts/entities/insight-run-trigger.entity.ts
@@ -8,8 +8,5 @@ export class InsightRunTrigger extends UiTrigger<InsightRunResponseApiDto> {
   dataMartId: string;
 
   @Column()
-  projectId: string;
-
-  @Column()
   insightId: string;
 }

--- a/apps/backend/src/data-marts/entities/insight-template-run-trigger.entity.ts
+++ b/apps/backend/src/data-marts/entities/insight-template-run-trigger.entity.ts
@@ -8,8 +8,5 @@ export class InsightTemplateRunTrigger extends UiTrigger<InsightTemplateRunRespo
   dataMartId: string;
 
   @Column()
-  projectId: string;
-
-  @Column()
   insightTemplateId: string;
 }

--- a/apps/backend/src/data-marts/entities/publish-drafts-trigger.entity.ts
+++ b/apps/backend/src/data-marts/entities/publish-drafts-trigger.entity.ts
@@ -6,7 +6,4 @@ import { PublishDataStorageDraftsResponseApiDto } from '../dto/presentation/publ
 export class PublishDraftsTrigger extends UiTrigger<PublishDataStorageDraftsResponseApiDto> {
   @Column()
   dataStorageId: string;
-
-  @Column()
-  projectId: string;
 }

--- a/apps/backend/src/data-marts/entities/schema-actualize-trigger.entity.ts
+++ b/apps/backend/src/data-marts/entities/schema-actualize-trigger.entity.ts
@@ -6,7 +6,4 @@ import { SchemaActualizeResponseApiDto } from '../dto/presentation/schema-actual
 export class SchemaActualizeTrigger extends UiTrigger<SchemaActualizeResponseApiDto> {
   @Column()
   dataMartId: string;
-
-  @Column()
-  projectId: string;
 }

--- a/apps/backend/src/data-marts/entities/sql-dry-run-trigger.entity.ts
+++ b/apps/backend/src/data-marts/entities/sql-dry-run-trigger.entity.ts
@@ -15,12 +15,6 @@ export class SqlDryRunTrigger extends UiTrigger<SqlDryRunResponseApiDto> {
   dataMartId: string;
 
   /**
-   * ID of the user's project
-   */
-  @Column()
-  projectId: string;
-
-  /**
    * SQL query to validate
    */
   @Column({ type: 'text' })

--- a/apps/backend/src/data-marts/services/connector/connector-oauth.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-oauth.service.spec.ts
@@ -105,11 +105,12 @@ describe('ConnectorOauthService', () => {
   });
 
   describe('getCredentialStatus', () => {
-    it('returns valid status for non-expired credential', async () => {
+    it('returns valid status for non-expired credential in the same project', async () => {
       const { service, connectorSourceCredentialsService } = createService();
 
       const credential = {
         id: 'cred-1',
+        projectId: 'proj-1',
         connectorName: 'TestConnector',
         expiresAt: new Date(Date.now() + 1000 * 60 * 60),
         user: { name: 'Test User' },
@@ -120,17 +121,18 @@ describe('ConnectorOauthService', () => {
       );
       (connectorSourceCredentialsService.isExpired as jest.Mock).mockResolvedValue(false);
 
-      const result = await service.getCredentialStatus('TestConnector', 'cred-1');
+      const result = await service.getCredentialStatus('TestConnector', 'cred-1', 'proj-1');
 
       expect(result.isValid).toBe(true);
       expect(result.user).toEqual({ name: 'Test User' });
     });
 
-    it('returns expired status for expired credential', async () => {
+    it('returns expired status for expired credential in the same project', async () => {
       const { service, connectorSourceCredentialsService } = createService();
 
       const credential = {
         id: 'cred-1',
+        projectId: 'proj-1',
         connectorName: 'TestConnector',
         expiresAt: new Date(Date.now() - 1000 * 60 * 60),
         user: undefined,
@@ -141,7 +143,7 @@ describe('ConnectorOauthService', () => {
       );
       (connectorSourceCredentialsService.isExpired as jest.Mock).mockResolvedValue(true);
 
-      const result = await service.getCredentialStatus('TestConnector', 'cred-1');
+      const result = await service.getCredentialStatus('TestConnector', 'cred-1', 'proj-1');
 
       expect(result.isValid).toBe(false);
     });
@@ -151,9 +153,31 @@ describe('ConnectorOauthService', () => {
 
       (connectorSourceCredentialsService.getCredentialsById as jest.Mock).mockResolvedValue(null);
 
-      await expect(service.getCredentialStatus('TestConnector', 'missing')).rejects.toThrow(
-        'Credential with ID missing not found'
+      await expect(
+        service.getCredentialStatus('TestConnector', 'missing', 'proj-1')
+      ).rejects.toThrow('Credential with ID missing not found');
+    });
+
+    it('rejects a credential that belongs to another project', async () => {
+      const { service, connectorSourceCredentialsService } = createService();
+
+      const credential = {
+        id: 'cred-1',
+        projectId: 'other-proj',
+        connectorName: 'TestConnector',
+        expiresAt: new Date(Date.now() + 1000 * 60 * 60),
+        user: { name: 'Test User' },
+      } as ConnectorSourceCredentials;
+
+      (connectorSourceCredentialsService.getCredentialsById as jest.Mock).mockResolvedValue(
+        credential
       );
+
+      await expect(
+        service.getCredentialStatus('TestConnector', 'cred-1', 'proj-1')
+      ).rejects.toThrow('Credential with ID cred-1 not found');
+      // Cross-project lookups must not leak validity by probing expiry.
+      expect(connectorSourceCredentialsService.isExpired).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/data-marts/services/connector/connector-oauth.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-oauth.service.ts
@@ -66,12 +66,15 @@ export class ConnectorOauthService {
 
   async getCredentialStatus(
     connectorName: string,
-    credentialId: string
+    credentialId: string,
+    projectId: string
   ): Promise<ConnectorOAuthStatusSchema> {
     const credential =
       await this.connectorSourceCredentialsService.getCredentialsById(credentialId);
 
-    if (!credential) {
+    // A credential from another project is treated as non-existent so callers
+    // cannot probe credential status across the tenant boundary.
+    if (!credential || credential.projectId !== projectId) {
       throw new Error(`Credential with ID ${credentialId} not found`);
     }
 

--- a/apps/backend/src/data-marts/services/connector/connector.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector.service.spec.ts
@@ -177,5 +177,24 @@ describe('ConnectorService', () => {
       // A cross-project credential must never be copied into the caller's project.
       expect(connectorSourceCredentialsService.createCredentials).not.toHaveBeenCalled();
     });
+
+    it('rejects a credential issued for a different connector', async () => {
+      const { service, connectorSourceCredentialsService } = createService();
+
+      (connectorSourceCredentialsService.getCredentialsById as jest.Mock).mockResolvedValue({
+        id: 'cred-1',
+        projectId: 'proj-1',
+        connectorName: 'OtherConnector',
+        credentials: { refresh_token: 'secret' },
+        expiresAt: null,
+        userId: 'user-1',
+      });
+
+      await expect(
+        service.refreshCredentials('proj-1', 'TestConnector', {}, 'cred-1')
+      ).rejects.toThrow('Credential belongs to connector OtherConnector, not TestConnector');
+      // Tokens of one connector must never be rotated under another connector name.
+      expect(connectorSourceCredentialsService.createCredentials).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/backend/src/data-marts/services/connector/connector.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector.service.spec.ts
@@ -137,4 +137,45 @@ describe('ConnectorService', () => {
       expect(result[0]).toMatchObject({ name: 'ads', destinationName: 'ads' });
     });
   });
+
+  describe('refreshCredentials', () => {
+    it('refreshes a credential that belongs to the same project', async () => {
+      const { service, connectorSourceCredentialsService } = createService();
+
+      (connectorSourceCredentialsService.getCredentialsById as jest.Mock).mockResolvedValue({
+        id: 'cred-1',
+        projectId: 'proj-1',
+        connectorName: 'TestConnector',
+        credentials: {},
+        expiresAt: null,
+        userId: 'user-1',
+      });
+
+      // The connector source mock's refreshCredentials returns undefined (no rotation),
+      // so the existing credential id is returned unchanged.
+      const result = await service.refreshCredentials('proj-1', 'TestConnector', {}, 'cred-1');
+
+      expect(result).toBe('cred-1');
+      expect(connectorSourceCredentialsService.createCredentials).not.toHaveBeenCalled();
+    });
+
+    it('rejects a credential that belongs to another project', async () => {
+      const { service, connectorSourceCredentialsService } = createService();
+
+      (connectorSourceCredentialsService.getCredentialsById as jest.Mock).mockResolvedValue({
+        id: 'cred-1',
+        projectId: 'other-proj',
+        connectorName: 'TestConnector',
+        credentials: { refresh_token: 'secret' },
+        expiresAt: null,
+        userId: 'user-2',
+      });
+
+      await expect(
+        service.refreshCredentials('proj-1', 'TestConnector', {}, 'cred-1')
+      ).rejects.toThrow('Credential with ID cred-1 not found');
+      // A cross-project credential must never be copied into the caller's project.
+      expect(connectorSourceCredentialsService.createCredentials).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/backend/src/data-marts/services/connector/connector.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector.service.ts
@@ -244,6 +244,15 @@ export class ConnectorService {
       throw new Error(`Credential with ID ${credentialId} not found`);
     }
 
+    // Connector boundary: a credential must only be refreshed under the connector
+    // it was issued for. Otherwise one connector's stored tokens could be rotated
+    // and re-stored under a different connector name.
+    if (credential.connectorName !== connectorName) {
+      throw new Error(
+        `Credential belongs to connector ${credential.connectorName}, not ${connectorName}`
+      );
+    }
+
     const connector = this.createConnectorSource(connectorName);
 
     const oauthVariables = await this.getOAuthVariablesForRefresh(connectorName, configuration);

--- a/apps/backend/src/data-marts/services/connector/connector.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector.service.ts
@@ -238,6 +238,12 @@ export class ConnectorService {
       throw new Error(`Credential with ID ${credentialId} not found`);
     }
 
+    // Tenant boundary: never read or copy a credential that belongs to another
+    // project, even if its id is referenced from this project's configuration.
+    if (credential.projectId !== projectId) {
+      throw new Error(`Credential with ID ${credentialId} not found`);
+    }
+
     const connector = this.createConnectorSource(connectorName);
 
     const oauthVariables = await this.getOAuthVariablesForRefresh(connectorName, configuration);


### PR DESCRIPTION
## Summary

Follow-up to the notification-settings `projectId` fix. Several endpoints still
resolved entities by id alone, allowing one project to read/abort/refresh
another project's data. This PR binds those paths to `context.projectId`
(and `context.userId` where relevant).

Three tenant-boundary gaps are closed:

1. **UI trigger status / result / abort** fetched triggers by `triggerId` only.
2. **Connector OAuth status** returned credential status by `credentialId` without project context.
3. **Connector OAuth refresh** could read/copy a `_source_credential_id` from another project.

## Changes

### UI triggers
- Lifted `projectId` onto the base `UiTrigger` entity (it was duplicated
  identically across all 8 concrete trigger entities) and removed the
  per-subclass declarations. No schema change — these use concrete-table
  inheritance, so the column already exists in every table.
- `UiTriggerService.getTriggerStatus` / `getTriggerResponse` / `abortTriggerRun`
  / `getTriggerById` now take `projectId` and filter
  `findOne({ where: { id, projectId } })`. A trigger from another project is
  treated as not-found before any read or removal. `abortTriggerRun` keeps its
  existing `userId` ownership check on top.
- `getTriggerById` **fails closed** when `projectId` is missing: TypeORM drops
  `undefined` keys from a `where` clause, which would otherwise collapse the
  query to `{ id }` and silently disable the tenant filter.
- Base + subclass controllers (`ui-trigger-controller`, `ai-helper`,
  `sql-dry-run`) inject `@AuthContext()` and pass `context.projectId`. The other
  6 trigger controllers inherit the base behavior automatically.

### Connector OAuth
- `ConnectorOauthService.getCredentialStatus` takes `projectId` and treats a
  credential from another project as non-existent (same error as not-found, so
  validity isn't leaked by probing expiry). `ConnectorController` passes
  `context.projectId`.
- `ConnectorService.refreshCredentials` rejects a credential whose `projectId`
  differs from the caller's **before** reading or copying its secrets — closing
  the path where a cross-project credential could be copied into the attacker's
  project. Mirrors the check already present on the injection path.

## Behavior

- Same-project access is unchanged.
- Cross-project access returns not-found instead of leaking or mutating data.
- Connector checks fail **closed** on a missing `projectId`; the trigger path is
  now hardened to do the same.

## Tests

- New `ui-trigger.service.spec.ts` — same-project success and cross-project
  not-found for status / result / abort, the same-project / other-user forbidden
  case, and a fail-closed case asserting `findOne` is never called when
  `projectId` is missing.
- `connector-oauth.service.spec.ts` — updated for the new signature plus a
  cross-project denial case that asserts expiry is not probed.
- `connector.service.spec.ts` — refresh same-project-success and
  cross-project-denial, asserting no credential is copied across the boundary.

## Notes / out of scope

- The `Strategy.PARSE` auth path does not validate `projectId` presence. This PR
  hardens the trigger lookup against an undefined `projectId`; validating it at
  the auth-guard level (to harden all endpoints uniformly) is left as a separate
  change.
- Pre-existing `tsc` errors in unrelated files (`@owox/idp-protocol` exports from
  the recent user-provisioning work, and some other specs) are not affected by
  this PR.