### PR TITLE
ci: build native modules in integration tests by dropping --ignore-scripts

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -45,8 +45,10 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      # No --ignore-scripts: native modules (better-sqlite3) and workspace
+      # postinstall hooks must run for the app-booting suites to work.
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --ignore-scripts --no-fund --loglevel error
+        run: npm ci --prefer-offline --no-audit --no-fund --loglevel error
 
       - name: Build all workspace packages
         run: npm run build --workspaces --if-present

--- a/apps/backend/test/integration/http-data-real.integration.ts
+++ b/apps/backend/test/integration/http-data-real.integration.ts
@@ -95,7 +95,9 @@ if (NEED_APP) {
     const testApp = await createTestApp();
     sharedApp = testApp.app;
     sharedAgent = testApp.agent;
-  }, 60000);
+    // Cold NestJS + TypeORM bootstrap on a fresh CI runner can exceed 60s;
+    // match report-run-real's 180s budget for the app-creating hook.
+  }, 180000);
 
   afterAll(async () => {
     if (sharedApp) {


### PR DESCRIPTION
## Problem

The `Integration Tests (Real DB)` workflow was red on two suites — **Report read (Athena)** and **HTTP Data (Athena + BigQuery)** — both failing in `beforeAll`:

```
Could not locate the bindings file. Tried:
 → .../node_modules/better-sqlite3/build/Release/better_sqlite3.node
   at new Database (better-sqlite3/lib/database.js)
   at dataSourceFactory (src/app.module.ts:42)  → await dataSource.initialize()
```

## Root cause

The install step ran `npm ci` with `--ignore-scripts`, so `better-sqlite3`'s install script never ran and the native binding (`better_sqlite3.node`) was never built. The flag has been there since the suite was first set up (#1069) but was harmless — the older suites (BigQuery, Athena, Google Sheets) test connectors directly without booting the app.

The suites added in #1272 (`http-data-real`, `report-run-real`) are the first that boot the full NestJS app with a TypeORM SQLite `DataSource`, so they're the first to require the native binding — exposing the latent issue.

## Fixes

**1. Drop `--ignore-scripts`** so install scripts run and native modules build. This matches the existing `e2e-api.yml` workflow, which already does exactly this for the same reason:

> `# No --ignore-scripts: native modules (better-sqlite3) and workspace`
> `# postinstall hooks must run for E2E tests to work.`

**2. Raise the `http-data-real` bootstrap-hook timeout 60s → 180s.** Once the binding was fixed, a second, pre-existing failure surfaced in `http-data-real`: its top-level `beforeAll` (which only awaits `createTestApp()`) timed out at 60s. The cold NestJS + TypeORM bootstrap on a fresh CI runner exceeds 60s; the sibling `report-run-real` suite already uses 180s for the same hook. This bug was previously masked by the binding failure (the hook threw immediately).

## Verification

`workflow_dispatch` run on this branch — all 5 suites green:

```
✓ Report read (Athena)            6m32s
✓ HTTP Data (Athena + BigQuery)   7m16s
✓ BigQuery                        6m13s
✓ Google Sheets (column preserv.) 4m20s
✓ Athena                          5m45s
```

Run: https://github.com/OWOX/owox-data-marts/actions/runs/27146970861