### PR TITLE
feat(web): show SQL preview icon for every report

### DIFF
--- a/.changeset/preview-sql-for-every-report.md
+++ b/.changeset/preview-sql-for-every-report.md
@@ -1,0 +1,10 @@
+---
+"owox": minor
+---
+
+# SQL preview icon shown for every report
+
+The SQL preview icon is now visible on all reports (Google Sheets, Email, Looker Studio).
+When a report uses output controls (filters, sorting, or limits) or joined fields, clicking
+the icon opens the generated SQL dialog. Otherwise, the icon shows an informational tooltip
+explaining that the report queries the Data Mart source directly, with a link to Data Setup.

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Editor } from '@monaco-editor/react';
 import { useTheme } from 'next-themes';
-import { Copy, FileCode2, Loader2 } from 'lucide-react';
+import { Copy, ExternalLink, FileCode2, Loader2 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { Button } from '@owox/ui/components/button';
 import {
@@ -136,14 +136,16 @@ export function GeneratedSqlViewer({
       joins.{' '}
       <Link
         to={dataSetupUrl}
-        className='underline'
+        className='inline-flex items-center gap-0.5 underline'
+        target='_blank'
+        rel='noopener noreferrer'
         onClick={e => {
           e.stopPropagation();
         }}
       >
         Open Data Setup
+        <ExternalLink className='!h-3 !w-3 shrink-0' />
       </Link>
-      .
     </>
   );
 

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
@@ -134,7 +134,13 @@ export function GeneratedSqlViewer({
     <>
       No custom SQL generated: this report queries the Data Mart source directly without filters or
       joins.{' '}
-      <Link to={dataSetupUrl} className='underline' onClick={e => e.stopPropagation()}>
+      <Link
+        to={dataSetupUrl}
+        className='underline'
+        onClick={e => {
+          e.stopPropagation();
+        }}
+      >
         Open Data Setup
       </Link>
       .
@@ -152,8 +158,12 @@ export function GeneratedSqlViewer({
               variant='ghost'
               className='dm-card-table-body-row-actionbtn !cursor-default opacity-0 transition-opacity group-hover:opacity-100'
               aria-label={ariaLabel}
-              onClick={e => e.stopPropagation()}
-              onPointerDown={e => e.preventDefault()}
+              onClick={e => {
+                e.stopPropagation();
+              }}
+              onPointerDown={e => {
+                e.preventDefault();
+              }}
             >
               <FileCode2
                 className='dm-card-table-body-row-actionbtn-icon text-muted-foreground'
@@ -175,8 +185,10 @@ export function GeneratedSqlViewer({
             type='button'
             variant='outline'
             size='sm'
-            className='opacity-50 !cursor-default'
-            onPointerDown={e => e.preventDefault()}
+            className='!cursor-default opacity-50'
+            onPointerDown={e => {
+              e.preventDefault();
+            }}
           >
             <FileCode2 className='mr-2 h-4 w-4' />
             Preview SQL

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Editor } from '@monaco-editor/react';
 import { useTheme } from 'next-themes';
-import { Copy, Loader2, Network } from 'lucide-react';
+import { Copy, FileCode2, Loader2 } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { Button } from '@owox/ui/components/button';
 import {
@@ -12,6 +12,7 @@ import {
   DialogTrigger,
   DialogFooter,
 } from '@owox/ui/components/dialog';
+import { Link } from 'react-router-dom';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { Skeleton } from '@owox/ui/components/skeleton';
 import { reportService } from '../../../reports/shared/services/report.service';
@@ -24,35 +25,45 @@ interface GeneratedSqlViewerProps {
   reportId: string;
   /**
    * Data mart ID the report belongs to. Required to run the SQL dry-run
-   * validation (size estimate + syntax check) against the correct storage.
+   * validation (size estimate + syntax check) against the correct storage,
+   * and to build the Data Setup link shown in the info tooltip.
    */
   dataMartId: string;
   /**
    * Visual variant of the trigger:
    * - 'action-icon' (default): ghost icon button with tooltip, intended for
-   *   table row action cells. Uses hover-reveal styling that matches sibling
-   *   row actions.
-   * - 'outline-button': outline button with "View joined Data Marts SQL" text,
-   *   intended for use inside forms where a full button label makes sense.
+   *   table row action cells.
+   * - 'outline-button': outline button with label text, intended for use
+   *   inside forms.
    */
   variant?: GeneratedSqlViewerVariant;
   /**
    * Optional report title, used to build a descriptive aria-label for the
-   * action icon variant (e.g. "View joined Data Marts SQL: Test Report").
+   * action icon variant.
    */
   reportTitle?: string;
+  /**
+   * When true, no SQL dialog is opened. Instead, the icon shows an
+   * informational tooltip explaining that no output controls or joined fields
+   * are used and linking to the Data Setup page.
+   */
+  usesSourceDirectly?: boolean;
 }
 
 /**
- * Button that opens a dialog with the generated SQL for a report.
- * Provides copy-to-clipboard and copy-as-data-mart actions.
+ * Button that opens a dialog with the generated SQL for a report, or —
+ * when usesSourceDirectly is true — shows an informational tooltip with a link
+ * to the Data Setup page instead.
  */
 export function GeneratedSqlViewer({
   reportId,
   dataMartId,
   variant = 'action-icon',
   reportTitle,
+  usesSourceDirectly = false,
 }: GeneratedSqlViewerProps) {
+  // All state and handlers below are used only in SQL dialog mode.
+  // Hooks cannot be moved below the usesSourceDirectly early return (Rules of Hooks).
   const [isOpen, setIsOpen] = useState(false);
   const [sql, setSql] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -110,10 +121,75 @@ export function GeneratedSqlViewer({
     }
   }
 
-  const ariaLabel = reportTitle
-    ? `View joined Data Marts SQL: ${reportTitle}`
-    : 'View joined Data Marts SQL';
+  const ariaLabel = usesSourceDirectly
+    ? reportTitle
+      ? `Uses Data Mart source directly: ${reportTitle}`
+      : 'Uses Data Mart source directly'
+    : reportTitle
+      ? `Preview SQL: ${reportTitle}`
+      : 'Preview SQL';
+  const dataSetupUrl = scope(`/data-marts/${dataMartId}/data-setup`);
 
+  const infoTooltipContent = (
+    <>
+      No custom SQL generated: this report queries the Data Mart source directly without filters or
+      joins.{' '}
+      <Link to={dataSetupUrl} className='underline' onClick={e => e.stopPropagation()}>
+        Open Data Setup
+      </Link>
+      .
+    </>
+  );
+
+  // ── Info-tooltip mode (no output controls or joined fields) ──────────────
+  if (usesSourceDirectly) {
+    if (variant === 'action-icon') {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type='button'
+              variant='ghost'
+              className='dm-card-table-body-row-actionbtn !cursor-default opacity-0 transition-opacity group-hover:opacity-100'
+              aria-label={ariaLabel}
+              onClick={e => e.stopPropagation()}
+              onPointerDown={e => e.preventDefault()}
+            >
+              <FileCode2
+                className='dm-card-table-body-row-actionbtn-icon text-muted-foreground'
+                aria-hidden='true'
+              />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side='bottom' role='tooltip' className='w-fit max-w-[270px] text-balance'>
+            {infoTooltipContent}
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            className='opacity-50 !cursor-default'
+            onPointerDown={e => e.preventDefault()}
+          >
+            <FileCode2 className='mr-2 h-4 w-4' />
+            Preview SQL
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side='bottom' role='tooltip' className='w-fit max-w-[270px] text-balance'>
+          {infoTooltipContent}
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  // ── SQL dialog mode ───────────────────────────────────────────────────────
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       {variant === 'action-icon' ? (
@@ -123,32 +199,32 @@ export function GeneratedSqlViewer({
               <Button
                 type='button'
                 variant='ghost'
-                className='dm-card-table-body-row-actionbtn opacity-0 transition-opacity group-hover:opacity-100'
+                className='dm-card-table-body-row-actionbtn cursor-pointer opacity-0 transition-opacity group-hover:opacity-100'
                 aria-label={ariaLabel}
                 onClick={e => {
                   e.stopPropagation();
                 }}
               >
-                <Network className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
+                <FileCode2 className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
               </Button>
             </DialogTrigger>
           </TooltipTrigger>
           <TooltipContent side='bottom' role='tooltip'>
-            View joined Data Marts SQL
+            Preview SQL
           </TooltipContent>
         </Tooltip>
       ) : (
         <DialogTrigger asChild>
           <Button type='button' variant='outline' size='sm'>
-            <Network className='mr-2 h-4 w-4' />
-            View joined Data Marts SQL
+            <FileCode2 className='mr-2 h-4 w-4' />
+            Preview SQL
           </Button>
         </DialogTrigger>
       )}
 
       <DialogContent className='flex flex-col gap-4 sm:max-w-[80vw]'>
         <DialogHeader>
-          <DialogTitle>Joined Data Marts SQL</DialogTitle>
+          <DialogTitle>Report SQL</DialogTitle>
         </DialogHeader>
 
         <div className='min-h-[600px]'>

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -171,8 +171,8 @@ export const LookerStudioReportEditForm = forwardRef<
 
     const usesSourceDirectly =
       !hasBlendedSelection &&
-      !(form.watch('filterConfig')?.length) &&
-      !(form.watch('sortConfig')?.length) &&
+      !form.watch('filterConfig')?.length &&
+      !form.watch('sortConfig')?.length &&
       form.watch('limitConfig') === null;
 
     return (
@@ -249,18 +249,16 @@ export const LookerStudioReportEditForm = forwardRef<
                     onBlendedSelectionChange={setHasBlendedSelection}
                     onCountChange={setColumnsCount}
                   />
-                  {mode === ReportFormMode.EDIT &&
-                    initialReport?.id &&
-                    dataMart.id && (
-                      <div className='pt-1'>
-                        <GeneratedSqlViewer
-                          reportId={initialReport.id}
-                          dataMartId={dataMart.id}
-                          variant='outline-button'
-                          usesSourceDirectly={usesSourceDirectly}
-                        />
-                      </div>
-                    )}
+                  {mode === ReportFormMode.EDIT && initialReport?.id && dataMart.id && (
+                    <div className='pt-1'>
+                      <GeneratedSqlViewer
+                        reportId={initialReport.id}
+                        dataMartId={dataMart.id}
+                        variant='outline-button'
+                        usesSourceDirectly={usesSourceDirectly}
+                      />
+                    </div>
+                  )}
                 </div>
               )}
             </FormSection>

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -169,6 +169,12 @@ export const LookerStudioReportEditForm = forwardRef<
       onDirtyChange?.(isDirty || ownersDirty);
     }, [isDirty, ownersDirty, onDirtyChange]);
 
+    const usesSourceDirectly =
+      !hasBlendedSelection &&
+      !(form.watch('filterConfig')?.length) &&
+      !(form.watch('sortConfig')?.length) &&
+      form.watch('limitConfig') === null;
+
     return (
       <Form {...form}>
         <AppForm
@@ -243,8 +249,7 @@ export const LookerStudioReportEditForm = forwardRef<
                     onBlendedSelectionChange={setHasBlendedSelection}
                     onCountChange={setColumnsCount}
                   />
-                  {hasBlendedSelection &&
-                    mode === ReportFormMode.EDIT &&
+                  {mode === ReportFormMode.EDIT &&
                     initialReport?.id &&
                     dataMart.id && (
                       <div className='pt-1'>
@@ -252,6 +257,7 @@ export const LookerStudioReportEditForm = forwardRef<
                           reportId={initialReport.id}
                           dataMartId={dataMart.id}
                           variant='outline-button'
+                          usesSourceDirectly={usesSourceDirectly}
                         />
                       </div>
                     )}

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
@@ -17,7 +17,7 @@ import {
 import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
 import { ReportStatusEnum } from '../../../shared/enums';
-import { reportHasBlending, useReport } from '../../../shared';
+import { reportHasBlending, reportHasOutputControls, useReport } from '../../../shared';
 import { useBlendedFieldNames } from '../../../../shared/hooks/useBlendedFieldNames';
 import { GeneratedSqlViewer } from '../../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
 
@@ -35,10 +35,9 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { deleteReport, fetchReportsByDataMartId, runReport } = useReport();
 
-  // Show the "View SQL" icon only when the report actually produces blended output.
-  // The hook is safe to call per-row: React Query dedupes concurrent requests by key.
   const blendedFieldNames = useBlendedFieldNames(row.original.dataMart.id);
   const hasBlending = reportHasBlending(row.original, blendedFieldNames);
+  const usesSourceDirectly = !hasBlending && !reportHasOutputControls(row.original);
 
   const actionsMenuId = `actions-menu-${row.original.id}`;
 
@@ -113,14 +112,13 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
           </TooltipContent>
         </Tooltip>
 
-        {/* View SQL (only when report uses blending) */}
-        {hasBlending && (
-          <GeneratedSqlViewer
-            reportId={row.original.id}
-            dataMartId={row.original.dataMart.id}
-            reportTitle={row.original.title}
-          />
-        )}
+        {/* View SQL */}
+        <GeneratedSqlViewer
+          reportId={row.original.id}
+          dataMartId={row.original.dataMart.id}
+          reportTitle={row.original.title}
+          usesSourceDirectly={usesSourceDirectly}
+        />
 
         {/* More actions */}
         <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
@@ -15,7 +15,7 @@ import {
   TooltipTrigger,
 } from '@owox/ui/components/tooltip';
 import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
-import { getGoogleSheetTabUrl, reportHasBlending } from '../../../shared';
+import { getGoogleSheetTabUrl, reportHasBlending, reportHasOutputControls } from '../../../shared';
 import type {
   DataMartReport,
   GoogleSheetsDestinationConfig,
@@ -43,10 +43,10 @@ export function GoogleSheetsActionsCell({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { deleteReport, fetchReportsByDataMartId, runReport } = useReport();
 
-  // Show the "View SQL" icon only when the report actually produces blended output.
   // The hook is safe to call per-row: React Query dedupes concurrent requests by key.
   const blendedFieldNames = useBlendedFieldNames(row.original.dataMart.id);
   const hasBlending = reportHasBlending(row.original, blendedFieldNames);
+  const usesSourceDirectly = !hasBlending && !reportHasOutputControls(row.original);
 
   // Generate unique ID for the actions menu
   const actionsMenuId = `actions-menu-${row.original.id}`;
@@ -146,14 +146,13 @@ export function GoogleSheetsActionsCell({
           </TooltipContent>
         </Tooltip>
 
-        {/* View SQL (only when report uses blending) */}
-        {hasBlending && (
-          <GeneratedSqlViewer
-            reportId={row.original.id}
-            dataMartId={row.original.dataMart.id}
-            reportTitle={row.original.title}
-          />
-        )}
+        {/* View SQL */}
+        <GeneratedSqlViewer
+          reportId={row.original.id}
+          dataMartId={row.original.dataMart.id}
+          reportTitle={row.original.title}
+          usesSourceDirectly={usesSourceDirectly}
+        />
 
         {/* More actions */}
         <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>

--- a/apps/web/src/features/data-marts/reports/shared/utils/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './google-sheets-url.utils';
 export * from './report-has-blending.utils';
+export * from './report-has-output-controls.utils';
 export * from './service-account.utils';

--- a/apps/web/src/features/data-marts/reports/shared/utils/report-has-output-controls.utils.test.ts
+++ b/apps/web/src/features/data-marts/reports/shared/utils/report-has-output-controls.utils.test.ts
@@ -32,14 +32,14 @@ describe('reportHasOutputControls', () => {
   });
 
   it('returns false when filterConfig and sortConfig are empty arrays', () => {
-    expect(
-      reportHasOutputControls(makeReport({ filterConfig: [], sortConfig: [] }))
-    ).toBe(false);
+    expect(reportHasOutputControls(makeReport({ filterConfig: [], sortConfig: [] }))).toBe(false);
   });
 
   it('returns true when filterConfig has items', () => {
     expect(
-      reportHasOutputControls(makeReport({ filterConfig: [{ field: 'x', operator: 'eq', value: '1' } as any] }))
+      reportHasOutputControls(
+        makeReport({ filterConfig: [{ field: 'x', operator: 'eq', value: '1' } as any] })
+      )
     ).toBe(true);
   });
 

--- a/apps/web/src/features/data-marts/reports/shared/utils/report-has-output-controls.utils.test.ts
+++ b/apps/web/src/features/data-marts/reports/shared/utils/report-has-output-controls.utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { reportHasOutputControls } from './report-has-output-controls.utils';
+import type { DataMartReport } from '../model/types/data-mart-report';
+
+function makeReport(overrides: Partial<DataMartReport> = {}): DataMartReport {
+  return {
+    id: 'r1',
+    title: 'Test Report',
+    dataMart: { id: 'dm1' },
+    dataDestination: {} as any,
+    destinationConfig: {} as any,
+    columnConfig: null,
+    filterConfig: null,
+    sortConfig: null,
+    limitConfig: null,
+    lastRunDate: null,
+    lastRunStatus: null,
+    lastRunError: null,
+    runsCount: 0,
+    createdAt: new Date(),
+    modifiedAt: new Date(),
+    canRun: true,
+    canManageTriggers: true,
+    canEditConfig: true,
+    ...overrides,
+  };
+}
+
+describe('reportHasOutputControls', () => {
+  it('returns false when all configs are null', () => {
+    expect(reportHasOutputControls(makeReport())).toBe(false);
+  });
+
+  it('returns false when filterConfig and sortConfig are empty arrays', () => {
+    expect(
+      reportHasOutputControls(makeReport({ filterConfig: [], sortConfig: [] }))
+    ).toBe(false);
+  });
+
+  it('returns true when filterConfig has items', () => {
+    expect(
+      reportHasOutputControls(makeReport({ filterConfig: [{ field: 'x', operator: 'eq', value: '1' } as any] }))
+    ).toBe(true);
+  });
+
+  it('returns true when sortConfig has items', () => {
+    expect(
+      reportHasOutputControls(makeReport({ sortConfig: [{ field: 'x', direction: 'asc' } as any] }))
+    ).toBe(true);
+  });
+
+  it('returns true when limitConfig is set', () => {
+    expect(reportHasOutputControls(makeReport({ limitConfig: 100 }))).toBe(true);
+  });
+});

--- a/apps/web/src/features/data-marts/reports/shared/utils/report-has-output-controls.utils.ts
+++ b/apps/web/src/features/data-marts/reports/shared/utils/report-has-output-controls.utils.ts
@@ -1,0 +1,16 @@
+import type { DataMartReport } from '../model/types/data-mart-report';
+
+/**
+ * Returns true when the report has any output controls applied:
+ * at least one filter rule, sort rule, or a row limit.
+ *
+ * Used together with reportHasBlending to decide whether to show the SQL
+ * dialog (has controls) or an informational tooltip (no controls).
+ */
+export function reportHasOutputControls(report: DataMartReport): boolean {
+  return (
+    (report.filterConfig !== null && report.filterConfig.length > 0) ||
+    (report.sortConfig !== null && report.sortConfig.length > 0) ||
+    report.limitConfig !== null
+  );
+}


### PR DESCRIPTION
## Summary

- SQL preview icon (`FileCode2`) now appears on all reports: Google Sheets, Email, and Looker Studio
- When a report has output controls (filters/sort/limit) or joined fields → clicking opens the generated SQL dialog
- When a report uses the Data Mart source directly → icon is shown in disabled state with an explanatory tooltip and a link to Data Setup
- Added `reportHasOutputControls` utility with unit tests

## Test plan

- [ ] Open a report with no filters/sorts/joins → icon appears dimmed, tooltip explains source is Data Mart directly, "Open Data Setup" link navigates correctly
- [ ] Open a report with filters or sorts → clicking icon opens SQL dialog with generated SQL
- [ ] Open a report with joined fields → clicking icon opens SQL dialog
- [ ] Looker Studio edit form: same behavior based on current form state