### PR TITLE
Fix SQLite scheduled run transaction stability

### DIFF
--- a/.changeset/sqlite-scheduled-runs-stability.md
+++ b/.changeset/sqlite-scheduled-runs-stability.md
@@ -1,0 +1,7 @@
+---
+"owox": minor
+---
+
+# Improve SQLite runtime stability
+
+Improved runtime stability when using SQLite-backed deployments, with particular focus on scheduled run processing and transaction coordination during concurrent background activity.

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -16,6 +16,7 @@ import { validateConfig } from './config/env-validation.config';
 import { ClsModule } from 'nestjs-cls';
 import { DataSource } from 'typeorm';
 import { addTransactionalDataSource } from 'typeorm-transactional';
+import { serializeSqliteTransactions } from './config/sqlite-transaction-serializer';
 
 @Module({
   imports: [
@@ -40,7 +41,7 @@ import { addTransactionalDataSource } from 'typeorm-transactional';
         }
         const dataSource = new DataSource(options);
         await dataSource.initialize();
-        return addTransactionalDataSource(dataSource);
+        return serializeSqliteTransactions(addTransactionalDataSource(dataSource));
       },
     }),
     ScheduleModule.forRoot(),

--- a/apps/backend/src/config/sqlite-transaction-serializer.spec.ts
+++ b/apps/backend/src/config/sqlite-transaction-serializer.spec.ts
@@ -1,5 +1,13 @@
+import 'reflect-metadata';
 import { DataSource, EntityManager } from 'typeorm';
 import { IsolationLevel } from 'typeorm/driver/types/IsolationLevel';
+import {
+  addTransactionalDataSource,
+  deleteDataSourceByName,
+  initializeTransactionalContext,
+  StorageDriver,
+  Transactional,
+} from 'typeorm-transactional';
 import { serializeSqliteTransactions } from './sqlite-transaction-serializer';
 
 describe('serializeSqliteTransactions', () => {
@@ -33,11 +41,16 @@ describe('serializeSqliteTransactions', () => {
     } as unknown as DataSource;
   };
 
+  const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+  beforeAll(() => {
+    initializeTransactionalContext({ storageDriver: StorageDriver.AUTO });
+  });
+
   it('serializes concurrent better-sqlite3 transactions while preserving nested transactions', async () => {
     const dataSource = createDataSource('better-sqlite3');
     serializeSqliteTransactions(dataSource);
 
-    const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
     const activeTopLevelTransactions = new Set<string>();
     const executionOrder: string[] = [];
     let maxActiveTopLevelTransactions = 0;
@@ -87,6 +100,78 @@ describe('serializeSqliteTransactions', () => {
       'nested:third',
       'end:third',
     ]);
+  });
+
+  it('continues queued transactions after a transaction rejects', async () => {
+    const dataSource = createDataSource('better-sqlite3');
+    serializeSqliteTransactions(dataSource);
+
+    const firstError = new Error('first transaction failed');
+    const executionOrder: string[] = [];
+
+    const first = dataSource.transaction(async () => {
+      executionOrder.push('start:first');
+      throw firstError;
+    });
+    const second = dataSource.transaction(async () => {
+      executionOrder.push('start:second');
+      return 'second result';
+    });
+
+    const [firstResult, secondResult] = await Promise.allSettled([first, second]);
+
+    expect(firstResult.status).toBe('rejected');
+    if (firstResult.status === 'rejected') {
+      expect(firstResult.reason).toBe(firstError);
+    }
+    expect(secondResult).toEqual({
+      status: 'fulfilled',
+      value: 'second result',
+    });
+    expect(executionOrder).toEqual(['start:first', 'start:second']);
+  });
+
+  it('serializes @Transactional methods through the registered sqlite data source', async () => {
+    const dataSource = createDataSource('better-sqlite3');
+    const connectionName = 'sqlite-transaction-serializer-decorator-test';
+    serializeSqliteTransactions(
+      addTransactionalDataSource({
+        name: connectionName,
+        dataSource,
+        patch: false,
+      })
+    );
+
+    const activeTransactions = new Set<string>();
+    const executionOrder: string[] = [];
+    let maxActiveTransactions = 0;
+
+    class ScheduledTransactionFlow {
+      @Transactional({ connectionName })
+      async process(label: string, delay: number): Promise<void> {
+        activeTransactions.add(label);
+        executionOrder.push(`start:${label}`);
+        maxActiveTransactions = Math.max(maxActiveTransactions, activeTransactions.size);
+
+        try {
+          await wait(delay);
+        } finally {
+          executionOrder.push(`end:${label}`);
+          activeTransactions.delete(label);
+        }
+      }
+    }
+
+    try {
+      const flow = new ScheduledTransactionFlow();
+
+      await Promise.all([flow.process('first', 20), flow.process('second', 1)]);
+
+      expect(maxActiveTransactions).toBe(1);
+      expect(executionOrder).toEqual(['start:first', 'end:first', 'start:second', 'end:second']);
+    } finally {
+      deleteDataSourceByName(connectionName);
+    }
   });
 
   it('does not wrap a sqlite data source more than once', async () => {

--- a/apps/backend/src/config/sqlite-transaction-serializer.spec.ts
+++ b/apps/backend/src/config/sqlite-transaction-serializer.spec.ts
@@ -1,0 +1,132 @@
+import { DataSource, EntityManager } from 'typeorm';
+import { serializeSqliteTransactions } from './sqlite-transaction-serializer';
+
+describe('serializeSqliteTransactions', () => {
+  it('serializes concurrent better-sqlite3 transactions while preserving nested transactions', async () => {
+    const dataSource = new DataSource({
+      type: 'better-sqlite3',
+      database: ':memory:',
+    });
+
+    await dataSource.initialize();
+    serializeSqliteTransactions(dataSource);
+
+    try {
+      await dataSource.query('CREATE TABLE transaction_test (id integer primary key, label text)');
+
+      const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+      const activeTopLevelTransactions = new Set<string>();
+      const executionOrder: string[] = [];
+      let maxActiveTopLevelTransactions = 0;
+
+      const runWork = async (label: string, delays: [number, number, number]) => {
+        await dataSource.transaction(async outerManager => {
+          activeTopLevelTransactions.add(label);
+          executionOrder.push(`start:${label}`);
+          maxActiveTopLevelTransactions = Math.max(
+            maxActiveTopLevelTransactions,
+            activeTopLevelTransactions.size
+          );
+
+          try {
+            await outerManager.query('INSERT INTO transaction_test(label) VALUES (?)', [
+              `${label}-outer`,
+            ]);
+            await wait(delays[0]);
+
+            await dataSource.transaction(async innerManager => {
+              await innerManager.query('INSERT INTO transaction_test(label) VALUES (?)', [
+                `${label}-inner`,
+              ]);
+              await wait(delays[1]);
+            });
+
+            await wait(delays[2]);
+          } finally {
+            executionOrder.push(`end:${label}`);
+            activeTopLevelTransactions.delete(label);
+          }
+        });
+      };
+
+      await expect(
+        Promise.all([
+          runWork('first', [20, 30, 10]),
+          runWork('second', [10, 5, 40]),
+          runWork('third', [5, 20, 1]),
+        ])
+      ).resolves.toBeDefined();
+
+      const rows = await dataSource.query('SELECT count(*) as count FROM transaction_test');
+      expect(rows[0].count).toBe(6);
+      expect(maxActiveTopLevelTransactions).toBe(1);
+      expect(executionOrder).toEqual([
+        'start:first',
+        'end:first',
+        'start:second',
+        'end:second',
+        'start:third',
+        'end:third',
+      ]);
+    } finally {
+      await dataSource.destroy();
+    }
+  });
+
+  it('does not wrap a sqlite data source more than once', async () => {
+    const dataSource = new DataSource({
+      type: 'better-sqlite3',
+      database: ':memory:',
+    });
+
+    await dataSource.initialize();
+
+    try {
+      serializeSqliteTransactions(dataSource);
+      const firstWrappedTransaction = dataSource.transaction;
+
+      serializeSqliteTransactions(dataSource);
+
+      expect(dataSource.transaction).toBe(firstWrappedTransaction);
+    } finally {
+      await dataSource.destroy();
+    }
+  });
+
+  it('preserves the isolation-level transaction overload', async () => {
+    const dataSource = new DataSource({
+      type: 'better-sqlite3',
+      database: ':memory:',
+    });
+
+    await dataSource.initialize();
+    serializeSqliteTransactions(dataSource);
+
+    try {
+      await dataSource.query('CREATE TABLE isolation_test (id integer primary key, label text)');
+
+      await dataSource.transaction('SERIALIZABLE', async manager => {
+        await manager.query('INSERT INTO isolation_test(label) VALUES (?)', ['serialized']);
+      });
+
+      const rows = await dataSource.query('SELECT label FROM isolation_test');
+      expect(rows).toEqual([{ label: 'serialized' }]);
+    } finally {
+      await dataSource.destroy();
+    }
+  });
+
+  it('does not wrap non-sqlite data sources', async () => {
+    const transaction = jest.fn(async (callback: (manager: EntityManager) => Promise<void>) => {
+      await callback({} as EntityManager);
+    });
+    const dataSource = {
+      options: { type: 'mysql' },
+      transaction,
+    } as unknown as DataSource;
+
+    serializeSqliteTransactions(dataSource);
+
+    expect(dataSource.transaction).toBe(transaction);
+  });
+});

--- a/apps/backend/src/config/sqlite-transaction-serializer.spec.ts
+++ b/apps/backend/src/config/sqlite-transaction-serializer.spec.ts
@@ -1,129 +1,119 @@
 import { DataSource, EntityManager } from 'typeorm';
+import { IsolationLevel } from 'typeorm/driver/types/IsolationLevel';
 import { serializeSqliteTransactions } from './sqlite-transaction-serializer';
 
 describe('serializeSqliteTransactions', () => {
-  it('serializes concurrent better-sqlite3 transactions while preserving nested transactions', async () => {
-    const dataSource = new DataSource({
-      type: 'better-sqlite3',
-      database: ':memory:',
-    });
+  type TransactionCallback<T> = (manager: EntityManager) => Promise<T>;
+  type TransactionMock = jest.MockedFunction<
+    <T>(
+      isolationOrRunInTransaction: IsolationLevel | TransactionCallback<T>,
+      runInTransaction?: TransactionCallback<T>
+    ) => Promise<T>
+  >;
 
-    await dataSource.initialize();
+  const createDataSource = (type: DataSource['options']['type']): DataSource => {
+    const manager = {} as EntityManager;
+    const transaction: TransactionMock = jest.fn(
+      async <T>(
+        isolationOrRunInTransaction: IsolationLevel | TransactionCallback<T>,
+        runInTransaction?: TransactionCallback<T>
+      ): Promise<T> => {
+        const callback =
+          typeof isolationOrRunInTransaction === 'function'
+            ? isolationOrRunInTransaction
+            : runInTransaction!;
+
+        return callback(manager);
+      }
+    );
+
+    return {
+      options: { type },
+      transaction,
+    } as unknown as DataSource;
+  };
+
+  it('serializes concurrent better-sqlite3 transactions while preserving nested transactions', async () => {
+    const dataSource = createDataSource('better-sqlite3');
     serializeSqliteTransactions(dataSource);
 
-    try {
-      await dataSource.query('CREATE TABLE transaction_test (id integer primary key, label text)');
+    const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    const activeTopLevelTransactions = new Set<string>();
+    const executionOrder: string[] = [];
+    let maxActiveTopLevelTransactions = 0;
 
-      const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-      const activeTopLevelTransactions = new Set<string>();
-      const executionOrder: string[] = [];
-      let maxActiveTopLevelTransactions = 0;
+    const runWork = async (label: string, delays: [number, number, number]) => {
+      await dataSource.transaction(async () => {
+        activeTopLevelTransactions.add(label);
+        executionOrder.push(`start:${label}`);
+        maxActiveTopLevelTransactions = Math.max(
+          maxActiveTopLevelTransactions,
+          activeTopLevelTransactions.size
+        );
 
-      const runWork = async (label: string, delays: [number, number, number]) => {
-        await dataSource.transaction(async outerManager => {
-          activeTopLevelTransactions.add(label);
-          executionOrder.push(`start:${label}`);
-          maxActiveTopLevelTransactions = Math.max(
-            maxActiveTopLevelTransactions,
-            activeTopLevelTransactions.size
-          );
+        try {
+          await wait(delays[0]);
 
-          try {
-            await outerManager.query('INSERT INTO transaction_test(label) VALUES (?)', [
-              `${label}-outer`,
-            ]);
-            await wait(delays[0]);
+          await dataSource.transaction(async () => {
+            executionOrder.push(`nested:${label}`);
+            await wait(delays[1]);
+          });
 
-            await dataSource.transaction(async innerManager => {
-              await innerManager.query('INSERT INTO transaction_test(label) VALUES (?)', [
-                `${label}-inner`,
-              ]);
-              await wait(delays[1]);
-            });
+          await wait(delays[2]);
+        } finally {
+          executionOrder.push(`end:${label}`);
+          activeTopLevelTransactions.delete(label);
+        }
+      });
+    };
 
-            await wait(delays[2]);
-          } finally {
-            executionOrder.push(`end:${label}`);
-            activeTopLevelTransactions.delete(label);
-          }
-        });
-      };
+    await expect(
+      Promise.all([
+        runWork('first', [20, 30, 10]),
+        runWork('second', [10, 5, 40]),
+        runWork('third', [5, 20, 1]),
+      ])
+    ).resolves.toBeDefined();
 
-      await expect(
-        Promise.all([
-          runWork('first', [20, 30, 10]),
-          runWork('second', [10, 5, 40]),
-          runWork('third', [5, 20, 1]),
-        ])
-      ).resolves.toBeDefined();
-
-      const rows = await dataSource.query('SELECT count(*) as count FROM transaction_test');
-      expect(rows[0].count).toBe(6);
-      expect(maxActiveTopLevelTransactions).toBe(1);
-      expect(executionOrder).toEqual([
-        'start:first',
-        'end:first',
-        'start:second',
-        'end:second',
-        'start:third',
-        'end:third',
-      ]);
-    } finally {
-      await dataSource.destroy();
-    }
+    expect(maxActiveTopLevelTransactions).toBe(1);
+    expect(executionOrder).toEqual([
+      'start:first',
+      'nested:first',
+      'end:first',
+      'start:second',
+      'nested:second',
+      'end:second',
+      'start:third',
+      'nested:third',
+      'end:third',
+    ]);
   });
 
   it('does not wrap a sqlite data source more than once', async () => {
-    const dataSource = new DataSource({
-      type: 'better-sqlite3',
-      database: ':memory:',
-    });
+    const dataSource = createDataSource('better-sqlite3');
 
-    await dataSource.initialize();
+    serializeSqliteTransactions(dataSource);
+    const firstWrappedTransaction = dataSource.transaction;
 
-    try {
-      serializeSqliteTransactions(dataSource);
-      const firstWrappedTransaction = dataSource.transaction;
+    serializeSqliteTransactions(dataSource);
 
-      serializeSqliteTransactions(dataSource);
-
-      expect(dataSource.transaction).toBe(firstWrappedTransaction);
-    } finally {
-      await dataSource.destroy();
-    }
+    expect(dataSource.transaction).toBe(firstWrappedTransaction);
   });
 
   it('preserves the isolation-level transaction overload', async () => {
-    const dataSource = new DataSource({
-      type: 'better-sqlite3',
-      database: ':memory:',
-    });
-
-    await dataSource.initialize();
+    const dataSource = createDataSource('better-sqlite3');
+    const originalTransaction = dataSource.transaction as TransactionMock;
     serializeSqliteTransactions(dataSource);
 
-    try {
-      await dataSource.query('CREATE TABLE isolation_test (id integer primary key, label text)');
+    const result = await dataSource.transaction('SERIALIZABLE', async () => 'serialized');
 
-      await dataSource.transaction('SERIALIZABLE', async manager => {
-        await manager.query('INSERT INTO isolation_test(label) VALUES (?)', ['serialized']);
-      });
-
-      const rows = await dataSource.query('SELECT label FROM isolation_test');
-      expect(rows).toEqual([{ label: 'serialized' }]);
-    } finally {
-      await dataSource.destroy();
-    }
+    expect(result).toBe('serialized');
+    expect(originalTransaction).toHaveBeenCalledWith('SERIALIZABLE', expect.any(Function));
   });
 
   it('does not wrap non-sqlite data sources', async () => {
-    const transaction = jest.fn(async (callback: (manager: EntityManager) => Promise<void>) => {
-      await callback({} as EntityManager);
-    });
-    const dataSource = {
-      options: { type: 'mysql' },
-      transaction,
-    } as unknown as DataSource;
+    const dataSource = createDataSource('mysql');
+    const transaction = dataSource.transaction;
 
     serializeSqliteTransactions(dataSource);
 

--- a/apps/backend/src/config/sqlite-transaction-serializer.ts
+++ b/apps/backend/src/config/sqlite-transaction-serializer.ts
@@ -1,0 +1,78 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { DataSource, EntityManager } from 'typeorm';
+import { IsolationLevel } from 'typeorm/driver/types/IsolationLevel';
+
+const SQLITE_TRANSACTION_SERIALIZER = Symbol('SQLITE_TRANSACTION_SERIALIZER');
+const transactionOwner = new AsyncLocalStorage<boolean>();
+
+type RunInTransaction<T> = (entityManager: EntityManager) => Promise<T>;
+type TransactionMethod = DataSource['transaction'];
+type SerializableDataSource = DataSource & {
+  [SQLITE_TRANSACTION_SERIALIZER]?: true;
+  transaction: TransactionMethod;
+};
+
+class AsyncTransactionQueue {
+  private tail: Promise<void> = Promise.resolve();
+
+  async run<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.tail;
+    let release!: () => void;
+    this.tail = new Promise<void>(resolve => {
+      release = resolve;
+    });
+
+    await previous.catch(() => undefined);
+
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}
+
+export function serializeSqliteTransactions(dataSource: DataSource): DataSource {
+  if (dataSource.options.type !== 'better-sqlite3') {
+    return dataSource;
+  }
+
+  const serializableDataSource = dataSource as SerializableDataSource;
+  if (serializableDataSource[SQLITE_TRANSACTION_SERIALIZER]) {
+    return dataSource;
+  }
+
+  const queue = new AsyncTransactionQueue();
+  const originalTransaction = serializableDataSource.transaction.bind(
+    dataSource
+  ) as TransactionMethod;
+
+  const runOriginalTransaction = <T>(
+    isolationOrRunInTransaction: IsolationLevel | RunInTransaction<T>,
+    runInTransaction?: RunInTransaction<T>
+  ): Promise<T> => {
+    if (typeof isolationOrRunInTransaction === 'function') {
+      return originalTransaction(isolationOrRunInTransaction);
+    }
+
+    return originalTransaction(isolationOrRunInTransaction, runInTransaction!);
+  };
+
+  serializableDataSource.transaction = async <T>(
+    isolationOrRunInTransaction: IsolationLevel | RunInTransaction<T>,
+    runInTransaction?: RunInTransaction<T>
+  ): Promise<T> => {
+    if (transactionOwner.getStore()) {
+      return runOriginalTransaction(isolationOrRunInTransaction, runInTransaction);
+    }
+
+    return queue.run(() =>
+      transactionOwner.run(true, () =>
+        runOriginalTransaction(isolationOrRunInTransaction, runInTransaction)
+      )
+    );
+  };
+  serializableDataSource[SQLITE_TRANSACTION_SERIALIZER] = true;
+
+  return dataSource;
+}


### PR DESCRIPTION
## Summary
- Add SQLite-only serialization for top-level TypeORM transactions when the backend uses `better-sqlite3`.
- Preserve nested transaction behavior and both TypeORM transaction call forms.
- Add regression coverage for concurrent scheduled-run style transaction contention, idempotent wrapping, isolation-level overloads, and non-SQLite passthrough.

## Root Cause
Local SQLite deployments use TypeORM with the `better-sqlite3` driver. That driver keeps a single query runner for the data source, while scheduled trigger processing can run multiple ready triggers in parallel. When several scheduled run flows enter `@Transactional()` or `dataSource.transaction()` at the same time, TypeORM can try to manage multiple transaction and savepoint stacks on that same SQLite query runner.

Under unlucky interleavings this can surface as SQLite transaction/savepoint errors, for example `no such savepoint` during `RELEASE SAVEPOINT`, or similar nested transaction failures. MySQL does not have the same shape here because TypeORM can use separate query runners/connections from the pool for concurrent transactions.

## Fix
For `better-sqlite3` data sources, wrap `dataSource.transaction()` with a small FIFO queue. Independent top-level transactions are executed one at a time, while nested transactions inside the currently running transaction bypass the queue through `AsyncLocalStorage`. That preserves TypeORM nested transaction behavior and avoids a transaction waiting on its own parent.

Non-SQLite data sources are returned unchanged, so MySQL keeps its existing concurrent transaction behavior.

## Product Impact
This changes rare concurrent SQLite transaction collisions from immediate failures into bounded waiting before a transaction starts. In those rare cases another transaction may wait for the current transaction callback to finish, but the scheduled run flow can complete instead of failing and leaving the trigger unprocessed.

The serializer only covers the transactional callback itself. The expensive report or connector execution is not placed under one long global lock by this change, so the expected user-facing impact is limited to short SQLite transaction coordination windows during concurrent background activity.

## Test Plan
- `npm test -w @owox/backend -- sqlite-transaction-serializer.spec.ts --runInBand`
- `npx tsc -p apps/backend/tsconfig.build.json --noEmit`
- `npx eslint src/config/sqlite-transaction-serializer.ts src/config/sqlite-transaction-serializer.spec.ts src/app.module.ts --config ./eslint.config.mjs`