### PR TITLE
Fix API key table date overlap

### DIFF
--- a/apps/web/src/features/api-keys/components/ApiKeysTable/ApiKeysTable.test.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/ApiKeysTable.test.tsx
@@ -15,7 +15,9 @@ const key: ProjectMemberApiKey = {
 
 vi.mock('@owox/ui/components/common/relative-time', () => ({
   __esModule: true,
-  default: ({ date }: { date: Date }) => <span>{date.toISOString()}</span>,
+  default: ({ date, className }: { date: Date; className?: string }) => (
+    <span className={className}>{date.toISOString()}</span>
+  ),
 }));
 
 vi.mock('@owox/ui/components/tooltip', () => ({
@@ -229,5 +231,38 @@ describe('ApiKeysTable', () => {
       'Future soon',
       'Expired',
     ]);
+  });
+
+  it('lets date text wrap when old narrow widths are saved', () => {
+    localStorage.setItem(
+      'my-api-keys-column-sizing',
+      JSON.stringify({
+        createdAt: 130,
+        lastAuthenticatedAt: 150,
+      })
+    );
+
+    const authenticatedAt = '2026-06-01T09:00:00.000Z';
+
+    render(
+      <ApiKeysTable
+        keys={[{ ...key, lastAuthenticatedAt: authenticatedAt }]}
+        onCreateKey={vi.fn()}
+        onOpenDetails={vi.fn()}
+        onEditName={vi.fn()}
+        onRevoke={vi.fn()}
+      />
+    );
+
+    const createdValue = screen.getByText(key.createdAt);
+    const lastAuthenticatedValue = screen.getByText(authenticatedAt);
+
+    expect(createdValue).toHaveClass('block', 'max-w-full', 'whitespace-normal', 'break-words');
+    expect(lastAuthenticatedValue).toHaveClass(
+      'block',
+      'max-w-full',
+      'whitespace-normal',
+      'break-words'
+    );
   });
 });

--- a/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
+++ b/apps/web/src/features/api-keys/components/ApiKeysTable/columns.tsx
@@ -18,6 +18,9 @@ interface ApiKeysColumnsProps {
   onRevoke: (key: ProjectMemberApiKey) => void;
 }
 
+const relativeTimeCellClassName =
+  'text-muted-foreground block max-w-full whitespace-normal break-words';
+
 export const getApiKeysColumns = ({
   onEditName,
   onRevoke,
@@ -69,7 +72,7 @@ export const getApiKeysColumns = ({
     meta: { title: 'Created' },
     header: ({ column }) => <SortableHeader column={column}>Created</SortableHeader>,
     cell: ({ row }) => (
-      <RelativeTime date={new Date(row.original.createdAt)} className='text-muted-foreground' />
+      <RelativeTime date={new Date(row.original.createdAt)} className={relativeTimeCellClassName} />
     ),
   },
   {
@@ -81,7 +84,7 @@ export const getApiKeysColumns = ({
       const { lastAuthenticatedAt } = row.original;
       if (!lastAuthenticatedAt) return <span className='text-muted-foreground'>Never</span>;
       return (
-        <RelativeTime date={new Date(lastAuthenticatedAt)} className='text-muted-foreground' />
+        <RelativeTime date={new Date(lastAuthenticatedAt)} className={relativeTimeCellClassName} />
       );
     },
   },


### PR DESCRIPTION
## Summary
- Prevent relative date values in the API keys table from overlapping adjacent columns
- Preserve the existing column sizing instead of increasing fixed pixel widths
- Add test coverage for narrow saved column widths

## Root Cause
Long relative date labels could remain on a single line inside narrow persisted table column widths, visually spilling into the adjacent column.

## Verification
- `npm run test -w @owox/web -- ApiKeysTable.test.tsx`
- `npm run build -w @owox/web`