### PR TITLE
fix(backend): preserve user column formatting on Google Sheets refresh

### DIFF
--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
@@ -311,6 +311,41 @@ describe('GoogleSheetsApiAdapter (pure helpers)', () => {
     });
   });
 
+  describe('buildSetColumnFormatRequest', () => {
+    it('targets a single column over the row span as a repeatCell', () => {
+      const adapter = buildAdapter();
+      const format: sheets_v4.Schema$CellFormat = {
+        numberFormat: { type: 'CURRENCY', pattern: '"$"#,##0.00' },
+      };
+      const req = adapter.buildSetColumnFormatRequest(7, 2, 1, 4, format);
+
+      expect(req.repeatCell?.range).toEqual({
+        sheetId: 7,
+        startRowIndex: 1,
+        endRowIndex: 4,
+        startColumnIndex: 2,
+        endColumnIndex: 3,
+      });
+      expect(req.repeatCell?.cell?.userEnteredFormat).toBe(format);
+    });
+
+    it('excludes textFormat.link from the field mask so per-cell hyperlinks are not propagated', () => {
+      const adapter = buildAdapter();
+      const req = adapter.buildSetColumnFormatRequest(7, 0, 1, 3, { textFormat: { bold: true } });
+      const fields = req.repeatCell?.fields ?? '';
+
+      // The link must NOT be in the mask — otherwise the sampled row's URL is
+      // stamped over every row (cell shows id-5 but its link points to id-1).
+      expect(fields).not.toContain('textFormat.link');
+      // But the rest of the formatting IS restored.
+      expect(fields).toContain('userEnteredFormat.numberFormat');
+      expect(fields).toContain('userEnteredFormat.backgroundColor');
+      expect(fields).toContain('userEnteredFormat.textFormat.bold');
+      // It is a scoped mask, not the coarse whole-format mask.
+      expect(fields).not.toBe('userEnteredFormat');
+    });
+  });
+
   describe('findOwoxColumnsMetadataForSheet', () => {
     /**
      * Build a typed metadata fixture quickly. The adapter's filter only

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
@@ -12,6 +12,42 @@ export class GoogleSheetsApiAdapter {
   private static readonly SHEETS_SCOPE = ['https://www.googleapis.com/auth/spreadsheets'];
   private static readonly LOGGER = new Logger(GoogleSheetsApiAdapter.name);
 
+  /**
+   * Field mask used to restore a user's captured column format. It enumerates
+   * every `userEnteredFormat` subfield we copy column-wide — number format,
+   * colors, borders, alignment, wrap, and the cosmetic `textFormat` props —
+   * but deliberately OMITS `userEnteredFormat.textFormat.link`.
+   *
+   * Why exclude the link: a hyperlink is per-cell content, not a column-wide
+   * format. We sample one representative row's format and apply it to the whole
+   * column; if `textFormat.link` were in the mask, every row would be stamped
+   * with the sampled row's URL (the cell shows `…/id-5` but its link points to
+   * `…/id-1`). Leaving `link` out of the mask preserves each row's own link
+   * (and never propagates one row's link onto the others).
+   */
+  private static readonly RESTORE_FORMAT_FIELD_MASK = [
+    'userEnteredFormat.numberFormat',
+    'userEnteredFormat.backgroundColor',
+    'userEnteredFormat.backgroundColorStyle',
+    'userEnteredFormat.borders',
+    'userEnteredFormat.padding',
+    'userEnteredFormat.horizontalAlignment',
+    'userEnteredFormat.verticalAlignment',
+    'userEnteredFormat.wrapStrategy',
+    'userEnteredFormat.textDirection',
+    'userEnteredFormat.textRotation',
+    'userEnteredFormat.hyperlinkDisplayType',
+    'userEnteredFormat.textFormat.foregroundColor',
+    'userEnteredFormat.textFormat.foregroundColorStyle',
+    'userEnteredFormat.textFormat.fontFamily',
+    'userEnteredFormat.textFormat.fontSize',
+    'userEnteredFormat.textFormat.bold',
+    'userEnteredFormat.textFormat.italic',
+    'userEnteredFormat.textFormat.strikethrough',
+    'userEnteredFormat.textFormat.underline',
+    // NOTE: `userEnteredFormat.textFormat.link` is intentionally excluded.
+  ].join(',');
+
   private readonly service: sheets_v4.Sheets;
 
   /**
@@ -264,13 +300,15 @@ export class GoogleSheetsApiAdapter {
 
   /**
    * Builds a `repeatCell` request that applies a captured cell format to every
-   * cell of a single column within a row span. The field mask is the whole
-   * `userEnteredFormat`, so the full set of user-applied cell formatting is
-   * restored — number format, background/text colors, bold/italic, horizontal
-   * & vertical alignment, borders, wrap, padding, etc. — not just the number
-   * format. The provided `format` is treated as the source of truth for the
-   * range: subfields absent from it are reset to default (matching "copy this
-   * representative cell's formatting onto the column").
+   * cell of a single column within a row span. The field mask restores the set
+   * of user-applied formatting — number format, background/text colors,
+   * bold/italic, horizontal & vertical alignment, borders, wrap, padding,
+   * etc. — but deliberately EXCLUDES `textFormat.link` (a per-cell hyperlink is
+   * content, not a column-wide format; see
+   * {@link GoogleSheetsApiAdapter.RESTORE_FORMAT_FIELD_MASK}). Subfields inside
+   * the mask that are absent from `format` are reset to default on the range;
+   * subfields outside the mask (notably each cell's own link) are left
+   * untouched.
    *
    * Sheet-level constructs (conditional formatting, data validation) live
    * outside `userEnteredFormat` and are intentionally NOT touched here — the
@@ -298,7 +336,7 @@ export class GoogleSheetsApiAdapter {
         cell: {
           userEnteredFormat: format,
         },
-        fields: 'userEnteredFormat',
+        fields: GoogleSheetsApiAdapter.RESTORE_FORMAT_FIELD_MASK,
       },
     };
   }


### PR DESCRIPTION
## Problem

When a Report Run updates a Google Sheet, the column formatting a user set in
the Sheets UI (date / number / currency formats, and more broadly background &
text colors, bold, alignment, borders) was reset on every refresh. Expected
behaviour — formatting is preserved, the way the old OWOX Sheets extension
worked.

## Root cause

The writer commits every data cell with `valueInputOption: 'USER_ENTERED'`.
With `USER_ENTERED`, Sheets re-derives each cell's **number format** from the
parsed value and overwrites the user's explicit format. It's worst for
`TIMESTAMP` columns, which the writer itself stringifies to
`"yyyy-MM-dd HH:mm:ss"`, and for `DATE` columns arriving as ISO strings — both
are reparsed and stamped with Sheets' default format.

Ruled out as causes: the header-row "clear format" request only touches
`textFormat`/`backgroundColor` on row 1; `values.clear` preserves formatting;
and a stable schema runs zero structural column ops.

## Solution — capture & restore (reconstructing the old extension's behaviour)

The old extension never re-derived formats. We reproduce that:

1. **Before** the destructive write, capture each imported column's
   `userEnteredFormat`, keyed by the column's **canonical name** (so it follows
   the column through user reorder / ODM delete ops). To be robust when the
   first data row is unformatted, we sample a **bounded window** of data rows
   (rows 2..N, capped) and take the first non-empty format per column.
2. **After** the data write, in the same atomic `finalize` `batchUpdate`,
   re-apply the captured format over the written data rows. The re-applied
   format wins over whatever `USER_ENTERED` inferred. Bonus: the format now
   also extends to rows that grew on this refresh.

### What is preserved

The full `userEnteredFormat` is restored, not just the number format — number/
date/currency format, background & text colors, bold/italic/underline/
strikethrough, font, horizontal & vertical alignment, borders, padding, wrap,
text rotation.

### What is intentionally NOT propagated

`userEnteredFormat.textFormat.link` (a per-cell hyperlink) is **excluded** from
the restore field mask. A hyperlink is per-cell *content*, not a column-wide
format — including it would stamp the sampled row's URL onto every row (the cell
shows `…/id-5` but its link points to `…/id-1`). Excluding `link` from the mask
leaves each row's own link untouched. The restore mask is an explicit allowlist
of all `CellFormat` / `TextFormat` formatting subfields except `link`.

Out of scope (unchanged, and not broken by this PR): sheet-level constructs —
conditional formatting, data validation, cell notes on data cells — live outside
`userEnteredFormat` and the value write doesn't affect them. In-cell rich-text
runs (`textFormatRuns`, e.g. partial bold/link within one cell) are not
preserved; the value write already clears them on any refresh.

## Robustness / correctness details

- **Best-effort capture:** capturing formats is cosmetic and must never fail the
  export. Any error reading formats is logged and swallowed — the refresh
  proceeds and simply restores no formats that run, instead of turning a
  successful data export into a failed run.
- **Correct sheet selection:** `getColumnFormats` selects the destination tab by
  `sheetId`, not `sheets[0]` — `ranges` does not guarantee the requested tab is
  first, so a non-first destination sheet would otherwise read empty grid data
  and silently skip the restore. Logs a warning if the tab is missing.
- **No extra latency:** the capture read runs concurrently with row
  pre-allocation in `prepareToWriteReport` (independent operations), avoiding an
  extra sequential round-trip.
- **Keyed by name:** a dropped column's format is not re-applied to a neighbour;
  a reordered column keeps its format.
- First run captures/restores nothing; a failed refresh restores nothing
  (deferred-mutations / "sheet left untouched" contract preserved).

## Known limitation

Formatting is sampled from one representative row and applied column-wide
(matching the common "user formats a whole column" case). For a field a user
varies per row (most likely borders used as row separators, or manual per-row
highlights), the sampled row wins. This is cosmetic, not data loss.