### PR TITLE
test(blended): stub CreateViewService so SQL-composition tests run without BigQuery

### DIFF
--- a/apps/backend/test/blended-output-controls.e2e-spec.ts
+++ b/apps/backend/test/blended-output-controls.e2e-spec.ts
@@ -8,6 +8,8 @@ import {
   setupBlendedReportPrerequisites,
   type BlendedReportPrerequisites,
 } from '@owox/test-utils';
+import { CreateViewService } from 'src/data-marts/use-cases/create-view.service';
+import { CreateViewCommand } from 'src/data-marts/dto/domain/create-view.command';
 
 // Full-flow e2e: PUT /api/reports/:id → GET /api/reports/:id/generated-sql.
 // Exercises the entire pipeline (DTO → validator → entity persist → composer
@@ -28,8 +30,21 @@ describe('Blended output controls full-flow (e2e)', () => {
   let agent: supertest.Agent;
   let prereqs: BlendedReportPrerequisites;
 
+  // The /generated-sql path materializes a real BigQuery view for SQL-defined
+  // marts (composer → resolveTableName → ensureSqlViewIsUpToDate → CreateViewService),
+  // which needs live BigQuery credentials. These tests assert SQL *composition*
+  // (CTEs / WHERE), not real BQ execution, so stub CreateViewService to return a
+  // deterministic view name without hitting BigQuery — keeping the suite CI-runnable.
+  const createViewServiceMock = {
+    run: jest.fn(async (command: CreateViewCommand) => ({
+      fullyQualifiedName: `\`blended_test.${command.viewName}\``,
+    })),
+  };
+
   beforeAll(async () => {
-    const testApp = await createTestApp();
+    const testApp = await createTestApp([
+      { provide: CreateViewService, useValue: createViewServiceMock },
+    ]);
     app = testApp.app;
     agent = testApp.agent;
     prereqs = await setupBlendedReportPrerequisites(agent, { withSchemas: true });
@@ -143,7 +158,8 @@ describe('Blended output controls full-flow (e2e)', () => {
       expect(sql).toMatch(/users_raw AS \(/);
       const usersRawBody = extractCteBody(sql, 'users_raw');
       // Pre-join filter renders inside the CTE WHERE; its value is inlined.
-      expect(usersRawBody).toMatch(/WHERE[\s\S]+`role`\s*=\s*'admin'/);
+      // Simple identifiers are emitted unquoted (quoteIdentifier skips them).
+      expect(usersRawBody).toMatch(/WHERE[\s\S]+\brole\b\s*=\s*'admin'/);
     });
 
     it('combines multiple pre-join filters on the same CTE with AND', async () => {
@@ -170,8 +186,8 @@ describe('Blended output controls full-flow (e2e)', () => {
       const sql = await getGeneratedSql();
       const usersRawBody = extractCteBody(sql, 'users_raw');
       expect(usersRawBody).toMatch(/WHERE[\s\S]+AND/);
-      expect(usersRawBody).toContain('`role`');
-      expect(usersRawBody).toContain('`is_active`');
+      expect(usersRawBody).toContain('role');
+      expect(usersRawBody).toContain('is_active');
     });
 
     it('routes each pre-join filter into its own joined-mart CTE (no cross-CTE leakage)', async () => {


### PR DESCRIPTION
## Problem

`blended-output-controls.e2e-spec.ts` is the only remaining red suite in the sharded `E2E API Tests` on `main` (shard 1/3) — **9 failed** with `Error: Storage setup is not finished.` → HTTP 500.

These tests assert generated **SQL composition** (CTEs / WHERE), not real BigQuery execution. But the `GET /api/reports/:id/generated-sql` path, for SQL-defined data marts, materializes a real BigQuery view:

```
composeStatic → compose → resolveTableNameForDataMart
  → ensureSqlViewIsUpToDate → CreateViewService.run  → needs storage.credentialId
```

The blended storage is created without credentials, so `CreateViewService` throws. The suite passed locally because BQ creds were present in `.env.tests`; in CI (`e2e-api` workflow, no BQ creds) it always failed. The failures were masked by the E2E API 15-min timeout until the suite was sharded, which surfaced them.

This is a test wiring issue, not a product bug — view materialization for SQL-defined marts is by design.

## Fix

1. **Stub `CreateViewService`** in the test app (via `createTestApp` provider override) to return a deterministic view name, so the composition pipeline runs without hitting BigQuery. Keeps the suite CI-runnable while still exercising the full DTO → validator → composer → blended-builder path.
2. **Drop two stale backtick expectations** for pre-join columns (`` `role` `` → `role`, `` `is_active` `` → `is_active`). `quoteIdentifier` intentionally leaves simple identifiers unquoted (since #1227/#1152), and the post-join assertions in the same file already expect unquoted columns — these two were drift.

## Verification

- `npm run test:e2e -w @owox/backend -- blended-output-controls` → **20 passed, 20 total** (was 9 failed).
- No production code changed; only the test file.

## Context

The other shard-1 failures (`report-operate-access`, `permissions-entity-access-critical`) were a separate SQLite concurrent-transaction issue already fixed on `main` by #1289. With this PR, shard 1 should go green → the whole E2E API suite green.