### PR TITLE
ci: shard E2E API tests across 3 parallel jobs

### DIFF
--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -15,9 +15,19 @@ concurrency:
 
 jobs:
   e2e-api:
-    name: API E2E Tests
+    name: API E2E Tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    # The e2e suite runs jest with maxWorkers:1 (parallel workers flake — they
+    # share process state and overwrite the in-memory DB). To cut wall-clock
+    # without reintroducing that flakiness, split the test files across separate
+    # runner jobs with jest --shard: each shard stays single-worker and fully
+    # isolated on its own runner. Bump the shard count if the suite grows.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - name: Checkout repository
@@ -38,6 +48,6 @@ jobs:
         run: npm run build --workspaces --if-present
 
       - name: Run API E2E tests
-        run: npm run test:e2e -w @owox/backend
+        run: npm run test:e2e -w @owox/backend -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
         env:
           NODE_ENV: test


### PR DESCRIPTION
## Problem

`E2E API Tests` has been chronically red on `main` since early June — every run hits the **15-minute job timeout** and is cancelled. Root cause is not a hang but raw runtime: the 33 `*.e2e-spec.ts` files run **sequentially** (`jest maxWorkers:1`), and each one re-bootstraps the full NestJS app in `beforeAll` (~10s), so install + build + tests exceeds 15 minutes.

## Why not just raise `maxWorkers`

Parallel workers within a single process flake — they share process state and overwrite the in-memory SQLite DB. That is exactly why `maxWorkers:1` was set deliberately in #1149 (the DB was already `:memory:` at that point and it still wasn't enough). Raising it would reintroduce the flakiness.

## Fix

Parallelize across **separate runner jobs** with `jest --shard` instead of across workers in one process. Each shard:

- runs on its own runner (no shared state between shards),
- stays `maxWorkers:1` internally (no flakiness),
- runs ~1/3 of the suite.

`--listTests` confirms an even split — **11 / 11 / 11** files. Per-job runtime drops to ~3.8 min of tests + ~4.5 min install/build ≈ **~8.5 min**, comfortably under the 15-min timeout.

Shard count lives in the matrix (`shard: [1, 2, 3]`) — bump it if the suite grows.

## Trade-off

~3× runner-minutes (install/build repeat per shard) in exchange for ~3× lower wall-clock and a green, non-flaky suite.

## Note

Real test failures are currently hidden under the timeout (e.g. `report-operate-access` ~97s). Once the suite finishes within the limit, any genuinely failing specs will surface — those are a separate concern from this runtime fix.