### PR TITLE
Improve API key expiration visibility and sorting

### DIFF
--- a/apps/web/src/features/api-keys/components/ApiKeyExpirationValue.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeyExpirationValue.tsx
@@ -1,0 +1,63 @@
+import { Badge } from '@owox/ui/components/badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { cn } from '@owox/ui/lib/utils';
+import { formatDateOnly } from '../../../utils';
+import {
+  API_KEY_EXPIRED_NOTICE,
+  API_KEY_EXPIRING_SOON_NOTICE,
+  isApiKeyExpired,
+  isApiKeyExpiringSoon,
+} from '../utils';
+
+interface ApiKeyExpirationValueProps {
+  expiresAt: string | null | undefined;
+  focusable?: boolean;
+}
+
+export function ApiKeyExpirationValue({ expiresAt, focusable }: ApiKeyExpirationValueProps) {
+  if (!expiresAt) return <span className='text-muted-foreground text-sm'>Never</span>;
+
+  const dateLabel = formatDateOnly(expiresAt, { timeZone: 'UTC' });
+  const expired = isApiKeyExpired(expiresAt);
+  const expiresSoon = isApiKeyExpiringSoon(expiresAt);
+
+  if (!expired && !expiresSoon) return <span className='text-foreground text-sm'>{dateLabel}</span>;
+
+  const status = expired
+    ? {
+        badgeClassName: 'border-destructive/20 bg-destructive/10 text-destructive',
+        label: 'Expired',
+        tooltip: API_KEY_EXPIRED_NOTICE,
+      }
+    : {
+        badgeClassName:
+          'border-amber-300/50 bg-amber-50 text-amber-700 dark:border-amber-400/30 dark:bg-amber-500/10 dark:text-amber-300',
+        label: 'Expires soon',
+        tooltip: API_KEY_EXPIRING_SOON_NOTICE,
+      };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          tabIndex={focusable ? 0 : undefined}
+          className='inline-flex items-center gap-2 text-sm whitespace-nowrap'
+        >
+          <span className='text-foreground'>{dateLabel}</span>
+          <Badge
+            variant='outline'
+            className={cn(
+              'h-5 rounded-sm px-1.5 py-0 text-[11px] leading-4 font-medium',
+              status.badgeClassName
+            )}
+          >
+            {status.label}
+          </Badge>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side='top' align='start'>
+        {status.tooltip}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/features/api-keys/components/ApiKeysTable/ApiKeysTable.test.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/ApiKeysTable.test.tsx
@@ -121,8 +121,18 @@ describe('ApiKeysTable', () => {
     );
 
     const expirationDate = screen.getByText(formatDateOnly(expiresAt, { timeZone: 'UTC' }));
+    const expiresCell = expirationDate.closest('td');
+    expect(expiresCell).not.toBeNull();
+    const statusBadge = within(expiresCell as HTMLElement).getByText('Expires soon');
 
-    expect(expirationDate).toHaveClass('font-medium', 'text-amber-600');
+    expect(expirationDate).toHaveClass('text-foreground');
+    expect(expirationDate).not.toHaveClass('text-amber-600');
+    expect(expirationDate).not.toHaveClass('font-medium');
+    expect(statusBadge).toHaveAttribute('data-slot', 'badge');
+    expect(statusBadge).toHaveClass('text-[11px]', 'text-amber-700');
+    expect(
+      expirationDate.compareDocumentPosition(statusBadge) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
     expect(screen.getByRole('tooltip')).toHaveTextContent('This API key expires within 30 days.');
   });
 
@@ -140,8 +150,18 @@ describe('ApiKeysTable', () => {
     );
 
     const expirationDate = screen.getByText(formatDateOnly(expiresAt, { timeZone: 'UTC' }));
+    const expiresCell = expirationDate.closest('td');
+    expect(expiresCell).not.toBeNull();
+    const statusBadge = within(expiresCell as HTMLElement).getByText('Expired');
 
-    expect(expirationDate).toHaveClass('font-medium', 'text-destructive');
+    expect(expirationDate).toHaveClass('text-foreground');
+    expect(expirationDate).not.toHaveClass('text-destructive');
+    expect(expirationDate).not.toHaveClass('font-medium');
+    expect(statusBadge).toHaveAttribute('data-slot', 'badge');
+    expect(statusBadge).toHaveClass('text-[11px]', 'text-destructive');
+    expect(
+      expirationDate.compareDocumentPosition(statusBadge) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
     expect(screen.getByRole('tooltip')).toHaveTextContent('This API key has expired.');
     expect(container.querySelector('svg.lucide-circle-alert')).toBeNull();
   });

--- a/apps/web/src/features/api-keys/components/ApiKeysTable/ApiKeysTable.test.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/ApiKeysTable.test.tsx
@@ -34,6 +34,7 @@ function pastIso(days: number) {
 
 describe('ApiKeysTable', () => {
   beforeEach(() => {
+    localStorage.clear();
     Object.defineProperty(navigator, 'clipboard', {
       value: {
         writeText: vi.fn().mockResolvedValue(undefined),
@@ -143,5 +144,66 @@ describe('ApiKeysTable', () => {
     expect(expirationDate).toHaveClass('font-medium', 'text-destructive');
     expect(screen.getByRole('tooltip')).toHaveTextContent('This API key has expired.');
     expect(container.querySelector('svg.lucide-circle-alert')).toBeNull();
+  });
+
+  it('sorts keys that never expire as the furthest expiration date', () => {
+    const keys: ProjectMemberApiKey[] = [
+      { ...key, apiKeyId: 'pmk_never_1', name: 'Never 1', expiresAt: null },
+      {
+        ...key,
+        apiKeyId: 'pmk_future_later',
+        name: 'Future later',
+        expiresAt: '2026-08-06T23:59:59.999Z',
+      },
+      {
+        ...key,
+        apiKeyId: 'pmk_expired',
+        name: 'Expired',
+        expiresAt: '2026-05-29T23:59:59.999Z',
+      },
+      {
+        ...key,
+        apiKeyId: 'pmk_future_soon',
+        name: 'Future soon',
+        expiresAt: '2026-06-18T23:59:59.999Z',
+      },
+      { ...key, apiKeyId: 'pmk_never_2', name: 'Never 2', expiresAt: null },
+    ];
+
+    render(
+      <ApiKeysTable
+        keys={keys}
+        onCreateKey={vi.fn()}
+        onOpenDetails={vi.fn()}
+        onEditName={vi.fn()}
+        onRevoke={vi.fn()}
+      />
+    );
+
+    const getRenderedNames = () =>
+      screen
+        .getAllByRole('row')
+        .slice(1)
+        .map(row => within(row).getAllByRole('cell')[0].textContent);
+
+    fireEvent.click(screen.getByRole('button', { name: /Expires - not sorted/i }));
+
+    expect(getRenderedNames()).toEqual([
+      'Expired',
+      'Future soon',
+      'Future later',
+      'Never 1',
+      'Never 2',
+    ]);
+
+    fireEvent.click(screen.getByRole('button', { name: /Expires - sorted ascending/i }));
+
+    expect(getRenderedNames()).toEqual([
+      'Never 1',
+      'Never 2',
+      'Future later',
+      'Future soon',
+      'Expired',
+    ]);
   });
 });

--- a/apps/web/src/features/api-keys/components/ApiKeysTable/ApiKeysTable.test.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/ApiKeysTable.test.tsx
@@ -28,6 +28,10 @@ function futureIso(days: number) {
   return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
 }
 
+function pastIso(days: number) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
 describe('ApiKeysTable', () => {
   beforeEach(() => {
     Object.defineProperty(navigator, 'clipboard', {
@@ -119,5 +123,25 @@ describe('ApiKeysTable', () => {
 
     expect(expirationDate).toHaveClass('font-medium', 'text-amber-600');
     expect(screen.getByRole('tooltip')).toHaveTextContent('This API key expires within 30 days.');
+  });
+
+  it('makes expired API keys visually obvious', () => {
+    const expiresAt = pastIso(2);
+
+    const { container } = render(
+      <ApiKeysTable
+        keys={[{ ...key, expiresAt }]}
+        onCreateKey={vi.fn()}
+        onOpenDetails={vi.fn()}
+        onEditName={vi.fn()}
+        onRevoke={vi.fn()}
+      />
+    );
+
+    const expirationDate = screen.getByText(formatDateOnly(expiresAt, { timeZone: 'UTC' }));
+
+    expect(expirationDate).toHaveClass('font-medium', 'text-destructive');
+    expect(screen.getByRole('tooltip')).toHaveTextContent('This API key has expired.');
+    expect(container.querySelector('svg.lucide-circle-alert')).toBeNull();
   });
 });

--- a/apps/web/src/features/api-keys/components/ApiKeysTable/ApiKeysTable.test.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/ApiKeysTable.test.tsx
@@ -167,25 +167,29 @@ describe('ApiKeysTable', () => {
   });
 
   it('sorts keys that never expire as the furthest expiration date', () => {
+    const expiredAt = pastIso(10);
+    const futureSoonAt = futureIso(20);
+    const futureLaterAt = futureIso(60);
+
     const keys: ProjectMemberApiKey[] = [
       { ...key, apiKeyId: 'pmk_never_1', name: 'Never 1', expiresAt: null },
       {
         ...key,
         apiKeyId: 'pmk_future_later',
         name: 'Future later',
-        expiresAt: '2026-08-06T23:59:59.999Z',
+        expiresAt: futureLaterAt,
       },
       {
         ...key,
         apiKeyId: 'pmk_expired',
         name: 'Expired',
-        expiresAt: '2026-05-29T23:59:59.999Z',
+        expiresAt: expiredAt,
       },
       {
         ...key,
         apiKeyId: 'pmk_future_soon',
         name: 'Future soon',
-        expiresAt: '2026-06-18T23:59:59.999Z',
+        expiresAt: futureSoonAt,
       },
       { ...key, apiKeyId: 'pmk_never_2', name: 'Never 2', expiresAt: null },
     ];

--- a/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
@@ -14,8 +14,11 @@ import { SortableHeader, ToggleColumnsHeader } from '../../../../shared/componen
 import type { ProjectMemberApiKey } from '../../types';
 import toast from 'react-hot-toast';
 import {
+  API_KEY_EXPIRED_CLASS_NAME,
+  API_KEY_EXPIRED_NOTICE,
   API_KEY_EXPIRING_SOON_CLASS_NAME,
   API_KEY_EXPIRING_SOON_NOTICE,
+  isApiKeyExpired,
   isApiKeyExpiringSoon,
 } from '../../utils';
 
@@ -68,6 +71,19 @@ export const getApiKeysColumns = ({
       const { expiresAt } = row.original;
       if (!expiresAt) return <span className='text-muted-foreground'>Never</span>;
       const dateLabel = formatDateOnly(expiresAt, { timeZone: 'UTC' });
+      if (isApiKeyExpired(expiresAt)) {
+        return (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className={API_KEY_EXPIRED_CLASS_NAME}>{dateLabel}</span>
+            </TooltipTrigger>
+            <TooltipContent side='top' align='start'>
+              {API_KEY_EXPIRED_NOTICE}
+            </TooltipContent>
+          </Tooltip>
+        );
+      }
+
       if (!isApiKeyExpiringSoon(expiresAt)) return <span>{dateLabel}</span>;
 
       return (

--- a/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
@@ -63,9 +63,12 @@ export const getApiKeysColumns = ({
     ),
   },
   {
-    accessorKey: 'expiresAt',
+    id: 'expiresAt',
+    accessorFn: row =>
+      row.expiresAt ? new Date(row.expiresAt).getTime() : Number.POSITIVE_INFINITY,
     size: 140,
     meta: { title: 'Expires' },
+    sortingFn: 'basic',
     header: ({ column }) => <SortableHeader column={column}>Expires</SortableHeader>,
     cell: ({ row }) => {
       const { expiresAt } = row.original;

--- a/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
@@ -6,21 +6,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@owox/ui/components/dropdown-menu';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { Copy, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import RelativeTime from '@owox/ui/components/common/relative-time';
-import { formatDateOnly } from '../../../../utils';
 import { SortableHeader, ToggleColumnsHeader } from '../../../../shared/components/Table';
 import type { ProjectMemberApiKey } from '../../types';
 import toast from 'react-hot-toast';
-import {
-  API_KEY_EXPIRED_CLASS_NAME,
-  API_KEY_EXPIRED_NOTICE,
-  API_KEY_EXPIRING_SOON_CLASS_NAME,
-  API_KEY_EXPIRING_SOON_NOTICE,
-  isApiKeyExpired,
-  isApiKeyExpiringSoon,
-} from '../../utils';
+import { ApiKeyExpirationValue } from '../ApiKeyExpirationValue';
 
 interface ApiKeysColumnsProps {
   onEditName: (key: ProjectMemberApiKey) => void;
@@ -33,14 +24,14 @@ export const getApiKeysColumns = ({
 }: ApiKeysColumnsProps): ColumnDef<ProjectMemberApiKey>[] => [
   {
     accessorKey: 'name',
-    size: 200,
+    size: 190,
     meta: { title: 'Name' },
     header: ({ column }) => <SortableHeader column={column}>Name</SortableHeader>,
     cell: ({ row }) => <span className='font-medium'>{row.original.name}</span>,
   },
   {
     accessorKey: 'apiKeyId',
-    size: 260,
+    size: 240,
     meta: { title: 'API Key ID' },
     header: ({ column }) => <SortableHeader column={column}>API Key ID</SortableHeader>,
     cell: ({ row }) => (
@@ -66,40 +57,11 @@ export const getApiKeysColumns = ({
     id: 'expiresAt',
     accessorFn: row =>
       row.expiresAt ? new Date(row.expiresAt).getTime() : Number.POSITIVE_INFINITY,
-    size: 140,
+    size: 200,
     meta: { title: 'Expires' },
     sortingFn: 'basic',
     header: ({ column }) => <SortableHeader column={column}>Expires</SortableHeader>,
-    cell: ({ row }) => {
-      const { expiresAt } = row.original;
-      if (!expiresAt) return <span className='text-muted-foreground'>Never</span>;
-      const dateLabel = formatDateOnly(expiresAt, { timeZone: 'UTC' });
-      if (isApiKeyExpired(expiresAt)) {
-        return (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className={API_KEY_EXPIRED_CLASS_NAME}>{dateLabel}</span>
-            </TooltipTrigger>
-            <TooltipContent side='top' align='start'>
-              {API_KEY_EXPIRED_NOTICE}
-            </TooltipContent>
-          </Tooltip>
-        );
-      }
-
-      if (!isApiKeyExpiringSoon(expiresAt)) return <span>{dateLabel}</span>;
-
-      return (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className={API_KEY_EXPIRING_SOON_CLASS_NAME}>{dateLabel}</span>
-          </TooltipTrigger>
-          <TooltipContent side='top' align='start'>
-            {API_KEY_EXPIRING_SOON_NOTICE}
-          </TooltipContent>
-        </Tooltip>
-      );
-    },
+    cell: ({ row }) => <ApiKeyExpirationValue expiresAt={row.original.expiresAt} />,
   },
   {
     accessorKey: 'createdAt',

--- a/apps/web/src/features/api-keys/components/EditApiKeySheet.test.tsx
+++ b/apps/web/src/features/api-keys/components/EditApiKeySheet.test.tsx
@@ -32,6 +32,10 @@ function futureIso(days: number) {
   return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
 }
 
+function pastIso(days: number) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
 function renderEditApiKeySheet(props?: Partial<ComponentProps<typeof EditApiKeySheet>>) {
   return render(
     <EditApiKeySheet
@@ -90,6 +94,17 @@ describe('EditApiKeySheet', () => {
 
     expect(expirationDate).toHaveClass('font-medium', 'text-amber-600');
     expect(screen.getByText('This API key expires within 30 days.')).toBeInTheDocument();
+  });
+
+  it('makes expired API keys visually obvious', () => {
+    const expiresAt = pastIso(2);
+
+    renderEditApiKeySheet({ apiKey: { ...apiKey, expiresAt } });
+
+    const expirationDate = screen.getByText(formatDateOnly(expiresAt, { timeZone: 'UTC' }));
+
+    expect(expirationDate).toHaveClass('font-medium', 'text-destructive');
+    expect(screen.getByText('This API key has expired.')).toBeInTheDocument();
   });
 
   it('does not expose the full API Key after the creation dialog is closed', () => {

--- a/apps/web/src/features/api-keys/components/EditApiKeySheet.test.tsx
+++ b/apps/web/src/features/api-keys/components/EditApiKeySheet.test.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, ReactNode } from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { EditApiKeySheet } from './EditApiKeySheet';
 import type { ProjectMemberApiKey } from '../types';
 import { formatDateOnly } from '../../../utils';
@@ -78,9 +78,10 @@ describe('EditApiKeySheet', () => {
     expect(generalSection?.textContent).toContain('Created');
     expect(generalSection?.textContent).toContain('Expires');
     expect(generalSection?.textContent).toContain('Last authenticated');
-    expect(
-      screen.getByText(formatDateOnly(apiKey.expiresAt, { timeZone: 'UTC' }))
-    ).toBeInTheDocument();
+    expect(generalSection?.textContent).toContain(
+      formatDateOnly(apiKey.expiresAt, { timeZone: 'UTC' })
+    );
+    expect(generalSection?.textContent).toContain('Expired');
     expect(screen.queryByText(/02:59/)).not.toBeInTheDocument();
     expect(screen.getAllByText('Never')).toHaveLength(1);
   });
@@ -91,8 +92,18 @@ describe('EditApiKeySheet', () => {
     renderEditApiKeySheet({ apiKey: { ...apiKey, expiresAt } });
 
     const expirationDate = screen.getByText(formatDateOnly(expiresAt, { timeZone: 'UTC' }));
+    const expiresField = expirationDate.closest('[data-slot="form-item"]');
+    expect(expiresField).not.toBeNull();
+    const statusBadge = within(expiresField as HTMLElement).getByText('Expires soon');
 
-    expect(expirationDate).toHaveClass('font-medium', 'text-amber-600');
+    expect(expirationDate).toHaveClass('text-foreground');
+    expect(expirationDate).not.toHaveClass('text-amber-600');
+    expect(expirationDate).not.toHaveClass('font-medium');
+    expect(statusBadge).toHaveAttribute('data-slot', 'badge');
+    expect(statusBadge).toHaveClass('text-[11px]', 'text-amber-700');
+    expect(
+      expirationDate.compareDocumentPosition(statusBadge) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
     expect(screen.getByText('This API key expires within 30 days.')).toBeInTheDocument();
   });
 
@@ -102,8 +113,18 @@ describe('EditApiKeySheet', () => {
     renderEditApiKeySheet({ apiKey: { ...apiKey, expiresAt } });
 
     const expirationDate = screen.getByText(formatDateOnly(expiresAt, { timeZone: 'UTC' }));
+    const expiresField = expirationDate.closest('[data-slot="form-item"]');
+    expect(expiresField).not.toBeNull();
+    const statusBadge = within(expiresField as HTMLElement).getByText('Expired');
 
-    expect(expirationDate).toHaveClass('font-medium', 'text-destructive');
+    expect(expirationDate).toHaveClass('text-foreground');
+    expect(expirationDate).not.toHaveClass('text-destructive');
+    expect(expirationDate).not.toHaveClass('font-medium');
+    expect(statusBadge).toHaveAttribute('data-slot', 'badge');
+    expect(statusBadge).toHaveClass('text-[11px]', 'text-destructive');
+    expect(
+      expirationDate.compareDocumentPosition(statusBadge) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
     expect(screen.getByText('This API key has expired.')).toBeInTheDocument();
   });
 

--- a/apps/web/src/features/api-keys/components/EditApiKeySheet.tsx
+++ b/apps/web/src/features/api-keys/components/EditApiKeySheet.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type ReactNode } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -27,17 +27,10 @@ import { cn } from '@owox/ui/lib/utils';
 import { Copy, Loader2, Trash2 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { apiKeysService } from '../services/api-keys.service';
-import { formatDateOnly, formatDateShort } from '../../../utils';
+import { formatDateShort } from '../../../utils';
 import type { ProjectMemberApiKey } from '../types';
 import { ApiKeyDocumentationSection, ApiKeyFormLabel } from './ApiKeyFormShared';
-import {
-  API_KEY_EXPIRED_CLASS_NAME,
-  API_KEY_EXPIRED_NOTICE,
-  API_KEY_EXPIRING_SOON_CLASS_NAME,
-  API_KEY_EXPIRING_SOON_NOTICE,
-  isApiKeyExpired,
-  isApiKeyExpiringSoon,
-} from '../utils';
+import { ApiKeyExpirationValue } from './ApiKeyExpirationValue';
 
 const editApiKeySchema = z.object({
   name: z.string().min(1, 'Name is required').max(100, 'Name must be 100 characters or less'),
@@ -63,19 +56,22 @@ function MetadataItem({
   valueTooltip,
 }: {
   label: string;
-  value: string;
+  value: ReactNode;
   description: string;
   valueClassName?: string;
   valueTooltip?: string;
 }) {
-  const valueNode = (
-    <span
-      tabIndex={valueTooltip ? 0 : undefined}
-      className={cn('text-sm', valueClassName ?? 'text-muted-foreground')}
-    >
-      {value}
-    </span>
-  );
+  const valueNode =
+    typeof value === 'string' ? (
+      <span
+        tabIndex={valueTooltip ? 0 : undefined}
+        className={cn('text-sm', valueClassName ?? 'text-muted-foreground')}
+      >
+        {value}
+      </span>
+    ) : (
+      value
+    );
 
   return (
     <FormItem>
@@ -107,21 +103,6 @@ export function EditApiKeySheet({ apiKey, onClose, onUpdated, onRevoke }: EditAp
   const { control, handleSubmit, reset } = form;
 
   const createdAt = apiKey?.createdAt ? formatDateShort(apiKey.createdAt) : 'Unknown';
-  const expiresAt = apiKey?.expiresAt
-    ? formatDateOnly(apiKey.expiresAt, { timeZone: 'UTC' })
-    : 'Never';
-  const expired = isApiKeyExpired(apiKey?.expiresAt);
-  const expiresSoon = isApiKeyExpiringSoon(apiKey?.expiresAt);
-  const expiresValueClassName = expired
-    ? API_KEY_EXPIRED_CLASS_NAME
-    : expiresSoon
-      ? API_KEY_EXPIRING_SOON_CLASS_NAME
-      : undefined;
-  const expiresValueTooltip = expired
-    ? API_KEY_EXPIRED_NOTICE
-    : expiresSoon
-      ? API_KEY_EXPIRING_SOON_NOTICE
-      : undefined;
   const lastAuthenticatedAt = apiKey?.lastAuthenticatedAt
     ? formatDateShort(apiKey.lastAuthenticatedAt)
     : 'Never';
@@ -212,10 +193,8 @@ export function EditApiKeySheet({ apiKey, onClose, onUpdated, onRevoke }: EditAp
                 </FormItem>
                 <MetadataItem
                   label='Expires'
-                  value={expiresAt}
+                  value={<ApiKeyExpirationValue expiresAt={apiKey?.expiresAt} focusable />}
                   description='UTC date when this API key stops working. Never means it does not expire automatically.'
-                  valueClassName={expiresValueClassName}
-                  valueTooltip={expiresValueTooltip}
                 />
                 <MetadataItem
                   label='Created'

--- a/apps/web/src/features/api-keys/components/EditApiKeySheet.tsx
+++ b/apps/web/src/features/api-keys/components/EditApiKeySheet.tsx
@@ -31,8 +31,11 @@ import { formatDateOnly, formatDateShort } from '../../../utils';
 import type { ProjectMemberApiKey } from '../types';
 import { ApiKeyDocumentationSection, ApiKeyFormLabel } from './ApiKeyFormShared';
 import {
+  API_KEY_EXPIRED_CLASS_NAME,
+  API_KEY_EXPIRED_NOTICE,
   API_KEY_EXPIRING_SOON_CLASS_NAME,
   API_KEY_EXPIRING_SOON_NOTICE,
+  isApiKeyExpired,
   isApiKeyExpiringSoon,
 } from '../utils';
 
@@ -107,7 +110,18 @@ export function EditApiKeySheet({ apiKey, onClose, onUpdated, onRevoke }: EditAp
   const expiresAt = apiKey?.expiresAt
     ? formatDateOnly(apiKey.expiresAt, { timeZone: 'UTC' })
     : 'Never';
+  const expired = isApiKeyExpired(apiKey?.expiresAt);
   const expiresSoon = isApiKeyExpiringSoon(apiKey?.expiresAt);
+  const expiresValueClassName = expired
+    ? API_KEY_EXPIRED_CLASS_NAME
+    : expiresSoon
+      ? API_KEY_EXPIRING_SOON_CLASS_NAME
+      : undefined;
+  const expiresValueTooltip = expired
+    ? API_KEY_EXPIRED_NOTICE
+    : expiresSoon
+      ? API_KEY_EXPIRING_SOON_NOTICE
+      : undefined;
   const lastAuthenticatedAt = apiKey?.lastAuthenticatedAt
     ? formatDateShort(apiKey.lastAuthenticatedAt)
     : 'Never';
@@ -200,8 +214,8 @@ export function EditApiKeySheet({ apiKey, onClose, onUpdated, onRevoke }: EditAp
                   label='Expires'
                   value={expiresAt}
                   description='UTC date when this API key stops working. Never means it does not expire automatically.'
-                  valueClassName={expiresSoon ? API_KEY_EXPIRING_SOON_CLASS_NAME : undefined}
-                  valueTooltip={expiresSoon ? API_KEY_EXPIRING_SOON_NOTICE : undefined}
+                  valueClassName={expiresValueClassName}
+                  valueTooltip={expiresValueTooltip}
                 />
                 <MetadataItem
                   label='Created'

--- a/apps/web/src/features/api-keys/utils.ts
+++ b/apps/web/src/features/api-keys/utils.ts
@@ -1,5 +1,16 @@
 export const API_KEY_EXPIRING_SOON_NOTICE = 'This API key expires within 30 days.';
 export const API_KEY_EXPIRING_SOON_CLASS_NAME = 'font-medium text-amber-600';
+export const API_KEY_EXPIRED_NOTICE = 'This API key has expired.';
+export const API_KEY_EXPIRED_CLASS_NAME = 'font-medium text-destructive';
+
+export function isApiKeyExpired(dateStr: string | null | undefined): boolean {
+  if (!dateStr) return false;
+
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return false;
+
+  return date.getTime() <= Date.now();
+}
 
 export function isApiKeyExpiringSoon(dateStr: string | null | undefined): boolean {
   if (!dateStr) return false;

--- a/apps/web/src/features/api-keys/utils.ts
+++ b/apps/web/src/features/api-keys/utils.ts
@@ -1,7 +1,5 @@
 export const API_KEY_EXPIRING_SOON_NOTICE = 'This API key expires within 30 days.';
-export const API_KEY_EXPIRING_SOON_CLASS_NAME = 'font-medium text-amber-600';
 export const API_KEY_EXPIRED_NOTICE = 'This API key has expired.';
-export const API_KEY_EXPIRED_CLASS_NAME = 'font-medium text-destructive';
 
 export function isApiKeyExpired(dateStr: string | null | undefined): boolean {
   if (!dateStr) return false;


### PR DESCRIPTION
## Summary

- Sort API key expiration dates chronologically, with `Never` treated as the furthest expiration date.
- Make expired and soon-to-expire API keys easier to scan in the table.
- Reuse the same expiration representation in the API key details sidebar.
- Show expiration state as a compact badge after the neutral date text.

## Verification

- Ran focused API key table/sidebar tests.
- Ran ESLint on touched files.
- Ran `git diff --check`.
- Ran web build.
- Verified table and sidebar rendering in the browser.