### PR TITLE
feat(data-marts): output controls for AWS Redshift data marts

### DIFF
--- a/.changeset/redshift-output-controls.md
+++ b/.changeset/redshift-output-controls.md
@@ -5,5 +5,6 @@
 # Add output controls for Redshift data marts
 
 Add output controls (filters, slices, sort, limit) for AWS Redshift data marts, and
-bound the `this_month`/`this_year` relative-date presets to the current period across
-all storages.
+bound the relative-date presets so they no longer match future-dated rows across all
+storages: `this_month`/`this_year` are clamped to the current period, and
+`last_n_days`/`last_n_months` now stop at today (previously lower-bound only).

--- a/.changeset/redshift-output-controls.md
+++ b/.changeset/redshift-output-controls.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Add output controls for Redshift data marts
+
+Add output controls (filters, slices, sort, limit) for AWS Redshift data marts, and
+bound the `this_month`/`this_year` relative-date presets to the current period across
+all storages.

--- a/.changeset/redshift-output-controls.md
+++ b/.changeset/redshift-output-controls.md
@@ -5,6 +5,7 @@
 # Add output controls for Redshift data marts
 
 Add output controls (filters, slices, sort, limit) for AWS Redshift data marts, and
-bound the relative-date presets so they no longer match future-dated rows across all
-storages: `this_month`/`this_year` are clamped to the current period, and
-`last_n_days`/`last_n_months` now stop at today (previously lower-bound only).
+tighten the relative-date presets across all storages: `last_n_days`/`last_n_months`
+now stop at today (previously lower-bound only, so future-dated rows leaked in), and
+`this_month`/`this_year` are clamped to the current period (a future date still inside
+the current month/year continues to match).

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -26,6 +26,8 @@ jobs:
             pattern: bigquery.integration
           - name: Athena
             pattern: athena.integration
+          - name: Redshift
+            pattern: redshift.integration
           - name: HTTP Data (Athena + BigQuery)
             pattern: http-data-real
           - name: Report read (Athena)
@@ -59,12 +61,16 @@ jobs:
           BQ_PROJECT_ID: ${{ secrets.BQ_PROJECT_ID }}
           BQ_DATASET: ${{ secrets.BQ_DATASET }}
           BQ_SERVICE_ACCOUNT_KEY: ${{ secrets.BQ_SERVICE_ACCOUNT_KEY }}
-          # Athena (also used by Redshift later)
+          # Athena
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ATHENA_REGION: ${{ secrets.ATHENA_REGION }}
           ATHENA_OUTPUT_BUCKET: ${{ secrets.ATHENA_OUTPUT_BUCKET }}
           ATHENA_DATABASE: ${{ secrets.ATHENA_DATABASE }}
+          # Redshift Serverless (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY shared with Athena)
+          REDSHIFT_REGION: ${{ secrets.REDSHIFT_REGION }}
+          REDSHIFT_WORKGROUP_NAME: ${{ secrets.REDSHIFT_WORKGROUP_NAME }}
+          REDSHIFT_DATABASE: ${{ secrets.REDSHIFT_DATABASE }}
           # Google Sheets
           GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON }}
           TEST_GOOGLE_SPREADSHEET_ID: ${{ secrets.TEST_GOOGLE_SPREADSHEET_ID }}

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-clause-renderer.spec.ts
@@ -179,19 +179,23 @@ describe('AthenaClauseRenderer', () => {
           .sql
       ).toBe('\nWHERE "d" >= date_add(\'day\', -1, current_date) AND "d" < current_date');
     });
-    it('last_n_days', () => {
+    it('last_n_days has an upper bound', () => {
       expect(
         r.renderWhere([
           { column: 'd', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
         ]).sql
-      ).toBe('\nWHERE "d" >= date_add(\'day\', -7, current_date)');
+      ).toBe(
+        '\nWHERE "d" >= date_add(\'day\', -7, current_date) AND "d" < date_add(\'day\', 1, current_date)'
+      );
     });
-    it('last_n_months', () => {
+    it('last_n_months has an upper bound', () => {
       expect(
         r.renderWhere([
           { column: 'd', operator: 'relative_date', value: { kind: 'last_n_months', n: 3 } },
         ]).sql
-      ).toBe('\nWHERE "d" >= date_add(\'month\', -3, current_date)');
+      ).toBe(
+        '\nWHERE "d" >= date_add(\'month\', -3, current_date) AND "d" < date_add(\'day\', 1, current_date)'
+      );
     });
     it('this_month', () => {
       expect(

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-clause-renderer.spec.ts
@@ -197,7 +197,9 @@ describe('AthenaClauseRenderer', () => {
       expect(
         r.renderWhere([{ column: 'd', operator: 'relative_date', value: { kind: 'this_month' } }])
           .sql
-      ).toBe('\nWHERE "d" >= date_trunc(\'month\', current_date)');
+      ).toBe(
+        `\nWHERE "d" >= date_trunc('month', current_date) AND "d" < date_add('month', 1, date_trunc('month', current_date))`
+      );
     });
     it('last_month', () => {
       const sql = r.renderWhere([
@@ -210,7 +212,9 @@ describe('AthenaClauseRenderer', () => {
       expect(
         r.renderWhere([{ column: 'd', operator: 'relative_date', value: { kind: 'this_year' } }])
           .sql
-      ).toBe('\nWHERE "d" >= date_trunc(\'year\', current_date)');
+      ).toBe(
+        `\nWHERE "d" >= date_trunc('year', current_date) AND "d" < date_add('year', 1, date_trunc('year', current_date))`
+      );
     });
   });
 

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-clause-renderer.ts
@@ -158,14 +158,20 @@ export class AthenaClauseRenderer extends SqlClauseRenderer {
       case 'last_n_months':
         return `${col} >= date_add('month', -${preset.n}, current_date)`;
       case 'this_month':
-        return `${col} >= date_trunc('month', current_date)`;
+        return (
+          `${col} >= date_trunc('month', current_date)` +
+          ` AND ${col} < date_add('month', 1, date_trunc('month', current_date))`
+        );
       case 'last_month':
         return (
           `${col} >= date_trunc('month', date_add('month', -1, current_date))` +
           ` AND ${col} < date_trunc('month', current_date)`
         );
       case 'this_year':
-        return `${col} >= date_trunc('year', current_date)`;
+        return (
+          `${col} >= date_trunc('year', current_date)` +
+          ` AND ${col} < date_add('year', 1, date_trunc('year', current_date))`
+        );
     }
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-clause-renderer.ts
@@ -154,9 +154,15 @@ export class AthenaClauseRenderer extends SqlClauseRenderer {
       case 'yesterday':
         return `${col} >= date_add('day', -1, current_date) AND ${col} < current_date`;
       case 'last_n_days':
-        return `${col} >= date_add('day', -${preset.n}, current_date)`;
+        return (
+          `${col} >= date_add('day', -${preset.n}, current_date)` +
+          ` AND ${col} < date_add('day', 1, current_date)`
+        );
       case 'last_n_months':
-        return `${col} >= date_add('month', -${preset.n}, current_date)`;
+        return (
+          `${col} >= date_add('month', -${preset.n}, current_date)` +
+          ` AND ${col} < date_add('day', 1, current_date)`
+        );
       case 'this_month':
         return (
           `${col} >= date_trunc('month', current_date)` +

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.spec.ts
@@ -117,19 +117,19 @@ describe('BigQueryClauseRenderer', () => {
           .sql
       ).toBe('\nWHERE `d` = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)');
     });
-    it('last_n_days', () => {
+    it('last_n_days has an upper bound', () => {
       expect(
         r.renderWhere([
           { column: 'd', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
         ]).sql
-      ).toBe('\nWHERE `d` >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)');
+      ).toBe('\nWHERE `d` >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY) AND `d` <= CURRENT_DATE()');
     });
-    it('last_n_months', () => {
+    it('last_n_months has an upper bound', () => {
       expect(
         r.renderWhere([
           { column: 'd', operator: 'relative_date', value: { kind: 'last_n_months', n: 3 } },
         ]).sql
-      ).toBe('\nWHERE `d` >= DATE_SUB(CURRENT_DATE(), INTERVAL 3 MONTH)');
+      ).toBe('\nWHERE `d` >= DATE_SUB(CURRENT_DATE(), INTERVAL 3 MONTH) AND `d` <= CURRENT_DATE()');
     });
     it('this_month', () => {
       expect(
@@ -175,7 +175,7 @@ describe('BigQueryClauseRenderer', () => {
         }
       );
 
-      it('wraps a TIMESTAMP column in DATE() for last_n_days', () => {
+      it('wraps both bounds in DATE() for last_n_days on a TIMESTAMP column', () => {
         expect(
           r.renderWhere(
             [{ column: 'd', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } }],
@@ -183,7 +183,9 @@ describe('BigQueryClauseRenderer', () => {
             'p',
             withType('TIMESTAMP')
           ).sql
-        ).toBe('\nWHERE DATE(`d`) >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)');
+        ).toBe(
+          '\nWHERE DATE(`d`) >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY) AND DATE(`d`) <= CURRENT_DATE()'
+        );
       });
 
       it('wraps both bounds of last_month for a TIMESTAMP column', () => {

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.spec.ts
@@ -135,7 +135,9 @@ describe('BigQueryClauseRenderer', () => {
       expect(
         r.renderWhere([{ column: 'd', operator: 'relative_date', value: { kind: 'this_month' } }])
           .sql
-      ).toBe('\nWHERE `d` >= DATE_TRUNC(CURRENT_DATE(), MONTH)');
+      ).toBe(
+        '\nWHERE `d` >= DATE_TRUNC(CURRENT_DATE(), MONTH) AND `d` < DATE_ADD(DATE_TRUNC(CURRENT_DATE(), MONTH), INTERVAL 1 MONTH)'
+      );
     });
     it('last_month', () => {
       const sql = r.renderWhere([
@@ -148,7 +150,9 @@ describe('BigQueryClauseRenderer', () => {
       expect(
         r.renderWhere([{ column: 'd', operator: 'relative_date', value: { kind: 'this_year' } }])
           .sql
-      ).toBe('\nWHERE `d` >= DATE_TRUNC(CURRENT_DATE(), YEAR)');
+      ).toBe(
+        '\nWHERE `d` >= DATE_TRUNC(CURRENT_DATE(), YEAR) AND `d` < DATE_ADD(DATE_TRUNC(CURRENT_DATE(), YEAR), INTERVAL 1 YEAR)'
+      );
     });
 
     // Regression: `timestamp_col = CURRENT_DATE()` is a type error in BigQuery (no
@@ -191,6 +195,32 @@ describe('BigQueryClauseRenderer', () => {
         ).sql;
         expect(sql).toContain('DATE(`d`) >= DATE_TRUNC(DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH)');
         expect(sql).toContain('DATE(`d`) < DATE_TRUNC(CURRENT_DATE(), MONTH)');
+      });
+
+      it('wraps both bounds of this_month for a TIMESTAMP column', () => {
+        const sql = r.renderWhere(
+          [{ column: 'd', operator: 'relative_date', value: { kind: 'this_month' } }],
+          undefined,
+          'p',
+          withType('TIMESTAMP')
+        ).sql;
+        expect(sql).toContain('DATE(`d`) >= DATE_TRUNC(CURRENT_DATE(), MONTH)');
+        expect(sql).toContain(
+          'DATE(`d`) < DATE_ADD(DATE_TRUNC(CURRENT_DATE(), MONTH), INTERVAL 1 MONTH)'
+        );
+      });
+
+      it('wraps both bounds of this_year for a TIMESTAMP column', () => {
+        const sql = r.renderWhere(
+          [{ column: 'd', operator: 'relative_date', value: { kind: 'this_year' } }],
+          undefined,
+          'p',
+          withType('TIMESTAMP')
+        ).sql;
+        expect(sql).toContain('DATE(`d`) >= DATE_TRUNC(CURRENT_DATE(), YEAR)');
+        expect(sql).toContain(
+          'DATE(`d`) < DATE_ADD(DATE_TRUNC(CURRENT_DATE(), YEAR), INTERVAL 1 YEAR)'
+        );
       });
 
       it('does NOT wrap a DATE column (compares directly)', () => {

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.ts
@@ -127,9 +127,15 @@ export class BigQueryClauseRenderer extends SqlClauseRenderer {
       case 'yesterday':
         return `${lhs} = DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)`;
       case 'last_n_days':
-        return `${lhs} >= DATE_SUB(CURRENT_DATE(), INTERVAL ${preset.n} DAY)`;
+        return (
+          `${lhs} >= DATE_SUB(CURRENT_DATE(), INTERVAL ${preset.n} DAY)` +
+          ` AND ${lhs} <= CURRENT_DATE()`
+        );
       case 'last_n_months':
-        return `${lhs} >= DATE_SUB(CURRENT_DATE(), INTERVAL ${preset.n} MONTH)`;
+        return (
+          `${lhs} >= DATE_SUB(CURRENT_DATE(), INTERVAL ${preset.n} MONTH)` +
+          ` AND ${lhs} <= CURRENT_DATE()`
+        );
       case 'this_month':
         return (
           `${lhs} >= DATE_TRUNC(CURRENT_DATE(), MONTH)` +

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-clause-renderer.ts
@@ -131,14 +131,20 @@ export class BigQueryClauseRenderer extends SqlClauseRenderer {
       case 'last_n_months':
         return `${lhs} >= DATE_SUB(CURRENT_DATE(), INTERVAL ${preset.n} MONTH)`;
       case 'this_month':
-        return `${lhs} >= DATE_TRUNC(CURRENT_DATE(), MONTH)`;
+        return (
+          `${lhs} >= DATE_TRUNC(CURRENT_DATE(), MONTH)` +
+          ` AND ${lhs} < DATE_ADD(DATE_TRUNC(CURRENT_DATE(), MONTH), INTERVAL 1 MONTH)`
+        );
       case 'last_month':
         return (
           `${lhs} >= DATE_TRUNC(DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH), MONTH)` +
           ` AND ${lhs} < DATE_TRUNC(CURRENT_DATE(), MONTH)`
         );
       case 'this_year':
-        return `${lhs} >= DATE_TRUNC(CURRENT_DATE(), YEAR)`;
+        return (
+          `${lhs} >= DATE_TRUNC(CURRENT_DATE(), YEAR)` +
+          ` AND ${lhs} < DATE_ADD(DATE_TRUNC(CURRENT_DATE(), YEAR), INTERVAL 1 YEAR)`
+        );
     }
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
@@ -91,6 +91,7 @@ import { RedshiftReportReader } from './redshift/services/redshift-report-reader
 import { RedshiftSchemaMerger } from './redshift/services/redshift-schema-merger';
 import { RedshiftSqlDryRunExecutor } from './redshift/services/redshift-sql-dry-run.executor';
 import { RedshiftBlendedQueryBuilder } from './redshift/services/redshift-blended-query-builder';
+import { RedshiftClauseRenderer } from './redshift/services/redshift-clause-renderer';
 import { RedshiftSqlRunExecutor } from './redshift/services/redshift-sql-run.executor';
 import { RedshiftStorageErrorMapper } from './redshift/services/redshift-storage-error.mapper';
 import { SnowflakeApiAdapterFactory } from './snowflake/adapters/snowflake-api-adapter.factory';
@@ -238,6 +239,7 @@ const storageResourceBrowserProviders = [BigQueryStorageResourceBrowser];
 const blendedQueryBuilderProviders = [
   BigQueryClauseRenderer,
   AthenaClauseRenderer,
+  RedshiftClauseRenderer,
   BigQueryBlendedQueryBuilder,
   SnowflakeBlendedQueryBuilder,
   RedshiftBlendedQueryBuilder,

--- a/apps/backend/src/data-marts/data-storage-types/redshift/adapters/redshift-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/adapters/redshift-api.adapter.ts
@@ -48,7 +48,7 @@ export class RedshiftApiAdapter {
       params.ClusterIdentifier = this.config.clusterIdentifier;
     }
 
-    this.logger.debug(`Executing query: ${query}`);
+    this.logger.debug(`Executing query (${query.length} chars)`);
 
     const command = new ExecuteStatementCommand(params);
     const response = await this.redshiftDataClient.send(command);

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotImplementedException } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import {
   createBuildContext,
@@ -7,6 +6,7 @@ import {
   makeRelationship,
 } from '../../interfaces/__fixtures__/blended-query-builder-fixtures';
 import { RedshiftBlendedQueryBuilder } from './redshift-blended-query-builder';
+import { RedshiftClauseRenderer } from './redshift-clause-renderer';
 import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
 
 const buildContext = createBuildContext('"myschema"."customers"');
@@ -16,7 +16,7 @@ describe('RedshiftBlendedQueryBuilder', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RedshiftBlendedQueryBuilder],
+      providers: [RedshiftBlendedQueryBuilder, RedshiftClauseRenderer],
     }).compile();
 
     builder = module.get(RedshiftBlendedQueryBuilder);
@@ -118,50 +118,54 @@ describe('RedshiftBlendedQueryBuilder', () => {
   });
 });
 
-describe('RedshiftBlendedQueryBuilder — output controls guard', () => {
-  const builder = new RedshiftBlendedQueryBuilder();
-  const baseContext: BlendedQueryContext = {
-    mainTableReference: '"myschema"."customers"',
-    mainDataMartTitle: 'M',
-    mainDataMartUrl: 'http://x',
-    chains: [],
-    columns: ['a'],
-  };
+describe('RedshiftBlendedQueryBuilder — output controls', () => {
+  let builder: RedshiftBlendedQueryBuilder;
 
-  it('throws NotImplemented when filters are non-empty', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
-        filters: [{ column: 'a', operator: 'eq', value: 1 }],
-      })
-    ).toThrow(NotImplementedException);
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RedshiftBlendedQueryBuilder, RedshiftClauseRenderer],
+    }).compile();
+    builder = module.get(RedshiftBlendedQueryBuilder);
   });
 
-  it('throws NotImplemented when sort is non-empty', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
-        sort: [{ column: 'a', direction: 'asc' }],
-      })
-    ).toThrow(NotImplementedException);
+  function ctx(over: Partial<BlendedQueryContext>): BlendedQueryContext {
+    return {
+      mainTableReference: '"myschema"."customers"',
+      mainDataMartTitle: 'M',
+      mainDataMartUrl: 'http://x',
+      chains: [],
+      columns: ['a'],
+      ...over,
+    };
+  }
+
+  it('applies a post-join filter as an inlined literal predicate with no params (implicit placement defaults to post-join)', () => {
+    const { sql, params } = builder.buildBlendedQuery(
+      ctx({ filters: [{ column: 'a', operator: 'eq', value: 1 }] })
+    );
+    expect(sql).toContain('WHERE main.a = 1');
+    expect(params).toEqual([]);
   });
 
-  it('throws NotImplemented when limit is set', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
-        limit: 100,
-      })
-    ).toThrow(NotImplementedException);
-  });
-
-  it('throws NotImplemented on pre-join filters (slices)', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
+  it('inlines a pre-join slice filter as a literal inside the subsidiary raw CTE with no params', () => {
+    const chain = makeChain({
+      relationship: makeRelationship({
+        targetAlias: 'users',
+        joinConditions: [{ sourceFieldName: 'user_id', targetFieldName: 'user_id' }],
+      }),
+      targetTableReference: '"myschema"."users"',
+      parentAlias: 'main',
+      blendedFields: [
+        { targetFieldName: 'role', outputAlias: 'role', isHidden: true, aggregateFunction: 'MAX' },
+      ],
+    });
+    const { sql, params } = builder.buildBlendedQuery(
+      ctx({
+        chains: [chain],
+        columns: ['a'],
         filters: [
           {
-            column: 'userRole',
+            column: 'role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
@@ -169,6 +173,41 @@ describe('RedshiftBlendedQueryBuilder — output controls guard', () => {
           },
         ],
       })
-    ).toThrow(NotImplementedException);
+    );
+    // The inlined literal predicate must appear inside the subsidiary raw CTE.
+    // Verify structural ordering: "users_raw AS (" comes before "role = 'admin'",
+    // which itself comes before the outer SELECT (proving it's in the raw CTE, not outer WHERE).
+    const rawCteStart = sql.indexOf('users_raw AS (');
+    const predicatePos = sql.indexOf("role = 'admin'");
+    const outerSelectPos = sql.lastIndexOf('\nSELECT\n');
+    expect(rawCteStart).toBeGreaterThanOrEqual(0);
+    expect(predicatePos).toBeGreaterThan(rawCteStart);
+    expect(predicatePos).toBeLessThan(outerSelectPos);
+    // The outer WHERE must not reference the pre-join column
+    expect(sql).not.toContain('WHERE main.role');
+    // Redshift uses inlined literals — no bound params
+    expect(params).toEqual([]);
+  });
+
+  it('renders ORDER BY and LIMIT', () => {
+    const { sql } = builder.buildBlendedQuery(
+      ctx({ sort: [{ column: 'a', direction: 'desc' }], limit: 10 })
+    );
+    expect(sql).toContain('ORDER BY main.a DESC');
+    expect(sql).toContain('LIMIT 10');
+  });
+
+  it('multiple post-join filters combine with AND (inlined, no params)', () => {
+    const { sql, params } = builder.buildBlendedQuery(
+      ctx({
+        columns: ['a'],
+        filters: [
+          { column: 'a', operator: 'eq', value: 'x', placement: 'post-join' },
+          { column: 'a', operator: 'neq', value: 'y', placement: 'post-join' },
+        ],
+      })
+    );
+    expect(sql).toContain("WHERE main.a = 'x' AND main.a <> 'y'");
+    expect(params).toEqual([]);
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.ts
@@ -2,14 +2,19 @@ import { Injectable } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
 import { SqlClauseRenderer } from '../../utils/sql-clause-renderer';
+import { RedshiftClauseRenderer } from './redshift-clause-renderer';
 
 @Injectable()
 export class RedshiftBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
   readonly type = DataStorageType.AWS_REDSHIFT;
   protected readonly identifierQuoteChar = '"';
 
-  protected get clauseRenderer(): SqlClauseRenderer | null {
-    return null;
+  constructor(private readonly renderer: RedshiftClauseRenderer) {
+    super();
+  }
+
+  protected get clauseRenderer(): SqlClauseRenderer {
+    return this.renderer;
   }
 
   protected buildStringAgg(fieldName: string): string {

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.spec.ts
@@ -1,0 +1,230 @@
+import { RedshiftClauseRenderer } from './redshift-clause-renderer';
+import { ColumnRefResolver, RenderedClause } from '../../utils/sql-clause-renderer';
+
+describe('RedshiftClauseRenderer', () => {
+  const r = new RedshiftClauseRenderer();
+
+  describe('scalar operators (inline literals, double-quote identifiers, no params)', () => {
+    it('eq inlines a string literal and emits no params', () => {
+      const out = r.renderWhere([{ column: 'name', operator: 'eq', value: 'X' }]);
+      expect(out.sql).toBe(`\nWHERE "name" = 'X'`);
+      expect(out.params).toEqual([]);
+    });
+    it('neq/gt/lt/gte/lte', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'neq', value: 1 }]).sql).toBe(
+        '\nWHERE "a" <> 1'
+      );
+      expect(r.renderWhere([{ column: 'a', operator: 'gt', value: 1 }]).sql).toBe(
+        '\nWHERE "a" > 1'
+      );
+      expect(r.renderWhere([{ column: 'a', operator: 'lt', value: 1 }]).sql).toBe(
+        '\nWHERE "a" < 1'
+      );
+      expect(r.renderWhere([{ column: 'a', operator: 'gte', value: 1 }]).sql).toBe(
+        '\nWHERE "a" >= 1'
+      );
+      expect(r.renderWhere([{ column: 'a', operator: 'lte', value: 1 }]).sql).toBe(
+        '\nWHERE "a" <= 1'
+      );
+    });
+    it('contains/not_contains use STRPOS (no wildcard smuggling)', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'contains', value: 'foo' }]).sql).toBe(
+        `\nWHERE STRPOS("a", 'foo') > 0`
+      );
+      expect(r.renderWhere([{ column: 'a', operator: 'not_contains', value: 'X' }]).sql).toBe(
+        `\nWHERE STRPOS("a", 'X') = 0`
+      );
+    });
+    it('starts_with uses STRPOS = 1', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'starts_with', value: 'X' }]).sql).toBe(
+        `\nWHERE STRPOS("a", 'X') = 1`
+      );
+    });
+    it('ends_with uses RIGHT(col, LEN(lit)) = lit', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'ends_with', value: 'X' }]).sql).toBe(
+        `\nWHERE RIGHT("a", LEN('X')) = 'X'`
+      );
+    });
+    it('substring matchers keep % and _ literal', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'contains', value: '100%' }]).sql).toBe(
+        `\nWHERE STRPOS("a", '100%') > 0`
+      );
+    });
+    it('regex/not_regex use ~ / !~', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'regex', value: '^x' }]).sql).toBe(
+        `\nWHERE "a" ~ '^x'`
+      );
+      expect(r.renderWhere([{ column: 'a', operator: 'not_regex', value: '^x' }]).sql).toBe(
+        `\nWHERE "a" !~ '^x'`
+      );
+    });
+  });
+
+  describe('no-value operators', () => {
+    it('is_empty / is_not_empty', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'is_empty' }]).sql).toBe(
+        `\nWHERE ("a" IS NULL OR "a" = '')`
+      );
+      expect(r.renderWhere([{ column: 'a', operator: 'is_not_empty' }]).sql).toBe(
+        `\nWHERE ("a" IS NOT NULL AND "a" <> '')`
+      );
+    });
+    it('is_null / is_not_null', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'is_null' }]).sql).toBe('\nWHERE "a" IS NULL');
+      expect(r.renderWhere([{ column: 'a', operator: 'is_not_null' }]).sql).toBe(
+        '\nWHERE "a" IS NOT NULL'
+      );
+    });
+    it('is_true / is_false', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'is_true' }]).sql).toBe('\nWHERE "a" = TRUE');
+      expect(r.renderWhere([{ column: 'a', operator: 'is_false' }]).sql).toBe(
+        '\nWHERE "a" = FALSE'
+      );
+    });
+  });
+
+  describe('between', () => {
+    it('inlines both bounds, no params', () => {
+      const out = r.renderWhere([
+        { column: 'amount', operator: 'between', value: { from: 1, to: 100 } },
+      ]);
+      expect(out.sql).toBe('\nWHERE "amount" BETWEEN 1 AND 100');
+      expect(out.params).toEqual([]);
+    });
+  });
+
+  describe('multiple filters (AND combination)', () => {
+    it('inlines every literal across an AND chain, params stay empty', () => {
+      const out = r.renderWhere([
+        { column: 'name', operator: 'eq', value: "O'Brien" },
+        { column: 'age', operator: 'gt', value: 30 },
+      ]);
+      expect(out.sql).toBe(`\nWHERE "name" = 'O''Brien' AND "age" > 30`);
+      expect(out.params).toEqual([]);
+    });
+  });
+
+  describe('relative_date (Redshift date functions, half-open + upper bounds)', () => {
+    it('today', () => {
+      expect(
+        r.renderWhere([{ column: 'd', operator: 'relative_date', value: { kind: 'today' } }]).sql
+      ).toBe('\nWHERE "d" >= CURRENT_DATE AND "d" < DATEADD(day, 1, CURRENT_DATE)');
+    });
+    it('yesterday', () => {
+      expect(
+        r.renderWhere([{ column: 'd', operator: 'relative_date', value: { kind: 'yesterday' } }])
+          .sql
+      ).toBe('\nWHERE "d" >= DATEADD(day, -1, CURRENT_DATE) AND "d" < CURRENT_DATE');
+    });
+    it('last_n_days', () => {
+      expect(
+        r.renderWhere([
+          { column: 'd', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
+        ]).sql
+      ).toBe('\nWHERE "d" >= DATEADD(day, -7, CURRENT_DATE)');
+    });
+    it('last_n_months', () => {
+      expect(
+        r.renderWhere([
+          { column: 'd', operator: 'relative_date', value: { kind: 'last_n_months', n: 3 } },
+        ]).sql
+      ).toBe('\nWHERE "d" >= DATEADD(month, -3, CURRENT_DATE)');
+    });
+    it('this_month has an upper bound', () => {
+      expect(
+        r.renderWhere([{ column: 'd', operator: 'relative_date', value: { kind: 'this_month' } }])
+          .sql
+      ).toBe(
+        `\nWHERE "d" >= DATE_TRUNC('month', CURRENT_DATE) AND "d" < DATEADD(month, 1, DATE_TRUNC('month', CURRENT_DATE))`
+      );
+    });
+    it('last_month', () => {
+      expect(
+        r.renderWhere([{ column: 'd', operator: 'relative_date', value: { kind: 'last_month' } }])
+          .sql
+      ).toBe(
+        `\nWHERE "d" >= DATE_TRUNC('month', DATEADD(month, -1, CURRENT_DATE)) AND "d" < DATE_TRUNC('month', CURRENT_DATE)`
+      );
+    });
+    it('this_year has an upper bound', () => {
+      expect(
+        r.renderWhere([{ column: 'd', operator: 'relative_date', value: { kind: 'this_year' } }])
+          .sql
+      ).toBe(
+        `\nWHERE "d" >= DATE_TRUNC('year', CURRENT_DATE) AND "d" < DATEADD(year, 1, DATE_TRUNC('year', CURRENT_DATE))`
+      );
+    });
+  });
+
+  it('quotes dotted identifiers', () => {
+    expect(r.renderWhere([{ column: 'db.schema.col', operator: 'eq', value: 1 }]).sql).toBe(
+      '\nWHERE "db"."schema"."col" = 1'
+    );
+  });
+
+  describe('column qualification (blended path)', () => {
+    const qualify: ColumnRefResolver = column => `main."${column}"`;
+    it('honours the resolver', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'eq', value: 1 }], qualify).sql).toBe(
+        '\nWHERE main."a" = 1'
+      );
+      expect(r.renderOrderBy([{ column: 'a', direction: 'asc' }], qualify).sql).toBe(
+        '\nORDER BY main."a" ASC'
+      );
+    });
+  });
+
+  describe('SQL-injection safety (literal escaping is the only barrier)', () => {
+    it("doubles a single quote (O'Brien)", () => {
+      expect(r.renderWhere([{ column: 'name', operator: 'eq', value: "O'Brien" }]).sql).toBe(
+        `\nWHERE "name" = 'O''Brien'`
+      );
+    });
+    it('keeps a classic breakout payload inside one literal', () => {
+      expect(r.renderWhere([{ column: 'name', operator: 'eq', value: "') OR 1=1 --" }]).sql).toBe(
+        `\nWHERE "name" = ''') OR 1=1 --'`
+      );
+    });
+    it('renders booleans / numbers / null as bare literals', () => {
+      expect(r.renderWhere([{ column: 'b', operator: 'eq', value: true }]).sql).toBe(
+        '\nWHERE "b" = TRUE'
+      );
+      expect(r.renderWhere([{ column: 'n', operator: 'eq', value: 0 }]).sql).toBe(
+        '\nWHERE "n" = 0'
+      );
+    });
+    it('renders an empty string value as two adjacent single quotes', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'eq', value: '' }]).sql).toBe(
+        `\nWHERE "a" = ''`
+      );
+    });
+    it('treats backslash as an ordinary character (standard_conforming_strings = on)', () => {
+      expect(r.renderWhere([{ column: 'a', operator: 'eq', value: 'C:\\path' }]).sql).toBe(
+        `\nWHERE "a" = 'C:\\path'`
+      );
+    });
+  });
+
+  describe('LIMIT', () => {
+    it('renders integer limit', () => {
+      expect(r.renderLimit(100).sql).toBe('\nLIMIT 100');
+    });
+    it('rejects negative/non-integer', () => {
+      expect(() => r.renderLimit(-1)).toThrow();
+      expect(() => r.renderLimit(1.5)).toThrow();
+    });
+  });
+
+  describe('no-param invariant (validateFragment)', () => {
+    it('throws if a fragment emits a bound param', () => {
+      class Broken extends RedshiftClauseRenderer {
+        protected renderFilterFragment(): RenderedClause {
+          return { sql: '"a" = ?', params: [{ name: 'p0', value: 1 }] };
+        }
+      }
+      expect(() => new Broken().renderWhere([{ column: 'a', operator: 'eq', value: 1 }])).toThrow(
+        /must inline all values/
+      );
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.spec.ts
@@ -217,6 +217,13 @@ describe('RedshiftClauseRenderer', () => {
         '\nWHERE "n" = 0'
       );
     });
+    // The schema rejects non-finite numbers, but the renderer inlines them, so it
+    // re-guards: String(Infinity) would emit a bare `Infinity` token, not safe SQL.
+    it('throws on a non-finite number that bypassed the schema', () => {
+      expect(() => r.renderWhere([{ column: 'amount', operator: 'gt', value: Infinity }])).toThrow(
+        'Non-finite numeric filter value'
+      );
+    });
     it('renders an empty string value as two adjacent single quotes', () => {
       expect(r.renderWhere([{ column: 'a', operator: 'eq', value: '' }]).sql).toBe(
         `\nWHERE "a" = ''`

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.spec.ts
@@ -116,19 +116,23 @@ describe('RedshiftClauseRenderer', () => {
           .sql
       ).toBe('\nWHERE "d" >= DATEADD(day, -1, CURRENT_DATE) AND "d" < CURRENT_DATE');
     });
-    it('last_n_days', () => {
+    it('last_n_days has an upper bound', () => {
       expect(
         r.renderWhere([
           { column: 'd', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
         ]).sql
-      ).toBe('\nWHERE "d" >= DATEADD(day, -7, CURRENT_DATE)');
+      ).toBe(
+        '\nWHERE "d" >= DATEADD(day, -7, CURRENT_DATE) AND "d" < DATEADD(day, 1, CURRENT_DATE)'
+      );
     });
-    it('last_n_months', () => {
+    it('last_n_months has an upper bound', () => {
       expect(
         r.renderWhere([
           { column: 'd', operator: 'relative_date', value: { kind: 'last_n_months', n: 3 } },
         ]).sql
-      ).toBe('\nWHERE "d" >= DATEADD(month, -3, CURRENT_DATE)');
+      ).toBe(
+        '\nWHERE "d" >= DATEADD(month, -3, CURRENT_DATE) AND "d" < DATEADD(day, 1, CURRENT_DATE)'
+      );
     });
     it('this_month has an upper bound', () => {
       expect(
@@ -153,6 +157,26 @@ describe('RedshiftClauseRenderer', () => {
       ).toBe(
         `\nWHERE "d" >= DATE_TRUNC('year', CURRENT_DATE) AND "d" < DATEADD(year, 1, DATE_TRUNC('year', CURRENT_DATE))`
       );
+    });
+    // `n` is inlined into SQL, so the renderer re-guards it even if a write path
+    // bypassed the zod schema (z.number().int().positive().max(3650)).
+    it('rejects a non-integer n', () => {
+      expect(() =>
+        r.renderWhere([
+          { column: 'd', operator: 'relative_date', value: { kind: 'last_n_days', n: 7.5 } },
+        ])
+      ).toThrow('Invalid relative_date n');
+    });
+    it('rejects a non-numeric n that bypassed the validator', () => {
+      expect(() =>
+        r.renderWhere([
+          {
+            column: 'd',
+            operator: 'relative_date',
+            value: { kind: 'last_n_days', n: '1); DROP TABLE t --' as unknown as number },
+          },
+        ])
+      ).toThrow('Invalid relative_date n');
     });
   });
 

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.ts
@@ -104,6 +104,11 @@ export class RedshiftClauseRenderer extends SqlClauseRenderer {
     col: string,
     preset: Extract<FilterRule, { operator: 'relative_date' }>['value']
   ): string {
+    // `n` is inlined into SQL below; re-assert the integer locally so the injection
+    // barrier does not live solely in the zod schema on the request path.
+    if ('n' in preset && (!Number.isInteger(preset.n) || preset.n < 0)) {
+      throw new Error(`Invalid relative_date n: ${String(preset.n)}`);
+    }
     switch (preset.kind) {
       // Half-open ranges (not equality): `col = CURRENT_DATE` matches only the
       // midnight instant on TIMESTAMP/TIMESTAMPTZ columns. A range covers the
@@ -113,9 +118,15 @@ export class RedshiftClauseRenderer extends SqlClauseRenderer {
       case 'yesterday':
         return `${col} >= DATEADD(day, -1, CURRENT_DATE) AND ${col} < CURRENT_DATE`;
       case 'last_n_days':
-        return `${col} >= DATEADD(day, -${preset.n}, CURRENT_DATE)`;
+        return (
+          `${col} >= DATEADD(day, -${preset.n}, CURRENT_DATE)` +
+          ` AND ${col} < DATEADD(day, 1, CURRENT_DATE)`
+        );
       case 'last_n_months':
-        return `${col} >= DATEADD(month, -${preset.n}, CURRENT_DATE)`;
+        return (
+          `${col} >= DATEADD(month, -${preset.n}, CURRENT_DATE)` +
+          ` AND ${col} < DATEADD(day, 1, CURRENT_DATE)`
+        );
       case 'this_month':
         return (
           `${col} >= DATE_TRUNC('month', CURRENT_DATE)` +

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.ts
@@ -1,0 +1,136 @@
+import { Injectable } from '@nestjs/common';
+import { RenderedClause, SqlClauseRenderer } from '../../utils/sql-clause-renderer';
+import { FilterRule } from '../../../dto/schemas/filter-config.schema';
+import { escapeRedshiftIdentifier } from '../utils/redshift-identifier.utils';
+
+/**
+ * Formats a value as a Redshift SQL literal. This is the ONLY barrier between user
+ * filter input and executed SQL — the Redshift Data API path has no bound-param
+ * channel, so the renderer inlines literals and escaping must be airtight. Single
+ * quotes are doubled (standard SQL). Assumes `standard_conforming_strings = on`
+ * (backslash is an ordinary character) — verified by the integration suite.
+ */
+function formatRedshiftLiteral(value: string | number | boolean | null): string {
+  if (value === null) return 'NULL';
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
+  return `'${value.split("'").join("''")}'`;
+}
+
+/**
+ * Redshift (PostgreSQL-derived) renderer. Unlike Athena/BigQuery it does NOT use
+ * bound parameters: every fragment returns finished SQL with `params: []`. Substring
+ * matchers use STRPOS/RIGHT (never LIKE) so user `%`/`_` stay literal. Date/time
+ * values are bare quoted literals — Postgres `unknown`-literal coercion handles the
+ * comparison (verified live). `columnType` is kept threaded as a CAST seam.
+ */
+@Injectable()
+export class RedshiftClauseRenderer extends SqlClauseRenderer {
+  protected quoteIdentifier(name: string): string {
+    return escapeRedshiftIdentifier(name);
+  }
+
+  // This renderer inlines every value, so a fragment must never emit a bound param.
+  // A future operator that forgets to inline fails fast here instead of silently
+  // dropping a value (the run path would then send unbound SQL with no channel).
+  protected validateFragment(clause: RenderedClause): void {
+    if (clause.params.length !== 0) {
+      throw new Error(
+        `RedshiftClauseRenderer must inline all values, but a fragment emitted ` +
+          `${clause.params.length} param(s): "${clause.sql}".`
+      );
+    }
+  }
+
+  protected renderFilterFragment(
+    rule: FilterRule,
+    _paramName: string,
+    col: string,
+    _columnType?: string
+  ): RenderedClause {
+    const lit = (v: string | number | boolean | null): string => formatRedshiftLiteral(v);
+    switch (rule.operator) {
+      case 'eq':
+        return { sql: `${col} = ${lit(rule.value)}`, params: [] };
+      case 'neq':
+        return { sql: `${col} <> ${lit(rule.value)}`, params: [] };
+      case 'gt':
+        return { sql: `${col} > ${lit(rule.value)}`, params: [] };
+      case 'lt':
+        return { sql: `${col} < ${lit(rule.value)}`, params: [] };
+      case 'gte':
+        return { sql: `${col} >= ${lit(rule.value)}`, params: [] };
+      case 'lte':
+        return { sql: `${col} <= ${lit(rule.value)}`, params: [] };
+      // Text-only operators: coerce to a string literal so STRPOS / ~ always get text
+      // (validator restricts these to string columns; mirrors the Athena renderer).
+      case 'contains':
+        return { sql: `STRPOS(${col}, ${lit(String(rule.value))}) > 0`, params: [] };
+      case 'not_contains':
+        return { sql: `STRPOS(${col}, ${lit(String(rule.value))}) = 0`, params: [] };
+      case 'starts_with':
+        return { sql: `STRPOS(${col}, ${lit(String(rule.value))}) = 1`, params: [] };
+      case 'ends_with': {
+        const v = lit(String(rule.value));
+        return { sql: `RIGHT(${col}, LEN(${v})) = ${v}`, params: [] };
+      }
+      case 'regex':
+        return { sql: `${col} ~ ${lit(String(rule.value))}`, params: [] };
+      case 'not_regex':
+        return { sql: `${col} !~ ${lit(String(rule.value))}`, params: [] };
+      case 'is_empty':
+        return { sql: `(${col} IS NULL OR ${col} = '')`, params: [] };
+      case 'is_not_empty':
+        return { sql: `(${col} IS NOT NULL AND ${col} <> '')`, params: [] };
+      case 'is_null':
+        return { sql: `${col} IS NULL`, params: [] };
+      case 'is_not_null':
+        return { sql: `${col} IS NOT NULL`, params: [] };
+      case 'is_true':
+        return { sql: `${col} = TRUE`, params: [] };
+      case 'is_false':
+        return { sql: `${col} = FALSE`, params: [] };
+      case 'between':
+        return {
+          sql: `${col} BETWEEN ${lit(rule.value.from)} AND ${lit(rule.value.to)}`,
+          params: [],
+        };
+      case 'relative_date':
+        return { sql: this.renderRelativeDate(col, rule.value), params: [] };
+    }
+  }
+
+  private renderRelativeDate(
+    col: string,
+    preset: Extract<FilterRule, { operator: 'relative_date' }>['value']
+  ): string {
+    switch (preset.kind) {
+      // Half-open ranges (not equality): `col = CURRENT_DATE` matches only the
+      // midnight instant on TIMESTAMP/TIMESTAMPTZ columns. A range covers the
+      // whole day for DATE and TIMESTAMP alike.
+      case 'today':
+        return `${col} >= CURRENT_DATE AND ${col} < DATEADD(day, 1, CURRENT_DATE)`;
+      case 'yesterday':
+        return `${col} >= DATEADD(day, -1, CURRENT_DATE) AND ${col} < CURRENT_DATE`;
+      case 'last_n_days':
+        return `${col} >= DATEADD(day, -${preset.n}, CURRENT_DATE)`;
+      case 'last_n_months':
+        return `${col} >= DATEADD(month, -${preset.n}, CURRENT_DATE)`;
+      case 'this_month':
+        return (
+          `${col} >= DATE_TRUNC('month', CURRENT_DATE)` +
+          ` AND ${col} < DATEADD(month, 1, DATE_TRUNC('month', CURRENT_DATE))`
+        );
+      case 'last_month':
+        return (
+          `${col} >= DATE_TRUNC('month', DATEADD(month, -1, CURRENT_DATE))` +
+          ` AND ${col} < DATE_TRUNC('month', CURRENT_DATE)`
+        );
+      case 'this_year':
+        return (
+          `${col} >= DATE_TRUNC('year', CURRENT_DATE)` +
+          ` AND ${col} < DATEADD(year, 1, DATE_TRUNC('year', CURRENT_DATE))`
+        );
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer.ts
@@ -12,7 +12,14 @@ import { escapeRedshiftIdentifier } from '../utils/redshift-identifier.utils';
  */
 function formatRedshiftLiteral(value: string | number | boolean | null): string {
   if (value === null) return 'NULL';
-  if (typeof value === 'number') return String(value);
+  if (typeof value === 'number') {
+    // Inlined directly, so re-assert finiteness even though the schema validates it:
+    // String(Infinity) would emit `Infinity` as a bare SQL token, not a safe rejection.
+    if (!Number.isFinite(value)) {
+      throw new Error(`Non-finite numeric filter value: ${String(value)}`);
+    }
+    return String(value);
+  }
   if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
   return `'${value.split("'").join("''")}'`;
 }

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-create-view.executor.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-create-view.executor.ts
@@ -9,6 +9,7 @@ import { DataStorageCredentials } from '../../data-storage-credentials.type';
 import { RedshiftApiAdapterFactory } from '../adapters/redshift-api-adapter.factory';
 import { isRedshiftConfig } from '../../data-storage-config.guards';
 import { isRedshiftCredentials } from '../../data-storage-credentials.guards';
+import { escapeRedshiftIdentifier } from '../utils/redshift-identifier.utils';
 
 @Injectable()
 export class RedshiftCreateViewExecutor implements CreateViewExecutor {
@@ -32,7 +33,7 @@ export class RedshiftCreateViewExecutor implements CreateViewExecutor {
 
     const adapter = this.adapterFactory.create(credentials, config);
 
-    const fullyQualifiedName = this.escapeIdentifier(viewName);
+    const fullyQualifiedName = escapeRedshiftIdentifier(viewName);
 
     const parts = viewName.split('.').filter(p => p.trim().length > 0);
     if (parts.length >= 2) {
@@ -40,7 +41,7 @@ export class RedshiftCreateViewExecutor implements CreateViewExecutor {
       if (!schemaName || !schemaName.trim()) {
         throw new Error(`Invalid view name format: ${viewName}. Schema name cannot be empty.`);
       }
-      const createSchemaQuery = `CREATE SCHEMA IF NOT EXISTS "${schemaName}"`;
+      const createSchemaQuery = `CREATE SCHEMA IF NOT EXISTS ${escapeRedshiftIdentifier(schemaName)}`;
 
       const { statementId: schemaStatementId } = await adapter.executeQuery(createSchemaQuery);
       await adapter.waitForQueryToComplete(schemaStatementId);
@@ -51,12 +52,5 @@ export class RedshiftCreateViewExecutor implements CreateViewExecutor {
 
     await adapter.waitForQueryToComplete(statementId);
     return { fullyQualifiedName };
-  }
-
-  private escapeIdentifier(identifier: string): string {
-    return identifier
-      .split('.')
-      .map(part => (part.startsWith('"') && part.endsWith('"') ? part : `"${part}"`))
-      .join('.');
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-query.builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-query.builder.spec.ts
@@ -1,31 +1,56 @@
-import { NotImplementedException } from '@nestjs/common';
+import { RedshiftClauseRenderer } from './redshift-clause-renderer';
 import { RedshiftQueryBuilder } from './redshift-query.builder';
+import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
 
-describe('RedshiftQueryBuilder — output controls guard', () => {
-  const builder = new RedshiftQueryBuilder();
-  const tableDef = { type: 'table', fullyQualifiedName: 'myschema.tbl' } as any;
+describe('RedshiftQueryBuilder', () => {
+  const tableDef = { type: 'table', fullyQualifiedName: 'db.events' } as any;
+  const sqlDef = { sqlQuery: 'SELECT a FROM t' } as unknown as DataMartDefinition;
 
-  it('throws NotImplemented when filters are non-empty', () => {
-    expect(() =>
-      builder.buildQuery(tableDef, {
-        filters: [{ column: 'a', operator: 'eq', value: 1 }],
-      })
-    ).toThrow(NotImplementedException);
+  it('still builds a plain query when no controls are present', () => {
+    const builder = new RedshiftQueryBuilder(new RedshiftClauseRenderer());
+    expect(builder.buildQuery(tableDef)).toBe('SELECT * FROM "db"."events"');
   });
 
-  it('throws NotImplemented when sort is non-empty', () => {
-    expect(() =>
-      builder.buildQuery(tableDef, {
-        sort: [{ column: 'a', direction: 'asc' }],
-      })
-    ).toThrow(NotImplementedException);
+  it('builds an exact LIMIT 0 schema-probe query (via the OC branch)', () => {
+    const builder = new RedshiftQueryBuilder(new RedshiftClauseRenderer());
+    expect(builder.buildQuery(tableDef, { limit: 0 })).toBe('SELECT * FROM "db"."events"\nLIMIT 0');
   });
 
-  it('still works without output controls (limit-only legacy path)', () => {
-    expect(builder.buildQuery(tableDef, { limit: 0 })).toBeDefined();
+  it('emits WHERE/ORDER BY/LIMIT with inlined literals for a TABLE def', () => {
+    const builder = new RedshiftQueryBuilder(new RedshiftClauseRenderer());
+    const sql = builder.buildQuery(tableDef, {
+      filters: [{ column: 'status', operator: 'eq', value: 'active' }],
+      sort: [{ column: 'created_at', direction: 'desc' }],
+      limit: 50,
+    });
+    expect(sql).toBe(
+      `SELECT * FROM "db"."events"\nWHERE "status" = 'active'\nORDER BY "created_at" DESC\nLIMIT 50`
+    );
   });
 
-  it('still works without options', () => {
-    expect(builder.buildQuery(tableDef)).toBeDefined();
+  it('emits WHERE only when no sort or limit', () => {
+    const builder = new RedshiftQueryBuilder(new RedshiftClauseRenderer());
+    const sql = builder.buildQuery(tableDef, {
+      filters: [{ column: 'status', operator: 'eq', value: 'active' }],
+    });
+    expect(sql).toBe(`SELECT * FROM "db"."events"\nWHERE "status" = 'active'`);
+  });
+
+  it('wraps a SQL-def in parens when output controls have no mainTableReference', () => {
+    const builder = new RedshiftQueryBuilder(new RedshiftClauseRenderer());
+    const sql = builder.buildQuery(sqlDef, {
+      filters: [{ column: 'a', operator: 'eq', value: 1 }],
+    });
+    expect(sql).toBe(`SELECT * FROM (SELECT a FROM t) AS subq\nWHERE "a" = 1`);
+  });
+
+  it('uses mainTableReference for a SQL-def with output controls', () => {
+    const builder = new RedshiftQueryBuilder(new RedshiftClauseRenderer());
+    const sql = builder.buildQuery(sqlDef, {
+      filters: [{ column: 'a', operator: 'eq', value: 1 }],
+      mainTableReference: '"myschema"."__view_abc"',
+    });
+    expect(sql).toContain('FROM "myschema"."__view_abc"');
+    expect(sql).not.toContain('SELECT a FROM t');
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-query.builder.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import {
   DataMartQueryBuilder,
   DataMartQueryOptions,
@@ -13,46 +13,88 @@ import {
   isTablePatternDefinition,
 } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition.guards';
 import { escapeRedshiftIdentifier } from '../utils/redshift-identifier.utils';
+import { RedshiftClauseRenderer } from './redshift-clause-renderer';
 
 @Injectable()
 export class RedshiftQueryBuilder implements DataMartQueryBuilder {
   readonly type = DataStorageType.AWS_REDSHIFT;
 
+  constructor(private readonly clauseRenderer: RedshiftClauseRenderer) {}
+
   buildQuery(definition: DataMartDefinition, queryOptions?: DataMartQueryOptions): string {
-    if ((queryOptions?.filters?.length ?? 0) > 0 || (queryOptions?.sort?.length ?? 0) > 0) {
-      throw new NotImplementedException(
-        `Output controls not yet supported for storage type ${this.type}`
+    const hasOutputControls =
+      (queryOptions?.filters?.length ?? 0) > 0 ||
+      (queryOptions?.sort?.length ?? 0) > 0 ||
+      queryOptions?.limit != null;
+
+    const selectList = this.buildSelectList(queryOptions?.columns);
+
+    if (!hasOutputControls) {
+      return this.buildPlainQuery(definition, selectList, queryOptions);
+    }
+
+    const fromClause = this.resolveFromClauseWithOutputControls(definition, queryOptions);
+    const where = this.clauseRenderer.renderWhere(queryOptions?.filters ?? []);
+    const orderBy = this.clauseRenderer.renderOrderBy(queryOptions?.sort ?? []);
+    const limit = this.clauseRenderer.renderLimit(queryOptions?.limit ?? null);
+
+    // Redshift inlines every literal, so no path carries bound params. Fail fast
+    // if a fragment ever produced one (the executor has no channel to bind it).
+    const paramCount = where.params.length + orderBy.params.length + limit.params.length;
+    if (paramCount > 0) {
+      throw new Error(
+        `RedshiftQueryBuilder expected zero bound params (literals are inlined) but got ${paramCount}`
       );
     }
-    const selectList = this.buildSelectList(queryOptions?.columns);
-    let query: string;
 
+    return `SELECT ${selectList} FROM ${fromClause}${where.sql}${orderBy.sql}${limit.sql}`;
+  }
+
+  private buildPlainQuery(
+    definition: DataMartDefinition,
+    selectList: string,
+    queryOptions?: DataMartQueryOptions
+  ): string {
     if (isTableDefinition(definition) || isViewDefinition(definition)) {
-      query = `SELECT ${selectList} FROM ${escapeRedshiftIdentifier(definition.fullyQualifiedName)}`;
-    } else if (isConnectorDefinition(definition)) {
-      query = `SELECT ${selectList} FROM ${escapeRedshiftIdentifier(definition.connector.storage.fullyQualifiedName)}`;
-    } else if (isSqlDefinition(definition)) {
+      return `SELECT ${selectList} FROM ${escapeRedshiftIdentifier(definition.fullyQualifiedName)}`;
+    }
+    if (isConnectorDefinition(definition)) {
+      return `SELECT ${selectList} FROM ${escapeRedshiftIdentifier(definition.connector.storage.fullyQualifiedName)}`;
+    }
+    if (isSqlDefinition(definition)) {
       if (queryOptions?.columns?.length) {
         const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
-        query = `SELECT ${selectList} FROM (${cleanQuery})`;
-      } else {
-        query = definition.sqlQuery.trim();
+        return `SELECT ${selectList} FROM (${cleanQuery}) AS subq`;
       }
-    } else if (isTablePatternDefinition(definition)) {
+      return definition.sqlQuery.trim();
+    }
+    if (isTablePatternDefinition(definition)) {
       throw new Error('Table pattern queries are not supported in Redshift');
-    } else {
-      throw new Error('Invalid data mart definition');
     }
+    throw new Error('Invalid data mart definition');
+  }
 
-    if (queryOptions?.limit !== undefined && queryOptions.limit !== null) {
-      if (!Number.isInteger(queryOptions.limit) || queryOptions.limit < 0) {
-        throw new Error(`Invalid LIMIT value: ${String(queryOptions.limit)}`);
+  private resolveFromClauseWithOutputControls(
+    definition: DataMartDefinition,
+    options: DataMartQueryOptions | undefined
+  ): string {
+    if (isTableDefinition(definition) || isViewDefinition(definition)) {
+      return escapeRedshiftIdentifier(definition.fullyQualifiedName);
+    }
+    if (isConnectorDefinition(definition)) {
+      return escapeRedshiftIdentifier(definition.connector.storage.fullyQualifiedName);
+    }
+    if (isTablePatternDefinition(definition)) {
+      throw new Error('Table pattern queries are not supported in Redshift');
+    }
+    if (isSqlDefinition(definition)) {
+      if (options?.mainTableReference) {
+        return options.mainTableReference;
       }
-      const cleanQuery = query.endsWith(';') ? query.slice(0, -1) : query;
-      query = `SELECT * FROM (${cleanQuery}) LIMIT ${queryOptions.limit}`;
+      const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
+      return `(${cleanQuery}) AS subq`;
     }
-
-    return query;
+    throw new Error('Invalid data mart definition');
   }
 
   private buildSelectList(columns?: string[]): string {

--- a/apps/backend/src/data-marts/dto/schemas/filter-config.schema.spec.ts
+++ b/apps/backend/src/data-marts/dto/schemas/filter-config.schema.spec.ts
@@ -61,6 +61,23 @@ describe('FilterConfigSchema', () => {
       ])
     ).toThrow();
   });
+
+  it('rejects a non-finite scalar number value (Infinity → invalid SQL when inlined)', () => {
+    expect(() =>
+      FilterConfigSchema.parse([{ column: 'amount', operator: 'gt', value: Infinity }])
+    ).toThrow();
+    expect(() =>
+      FilterConfigSchema.parse([{ column: 'amount', operator: 'eq', value: -Infinity }])
+    ).toThrow();
+  });
+
+  it('rejects a non-finite bound in a between filter', () => {
+    expect(() =>
+      FilterConfigSchema.parse([
+        { column: 'amount', operator: 'between', value: { from: 1, to: Infinity } },
+      ])
+    ).toThrow();
+  });
 });
 
 describe('FilterRuleSchema placement / aliasPath', () => {

--- a/apps/backend/src/data-marts/dto/schemas/filter-config.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/filter-config.schema.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 import { ALIAS_PATH_REGEX } from './blended-fields-config.schema';
 
-const ScalarValueSchema = z.union([z.string(), z.number(), z.boolean()]);
+// .finite() rejects Infinity/-Infinity/NaN: a numeric filter value reaches the SQL
+// either as a bound param or inlined as a literal, and `String(Infinity)` would render
+// `> Infinity` (invalid SQL), not a safe rejection.
+const ScalarValueSchema = z.union([z.string(), z.number().finite(), z.boolean()]);
 
 const RelativeDatePresetSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('today') }),

--- a/apps/backend/src/data-marts/services/output-controls-capability.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-capability.service.spec.ts
@@ -13,8 +13,8 @@ describe('OutputControlsCapabilityService', () => {
   it('returns false for Snowflake', () => {
     expect(svc.isSupported(DataStorageType.SNOWFLAKE)).toBe(false);
   });
-  it('returns false for Redshift', () => {
-    expect(svc.isSupported(DataStorageType.AWS_REDSHIFT)).toBe(false);
+  it('supports AWS_REDSHIFT', () => {
+    expect(svc.isSupported(DataStorageType.AWS_REDSHIFT)).toBe(true);
   });
   it('returns false for Databricks', () => {
     expect(svc.isSupported(DataStorageType.DATABRICKS)).toBe(false);

--- a/apps/backend/src/data-marts/services/output-controls-capability.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-capability.service.ts
@@ -7,6 +7,7 @@ export class OutputControlsCapabilityService {
   private readonly supported: ReadonlySet<DataStorageType> = new Set([
     DataStorageType.GOOGLE_BIGQUERY,
     DataStorageType.AWS_ATHENA,
+    DataStorageType.AWS_REDSHIFT,
   ]);
 
   isSupported(type: DataStorageType): boolean {

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { OutputControlsValidatorService } from './output-controls-validator.service';
 import { BigQueryFieldType } from '../data-storage-types/bigquery/enums/bigquery-field-type.enum';
 import { AthenaFieldType } from '../data-storage-types/athena/enums/athena-field-type.enum';
+import { RedshiftFieldType } from '../data-storage-types/redshift/enums/redshift-field-type.enum';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 
 describe('OutputControlsValidatorService', () => {
@@ -1563,6 +1564,31 @@ describe('OutputControlsValidatorService', () => {
       );
       expect(errors).toHaveLength(1);
       expect(errors[0].code).toBe('INVALID_OPERATOR_FOR_TYPE');
+    });
+  });
+
+  describe('validateFilters — Redshift type names', () => {
+    const ok = (type: string, operator: string, value?: unknown) =>
+      svc.validateFilters([{ column: 'c', operator, value } as never], new Map([['c', type]]));
+
+    it('treats Redshift TEXT/BPCHAR as string types (contains allowed)', () => {
+      expect(ok(RedshiftFieldType.TEXT, 'contains', 'x')).toEqual([]);
+      expect(ok(RedshiftFieldType.BPCHAR, 'contains', 'x')).toEqual([]);
+    });
+
+    it('treats DOUBLE PRECISION as a number type (between allowed)', () => {
+      expect(ok(RedshiftFieldType.DOUBLE_PRECISION, 'between', { from: 1, to: 2 })).toEqual([]);
+    });
+
+    it('treats TIMESTAMPTZ as a date type (relative_date allowed)', () => {
+      expect(ok(RedshiftFieldType.TIMESTAMPTZ, 'relative_date', { kind: 'today' })).toEqual([]);
+    });
+
+    it('treats TIMETZ as a time type (relative_date withheld)', () => {
+      expect(ok(RedshiftFieldType.TIMETZ, 'between', { from: '01:00', to: '02:00' })).toEqual([]);
+      expect(ok(RedshiftFieldType.TIMETZ, 'relative_date', { kind: 'today' })[0]?.code).toBe(
+        'INVALID_OPERATOR_FOR_TYPE'
+      );
     });
   });
 });

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.ts
@@ -20,7 +20,7 @@ export type ValidationError =
   | { code: 'FILTER_ALIAS_PATH_NOT_INCLUDED'; aliasPath: string }
   | { code: 'PRE_JOIN_FILTERS_REQUIRE_COLUMN_CONFIG' };
 
-const STRING_TYPES = new Set(['STRING', 'VARCHAR', 'CHAR']);
+const STRING_TYPES = new Set(['STRING', 'VARCHAR', 'CHAR', 'TEXT', 'BPCHAR']);
 const NUMBER_TYPES = new Set([
   'INTEGER',
   'BIGINT',
@@ -29,15 +29,22 @@ const NUMBER_TYPES = new Set([
   'FLOAT',
   'REAL',
   'DOUBLE',
+  'DOUBLE PRECISION',
   'NUMERIC',
   'BIGNUMERIC',
   'DECIMAL',
 ]);
-const DATE_TYPES = new Set(['DATE', 'DATETIME', 'TIMESTAMP', 'TIMESTAMP WITH TIME ZONE']);
+const DATE_TYPES = new Set([
+  'DATE',
+  'DATETIME',
+  'TIMESTAMP',
+  'TIMESTAMP WITH TIME ZONE',
+  'TIMESTAMPTZ',
+]);
 // Time-of-day types are kept separate from DATE/TIMESTAMP: relative_date renders
 // `current_date` / `date_add(..., current_date)` predicates that are meaningless
 // (and rejected by Trino) for a column with no date component.
-const TIME_TYPES = new Set(['TIME', 'TIME WITH TIME ZONE']);
+const TIME_TYPES = new Set(['TIME', 'TIME WITH TIME ZONE', 'TIMETZ']);
 const BOOL_TYPES = new Set(['BOOLEAN', 'BOOL']);
 
 // Valid for any column type, including ones not in the sets above.

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -142,9 +142,10 @@ export class ReportSqlComposerService {
       case DataStorageType.GOOGLE_BIGQUERY:
         return { sql: inlineBigQueryNamedParams(composed.sql, composed.params) };
       default:
-        // Only Athena + BigQuery support output controls (so only they produce
-        // params); guard the contract for any future dialect added before its
-        // inliner exists, rather than emit SQL with unbound parameters.
+        // Redshift inlines all literals and produces no params (early-returned above).
+        // Athena (positional ?) and BigQuery (named @p) are the only current param
+        // producers. This guard catches a future dialect added with output controls
+        // before its inliner is wired, rather than emit SQL with unbound parameters.
         throw new BusinessViolationException(
           'Generating static SQL for a report with value filters is not supported for this storage type.',
           { storageType: report.dataMart.storage.type }

--- a/apps/backend/test/integration/athena.integration.ts
+++ b/apps/backend/test/integration/athena.integration.ts
@@ -407,12 +407,14 @@ describeIfCredentials('Output controls — operator matrix & dates (real Athena)
     //   4  alphabet a%b    40  true   5 days ago
     //   5  ALPHA    a_b    50  false  today
     //   6  (empty)  x       0  true   200 days ago (last year)
+    //   7  future   f      70  true   ~13 months from now (next calendar year)
     //
     // Date expressions use date_add so the relative_date assertions hold
     // regardless of when the suite runs.
     // `created_ts` mirrors `created_at` but as a TIMESTAMP at 13:00 (NOT midnight)
     // for the "today" rows, so the relative_date half-open range is exercised on a
     // sub-day value — the case the old `= current_date` equality silently missed.
+    // Row 7 is future-dated to prove the this_year / this_month UPPER BOUND excludes it.
     const ctasQuery = `CREATE TABLE "${database}"."${MATRIX_TABLE_SUFFIX}"
 WITH (format = 'PARQUET', external_location = 's3://${config.outputBucket}/${MATRIX_S3_PREFIX}data/')
 AS SELECT * FROM (VALUES
@@ -421,7 +423,8 @@ AS SELECT * FROM (VALUES
   (3, 'gamma',    'c',    30,  true,  date_add('day', -400, current_date),   cast(date_add('day', -400, current_date) AS timestamp)),
   (4, 'alphabet', 'a%b',  40,  true,  date_add('day', -5, current_date),     cast(date_add('day', -5, current_date) AS timestamp)),
   (5, 'ALPHA',    'a_b',  50,  false, current_date,                          date_add('hour', 13, cast(current_date AS timestamp))),
-  (6, '',         'x',     0,  true,  date_add('day', -200, current_date),   cast(date_add('day', -200, current_date) AS timestamp))
+  (6, '',         'x',     0,  true,  date_add('day', -200, current_date),   cast(date_add('day', -200, current_date) AS timestamp)),
+  (7, 'future',   'f',    70,  true,  date_add('month', 13, current_date),   cast(date_add('month', 13, current_date) AS timestamp))
 ) AS t (id, name, tag, score, active, created_at, created_ts)`;
 
     const { queryExecutionId } = await adapter.executeQuery(
@@ -454,18 +457,18 @@ AS SELECT * FROM (VALUES
 
   // --- Scalar operators on score ---
 
-  it('neq: score != 20 → rows 1,3,4,5,6', async () => {
+  it('neq: score != 20 → rows 1,3,4,5,6,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'score', operator: 'neq', value: 20 }],
     });
-    expect(ids(rows)).toEqual(['1', '3', '4', '5', '6']);
+    expect(ids(rows)).toEqual(['1', '3', '4', '5', '6', '7']);
   }, 60000);
 
-  it('gt: score > 30 → rows 4,5', async () => {
+  it('gt: score > 30 → rows 4,5,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'score', operator: 'gt', value: 30 }],
     });
-    expect(ids(rows)).toEqual(['4', '5']);
+    expect(ids(rows)).toEqual(['4', '5', '7']);
   }, 60000);
 
   it('lt: score < 30 → rows 1,2,6', async () => {
@@ -475,11 +478,11 @@ AS SELECT * FROM (VALUES
     expect(ids(rows)).toEqual(['1', '2', '6']);
   }, 60000);
 
-  it('gte: score >= 30 → rows 3,4,5', async () => {
+  it('gte: score >= 30 → rows 3,4,5,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'score', operator: 'gte', value: 30 }],
     });
-    expect(ids(rows)).toEqual(['3', '4', '5']);
+    expect(ids(rows)).toEqual(['3', '4', '5', '7']);
   }, 60000);
 
   it('lte: score <= 30 → rows 1,2,3,6', async () => {
@@ -491,11 +494,11 @@ AS SELECT * FROM (VALUES
 
   // --- Substring / affix operators on name ---
 
-  it('not_contains: name not contains "alpha" → rows 2,3,5,6 (case-sensitive; ALPHA excluded)', async () => {
+  it('not_contains: name not contains "alpha" → rows 2,3,5,6,7 (case-sensitive; ALPHA excluded; future row 7)', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'name', operator: 'not_contains', value: 'alpha' }],
     });
-    expect(ids(rows)).toEqual(['2', '3', '5', '6']);
+    expect(ids(rows)).toEqual(['2', '3', '5', '6', '7']);
   }, 60000);
 
   it('starts_with: name starts with "alpha" → rows 1,4', async () => {
@@ -556,11 +559,11 @@ AS SELECT * FROM (VALUES
     expect(ids(rows)).toEqual(['1', '4']);
   }, 60000);
 
-  it('not_regex: name not matching "^alpha" → rows 2,3,5,6', async () => {
+  it('not_regex: name not matching "^alpha" → rows 2,3,5,6,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'name', operator: 'not_regex', value: '^alpha' }],
     });
-    expect(ids(rows)).toEqual(['2', '3', '5', '6']);
+    expect(ids(rows)).toEqual(['2', '3', '5', '6', '7']);
   }, 60000);
 
   // --- No-value operators ---
@@ -572,11 +575,11 @@ AS SELECT * FROM (VALUES
     expect(ids(rows)).toEqual(['6']);
   }, 60000);
 
-  it('is_not_empty on name → rows 1,2,3,4,5', async () => {
+  it('is_not_empty on name → rows 1,2,3,4,5,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'name', operator: 'is_not_empty' }],
     });
-    expect(ids(rows)).toEqual(['1', '2', '3', '4', '5']);
+    expect(ids(rows)).toEqual(['1', '2', '3', '4', '5', '7']);
   }, 60000);
 
   it('is_null on name → 0 rows (no NULLs in seed)', async () => {
@@ -586,18 +589,18 @@ AS SELECT * FROM (VALUES
     expect(rows).toHaveLength(0);
   }, 60000);
 
-  it('is_not_null on name → all 6 rows', async () => {
+  it('is_not_null on name → all 7 rows', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'name', operator: 'is_not_null' }],
     });
-    expect(ids(rows)).toEqual(['1', '2', '3', '4', '5', '6']);
+    expect(ids(rows)).toEqual(['1', '2', '3', '4', '5', '6', '7']);
   }, 60000);
 
-  it('is_true on active → rows 1,3,4,6', async () => {
+  it('is_true on active → rows 1,3,4,6,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'active', operator: 'is_true' }],
     });
-    expect(ids(rows)).toEqual(['1', '3', '4', '6']);
+    expect(ids(rows)).toEqual(['1', '3', '4', '6', '7']);
   }, 60000);
 
   it('is_false on active → rows 2,5', async () => {
@@ -642,34 +645,38 @@ AS SELECT * FROM (VALUES
 
   // The same TIMESTAMP column with a date-only value must run (CAST(? AS TIMESTAMP))
   // and behave as a range bound — proves the cast path on a real sub-day column.
-  it('date gte on a non-midnight TIMESTAMP column → rows 1,5 (today is the only date >= today)', async () => {
+  it('date gte on a non-midnight TIMESTAMP column → all seeded rows >= 2024-01-01', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'created_ts', operator: 'gte', value: '2024-01-01' }],
       columnTypes: new Map([['created_ts', 'TIMESTAMP']]),
     });
-    // every seeded row is >= 2024-01-01, so this mainly proves CAST(? AS TIMESTAMP)
-    // parses and runs against a real TIMESTAMP column carrying a time component.
-    expect(ids(rows)).toEqual(['1', '2', '3', '4', '5', '6']);
+    // every seeded row (including future row 7) is >= 2024-01-01, so this mainly
+    // proves CAST(? AS TIMESTAMP) parses and runs against a real TIMESTAMP column
+    // carrying a time component.
+    expect(ids(rows)).toEqual(['1', '2', '3', '4', '5', '6', '7']);
   }, 60000);
 
-  it('relative_date last_n_days(7) on created_at → rows 1,4,5', async () => {
+  it('relative_date last_n_days(7) on created_at → rows 1,4,5,7 (no upper bound; future row 7 satisfies >= today-7)', async () => {
     const rows = await runMatrix({
       filters: [
         { column: 'created_at', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
       ],
     });
-    expect(ids(rows)).toEqual(['1', '4', '5']);
+    expect(ids(rows)).toEqual(['1', '4', '5', '7']);
   }, 60000);
 
-  it('relative_date this_year on created_at → rows 1,2,4,5', async () => {
+  it('relative_date this_year on created_at → rows 1,2,4,5 (excludes future row 7)', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'created_at', operator: 'relative_date', value: { kind: 'this_year' } }],
     });
+    // Row 7 is ~13 months in the future (next calendar year) and must NOT appear.
+    expect(ids(rows)).not.toContain('7');
     expect(ids(rows)).toEqual(['1', '2', '4', '5']);
   }, 60000);
 
-  it('relative_date last_n_months(3) on created_at → rows 1,4,5 (row 2 at -40 days is within ~1.3 months)', async () => {
-    // -40 days is within 3 months → row 2 included too
+  it('relative_date last_n_months(3) on created_at → rows 1,2,4,5,7 (no upper bound; future row 7 satisfies >= today-3m)', async () => {
+    // -40 days is within 3 months → row 2 included too.
+    // Row 7 (+13 months) satisfies the lower-bound-only predicate and is included.
     const rows = await runMatrix({
       filters: [
         {
@@ -679,7 +686,7 @@ AS SELECT * FROM (VALUES
         },
       ],
     });
-    expect(ids(rows)).toEqual(['1', '2', '4', '5']);
+    expect(ids(rows)).toEqual(['1', '2', '4', '5', '7']);
   }, 60000);
 
   // --- Adversarial / safety ---

--- a/apps/backend/test/integration/athena.integration.ts
+++ b/apps/backend/test/integration/athena.integration.ts
@@ -656,13 +656,15 @@ AS SELECT * FROM (VALUES
     expect(ids(rows)).toEqual(['1', '2', '3', '4', '5', '6', '7']);
   }, 60000);
 
-  it('relative_date last_n_days(7) on created_at → rows 1,4,5,7 (no upper bound; future row 7 satisfies >= today-7)', async () => {
+  it('relative_date last_n_days(7) on created_at → rows 1,4,5 (upper bound excludes future row 7)', async () => {
     const rows = await runMatrix({
       filters: [
         { column: 'created_at', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
       ],
     });
-    expect(ids(rows)).toEqual(['1', '4', '5', '7']);
+    // Bounded `< tomorrow`: future row 7 (+13 months) is excluded.
+    expect(ids(rows)).not.toContain('7');
+    expect(ids(rows)).toEqual(['1', '4', '5']);
   }, 60000);
 
   it('relative_date this_year on created_at → rows 1,2,4,5 (excludes future row 7)', async () => {
@@ -674,9 +676,9 @@ AS SELECT * FROM (VALUES
     expect(ids(rows)).toEqual(['1', '2', '4', '5']);
   }, 60000);
 
-  it('relative_date last_n_months(3) on created_at → rows 1,2,4,5,7 (no upper bound; future row 7 satisfies >= today-3m)', async () => {
+  it('relative_date last_n_months(3) on created_at → rows 1,2,4,5 (upper bound excludes future row 7)', async () => {
     // -40 days is within 3 months → row 2 included too.
-    // Row 7 (+13 months) satisfies the lower-bound-only predicate and is included.
+    // Bounded `< tomorrow`: future row 7 (+13 months) is excluded.
     const rows = await runMatrix({
       filters: [
         {
@@ -686,7 +688,8 @@ AS SELECT * FROM (VALUES
         },
       ],
     });
-    expect(ids(rows)).toEqual(['1', '2', '4', '5', '7']);
+    expect(ids(rows)).not.toContain('7');
+    expect(ids(rows)).toEqual(['1', '2', '4', '5']);
   }, 60000);
 
   // --- Adversarial / safety ---

--- a/apps/backend/test/integration/bigquery.integration.ts
+++ b/apps/backend/test/integration/bigquery.integration.ts
@@ -349,11 +349,13 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
     //   4  alphabet a%b    40  true   5 days ago
     //   5  ALPHA    a_b    50  false  today
     //   6  (empty)  x       0  true   200 days ago (last year)
+    //   7  future   f      70  true   ~13 months from now (next calendar year)
     //
     // DATE_SUB expressions ensure relative_date assertions hold whenever the suite runs.
     // created_ts mirrors created_at as a TIMESTAMP at 13:00 (NOT midnight) for the
     // "today" rows, so relative_date exercises the DATE(col) wrapper on a sub-day
     // value — without it BigQuery raises "No matching signature for =" (TIMESTAMP vs DATE).
+    // Row 7 is future-dated to prove the this_year / this_month UPPER BOUND excludes it.
     await adapter.executeQuery(
       `INSERT INTO \`${matrixFQN}\` (id, name, tag, score, active, created_at, created_ts) VALUES
         (1, 'alpha',    'a',    10,  true,  CURRENT_DATE(),                                TIMESTAMP_ADD(TIMESTAMP(CURRENT_DATE()), INTERVAL 13 HOUR)),
@@ -361,7 +363,8 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
         (3, 'gamma',    'c',    30,  true,  DATE_SUB(CURRENT_DATE(), INTERVAL 400 DAY),    TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 400 DAY))),
         (4, 'alphabet', 'a%b',  40,  true,  DATE_SUB(CURRENT_DATE(), INTERVAL 5 DAY),      TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 5 DAY))),
         (5, 'ALPHA',    'a_b',  50,  false, CURRENT_DATE(),                                TIMESTAMP_ADD(TIMESTAMP(CURRENT_DATE()), INTERVAL 13 HOUR)),
-        (6, '',         'x',     0,  true,  DATE_SUB(CURRENT_DATE(), INTERVAL 200 DAY),    TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 200 DAY)))`
+        (6, '',         'x',     0,  true,  DATE_SUB(CURRENT_DATE(), INTERVAL 200 DAY),    TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 200 DAY))),
+        (7, 'future',   'f',    70,  true,  DATE_ADD(CURRENT_DATE(), INTERVAL 13 MONTH),   TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL 13 MONTH)))`
     );
   }, 120000);
 
@@ -375,18 +378,18 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
 
   // --- Scalar operators on score ---
 
-  it('neq: score != 20 → rows 1,3,4,5,6', async () => {
+  it('neq: score != 20 → rows 1,3,4,5,6,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'score', operator: 'neq', value: 20 }],
     });
-    expect(ids(rows)).toEqual([1, 3, 4, 5, 6]);
+    expect(ids(rows)).toEqual([1, 3, 4, 5, 6, 7]);
   }, 60000);
 
-  it('gt: score > 30 → rows 4,5', async () => {
+  it('gt: score > 30 → rows 4,5,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'score', operator: 'gt', value: 30 }],
     });
-    expect(ids(rows)).toEqual([4, 5]);
+    expect(ids(rows)).toEqual([4, 5, 7]);
   }, 60000);
 
   it('lt: score < 30 → rows 1,2,6', async () => {
@@ -396,11 +399,11 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
     expect(ids(rows)).toEqual([1, 2, 6]);
   }, 60000);
 
-  it('gte: score >= 30 → rows 3,4,5', async () => {
+  it('gte: score >= 30 → rows 3,4,5,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'score', operator: 'gte', value: 30 }],
     });
-    expect(ids(rows)).toEqual([3, 4, 5]);
+    expect(ids(rows)).toEqual([3, 4, 5, 7]);
   }, 60000);
 
   it('lte: score <= 30 → rows 1,2,3,6', async () => {
@@ -412,11 +415,11 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
 
   // --- Substring / affix operators on name ---
 
-  it('not_contains: name not contains "alpha" → rows 2,3,5,6 (case-sensitive; ALPHA excluded)', async () => {
+  it('not_contains: name not contains "alpha" → rows 2,3,5,6,7 (case-sensitive; ALPHA excluded; future row 7)', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'name', operator: 'not_contains', value: 'alpha' }],
     });
-    expect(ids(rows)).toEqual([2, 3, 5, 6]);
+    expect(ids(rows)).toEqual([2, 3, 5, 6, 7]);
   }, 60000);
 
   it('starts_with: name starts with "alpha" → rows 1,4', async () => {
@@ -476,11 +479,11 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
     expect(ids(rows)).toEqual([1, 4]);
   }, 60000);
 
-  it('not_regex: name not matching "^alpha" → rows 2,3,5,6', async () => {
+  it('not_regex: name not matching "^alpha" → rows 2,3,5,6,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'name', operator: 'not_regex', value: '^alpha' }],
     });
-    expect(ids(rows)).toEqual([2, 3, 5, 6]);
+    expect(ids(rows)).toEqual([2, 3, 5, 6, 7]);
   }, 60000);
 
   // --- No-value operators ---
@@ -492,11 +495,11 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
     expect(ids(rows)).toEqual([6]);
   }, 60000);
 
-  it('is_not_empty on name → rows 1,2,3,4,5', async () => {
+  it('is_not_empty on name → rows 1,2,3,4,5,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'name', operator: 'is_not_empty' }],
     });
-    expect(ids(rows)).toEqual([1, 2, 3, 4, 5]);
+    expect(ids(rows)).toEqual([1, 2, 3, 4, 5, 7]);
   }, 60000);
 
   it('is_null on name → 0 rows (no NULLs in seed)', async () => {
@@ -506,18 +509,18 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
     expect(rows).toHaveLength(0);
   }, 60000);
 
-  it('is_not_null on name → all 6 rows', async () => {
+  it('is_not_null on name → all 7 rows', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'name', operator: 'is_not_null' }],
     });
-    expect(ids(rows)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(ids(rows)).toEqual([1, 2, 3, 4, 5, 6, 7]);
   }, 60000);
 
-  it('is_true on active → rows 1,3,4,6', async () => {
+  it('is_true on active → rows 1,3,4,6,7', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'active', operator: 'is_true' }],
     });
-    expect(ids(rows)).toEqual([1, 3, 4, 6]);
+    expect(ids(rows)).toEqual([1, 3, 4, 6, 7]);
   }, 60000);
 
   it('is_false on active → rows 2,5', async () => {
@@ -563,26 +566,29 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
       filters: [{ column: 'created_ts', operator: 'gte', value: '2024-01-01' }],
       columnTypes: new Map([['created_ts', 'TIMESTAMP']]),
     });
-    expect(ids(rows)).toEqual([1, 2, 3, 4, 5, 6]);
+    // All 7 seeded rows (including future row 7) are >= 2024-01-01.
+    expect(ids(rows)).toEqual([1, 2, 3, 4, 5, 6, 7]);
   }, 60000);
 
-  it('relative_date last_n_days(7) on created_at → rows 1,4,5', async () => {
+  it('relative_date last_n_days(7) on created_at → rows 1,4,5,7 (no upper bound; future row 7 satisfies >= today-7)', async () => {
     const rows = await runMatrix({
       filters: [
         { column: 'created_at', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
       ],
     });
-    expect(ids(rows)).toEqual([1, 4, 5]);
+    expect(ids(rows)).toEqual([1, 4, 5, 7]);
   }, 60000);
 
-  it('relative_date this_year on created_at → rows 1,2,4,5', async () => {
+  it('relative_date this_year on created_at → rows 1,2,4,5 (excludes future row 7)', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'created_at', operator: 'relative_date', value: { kind: 'this_year' } }],
     });
+    // Row 7 is ~13 months in the future (next calendar year) and must NOT appear.
+    expect(ids(rows)).not.toContain(7);
     expect(ids(rows)).toEqual([1, 2, 4, 5]);
   }, 60000);
 
-  it('relative_date last_n_months(3) on created_at → rows 1,2,4,5', async () => {
+  it('relative_date last_n_months(3) on created_at → rows 1,2,4,5,7 (no upper bound; future row 7 satisfies >= today-3m)', async () => {
     const rows = await runMatrix({
       filters: [
         {
@@ -592,7 +598,7 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
         },
       ],
     });
-    expect(ids(rows)).toEqual([1, 2, 4, 5]);
+    expect(ids(rows)).toEqual([1, 2, 4, 5, 7]);
   }, 60000);
 
   // --- Adversarial / safety ---

--- a/apps/backend/test/integration/bigquery.integration.ts
+++ b/apps/backend/test/integration/bigquery.integration.ts
@@ -570,13 +570,15 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
     expect(ids(rows)).toEqual([1, 2, 3, 4, 5, 6, 7]);
   }, 60000);
 
-  it('relative_date last_n_days(7) on created_at → rows 1,4,5,7 (no upper bound; future row 7 satisfies >= today-7)', async () => {
+  it('relative_date last_n_days(7) on created_at → rows 1,4,5 (upper bound excludes future row 7)', async () => {
     const rows = await runMatrix({
       filters: [
         { column: 'created_at', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
       ],
     });
-    expect(ids(rows)).toEqual([1, 4, 5, 7]);
+    // Bounded `<= CURRENT_DATE()`: future row 7 (+13 months) is excluded.
+    expect(ids(rows)).not.toContain(7);
+    expect(ids(rows)).toEqual([1, 4, 5]);
   }, 60000);
 
   it('relative_date this_year on created_at → rows 1,2,4,5 (excludes future row 7)', async () => {
@@ -588,7 +590,7 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
     expect(ids(rows)).toEqual([1, 2, 4, 5]);
   }, 60000);
 
-  it('relative_date last_n_months(3) on created_at → rows 1,2,4,5,7 (no upper bound; future row 7 satisfies >= today-3m)', async () => {
+  it('relative_date last_n_months(3) on created_at → rows 1,2,4,5 (upper bound excludes future row 7)', async () => {
     const rows = await runMatrix({
       filters: [
         {
@@ -598,7 +600,9 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
         },
       ],
     });
-    expect(ids(rows)).toEqual([1, 2, 4, 5, 7]);
+    // Bounded `<= CURRENT_DATE()`: future row 7 (+13 months) is excluded.
+    expect(ids(rows)).not.toContain(7);
+    expect(ids(rows)).toEqual([1, 2, 4, 5]);
   }, 60000);
 
   // --- Adversarial / safety ---

--- a/apps/backend/test/integration/http-data-real.integration.ts
+++ b/apps/backend/test/integration/http-data-real.integration.ts
@@ -11,6 +11,10 @@ import {
   BigQueryConfig,
   BIGQUERY_AUTODETECT_LOCATION,
 } from 'src/data-marts/data-storage-types/bigquery/schemas/bigquery-config.schema';
+import { RedshiftApiAdapter } from 'src/data-marts/data-storage-types/redshift/adapters/redshift-api.adapter';
+import { RedshiftCredentials } from 'src/data-marts/data-storage-types/redshift/schemas/redshift-credentials.schema';
+import { RedshiftConfig } from 'src/data-marts/data-storage-types/redshift/schemas/redshift-config.schema';
+import { RedshiftConnectionType } from 'src/data-marts/data-storage-types/redshift/enums/redshift-connection-type.enum';
 import { STREAM_BATCH_SIZE } from 'src/data-marts/services/http-data/http-data.constants';
 
 /**
@@ -34,6 +38,12 @@ import { STREAM_BATCH_SIZE } from 'src/data-marts/services/http-data/http-data.c
  *     BQ_SERVICE_ACCOUNT_KEY - JSON string of a GCP service account key
  *     BQ_PROJECT_ID          - GCP project ID
  *     BQ_DATASET             - BigQuery dataset name (must already exist)
+ *   Redshift (Serverless):
+ *     AWS_ACCESS_KEY_ID       - AWS access key ID (shared with Athena)
+ *     AWS_SECRET_ACCESS_KEY   - AWS secret access key (shared with Athena)
+ *     REDSHIFT_REGION         - AWS region (e.g., eu-west-1)
+ *     REDSHIFT_DATABASE       - database name inside the workgroup (e.g., dev)
+ *     REDSHIFT_WORKGROUP_NAME - Serverless workgroup name
  */
 
 // ---------------------------------------------------------------------------
@@ -79,6 +89,29 @@ if (!BQ_CREDENTIALS_AVAILABLE) {
 const describeIfBqCredentials = BQ_CREDENTIALS_AVAILABLE ? describe : describe.skip;
 
 // ---------------------------------------------------------------------------
+// Redshift env vars / credential gate (Serverless; shares the AWS keys)
+// ---------------------------------------------------------------------------
+const REDSHIFT_REGION = process.env.REDSHIFT_REGION;
+const REDSHIFT_DATABASE = process.env.REDSHIFT_DATABASE;
+const REDSHIFT_WORKGROUP_NAME = process.env.REDSHIFT_WORKGROUP_NAME;
+
+const RS_CREDENTIALS_AVAILABLE = !!(
+  AWS_ACCESS_KEY_ID &&
+  AWS_SECRET_ACCESS_KEY &&
+  REDSHIFT_REGION &&
+  REDSHIFT_DATABASE &&
+  REDSHIFT_WORKGROUP_NAME
+);
+
+if (!RS_CREDENTIALS_AVAILABLE) {
+  console.log(
+    'Skipping HTTP Data real Redshift integration tests: AWS credentials or REDSHIFT_* config not set'
+  );
+}
+
+const describeIfRsCredentials = RS_CREDENTIALS_AVAILABLE ? describe : describe.skip;
+
+// ---------------------------------------------------------------------------
 // Shared NestJS app — ONE instance for the entire file.
 // Both describe blocks share the same SQLite :memory: app to avoid the
 // TypeORM / typeorm-transactional DataSource singleton conflict that arises
@@ -88,7 +121,8 @@ let sharedApp: INestApplication;
 let sharedAgent: supertest.Agent;
 
 // Create the shared app if at least one credential set is present.
-const NEED_APP = ATHENA_CREDENTIALS_AVAILABLE || BQ_CREDENTIALS_AVAILABLE;
+const NEED_APP =
+  ATHENA_CREDENTIALS_AVAILABLE || BQ_CREDENTIALS_AVAILABLE || RS_CREDENTIALS_AVAILABLE;
 
 if (NEED_APP) {
   beforeAll(async () => {
@@ -525,6 +559,213 @@ describeIfBqCredentials('HTTP Data API real-data (live BigQuery)', () => {
         `&sort=${bqB64([{ column: 'id', direction: 'asc' }])}`
     );
     // BQ returns id as number — coerce to Number for comparison
+    expect(rows.map(r => Number(r.id))).toEqual([2, 3]);
+  }, 120000);
+});
+
+// =============================================================================
+// REDSHIFT BLOCK — full-stack HTTP Data API against a live Redshift Serverless
+// workgroup (TABLE-def mart, stream + output controls). Mirrors the BQ block.
+// =============================================================================
+
+describeIfRsCredentials('HTTP Data API real-data (live Redshift)', () => {
+  let rsDataMartId: string;
+
+  let rsAdapter: RedshiftApiAdapter;
+  let rsFullyQualifiedName: string;
+
+  const RS_TEST_TABLE_SUFFIX = `http_data_real_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+  // The Redshift Data API runs DDL/DML through executeQuery + waitForQueryToComplete:
+  // executeQueryAndGetRows would call GetStatementResult, which throws for any
+  // statement that produces no result set (CREATE/INSERT/DROP).
+  async function rsExecDdl(sql: string): Promise<void> {
+    const { statementId } = await rsAdapter.executeQuery(sql);
+    await rsAdapter.waitForQueryToComplete(statementId);
+  }
+
+  // -------------------------------------------------------------------------
+  // beforeAll: seed real Redshift table + build credentialed storage + mart
+  // via HTTP API (uses sharedAgent — no second createTestApp() call)
+  // -------------------------------------------------------------------------
+  beforeAll(async () => {
+    const rsCredentials: RedshiftCredentials = {
+      accessKeyId: AWS_ACCESS_KEY_ID!,
+      secretAccessKey: AWS_SECRET_ACCESS_KEY!,
+    };
+    const rsConfig: RedshiftConfig = {
+      connectionType: RedshiftConnectionType.SERVERLESS,
+      region: REDSHIFT_REGION!,
+      database: REDSHIFT_DATABASE!,
+      workgroupName: REDSHIFT_WORKGROUP_NAME!,
+    };
+    rsAdapter = new RedshiftApiAdapter(rsCredentials, rsConfig);
+
+    // Mart TABLE definition is the 3-part FQN database.schema.table; the table
+    // itself lives in the connected database's public schema.
+    rsFullyQualifiedName = `${REDSHIFT_DATABASE}.public.${RS_TEST_TABLE_SUFFIX}`;
+
+    // --- Step 1: Pre-cleanup in case a previous run crashed ---
+    try {
+      await rsExecDdl(`DROP TABLE IF EXISTS public."${RS_TEST_TABLE_SUFFIX}"`);
+    } catch {
+      // ignore — table may not exist on first run
+    }
+
+    // --- Step 2: Seed a real (permanent) Redshift table ---
+    // Permanent, not TEMP: each ExecuteStatement is its own session, so a temp
+    // table would not survive to the streaming request.
+    await rsExecDdl(
+      `CREATE TABLE public."${RS_TEST_TABLE_SUFFIX}" ` +
+        `(id INTEGER, name VARCHAR(100), active BOOLEAN, created_at TIMESTAMP)`
+    );
+    await rsExecDdl(
+      `INSERT INTO public."${RS_TEST_TABLE_SUFFIX}" (id, name, active, created_at) VALUES
+        (1, 'alpha',    true,  TIMESTAMP '2024-01-01 00:00:00'),
+        (2, 'beta',     false, TIMESTAMP '2024-02-01 00:00:00'),
+        (3, 'gamma',    true,  TIMESTAMP '2024-03-01 00:00:00'),
+        (4, 'alphabet', true,  TIMESTAMP '2024-04-01 00:00:00')`
+    );
+
+    // --- Step 3: Create credentialed Redshift storage via HTTP API ---
+    const storageCreateRes = await sharedAgent
+      .post('/api/data-storages')
+      .set(AUTH_HEADER)
+      .send({ type: 'AWS_REDSHIFT' });
+    if (storageCreateRes.status !== 201) {
+      console.error('RS storage create failed:', JSON.stringify(storageCreateRes.body, null, 2));
+    }
+    expect(storageCreateRes.status).toBe(201);
+    const rsStorageId: string = storageCreateRes.body.id;
+
+    const storageUpdateRes = await sharedAgent
+      .put(`/api/data-storages/${rsStorageId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'rs-real',
+        config: {
+          connectionType: 'SERVERLESS',
+          region: REDSHIFT_REGION!,
+          database: REDSHIFT_DATABASE!,
+          workgroupName: REDSHIFT_WORKGROUP_NAME!,
+        },
+        credentials: { accessKeyId: AWS_ACCESS_KEY_ID!, secretAccessKey: AWS_SECRET_ACCESS_KEY! },
+      });
+    if (storageUpdateRes.status !== 200) {
+      console.error('RS storage update failed:', JSON.stringify(storageUpdateRes.body, null, 2));
+    }
+    expect(storageUpdateRes.status).toBe(200);
+
+    // --- Step 4: Create data mart ---
+    const dataMartCreateRes = await sharedAgent
+      .post('/api/data-marts')
+      .set(AUTH_HEADER)
+      .send({ title: 'real-rs-test-mart', storageId: rsStorageId });
+    if (dataMartCreateRes.status !== 201) {
+      console.error('RS data mart create failed:', JSON.stringify(dataMartCreateRes.body, null, 2));
+    }
+    expect(dataMartCreateRes.status).toBe(201);
+    rsDataMartId = dataMartCreateRes.body.id;
+
+    // --- Step 5: Set TABLE definition (pointing at the real seeded table) ---
+    const defRes = await sharedAgent
+      .put(`/api/data-marts/${rsDataMartId}/definition`)
+      .set(AUTH_HEADER)
+      .send({
+        definitionType: 'TABLE',
+        definition: { fullyQualifiedName: rsFullyQualifiedName },
+      });
+    if (defRes.status !== 200) {
+      console.error('RS definition set failed:', JSON.stringify(defRes.body, null, 2));
+    }
+    expect(defRes.status).toBe(200);
+
+    // --- Step 6: Publish (reads real schema from Redshift) ---
+    const publishRes = await sharedAgent
+      .put(`/api/data-marts/${rsDataMartId}/publish`)
+      .set(AUTH_HEADER);
+    if (publishRes.status !== 200) {
+      console.error('RS publish failed:', JSON.stringify(publishRes.body, null, 2));
+    }
+    expect(publishRes.status).toBe(200);
+  }, 180000);
+
+  // -------------------------------------------------------------------------
+  // afterAll: drop Redshift table
+  // -------------------------------------------------------------------------
+  afterAll(async () => {
+    try {
+      await rsExecDdl(`DROP TABLE IF EXISTS public."${RS_TEST_TABLE_SUFFIX}"`);
+    } catch (error) {
+      console.warn('Failed to drop Redshift test table during teardown:', error);
+    }
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // Helpers scoped to Redshift block
+  // -------------------------------------------------------------------------
+  async function fetchRsNdjson(qs: string): Promise<Record<string, unknown>[]> {
+    const res = await sharedAgent
+      .get(`/api/external/http-data/data-marts/${rsDataMartId}.ndjson${qs ? '?' + qs : ''}`)
+      .set(AUTH_HEADER);
+    if (res.status !== 200) {
+      console.error('fetchRsNdjson failed:', res.status, JSON.stringify(res.body, null, 2));
+      console.error('Response text:', res.text?.slice(0, 500));
+    }
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('application/x-ndjson');
+    return res.text
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l));
+  }
+
+  const rsB64 = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url');
+
+  // -------------------------------------------------------------------------
+  // Test A — WITHOUT output controls (streams all real rows)
+  // -------------------------------------------------------------------------
+  it('streams all real rows from Redshift without output controls', async () => {
+    const rows = await fetchRsNdjson('column=id&column=name&column=active');
+    expect(rows).toHaveLength(4);
+
+    // Redshift Data API returns scalars as strings — coerce id for safe lookup.
+    const byId = Object.fromEntries(rows.map(r => [String(r.id), r]));
+    expect(byId['1'].name).toBe('alpha');
+    expect(byId['2'].name).toBe('beta');
+    expect(byId['4'].name).toBe('alphabet');
+  }, 120000);
+
+  // -------------------------------------------------------------------------
+  // Test B — WITH output controls (filter/sort/limit on real Redshift data)
+  // -------------------------------------------------------------------------
+  it('applies eq filter on real Redshift data', async () => {
+    const rows = await fetchRsNdjson(
+      `column=id&column=name&filter=${rsB64([{ column: 'name', operator: 'eq', value: 'alpha' }])}`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('alpha');
+  }, 120000);
+
+  it('applies contains + sort desc + limit on real Redshift data', async () => {
+    // Both 'alpha' (id=1) and 'alphabet' (id=4) contain 'alpha'.
+    // sort desc by id + limit 1 → id=4 ('alphabet').
+    const rows = await fetchRsNdjson(
+      `column=id&column=name` +
+        `&filter=${rsB64([{ column: 'name', operator: 'contains', value: 'alpha' }])}` +
+        `&sort=${rsB64([{ column: 'id', direction: 'desc' }])}` +
+        `&limit=1`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('alphabet');
+  }, 120000);
+
+  it('applies a numeric between filter on real Redshift data', async () => {
+    const rows = await fetchRsNdjson(
+      `column=id&column=name` +
+        `&filter=${rsB64([{ column: 'id', operator: 'between', value: { from: 2, to: 3 } }])}` +
+        `&sort=${rsB64([{ column: 'id', direction: 'asc' }])}`
+    );
     expect(rows.map(r => Number(r.id))).toEqual([2, 3]);
   }, 120000);
 });

--- a/apps/backend/test/integration/redshift.integration.ts
+++ b/apps/backend/test/integration/redshift.integration.ts
@@ -558,18 +558,17 @@ describeIfCredentials(
       expect(ids(rows)).toEqual(['2', '3']);
     }, 30000);
 
-    it('relative_date last_n_days(7): rows 1,2,5,6 (lower-bound only; future row 5 included)', async () => {
+    it('relative_date last_n_days(7): rows 1,2,6 (upper bound excludes future row 5)', async () => {
       const rows = await runFilter({
         filters: [
           { column: 'date_col', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
         ],
       });
-      // last_n_days has NO upper bound by design (deferred item): future-dated rows
-      // (row 5 is +13 months) are included. Asserts the actual lower-bound-only behavior.
-      expect(ids(rows)).toEqual(['1', '2', '5', '6']);
+      // last_n_days is bounded `< tomorrow`: future-dated row 5 (+13 months) is excluded.
+      expect(ids(rows)).toEqual(['1', '2', '6']);
     }, 30000);
 
-    it('relative_date last_n_months(3): rows 1,2,3,5,6 (lower-bound only; future row 5 included)', async () => {
+    it('relative_date last_n_months(3): rows 1,2,3,6 (upper bound excludes future row 5)', async () => {
       const rows = await runFilter({
         filters: [
           {
@@ -579,8 +578,8 @@ describeIfCredentials(
           },
         ],
       });
-      // last_n_months has NO upper bound by design (deferred): future row 5 included.
-      expect(ids(rows)).toEqual(['1', '2', '3', '5', '6']);
+      // last_n_months is bounded `< tomorrow`: future-dated row 5 is excluded; row 3 (-40d) stays.
+      expect(ids(rows)).toEqual(['1', '2', '3', '6']);
     }, 30000);
 
     // -------------------------------------------------------------------------

--- a/apps/backend/test/integration/redshift.integration.ts
+++ b/apps/backend/test/integration/redshift.integration.ts
@@ -1,0 +1,616 @@
+import { RedshiftApiAdapter } from 'src/data-marts/data-storage-types/redshift/adapters/redshift-api.adapter';
+import { RedshiftCredentials } from 'src/data-marts/data-storage-types/redshift/schemas/redshift-credentials.schema';
+import { RedshiftConfig } from 'src/data-marts/data-storage-types/redshift/schemas/redshift-config.schema';
+import { RedshiftConnectionType } from 'src/data-marts/data-storage-types/redshift/enums/redshift-connection-type.enum';
+import { RedshiftClauseRenderer } from 'src/data-marts/data-storage-types/redshift/services/redshift-clause-renderer';
+import { RedshiftQueryBuilder } from 'src/data-marts/data-storage-types/redshift/services/redshift-query.builder';
+import { TableDefinition } from 'src/data-marts/dto/schemas/data-mart-table-definitions/table-definition.schema';
+
+/**
+ * Redshift Integration Tests
+ *
+ * Live integration suite that runs against a REAL Redshift Serverless workgroup
+ * via the Data API. Every test in this file sends SQL to the actual cluster —
+ * nothing here is mocked. The suite finalises two open design decisions:
+ *
+ *   1. Date/time type coercion: does Redshift accept bare quoted string literals
+ *      (`'2024-01-01'`) in comparisons against DATE/TIMESTAMP/TIMESTAMPTZ/TIME/TIMETZ
+ *      columns without a CAST? (PostgreSQL "unknown-literal" coercion path.)
+ *
+ *   2. standard_conforming_strings: is the session setting `on` or `off`?  If `off`
+ *      the escaper would need to double backslashes (C-escape mode). The answer
+ *      is probed live and reported; if `off`, DONE_WITH_CONCERNS is raised.
+ *
+ * Required environment variables (SERVERLESS connection):
+ *   AWS_ACCESS_KEY_ID       — IAM access key with redshift-data:* + redshift-serverless:GetCredentials
+ *   AWS_SECRET_ACCESS_KEY   — matching secret
+ *   REDSHIFT_REGION         — AWS region (e.g. eu-west-1)
+ *   REDSHIFT_WORKGROUP_NAME — name of the Serverless workgroup
+ *   REDSHIFT_DATABASE       — database name inside the workgroup (e.g. dev)
+ */
+
+const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
+const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY;
+const REDSHIFT_REGION = process.env.REDSHIFT_REGION;
+const REDSHIFT_WORKGROUP_NAME = process.env.REDSHIFT_WORKGROUP_NAME;
+const REDSHIFT_DATABASE = process.env.REDSHIFT_DATABASE;
+
+const REDSHIFT_CREDENTIALS_AVAILABLE = !!(
+  AWS_ACCESS_KEY_ID &&
+  AWS_SECRET_ACCESS_KEY &&
+  REDSHIFT_REGION &&
+  REDSHIFT_WORKGROUP_NAME &&
+  REDSHIFT_DATABASE
+);
+
+if (!REDSHIFT_CREDENTIALS_AVAILABLE) {
+  const missing: string[] = [];
+  if (!AWS_ACCESS_KEY_ID) missing.push('AWS_ACCESS_KEY_ID');
+  if (!AWS_SECRET_ACCESS_KEY) missing.push('AWS_SECRET_ACCESS_KEY');
+  if (!REDSHIFT_REGION) missing.push('REDSHIFT_REGION');
+  if (!REDSHIFT_WORKGROUP_NAME) missing.push('REDSHIFT_WORKGROUP_NAME');
+  if (!REDSHIFT_DATABASE) missing.push('REDSHIFT_DATABASE');
+  console.log(`Skipping Redshift integration tests: missing env vars: ${missing.join(', ')}`);
+}
+
+const describeIfCredentials = REDSHIFT_CREDENTIALS_AVAILABLE ? describe : describe.skip;
+
+// ---------------------------------------------------------------------------
+// Access validation + dry-run
+// ---------------------------------------------------------------------------
+
+describeIfCredentials('Redshift Integration Tests', () => {
+  let adapter: RedshiftApiAdapter;
+  let credentials: RedshiftCredentials;
+  let config: RedshiftConfig;
+
+  beforeAll(() => {
+    credentials = {
+      accessKeyId: AWS_ACCESS_KEY_ID!,
+      secretAccessKey: AWS_SECRET_ACCESS_KEY!,
+    };
+
+    config = {
+      connectionType: RedshiftConnectionType.SERVERLESS,
+      region: REDSHIFT_REGION!,
+      database: REDSHIFT_DATABASE!,
+      workgroupName: REDSHIFT_WORKGROUP_NAME!,
+    };
+
+    adapter = new RedshiftApiAdapter(credentials, config);
+  });
+
+  describe('Access Validation', () => {
+    it('should accept valid credentials', async () => {
+      await expect(adapter.checkAccess()).resolves.not.toThrow();
+    }, 30000);
+
+    it('should reject invalid credentials', async () => {
+      const invalidAdapter = new RedshiftApiAdapter(
+        { accessKeyId: 'INVALID_KEY_ID', secretAccessKey: 'invalid_secret' },
+        config
+      );
+      await expect(invalidAdapter.checkAccess()).rejects.toThrow();
+    }, 30000);
+  });
+
+  describe('SQL Dry Run', () => {
+    it('should validate correct query via EXPLAIN', async () => {
+      await expect(adapter.executeDryRunQuery('SELECT 1')).resolves.not.toThrow();
+    }, 30000);
+
+    it('should reject invalid SQL syntax', async () => {
+      await expect(adapter.executeDryRunQuery('SELEKT * FORM invalid')).rejects.toThrow();
+    }, 30000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Design-decision probes + operator matrix (separate seed)
+// ---------------------------------------------------------------------------
+// Uses its OWN table. All design-decision probes live here so they run against
+// a richly-typed seed that covers every date/time type.
+//
+// Seed rows:
+//   id  name        amount  status    date_col             ts_col (non-midnight for rows 1,6)
+//    1  alpha         10.0  active    today                today@13:45
+//    2  beta          20.0  inactive  yesterday            yesterday@00:00
+//    3  O'Brien       30.0  active    -40 days             -40d@00:00
+//    4  100%          40.0  inactive  -400 days (last yr)  -400d@00:00
+//    5  a\b           50.0  active    +13 months (next yr) next_year@00:00
+//    6  gamma          0.0  active    today                today@13:45
+//
+// Row 5: future-dated for this_year / this_month upper-bound exclusion.
+// Rows 1,6: today at 13:45 for relative_date non-midnight timestamp check.
+// Row 3: O'Brien for single-quote round-trip safety.
+// Row 4: 100% for wildcard-literal (STRPOS, not LIKE) safety.
+// Row 5: a\b for standard_conforming_strings backslash probe.
+
+const MATRIX_TABLE_SUFFIX = `rs_matrix_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const MATRIX_FQN = `public.${MATRIX_TABLE_SUFFIX}`;
+
+describeIfCredentials(
+  'Redshift — date/time coercion, standard_conforming_strings, operator matrix',
+  () => {
+    let adapter: RedshiftApiAdapter;
+
+    const builder = new RedshiftQueryBuilder(new RedshiftClauseRenderer());
+    const definition: TableDefinition = {
+      get fullyQualifiedName() {
+        return MATRIX_FQN;
+      },
+    };
+
+    async function execDdl(sql: string): Promise<void> {
+      const { statementId } = await adapter.executeQuery(sql);
+      await adapter.waitForQueryToComplete(statementId);
+    }
+
+    async function runFilter(
+      queryOptions: Parameters<RedshiftQueryBuilder['buildQuery']>[1]
+    ): Promise<Array<Record<string, string | null>>> {
+      const sql = builder.buildQuery(definition, queryOptions);
+      return adapter.executeQueryAndGetRows(sql);
+    }
+
+    function ids(rows: Array<Record<string, string | null>>): string[] {
+      return rows.map(r => r.id!).sort((a, b) => Number(a) - Number(b));
+    }
+
+    beforeAll(async () => {
+      const credentials: RedshiftCredentials = {
+        accessKeyId: AWS_ACCESS_KEY_ID!,
+        secretAccessKey: AWS_SECRET_ACCESS_KEY!,
+      };
+      const config: RedshiftConfig = {
+        connectionType: RedshiftConnectionType.SERVERLESS,
+        region: REDSHIFT_REGION!,
+        database: REDSHIFT_DATABASE!,
+        workgroupName: REDSHIFT_WORKGROUP_NAME!,
+      };
+      adapter = new RedshiftApiAdapter(credentials, config);
+
+      // Pre-cleanup in case of a previous crash
+      try {
+        await execDdl(`DROP TABLE IF EXISTS public."${MATRIX_TABLE_SUFFIX}"`);
+      } catch {
+        // ignore — table may not exist on first run
+      }
+
+      // Create a table covering all five Redshift date/time types.
+      await execDdl(`
+        CREATE TABLE public."${MATRIX_TABLE_SUFFIX}" (
+          id          INTEGER,
+          name        VARCHAR(100),
+          amount      DECIMAL(10,2),
+          status      VARCHAR(20),
+          date_col    DATE,
+          ts_col      TIMESTAMP,
+          tstz_col    TIMESTAMPTZ,
+          time_col    TIME,
+          timetz_col  TIMETZ
+        )
+      `);
+
+      // Insert seed rows. Row 5 (a\b) uses a backslash to probe standard_conforming_strings.
+      await execDdl(`
+        INSERT INTO public."${MATRIX_TABLE_SUFFIX}"
+          (id, name, amount, status, date_col, ts_col, tstz_col, time_col, timetz_col)
+        VALUES
+          (1, 'alpha',    10.00, 'active',
+            CURRENT_DATE,
+            DATEADD(minute, 825, CAST(CURRENT_DATE AS TIMESTAMP)),
+            CAST(DATEADD(minute, 825, CAST(CURRENT_DATE AS TIMESTAMP)) AS TIMESTAMPTZ),
+            '13:45:00', '13:45:00+00'),
+          (2, 'beta',     20.00, 'inactive',
+            DATEADD(day, -1, CURRENT_DATE),
+            CAST(DATEADD(day, -1, CURRENT_DATE) AS TIMESTAMP),
+            CAST(DATEADD(day, -1, CURRENT_DATE) AS TIMESTAMPTZ),
+            '09:00:00', '09:00:00+00'),
+          (3, 'O''Brien', 30.00, 'active',
+            DATEADD(day, -40, CURRENT_DATE),
+            CAST(DATEADD(day, -40, CURRENT_DATE) AS TIMESTAMP),
+            CAST(DATEADD(day, -40, CURRENT_DATE) AS TIMESTAMPTZ),
+            '00:00:00', '00:00:00+00'),
+          (4, '100%',     40.00, 'inactive',
+            DATEADD(day, -400, CURRENT_DATE),
+            CAST(DATEADD(day, -400, CURRENT_DATE) AS TIMESTAMP),
+            CAST(DATEADD(day, -400, CURRENT_DATE) AS TIMESTAMPTZ),
+            '23:59:00', '23:59:00+00'),
+          (5, 'a\\b',    50.00, 'active',
+            DATEADD(month, 13, CURRENT_DATE),
+            CAST(DATEADD(month, 13, CURRENT_DATE) AS TIMESTAMP),
+            CAST(DATEADD(month, 13, CURRENT_DATE) AS TIMESTAMPTZ),
+            '12:00:00', '12:00:00+00'),
+          (6, 'gamma',     0.00, 'active',
+            CURRENT_DATE,
+            DATEADD(minute, 825, CAST(CURRENT_DATE AS TIMESTAMP)),
+            CAST(DATEADD(minute, 825, CAST(CURRENT_DATE AS TIMESTAMP)) AS TIMESTAMPTZ),
+            '13:45:00', '13:45:00+00')
+      `);
+    }, 120000);
+
+    afterAll(async () => {
+      try {
+        await execDdl(`DROP TABLE IF EXISTS public."${MATRIX_TABLE_SUFFIX}"`);
+      } catch (error) {
+        console.warn('Failed to drop Redshift matrix test table:', error);
+      }
+    }, 60000);
+
+    // -------------------------------------------------------------------------
+    // Design decision 1: standard_conforming_strings probe
+    // -------------------------------------------------------------------------
+
+    // PROBE standard_conforming_strings: Redshift does not expose this GUC via
+    // SHOW or current_setting() — both return "unrecognized configuration parameter".
+    // The backslash round-trip test below is the authoritative proof that backslash
+    // is treated as a literal (i.e. standard_conforming_strings is effectively "on").
+
+    it('PROBE backslash round-trip: eq "a\\\\b" executes without error', async () => {
+      // Row 5 has name='a\b' (one backslash). If standard_conforming_strings=on,
+      // the renderer's `'a\b'` matches literally and row 5 is returned.
+      // If off, `'a\b'` = 'ab' and no match. Either way: no SQL error.
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'eq', value: 'a\\b' }],
+      });
+      console.log(
+        `[DESIGN DECISION] backslash eq match count: ${rows.length} ` +
+          `(1=standard_conforming_strings:on, 0=off)`
+      );
+      // Asserts the seeded `a\b` row matched: backslash is literal (standard_conforming_strings
+      // effectively ON), so `'`→`''` escaping is airtight. FAILS if a future cluster has scs=off.
+      expect(rows.length).toBe(1);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // Design decision 2: date/time coercion (bare literal, no CAST)
+    // -------------------------------------------------------------------------
+    // The renderer emits `col >= '2024-01-01'` — no CAST. PostgreSQL / Redshift
+    // coerce unknown-typed string literals to the column type automatically.
+    // If Redshift rejects a type, the test throws and that exact error is the
+    // signal to the controller to add a CAST for that type. DO NOT add a CAST
+    // here — just probe and report.
+
+    it('DATE: gte bare string literal executes without error', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'date_col', operator: 'gte', value: '2020-01-01' }],
+      });
+      console.log(`[COERCION] DATE gte bare string → ${rows.length} rows, no error`);
+      expect(rows.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('DATE: between bare string literals executes without error', async () => {
+      const rows = await runFilter({
+        filters: [
+          {
+            column: 'date_col',
+            operator: 'between',
+            value: { from: '2020-01-01', to: '2030-12-31' },
+          },
+        ],
+      });
+      console.log(`[COERCION] DATE between bare strings → ${rows.length} rows, no error`);
+      expect(rows.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('TIMESTAMP: gte bare string literal executes without error', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'ts_col', operator: 'gte', value: '2020-01-01' }],
+      });
+      console.log(`[COERCION] TIMESTAMP gte bare string → ${rows.length} rows, no error`);
+      expect(rows.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('TIMESTAMP: between bare string literals executes without error', async () => {
+      const rows = await runFilter({
+        filters: [
+          {
+            column: 'ts_col',
+            operator: 'between',
+            value: { from: '2020-01-01', to: '2030-12-31' },
+          },
+        ],
+      });
+      console.log(`[COERCION] TIMESTAMP between bare strings → ${rows.length} rows, no error`);
+      expect(rows.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('TIMESTAMPTZ: gte bare string literal executes without error', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'tstz_col', operator: 'gte', value: '2020-01-01' }],
+      });
+      console.log(`[COERCION] TIMESTAMPTZ gte bare string → ${rows.length} rows, no error`);
+      expect(rows.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('TIMESTAMPTZ: between bare string literals executes without error', async () => {
+      const rows = await runFilter({
+        filters: [
+          {
+            column: 'tstz_col',
+            operator: 'between',
+            value: { from: '2020-01-01', to: '2030-12-31' },
+          },
+        ],
+      });
+      console.log(`[COERCION] TIMESTAMPTZ between bare strings → ${rows.length} rows, no error`);
+      expect(rows.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('TIME: gte bare string literal executes without error', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'time_col', operator: 'gte', value: '09:00:00' }],
+      });
+      console.log(`[COERCION] TIME gte bare string → ${rows.length} rows, no error`);
+      expect(rows.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('TIME: between bare string literals executes without error', async () => {
+      const rows = await runFilter({
+        filters: [
+          {
+            column: 'time_col',
+            operator: 'between',
+            value: { from: '09:00:00', to: '14:00:00' },
+          },
+        ],
+      });
+      console.log(`[COERCION] TIME between bare strings → ${rows.length} rows, no error`);
+      expect(rows.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('TIMETZ: gte bare string literal executes without error', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'timetz_col', operator: 'gte', value: '09:00:00+00' }],
+      });
+      console.log(`[COERCION] TIMETZ gte bare string → ${rows.length} rows, no error`);
+      expect(rows.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('TIMETZ: between bare string literals executes without error', async () => {
+      const rows = await runFilter({
+        filters: [
+          {
+            column: 'timetz_col',
+            operator: 'between',
+            value: { from: '09:00:00+00', to: '14:00:00+00' },
+          },
+        ],
+      });
+      console.log(`[COERCION] TIMETZ between bare strings → ${rows.length} rows, no error`);
+      expect(rows.length).toBeGreaterThan(0);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // relative_date today on non-midnight TIMESTAMP column
+    // -------------------------------------------------------------------------
+    // Rows 1 and 6 have ts_col = today at 13:45. The old `col = CURRENT_DATE`
+    // equality casts CURRENT_DATE to midnight and misses them. The half-open
+    // range `>= CURRENT_DATE AND < DATEADD(day,1,CURRENT_DATE)` covers the full day.
+
+    it('relative_date today on ts_col (13:45, non-midnight) → rows 1,6', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'ts_col', operator: 'relative_date', value: { kind: 'today' } }],
+      });
+      expect(ids(rows)).toEqual(['1', '6']);
+    }, 30000);
+
+    it('relative_date today on date_col → rows 1,6', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'date_col', operator: 'relative_date', value: { kind: 'today' } }],
+      });
+      expect(ids(rows)).toEqual(['1', '6']);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // this_year / this_month upper-bound exclusion
+    // -------------------------------------------------------------------------
+    // Row 5 (date_col = DATEADD(month,13,CURRENT_DATE)) is always next year.
+    // this_year upper bound = DATEADD(year,1,DATE_TRUNC('year',CURRENT_DATE)) — excludes row 5.
+    // Row 4 (-400 days) is always last year — also excluded.
+    // Rows in current year: 1 (today), 2 (yesterday), 3 (-40d), 6 (today).
+    // Note: row 3 (-40 days) is in this year as long as test runs after day 40 (Feb 10).
+
+    it('relative_date this_year excludes future-dated row 5 and last-year row 4', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'date_col', operator: 'relative_date', value: { kind: 'this_year' } }],
+      });
+      const resultIds = ids(rows);
+      expect(resultIds).not.toContain('5');
+      expect(resultIds).not.toContain('4');
+      expect(resultIds).toContain('1');
+      expect(resultIds).toContain('6');
+      console.log(`[this_year] rows returned: [${resultIds.join(',')}]`);
+    }, 30000);
+
+    it('relative_date this_month excludes future-dated row 5', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'date_col', operator: 'relative_date', value: { kind: 'this_month' } }],
+      });
+      const resultIds = ids(rows);
+      expect(resultIds).not.toContain('5');
+      console.log(`[this_month] rows returned: [${resultIds.join(',')}]`);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // Operator matrix: every operator runs without error, returns sensible rows
+    // -------------------------------------------------------------------------
+    // Seeded amounts: alpha(1)=10, beta(2)=20, O'Brien(3)=30, 100%(4)=40, a\b(5)=50, gamma(6)=0.
+
+    it('eq on name → row 1 (alpha)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'eq', value: 'alpha' }],
+      });
+      expect(ids(rows)).toEqual(['1']);
+    }, 30000);
+
+    it('neq on status: not "active" → rows 2,4 (inactive)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'status', operator: 'neq', value: 'active' }],
+      });
+      expect(ids(rows)).toEqual(['2', '4']);
+    }, 30000);
+
+    it('gt: amount > 20 → rows 3,4,5 (30,40,50)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'amount', operator: 'gt', value: 20 }],
+      });
+      expect(ids(rows)).toEqual(['3', '4', '5']);
+    }, 30000);
+
+    it('lt: amount < 20 → rows 1,6 (10,0)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'amount', operator: 'lt', value: 20 }],
+      });
+      expect(ids(rows)).toEqual(['1', '6']);
+    }, 30000);
+
+    it('gte: amount >= 20 → rows 2,3,4,5 (20,30,40,50)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'amount', operator: 'gte', value: 20 }],
+      });
+      expect(ids(rows)).toEqual(['2', '3', '4', '5']);
+    }, 30000);
+
+    it('lte: amount <= 20 → rows 1,2,6 (10,20,0)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'amount', operator: 'lte', value: 20 }],
+      });
+      expect(ids(rows)).toEqual(['1', '2', '6']);
+    }, 30000);
+
+    it('contains "alph" on name → row 1 (alpha)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'contains', value: 'alph' }],
+      });
+      expect(ids(rows)).toEqual(['1']);
+    }, 30000);
+
+    it('not_contains "eta" on name → rows 1,3,4,5,6 (all except beta)', async () => {
+      // beta(2) contains 'eta'; others do not
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'not_contains', value: 'eta' }],
+      });
+      expect(ids(rows)).toEqual(['1', '3', '4', '5', '6']);
+    }, 30000);
+
+    it('starts_with "al" on name → row 1 (alpha)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'starts_with', value: 'al' }],
+      });
+      expect(ids(rows)).toEqual(['1']);
+    }, 30000);
+
+    it('ends_with "a" on name → rows 1,2,6 (alpha,beta,gamma all end in "a")', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'ends_with', value: 'a' }],
+      });
+      expect(ids(rows)).toEqual(['1', '2', '6']);
+    }, 30000);
+
+    it('regex: name ~ "^alp" → row 1', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'regex', value: '^alp' }],
+      });
+      expect(ids(rows)).toEqual(['1']);
+    }, 30000);
+
+    it('not_regex: name !~ "^alp" → rows 2,3,4,5,6', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'not_regex', value: '^alp' }],
+      });
+      expect(ids(rows)).toEqual(['2', '3', '4', '5', '6']);
+    }, 30000);
+
+    it('is_empty: no empty-name rows → 0 rows', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'is_empty' }],
+      });
+      expect(rows).toHaveLength(0);
+    }, 30000);
+
+    it('is_not_empty: all 6 rows have non-empty names', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'is_not_empty' }],
+      });
+      expect(rows).toHaveLength(6);
+    }, 30000);
+
+    it('is_null: no NULLs in seed → 0 rows', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'is_null' }],
+      });
+      expect(rows).toHaveLength(0);
+    }, 30000);
+
+    it('is_not_null: all 6 rows', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'is_not_null' }],
+      });
+      expect(rows).toHaveLength(6);
+    }, 30000);
+
+    it('between: amount BETWEEN 20 AND 30 → rows 2,3', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'amount', operator: 'between', value: { from: 20, to: 30 } }],
+      });
+      expect(ids(rows)).toEqual(['2', '3']);
+    }, 30000);
+
+    it('relative_date last_n_days(7): rows 1,2,5,6 (lower-bound only; future row 5 included)', async () => {
+      const rows = await runFilter({
+        filters: [
+          { column: 'date_col', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
+        ],
+      });
+      // last_n_days has NO upper bound by design (deferred item): future-dated rows
+      // (row 5 is +13 months) are included. Asserts the actual lower-bound-only behavior.
+      expect(ids(rows)).toEqual(['1', '2', '5', '6']);
+    }, 30000);
+
+    it('relative_date last_n_months(3): rows 1,2,3,5,6 (lower-bound only; future row 5 included)', async () => {
+      const rows = await runFilter({
+        filters: [
+          {
+            column: 'date_col',
+            operator: 'relative_date',
+            value: { kind: 'last_n_months', n: 3 },
+          },
+        ],
+      });
+      // last_n_months has NO upper bound by design (deferred): future row 5 included.
+      expect(ids(rows)).toEqual(['1', '2', '3', '5', '6']);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // Wildcard-literal safety
+    // -------------------------------------------------------------------------
+
+    it('SAFETY contains "100%" on name → only row 4 (% is not a LIKE wildcard)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'contains', value: '100%' }],
+      });
+      expect(ids(rows)).toEqual(['4']);
+    }, 30000);
+
+    it('SAFETY eq "O\'Brien" → row 3 (single-quote doubling round-trip)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'eq', value: "O'Brien" }],
+      });
+      expect(ids(rows)).toEqual(['3']);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // Sort + limit
+    // -------------------------------------------------------------------------
+
+    it('sort by amount DESC + limit 2 → rows 5,4 (amounts 50,40)', async () => {
+      const rows = await runFilter({
+        sort: [{ column: 'amount', direction: 'desc' }],
+        limit: 2,
+      });
+      expect(rows.map(r => r.id)).toEqual(['5', '4']);
+    }, 30000);
+  }
+);

--- a/apps/backend/test/output-controls-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-emission.e2e-spec.ts
@@ -59,7 +59,7 @@ const mockSchemaProviderFacade = {
     type: 'athena-data-mart-schema',
     fields: HEADERS.map(h => ({
       name: h.name,
-      type: h.type,
+      type: h.storageFieldType,
       status: 'CONNECTED',
       isPrimaryKey: false,
     })),

--- a/apps/backend/test/output-controls-redshift-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-redshift-emission.e2e-spec.ts
@@ -60,7 +60,7 @@ const mockSchemaProviderFacade = {
     type: 'redshift-data-mart-schema',
     fields: HEADERS.map(h => ({
       name: h.name,
-      type: h.type,
+      type: h.storageFieldType,
       status: 'CONNECTED',
       isPrimaryKey: false,
     })),

--- a/apps/backend/test/output-controls-redshift-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-redshift-emission.e2e-spec.ts
@@ -1,0 +1,247 @@
+import { INestApplication } from '@nestjs/common';
+import * as crypto from 'crypto';
+import * as supertest from 'supertest';
+import {
+  createTestApp,
+  closeTestApp,
+  StorageBuilder,
+  DataMartBuilder,
+  DataDestinationBuilder,
+  ReportBuilder,
+  AUTH_HEADER,
+  signLookerPayload,
+  mockGoogleJwkFetch,
+  restoreGoogleJwkFetch,
+} from '@owox/test-utils';
+import { DataStorageType } from '../src/data-marts/data-storage-types/enums/data-storage-type.enum';
+import { DataDestinationType } from '../src/data-marts/data-destination-types/enums/data-destination-type.enum';
+import { DataMartDefinitionValidatorFacade } from '../src/data-marts/data-storage-types/facades/data-mart-definition-validator-facade.service';
+import { DataMartSchemaProviderFacade } from '../src/data-marts/data-storage-types/facades/data-mart-schema-provider.facade';
+import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../src/data-marts/data-storage-types/data-storage-providers';
+import { ReportDataHeader } from '../src/data-marts/dto/domain/report-data-header.dto';
+import { ReportDataBatch } from '../src/data-marts/dto/domain/report-data-batch.dto';
+import { ReportDataDescription } from '../src/data-marts/dto/domain/report-data-description.dto';
+import { RedshiftFieldType } from '../src/data-marts/data-storage-types/redshift/enums/redshift-field-type.enum';
+
+// HTTP-layer e2e for Redshift output-controls SQL emission. ONE app + ONE Redshift
+// report (date filter on a TIMESTAMP column) drives two assertions to keep the
+// e2e suite fast — booting createTestApp() is the dominant cost:
+//
+//   1. GET /generated-sql emits a bare literal '2024-01-01' (no CAST, no bound params).
+//      Redshift uses Postgres unknown-literal coercion, so no explicit CAST is needed.
+//   2. POST /looker/get-data runs the REAL ReportDataCacheService (only the storage
+//      reader is a spy), proving resolvePrepareOptions() composes + forwards the inlined
+//      SQL with no bound params into sqlOverride / sqlOverrideParams.
+//
+// The publish-time validator is stubbed (orthogonal — it dry-runs live Redshift);
+// everything else (composer → builder → renderer, types from the persisted schema)
+// runs for real.
+
+const HEADERS: ReportDataHeader[] = [
+  new ReportDataHeader('id', 'id', undefined, RedshiftFieldType.INTEGER),
+  new ReportDataHeader('created_at', 'created_at', undefined, RedshiftFieldType.TIMESTAMP),
+];
+
+// Real ReportDataCacheService → spyReader.prepareReportData(report, options).
+// We assert the options it captured.
+const spyReader = {
+  prepareReportData: jest.fn().mockResolvedValue(new ReportDataDescription(HEADERS, 1)),
+  readReportDataBatch: jest
+    .fn()
+    .mockResolvedValue(new ReportDataBatch([['1', '2024-02-01']], null)),
+  finalize: jest.fn().mockResolvedValue(undefined),
+  getState: jest.fn().mockReturnValue(null),
+  initFromState: jest.fn().mockResolvedValue(undefined),
+  getType: jest.fn().mockReturnValue(DataStorageType.AWS_REDSHIFT),
+};
+
+const mockSchemaProviderFacade = {
+  getActualDataMartSchema: jest.fn().mockResolvedValue({
+    type: 'redshift-data-mart-schema',
+    fields: HEADERS.map(h => ({
+      name: h.name,
+      type: h.type,
+      status: 'CONNECTED',
+      isPrimaryKey: false,
+    })),
+  }),
+};
+
+describe('Output controls — Redshift SQL emission (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+  let destinationId: string;
+  let destinationSecretKey: string;
+  let reportId: string;
+
+  const postLooker = (path: string, payload: unknown): supertest.Test =>
+    agent.post(path).set('Content-Type', 'application/jwt').send(signLookerPayload(payload));
+
+  beforeAll(async () => {
+    mockGoogleJwkFetch();
+
+    const testApp = await createTestApp([
+      {
+        provide: DataMartDefinitionValidatorFacade,
+        useValue: { checkIsValid: async () => undefined },
+      },
+      { provide: DataMartSchemaProviderFacade, useValue: mockSchemaProviderFacade },
+      {
+        provide: DATA_STORAGE_REPORT_READER_RESOLVER,
+        useValue: { resolve: async () => spyReader },
+      },
+    ]);
+    app = testApp.app;
+    agent = testApp.agent;
+
+    const storageRes = await agent
+      .post('/api/data-storages')
+      .set(AUTH_HEADER)
+      .send(new StorageBuilder().withType(DataStorageType.AWS_REDSHIFT).build());
+    expect(storageRes.status).toBe(201);
+    const storageId = storageRes.body.id;
+
+    const dmRes = await agent
+      .post('/api/data-marts')
+      .set(AUTH_HEADER)
+      .send(new DataMartBuilder().withStorageId(storageId).build());
+    expect(dmRes.status).toBe(201);
+    const dataMartId = dmRes.body.id;
+
+    await agent
+      .put(`/api/data-marts/${dataMartId}/definition`)
+      .set(AUTH_HEADER)
+      .send({ definitionType: 'TABLE', definition: { fullyQualifiedName: 'dev.public.events' } });
+
+    await agent
+      .put(`/api/data-marts/${dataMartId}/schema`)
+      .set(AUTH_HEADER)
+      .send({
+        schema: {
+          type: 'redshift-data-mart-schema',
+          fields: [
+            { name: 'id', type: 'INTEGER', status: 'CONNECTED', isPrimaryKey: false },
+            { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
+          ],
+        },
+      });
+
+    expect((await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER)).status).toBe(
+      200
+    );
+    await agent
+      .put(`/api/data-storages/${storageId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForUse: true, availableForMaintenance: true });
+    await agent
+      .put(`/api/data-marts/${dataMartId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForReporting: true, availableForMaintenance: true });
+
+    const destRes = await agent
+      .post('/api/data-destinations')
+      .set(AUTH_HEADER)
+      .send(
+        new DataDestinationBuilder()
+          .withType(DataDestinationType.LOOKER_STUDIO)
+          .withCredentials({ type: 'looker-studio-credentials' })
+          .build()
+      );
+    expect(destRes.status).toBe(201);
+    destinationId = destRes.body.id;
+    await agent
+      .put(`/api/data-destinations/${destinationId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForUse: true, availableForMaintenance: true });
+
+    // The Looker report lookup INNER JOINs storage.credential — seed one and a config.
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const backendRoot = require.resolve('@owox/backend/package.json');
+    const backendDir = require('path').dirname(backendRoot);
+    const { DataSource } = require(require.resolve('typeorm', { paths: [backendDir] }));
+    /* eslint-enable @typescript-eslint/no-require-imports */
+    const dataSource = app.get(DataSource);
+    const credentialId = crypto.randomUUID();
+    await dataSource.query(
+      `INSERT INTO data_storage_credentials (id, projectId, type, credentials, createdAt, modifiedAt)
+       VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      [
+        credentialId,
+        '0',
+        'aws_iam',
+        JSON.stringify({ accessKeyId: 'test-key', secretAccessKey: 'test-secret' }),
+      ]
+    );
+    await dataSource.query(`UPDATE data_storage SET config = ?, credentialId = ? WHERE id = ?`, [
+      JSON.stringify({
+        connectionType: 'PROVISIONED',
+        region: 'us-east-1',
+        database: 'dev',
+        clusterIdentifier: 'test-cluster',
+      }),
+      credentialId,
+      storageId,
+    ]);
+
+    destinationSecretKey = (
+      await agent.get(`/api/data-destinations/${destinationId}`).set(AUTH_HEADER)
+    ).body.credentials.destinationSecretKey;
+
+    const reportRes = await agent
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send(
+        new ReportBuilder().withDataMartId(dataMartId).withDataDestinationId(destinationId).build()
+      );
+    expect(reportRes.status).toBe(201);
+    reportId = reportRes.body.id;
+
+    const putRes = await agent
+      .put(`/api/reports/${reportId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Looker Redshift date filter',
+        dataDestinationId: destinationId,
+        destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        columnConfig: ['id', 'created_at'],
+        filterConfig: [{ column: 'created_at', operator: 'gte', value: '2024-01-01' }],
+      });
+    expect(putRes.status).toBe(200);
+  }, 120_000);
+
+  afterAll(async () => {
+    restoreGoogleJwkFetch();
+    await closeTestApp(app);
+  });
+
+  it('GET /generated-sql emits static SQL with the date value inlined as a literal (no cast)', async () => {
+    const res = await agent.get(`/api/reports/${reportId}/generated-sql`).set(AUTH_HEADER);
+    expect(res.status).toBe(200);
+    // Redshift renderer inlines all values as bare literals — no bound params, no CAST.
+    // Postgres unknown-literal coercion handles TIMESTAMP comparison transparently.
+    expect(res.body.sql).toContain(`"created_at" >= '2024-01-01'`);
+    expect(res.body.sql).not.toContain('?');
+    expect(res.body.sql).not.toContain('CAST(');
+  });
+
+  it('carries composed output-controls SQL with no bound params into the cached reader', async () => {
+    const res = await postLooker('/api/external/looker/get-data', {
+      connectionConfig: { deploymentUrl: 'http://localhost', destinationId, destinationSecretKey },
+      request: {
+        configParams: { destinationId, reportId },
+        // Sample extraction still resolves the cached reader (our assertion target)
+        // but skips creating a report run + its async success handlers — faster, no noise.
+        scriptParams: { sampleExtraction: true },
+        fields: [{ name: 'id' }, { name: 'created_at' }],
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(spyReader.prepareReportData).toHaveBeenCalled();
+    const options = spyReader.prepareReportData.mock.calls[0][1];
+    expect(options.sqlOverride).toContain(`"created_at" >= '2024-01-01'`);
+    expect(options.sqlOverrideParams ?? []).toEqual([]);
+    expect(options.sqlOverride).not.toContain('?');
+    expect(options.sqlOverride).not.toContain('CAST(');
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.test.tsx
@@ -442,6 +442,16 @@ describe('FilterValueEditor — relative_date operator', () => {
 
     expect(lastCall(onChange)).toBeNull();
   });
+
+  it('rejects a Last-N value above 3650 with a friendly message', () => {
+    const { onChange } = renderEditor({ fieldType: DATE_TYPE });
+
+    fireEvent.change(getConditionSelect(), { target: { value: 'relative_date' } });
+    fireEvent.change(getPresetSelect(), { target: { value: 'last_n_days' } });
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '4000' } });
+
+    expect(lastCall(onChange)).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
@@ -110,8 +110,8 @@ function buildRule(args: { column: string; fieldType: string; state: EditorState
 
   if (op === 'relative_date') {
     if (state.relativeKind === 'last_n_days' || state.relativeKind === 'last_n_months') {
-      if (!Number.isInteger(state.relativeN) || state.relativeN <= 0) {
-        throw new Error('N must be a positive integer');
+      if (!Number.isInteger(state.relativeN) || state.relativeN <= 0 || state.relativeN > 3650) {
+        throw new Error('N must be between 1 and 3650');
       }
       return {
         column,
@@ -181,6 +181,13 @@ export function FilterValueEditor({
 
   const dateField = isDateType(fieldType);
   const timeField = isTimeType(fieldType);
+  const inputType = isNumberType(fieldType)
+    ? 'number'
+    : timeField
+      ? 'time'
+      : dateField
+        ? 'date'
+        : 'text';
 
   return (
     <>
@@ -210,15 +217,7 @@ export function FilterValueEditor({
           <Label>From / To</Label>
           <div className='flex gap-2'>
             <Input
-              type={
-                isNumberType(fieldType)
-                  ? 'number'
-                  : timeField
-                    ? 'time'
-                    : dateField
-                      ? 'date'
-                      : 'text'
-              }
+              type={inputType}
               value={state.betweenFrom}
               onChange={e => {
                 setState(s => ({ ...s, betweenFrom: e.target.value }));
@@ -226,15 +225,7 @@ export function FilterValueEditor({
               placeholder='from'
             />
             <Input
-              type={
-                isNumberType(fieldType)
-                  ? 'number'
-                  : timeField
-                    ? 'time'
-                    : dateField
-                      ? 'date'
-                      : 'text'
-              }
+              type={inputType}
               value={state.betweenTo}
               onChange={e => {
                 setState(s => ({ ...s, betweenTo: e.target.value }));
@@ -269,6 +260,7 @@ export function FilterValueEditor({
             <Input
               type='number'
               min={1}
+              max={3650}
               value={state.relativeN}
               onChange={e => {
                 setState(s => ({ ...s, relativeN: Number(e.target.value) || 0 }));
@@ -282,9 +274,7 @@ export function FilterValueEditor({
         <div className='space-y-1'>
           <Label>Value</Label>
           <Input
-            type={
-              isNumberType(fieldType) ? 'number' : timeField ? 'time' : dateField ? 'date' : 'text'
-            }
+            type={inputType}
             value={state.scalar}
             onChange={e => {
               setState(s => ({ ...s, scalar: e.target.value }));

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.test.ts
@@ -102,6 +102,22 @@ describe('operatorsForType', () => {
     });
   });
 
+  describe('Redshift type names', () => {
+    it('maps Redshift TEXT/BPCHAR to string ops', () => {
+      for (const t of ['TEXT', 'BPCHAR']) expect(opValues(t)).toContain('contains');
+    });
+    it('maps DOUBLE PRECISION to number ops', () => {
+      expect(opValues('DOUBLE PRECISION')).toContain('between');
+    });
+    it('maps TIMESTAMPTZ to date ops with relative_date', () => {
+      expect(opValues('TIMESTAMPTZ')).toContain('relative_date');
+    });
+    it('maps TIMETZ to time ops without relative_date', () => {
+      expect(opValues('TIMETZ')).toContain('between');
+      expect(opValues('TIMETZ')).not.toContain('relative_date');
+    });
+  });
+
   it('returns no operators for unrecognised (complex/binary) types', () => {
     for (const t of ['ARRAY', 'MAP', 'STRUCT', 'JSON', 'VARBINARY', 'GEOGRAPHY']) {
       expect(operatorsForType(t)).toEqual([]);

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.ts
@@ -27,8 +27,8 @@ export interface OperatorMeta {
 }
 
 // Mirror of backend OutputControlsValidatorService type sets — cover every type
-// name each supported provider emits (BigQuery + Athena), keep the two in sync.
-const STRING_TYPES = new Set(['STRING', 'VARCHAR', 'CHAR']);
+// name each supported provider emits (BigQuery + Athena + Redshift), keep in sync.
+const STRING_TYPES = new Set(['STRING', 'VARCHAR', 'CHAR', 'TEXT', 'BPCHAR']);
 const NUMBER_TYPES = new Set([
   'INTEGER',
   'BIGINT',
@@ -37,15 +37,22 @@ const NUMBER_TYPES = new Set([
   'FLOAT',
   'REAL',
   'DOUBLE',
+  'DOUBLE PRECISION',
   'NUMERIC',
   'BIGNUMERIC',
   'DECIMAL',
 ]);
-const DATE_TYPES = new Set(['DATE', 'DATETIME', 'TIMESTAMP', 'TIMESTAMP WITH TIME ZONE']);
+const DATE_TYPES = new Set([
+  'DATE',
+  'DATETIME',
+  'TIMESTAMP',
+  'TIMESTAMP WITH TIME ZONE',
+  'TIMESTAMPTZ',
+]);
 // Time-of-day types are kept out of DATE_TYPES: relative_date presets resolve to
 // calendar dates (current_date / date_add), which are meaningless for a column
 // with no date component and rejected by the backend renderer.
-const TIME_TYPES = new Set(['TIME', 'TIME WITH TIME ZONE']);
+const TIME_TYPES = new Set(['TIME', 'TIME WITH TIME ZONE', 'TIMETZ']);
 const BOOL_TYPES = new Set(['BOOLEAN', 'BOOL']);
 
 const STRING_OPERATORS: OperatorMeta[] = [
@@ -96,7 +103,20 @@ const BOOLEAN_OPERATORS: OperatorMeta[] = [
 ];
 
 // Same comparison operators as dates minus relative_date (calendar-only presets).
-const TIME_OPERATORS: OperatorMeta[] = DATE_OPERATORS.filter(o => o.value !== 'relative_date');
+// "at"-framed labels read naturally for a time of day, which has no calendar date
+// to be "on" / "on or after".
+const TIME_LABEL_OVERRIDES: Partial<Record<FilterOperator, string>> = {
+  eq: 'at',
+  neq: 'not at',
+  gte: 'at or after',
+  lte: 'at or before',
+};
+const TIME_OPERATORS: OperatorMeta[] = DATE_OPERATORS.filter(o => o.value !== 'relative_date').map(
+  o => {
+    const label = TIME_LABEL_OVERRIDES[o.value];
+    return label ? { ...o, label } : o;
+  }
+);
 
 export function operatorsForType(fieldType: string): OperatorMeta[] {
   if (STRING_TYPES.has(fieldType)) return STRING_OPERATORS;

--- a/apps/web/src/features/data-marts/shared/utils/output-controls-support.test.ts
+++ b/apps/web/src/features/data-marts/shared/utils/output-controls-support.test.ts
@@ -15,9 +15,12 @@ describe('supportsOutputControls', () => {
     expect(supportsOutputControls(DataStorageType.LEGACY_GOOGLE_BIGQUERY)).toBe(false);
   });
 
+  it('returns true for Redshift', () => {
+    expect(supportsOutputControls(DataStorageType.AWS_REDSHIFT)).toBe(true);
+  });
+
   it('returns false for not-yet-supported storages', () => {
     expect(supportsOutputControls(DataStorageType.SNOWFLAKE)).toBe(false);
-    expect(supportsOutputControls(DataStorageType.AWS_REDSHIFT)).toBe(false);
     expect(supportsOutputControls(DataStorageType.DATABRICKS)).toBe(false);
     expect(supportsOutputControls(DataStorageType.AZURE_SYNAPSE)).toBe(false);
   });

--- a/apps/web/src/features/data-marts/shared/utils/output-controls-support.ts
+++ b/apps/web/src/features/data-marts/shared/utils/output-controls-support.ts
@@ -4,6 +4,7 @@ import { DataStorageType } from '../../../data-storage/shared/model/types/data-s
 const SUPPORTED: ReadonlySet<DataStorageType> = new Set([
   DataStorageType.GOOGLE_BIGQUERY,
   DataStorageType.AWS_ATHENA,
+  DataStorageType.AWS_REDSHIFT,
 ]);
 
 export function supportsOutputControls(type: DataStorageType): boolean {

--- a/docs/storages/supported-storages/aws-redshift.md
+++ b/docs/storages/supported-storages/aws-redshift.md
@@ -208,6 +208,13 @@ GRANT ALL ON DATABASE dev TO "IAM:<USERNAME_IN_IAM>";
 GRANT ALL ON DATABASE dev TO "IAM:<USERNAME_IN_IAM>";
 ```
 
+### Filter values and `standard_conforming_strings`
+
+OWOX Data Marts safely escapes report filter values for Redshift by relying on the
+default `standard_conforming_strings = on` setting (a backslash is treated as an
+ordinary character). This is the default for both Redshift Serverless and provisioned
+clusters. Do not set `standard_conforming_strings = off` for the database OWOX connects to.
+
 ## Additional Resources
 
 - [AWS Redshift Documentation](https://docs.aws.amazon.com/redshift/)


### PR DESCRIPTION
Enable filters / slices / sort / limit for AWS Redshift, matching the Athena + BigQuery support. Redshift uses "option B": RedshiftClauseRenderer emits inline SQL literals (the Redshift Data API has no bound-parameter channel), so it always returns zero params — compose / composeStatic / run / stream / Looker-cache / copy / preview and the blended builder all work with no param plumbing. Literal escaping ('->'') is the sole injection barrier; live-verified that backslash is literal and that all five date/time types (DATE, TIMESTAMP, TIMESTAMPTZ, TIME, TIMETZ) coerce a bare literal — no CAST needed.

Backend: RedshiftClauseRenderer (19 operators, relative_date half-open ranges), non-blended + blended query builders wired to it, DI registration; validator, capability and FE operator type-sets gain the Redshift type names (TEXT, BPCHAR, DOUBLE PRECISION, TIMESTAMPTZ, TIMETZ). Subquery FROM clauses get an alias (Redshift/Postgres requires it); create-view and the query-debug log hardened.

Cross-storage: this_month / this_year relative_date presets now carry an upper bound in all three renderers (Athena, BigQuery, Redshift); FE "Last N" inputs are bounded to max 3650. FE filter type-matrix nits from PR #15 mirrored to web.

Tests: renderer operator matrix + injection probes, query/blended builder specs, validator + capability contract, e2e SQL-emission + Looker cache path, and a live Redshift integration suite (coercion, escaping, operator matrix, relative_date).