### PR TITLE
Feature suggestion: project-level Data Mart activity pages

### DIFF
--- a/.changeset/project-data-mart-activity-pages.md
+++ b/.changeset/project-data-mart-activity-pages.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Project-wide Data Mart activity pages
+
+Added project-wide pages for Data Mart triggers, reports, insights, and run history.
+The lists reuse Data Mart table controls, support project-level search and filters,
+and preserve row-level permissions for actions.

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.ts
@@ -339,7 +339,7 @@ export class DataMartController {
   async getRunHistory(
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string,
-    @Query('limit') limit: number = 20,
+    @Query('limit') limit: number = 100,
     @Query('offset') offset: number = 0
   ): Promise<DataMartRunsResponseApiDto> {
     const command = this.mapper.toGetDataMartRunsCommand(id, context, limit, offset);

--- a/apps/backend/src/data-marts/controllers/project-data-mart-runs.controller.ts
+++ b/apps/backend/src/data-marts/controllers/project-data-mart-runs.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Auth, AuthContext, AuthorizationContext, Role, Strategy } from '../../idp';
+import { ListProjectDataMartRunsCommand } from '../dto/domain/list-project-data-mart-runs.command';
+import { ProjectDataMartRunsResponseApiDto } from '../dto/presentation/project-data-mart-runs-response-api.dto';
+import { DataMartMapper } from '../mappers/data-mart.mapper';
+import { ListProjectDataMartRunsService } from '../use-cases/list-project-data-mart-runs.service';
+import { normalizeProjectListPagination } from '../utils/normalize-project-list-pagination';
+import { GetProjectDataMartRunsSpec } from './spec/project-data-mart-runs.api';
+
+@Controller('data-marts/runs')
+@ApiTags('Run History')
+export class ProjectDataMartRunsController {
+  constructor(
+    private readonly listProjectDataMartRunsService: ListProjectDataMartRunsService,
+    private readonly mapper: DataMartMapper
+  ) {}
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get()
+  @GetProjectDataMartRunsSpec()
+  async list(
+    @AuthContext() context: AuthorizationContext,
+    @Query('limit') limit?: string | number,
+    @Query('offset') offset?: string | number
+  ): Promise<ProjectDataMartRunsResponseApiDto> {
+    const pagination = normalizeProjectListPagination(limit, offset);
+    const command = new ListProjectDataMartRunsCommand(
+      context.projectId,
+      pagination.limit,
+      pagination.offset,
+      context.userId,
+      context.roles ?? []
+    );
+    const runs = await this.listProjectDataMartRunsService.run(command);
+    return this.mapper.toProjectRunsResponse(runs);
+  }
+}

--- a/apps/backend/src/data-marts/controllers/project-insight-templates.controller.ts
+++ b/apps/backend/src/data-marts/controllers/project-insight-templates.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Auth, AuthContext, AuthorizationContext, Role, Strategy } from '../../idp';
+import { ListProjectInsightTemplatesCommand } from '../dto/domain/list-project-insight-templates.command';
+import { ProjectInsightTemplatesResponseApiDto } from '../dto/presentation/project-insight-templates-response-api.dto';
+import { InsightTemplateMapper } from '../mappers/insight-template.mapper';
+import { ListProjectInsightTemplatesService } from '../use-cases/list-project-insight-templates.service';
+import { normalizeProjectListPagination } from '../utils/normalize-project-list-pagination';
+import { ListProjectInsightTemplatesSpec } from './spec/project-insight-templates.api';
+
+@Controller('data-marts/insight-templates')
+@ApiTags('Insights')
+export class ProjectInsightTemplatesController {
+  constructor(
+    private readonly listProjectInsightTemplatesService: ListProjectInsightTemplatesService,
+    private readonly mapper: InsightTemplateMapper
+  ) {}
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get()
+  @ListProjectInsightTemplatesSpec()
+  async list(
+    @AuthContext() context: AuthorizationContext,
+    @Query('limit') limit?: string | number,
+    @Query('offset') offset?: string | number
+  ): Promise<ProjectInsightTemplatesResponseApiDto> {
+    const pagination = normalizeProjectListPagination(limit, offset);
+    const command = new ListProjectInsightTemplatesCommand(
+      context.projectId,
+      pagination.limit,
+      pagination.offset,
+      context.userId,
+      context.roles ?? []
+    );
+    const insightTemplates = await this.listProjectInsightTemplatesService.run(command);
+    return this.mapper.toProjectResponseList(insightTemplates);
+  }
+}

--- a/apps/backend/src/data-marts/controllers/project-reports.controller.ts
+++ b/apps/backend/src/data-marts/controllers/project-reports.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, ParseEnumPipe, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Auth, AuthContext, AuthorizationContext, Role, Strategy } from '../../idp';
+import { ReportResponseApiDto } from '../dto/presentation/report-response-api.dto';
+import { OwnerFilter } from '../enums/owner-filter.enum';
+import { ReportMapper } from '../mappers/report.mapper';
+import { ListReportsByProjectService } from '../use-cases/list-reports-by-project.service';
+import { normalizeProjectListPagination } from '../utils/normalize-project-list-pagination';
+import { ListReportsByProjectSpec } from './spec/project-reports.api';
+
+@Controller('reports')
+@ApiTags('Reports')
+export class ProjectReportsController {
+  constructor(
+    private readonly listReportsByProjectService: ListReportsByProjectService,
+    private readonly mapper: ReportMapper
+  ) {}
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get()
+  @ListReportsByProjectSpec()
+  async list(
+    @AuthContext() context: AuthorizationContext,
+    @Query('limit') limit?: string | number,
+    @Query('offset') offset?: string | number,
+    @Query('ownerFilter', new ParseEnumPipe(OwnerFilter, { optional: true }))
+    ownerFilter?: OwnerFilter
+  ): Promise<ReportResponseApiDto[]> {
+    const pagination =
+      limit === undefined && offset === undefined
+        ? null
+        : normalizeProjectListPagination(limit, offset);
+    const command = this.mapper.toListByProjectCommand(
+      context,
+      ownerFilter,
+      pagination?.limit,
+      pagination?.offset
+    );
+    const reports = await this.listReportsByProjectService.run(command);
+    return this.mapper.toResponseList(reports);
+  }
+}

--- a/apps/backend/src/data-marts/controllers/project-scheduled-triggers.controller.ts
+++ b/apps/backend/src/data-marts/controllers/project-scheduled-triggers.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Auth, AuthContext, AuthorizationContext, Role, Strategy } from '../../idp';
+import { ListProjectScheduledTriggersCommand } from '../dto/domain/list-project-scheduled-triggers.command';
+import { ProjectScheduledTriggersResponseApiDto } from '../dto/presentation/project-scheduled-triggers-response-api.dto';
+import { ScheduledTriggerMapper } from '../mappers/scheduled-trigger.mapper';
+import { ListProjectScheduledTriggersService } from '../use-cases/list-project-scheduled-triggers.service';
+import { normalizeProjectListPagination } from '../utils/normalize-project-list-pagination';
+import { ListProjectScheduledTriggersSpec } from './spec/project-scheduled-triggers.api';
+
+@Controller('data-marts/scheduled-triggers')
+@ApiTags('ScheduledTriggers')
+export class ProjectScheduledTriggersController {
+  constructor(
+    private readonly listProjectScheduledTriggersService: ListProjectScheduledTriggersService,
+    private readonly mapper: ScheduledTriggerMapper
+  ) {}
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get()
+  @ListProjectScheduledTriggersSpec()
+  async list(
+    @AuthContext() context: AuthorizationContext,
+    @Query('limit') limit?: string | number,
+    @Query('offset') offset?: string | number
+  ): Promise<ProjectScheduledTriggersResponseApiDto> {
+    const pagination = normalizeProjectListPagination(limit, offset);
+    const command = new ListProjectScheduledTriggersCommand(
+      context.projectId,
+      pagination.limit,
+      pagination.offset,
+      context.userId,
+      context.roles ?? []
+    );
+    const triggers = await this.listProjectScheduledTriggersService.run(command);
+    return this.mapper.toProjectResponseList(triggers);
+  }
+}

--- a/apps/backend/src/data-marts/controllers/report.controller.ts
+++ b/apps/backend/src/data-marts/controllers/report.controller.ts
@@ -1,14 +1,4 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Put,
-  Body,
-  Param,
-  Delete,
-  ParseEnumPipe,
-  Query,
-} from '@nestjs/common';
+import { Controller, Get, Post, Put, Body, Param, Delete } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { AuthContext, AuthorizationContext, Auth } from '../../idp';
 import { Role, Strategy } from '../../idp/types/role-config.types';
@@ -19,7 +9,6 @@ import { ReportResponseApiDto } from '../dto/presentation/report-response-api.dt
 import { CreateReportService } from '../use-cases/create-report.service';
 import { GetReportService } from '../use-cases/get-report.service';
 import { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
-import { ListReportsByProjectService } from '../use-cases/list-reports-by-project.service';
 import { ListReportsByInsightTemplateService } from '../use-cases/list-reports-by-insight-template.service';
 import { DeleteReportService } from '../use-cases/delete-report.service';
 import { RunReportService } from '../use-cases/run-report.service';
@@ -30,7 +19,6 @@ import {
   CreateReportSpec,
   GetReportSpec,
   ListReportsByDataMartSpec,
-  ListReportsByProjectSpec,
   DeleteReportSpec,
   RunReportSpec,
   UpdateReportSpec,
@@ -38,7 +26,6 @@ import {
   GetReportGeneratedSqlSpec,
   CopyReportAsDataMartSpec,
 } from './spec/report.api';
-import { OwnerFilter } from '../enums/owner-filter.enum';
 
 @Controller('reports')
 @ApiTags('Reports')
@@ -47,7 +34,6 @@ export class ReportController {
     private readonly createReportService: CreateReportService,
     private readonly getReportService: GetReportService,
     private readonly listReportsByDataMartService: ListReportsByDataMartService,
-    private readonly listReportsByProjectService: ListReportsByProjectService,
     private readonly listReportsByInsightTemplateService: ListReportsByInsightTemplateService,
     private readonly deleteReportService: DeleteReportService,
     private readonly runReportService: RunReportService,
@@ -107,19 +93,6 @@ export class ReportController {
       context
     );
     const reports = await this.listReportsByInsightTemplateService.run(command);
-    return this.mapper.toResponseList(reports);
-  }
-
-  @Auth(Role.viewer(Strategy.PARSE))
-  @Get()
-  @ListReportsByProjectSpec()
-  async listByProject(
-    @AuthContext() context: AuthorizationContext,
-    @Query('ownerFilter', new ParseEnumPipe(OwnerFilter, { optional: true }))
-    ownerFilter?: OwnerFilter
-  ): Promise<ReportResponseApiDto[]> {
-    const command = this.mapper.toListByProjectCommand(context, ownerFilter);
-    const reports = await this.listReportsByProjectService.run(command);
     return this.mapper.toResponseList(reports);
   }
 

--- a/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
@@ -193,8 +193,8 @@ export function GetDataMartRunsSpec() {
       name: 'limit',
       required: false,
       type: Number,
-      example: 20,
-      description: 'Maximum number of runs to return',
+      example: 100,
+      description: 'Maximum number of runs to return. Defaults to 100.',
     }),
     ApiQuery({
       name: 'offset',

--- a/apps/backend/src/data-marts/controllers/spec/project-data-mart-runs.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/project-data-mart-runs.api.ts
@@ -1,0 +1,24 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ProjectDataMartRunsResponseApiDto } from '../../dto/presentation/project-data-mart-runs-response-api.dto';
+
+export function GetProjectDataMartRunsSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get project DataMart run history' }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      example: 100,
+      description: 'Maximum number of runs to return. Defaults to 100; max 100.',
+    }),
+    ApiQuery({
+      name: 'offset',
+      required: false,
+      type: Number,
+      example: 0,
+      description: 'Number of runs to skip before returning results',
+    }),
+    ApiOkResponse({ type: ProjectDataMartRunsResponseApiDto })
+  );
+}

--- a/apps/backend/src/data-marts/controllers/spec/project-insight-templates.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/project-insight-templates.api.ts
@@ -1,0 +1,25 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ProjectInsightTemplatesResponseApiDto } from '../../dto/presentation/project-insight-templates-response-api.dto';
+
+export function ListProjectInsightTemplatesSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'List insight templates across accessible Data Marts in the project' }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      description: 'Maximum number of insight templates to return. Defaults to 100; max 100.',
+    }),
+    ApiQuery({
+      name: 'offset',
+      required: false,
+      type: Number,
+      description: 'Number of insight templates to skip. Defaults to 0.',
+    }),
+    ApiOkResponse({
+      description: 'Project insight templates visible to the current user',
+      type: ProjectInsightTemplatesResponseApiDto,
+    })
+  );
+}

--- a/apps/backend/src/data-marts/controllers/spec/project-reports.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/project-reports.api.ts
@@ -1,0 +1,34 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ReportResponseApiDto } from '../../dto/presentation/report-response-api.dto';
+import { OwnerFilter } from '../../enums/owner-filter.enum';
+
+export function ListReportsByProjectSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: 'Get all reports for a project' }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      description:
+        'Maximum number of reports to return. When omitted, the legacy unpaginated response is returned.',
+    }),
+    ApiQuery({
+      name: 'offset',
+      required: false,
+      type: Number,
+      description: 'Number of reports to skip when limit or offset pagination is used.',
+    }),
+    ApiQuery({
+      name: 'ownerFilter',
+      required: false,
+      enum: OwnerFilter,
+      example: OwnerFilter.HAS_OWNERS,
+      description: 'Filter reports by whether they have owners',
+    }),
+    ApiOkResponse({
+      description: 'List of reports for the project',
+      type: [ReportResponseApiDto],
+    })
+  );
+}

--- a/apps/backend/src/data-marts/controllers/spec/project-scheduled-triggers.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/project-scheduled-triggers.api.ts
@@ -1,0 +1,27 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ProjectScheduledTriggersResponseApiDto } from '../../dto/presentation/project-scheduled-triggers-response-api.dto';
+
+export function ListProjectScheduledTriggersSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'List scheduled triggers across accessible Data Marts in the project',
+    }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      description: 'Maximum number of triggers to return. Defaults to 100; max 100.',
+    }),
+    ApiQuery({
+      name: 'offset',
+      required: false,
+      type: Number,
+      description: 'Number of triggers to skip. Defaults to 0.',
+    }),
+    ApiOkResponse({
+      description: 'Project scheduled triggers visible to the current user',
+      type: ProjectScheduledTriggersResponseApiDto,
+    })
+  );
+}

--- a/apps/backend/src/data-marts/controllers/spec/report.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.api.ts
@@ -6,10 +6,8 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
-  ApiQuery,
 } from '@nestjs/swagger';
 import { ReportResponseApiDto } from '../../dto/presentation/report-response-api.dto';
-import { OwnerFilter } from '../../enums/owner-filter.enum';
 import {
   createReportRequestBodySchema,
   REPORT_OPENAPI_MODELS,
@@ -34,23 +32,6 @@ export function ListReportsByDataMartSpec() {
     ApiParam({ name: 'dataMartId', description: 'Data mart ID' }),
     ApiOkResponse({
       description: 'List of reports for the data mart',
-      type: [ReportResponseApiDto],
-    })
-  );
-}
-
-export function ListReportsByProjectSpec() {
-  return applyDecorators(
-    ApiOperation({ summary: 'Get all reports for a project' }),
-    ApiQuery({
-      name: 'ownerFilter',
-      required: false,
-      enum: OwnerFilter,
-      example: OwnerFilter.HAS_OWNERS,
-      description: 'Filter reports by whether they have owners',
-    }),
-    ApiOkResponse({
-      description: 'List of reports for the project',
       type: [ReportResponseApiDto],
     })
   );

--- a/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
@@ -6,9 +6,16 @@ jest.mock('../../../idp', () => ({
   __esModule: true,
   Auth: () => () => undefined,
   AuthContext: () => () => undefined,
+  Role: {
+    viewer: jest.fn(),
+  },
+  Strategy: {
+    PARSE: 'parse',
+  },
 }));
 
 import { ReportController } from '../report.controller';
+import { ProjectReportsController } from '../project-reports.controller';
 import { CopyReportAsDataMartService } from '../../use-cases/copy-report-as-data-mart.service';
 import { CreateReportService } from '../../use-cases/create-report.service';
 import { DeleteReportService } from '../../use-cases/delete-report.service';
@@ -41,7 +48,7 @@ describe('ReportController OpenAPI', () => {
     ].map(provide => ({ provide, useValue: {} }));
 
     const moduleRef = await Test.createTestingModule({
-      controllers: [ReportController],
+      controllers: [ProjectReportsController, ReportController],
       providers,
     }).compile();
 

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -16,6 +16,10 @@ import { HttpDataRequestValidator } from './services/http-data/http-data-request
 import { HttpDataColumnResolver } from './services/http-data/http-data-column-resolver.service';
 import { HttpDataColumnValidator } from './services/http-data/http-data-column-validator.service';
 import { MarkdownParserController } from './controllers/markdown-parser.controller';
+import { ProjectDataMartRunsController } from './controllers/project-data-mart-runs.controller';
+import { ProjectInsightTemplatesController } from './controllers/project-insight-templates.controller';
+import { ProjectReportsController } from './controllers/project-reports.controller';
+import { ProjectScheduledTriggersController } from './controllers/project-scheduled-triggers.controller';
 import { ReportController } from './controllers/report.controller';
 import { InsightController } from './controllers/insight.controller';
 import { AiAssistantController } from './controllers/ai-assistant.controller';
@@ -39,6 +43,9 @@ import { MoveLegacyDataStorageService } from './use-cases/legacy-data-marts/move
 import { SyncLegacyGcpStoragesForProjectService } from './use-cases/legacy-data-marts/sync-legacy-gcp-storages-for-project.service';
 import { ListDataMartsService } from './use-cases/list-data-marts.service';
 import { ListDataMartsByConnectorNameService } from './use-cases/list-data-marts-by-connector-name.service';
+import { ListProjectDataMartRunsService } from './use-cases/list-project-data-mart-runs.service';
+import { ListProjectInsightTemplatesService } from './use-cases/list-project-insight-templates.service';
+import { ListProjectScheduledTriggersService } from './use-cases/list-project-scheduled-triggers.service';
 import { GetDataMartService } from './use-cases/get-data-mart.service';
 import { DataMartMapper } from './mappers/data-mart.mapper';
 import { ScheduledTriggerMapper } from './mappers/scheduled-trigger.mapper';
@@ -432,6 +439,10 @@ import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-m
     IdpModule,
   ],
   controllers: [
+    ProjectDataMartRunsController,
+    ProjectScheduledTriggersController,
+    ProjectInsightTemplatesController,
+    ProjectReportsController,
     DataMartController,
     DataStorageController,
     DataDestinationController,
@@ -476,6 +487,9 @@ import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-m
     ListDataMartsByConnectorNameService,
     GetDataMartService,
     ListDataMartRunsService,
+    ListProjectDataMartRunsService,
+    ListProjectInsightTemplatesService,
+    ListProjectScheduledTriggersService,
     UpdateDataMartDefinitionService,
     PublishDataMartService,
     UpdateBlendedFieldsConfigService,

--- a/apps/backend/src/data-marts/dto/domain/list-project-data-mart-runs.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/list-project-data-mart-runs.command.ts
@@ -1,0 +1,9 @@
+export class ListProjectDataMartRunsCommand {
+  constructor(
+    public readonly projectId: string,
+    public readonly limit: number,
+    public readonly offset: number,
+    public readonly userId: string,
+    public readonly roles: string[] = []
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/list-project-insight-templates.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/list-project-insight-templates.command.ts
@@ -1,0 +1,9 @@
+export class ListProjectInsightTemplatesCommand {
+  constructor(
+    public readonly projectId: string,
+    public readonly limit: number,
+    public readonly offset: number,
+    public readonly userId: string,
+    public readonly roles: string[] = []
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/list-project-scheduled-triggers.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/list-project-scheduled-triggers.command.ts
@@ -1,0 +1,9 @@
+export class ListProjectScheduledTriggersCommand {
+  constructor(
+    public readonly projectId: string,
+    public readonly limit: number,
+    public readonly offset: number,
+    public readonly userId: string,
+    public readonly roles: string[] = []
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/list-reports-by-project.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/list-reports-by-project.command.ts
@@ -5,6 +5,8 @@ export class ListReportsByProjectCommand {
     public readonly projectId: string,
     public readonly userId: string,
     public readonly roles: string[],
-    public readonly ownerFilter?: OwnerFilter
+    public readonly ownerFilter?: OwnerFilter,
+    public readonly limit?: number,
+    public readonly offset?: number
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/project-data-mart-run.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/project-data-mart-run.dto.ts
@@ -1,0 +1,13 @@
+import { DataMartRunDto } from './data-mart-run.dto';
+
+export interface ProjectDataMartRunRefDto {
+  readonly id: string;
+  readonly title: string;
+}
+
+export class ProjectDataMartRunDto {
+  constructor(
+    public readonly run: DataMartRunDto,
+    public readonly dataMart: ProjectDataMartRunRefDto
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/project-insight-template.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/project-insight-template.dto.ts
@@ -1,0 +1,13 @@
+import { InsightTemplateDto } from './insight-template.dto';
+
+export interface ProjectInsightTemplateDataMartRefDto {
+  readonly id: string;
+  readonly title: string;
+}
+
+export class ProjectInsightTemplateDto {
+  constructor(
+    public readonly insightTemplate: InsightTemplateDto,
+    public readonly dataMart: ProjectInsightTemplateDataMartRefDto
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/project-insight-template.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/project-insight-template.dto.ts
@@ -8,6 +8,7 @@ export interface ProjectInsightTemplateDataMartRefDto {
 export class ProjectInsightTemplateDto {
   constructor(
     public readonly insightTemplate: InsightTemplateDto,
-    public readonly dataMart: ProjectInsightTemplateDataMartRefDto
+    public readonly dataMart: ProjectInsightTemplateDataMartRefDto,
+    public readonly canDelete: boolean
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/project-scheduled-trigger.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/project-scheduled-trigger.dto.ts
@@ -1,0 +1,13 @@
+import { ScheduledTriggerDto } from './scheduled-trigger.dto';
+
+export interface ProjectScheduledTriggerDataMartRefDto {
+  readonly id: string;
+  readonly title: string;
+}
+
+export class ProjectScheduledTriggerDto {
+  constructor(
+    public readonly trigger: ScheduledTriggerDto,
+    public readonly dataMart: ProjectScheduledTriggerDataMartRefDto
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/project-scheduled-trigger.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/project-scheduled-trigger.dto.ts
@@ -8,6 +8,8 @@ export interface ProjectScheduledTriggerDataMartRefDto {
 export class ProjectScheduledTriggerDto {
   constructor(
     public readonly trigger: ScheduledTriggerDto,
-    public readonly dataMart: ProjectScheduledTriggerDataMartRefDto
+    public readonly dataMart: ProjectScheduledTriggerDataMartRefDto,
+    public readonly canEdit: boolean,
+    public readonly canDelete: boolean
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/presentation/project-data-mart-runs-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/project-data-mart-runs-response-api.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { DataMartRunResponseApiDto } from './data-mart-run-response-api.dto';
+
+export class ProjectDataMartRunRefResponseApiDto {
+  @ApiProperty({ example: 'a5c9b1d2-3456-7890-abcd-ef0123456789' })
+  id: string;
+
+  @ApiProperty({ example: 'Marketing performance' })
+  title: string;
+}
+
+export class ProjectDataMartRunResponseApiDto extends DataMartRunResponseApiDto {
+  @ApiProperty({ type: ProjectDataMartRunRefResponseApiDto })
+  dataMart: ProjectDataMartRunRefResponseApiDto;
+}
+
+export class ProjectDataMartRunsResponseApiDto {
+  @ApiProperty({ type: [ProjectDataMartRunResponseApiDto] })
+  runs: ProjectDataMartRunResponseApiDto[];
+}

--- a/apps/backend/src/data-marts/dto/presentation/project-insight-templates-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/project-insight-templates-response-api.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { InsightTemplateListItemResponseApiDto } from './insight-template-list-item-response-api.dto';
+
+export class ProjectInsightTemplateDataMartRefResponseApiDto {
+  @ApiProperty({ example: 'a5c9b1d2-3456-7890-abcd-ef0123456789' })
+  id: string;
+
+  @ApiProperty({ example: 'Marketing performance' })
+  title: string;
+}
+
+export class ProjectInsightTemplateResponseApiDto extends InsightTemplateListItemResponseApiDto {
+  @ApiProperty({ type: ProjectInsightTemplateDataMartRefResponseApiDto })
+  dataMart: ProjectInsightTemplateDataMartRefResponseApiDto;
+}
+
+export class ProjectInsightTemplatesResponseApiDto {
+  @ApiProperty({ type: [ProjectInsightTemplateResponseApiDto] })
+  insights: ProjectInsightTemplateResponseApiDto[];
+}

--- a/apps/backend/src/data-marts/dto/presentation/project-insight-templates-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/project-insight-templates-response-api.dto.ts
@@ -12,6 +12,9 @@ export class ProjectInsightTemplateDataMartRefResponseApiDto {
 export class ProjectInsightTemplateResponseApiDto extends InsightTemplateListItemResponseApiDto {
   @ApiProperty({ type: ProjectInsightTemplateDataMartRefResponseApiDto })
   dataMart: ProjectInsightTemplateDataMartRefResponseApiDto;
+
+  @ApiProperty({ example: true })
+  canDelete: boolean;
 }
 
 export class ProjectInsightTemplatesResponseApiDto {

--- a/apps/backend/src/data-marts/dto/presentation/project-scheduled-triggers-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/project-scheduled-triggers-response-api.dto.ts
@@ -1,0 +1,100 @@
+import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
+import { UserProjectionDto } from '../../../idp/dto/domain/user-projection.dto';
+import { ScheduledTriggerType } from '../../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { ScheduledReportRunConfigType } from '../../scheduled-trigger-types/scheduled-report-run/schemas/scheduled-report-run-config.schema';
+import { ReportResponseApiDto } from './report-response-api.dto';
+
+export const ScheduledConnectorRunConfigType = 'scheduled-connector-run-config';
+
+export class ProjectScheduledReportRunConfigResponseApiDto {
+  @ApiProperty({ example: ScheduledReportRunConfigType })
+  type: typeof ScheduledReportRunConfigType;
+
+  @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
+  reportId: string;
+
+  @ApiProperty({ type: ReportResponseApiDto, required: false })
+  report?: ReportResponseApiDto;
+}
+
+export class ProjectScheduledConnectorRunConfigResponseApiDto {
+  @ApiProperty({ example: ScheduledConnectorRunConfigType })
+  type: typeof ScheduledConnectorRunConfigType;
+
+  @ApiProperty({
+    required: false,
+    type: Object,
+    additionalProperties: true,
+    description: 'Masked connector definition used by the connector run target.',
+  })
+  connector?: unknown;
+}
+
+export type ProjectScheduledTriggerConfigResponseApiDto =
+  | ProjectScheduledReportRunConfigResponseApiDto
+  | ProjectScheduledConnectorRunConfigResponseApiDto;
+
+export class ProjectScheduledTriggerDataMartRefResponseApiDto {
+  @ApiProperty({ example: 'a5c9b1d2-3456-7890-abcd-ef0123456789' })
+  id: string;
+
+  @ApiProperty({ example: 'Marketing performance' })
+  title: string;
+}
+
+@ApiExtraModels(
+  ProjectScheduledReportRunConfigResponseApiDto,
+  ProjectScheduledConnectorRunConfigResponseApiDto
+)
+export class ProjectScheduledTriggerResponseApiDto {
+  @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
+  id: string;
+
+  @ApiProperty({ enum: ScheduledTriggerType, example: ScheduledTriggerType.CONNECTOR_RUN })
+  type: ScheduledTriggerType;
+
+  @ApiProperty({ example: '0 0 * * *' })
+  cronExpression: string;
+
+  @ApiProperty({ example: 'UTC' })
+  timeZone: string;
+
+  @ApiProperty({ example: true })
+  isActive: boolean;
+
+  @ApiProperty({ example: '2024-01-01T12:00:00.000Z', nullable: true })
+  nextRunTimestamp: Date | null;
+
+  @ApiProperty({ example: '2024-01-01T12:00:00.000Z', nullable: true })
+  lastRunTimestamp: Date | null;
+
+  @ApiProperty({
+    oneOf: [
+      { $ref: getSchemaPath(ProjectScheduledReportRunConfigResponseApiDto) },
+      { $ref: getSchemaPath(ProjectScheduledConnectorRunConfigResponseApiDto) },
+    ],
+    nullable: true,
+    required: false,
+  })
+  triggerConfig?: ProjectScheduledTriggerConfigResponseApiDto;
+
+  @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
+  createdById: string;
+
+  @ApiProperty({ example: '2024-01-01T12:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2024-01-02T15:30:00.000Z' })
+  modifiedAt: Date;
+
+  @ApiProperty({ type: UserProjectionDto, required: false, nullable: true })
+  createdByUser?: UserProjectionDto | null;
+
+  @ApiProperty({ type: ProjectScheduledTriggerDataMartRefResponseApiDto })
+  dataMart: ProjectScheduledTriggerDataMartRefResponseApiDto;
+}
+
+export class ProjectScheduledTriggersResponseApiDto {
+  @ApiProperty({ type: [ProjectScheduledTriggerResponseApiDto] })
+  triggers: ProjectScheduledTriggerResponseApiDto[];
+}

--- a/apps/backend/src/data-marts/dto/presentation/project-scheduled-triggers-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/project-scheduled-triggers-response-api.dto.ts
@@ -92,6 +92,12 @@ export class ProjectScheduledTriggerResponseApiDto {
 
   @ApiProperty({ type: ProjectScheduledTriggerDataMartRefResponseApiDto })
   dataMart: ProjectScheduledTriggerDataMartRefResponseApiDto;
+
+  @ApiProperty({ example: true })
+  canEdit: boolean;
+
+  @ApiProperty({ example: true })
+  canDelete: boolean;
 }
 
 export class ProjectScheduledTriggersResponseApiDto {

--- a/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
@@ -42,6 +42,8 @@ import { DataMartListItemResponseApiDto } from '../dto/presentation/data-mart-li
 import { DataMartResponseApiDto } from '../dto/presentation/data-mart-response-api.dto';
 import { DataMartRunResponseApiDto } from '../dto/presentation/data-mart-run-response-api.dto';
 import { DataMartRunsResponseApiDto } from '../dto/presentation/data-mart-runs-response-api.dto';
+import { ProjectDataMartRunDto } from '../dto/domain/project-data-mart-run.dto';
+import { ProjectDataMartRunsResponseApiDto } from '../dto/presentation/project-data-mart-runs-response-api.dto';
 import { DataMartValidationResponseApiDto } from '../dto/presentation/data-mart-validation-response-api.dto';
 import { PaginatedDataMartsResponseApiDto } from '../dto/presentation/paginated-data-marts-response-api.dto';
 import { SqlDryRunRequestApiDto } from '../dto/presentation/sql-dry-run-request-api.dto';
@@ -572,6 +574,40 @@ export class DataMartMapper {
           finishedAt: run.finishedAt,
           createdByUser: run.createdByUser,
           additionalParams: this.maskAdditionalParams(run),
+        };
+      })
+    );
+    return { runs: maskedRuns };
+  }
+
+  async toProjectRunsResponse(
+    runs: ProjectDataMartRunDto[]
+  ): Promise<ProjectDataMartRunsResponseApiDto> {
+    const maskedRuns = await Promise.all(
+      runs.map(async item => {
+        const maskedDefinitionRun = await this.maskDefinitionRun(item.run.definitionRun);
+        return {
+          id: item.run.id,
+          status: item.run.status,
+          type: item.run.type,
+          runType: item.run.runType,
+          dataMartId: item.run.dataMartId,
+          dataMart: item.dataMart,
+          definitionRun: maskedDefinitionRun || item.run.definitionRun,
+          reportId: item.run.reportId,
+          reportDefinition: item.run.reportDefinition,
+          insightId: item.run.insightId,
+          insightDefinition: item.run.insightDefinition || null,
+          insightTemplateId: item.run.insightTemplateId,
+          insightTemplateDefinition: item.run.insightTemplateDefinition || null,
+          aiSourceDefinition: item.run.aiSourceDefinition,
+          logs: item.run.logs,
+          errors: item.run.errors,
+          createdAt: item.run.createdAt,
+          startedAt: item.run.startedAt,
+          finishedAt: item.run.finishedAt,
+          createdByUser: item.run.createdByUser,
+          additionalParams: this.maskAdditionalParams(item.run),
         };
       })
     );

--- a/apps/backend/src/data-marts/mappers/insight-template.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/insight-template.mapper.ts
@@ -121,6 +121,7 @@ export class InsightTemplateMapper {
       insights: dtos.map(dto => ({
         ...this.toListItemResponse(dto.insightTemplate),
         dataMart: dto.dataMart,
+        canDelete: dto.canDelete,
       })),
     };
   }

--- a/apps/backend/src/data-marts/mappers/insight-template.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/insight-template.mapper.ts
@@ -8,10 +8,12 @@ import { DeleteInsightTemplateCommand } from '../dto/domain/delete-insight-templ
 import { GetInsightTemplateCommand } from '../dto/domain/get-insight-template.command';
 import { InsightTemplateDto } from '../dto/domain/insight-template.dto';
 import { ListInsightTemplatesCommand } from '../dto/domain/list-insight-templates.command';
+import { ProjectInsightTemplateDto } from '../dto/domain/project-insight-template.dto';
 import { UpdateInsightTemplateCommand } from '../dto/domain/update-insight-template.command';
 import { UpdateInsightTemplateTitleCommand } from '../dto/domain/update-insight-template-title.command';
 import { CreateInsightTemplateRequestApiDto } from '../dto/presentation/create-insight-template-request-api.dto';
 import { InsightTemplateListItemResponseApiDto } from '../dto/presentation/insight-template-list-item-response-api.dto';
+import { ProjectInsightTemplatesResponseApiDto } from '../dto/presentation/project-insight-templates-response-api.dto';
 import { InsightTemplateResponseApiDto } from '../dto/presentation/insight-template-response-api.dto';
 import { UpdateInsightTemplateRequestApiDto } from '../dto/presentation/update-insight-template-request-api.dto';
 import { UpdateInsightTemplateTitleApiDto } from '../dto/presentation/update-insight-template-title-api.dto';
@@ -112,6 +114,15 @@ export class InsightTemplateMapper {
 
   toListItemResponseList(dtos: InsightTemplateDto[]): InsightTemplateListItemResponseApiDto[] {
     return dtos.map(dto => this.toListItemResponse(dto));
+  }
+
+  toProjectResponseList(dtos: ProjectInsightTemplateDto[]): ProjectInsightTemplatesResponseApiDto {
+    return {
+      insights: dtos.map(dto => ({
+        ...this.toListItemResponse(dto.insightTemplate),
+        dataMart: dto.dataMart,
+      })),
+    };
   }
 
   toGetCommand(

--- a/apps/backend/src/data-marts/mappers/report.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.ts
@@ -149,13 +149,17 @@ export class ReportMapper {
 
   toListByProjectCommand(
     context: AuthorizationContext,
-    ownerFilter?: OwnerFilter
+    ownerFilter?: OwnerFilter,
+    limit?: number,
+    offset?: number
   ): ListReportsByProjectCommand {
     return new ListReportsByProjectCommand(
       context.projectId,
       context.userId,
       context.roles ?? [],
-      ownerFilter
+      ownerFilter,
+      limit,
+      offset
     );
   }
 

--- a/apps/backend/src/data-marts/mappers/scheduled-trigger.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/scheduled-trigger.mapper.ts
@@ -4,9 +4,11 @@ import { CreateScheduledTriggerCommand } from '../dto/domain/create-scheduled-tr
 import { DeleteScheduledTriggerCommand } from '../dto/domain/delete-scheduled-trigger.command';
 import { GetScheduledTriggerCommand } from '../dto/domain/get-scheduled-trigger.command';
 import { ListScheduledTriggersCommand } from '../dto/domain/list-scheduled-triggers.command';
+import { ProjectScheduledTriggerDto } from '../dto/domain/project-scheduled-trigger.dto';
 import { ScheduledTriggerDto } from '../dto/domain/scheduled-trigger.dto';
 import { UpdateScheduledTriggerCommand } from '../dto/domain/update-scheduled-trigger.command';
 import { CreateScheduledTriggerRequestApiDto } from '../dto/presentation/create-scheduled-trigger-request-api.dto';
+import { ProjectScheduledTriggersResponseApiDto } from '../dto/presentation/project-scheduled-triggers-response-api.dto';
 import { ScheduledTriggerResponseApiDto } from '../dto/presentation/scheduled-trigger-response-api.dto';
 import { UpdateScheduledTriggerRequestApiDto } from '../dto/presentation/update-scheduled-trigger-request-api.dto';
 import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
@@ -69,6 +71,17 @@ export class ScheduledTriggerMapper {
 
   toResponseList(dtos: ScheduledTriggerDto[]): ScheduledTriggerResponseApiDto[] {
     return dtos.map(dto => this.toResponse(dto));
+  }
+
+  toProjectResponseList(
+    dtos: ProjectScheduledTriggerDto[]
+  ): ProjectScheduledTriggersResponseApiDto {
+    return {
+      triggers: dtos.map(dto => ({
+        ...this.toResponse(dto.trigger),
+        dataMart: dto.dataMart,
+      })),
+    };
   }
 
   toCreateCommand(

--- a/apps/backend/src/data-marts/mappers/scheduled-trigger.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/scheduled-trigger.mapper.ts
@@ -80,6 +80,8 @@ export class ScheduledTriggerMapper {
       triggers: dtos.map(dto => ({
         ...this.toResponse(dto.trigger),
         dataMart: dto.dataMart,
+        canEdit: dto.canEdit,
+        canDelete: dto.canDelete,
       })),
     };
   }

--- a/apps/backend/src/data-marts/services/data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.ts
@@ -14,8 +14,10 @@ import { InsightTemplate } from '../entities/insight-template.entity';
 import { Report } from '../entities/report.entity';
 import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
 import { DataMartRunType } from '../enums/data-mart-run-type.enum';
+import { RoleScope } from '../enums/role-scope.enum';
 import { ReportRunCompletedSuccessfullyEvent } from '../events/report-run-completed-successfully.event';
 import { HttpDataRunMetadata } from '../dto/schemas/http-data-run-metadata.schema';
+import { applyDataMartVisibilityFilter } from '../utils/apply-data-mart-visibility-filter';
 import { HTTP_DATA_PARAMS_KEY } from './http-data/http-data.constants';
 import { CANCELLABLE_DATA_MART_RUN_STATUSES } from '../utils/data-mart-run-cancellation';
 
@@ -80,6 +82,15 @@ export interface HttpDataRunRecord {
   errors?: string[];
 }
 
+export interface ListVisibleProjectRunsOptions {
+  projectId: string;
+  userId: string;
+  roles: string[];
+  roleScope: RoleScope;
+  limit?: number;
+  offset?: number;
+}
+
 /**
  * Service managing the underlying DataMartRun entity lifecycle.
  *
@@ -123,6 +134,33 @@ export class DataMartRunService {
       take: limit,
       skip: offset,
     });
+  }
+
+  /**
+   * Lists project runs for Data Marts visible to the current user.
+   */
+  public async listVisibleByProject(
+    options: ListVisibleProjectRunsOptions
+  ): Promise<DataMartRun[]> {
+    const qb = this.dataMartRunRepository
+      .createQueryBuilder('run')
+      .innerJoinAndSelect('run.dataMart', 'dataMart')
+      .where('dataMart.projectId = :projectId', { projectId: options.projectId })
+      .andWhere('dataMart.deletedAt IS NULL')
+      .orderBy('run.createdAt', 'DESC')
+      .addOrderBy('run.id', 'DESC')
+      .take(options.limit ?? 20)
+      .skip(options.offset ?? 0);
+
+    applyDataMartVisibilityFilter(qb, {
+      dataMartAlias: 'dataMart',
+      projectId: options.projectId,
+      userId: options.userId,
+      roles: options.roles,
+      roleScope: options.roleScope,
+    });
+
+    return qb.getMany();
   }
 
   /**

--- a/apps/backend/src/data-marts/services/insight-template.service.spec.ts
+++ b/apps/backend/src/data-marts/services/insight-template.service.spec.ts
@@ -1,0 +1,74 @@
+import { RoleScope } from '../enums/role-scope.enum';
+import { InsightTemplateService } from './insight-template.service';
+
+describe('InsightTemplateService', () => {
+  function createQueryBuilder(result: unknown[] = []) {
+    return {
+      innerJoinAndSelect: jest.fn().mockReturnThis(),
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(result),
+    };
+  }
+
+  it('lists project-visible insight templates with Data Mart visibility filtering and pagination', async () => {
+    const qb = createQueryBuilder([{ id: 'insight-template-1' }]);
+    const repository = {
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    };
+    const service = new InsightTemplateService(repository as never);
+
+    const result = await service.listVisibleByProject({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+      limit: 20,
+      offset: 40,
+    });
+
+    expect(result).toEqual([{ id: 'insight-template-1' }]);
+    expect(repository.createQueryBuilder).toHaveBeenCalledWith('insightTemplate');
+    expect(qb.innerJoinAndSelect).toHaveBeenCalledWith('insightTemplate.dataMart', 'dataMart');
+    expect(qb.leftJoinAndSelect).toHaveBeenCalledWith(
+      'insightTemplate.sourceEntities',
+      'sourceEntities'
+    );
+    expect(qb.where).toHaveBeenCalledWith('dataMart.projectId = :projectId', {
+      projectId: 'project-1',
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith('dataMart.deletedAt IS NULL');
+    expect(qb.andWhere).toHaveBeenCalledWith(expect.stringContaining('data_mart_contexts'), {
+      userId: 'user-1',
+      isTrue: true,
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+      entireProjectScope: RoleScope.ENTIRE_PROJECT,
+      projectId: 'project-1',
+    });
+    expect(qb.take).toHaveBeenCalledWith(20);
+    expect(qb.skip).toHaveBeenCalledWith(40);
+  });
+
+  it('defaults project-visible insight template pagination to 100', async () => {
+    const qb = createQueryBuilder();
+    const repository = {
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    };
+    const service = new InsightTemplateService(repository as never);
+
+    await service.listVisibleByProject({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['admin'],
+      roleScope: RoleScope.ENTIRE_PROJECT,
+    });
+
+    expect(qb.take).toHaveBeenCalledWith(100);
+    expect(qb.skip).toHaveBeenCalledWith(0);
+  });
+});

--- a/apps/backend/src/data-marts/services/insight-template.service.ts
+++ b/apps/backend/src/data-marts/services/insight-template.service.ts
@@ -2,7 +2,18 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { InsightTemplate } from '../entities/insight-template.entity';
+import { RoleScope } from '../enums/role-scope.enum';
+import { applyDataMartVisibilityFilter } from '../utils/apply-data-mart-visibility-filter';
 import { DEFAULT_INSIGHT_TITLE } from '../use-cases/utils/generate-ai-assistant-session-title-from-message.util';
+
+export interface ListVisibleProjectInsightTemplatesOptions {
+  projectId: string;
+  userId: string;
+  roles: string[];
+  roleScope: RoleScope;
+  limit?: number;
+  offset?: number;
+}
 
 @Injectable()
 export class InsightTemplateService {
@@ -69,6 +80,31 @@ export class InsightTemplateService {
       relations: ['dataMart'],
       order: { createdAt: 'DESC' },
     });
+  }
+
+  async listVisibleByProject(
+    options: ListVisibleProjectInsightTemplatesOptions
+  ): Promise<InsightTemplate[]> {
+    const qb = this.repository
+      .createQueryBuilder('insightTemplate')
+      .innerJoinAndSelect('insightTemplate.dataMart', 'dataMart')
+      .leftJoinAndSelect('insightTemplate.sourceEntities', 'sourceEntities')
+      .where('dataMart.projectId = :projectId', { projectId: options.projectId })
+      .andWhere('dataMart.deletedAt IS NULL')
+      .orderBy('insightTemplate.modifiedAt', 'DESC')
+      .addOrderBy('insightTemplate.id', 'DESC')
+      .take(options.limit ?? 100)
+      .skip(options.offset ?? 0);
+
+    applyDataMartVisibilityFilter(qb, {
+      dataMartAlias: 'dataMart',
+      projectId: options.projectId,
+      userId: options.userId,
+      roles: options.roles,
+      roleScope: options.roleScope,
+    });
+
+    return qb.getMany();
   }
 
   async updateTitleOnlyIfHasDefaultTitle(

--- a/apps/backend/src/data-marts/services/report.service.ts
+++ b/apps/backend/src/data-marts/services/report.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, OptimisticLockVersionMismatchError } from 'typeorm';
+import { In, Repository, OptimisticLockVersionMismatchError } from 'typeorm';
 import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
 import { LookerStudioConnectorCredentialsType } from '../data-destination-types/looker-studio-connector/schemas/looker-studio-connector-credentials.schema';
 import { Report } from '../entities/report.entity';
@@ -46,6 +46,30 @@ export class ReportService {
     }
 
     return report;
+  }
+
+  /**
+   * Fetches reports by IDs within a project with related entities.
+   */
+  async getByIdsAndProjectIdAndDataMartIds(
+    ids: string[],
+    projectId: string,
+    dataMartIds: string[]
+  ): Promise<Report[]> {
+    if (ids.length === 0 || dataMartIds.length === 0) {
+      return [];
+    }
+
+    return this.repository.find({
+      where: {
+        id: In(ids),
+        dataMart: {
+          id: In(dataMartIds),
+          projectId,
+        },
+      },
+      relations: ['dataMart', 'dataDestination'],
+    });
   }
 
   /**

--- a/apps/backend/src/data-marts/services/scheduled-trigger.service.ts
+++ b/apps/backend/src/data-marts/services/scheduled-trigger.service.ts
@@ -2,7 +2,18 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
+import { RoleScope } from '../enums/role-scope.enum';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { applyDataMartVisibilityFilter } from '../utils/apply-data-mart-visibility-filter';
+
+export interface ListVisibleProjectScheduledTriggersOptions {
+  projectId: string;
+  userId: string;
+  roles: string[];
+  roleScope: RoleScope;
+  limit?: number;
+  offset?: number;
+}
 
 @Injectable()
 export class ScheduledTriggerService {
@@ -47,6 +58,30 @@ export class ScheduledTriggerService {
       },
       relations: ['dataMart'],
     });
+  }
+
+  async listVisibleByProject(
+    options: ListVisibleProjectScheduledTriggersOptions
+  ): Promise<DataMartScheduledTrigger[]> {
+    const qb = this.triggerRepository
+      .createQueryBuilder('scheduledTrigger')
+      .innerJoinAndSelect('scheduledTrigger.dataMart', 'dataMart')
+      .where('dataMart.projectId = :projectId', { projectId: options.projectId })
+      .andWhere('dataMart.deletedAt IS NULL')
+      .orderBy('scheduledTrigger.createdAt', 'DESC')
+      .addOrderBy('scheduledTrigger.id', 'DESC')
+      .take(options.limit ?? 20)
+      .skip(options.offset ?? 0);
+
+    applyDataMartVisibilityFilter(qb, {
+      dataMartAlias: 'dataMart',
+      projectId: options.projectId,
+      userId: options.userId,
+      roles: options.roles,
+      roleScope: options.roleScope,
+    });
+
+    return qb.getMany();
   }
 
   async deleteAllByDataMartIdAndProjectId(dataMartId: string, projectId: string): Promise<void> {

--- a/apps/backend/src/data-marts/use-cases/create-scheduled-trigger.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-scheduled-trigger.service.spec.ts
@@ -11,6 +11,7 @@ import { CreateScheduledTriggerService } from './create-scheduled-trigger.servic
 import { CreateScheduledTriggerCommand } from '../dto/domain/create-scheduled-trigger.command';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
 import { DataMartStatus } from '../enums/data-mart-status.enum';
+import { Action, EntityType } from '../services/access-decision';
 
 describe('CreateScheduledTriggerService', () => {
   const dataMart = { id: 'dm-1', status: DataMartStatus.PUBLISHED, projectId: 'proj-1' };
@@ -41,6 +42,13 @@ describe('CreateScheduledTriggerService', () => {
           (roles: string[]) => roles.includes('editor') || roles.includes('admin')
         ),
     };
+    const accessDecisionService = {
+      canAccess: jest
+        .fn()
+        .mockImplementation((_userId, roles: string[]) =>
+          Promise.resolve(roles.includes('editor') || roles.includes('admin'))
+        ),
+    };
 
     const eventDispatcher = { publishExternal: jest.fn().mockResolvedValue(undefined) };
 
@@ -50,10 +58,11 @@ describe('CreateScheduledTriggerService', () => {
       dataMartService as never,
       mapper as never,
       eventDispatcher as never,
-      reportAccessService as never
+      reportAccessService as never,
+      accessDecisionService as never
     );
 
-    return { service, reportAccessService, triggerRepository };
+    return { service, reportAccessService, triggerRepository, accessDecisionService };
   };
 
   beforeEach(() => {
@@ -125,7 +134,7 @@ describe('CreateScheduledTriggerService', () => {
   });
 
   it('should allow editor to create CONNECTOR_RUN trigger', async () => {
-    const { service } = createService();
+    const { service, accessDecisionService } = createService();
 
     const command = new CreateScheduledTriggerCommand(
       'proj-1',
@@ -140,6 +149,41 @@ describe('CreateScheduledTriggerService', () => {
     );
 
     await expect(service.run(command)).resolves.toBeDefined();
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.DATA_MART,
+      'dm-1',
+      Action.MANAGE_TRIGGERS,
+      'proj-1'
+    );
+  });
+
+  it('should reject editor creating CONNECTOR_RUN trigger without Data Mart trigger management access', async () => {
+    const { service, accessDecisionService } = createService();
+    accessDecisionService.canAccess.mockResolvedValueOnce(false);
+
+    const command = new CreateScheduledTriggerCommand(
+      'proj-1',
+      'user-1',
+      'dm-1',
+      ScheduledTriggerType.CONNECTOR_RUN,
+      '0 9 * * *',
+      'UTC',
+      true,
+      undefined,
+      ['editor']
+    );
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.DATA_MART,
+      'dm-1',
+      Action.MANAGE_TRIGGERS,
+      'proj-1'
+    );
   });
 
   it('allows viewer who can operate the report (BO DM) to create REPORT_RUN trigger', async () => {

--- a/apps/backend/src/data-marts/use-cases/create-scheduled-trigger.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-scheduled-trigger.service.ts
@@ -14,6 +14,7 @@ import { ScheduledTriggerValidatorFacade } from '../scheduled-trigger-types/faca
 import { ReportAccessService } from '../services/report-access.service';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
 import { isScheduledReportRunConfig } from '../scheduled-trigger-types/scheduled-trigger-config.guards';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
 
 @Injectable()
 export class CreateScheduledTriggerService {
@@ -24,7 +25,8 @@ export class CreateScheduledTriggerService {
     private readonly dataMartService: DataMartService,
     private readonly mapper: ScheduledTriggerMapper,
     private readonly eventDispatcher: OwoxEventDispatcher,
-    private readonly reportAccessService: ReportAccessService
+    private readonly reportAccessService: ReportAccessService,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   async run(command: CreateScheduledTriggerCommand): Promise<ScheduledTriggerDto> {
@@ -95,9 +97,19 @@ export class CreateScheduledTriggerService {
         command.projectId
       );
     } else {
-      // CONNECTOR_RUN requires editor role
-      if (!this.reportAccessService.isTechnicalUser(command.roles)) {
-        throw new ForbiddenException('Only Technical Users can create connector run triggers.');
+      const canManageTriggers = await this.accessDecisionService.canAccess(
+        command.userId,
+        command.roles,
+        EntityType.DATA_MART,
+        command.dataMartId,
+        Action.MANAGE_TRIGGERS,
+        command.projectId
+      );
+
+      if (!canManageTriggers) {
+        throw new ForbiddenException(
+          'You do not have permission to manage triggers for this DataMart.'
+        );
       }
     }
   }

--- a/apps/backend/src/data-marts/use-cases/delete-scheduled-trigger.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-scheduled-trigger.service.spec.ts
@@ -1,0 +1,91 @@
+import { ForbiddenException } from '@nestjs/common';
+import { DeleteScheduledTriggerCommand } from '../dto/domain/delete-scheduled-trigger.command';
+import { Action } from '../services/access-decision';
+import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { DeleteScheduledTriggerService } from './delete-scheduled-trigger.service';
+
+describe('DeleteScheduledTriggerService', () => {
+  const connectorRunTrigger = {
+    id: 'trigger-1',
+    type: ScheduledTriggerType.CONNECTOR_RUN,
+    dataMart: {
+      id: 'dm-1',
+    },
+  };
+
+  const createService = () => {
+    const triggerRepository = {
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+    const scheduledTriggerService = {
+      getByIdAndDataMartIdAndProjectId: jest.fn().mockResolvedValue(connectorRunTrigger),
+    };
+    const reportAccessService = {
+      checkOperateAccess: jest.fn().mockResolvedValue(undefined),
+      isTechnicalUser: jest
+        .fn()
+        .mockImplementation(
+          (roles: string[]) => roles.includes('editor') || roles.includes('admin')
+        ),
+    };
+    const reportService = {
+      getByIdAndDataMartIdAndProjectId: jest.fn(),
+    };
+    const accessDecisionService = {
+      canAccessDmTrigger: jest.fn().mockResolvedValue(true),
+    };
+
+    const service = new DeleteScheduledTriggerService(
+      triggerRepository as never,
+      scheduledTriggerService as never,
+      reportAccessService as never,
+      reportService as never,
+      accessDecisionService as never
+    );
+
+    return { service, triggerRepository, accessDecisionService };
+  };
+
+  const command = new DeleteScheduledTriggerCommand('trigger-1', 'dm-1', 'project-1', 'user-1', [
+    'editor',
+  ]);
+
+  it('deletes connector-run triggers when Data Mart trigger management is allowed', async () => {
+    const { service, triggerRepository, accessDecisionService } = createService();
+
+    await expect(service.run(command)).resolves.toBeUndefined();
+
+    expect(accessDecisionService.canAccessDmTrigger).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      'trigger-1',
+      'dm-1',
+      Action.MANAGE_TRIGGERS,
+      'project-1'
+    );
+    expect(triggerRepository.delete).toHaveBeenCalledWith({
+      id: 'trigger-1',
+      dataMart: {
+        id: 'dm-1',
+        projectId: 'project-1',
+      },
+    });
+  });
+
+  it('rejects connector-run trigger deletes when Data Mart trigger management is denied', async () => {
+    const { service, triggerRepository, accessDecisionService } = createService();
+    accessDecisionService.canAccessDmTrigger.mockResolvedValueOnce(false);
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+
+    expect(accessDecisionService.canAccessDmTrigger).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      'trigger-1',
+      'dm-1',
+      Action.MANAGE_TRIGGERS,
+      'project-1'
+    );
+    expect(triggerRepository.delete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/delete-scheduled-trigger.service.ts
+++ b/apps/backend/src/data-marts/use-cases/delete-scheduled-trigger.service.ts
@@ -8,6 +8,7 @@ import { ReportAccessService } from '../services/report-access.service';
 import { ReportService } from '../services/report.service';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
 import { isScheduledReportRunConfig } from '../scheduled-trigger-types/scheduled-trigger-config.guards';
+import { AccessDecisionService, Action } from '../services/access-decision';
 
 @Injectable()
 export class DeleteScheduledTriggerService {
@@ -16,7 +17,8 @@ export class DeleteScheduledTriggerService {
     private readonly triggerRepository: Repository<DataMartScheduledTrigger>,
     private readonly scheduledTriggerService: ScheduledTriggerService,
     private readonly reportAccessService: ReportAccessService,
-    private readonly reportService: ReportService
+    private readonly reportService: ReportService,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   async run(command: DeleteScheduledTriggerCommand): Promise<void> {
@@ -59,8 +61,19 @@ export class DeleteScheduledTriggerService {
         command.projectId
       );
     } else {
-      if (!this.reportAccessService.isTechnicalUser(command.roles)) {
-        throw new ForbiddenException('Only Technical Users can delete connector run triggers.');
+      const canManageTriggers = await this.accessDecisionService.canAccessDmTrigger(
+        command.userId,
+        command.roles,
+        trigger.id,
+        command.dataMartId,
+        Action.MANAGE_TRIGGERS,
+        command.projectId
+      );
+
+      if (!canManageTriggers) {
+        throw new ForbiddenException(
+          'You do not have permission to manage triggers for this DataMart.'
+        );
       }
     }
   }

--- a/apps/backend/src/data-marts/use-cases/list-project-data-mart-runs.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-data-mart-runs.service.spec.ts
@@ -1,0 +1,99 @@
+import { ListProjectDataMartRunsCommand } from '../dto/domain/list-project-data-mart-runs.command';
+import type { DataMartRunDto } from '../dto/domain/data-mart-run.dto';
+import { RoleScope } from '../enums/role-scope.enum';
+import { ListProjectDataMartRunsService } from './list-project-data-mart-runs.service';
+
+describe('ListProjectDataMartRunsService', () => {
+  const run = {
+    id: 'run-1',
+    createdById: 'creator-1',
+    dataMart: {
+      id: 'dm-1',
+      title: 'Marketing data mart',
+    },
+  };
+
+  const runDto = { id: 'run-1', dataMartId: 'dm-1' } as DataMartRunDto;
+
+  const createService = () => {
+    const dataMartRunService = {
+      listVisibleByProject: jest.fn().mockResolvedValue([run]),
+    };
+    const contextAccessService = {
+      getRoleScope: jest.fn().mockResolvedValue(RoleScope.SELECTED_CONTEXTS),
+    };
+    const userProjections = {
+      getByUserId: jest.fn().mockReturnValue({ id: 'creator-1', name: 'Creator' }),
+    };
+    const userProjectionsFetcherService = {
+      fetchRelevantUserProjections: jest.fn().mockResolvedValue(userProjections),
+    };
+    const mapper = {
+      toDataMartRunDto: jest.fn().mockReturnValue(runDto),
+    };
+
+    const service = new ListProjectDataMartRunsService(
+      dataMartRunService as never,
+      contextAccessService as never,
+      userProjectionsFetcherService as never,
+      mapper as never
+    );
+
+    return {
+      service,
+      dataMartRunService,
+      contextAccessService,
+      userProjectionsFetcherService,
+      userProjections,
+      mapper,
+    };
+  };
+
+  it('passes selected-context scope to the visible-runs query for non-admin users', async () => {
+    const { service, dataMartRunService, contextAccessService, mapper, userProjections } =
+      createService();
+
+    const result = await service.run(
+      new ListProjectDataMartRunsCommand('project-1', 20, 40, 'user-1', ['editor'])
+    );
+
+    expect(contextAccessService.getRoleScope).toHaveBeenCalledWith('user-1', 'project-1');
+    expect(dataMartRunService.listVisibleByProject).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['editor'],
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+      limit: 20,
+      offset: 40,
+    });
+    expect(mapper.toDataMartRunDto).toHaveBeenCalledWith(
+      run,
+      userProjections.getByUserId('creator-1')
+    );
+    expect(result).toEqual([
+      {
+        run: runDto,
+        dataMart: {
+          id: 'dm-1',
+          title: 'Marketing data mart',
+        },
+      },
+    ]);
+  });
+
+  it('uses entire-project scope without loading role scope for admin users', async () => {
+    const { service, dataMartRunService, contextAccessService } = createService();
+
+    await service.run(new ListProjectDataMartRunsCommand('project-1', 10, 0, 'admin-1', ['admin']));
+
+    expect(contextAccessService.getRoleScope).not.toHaveBeenCalled();
+    expect(dataMartRunService.listVisibleByProject).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'admin-1',
+      roles: ['admin'],
+      roleScope: RoleScope.ENTIRE_PROJECT,
+      limit: 10,
+      offset: 0,
+    });
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/list-project-data-mart-runs.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-data-mart-runs.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { ListProjectDataMartRunsCommand } from '../dto/domain/list-project-data-mart-runs.command';
+import { ProjectDataMartRunDto } from '../dto/domain/project-data-mart-run.dto';
+import { RoleScope } from '../enums/role-scope.enum';
+import { DataMartMapper } from '../mappers/data-mart.mapper';
+import { ContextAccessService } from '../services/context/context-access.service';
+import { DataMartRunService } from '../services/data-mart-run.service';
+import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+
+@Injectable()
+export class ListProjectDataMartRunsService {
+  constructor(
+    private readonly dataMartRunService: DataMartRunService,
+    private readonly contextAccessService: ContextAccessService,
+    private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
+    private readonly mapper: DataMartMapper
+  ) {}
+
+  async run(command: ListProjectDataMartRunsCommand): Promise<ProjectDataMartRunDto[]> {
+    const isAdmin = command.roles.includes('admin');
+    const roleScope = isAdmin
+      ? RoleScope.ENTIRE_PROJECT
+      : await this.contextAccessService.getRoleScope(command.userId, command.projectId);
+
+    const runs = await this.dataMartRunService.listVisibleByProject({
+      projectId: command.projectId,
+      userId: command.userId,
+      roles: command.roles,
+      roleScope,
+      limit: command.limit,
+      offset: command.offset,
+    });
+
+    const userProjections =
+      await this.userProjectionsFetcherService.fetchRelevantUserProjections(runs);
+
+    return runs.map(run => {
+      const createdByUser = run.createdById
+        ? (userProjections.getByUserId(run.createdById) ?? null)
+        : null;
+
+      return new ProjectDataMartRunDto(this.mapper.toDataMartRunDto(run, createdByUser), {
+        id: run.dataMart.id,
+        title: run.dataMart.title,
+      });
+    });
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/list-project-insight-templates.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-insight-templates.service.spec.ts
@@ -1,6 +1,7 @@
 import { ListProjectInsightTemplatesCommand } from '../dto/domain/list-project-insight-templates.command';
 import type { InsightTemplateDto } from '../dto/domain/insight-template.dto';
 import { RoleScope } from '../enums/role-scope.enum';
+import { Action, EntityType } from '../services/access-decision';
 import { ListProjectInsightTemplatesService } from './list-project-insight-templates.service';
 
 describe('ListProjectInsightTemplatesService', () => {
@@ -31,12 +32,16 @@ describe('ListProjectInsightTemplatesService', () => {
     const mapper = {
       toDomainDto: jest.fn().mockReturnValue(insightTemplateDto),
     };
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(true),
+    };
 
     const service = new ListProjectInsightTemplatesService(
       insightTemplateService as never,
       contextAccessService as never,
       userProjectionsFetcherService as never,
-      mapper as never
+      mapper as never,
+      accessDecisionService as never
     );
 
     return {
@@ -45,6 +50,7 @@ describe('ListProjectInsightTemplatesService', () => {
       contextAccessService,
       userProjections,
       mapper,
+      accessDecisionService,
     };
   };
 
@@ -77,6 +83,7 @@ describe('ListProjectInsightTemplatesService', () => {
           id: 'dm-1',
           title: 'Marketing data mart',
         },
+        canDelete: true,
       },
     ]);
   });
@@ -97,5 +104,28 @@ describe('ListProjectInsightTemplatesService', () => {
       limit: 10,
       offset: 0,
     });
+  });
+
+  it('marks project insights deletable only when the caller can edit the owning data mart', async () => {
+    const { service, accessDecisionService } = createService();
+    accessDecisionService.canAccess.mockResolvedValueOnce(false);
+
+    const result = await service.run(
+      new ListProjectInsightTemplatesCommand('project-1', 20, 0, 'user-1', ['viewer'])
+    );
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['viewer'],
+      EntityType.DATA_MART,
+      'dm-1',
+      Action.EDIT,
+      'project-1'
+    );
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        canDelete: false,
+      })
+    );
   });
 });

--- a/apps/backend/src/data-marts/use-cases/list-project-insight-templates.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-insight-templates.service.spec.ts
@@ -1,0 +1,101 @@
+import { ListProjectInsightTemplatesCommand } from '../dto/domain/list-project-insight-templates.command';
+import type { InsightTemplateDto } from '../dto/domain/insight-template.dto';
+import { RoleScope } from '../enums/role-scope.enum';
+import { ListProjectInsightTemplatesService } from './list-project-insight-templates.service';
+
+describe('ListProjectInsightTemplatesService', () => {
+  const insightTemplate = {
+    id: 'insight-template-1',
+    createdById: 'creator-1',
+    dataMart: {
+      id: 'dm-1',
+      title: 'Marketing data mart',
+    },
+  };
+
+  const insightTemplateDto = { id: 'insight-template-1' } as InsightTemplateDto;
+
+  const createService = () => {
+    const insightTemplateService = {
+      listVisibleByProject: jest.fn().mockResolvedValue([insightTemplate]),
+    };
+    const contextAccessService = {
+      getRoleScope: jest.fn().mockResolvedValue(RoleScope.SELECTED_CONTEXTS),
+    };
+    const userProjections = {
+      getByUserId: jest.fn().mockReturnValue({ id: 'creator-1', name: 'Creator' }),
+    };
+    const userProjectionsFetcherService = {
+      fetchRelevantUserProjections: jest.fn().mockResolvedValue(userProjections),
+    };
+    const mapper = {
+      toDomainDto: jest.fn().mockReturnValue(insightTemplateDto),
+    };
+
+    const service = new ListProjectInsightTemplatesService(
+      insightTemplateService as never,
+      contextAccessService as never,
+      userProjectionsFetcherService as never,
+      mapper as never
+    );
+
+    return {
+      service,
+      insightTemplateService,
+      contextAccessService,
+      userProjections,
+      mapper,
+    };
+  };
+
+  it('passes selected-context scope to the visible insight-template query for non-admin users', async () => {
+    const { service, insightTemplateService, contextAccessService, mapper, userProjections } =
+      createService();
+
+    const result = await service.run(
+      new ListProjectInsightTemplatesCommand('project-1', 20, 40, 'user-1', ['viewer'])
+    );
+
+    expect(contextAccessService.getRoleScope).toHaveBeenCalledWith('user-1', 'project-1');
+    expect(insightTemplateService.listVisibleByProject).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+      limit: 20,
+      offset: 40,
+    });
+    expect(mapper.toDomainDto).toHaveBeenCalledWith(
+      insightTemplate,
+      null,
+      userProjections.getByUserId('creator-1')
+    );
+    expect(result).toEqual([
+      {
+        insightTemplate: insightTemplateDto,
+        dataMart: {
+          id: 'dm-1',
+          title: 'Marketing data mart',
+        },
+      },
+    ]);
+  });
+
+  it('uses entire-project scope without loading role scope for admin users', async () => {
+    const { service, insightTemplateService, contextAccessService } = createService();
+
+    await service.run(
+      new ListProjectInsightTemplatesCommand('project-1', 10, 0, 'admin-1', ['admin'])
+    );
+
+    expect(contextAccessService.getRoleScope).not.toHaveBeenCalled();
+    expect(insightTemplateService.listVisibleByProject).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'admin-1',
+      roles: ['admin'],
+      roleScope: RoleScope.ENTIRE_PROJECT,
+      limit: 10,
+      offset: 0,
+    });
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/list-project-insight-templates.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-insight-templates.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { ListProjectInsightTemplatesCommand } from '../dto/domain/list-project-insight-templates.command';
+import { ProjectInsightTemplateDto } from '../dto/domain/project-insight-template.dto';
+import { RoleScope } from '../enums/role-scope.enum';
+import { InsightTemplateMapper } from '../mappers/insight-template.mapper';
+import { ContextAccessService } from '../services/context/context-access.service';
+import { InsightTemplateService } from '../services/insight-template.service';
+import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+
+@Injectable()
+export class ListProjectInsightTemplatesService {
+  constructor(
+    private readonly insightTemplateService: InsightTemplateService,
+    private readonly contextAccessService: ContextAccessService,
+    private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
+    private readonly mapper: InsightTemplateMapper
+  ) {}
+
+  async run(command: ListProjectInsightTemplatesCommand): Promise<ProjectInsightTemplateDto[]> {
+    const isAdmin = command.roles.includes('admin');
+    const roleScope = isAdmin
+      ? RoleScope.ENTIRE_PROJECT
+      : await this.contextAccessService.getRoleScope(command.userId, command.projectId);
+
+    const insightTemplates = await this.insightTemplateService.listVisibleByProject({
+      projectId: command.projectId,
+      userId: command.userId,
+      roles: command.roles,
+      roleScope,
+      limit: command.limit,
+      offset: command.offset,
+    });
+
+    const userProjections =
+      await this.userProjectionsFetcherService.fetchRelevantUserProjections(insightTemplates);
+
+    return insightTemplates.map(insightTemplate => {
+      const createdByUser = insightTemplate.createdById
+        ? (userProjections.getByUserId(insightTemplate.createdById) ?? null)
+        : null;
+
+      return new ProjectInsightTemplateDto(
+        this.mapper.toDomainDto(insightTemplate, null, createdByUser),
+        {
+          id: insightTemplate.dataMart.id,
+          title: insightTemplate.dataMart.title,
+        }
+      );
+    });
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/list-project-insight-templates.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-insight-templates.service.ts
@@ -3,6 +3,7 @@ import { ListProjectInsightTemplatesCommand } from '../dto/domain/list-project-i
 import { ProjectInsightTemplateDto } from '../dto/domain/project-insight-template.dto';
 import { RoleScope } from '../enums/role-scope.enum';
 import { InsightTemplateMapper } from '../mappers/insight-template.mapper';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
 import { ContextAccessService } from '../services/context/context-access.service';
 import { InsightTemplateService } from '../services/insight-template.service';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
@@ -13,7 +14,8 @@ export class ListProjectInsightTemplatesService {
     private readonly insightTemplateService: InsightTemplateService,
     private readonly contextAccessService: ContextAccessService,
     private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
-    private readonly mapper: InsightTemplateMapper
+    private readonly mapper: InsightTemplateMapper,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   async run(command: ListProjectInsightTemplatesCommand): Promise<ProjectInsightTemplateDto[]> {
@@ -34,18 +36,29 @@ export class ListProjectInsightTemplatesService {
     const userProjections =
       await this.userProjectionsFetcherService.fetchRelevantUserProjections(insightTemplates);
 
-    return insightTemplates.map(insightTemplate => {
-      const createdByUser = insightTemplate.createdById
-        ? (userProjections.getByUserId(insightTemplate.createdById) ?? null)
-        : null;
+    return Promise.all(
+      insightTemplates.map(async insightTemplate => {
+        const createdByUser = insightTemplate.createdById
+          ? (userProjections.getByUserId(insightTemplate.createdById) ?? null)
+          : null;
+        const canDelete = await this.accessDecisionService.canAccess(
+          command.userId,
+          command.roles,
+          EntityType.DATA_MART,
+          insightTemplate.dataMart.id,
+          Action.EDIT,
+          command.projectId
+        );
 
-      return new ProjectInsightTemplateDto(
-        this.mapper.toDomainDto(insightTemplate, null, createdByUser),
-        {
-          id: insightTemplate.dataMart.id,
-          title: insightTemplate.dataMart.title,
-        }
-      );
-    });
+        return new ProjectInsightTemplateDto(
+          this.mapper.toDomainDto(insightTemplate, null, createdByUser),
+          {
+            id: insightTemplate.dataMart.id,
+            title: insightTemplate.dataMart.title,
+          },
+          canDelete
+        );
+      })
+    );
   }
 }

--- a/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.spec.ts
@@ -3,6 +3,7 @@ import type { ScheduledTriggerDto } from '../dto/domain/scheduled-trigger.dto';
 import { RoleScope } from '../enums/role-scope.enum';
 import { ScheduledReportRunConfigType } from '../scheduled-trigger-types/scheduled-report-run/schemas/scheduled-report-run-config.schema';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { Action } from '../services/access-decision';
 import { ListProjectScheduledTriggersService } from './list-project-scheduled-triggers.service';
 
 describe('ListProjectScheduledTriggersService', () => {
@@ -58,6 +59,13 @@ describe('ListProjectScheduledTriggersService', () => {
         (roles: string[]) => roles.includes('editor') || roles.includes('admin')
       ),
     };
+    const accessDecisionService = {
+      canAccessDmTrigger: jest
+        .fn()
+        .mockImplementation((_userId, roles: string[]) =>
+          Promise.resolve(roles.includes('editor') || roles.includes('admin'))
+        ),
+    };
 
     const service = new ListProjectScheduledTriggersService(
       scheduledTriggerService as never,
@@ -67,7 +75,8 @@ describe('ListProjectScheduledTriggersService', () => {
       reportService as never,
       reportMapper as never,
       connectorSecretService as never,
-      reportAccessService as never
+      reportAccessService as never,
+      accessDecisionService as never
     );
 
     return {
@@ -80,6 +89,7 @@ describe('ListProjectScheduledTriggersService', () => {
       reportMapper,
       connectorSecretService,
       reportAccessService,
+      accessDecisionService,
       reportResponse,
     };
   };
@@ -194,8 +204,9 @@ describe('ListProjectScheduledTriggersService', () => {
     );
   });
 
-  it('marks project connector-run triggers manageable only for technical users', async () => {
-    const { service, scheduledTriggerService, reportAccessService } = createService();
+  it('uses Data Mart trigger management access for project connector-run trigger capabilities', async () => {
+    const { service, scheduledTriggerService, reportAccessService, accessDecisionService } =
+      createService();
     scheduledTriggerService.listVisibleByProject.mockResolvedValueOnce([
       {
         ...trigger,
@@ -214,6 +225,50 @@ describe('ListProjectScheduledTriggersService', () => {
     );
 
     expect(reportAccessService.canOperate).not.toHaveBeenCalled();
+    expect(accessDecisionService.canAccessDmTrigger).toHaveBeenCalledWith(
+      'user-1',
+      ['viewer'],
+      'trigger-2',
+      'dm-2',
+      Action.MANAGE_TRIGGERS,
+      'project-1'
+    );
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        canEdit: false,
+        canDelete: false,
+      })
+    );
+  });
+
+  it('does not mark connector-run triggers manageable when Data Mart trigger management is denied', async () => {
+    const { service, scheduledTriggerService, accessDecisionService } = createService();
+    accessDecisionService.canAccessDmTrigger.mockResolvedValueOnce(false);
+    scheduledTriggerService.listVisibleByProject.mockResolvedValueOnce([
+      {
+        ...trigger,
+        id: 'trigger-2',
+        type: ScheduledTriggerType.CONNECTOR_RUN,
+        triggerConfig: undefined,
+        dataMart: {
+          id: 'dm-2',
+          title: 'Connector data mart',
+        },
+      },
+    ]);
+
+    const result = await service.run(
+      new ListProjectScheduledTriggersCommand('project-1', 20, 0, 'user-1', ['editor'])
+    );
+
+    expect(accessDecisionService.canAccessDmTrigger).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      'trigger-2',
+      'dm-2',
+      Action.MANAGE_TRIGGERS,
+      'project-1'
+    );
     expect(result[0]).toEqual(
       expect.objectContaining({
         canEdit: false,

--- a/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.spec.ts
@@ -1,0 +1,211 @@
+import { ListProjectScheduledTriggersCommand } from '../dto/domain/list-project-scheduled-triggers.command';
+import type { ScheduledTriggerDto } from '../dto/domain/scheduled-trigger.dto';
+import { RoleScope } from '../enums/role-scope.enum';
+import { ScheduledReportRunConfigType } from '../scheduled-trigger-types/scheduled-report-run/schemas/scheduled-report-run-config.schema';
+import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { ListProjectScheduledTriggersService } from './list-project-scheduled-triggers.service';
+
+describe('ListProjectScheduledTriggersService', () => {
+  const trigger = {
+    id: 'trigger-1',
+    type: ScheduledTriggerType.REPORT_RUN,
+    triggerConfig: {
+      type: ScheduledReportRunConfigType,
+      reportId: 'report-1',
+    },
+    createdById: 'creator-1',
+    dataMart: {
+      id: 'dm-1',
+      title: 'Marketing data mart',
+    },
+  };
+
+  const triggerDto = { id: 'trigger-1' } as ScheduledTriggerDto;
+
+  const createService = () => {
+    const scheduledTriggerService = {
+      listVisibleByProject: jest.fn().mockResolvedValue([trigger]),
+    };
+    const contextAccessService = {
+      getRoleScope: jest.fn().mockResolvedValue(RoleScope.SELECTED_CONTEXTS),
+    };
+    const userProjections = {
+      getByUserId: jest.fn().mockReturnValue({ id: 'creator-1', name: 'Creator' }),
+    };
+    const userProjectionsFetcherService = {
+      fetchRelevantUserProjections: jest.fn().mockResolvedValue(userProjections),
+    };
+    const mapper = {
+      toDomainDto: jest.fn().mockReturnValue(triggerDto),
+    };
+    const report = { id: 'report-1' };
+    const reportDto = { id: 'report-1', title: 'Report target' };
+    const reportResponse = { id: 'report-1', title: 'Report target' };
+    const reportService = {
+      getByIdsAndProjectIdAndDataMartIds: jest.fn().mockResolvedValue([report]),
+    };
+    const reportMapper = {
+      toDomainDto: jest.fn().mockReturnValue(reportDto),
+      toResponse: jest.fn().mockResolvedValue(reportResponse),
+    };
+    const connectorSecretService = {
+      mask: jest.fn(async definition => definition),
+    };
+
+    const service = new ListProjectScheduledTriggersService(
+      scheduledTriggerService as never,
+      contextAccessService as never,
+      userProjectionsFetcherService as never,
+      mapper as never,
+      reportService as never,
+      reportMapper as never,
+      connectorSecretService as never
+    );
+
+    return {
+      service,
+      scheduledTriggerService,
+      contextAccessService,
+      userProjections,
+      mapper,
+      reportService,
+      reportMapper,
+      connectorSecretService,
+      reportResponse,
+    };
+  };
+
+  it('passes selected-context scope to the visible-triggers query for non-admin users', async () => {
+    const { service, scheduledTriggerService, contextAccessService, mapper, userProjections } =
+      createService();
+
+    const result = await service.run(
+      new ListProjectScheduledTriggersCommand('project-1', 20, 40, 'user-1', ['viewer'])
+    );
+
+    expect(contextAccessService.getRoleScope).toHaveBeenCalledWith('user-1', 'project-1');
+    expect(scheduledTriggerService.listVisibleByProject).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+      limit: 20,
+      offset: 40,
+    });
+    expect(mapper.toDomainDto).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: trigger.id,
+        triggerConfig: expect.objectContaining({
+          report: expect.objectContaining({ id: 'report-1' }),
+        }),
+      }),
+      userProjections.getByUserId('creator-1')
+    );
+    expect(result).toEqual([
+      {
+        trigger: triggerDto,
+        dataMart: {
+          id: 'dm-1',
+          title: 'Marketing data mart',
+        },
+      },
+    ]);
+  });
+
+  it('uses entire-project scope without loading role scope for admin users', async () => {
+    const { service, scheduledTriggerService, contextAccessService } = createService();
+
+    await service.run(
+      new ListProjectScheduledTriggersCommand('project-1', 10, 0, 'admin-1', ['admin'])
+    );
+
+    expect(contextAccessService.getRoleScope).not.toHaveBeenCalled();
+    expect(scheduledTriggerService.listVisibleByProject).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'admin-1',
+      roles: ['admin'],
+      roleScope: RoleScope.ENTIRE_PROJECT,
+      limit: 10,
+      offset: 0,
+    });
+  });
+
+  it('adds hydrated report data to project report-run trigger configs', async () => {
+    const { service, mapper, reportService, reportMapper, reportResponse } = createService();
+
+    await service.run(new ListProjectScheduledTriggersCommand('project-1', 20, 0, 'user-1', []));
+
+    expect(reportService.getByIdsAndProjectIdAndDataMartIds).toHaveBeenCalledWith(
+      ['report-1'],
+      'project-1',
+      ['dm-1']
+    );
+    expect(reportMapper.toResponse).toHaveBeenCalledWith({
+      id: 'report-1',
+      title: 'Report target',
+    });
+    expect(mapper.toDomainDto).toHaveBeenCalledWith(
+      expect.objectContaining({
+        triggerConfig: {
+          type: ScheduledReportRunConfigType,
+          reportId: 'report-1',
+          report: reportResponse,
+        },
+      }),
+      expect.anything()
+    );
+  });
+
+  it('adds masked connector definition data to project connector-run trigger configs', async () => {
+    const connectorDefinition = {
+      connector: {
+        source: {
+          name: 'FacebookMarketing',
+          configuration: [{ accountId: '123' }],
+          node: 'ads',
+          fields: ['campaign'],
+        },
+        storage: { fullyQualifiedName: 'dataset.table' },
+      },
+    };
+    const maskedConnectorDefinition = {
+      connector: {
+        source: {
+          name: 'FacebookMarketing',
+          configuration: [{ accountId: '123', apiKey: '**********' }],
+          node: 'ads',
+          fields: ['campaign'],
+        },
+        storage: { fullyQualifiedName: 'dataset.table' },
+      },
+    };
+    const { service, scheduledTriggerService, mapper, connectorSecretService } = createService();
+    connectorSecretService.mask.mockResolvedValueOnce(maskedConnectorDefinition);
+    scheduledTriggerService.listVisibleByProject.mockResolvedValueOnce([
+      {
+        ...trigger,
+        id: 'trigger-2',
+        type: ScheduledTriggerType.CONNECTOR_RUN,
+        triggerConfig: undefined,
+        dataMart: {
+          id: 'dm-2',
+          title: 'Connector data mart',
+          definition: connectorDefinition,
+        },
+      },
+    ]);
+
+    await service.run(new ListProjectScheduledTriggersCommand('project-1', 20, 0, 'user-1', []));
+
+    expect(connectorSecretService.mask).toHaveBeenCalledWith(connectorDefinition);
+    expect(mapper.toDomainDto).toHaveBeenCalledWith(
+      expect.objectContaining({
+        triggerConfig: {
+          type: 'scheduled-connector-run-config',
+          connector: maskedConnectorDefinition,
+        },
+      }),
+      expect.anything()
+    );
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.spec.ts
@@ -43,6 +43,7 @@ describe('ListProjectScheduledTriggersService', () => {
     const reportResponse = { id: 'report-1', title: 'Report target' };
     const reportService = {
       getByIdsAndProjectIdAndDataMartIds: jest.fn().mockResolvedValue([report]),
+      getByIdAndDataMartIdAndProjectId: jest.fn().mockResolvedValue(report),
     };
     const reportMapper = {
       toDomainDto: jest.fn().mockReturnValue(reportDto),
@@ -50,6 +51,12 @@ describe('ListProjectScheduledTriggersService', () => {
     };
     const connectorSecretService = {
       mask: jest.fn(async definition => definition),
+    };
+    const reportAccessService = {
+      canOperate: jest.fn().mockResolvedValue(true),
+      isTechnicalUser: jest.fn(
+        (roles: string[]) => roles.includes('editor') || roles.includes('admin')
+      ),
     };
 
     const service = new ListProjectScheduledTriggersService(
@@ -59,7 +66,8 @@ describe('ListProjectScheduledTriggersService', () => {
       mapper as never,
       reportService as never,
       reportMapper as never,
-      connectorSecretService as never
+      connectorSecretService as never,
+      reportAccessService as never
     );
 
     return {
@@ -71,6 +79,7 @@ describe('ListProjectScheduledTriggersService', () => {
       reportService,
       reportMapper,
       connectorSecretService,
+      reportAccessService,
       reportResponse,
     };
   };
@@ -108,6 +117,8 @@ describe('ListProjectScheduledTriggersService', () => {
           id: 'dm-1',
           title: 'Marketing data mart',
         },
+        canEdit: true,
+        canDelete: true,
       },
     ]);
   });
@@ -153,6 +164,61 @@ describe('ListProjectScheduledTriggersService', () => {
         },
       }),
       expect.anything()
+    );
+  });
+
+  it('marks project report-run triggers manageable only when the report can be operated', async () => {
+    const { service, reportAccessService, reportService } = createService();
+    reportAccessService.canOperate.mockResolvedValueOnce(false);
+
+    const result = await service.run(
+      new ListProjectScheduledTriggersCommand('project-1', 20, 0, 'user-1', ['viewer'])
+    );
+
+    expect(reportAccessService.canOperate).toHaveBeenCalledWith(
+      'user-1',
+      ['viewer'],
+      'report-1',
+      'project-1'
+    );
+    expect(reportService.getByIdAndDataMartIdAndProjectId).toHaveBeenCalledWith(
+      'report-1',
+      'dm-1',
+      'project-1'
+    );
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        canEdit: false,
+        canDelete: false,
+      })
+    );
+  });
+
+  it('marks project connector-run triggers manageable only for technical users', async () => {
+    const { service, scheduledTriggerService, reportAccessService } = createService();
+    scheduledTriggerService.listVisibleByProject.mockResolvedValueOnce([
+      {
+        ...trigger,
+        id: 'trigger-2',
+        type: ScheduledTriggerType.CONNECTOR_RUN,
+        triggerConfig: undefined,
+        dataMart: {
+          id: 'dm-2',
+          title: 'Connector data mart',
+        },
+      },
+    ]);
+
+    const result = await service.run(
+      new ListProjectScheduledTriggersCommand('project-1', 20, 0, 'user-1', ['viewer'])
+    );
+
+    expect(reportAccessService.canOperate).not.toHaveBeenCalled();
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        canEdit: false,
+        canDelete: false,
+      })
     );
   });
 

--- a/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.ts
@@ -1,0 +1,139 @@
+import { Injectable } from '@nestjs/common';
+import { ListProjectScheduledTriggersCommand } from '../dto/domain/list-project-scheduled-triggers.command';
+import { ProjectScheduledTriggerDto } from '../dto/domain/project-scheduled-trigger.dto';
+import { ReportMapper } from '../mappers/report.mapper';
+import { RoleScope } from '../enums/role-scope.enum';
+import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { ScheduledReportRunConfigType } from '../scheduled-trigger-types/scheduled-report-run/schemas/scheduled-report-run-config.schema';
+import { isConnectorDefinition } from '../dto/schemas/data-mart-table-definitions/data-mart-definition.guards';
+import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
+import { ScheduledTriggerMapper } from '../mappers/scheduled-trigger.mapper';
+import { ConnectorSecretService } from '../services/connector/connector-secret.service';
+import { ContextAccessService } from '../services/context/context-access.service';
+import { ReportService } from '../services/report.service';
+import { ScheduledTriggerService } from '../services/scheduled-trigger.service';
+import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+
+const ScheduledConnectorRunConfigType = 'scheduled-connector-run-config';
+
+@Injectable()
+export class ListProjectScheduledTriggersService {
+  constructor(
+    private readonly scheduledTriggerService: ScheduledTriggerService,
+    private readonly contextAccessService: ContextAccessService,
+    private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
+    private readonly mapper: ScheduledTriggerMapper,
+    private readonly reportService: ReportService,
+    private readonly reportMapper: ReportMapper,
+    private readonly connectorSecretService: ConnectorSecretService
+  ) {}
+
+  async run(command: ListProjectScheduledTriggersCommand): Promise<ProjectScheduledTriggerDto[]> {
+    const isAdmin = command.roles.includes('admin');
+    const roleScope = isAdmin
+      ? RoleScope.ENTIRE_PROJECT
+      : await this.contextAccessService.getRoleScope(command.userId, command.projectId);
+
+    const triggers = await this.scheduledTriggerService.listVisibleByProject({
+      projectId: command.projectId,
+      userId: command.userId,
+      roles: command.roles,
+      roleScope,
+      limit: command.limit,
+      offset: command.offset,
+    });
+
+    const userProjections =
+      await this.userProjectionsFetcherService.fetchRelevantUserProjections(triggers);
+
+    const triggersWithRunTargets = await this.enrichRunTargets(triggers, command.projectId);
+
+    return triggersWithRunTargets.map(trigger => {
+      const createdByUser = trigger.createdById
+        ? (userProjections.getByUserId(trigger.createdById) ?? null)
+        : null;
+
+      return new ProjectScheduledTriggerDto(this.mapper.toDomainDto(trigger, createdByUser), {
+        id: trigger.dataMart.id,
+        title: trigger.dataMart.title,
+      });
+    });
+  }
+
+  private async enrichRunTargets(
+    triggers: DataMartScheduledTrigger[],
+    projectId: string
+  ): Promise<DataMartScheduledTrigger[]> {
+    const reportIds = [
+      ...new Set(
+        triggers
+          .filter(trigger => trigger.type === ScheduledTriggerType.REPORT_RUN)
+          .map(trigger => trigger.triggerConfig?.reportId)
+          .filter((reportId): reportId is string => Boolean(reportId))
+      ),
+    ];
+
+    const dataMartIds = [...new Set(triggers.map(trigger => trigger.dataMart.id).filter(Boolean))];
+    const reports = await this.reportService.getByIdsAndProjectIdAndDataMartIds(
+      reportIds,
+      projectId,
+      dataMartIds
+    );
+    const reportResponseEntries = await Promise.all(
+      reports.map(async report => {
+        const reportDto = this.reportMapper.toDomainDto(report);
+        const reportResponse = await this.reportMapper.toResponse(reportDto);
+        return [report.id, reportResponse] as const;
+      })
+    );
+    const reportResponseById = new Map(reportResponseEntries);
+
+    return Promise.all(
+      triggers.map(async trigger => {
+        if (trigger.type === ScheduledTriggerType.REPORT_RUN) {
+          const reportId = trigger.triggerConfig?.reportId;
+          const reportResponse = reportId ? reportResponseById.get(reportId) : undefined;
+
+          if (!reportId || !reportResponse) {
+            return trigger;
+          }
+
+          return this.cloneTriggerWithConfig(trigger, {
+            type: ScheduledReportRunConfigType,
+            reportId,
+            report: reportResponse,
+          } as unknown as DataMartScheduledTrigger['triggerConfig']);
+        }
+
+        if (
+          trigger.type === ScheduledTriggerType.CONNECTOR_RUN &&
+          trigger.dataMart.definition &&
+          isConnectorDefinition(trigger.dataMart.definition)
+        ) {
+          const maskedDefinition = await this.connectorSecretService.mask(
+            trigger.dataMart.definition
+          );
+
+          return this.cloneTriggerWithConfig(trigger, {
+            type: ScheduledConnectorRunConfigType,
+            connector: maskedDefinition,
+          } as unknown as DataMartScheduledTrigger['triggerConfig']);
+        }
+
+        return trigger;
+      })
+    );
+  }
+
+  private cloneTriggerWithConfig(
+    trigger: DataMartScheduledTrigger,
+    triggerConfig: DataMartScheduledTrigger['triggerConfig']
+  ): DataMartScheduledTrigger {
+    const clone = Object.assign(
+      Object.create(Object.getPrototypeOf(trigger)),
+      trigger
+    ) as DataMartScheduledTrigger;
+    clone.triggerConfig = triggerConfig;
+    return clone;
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.ts
@@ -5,11 +5,13 @@ import { ReportMapper } from '../mappers/report.mapper';
 import { RoleScope } from '../enums/role-scope.enum';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
 import { ScheduledReportRunConfigType } from '../scheduled-trigger-types/scheduled-report-run/schemas/scheduled-report-run-config.schema';
+import { isScheduledReportRunConfig } from '../scheduled-trigger-types/scheduled-trigger-config.guards';
 import { isConnectorDefinition } from '../dto/schemas/data-mart-table-definitions/data-mart-definition.guards';
 import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
 import { ScheduledTriggerMapper } from '../mappers/scheduled-trigger.mapper';
 import { ConnectorSecretService } from '../services/connector/connector-secret.service';
 import { ContextAccessService } from '../services/context/context-access.service';
+import { ReportAccessService } from '../services/report-access.service';
 import { ReportService } from '../services/report.service';
 import { ScheduledTriggerService } from '../services/scheduled-trigger.service';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
@@ -25,7 +27,8 @@ export class ListProjectScheduledTriggersService {
     private readonly mapper: ScheduledTriggerMapper,
     private readonly reportService: ReportService,
     private readonly reportMapper: ReportMapper,
-    private readonly connectorSecretService: ConnectorSecretService
+    private readonly connectorSecretService: ConnectorSecretService,
+    private readonly reportAccessService: ReportAccessService
   ) {}
 
   async run(command: ListProjectScheduledTriggersCommand): Promise<ProjectScheduledTriggerDto[]> {
@@ -48,16 +51,54 @@ export class ListProjectScheduledTriggersService {
 
     const triggersWithRunTargets = await this.enrichRunTargets(triggers, command.projectId);
 
-    return triggersWithRunTargets.map(trigger => {
-      const createdByUser = trigger.createdById
-        ? (userProjections.getByUserId(trigger.createdById) ?? null)
-        : null;
+    return Promise.all(
+      triggersWithRunTargets.map(async trigger => {
+        const createdByUser = trigger.createdById
+          ? (userProjections.getByUserId(trigger.createdById) ?? null)
+          : null;
+        const canManage = await this.canManageTrigger(trigger, command);
 
-      return new ProjectScheduledTriggerDto(this.mapper.toDomainDto(trigger, createdByUser), {
-        id: trigger.dataMart.id,
-        title: trigger.dataMart.title,
-      });
-    });
+        return new ProjectScheduledTriggerDto(
+          this.mapper.toDomainDto(trigger, createdByUser),
+          {
+            id: trigger.dataMart.id,
+            title: trigger.dataMart.title,
+          },
+          canManage,
+          canManage
+        );
+      })
+    );
+  }
+
+  private async canManageTrigger(
+    trigger: DataMartScheduledTrigger,
+    command: ListProjectScheduledTriggersCommand
+  ): Promise<boolean> {
+    if (trigger.type !== ScheduledTriggerType.REPORT_RUN) {
+      return this.reportAccessService.isTechnicalUser(command.roles);
+    }
+
+    if (!isScheduledReportRunConfig(trigger.triggerConfig)) {
+      return false;
+    }
+
+    try {
+      await this.reportService.getByIdAndDataMartIdAndProjectId(
+        trigger.triggerConfig.reportId,
+        trigger.dataMart.id,
+        command.projectId
+      );
+    } catch {
+      return false;
+    }
+
+    return this.reportAccessService.canOperate(
+      command.userId,
+      command.roles,
+      trigger.triggerConfig.reportId,
+      command.projectId
+    );
   }
 
   private async enrichRunTargets(

--- a/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-project-scheduled-triggers.service.ts
@@ -15,6 +15,7 @@ import { ReportAccessService } from '../services/report-access.service';
 import { ReportService } from '../services/report.service';
 import { ScheduledTriggerService } from '../services/scheduled-trigger.service';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
+import { AccessDecisionService, Action } from '../services/access-decision';
 
 const ScheduledConnectorRunConfigType = 'scheduled-connector-run-config';
 
@@ -28,7 +29,8 @@ export class ListProjectScheduledTriggersService {
     private readonly reportService: ReportService,
     private readonly reportMapper: ReportMapper,
     private readonly connectorSecretService: ConnectorSecretService,
-    private readonly reportAccessService: ReportAccessService
+    private readonly reportAccessService: ReportAccessService,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   async run(command: ListProjectScheduledTriggersCommand): Promise<ProjectScheduledTriggerDto[]> {
@@ -76,7 +78,14 @@ export class ListProjectScheduledTriggersService {
     command: ListProjectScheduledTriggersCommand
   ): Promise<boolean> {
     if (trigger.type !== ScheduledTriggerType.REPORT_RUN) {
-      return this.reportAccessService.isTechnicalUser(command.roles);
+      return this.accessDecisionService.canAccessDmTrigger(
+        command.userId,
+        command.roles,
+        trigger.id,
+        trigger.dataMart.id,
+        Action.MANAGE_TRIGGERS,
+        command.projectId
+      );
     }
 
     if (!isScheduledReportRunConfig(trigger.triggerConfig)) {

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.spec.ts
@@ -1,0 +1,123 @@
+import { ListReportsByProjectCommand } from '../dto/domain/list-reports-by-project.command';
+import { OwnerFilter } from '../enums/owner-filter.enum';
+import { RoleScope } from '../enums/role-scope.enum';
+import { ListReportsByProjectService } from './list-reports-by-project.service';
+
+describe('ListReportsByProjectService', () => {
+  function createQueryBuilder(reports: unknown[]) {
+    return {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(reports),
+    };
+  }
+
+  function createService(reports = [buildReport()]) {
+    const qb = createQueryBuilder(reports);
+    const reportRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    };
+    const mapper = {
+      toDomainDto: jest.fn(report => ({ id: report.id })),
+    };
+    const userProjectionsList = {
+      getByUserId: jest.fn(userId => ({ id: userId, fullName: userId })),
+    };
+    const userProjectionsFetcherService = {
+      fetchUserProjectionsList: jest.fn().mockResolvedValue(userProjectionsList),
+    };
+    const contextAccessService = {
+      getRoleScope: jest.fn().mockResolvedValue(RoleScope.SELECTED_CONTEXTS),
+    };
+    const reportAccessService = {
+      computeCapabilitiesForReport: jest.fn().mockResolvedValue({
+        canRun: true,
+        canManageTriggers: true,
+        canEditConfig: false,
+      }),
+    };
+
+    const service = new ListReportsByProjectService(
+      reportRepository as never,
+      mapper as never,
+      userProjectionsFetcherService as never,
+      contextAccessService as never,
+      reportAccessService as never
+    );
+
+    return {
+      service,
+      qb,
+      contextAccessService,
+      reportAccessService,
+      mapper,
+    };
+  }
+
+  it('applies pagination while keeping DB-side Data Mart visibility filtering', async () => {
+    const { service, qb, contextAccessService, reportAccessService } = createService();
+
+    await service.run(
+      new ListReportsByProjectCommand('project-1', 'user-1', ['viewer'], OwnerFilter.ALL, 25, 50)
+    );
+
+    expect(contextAccessService.getRoleScope).toHaveBeenCalledWith('user-1', 'project-1');
+    expect(qb.take).toHaveBeenCalledWith(25);
+    expect(qb.skip).toHaveBeenCalledWith(50);
+    expect(qb.andWhere).toHaveBeenCalledWith(expect.stringContaining('data_mart_contexts'), {
+      userId: 'user-1',
+      isTrue: true,
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+      entireProjectScope: RoleScope.ENTIRE_PROJECT,
+      projectId: 'project-1',
+    });
+    expect(reportAccessService.computeCapabilitiesForReport).toHaveBeenCalledWith(
+      'user-1',
+      ['viewer'],
+      expect.objectContaining({ id: 'report-1' }),
+      'project-1'
+    );
+  });
+
+  it('does not add per-user visibility predicates for admins', async () => {
+    const { service, qb, contextAccessService } = createService();
+
+    await service.run(
+      new ListReportsByProjectCommand('project-1', 'admin-1', ['admin'], undefined, 10, 0)
+    );
+
+    expect(contextAccessService.getRoleScope).not.toHaveBeenCalled();
+    expect(qb.take).toHaveBeenCalledWith(10);
+    expect(qb.skip).toHaveBeenCalledWith(0);
+    expect(qb.andWhere).not.toHaveBeenCalledWith(
+      expect.stringContaining('data_mart_contexts'),
+      expect.anything()
+    );
+  });
+
+  it('does not constrain the legacy project list when pagination is omitted', async () => {
+    const { service, qb } = createService();
+
+    await service.run(new ListReportsByProjectCommand('project-1', 'user-1', ['viewer']));
+
+    expect(qb.take).not.toHaveBeenCalled();
+    expect(qb.skip).not.toHaveBeenCalled();
+  });
+});
+
+function buildReport() {
+  return {
+    id: 'report-1',
+    createdById: 'creator-1',
+    ownerIds: ['owner-1'],
+    dataMart: {
+      id: 'dm-1',
+      projectId: 'project-1',
+    },
+  };
+}

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.ts
@@ -8,10 +8,10 @@ import { ReportDto } from '../dto/domain/report.dto';
 import { OwnerFilter } from '../enums/owner-filter.enum';
 import { RoleScope } from '../enums/role-scope.enum';
 import { ContextAccessService } from '../services/context/context-access.service';
-import { buildContextGateSql } from '../utils/build-context-gate-sql';
 import { UserProjectionsFetcherService } from '../services/user-projections-fetcher.service';
 import { ReportAccessService } from '../services/report-access.service';
 import { resolveOwnerUsers } from '../utils/resolve-owner-users';
+import { applyDataMartVisibilityFilter } from '../utils/apply-data-mart-visibility-filter';
 
 @Injectable()
 export class ListReportsByProjectService {
@@ -26,7 +26,6 @@ export class ListReportsByProjectService {
 
   async run(command: ListReportsByProjectCommand): Promise<ReportDto[]> {
     const isAdmin = command.roles.includes('admin');
-    const isTu = command.roles.includes('editor') || isAdmin;
     const roleScope: RoleScope = isAdmin
       ? RoleScope.ENTIRE_PROJECT
       : await this.contextAccessService.getRoleScope(command.userId, command.projectId);
@@ -41,39 +40,28 @@ export class ListReportsByProjectService {
       .where('dataMart.projectId = :projectId', { projectId: command.projectId })
       .andWhere('dataMart.deletedAt IS NULL');
 
-    // Reports inherit DM visibility: only show reports on visible DataMarts
-    if (!isAdmin) {
-      const contextGate = buildContextGateSql({
-        joinTable: 'data_mart_contexts',
-        entityIdColumn: 'data_mart_id',
-        entityAlias: 'dataMart',
-      });
-      const sharedClause = isTu
-        ? `(dataMart.availableForReporting = :isTrue OR dataMart.availableForMaintenance = :isTrue)`
-        : `dataMart.availableForReporting = :isTrue`;
-      qb = qb.andWhere(
-        `(
-          EXISTS (SELECT 1 FROM data_mart_technical_owners t WHERE t.data_mart_id = dataMart.id AND t.user_id = :userId)
-          OR EXISTS (SELECT 1 FROM data_mart_business_owners b WHERE b.data_mart_id = dataMart.id AND b.user_id = :userId)
-          OR (
-            ${sharedClause}
-            AND ${contextGate}
-          )
-        )`,
-        {
-          userId: command.userId,
-          isTrue: true,
-          roleScope,
-          entireProjectScope: RoleScope.ENTIRE_PROJECT,
-          projectId: command.projectId,
-        }
-      );
-    }
+    applyDataMartVisibilityFilter(qb, {
+      dataMartAlias: 'dataMart',
+      projectId: command.projectId,
+      userId: command.userId,
+      roles: command.roles,
+      roleScope,
+    });
 
     if (command.ownerFilter === OwnerFilter.HAS_OWNERS) {
       qb = qb.andWhere('EXISTS (SELECT 1 FROM report_owners o WHERE o.report_id = r.id)');
     } else if (command.ownerFilter === OwnerFilter.NO_OWNERS) {
       qb = qb.andWhere('NOT EXISTS (SELECT 1 FROM report_owners o WHERE o.report_id = r.id)');
+    }
+
+    qb = qb.orderBy('r.createdAt', 'DESC').addOrderBy('r.id', 'DESC');
+
+    if (command.limit !== undefined) {
+      qb = qb.take(command.limit);
+    }
+
+    if (command.offset !== undefined) {
+      qb = qb.skip(command.offset);
     }
 
     const reports = await qb.getMany();

--- a/apps/backend/src/data-marts/use-cases/update-scheduled-trigger.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-scheduled-trigger.service.spec.ts
@@ -1,0 +1,111 @@
+import { ForbiddenException } from '@nestjs/common';
+import { UpdateScheduledTriggerCommand } from '../dto/domain/update-scheduled-trigger.command';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
+import { Action } from '../services/access-decision';
+import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { UpdateScheduledTriggerService } from './update-scheduled-trigger.service';
+
+describe('UpdateScheduledTriggerService', () => {
+  const connectorRunTrigger = {
+    id: 'trigger-1',
+    type: ScheduledTriggerType.CONNECTOR_RUN,
+    cronExpression: '0 9 * * *',
+    timeZone: 'UTC',
+    isActive: true,
+    dataMart: {
+      id: 'dm-1',
+      status: DataMartStatus.PUBLISHED,
+    },
+    scheduleNextRun: jest.fn(),
+    discardNextRun: jest.fn(),
+  };
+
+  const createService = () => {
+    const triggerRepository = {
+      save: jest.fn().mockImplementation(trigger => Promise.resolve(trigger)),
+    };
+    const scheduledTriggerService = {
+      getByIdAndDataMartIdAndProjectId: jest.fn().mockResolvedValue({
+        ...connectorRunTrigger,
+        scheduleNextRun: jest.fn(),
+        discardNextRun: jest.fn(),
+      }),
+    };
+    const mapper = {
+      toDomainDto: jest.fn().mockReturnValue({ id: 'trigger-1' }),
+    };
+    const userProjectionsFetcherService = {
+      fetchCreatedByUser: jest.fn().mockResolvedValue(null),
+    };
+    const reportAccessService = {
+      checkOperateAccess: jest.fn().mockResolvedValue(undefined),
+      isTechnicalUser: jest
+        .fn()
+        .mockImplementation(
+          (roles: string[]) => roles.includes('editor') || roles.includes('admin')
+        ),
+    };
+    const reportService = {
+      getByIdAndDataMartIdAndProjectId: jest.fn(),
+    };
+    const accessDecisionService = {
+      canAccessDmTrigger: jest.fn().mockResolvedValue(true),
+    };
+
+    const service = new UpdateScheduledTriggerService(
+      triggerRepository as never,
+      scheduledTriggerService as never,
+      mapper as never,
+      userProjectionsFetcherService as never,
+      reportAccessService as never,
+      reportService as never,
+      accessDecisionService as never
+    );
+
+    return { service, triggerRepository, accessDecisionService };
+  };
+
+  const command = new UpdateScheduledTriggerCommand(
+    'trigger-1',
+    'dm-1',
+    'project-1',
+    'user-1',
+    ['editor'],
+    '0 10 * * *',
+    'UTC',
+    true
+  );
+
+  it('updates connector-run triggers when Data Mart trigger management is allowed', async () => {
+    const { service, triggerRepository, accessDecisionService } = createService();
+
+    await expect(service.run(command)).resolves.toEqual({ id: 'trigger-1' });
+
+    expect(accessDecisionService.canAccessDmTrigger).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      'trigger-1',
+      'dm-1',
+      Action.MANAGE_TRIGGERS,
+      'project-1'
+    );
+    expect(triggerRepository.save).toHaveBeenCalled();
+  });
+
+  it('rejects connector-run trigger updates when Data Mart trigger management is denied', async () => {
+    const { service, triggerRepository, accessDecisionService } = createService();
+    accessDecisionService.canAccessDmTrigger.mockResolvedValueOnce(false);
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+
+    expect(accessDecisionService.canAccessDmTrigger).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      'trigger-1',
+      'dm-1',
+      Action.MANAGE_TRIGGERS,
+      'project-1'
+    );
+    expect(triggerRepository.save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/update-scheduled-trigger.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-scheduled-trigger.service.ts
@@ -13,6 +13,7 @@ import { ReportAccessService } from '../services/report-access.service';
 import { ReportService } from '../services/report.service';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
 import { isScheduledReportRunConfig } from '../scheduled-trigger-types/scheduled-trigger-config.guards';
+import { AccessDecisionService, Action } from '../services/access-decision';
 
 @Injectable()
 export class UpdateScheduledTriggerService {
@@ -23,7 +24,8 @@ export class UpdateScheduledTriggerService {
     private readonly mapper: ScheduledTriggerMapper,
     private readonly userProjectionsFetcherService: UserProjectionsFetcherService,
     private readonly reportAccessService: ReportAccessService,
-    private readonly reportService: ReportService
+    private readonly reportService: ReportService,
+    private readonly accessDecisionService: AccessDecisionService
   ) {}
 
   async run(command: UpdateScheduledTriggerCommand): Promise<ScheduledTriggerDto> {
@@ -85,8 +87,19 @@ export class UpdateScheduledTriggerService {
         command.projectId
       );
     } else {
-      if (!this.reportAccessService.isTechnicalUser(command.roles)) {
-        throw new ForbiddenException('Only Technical Users can update connector run triggers.');
+      const canManageTriggers = await this.accessDecisionService.canAccessDmTrigger(
+        command.userId,
+        command.roles,
+        trigger.id,
+        command.dataMartId,
+        Action.MANAGE_TRIGGERS,
+        command.projectId
+      );
+
+      if (!canManageTriggers) {
+        throw new ForbiddenException(
+          'You do not have permission to manage triggers for this DataMart.'
+        );
       }
     }
   }

--- a/apps/backend/src/data-marts/utils/apply-data-mart-visibility-filter.ts
+++ b/apps/backend/src/data-marts/utils/apply-data-mart-visibility-filter.ts
@@ -1,0 +1,51 @@
+import { ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+import { RoleScope } from '../enums/role-scope.enum';
+import { buildContextGateSql } from './build-context-gate-sql';
+
+export interface DataMartVisibilityFilterOptions {
+  readonly dataMartAlias: string;
+  readonly projectId: string;
+  readonly userId?: string;
+  readonly roles?: string[];
+  readonly roleScope?: RoleScope;
+}
+
+export function applyDataMartVisibilityFilter<T extends ObjectLiteral>(
+  qb: SelectQueryBuilder<T>,
+  options: DataMartVisibilityFilterOptions
+): SelectQueryBuilder<T> {
+  const isAdmin = options.roles?.includes('admin');
+  if (isAdmin || !options.userId) {
+    return qb;
+  }
+
+  const isEditor = options.roles?.includes('editor');
+  const roleScope = options.roleScope ?? RoleScope.ENTIRE_PROJECT;
+  const { dataMartAlias } = options;
+  const contextGate = buildContextGateSql({
+    joinTable: 'data_mart_contexts',
+    entityIdColumn: 'data_mart_id',
+    entityAlias: dataMartAlias,
+  });
+  const sharedClause = isEditor
+    ? `(${dataMartAlias}.availableForReporting = :isTrue OR ${dataMartAlias}.availableForMaintenance = :isTrue)`
+    : `${dataMartAlias}.availableForReporting = :isTrue`;
+
+  return qb.andWhere(
+    `(
+      EXISTS (SELECT 1 FROM data_mart_technical_owners t WHERE t.data_mart_id = ${dataMartAlias}.id AND t.user_id = :userId)
+      OR EXISTS (SELECT 1 FROM data_mart_business_owners b WHERE b.data_mart_id = ${dataMartAlias}.id AND b.user_id = :userId)
+      OR (
+        ${sharedClause}
+        AND ${contextGate}
+      )
+    )`,
+    {
+      userId: options.userId,
+      isTrue: true,
+      roleScope,
+      entireProjectScope: RoleScope.ENTIRE_PROJECT,
+      projectId: options.projectId,
+    }
+  );
+}

--- a/apps/backend/src/data-marts/utils/normalize-project-list-pagination.spec.ts
+++ b/apps/backend/src/data-marts/utils/normalize-project-list-pagination.spec.ts
@@ -1,0 +1,11 @@
+import { normalizeProjectListPagination } from './normalize-project-list-pagination';
+
+const MAX_PROJECT_LIST_OFFSET = 100_000;
+
+describe('normalizeProjectListPagination', () => {
+  it('caps offset to the maximum supported project-list offset', () => {
+    expect(normalizeProjectListPagination(100, MAX_PROJECT_LIST_OFFSET + 1).offset).toBe(
+      MAX_PROJECT_LIST_OFFSET
+    );
+  });
+});

--- a/apps/backend/src/data-marts/utils/normalize-project-list-pagination.ts
+++ b/apps/backend/src/data-marts/utils/normalize-project-list-pagination.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_PROJECT_LIST_LIMIT = 100;
 export const MAX_PROJECT_LIST_LIMIT = 100;
+export const MAX_PROJECT_LIST_OFFSET = 100_000;
 
 export interface ProjectListPagination {
   limit: number;
@@ -33,7 +34,7 @@ function normalizeOffset(value: unknown): number {
     return 0;
   }
 
-  return parsed;
+  return Math.min(parsed, MAX_PROJECT_LIST_OFFSET);
 }
 
 function parseInteger(value: unknown): number | null {

--- a/apps/backend/src/data-marts/utils/normalize-project-list-pagination.ts
+++ b/apps/backend/src/data-marts/utils/normalize-project-list-pagination.ts
@@ -1,0 +1,47 @@
+export const DEFAULT_PROJECT_LIST_LIMIT = 100;
+export const MAX_PROJECT_LIST_LIMIT = 100;
+
+export interface ProjectListPagination {
+  limit: number;
+  offset: number;
+}
+
+export function normalizeProjectListPagination(
+  limit: unknown,
+  offset: unknown
+): ProjectListPagination {
+  return {
+    limit: normalizeLimit(limit),
+    offset: normalizeOffset(offset),
+  };
+}
+
+function normalizeLimit(value: unknown): number {
+  const parsed = parseInteger(value);
+
+  if (parsed === null || parsed <= 0) {
+    return DEFAULT_PROJECT_LIST_LIMIT;
+  }
+
+  return Math.min(parsed, MAX_PROJECT_LIST_LIMIT);
+}
+
+function normalizeOffset(value: unknown): number {
+  const parsed = parseInteger(value);
+
+  if (parsed === null || parsed <= 0) {
+    return 0;
+  }
+
+  return parsed;
+}
+
+function parseInteger(value: unknown): number | null {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return Math.floor(parsed);
+}

--- a/apps/backend/src/data-marts/utils/project-list-sql-dialects.spec.ts
+++ b/apps/backend/src/data-marts/utils/project-list-sql-dialects.spec.ts
@@ -1,0 +1,140 @@
+import 'reflect-metadata';
+import { join } from 'path';
+import { DataSource, SelectQueryBuilder } from 'typeorm';
+import { Report } from '../entities/report.entity';
+import { DataMartRun } from '../entities/data-mart-run.entity';
+import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
+import { InsightTemplate } from '../entities/insight-template.entity';
+import { RoleScope } from '../enums/role-scope.enum';
+import { OwnerFilter } from '../enums/owner-filter.enum';
+import { applyDataMartVisibilityFilter } from './apply-data-mart-visibility-filter';
+
+type Dialect = 'better-sqlite3' | 'mysql';
+
+async function createDialectDataSource(type: Dialect): Promise<DataSource> {
+  const dataSource = new DataSource({
+    type,
+    database: type === 'better-sqlite3' ? ':memory:' : 'owox_review',
+    host: type === 'mysql' ? '127.0.0.1' : undefined,
+    username: type === 'mysql' ? 'owox_review' : undefined,
+    password: type === 'mysql' ? 'owox_review' : undefined,
+    entities: [join(process.cwd(), 'src/**/*.entity.ts')],
+    synchronize: false,
+    logging: false,
+  });
+
+  await dataSource.buildMetadatas();
+  return dataSource;
+}
+
+function applyViewerVisibility<T extends object>(qb: SelectQueryBuilder<T>) {
+  return applyDataMartVisibilityFilter(qb, {
+    dataMartAlias: 'dataMart',
+    projectId: 'project-1',
+    userId: 'user-1',
+    roles: ['viewer'],
+    roleScope: RoleScope.SELECTED_CONTEXTS,
+  });
+}
+
+function buildProjectReportQuery(dataSource: DataSource, ownerFilter?: OwnerFilter) {
+  const qb = dataSource
+    .getRepository(Report)
+    .createQueryBuilder('r')
+    .leftJoinAndSelect('r.dataMart', 'dataMart')
+    .leftJoinAndSelect('dataMart.storage', 'storage')
+    .leftJoinAndSelect('r.dataDestination', 'dataDestination')
+    .leftJoinAndSelect('r.owners', 'owners')
+    .where('dataMart.projectId = :projectId', { projectId: 'project-1' })
+    .andWhere('dataMart.deletedAt IS NULL');
+
+  applyViewerVisibility(qb);
+
+  if (ownerFilter === OwnerFilter.HAS_OWNERS) {
+    qb.andWhere('EXISTS (SELECT 1 FROM report_owners o WHERE o.report_id = r.id)');
+  } else if (ownerFilter === OwnerFilter.NO_OWNERS) {
+    qb.andWhere('NOT EXISTS (SELECT 1 FROM report_owners o WHERE o.report_id = r.id)');
+  }
+
+  return qb.orderBy('r.createdAt', 'DESC').addOrderBy('r.id', 'DESC').take(100).skip(0);
+}
+
+function buildProjectRunQuery(dataSource: DataSource) {
+  const qb = dataSource
+    .getRepository(DataMartRun)
+    .createQueryBuilder('run')
+    .innerJoinAndSelect('run.dataMart', 'dataMart')
+    .where('dataMart.projectId = :projectId', { projectId: 'project-1' })
+    .andWhere('dataMart.deletedAt IS NULL')
+    .orderBy('run.createdAt', 'DESC')
+    .addOrderBy('run.id', 'DESC')
+    .take(100)
+    .skip(0);
+
+  return applyViewerVisibility(qb);
+}
+
+function buildProjectScheduledTriggerQuery(dataSource: DataSource) {
+  const qb = dataSource
+    .getRepository(DataMartScheduledTrigger)
+    .createQueryBuilder('scheduledTrigger')
+    .innerJoinAndSelect('scheduledTrigger.dataMart', 'dataMart')
+    .where('dataMart.projectId = :projectId', { projectId: 'project-1' })
+    .andWhere('dataMart.deletedAt IS NULL')
+    .orderBy('scheduledTrigger.createdAt', 'DESC')
+    .addOrderBy('scheduledTrigger.id', 'DESC')
+    .take(100)
+    .skip(0);
+
+  return applyViewerVisibility(qb);
+}
+
+function buildProjectInsightTemplateQuery(dataSource: DataSource) {
+  const qb = dataSource
+    .getRepository(InsightTemplate)
+    .createQueryBuilder('insightTemplate')
+    .innerJoinAndSelect('insightTemplate.dataMart', 'dataMart')
+    .leftJoinAndSelect('insightTemplate.sourceEntities', 'sourceEntities')
+    .where('dataMart.projectId = :projectId', { projectId: 'project-1' })
+    .andWhere('dataMart.deletedAt IS NULL')
+    .orderBy('insightTemplate.modifiedAt', 'DESC')
+    .addOrderBy('insightTemplate.id', 'DESC')
+    .take(100)
+    .skip(0);
+
+  return applyViewerVisibility(qb);
+}
+
+describe('project Data Mart list SQL dialects', () => {
+  const unsupportedDialectPatterns = [
+    /\bILIKE\b/i,
+    /::/,
+    /\bDATE_TRUNC\b/i,
+    /\bjson_extract\b/i,
+    /\bJSON_EXTRACT\b/,
+  ];
+
+  it.each<Dialect>(['better-sqlite3', 'mysql'])(
+    'generates portable project list SQL for %s',
+    async dialect => {
+      const dataSource = await createDialectDataSource(dialect);
+      const queries = [
+        buildProjectReportQuery(dataSource, OwnerFilter.HAS_OWNERS),
+        buildProjectReportQuery(dataSource, OwnerFilter.NO_OWNERS),
+        buildProjectRunQuery(dataSource),
+        buildProjectScheduledTriggerQuery(dataSource),
+        buildProjectInsightTemplateQuery(dataSource),
+      ];
+
+      for (const qb of queries) {
+        const sql = qb.getSql();
+        expect(sql).toContain('data_mart_contexts');
+        for (const pattern of unsupportedDialectPatterns) {
+          expect(sql).not.toMatch(pattern);
+        }
+      }
+
+      expect(buildProjectInsightTemplateQuery(dataSource).getSql()).toContain('sourceEntities');
+    }
+  );
+});

--- a/apps/backend/test/project-activity-lists.e2e-spec.ts
+++ b/apps/backend/test/project-activity-lists.e2e-spec.ts
@@ -1,0 +1,212 @@
+import { INestApplication } from '@nestjs/common';
+import * as supertest from 'supertest';
+import {
+  AUTH_HEADER,
+  closeTestApp,
+  createTestApp,
+  ReportBuilder,
+  ScheduledTriggerBuilder,
+  setupReportPrerequisites,
+} from '@owox/test-utils';
+import type { IdpProvider, Payload } from '@owox/idp-protocol';
+import { IdpProjectionsFacade } from '../src/idp/facades/idp-projections.facade';
+import { ProjectMemberDto } from '../src/idp/dto/domain/project-member.dto';
+import { ScheduledTriggerType } from '../src/data-marts/scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { ScheduledReportRunConfigType } from '../src/data-marts/scheduled-trigger-types/scheduled-report-run/schemas/scheduled-report-run-config.schema';
+
+const EDITOR_AUTH_HEADER = { 'x-owox-authorization': 'editor-token' };
+
+const ADMIN_PAYLOAD: Payload = {
+  userId: '0',
+  email: 'admin@localhost',
+  roles: ['admin'],
+  fullName: 'Admin',
+  projectId: '0',
+};
+
+const EDITOR_PAYLOAD: Payload = {
+  userId: '1',
+  email: 'editor@localhost',
+  roles: ['editor'],
+  fullName: 'Technical User',
+  projectId: '0',
+};
+
+function resolvePayload(token: string): Payload {
+  return token.startsWith('editor') ? EDITOR_PAYLOAD : ADMIN_PAYLOAD;
+}
+
+describe('Project Data Mart activity list API (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+  let reportDataMartId: string;
+  let reportId: string;
+  let scheduledTriggerId: string;
+  let insightTemplateId: string;
+
+  beforeAll(async () => {
+    const testApp = await createTestApp();
+    app = testApp.app;
+    agent = testApp.agent;
+
+    const expressApp = (
+      app.getHttpAdapter() as { getInstance(): Express.Application }
+    ).getInstance();
+    const idpProvider = expressApp.get('idp') as IdpProvider;
+    jest.spyOn(idpProvider, 'introspectToken').mockImplementation(async token => {
+      return resolvePayload(token);
+    });
+    jest.spyOn(idpProvider, 'parseToken').mockImplementation(async token => {
+      return resolvePayload(token);
+    });
+
+    const reportPrereqs = await setupReportPrerequisites(agent);
+    reportDataMartId = reportPrereqs.dataMartId;
+
+    const facade = app.get(IdpProjectionsFacade);
+    jest
+      .spyOn(facade, 'getProjectMembers')
+      .mockResolvedValue([
+        new ProjectMemberDto('0', 'admin@localhost', 'Admin', undefined, 'admin', true, false),
+        new ProjectMemberDto(
+          '1',
+          'editor@localhost',
+          'Technical User',
+          undefined,
+          'editor',
+          true,
+          false
+        ),
+      ]);
+
+    const reportRes = await agent
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send(
+        new ReportBuilder()
+          .withDataMartId(reportDataMartId)
+          .withDataDestinationId(reportPrereqs.dataDestinationId)
+          .withTitle('Project activity report')
+          .build()
+      );
+    expect(reportRes.status).toBe(201);
+    reportId = reportRes.body.id;
+
+    const triggerRes = await agent
+      .post(`/api/data-marts/${reportDataMartId}/scheduled-triggers`)
+      .set(AUTH_HEADER)
+      .send(
+        new ScheduledTriggerBuilder()
+          .withType(ScheduledTriggerType.REPORT_RUN)
+          .withTriggerConfig({
+            type: ScheduledReportRunConfigType,
+            reportId,
+          })
+          .build()
+      );
+    expect(triggerRes.status).toBe(201);
+    scheduledTriggerId = triggerRes.body.id;
+
+    const insightTemplateRes = await agent
+      .post(`/api/data-marts/${reportDataMartId}/insight-templates`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Project activity insight',
+        template: '### Project activity insight',
+      });
+    expect(insightTemplateRes.status).toBe(201);
+    insightTemplateId = insightTemplateRes.body.id;
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  it('returns project activity lists with Data Mart references for admin', async () => {
+    const reportsRes = await agent
+      .get('/api/reports')
+      .query({ limit: 100, offset: 0 })
+      .set(AUTH_HEADER);
+    const triggersRes = await agent
+      .get('/api/data-marts/scheduled-triggers')
+      .query({ limit: 100, offset: 0 })
+      .set(AUTH_HEADER);
+    const insightsRes = await agent
+      .get('/api/data-marts/insight-templates')
+      .query({ limit: 100, offset: 0 })
+      .set(AUTH_HEADER);
+    const runsRes = await agent
+      .get('/api/data-marts/runs')
+      .query({ limit: 100, offset: 0 })
+      .set(AUTH_HEADER);
+
+    expect(reportsRes.status).toBe(200);
+    expect(triggersRes.status).toBe(200);
+    expect(insightsRes.status).toBe(200);
+    expect(runsRes.status).toBe(200);
+
+    expect(reportsRes.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: reportId,
+          dataMart: expect.objectContaining({ id: reportDataMartId }),
+        }),
+      ])
+    );
+    expect(triggersRes.body.triggers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: scheduledTriggerId,
+          dataMart: expect.objectContaining({ id: reportDataMartId }),
+          triggerConfig: expect.objectContaining({
+            type: ScheduledReportRunConfigType,
+            reportId,
+            report: expect.objectContaining({ id: reportId }),
+          }),
+        }),
+      ])
+    );
+    expect(insightsRes.body.insights).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: insightTemplateId,
+          dataMart: expect.objectContaining({ id: reportDataMartId }),
+        }),
+      ])
+    );
+    expect(Array.isArray(runsRes.body.runs)).toBe(true);
+  });
+
+  it('filters project activity lists by Data Mart visibility for non-owner users', async () => {
+    await agent
+      .put(`/api/data-marts/${reportDataMartId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForReporting: false, availableForMaintenance: false });
+    const reportsRes = await agent
+      .get('/api/reports')
+      .query({ limit: 100, offset: 0 })
+      .set(EDITOR_AUTH_HEADER);
+    const triggersRes = await agent
+      .get('/api/data-marts/scheduled-triggers')
+      .query({ limit: 100, offset: 0 })
+      .set(EDITOR_AUTH_HEADER);
+    const insightsRes = await agent
+      .get('/api/data-marts/insight-templates')
+      .query({ limit: 100, offset: 0 })
+      .set(EDITOR_AUTH_HEADER);
+    const runsRes = await agent
+      .get('/api/data-marts/runs')
+      .query({ limit: 100, offset: 0 })
+      .set(EDITOR_AUTH_HEADER);
+
+    expect(reportsRes.status).toBe(200);
+    expect(triggersRes.status).toBe(200);
+    expect(insightsRes.status).toBe(200);
+    expect(runsRes.status).toBe(200);
+
+    expect(reportsRes.body).toEqual([]);
+    expect(triggersRes.body.triggers).toEqual([]);
+    expect(insightsRes.body.insights).toEqual([]);
+    expect(runsRes.body.runs).toEqual([]);
+  });
+});

--- a/apps/web/src/components/AppSidebar/MainMenu/MainMenu.test.tsx
+++ b/apps/web/src/components/AppSidebar/MainMenu/MainMenu.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { SidebarProvider } from '@owox/ui/components/sidebar';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MainMenu } from './MainMenu';
 
 vi.mock('../../../features/idp', () => ({
@@ -16,11 +16,15 @@ vi.mock('../../../features/idp', () => ({
 }));
 
 describe('MainMenu', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it.each([
-    ['Run History', '/ui/project-1/data-marts/runs'],
-    ['Triggers', '/ui/project-1/data-marts/schedules'],
     ['Reports', '/ui/project-1/data-marts/reports'],
     ['Insights', '/ui/project-1/data-marts/insights'],
+    ['Triggers', '/ui/project-1/data-marts/schedules'],
+    ['Run History', '/ui/project-1/data-marts/runs'],
   ])('marks the project-wide %s item active without also activating Data Marts', (label, path) => {
     renderMenu(path);
 
@@ -28,20 +32,77 @@ describe('MainMenu', () => {
     expect(screen.getByRole('link', { name: 'Data Marts' })).not.toHaveClass('bg-sidebar-active');
   });
 
-  it('keeps project-wide Data Mart items at the end in tab order', () => {
-    renderMenu('/ui/project-1/data-marts');
+  it('renders project-wide Data Mart items as sub-items under Data Marts', () => {
+    renderMenu('/ui/project-1/data-marts/reports');
 
     const labels = screen.getAllByRole('link').map(link => link.textContent);
 
     expect(labels).toEqual([
       'Data Marts',
-      'Storages',
-      'Destinations',
-      'Triggers',
       'Reports',
       'Insights',
+      'Triggers',
       'Run History',
+      'Storages',
+      'Destinations',
     ]);
+    expect(
+      screen.getByRole('link', { name: 'Reports' }).closest('[data-sidebar="menu-sub"]')
+    ).not.toBeNull();
+    expect(
+      screen.getByRole('link', { name: 'Run History' }).closest('[data-sidebar="menu-sub"]')
+    ).not.toBeNull();
+  });
+
+  it('does not open Data Mart sub-items just because the Data Marts item is selected', () => {
+    renderMenu('/ui/project-1/data-marts');
+
+    expect(screen.getByRole('link', { name: 'Data Marts' })).toHaveClass('bg-sidebar-active');
+    expect(screen.queryByRole('link', { name: 'Reports' })).not.toBeInTheDocument();
+  });
+
+  it('opens Data Mart sub-items from direct project-wide links', () => {
+    renderMenu('/ui/project-1/data-marts/reports');
+
+    expect(screen.getByRole('link', { name: 'Reports' })).toHaveClass('bg-sidebar-active');
+  });
+
+  it('keeps the Data Marts toggle button clickable without drawing a separator', () => {
+    renderMenu('/ui/project-1/data-marts');
+
+    const toggleButton = screen.getByRole('button', { name: 'Expand Data Marts' });
+
+    expect(toggleButton).not.toHaveClass('border-l');
+    expect(toggleButton.className).not.toContain('before:');
+    expect(toggleButton).toHaveClass('cursor-pointer');
+  });
+
+  it('points the Data Marts toggle icon down when closed and up when open', () => {
+    renderMenu('/ui/project-1/data-marts');
+
+    const expandButton = screen.getByRole('button', { name: 'Expand Data Marts' });
+    expect(expandButton.querySelector('svg')).not.toHaveClass('rotate-180');
+
+    fireEvent.click(expandButton);
+
+    expect(
+      screen.getByRole('button', { name: 'Collapse Data Marts' }).querySelector('svg')
+    ).toHaveClass('rotate-180');
+  });
+
+  it('persists manual Data Mart sub-menu open state between renders', () => {
+    const { unmount } = renderMenu('/ui/project-1/data-marts');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand Data Marts' }));
+    expect(screen.getByRole('link', { name: 'Reports' })).toBeInTheDocument();
+
+    unmount();
+    renderMenu('/ui/project-1/data-marts');
+
+    expect(screen.getByRole('link', { name: 'Reports' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse Data Marts' }));
+    expect(screen.queryByRole('link', { name: 'Reports' })).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/AppSidebar/MainMenu/MainMenu.test.tsx
+++ b/apps/web/src/components/AppSidebar/MainMenu/MainMenu.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SidebarProvider } from '@owox/ui/components/sidebar';
+import { describe, expect, it, vi } from 'vitest';
+import { MainMenu } from './MainMenu';
+
+vi.mock('../../../features/idp', () => ({
+  useAuth: () => ({
+    status: 'authenticated',
+    user: {
+      id: 'user-1',
+      projectId: 'project-1',
+      roles: ['viewer'],
+    },
+  }),
+}));
+
+describe('MainMenu', () => {
+  it.each([
+    ['Run History', '/ui/project-1/data-marts/runs'],
+    ['Triggers', '/ui/project-1/data-marts/schedules'],
+    ['Reports', '/ui/project-1/data-marts/reports'],
+    ['Insights', '/ui/project-1/data-marts/insights'],
+  ])('marks the project-wide %s item active without also activating Data Marts', (label, path) => {
+    renderMenu(path);
+
+    expect(screen.getByRole('link', { name: label })).toHaveClass('bg-sidebar-active');
+    expect(screen.getByRole('link', { name: 'Data Marts' })).not.toHaveClass('bg-sidebar-active');
+  });
+
+  it('keeps project-wide Data Mart items at the end in tab order', () => {
+    renderMenu('/ui/project-1/data-marts');
+
+    const labels = screen.getAllByRole('link').map(link => link.textContent);
+
+    expect(labels).toEqual([
+      'Data Marts',
+      'Storages',
+      'Destinations',
+      'Triggers',
+      'Reports',
+      'Insights',
+      'Run History',
+    ]);
+  });
+});
+
+function renderMenu(pathname: string) {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <SidebarProvider>
+        <MainMenu />
+      </SidebarProvider>
+    </MemoryRouter>
+  );
+}

--- a/apps/web/src/components/AppSidebar/MainMenu/MainMenu.test.tsx
+++ b/apps/web/src/components/AppSidebar/MainMenu/MainMenu.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { SidebarProvider } from '@owox/ui/components/sidebar';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { MainMenu } from './MainMenu';
 
 vi.mock('../../../features/idp', () => ({
@@ -16,10 +16,6 @@ vi.mock('../../../features/idp', () => ({
 }));
 
 describe('MainMenu', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
   it.each([
     ['Reports', '/ui/project-1/data-marts/reports'],
     ['Insights', '/ui/project-1/data-marts/insights'],
@@ -54,11 +50,12 @@ describe('MainMenu', () => {
     ).not.toBeNull();
   });
 
-  it('does not open Data Mart sub-items just because the Data Marts item is selected', () => {
+  it('always shows Data Mart sub-items when the Data Marts item is selected', () => {
     renderMenu('/ui/project-1/data-marts');
 
     expect(screen.getByRole('link', { name: 'Data Marts' })).toHaveClass('bg-sidebar-active');
-    expect(screen.queryByRole('link', { name: 'Reports' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Reports' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Data Marts/ })).not.toBeInTheDocument();
   });
 
   it('opens Data Mart sub-items from direct project-wide links', () => {
@@ -67,42 +64,19 @@ describe('MainMenu', () => {
     expect(screen.getByRole('link', { name: 'Reports' })).toHaveClass('bg-sidebar-active');
   });
 
-  it('keeps the Data Marts toggle button clickable without drawing a separator', () => {
-    renderMenu('/ui/project-1/data-marts');
+  it('keeps the production active background instead of SidebarMenu data-active accent', () => {
+    renderMenu('/ui/project-1/data-marts/reports');
 
-    const toggleButton = screen.getByRole('button', { name: 'Expand Data Marts' });
+    const activeProjectItem = screen.getByRole('link', { name: 'Reports' });
+    const inactiveParentItem = screen.getByRole('link', { name: 'Data Marts' });
 
-    expect(toggleButton).not.toHaveClass('border-l');
-    expect(toggleButton.className).not.toContain('before:');
-    expect(toggleButton).toHaveClass('cursor-pointer');
-  });
-
-  it('points the Data Marts toggle icon down when closed and up when open', () => {
-    renderMenu('/ui/project-1/data-marts');
-
-    const expandButton = screen.getByRole('button', { name: 'Expand Data Marts' });
-    expect(expandButton.querySelector('svg')).not.toHaveClass('rotate-180');
-
-    fireEvent.click(expandButton);
-
-    expect(
-      screen.getByRole('button', { name: 'Collapse Data Marts' }).querySelector('svg')
-    ).toHaveClass('rotate-180');
-  });
-
-  it('persists manual Data Mart sub-menu open state between renders', () => {
-    const { unmount } = renderMenu('/ui/project-1/data-marts');
-
-    fireEvent.click(screen.getByRole('button', { name: 'Expand Data Marts' }));
-    expect(screen.getByRole('link', { name: 'Reports' })).toBeInTheDocument();
-
-    unmount();
-    renderMenu('/ui/project-1/data-marts');
-
-    expect(screen.getByRole('link', { name: 'Reports' })).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Collapse Data Marts' }));
-    expect(screen.queryByRole('link', { name: 'Reports' })).not.toBeInTheDocument();
+    expect(activeProjectItem).toHaveClass(
+      'bg-sidebar-active',
+      'text-sidebar-active-foreground',
+      'shadow-sm'
+    );
+    expect(activeProjectItem).not.toHaveAttribute('data-active', 'true');
+    expect(inactiveParentItem).not.toHaveAttribute('data-active', 'true');
   });
 });
 

--- a/apps/web/src/components/AppSidebar/MainMenu/MainMenu.tsx
+++ b/apps/web/src/components/AppSidebar/MainMenu/MainMenu.tsx
@@ -1,8 +1,25 @@
+import { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { SidebarMenu, SidebarMenuItem, SidebarMenuButton } from '@owox/ui/components/sidebar';
+import { ChevronDown } from 'lucide-react';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@owox/ui/components/collapsible';
+import {
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarMenuAction,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+} from '@owox/ui/components/sidebar';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { useProjectRoute } from '../../../shared/hooks';
+import { storageService } from '../../../services';
 import { MainMenuItems } from './items';
+import type { MainMenuItem } from './types';
 
 const PROJECT_WIDE_DATA_MART_PATHS = [
   '/data-marts/runs',
@@ -10,6 +27,7 @@ const PROJECT_WIDE_DATA_MART_PATHS = [
   '/data-marts/reports',
   '/data-marts/insights',
 ];
+const MAIN_MENU_BRANCH_STORAGE_PREFIX = 'owox.main-menu.branch-open';
 
 export function MainMenu() {
   const { scope } = useProjectRoute();
@@ -17,42 +35,140 @@ export function MainMenu() {
 
   return (
     <SidebarMenu>
-      {MainMenuItems.map(item => {
-        const Icon = item.icon;
-        const href = scope(item.url);
-        const isActive = isMenuItemActive(item.url, location.pathname, scope);
-
-        return (
-          <SidebarMenuItem key={item.title}>
-            <Tooltip delayDuration={500}>
-              <TooltipTrigger asChild>
-                <SidebarMenuButton
-                  asChild
-                  isActive={isActive}
-                  className={
-                    isActive
-                      ? 'bg-sidebar-active text-sidebar-active-foreground font-medium shadow-sm hover:bg-transparent'
-                      : ''
-                  }
-                >
-                  <Link to={href} aria-current={isActive ? 'page' : undefined}>
-                    <Icon className='size-4 shrink-0 transition-all' />
-                    <span>{item.title}</span>
-                    {item.badge && (
-                      <span className='bg-primary/20 text-primary ml-auto rounded-full px-2 py-0.5 text-xs'>
-                        {item.badge}
-                      </span>
-                    )}
-                  </Link>
-                </SidebarMenuButton>
-              </TooltipTrigger>
-              <TooltipContent side='right'>{item.title}</TooltipContent>
-            </Tooltip>
-          </SidebarMenuItem>
-        );
-      })}
+      {MainMenuItems.map(item =>
+        item.children?.length ? (
+          <MainMenuBranch key={item.title} item={item} pathname={location.pathname} scope={scope} />
+        ) : (
+          <MainMenuLeaf key={item.title} item={item} pathname={location.pathname} scope={scope} />
+        )
+      )}
     </SidebarMenu>
   );
+}
+
+interface MainMenuItemProps {
+  item: MainMenuItem;
+  pathname: string;
+  scope: (path: string) => string;
+}
+
+function MainMenuLeaf({ item, pathname, scope }: MainMenuItemProps) {
+  const Icon = item.icon;
+  const href = scope(item.url);
+  const isActive = isMenuItemActive(item.url, pathname, scope);
+
+  return (
+    <SidebarMenuItem key={item.title}>
+      <Tooltip delayDuration={500}>
+        <TooltipTrigger asChild>
+          <SidebarMenuButton
+            asChild
+            isActive={isActive}
+            className={getActiveMenuItemClassName(isActive)}
+          >
+            <Link to={href} aria-current={isActive ? 'page' : undefined}>
+              <Icon className='size-4 shrink-0 transition-all' />
+              <span>{item.title}</span>
+              {item.badge && (
+                <span className='bg-primary/20 text-primary ml-auto rounded-full px-2 py-0.5 text-xs'>
+                  {item.badge}
+                </span>
+              )}
+            </Link>
+          </SidebarMenuButton>
+        </TooltipTrigger>
+        <TooltipContent side='right'>{item.title}</TooltipContent>
+      </Tooltip>
+    </SidebarMenuItem>
+  );
+}
+
+function MainMenuBranch({ item, pathname, scope }: MainMenuItemProps) {
+  const Icon = item.icon;
+  const href = scope(item.url);
+  const isActive = isMenuItemActive(item.url, pathname, scope);
+  const hasActiveChild = item.children?.some(child => isMenuItemActive(child.url, pathname, scope));
+  const [isOpen, setIsOpen] = useState(
+    () => Boolean(hasActiveChild) || readStoredBranchOpenState(item.url)
+  );
+
+  useEffect(() => {
+    if (hasActiveChild) {
+      setIsOpen(true);
+    }
+  }, [hasActiveChild]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setIsOpen(nextOpen);
+    writeStoredBranchOpenState(item.url, nextOpen);
+  };
+
+  return (
+    <Collapsible asChild open={isOpen} onOpenChange={handleOpenChange}>
+      <SidebarMenuItem key={item.title}>
+        <Tooltip delayDuration={500}>
+          <TooltipTrigger asChild>
+            <SidebarMenuButton
+              asChild
+              isActive={isActive}
+              className={getActiveMenuItemClassName(isActive)}
+            >
+              <Link to={href} aria-current={isActive ? 'page' : undefined}>
+                <Icon className='size-4 shrink-0 transition-all' />
+                <span>{item.title}</span>
+                {item.badge && (
+                  <span className='bg-primary/20 text-primary ml-auto rounded-full px-2 py-0.5 text-xs'>
+                    {item.badge}
+                  </span>
+                )}
+              </Link>
+            </SidebarMenuButton>
+          </TooltipTrigger>
+          <TooltipContent side='right'>{item.title}</TooltipContent>
+        </Tooltip>
+
+        <CollapsibleTrigger asChild>
+          <SidebarMenuAction
+            aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${item.title}`}
+            className='cursor-pointer'
+          >
+            <ChevronDown className={`transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+          </SidebarMenuAction>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <SidebarMenuSub>
+            {item.children?.map(child => {
+              const ChildIcon = child.icon;
+              const childHref = scope(child.url);
+              const isChildActive = isMenuItemActive(child.url, pathname, scope);
+
+              return (
+                <SidebarMenuSubItem key={child.title}>
+                  <SidebarMenuSubButton
+                    asChild
+                    isActive={isChildActive}
+                    className={getActiveMenuItemClassName(isChildActive)}
+                  >
+                    <Link to={childHref} aria-current={isChildActive ? 'page' : undefined}>
+                      <ChildIcon className='size-4 shrink-0 transition-all' />
+                      <span>{child.title}</span>
+                    </Link>
+                  </SidebarMenuSubButton>
+                </SidebarMenuSubItem>
+              );
+            })}
+          </SidebarMenuSub>
+        </CollapsibleContent>
+      </SidebarMenuItem>
+    </Collapsible>
+  );
+}
+
+function getActiveMenuItemClassName(isActive: boolean): string {
+  return isActive
+    ? 'bg-sidebar-active text-sidebar-active-foreground font-medium shadow-sm hover:bg-transparent'
+    : '';
 }
 
 function isMenuItemActive(
@@ -75,4 +191,16 @@ function isMenuItemActive(
 
 function isSameOrNestedPath(pathname: string, targetPath: string): boolean {
   return pathname === targetPath || pathname.startsWith(`${targetPath}/`);
+}
+
+function readStoredBranchOpenState(itemUrl: string): boolean {
+  return storageService.get(getBranchStorageKey(itemUrl), 'boolean') ?? false;
+}
+
+function writeStoredBranchOpenState(itemUrl: string, isOpen: boolean): void {
+  storageService.set(getBranchStorageKey(itemUrl), isOpen);
+}
+
+function getBranchStorageKey(itemUrl: string): string {
+  return `${MAIN_MENU_BRANCH_STORAGE_PREFIX}:${itemUrl}`;
 }

--- a/apps/web/src/components/AppSidebar/MainMenu/MainMenu.tsx
+++ b/apps/web/src/components/AppSidebar/MainMenu/MainMenu.tsx
@@ -1,52 +1,78 @@
-import { NavLink } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { SidebarMenu, SidebarMenuItem, SidebarMenuButton } from '@owox/ui/components/sidebar';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { useProjectRoute } from '../../../shared/hooks';
 import { MainMenuItems } from './items';
 
+const PROJECT_WIDE_DATA_MART_PATHS = [
+  '/data-marts/runs',
+  '/data-marts/schedules',
+  '/data-marts/reports',
+  '/data-marts/insights',
+];
+
 export function MainMenu() {
   const { scope } = useProjectRoute();
+  const location = useLocation();
 
   return (
     <SidebarMenu>
       {MainMenuItems.map(item => {
         const Icon = item.icon;
+        const href = scope(item.url);
+        const isActive = isMenuItemActive(item.url, location.pathname, scope);
+
         return (
           <SidebarMenuItem key={item.title}>
-            <NavLink
-              to={scope(item.url)}
-              className={({ isActive }) =>
-                `flex w-full items-center gap-2 rounded-md font-medium transition-colors ${
-                  isActive
-                    ? 'bg-sidebar-active text-sidebar-active-foreground font-medium shadow-sm'
-                    : ''
-                }`
-              }
-            >
-              {({ isActive }) => (
-                <Tooltip delayDuration={500}>
-                  <TooltipTrigger asChild>
-                    <SidebarMenuButton
-                      className={`${
-                        isActive ? 'hover:bg-transparent' : '' // disable hover if active
-                      }`}
-                    >
-                      <Icon className='size-4 shrink-0 transition-all' />
-                      <span>{item.title}</span>
-                      {item.badge && (
-                        <span className='bg-primary/20 text-primary ml-auto rounded-full px-2 py-0.5 text-xs'>
-                          {item.badge}
-                        </span>
-                      )}
-                    </SidebarMenuButton>
-                  </TooltipTrigger>
-                  <TooltipContent side='right'>{item.title}</TooltipContent>
-                </Tooltip>
-              )}
-            </NavLink>
+            <Tooltip delayDuration={500}>
+              <TooltipTrigger asChild>
+                <SidebarMenuButton
+                  asChild
+                  isActive={isActive}
+                  className={
+                    isActive
+                      ? 'bg-sidebar-active text-sidebar-active-foreground font-medium shadow-sm hover:bg-transparent'
+                      : ''
+                  }
+                >
+                  <Link to={href} aria-current={isActive ? 'page' : undefined}>
+                    <Icon className='size-4 shrink-0 transition-all' />
+                    <span>{item.title}</span>
+                    {item.badge && (
+                      <span className='bg-primary/20 text-primary ml-auto rounded-full px-2 py-0.5 text-xs'>
+                        {item.badge}
+                      </span>
+                    )}
+                  </Link>
+                </SidebarMenuButton>
+              </TooltipTrigger>
+              <TooltipContent side='right'>{item.title}</TooltipContent>
+            </Tooltip>
           </SidebarMenuItem>
         );
       })}
     </SidebarMenu>
   );
+}
+
+function isMenuItemActive(
+  itemUrl: string,
+  pathname: string,
+  scope: (path: string) => string
+): boolean {
+  if (itemUrl === '/data-marts') {
+    const isProjectWideDataMartPage = PROJECT_WIDE_DATA_MART_PATHS.some(path =>
+      isSameOrNestedPath(pathname, scope(path))
+    );
+
+    if (isProjectWideDataMartPage) {
+      return false;
+    }
+  }
+
+  return isSameOrNestedPath(pathname, scope(itemUrl));
+}
+
+function isSameOrNestedPath(pathname: string, targetPath: string): boolean {
+  return pathname === targetPath || pathname.startsWith(`${targetPath}/`);
 }

--- a/apps/web/src/components/AppSidebar/MainMenu/MainMenu.tsx
+++ b/apps/web/src/components/AppSidebar/MainMenu/MainMenu.tsx
@@ -1,23 +1,14 @@
-import { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { ChevronDown } from 'lucide-react';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@owox/ui/components/collapsible';
 import {
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuButton,
-  SidebarMenuAction,
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
 } from '@owox/ui/components/sidebar';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { useProjectRoute } from '../../../shared/hooks';
-import { storageService } from '../../../services';
 import { MainMenuItems } from './items';
 import type { MainMenuItem } from './types';
 
@@ -27,7 +18,6 @@ const PROJECT_WIDE_DATA_MART_PATHS = [
   '/data-marts/reports',
   '/data-marts/insights',
 ];
-const MAIN_MENU_BRANCH_STORAGE_PREFIX = 'owox.main-menu.branch-open';
 
 export function MainMenu() {
   const { scope } = useProjectRoute();
@@ -61,11 +51,7 @@ function MainMenuLeaf({ item, pathname, scope }: MainMenuItemProps) {
     <SidebarMenuItem key={item.title}>
       <Tooltip delayDuration={500}>
         <TooltipTrigger asChild>
-          <SidebarMenuButton
-            asChild
-            isActive={isActive}
-            className={getActiveMenuItemClassName(isActive)}
-          >
+          <SidebarMenuButton asChild className={getActiveMenuItemClassName(isActive)}>
             <Link to={href} aria-current={isActive ? 'page' : undefined}>
               <Icon className='size-4 shrink-0 transition-all' />
               <span>{item.title}</span>
@@ -87,81 +73,45 @@ function MainMenuBranch({ item, pathname, scope }: MainMenuItemProps) {
   const Icon = item.icon;
   const href = scope(item.url);
   const isActive = isMenuItemActive(item.url, pathname, scope);
-  const hasActiveChild = item.children?.some(child => isMenuItemActive(child.url, pathname, scope));
-  const [isOpen, setIsOpen] = useState(
-    () => Boolean(hasActiveChild) || readStoredBranchOpenState(item.url)
-  );
-
-  useEffect(() => {
-    if (hasActiveChild) {
-      setIsOpen(true);
-    }
-  }, [hasActiveChild]);
-
-  const handleOpenChange = (nextOpen: boolean) => {
-    setIsOpen(nextOpen);
-    writeStoredBranchOpenState(item.url, nextOpen);
-  };
 
   return (
-    <Collapsible asChild open={isOpen} onOpenChange={handleOpenChange}>
-      <SidebarMenuItem key={item.title}>
-        <Tooltip delayDuration={500}>
-          <TooltipTrigger asChild>
-            <SidebarMenuButton
-              asChild
-              isActive={isActive}
-              className={getActiveMenuItemClassName(isActive)}
-            >
-              <Link to={href} aria-current={isActive ? 'page' : undefined}>
-                <Icon className='size-4 shrink-0 transition-all' />
-                <span>{item.title}</span>
-                {item.badge && (
-                  <span className='bg-primary/20 text-primary ml-auto rounded-full px-2 py-0.5 text-xs'>
-                    {item.badge}
-                  </span>
-                )}
-              </Link>
-            </SidebarMenuButton>
-          </TooltipTrigger>
-          <TooltipContent side='right'>{item.title}</TooltipContent>
-        </Tooltip>
+    <SidebarMenuItem key={item.title}>
+      <Tooltip delayDuration={500}>
+        <TooltipTrigger asChild>
+          <SidebarMenuButton asChild className={getActiveMenuItemClassName(isActive)}>
+            <Link to={href} aria-current={isActive ? 'page' : undefined}>
+              <Icon className='size-4 shrink-0 transition-all' />
+              <span>{item.title}</span>
+              {item.badge && (
+                <span className='bg-primary/20 text-primary ml-auto rounded-full px-2 py-0.5 text-xs'>
+                  {item.badge}
+                </span>
+              )}
+            </Link>
+          </SidebarMenuButton>
+        </TooltipTrigger>
+        <TooltipContent side='right'>{item.title}</TooltipContent>
+      </Tooltip>
 
-        <CollapsibleTrigger asChild>
-          <SidebarMenuAction
-            aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${item.title}`}
-            className='cursor-pointer'
-          >
-            <ChevronDown className={`transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-          </SidebarMenuAction>
-        </CollapsibleTrigger>
+      <SidebarMenuSub>
+        {item.children?.map(child => {
+          const ChildIcon = child.icon;
+          const childHref = scope(child.url);
+          const isChildActive = isMenuItemActive(child.url, pathname, scope);
 
-        <CollapsibleContent>
-          <SidebarMenuSub>
-            {item.children?.map(child => {
-              const ChildIcon = child.icon;
-              const childHref = scope(child.url);
-              const isChildActive = isMenuItemActive(child.url, pathname, scope);
-
-              return (
-                <SidebarMenuSubItem key={child.title}>
-                  <SidebarMenuSubButton
-                    asChild
-                    isActive={isChildActive}
-                    className={getActiveMenuItemClassName(isChildActive)}
-                  >
-                    <Link to={childHref} aria-current={isChildActive ? 'page' : undefined}>
-                      <ChildIcon className='size-4 shrink-0 transition-all' />
-                      <span>{child.title}</span>
-                    </Link>
-                  </SidebarMenuSubButton>
-                </SidebarMenuSubItem>
-              );
-            })}
-          </SidebarMenuSub>
-        </CollapsibleContent>
-      </SidebarMenuItem>
-    </Collapsible>
+          return (
+            <SidebarMenuSubItem key={child.title}>
+              <SidebarMenuSubButton asChild className={getActiveMenuItemClassName(isChildActive)}>
+                <Link to={childHref} aria-current={isChildActive ? 'page' : undefined}>
+                  <ChildIcon className='size-4 shrink-0 transition-all' />
+                  <span>{child.title}</span>
+                </Link>
+              </SidebarMenuSubButton>
+            </SidebarMenuSubItem>
+          );
+        })}
+      </SidebarMenuSub>
+    </SidebarMenuItem>
   );
 }
 
@@ -191,16 +141,4 @@ function isMenuItemActive(
 
 function isSameOrNestedPath(pathname: string, targetPath: string): boolean {
   return pathname === targetPath || pathname.startsWith(`${targetPath}/`);
-}
-
-function readStoredBranchOpenState(itemUrl: string): boolean {
-  return storageService.get(getBranchStorageKey(itemUrl), 'boolean') ?? false;
-}
-
-function writeStoredBranchOpenState(itemUrl: string, isOpen: boolean): void {
-  storageService.set(getBranchStorageKey(itemUrl), isOpen);
-}
-
-function getBranchStorageKey(itemUrl: string): string {
-  return `${MAIN_MENU_BRANCH_STORAGE_PREFIX}:${itemUrl}`;
 }

--- a/apps/web/src/components/AppSidebar/MainMenu/items.ts
+++ b/apps/web/src/components/AppSidebar/MainMenu/items.ts
@@ -1,4 +1,12 @@
-import { Box, DatabaseIcon, ArchiveRestore } from 'lucide-react';
+import {
+  ArchiveRestore,
+  Box,
+  CalendarClock,
+  DatabaseIcon,
+  FileText,
+  HistoryIcon,
+  Sparkles,
+} from 'lucide-react';
 import type { MainMenuItem } from './types';
 
 export const MainMenuItems: MainMenuItem[] = [
@@ -16,5 +24,25 @@ export const MainMenuItems: MainMenuItem[] = [
     title: 'Destinations',
     url: '/data-destinations',
     icon: ArchiveRestore,
+  },
+  {
+    title: 'Triggers',
+    url: '/data-marts/schedules',
+    icon: CalendarClock,
+  },
+  {
+    title: 'Reports',
+    url: '/data-marts/reports',
+    icon: FileText,
+  },
+  {
+    title: 'Insights',
+    url: '/data-marts/insights',
+    icon: Sparkles,
+  },
+  {
+    title: 'Run History',
+    url: '/data-marts/runs',
+    icon: HistoryIcon,
   },
 ];

--- a/apps/web/src/components/AppSidebar/MainMenu/items.ts
+++ b/apps/web/src/components/AppSidebar/MainMenu/items.ts
@@ -14,6 +14,28 @@ export const MainMenuItems: MainMenuItem[] = [
     title: 'Data Marts',
     url: '/data-marts',
     icon: Box,
+    children: [
+      {
+        title: 'Reports',
+        url: '/data-marts/reports',
+        icon: FileText,
+      },
+      {
+        title: 'Insights',
+        url: '/data-marts/insights',
+        icon: Sparkles,
+      },
+      {
+        title: 'Triggers',
+        url: '/data-marts/schedules',
+        icon: CalendarClock,
+      },
+      {
+        title: 'Run History',
+        url: '/data-marts/runs',
+        icon: HistoryIcon,
+      },
+    ],
   },
   {
     title: 'Storages',
@@ -24,25 +46,5 @@ export const MainMenuItems: MainMenuItem[] = [
     title: 'Destinations',
     url: '/data-destinations',
     icon: ArchiveRestore,
-  },
-  {
-    title: 'Triggers',
-    url: '/data-marts/schedules',
-    icon: CalendarClock,
-  },
-  {
-    title: 'Reports',
-    url: '/data-marts/reports',
-    icon: FileText,
-  },
-  {
-    title: 'Insights',
-    url: '/data-marts/insights',
-    icon: Sparkles,
-  },
-  {
-    title: 'Run History',
-    url: '/data-marts/runs',
-    icon: HistoryIcon,
   },
 ];

--- a/apps/web/src/components/AppSidebar/MainMenu/types.ts
+++ b/apps/web/src/components/AppSidebar/MainMenu/types.ts
@@ -4,6 +4,7 @@ export interface MainMenuItem {
   title: string;
   url: string;
   icon: LucideIcon;
+  children?: MainMenuItem[];
   external?: boolean;
   badge?: string;
 }

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistory.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistory.tsx
@@ -88,7 +88,7 @@ export function DataMartRunHistory() {
           ))}
 
           {hasMoreRunsToLoad && (
-            <div className='flex justify-center pt-4'>
+            <div className='flex justify-center pt-4 pb-6'>
               <Button
                 variant='outline'
                 size='sm'

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RunItem } from './RunItem';
@@ -38,31 +39,73 @@ const createRun = (overrides: Partial<DataMartRunItem> = {}): DataMartRunItem =>
     ...overrides,
   }) as DataMartRunItem;
 
+type DataMartRef = {
+  id: string;
+  title: string;
+  href: string;
+};
+
 const renderRunItem = (
   run: DataMartRunItem,
   isExpanded = false,
   cancelDataMartRun = vi.fn().mockResolvedValue(undefined),
-  dataMartId: string | undefined = 'dm-1'
+  dataMartId: string | undefined = 'dm-1',
+  dataMartRef?: DataMartRef
 ) => {
   const onToggle = vi.fn();
 
   render(
-    <RunItem
-      run={run}
-      isExpanded={isExpanded}
-      onToggle={onToggle}
-      logViewType={LogViewType.STRUCTURED}
-      setLogViewType={vi.fn()}
-      searchTerm=''
-      setSearchTerm={vi.fn()}
-      cancelDataMartRun={cancelDataMartRun}
-      dataMartId={dataMartId}
-      dataMartConnectorInfo={null}
-    />
+    <MemoryRouter>
+      <RunItem
+        run={run}
+        isExpanded={isExpanded}
+        onToggle={onToggle}
+        logViewType={LogViewType.STRUCTURED}
+        setLogViewType={vi.fn()}
+        searchTerm=''
+        setSearchTerm={vi.fn()}
+        cancelDataMartRun={cancelDataMartRun}
+        dataMartId={dataMartId}
+        dataMartConnectorInfo={null}
+        dataMartRef={dataMartRef}
+      />
+    </MemoryRouter>
   );
 
   return { onToggle, cancelDataMartRun };
 };
+
+const createReportRun = (dataMartRef?: DataMartRef): DataMartRunItem =>
+  createRun({
+    type: DataMartRunType.EMAIL,
+    triggerType: DataMartRunTriggerType.SCHEDULED,
+    createdAt: new Date('2026-06-07T15:35:00.000Z'),
+    startedAt: new Date('2026-06-07T15:35:00.000Z'),
+    definitionRun: {
+      sqlQuery: 'select 1',
+    } as DataMartRunItem['definitionRun'],
+    reportDefinition: {
+      title: 'Campaigns Campaigns Campaigns Campaigns Campaigns Campaigns',
+      destination: {
+        id: 'destination-1',
+        title: 'Looker Studio',
+        type: 'LOOKER_STUDIO',
+      },
+      destinationConfig: {
+        type: 'looker-studio-config',
+        cacheLifetime: 3600,
+      },
+    },
+    reportId: 'report-1',
+    createdByUser: dataMartRef
+      ? {
+          userId: '320',
+          fullName: 'Oleksandr Kalnyk',
+          email: 'a.kalnik@owox.com',
+          avatar: null,
+        }
+      : null,
+  });
 
 describe('RunItem', () => {
   beforeEach(() => {
@@ -146,17 +189,19 @@ describe('RunItem', () => {
 
   it('does not show a cancel button when data mart id is unavailable', () => {
     render(
-      <RunItem
-        run={createRun()}
-        isExpanded={true}
-        onToggle={vi.fn()}
-        logViewType={LogViewType.STRUCTURED}
-        setLogViewType={vi.fn()}
-        searchTerm=''
-        setSearchTerm={vi.fn()}
-        cancelDataMartRun={vi.fn()}
-        dataMartConnectorInfo={null}
-      />
+      <MemoryRouter>
+        <RunItem
+          run={createRun()}
+          isExpanded={true}
+          onToggle={vi.fn()}
+          logViewType={LogViewType.STRUCTURED}
+          setLogViewType={vi.fn()}
+          searchTerm=''
+          setSearchTerm={vi.fn()}
+          cancelDataMartRun={vi.fn()}
+          dataMartConnectorInfo={null}
+        />
+      </MemoryRouter>
     );
 
     expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument();
@@ -170,37 +215,69 @@ describe('RunItem', () => {
 
   it('does not show a cancel button for Looker Studio or HTTP Data runs', () => {
     const { rerender } = render(
-      <RunItem
-        run={createRun({ type: DataMartRunType.LOOKER_STUDIO })}
-        isExpanded={true}
-        onToggle={vi.fn()}
-        logViewType={LogViewType.STRUCTURED}
-        setLogViewType={vi.fn()}
-        searchTerm=''
-        setSearchTerm={vi.fn()}
-        cancelDataMartRun={vi.fn()}
-        dataMartId='dm-1'
-        dataMartConnectorInfo={null}
-      />
+      <MemoryRouter>
+        <RunItem
+          run={createRun({ type: DataMartRunType.LOOKER_STUDIO })}
+          isExpanded={true}
+          onToggle={vi.fn()}
+          logViewType={LogViewType.STRUCTURED}
+          setLogViewType={vi.fn()}
+          searchTerm=''
+          setSearchTerm={vi.fn()}
+          cancelDataMartRun={vi.fn()}
+          dataMartId='dm-1'
+          dataMartConnectorInfo={null}
+        />
+      </MemoryRouter>
     );
 
     expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
 
     rerender(
-      <RunItem
-        run={createRun({ type: DataMartRunType.HTTP_DATA })}
-        isExpanded={true}
-        onToggle={vi.fn()}
-        logViewType={LogViewType.STRUCTURED}
-        setLogViewType={vi.fn()}
-        searchTerm=''
-        setSearchTerm={vi.fn()}
-        cancelDataMartRun={vi.fn()}
-        dataMartId='dm-1'
-        dataMartConnectorInfo={null}
-      />
+      <MemoryRouter>
+        <RunItem
+          run={createRun({ type: DataMartRunType.HTTP_DATA })}
+          isExpanded={true}
+          onToggle={vi.fn()}
+          logViewType={LogViewType.STRUCTURED}
+          setLogViewType={vi.fn()}
+          searchTerm=''
+          setSearchTerm={vi.fn()}
+          cancelDataMartRun={vi.fn()}
+          dataMartId='dm-1'
+          dataMartConnectorInfo={null}
+        />
+      </MemoryRouter>
     );
 
     expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps the Data Mart tab row on one line when no Data Mart reference is shown', () => {
+    renderRunItem(createReportRun());
+
+    expect(screen.queryByRole('link', { name: 'Campaigns' })).not.toBeInTheDocument();
+
+    const startedAt = screen.getByText(/2026-06-07 \d{2}:35:00/);
+    const summary = screen.getByText('Scheduled report run');
+    expect(startedAt).toHaveClass('shrink-0', 'whitespace-nowrap');
+    expect(startedAt.closest('.flex-wrap')).toBeNull();
+    expect(summary.closest('.flex-wrap')).toBeNull();
+  });
+
+  it('uses the wrapped two-line layout when a project-wide Data Mart reference is shown', () => {
+    const dataMartRef = {
+      id: 'dm-1',
+      title: 'Campaigns',
+      href: '/ui/project-1/data-marts/dm-1/run-history',
+    };
+
+    renderRunItem(createReportRun(dataMartRef), false, undefined, 'dm-1', dataMartRef);
+
+    expect(screen.getByRole('link', { name: 'Campaigns' })).toHaveAttribute(
+      'href',
+      '/ui/project-1/data-marts/dm-1/run-history'
+    );
+    expect(screen.getByText(/2026-06-07 \d{2}:35:00/).closest('.flex-wrap')).not.toBeNull();
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
@@ -39,11 +39,11 @@ const createRun = (overrides: Partial<DataMartRunItem> = {}): DataMartRunItem =>
     ...overrides,
   }) as DataMartRunItem;
 
-type DataMartRef = {
+interface DataMartRef {
   id: string;
   title: string;
   href: string;
-};
+}
 
 const renderRunItem = (
   run: DataMartRunItem,

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.test.tsx
@@ -79,8 +79,8 @@ const createReportRun = (dataMartRef?: DataMartRef): DataMartRunItem =>
   createRun({
     type: DataMartRunType.EMAIL,
     triggerType: DataMartRunTriggerType.SCHEDULED,
-    createdAt: new Date('2026-06-07T15:35:00.000Z'),
-    startedAt: new Date('2026-06-07T15:35:00.000Z'),
+    createdAt: buildRunTimestamp(),
+    startedAt: buildRunTimestamp(),
     definitionRun: {
       sqlQuery: 'select 1',
     } as DataMartRunItem['definitionRun'],
@@ -106,6 +106,11 @@ const createReportRun = (dataMartRef?: DataMartRef): DataMartRunItem =>
         }
       : null,
   });
+
+function buildRunTimestamp(): Date {
+  // Keep the expected local display stable across developer and CI time zones.
+  return new Date(2026, 5, 7, 18, 35, 0);
+}
 
 describe('RunItem', () => {
   beforeEach(() => {
@@ -258,7 +263,7 @@ describe('RunItem', () => {
 
     expect(screen.queryByRole('link', { name: 'Campaigns' })).not.toBeInTheDocument();
 
-    const startedAt = screen.getByText(/2026-06-07 \d{2}:35:00/);
+    const startedAt = screen.getByText('2026-06-07 18:35:00');
     const summary = screen.getByText('Scheduled report run');
     expect(startedAt).toHaveClass('shrink-0', 'whitespace-nowrap');
     expect(startedAt.closest('.flex-wrap')).toBeNull();
@@ -278,6 +283,6 @@ describe('RunItem', () => {
       'href',
       '/ui/project-1/data-marts/dm-1/run-history'
     );
-    expect(screen.getByText(/2026-06-07 \d{2}:35:00/).closest('.flex-wrap')).not.toBeNull();
+    expect(screen.getByText('2026-06-07 18:35:00').closest('.flex-wrap')).not.toBeNull();
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/RunItem.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Box, ChevronDown } from 'lucide-react';
 import { UserReference } from '../../../../../shared/components/UserReference';
 import { StatusBadge } from './StatusBadge';
 import { LogControls } from './LogControls';
@@ -33,6 +34,11 @@ interface RunItemProps {
   cancelDataMartRun: (id: string, runId: string) => Promise<void>;
   dataMartId?: string;
   dataMartConnectorInfo: ConnectorListItem | null;
+  dataMartRef?: {
+    id: string;
+    title: string;
+    href: string;
+  };
 }
 
 export function RunItem({
@@ -46,6 +52,7 @@ export function RunItem({
   cancelDataMartRun,
   dataMartId,
   dataMartConnectorInfo,
+  dataMartRef,
 }: RunItemProps) {
   const { copiedSection, handleCopy } = useClipboard();
 
@@ -101,56 +108,88 @@ export function RunItem({
   const startedAtValue = getStartedAtDisplay(run);
   const tooltipContent = getTooltipContent(run);
   const [runDescription, reportTitle] = getRunSummaryParts(run, dataMartConnectorInfo?.displayName);
+  const startedAtContent = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className='text-foreground flex shrink-0 items-center font-mono text-sm font-medium whitespace-nowrap'>
+          {startedAtValue}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className='space-y-1'>
+          <div>Started At: {tooltipContent.startedAt}</div>
+          <div>Finished At: {tooltipContent.finishedAt}</div>
+          {tooltipContent.duration && <div>Duration: {tooltipContent.duration}</div>}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+  const runSummaryContent = (
+    <div className='text-muted-foreground flex min-w-0 flex-1 items-center gap-2 text-sm'>
+      {getTriggerTypeIcon(run.triggerType)}
+      <div className='inline-flex min-w-0 items-center gap-2'>
+        <span className='shrink-0'>{runDescription}</span>
+        {run.createdByUser && (
+          <>
+            {' by '}
+            <UserReference userProjection={run.createdByUser} />
+          </>
+        )}
+        {reportTitle && (
+          <>
+            {' • '}
+            <span className='truncate'>{reportTitle}</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+  const mainRowContent = dataMartRef ? (
+    <div className='flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1'>
+      {startedAtContent}
+      {runSummaryContent}
+    </div>
+  ) : (
+    <div className='flex min-w-0 items-center gap-3'>
+      {startedAtContent}
+      {runSummaryContent}
+    </div>
+  );
 
   return (
-    <div className='dm-card-block'>
+    <div className='dm-card-block !gap-1'>
+      {dataMartRef && (
+        <div className='h-4 min-w-0 leading-4'>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Link
+                to={dataMartRef.href}
+                onClick={event => {
+                  event.stopPropagation();
+                }}
+                className='text-muted-foreground hover:text-primary inline-flex h-4 max-w-full items-center gap-1.5 text-xs leading-4 font-medium transition-colors'
+              >
+                <Box className='h-3.5 w-3.5 shrink-0' />
+                <span className='truncate'>{dataMartRef.title}</span>
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent>Open Data Mart</TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+
       <div
-        className='flex cursor-pointer items-center justify-between'
+        className='flex cursor-pointer items-center justify-between gap-4'
         onClick={() => {
           onToggle(run.id);
         }}
       >
-        <div className='flex items-center gap-2'>
-          <div>
-            <TypeIcon type={run.type} base64Icon={dataMartConnectorInfo?.logoBase64} />
-          </div>
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className='text-foreground align-center mr-12 flex items-center font-mono text-sm font-medium'>
-                {startedAtValue}
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>
-              <div className='space-y-1'>
-                <div>Started At: {tooltipContent.startedAt}</div>
-                <div>Finished At: {tooltipContent.finishedAt}</div>
-                {tooltipContent.duration && <div>Duration: {tooltipContent.duration}</div>}
-              </div>
-            </TooltipContent>
-          </Tooltip>
-
-          <div className='text-muted-foreground flex items-center gap-2 text-sm'>
-            {getTriggerTypeIcon(run.triggerType)}
-            <div className='inline-flex items-center gap-2'>
-              {runDescription}
-              {run.createdByUser && (
-                <>
-                  {' by '}
-                  <UserReference userProjection={run.createdByUser} />
-                </>
-              )}
-              {reportTitle && (
-                <>
-                  {' • '}
-                  {reportTitle}
-                </>
-              )}
-            </div>
-          </div>
+        <div className='flex min-w-0 flex-1 items-center gap-3'>
+          <TypeIcon type={run.type} base64Icon={dataMartConnectorInfo?.logoBase64} />
+          <div className='min-w-0 flex-1'>{mainRowContent}</div>
         </div>
 
-        <div className='flex items-center gap-2'>
+        <div className='flex shrink-0 items-center gap-2'>
           <StatusBadge status={run.status} />
           <ChevronDown
             className={`text-muted-foreground h-4 w-4 transition-transform ${
@@ -161,7 +200,10 @@ export function RunItem({
       </div>
 
       {isExpanded && (
-        <div className='border-border bg-muted/30 space-y-4 border-t p-4' data-testid='runLogView'>
+        <div
+          className='border-border bg-muted/30 mt-4 space-y-4 border-t p-4'
+          data-testid='runLogView'
+        >
           <div className='flex items-center'>
             <h3 className='text-foreground mr-2 font-medium'>Run ID: {run.id}</h3>
             <CopyButton

--- a/apps/web/src/features/data-marts/edit/constants.ts
+++ b/apps/web/src/features/data-marts/edit/constants.ts
@@ -1,4 +1,4 @@
 /**
  * Number of runs to load per page for data mart run history
  */
-export const DATA_MART_RUNS_PAGE_SIZE = 20;
+export const DATA_MART_RUNS_PAGE_SIZE = 100;

--- a/apps/web/src/features/data-marts/edit/constants.ts
+++ b/apps/web/src/features/data-marts/edit/constants.ts
@@ -1,4 +1,4 @@
 /**
  * Number of runs to load per page for data mart run history
  */
-export const DATA_MART_RUNS_PAGE_SIZE = 100;
+export const DATA_MART_RUNS_PAGE_SIZE = 20;

--- a/apps/web/src/features/data-marts/edit/model/mappers/data-mart-run-mappers.ts
+++ b/apps/web/src/features/data-marts/edit/model/mappers/data-mart-run-mappers.ts
@@ -1,5 +1,8 @@
-import type { DataMartRunItem } from '../types';
-import type { DataMartRunResponseDto } from '../../../shared/types/api';
+import type { DataMartRunItem, ProjectDataMartRunItem } from '../types';
+import type {
+  DataMartRunResponseDto,
+  ProjectDataMartRunResponseDto,
+} from '../../../shared/types/api';
 import type {
   DataMartRunAiAssistantDefinition,
   DataMartDefinitionConfig,
@@ -8,6 +11,7 @@ import type {
 } from '../types';
 import type { DataMartRunTriggerType, DataMartRunType } from '../../../shared';
 import type { DataMartRunListResponseDto } from '../../../shared/types/api';
+import type { ProjectDataMartRunListResponseDto } from '../../../shared/types/api';
 
 export const mapDataMartRunResponseDtoToEntity = (
   dto: DataMartRunResponseDto
@@ -43,4 +47,17 @@ export const mapDataMartRunListResponseDtoToEntity = (
   dto: DataMartRunListResponseDto
 ): DataMartRunItem[] => {
   return dto.runs.map(mapDataMartRunResponseDtoToEntity);
+};
+
+export const mapProjectDataMartRunResponseDtoToEntity = (
+  dto: ProjectDataMartRunResponseDto
+): ProjectDataMartRunItem => ({
+  ...mapDataMartRunResponseDtoToEntity(dto),
+  dataMart: dto.dataMart,
+});
+
+export const mapProjectDataMartRunListResponseDtoToEntity = (
+  dto: ProjectDataMartRunListResponseDto
+): ProjectDataMartRunItem[] => {
+  return dto.runs.map(mapProjectDataMartRunResponseDtoToEntity);
 };

--- a/apps/web/src/features/data-marts/edit/model/types/data-mart-run.ts
+++ b/apps/web/src/features/data-marts/edit/model/types/data-mart-run.ts
@@ -28,3 +28,12 @@ export interface DataMartRunItem {
   createdByUser: UserProjection | null;
   additionalParams: Record<string, unknown> | null;
 }
+
+export interface DataMartRunDataMartRef {
+  id: string;
+  title: string;
+}
+
+export interface ProjectDataMartRunItem extends DataMartRunItem {
+  dataMart: DataMartRunDataMartRef;
+}

--- a/apps/web/src/features/data-marts/insights/components/InsightRowActionsCell.tsx
+++ b/apps/web/src/features/data-marts/insights/components/InsightRowActionsCell.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { MoreHorizontal, Trash2 } from 'lucide-react';
+import { Button } from '@owox/ui/components/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@owox/ui/components/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { NO_PERMISSION_MESSAGE } from '../../../../app/permissions';
+
+interface InsightRowActionsCellProps {
+  id: string;
+  canDelete: boolean;
+  onDelete: (id: string) => void;
+}
+
+export function InsightRowActionsCell({ id, canDelete, onDelete }: InsightRowActionsCellProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <div
+      className='text-right'
+      onClick={e => {
+        e.stopPropagation();
+      }}
+    >
+      <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant='ghost'
+            className={`dm-card-table-body-row-actionbtn opacity-0 transition-opacity ${
+              isMenuOpen ? 'opacity-100' : 'group-hover:opacity-100'
+            }`}
+            aria-label='Insight actions'
+          >
+            <MoreHorizontal className='dm-card-table-body-row-actionbtn-icon' />
+          </Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent align='end'>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className='w-full'>
+                <DropdownMenuItem
+                  className='text-destructive'
+                  onClick={() => {
+                    onDelete(id);
+                  }}
+                  disabled={!canDelete}
+                >
+                  <Trash2 className='h-4 w-4 text-red-600' />
+                  <span className='text-red-600'>Delete insight</span>
+                </DropdownMenuItem>
+              </div>
+            </TooltipTrigger>
+            {!canDelete && <TooltipContent side='left'>{NO_PERMISSION_MESSAGE}</TooltipContent>}
+          </Tooltip>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/insights/components/InsightsListView.tsx
+++ b/apps/web/src/features/data-marts/insights/components/InsightsListView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { MoreHorizontal, Plus, Sparkles, Trash2 } from 'lucide-react';
+import { Plus, Sparkles } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { Button } from '@owox/ui/components/button';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -12,12 +12,6 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '@owox/ui/components/empty';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@owox/ui/components/dropdown-menu';
 import {
   CollapsibleCard,
   CollapsibleCardContent,
@@ -44,6 +38,7 @@ import {
   mapInsightTemplateFromDto,
   mapInsightTemplateListFromDto,
 } from '../model';
+import { InsightRowActionsCell } from './InsightRowActionsCell';
 
 interface InsightTableItem {
   id: string;
@@ -52,59 +47,6 @@ interface InsightTableItem {
   modifiedAt: Date;
   createdById: string;
   createdByUser?: import('../../../../shared/types').UserProjection | null;
-}
-
-interface RowActionsProps {
-  id: string;
-  canDelete: boolean;
-  onDelete: (id: string) => void;
-}
-
-function RowActions({ id, canDelete, onDelete }: RowActionsProps) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  return (
-    <div
-      className='text-right'
-      onClick={e => {
-        e.stopPropagation();
-      }}
-    >
-      <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant='ghost'
-            className={`dm-card-table-body-row-actionbtn opacity-0 transition-opacity ${
-              isMenuOpen ? 'opacity-100' : 'group-hover:opacity-100'
-            }`}
-            aria-label='Insight actions'
-          >
-            <MoreHorizontal className='dm-card-table-body-row-actionbtn-icon' />
-          </Button>
-        </DropdownMenuTrigger>
-
-        <DropdownMenuContent align='end'>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className='w-full'>
-                <DropdownMenuItem
-                  className='text-destructive'
-                  onClick={() => {
-                    onDelete(id);
-                  }}
-                  disabled={!canDelete}
-                >
-                  <Trash2 className='h-4 w-4 text-red-600' />
-                  <span className='text-red-600'>Delete insight</span>
-                </DropdownMenuItem>
-              </div>
-            </TooltipTrigger>
-            {!canDelete && <TooltipContent side='left'>{NO_PERMISSION_MESSAGE}</TooltipContent>}
-          </Tooltip>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  );
 }
 
 export default function InsightsListView() {
@@ -187,7 +129,7 @@ export default function InsightsListView() {
         enableResizing: false,
         header: ({ table }) => <ToggleColumnsHeader table={table} />,
         cell: ({ row }) => (
-          <RowActions
+          <InsightRowActionsCell
             id={row.original.id}
             canDelete={canDelete}
             onDelete={id => {

--- a/apps/web/src/features/data-marts/insights/model/templates/mappers/insight-templates.mapper.ts
+++ b/apps/web/src/features/data-marts/insights/model/templates/mappers/insight-templates.mapper.ts
@@ -65,6 +65,7 @@ export const mapProjectInsightTemplateListItemFromDto = (
     id: dto.dataMart.id,
     title: dto.dataMart.title,
   },
+  canDelete: dto.canDelete,
 });
 
 export const mapProjectInsightTemplateListFromDto = (

--- a/apps/web/src/features/data-marts/insights/model/templates/mappers/insight-templates.mapper.ts
+++ b/apps/web/src/features/data-marts/insights/model/templates/mappers/insight-templates.mapper.ts
@@ -3,9 +3,12 @@ import type {
   CreateInsightTemplateRequestDto,
   InsightTemplateListItemDto,
   InsightTemplateListResponseDto,
+  ProjectInsightTemplateListItemDto,
+  ProjectInsightTemplateListResponseDto,
   InsightTemplateResponseDto,
   UpdateInsightTemplateRequestDto,
 } from '../types/insight-templates.dto';
+import type { ProjectInsightTemplateEntity } from '../types/insight-template.entity';
 
 export const mapInsightTemplateFromDto = (
   dto: InsightTemplateResponseDto
@@ -53,6 +56,20 @@ export const mapInsightTemplateListItemFromDto = (
 export const mapInsightTemplateListFromDto = (
   dto: InsightTemplateListResponseDto
 ): InsightTemplateEntity[] => dto.data.map(mapInsightTemplateListItemFromDto);
+
+export const mapProjectInsightTemplateListItemFromDto = (
+  dto: ProjectInsightTemplateListItemDto
+): ProjectInsightTemplateEntity => ({
+  ...mapInsightTemplateListItemFromDto(dto),
+  dataMart: {
+    id: dto.dataMart.id,
+    title: dto.dataMart.title,
+  },
+});
+
+export const mapProjectInsightTemplateListFromDto = (
+  dto: ProjectInsightTemplateListResponseDto
+): ProjectInsightTemplateEntity[] => dto.insights.map(mapProjectInsightTemplateListItemFromDto);
 
 export const mapToCreateInsightTemplateRequest = (data: {
   title: string;

--- a/apps/web/src/features/data-marts/insights/model/templates/services/insight-templates.service.test.ts
+++ b/apps/web/src/features/data-marts/insights/model/templates/services/insight-templates.service.test.ts
@@ -63,4 +63,16 @@ describe('InsightTemplatesService', () => {
     );
     expect(result).toEqual({ triggerId: 'trigger-2' });
   });
+
+  it('fetches paginated project-wide insight templates', async () => {
+    const response = { insights: [] };
+    (apiClient.get as any).mockResolvedValueOnce({ data: response });
+
+    const result = await service.getProjectInsightTemplates(100, 200);
+
+    expect(apiClient.get).toHaveBeenCalledWith('/data-marts/insight-templates', {
+      params: { limit: 100, offset: 200 },
+    });
+    expect(result).toEqual(response);
+  });
 });

--- a/apps/web/src/features/data-marts/insights/model/templates/services/insight-templates.service.ts
+++ b/apps/web/src/features/data-marts/insights/model/templates/services/insight-templates.service.ts
@@ -4,6 +4,7 @@ import type {
   CreateInsightTemplateRequestDto,
   InsightTemplateExecutionStatusResponseDto,
   InsightTemplateListResponseDto,
+  ProjectInsightTemplateListResponseDto,
   InsightTemplateResponseDto,
   InsightTemplateRunTriggersListResponseDto,
   StartInsightTemplateExecutionRequestDto,
@@ -17,6 +18,16 @@ export class InsightTemplatesService extends ApiService {
 
   async getInsightTemplates(dataMartId: string): Promise<InsightTemplateListResponseDto> {
     return this.get<InsightTemplateListResponseDto>(`/${dataMartId}/insight-templates`);
+  }
+
+  async getProjectInsightTemplates(
+    limit = 100,
+    offset = 0
+  ): Promise<ProjectInsightTemplateListResponseDto> {
+    return this.get<ProjectInsightTemplateListResponseDto>('/insight-templates', {
+      limit,
+      offset,
+    });
   }
 
   async getInsightTemplateById(

--- a/apps/web/src/features/data-marts/insights/model/templates/types/insight-template.entity.ts
+++ b/apps/web/src/features/data-marts/insights/model/templates/types/insight-template.entity.ts
@@ -21,4 +21,5 @@ export interface ProjectInsightTemplateEntity extends InsightTemplateEntity {
     id: string;
     title: string;
   };
+  canDelete: boolean;
 }

--- a/apps/web/src/features/data-marts/insights/model/templates/types/insight-template.entity.ts
+++ b/apps/web/src/features/data-marts/insights/model/templates/types/insight-template.entity.ts
@@ -15,3 +15,10 @@ export interface InsightTemplateEntity {
   modifiedAt: Date;
   createdByUser?: import('../../../../../../shared/types').UserProjection | null;
 }
+
+export interface ProjectInsightTemplateEntity extends InsightTemplateEntity {
+  dataMart: {
+    id: string;
+    title: string;
+  };
+}

--- a/apps/web/src/features/data-marts/insights/model/templates/types/insight-templates.dto.ts
+++ b/apps/web/src/features/data-marts/insights/model/templates/types/insight-templates.dto.ts
@@ -40,6 +40,19 @@ export interface InsightTemplateListResponseDto {
   data: InsightTemplateListItemDto[];
 }
 
+export interface ProjectInsightTemplateDataMartRefDto {
+  id: string;
+  title: string;
+}
+
+export interface ProjectInsightTemplateListItemDto extends InsightTemplateListItemDto {
+  dataMart: ProjectInsightTemplateDataMartRefDto;
+}
+
+export interface ProjectInsightTemplateListResponseDto {
+  insights: ProjectInsightTemplateListItemDto[];
+}
+
 export interface CreateInsightTemplateRequestDto {
   title?: string;
   template?: string | null;

--- a/apps/web/src/features/data-marts/insights/model/templates/types/insight-templates.dto.ts
+++ b/apps/web/src/features/data-marts/insights/model/templates/types/insight-templates.dto.ts
@@ -47,6 +47,7 @@ export interface ProjectInsightTemplateDataMartRefDto {
 
 export interface ProjectInsightTemplateListItemDto extends InsightTemplateListItemDto {
   dataMart: ProjectInsightTemplateDataMartRefDto;
+  canDelete: boolean;
 }
 
 export interface ProjectInsightTemplateListResponseDto {

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -34,9 +34,8 @@ import {
   DataDestinationTypeModel,
   useDataDestination,
 } from '../../../../../data-destination';
-import { Link, useOutletContext } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useProjectRoute } from '../../../../../../shared/hooks';
-import type { DataMartContextType } from '../../../../edit/model/context/types.ts';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { Alert, AlertDescription, AlertTitle } from '@owox/ui/components/alert';
 import { AlertCircle, ExternalLink } from 'lucide-react';
@@ -63,6 +62,7 @@ import {
   type ReportColumnSelectionCount,
 } from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
 import { DEFAULT_REPORT_TITLE } from '../../../shared';
+import { useDataMartContext } from '../../../../edit/model';
 
 interface GoogleSheetsReportEditFormProps {
   initialReport?: DataMartReport;
@@ -96,7 +96,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
     const documentUrlInputId = 'google-sheets-document-url-input';
     const dataDestinationSelectId = 'google-sheets-data-destination-select';
 
-    const { dataMart } = useOutletContext<DataMartContextType>();
+    const { dataMart } = useDataMartContext();
     const { scope } = useProjectRoute();
     const {
       dataDestinations,

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -28,8 +28,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@owox/ui/components/select';
-import { useOutletContext } from 'react-router-dom';
-import type { DataMartContextType } from '../../../../edit/model/context/types.ts';
 import { type DataDestination } from '../../../../../data-destination';
 import { ReportFormMode } from '../../../shared';
 import { Button } from '@owox/ui/components/button';
@@ -42,6 +40,7 @@ import {
   type ReportColumnSelectionCount,
 } from '../../../../edit/components/ReportColumnPicker/ReportColumnPicker';
 import { GeneratedSqlViewer } from '../../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
+import { useDataMartContext } from '../../../../edit/model';
 
 interface LookerStudioReportEditFormProps {
   initialReport?: DataMartReport;
@@ -87,7 +86,7 @@ export const LookerStudioReportEditForm = forwardRef<
   ) => {
     const formId = 'looker-studio-edit-form';
 
-    const { dataMart } = useOutletContext<DataMartContextType>();
+    const { dataMart } = useDataMartContext();
     const [hasBlendedSelection, setHasBlendedSelection] = useState(false);
     const [columnsCount, setColumnsCount] = useState<ReportColumnSelectionCount>({
       selected: 0,

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
@@ -25,9 +25,17 @@ interface EmailActionsCellProps {
   row: { original: DataMartReport };
   onDeleteSuccess?: () => void;
   onEditReport?: (report: DataMartReport) => void;
+  onRunSuccess?: () => void | Promise<void>;
 }
 
-export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailActionsCellProps) {
+export function EmailActionsCell({
+  row,
+  onDeleteSuccess,
+  onEditReport,
+  onRunSuccess,
+}: EmailActionsCellProps) {
+  const canRun = row.original.canRun;
+  const canEditConfig = row.original.canEditConfig;
   const [isRunning, setIsRunning] = useState(
     row.original.lastRunStatus === ReportStatusEnum.RUNNING
   );
@@ -47,6 +55,8 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
   }, [row.original.lastRunStatus]);
 
   const handleDelete = useCallback(async () => {
+    if (!canEditConfig) return;
+
     try {
       await deleteReport(row.original.id);
       await fetchReportsByDataMartId(row.original.dataMart.id);
@@ -58,30 +68,38 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
   }, [
     deleteReport,
     fetchReportsByDataMartId,
+    canEditConfig,
     onDeleteSuccess,
     row.original.id,
     row.original.dataMart.id,
   ]);
 
   const handleEdit = useCallback(() => {
+    if (!canEditConfig) return;
+
     onEditReport?.(row.original);
     setMenuOpen(false);
-  }, [onEditReport, row.original]);
+  }, [canEditConfig, onEditReport, row.original]);
 
   const handleRun = useCallback(async () => {
+    if (!canRun) return;
+
     try {
       setIsRunning(true);
       await runReport(row.original.id);
+      await onRunSuccess?.();
     } catch (error) {
       setIsRunning(false);
       console.error('Failed to run report:', error);
     }
-  }, [runReport, row.original.id]);
+  }, [canRun, onRunSuccess, runReport, row.original.id]);
 
   const handleDeleteClick = useCallback(() => {
+    if (!canEditConfig) return;
+
     setIsDeleteDialogOpen(true);
     setMenuOpen(false);
-  }, []);
+  }, [canEditConfig]);
 
   return (
     <TooltipProvider>
@@ -101,7 +119,7 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
               }}
               variant='ghost'
               className='dm-card-table-body-row-actionbtn opacity-0 transition-opacity group-hover:opacity-100 disabled:opacity-0 disabled:group-hover:opacity-50'
-              disabled={isRunning}
+              disabled={isRunning || !canRun}
               aria-label={isRunning ? 'Running report...' : `Run report: ${row.original.title}`}
             >
               <Play className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
@@ -142,6 +160,7 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
 
           <DropdownMenuContent id={actionsMenuId} align='end' role='menu'>
             <DropdownMenuItem
+              disabled={!canEditConfig}
               onClick={e => {
                 e.stopPropagation();
                 handleEdit();
@@ -155,6 +174,7 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
             <DropdownMenuSeparator />
 
             <DropdownMenuItem
+              disabled={!canEditConfig}
               onClick={e => {
                 e.stopPropagation();
                 handleDeleteClick();

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
@@ -29,13 +29,17 @@ interface GoogleSheetsActionsCellProps {
   row: { original: DataMartReport };
   onDeleteSuccess?: () => void;
   onEditReport?: (report: DataMartReport) => void;
+  onRunSuccess?: () => void | Promise<void>;
 }
 
 export function GoogleSheetsActionsCell({
   row,
   onDeleteSuccess,
   onEditReport,
+  onRunSuccess,
 }: GoogleSheetsActionsCellProps) {
+  const canRun = row.original.canRun;
+  const canEditConfig = row.original.canEditConfig;
   const [isRunning, setIsRunning] = useState(
     row.original.lastRunStatus === ReportStatusEnum.RUNNING
   );
@@ -58,6 +62,8 @@ export function GoogleSheetsActionsCell({
 
   // Memoize delete handler to avoid unnecessary re-renders
   const handleDelete = useCallback(async () => {
+    if (!canEditConfig) return;
+
     try {
       await deleteReport(row.original.id);
       await fetchReportsByDataMartId(row.original.dataMart.id);
@@ -69,30 +75,38 @@ export function GoogleSheetsActionsCell({
   }, [
     deleteReport,
     fetchReportsByDataMartId,
+    canEditConfig,
     onDeleteSuccess,
     row.original.id,
     row.original.dataMart.id,
   ]);
 
   const handleEdit = useCallback(() => {
+    if (!canEditConfig) return;
+
     onEditReport?.(row.original);
     setMenuOpen(false);
-  }, [onEditReport, row.original]);
+  }, [canEditConfig, onEditReport, row.original]);
 
   const handleRun = useCallback(async () => {
+    if (!canRun) return;
+
     try {
       setIsRunning(true);
       await runReport(row.original.id);
+      await onRunSuccess?.();
     } catch (error) {
       setIsRunning(false);
       console.error('Failed to run report:', error);
     }
-  }, [runReport, row.original.id]);
+  }, [canRun, onRunSuccess, runReport, row.original.id]);
 
   const handleDeleteClick = useCallback(() => {
+    if (!canEditConfig) return;
+
     setIsDeleteDialogOpen(true);
     setMenuOpen(false);
-  }, []);
+  }, [canEditConfig]);
 
   return (
     <TooltipProvider>
@@ -112,7 +126,7 @@ export function GoogleSheetsActionsCell({
               }}
               variant='ghost'
               className='dm-card-table-body-row-actionbtn opacity-0 transition-opacity group-hover:opacity-100 disabled:opacity-0 disabled:group-hover:opacity-50'
-              disabled={isRunning}
+              disabled={isRunning || !canRun}
               aria-label={isRunning ? 'Running report...' : `Run report: ${row.original.title}`}
             >
               <Play className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
@@ -173,6 +187,7 @@ export function GoogleSheetsActionsCell({
           </DropdownMenuTrigger>
           <DropdownMenuContent id={actionsMenuId} align='end' role='menu'>
             <DropdownMenuItem
+              disabled={!canEditConfig}
               onClick={e => {
                 e.stopPropagation();
                 handleEdit();
@@ -184,6 +199,7 @@ export function GoogleSheetsActionsCell({
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
+              disabled={!canEditConfig}
               onClick={e => {
                 e.stopPropagation();
                 handleDeleteClick();

--- a/apps/web/src/features/data-marts/reports/shared/model/mappers/report.mapper.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/mappers/report.mapper.ts
@@ -1,6 +1,7 @@
 import type { DataMartReport, DestinationConfig } from '../types/data-mart-report';
 import type { DestinationConfigDto, ReportResponseDto } from '../../services';
 import { mapDataDestinationFromDto } from '../../../../../data-destination/shared/model/mappers/data-destination.mapper';
+import { mapDataStorageFromDto } from '../../../../../data-storage/shared/model/mappers';
 import { DestinationConfigMapperFactory } from './destination-config-mapper.factory.ts';
 
 /**
@@ -25,7 +26,11 @@ export function mapReportDtoToEntity(reportDto: ReportResponseDto): DataMartRepo
   return {
     id: reportDto.id,
     title: reportDto.title,
-    dataMart: { id: reportDto.dataMart.id },
+    dataMart: {
+      id: reportDto.dataMart.id,
+      title: reportDto.dataMart.title,
+      storage: mapDataStorageFromDto(reportDto.dataMart.storage),
+    },
     dataDestination: mapDataDestinationFromDto(reportDto.dataDestinationAccess),
     destinationConfig,
     columnConfig: reportDto.columnConfig ?? null,

--- a/apps/web/src/features/data-marts/reports/shared/model/types/data-mart-report.ts
+++ b/apps/web/src/features/data-marts/reports/shared/model/types/data-mart-report.ts
@@ -5,6 +5,7 @@ import {
 } from '../../enums';
 import { type DataDestination } from '../../../../../data-destination';
 import type { DataMart } from '../../../../edit';
+import type { DataStorage } from '../../../../../data-storage/shared/model/types/data-storage';
 import type { ReportConditionEnum } from '../../enums/report-condition.enum.ts';
 import type { UserProjection } from '../../../../../../shared/types';
 import type { FilterRule, SortRule } from '../../../../shared/types/output-config';
@@ -96,7 +97,7 @@ export function isCustomMessageTemplateSource(
 export interface DataMartReport {
   id: string;
   title: string;
-  dataMart: Pick<DataMart, 'id'>;
+  dataMart: Pick<DataMart, 'id' | 'title'> & { storage?: DataStorage | null };
   dataDestination: DataDestination;
   destinationConfig: DestinationConfig;
   columnConfig: string[] | null;

--- a/apps/web/src/features/data-marts/reports/shared/services/report.service.test.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/report.service.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import apiClient from '../../../../../app/api/apiClient.ts';
+import { ReportService } from './report.service.ts';
+
+vi.mock('../../../../../app/api/apiClient.ts', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe('ReportService', () => {
+  let service: ReportService;
+
+  beforeEach(() => {
+    service = new ReportService();
+    vi.resetAllMocks();
+    (apiClient.get as any).mockResolvedValue({ data: [] });
+  });
+
+  it('fetches project reports without pagination when no limit is provided', async () => {
+    await service.getReportsByProject();
+
+    expect(apiClient.get).toHaveBeenCalledWith('/reports/', { params: undefined });
+  });
+
+  it('fetches paginated project reports', async () => {
+    await service.getReportsByProject(100, 200);
+
+    expect(apiClient.get).toHaveBeenCalledWith('/reports/', {
+      params: { limit: 100, offset: 200 },
+    });
+  });
+});

--- a/apps/web/src/features/data-marts/reports/shared/services/report.service.test.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/report.service.test.ts
@@ -20,10 +20,18 @@ describe('ReportService', () => {
     (apiClient.get as any).mockResolvedValue({ data: [] });
   });
 
-  it('fetches project reports without pagination when no limit is provided', async () => {
+  it('fetches project reports without pagination when no pagination parameters are provided', async () => {
     await service.getReportsByProject();
 
     expect(apiClient.get).toHaveBeenCalledWith('/reports/', { params: undefined });
+  });
+
+  it('fetches project reports with limit-only pagination', async () => {
+    await service.getReportsByProject(100);
+
+    expect(apiClient.get).toHaveBeenCalledWith('/reports/', {
+      params: { limit: 100 },
+    });
   });
 
   it('fetches paginated project reports', async () => {
@@ -31,6 +39,14 @@ describe('ReportService', () => {
 
     expect(apiClient.get).toHaveBeenCalledWith('/reports/', {
       params: { limit: 100, offset: 200 },
+    });
+  });
+
+  it('fetches project reports with offset-only pagination', async () => {
+    await service.getReportsByProject(undefined, 200);
+
+    expect(apiClient.get).toHaveBeenCalledWith('/reports/', {
+      params: { offset: 200 },
     });
   });
 });

--- a/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
@@ -70,11 +70,11 @@ export class ReportService extends ApiService {
    */
   async getReportsByProject(limit?: number, offset?: number): Promise<ReportResponseDto[]> {
     const params =
-      limit === undefined
+      limit === undefined && offset === undefined
         ? undefined
         : {
-            limit,
-            offset: offset ?? 0,
+            ...(limit !== undefined ? { limit } : {}),
+            ...(offset !== undefined ? { offset } : {}),
           };
 
     return this.get<ReportResponseDto[]>('/', params);

--- a/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
@@ -68,8 +68,16 @@ export class ReportService extends ApiService {
    * List reports by project
    * @returns Promise with list of reports
    */
-  async getReportsByProject(): Promise<ReportResponseDto[]> {
-    return this.get<ReportResponseDto[]>('/');
+  async getReportsByProject(limit?: number, offset?: number): Promise<ReportResponseDto[]> {
+    const params =
+      limit === undefined
+        ? undefined
+        : {
+            limit,
+            offset: offset ?? 0,
+          };
+
+    return this.get<ReportResponseDto[]>('/', params);
   }
 
   /**

--- a/apps/web/src/features/data-marts/reports/shared/utils/report-has-output-controls.utils.test.ts
+++ b/apps/web/src/features/data-marts/reports/shared/utils/report-has-output-controls.utils.test.ts
@@ -6,7 +6,7 @@ function makeReport(overrides: Partial<DataMartReport> = {}): DataMartReport {
   return {
     id: 'r1',
     title: 'Test Report',
-    dataMart: { id: 'dm1' },
+    dataMart: { id: 'dm1', title: 'Test Data Mart' },
     dataDestination: {} as any,
     destinationConfig: {} as any,
     columnConfig: null,

--- a/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerTable/ScheduledTriggerActionsCell.tsx
+++ b/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerTable/ScheduledTriggerActionsCell.tsx
@@ -15,15 +15,23 @@ interface ScheduledTriggerActionsCellProps {
   trigger: ScheduledTrigger;
   onEditTrigger: (id: string) => void;
   onDeleteTrigger: (id: string) => void;
+  canEdit?: boolean;
+  canDelete?: boolean;
 }
 
 export function ScheduledTriggerActionsCell({
   trigger,
   onEditTrigger,
   onDeleteTrigger,
+  canEdit = true,
+  canDelete = true,
 }: ScheduledTriggerActionsCellProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  if (!canEdit && !canDelete) {
+    return null;
+  }
 
   const handleDelete = () => {
     setIsDeleteDialogOpen(false);
@@ -48,23 +56,27 @@ export function ScheduledTriggerActionsCell({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align='end'>
-          <DropdownMenuItem
-            onClick={() => {
-              onEditTrigger(trigger.id);
-            }}
-          >
-            <Pencil className='text-foreground h-4 w-4' aria-hidden='true' />
-            Edit trigger
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onClick={() => {
-              setIsDeleteDialogOpen(true);
-            }}
-          >
-            <Trash2 className='h-4 w-4 text-red-600' aria-hidden='true' />
-            <span className='text-red-600'>Delete trigger</span>
-          </DropdownMenuItem>
+          {canEdit && (
+            <DropdownMenuItem
+              onClick={() => {
+                onEditTrigger(trigger.id);
+              }}
+            >
+              <Pencil className='text-foreground h-4 w-4' aria-hidden='true' />
+              Edit trigger
+            </DropdownMenuItem>
+          )}
+          {canEdit && canDelete && <DropdownMenuSeparator />}
+          {canDelete && (
+            <DropdownMenuItem
+              onClick={() => {
+                setIsDeleteDialogOpen(true);
+              }}
+            >
+              <Trash2 className='h-4 w-4 text-red-600' aria-hidden='true' />
+              <span className='text-red-600'>Delete trigger</span>
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerTable/ScheduledTriggerRunTarget.tsx
+++ b/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerTable/ScheduledTriggerRunTarget.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { Database, Info } from 'lucide-react';
+import { Database, FileText, Info } from 'lucide-react';
 import { RawBase64Icon } from '../../../../../shared';
 import { ConnectorHoverCard, ConnectorNameDisplay } from '../../../../connectors/shared/components';
+import { useConnector } from '../../../../connectors/shared/model/hooks/useConnector';
 import { DataDestinationTypeModel } from '../../../../data-destination';
 import { ReportHoverCard } from '../../../reports/shared/components/ReportHoverCard';
 import { ScheduledTriggerType } from '../../enums';
+import type { ConnectorListItem } from '../../../../connectors/shared/model/types/connector';
 import type { ScheduledTrigger } from '../../model/scheduled-trigger.model';
 import type {
   ScheduledConnectorRunConfig,
@@ -15,7 +17,18 @@ import type {
  * Renders the target for a report run trigger
  */
 function renderReportRunTarget(trigger: ScheduledTrigger) {
-  const config = trigger.triggerConfig as ScheduledReportRunConfig;
+  const config = trigger.triggerConfig as ScheduledReportRunConfig | undefined;
+  if (!config?.report) {
+    return (
+      <div className='text-muted-foreground inline-flex max-w-full min-w-0 items-center gap-2 overflow-hidden text-sm whitespace-nowrap'>
+        <FileText className='h-4 w-4 shrink-0' size={16} />
+        <span className='max-w-full flex-1 truncate' title={config?.reportId}>
+          Report
+        </span>
+      </div>
+    );
+  }
+
   const Icon = DataDestinationTypeModel.getInfo(config.report.dataDestination.type).icon;
   return (
     <div className='group inline-flex max-w-full min-w-0 items-center gap-2 overflow-hidden whitespace-nowrap'>
@@ -33,11 +46,22 @@ function renderReportRunTarget(trigger: ScheduledTrigger) {
 /**
  * Renders the target for a connector run trigger
  */
-function renderConnectorRunTarget(trigger: ScheduledTrigger) {
-  const triggerConfig = trigger.triggerConfig as ScheduledConnectorRunConfig;
+function renderConnectorRunTarget(trigger: ScheduledTrigger, connectors: ConnectorListItem[]) {
+  const triggerConfig = trigger.triggerConfig as ScheduledConnectorRunConfig | undefined;
+  if (!triggerConfig?.connector) {
+    return (
+      <div className='text-muted-foreground inline-flex max-w-full min-w-0 items-center gap-2 overflow-hidden text-sm whitespace-nowrap'>
+        <Database className='h-4 w-4 shrink-0' size={16} />
+        <span className='max-w-full flex-1 truncate'>Connector</span>
+      </div>
+    );
+  }
+
   const { connector } = triggerConfig.connector;
-  const connectorIcon = connector.info?.logoBase64 ? (
-    <RawBase64Icon base64={connector.info.logoBase64} className='h-4 w-4 shrink-0' size={16} />
+  const connectorInfo = connectors.find(item => item.name === connector.source.name);
+  const connectorLogo = connector.info?.logoBase64 ?? connectorInfo?.logoBase64;
+  const connectorIcon = connectorLogo ? (
+    <RawBase64Icon base64={connectorLogo} className='h-4 w-4 shrink-0' size={16} />
   ) : (
     <Database className='h-4 w-4' size={16} />
   );
@@ -59,20 +83,22 @@ function renderConnectorRunTarget(trigger: ScheduledTrigger) {
  */
 export const ScheduledTriggerRunTarget = React.memo(
   function ScheduledTriggerRunTarget({ trigger }: { trigger: ScheduledTrigger }) {
+    const { connectors } = useConnector();
+
     switch (trigger.type) {
       case ScheduledTriggerType.REPORT_RUN:
         return renderReportRunTarget(trigger);
       case ScheduledTriggerType.CONNECTOR_RUN:
-        return renderConnectorRunTarget(trigger);
+        return renderConnectorRunTarget(trigger, connectors);
       default:
         return <div className='text-muted-foreground text-sm'>—</div>;
     }
   },
   (prevProps, nextProps) => {
-    // Only re-render if trigger ID or type changes
     return (
       prevProps.trigger.id === nextProps.trigger.id &&
-      prevProps.trigger.type === nextProps.trigger.type
+      prevProps.trigger.type === nextProps.trigger.type &&
+      prevProps.trigger.triggerConfig === nextProps.trigger.triggerConfig
     );
   }
 );

--- a/apps/web/src/features/data-marts/scheduled-triggers/model/api/response/scheduled-trigger-list.response.dto.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/model/api/response/scheduled-trigger-list.response.dto.ts
@@ -1,6 +1,13 @@
-import { type ScheduledTriggerResponseApiDto } from './scheduled-trigger.response.dto';
+import {
+  type ProjectScheduledTriggerResponseApiDto,
+  type ScheduledTriggerResponseApiDto,
+} from './scheduled-trigger.response.dto';
 
 /**
  * Response DTO for a list of scheduled triggers
  */
 export type ScheduledTriggerListResponseApiDto = ScheduledTriggerResponseApiDto[];
+
+export interface ProjectScheduledTriggerListResponseApiDto {
+  triggers: ProjectScheduledTriggerResponseApiDto[];
+}

--- a/apps/web/src/features/data-marts/scheduled-triggers/model/api/response/scheduled-trigger.response.dto.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/model/api/response/scheduled-trigger.response.dto.ts
@@ -84,4 +84,6 @@ export interface ProjectScheduledTriggerDataMartRefResponseApiDto {
 
 export interface ProjectScheduledTriggerResponseApiDto extends ScheduledTriggerResponseApiDto {
   dataMart: ProjectScheduledTriggerDataMartRefResponseApiDto;
+  canEdit: boolean;
+  canDelete: boolean;
 }

--- a/apps/web/src/features/data-marts/scheduled-triggers/model/api/response/scheduled-trigger.response.dto.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/model/api/response/scheduled-trigger.response.dto.ts
@@ -76,3 +76,12 @@ export interface ScheduledTriggerResponseApiDto {
    */
   createdByUser?: UserProjection | null;
 }
+
+export interface ProjectScheduledTriggerDataMartRefResponseApiDto {
+  id: string;
+  title: string;
+}
+
+export interface ProjectScheduledTriggerResponseApiDto extends ScheduledTriggerResponseApiDto {
+  dataMart: ProjectScheduledTriggerDataMartRefResponseApiDto;
+}

--- a/apps/web/src/features/data-marts/scheduled-triggers/model/mappers/report-run-trigger.mapper.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/model/mappers/report-run-trigger.mapper.ts
@@ -6,8 +6,9 @@ import type {
   ScheduledTriggerResponseApiDto,
   UpdateScheduledTriggerRequestApiDto,
 } from '../api';
-import { reportService } from '../../../reports/shared';
 import { mapReportDtoToEntity } from '../../../reports/shared/model/mappers';
+import type { ReportResponseDto } from '../../../reports/shared/services';
+import { reportService } from '../../../reports/shared';
 import type { ScheduledReportRunConfig } from '../trigger-config.types.ts';
 
 /**
@@ -26,7 +27,7 @@ export class ReportRunTriggerMapper implements TriggerMapper {
       isActive: dto.isActive,
       nextRun: dto.nextRunTimestamp ? new Date(dto.nextRunTimestamp) : null,
       lastRun: dto.lastRunTimestamp ? new Date(dto.lastRunTimestamp) : null,
-      triggerConfig: dto.triggerConfig,
+      triggerConfig: mapReportRunConfigFromDto(dto.triggerConfig),
       createdById: dto.createdById,
       createdAt: new Date(dto.createdAt),
       modifiedAt: new Date(dto.modifiedAt),
@@ -98,4 +99,19 @@ export class ReportRunTriggerMapper implements TriggerMapper {
       isActive: model.isActive,
     };
   }
+}
+
+function mapReportRunConfigFromDto(
+  config: ScheduledTriggerResponseApiDto['triggerConfig']
+): ScheduledReportRunConfig {
+  const reportConfig = config as ScheduledReportRunConfig;
+  const report = (reportConfig as { report?: unknown }).report;
+  if (report && typeof report === 'object' && 'dataDestinationAccess' in report) {
+    return {
+      ...reportConfig,
+      report: mapReportDtoToEntity(report as ReportResponseDto),
+    };
+  }
+
+  return reportConfig;
 }

--- a/apps/web/src/features/data-marts/scheduled-triggers/model/mappers/scheduled-trigger-mapper.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/model/mappers/scheduled-trigger-mapper.ts
@@ -42,6 +42,8 @@ export const ScheduledTriggerMapper = {
     return {
       ...this.mapFromDto(dto),
       dataMart: dto.dataMart,
+      canEdit: dto.canEdit,
+      canDelete: dto.canDelete,
     };
   },
 

--- a/apps/web/src/features/data-marts/scheduled-triggers/model/mappers/scheduled-trigger-mapper.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/model/mappers/scheduled-trigger-mapper.ts
@@ -1,10 +1,12 @@
 import type {
   CreateScheduledTriggerRequestApiDto,
+  ProjectScheduledTriggerListResponseApiDto,
+  ProjectScheduledTriggerResponseApiDto,
   ScheduledTriggerListResponseApiDto,
   ScheduledTriggerResponseApiDto,
   UpdateScheduledTriggerRequestApiDto,
 } from '../api';
-import type { ScheduledTrigger } from '../scheduled-trigger.model';
+import type { ProjectScheduledTrigger, ScheduledTrigger } from '../scheduled-trigger.model';
 import { TriggerMapperFactory } from './trigger-mapper.factory';
 import { ScheduledTriggerType } from '../../enums';
 import { ReportRunTriggerMapper } from './report-run-trigger.mapper';
@@ -34,6 +36,19 @@ export const ScheduledTriggerMapper = {
    */
   mapFromDtoList(dtoList: ScheduledTriggerListResponseApiDto): ScheduledTrigger[] {
     return dtoList.map(dto => this.mapFromDto(dto));
+  },
+
+  mapProjectFromDto(dto: ProjectScheduledTriggerResponseApiDto): ProjectScheduledTrigger {
+    return {
+      ...this.mapFromDto(dto),
+      dataMart: dto.dataMart,
+    };
+  },
+
+  mapProjectFromDtoList(
+    dtoList: ProjectScheduledTriggerListResponseApiDto
+  ): ProjectScheduledTrigger[] {
+    return dtoList.triggers.map(dto => this.mapProjectFromDto(dto));
   },
 
   /**

--- a/apps/web/src/features/data-marts/scheduled-triggers/model/scheduled-trigger.model.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/model/scheduled-trigger.model.ts
@@ -74,6 +74,8 @@ export interface ScheduledTriggerDataMartRef {
 
 export interface ProjectScheduledTrigger extends ScheduledTrigger {
   dataMart: ScheduledTriggerDataMartRef;
+  canEdit: boolean;
+  canDelete: boolean;
 }
 
 /**

--- a/apps/web/src/features/data-marts/scheduled-triggers/model/scheduled-trigger.model.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/model/scheduled-trigger.model.ts
@@ -67,6 +67,15 @@ export interface ScheduledTrigger {
   createdByUser?: UserProjection | null;
 }
 
+export interface ScheduledTriggerDataMartRef {
+  id: string;
+  title: string;
+}
+
+export interface ProjectScheduledTrigger extends ScheduledTrigger {
+  dataMart: ScheduledTriggerDataMartRef;
+}
+
 /**
  * Maps trigger types to their respective configuration types
  */

--- a/apps/web/src/features/data-marts/scheduled-triggers/model/trigger-config.types.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/model/trigger-config.types.ts
@@ -19,7 +19,7 @@ export interface ScheduledReportRunConfig {
   /**
    * Represents a report object containing data from a DataMart.
    */
-  report: DataMartReport;
+  report?: DataMartReport;
 }
 
 /**
@@ -27,7 +27,7 @@ export interface ScheduledReportRunConfig {
  */
 export interface ScheduledConnectorRunConfig {
   type: typeof TRIGGER_CONFIG_TYPES.SCHEDULED_CONNECTOR_RUN;
-  connector: ConnectorDefinitionConfig;
+  connector?: ConnectorDefinitionConfig;
 }
 
 /**

--- a/apps/web/src/features/data-marts/scheduled-triggers/services/scheduled-trigger.service.test.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/services/scheduled-trigger.service.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import apiClient from '../../../../app/api/apiClient.ts';
+import { ScheduledTriggerService } from './scheduled-trigger.service.ts';
+
+vi.mock('../../../../app/api/apiClient.ts', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe('ScheduledTriggerService', () => {
+  let service: ScheduledTriggerService;
+
+  beforeEach(() => {
+    service = new ScheduledTriggerService();
+    vi.resetAllMocks();
+    (apiClient.get as any).mockResolvedValue({ data: {} });
+  });
+
+  it('fetches project-wide scheduled triggers', async () => {
+    const response = { triggers: [] };
+    (apiClient.get as any).mockResolvedValueOnce({ data: response });
+
+    const result = await service.getProjectScheduledTriggers(20, 40);
+
+    expect(apiClient.get).toHaveBeenCalledWith('/data-marts/scheduled-triggers', {
+      params: { limit: 20, offset: 40 },
+    });
+    expect(result).toEqual(response);
+  });
+});

--- a/apps/web/src/features/data-marts/scheduled-triggers/services/scheduled-trigger.service.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/services/scheduled-trigger.service.ts
@@ -1,6 +1,7 @@
 import { ApiService } from '../../../../services';
 import type {
   CreateScheduledTriggerRequestApiDto,
+  ProjectScheduledTriggerListResponseApiDto,
   ScheduledTriggerListResponseApiDto,
   ScheduledTriggerResponseApiDto,
   UpdateScheduledTriggerRequestApiDto,
@@ -25,6 +26,19 @@ export class ScheduledTriggerService extends ApiService {
    */
   async getScheduledTriggers(dataMartId: string): Promise<ScheduledTriggerListResponseApiDto> {
     return this.get<ScheduledTriggerListResponseApiDto>(`/${dataMartId}/scheduled-triggers`);
+  }
+
+  /**
+   * Fetch scheduled triggers across all accessible data marts in the current project.
+   */
+  async getProjectScheduledTriggers(
+    limit = 100,
+    offset = 0
+  ): Promise<ProjectScheduledTriggerListResponseApiDto> {
+    return this.get<ProjectScheduledTriggerListResponseApiDto>('/scheduled-triggers', {
+      limit,
+      offset,
+    });
   }
 
   /**

--- a/apps/web/src/features/data-marts/shared/services/data-mart.service.test.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart.service.test.ts
@@ -90,6 +90,20 @@ describe('DataMartService', () => {
     });
   });
 
+  describe('getProjectDataMartRuns', () => {
+    it('should fetch project-wide data mart runs', async () => {
+      const response = { runs: [] };
+      (apiClient.get as any).mockResolvedValueOnce({ data: response });
+
+      const result = await service.getProjectDataMartRuns(20, 40);
+
+      expect(apiClient.get).toHaveBeenCalledWith('/data-marts/runs', {
+        params: { limit: 20, offset: 40 },
+      });
+      expect(result).toEqual(response);
+    });
+  });
+
   describe('createDataMart', () => {
     it('should create a new data mart', async () => {
       (apiClient.post as any).mockResolvedValueOnce({ data: mockDataMartResponse });

--- a/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
@@ -8,6 +8,7 @@ import type {
   DataMartListResponseDto,
   DataMartResponseDto,
   DataMartRunListResponseDto,
+  ProjectDataMartRunListResponseDto,
   SqlValidationResponseDto,
   UpdateDataMartDefinitionRequestDto,
   UpdateDataMartRequestDto,
@@ -319,6 +320,17 @@ export class DataMartService extends ApiService {
     config?: AxiosRequestConfig
   ): Promise<DataMartRunListResponseDto> {
     return await this.get<DataMartRunListResponseDto>(`/${id}/runs`, { limit, offset }, config);
+  }
+
+  /**
+   * Get run history across all Data Marts visible in the current project.
+   */
+  async getProjectDataMartRuns(
+    limit = 100,
+    offset = 0,
+    config?: AxiosRequestConfig
+  ): Promise<ProjectDataMartRunListResponseDto> {
+    return await this.get<ProjectDataMartRunListResponseDto>('/runs', { limit, offset }, config);
   }
 
   /**

--- a/apps/web/src/features/data-marts/shared/types/api/response/data-mart-run-list.response.dto.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/response/data-mart-run-list.response.dto.ts
@@ -1,5 +1,12 @@
-import type { DataMartRunResponseDto } from './data-mart-run.response.dto';
+import type {
+  DataMartRunResponseDto,
+  ProjectDataMartRunResponseDto,
+} from './data-mart-run.response.dto';
 
 export interface DataMartRunListResponseDto {
   runs: DataMartRunResponseDto[];
+}
+
+export interface ProjectDataMartRunListResponseDto {
+  runs: ProjectDataMartRunResponseDto[];
 }

--- a/apps/web/src/features/data-marts/shared/types/api/response/data-mart-run.response.dto.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/response/data-mart-run.response.dto.ts
@@ -31,3 +31,12 @@ export interface DataMartRunResponseDto {
   createdByUser: UserProjectionDto | null;
   additionalParams: Record<string, unknown> | null;
 }
+
+export interface ProjectDataMartRunRefResponseDto {
+  id: string;
+  title: string;
+}
+
+export interface ProjectDataMartRunResponseDto extends DataMartRunResponseDto {
+  dataMart: ProjectDataMartRunRefResponseDto;
+}

--- a/apps/web/src/features/project-settings/members/components/UserProvisioningSettings/UserProvisioningSettings.test.tsx
+++ b/apps/web/src/features/project-settings/members/components/UserProvisioningSettings/UserProvisioningSettings.test.tsx
@@ -241,10 +241,11 @@ describe('UserProvisioningSettings', () => {
 
     render(<UserProvisioningSettings contexts={[]} isAdmin={true} />);
 
+    const manualModeRadio = await screen.findByTestId('radio-require-request');
     await waitFor(() => {
-      expect(screen.getByTestId('radio-require-request')).toBeChecked();
-      expect(screen.queryByTestId('change-default-roles-btn')).not.toBeInTheDocument();
+      expect(manualModeRadio).toBeChecked();
     });
+    expect(screen.queryByTestId('change-default-roles-btn')).not.toBeInTheDocument();
   });
 
   it('opens DefaultRoleSheet when role/scope button is clicked', async () => {

--- a/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.test.tsx
@@ -21,7 +21,7 @@ vi.mock('../../../features/data-marts/insights/model', async importOriginal => {
 vi.mock('../../../features/idp', () => ({
   useRole: () => ({
     isAdmin: false,
-    canEdit: false,
+    canEdit: true,
   }),
   useAuth: () => ({
     status: 'authenticated',
@@ -214,6 +214,17 @@ describe('DataMartInsightsPage', () => {
     expect(await screen.findByText('Delete insight')).toBeInTheDocument();
   });
 
+  it('does not expose insight delete actions when the row cannot be deleted', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [buildInsightTemplateResponse({ canDelete: false })],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Revenue Summary')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Insight actions' })).not.toBeInTheDocument();
+  });
+
   it('loads additional insight pages when project search is active', async () => {
     vi.mocked(insightTemplatesService.getProjectInsightTemplates)
       .mockResolvedValueOnce({
@@ -276,7 +287,7 @@ function getColumnHeaderLabels() {
 }
 
 function buildInsightTemplateResponse(
-  overrides: { id?: string; title?: string; dataMartTitle?: string } = {}
+  overrides: { id?: string; title?: string; dataMartTitle?: string; canDelete?: boolean } = {}
 ) {
   return {
     id: overrides.id ?? 'insight-1',
@@ -291,5 +302,6 @@ function buildInsightTemplateResponse(
       id: 'dm-1',
       title: overrides.dataMartTitle ?? 'Marketing Mart',
     },
+    canDelete: overrides.canDelete ?? true,
   };
 }

--- a/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.test.tsx
@@ -1,0 +1,295 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { insightTemplatesService } from '../../../features/data-marts/insights/model';
+import DataMartInsightsPage from './DataMartInsightsPage';
+
+const insightTemplatesServiceMock = vi.hoisted(() => ({
+  getProjectInsightTemplates: vi.fn(),
+  deleteInsightTemplate: vi.fn(),
+}));
+
+vi.mock('../../../features/data-marts/insights/model', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../../features/data-marts/insights/model')>();
+  return {
+    ...actual,
+    insightTemplatesService: insightTemplatesServiceMock,
+  };
+});
+
+vi.mock('../../../features/idp', () => ({
+  useRole: () => ({
+    isAdmin: false,
+    canEdit: false,
+  }),
+  useAuth: () => ({
+    status: 'authenticated',
+    user: {
+      id: 'user-1',
+      projectId: 'project-1',
+      roles: ['viewer'],
+    },
+  }),
+}));
+
+describe('DataMartInsightsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    insightTemplatesServiceMock.deleteInsightTemplate.mockResolvedValue(undefined);
+  });
+
+  it('loads project insights by 100 and shows their Data Mart context', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [buildInsightTemplateResponse()],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Insights')).toBeInTheDocument();
+    expect(await screen.findByText('Revenue Summary')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Marketing Mart' })).toHaveAttribute(
+      'href',
+      '/ui/project-1/data-marts/dm-1/insights-v2'
+    );
+    expect(screen.getByRole('button', { name: 'Toggle columns' })).toBeInTheDocument();
+    expect(insightTemplatesService.getProjectInsightTemplates).toHaveBeenCalledWith(100, 0);
+  });
+
+  it('shows Data Mart as the first table column', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [buildInsightTemplateResponse()],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Revenue Summary')).toBeInTheDocument();
+    expect(getColumnHeaderLabels().slice(0, 2)).toEqual(['Data Mart', 'Insight']);
+  });
+
+  it('shows a Data Mart-focused empty state when there are no project-wide insights', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [],
+    });
+
+    const { container } = renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'No insights yet' })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Insights created from Data Mart data will appear here/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Choose a Data Mart' })).toHaveAttribute(
+      'href',
+      '/ui/project-1/data-marts'
+    );
+    expect(container.querySelector('.lucide-sparkles')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Toggle columns' })).not.toBeInTheDocument();
+  });
+
+  it('links the Insight title to the insight details page', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [buildInsightTemplateResponse()],
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('link', { name: 'Revenue Summary' })).toHaveAttribute(
+      'href',
+      '/ui/project-1/data-marts/dm-1/insights-v2/insight-1'
+    );
+  });
+
+  it('does not navigate to the insight details page when clicking a non-title row area', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [buildInsightTemplateResponse()],
+    });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('row', { name: /Marketing Mart Revenue Summary/ }));
+
+    expect(screen.getByTestId('currentPath')).toHaveTextContent(
+      '/ui/project-1/data-marts/insights'
+    );
+  });
+
+  it('does not show the Sources column because the Data Mart insights tab does not have it', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [buildInsightTemplateResponse()],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Revenue Summary')).toBeInTheDocument();
+    const headerLabels = getColumnHeaderLabels();
+    expect(headerLabels.slice(0, 4)).toEqual(['Data Mart', 'Insight', 'Updated', 'Created By']);
+    expect(headerLabels).not.toContain('Sources');
+  });
+
+  it('renders Data Marts list-style card controls and applies Data Mart URL filters', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [
+        buildInsightTemplateResponse(),
+        buildInsightTemplateResponse({
+          id: 'insight-2',
+          title: 'Product Insight',
+          dataMartTitle: 'Product Mart',
+        }),
+      ],
+    });
+
+    const { container } = renderPage(buildFilterPath('data-marts/insights', 'Marketing Mart'));
+
+    expect(await screen.findByText('Revenue Summary')).toBeInTheDocument();
+    expect(screen.queryByText('Product Insight')).not.toBeInTheDocument();
+    expect(container.querySelector('.dm-card')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Filters/ })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
+  });
+
+  it('searches insights by the Data Mart column', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [
+        buildInsightTemplateResponse(),
+        buildInsightTemplateResponse({
+          id: 'insight-2',
+          title: 'Product Insight',
+          dataMartTitle: 'Product Mart',
+        }),
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Product Insight')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Marketing' },
+    });
+
+    expect(screen.getByText('Revenue Summary')).toBeInTheDocument();
+    expect(screen.queryByText('Product Insight')).not.toBeInTheDocument();
+  });
+
+  it('searches insights by the Insight column', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [
+        buildInsightTemplateResponse({
+          title: 'Revenue Summary',
+          dataMartTitle: 'Marketing Mart',
+        }),
+        buildInsightTemplateResponse({
+          id: 'insight-2',
+          title: 'Churn Signal',
+          dataMartTitle: 'Customer Mart',
+        }),
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Churn Signal')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Churn' },
+    });
+
+    expect(screen.getByText('Churn Signal')).toBeInTheDocument();
+    expect(screen.queryByText('Revenue Summary')).not.toBeInTheDocument();
+  });
+
+  it('renders insight row actions like the Data Mart insights tab', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [buildInsightTemplateResponse()],
+    });
+
+    renderPage();
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Insight actions' }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(await screen.findByText('Delete insight')).toBeInTheDocument();
+  });
+
+  it('loads additional insight pages when project search is active', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates)
+      .mockResolvedValueOnce({
+        insights: Array.from({ length: 100 }, (_, index) =>
+          buildInsightTemplateResponse({
+            id: `insight-${index + 1}`,
+            title: `Insight ${index + 1}`,
+          })
+        ),
+      })
+      .mockResolvedValueOnce({
+        insights: [
+          buildInsightTemplateResponse({
+            id: 'insight-needle',
+            title: 'Needle Insight',
+          }),
+        ],
+      });
+
+    renderPage();
+
+    expect(await screen.findByText('Insight 1')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Needle' },
+    });
+
+    expect(await screen.findByText('Needle Insight')).toBeInTheDocument();
+    expect(insightTemplatesService.getProjectInsightTemplates).toHaveBeenCalledWith(100, 100);
+  });
+});
+
+function renderPage(path = '/ui/project-1/data-marts/insights') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <DataMartInsightsPage />
+      <LocationProbe />
+    </MemoryRouter>
+  );
+}
+
+function LocationProbe() {
+  const location = useLocation();
+
+  return <div data-testid='currentPath'>{location.pathname}</div>;
+}
+
+function buildFilterPath(path: string, dataMartTitle: string) {
+  const filters = encodeURIComponent(
+    JSON.stringify([{ f: 'dataMart', o: 'eq', v: [dataMartTitle] }])
+  );
+  return `/ui/project-1/${path}?filters=${filters}`;
+}
+
+function getColumnHeaderLabels() {
+  return screen
+    .getAllByRole('columnheader')
+    .map(header => header.textContent.trim())
+    .filter((label): label is string => Boolean(label));
+}
+
+function buildInsightTemplateResponse(
+  overrides: { id?: string; title?: string; dataMartTitle?: string } = {}
+) {
+  return {
+    id: overrides.id ?? 'insight-1',
+    title: overrides.title ?? 'Revenue Summary',
+    sourcesCount: 2,
+    lastRenderedTemplateUpdatedAt: null,
+    createdById: 'user-1',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    modifiedAt: '2026-06-05T12:00:00.000Z',
+    createdByUser: null,
+    dataMart: {
+      id: 'dm-1',
+      title: overrides.dataMartTitle ?? 'Marketing Mart',
+    },
+  };
+}

--- a/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.test.tsx
@@ -68,6 +68,19 @@ describe('DataMartInsightsPage', () => {
     expect(getColumnHeaderLabels().slice(0, 2)).toEqual(['Data Mart', 'Insight']);
   });
 
+  it('renders the Data Mart title without truncation so long titles can wrap', async () => {
+    const longDataMartTitle = 'Marketing Campaign Performance Data Mart With Long Title';
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [buildInsightTemplateResponse({ dataMartTitle: longDataMartTitle })],
+    });
+
+    renderPage();
+
+    const dataMartLink = await screen.findByRole('link', { name: longDataMartTitle });
+    expect(dataMartLink).toHaveClass('block', 'w-full', 'whitespace-normal', 'break-words');
+    expect(dataMartLink).not.toHaveClass('truncate');
+  });
+
   it('shows a Data Mart-focused empty state when there are no project-wide insights', async () => {
     vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
       insights: [],

--- a/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.tsx
+++ b/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.tsx
@@ -1,0 +1,388 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import type { ColumnDef } from '@tanstack/react-table';
+import { RefreshCw } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+import { Button } from '@owox/ui/components/button';
+import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
+import { usePermissions } from '../../../app/permissions';
+import { extractApiError } from '../../../app/api';
+import { InsightRowActionsCell } from '../../../features/data-marts/insights/components/InsightRowActionsCell';
+import {
+  insightTemplatesService,
+  mapProjectInsightTemplateListFromDto,
+  type ProjectInsightTemplateEntity,
+} from '../../../features/data-marts/insights/model';
+import { BaseTable, SortableHeader, ToggleColumnsHeader } from '../../../shared/components/Table';
+import {
+  applyFiltersToData,
+  type FilterAccessors,
+  type FilterConfigItem,
+} from '../../../shared/components/TableFilters';
+import { collectOptionsFromData } from '../../../shared/components/TableFilters/collectOptions.utils';
+import { UserReference } from '../../../shared/components/UserReference';
+import { useBaseTable, usePersistentFilters, useProjectRoute } from '../../../shared/hooks';
+import { ProjectDataMartTableFilters } from '../shared/ProjectDataMartTableFilters';
+import { ProjectDataMartTableSearch } from '../shared/ProjectDataMartTableSearch';
+import {
+  buildProjectTableUserLabelMapper,
+  matchesProjectTableSearch,
+} from '../shared/ProjectDataMartTableFilters.utils';
+import { ConfirmationDialog } from '../../../shared/components/ConfirmationDialog';
+import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
+import { formatDateShort, trackEvent } from '../../../utils';
+
+const PROJECT_INSIGHTS_PAGE_SIZE = 100;
+const PROJECT_INSIGHTS_TABLE_ID = 'project-insights-table';
+
+type ProjectInsightFilterKey = 'dataMart' | 'insight' | 'createdBy';
+
+const projectInsightFilterAccessors: FilterAccessors<
+  ProjectInsightFilterKey,
+  ProjectInsightTemplateEntity
+> = {
+  dataMart: row => row.dataMart.title,
+  insight: row => row.title,
+  createdBy: row => row.createdByUser?.userId,
+};
+
+function buildProjectInsightFilters(
+  data: ProjectInsightTemplateEntity[]
+): FilterConfigItem<ProjectInsightFilterKey>[] {
+  const userLabelMapper = buildProjectTableUserLabelMapper(
+    data.map(insight => insight.createdByUser)
+  );
+
+  return [
+    {
+      id: 'dataMart',
+      label: 'Data Mart',
+      dataType: 'string',
+      operators: ['contains', 'not_contains', 'eq', 'neq'],
+      options: collectOptionsFromData(data, projectInsightFilterAccessors.dataMart),
+    },
+    {
+      id: 'insight',
+      label: 'Insight',
+      dataType: 'string',
+      operators: ['contains', 'not_contains', 'eq', 'neq'],
+      options: collectOptionsFromData(data, projectInsightFilterAccessors.insight),
+    },
+    {
+      id: 'createdBy',
+      label: 'Created By',
+      dataType: 'enum',
+      operators: ['eq', 'neq'],
+      options: collectOptionsFromData(data, projectInsightFilterAccessors.createdBy, {
+        labelMapper: userLabelMapper,
+      }),
+    },
+  ];
+}
+
+export default function DataMartInsightsPage() {
+  const { projectId = '' } = useParams<{ projectId: string }>();
+  const { scope } = useProjectRoute();
+  const { canDelete } = usePermissions();
+  const [insights, setInsights] = useState<ProjectInsightTemplateEntity[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMoreInsightsToLoad, setHasMoreInsightsToLoad] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [deletingInsight, setDeletingInsight] = useState<ProjectInsightTemplateEntity | null>(null);
+
+  const loadInsights = useCallback(async (offset = 0) => {
+    const isInitialLoad = offset === 0;
+    if (isInitialLoad) {
+      setIsLoading(true);
+    } else {
+      setIsLoadingMore(true);
+    }
+    setError(null);
+
+    try {
+      const response = await insightTemplatesService.getProjectInsightTemplates(
+        PROJECT_INSIGHTS_PAGE_SIZE,
+        offset
+      );
+      const nextInsights = mapProjectInsightTemplateListFromDto(response);
+      setInsights(currentInsights =>
+        isInitialLoad ? nextInsights : [...currentInsights, ...nextInsights]
+      );
+      setHasMoreInsightsToLoad(nextInsights.length >= PROJECT_INSIGHTS_PAGE_SIZE);
+    } catch (caught) {
+      setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart insights');
+    } finally {
+      setIsLoading(false);
+      setIsLoadingMore(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadInsights(0);
+  }, [loadInsights]);
+
+  const loadMoreInsights = useCallback(async () => {
+    if (isLoadingMore || !hasMoreInsightsToLoad) return;
+    await loadInsights(insights.length);
+  }, [hasMoreInsightsToLoad, insights.length, isLoadingMore, loadInsights]);
+
+  const handleConfirmDelete = useCallback(() => {
+    void (async () => {
+      if (!deletingInsight) return;
+
+      try {
+        await insightTemplatesService.deleteInsightTemplate(
+          deletingInsight.dataMart.id,
+          deletingInsight.id
+        );
+        trackEvent({
+          event: 'insight_deleted',
+          category: 'Insights',
+          action: 'Delete',
+          label: deletingInsight.id,
+          context: deletingInsight.dataMart.id,
+        });
+        setInsights(currentInsights =>
+          currentInsights.filter(insight => insight.id !== deletingInsight.id)
+        );
+        toast.success('Insight deleted');
+      } catch {
+        trackEvent({
+          event: 'insight_error',
+          category: 'Insights',
+          action: 'DeleteError',
+          label: deletingInsight.id,
+          context: deletingInsight.dataMart.id,
+        });
+        toast.error('Failed to delete insight');
+      } finally {
+        setDeletingInsight(null);
+      }
+    })();
+  }, [deletingInsight]);
+
+  const filtersConfig = useMemo(() => buildProjectInsightFilters(insights), [insights]);
+
+  const { appliedState, apply, clear } = usePersistentFilters<ProjectInsightFilterKey>({
+    projectId,
+    tableId: PROJECT_INSIGHTS_TABLE_ID,
+    urlParam: 'filters',
+    config: filtersConfig,
+  });
+
+  const shouldLoadAllInsightsForQuery =
+    searchQuery.trim().length > 0 || appliedState.filters.length > 0;
+
+  useEffect(() => {
+    if (!shouldLoadAllInsightsForQuery || !hasMoreInsightsToLoad || isLoading || isLoadingMore) {
+      return;
+    }
+
+    void loadInsights(insights.length);
+  }, [
+    hasMoreInsightsToLoad,
+    insights.length,
+    isLoading,
+    isLoadingMore,
+    loadInsights,
+    shouldLoadAllInsightsForQuery,
+  ]);
+
+  const filteredInsights = useMemo(
+    () =>
+      applyFiltersToData<ProjectInsightFilterKey, ProjectInsightTemplateEntity>(
+        insights,
+        appliedState,
+        projectInsightFilterAccessors
+      ),
+    [appliedState, insights]
+  );
+
+  const searchedInsights = useMemo(
+    () =>
+      filteredInsights.filter(insight =>
+        matchesProjectTableSearch(searchQuery, [
+          insight.dataMart.title,
+          insight.title,
+          insight.createdByUser?.fullName,
+          insight.createdByUser?.email,
+        ])
+      ),
+    [filteredInsights, searchQuery]
+  );
+
+  const columns = useMemo<ColumnDef<ProjectInsightTemplateEntity>[]>(
+    () => [
+      {
+        id: 'dataMart',
+        accessorFn: row => row.dataMart.title,
+        size: 260,
+        meta: { title: 'Data Mart' },
+        header: ({ column }) => <SortableHeader column={column}>Data Mart</SortableHeader>,
+        cell: ({ row }) => (
+          <Link
+            to={scope(`/data-marts/${row.original.dataMart.id}/insights-v2`)}
+            onClick={event => {
+              event.stopPropagation();
+            }}
+            className='text-foreground hover:text-primary inline-block max-w-full truncate transition-colors'
+          >
+            {row.original.dataMart.title}
+          </Link>
+        ),
+      },
+      {
+        accessorKey: 'title',
+        size: 320,
+        meta: { title: 'Insight' },
+        header: ({ column }) => <SortableHeader column={column}>Insight</SortableHeader>,
+        cell: ({ row }) => (
+          <Link
+            to={scope(`/data-marts/${row.original.dataMart.id}/insights-v2/${row.original.id}`)}
+            onClick={event => {
+              event.stopPropagation();
+            }}
+            className='text-foreground hover:text-primary inline-block max-w-full truncate transition-colors'
+          >
+            {row.original.title}
+          </Link>
+        ),
+      },
+      {
+        accessorKey: 'modifiedAt',
+        size: 180,
+        sortDescFirst: true,
+        meta: { title: 'Updated' },
+        header: ({ column }) => <SortableHeader column={column}>Updated</SortableHeader>,
+        cell: ({ row }) => (
+          <div className='text-muted-foreground'>{formatDateShort(row.original.modifiedAt)}</div>
+        ),
+      },
+      {
+        id: 'createdBy',
+        accessorFn: row => row.createdByUser?.fullName ?? row.createdByUser?.email,
+        size: 190,
+        meta: { title: 'Created By' },
+        header: ({ column }) => <SortableHeader column={column}>Created By</SortableHeader>,
+        cell: ({ row }) => {
+          const user = row.original.createdByUser;
+          if (!user) return <span className='text-muted-foreground'>-</span>;
+          return <UserReference userProjection={user} />;
+        },
+      },
+      {
+        id: 'actions',
+        size: 80,
+        enableResizing: false,
+        enableSorting: false,
+        header: ({ table }) => <ToggleColumnsHeader table={table} />,
+        cell: ({ row }) => (
+          <InsightRowActionsCell
+            id={row.original.id}
+            canDelete={canDelete}
+            onDelete={() => {
+              setDeletingInsight(row.original);
+            }}
+          />
+        ),
+      },
+    ],
+    [canDelete, scope]
+  );
+
+  const { table } = useBaseTable<ProjectInsightTemplateEntity>({
+    data: searchedInsights,
+    columns,
+    storageKeyPrefix: 'project-data-mart-insights',
+    defaultSortingColumn: 'modifiedAt',
+    defaultPageSize: PROJECT_INSIGHTS_PAGE_SIZE,
+    enableRowSelection: false,
+  });
+
+  return (
+    <div className='dm-page' data-testid='dataMartInsightsPage'>
+      <header className='dm-page-header'>
+        <h1 className='dm-page-header-title'>Insights</h1>
+      </header>
+
+      <div className='dm-page-content'>
+        {isLoading ? (
+          <SkeletonList />
+        ) : error ? (
+          <div className='dm-card-block text-destructive text-sm'>{error}</div>
+        ) : insights.length === 0 ? (
+          <div className='dm-card'>
+            <ProjectDataMartEmptyState variant='insights' />
+          </div>
+        ) : (
+          <div className='dm-card' data-testid='projectInsightsTable'>
+            <BaseTable
+              tableId={PROJECT_INSIGHTS_TABLE_ID}
+              table={table}
+              ariaLabel='Project Data Mart Insights'
+              paginationProps={{ displaySelected: false }}
+              renderToolbarLeft={() => (
+                <>
+                  <ProjectDataMartTableFilters
+                    appliedState={appliedState}
+                    config={filtersConfig}
+                    onApply={apply}
+                    onClear={clear}
+                  />
+                  <ProjectDataMartTableSearch value={searchQuery} onChange={setSearchQuery} />
+                </>
+              )}
+              renderEmptyState={() => (
+                <div
+                  className='flex h-32 items-center justify-center text-center'
+                  role='status'
+                  aria-live='polite'
+                >
+                  No insights found for accessible Data Marts
+                </div>
+              )}
+            />
+
+            {hasMoreInsightsToLoad && (
+              <div className='flex justify-center pt-4 pb-6'>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={() => void loadMoreInsights()}
+                  disabled={isLoadingMore}
+                  className='flex items-center gap-2'
+                >
+                  {isLoadingMore ? (
+                    <>
+                      <RefreshCw className='h-4 w-4 animate-spin' />
+                      Loading...
+                    </>
+                  ) : (
+                    'Load More'
+                  )}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <ConfirmationDialog
+        open={deletingInsight !== null}
+        onOpenChange={open => {
+          if (!open) {
+            setDeletingInsight(null);
+          }
+        }}
+        title='Delete insight'
+        description='Are you sure you want to delete this insight? This action cannot be undone.'
+        confirmLabel='Delete'
+        cancelLabel='Cancel'
+        variant='destructive'
+        onConfirm={handleConfirmDelete}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.tsx
+++ b/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.tsx
@@ -29,6 +29,7 @@ import {
 } from '../shared/ProjectDataMartTableFilters.utils';
 import { ConfirmationDialog } from '../../../shared/components/ConfirmationDialog';
 import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
+import { ProjectDataMartTitleLink } from '../shared/ProjectDataMartTitleLink';
 import { formatDateShort, trackEvent } from '../../../utils';
 
 const PROJECT_INSIGHTS_PAGE_SIZE = 100;
@@ -220,15 +221,10 @@ export default function DataMartInsightsPage() {
         meta: { title: 'Data Mart' },
         header: ({ column }) => <SortableHeader column={column}>Data Mart</SortableHeader>,
         cell: ({ row }) => (
-          <Link
+          <ProjectDataMartTitleLink
             to={scope(`/data-marts/${row.original.dataMart.id}/insights-v2`)}
-            onClick={event => {
-              event.stopPropagation();
-            }}
-            className='text-foreground hover:text-primary inline-block max-w-full truncate transition-colors'
-          >
-            {row.original.dataMart.title}
-          </Link>
+            title={row.original.dataMart.title}
+          />
         ),
       },
       {

--- a/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.tsx
+++ b/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.tsx
@@ -5,7 +5,6 @@ import { RefreshCw } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { Button } from '@owox/ui/components/button';
 import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
-import { usePermissions } from '../../../app/permissions';
 import { extractApiError } from '../../../app/api';
 import { InsightRowActionsCell } from '../../../features/data-marts/insights/components/InsightRowActionsCell';
 import {
@@ -83,7 +82,6 @@ function buildProjectInsightFilters(
 export default function DataMartInsightsPage() {
   const { projectId = '' } = useParams<{ projectId: string }>();
   const { scope } = useProjectRoute();
-  const { canDelete } = usePermissions();
   const [insights, setInsights] = useState<ProjectInsightTemplateEntity[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -278,18 +276,19 @@ export default function DataMartInsightsPage() {
         enableResizing: false,
         enableSorting: false,
         header: ({ table }) => <ToggleColumnsHeader table={table} />,
-        cell: ({ row }) => (
-          <InsightRowActionsCell
-            id={row.original.id}
-            canDelete={canDelete}
-            onDelete={() => {
-              setDeletingInsight(row.original);
-            }}
-          />
-        ),
+        cell: ({ row }) =>
+          row.original.canDelete ? (
+            <InsightRowActionsCell
+              id={row.original.id}
+              canDelete={row.original.canDelete}
+              onDelete={() => {
+                setDeletingInsight(row.original);
+              }}
+            />
+          ) : null,
       },
     ],
-    [canDelete, scope]
+    [scope]
   );
 
   const { table } = useBaseTable<ProjectInsightTemplateEntity>({

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
@@ -134,6 +134,19 @@ describe('DataMartReportsPage', () => {
     expect(getColumnHeaderLabels().slice(0, 2)).toEqual(['Data Mart', 'Report']);
   });
 
+  it('renders the Data Mart title without truncation so long titles can wrap', async () => {
+    const longDataMartTitle = 'Marketing Campaign Performance Data Mart With Long Title';
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildReportResponse({ dataMartTitle: longDataMartTitle }),
+    ]);
+
+    renderPage();
+
+    const dataMartLink = await screen.findByRole('link', { name: longDataMartTitle });
+    expect(dataMartLink).toHaveClass('block', 'w-full', 'whitespace-normal', 'break-words');
+    expect(dataMartLink).not.toHaveClass('truncate');
+  });
+
   it('shows a Data Mart-focused empty state when there are no project-wide reports', async () => {
     vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([]);
 

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
@@ -1,0 +1,542 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DataDestinationType } from '../../../features/data-destination';
+import { DataDestinationCredentialsType } from '../../../features/data-destination/shared/enums/data-destination-credentials-type.enum';
+import { DataStorageType } from '../../../features/data-storage/shared';
+import { DataMartStatus, DataMartDefinitionType } from '../../../features/data-marts/shared';
+import {
+  DestinationTypeConfigEnum,
+  ReportStatusEnum,
+  TemplateSourceTypeEnum,
+} from '../../../features/data-marts/reports/shared/enums';
+import { ReportConditionEnum } from '../../../features/data-marts/reports/shared/enums/report-condition.enum';
+import type { ReportResponseDto } from '../../../features/data-marts/reports/shared/services';
+import { reportService } from '../../../features/data-marts/reports/shared/services';
+import DataMartReportsPage from './DataMartReportsPage';
+
+const reportServiceMock = vi.hoisted(() => ({
+  getReportsByProject: vi.fn(),
+  getReportsByDataMartId: vi.fn(),
+  getReportById: vi.fn(),
+  runReport: vi.fn(),
+  deleteReport: vi.fn(),
+  getGeneratedSql: vi.fn(),
+  copyAsDataMart: vi.fn(),
+}));
+
+const reportStatusPollingServiceMock = vi.hoisted(() => ({
+  setConfig: vi.fn(),
+  startPolling: vi.fn(),
+  stopPolling: vi.fn(),
+  stopAllPolling: vi.fn(),
+}));
+
+const useBlendedFieldNamesMock = vi.hoisted(() => vi.fn(() => new Set(['joined_field'])));
+
+vi.mock('../../../features/data-marts/reports/shared/services', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../../features/data-marts/reports/shared/services')>();
+  return {
+    ...actual,
+    reportService: reportServiceMock,
+    reportStatusPollingService: reportStatusPollingServiceMock,
+  };
+});
+
+vi.mock('../../../features/data-marts/shared/hooks/useBlendedFieldNames', () => ({
+  useBlendedFieldNames: useBlendedFieldNamesMock,
+}));
+
+vi.mock('../../../components/AppSidebar/SetupChecklist/useSetupProgress', () => ({
+  useRefreshSetupProgress: () => vi.fn(),
+}));
+
+vi.mock(
+  '../../../features/data-marts/reports/list/components/DestinationCard/ReportEditSheetRenderer',
+  async () => {
+    const { useDataMartContext } = await import('../../../features/data-marts/edit/model');
+    const { useReportContext } =
+      await import('../../../features/data-marts/reports/shared/model/context');
+
+    return {
+      ReportEditSheetRenderer: ({
+        isOpen,
+        initialReport,
+      }: {
+        isOpen: boolean;
+        initialReport?: { title: string } | null;
+      }) => {
+        const { dataMart } = useDataMartContext();
+        useReportContext();
+
+        return isOpen ? (
+          <div role='dialog' aria-label='Report edit sheet'>
+            Editing report {initialReport?.title} for {dataMart?.title} via {dataMart?.storage.type}
+          </div>
+        ) : null;
+      },
+    };
+  }
+);
+
+vi.mock('../../../features/idp', () => ({
+  useAuth: () => ({
+    status: 'authenticated',
+    user: {
+      id: 'user-1',
+      projectId: 'project-1',
+      roles: ['viewer'],
+    },
+  }),
+}));
+
+describe('DataMartReportsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    reportServiceMock.getReportsByDataMartId.mockResolvedValue([]);
+    reportServiceMock.getReportById.mockResolvedValue(buildReportResponse());
+    reportServiceMock.runReport.mockResolvedValue(undefined);
+    reportServiceMock.deleteReport.mockResolvedValue(undefined);
+    reportServiceMock.getGeneratedSql.mockResolvedValue({ sql: 'select 1' });
+    reportServiceMock.copyAsDataMart.mockResolvedValue({ dataMartId: 'dm-copy' });
+    useBlendedFieldNamesMock.mockReturnValue(new Set(['joined_field']));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('loads project reports by 100 and shows their Data Mart context', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([buildReportResponse()]);
+
+    renderPage();
+
+    expect(await screen.findByText('Reports')).toBeInTheDocument();
+    expect(await screen.findByText('Daily Sales Report')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Marketing Mart' })).toHaveAttribute(
+      'href',
+      '/ui/project-1/data-marts/dm-1/reports'
+    );
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Success' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Toggle columns' })).toBeInTheDocument();
+    expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 0);
+  });
+
+  it('shows Data Mart as the first table column', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([buildReportResponse()]);
+
+    renderPage();
+
+    expect(await screen.findByText('Daily Sales Report')).toBeInTheDocument();
+    expect(getColumnHeaderLabels().slice(0, 2)).toEqual(['Data Mart', 'Report']);
+  });
+
+  it('shows a Data Mart-focused empty state when there are no project-wide reports', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([]);
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'No reports yet' })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Reports configured inside Data Marts will appear here/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Choose a Data Mart' })).toHaveAttribute(
+      'href',
+      '/ui/project-1/data-marts'
+    );
+    expect(screen.queryByRole('button', { name: 'Toggle columns' })).not.toBeInTheDocument();
+  });
+
+  it('shows a muted dash when a report has no title', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildReportResponse({
+        title: '',
+      }),
+    ]);
+
+    renderPage();
+
+    const emptyTitleFallback = await screen.findByText('—');
+    expect(emptyTitleFallback).toHaveClass('text-muted-foreground');
+  });
+
+  it('shows a muted long dash when a report has no run status', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildReportResponse({
+        lastRunAt: null,
+        lastRunStatus: null,
+      }),
+    ]);
+
+    renderPage();
+
+    const runStatusFallback = await screen.findByText('—');
+    expect(runStatusFallback).toHaveClass('text-muted-foreground');
+  });
+
+  it('renders Data Marts list-style card controls and applies Data Mart URL filters', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildReportResponse(),
+      buildReportResponse({
+        id: 'report-2',
+        title: 'Product Report',
+        dataMartTitle: 'Product Mart',
+      }),
+    ]);
+
+    const { container } = renderPage(buildFilterPath('data-marts/reports', 'Marketing Mart'));
+
+    expect(await screen.findByText('Daily Sales Report')).toBeInTheDocument();
+    expect(screen.queryByText('Product Report')).not.toBeInTheDocument();
+    expect(container.querySelector('.dm-card')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Filters/ })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
+  });
+
+  it('searches reports by the Data Mart column', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildReportResponse(),
+      buildReportResponse({
+        id: 'report-2',
+        title: 'Product Report',
+        dataMartTitle: 'Product Mart',
+      }),
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText('Product Report')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Marketing' },
+    });
+
+    expect(screen.getByText('Daily Sales Report')).toBeInTheDocument();
+    expect(screen.queryByText('Product Report')).not.toBeInTheDocument();
+  });
+
+  it('searches reports by the Report column', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildReportResponse({
+        title: 'Daily Sales Report',
+        dataMartTitle: 'Marketing Mart',
+      }),
+      buildReportResponse({
+        id: 'report-2',
+        title: 'Inventory Variance',
+        dataMartTitle: 'Warehouse Mart',
+      }),
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText('Inventory Variance')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Inventory' },
+    });
+
+    expect(screen.getByText('Inventory Variance')).toBeInTheDocument();
+    expect(screen.queryByText('Daily Sales Report')).not.toBeInTheDocument();
+  });
+
+  it('opens the report edit sheet when a report row is clicked', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([buildReportResponse()]);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByText('Daily Sales Report'));
+
+    expect(screen.getByRole('dialog', { name: 'Report edit sheet' })).toHaveTextContent(
+      'Editing report Daily Sales Report for Marketing Mart via GOOGLE_BIGQUERY'
+    );
+  });
+
+  it('does not open the report edit sheet when the caller cannot edit report config', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildReportResponse({ canEditConfig: false }),
+    ]);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByText('Daily Sales Report'));
+
+    expect(screen.queryByRole('dialog', { name: 'Report edit sheet' })).not.toBeInTheDocument();
+  });
+
+  it('renders report row actions like the Data Mart reports tab', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildGoogleSheetsReportResponse({
+        title: 'Blended Sheet Report',
+        columnConfig: ['joined_field'],
+      }),
+    ]);
+    const { container } = renderPage();
+
+    expect(await screen.findByText('Blended Sheet Report')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Run report: Blended Sheet Report' })
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(
+        'a[href="https://docs.google.com/spreadsheets/d/spreadsheet-1/edit#gid=123"]'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Preview SQL: Blended Sheet Report',
+      })
+    ).toBeInTheDocument();
+
+    fireEvent.pointerDown(
+      screen.getByRole('button', {
+        name: 'Actions for report: Blended Sheet Report',
+      }),
+      {
+        button: 0,
+        ctrlKey: false,
+      }
+    );
+
+    expect(await screen.findByText('Edit report')).toBeInTheDocument();
+    expect(screen.getByText('Delete report')).toBeInTheDocument();
+  });
+
+  it('runs a report from the project-wide reports action cell', async () => {
+    vi.mocked(reportService.getReportsByProject)
+      .mockResolvedValueOnce([
+        buildGoogleSheetsReportResponse({
+          title: 'Blended Sheet Report',
+        }),
+      ])
+      .mockResolvedValueOnce([
+        buildGoogleSheetsReportResponse({
+          title: 'Blended Sheet Report',
+          lastRunStatus: ReportStatusEnum.RUNNING,
+        }),
+      ]);
+
+    renderPage();
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Run report: Blended Sheet Report' })
+    );
+
+    await waitFor(() => {
+      expect(reportService.runReport).toHaveBeenCalledWith('report-1');
+    });
+    await waitFor(() => {
+      expect(reportService.getReportsByProject).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('keeps report run actions disabled when the caller cannot run reports', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildGoogleSheetsReportResponse({
+        title: 'Restricted Sheet Report',
+        canRun: false,
+      }),
+    ]);
+
+    renderPage();
+
+    const runButton = await screen.findByRole('button', {
+      name: 'Run report: Restricted Sheet Report',
+    });
+    expect(runButton).toBeDisabled();
+
+    fireEvent.click(runButton);
+
+    expect(reportService.runReport).not.toHaveBeenCalled();
+  });
+
+  it('polls project reports while any loaded report is still running', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(reportService.getReportsByProject).mockResolvedValue([
+      buildReportResponse({
+        lastRunStatus: ReportStatusEnum.RUNNING,
+      }),
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText('Daily Sales Report')).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await waitFor(() => {
+      expect(reportService.getReportsByProject).toHaveBeenCalledTimes(2);
+    });
+
+    vi.useRealTimers();
+  });
+
+  it('loads additional report pages when project search is active', async () => {
+    vi.mocked(reportService.getReportsByProject)
+      .mockResolvedValueOnce(
+        Array.from({ length: 100 }, (_, index) =>
+          buildReportResponse({
+            id: `report-${index + 1}`,
+            title: `Report ${index + 1}`,
+          })
+        )
+      )
+      .mockResolvedValueOnce([
+        buildReportResponse({
+          id: 'report-needle',
+          title: 'Needle Report',
+        }),
+      ]);
+
+    renderPage();
+
+    expect(await screen.findByText('Report 1')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Needle' },
+    });
+
+    expect(await screen.findByText('Needle Report')).toBeInTheDocument();
+    expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 100);
+  });
+});
+
+function renderPage(path = '/ui/project-1/data-marts/reports') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <DataMartReportsPage />
+    </MemoryRouter>
+  );
+}
+
+function buildFilterPath(path: string, dataMartTitle: string) {
+  const filters = encodeURIComponent(
+    JSON.stringify([{ f: 'dataMart', o: 'eq', v: [dataMartTitle] }])
+  );
+  return `/ui/project-1/${path}?filters=${filters}`;
+}
+
+function getColumnHeaderLabels() {
+  return screen
+    .getAllByRole('columnheader')
+    .map(header => header.textContent.trim())
+    .filter((label): label is string => Boolean(label));
+}
+
+function buildReportResponse(overrides: ReportFixtureOverrides = {}): ReportResponseDto {
+  return {
+    id: overrides.id ?? 'report-1',
+    title: overrides.title ?? 'Daily Sales Report',
+    dataMart: {
+      id: 'dm-1',
+      title: overrides.dataMartTitle ?? 'Marketing Mart',
+      status: DataMartStatus.PUBLISHED,
+      storage: buildDataStorageResponse(),
+      definitionType: DataMartDefinitionType.SQL,
+      definition: null,
+      description: null,
+      triggersCount: 0,
+      reportsCount: 1,
+      createdByUser: null,
+      businessOwnerUsers: [],
+      technicalOwnerUsers: [],
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      modifiedAt: new Date('2026-06-01T00:00:00.000Z'),
+      schema: null,
+    },
+    dataDestinationAccess: {
+      id: 'dest-1',
+      title: 'Email',
+      type: DataDestinationType.EMAIL,
+      projectId: 'project-1',
+      credentials: {
+        type: DataDestinationCredentialsType.EMAIL_CREDENTIALS,
+        to: ['daily@example.com'],
+      },
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      modifiedAt: new Date('2026-06-01T00:00:00.000Z'),
+    },
+    destinationConfig: {
+      type: DestinationTypeConfigEnum.EMAIL_CONFIG,
+      reportCondition: ReportConditionEnum.ALWAYS,
+      subject: 'Daily Sales',
+      templateSource: {
+        type: TemplateSourceTypeEnum.CUSTOM_MESSAGE,
+        config: {
+          messageTemplate: 'Daily report',
+        },
+      },
+    },
+    columnConfig: overrides.columnConfig ?? null,
+    filterConfig: null,
+    sortConfig: null,
+    limitConfig: null,
+    lastRunAt: overrides.lastRunAt === undefined ? '2026-06-05T12:00:00.000Z' : overrides.lastRunAt,
+    lastRunStatus:
+      overrides.lastRunStatus === undefined ? ReportStatusEnum.SUCCESS : overrides.lastRunStatus,
+    lastRunError: null,
+    runsCount: 3,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    modifiedAt: '2026-06-05T12:00:00.000Z',
+    createdByUser: null,
+    ownerUsers: [],
+    canRun: overrides.canRun ?? true,
+    canManageTriggers: overrides.canManageTriggers ?? true,
+    canEditConfig: overrides.canEditConfig ?? true,
+  };
+}
+
+function buildGoogleSheetsReportResponse(
+  overrides: ReportFixtureOverrides = {}
+): ReportResponseDto {
+  return {
+    ...buildReportResponse(overrides),
+    dataDestinationAccess: {
+      id: 'dest-sheets-1',
+      title: 'Google Sheets',
+      type: DataDestinationType.GOOGLE_SHEETS,
+      projectId: 'project-1',
+      credentials: {
+        type: DataDestinationCredentialsType.GOOGLE_SHEETS_CREDENTIALS,
+        serviceAccountKey: {},
+      },
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      modifiedAt: new Date('2026-06-01T00:00:00.000Z'),
+    },
+    destinationConfig: {
+      type: DestinationTypeConfigEnum.GOOGLE_SHEETS_CONFIG,
+      spreadsheetId: 'spreadsheet-1',
+      sheetId: 123,
+    },
+  };
+}
+
+interface ReportFixtureOverrides extends Partial<
+  Pick<ReportResponseDto, 'id' | 'title' | 'lastRunAt' | 'lastRunStatus'>
+> {
+  dataMartTitle?: string;
+  columnConfig?: ReportResponseDto['columnConfig'];
+  canRun?: boolean;
+  canManageTriggers?: boolean;
+  canEditConfig?: boolean;
+}
+
+function buildDataStorageResponse(): ReportResponseDto['dataMart']['storage'] {
+  return {
+    id: 'storage-1',
+    title: 'BigQuery Storage',
+    type: DataStorageType.GOOGLE_BIGQUERY,
+    credentials: null,
+    config: {
+      projectId: 'test-project',
+      location: 'US',
+    },
+    createdAt: '2026-06-01T00:00:00.000Z',
+    modifiedAt: '2026-06-01T00:00:00.000Z',
+    publishedDataMartsCount: 1,
+    draftDataMartsCount: 0,
+  };
+}

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
@@ -194,6 +194,7 @@ describe('DataMartReportsPage', () => {
     expect(container.querySelector('.dm-card')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Filters/ })).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Search' })).toBeInTheDocument();
   });
 
   it('searches reports by the Data Mart column', async () => {
@@ -305,6 +306,24 @@ describe('DataMartReportsPage', () => {
     expect(screen.getByText('Delete report')).toBeInTheDocument();
   });
 
+  it('renders notification report row actions like the Data Mart reports tab', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildReportResponse({
+        title: 'Slack Alert',
+        destinationTitle: 'Slack workspace',
+        destinationType: DataDestinationType.SLACK,
+      }),
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText('Slack Alert')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run report: Slack Alert' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Actions for report: Slack Alert' })
+    ).toBeInTheDocument();
+  });
+
   it('runs a report from the project-wide reports action cell', async () => {
     vi.mocked(reportService.getReportsByProject)
       .mockResolvedValueOnce([
@@ -370,6 +389,55 @@ describe('DataMartReportsPage', () => {
     await waitFor(() => {
       expect(reportService.getReportsByProject).toHaveBeenCalledTimes(2);
     });
+
+    vi.useRealTimers();
+  });
+
+  it('keeps already loaded report pages during silent polling', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(reportService.getReportsByProject)
+      .mockResolvedValueOnce(
+        Array.from({ length: 100 }, (_, index) =>
+          buildReportResponse({
+            id: `report-${index + 1}`,
+            title: `Report ${index + 1}`,
+            lastRunStatus: index === 0 ? ReportStatusEnum.RUNNING : ReportStatusEnum.SUCCESS,
+          })
+        )
+      )
+      .mockResolvedValueOnce([
+        buildReportResponse({
+          id: 'report-101',
+          title: 'Loaded Second Page Report',
+          lastRunStatus: ReportStatusEnum.SUCCESS,
+        }),
+      ])
+      .mockResolvedValueOnce([
+        buildReportResponse({
+          id: 'report-1',
+          title: 'Report 1',
+          lastRunStatus: ReportStatusEnum.RUNNING,
+        }),
+      ]);
+
+    renderPage();
+
+    expect(await screen.findByText('Report 1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load More' }));
+    await waitFor(() => {
+      expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 100);
+    });
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Loaded Second' },
+    });
+    expect(await screen.findByText('Loaded Second Page Report')).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(await screen.findByText('Loaded Second Page Report')).toBeInTheDocument();
+    expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 0);
+    expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 100);
 
     vi.useRealTimers();
   });
@@ -449,8 +517,8 @@ function buildReportResponse(overrides: ReportFixtureOverrides = {}): ReportResp
     },
     dataDestinationAccess: {
       id: 'dest-1',
-      title: 'Email',
-      type: DataDestinationType.EMAIL,
+      title: overrides.destinationTitle ?? 'Email',
+      type: overrides.destinationType ?? DataDestinationType.EMAIL,
       projectId: 'project-1',
       credentials: {
         type: DataDestinationCredentialsType.EMAIL_CREDENTIALS,
@@ -518,6 +586,8 @@ interface ReportFixtureOverrides extends Partial<
   Pick<ReportResponseDto, 'id' | 'title' | 'lastRunAt' | 'lastRunStatus'>
 > {
   dataMartTitle?: string;
+  destinationTitle?: string;
+  destinationType?: DataDestinationType;
   columnConfig?: ReportResponseDto['columnConfig'];
   canRun?: boolean;
   canManageTriggers?: boolean;

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import type { ColumnDef } from '@tanstack/react-table';
 import { RefreshCw } from 'lucide-react';
 import { Button } from '@owox/ui/components/button';
@@ -39,6 +39,7 @@ import {
 } from '../shared/ProjectDataMartTableFilters.utils';
 import { buildProjectDataMartContextValue } from '../shared/projectDataMartContext';
 import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
+import { ProjectDataMartTitleLink } from '../shared/ProjectDataMartTitleLink';
 
 const PROJECT_REPORTS_PAGE_SIZE = 100;
 const PROJECT_REPORTS_TABLE_ID = 'project-reports-table';
@@ -326,15 +327,10 @@ export default function DataMartReportsPage() {
         meta: { title: 'Data Mart' },
         header: ({ column }) => <SortableHeader column={column}>Data Mart</SortableHeader>,
         cell: ({ row }) => (
-          <Link
+          <ProjectDataMartTitleLink
             to={scope(`/data-marts/${row.original.dataMart.id}/reports`)}
-            onClick={event => {
-              event.stopPropagation();
-            }}
-            className='text-foreground hover:text-primary inline-block max-w-full truncate transition-colors'
-          >
-            {row.original.dataMart.title}
-          </Link>
+            title={row.original.dataMart.title}
+          />
         ),
       },
       {

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import type { ColumnDef } from '@tanstack/react-table';
 import { RefreshCw } from 'lucide-react';
@@ -140,14 +141,22 @@ function ProjectReportActionsCell({
     onRunSuccess: onReportActionComplete,
   };
 
+  let actionsCell: ReactNode = null;
+
+  switch (report.dataDestination.type) {
+    case DataDestinationType.GOOGLE_SHEETS:
+      actionsCell = <GoogleSheetsActionsCell {...actionProps} />;
+      break;
+    case DataDestinationType.EMAIL:
+    case DataDestinationType.SLACK:
+    case DataDestinationType.GOOGLE_CHAT:
+    case DataDestinationType.MS_TEAMS:
+      actionsCell = <EmailActionsCell {...actionProps} />;
+      break;
+  }
+
   return (
-    <DataMartContext.Provider value={dataMartContextValue}>
-      {report.dataDestination.type === DataDestinationType.GOOGLE_SHEETS ? (
-        <GoogleSheetsActionsCell {...actionProps} />
-      ) : report.dataDestination.type === DataDestinationType.EMAIL ? (
-        <EmailActionsCell {...actionProps} />
-      ) : null}
-    </DataMartContext.Provider>
+    <DataMartContext.Provider value={dataMartContextValue}>{actionsCell}</DataMartContext.Provider>
   );
 }
 
@@ -185,10 +194,23 @@ export default function DataMartReportsPage() {
     try {
       const response = await reportService.getReportsByProject(PROJECT_REPORTS_PAGE_SIZE, offset);
       const nextReports = response.map(mapReportDtoToEntity);
-      setReports(currentReports =>
-        isInitialLoad ? nextReports : [...currentReports, ...nextReports]
-      );
-      setHasMoreReportsToLoad(nextReports.length >= PROJECT_REPORTS_PAGE_SIZE);
+      setReports(currentReports => {
+        if (!isInitialLoad) {
+          return [...currentReports, ...nextReports];
+        }
+
+        if (!isSilent) {
+          return nextReports;
+        }
+
+        const nextReportIds = new Set(nextReports.map(report => report.id));
+        const loadedOlderReports = currentReports.filter(report => !nextReportIds.has(report.id));
+        return [...nextReports, ...loadedOlderReports];
+      });
+
+      if (!isInitialLoad || !isSilent) {
+        setHasMoreReportsToLoad(nextReports.length >= PROJECT_REPORTS_PAGE_SIZE);
+      }
     } catch (caught) {
       if (!isSilent) {
         setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart reports');

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
@@ -1,0 +1,521 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import type { ColumnDef } from '@tanstack/react-table';
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@owox/ui/components/button';
+import RelativeTime from '@owox/ui/components/common/relative-time';
+import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
+import { extractApiError } from '../../../app/api';
+import { DataDestinationType, DataDestinationTypeModel } from '../../../features/data-destination';
+import { DataMartContext } from '../../../features/data-marts/edit/model/context/context';
+import {
+  EmailActionsCell,
+  GoogleSheetsActionsCell,
+  StatusIcon,
+} from '../../../features/data-marts/reports/list/components';
+import { ReportEditSheetRenderer } from '../../../features/data-marts/reports/list/components/DestinationCard/ReportEditSheetRenderer';
+import { useReportSidesheet } from '../../../features/data-marts/reports/list/model/hooks';
+import { mapReportDtoToEntity } from '../../../features/data-marts/reports/shared/model/mappers';
+import { ReportsProvider } from '../../../features/data-marts/reports/shared/model/context';
+import type { DataMartReport } from '../../../features/data-marts/reports/shared/model/types/data-mart-report';
+import { ReportStatusEnum } from '../../../features/data-marts/reports/shared/enums';
+import { reportService } from '../../../features/data-marts/reports/shared/services';
+import { BaseTable, SortableHeader, ToggleColumnsHeader } from '../../../shared/components/Table';
+import {
+  applyFiltersToData,
+  type FilterAccessors,
+  type FilterConfigItem,
+} from '../../../shared/components/TableFilters';
+import { collectOptionsFromData } from '../../../shared/components/TableFilters/collectOptions.utils';
+import { UserAvatarGroup } from '../../../shared/components/UserAvatarGroup';
+import { UserReference } from '../../../shared/components/UserReference';
+import { useBaseTable, usePersistentFilters, useProjectRoute } from '../../../shared/hooks';
+import { ProjectDataMartTableFilters } from '../shared/ProjectDataMartTableFilters';
+import { ProjectDataMartTableSearch } from '../shared/ProjectDataMartTableSearch';
+import {
+  buildProjectTableUserLabelMapper,
+  matchesProjectTableSearch,
+} from '../shared/ProjectDataMartTableFilters.utils';
+import { buildProjectDataMartContextValue } from '../shared/projectDataMartContext';
+import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
+
+const PROJECT_REPORTS_PAGE_SIZE = 100;
+const PROJECT_REPORTS_TABLE_ID = 'project-reports-table';
+
+type ProjectReportFilterKey =
+  | 'dataMart'
+  | 'report'
+  | 'destination'
+  | 'runStatus'
+  | 'createdBy'
+  | 'owners';
+
+const projectReportFilterAccessors: FilterAccessors<ProjectReportFilterKey, DataMartReport> = {
+  dataMart: row => row.dataMart.title,
+  report: row => row.title,
+  destination: row => row.dataDestination.title,
+  runStatus: row => row.lastRunStatus ?? 'never',
+  createdBy: row => row.createdByUser?.userId,
+  owners: row => (row.ownerUsers ?? []).map(user => user.userId),
+};
+
+function buildProjectReportFilters(
+  data: DataMartReport[]
+): FilterConfigItem<ProjectReportFilterKey>[] {
+  const userLabelMapper = buildProjectTableUserLabelMapper(
+    data.flatMap(report => [report.createdByUser, ...(report.ownerUsers ?? [])])
+  );
+
+  return [
+    {
+      id: 'dataMart',
+      label: 'Data Mart',
+      dataType: 'string',
+      operators: ['contains', 'not_contains', 'eq', 'neq'],
+      options: collectOptionsFromData(data, projectReportFilterAccessors.dataMart),
+    },
+    {
+      id: 'report',
+      label: 'Report',
+      dataType: 'string',
+      operators: ['contains', 'not_contains', 'eq', 'neq'],
+      options: collectOptionsFromData(data, projectReportFilterAccessors.report),
+    },
+    {
+      id: 'destination',
+      label: 'Destination',
+      dataType: 'string',
+      operators: ['contains', 'not_contains', 'eq', 'neq'],
+      options: collectOptionsFromData(data, projectReportFilterAccessors.destination),
+    },
+    {
+      id: 'runStatus',
+      label: 'Run Status',
+      dataType: 'enum',
+      operators: ['eq', 'neq'],
+      options: collectOptionsFromData(data, projectReportFilterAccessors.runStatus, {
+        labelMapper: value => (value === 'never' ? 'Never run' : value),
+      }),
+    },
+    {
+      id: 'createdBy',
+      label: 'Created By',
+      dataType: 'enum',
+      operators: ['eq', 'neq'],
+      options: collectOptionsFromData(data, projectReportFilterAccessors.createdBy, {
+        labelMapper: userLabelMapper,
+      }),
+    },
+    {
+      id: 'owners',
+      label: 'Owners',
+      dataType: 'enum',
+      operators: ['eq', 'neq'],
+      options: collectOptionsFromData(data, projectReportFilterAccessors.owners, {
+        labelMapper: userLabelMapper,
+      }),
+    },
+  ];
+}
+
+interface ProjectReportActionsCellProps {
+  report: DataMartReport;
+  onEditReport: (report: DataMartReport) => void;
+  onReportActionComplete: () => void | Promise<void>;
+}
+
+function ProjectReportActionsCell({
+  report,
+  onEditReport,
+  onReportActionComplete,
+}: ProjectReportActionsCellProps) {
+  const dataMartContextValue = useMemo(
+    () => buildProjectDataMartContextValue(report.dataMart),
+    [report.dataMart]
+  );
+  const actionProps = {
+    row: { original: report },
+    onDeleteSuccess: onReportActionComplete,
+    onEditReport,
+    onRunSuccess: onReportActionComplete,
+  };
+
+  return (
+    <DataMartContext.Provider value={dataMartContextValue}>
+      {report.dataDestination.type === DataDestinationType.GOOGLE_SHEETS ? (
+        <GoogleSheetsActionsCell {...actionProps} />
+      ) : report.dataDestination.type === DataDestinationType.EMAIL ? (
+        <EmailActionsCell {...actionProps} />
+      ) : null}
+    </DataMartContext.Provider>
+  );
+}
+
+export default function DataMartReportsPage() {
+  const { projectId = '' } = useParams<{ projectId: string }>();
+  const { scope } = useProjectRoute();
+  const [reports, setReports] = useState<DataMartReport[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMoreReportsToLoad, setHasMoreReportsToLoad] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const {
+    isOpen: isReportEditSheetOpen,
+    mode: reportEditMode,
+    editingReport,
+    handleEditReport,
+    handleCloseModal,
+  } = useReportSidesheet();
+
+  const loadReports = useCallback(async (offset = 0, options?: { silent?: boolean }) => {
+    const isInitialLoad = offset === 0;
+    const isSilent = options?.silent === true;
+
+    if (isInitialLoad && !isSilent) {
+      setIsLoading(true);
+    } else if (!isInitialLoad) {
+      setIsLoadingMore(true);
+    }
+
+    if (!isSilent) {
+      setError(null);
+    }
+
+    try {
+      const response = await reportService.getReportsByProject(PROJECT_REPORTS_PAGE_SIZE, offset);
+      const nextReports = response.map(mapReportDtoToEntity);
+      setReports(currentReports =>
+        isInitialLoad ? nextReports : [...currentReports, ...nextReports]
+      );
+      setHasMoreReportsToLoad(nextReports.length >= PROJECT_REPORTS_PAGE_SIZE);
+    } catch (caught) {
+      if (!isSilent) {
+        setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart reports');
+      }
+    } finally {
+      if (isInitialLoad && !isSilent) {
+        setIsLoading(false);
+      } else if (!isInitialLoad) {
+        setIsLoadingMore(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadReports(0);
+  }, [loadReports]);
+
+  const loadMoreReports = useCallback(async () => {
+    if (isLoadingMore || !hasMoreReportsToLoad) return;
+    await loadReports(reports.length);
+  }, [hasMoreReportsToLoad, isLoadingMore, loadReports, reports.length]);
+
+  const handleCloseReportEditSheet = useCallback(() => {
+    handleCloseModal();
+    void loadReports(0);
+  }, [handleCloseModal, loadReports]);
+
+  const handleReportActionComplete = useCallback(async () => {
+    await loadReports(0);
+  }, [loadReports]);
+
+  const hasRunningReports = useMemo(
+    () => reports.some(report => report.lastRunStatus === ReportStatusEnum.RUNNING),
+    [reports]
+  );
+
+  useEffect(() => {
+    if (!hasRunningReports || isLoadingMore) return;
+
+    const intervalId = window.setInterval(() => {
+      void loadReports(0, { silent: true });
+    }, 5000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [hasRunningReports, isLoadingMore, loadReports]);
+
+  const reportDataMartContextValue = useMemo(
+    () => (editingReport ? buildProjectDataMartContextValue(editingReport.dataMart) : null),
+    [editingReport]
+  );
+
+  const filtersConfig = useMemo(() => buildProjectReportFilters(reports), [reports]);
+
+  const { appliedState, apply, clear } = usePersistentFilters<ProjectReportFilterKey>({
+    projectId,
+    tableId: PROJECT_REPORTS_TABLE_ID,
+    urlParam: 'filters',
+    config: filtersConfig,
+  });
+
+  const shouldLoadAllReportsForQuery =
+    searchQuery.trim().length > 0 || appliedState.filters.length > 0;
+
+  useEffect(() => {
+    if (!shouldLoadAllReportsForQuery || !hasMoreReportsToLoad || isLoading || isLoadingMore) {
+      return;
+    }
+
+    void loadReports(reports.length, { silent: true });
+  }, [
+    hasMoreReportsToLoad,
+    isLoading,
+    isLoadingMore,
+    loadReports,
+    reports.length,
+    shouldLoadAllReportsForQuery,
+  ]);
+
+  const filteredReports = useMemo(
+    () =>
+      applyFiltersToData<ProjectReportFilterKey, DataMartReport>(
+        reports,
+        appliedState,
+        projectReportFilterAccessors
+      ),
+    [appliedState, reports]
+  );
+
+  const searchedReports = useMemo(
+    () =>
+      filteredReports.filter(report =>
+        matchesProjectTableSearch(searchQuery, [
+          report.dataMart.title,
+          report.title,
+          report.dataDestination.title,
+          report.lastRunStatus,
+          report.createdByUser?.fullName,
+          report.createdByUser?.email,
+          (report.ownerUsers ?? []).flatMap(user => [user.fullName, user.email]),
+        ])
+      ),
+    [filteredReports, searchQuery]
+  );
+
+  const columns = useMemo<ColumnDef<DataMartReport>[]>(
+    () => [
+      {
+        id: 'dataMart',
+        accessorFn: row => row.dataMart.title,
+        size: 260,
+        meta: { title: 'Data Mart' },
+        header: ({ column }) => <SortableHeader column={column}>Data Mart</SortableHeader>,
+        cell: ({ row }) => (
+          <Link
+            to={scope(`/data-marts/${row.original.dataMart.id}/reports`)}
+            onClick={event => {
+              event.stopPropagation();
+            }}
+            className='text-foreground hover:text-primary inline-block max-w-full truncate transition-colors'
+          >
+            {row.original.dataMart.title}
+          </Link>
+        ),
+      },
+      {
+        accessorKey: 'title',
+        size: 320,
+        meta: { title: 'Report' },
+        header: ({ column }) => <SortableHeader column={column}>Report</SortableHeader>,
+        cell: ({ row }) => {
+          const title = row.original.title.trim();
+          if (!title) {
+            return <span className='text-muted-foreground'>—</span>;
+          }
+          return <div className='overflow-hidden text-ellipsis'>{title}</div>;
+        },
+      },
+      {
+        id: 'destination',
+        accessorFn: row => row.dataDestination.title,
+        size: 220,
+        meta: { title: 'Destination' },
+        header: ({ column }) => <SortableHeader column={column}>Destination</SortableHeader>,
+        cell: ({ row }) => {
+          const { displayName, icon: Icon } = DataDestinationTypeModel.getInfo(
+            row.original.dataDestination.type
+          );
+
+          return (
+            <div className='text-muted-foreground flex min-w-0 items-center gap-2'>
+              <Icon size={18} className='shrink-0' />
+              <span className='truncate'>{row.original.dataDestination.title || displayName}</span>
+            </div>
+          );
+        },
+      },
+      {
+        accessorKey: 'lastRunDate',
+        size: 170,
+        sortDescFirst: true,
+        meta: { title: 'Last Run' },
+        header: ({ column }) => <SortableHeader column={column}>Last Run</SortableHeader>,
+        cell: ({ row }) => (
+          <div className='text-muted-foreground text-sm'>
+            {row.original.lastRunDate ? (
+              <RelativeTime date={row.original.lastRunDate} />
+            ) : (
+              'Never run'
+            )}
+          </div>
+        ),
+      },
+      {
+        accessorKey: 'lastRunStatus',
+        size: 150,
+        meta: { title: 'Run Status' },
+        header: ({ column }) => <SortableHeader column={column}>Run Status</SortableHeader>,
+        cell: ({ row }) =>
+          row.original.lastRunStatus ? (
+            <StatusIcon status={row.original.lastRunStatus} error={row.original.lastRunError} />
+          ) : (
+            <span className='text-muted-foreground text-sm'>—</span>
+          ),
+      },
+      {
+        id: 'createdBy',
+        accessorFn: row => row.createdByUser?.fullName ?? row.createdByUser?.email,
+        size: 190,
+        meta: { title: 'Created By' },
+        header: ({ column }) => <SortableHeader column={column}>Created By</SortableHeader>,
+        cell: ({ row }) => {
+          const user = row.original.createdByUser;
+          if (!user) return <span className='text-muted-foreground'>-</span>;
+          return <UserReference userProjection={user} />;
+        },
+      },
+      {
+        id: 'owners',
+        accessorFn: row =>
+          (row.ownerUsers ?? []).map(user => user.fullName ?? user.email).join(', '),
+        size: 190,
+        meta: { title: 'Owners' },
+        header: ({ column }) => <SortableHeader column={column}>Owners</SortableHeader>,
+        cell: ({ row }) => {
+          const users = row.original.ownerUsers ?? [];
+          if (users.length === 0) {
+            return <span className='text-muted-foreground text-sm'>Not assigned</span>;
+          }
+          if (users.length === 1) return <UserReference userProjection={users[0]} />;
+          return <UserAvatarGroup users={users} />;
+        },
+      },
+      {
+        id: 'actions',
+        size: 140,
+        enableResizing: false,
+        enableSorting: false,
+        header: ({ table }) => <ToggleColumnsHeader table={table} />,
+        cell: ({ row }) => (
+          <ProjectReportActionsCell
+            report={row.original}
+            onEditReport={handleEditReport}
+            onReportActionComplete={handleReportActionComplete}
+          />
+        ),
+      },
+    ],
+    [handleEditReport, handleReportActionComplete, scope]
+  );
+
+  const { table } = useBaseTable<DataMartReport>({
+    data: searchedReports,
+    columns,
+    storageKeyPrefix: 'project-data-mart-reports',
+    defaultSortingColumn: 'lastRunDate',
+    defaultPageSize: PROJECT_REPORTS_PAGE_SIZE,
+    enableRowSelection: false,
+  });
+
+  return (
+    <ReportsProvider>
+      <div className='dm-page' data-testid='dataMartReportsPage'>
+        <header className='dm-page-header'>
+          <h1 className='dm-page-header-title'>Reports</h1>
+        </header>
+
+        <div className='dm-page-content'>
+          {isLoading ? (
+            <SkeletonList />
+          ) : error ? (
+            <div className='dm-card-block text-destructive text-sm'>{error}</div>
+          ) : reports.length === 0 ? (
+            <div className='dm-card'>
+              <ProjectDataMartEmptyState variant='reports' />
+            </div>
+          ) : (
+            <div className='dm-card' data-testid='projectReportsTable'>
+              <BaseTable
+                tableId={PROJECT_REPORTS_TABLE_ID}
+                table={table}
+                ariaLabel='Project Data Mart Reports'
+                paginationProps={{ displaySelected: false }}
+                renderToolbarLeft={() => (
+                  <>
+                    <ProjectDataMartTableFilters
+                      appliedState={appliedState}
+                      config={filtersConfig}
+                      onApply={apply}
+                      onClear={clear}
+                    />
+                    <ProjectDataMartTableSearch value={searchQuery} onChange={setSearchQuery} />
+                  </>
+                )}
+                renderEmptyState={() => (
+                  <div
+                    className='flex h-32 items-center justify-center text-center'
+                    role='status'
+                    aria-live='polite'
+                  >
+                    No reports found for accessible Data Marts
+                  </div>
+                )}
+                onRowClick={row => {
+                  if (row.original.canEditConfig) {
+                    handleEditReport(row.original);
+                  }
+                }}
+              />
+
+              {hasMoreReportsToLoad && (
+                <div className='flex justify-center pt-4 pb-6'>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={() => void loadMoreReports()}
+                    disabled={isLoadingMore}
+                    className='flex items-center gap-2'
+                  >
+                    {isLoadingMore ? (
+                      <>
+                        <RefreshCw className='h-4 w-4 animate-spin' />
+                        Loading...
+                      </>
+                    ) : (
+                      'Load More'
+                    )}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {editingReport && reportDataMartContextValue && (
+          <DataMartContext.Provider value={reportDataMartContextValue}>
+            <ReportEditSheetRenderer
+              destination={editingReport.dataDestination}
+              isOpen={isReportEditSheetOpen}
+              onClose={handleCloseReportEditSheet}
+              mode={reportEditMode}
+              initialReport={editingReport}
+            />
+          </DataMartContext.Provider>
+        )}
+      </div>
+    </ReportsProvider>
+  );
+}

--- a/apps/web/src/pages/data-marts/runs/DataMartRunsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/runs/DataMartRunsPage.test.tsx
@@ -94,6 +94,22 @@ describe('DataMartRunsPage', () => {
     );
   });
 
+  it('does not crash when a project connector run has no definition payload', async () => {
+    vi.mocked(dataMartService.getProjectDataMartRuns).mockResolvedValueOnce({
+      runs: [
+        {
+          ...buildProjectRun({ status: DataMartRunStatus.SUCCESS }),
+          definitionRun: null as never,
+        },
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('link', { name: 'Marketing Mart' })).toBeInTheDocument();
+    expect(getConnectorInfoByName).not.toHaveBeenCalled();
+  });
+
   it('refreshes the first page while a loaded run is not final and stops after completion', async () => {
     vi.useFakeTimers();
     vi.mocked(dataMartService.getProjectDataMartRuns)

--- a/apps/web/src/pages/data-marts/runs/DataMartRunsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/runs/DataMartRunsPage.test.tsx
@@ -1,0 +1,176 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DataMartRunStatus,
+  DataMartRunTriggerType,
+  DataMartRunType,
+} from '../../../features/data-marts/shared';
+import { dataMartService } from '../../../features/data-marts/shared';
+import { getConnectorInfoByName } from '../../../features/connectors/shared/utils';
+import DataMartRunsPage from './DataMartRunsPage';
+
+const dataMartServiceMock = vi.hoisted(() => ({
+  getProjectDataMartRuns: vi.fn(),
+  cancelDataMartRun: vi.fn(),
+}));
+
+const getConnectorInfoByNameMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../features/data-marts/shared', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../features/data-marts/shared')>();
+  return {
+    ...actual,
+    dataMartService: dataMartServiceMock,
+  };
+});
+
+vi.mock('../../../features/connectors/shared/utils', () => ({
+  getConnectorInfoByName: getConnectorInfoByNameMock,
+}));
+
+vi.mock('../../../features/idp', () => ({
+  useAuth: () => ({
+    status: 'authenticated',
+    user: {
+      id: 'user-1',
+      projectId: 'project-1',
+      roles: ['viewer'],
+    },
+  }),
+}));
+
+describe('DataMartRunsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getConnectorInfoByName).mockResolvedValue({
+      name: 'FacebookMarketing',
+      displayName: 'Facebook Marketing',
+      description: 'Facebook Marketing connector',
+      logoBase64: 'data:image/png;base64,connector-logo',
+      docUrl: null,
+    });
+  });
+
+  it('shows a Data Mart-focused empty state when there are no project-wide runs', async () => {
+    vi.mocked(dataMartService.getProjectDataMartRuns).mockResolvedValueOnce({
+      runs: [],
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'No runs yet' })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Data Mart runs will appear here as they start and finish/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Choose a Data Mart' })).toHaveAttribute(
+      'href',
+      '/ui/project-1/data-marts'
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders connector logo and a Data Mart link for project-wide connector runs', async () => {
+    vi.mocked(dataMartService.getProjectDataMartRuns).mockResolvedValueOnce({
+      runs: [buildProjectRun({ status: DataMartRunStatus.SUCCESS })],
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('link', { name: 'Marketing Mart' })).toHaveAttribute(
+      'href',
+      '/ui/project-1/data-marts/dm-1/run-history'
+    );
+
+    await waitFor(() => {
+      expect(getConnectorInfoByName).toHaveBeenCalledWith('FacebookMarketing');
+    });
+    expect(await screen.findByRole('img', { name: 'icon' })).toHaveAttribute(
+      'src',
+      'data:image/png;base64,connector-logo'
+    );
+  });
+
+  it('refreshes the first page while a loaded run is not final and stops after completion', async () => {
+    vi.useFakeTimers();
+    vi.mocked(dataMartService.getProjectDataMartRuns)
+      .mockResolvedValueOnce({ runs: [buildProjectRun({ status: DataMartRunStatus.RUNNING })] })
+      .mockResolvedValueOnce({ runs: [buildProjectRun({ status: DataMartRunStatus.SUCCESS })] });
+
+    renderPage();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(dataMartService.getProjectDataMartRuns).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await Promise.resolve();
+    });
+
+    expect(dataMartService.getProjectDataMartRuns).toHaveBeenCalledTimes(2);
+    expect(dataMartService.getProjectDataMartRuns).toHaveBeenLastCalledWith(100, 0, {
+      skipLoadingIndicator: true,
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await Promise.resolve();
+    });
+
+    expect(dataMartService.getProjectDataMartRuns).toHaveBeenCalledTimes(2);
+  });
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/ui/project-1/data-marts/runs']}>
+      <DataMartRunsPage />
+    </MemoryRouter>
+  );
+}
+
+function buildProjectRun({ status }: { status: DataMartRunStatus }) {
+  return {
+    id: 'run-1',
+    dataMartId: 'dm-1',
+    status,
+    createdAt: '2026-06-05T10:00:00.000Z',
+    logs: [],
+    errors: [],
+    definitionRun: {
+      connector: {
+        source: {
+          name: 'FacebookMarketing',
+          configuration: [],
+          node: 'default',
+          fields: [],
+        },
+        storage: {
+          fullyQualifiedName: 'dataset.table',
+        },
+      },
+    },
+    type: DataMartRunType.CONNECTOR,
+    runType: DataMartRunTriggerType.MANUAL,
+    startedAt: '2026-06-05T10:00:00.000Z',
+    finishedAt: status === DataMartRunStatus.SUCCESS ? '2026-06-05T10:01:00.000Z' : null,
+    reportDefinition: null,
+    reportId: null,
+    insightDefinition: null,
+    insightId: null,
+    insightTemplateDefinition: null,
+    insightTemplateId: null,
+    aiSourceDefinition: null,
+    createdByUser: null,
+    additionalParams: null,
+    dataMart: {
+      id: 'dm-1',
+      title: 'Marketing Mart',
+    },
+  };
+}

--- a/apps/web/src/pages/data-marts/runs/DataMartRunsPage.tsx
+++ b/apps/web/src/pages/data-marts/runs/DataMartRunsPage.tsx
@@ -5,7 +5,6 @@ import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
 import { extractApiError } from '../../../app/api';
 import { DataMartRunType, dataMartService } from '../../../features/data-marts/shared';
 import { isDataMartRunFinalStatus } from '../../../features/data-marts/shared/utils/status.utils';
-import { DATA_MART_RUNS_PAGE_SIZE } from '../../../features/data-marts/edit/constants';
 import { RunItem } from '../../../features/data-marts/edit/components/DataMartRunHistoryView';
 import { LogViewType } from '../../../features/data-marts/edit/components/DataMartRunHistoryView/types';
 import { mapProjectDataMartRunListResponseDtoToEntity } from '../../../features/data-marts/edit/model/mappers';
@@ -14,6 +13,8 @@ import type { ConnectorListItem } from '../../../features/connectors/shared/mode
 import { getConnectorInfoByName } from '../../../features/connectors/shared/utils';
 import { useProjectRoute } from '../../../shared/hooks';
 import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
+
+const PROJECT_RUNS_PAGE_SIZE = 100;
 
 export default function DataMartRunsPage() {
   const { scope } = useProjectRoute();
@@ -46,7 +47,7 @@ export default function DataMartRunsPage() {
 
     try {
       const response = await dataMartService.getProjectDataMartRuns(
-        DATA_MART_RUNS_PAGE_SIZE,
+        PROJECT_RUNS_PAGE_SIZE,
         offset,
         isSilent ? { skipLoadingIndicator: true } : undefined
       );
@@ -66,7 +67,7 @@ export default function DataMartRunsPage() {
       });
 
       if (!isSilent) {
-        setHasMoreRunsToLoad(nextRuns.length >= DATA_MART_RUNS_PAGE_SIZE);
+        setHasMoreRunsToLoad(nextRuns.length >= PROJECT_RUNS_PAGE_SIZE);
       }
     } catch (caught) {
       if (!isSilent) {
@@ -220,9 +221,13 @@ export default function DataMartRunsPage() {
 }
 
 function getConnectorSourceName(run: ProjectDataMartRunItem): string | null {
-  if (run.type !== DataMartRunType.CONNECTOR || !('connector' in run.definitionRun)) return null;
+  const definitionRun = run.definitionRun as ProjectDataMartRunItem['definitionRun'] | null;
 
-  return run.definitionRun.connector.source.name;
+  if (run.type !== DataMartRunType.CONNECTOR || !definitionRun || !('connector' in definitionRun)) {
+    return null;
+  }
+
+  return definitionRun.connector.source.name;
 }
 
 function getConnectorInfoForRun(

--- a/apps/web/src/pages/data-marts/runs/DataMartRunsPage.tsx
+++ b/apps/web/src/pages/data-marts/runs/DataMartRunsPage.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@owox/ui/components/button';
+import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
+import { extractApiError } from '../../../app/api';
+import { DataMartRunType, dataMartService } from '../../../features/data-marts/shared';
+import { isDataMartRunFinalStatus } from '../../../features/data-marts/shared/utils/status.utils';
+import { DATA_MART_RUNS_PAGE_SIZE } from '../../../features/data-marts/edit/constants';
+import { RunItem } from '../../../features/data-marts/edit/components/DataMartRunHistoryView';
+import { LogViewType } from '../../../features/data-marts/edit/components/DataMartRunHistoryView/types';
+import { mapProjectDataMartRunListResponseDtoToEntity } from '../../../features/data-marts/edit/model/mappers';
+import type { ProjectDataMartRunItem } from '../../../features/data-marts/edit/model/types';
+import type { ConnectorListItem } from '../../../features/connectors/shared/model/types/connector';
+import { getConnectorInfoByName } from '../../../features/connectors/shared/utils';
+import { useProjectRoute } from '../../../shared/hooks';
+import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
+
+export default function DataMartRunsPage() {
+  const { scope } = useProjectRoute();
+  const [runs, setRuns] = useState<ProjectDataMartRunItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMoreRunsToLoad, setHasMoreRunsToLoad] = useState(false);
+  const [expandedRun, setExpandedRun] = useState<string | null>(null);
+  const [logViewType, setLogViewType] = useState<LogViewType>(LogViewType.STRUCTURED);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [connectorInfoByName, setConnectorInfoByName] = useState<
+    Record<string, ConnectorListItem | null>
+  >({});
+
+  const loadRuns = useCallback(async (offset = 0, options?: { silent?: boolean }) => {
+    const isInitialLoad = offset === 0;
+    const isSilent = options?.silent === true;
+
+    if (isInitialLoad) {
+      if (!isSilent) {
+        setIsLoading(true);
+      }
+    } else {
+      setIsLoadingMore(true);
+    }
+    if (!isSilent) {
+      setError(null);
+    }
+
+    try {
+      const response = await dataMartService.getProjectDataMartRuns(
+        DATA_MART_RUNS_PAGE_SIZE,
+        offset,
+        isSilent ? { skipLoadingIndicator: true } : undefined
+      );
+      const nextRuns = mapProjectDataMartRunListResponseDtoToEntity(response);
+      setRuns(currentRuns => {
+        if (!isInitialLoad) {
+          return [...currentRuns, ...nextRuns];
+        }
+
+        if (!isSilent) {
+          return nextRuns;
+        }
+
+        const nextRunIds = new Set(nextRuns.map(run => run.id));
+        const loadedOlderRuns = currentRuns.filter(run => !nextRunIds.has(run.id));
+        return [...nextRuns, ...loadedOlderRuns];
+      });
+
+      if (!isSilent) {
+        setHasMoreRunsToLoad(nextRuns.length >= DATA_MART_RUNS_PAGE_SIZE);
+      }
+    } catch (caught) {
+      if (!isSilent) {
+        setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart runs');
+      }
+    } finally {
+      if (isInitialLoad) {
+        if (!isSilent) {
+          setIsLoading(false);
+        }
+      } else {
+        setIsLoadingMore(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRuns(0);
+  }, [loadRuns]);
+
+  const hasActiveRuns = useMemo(
+    () => runs.some(run => !isDataMartRunFinalStatus(run.status)),
+    [runs]
+  );
+
+  useEffect(() => {
+    if (!hasActiveRuns || isLoadingMore) return;
+
+    const intervalId = window.setInterval(() => {
+      void loadRuns(0, { silent: true });
+    }, 5000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [hasActiveRuns, isLoadingMore, loadRuns]);
+
+  const connectorSourceNames = useMemo(() => {
+    const names = runs.map(getConnectorSourceName).filter((name): name is string => Boolean(name));
+    return Array.from(new Set(names)).sort();
+  }, [runs]);
+
+  useEffect(() => {
+    const missingConnectorNames = connectorSourceNames.filter(
+      name => !(name in connectorInfoByName)
+    );
+    if (missingConnectorNames.length === 0) return;
+
+    void (async () => {
+      const entries: [string, ConnectorListItem | null][] = [];
+
+      for (const name of missingConnectorNames) {
+        try {
+          entries.push([name, await getConnectorInfoByName(name)]);
+        } catch {
+          entries.push([name, null]);
+        }
+      }
+
+      setConnectorInfoByName(current => ({
+        ...current,
+        ...Object.fromEntries(entries),
+      }));
+    })();
+  }, [connectorInfoByName, connectorSourceNames]);
+
+  const loadMoreRuns = useCallback(async () => {
+    if (isLoadingMore || !hasMoreRunsToLoad) return;
+    await loadRuns(runs.length);
+  }, [hasMoreRunsToLoad, isLoadingMore, loadRuns, runs.length]);
+
+  const cancelDataMartRun = useCallback(
+    async (dataMartId: string, runId: string) => {
+      try {
+        await dataMartService.cancelDataMartRun(dataMartId, runId);
+        await loadRuns(0);
+      } catch (caught) {
+        throw new Error(extractApiError(caught).message ?? 'Failed to cancel Data Mart run');
+      }
+    },
+    [loadRuns]
+  );
+
+  const toggleRunDetails = (runId: string) => {
+    setExpandedRun(current => (current === runId ? null : runId));
+  };
+
+  return (
+    <div className='dm-page' data-testid='dataMartRunsPage'>
+      <header className='dm-page-header'>
+        <h1 className='dm-page-header-title'>Run History</h1>
+      </header>
+
+      <div className='dm-page-content'>
+        {isLoading ? (
+          <SkeletonList />
+        ) : error ? (
+          <div className='dm-card-block text-destructive text-sm'>{error}</div>
+        ) : runs.length === 0 ? (
+          <div className='dm-card'>
+            <ProjectDataMartEmptyState variant='runs' />
+          </div>
+        ) : (
+          <div className='space-y-2' data-testid='projectRunHistoryList'>
+            {runs.map(run => (
+              <RunItem
+                key={run.id}
+                run={run}
+                isExpanded={expandedRun === run.id}
+                onToggle={toggleRunDetails}
+                logViewType={logViewType}
+                setLogViewType={setLogViewType}
+                searchTerm={searchTerm}
+                setSearchTerm={setSearchTerm}
+                cancelDataMartRun={cancelDataMartRun}
+                dataMartId={run.dataMart.id}
+                dataMartConnectorInfo={getConnectorInfoForRun(run, connectorInfoByName)}
+                dataMartRef={{
+                  id: run.dataMart.id,
+                  title: run.dataMart.title,
+                  href: scope(`/data-marts/${run.dataMart.id}/run-history`),
+                }}
+              />
+            ))}
+
+            {hasMoreRunsToLoad && (
+              <div className='flex justify-center pt-4 pb-6'>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={() => void loadMoreRuns()}
+                  disabled={isLoadingMore}
+                  className='flex items-center gap-2'
+                >
+                  {isLoadingMore ? (
+                    <>
+                      <RefreshCw className='h-4 w-4 animate-spin' />
+                      Loading...
+                    </>
+                  ) : (
+                    'Load More'
+                  )}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function getConnectorSourceName(run: ProjectDataMartRunItem): string | null {
+  if (run.type !== DataMartRunType.CONNECTOR || !('connector' in run.definitionRun)) return null;
+
+  return run.definitionRun.connector.source.name;
+}
+
+function getConnectorInfoForRun(
+  run: ProjectDataMartRunItem,
+  connectorInfoByName: Record<string, ConnectorListItem | null>
+): ConnectorListItem | null {
+  const connectorSourceName = getConnectorSourceName(run);
+  if (!connectorSourceName) return null;
+
+  return connectorInfoByName[connectorSourceName] ?? null;
+}

--- a/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.test.tsx
+++ b/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.test.tsx
@@ -89,6 +89,19 @@ describe('DataMartSchedulesPage', () => {
     expect(getColumnHeaderLabels().slice(0, 2)).toEqual(['Data Mart', 'Trigger Type']);
   });
 
+  it('renders the Data Mart title without truncation so long titles can wrap', async () => {
+    const longDataMartTitle = 'Marketing Campaign Performance Data Mart With Long Title';
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectReportTrigger({ dataMartTitle: longDataMartTitle })],
+    });
+
+    renderPage();
+
+    const dataMartLink = await screen.findByRole('link', { name: longDataMartTitle });
+    expect(dataMartLink).toHaveClass('block', 'w-full', 'whitespace-normal', 'break-words');
+    expect(dataMartLink).not.toHaveClass('truncate');
+  });
+
   it('shows a Data Mart-focused empty state when there are no project-wide triggers', async () => {
     vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
       triggers: [],

--- a/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.test.tsx
+++ b/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.test.tsx
@@ -211,6 +211,19 @@ describe('DataMartSchedulesPage', () => {
     expect(screen.getByText('Delete trigger')).toBeInTheDocument();
   });
 
+  it('does not expose trigger edit or delete actions when the row cannot be managed', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectReportTrigger({ canEdit: false, canDelete: false })],
+    });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByText('Daily Sales Report'));
+
+    expect(screen.queryByTestId('projectTriggerEditSheet')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Open menu' })).not.toBeInTheDocument();
+  });
+
   it('restores hidden columns like the Data Mart triggers tab', async () => {
     localStorage.setItem(
       'project-data-mart-scheduled-triggers-column-visibility',
@@ -329,11 +342,18 @@ function getColumnHeaderLabels() {
 }
 
 function buildProjectReportTrigger(
-  overrides: { id?: string; reportId?: string; reportTitle?: string; dataMartTitle?: string } = {}
+  overrides: {
+    id?: string;
+    reportId?: string;
+    reportTitle?: string;
+    dataMartTitle?: string;
+    canEdit?: boolean;
+    canDelete?: boolean;
+  } = {}
 ): ProjectScheduledTriggerResponseApiDto {
   const reportId = overrides.reportId ?? 'report-1';
 
-  return {
+  const trigger = {
     id: overrides.id ?? 'trigger-1',
     type: ScheduledTriggerType.REPORT_RUN,
     cronExpression: '0 9 * * *',
@@ -357,7 +377,11 @@ function buildProjectReportTrigger(
       id: 'dm-1',
       title: overrides.dataMartTitle ?? 'Marketing Mart',
     },
+    canEdit: overrides.canEdit ?? true,
+    canDelete: overrides.canDelete ?? true,
   };
+
+  return trigger as ProjectScheduledTriggerResponseApiDto;
 }
 
 function buildReportResponse(overrides: { id?: string; title?: string } = {}): ReportResponseDto {

--- a/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.test.tsx
+++ b/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.test.tsx
@@ -1,0 +1,481 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DataDestinationType } from '../../../features/data-destination';
+import { DataDestinationCredentialsType } from '../../../features/data-destination/shared/enums/data-destination-credentials-type.enum';
+import { DataStorageType } from '../../../features/data-storage/shared';
+import { ScheduledTriggerType } from '../../../features/data-marts/scheduled-triggers/enums';
+import { TRIGGER_CONFIG_TYPES } from '../../../features/data-marts/scheduled-triggers/enums/trigger-config-types.enum';
+import type { ProjectScheduledTriggerResponseApiDto } from '../../../features/data-marts/scheduled-triggers/model/api/response/scheduled-trigger.response.dto';
+import { scheduledTriggerService } from '../../../features/data-marts/scheduled-triggers/services';
+import { DestinationTypeConfigEnum } from '../../../features/data-marts/reports/shared/enums/destination-type-config.enum';
+import { ReportConditionEnum } from '../../../features/data-marts/reports/shared/enums/report-condition.enum';
+import { TemplateSourceTypeEnum } from '../../../features/data-marts/reports/shared/enums/template-source-type.enum';
+import type { ReportResponseDto } from '../../../features/data-marts/reports/shared/services';
+import { DataMartStatus, DataMartDefinitionType } from '../../../features/data-marts/shared';
+import DataMartSchedulesPage from './DataMartSchedulesPage';
+
+const scheduledTriggerServiceMock = vi.hoisted(() => ({
+  getProjectScheduledTriggers: vi.fn(),
+}));
+
+const connectorApiServiceMock = vi.hoisted(() => ({
+  getAvailableConnectors: vi.fn(),
+}));
+
+vi.mock('../../../features/data-marts/scheduled-triggers/services', () => ({
+  scheduledTriggerService: scheduledTriggerServiceMock,
+}));
+
+vi.mock('../../../features/connectors/shared/api', () => ({
+  ConnectorApiService: vi.fn(function () {
+    return connectorApiServiceMock;
+  }),
+}));
+
+vi.mock('../../../features/data-marts/scheduled-triggers/components/ScheduledTriggerForm', () => ({
+  ScheduledTriggerForm: ({ initialData }: { initialData?: { cronExpression: string } }) => (
+    <div>Trigger form {initialData?.cronExpression}</div>
+  ),
+}));
+
+vi.mock('../../../features/idp', () => ({
+  useAuth: () => ({
+    status: 'authenticated',
+    user: {
+      id: 'user-1',
+      projectId: 'project-1',
+      roles: ['viewer'],
+    },
+  }),
+}));
+
+describe('DataMartSchedulesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    connectorApiServiceMock.getAvailableConnectors.mockResolvedValue([
+      {
+        name: 'FacebookMarketing',
+        title: 'Facebook Marketing',
+        description: null,
+        logo: 'data:image/png;base64,facebook-logo',
+        docUrl: null,
+      },
+    ]);
+  });
+
+  it('shows the run target for project-wide scheduled triggers', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectReportTrigger()],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Run Target')).toBeInTheDocument();
+    expect(await screen.findByText('Daily Sales Report')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Toggle columns' })).toBeInTheDocument();
+    expect(scheduledTriggerService.getProjectScheduledTriggers).toHaveBeenCalledWith(100, 0);
+  });
+
+  it('shows Data Mart as the first table column', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectReportTrigger()],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Daily Sales Report')).toBeInTheDocument();
+    expect(getColumnHeaderLabels().slice(0, 2)).toEqual(['Data Mart', 'Trigger Type']);
+  });
+
+  it('shows a Data Mart-focused empty state when there are no project-wide triggers', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [],
+    });
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'No triggers yet' })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Triggers created inside Data Marts will appear here/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Choose a Data Mart' })).toHaveAttribute(
+      'href',
+      '/ui/project-1/data-marts'
+    );
+    expect(screen.queryByRole('button', { name: 'Toggle columns' })).not.toBeInTheDocument();
+  });
+
+  it('renders Data Marts list-style card controls and applies Data Mart URL filters', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [
+        buildProjectReportTrigger(),
+        buildProjectReportTrigger({
+          id: 'trigger-2',
+          reportId: 'report-2',
+          reportTitle: 'Product Report',
+          dataMartTitle: 'Product Mart',
+        }),
+      ],
+    });
+
+    const { container } = renderPage(buildFilterPath('data-marts/schedules', 'Marketing Mart'));
+
+    expect(await screen.findByText('Daily Sales Report')).toBeInTheDocument();
+    expect(screen.queryByText('Product Report')).not.toBeInTheDocument();
+    expect(container.querySelector('.dm-card')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Filters/ })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
+  });
+
+  it('searches triggers by the Data Mart column', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [
+        buildProjectReportTrigger(),
+        buildProjectReportTrigger({
+          id: 'trigger-2',
+          reportId: 'report-2',
+          reportTitle: 'Product Report',
+          dataMartTitle: 'Product Mart',
+        }),
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Product Report')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Marketing' },
+    });
+
+    expect(screen.getByText('Daily Sales Report')).toBeInTheDocument();
+    expect(screen.queryByText('Product Report')).not.toBeInTheDocument();
+  });
+
+  it('searches triggers by the Run Target column', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [
+        buildProjectReportTrigger({
+          reportTitle: 'Daily Sales Report',
+          dataMartTitle: 'Marketing Mart',
+        }),
+        buildProjectReportTrigger({
+          id: 'trigger-2',
+          reportId: 'report-2',
+          reportTitle: 'Inventory Audit',
+          dataMartTitle: 'Warehouse Mart',
+        }),
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Inventory Audit')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Inventory' },
+    });
+
+    expect(screen.getByText('Inventory Audit')).toBeInTheDocument();
+    expect(screen.queryByText('Daily Sales Report')).not.toBeInTheDocument();
+  });
+
+  it('opens the trigger edit sheet when a trigger row is clicked', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectReportTrigger()],
+    });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByText('Daily Sales Report'));
+
+    expect(await screen.findByTestId('projectTriggerEditSheet')).toBeInTheDocument();
+    expect(screen.getByText('Trigger form 0 9 * * *')).toBeInTheDocument();
+  });
+
+  it('renders trigger row actions like the Data Mart triggers tab', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectReportTrigger()],
+    });
+
+    renderPage();
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Open menu' }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(await screen.findByText('Edit trigger')).toBeInTheDocument();
+    expect(screen.getByText('Delete trigger')).toBeInTheDocument();
+  });
+
+  it('restores hidden columns like the Data Mart triggers tab', async () => {
+    localStorage.setItem(
+      'project-data-mart-scheduled-triggers-column-visibility',
+      JSON.stringify({ triggerConfig: false })
+    );
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectReportTrigger()],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Trigger Type')).toBeInTheDocument();
+    expect(screen.queryByText('Run Target')).not.toBeInTheDocument();
+    expect(screen.queryByText('Daily Sales Report')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Toggle columns' })).toBeInTheDocument();
+  });
+
+  it('does not crash when a project-wide report trigger has no hydrated report', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectReportTriggerWithoutReport()],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Run Target')).toBeInTheDocument();
+    expect(await screen.findByText('Report')).toBeInTheDocument();
+  });
+
+  it('does not crash when a project-wide connector trigger has no hydrated connector', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectConnectorTriggerWithoutConfig()],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Run Target')).toBeInTheDocument();
+    expect(await screen.findByText('Connector')).toBeInTheDocument();
+  });
+
+  it('renders a project-wide connector trigger with the connector type title', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectConnectorTrigger()],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Run Target')).toBeInTheDocument();
+    expect(await screen.findByText('Facebook Marketing')).toBeInTheDocument();
+  });
+
+  it('uses the connector type icon for project-wide connector trigger run targets', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [buildProjectConnectorTrigger()],
+    });
+
+    renderPage();
+
+    const connectorIcon = await screen.findByRole('img', { name: 'icon' });
+    expect(connectorIcon).toHaveAttribute('src', 'data:image/png;base64,facebook-logo');
+  });
+
+  it('loads additional trigger pages when project search is active', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers)
+      .mockResolvedValueOnce({
+        triggers: Array.from({ length: 100 }, (_, index) =>
+          buildProjectReportTrigger({
+            id: `trigger-${index + 1}`,
+            reportId: `report-${index + 1}`,
+            reportTitle: `Report ${index + 1}`,
+          })
+        ),
+      })
+      .mockResolvedValueOnce({
+        triggers: [
+          buildProjectReportTrigger({
+            id: 'trigger-needle',
+            reportId: 'report-needle',
+            reportTitle: 'Needle Trigger Target',
+          }),
+        ],
+      });
+
+    renderPage();
+
+    expect(await screen.findByText('Report 1')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Needle' },
+    });
+
+    expect(await screen.findByText('Needle Trigger Target')).toBeInTheDocument();
+    expect(scheduledTriggerService.getProjectScheduledTriggers).toHaveBeenCalledWith(100, 100);
+  });
+});
+
+function renderPage(path = '/ui/project-1/data-marts/schedules') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <DataMartSchedulesPage />
+    </MemoryRouter>
+  );
+}
+
+function buildFilterPath(path: string, dataMartTitle: string) {
+  const filters = encodeURIComponent(
+    JSON.stringify([{ f: 'dataMart', o: 'eq', v: [dataMartTitle] }])
+  );
+  return `/ui/project-1/${path}?filters=${filters}`;
+}
+
+function getColumnHeaderLabels() {
+  return screen
+    .getAllByRole('columnheader')
+    .map(header => header.textContent.trim())
+    .filter((label): label is string => Boolean(label));
+}
+
+function buildProjectReportTrigger(
+  overrides: { id?: string; reportId?: string; reportTitle?: string; dataMartTitle?: string } = {}
+): ProjectScheduledTriggerResponseApiDto {
+  const reportId = overrides.reportId ?? 'report-1';
+
+  return {
+    id: overrides.id ?? 'trigger-1',
+    type: ScheduledTriggerType.REPORT_RUN,
+    cronExpression: '0 9 * * *',
+    timeZone: 'UTC',
+    isActive: true,
+    nextRunTimestamp: '2026-06-06T09:00:00.000Z',
+    lastRunTimestamp: null,
+    triggerConfig: {
+      type: TRIGGER_CONFIG_TYPES.SCHEDULED_REPORT_RUN,
+      reportId,
+      report: buildReportResponse({
+        id: reportId,
+        title: overrides.reportTitle,
+      }),
+    } as unknown as ProjectScheduledTriggerResponseApiDto['triggerConfig'],
+    createdById: 'user-1',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    modifiedAt: '2026-06-01T00:00:00.000Z',
+    createdByUser: null,
+    dataMart: {
+      id: 'dm-1',
+      title: overrides.dataMartTitle ?? 'Marketing Mart',
+    },
+  };
+}
+
+function buildReportResponse(overrides: { id?: string; title?: string } = {}): ReportResponseDto {
+  return {
+    id: overrides.id ?? 'report-1',
+    title: overrides.title ?? 'Daily Sales Report',
+    dataMart: {
+      id: 'dm-1',
+      title: 'Marketing Mart',
+      status: DataMartStatus.PUBLISHED,
+      storage: buildDataStorageResponse(),
+      definitionType: DataMartDefinitionType.SQL,
+      definition: null,
+      description: null,
+      triggersCount: 0,
+      reportsCount: 1,
+      createdByUser: null,
+      businessOwnerUsers: [],
+      technicalOwnerUsers: [],
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      modifiedAt: new Date('2026-06-01T00:00:00.000Z'),
+      schema: null,
+    },
+    dataDestinationAccess: {
+      id: 'dest-1',
+      title: 'Email',
+      type: DataDestinationType.EMAIL,
+      projectId: 'project-1',
+      credentials: {
+        type: DataDestinationCredentialsType.EMAIL_CREDENTIALS,
+        to: ['daily@example.com'],
+      },
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      modifiedAt: new Date('2026-06-01T00:00:00.000Z'),
+    },
+    destinationConfig: {
+      type: DestinationTypeConfigEnum.EMAIL_CONFIG,
+      reportCondition: ReportConditionEnum.ALWAYS,
+      subject: 'Daily Sales',
+      templateSource: {
+        type: TemplateSourceTypeEnum.CUSTOM_MESSAGE,
+        config: {
+          messageTemplate: 'Daily report',
+        },
+      },
+    },
+    columnConfig: null,
+    filterConfig: null,
+    sortConfig: null,
+    limitConfig: null,
+    lastRunAt: null,
+    lastRunStatus: null,
+    lastRunError: null,
+    runsCount: 0,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    modifiedAt: '2026-06-01T00:00:00.000Z',
+    createdByUser: null,
+    ownerUsers: [],
+    canRun: true,
+    canManageTriggers: true,
+    canEditConfig: true,
+  };
+}
+
+function buildProjectReportTriggerWithoutReport(): ProjectScheduledTriggerResponseApiDto {
+  return {
+    ...buildProjectReportTrigger(),
+    triggerConfig: {
+      type: TRIGGER_CONFIG_TYPES.SCHEDULED_REPORT_RUN,
+      reportId: 'report-1',
+    } as ProjectScheduledTriggerResponseApiDto['triggerConfig'],
+  };
+}
+
+function buildProjectConnectorTriggerWithoutConfig(): ProjectScheduledTriggerResponseApiDto {
+  return {
+    ...buildProjectReportTrigger(),
+    id: 'trigger-2',
+    type: ScheduledTriggerType.CONNECTOR_RUN,
+    triggerConfig: undefined as unknown as ProjectScheduledTriggerResponseApiDto['triggerConfig'],
+  };
+}
+
+function buildProjectConnectorTrigger(): ProjectScheduledTriggerResponseApiDto {
+  return {
+    ...buildProjectConnectorTriggerWithoutConfig(),
+    triggerConfig: {
+      type: TRIGGER_CONFIG_TYPES.SCHEDULED_CONNECTOR_RUN,
+      connector: {
+        connector: {
+          source: {
+            name: 'FacebookMarketing',
+            configuration: [],
+            node: 'ads',
+            fields: ['campaign'],
+          },
+          storage: {
+            fullyQualifiedName: 'dataset.table',
+          },
+        },
+      },
+    } as unknown as ProjectScheduledTriggerResponseApiDto['triggerConfig'],
+  };
+}
+
+function buildDataStorageResponse(): ReportResponseDto['dataMart']['storage'] {
+  return {
+    id: 'storage-1',
+    title: 'BigQuery Storage',
+    type: DataStorageType.GOOGLE_BIGQUERY,
+    credentials: null,
+    config: {
+      projectId: 'test-project',
+      location: 'US',
+    },
+    createdAt: '2026-06-01T00:00:00.000Z',
+    modifiedAt: '2026-06-01T00:00:00.000Z',
+    publishedDataMartsCount: 1,
+    draftDataMartsCount: 0,
+  };
+}

--- a/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.tsx
+++ b/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.tsx
@@ -427,6 +427,8 @@ function DataMartSchedulesPageContent() {
         cell: ({ row }) => (
           <ScheduledTriggerActionsCell
             trigger={row.original}
+            canEdit={row.original.canEdit}
+            canDelete={row.original.canDelete}
             onEditTrigger={() => {
               setEditingTrigger(row.original);
             }}
@@ -492,7 +494,9 @@ function DataMartSchedulesPageContent() {
                 </div>
               )}
               onRowClick={row => {
-                setEditingTrigger(row.original);
+                if (row.original.canEdit) {
+                  setEditingTrigger(row.original);
+                }
               }}
             />
 

--- a/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.tsx
+++ b/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.tsx
@@ -1,0 +1,539 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import type { ColumnDef } from '@tanstack/react-table';
+import { RefreshCw } from 'lucide-react';
+import { Badge } from '@owox/ui/components/badge';
+import { Button } from '@owox/ui/components/button';
+import RelativeTime from '@owox/ui/components/common/relative-time';
+import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
+import { extractApiError } from '../../../app/api';
+import { ConnectorContextProvider } from '../../../features/connectors/shared/model/context';
+import { useConnector } from '../../../features/connectors/shared/model/hooks/useConnector';
+import type { ConnectorListItem } from '../../../features/connectors/shared/model/types/connector';
+import { DataMartContext } from '../../../features/data-marts/edit/model/context/context';
+import { ScheduledTriggerType } from '../../../features/data-marts/scheduled-triggers/enums';
+import { ScheduleDisplay } from '../../../features/data-marts/scheduled-triggers/components/ScheduleDisplay/ScheduleDisplay';
+import { ScheduledTriggerActionsCell } from '../../../features/data-marts/scheduled-triggers/components/ScheduledTriggerTable/ScheduledTriggerActionsCell';
+import { ScheduledTriggerRunTarget } from '../../../features/data-marts/scheduled-triggers/components/ScheduledTriggerTable/ScheduledTriggerRunTarget';
+import { ScheduledTriggerMapper } from '../../../features/data-marts/scheduled-triggers/model/mappers';
+import type { ProjectScheduledTrigger } from '../../../features/data-marts/scheduled-triggers/model/scheduled-trigger.model';
+import type {
+  ScheduledConnectorRunConfig,
+  ScheduledReportRunConfig,
+} from '../../../features/data-marts/scheduled-triggers/model/trigger-config.types';
+import { scheduledTriggerService } from '../../../features/data-marts/scheduled-triggers/services';
+import {
+  ScheduledTriggerColumnKey,
+  ScheduledTriggerColumnLabels,
+} from '../../../features/data-marts/scheduled-triggers/components/ScheduledTriggerTable/columns';
+import { StatusLabel, StatusTypeEnum } from '../../../shared/components/StatusLabel';
+import { BaseTable, SortableHeader, ToggleColumnsHeader } from '../../../shared/components/Table';
+import {
+  applyFiltersToData,
+  type FilterAccessors,
+  type FilterConfigItem,
+} from '../../../shared/components/TableFilters';
+import { collectOptionsFromData } from '../../../shared/components/TableFilters/collectOptions.utils';
+import { UserReference } from '../../../shared/components/UserReference';
+import { useBaseTable, usePersistentFilters, useProjectRoute } from '../../../shared/hooks';
+import { ProjectDataMartTableFilters } from '../shared/ProjectDataMartTableFilters';
+import { ProjectDataMartTableSearch } from '../shared/ProjectDataMartTableSearch';
+import {
+  buildProjectTableUserLabelMapper,
+  matchesProjectTableSearch,
+} from '../shared/ProjectDataMartTableFilters.utils';
+import { buildProjectDataMartContextValue } from '../shared/projectDataMartContext';
+import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
+import { ProjectScheduledTriggerEditSheet } from './ProjectScheduledTriggerEditSheet';
+
+const DATA_MART_SCHEDULES_PAGE_SIZE = 100;
+const PROJECT_SCHEDULED_TRIGGERS_TABLE_ID = 'project-scheduled-triggers-table';
+
+type ProjectScheduledTriggerFilterKey =
+  | 'dataMart'
+  | 'triggerType'
+  | 'runTarget'
+  | 'triggerStatus'
+  | 'createdBy';
+
+function buildProjectScheduledTriggerFilterAccessors(
+  connectors: ConnectorListItem[]
+): FilterAccessors<ProjectScheduledTriggerFilterKey, ProjectScheduledTrigger> {
+  return {
+    dataMart: row => row.dataMart.title,
+    triggerType: row => row.type,
+    runTarget: row => getScheduledTriggerRunTargetTitle(row, connectors),
+    triggerStatus: row => String(row.isActive),
+    createdBy: row => row.createdByUser?.userId,
+  };
+}
+
+function getScheduledTriggerTypeLabel(value: string) {
+  switch (value) {
+    case 'REPORT_RUN':
+      return 'Report Run';
+    case 'CONNECTOR_RUN':
+      return 'Connector Run';
+    default:
+      return value;
+  }
+}
+
+function getScheduledTriggerRunTargetTitle(
+  trigger: ProjectScheduledTrigger,
+  connectors: ConnectorListItem[] = []
+) {
+  if (trigger.type === ScheduledTriggerType.REPORT_RUN) {
+    const config = trigger.triggerConfig as ScheduledReportRunConfig | undefined;
+    return config?.report?.title ?? config?.reportId ?? 'Report';
+  }
+
+  const config = trigger.triggerConfig as ScheduledConnectorRunConfig | undefined;
+  const connectorSourceName = config?.connector?.connector.source.name;
+  const connector = connectors.find(item => item.name === connectorSourceName);
+  return (
+    connector?.displayName ??
+    config?.connector?.connector.info?.displayName ??
+    connectorSourceName ??
+    'Connector'
+  );
+}
+
+function buildProjectScheduledTriggerFilters(
+  data: ProjectScheduledTrigger[],
+  connectors: ConnectorListItem[]
+): FilterConfigItem<ProjectScheduledTriggerFilterKey>[] {
+  const filterAccessors = buildProjectScheduledTriggerFilterAccessors(connectors);
+  const userLabelMapper = buildProjectTableUserLabelMapper(
+    data.map(trigger => trigger.createdByUser)
+  );
+
+  return [
+    {
+      id: 'dataMart',
+      label: 'Data Mart',
+      dataType: 'string',
+      operators: ['contains', 'not_contains', 'eq', 'neq'],
+      options: collectOptionsFromData(data, filterAccessors.dataMart),
+    },
+    {
+      id: 'triggerType',
+      label: 'Trigger Type',
+      dataType: 'enum',
+      operators: ['eq', 'neq'],
+      options: collectOptionsFromData(data, filterAccessors.triggerType, {
+        labelMapper: getScheduledTriggerTypeLabel,
+      }),
+    },
+    {
+      id: 'runTarget',
+      label: 'Run Target',
+      dataType: 'string',
+      operators: ['contains', 'not_contains', 'eq', 'neq'],
+      options: collectOptionsFromData(data, filterAccessors.runTarget),
+    },
+    {
+      id: 'triggerStatus',
+      label: 'Trigger Status',
+      dataType: 'enum',
+      operators: ['eq', 'neq'],
+      options: collectOptionsFromData(data, filterAccessors.triggerStatus, {
+        labelMapper: value => (value === 'true' ? 'Enabled' : 'Disabled'),
+      }),
+    },
+    {
+      id: 'createdBy',
+      label: 'Created By',
+      dataType: 'enum',
+      operators: ['eq', 'neq'],
+      options: collectOptionsFromData(data, filterAccessors.createdBy, {
+        labelMapper: userLabelMapper,
+      }),
+    },
+  ];
+}
+
+function DataMartSchedulesPageContent() {
+  const { projectId = '' } = useParams<{ projectId: string }>();
+  const { scope } = useProjectRoute();
+  const { connectors, fetchAvailableConnectors } = useConnector();
+  const [triggers, setTriggers] = useState<ProjectScheduledTrigger[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMoreTriggersToLoad, setHasMoreTriggersToLoad] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [editingTrigger, setEditingTrigger] = useState<ProjectScheduledTrigger | null>(null);
+
+  const loadTriggers = useCallback(async (offset = 0) => {
+    const isInitialLoad = offset === 0;
+    if (isInitialLoad) {
+      setIsLoading(true);
+    } else {
+      setIsLoadingMore(true);
+    }
+    setError(null);
+
+    try {
+      const response = await scheduledTriggerService.getProjectScheduledTriggers(
+        DATA_MART_SCHEDULES_PAGE_SIZE,
+        offset
+      );
+      const nextTriggers = ScheduledTriggerMapper.mapProjectFromDtoList(response);
+      setTriggers(currentTriggers =>
+        isInitialLoad ? nextTriggers : [...currentTriggers, ...nextTriggers]
+      );
+      setHasMoreTriggersToLoad(nextTriggers.length >= DATA_MART_SCHEDULES_PAGE_SIZE);
+    } catch (caught) {
+      setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart triggers');
+    } finally {
+      setIsLoading(false);
+      setIsLoadingMore(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadTriggers(0);
+  }, [loadTriggers]);
+
+  useEffect(() => {
+    void fetchAvailableConnectors();
+  }, [fetchAvailableConnectors]);
+
+  const loadMoreTriggers = useCallback(async () => {
+    if (isLoadingMore || !hasMoreTriggersToLoad) return;
+    await loadTriggers(triggers.length);
+  }, [hasMoreTriggersToLoad, isLoadingMore, loadTriggers, triggers.length]);
+
+  const handleCloseTriggerEditSheet = useCallback(() => {
+    setEditingTrigger(null);
+  }, []);
+
+  const handleTriggerSaved = useCallback(async () => {
+    await loadTriggers(0);
+  }, [loadTriggers]);
+
+  const handleDeleteTrigger = useCallback(
+    async (trigger: ProjectScheduledTrigger) => {
+      await scheduledTriggerService.deleteScheduledTrigger(trigger.dataMart.id, trigger.id);
+      await loadTriggers(0);
+    },
+    [loadTriggers]
+  );
+
+  const filterAccessors = useMemo(
+    () => buildProjectScheduledTriggerFilterAccessors(connectors),
+    [connectors]
+  );
+
+  const filtersConfig = useMemo(
+    () => buildProjectScheduledTriggerFilters(triggers, connectors),
+    [connectors, triggers]
+  );
+
+  const { appliedState, apply, clear } = usePersistentFilters<ProjectScheduledTriggerFilterKey>({
+    projectId,
+    tableId: PROJECT_SCHEDULED_TRIGGERS_TABLE_ID,
+    urlParam: 'filters',
+    config: filtersConfig,
+  });
+
+  const shouldLoadAllTriggersForQuery =
+    searchQuery.trim().length > 0 || appliedState.filters.length > 0;
+
+  useEffect(() => {
+    if (!shouldLoadAllTriggersForQuery || !hasMoreTriggersToLoad || isLoading || isLoadingMore) {
+      return;
+    }
+
+    void loadTriggers(triggers.length);
+  }, [
+    hasMoreTriggersToLoad,
+    isLoading,
+    isLoadingMore,
+    loadTriggers,
+    shouldLoadAllTriggersForQuery,
+    triggers.length,
+  ]);
+
+  const filteredTriggers = useMemo(
+    () =>
+      applyFiltersToData<ProjectScheduledTriggerFilterKey, ProjectScheduledTrigger>(
+        triggers,
+        appliedState,
+        filterAccessors
+      ),
+    [appliedState, filterAccessors, triggers]
+  );
+
+  const searchedTriggers = useMemo(
+    () =>
+      filteredTriggers.filter(trigger =>
+        matchesProjectTableSearch(searchQuery, [
+          trigger.dataMart.title,
+          getScheduledTriggerTypeLabel(trigger.type),
+          getScheduledTriggerRunTargetTitle(trigger, connectors),
+          trigger.cronExpression,
+          trigger.isActive ? 'Enabled' : 'Disabled',
+          trigger.createdByUser?.fullName,
+          trigger.createdByUser?.email,
+        ])
+      ),
+    [connectors, filteredTriggers, searchQuery]
+  );
+
+  const columns = useMemo<ColumnDef<ProjectScheduledTrigger>[]>(
+    () => [
+      {
+        id: 'dataMart',
+        accessorFn: row => row.dataMart.title,
+        meta: { title: 'Data Mart' },
+        size: 260,
+        header: ({ column }) => <SortableHeader column={column}>Data Mart</SortableHeader>,
+        cell: ({ row }) => (
+          <Link
+            to={scope(`/data-marts/${row.original.dataMart.id}/triggers`)}
+            onClick={event => {
+              event.stopPropagation();
+            }}
+            className='text-foreground hover:text-primary inline-block max-w-full truncate transition-colors'
+          >
+            {row.original.dataMart.title}
+          </Link>
+        ),
+      },
+      {
+        accessorKey: ScheduledTriggerColumnKey.TYPE,
+        meta: { title: ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.TYPE] },
+        size: 170,
+        header: ({ column }) => (
+          <SortableHeader column={column}>
+            {ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.TYPE]}
+          </SortableHeader>
+        ),
+        cell: ({ row }) => {
+          const label =
+            row.original.type === ScheduledTriggerType.REPORT_RUN ? 'Report Run' : 'Connector Run';
+          return <Badge variant='outline'>{label}</Badge>;
+        },
+      },
+      {
+        accessorKey: ScheduledTriggerColumnKey.TRIGGER_CONFIG,
+        meta: { title: ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.TRIGGER_CONFIG] },
+        size: 220,
+        header: ({ column }) => (
+          <SortableHeader column={column}>
+            {ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.TRIGGER_CONFIG]}
+          </SortableHeader>
+        ),
+        cell: ({ row }) => (
+          <DataMartContext.Provider value={buildProjectDataMartContextValue(row.original.dataMart)}>
+            <ScheduledTriggerRunTarget trigger={row.original} />
+          </DataMartContext.Provider>
+        ),
+      },
+      {
+        accessorKey: ScheduledTriggerColumnKey.CRON_EXPRESSION,
+        meta: { title: ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.CRON_EXPRESSION] },
+        size: 190,
+        header: ({ column }) => (
+          <SortableHeader column={column}>
+            {ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.CRON_EXPRESSION]}
+          </SortableHeader>
+        ),
+        cell: ({ row }) => (
+          <ScheduleDisplay
+            cronExpression={row.original.cronExpression}
+            timeZone={row.original.timeZone}
+            isEnabled={row.original.isActive}
+          />
+        ),
+      },
+      {
+        accessorKey: ScheduledTriggerColumnKey.NEXT_RUN,
+        meta: { title: ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.NEXT_RUN] },
+        size: 160,
+        header: ({ column }) => (
+          <SortableHeader column={column}>
+            {ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.NEXT_RUN]}
+          </SortableHeader>
+        ),
+        cell: ({ row }) => (
+          <div className='text-muted-foreground text-sm'>
+            {row.original.nextRun ? <RelativeTime date={row.original.nextRun} /> : 'Not scheduled'}
+          </div>
+        ),
+      },
+      {
+        accessorKey: ScheduledTriggerColumnKey.LAST_RUN,
+        meta: { title: ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.LAST_RUN] },
+        size: 150,
+        header: ({ column }) => (
+          <SortableHeader column={column}>
+            {ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.LAST_RUN]}
+          </SortableHeader>
+        ),
+        cell: ({ row }) => (
+          <div className='text-sm'>
+            {row.original.lastRun ? (
+              <RelativeTime date={row.original.lastRun} />
+            ) : (
+              <span className='text-muted-foreground text-sm'>Never run</span>
+            )}
+          </div>
+        ),
+      },
+      {
+        accessorKey: ScheduledTriggerColumnKey.IS_ACTIVE,
+        meta: { title: ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.IS_ACTIVE] },
+        size: 150,
+        header: ({ column }) => (
+          <SortableHeader column={column}>
+            {ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.IS_ACTIVE]}
+          </SortableHeader>
+        ),
+        cell: ({ row }) => (
+          <StatusLabel
+            type={row.original.isActive ? StatusTypeEnum.SUCCESS : StatusTypeEnum.NEUTRAL}
+            variant='ghost'
+            showIcon={false}
+          >
+            {row.original.isActive ? 'Enabled' : 'Disabled'}
+          </StatusLabel>
+        ),
+      },
+      {
+        id: ScheduledTriggerColumnKey.CREATED_BY,
+        accessorFn: row => row.createdByUser?.fullName ?? row.createdByUser?.email,
+        meta: { title: ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.CREATED_BY] },
+        size: 180,
+        header: ({ column }) => (
+          <SortableHeader column={column}>
+            {ScheduledTriggerColumnLabels[ScheduledTriggerColumnKey.CREATED_BY]}
+          </SortableHeader>
+        ),
+        cell: ({ row }) => {
+          const user = row.original.createdByUser;
+          if (!user) return <span className='text-muted-foreground'>-</span>;
+          return <UserReference userProjection={user} />;
+        },
+      },
+      {
+        id: 'actions',
+        size: 80,
+        enableResizing: false,
+        enableSorting: false,
+        header: ({ table }) => <ToggleColumnsHeader table={table} />,
+        cell: ({ row }) => (
+          <ScheduledTriggerActionsCell
+            trigger={row.original}
+            onEditTrigger={() => {
+              setEditingTrigger(row.original);
+            }}
+            onDeleteTrigger={() => {
+              void handleDeleteTrigger(row.original);
+            }}
+          />
+        ),
+      },
+    ],
+    [handleDeleteTrigger, scope]
+  );
+
+  const { table } = useBaseTable<ProjectScheduledTrigger>({
+    data: searchedTriggers,
+    columns,
+    storageKeyPrefix: 'project-data-mart-scheduled-triggers',
+    defaultSortingColumn: ScheduledTriggerColumnKey.NEXT_RUN,
+    defaultPageSize: DATA_MART_SCHEDULES_PAGE_SIZE,
+    enableRowSelection: false,
+  });
+
+  return (
+    <div className='dm-page' data-testid='dataMartSchedulesPage'>
+      <header className='dm-page-header'>
+        <h1 className='dm-page-header-title'>Triggers</h1>
+      </header>
+
+      <div className='dm-page-content'>
+        {isLoading ? (
+          <SkeletonList />
+        ) : error ? (
+          <div className='dm-card-block text-destructive text-sm'>{error}</div>
+        ) : triggers.length === 0 ? (
+          <div className='dm-card'>
+            <ProjectDataMartEmptyState variant='triggers' />
+          </div>
+        ) : (
+          <div className='dm-card' data-testid='projectScheduledTriggersTable'>
+            <BaseTable
+              tableId={PROJECT_SCHEDULED_TRIGGERS_TABLE_ID}
+              table={table}
+              ariaLabel='Project Data Mart Triggers'
+              paginationProps={{ displaySelected: false }}
+              renderToolbarLeft={() => (
+                <>
+                  <ProjectDataMartTableFilters
+                    appliedState={appliedState}
+                    config={filtersConfig}
+                    onApply={apply}
+                    onClear={clear}
+                  />
+                  <ProjectDataMartTableSearch value={searchQuery} onChange={setSearchQuery} />
+                </>
+              )}
+              renderEmptyState={() => (
+                <div
+                  className='flex h-32 items-center justify-center text-center'
+                  role='status'
+                  aria-live='polite'
+                >
+                  No triggers found for accessible Data Marts
+                </div>
+              )}
+              onRowClick={row => {
+                setEditingTrigger(row.original);
+              }}
+            />
+
+            {hasMoreTriggersToLoad && (
+              <div className='flex justify-center pt-4 pb-6'>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={() => void loadMoreTriggers()}
+                  disabled={isLoadingMore}
+                  className='flex items-center gap-2'
+                >
+                  {isLoadingMore ? (
+                    <>
+                      <RefreshCw className='h-4 w-4 animate-spin' />
+                      Loading...
+                    </>
+                  ) : (
+                    'Load More'
+                  )}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <ProjectScheduledTriggerEditSheet
+        trigger={editingTrigger}
+        isOpen={editingTrigger !== null}
+        onClose={handleCloseTriggerEditSheet}
+        onSaved={handleTriggerSaved}
+      />
+    </div>
+  );
+}
+
+export default function DataMartSchedulesPage() {
+  return (
+    <ConnectorContextProvider>
+      <DataMartSchedulesPageContent />
+    </ConnectorContextProvider>
+  );
+}

--- a/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.tsx
+++ b/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import type { ColumnDef } from '@tanstack/react-table';
 import { RefreshCw } from 'lucide-react';
 import { Badge } from '@owox/ui/components/badge';
@@ -44,6 +44,7 @@ import {
 } from '../shared/ProjectDataMartTableFilters.utils';
 import { buildProjectDataMartContextValue } from '../shared/projectDataMartContext';
 import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
+import { ProjectDataMartTitleLink } from '../shared/ProjectDataMartTitleLink';
 import { ProjectScheduledTriggerEditSheet } from './ProjectScheduledTriggerEditSheet';
 
 const DATA_MART_SCHEDULES_PAGE_SIZE = 100;
@@ -291,15 +292,10 @@ function DataMartSchedulesPageContent() {
         size: 260,
         header: ({ column }) => <SortableHeader column={column}>Data Mart</SortableHeader>,
         cell: ({ row }) => (
-          <Link
+          <ProjectDataMartTitleLink
             to={scope(`/data-marts/${row.original.dataMart.id}/triggers`)}
-            onClick={event => {
-              event.stopPropagation();
-            }}
-            className='text-foreground hover:text-primary inline-block max-w-full truncate transition-colors'
-          >
-            {row.original.dataMart.title}
-          </Link>
+            title={row.original.dataMart.title}
+          />
         ),
       },
       {

--- a/apps/web/src/pages/data-marts/schedules/ProjectScheduledTriggerEditSheet.tsx
+++ b/apps/web/src/pages/data-marts/schedules/ProjectScheduledTriggerEditSheet.tsx
@@ -1,0 +1,136 @@
+import { useCallback, useMemo } from 'react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@owox/ui/components/sheet';
+import { ConfirmationDialog } from '../../../shared/components/ConfirmationDialog';
+import { useUnsavedGuard } from '../../../hooks/useUnsavedGuard';
+import { useIntercomLauncher } from '../../../shared/hooks/useIntercomLauncher';
+import { DataMartContext } from '../../../features/data-marts/edit/model/context/context';
+import { ScheduledTriggerForm } from '../../../features/data-marts/scheduled-triggers/components/ScheduledTriggerForm';
+import {
+  ScheduledTriggerType,
+  TRIGGER_CONFIG_TYPES,
+} from '../../../features/data-marts/scheduled-triggers/enums';
+import type { ProjectScheduledTrigger } from '../../../features/data-marts/scheduled-triggers/model/scheduled-trigger.model';
+import type { ScheduledReportRunConfig } from '../../../features/data-marts/scheduled-triggers/model/trigger-config.types';
+import type { ScheduledTriggerFormData } from '../../../features/data-marts/scheduled-triggers/schemas';
+import { scheduledTriggerService } from '../../../features/data-marts/scheduled-triggers/services';
+import { buildProjectDataMartContextValue } from '../shared/projectDataMartContext';
+
+interface ProjectScheduledTriggerEditSheetProps {
+  trigger: ProjectScheduledTrigger | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSaved?: () => Promise<void> | void;
+}
+
+export function ProjectScheduledTriggerEditSheet({
+  trigger,
+  isOpen,
+  onClose,
+  onSaved,
+}: ProjectScheduledTriggerEditSheetProps) {
+  useIntercomLauncher(isOpen);
+
+  const {
+    showUnsavedDialog,
+    setShowUnsavedDialog,
+    handleClose,
+    confirmClose,
+    handleFormDirtyChange,
+    handleFormSubmitSuccess,
+  } = useUnsavedGuard(onClose);
+
+  const initialFormData = useMemo<ScheduledTriggerFormData | undefined>(() => {
+    if (!trigger) return undefined;
+
+    return {
+      type: trigger.type,
+      cronExpression: trigger.cronExpression,
+      timeZone: trigger.timeZone,
+      isActive: trigger.isActive,
+      triggerConfig:
+        trigger.type === ScheduledTriggerType.REPORT_RUN
+          ? {
+              type: TRIGGER_CONFIG_TYPES.SCHEDULED_REPORT_RUN,
+              reportId: (trigger.triggerConfig as ScheduledReportRunConfig).reportId,
+            }
+          : null,
+    };
+  }, [trigger]);
+
+  const dataMartContextValue = useMemo(() => {
+    if (!trigger) return null;
+    return buildProjectDataMartContextValue({
+      ...trigger.dataMart,
+      createdAt: trigger.createdAt,
+      modifiedAt: trigger.modifiedAt,
+      createdByUser: trigger.createdByUser,
+    });
+  }, [trigger]);
+
+  const handleSubmit = useCallback(
+    async (data: ScheduledTriggerFormData) => {
+      if (!trigger) return;
+
+      await scheduledTriggerService.updateScheduledTrigger(trigger.dataMart.id, trigger.id, {
+        cronExpression: data.cronExpression,
+        timeZone: data.timeZone,
+        isActive: data.isActive,
+      });
+      await onSaved?.();
+      handleFormSubmitSuccess();
+    },
+    [handleFormSubmitSuccess, onSaved, trigger]
+  );
+
+  if (!trigger || !initialFormData || !dataMartContextValue) {
+    return null;
+  }
+
+  return (
+    <>
+      <Sheet
+        open={isOpen}
+        onOpenChange={open => {
+          if (!open) {
+            handleClose();
+          }
+        }}
+      >
+        <SheetContent data-testid='projectTriggerEditSheet'>
+          <SheetHeader>
+            <SheetTitle>Edit Scheduled Trigger</SheetTitle>
+            <SheetDescription>
+              Configure automatic runs for your reports or connectors.
+            </SheetDescription>
+          </SheetHeader>
+
+          <DataMartContext.Provider value={dataMartContextValue}>
+            <ScheduledTriggerForm
+              initialData={initialFormData}
+              onSubmit={handleSubmit}
+              onCancel={handleClose}
+              onDirtyChange={handleFormDirtyChange}
+            />
+          </DataMartContext.Provider>
+        </SheetContent>
+      </Sheet>
+
+      <ConfirmationDialog
+        open={showUnsavedDialog}
+        onOpenChange={setShowUnsavedDialog}
+        title='Unsaved Changes'
+        description='You have unsaved changes. Exit without saving?'
+        confirmLabel='Yes, leave now'
+        cancelLabel='No, stay here'
+        onConfirm={confirmClose}
+        variant='destructive'
+      />
+    </>
+  );
+}

--- a/apps/web/src/pages/data-marts/shared/ProjectDataMartEmptyState.tsx
+++ b/apps/web/src/pages/data-marts/shared/ProjectDataMartEmptyState.tsx
@@ -1,0 +1,63 @@
+import { Link } from 'react-router-dom';
+import { ArrowRight, CalendarClock, FileText, History, Sparkles } from 'lucide-react';
+import { Button } from '@owox/ui/components/button';
+import { useProjectRoute } from '../../../shared/hooks';
+
+type ProjectDataMartEmptyStateVariant = 'triggers' | 'reports' | 'insights' | 'runs';
+
+const EMPTY_STATE_COPY = {
+  triggers: {
+    icon: CalendarClock,
+    title: 'No triggers yet',
+    description:
+      'Triggers created inside Data Marts will appear here with their schedule, run target, and status.',
+  },
+  reports: {
+    icon: FileText,
+    title: 'No reports yet',
+    description:
+      'Reports configured inside Data Marts will appear here with their destination, run status, and actions.',
+  },
+  insights: {
+    icon: Sparkles,
+    title: 'No insights yet',
+    description:
+      'Insights created from Data Mart data will appear here with their update details and actions.',
+  },
+  runs: {
+    icon: History,
+    title: 'No runs yet',
+    description: 'Data Mart runs will appear here as they start and finish across the project.',
+  },
+} satisfies Record<
+  ProjectDataMartEmptyStateVariant,
+  {
+    icon: typeof CalendarClock;
+    title: string;
+    description: string;
+  }
+>;
+
+interface ProjectDataMartEmptyStateProps {
+  variant: ProjectDataMartEmptyStateVariant;
+}
+
+export function ProjectDataMartEmptyState({ variant }: ProjectDataMartEmptyStateProps) {
+  const { scope } = useProjectRoute();
+  const copy = EMPTY_STATE_COPY[variant];
+  const Icon = copy.icon;
+
+  return (
+    <div className='dm-empty-state' data-testid={`project-${variant}-empty-state`}>
+      <Icon className='dm-empty-state-ico' strokeWidth={1} />
+      <h2 className='dm-empty-state-title'>{copy.title}</h2>
+      <p className='dm-empty-state-subtitle'>{copy.description}</p>
+      <Button variant='outline' asChild>
+        <Link to={scope('/data-marts')}>
+          <ArrowRight className='h-4 w-4' />
+          Choose a Data Mart
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/pages/data-marts/shared/ProjectDataMartTableFilters.tsx
+++ b/apps/web/src/pages/data-marts/shared/ProjectDataMartTableFilters.tsx
@@ -1,0 +1,28 @@
+import {
+  TableFilters,
+  TableFiltersContent,
+  TableFiltersTrigger,
+  type FilterConfigItem,
+} from '../../../shared/components/TableFilters';
+import type { FiltersState } from '../../../shared/components/TableFilters/types';
+
+interface ProjectDataMartTableFiltersProps<K extends string> {
+  appliedState: FiltersState<K>;
+  config: FilterConfigItem<K>[];
+  onApply: (state: FiltersState<K>) => void;
+  onClear: () => void;
+}
+
+export function ProjectDataMartTableFilters<K extends string>({
+  appliedState,
+  config,
+  onApply,
+  onClear,
+}: ProjectDataMartTableFiltersProps<K>) {
+  return (
+    <TableFilters appliedState={appliedState} onApply={onApply} onClear={onClear}>
+      <TableFiltersTrigger />
+      <TableFiltersContent config={config} />
+    </TableFilters>
+  );
+}

--- a/apps/web/src/pages/data-marts/shared/ProjectDataMartTableFilters.utils.ts
+++ b/apps/web/src/pages/data-marts/shared/ProjectDataMartTableFilters.utils.ts
@@ -1,0 +1,34 @@
+import type { UserProjection } from '../../../shared/types';
+
+export function buildProjectTableUserLabelMapper(users: (UserProjection | null | undefined)[]) {
+  const userLabelMap = new Map<string, string>();
+
+  for (const user of users) {
+    if (!user) continue;
+    userLabelMap.set(user.userId, user.fullName ?? user.email ?? user.userId);
+  }
+
+  return (userId: string) => userLabelMap.get(userId) ?? userId;
+}
+
+export function matchesProjectTableSearch(query: string, values: unknown[]) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  return values.flatMap(toSearchValues).join(' ').toLowerCase().includes(normalizedQuery);
+}
+
+function toSearchValues(value: unknown): string[] {
+  if (value == null) return [];
+  if (Array.isArray(value)) return value.flatMap(toSearchValues);
+  if (value instanceof Date) return [value.toISOString()];
+
+  switch (typeof value) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+      return [String(value)];
+    default:
+      return [];
+  }
+}

--- a/apps/web/src/pages/data-marts/shared/ProjectDataMartTableSearch.tsx
+++ b/apps/web/src/pages/data-marts/shared/ProjectDataMartTableSearch.tsx
@@ -14,8 +14,12 @@ export function ProjectDataMartTableSearch({
 }: ProjectDataMartTableSearchProps) {
   return (
     <div className='relative max-w-md min-w-0 flex-1'>
-      <Search className='text-muted-foreground absolute top-2.5 left-2 h-4 w-4' />
+      <Search
+        className='text-muted-foreground absolute top-2.5 left-2 h-4 w-4'
+        aria-hidden='true'
+      />
       <Input
+        aria-label={placeholder}
         placeholder={placeholder}
         value={value}
         onChange={event => {

--- a/apps/web/src/pages/data-marts/shared/ProjectDataMartTableSearch.tsx
+++ b/apps/web/src/pages/data-marts/shared/ProjectDataMartTableSearch.tsx
@@ -1,0 +1,28 @@
+import { Input } from '@owox/ui/components/input';
+import { Search } from 'lucide-react';
+
+interface ProjectDataMartTableSearchProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export function ProjectDataMartTableSearch({
+  value,
+  onChange,
+  placeholder = 'Search',
+}: ProjectDataMartTableSearchProps) {
+  return (
+    <div className='relative max-w-md min-w-0 flex-1'>
+      <Search className='text-muted-foreground absolute top-2.5 left-2 h-4 w-4' />
+      <Input
+        placeholder={placeholder}
+        value={value}
+        onChange={event => {
+          onChange(event.target.value);
+        }}
+        className='border-muted dark:border-muted/50 rounded-md border bg-white pl-8 text-sm dark:bg-white/4 dark:hover:bg-white/8'
+      />
+    </div>
+  );
+}

--- a/apps/web/src/pages/data-marts/shared/ProjectDataMartTitleLink.tsx
+++ b/apps/web/src/pages/data-marts/shared/ProjectDataMartTitleLink.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom';
+
+interface ProjectDataMartTitleLinkProps {
+  title: string;
+  to: string;
+}
+
+export function ProjectDataMartTitleLink({ title, to }: ProjectDataMartTitleLinkProps) {
+  return (
+    <Link
+      to={to}
+      onClick={event => {
+        event.stopPropagation();
+      }}
+      className='text-foreground hover:text-primary block w-full [overflow-wrap:anywhere] break-words whitespace-normal transition-colors'
+    >
+      {title}
+    </Link>
+  );
+}

--- a/apps/web/src/pages/data-marts/shared/projectDataMartContext.ts
+++ b/apps/web/src/pages/data-marts/shared/projectDataMartContext.ts
@@ -1,0 +1,92 @@
+import type { UserProjection } from '../../../shared/types';
+import type { DataMart } from '../../../features/data-marts/edit/model/types';
+import type { DataMartContextType } from '../../../features/data-marts/edit/model/context/types';
+import { DataMartStatus, DataMartStatusModel } from '../../../features/data-marts/shared';
+import { DataStorageType } from '../../../features/data-storage/shared/model/types/data-storage-type.enum';
+import type { DataStorage } from '../../../features/data-storage/shared/model/types/data-storage';
+
+interface ProjectDataMartContextRef {
+  id: string;
+  title: string;
+  createdAt?: Date;
+  modifiedAt?: Date;
+  createdByUser?: UserProjection | null;
+  storage?: DataStorage | null;
+}
+
+export function buildProjectDataMartContextValue(
+  dataMartRef: ProjectDataMartContextRef
+): DataMartContextType {
+  const fallbackDate = new Date(0);
+  const dataMart = {
+    id: dataMartRef.id,
+    title: dataMartRef.title,
+    description: null,
+    status: DataMartStatusModel.getInfo(DataMartStatus.PUBLISHED),
+    storage: dataMartRef.storage ?? buildFallbackStorage(fallbackDate),
+    definitionType: null,
+    definition: null,
+    canPublish: false,
+    validationErrors: [],
+    createdAt: dataMartRef.createdAt ?? fallbackDate,
+    modifiedAt: dataMartRef.modifiedAt ?? fallbackDate,
+    schema: null,
+    canActualizeSchema: false,
+    connectorState: null,
+    blendedFieldsConfig: null,
+    createdByUser: dataMartRef.createdByUser ?? null,
+    businessOwnerUsers: [],
+    technicalOwnerUsers: [],
+    availableForReporting: true,
+    availableForMaintenance: true,
+    contexts: [],
+  } as unknown as DataMart;
+
+  const noopPromise = () => Promise.resolve();
+
+  return {
+    dataMart,
+    isLoading: false,
+    isLoadingMoreRuns: false,
+    error: null,
+    runs: [],
+    isManualRunTriggered: false,
+    hasMoreRunsToLoad: false,
+    hasActiveRuns: false,
+    getDataMart: noopPromise,
+    syncDataMartFromResponse: noopPromise,
+    refreshDataMart: noopPromise,
+    createDataMart: () => Promise.resolve({ id: dataMart.id, title: dataMart.title }),
+    updateDataMart: noopPromise,
+    deleteDataMart: noopPromise,
+    updateDataMartTitle: noopPromise,
+    updateDataMartDescription: noopPromise,
+    updateDataMartStorage: () => undefined,
+    updateDataMartDefinition: noopPromise,
+    publishDataMart: noopPromise,
+    runDataMart: noopPromise,
+    cancelDataMartRun: noopPromise,
+    actualizeDataMartSchema: noopPromise,
+    updateDataMartSchema: noopPromise,
+    getDataMartRuns: () => Promise.resolve([]),
+    getDataMartRunById: () =>
+      Promise.reject(new Error('Data Mart run details are not available from project lists.')),
+    loadMoreDataMartRuns: () => Promise.resolve([]),
+    updateDataMartOwners: noopPromise,
+    getErrorMessage: () => null,
+    resetManualRunTriggered: () => undefined,
+    reset: () => undefined,
+  } as DataMartContextType;
+}
+
+function buildFallbackStorage(fallbackDate: Date): DataStorage {
+  return {
+    id: '',
+    title: '',
+    type: DataStorageType.GOOGLE_BIGQUERY,
+    credentials: null,
+    config: null,
+    createdAt: fallbackDate,
+    modifiedAt: fallbackDate,
+  } as unknown as DataStorage;
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -3,6 +3,10 @@ import MainLayout from '../layouts/MainLayout';
 import About from '../pages/About';
 import NotFound from '../pages/NotFound';
 import DataMartsPage from '../pages/data-marts/list/DataMartsPage.tsx';
+import DataMartInsightsPage from '../pages/data-marts/insights/DataMartInsightsPage.tsx';
+import DataMartReportsPage from '../pages/data-marts/reports/DataMartReportsPage.tsx';
+import DataMartRunsPage from '../pages/data-marts/runs/DataMartRunsPage.tsx';
+import DataMartSchedulesPage from '../pages/data-marts/schedules/DataMartSchedulesPage.tsx';
 import { DataMartDetailsPage } from '../pages/data-marts/edit';
 import CreateDataMartPage from '../pages/data-marts/create/CreateDataMartPage.tsx';
 import { DataStorageListPage } from '../pages/data-storage';
@@ -53,6 +57,26 @@ const routes: RouteObject[] = [
       {
         path: 'data-marts/create',
         element: <CreateDataMartPage />,
+        errorElement: <LayoutErrorBoundary />,
+      },
+      {
+        path: 'data-marts/runs',
+        element: <DataMartRunsPage />,
+        errorElement: <LayoutErrorBoundary />,
+      },
+      {
+        path: 'data-marts/schedules',
+        element: <DataMartSchedulesPage />,
+        errorElement: <LayoutErrorBoundary />,
+      },
+      {
+        path: 'data-marts/reports',
+        element: <DataMartReportsPage />,
+        errorElement: <LayoutErrorBoundary />,
+      },
+      {
+        path: 'data-marts/insights',
+        element: <DataMartInsightsPage />,
         errorElement: <LayoutErrorBoundary />,
       },
       {

--- a/apps/web/src/shared/components/Table/BaseTable.tsx
+++ b/apps/web/src/shared/components/Table/BaseTable.tsx
@@ -175,7 +175,12 @@ export function BaseTable<TData>({
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() && 'selected'}
-                  className='group cursor-pointer transition-colors duration-200 hover:bg-black/4 dark:border-white/4 dark:bg-transparent dark:hover:bg-white/4'
+                  className={cn(
+                    'group transition-colors duration-200 dark:border-white/4 dark:bg-transparent',
+                    onRowClick
+                      ? 'cursor-pointer hover:bg-black/4 dark:hover:bg-white/4'
+                      : 'cursor-default'
+                  )}
                   onClick={
                     onRowClick
                       ? e => {

--- a/apps/web/src/shared/hooks/useBaseTable.ts
+++ b/apps/web/src/shared/hooks/useBaseTable.ts
@@ -27,6 +27,8 @@ export interface UseBaseTableConfig<TData> {
   defaultColumnVisibility?: VisibilityState;
   /** Default column ID for initial sorting */
   defaultSortingColumn?: string;
+  /** Default table page size */
+  defaultPageSize?: number;
   /** Enable row selection functionality */
   enableRowSelection?: boolean;
 }
@@ -70,6 +72,7 @@ export function useBaseTable<TData>({
   storageKeyPrefix,
   defaultColumnVisibility,
   defaultSortingColumn,
+  defaultPageSize,
   enableRowSelection = false,
 }: UseBaseTableConfig<TData>): UseBaseTableReturn<TData> {
   // Initialize table storage (sorting, visibility, pagination, sizing)
@@ -87,6 +90,7 @@ export function useBaseTable<TData>({
     storageKeyPrefix,
     defaultColumnVisibility,
     defaultSortingColumn,
+    defaultPageSize,
   });
 
   // Local state for column filters and row selection


### PR DESCRIPTION
## Feature Suggestion

This draft PR proposes adding project-level Data Mart activity pages. The idea is to keep the existing per-Data-Mart tabs, but also give users a faster way to understand what is configured and what is currently happening across the whole project.

Today the user often has to open individual Data Marts to answer project-level questions like "what is scheduled?", "which reports and insights exist?", or "what has failed recently?". These pages make those answers available from the left navigation while preserving the existing detail workflows.

## Access Model

The project-level lists keep the current access model in place.

- All new list endpoints require the existing viewer-level auth context.
- Admins can see the full project; non-admin users are filtered through the same role scope and Data Mart visibility rules used elsewhere.
- Reports are returned with existing action capabilities: `canRun`, `canManageTriggers`, and `canEditConfig`.
- Trigger edit/delete availability is computed per row, including report-operability checks for report runs and technical-user checks for connector runs.
- Insights compute delete availability through `AccessDecisionService` on the parent Data Mart.
- Run History is read-only and only lists runs from visible Data Marts.

This keeps the pages useful as project-wide overviews without turning them into permission bypasses or metadata leaks.

## Proposed Pages

### Triggers

Adds a project-level Triggers page for scheduled Data Mart work. It shows the Data Mart first, then the schedule, run target, next/last run context, status, and row actions. The page also supports the same search/filter/table treatment as the Data Mart list, and trigger rows can open the same side panel used from the Data Mart tab.

Screenshots:

<img width="1440" height="760" alt="triggers-empty" src="https://github.com/user-attachments/assets/9d13ccc8-5223-4ff2-988b-ca443690d152" />

<img width="1440" height="760" alt="triggers-demo" src="https://github.com/user-attachments/assets/f30bc185-8d5c-4170-9206-edb815faf396" />

### Reports

Adds a project-level Reports page for all accessible reports. It keeps the Data Mart as the first column, shows the report title or a muted dash when the title is absent, keeps the existing report actions available from the row menu, and opens the report side panel for editing from this cross-project view.

Screenshots:

<img width="1440" height="760" alt="reports-empty" src="https://github.com/user-attachments/assets/e3c62bf6-5021-45b2-8bec-7f9eebdca36f" />
<img width="1440" height="760" alt="reports-demo" src="https://github.com/user-attachments/assets/11caabc8-8a78-44f6-8ede-e291168caf7e" />

### Insights

Adds a project-level Insights page for accessible insight templates. The Data Mart is the first column, insight title links to the insight detail view, and row actions mirror the per-Data-Mart tab where applicable. The page intentionally omits columns that are not present on the tab, such as sources.

Screenshots:

<img width="1440" height="760" alt="insights-empty" src="https://github.com/user-attachments/assets/fb135050-cd27-4c75-83fe-c5dab3380c9d" />
<img width="1440" height="760" alt="insights-demo" src="https://github.com/user-attachments/assets/a097b995-91cd-4b84-9336-24744115ea18" />

### Run History

Adds a project-level Run History page for recent runs across visible Data Marts. Each row keeps the Data Mart association visible, uses connector/report icons for scanability, includes run target/status details, and continues polling while active runs are present so the overview stays current.

Screenshots:

<img width="1440" height="760" alt="run-history-empty" src="https://github.com/user-attachments/assets/ba14051c-f614-4fdd-8f44-b7a886ada245" />
<img width="1440" height="760" alt="run-history-demo" src="https://github.com/user-attachments/assets/81287c80-d72d-4a40-8d98-bca3cdab534e" />

## Verification

- `npm run build -w @owox/web`
- `npm run test -w @owox/web -- DataMartSchedulesPage DataMartReportsPage DataMartInsightsPage DataMartRunsPage`
- `npm run test -w @owox/backend -- --runInBand --testPathPatterns='project|scheduled|report|insight|data-mart-run'`

