### PR TITLE
ci: bump checkout and setup-node to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/audit-all.yml
+++ b/.github/workflows/audit-all.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js 🔧
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -53,7 +53,7 @@ jobs:
           HEADERS_TIMEOUT_MS: '185000'
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
@@ -61,7 +61,7 @@ jobs:
           retention-days: 7
 
       - name: Upload Playwright traces
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-traces

--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/lint-owox.yml
+++ b/.github/workflows/lint-owox.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/lint-root.yml
+++ b/.github/workflows/lint-root.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
           fetch-depth: 0 # Required for changesets to work properly
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Build and push "latest" container image
         if: steps.latest_image_exists.outputs.exists == 'false'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -277,7 +277,7 @@ jobs:
           exit 1
 
       - name: Build and push "next" container image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Required for changesets to work properly
 
@@ -30,7 +30,7 @@ jobs:
           echo "repo_lower=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Required for changesets to work properly
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -84,7 +84,7 @@ jobs:
       issues: write
     steps:
       - name: Open or update tracking issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const label = 'integration-failure';

--- a/.github/workflows/test-owox.yml
+++ b/.github/workflows/test-owox.yml
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## Why

These workflows pin GitHub Actions that run on the **deprecated Node.js 20 runtime**. The runner flags **any** action whose `runs.using` is `node20`, regardless of author — so every run currently emits a Node 20 deprecation warning, and clearing it means moving *every* node20 action off node20.

GitHub timeline:

- **June 16, 2026** — runners default to the Node 24 runtime.
- **Fall 2026** — Node 20 removed from runners entirely.

Nothing breaks before then — this is CI hygiene to clear the warning.

## What

Bump every node20 action across all 12 workflows to a node24 release. Each target version was verified to declare `runs.using: node24` in its `action.yml`.

**Drop-in runtime bumps (no config change):**

- ✅ `actions/checkout@v4` → `@v5` (×12)
- ✅ `actions/setup-node@v4` → `@v5` (×12)
- ✅ `actions/github-script@v7` → `@v8`
- ✅ `actions/upload-artifact@v4` → `@v7` (×2)
- ✅ `docker/setup-buildx-action@v3` → `@v4`
- ✅ `docker/login-action@v3` → `@v4`
- ✅ `docker/build-push-action@v5` → `@v7` (×2)

**Already node24 — no change needed:** `changesets/action@v1` and `JamesIves/github-pages-deploy-action@v4` — their floating major tags already resolve to a node24 release (`JamesIves` → `v4.8.0`).

## Risk

Most bumps are pure runtime/dependency updates. The two to keep an eye on:

- `docker/build-push-action` v5 → v7 spans two majors. All inputs in use (`context`, `push`, `platforms`, `build-args`, `tags`) are unchanged, so no config breakage — but this is the publish path, so the **next publish run should be confirmed** to push the multi-arch image to GHCR as before.
- `actions/upload-artifact` v4 → v7: artifact names are unique per upload (`playwright-report`, `playwright-traces`); no removed inputs in use.

## Verification

- All 12 changed workflow files validated as parseable YAML.
- No functional changes — runtime bumps only.
