### PR TITLE
feat(web): make Google Sheets access emails visible and copyable for OAuth and Service Account methods

### DIFF
--- a/.changeset/google-sheets-copyable-email-oauth-and-sa.md
+++ b/.changeset/google-sheets-copyable-email-oauth-and-sa.md
@@ -1,0 +1,12 @@
+---
+'owox': minor
+---
+
+# Google Sheets destination access email is now visible and copyable for both auth methods
+
+Previously, you could only see the email address that needs document access when the
+destination was connected via a Service Account. If you used Google OAuth, the email was
+hidden, so you had to guess which account to share the Google Sheet with.
+
+Now, whether you connect via Service Account or Google OAuth, the exact email address is
+shown right in the destination form and the report form — and you can copy it in one click.

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleSheetsFields.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleSheetsFields.tsx
@@ -68,9 +68,10 @@ export function GoogleSheetsFields({ form }: GoogleSheetsFieldsProps) {
   const credentialIdValue = form.watch('credentials.credentialId');
 
   useEffect(() => {
+    const abortController = new AbortController();
     if (authMethod === 'oauth' && credentialIdValue) {
       destinationOAuthApi
-        .getCredentialStatus(credentialIdValue)
+        .getCredentialStatus(credentialIdValue, { signal: abortController.signal })
         .then(status => {
           setOauthEmail(status.user?.email ?? null);
         })
@@ -80,6 +81,9 @@ export function GoogleSheetsFields({ form }: GoogleSheetsFieldsProps) {
     } else {
       setOauthEmail(null);
     }
+    return () => {
+      abortController.abort();
+    };
   }, [authMethod, credentialIdValue]);
 
   const handleOAuthStatusChange = (isConnected: boolean, credentialId?: string) => {

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleSheetsFields.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleSheetsFields.tsx
@@ -14,13 +14,11 @@ import { type DataDestinationFormData, DataDestinationType } from '../../../shar
 import GoogleSheetsServiceAccountDescription from './FormDescriptions/GoogleSheetsServiceAccountDescription';
 import GoogleSheetsOAuthDescription from './FormDescriptions/GoogleSheetsOAuthDescription';
 import GoogleSheetsAuthMethodDescription from './FormDescriptions/GoogleSheetsAuthMethodDescription';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { CopyableField } from '@owox/ui/components/common/copyable-field';
 import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
-import { getServiceAccountLink } from '../../../../../utils/google-cloud-utils';
-import {
-  GoogleOAuthConnectButton,
-  destinationOAuthApi,
-} from '../../../../../features/google-oauth';
+import { getServiceAccountLink } from '../../../../../utils';
+import { Copy, Check } from 'lucide-react';
+import { GoogleOAuthConnectButton, destinationOAuthApi } from '../../../../google-oauth';
 import { Tabs, TabsList, TabsTrigger } from '@owox/ui/components/tabs';
 import { AuthenticationSectionHeader } from '../../../../../shared/components/AuthenticationSectionHeader';
 import { CopyDestinationCredentialsButton } from '../CopyDestinationCredentialsButton';
@@ -48,6 +46,8 @@ export function GoogleSheetsFields({ form }: GoogleSheetsFieldsProps) {
   const [stashedCredentialId, setStashedCredentialId] = useState<string | null | undefined>(
     undefined
   );
+  const [oauthEmail, setOauthEmail] = useState<string | null>(null);
+  const [saCopied, setSaCopied] = useState(false);
 
   useEffect(() => {
     destinationOAuthApi
@@ -66,6 +66,21 @@ export function GoogleSheetsFields({ form }: GoogleSheetsFieldsProps) {
   }, []);
 
   const credentialIdValue = form.watch('credentials.credentialId');
+
+  useEffect(() => {
+    if (authMethod === 'oauth' && credentialIdValue) {
+      destinationOAuthApi
+        .getCredentialStatus(credentialIdValue)
+        .then(status => {
+          setOauthEmail(status.user?.email ?? null);
+        })
+        .catch(() => {
+          setOauthEmail(null);
+        });
+    } else {
+      setOauthEmail(null);
+    }
+  }, [authMethod, credentialIdValue]);
 
   const handleOAuthStatusChange = (isConnected: boolean, credentialId?: string) => {
     if (isConnected && credentialId) {
@@ -170,6 +185,12 @@ export function GoogleSheetsFields({ form }: GoogleSheetsFieldsProps) {
                 onSuccess={handleOAuthSuccess}
                 onStatusChange={handleOAuthStatusChange}
               />
+              {oauthEmail && (
+                <div className='mt-2 flex flex-col gap-1'>
+                  <FormLabel>Authenticated email</FormLabel>
+                  <CopyableField value={oauthEmail}>{oauthEmail}</CopyableField>
+                </div>
+              )}
               <FormDescription>
                 <GoogleSheetsOAuthDescription />
               </FormDescription>
@@ -199,16 +220,33 @@ export function GoogleSheetsFields({ form }: GoogleSheetsFieldsProps) {
                   </div>
                   <FormControl>
                     {!isEditing && serviceAccountLink ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <ExternalAnchor href={serviceAccountLink.url} variant='field'>
-                            {serviceAccountLink.email}
-                          </ExternalAnchor>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>View in Google Cloud Console</p>
-                        </TooltipContent>
-                      </Tooltip>
+                      <div className='flex items-center gap-2'>
+                        <ExternalAnchor
+                          href={serviceAccountLink.url}
+                          variant='field'
+                          className='flex-1 truncate'
+                        >
+                          {serviceAccountLink.email}
+                        </ExternalAnchor>
+                        <button
+                          type='button'
+                          onClick={() => {
+                            void navigator.clipboard.writeText(serviceAccountLink.email);
+                            setSaCopied(true);
+                            setTimeout(() => {
+                              setSaCopied(false);
+                            }, 2000);
+                          }}
+                          className='text-muted-foreground hover:text-foreground hover:bg-accent shrink-0 rounded-md p-1 transition-colors'
+                          aria-label='Copy email'
+                        >
+                          {saCopied ? (
+                            <Check className='h-4 w-4 text-green-500' />
+                          ) : (
+                            <Copy className='h-4 w-4' />
+                          )}
+                        </button>
+                      </div>
                     ) : (
                       <Textarea
                         {...field}

--- a/apps/web/src/features/data-destination/shared/model/mappers/google-sheets.mapper.ts
+++ b/apps/web/src/features/data-destination/shared/model/mappers/google-sheets.mapper.ts
@@ -32,6 +32,10 @@ export class GoogleSheetsMapper implements DestinationMapper {
       credentials: {
         serviceAccount: serviceAccountJson,
         credentialId: dto.credentialId,
+        identity:
+          dto.credentials.type === DataDestinationCredentialsType.GOOGLE_SHEETS_OAUTH_CREDENTIALS
+            ? dto.credentials.identity
+            : null,
       },
       createdAt: new Date(dto.createdAt),
       modifiedAt: new Date(dto.modifiedAt),

--- a/apps/web/src/features/data-destination/shared/model/types/data-destination.ts
+++ b/apps/web/src/features/data-destination/shared/model/types/data-destination.ts
@@ -1,4 +1,5 @@
 import { DataDestinationType } from '../../enums';
+import type { CredentialIdentity, UserProjection } from '../../../../../shared/types';
 import type { DataDestinationCredentials } from './credentials.ts';
 import type { EmailCredentials } from './email-credentials.ts';
 import type { LookerStudioCredentials } from './looker-studio-credentials.ts';
@@ -11,8 +12,8 @@ export interface BaseDataDestination<T extends DataDestinationCredentials> {
   credentials: T;
   createdAt: Date;
   modifiedAt: Date;
-  createdByUser?: import('../../../../../shared/types').UserProjection | null;
-  ownerUsers?: import('../../../../../shared/types').UserProjection[];
+  createdByUser?: UserProjection | null;
+  ownerUsers?: UserProjection[];
   availableForUse?: boolean;
   availableForMaintenance?: boolean;
   contexts?: { id: string; name: string }[];
@@ -25,6 +26,7 @@ export interface GoogleSheetsCredentials {
 export interface GoogleSheetsOAuthCredentials {
   serviceAccount?: string;
   credentialId?: string | null;
+  identity?: CredentialIdentity | null;
 }
 
 export interface GoogleSheetsDataDestination extends BaseDataDestination<GoogleSheetsOAuthCredentials> {

--- a/apps/web/src/features/data-destination/shared/services/types/data-destination.response.dto.ts
+++ b/apps/web/src/features/data-destination/shared/services/types/data-destination.response.dto.ts
@@ -1,5 +1,5 @@
 import { DataDestinationCredentialsType, DataDestinationType } from '../../enums';
-import type { GoogleServiceAccount } from '../../../../../shared/types';
+import type { CredentialIdentity, GoogleServiceAccount } from '../../../../../shared/types';
 
 /**
  * Google Sheets credentials response
@@ -21,6 +21,7 @@ export interface LookerStudioCredentialsResponse {
 
 export interface GoogleSheetsOAuthCredentialsResponse {
   type: DataDestinationCredentialsType.GOOGLE_SHEETS_OAUTH_CREDENTIALS;
+  identity: CredentialIdentity | null;
 }
 
 export interface EmailCredentialsResponse {

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useEffect, useState, useRef } from 'react';
-import { useOwnerState } from '../../../../../../shared/hooks/useOwnerState';
-import { UserReference } from '../../../../../../shared/components/UserReference/UserReference';
-import { useUser } from '../../../../../idp/hooks/useAuthState';
+import { useOwnerState } from '../../../../../../shared/hooks';
+import { UserReference } from '../../../../../../shared/components/UserReference';
+import { useUser } from '../../../../../idp';
 import { Input } from '@owox/ui/components/input';
 import { useAutoFocus } from '../../../../../../hooks/useAutoFocus.ts';
 import {
@@ -41,8 +41,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/too
 import { Alert, AlertDescription, AlertTitle } from '@owox/ui/components/alert';
 import { AlertCircle, ExternalLink } from 'lucide-react';
 import {
-  extractServiceAccountEmail,
   getGoogleSheetTabUrl,
+  getGoogleSheetsDestinationEmail,
   isValidGoogleSheetsUrl,
   ReportFormMode,
 } from '../../../shared';
@@ -52,7 +52,6 @@ import {
   type ReportSchedulesInlineListHandle,
 } from '../../../../scheduled-triggers/components/ReportSchedulesInlineList/ReportSchedulesInlineList';
 import DocumentLinkDescription from './FormDescriptions/DocumentLinkDescription.tsx';
-import { isGoogleServiceAccountCredentials } from '../../../../../../shared/types';
 import { CopyableField } from '@owox/ui/components/common/copyable-field';
 import { useReport } from '../../../shared';
 import { ReportFormActions } from '../shared/ReportFormActions';
@@ -312,18 +311,16 @@ export const GoogleSheetsReportEditForm = forwardRef<
                         {filteredDestinations.map(destination => {
                           const typeInfo = DataDestinationTypeModel.getInfo(destination.type);
                           const IconComponent = typeInfo.icon;
-                          const saEmail = isGoogleServiceAccountCredentials(destination.credentials)
-                            ? extractServiceAccountEmail(destination.credentials.serviceAccount)
-                            : null;
+                          const accessEmail = getGoogleSheetsDestinationEmail(destination);
                           return (
                             <SelectItem key={destination.id} value={destination.id}>
                               <div className='flex w-full min-w-0 items-center gap-2'>
                                 <IconComponent className='flex-shrink-0' size={18} />
                                 <div className='flex min-w-0 flex-col'>
                                   <span className='truncate'>{destination.title}</span>
-                                  {saEmail && (
+                                  {accessEmail && (
                                     <span className='text-muted-foreground truncate text-xs'>
-                                      {saEmail}
+                                      {accessEmail}
                                     </span>
                                   )}
                                 </div>
@@ -355,18 +352,14 @@ export const GoogleSheetsReportEditForm = forwardRef<
                           destination => destination.id === field.value
                         );
                         if (selectedDestination) {
-                          const saEmail = isGoogleServiceAccountCredentials(
-                            selectedDestination.credentials
-                          )
-                            ? extractServiceAccountEmail(
-                                selectedDestination.credentials.serviceAccount
-                              )
-                            : null;
-                          if (!saEmail) return null;
+                          const accessEmail = getGoogleSheetsDestinationEmail(selectedDestination);
+                          if (!accessEmail) return null;
                           return (
                             <div className='mt-2 flex flex-col gap-1'>
-                              <FormLabel>Service Account Email</FormLabel>
-                              <CopyableField value={saEmail}>{saEmail}</CopyableField>
+                              <FormLabel tooltip='Share the Google Sheet with this email to allow writing'>
+                                Share document with
+                              </FormLabel>
+                              <CopyableField value={accessEmail}>{accessEmail}</CopyableField>
                             </div>
                           );
                         }

--- a/apps/web/src/features/data-marts/reports/shared/utils/google-sheets-destination-email.utils.ts
+++ b/apps/web/src/features/data-marts/reports/shared/utils/google-sheets-destination-email.utils.ts
@@ -1,0 +1,26 @@
+import { DataDestinationType } from '../../../../data-destination';
+import type { DataDestination } from '../../../../data-destination';
+import { extractServiceAccountEmail } from './service-account.utils';
+
+/**
+ * Extracts the email address that should be granted access to the Google Sheet
+ * for a given Google Sheets destination.
+ *
+ * - Service Account: parses client_email from the JSON key.
+ * - OAuth: uses the identity.email of the authorized Google account.
+ */
+export function getGoogleSheetsDestinationEmail(destination: DataDestination): string | undefined {
+  if (destination.type !== DataDestinationType.GOOGLE_SHEETS) {
+    return undefined;
+  }
+
+  if (destination.credentials.serviceAccount) {
+    return extractServiceAccountEmail(destination.credentials.serviceAccount);
+  }
+
+  if (destination.credentials.identity?.email) {
+    return destination.credentials.identity.email;
+  }
+
+  return undefined;
+}

--- a/apps/web/src/features/data-marts/reports/shared/utils/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './google-sheets-destination-email.utils';
 export * from './google-sheets-url.utils';
 export * from './report-has-blending.utils';
 export * from './report-has-output-controls.utils';

--- a/apps/web/src/features/google-oauth/api/google-oauth-api.service.ts
+++ b/apps/web/src/features/google-oauth/api/google-oauth-api.service.ts
@@ -1,4 +1,5 @@
-import { ApiService } from '../../../services/api-service';
+import { ApiService } from '../../../services';
+import type { AxiosRequestConfig } from 'axios';
 
 export interface OAuthSettings {
   available: boolean;
@@ -80,8 +81,8 @@ class DestinationOAuthApiService extends ApiService {
     return this.get<OAuthStatus>(`/${destinationId}/oauth/status`);
   }
 
-  getCredentialStatus(credentialId: string): Promise<OAuthStatus> {
-    return this.get<OAuthStatus>(`/oauth/credential-status/${credentialId}`);
+  getCredentialStatus(credentialId: string, config?: AxiosRequestConfig): Promise<OAuthStatus> {
+    return this.get<OAuthStatus>(`/oauth/credential-status/${credentialId}`, undefined, config);
   }
 }
 

--- a/apps/web/src/shared/types/index.ts
+++ b/apps/web/src/shared/types/index.ts
@@ -1,3 +1,4 @@
+export * from './credential-identity';
 export * from './google-service-account-credentials.dto';
 export * from './google-service-account-credentials';
 export * from './google-service.account.ts';


### PR DESCRIPTION
This pull request introduces functionality to display and enable copying of the access emails for Google Sheets integration. It applies to both OAuth and Service Account methods, improving usability for handling configuration needs.

## What's new
 - Added display of the email address that needs to be granted access to a Google Sheet document.
 - This now works for **both** authentication methods:
   - **Service Account** — `client_email` from the JSON key.
   - **Google OAuth** — email of the authenticated Google account.
 - The email is **copyable with one click** in both the destination form and the report form.
 - Updated the dropdown in the report form to show the email regardless of auth method.

 ## How to test

 1. **Service Account**
    - Create or edit a Google Sheets destination with a Service Account JSON.
    - Observe the email is shown as a link to Google Cloud Console with a copy button.
    - Create a report using this destination — the email is visible in the dropdown and below it.

 2. **OAuth**
    - Connect a Google Sheets destination via OAuth.
    - In the destination form, the "Authenticated email" appears under the OAuth button.
    - Create a report using this destination — the email is visible in the dropdown and below it.

 3. **Copy functionality**
    - Click the email field (or the copy icon for SA) — it should be copied to clipboard.
