### PR TITLE
Add run cancellation for connector and report runs

### DIFF
--- a/apps/backend/src/common/scheduler/facades/scheduler-facade.impl.spec.ts
+++ b/apps/backend/src/common/scheduler/facades/scheduler-facade.impl.spec.ts
@@ -1,0 +1,117 @@
+import { ConfigService } from '@nestjs/config';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { Repository } from 'typeorm';
+import { CronJob } from 'cron';
+import { SchedulerFacadeImpl } from './scheduler-facade.impl';
+import { TriggerFetcherFactory } from '../services/fetchers/trigger-fetcher-factory.service';
+import { TriggerFetcherService } from '../services/fetchers/trigger-fetcher.service';
+import { GracefulShutdownService } from '../services/graceful-shutdown.service';
+import { SystemTimeService } from '../services/system-time.service';
+import { TriggerRunnerFactory } from '../services/runners/trigger-runner.factory';
+import { TriggerRunnerService } from '../services/runners/trigger-runner.interface';
+import { Trigger } from '../shared/entities/trigger.entity';
+import { TriggerHandler } from '../shared/trigger-handler.interface';
+
+class TestTrigger extends Trigger {}
+
+class TestTriggerHandler implements TriggerHandler<TestTrigger> {
+  constructor(private readonly repository: Repository<TestTrigger>) {}
+
+  getTriggerRepository(): Repository<TestTrigger> {
+    return this.repository;
+  }
+
+  async handleTrigger(): Promise<void> {}
+
+  processingCronExpression(): string {
+    return '* * * * * *';
+  }
+}
+
+describe('SchedulerFacadeImpl', () => {
+  const registeredJobs = new Map<string, CronJob>();
+
+  let service: SchedulerFacadeImpl;
+  let fetcher: jest.Mocked<
+    Pick<
+      TriggerFetcherService<TestTrigger>,
+      'fetchTriggersReadyForProcessing' | 'fetchTriggersForRunCancellation'
+    >
+  >;
+  let runner: jest.Mocked<TriggerRunnerService<TestTrigger>>;
+
+  beforeEach(() => {
+    registeredJobs.clear();
+
+    const schedulerRegistry = {
+      addCronJob: jest.fn((name: string, job: CronJob) => {
+        registeredJobs.set(name, job);
+      }),
+    } as unknown as SchedulerRegistry;
+
+    const configService = {
+      get: jest.fn((key: string) => {
+        if (key === 'SCHEDULER_EXECUTION_ENABLED') {
+          return true;
+        }
+        if (key === 'SCHEDULER_TIMEZONE') {
+          return 'UTC';
+        }
+        return undefined;
+      }),
+    } as unknown as ConfigService;
+
+    fetcher = {
+      fetchTriggersReadyForProcessing: jest.fn(async () => []),
+      fetchTriggersForRunCancellation: jest.fn(async () => []),
+    };
+    const triggerFetcherFactory = {
+      createFetcher: jest.fn(() => fetcher),
+    } as unknown as TriggerFetcherFactory;
+
+    runner = {
+      runTriggers: jest.fn(async () => {}),
+      abortTriggerRuns: jest.fn(async () => {}),
+    };
+    const triggerRunnerFactory = {
+      createRunner: jest.fn(async () => runner),
+    } as unknown as TriggerRunnerFactory;
+
+    const systemTimeService = {} as SystemTimeService;
+    const gracefulShutdownService = {
+      isInShutdownMode: jest.fn(() => false),
+    } as unknown as GracefulShutdownService;
+
+    service = new SchedulerFacadeImpl(
+      schedulerRegistry,
+      configService,
+      triggerFetcherFactory,
+      triggerRunnerFactory,
+      systemTimeService,
+      gracefulShutdownService
+    );
+  });
+
+  afterEach(() => {
+    for (const job of registeredJobs.values()) {
+      void job.stop();
+    }
+  });
+
+  it('uses the scheduler abort job to abort cancelling trigger runs', async () => {
+    const repository = {} as Repository<TestTrigger>;
+    const triggerHandler = new TestTriggerHandler(repository);
+    const trigger = Object.assign(new TestTrigger(), { id: 'trigger-1' });
+    fetcher.fetchTriggersForRunCancellation.mockResolvedValueOnce([trigger]);
+
+    await service.registerTriggerHandler(triggerHandler);
+
+    const abortJob = registeredJobs.get('TestTriggerHandler [abort-run-check]');
+    expect(abortJob).toBeDefined();
+
+    await abortJob!.fireOnTick();
+
+    expect(fetcher.fetchTriggersForRunCancellation).toHaveBeenCalledTimes(1);
+    expect(runner.abortTriggerRuns).toHaveBeenCalledWith([trigger]);
+  });
+});

--- a/apps/backend/src/data-marts/entities/connector-run-trigger.entity.ts
+++ b/apps/backend/src/data-marts/entities/connector-run-trigger.entity.ts
@@ -12,7 +12,7 @@ export class ConnectorRunTrigger extends Trigger {
    * to keep the trigger active for the next processing cycle.
    */
   override onSuccess(_lastRunTimestamp?: Date) {
-    if (this.status === TriggerStatus.IDLE) {
+    if (this.status === TriggerStatus.IDLE || this.status === TriggerStatus.CANCELLED) {
       return;
     }
     super.onSuccess(_lastRunTimestamp);

--- a/apps/backend/src/data-marts/entities/report-run-trigger.entity.ts
+++ b/apps/backend/src/data-marts/entities/report-run-trigger.entity.ts
@@ -12,7 +12,7 @@ export class ReportRunTrigger extends Trigger {
    * to keep the trigger active for the next processing cycle.
    */
   override onSuccess(_lastRunTimestamp?: Date) {
-    if (this.status === TriggerStatus.IDLE) {
+    if (this.status === TriggerStatus.IDLE || this.status === TriggerStatus.CANCELLED) {
       return;
     }
     super.onSuccess(_lastRunTimestamp);

--- a/apps/backend/src/data-marts/services/base-run-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/base-run-trigger-handler.service.ts
@@ -1,8 +1,10 @@
 import { Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, In, Repository } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { SchedulerFacade } from '../../common/scheduler/shared/scheduler.facade';
 import { TriggerHandler } from '../../common/scheduler/shared/trigger-handler.interface';
 import { Trigger } from '../../common/scheduler/shared/entities/trigger.entity';
+import { TriggerStatus } from '../../common/scheduler/shared/entities/trigger-status';
 import { DataMartRun } from '../entities/data-mart-run.entity';
 import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
 import { DataMartRunService } from './data-mart-run.service';
@@ -46,6 +48,42 @@ export abstract class BaseRunTriggerHandlerService<T extends Trigger>
    * Returns the field name used to link trigger to DataMartRun.
    */
   protected abstract getTriggerRunIdField(): string;
+
+  protected async cancelTriggerIfRunAlreadyCancelled(trigger: T): Promise<boolean> {
+    const dataMartRunId = this.getTriggerDataMartRunId(trigger);
+    const existingRun = await this.dataMartRunService.findById(dataMartRunId);
+    if (existingRun?.status !== DataMartRunStatus.CANCELLED) {
+      return false;
+    }
+
+    await this.markTriggerAsCancelled(trigger);
+    return true;
+  }
+
+  protected async markTriggerAsCancelled(trigger: T): Promise<void> {
+    trigger.status = TriggerStatus.CANCELLED;
+    trigger.isActive = false;
+
+    await this.getTriggerRepository().update(
+      {
+        id: trigger.id,
+        status: In([TriggerStatus.PROCESSING, TriggerStatus.CANCELLING]),
+      } as FindOptionsWhere<T>,
+      {
+        status: TriggerStatus.CANCELLED,
+        isActive: false,
+        version: () => 'version + 1',
+      } as QueryDeepPartialEntity<T>
+    );
+
+    this.logger.log(
+      `Skipping run trigger ${trigger.id}: DataMartRun ${this.getTriggerDataMartRunId(trigger)} is already CANCELLED`
+    );
+  }
+
+  private getTriggerDataMartRunId(trigger: T): string {
+    return (trigger as unknown as Record<string, string>)[this.getTriggerRunIdField()];
+  }
 
   /**
    * Safely marks a DataMartRun as FAILED, handling any errors during the operation.

--- a/apps/backend/src/data-marts/services/base-run-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/base-run-trigger-handler.service.ts
@@ -56,11 +56,14 @@ export abstract class BaseRunTriggerHandlerService<T extends Trigger>
       return false;
     }
 
-    await this.markTriggerAsCancelled(trigger);
+    await this.markTriggerAsCancelled(
+      trigger,
+      `Skipping run trigger ${trigger.id}: DataMartRun ${dataMartRunId} is already CANCELLED`
+    );
     return true;
   }
 
-  protected async markTriggerAsCancelled(trigger: T): Promise<void> {
+  protected async markTriggerAsCancelled(trigger: T, logMessage?: string): Promise<void> {
     trigger.status = TriggerStatus.CANCELLED;
     trigger.isActive = false;
 
@@ -76,9 +79,9 @@ export abstract class BaseRunTriggerHandlerService<T extends Trigger>
       } as QueryDeepPartialEntity<T>
     );
 
-    this.logger.log(
-      `Skipping run trigger ${trigger.id}: DataMartRun ${this.getTriggerDataMartRunId(trigger)} is already CANCELLED`
-    );
+    if (logMessage) {
+      this.logger.log(logMessage);
+    }
   }
 
   private getTriggerDataMartRunId(trigger: T): string {

--- a/apps/backend/src/data-marts/services/connector/connector-execution.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-execution.service.spec.ts
@@ -8,7 +8,6 @@ describe('ConnectorExecutionService (facade)', () => {
   const createService = () => {
     const connectorRunService = {
       run: jest.fn().mockResolvedValue('run-1'),
-      cancelRun: jest.fn().mockResolvedValue(undefined),
       executeExistingRun: jest.fn().mockResolvedValue(undefined),
       executeInterruptedRuns: jest.fn().mockResolvedValue(undefined),
       getDataMartConnectorRunsByStatus: jest.fn().mockResolvedValue([]),
@@ -27,14 +26,6 @@ describe('ConnectorExecutionService (facade)', () => {
 
     expect(result).toBe('run-1');
     expect(connectorRunService.run).toHaveBeenCalledWith(dm, 'user-1', 'MANUAL', {});
-  });
-
-  it('delegates cancelRun to ConnectorRunService', async () => {
-    const { service, connectorRunService } = createService();
-
-    await service.cancelRun('dm-1', 'run-1');
-
-    expect(connectorRunService.cancelRun).toHaveBeenCalledWith('dm-1', 'run-1');
   });
 
   it('delegates executeExistingRun to ConnectorRunService', async () => {

--- a/apps/backend/src/data-marts/services/connector/connector-execution.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-execution.service.ts
@@ -22,10 +22,6 @@ export class ConnectorExecutionService {
     return this.connectorRunService.run(dataMart, createdById, runType, payload);
   }
 
-  async cancelRun(dataMartId: string, runId: string): Promise<void> {
-    return this.connectorRunService.cancelRun(dataMartId, runId);
-  }
-
   async executeExistingRun(
     dataMart: DataMart,
     run: DataMartRun,

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -51,17 +51,21 @@ describe('ConnectorExecutorService', () => {
       }),
     } as unknown as ConnectorOutputCaptureService;
 
+    const emitSuccessMessage = () => {
+      if (capturedOnMessage) {
+        capturedOnMessage({
+          type: ConnectorMessageType.STATUS,
+          status: 'SUCCESS',
+          at: new Date().toISOString(),
+          toFormattedString: () => 'STATUS: SUCCESS',
+        });
+      }
+    };
+
     const processSpawner = {
       spawnConnector: jest.fn().mockImplementation(() => {
         // Simulate a successful connector run by triggering a STATUS SUCCESS message
-        if (capturedOnMessage) {
-          capturedOnMessage({
-            type: ConnectorMessageType.STATUS,
-            status: 'SUCCESS',
-            at: new Date().toISOString(),
-            toFormattedString: () => 'STATUS: SUCCESS',
-          });
-        }
+        emitSuccessMessage();
         return Promise.resolve();
       }),
     } as unknown as ConnectorProcessSpawnerService;
@@ -144,6 +148,7 @@ describe('ConnectorExecutorService', () => {
       eventDispatcher,
       projectBalanceService,
       dataMartService,
+      emitSuccessMessage,
     };
   };
 
@@ -189,6 +194,45 @@ describe('ConnectorExecutorService', () => {
     expect(consumptionTracker.registerConnectorRunConsumption).toHaveBeenCalled();
     expect(eventDispatcher.publishExternal).toHaveBeenCalled();
     expect(dataMartService.actualizeSchema).toHaveBeenCalledWith('dm-1', 'proj-1');
+  });
+
+  it('lets normal completion replace a committed cancellation when abort is not delivered', async () => {
+    const {
+      service,
+      dataMartRunRepository,
+      processSpawner,
+      consumptionTracker,
+      eventDispatcher,
+      emitSuccessMessage,
+    } = createService();
+    const statusHistory: DataMartRunStatus[] = [];
+    (dataMartRunRepository.update as jest.Mock).mockImplementation(async (_runId, update) => {
+      if (update.status) {
+        statusHistory.push(update.status);
+      }
+    });
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
+      // Simulate the cancel endpoint committing CANCELLED while this worker keeps running.
+      statusHistory.push(DataMartRunStatus.CANCELLED);
+      emitSuccessMessage();
+    });
+
+    await service.executeInBackground(createDataMart(), createRun(), null);
+
+    expect(statusHistory).toEqual([
+      DataMartRunStatus.RUNNING,
+      DataMartRunStatus.CANCELLED,
+      DataMartRunStatus.SUCCESS,
+    ]);
+    expect(dataMartRunRepository.update).toHaveBeenLastCalledWith(
+      'run-1',
+      expect.objectContaining({ status: DataMartRunStatus.SUCCESS })
+    );
+    expect(consumptionTracker.registerConnectorRunConsumption).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'dm-1' }),
+      'run-1'
+    );
+    expect(eventDispatcher.publishExternal).toHaveBeenCalled();
   });
 
   it('skips execution in shutdown mode', async () => {

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -332,4 +332,46 @@ describe('ConnectorExecutorService', () => {
     );
     expect(eventDispatcher.publishExternal).not.toHaveBeenCalled();
   });
+
+  it('keeps an aborted connector run CANCELLED during graceful shutdown', async () => {
+    const { service, dataMartRunRepository, gracefulShutdownService } = createService();
+    const controller = new AbortController();
+    controller.abort();
+    (gracefulShutdownService.isInShutdownMode as jest.Mock).mockReturnValue(true);
+
+    await service.executeInBackground(createDataMart(), createRun(), null, controller.signal);
+
+    expect(dataMartRunRepository.update).toHaveBeenLastCalledWith(
+      'run-1',
+      expect.objectContaining({ status: DataMartRunStatus.CANCELLED })
+    );
+  });
+
+  it('registers consumption when abort arrives after a successful connector upload', async () => {
+    const {
+      service,
+      dataMartRunRepository,
+      processSpawner,
+      consumptionTracker,
+      eventDispatcher,
+      emitSuccessMessage,
+    } = createService();
+    const controller = new AbortController();
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
+      emitSuccessMessage();
+      controller.abort();
+    });
+
+    await service.executeInBackground(createDataMart(), createRun(), null, controller.signal);
+
+    expect(dataMartRunRepository.update).toHaveBeenLastCalledWith(
+      'run-1',
+      expect.objectContaining({ status: DataMartRunStatus.SUCCESS })
+    );
+    expect(consumptionTracker.registerConnectorRunConsumption).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'dm-1' }),
+      'run-1'
+    );
+    expect(eventDispatcher.publishExternal).toHaveBeenCalled();
+  });
 });

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -271,4 +271,21 @@ describe('ConnectorExecutorService', () => {
     expect(updateCall).toBeDefined();
     expect(updateCall![1]).not.toHaveProperty('startedAt');
   });
+
+  it('marks an aborted connector run as CANCELLED', async () => {
+    const { service, dataMartRunRepository, processSpawner, eventDispatcher } = createService();
+    const controller = new AbortController();
+    controller.abort();
+    (processSpawner.spawnConnector as jest.Mock).mockRejectedValue(
+      new Error('Connector process was aborted')
+    );
+
+    await service.executeInBackground(createDataMart(), createRun(), null, controller.signal);
+
+    expect(dataMartRunRepository.update).toHaveBeenLastCalledWith(
+      'run-1',
+      expect.objectContaining({ status: DataMartRunStatus.CANCELLED })
+    );
+    expect(eventDispatcher.publishExternal).not.toHaveBeenCalled();
+  });
 });

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -101,7 +101,6 @@ export class ConnectorExecutorService {
         payload,
         signal
       );
-      wasCancelled = signal?.aborted === true;
 
       configurationResults.forEach(result => {
         result.logs.forEach(log => addMessageToArray(capturedLogs, log));
@@ -111,12 +110,13 @@ export class ConnectorExecutorService {
       const successCount = configurationResults.filter(r => r.success).length;
       const totalCount = configurationResults.length;
       hasSuccessfulRun = successCount > 0;
+      wasCancelled = signal?.aborted === true && !hasSuccessfulRun;
       this.logger.log(
         `Connector execution completed: ${successCount}/${totalCount} configurations successful`,
         { dataMartId: dataMart.id, projectId: dataMart.projectId, runId, successCount, totalCount }
       );
     } catch (error) {
-      wasCancelled = signal?.aborted === true;
+      wasCancelled = signal?.aborted === true && !hasSuccessfulRun;
       const errorMessage = error instanceof Error ? error.message : String(error);
       addMessageToArray(capturedErrors, {
         type: ConnectorMessageType.ERROR,
@@ -153,7 +153,7 @@ export class ConnectorExecutorService {
         wasCancelled
       );
 
-      if (hasSuccessfulRun && !wasCancelled) {
+      if (hasSuccessfulRun) {
         await this.consumptionTracker.registerConnectorRunConsumption(dataMart, runId);
         await this.eventDispatcher.publishExternal(
           new ConnectorRunEvent(
@@ -387,7 +387,7 @@ export class ConnectorExecutorService {
         : operationBlockedException
           ? DataMartRunStatus.RESTRICTED
           : DataMartRunStatus.FAILED;
-    if (this.gracefulShutdownService.isInShutdownMode()) {
+    if (!wasCancelled && !hasSuccessfulRun && this.gracefulShutdownService.isInShutdownMode()) {
       status = DataMartRunStatus.INTERRUPTED;
     }
 

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -74,6 +74,7 @@ export class ConnectorExecutorService {
     const capturedLogs: ConnectorMessage[] = [];
     const capturedErrors: ConnectorMessage[] = [];
     let hasSuccessfulRun = false;
+    let wasCancelled = false;
     let operationBlockedException: ProjectOperationBlockedException | undefined;
 
     try {
@@ -100,6 +101,7 @@ export class ConnectorExecutorService {
         payload,
         signal
       );
+      wasCancelled = signal?.aborted === true;
 
       configurationResults.forEach(result => {
         result.logs.forEach(log => addMessageToArray(capturedLogs, log));
@@ -114,6 +116,7 @@ export class ConnectorExecutorService {
         { dataMartId: dataMart.id, projectId: dataMart.projectId, runId, successCount, totalCount }
       );
     } catch (error) {
+      wasCancelled = signal?.aborted === true;
       const errorMessage = error instanceof Error ? error.message : String(error);
       addMessageToArray(capturedErrors, {
         type: ConnectorMessageType.ERROR,
@@ -146,10 +149,11 @@ export class ConnectorExecutorService {
         capturedLogs,
         capturedErrors,
         mergeWithExisting,
-        operationBlockedException
+        operationBlockedException,
+        wasCancelled
       );
 
-      if (hasSuccessfulRun) {
+      if (hasSuccessfulRun && !wasCancelled) {
         await this.consumptionTracker.registerConnectorRunConsumption(dataMart, runId);
         await this.eventDispatcher.publishExternal(
           new ConnectorRunEvent(
@@ -161,7 +165,7 @@ export class ConnectorExecutorService {
             'successfully'
           )
         );
-      } else if (!this.gracefulShutdownService.isInShutdownMode()) {
+      } else if (!wasCancelled && !this.gracefulShutdownService.isInShutdownMode()) {
         await this.eventDispatcher.publishExternal(
           new ConnectorRunEvent(
             dataMart.id,
@@ -371,15 +375,18 @@ export class ConnectorExecutorService {
     capturedLogs: ConnectorMessage[],
     capturedErrors: ConnectorMessage[],
     mergeWithExisting: boolean = false,
-    operationBlockedException?: ProjectOperationBlockedException
+    operationBlockedException?: ProjectOperationBlockedException,
+    wasCancelled: boolean = false
   ): Promise<void> {
     const hasLogs = capturedLogs.length > 0;
     const hasErrors = capturedErrors.length > 0;
-    let status = hasSuccessfulRun
-      ? DataMartRunStatus.SUCCESS
-      : operationBlockedException
-        ? DataMartRunStatus.RESTRICTED
-        : DataMartRunStatus.FAILED;
+    let status = wasCancelled
+      ? DataMartRunStatus.CANCELLED
+      : hasSuccessfulRun
+        ? DataMartRunStatus.SUCCESS
+        : operationBlockedException
+          ? DataMartRunStatus.RESTRICTED
+          : DataMartRunStatus.FAILED;
     if (this.gracefulShutdownService.isInShutdownMode()) {
       status = DataMartRunStatus.INTERRUPTED;
     }

--- a/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.spec.ts
@@ -212,6 +212,9 @@ describe('ConnectorRunTriggerHandlerService', () => {
       } = createService();
       const abortController = new AbortController();
       const trigger = Object.assign(new ConnectorRunTrigger(), mockTrigger);
+      const logSpy = jest
+        .spyOn((service as unknown as { logger: { log: (message: string) => void } }).logger, 'log')
+        .mockImplementation();
 
       (dataMartService.getByIdAndProjectId as jest.Mock).mockResolvedValue(mockDataMart);
       (mockManager.findOneOrFail as jest.Mock).mockResolvedValue(mockRun);
@@ -227,6 +230,7 @@ describe('ConnectorRunTriggerHandlerService', () => {
       );
       trigger.onSuccess(new Date('2026-06-04T12:00:00.000Z'));
       expect(trigger.status).toBe(TriggerStatus.CANCELLED);
+      expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('already CANCELLED'));
     });
 
     it('fails the run when claim fails and run is not RUNNING', async () => {

--- a/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.spec.ts
@@ -1,4 +1,4 @@
-import { Repository, DataSource, EntityManager } from 'typeorm';
+import { Repository, DataSource, EntityManager, In } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { ConnectorRunTriggerHandlerService } from './connector-run-trigger-handler.service';
 import { ConnectorExecutionService } from './connector-execution.service';
@@ -14,6 +14,7 @@ describe('ConnectorRunTriggerHandlerService', () => {
   const createService = () => {
     const triggerRepository = {
       save: jest.fn().mockImplementation(data => Promise.resolve(data)),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
     } as unknown as Repository<ConnectorRunTrigger>;
 
     const dataMartRunRepository = {
@@ -194,11 +195,9 @@ describe('ConnectorRunTriggerHandlerService', () => {
 
       await expect(service.handleTrigger(mockTrigger)).resolves.toBeUndefined();
 
-      expect(triggerRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: TriggerStatus.CANCELLED,
-          isActive: false,
-        })
+      expect(triggerRepository.update).toHaveBeenCalledWith(
+        { id: 'trigger-1', status: In([TriggerStatus.PROCESSING, TriggerStatus.CANCELLING]) },
+        { status: TriggerStatus.CANCELLED, isActive: false, version: expect.any(Function) }
       );
       expect(connectorExecutionService.executeExistingRun).not.toHaveBeenCalled();
     });
@@ -222,11 +221,9 @@ describe('ConnectorRunTriggerHandlerService', () => {
 
       await service.handleTrigger(trigger, { signal: abortController.signal });
 
-      expect(triggerRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: TriggerStatus.CANCELLED,
-          isActive: false,
-        })
+      expect(triggerRepository.update).toHaveBeenCalledWith(
+        { id: 'trigger-1', status: In([TriggerStatus.PROCESSING, TriggerStatus.CANCELLING]) },
+        { status: TriggerStatus.CANCELLED, isActive: false, version: expect.any(Function) }
       );
       trigger.onSuccess(new Date('2026-06-04T12:00:00.000Z'));
       expect(trigger.status).toBe(TriggerStatus.CANCELLED);

--- a/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.spec.ts
@@ -175,6 +175,63 @@ describe('ConnectorRunTriggerHandlerService', () => {
       expect(dataMartRunRepository.save).not.toHaveBeenCalled();
     });
 
+    it('marks trigger cancelled and skips execution when run is already CANCELLED', async () => {
+      const {
+        service,
+        dataMartService,
+        dataMartRunService,
+        triggerRepository,
+        connectorExecutionService,
+        mockManager,
+      } = createService();
+
+      (dataMartService.getByIdAndProjectId as jest.Mock).mockResolvedValue(mockDataMart);
+      (mockManager.update as jest.Mock).mockResolvedValue({ affected: 0 });
+      (dataMartRunService.findById as jest.Mock).mockResolvedValue({
+        id: 'run-1',
+        status: DataMartRunStatus.CANCELLED,
+      });
+
+      await expect(service.handleTrigger(mockTrigger)).resolves.toBeUndefined();
+
+      expect(triggerRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: TriggerStatus.CANCELLED,
+          isActive: false,
+        })
+      );
+      expect(connectorExecutionService.executeExistingRun).not.toHaveBeenCalled();
+    });
+
+    it('marks trigger cancelled after execution is aborted by scheduler signal', async () => {
+      const {
+        service,
+        dataMartService,
+        triggerRepository,
+        connectorExecutionService,
+        mockManager,
+      } = createService();
+      const abortController = new AbortController();
+      const trigger = Object.assign(new ConnectorRunTrigger(), mockTrigger);
+
+      (dataMartService.getByIdAndProjectId as jest.Mock).mockResolvedValue(mockDataMart);
+      (mockManager.findOneOrFail as jest.Mock).mockResolvedValue(mockRun);
+      (connectorExecutionService.executeExistingRun as jest.Mock).mockImplementation(async () => {
+        abortController.abort();
+      });
+
+      await service.handleTrigger(trigger, { signal: abortController.signal });
+
+      expect(triggerRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: TriggerStatus.CANCELLED,
+          isActive: false,
+        })
+      );
+      trigger.onSuccess(new Date('2026-06-04T12:00:00.000Z'));
+      expect(trigger.status).toBe(TriggerStatus.CANCELLED);
+    });
+
     it('fails the run when claim fails and run is not RUNNING', async () => {
       const { service, dataMartService, dataMartRunService, mockManager } = createService();
 

--- a/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.ts
@@ -66,7 +66,10 @@ export class ConnectorRunTriggerHandlerService extends BaseRunTriggerHandlerServ
         options?.signal
       );
       if (options?.signal?.aborted) {
-        await this.markTriggerAsCancelled(trigger);
+        await this.markTriggerAsCancelled(
+          trigger,
+          `Cancelled run trigger ${trigger.id}: abort signal received for DataMartRun ${trigger.dataMartRunId}`
+        );
       }
     } catch (error) {
       if (error instanceof ConcurrencyLimitExceededException) {
@@ -87,7 +90,10 @@ export class ConnectorRunTriggerHandlerService extends BaseRunTriggerHandlerServ
         return;
       }
       if (existingRun?.status === DataMartRunStatus.CANCELLED) {
-        await this.markTriggerAsCancelled(trigger);
+        await this.markTriggerAsCancelled(
+          trigger,
+          `Skipping run trigger ${trigger.id}: DataMartRun ${trigger.dataMartRunId} is already CANCELLED`
+        );
         return;
       }
 

--- a/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.ts
@@ -100,25 +100,6 @@ export class ConnectorRunTriggerHandlerService extends BaseRunTriggerHandlerServ
     }
   }
 
-  private async cancelTriggerIfRunAlreadyCancelled(trigger: ConnectorRunTrigger): Promise<boolean> {
-    const existingRun = await this.dataMartRunService.findById(trigger.dataMartRunId);
-    if (existingRun?.status !== DataMartRunStatus.CANCELLED) {
-      return false;
-    }
-
-    await this.markTriggerAsCancelled(trigger);
-    return true;
-  }
-
-  private async markTriggerAsCancelled(trigger: ConnectorRunTrigger): Promise<void> {
-    trigger.status = TriggerStatus.CANCELLED;
-    trigger.isActive = false;
-    await this.repository.save(trigger);
-    this.logger.log(
-      `Skipping connector run trigger ${trigger.id}: DataMartRun ${trigger.dataMartRunId} is already CANCELLED`
-    );
-  }
-
   /**
    * Claims a run slot using optimistic approach: claim first, then verify the limit.
    * 1. Atomically set run status to RUNNING (UPDATE WHERE status=PENDING)

--- a/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run-trigger-handler.service.ts
@@ -46,6 +46,10 @@ export class ConnectorRunTriggerHandlerService extends BaseRunTriggerHandlerServ
     let run: DataMartRun;
 
     try {
+      if (await this.cancelTriggerIfRunAlreadyCancelled(trigger)) {
+        return;
+      }
+
       dataMart = await this.dataMartService.getByIdAndProjectId(
         trigger.dataMartId,
         trigger.projectId
@@ -61,6 +65,9 @@ export class ConnectorRunTriggerHandlerService extends BaseRunTriggerHandlerServ
         trigger.payload,
         options?.signal
       );
+      if (options?.signal?.aborted) {
+        await this.markTriggerAsCancelled(trigger);
+      }
     } catch (error) {
       if (error instanceof ConcurrencyLimitExceededException) {
         this.logger.log(
@@ -79,6 +86,10 @@ export class ConnectorRunTriggerHandlerService extends BaseRunTriggerHandlerServ
         );
         return;
       }
+      if (existingRun?.status === DataMartRunStatus.CANCELLED) {
+        await this.markTriggerAsCancelled(trigger);
+        return;
+      }
 
       await this.failDataMartRunSafely(trigger.dataMartRunId, error);
 
@@ -87,6 +98,25 @@ export class ConnectorRunTriggerHandlerService extends BaseRunTriggerHandlerServ
       );
       throw error;
     }
+  }
+
+  private async cancelTriggerIfRunAlreadyCancelled(trigger: ConnectorRunTrigger): Promise<boolean> {
+    const existingRun = await this.dataMartRunService.findById(trigger.dataMartRunId);
+    if (existingRun?.status !== DataMartRunStatus.CANCELLED) {
+      return false;
+    }
+
+    await this.markTriggerAsCancelled(trigger);
+    return true;
+  }
+
+  private async markTriggerAsCancelled(trigger: ConnectorRunTrigger): Promise<void> {
+    trigger.status = TriggerStatus.CANCELLED;
+    trigger.isActive = false;
+    await this.repository.save(trigger);
+    this.logger.log(
+      `Skipping connector run trigger ${trigger.id}: DataMartRun ${trigger.dataMartRunId} is already CANCELLED`
+    );
   }
 
   /**

--- a/apps/backend/src/data-marts/services/connector/connector-run-trigger.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run-trigger.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { ConnectorRunTrigger } from '../../entities/connector-run-trigger.entity';
 import { TriggerStatus } from '../../../common/scheduler/shared/entities/trigger-status';
 import { RunType } from '../../../common/scheduler/shared/types';
+import { stopRunTriggersForRun } from '../../utils/run-trigger-cancellation';
 
 export interface CreateConnectorRunTriggerParams {
   dataMartId: string;
@@ -38,13 +39,6 @@ export class ConnectorRunTriggerService {
   }
 
   async stopTriggersForRun(dataMartRunId: string): Promise<void> {
-    await this.repository.update(
-      { dataMartRunId, status: In([TriggerStatus.IDLE, TriggerStatus.READY]) },
-      { status: TriggerStatus.CANCELLED, isActive: false, version: () => 'version + 1' }
-    );
-    await this.repository.update(
-      { dataMartRunId, status: TriggerStatus.PROCESSING },
-      { status: TriggerStatus.CANCELLING, isActive: false, version: () => 'version + 1' }
-    );
+    await stopRunTriggersForRun(this.repository, dataMartRunId);
   }
 }

--- a/apps/backend/src/data-marts/services/connector/connector-run-trigger.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run-trigger.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { ConnectorRunTrigger } from '../../entities/connector-run-trigger.entity';
 import { TriggerStatus } from '../../../common/scheduler/shared/entities/trigger-status';
 import { RunType } from '../../../common/scheduler/shared/types';
@@ -35,5 +35,16 @@ export class ConnectorRunTriggerService {
 
     const saved = await this.repository.save(trigger);
     return saved.id;
+  }
+
+  async stopTriggersForRun(dataMartRunId: string): Promise<void> {
+    await this.repository.update(
+      { dataMartRunId, status: In([TriggerStatus.IDLE, TriggerStatus.READY]) },
+      { status: TriggerStatus.CANCELLED, isActive: false, version: () => 'version + 1' }
+    );
+    await this.repository.update(
+      { dataMartRunId, status: TriggerStatus.PROCESSING },
+      { status: TriggerStatus.CANCELLING, isActive: false, version: () => 'version + 1' }
+    );
   }
 }

--- a/apps/backend/src/data-marts/services/connector/connector-run.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run.service.spec.ts
@@ -7,7 +7,6 @@ import { Repository } from 'typeorm';
 import { ConnectorRunService } from './connector-run.service';
 import { ConnectorRunTriggerService } from './connector-run-trigger.service';
 import { ConnectorExecutorService } from './connector-executor.service';
-import { SystemTimeService } from '../../../common/scheduler/services/system-time.service';
 import { DataMartRun } from '../../entities/data-mart-run.entity';
 import { DataMart } from '../../entities/data-mart.entity';
 import { DataMartRunStatus } from '../../enums/data-mart-run-status.enum';
@@ -34,15 +33,10 @@ describe('ConnectorRunService', () => {
       executeInBackground: jest.fn().mockResolvedValue(undefined),
     } as unknown as ConnectorExecutorService;
 
-    const systemTimeService = {
-      now: jest.fn().mockReturnValue(new Date('2025-01-15')),
-    } as unknown as SystemTimeService;
-
     const service = new ConnectorRunService(
       dataMartRunRepository,
       connectorRunTriggerService,
-      connectorExecutorService,
-      systemTimeService
+      connectorExecutorService
     );
 
     return {
@@ -50,7 +44,6 @@ describe('ConnectorRunService', () => {
       dataMartRunRepository,
       connectorRunTriggerService,
       connectorExecutorService,
-      systemTimeService,
     };
   };
 
@@ -105,73 +98,6 @@ describe('ConnectorRunService', () => {
       await expect(
         service.run(publishedConnectorDataMart, 'user-1', RunType.manual)
       ).rejects.toThrow('Connector is already running');
-    });
-  });
-
-  describe('cancelRun', () => {
-    it('cancels a PENDING run', async () => {
-      const { service, dataMartRunRepository } = createService();
-      (dataMartRunRepository.findOne as jest.Mock).mockResolvedValue({
-        id: 'run-1',
-        dataMartId: 'dm-1',
-        status: DataMartRunStatus.PENDING,
-      });
-
-      await service.cancelRun('dm-1', 'run-1');
-
-      expect(dataMartRunRepository.update).toHaveBeenCalledWith('run-1', {
-        status: DataMartRunStatus.CANCELLED,
-        finishedAt: expect.any(Date),
-      });
-    });
-
-    it('cancels a RUNNING run', async () => {
-      const { service, dataMartRunRepository } = createService();
-      (dataMartRunRepository.findOne as jest.Mock).mockResolvedValue({
-        id: 'run-1',
-        dataMartId: 'dm-1',
-        status: DataMartRunStatus.RUNNING,
-      });
-
-      await service.cancelRun('dm-1', 'run-1');
-
-      expect(dataMartRunRepository.update).toHaveBeenCalledWith('run-1', {
-        status: DataMartRunStatus.CANCELLED,
-        finishedAt: expect.any(Date),
-      });
-    });
-
-    it('throws when run not found', async () => {
-      const { service, dataMartRunRepository } = createService();
-      (dataMartRunRepository.findOne as jest.Mock).mockResolvedValue(null);
-
-      await expect(service.cancelRun('dm-1', 'run-1')).rejects.toThrow('Data mart run not found');
-    });
-
-    it('throws when run is already SUCCESS', async () => {
-      const { service, dataMartRunRepository } = createService();
-      (dataMartRunRepository.findOne as jest.Mock).mockResolvedValue({
-        id: 'run-1',
-        dataMartId: 'dm-1',
-        status: DataMartRunStatus.SUCCESS,
-      });
-
-      await expect(service.cancelRun('dm-1', 'run-1')).rejects.toThrow(
-        'Cannot cancel completed data mart run'
-      );
-    });
-
-    it('throws when run is already CANCELLED', async () => {
-      const { service, dataMartRunRepository } = createService();
-      (dataMartRunRepository.findOne as jest.Mock).mockResolvedValue({
-        id: 'run-1',
-        dataMartId: 'dm-1',
-        status: DataMartRunStatus.CANCELLED,
-      });
-
-      await expect(service.cancelRun('dm-1', 'run-1')).rejects.toThrow(
-        'Data mart run is already cancelled'
-      );
     });
   });
 

--- a/apps/backend/src/data-marts/services/connector/connector-run.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run.service.ts
@@ -11,7 +11,6 @@ import { DataMartStatus } from '../../enums/data-mart-status.enum';
 import { DataMartRunType } from '../../enums/data-mart-run-type.enum';
 import { ConnectorExecutionError } from '../../errors/connector-execution.error';
 import { RunType } from '../../../common/scheduler/shared/types';
-import { SystemTimeService } from '../../../common/scheduler/services/system-time.service';
 import { ConnectorRunTriggerService } from './connector-run-trigger.service';
 import { ConnectorExecutorService } from './connector-executor.service';
 
@@ -23,46 +22,8 @@ export class ConnectorRunService {
     @InjectRepository(DataMartRun)
     private readonly dataMartRunRepository: Repository<DataMartRun>,
     private readonly connectorRunTriggerService: ConnectorRunTriggerService,
-    private readonly connectorExecutorService: ConnectorExecutorService,
-    private readonly systemTimeService: SystemTimeService
+    private readonly connectorExecutorService: ConnectorExecutorService
   ) {}
-
-  async cancelRun(dataMartId: string, runId: string): Promise<void> {
-    const run = await this.dataMartRunRepository.findOne({
-      where: { id: runId, dataMartId },
-      relations: ['dataMart'],
-    });
-
-    if (!run) {
-      throw new ConnectorExecutionError('Data mart run not found', undefined, {
-        dataMartId,
-        runId,
-      });
-    }
-
-    if (run.status === DataMartRunStatus.SUCCESS || run.status === DataMartRunStatus.FAILED) {
-      throw new ConnectorExecutionError('Cannot cancel completed data mart run', undefined, {
-        dataMartId,
-        runId,
-        projectId: run?.dataMart?.projectId,
-      });
-    }
-
-    if (run.status === DataMartRunStatus.CANCELLED) {
-      throw new ConnectorExecutionError('Data mart run is already cancelled', undefined, {
-        dataMartId,
-        runId,
-        projectId: run?.dataMart?.projectId,
-      });
-    }
-
-    if (run.status === DataMartRunStatus.PENDING || run.status === DataMartRunStatus.RUNNING) {
-      await this.dataMartRunRepository.update(runId, {
-        status: DataMartRunStatus.CANCELLED,
-        finishedAt: this.systemTimeService.now(),
-      });
-    }
-  }
 
   @Transactional()
   async run(

--- a/apps/backend/src/data-marts/services/data-mart-run.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.spec.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { RunType } from '../../common/scheduler/shared/types';
 import { SystemTimeService } from '../../common/scheduler/services/system-time.service';
 import { OwoxEventDispatcher } from '../../common/event-dispatcher/owox-event-dispatcher';
@@ -56,6 +56,7 @@ function createService() {
     }),
     find: jest.fn(async () => []),
     findOne: jest.fn(async () => null),
+    update: jest.fn(async () => ({ affected: 1 })),
     createQueryBuilder: jest.fn(),
   } as unknown as jest.Mocked<Repository<DataMartRun>>;
 
@@ -187,6 +188,40 @@ describe('DataMartRunService', () => {
       expect(outputConfig).toBeDefined();
       expect(outputConfig['filterConfig']).toEqual(filterConfig);
       expect(runArg.status).toBe(DataMartRunStatus.RUNNING);
+    });
+  });
+
+  describe('markAsCancelled', () => {
+    it('marks an active data mart run as cancelled', async () => {
+      const { service, dataMartRunRepository, systemClock } = createService();
+      const run = {
+        id: 'run-1',
+        status: DataMartRunStatus.RUNNING,
+      } as DataMartRun;
+
+      await expect(service.markAsCancelled(run)).resolves.toBe(true);
+
+      expect(dataMartRunRepository.update).toHaveBeenCalledWith(
+        {
+          id: 'run-1',
+          status: In([DataMartRunStatus.PENDING, DataMartRunStatus.RUNNING]),
+        },
+        {
+          status: DataMartRunStatus.CANCELLED,
+          finishedAt: systemClock.now(),
+        }
+      );
+    });
+
+    it('does not overwrite a run that already left an active status', async () => {
+      const { service, dataMartRunRepository } = createService();
+      dataMartRunRepository.update.mockResolvedValue({ affected: 0, raw: [], generatedMaps: [] });
+      const run = {
+        id: 'run-1',
+        status: DataMartRunStatus.RUNNING,
+      } as DataMartRun;
+
+      await expect(service.markAsCancelled(run)).resolves.toBe(false);
     });
   });
 });

--- a/apps/backend/src/data-marts/services/data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { OwoxEventDispatcher } from '../../common/event-dispatcher/owox-event-dispatcher';
 import { SystemTimeService } from '../../common/scheduler/services/system-time.service';
 
@@ -17,6 +17,8 @@ import { DataMartRunType } from '../enums/data-mart-run-type.enum';
 import { ReportRunCompletedSuccessfullyEvent } from '../events/report-run-completed-successfully.event';
 import { HttpDataRunMetadata } from '../dto/schemas/http-data-run-metadata.schema';
 import { HTTP_DATA_PARAMS_KEY } from './http-data/http-data.constants';
+
+const CANCELLABLE_RUN_STATUSES = [DataMartRunStatus.PENDING, DataMartRunStatus.RUNNING];
 
 /**
  * Context for creating a new report run.
@@ -182,6 +184,24 @@ export class DataMartRunService {
     return this.dataMartRunRepository.findOne({
       where: { id: runId, dataMartId },
     });
+  }
+
+  /**
+   * Marks an existing DataMartRun as CANCELLED.
+   */
+  public async markAsCancelled(dataMartRun: DataMartRun): Promise<boolean> {
+    const result = await this.dataMartRunRepository.update(
+      {
+        id: dataMartRun.id,
+        status: In(CANCELLABLE_RUN_STATUSES),
+      },
+      {
+        status: DataMartRunStatus.CANCELLED,
+        finishedAt: this.systemClock.now(),
+      }
+    );
+
+    return (result.affected ?? 0) > 0;
   }
 
   /**

--- a/apps/backend/src/data-marts/services/data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.ts
@@ -17,8 +17,7 @@ import { DataMartRunType } from '../enums/data-mart-run-type.enum';
 import { ReportRunCompletedSuccessfullyEvent } from '../events/report-run-completed-successfully.event';
 import { HttpDataRunMetadata } from '../dto/schemas/http-data-run-metadata.schema';
 import { HTTP_DATA_PARAMS_KEY } from './http-data/http-data.constants';
-
-const CANCELLABLE_RUN_STATUSES = [DataMartRunStatus.PENDING, DataMartRunStatus.RUNNING];
+import { CANCELLABLE_DATA_MART_RUN_STATUSES } from '../utils/data-mart-run-cancellation';
 
 /**
  * Context for creating a new report run.
@@ -174,9 +173,6 @@ export class DataMartRunService {
     });
   }
 
-  /**
-   * Returns a run by id that belongs to specified Data Mart.
-   */
   public async getByIdAndDataMartId(
     runId: string,
     dataMartId: string
@@ -186,14 +182,11 @@ export class DataMartRunService {
     });
   }
 
-  /**
-   * Marks an existing DataMartRun as CANCELLED.
-   */
   public async markAsCancelled(dataMartRun: DataMartRun): Promise<boolean> {
     const result = await this.dataMartRunRepository.update(
       {
         id: dataMartRun.id,
-        status: In(CANCELLABLE_RUN_STATUSES),
+        status: In(CANCELLABLE_DATA_MART_RUN_STATUSES),
       },
       {
         status: DataMartRunStatus.CANCELLED,

--- a/apps/backend/src/data-marts/services/report-run-trigger-handler.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-run-trigger-handler.service.spec.ts
@@ -1,4 +1,4 @@
-import { DataSource, EntityManager, Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository, In } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { ReportRunTriggerHandlerService } from './report-run-trigger-handler.service';
 import { ReportRunTrigger } from '../entities/report-run-trigger.entity';
@@ -13,6 +13,7 @@ describe('ReportRunTriggerHandlerService', () => {
   const createService = () => {
     const triggerRepository = {
       save: jest.fn().mockImplementation(data => Promise.resolve(data)),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
     } as unknown as Repository<ReportRunTrigger>;
 
     const dataMartRunRepository = {
@@ -92,11 +93,9 @@ describe('ReportRunTriggerHandlerService', () => {
 
     await expect(service.handleTrigger(mockTrigger)).resolves.toBeUndefined();
 
-    expect(triggerRepository.save).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: TriggerStatus.CANCELLED,
-        isActive: false,
-      })
+    expect(triggerRepository.update).toHaveBeenCalledWith(
+      { id: 'trigger-1', status: In([TriggerStatus.PROCESSING, TriggerStatus.CANCELLING]) },
+      { status: TriggerStatus.CANCELLED, isActive: false, version: expect.any(Function) }
     );
     expect(runReportService.executeExistingRun).not.toHaveBeenCalled();
   });
@@ -112,11 +111,9 @@ describe('ReportRunTriggerHandlerService', () => {
 
     await service.handleTrigger(trigger, { signal: abortController.signal });
 
-    expect(triggerRepository.save).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: TriggerStatus.CANCELLED,
-        isActive: false,
-      })
+    expect(triggerRepository.update).toHaveBeenCalledWith(
+      { id: 'trigger-1', status: In([TriggerStatus.PROCESSING, TriggerStatus.CANCELLING]) },
+      { status: TriggerStatus.CANCELLED, isActive: false, version: expect.any(Function) }
     );
     trigger.onSuccess(new Date('2026-06-04T12:00:00.000Z'));
     expect(trigger.status).toBe(TriggerStatus.CANCELLED);

--- a/apps/backend/src/data-marts/services/report-run-trigger-handler.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-run-trigger-handler.service.spec.ts
@@ -1,0 +1,124 @@
+import { DataSource, EntityManager, Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { ReportRunTriggerHandlerService } from './report-run-trigger-handler.service';
+import { ReportRunTrigger } from '../entities/report-run-trigger.entity';
+import { DataMartRun } from '../entities/data-mart-run.entity';
+import { SchedulerFacade } from '../../common/scheduler/shared/scheduler.facade';
+import { RunReportService } from '../use-cases/run-report.service';
+import { DataMartRunService } from './data-mart-run.service';
+import { TriggerStatus } from '../../common/scheduler/shared/entities/trigger-status';
+import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
+
+describe('ReportRunTriggerHandlerService', () => {
+  const createService = () => {
+    const triggerRepository = {
+      save: jest.fn().mockImplementation(data => Promise.resolve(data)),
+    } as unknown as Repository<ReportRunTrigger>;
+
+    const dataMartRunRepository = {
+      save: jest.fn().mockImplementation(data => Promise.resolve(data)),
+    } as unknown as Repository<DataMartRun>;
+
+    const schedulerFacade = {
+      registerTriggerHandler: jest.fn().mockResolvedValue(undefined),
+    } as unknown as SchedulerFacade;
+
+    const runReportService = {
+      executeExistingRun: jest.fn().mockResolvedValue(undefined),
+    } as unknown as RunReportService;
+
+    const dataMartRunService = {
+      findById: jest.fn(),
+    } as unknown as DataMartRunService;
+
+    const configService = {
+      get: jest.fn().mockReturnValue(1000),
+    } as unknown as ConfigService;
+
+    const mockManager = {
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(0),
+      }),
+    } as unknown as EntityManager;
+
+    const dataSource = {
+      transaction: jest
+        .fn()
+        .mockImplementation((fn: (em: EntityManager) => Promise<unknown>) => fn(mockManager)),
+    } as unknown as DataSource;
+
+    const service = new ReportRunTriggerHandlerService(
+      triggerRepository,
+      dataMartRunRepository,
+      schedulerFacade,
+      runReportService,
+      dataMartRunService,
+      configService,
+      dataSource
+    );
+
+    return {
+      service,
+      triggerRepository,
+      runReportService,
+      dataMartRunService,
+      mockManager,
+    };
+  };
+
+  const mockTrigger = {
+    id: 'trigger-1',
+    reportId: 'report-1',
+    projectId: 'proj-1',
+    dataMartRunId: 'run-1',
+    createdById: 'user-1',
+    status: TriggerStatus.PROCESSING,
+    isActive: true,
+  } as unknown as ReportRunTrigger;
+
+  it('marks trigger cancelled and skips execution when run is already CANCELLED', async () => {
+    const { service, dataMartRunService, triggerRepository, runReportService, mockManager } =
+      createService();
+
+    (mockManager.update as jest.Mock).mockResolvedValue({ affected: 0 });
+    (dataMartRunService.findById as jest.Mock).mockResolvedValue({
+      id: 'run-1',
+      status: DataMartRunStatus.CANCELLED,
+    });
+
+    await expect(service.handleTrigger(mockTrigger)).resolves.toBeUndefined();
+
+    expect(triggerRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: TriggerStatus.CANCELLED,
+        isActive: false,
+      })
+    );
+    expect(runReportService.executeExistingRun).not.toHaveBeenCalled();
+  });
+
+  it('marks trigger cancelled after execution is aborted by scheduler signal', async () => {
+    const { service, triggerRepository, runReportService } = createService();
+    const abortController = new AbortController();
+    const trigger = Object.assign(new ReportRunTrigger(), mockTrigger);
+
+    (runReportService.executeExistingRun as jest.Mock).mockImplementation(async () => {
+      abortController.abort();
+    });
+
+    await service.handleTrigger(trigger, { signal: abortController.signal });
+
+    expect(triggerRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: TriggerStatus.CANCELLED,
+        isActive: false,
+      })
+    );
+    trigger.onSuccess(new Date('2026-06-04T12:00:00.000Z'));
+    expect(trigger.status).toBe(TriggerStatus.CANCELLED);
+  });
+});

--- a/apps/backend/src/data-marts/services/report-run-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/report-run-trigger-handler.service.ts
@@ -98,25 +98,6 @@ export class ReportRunTriggerHandlerService extends BaseRunTriggerHandlerService
     }
   }
 
-  private async cancelTriggerIfRunAlreadyCancelled(trigger: ReportRunTrigger): Promise<boolean> {
-    const existingRun = await this.dataMartRunService.findById(trigger.dataMartRunId);
-    if (existingRun?.status !== DataMartRunStatus.CANCELLED) {
-      return false;
-    }
-
-    await this.markTriggerAsCancelled(trigger);
-    return true;
-  }
-
-  private async markTriggerAsCancelled(trigger: ReportRunTrigger): Promise<void> {
-    trigger.status = TriggerStatus.CANCELLED;
-    trigger.isActive = false;
-    await this.repository.save(trigger);
-    this.logger.log(
-      `Skipping report run trigger ${trigger.id}: DataMartRun ${trigger.dataMartRunId} is already CANCELLED`
-    );
-  }
-
   /**
    * Claims a run slot using optimistic approach: claim first, then verify the limit.
    * 1. Atomically set run status to RUNNING (UPDATE WHERE status=PENDING)

--- a/apps/backend/src/data-marts/services/report-run-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/report-run-trigger-handler.service.ts
@@ -64,7 +64,10 @@ export class ReportRunTriggerHandlerService extends BaseRunTriggerHandlerService
         options?.signal
       );
       if (options?.signal?.aborted) {
-        await this.markTriggerAsCancelled(trigger);
+        await this.markTriggerAsCancelled(
+          trigger,
+          `Cancelled run trigger ${trigger.id}: abort signal received for DataMartRun ${trigger.dataMartRunId}`
+        );
       }
     } catch (error) {
       if (error instanceof ConcurrencyLimitExceededException) {
@@ -85,7 +88,10 @@ export class ReportRunTriggerHandlerService extends BaseRunTriggerHandlerService
         return;
       }
       if (existingRun?.status === DataMartRunStatus.CANCELLED) {
-        await this.markTriggerAsCancelled(trigger);
+        await this.markTriggerAsCancelled(
+          trigger,
+          `Skipping run trigger ${trigger.id}: DataMartRun ${trigger.dataMartRunId} is already CANCELLED`
+        );
         return;
       }
 

--- a/apps/backend/src/data-marts/services/report-run-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/report-run-trigger-handler.service.ts
@@ -47,6 +47,10 @@ export class ReportRunTriggerHandlerService extends BaseRunTriggerHandlerService
     options?: { signal?: AbortSignal }
   ): Promise<void> {
     try {
+      if (await this.cancelTriggerIfRunAlreadyCancelled(trigger)) {
+        return;
+      }
+
       await this.claimRunSlotAtomically(trigger.dataMartRunId, trigger.projectId);
 
       this.logger.log(
@@ -59,6 +63,9 @@ export class ReportRunTriggerHandlerService extends BaseRunTriggerHandlerService
         trigger.createdById,
         options?.signal
       );
+      if (options?.signal?.aborted) {
+        await this.markTriggerAsCancelled(trigger);
+      }
     } catch (error) {
       if (error instanceof ConcurrencyLimitExceededException) {
         this.logger.warn(
@@ -77,6 +84,10 @@ export class ReportRunTriggerHandlerService extends BaseRunTriggerHandlerService
         );
         return;
       }
+      if (existingRun?.status === DataMartRunStatus.CANCELLED) {
+        await this.markTriggerAsCancelled(trigger);
+        return;
+      }
 
       await this.failDataMartRunSafely(trigger.dataMartRunId, error);
 
@@ -85,6 +96,25 @@ export class ReportRunTriggerHandlerService extends BaseRunTriggerHandlerService
       );
       throw error;
     }
+  }
+
+  private async cancelTriggerIfRunAlreadyCancelled(trigger: ReportRunTrigger): Promise<boolean> {
+    const existingRun = await this.dataMartRunService.findById(trigger.dataMartRunId);
+    if (existingRun?.status !== DataMartRunStatus.CANCELLED) {
+      return false;
+    }
+
+    await this.markTriggerAsCancelled(trigger);
+    return true;
+  }
+
+  private async markTriggerAsCancelled(trigger: ReportRunTrigger): Promise<void> {
+    trigger.status = TriggerStatus.CANCELLED;
+    trigger.isActive = false;
+    await this.repository.save(trigger);
+    this.logger.log(
+      `Skipping report run trigger ${trigger.id}: DataMartRun ${trigger.dataMartRunId} is already CANCELLED`
+    );
   }
 
   /**

--- a/apps/backend/src/data-marts/services/report-run-trigger.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-run-trigger.service.spec.ts
@@ -1,18 +1,18 @@
 import { In, Repository } from 'typeorm';
-import { ConnectorRunTriggerService } from './connector-run-trigger.service';
-import { ConnectorRunTrigger } from '../../entities/connector-run-trigger.entity';
-import { TriggerStatus } from '../../../common/scheduler/shared/entities/trigger-status';
-import { RunType } from '../../../common/scheduler/shared/types';
+import { ReportRunTriggerService } from './report-run-trigger.service';
+import { ReportRunTrigger } from '../entities/report-run-trigger.entity';
+import { TriggerStatus } from '../../common/scheduler/shared/entities/trigger-status';
+import { RunType } from '../../common/scheduler/shared/types';
 
-describe('ConnectorRunTriggerService', () => {
+describe('ReportRunTriggerService', () => {
   const createService = () => {
     const repository = {
       create: jest.fn().mockImplementation(data => data),
       save: jest.fn().mockImplementation(data => Promise.resolve({ ...data, id: 'trigger-1' })),
       update: jest.fn().mockResolvedValue(undefined),
-    } as unknown as Repository<ConnectorRunTrigger>;
+    } as unknown as Repository<ReportRunTrigger>;
 
-    const service = new ConnectorRunTriggerService(repository);
+    const service = new ReportRunTriggerService(repository);
 
     return { service, repository };
   };
@@ -22,46 +22,26 @@ describe('ConnectorRunTriggerService', () => {
       const { service, repository } = createService();
 
       const result = await service.createTrigger({
-        dataMartId: 'dm-1',
+        reportId: 'report-1',
         projectId: 'proj-1',
         createdById: 'user-1',
         dataMartRunId: 'run-1',
         runType: RunType.manual,
-        payload: { key: 'value' },
       });
 
       expect(repository.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          dataMartId: 'dm-1',
+          reportId: 'report-1',
           projectId: 'proj-1',
           createdById: 'user-1',
           dataMartRunId: 'run-1',
           runType: RunType.manual,
-          payload: { key: 'value' },
           isActive: true,
           status: TriggerStatus.IDLE,
         })
       );
       expect(repository.save).toHaveBeenCalled();
       expect(result).toBe('trigger-1');
-    });
-
-    it('sets payload to null when not provided', async () => {
-      const { service, repository } = createService();
-
-      await service.createTrigger({
-        dataMartId: 'dm-1',
-        projectId: 'proj-1',
-        createdById: 'user-1',
-        dataMartRunId: 'run-1',
-        runType: RunType.manual,
-      });
-
-      expect(repository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          payload: null,
-        })
-      );
     });
   });
 

--- a/apps/backend/src/data-marts/services/report-run-trigger.service.ts
+++ b/apps/backend/src/data-marts/services/report-run-trigger.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { ReportRunTrigger } from '../entities/report-run-trigger.entity';
 import { TriggerStatus } from '../../common/scheduler/shared/entities/trigger-status';
 import { RunType } from '../../common/scheduler/shared/types';
@@ -33,5 +33,16 @@ export class ReportRunTriggerService {
 
     const saved = await this.repository.save(trigger);
     return saved.id;
+  }
+
+  async stopTriggersForRun(dataMartRunId: string): Promise<void> {
+    await this.repository.update(
+      { dataMartRunId, status: In([TriggerStatus.IDLE, TriggerStatus.READY]) },
+      { status: TriggerStatus.CANCELLED, isActive: false, version: () => 'version + 1' }
+    );
+    await this.repository.update(
+      { dataMartRunId, status: TriggerStatus.PROCESSING },
+      { status: TriggerStatus.CANCELLING, isActive: false, version: () => 'version + 1' }
+    );
   }
 }

--- a/apps/backend/src/data-marts/services/report-run-trigger.service.ts
+++ b/apps/backend/src/data-marts/services/report-run-trigger.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { ReportRunTrigger } from '../entities/report-run-trigger.entity';
 import { TriggerStatus } from '../../common/scheduler/shared/entities/trigger-status';
 import { RunType } from '../../common/scheduler/shared/types';
+import { stopRunTriggersForRun } from '../utils/run-trigger-cancellation';
 
 export interface CreateReportRunTriggerParams {
   reportId: string;
@@ -36,13 +37,6 @@ export class ReportRunTriggerService {
   }
 
   async stopTriggersForRun(dataMartRunId: string): Promise<void> {
-    await this.repository.update(
-      { dataMartRunId, status: In([TriggerStatus.IDLE, TriggerStatus.READY]) },
-      { status: TriggerStatus.CANCELLED, isActive: false, version: () => 'version + 1' }
-    );
-    await this.repository.update(
-      { dataMartRunId, status: TriggerStatus.PROCESSING },
-      { status: TriggerStatus.CANCELLING, isActive: false, version: () => 'version + 1' }
-    );
+    await stopRunTriggersForRun(this.repository, dataMartRunId);
   }
 }

--- a/apps/backend/src/data-marts/services/report.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report.service.spec.ts
@@ -24,8 +24,11 @@ describe('ReportService', () => {
 
     await service.markRunAsCancelled('report-1');
 
-    expect(repository.update).toHaveBeenCalledWith('report-1', {
-      lastRunStatus: ReportRunStatus.CANCELLED,
-    });
+    expect(repository.update).toHaveBeenCalledWith(
+      { id: 'report-1', lastRunStatus: ReportRunStatus.RUNNING },
+      {
+        lastRunStatus: ReportRunStatus.CANCELLED,
+      }
+    );
   });
 });

--- a/apps/backend/src/data-marts/services/report.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report.service.spec.ts
@@ -1,0 +1,31 @@
+import { Repository } from 'typeorm';
+import { ScheduledTriggerService } from './scheduled-trigger.service';
+import { SystemTimeService } from '../../common/scheduler/services/system-time.service';
+import { Report } from '../entities/report.entity';
+import { ReportRunStatus } from '../enums/report-run-status.enum';
+import { ReportService } from './report.service';
+
+describe('ReportService', () => {
+  const createService = () => {
+    const repository = {
+      update: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Repository<Report>;
+
+    const scheduledTriggerService = {} as unknown as ScheduledTriggerService;
+    const systemTimeService = {} as unknown as SystemTimeService;
+
+    const service = new ReportService(repository, scheduledTriggerService, systemTimeService);
+
+    return { service, repository };
+  };
+
+  it('marks report run state as cancelled without changing counters', async () => {
+    const { service, repository } = createService();
+
+    await service.markRunAsCancelled('report-1');
+
+    expect(repository.update).toHaveBeenCalledWith('report-1', {
+      lastRunStatus: ReportRunStatus.CANCELLED,
+    });
+  });
+});

--- a/apps/backend/src/data-marts/services/report.service.ts
+++ b/apps/backend/src/data-marts/services/report.service.ts
@@ -162,6 +162,15 @@ export class ReportService {
   }
 
   /**
+   * Marks the latest persisted report run state as cancelled without incrementing run counters.
+   */
+  async markRunAsCancelled(reportId: string): Promise<void> {
+    await this.repository.update(reportId, {
+      lastRunStatus: ReportRunStatus.CANCELLED,
+    });
+  }
+
+  /**
    * Persists Report entity changes.
    *
    * @param report - Report entity to save

--- a/apps/backend/src/data-marts/services/report.service.ts
+++ b/apps/backend/src/data-marts/services/report.service.ts
@@ -161,13 +161,13 @@ export class ReportService {
     });
   }
 
-  /**
-   * Marks the latest persisted report run state as cancelled without incrementing run counters.
-   */
   async markRunAsCancelled(reportId: string): Promise<void> {
-    await this.repository.update(reportId, {
-      lastRunStatus: ReportRunStatus.CANCELLED,
-    });
+    await this.repository.update(
+      { id: reportId, lastRunStatus: ReportRunStatus.RUNNING },
+      {
+        lastRunStatus: ReportRunStatus.CANCELLED,
+      }
+    );
   }
 
   /**

--- a/apps/backend/src/data-marts/use-cases/cancel-data-mart-run.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/cancel-data-mart-run.service.spec.ts
@@ -1,0 +1,176 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: jest.fn(
+    () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) => descriptor
+  ),
+}));
+
+import { BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
+import { DataMartService } from '../services/data-mart.service';
+import { AccessDecisionService } from '../services/access-decision';
+import { CancelDataMartRunService } from './cancel-data-mart-run.service';
+import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
+import { DataMartRunType } from '../enums/data-mart-run-type.enum';
+import { DataMartRunService } from '../services/data-mart-run.service';
+import { ConnectorRunTriggerService } from '../services/connector/connector-run-trigger.service';
+import { ReportRunTriggerService } from '../services/report-run-trigger.service';
+import { ReportService } from '../services/report.service';
+
+describe('CancelDataMartRunService', () => {
+  const createService = () => {
+    const dataMartService = {
+      getByIdAndProjectId: jest.fn().mockResolvedValue({
+        id: 'dm-1',
+        projectId: 'project-1',
+      }),
+    } as unknown as DataMartService;
+
+    const dataMartRunService = {
+      getByIdAndDataMartId: jest.fn(),
+      markAsCancelled: jest.fn().mockResolvedValue(true),
+    } as unknown as DataMartRunService;
+
+    const connectorRunTriggerService = {
+      stopTriggersForRun: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ConnectorRunTriggerService;
+
+    const reportRunTriggerService = {
+      stopTriggersForRun: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ReportRunTriggerService;
+
+    const reportService = {
+      markRunAsCancelled: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ReportService;
+
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(true),
+    } as unknown as AccessDecisionService;
+
+    const service = new CancelDataMartRunService(
+      dataMartService,
+      dataMartRunService,
+      connectorRunTriggerService,
+      reportRunTriggerService,
+      reportService,
+      accessDecisionService
+    );
+
+    return {
+      service,
+      dataMartService,
+      dataMartRunService,
+      connectorRunTriggerService,
+      reportRunTriggerService,
+      reportService,
+      accessDecisionService,
+    };
+  };
+
+  const command = {
+    id: 'dm-1',
+    runId: 'run-1',
+    projectId: 'project-1',
+    userId: 'user-1',
+    roles: [],
+  };
+
+  it('runs cancellation state changes in a transaction', () => {
+    expect(Transactional).toHaveBeenCalled();
+  });
+
+  it('cancels a connector run and stops its trigger', async () => {
+    const { service, dataMartRunService, connectorRunTriggerService } = createService();
+    const run = {
+      id: 'run-1',
+      dataMartId: 'dm-1',
+      type: DataMartRunType.CONNECTOR,
+      status: DataMartRunStatus.RUNNING,
+    };
+    (dataMartRunService.getByIdAndDataMartId as jest.Mock).mockResolvedValue(run);
+
+    await service.run(command);
+
+    expect(dataMartRunService.markAsCancelled).toHaveBeenCalledWith(run);
+    expect(connectorRunTriggerService.stopTriggersForRun).toHaveBeenCalledWith('run-1');
+  });
+
+  it('cancels a standard report run and updates the report status', async () => {
+    const { service, dataMartRunService, reportRunTriggerService, reportService } = createService();
+    const run = {
+      id: 'run-1',
+      dataMartId: 'dm-1',
+      reportId: 'report-1',
+      type: DataMartRunType.GOOGLE_SHEETS_EXPORT,
+      status: DataMartRunStatus.PENDING,
+    };
+    (dataMartRunService.getByIdAndDataMartId as jest.Mock).mockResolvedValue(run);
+
+    await service.run(command);
+
+    expect(dataMartRunService.markAsCancelled).toHaveBeenCalledWith(run);
+    expect(reportRunTriggerService.stopTriggersForRun).toHaveBeenCalledWith('run-1');
+    expect(reportService.markRunAsCancelled).toHaveBeenCalledWith('report-1');
+  });
+
+  it('rejects unsupported run types', async () => {
+    const { service, dataMartRunService } = createService();
+    (dataMartRunService.getByIdAndDataMartId as jest.Mock).mockResolvedValue({
+      id: 'run-1',
+      dataMartId: 'dm-1',
+      type: DataMartRunType.HTTP_DATA,
+      status: DataMartRunStatus.RUNNING,
+    });
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects completed runs', async () => {
+    const { service, dataMartRunService } = createService();
+    (dataMartRunService.getByIdAndDataMartId as jest.Mock).mockResolvedValue({
+      id: 'run-1',
+      dataMartId: 'dm-1',
+      type: DataMartRunType.CONNECTOR,
+      status: DataMartRunStatus.SUCCESS,
+    });
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('rejects when the run is no longer active by the time cancellation is persisted', async () => {
+    const { service, dataMartRunService, connectorRunTriggerService } = createService();
+    const run = {
+      id: 'run-1',
+      dataMartId: 'dm-1',
+      type: DataMartRunType.CONNECTOR,
+      status: DataMartRunStatus.RUNNING,
+    };
+    (dataMartRunService.getByIdAndDataMartId as jest.Mock).mockResolvedValue(run);
+    (dataMartRunService.markAsCancelled as jest.Mock).mockResolvedValue(false);
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(ConflictException);
+
+    expect(connectorRunTriggerService.stopTriggersForRun).not.toHaveBeenCalled();
+  });
+
+  it('rejects report runs without report reference before updating the run', async () => {
+    const { service, dataMartRunService } = createService();
+    (dataMartRunService.getByIdAndDataMartId as jest.Mock).mockResolvedValue({
+      id: 'run-1',
+      dataMartId: 'dm-1',
+      reportId: null,
+      type: DataMartRunType.GOOGLE_SHEETS_EXPORT,
+      status: DataMartRunStatus.RUNNING,
+    });
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(ConflictException);
+
+    expect(dataMartRunService.markAsCancelled).not.toHaveBeenCalled();
+  });
+
+  it('rejects users without edit access', async () => {
+    const { service, accessDecisionService } = createService();
+    (accessDecisionService.canAccess as jest.Mock).mockResolvedValue(false);
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/cancel-data-mart-run.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/cancel-data-mart-run.service.spec.ts
@@ -4,8 +4,12 @@ jest.mock('typeorm-transactional', () => ({
   ),
 }));
 
-import { BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
-import { Transactional } from 'typeorm-transactional';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { DataMartService } from '../services/data-mart.service';
 import { AccessDecisionService } from '../services/access-decision';
 import { CancelDataMartRunService } from './cancel-data-mart-run.service';
@@ -74,10 +78,6 @@ describe('CancelDataMartRunService', () => {
     roles: [],
   };
 
-  it('runs cancellation state changes in a transaction', () => {
-    expect(Transactional).toHaveBeenCalled();
-  });
-
   it('cancels a connector run and stops its trigger', async () => {
     const { service, dataMartRunService, connectorRunTriggerService } = createService();
     const run = {
@@ -122,6 +122,13 @@ describe('CancelDataMartRunService', () => {
     });
 
     await expect(service.run(command)).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('returns not found when the run does not belong to the data mart', async () => {
+    const { service, dataMartRunService } = createService();
+    (dataMartRunService.getByIdAndDataMartId as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(NotFoundException);
   });
 
   it('rejects completed runs', async () => {

--- a/apps/backend/src/data-marts/use-cases/cancel-data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/use-cases/cancel-data-mart-run.service.ts
@@ -52,7 +52,7 @@ export class CancelDataMartRunService {
   }
 
   @Transactional()
-  async cancelRunState(command: CancelDataMartRunCommand): Promise<void> {
+  private async cancelRunState(command: CancelDataMartRunCommand): Promise<void> {
     const run = await this.dataMartRunService.getByIdAndDataMartId(command.runId, command.id);
 
     if (!run) {

--- a/apps/backend/src/data-marts/use-cases/cancel-data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/use-cases/cancel-data-mart-run.service.ts
@@ -1,21 +1,46 @@
-import { ConflictException, Injectable, ForbiddenException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
 import { DataMartService } from '../services/data-mart.service';
-import { ConnectorExecutionService } from '../services/connector/connector-execution.service';
 import { CancelDataMartRunCommand } from '../dto/domain/cancel-data-mart-run.command';
-import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
-import { ConnectorExecutionError } from '../errors/connector-execution.error';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
+import { DataMartRunType } from '../enums/data-mart-run-type.enum';
+import { DataMartRunService } from '../services/data-mart-run.service';
+import { ConnectorRunTriggerService } from '../services/connector/connector-run-trigger.service';
+import { ReportRunTriggerService } from '../services/report-run-trigger.service';
+import { ReportService } from '../services/report.service';
+
+const STANDARD_REPORT_RUN_TYPES = new Set<DataMartRunType>([
+  DataMartRunType.GOOGLE_SHEETS_EXPORT,
+  DataMartRunType.EMAIL,
+  DataMartRunType.SLACK,
+  DataMartRunType.MS_TEAMS,
+  DataMartRunType.GOOGLE_CHAT,
+]);
+
+const CANCELLABLE_RUN_STATUSES = new Set<DataMartRunStatus>([
+  DataMartRunStatus.PENDING,
+  DataMartRunStatus.RUNNING,
+]);
 
 @Injectable()
 export class CancelDataMartRunService {
   constructor(
     private readonly dataMartService: DataMartService,
-    private readonly connectorExecutionService: ConnectorExecutionService,
+    private readonly dataMartRunService: DataMartRunService,
+    private readonly connectorRunTriggerService: ConnectorRunTriggerService,
+    private readonly reportRunTriggerService: ReportRunTriggerService,
+    private readonly reportService: ReportService,
     private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   async run(command: CancelDataMartRunCommand): Promise<void> {
-    const dataMart = await this.dataMartService.getByIdAndProjectId(command.id, command.projectId);
+    await this.dataMartService.getByIdAndProjectId(command.id, command.projectId);
 
     if (command.userId) {
       const canEdit = await this.accessDecisionService.canAccess(
@@ -31,17 +56,48 @@ export class CancelDataMartRunService {
       }
     }
 
-    if (dataMart.definitionType !== DataMartDefinitionType.CONNECTOR) {
-      throw new Error('Only data marts with connector definition can be cancelled');
+    await this.cancelRunState(command);
+  }
+
+  @Transactional()
+  private async cancelRunState(command: CancelDataMartRunCommand): Promise<void> {
+    const run = await this.dataMartRunService.getByIdAndDataMartId(command.runId, command.id);
+
+    if (!run) {
+      throw new ConflictException('Data mart run not found');
     }
 
-    try {
-      await this.connectorExecutionService.cancelRun(command.id, command.runId);
-    } catch (error) {
-      if (error instanceof ConnectorExecutionError) {
-        throw new ConflictException(error.message);
-      }
-      throw error;
+    if (!this.isSupportedRunType(run.type)) {
+      throw new BadRequestException('Only connector and standard report runs can be cancelled');
     }
+
+    if (!CANCELLABLE_RUN_STATUSES.has(run.status)) {
+      throw new ConflictException(`Cannot cancel data mart run in ${run.status} status`);
+    }
+
+    if (this.isStandardReportRun(run.type) && !run.reportId) {
+      throw new ConflictException('Report run is missing report reference');
+    }
+
+    const wasCancelled = await this.dataMartRunService.markAsCancelled(run);
+    if (!wasCancelled) {
+      throw new ConflictException('Cannot cancel data mart run because it is no longer active');
+    }
+
+    if (run.type === DataMartRunType.CONNECTOR) {
+      await this.connectorRunTriggerService.stopTriggersForRun(run.id);
+      return;
+    }
+
+    await this.reportRunTriggerService.stopTriggersForRun(run.id);
+    await this.reportService.markRunAsCancelled(run.reportId!);
+  }
+
+  private isSupportedRunType(type: DataMartRunType): boolean {
+    return type === DataMartRunType.CONNECTOR || this.isStandardReportRun(type);
+  }
+
+  private isStandardReportRun(type: DataMartRunType): boolean {
+    return STANDARD_REPORT_RUN_TYPES.has(type);
   }
 }

--- a/apps/backend/src/data-marts/use-cases/cancel-data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/use-cases/cancel-data-mart-run.service.ts
@@ -3,30 +3,22 @@ import {
   ConflictException,
   Injectable,
   ForbiddenException,
+  NotFoundException,
 } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 import { DataMartService } from '../services/data-mart.service';
 import { CancelDataMartRunCommand } from '../dto/domain/cancel-data-mart-run.command';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
-import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
 import { DataMartRunType } from '../enums/data-mart-run-type.enum';
+import { DataMartRun } from '../entities/data-mart-run.entity';
 import { DataMartRunService } from '../services/data-mart-run.service';
 import { ConnectorRunTriggerService } from '../services/connector/connector-run-trigger.service';
 import { ReportRunTriggerService } from '../services/report-run-trigger.service';
 import { ReportService } from '../services/report.service';
-
-const STANDARD_REPORT_RUN_TYPES = new Set<DataMartRunType>([
-  DataMartRunType.GOOGLE_SHEETS_EXPORT,
-  DataMartRunType.EMAIL,
-  DataMartRunType.SLACK,
-  DataMartRunType.MS_TEAMS,
-  DataMartRunType.GOOGLE_CHAT,
-]);
-
-const CANCELLABLE_RUN_STATUSES = new Set<DataMartRunStatus>([
-  DataMartRunStatus.PENDING,
-  DataMartRunStatus.RUNNING,
-]);
+import {
+  isCancellableDataMartRunStatus,
+  isStandardReportRunType,
+} from '../utils/data-mart-run-cancellation';
 
 @Injectable()
 export class CancelDataMartRunService {
@@ -60,37 +52,31 @@ export class CancelDataMartRunService {
   }
 
   @Transactional()
-  private async cancelRunState(command: CancelDataMartRunCommand): Promise<void> {
+  async cancelRunState(command: CancelDataMartRunCommand): Promise<void> {
     const run = await this.dataMartRunService.getByIdAndDataMartId(command.runId, command.id);
 
     if (!run) {
-      throw new ConflictException('Data mart run not found');
+      throw new NotFoundException('Data mart run not found');
     }
 
     if (!this.isSupportedRunType(run.type)) {
       throw new BadRequestException('Only connector and standard report runs can be cancelled');
     }
 
-    if (!CANCELLABLE_RUN_STATUSES.has(run.status)) {
+    if (!isCancellableDataMartRunStatus(run.status)) {
       throw new ConflictException(`Cannot cancel data mart run in ${run.status} status`);
     }
 
-    if (this.isStandardReportRun(run.type) && !run.reportId) {
-      throw new ConflictException('Report run is missing report reference');
-    }
-
-    const wasCancelled = await this.dataMartRunService.markAsCancelled(run);
-    if (!wasCancelled) {
-      throw new ConflictException('Cannot cancel data mart run because it is no longer active');
-    }
-
     if (run.type === DataMartRunType.CONNECTOR) {
+      await this.markActiveRunAsCancelled(run);
       await this.connectorRunTriggerService.stopTriggersForRun(run.id);
       return;
     }
 
+    const reportId = this.getStandardReportRunReportId(run);
+    await this.markActiveRunAsCancelled(run);
     await this.reportRunTriggerService.stopTriggersForRun(run.id);
-    await this.reportService.markRunAsCancelled(run.reportId!);
+    await this.reportService.markRunAsCancelled(reportId);
   }
 
   private isSupportedRunType(type: DataMartRunType): boolean {
@@ -98,6 +84,21 @@ export class CancelDataMartRunService {
   }
 
   private isStandardReportRun(type: DataMartRunType): boolean {
-    return STANDARD_REPORT_RUN_TYPES.has(type);
+    return isStandardReportRunType(type);
+  }
+
+  private async markActiveRunAsCancelled(run: DataMartRun): Promise<void> {
+    const wasCancelled = await this.dataMartRunService.markAsCancelled(run);
+    if (!wasCancelled) {
+      throw new ConflictException('Cannot cancel data mart run because it is no longer active');
+    }
+  }
+
+  private getStandardReportRunReportId(run: { reportId?: string | null }): string {
+    if (!run.reportId) {
+      throw new ConflictException('Report run is missing report reference');
+    }
+
+    return run.reportId;
   }
 }

--- a/apps/backend/src/data-marts/utils/data-mart-run-cancellation.ts
+++ b/apps/backend/src/data-marts/utils/data-mart-run-cancellation.ts
@@ -1,0 +1,28 @@
+import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
+import { DataMartRunType } from '../enums/data-mart-run-type.enum';
+
+export const CANCELLABLE_DATA_MART_RUN_STATUSES = [
+  DataMartRunStatus.PENDING,
+  DataMartRunStatus.RUNNING,
+];
+
+export const STANDARD_REPORT_RUN_TYPES = [
+  DataMartRunType.GOOGLE_SHEETS_EXPORT,
+  DataMartRunType.EMAIL,
+  DataMartRunType.SLACK,
+  DataMartRunType.MS_TEAMS,
+  DataMartRunType.GOOGLE_CHAT,
+];
+
+const CANCELLABLE_DATA_MART_RUN_STATUS_SET = new Set<DataMartRunStatus>(
+  CANCELLABLE_DATA_MART_RUN_STATUSES
+);
+const STANDARD_REPORT_RUN_TYPE_SET = new Set<DataMartRunType>(STANDARD_REPORT_RUN_TYPES);
+
+export function isCancellableDataMartRunStatus(status: DataMartRunStatus): boolean {
+  return CANCELLABLE_DATA_MART_RUN_STATUS_SET.has(status);
+}
+
+export function isStandardReportRunType(type: DataMartRunType): boolean {
+  return STANDARD_REPORT_RUN_TYPE_SET.has(type);
+}

--- a/apps/backend/src/data-marts/utils/run-trigger-cancellation.spec.ts
+++ b/apps/backend/src/data-marts/utils/run-trigger-cancellation.spec.ts
@@ -1,0 +1,22 @@
+import { In } from 'typeorm';
+import { TriggerStatus } from '../../common/scheduler/shared/entities/trigger-status';
+import { stopRunTriggersForRun } from './run-trigger-cancellation';
+
+describe('stopRunTriggersForRun', () => {
+  it('cancels queued triggers and requests active trigger cancellation', async () => {
+    const repository = {
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await stopRunTriggersForRun(repository, 'run-1');
+
+    expect(repository.update).toHaveBeenCalledWith(
+      { dataMartRunId: 'run-1', status: In([TriggerStatus.IDLE, TriggerStatus.READY]) },
+      { status: TriggerStatus.CANCELLED, isActive: false, version: expect.any(Function) }
+    );
+    expect(repository.update).toHaveBeenCalledWith(
+      { dataMartRunId: 'run-1', status: TriggerStatus.PROCESSING },
+      { status: TriggerStatus.CANCELLING, isActive: false, version: expect.any(Function) }
+    );
+  });
+});

--- a/apps/backend/src/data-marts/utils/run-trigger-cancellation.ts
+++ b/apps/backend/src/data-marts/utils/run-trigger-cancellation.ts
@@ -1,0 +1,35 @@
+import { FindOptionsWhere, In, Repository } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import { ConnectorRunTrigger } from '../entities/connector-run-trigger.entity';
+import { ReportRunTrigger } from '../entities/report-run-trigger.entity';
+import { TriggerStatus } from '../../common/scheduler/shared/entities/trigger-status';
+
+type DataMartRunTrigger = ConnectorRunTrigger | ReportRunTrigger;
+
+export async function stopRunTriggersForRun<T extends DataMartRunTrigger>(
+  repository: Pick<Repository<T>, 'update'>,
+  dataMartRunId: string
+): Promise<void> {
+  await repository.update(
+    {
+      dataMartRunId,
+      status: In([TriggerStatus.IDLE, TriggerStatus.READY]),
+    } as FindOptionsWhere<T>,
+    {
+      status: TriggerStatus.CANCELLED,
+      isActive: false,
+      version: () => 'version + 1',
+    } as QueryDeepPartialEntity<T>
+  );
+  await repository.update(
+    {
+      dataMartRunId,
+      status: TriggerStatus.PROCESSING,
+    } as FindOptionsWhere<T>,
+    {
+      status: TriggerStatus.CANCELLING,
+      isActive: false,
+      version: () => 'version + 1',
+    } as QueryDeepPartialEntity<T>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/CancelRunButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/CancelRunButton.tsx
@@ -40,7 +40,7 @@ function getCancelErrorMessage(error: unknown): string {
 
 interface CancelRunButtonProps {
   runId: string;
-  dataMartId?: string;
+  dataMartId: string;
   cancelDataMartRun: (id: string, runId: string) => Promise<void>;
   className?: string;
   variant?: 'destructive' | 'secondary';
@@ -66,7 +66,7 @@ export function CancelRunButton({
   }, []);
 
   const handleConfirm = useCallback(async () => {
-    if (!dataMartId || isCancelling) return;
+    if (isCancelling) return;
 
     setIsCancelling(true);
     try {

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/CancelRunButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/CancelRunButton.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useState } from 'react';
+import { X } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { Button } from '@owox/ui/components/button';
+import { ConfirmationDialog } from '../../../../../shared/components/ConfirmationDialog';
+import { cn } from '@owox/ui/lib/utils';
+
+const GLOBALLY_TOASTED_HTTP_STATUSES = new Set([400, 403, 404]);
+
+function getErrorResponse(error: unknown):
+  | {
+      status?: number;
+      data?: {
+        message?: unknown;
+      };
+    }
+  | undefined {
+  return (
+    error as {
+      response?: {
+        status?: number;
+        data?: {
+          message?: unknown;
+        };
+      };
+    }
+  ).response;
+}
+
+function getCancelErrorMessage(error: unknown): string {
+  const responseMessage = getErrorResponse(error)?.data?.message;
+  if (typeof responseMessage === 'string' && responseMessage.length > 0) {
+    return responseMessage;
+  }
+
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+
+  return 'Failed to cancel data mart run';
+}
+
+function shouldShowLocalErrorToast(error: unknown): boolean {
+  const status = getErrorResponse(error)?.status;
+  return status === undefined || !GLOBALLY_TOASTED_HTTP_STATUSES.has(status);
+}
+
+interface CancelRunButtonProps {
+  runId: string;
+  dataMartId?: string;
+  cancelDataMartRun: (id: string, runId: string) => Promise<void>;
+  className?: string;
+  variant?: 'destructive' | 'secondary';
+  iconClassName?: string;
+  labelClassName?: string;
+}
+
+export function CancelRunButton({
+  runId,
+  dataMartId,
+  cancelDataMartRun,
+  className,
+  variant = 'secondary',
+  iconClassName = 'size-3',
+  labelClassName = 'hidden sm:inline',
+}: CancelRunButtonProps) {
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
+
+  const handleOpenConfirm = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    setIsConfirmOpen(true);
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (!dataMartId || isCancelling) return;
+
+    setIsCancelling(true);
+    try {
+      await cancelDataMartRun(dataMartId, runId);
+      setIsConfirmOpen(false);
+    } catch (error) {
+      if (shouldShowLocalErrorToast(error)) {
+        toast.error(getCancelErrorMessage(error));
+      }
+    } finally {
+      setIsCancelling(false);
+    }
+  }, [cancelDataMartRun, dataMartId, isCancelling, runId]);
+
+  return (
+    <>
+      <Button
+        variant={variant}
+        size='sm'
+        aria-label='Cancel run'
+        onClick={handleOpenConfirm}
+        disabled={isCancelling}
+        className={cn(
+          'cursor-pointer font-medium',
+          variant === 'secondary' &&
+            'hover:bg-muted hover:text-foreground dark:hover:text-foreground text-xs dark:hover:bg-white/10',
+          className
+        )}
+      >
+        <X className={iconClassName} />
+        <span className={labelClassName}>{isCancelling ? 'Cancelling' : 'Cancel'}</span>
+      </Button>
+
+      <ConfirmationDialog
+        open={isConfirmOpen}
+        onOpenChange={setIsConfirmOpen}
+        title='Cancel run?'
+        description='This will request cancellation and stop the run if it is still in progress. Cancelling a run may result in incomplete data.'
+        confirmLabel='Cancel'
+        cancelLabel='Keep running'
+        onConfirm={() => {
+          void handleConfirm();
+        }}
+        variant='destructive'
+      />
+    </>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/CancelRunButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/CancelRunButton.tsx
@@ -5,8 +5,6 @@ import { Button } from '@owox/ui/components/button';
 import { ConfirmationDialog } from '../../../../../shared/components/ConfirmationDialog';
 import { cn } from '@owox/ui/lib/utils';
 
-const GLOBALLY_TOASTED_HTTP_STATUSES = new Set([400, 403, 404]);
-
 function getErrorResponse(error: unknown):
   | {
       status?: number;
@@ -38,11 +36,6 @@ function getCancelErrorMessage(error: unknown): string {
   }
 
   return 'Failed to cancel data mart run';
-}
-
-function shouldShowLocalErrorToast(error: unknown): boolean {
-  const status = getErrorResponse(error)?.status;
-  return status === undefined || !GLOBALLY_TOASTED_HTTP_STATUSES.has(status);
 }
 
 interface CancelRunButtonProps {
@@ -80,9 +73,7 @@ export function CancelRunButton({
       await cancelDataMartRun(dataMartId, runId);
       setIsConfirmOpen(false);
     } catch (error) {
-      if (shouldShowLocalErrorToast(error)) {
-        toast.error(getCancelErrorMessage(error));
-      }
+      toast.error(getCancelErrorMessage(error));
     } finally {
       setIsCancelling(false);
     }
@@ -112,8 +103,9 @@ export function CancelRunButton({
         onOpenChange={setIsConfirmOpen}
         title='Cancel run?'
         description='This will request cancellation and stop the run if it is still in progress. Cancelling a run may result in incomplete data.'
-        confirmLabel='Cancel'
+        confirmLabel='Cancel run'
         cancelLabel='Keep running'
+        confirmDisabled={isCancelling}
         onConfirm={() => {
           void handleConfirm();
         }}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/LogControls.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/LogControls.tsx
@@ -1,11 +1,12 @@
-import { Search, Download, X } from 'lucide-react';
-import { toast } from 'react-hot-toast';
+import { Search, Download } from 'lucide-react';
 import { Button } from '@owox/ui/components/button';
 import { Input } from '@owox/ui/components/input';
 import { LogViewType } from './types';
 import type { DataMartDefinitionConfig } from '../../model/types/data-mart-definition-config';
-import { DataMartRunStatus } from '../../../shared';
+import { DataMartRunStatus, DataMartRunType } from '../../../shared';
 import { downloadLogs } from './utils';
+import { canCancelDataMartRun } from './cancellable-runs';
+import { CancelRunButton } from './CancelRunButton';
 
 interface LogControlsProps {
   logViewType: LogViewType;
@@ -15,6 +16,7 @@ interface LogControlsProps {
   run: {
     id: string;
     status: DataMartRunStatus;
+    type: DataMartRunType;
     logs: string[];
     errors: string[];
     definitionRun: DataMartDefinitionConfig | null;
@@ -34,18 +36,6 @@ export function LogControls({
 }: LogControlsProps) {
   const handleStopPropagation = (e: React.MouseEvent) => {
     e.stopPropagation();
-  };
-
-  const handleCancelRun = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (dataMartId) {
-      try {
-        await cancelDataMartRun(dataMartId, run.id);
-        toast.success('Data mart run cancelled successfully');
-      } catch (error) {
-        toast.error(error instanceof Error ? error.message : 'Failed to cancel data mart run');
-      }
-    }
   };
 
   const getButtonSwitchClasses = (isActive: boolean) => {
@@ -106,11 +96,16 @@ export function LogControls({
         )}
       </div>
       <div className='flex items-center gap-2'>
-        {run.status === DataMartRunStatus.RUNNING && (
-          <Button variant='destructive' size='sm' onClick={e => void handleCancelRun(e)}>
-            <X className='h-4 w-4' />
-            Cancel
-          </Button>
+        {canCancelDataMartRun(run.type, run.status) && (
+          <CancelRunButton
+            runId={run.id}
+            dataMartId={dataMartId}
+            cancelDataMartRun={cancelDataMartRun}
+            variant='destructive'
+            className='flex items-center gap-2'
+            iconClassName='h-4 w-4'
+            labelClassName='inline'
+          />
         )}
         <Button
           variant='outline'

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/LogControls.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/LogControls.tsx
@@ -96,7 +96,7 @@ export function LogControls({
         )}
       </div>
       <div className='flex items-center gap-2'>
-        {canCancelDataMartRun(run.type, run.status) && (
+        {dataMartId && canCancelDataMartRun(run.type, run.status) && (
           <CancelRunButton
             runId={run.id}
             dataMartId={dataMartId}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import toast from 'react-hot-toast';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RunItem } from './RunItem';
@@ -82,7 +82,7 @@ describe('RunItem', () => {
     expect(screen.getByText('Cancel run?')).toBeInTheDocument();
     expect(screen.getByText(/may result in incomplete data/i)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Cancel run' }));
 
     await waitFor(() => {
       expect(cancelDataMartRun).toHaveBeenCalledWith('dm-1', 'run-1');
@@ -101,13 +101,33 @@ describe('RunItem', () => {
     renderRunItem(createRun(), true, cancelDataMartRun);
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel run' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Cancel run' }));
 
     await waitFor(() => {
       expect(cancelDataMartRun).toHaveBeenCalledWith('dm-1', 'run-1');
     });
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(toast.error).toHaveBeenCalledWith('Cannot cancel data mart run in SUCCESS status');
+  });
+
+  it('disables the dialog confirmation while cancellation is in progress', async () => {
+    const cancelDataMartRun = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          // Keep request pending to inspect the in-flight UI state.
+        })
+    );
+    renderRunItem(createRun(), true, cancelDataMartRun);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel run' }));
+    const dialog = screen.getByRole('dialog');
+    const confirmButton = within(dialog).getByRole('button', { name: 'Cancel run' });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(confirmButton).toBeDisabled();
+    });
+    expect(cancelDataMartRun).toHaveBeenCalledTimes(1);
   });
 
   it('shows the expanded controls cancel button for a pending standard report run', () => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import toast from 'react-hot-toast';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RunItem } from './RunItem';
+import { LogViewType } from './types';
+import { DataMartRunStatus, DataMartRunTriggerType, DataMartRunType } from '../../../shared';
+import type { DataMartRunItem } from '../../model/types/data-mart-run';
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: vi.fn(),
+  },
+}));
+
+const createRun = (overrides: Partial<DataMartRunItem> = {}): DataMartRunItem =>
+  ({
+    id: 'run-1',
+    status: DataMartRunStatus.RUNNING,
+    createdAt: new Date('2026-06-04T12:00:00.000Z'),
+    logs: [],
+    errors: [],
+    definitionRun: {} as DataMartRunItem['definitionRun'],
+    type: DataMartRunType.CONNECTOR,
+    triggerType: DataMartRunTriggerType.MANUAL,
+    startedAt: new Date('2026-06-04T12:00:00.000Z'),
+    finishedAt: null,
+    reportDefinition: null,
+    reportId: null,
+    insightDefinition: null,
+    insightId: null,
+    insightTemplateDefinition: null,
+    insightTemplateId: null,
+    aiAssistantDefinition: null,
+    createdByUser: null,
+    additionalParams: null,
+    ...overrides,
+  }) as DataMartRunItem;
+
+const renderRunItem = (
+  run: DataMartRunItem,
+  isExpanded = false,
+  cancelDataMartRun = vi.fn().mockResolvedValue(undefined)
+) => {
+  const onToggle = vi.fn();
+
+  render(
+    <RunItem
+      run={run}
+      isExpanded={isExpanded}
+      onToggle={onToggle}
+      logViewType={LogViewType.STRUCTURED}
+      setLogViewType={vi.fn()}
+      searchTerm=''
+      setSearchTerm={vi.fn()}
+      cancelDataMartRun={cancelDataMartRun}
+      dataMartId='dm-1'
+      dataMartConnectorInfo={null}
+    />
+  );
+
+  return { onToggle, cancelDataMartRun };
+};
+
+describe('RunItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requires confirmation before cancelling a running connector run', async () => {
+    const { cancelDataMartRun, onToggle } = renderRunItem(createRun(), true);
+    const cancelButton = screen.getByRole('button', { name: 'Cancel run' });
+
+    expect(cancelButton).toHaveClass('cursor-pointer');
+    expect(cancelButton).toHaveClass('bg-destructive');
+
+    fireEvent.click(cancelButton);
+
+    expect(cancelDataMartRun).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Cancel run?')).toBeInTheDocument();
+    expect(screen.getByText(/may result in incomplete data/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(cancelDataMartRun).toHaveBeenCalledWith('dm-1', 'run-1');
+    });
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('keeps confirmation open and shows an error when cancellation fails', async () => {
+    const cancelDataMartRun = vi.fn().mockRejectedValue({
+      response: {
+        data: {
+          message: 'Cannot cancel data mart run in SUCCESS status',
+        },
+      },
+    });
+    renderRunItem(createRun(), true, cancelDataMartRun);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel run' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(cancelDataMartRun).toHaveBeenCalledWith('dm-1', 'run-1');
+    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(toast.error).toHaveBeenCalledWith('Cannot cancel data mart run in SUCCESS status');
+  });
+
+  it('shows the expanded controls cancel button for a pending standard report run', () => {
+    renderRunItem(
+      createRun({
+        type: DataMartRunType.GOOGLE_SHEETS_EXPORT,
+        status: DataMartRunStatus.PENDING,
+        reportId: 'report-1',
+      }),
+      true
+    );
+
+    expect(screen.getByRole('button', { name: 'Cancel run' })).toBeInTheDocument();
+  });
+
+  it('does not show a cancel button in the collapsed row', () => {
+    renderRunItem(createRun());
+
+    expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument();
+  });
+
+  it('does not show a cancel button for Looker Studio or HTTP Data runs', () => {
+    const { rerender } = render(
+      <RunItem
+        run={createRun({ type: DataMartRunType.LOOKER_STUDIO })}
+        isExpanded={true}
+        onToggle={vi.fn()}
+        logViewType={LogViewType.STRUCTURED}
+        setLogViewType={vi.fn()}
+        searchTerm=''
+        setSearchTerm={vi.fn()}
+        cancelDataMartRun={vi.fn()}
+        dataMartId='dm-1'
+        dataMartConnectorInfo={null}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+
+    rerender(
+      <RunItem
+        run={createRun({ type: DataMartRunType.HTTP_DATA })}
+        isExpanded={true}
+        onToggle={vi.fn()}
+        logViewType={LogViewType.STRUCTURED}
+        setLogViewType={vi.fn()}
+        searchTerm=''
+        setSearchTerm={vi.fn()}
+        cancelDataMartRun={vi.fn()}
+        dataMartId='dm-1'
+        dataMartConnectorInfo={null}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
@@ -41,7 +41,8 @@ const createRun = (overrides: Partial<DataMartRunItem> = {}): DataMartRunItem =>
 const renderRunItem = (
   run: DataMartRunItem,
   isExpanded = false,
-  cancelDataMartRun = vi.fn().mockResolvedValue(undefined)
+  cancelDataMartRun = vi.fn().mockResolvedValue(undefined),
+  dataMartId: string | undefined = 'dm-1'
 ) => {
   const onToggle = vi.fn();
 
@@ -55,7 +56,7 @@ const renderRunItem = (
       searchTerm=''
       setSearchTerm={vi.fn()}
       cancelDataMartRun={cancelDataMartRun}
-      dataMartId='dm-1'
+      dataMartId={dataMartId}
       dataMartConnectorInfo={null}
     />
   );
@@ -141,6 +142,24 @@ describe('RunItem', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Cancel run' })).toBeInTheDocument();
+  });
+
+  it('does not show a cancel button when data mart id is unavailable', () => {
+    render(
+      <RunItem
+        run={createRun()}
+        isExpanded={true}
+        onToggle={vi.fn()}
+        logViewType={LogViewType.STRUCTURED}
+        setLogViewType={vi.fn()}
+        searchTerm=''
+        setSearchTerm={vi.fn()}
+        cancelDataMartRun={vi.fn()}
+        dataMartConnectorInfo={null}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument();
   });
 
   it('does not show a cancel button in the collapsed row', () => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/cancellable-runs.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/cancellable-runs.ts
@@ -1,0 +1,19 @@
+import { DataMartRunStatus, DataMartRunType } from '../../../shared';
+
+const CANCELLABLE_RUN_TYPES = new Set<DataMartRunType>([
+  DataMartRunType.CONNECTOR,
+  DataMartRunType.GOOGLE_SHEETS_EXPORT,
+  DataMartRunType.EMAIL,
+  DataMartRunType.SLACK,
+  DataMartRunType.MS_TEAMS,
+  DataMartRunType.GOOGLE_CHAT,
+]);
+
+const CANCELLABLE_RUN_STATUSES = new Set<DataMartRunStatus>([
+  DataMartRunStatus.PENDING,
+  DataMartRunStatus.RUNNING,
+]);
+
+export function canCancelDataMartRun(type: DataMartRunType, status: DataMartRunStatus): boolean {
+  return CANCELLABLE_RUN_TYPES.has(type) && CANCELLABLE_RUN_STATUSES.has(status);
+}

--- a/apps/web/src/features/data-marts/edit/model/context/DataMartContext.test.tsx
+++ b/apps/web/src/features/data-marts/edit/model/context/DataMartContext.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { useContext } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DataMartProvider } from './DataMartContext';
 import { DataMartContext } from './context';
 import { dataMartService } from '../../../shared';
@@ -33,26 +33,18 @@ vi.mock('../../../shared', async () => {
     ...actual,
     dataMartService: {
       cancelDataMartRun: vi.fn(),
+      getDataMartRuns: vi.fn(),
     },
   };
 });
 
 describe('DataMartProvider cancelDataMartRun', () => {
-  it('rejects when the API cancellation request fails', async () => {
-    const apiError = {
-      message: 'cancel failed',
-      path: '/api/data-marts/dm-1/runs/run-1/cancel',
-      statusCode: 409,
-      timestamp: '2026-06-04T12:00:00.000Z',
-    };
-    const axiosError = {
-      response: {
-        data: apiError,
-      },
-    };
-    let cancelPromise: Promise<void> | undefined;
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    vi.mocked(dataMartService.cancelDataMartRun).mockRejectedValue(axiosError);
+  function renderCancelConsumer() {
+    let cancelPromise: Promise<void> | undefined;
 
     function Consumer() {
       const context = useContext(DataMartContext)!;
@@ -76,8 +68,46 @@ describe('DataMartProvider cancelDataMartRun', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
+    return {
+      get cancelPromise() {
+        return cancelPromise;
+      },
+    };
+  }
+
+  it('rejects when the API cancellation request fails', async () => {
+    const apiError = {
+      message: 'cancel failed',
+      path: '/api/data-marts/dm-1/runs/run-1/cancel',
+      statusCode: 409,
+      timestamp: '2026-06-04T12:00:00.000Z',
+    };
+    const axiosError = {
+      response: {
+        data: apiError,
+      },
+    };
+
+    vi.mocked(dataMartService.cancelDataMartRun).mockRejectedValue(axiosError);
+    const result = renderCancelConsumer();
+
     await act(async () => {
-      await expect(cancelPromise).rejects.toBe(axiosError);
+      await expect(result.cancelPromise).rejects.toBe(axiosError);
     });
+  });
+
+  it('does not reject when cancellation succeeds but run history refresh fails', async () => {
+    const refreshError = new Error('refresh failed');
+    vi.mocked(dataMartService.cancelDataMartRun).mockResolvedValue(undefined);
+    vi.mocked(dataMartService.getDataMartRuns).mockRejectedValue(refreshError);
+
+    const result = renderCancelConsumer();
+
+    await act(async () => {
+      await expect(result.cancelPromise).resolves.toBeUndefined();
+    });
+
+    expect(dataMartService.cancelDataMartRun).toHaveBeenCalledWith('dm-1', 'run-1');
+    expect(dataMartService.getDataMartRuns).toHaveBeenCalledWith('dm-1', 5, 0, undefined);
   });
 });

--- a/apps/web/src/features/data-marts/edit/model/context/DataMartContext.test.tsx
+++ b/apps/web/src/features/data-marts/edit/model/context/DataMartContext.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useContext } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { DataMartProvider } from './DataMartContext';
+import { DataMartContext } from './context';
+import { dataMartService } from '../../../shared';
+
+vi.mock('../../../../../hooks/useAutoRefresh', () => ({
+  useAutoRefresh: vi.fn(),
+}));
+
+vi.mock('../../../../../components/AppSidebar/SetupChecklist/useSetupProgress', () => ({
+  useRefreshSetupProgress: () => vi.fn(),
+}));
+
+vi.mock('../../../../../utils', () => ({
+  pushToDataLayer: vi.fn(),
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../../shared', async () => {
+  const actual = await vi.importActual<typeof import('../../../shared')>('../../../shared');
+
+  return {
+    ...actual,
+    dataMartService: {
+      cancelDataMartRun: vi.fn(),
+    },
+  };
+});
+
+describe('DataMartProvider cancelDataMartRun', () => {
+  it('rejects when the API cancellation request fails', async () => {
+    const apiError = {
+      message: 'cancel failed',
+      path: '/api/data-marts/dm-1/runs/run-1/cancel',
+      statusCode: 409,
+      timestamp: '2026-06-04T12:00:00.000Z',
+    };
+    const axiosError = {
+      response: {
+        data: apiError,
+      },
+    };
+    let cancelPromise: Promise<void> | undefined;
+
+    vi.mocked(dataMartService.cancelDataMartRun).mockRejectedValue(axiosError);
+
+    function Consumer() {
+      const context = useContext(DataMartContext)!;
+      return (
+        <button
+          type='button'
+          onClick={() => {
+            cancelPromise = context.cancelDataMartRun('dm-1', 'run-1');
+          }}
+        >
+          Cancel
+        </button>
+      );
+    }
+
+    render(
+      <DataMartProvider>
+        <Consumer />
+      </DataMartProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await act(async () => {
+      await expect(cancelPromise).rejects.toBe(axiosError);
+    });
+  });
+});

--- a/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
+++ b/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
@@ -549,6 +549,7 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
           action: 'CancelRunError',
           error: apiError.message,
         });
+        throw error;
       }
     },
     [getDataMartRuns]

--- a/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
+++ b/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
@@ -529,14 +529,6 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
     async (id: string, runId: string): Promise<void> => {
       try {
         await dataMartService.cancelDataMartRun(id, runId);
-        await getDataMartRuns(id);
-        toast.success('Data Mart run canceled');
-        trackEvent({
-          event: 'data_mart_run_canceled',
-          category: 'DataMart',
-          action: 'CancelRun',
-          label: 'Manual',
-        });
       } catch (error) {
         const apiError = extractApiError(error);
         dispatch({
@@ -550,6 +542,26 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
           error: apiError.message,
         });
         throw error;
+      }
+
+      toast.success('Data Mart run canceled');
+      trackEvent({
+        event: 'data_mart_run_canceled',
+        category: 'DataMart',
+        action: 'CancelRun',
+        label: 'Manual',
+      });
+
+      try {
+        await getDataMartRuns(id);
+      } catch (error) {
+        const apiError = extractApiError(error) as { message?: string } | undefined;
+        trackEvent({
+          event: 'data_mart_error',
+          category: 'DataMart',
+          action: 'CancelRunRefreshError',
+          error: apiError?.message ?? 'Failed to refresh Data Mart runs after cancellation',
+        });
       }
     },
     [getDataMartRuns]

--- a/apps/web/src/features/data-marts/shared/services/data-mart.service.test.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart.service.test.ts
@@ -126,6 +126,18 @@ describe('DataMartService', () => {
     });
   });
 
+  describe('cancelDataMartRun', () => {
+    it('should suppress the global error toast so the run history button can show the specific message', async () => {
+      await service.cancelDataMartRun(mockDataMartId, 'run-1');
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        `/data-marts/${mockDataMartId}/runs/run-1/cancel`,
+        undefined,
+        { skipErrorToast: true }
+      );
+    });
+  });
+
   describe('updateDataMartDescription', () => {
     it('should update a data mart description', async () => {
       const description = 'New description';

--- a/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
@@ -158,7 +158,9 @@ export class DataMartService extends ApiService {
    * @returns Promise<void>
    */
   async cancelDataMartRun(id: string, runId: string): Promise<void> {
-    await this.post(`/${id}/runs/${runId}/cancel`);
+    await this.post(`/${id}/runs/${runId}/cancel`, undefined, {
+      skipErrorToast: true,
+    } as AxiosRequestConfig);
   }
 
   /**

--- a/apps/web/src/features/project-settings/members/components/UserProvisioningSettings/UserProvisioningSettings.test.tsx
+++ b/apps/web/src/features/project-settings/members/components/UserProvisioningSettings/UserProvisioningSettings.test.tsx
@@ -243,8 +243,8 @@ describe('UserProvisioningSettings', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('radio-require-request')).toBeChecked();
+      expect(screen.queryByTestId('change-default-roles-btn')).not.toBeInTheDocument();
     });
-    expect(screen.queryByTestId('change-default-roles-btn')).not.toBeInTheDocument();
   });
 
   it('opens DefaultRoleSheet when role/scope button is clicked', async () => {

--- a/apps/web/src/shared/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/apps/web/src/shared/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -18,6 +18,7 @@ interface ConfirmationDialogProps {
   cancelLabel?: string;
   onConfirm: () => void;
   onCancel?: () => void;
+  confirmDisabled?: boolean;
   variant?: 'destructive' | 'default' | 'brand' | 'outline' | 'secondary' | 'ghost' | 'link';
   children?: ReactNode;
 }
@@ -31,6 +32,7 @@ export const ConfirmationDialog = ({
   cancelLabel,
   onConfirm,
   onCancel,
+  confirmDisabled = false,
   variant = 'destructive',
   children,
 }: ConfirmationDialogProps) => {
@@ -55,7 +57,7 @@ export const ConfirmationDialog = ({
               {cancelLabel}
             </Button>
           )}
-          <Button variant={variant} onClick={onConfirm}>
+          <Button variant={variant} onClick={onConfirm} disabled={confirmDisabled}>
             {confirmLabel}
           </Button>
         </DialogFooter>


### PR DESCRIPTION
## Motivation

Connector and standard report runs can be left in non-terminal states when a worker goes down or when an in-progress trigger cannot be stopped from the UI. Users need a Run History action that can request cancellation, clear stuck run records from the active state, and stop the underlying trigger work when it is still running.

## What changed

- Extends Data Mart run cancellation to connector runs and standard report runs: Google Sheets, Email, Slack, MS Teams, and Google Chat.
- Keeps HTTP Data and Looker Studio runs out of this flow because they use separate execution models.
- Moves cancellation state changes through the relevant services instead of updating repositories directly in the use case.
- Marks active Data Mart runs as `CANCELLED` conditionally, so completed runs are not cancelled by stale requests.
- Stops matching connector/report run triggers by moving queued triggers to `CANCELLED` and in-progress triggers to `CANCELLING`.
- Relies on the existing scheduler abort job to fetch `CANCELLING` triggers and call `runner.abortTriggerRuns(...)` on active trigger controllers.
- Persists trigger cancellation with atomic status updates, avoiding stale entity saves after abort.
- Keeps cancelled runs from being overwritten by graceful-shutdown `INTERRUPTED` recovery.
- Preserves successful connector completion, including consumption tracking and success event registration, when an abort arrives after the connector upload already succeeded.
- Updates report last-run state only from `RUNNING` to `CANCELLED`.
- Removes the old unused connector cancellation chain from `ConnectorExecutionService`/`ConnectorRunService`.
- Adds a Run History cancel action with confirmation and an explicit warning that cancelling a run may leave incomplete data.

## Behavior
<img width="1048" height="395" alt="CleanShot 2026-06-05 at 16 40 48" src="https://github.com/user-attachments/assets/2de0765c-3c37-4625-9681-f01e0f68b31c" />

- The cancel action is shown only for connector and standard report runs in `PENDING` or `RUNNING` status.
- Cancellation is best-effort for live runs. The endpoint marks the Run History record as `CANCELLED` immediately, so stale/orphaned runs that no longer have a live worker stop showing as active.
- If the worker is still live, queued triggers are cancelled, in-progress triggers move to `CANCELLING`, and the scheduler abort job delivers the abort signal to the active runner.
- If a live worker has already passed the cancellation point and completes before the abort signal is delivered/observed, its normal finalizer may replace `CANCELLED` with `SUCCESS` or `FAILED`. In that case Run History shows the actual completed outcome instead of preserving a cancellation marker for work that already finished.
- If a connector upload already succeeded before a late abort is observed, the run remains successful and consumption tracking is still recorded.
- HTTP Data and Looker Studio runs remain non-cancellable.

## Verification

- `npm test -w @owox/backend -- --runInBand src/common/scheduler/facades/scheduler-facade.impl.spec.ts src/data-marts/services/connector/connector-run-trigger-handler.service.spec.ts src/data-marts/services/report-run-trigger-handler.service.spec.ts src/data-marts/services/connector/connector-executor.service.spec.ts src/data-marts/services/report.service.spec.ts src/data-marts/services/connector/connector-run.service.spec.ts src/data-marts/services/connector/connector-execution.service.spec.ts src/data-marts/use-cases/cancel-data-mart-run.service.spec.ts src/data-marts/services/data-mart-run.service.spec.ts`
- `npm test -w @owox/web -- RunItem.test.tsx data-mart.service.test.ts`
- `npx prettier --check <touched files>`
- `npm run lint -w @owox/backend`
- `npm run lint -w @owox/web`
- `npm run build -w @owox/backend`
- `npm run build -w @owox/web`
