### PR TITLE
ci: bump remaining third-party actions to Node 24 runtime

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -53,7 +53,7 @@ jobs:
           HEADERS_TIMEOUT_MS: '185000'
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
@@ -61,7 +61,7 @@ jobs:
           retention-days: 7
 
       - name: Upload Playwright traces
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-traces

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
           fetch-depth: 0 # Required for changesets to work properly
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Build and push "latest" container image
         if: steps.latest_image_exists.outputs.exists == 'false'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -277,7 +277,7 @@ jobs:
           exit 1
 
       - name: Build and push "next" container image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -86,7 +86,7 @@ jobs:
       issues: write
     steps:
       - name: Open or update tracking issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const label = 'integration-failure';


### PR DESCRIPTION
## Why

Follow-up to #1292, which bumped `actions/checkout` and `actions/setup-node` to `@v5`. Several other actions in these workflows still declare `runs.using: node20`, so workflow runs keep emitting the Node 20 deprecation warning even after #1292.

The runner flags **any** action whose declared runtime is `node20`, regardless of author — so clearing the warning means moving every node20 action off node20, not just the GitHub-authored ones.

GitHub timeline: runners default to Node 24 on **June 16, 2026**; Node 20 is removed from runners in **fall 2026**. Nothing breaks before then — this is hygiene, not an outage fix.

## What

| Action | From | To | File |
|---|---|---|---|
| `actions/upload-artifact` | `v4` | `v7` | `e2e-browser.yml` (×2) |
| `docker/setup-buildx-action` | `v3` | `v4` | `publish.yml` |
| `docker/login-action` | `v3` | `v4` | `publish.yml` |
| `docker/build-push-action` | `v5` | `v7` | `publish.yml` (×2) |
| `actions/github-script` | `v7` | `v8` | `test-integration.yml` |

Each target version was verified to declare `runs.using: node24` in its `action.yml`.

**Not touched** — already node24 via their floating major tags, so no change is needed:

- `changesets/action@v1` → resolves to a node24 release.
- `JamesIves/github-pages-deploy-action@v4` → resolves to `v4.8.0` (node24 migration).

## Risk

- `upload-artifact` v4→v7: artifact names are unique per upload (`playwright-report`, `playwright-traces`); no removed inputs in use. Low risk.
- `github-script` v7→v8: only the stable `github.rest.*` API surface is used. Low risk.
- `setup-buildx`/`login` v3→v4: runtime/dependency bumps only. Low risk.
- `build-push` v5→v7: spans two majors. All inputs in use (`context`, `push`, `platforms`, `build-args`, `tags`) are unchanged, so no config breakage — but this is the publish path, so the **next publish run should be watched** to confirm the multi-arch push to GHCR is unaffected.

## Verification

- All changed workflow files validated as parseable YAML.
- No functional changes — runtime bumps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
