### PR TITLE
fix: follow up project data mart pages

### DIFF
--- a/apps/web/src/features/data-destination/list/components/DataDestinationList/DataDestinationList.test.tsx
+++ b/apps/web/src/features/data-destination/list/components/DataDestinationList/DataDestinationList.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthStatus } from '../../../../../features/idp/types';
+import { DataDestinationType } from '../../../shared';
+import { dataDestinationService, useDataDestination } from '../../../shared';
+import { DataDestinationList } from './DataDestinationList';
+
+vi.mock('../../../shared', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../shared')>();
+  return {
+    ...actual,
+    dataDestinationService: {
+      getDataDestinationImpact: vi.fn(),
+    },
+    useDataDestination: vi.fn(),
+  };
+});
+
+vi.mock('../../../../../features/idp', () => ({
+  useAuth: () => ({
+    status: AuthStatus.AUTHENTICATED,
+    user: {
+      id: 'user-1',
+      projectId: 'project-1',
+      roles: ['admin'],
+    },
+  }),
+}));
+
+vi.mock('../DataDestinationTable', () => ({
+  DataDestinationTable: ({
+    data,
+    onDelete,
+  }: {
+    data: { id: string; title: string }[];
+    onDelete?: (id: string) => void;
+  }) => (
+    <div>
+      {data.map(destination => (
+        <button
+          key={destination.id}
+          type='button'
+          onClick={() => {
+            onDelete?.(destination.id);
+          }}
+        >
+          Delete {destination.title}
+        </button>
+      ))}
+    </div>
+  ),
+  getDataDestinationColumns: vi.fn(() => []),
+}));
+
+vi.mock('../../../edit', () => ({
+  DataDestinationConfigSheet: () => null,
+}));
+
+describe('DataDestinationList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(useDataDestination).mockReturnValue({
+      dataDestinations: [
+        {
+          id: 'destination-1',
+          title: '[Ok OAuth] Sheets',
+          type: DataDestinationType.GOOGLE_SHEETS,
+          projectId: 'project-1',
+          credentials: {},
+          createdAt: new Date('2026-06-09T10:00:00.000Z'),
+          modifiedAt: new Date('2026-06-09T10:00:00.000Z'),
+          contexts: [],
+        },
+      ],
+      currentDataDestination: null,
+      loading: false,
+      error: null,
+      fetchDataDestinations: vi.fn(),
+      getDataDestinationById: vi.fn(),
+      createDataDestination: vi.fn(),
+      updateDataDestination: vi.fn(),
+      deleteDataDestination: vi.fn(),
+      clearCurrentDataDestination: vi.fn(),
+      rotateSecretKey: vi.fn(),
+    });
+  });
+
+  it('links blocked destination reports to the project reports page filtered by destination', async () => {
+    vi.mocked(dataDestinationService.getDataDestinationImpact).mockResolvedValueOnce({
+      destinationId: 'destination-1',
+      destinationTitle: '[Ok OAuth] Sheets',
+      reportsCount: 17,
+      dataMartCount: 2,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/ui/project-1/data-destinations']}>
+        <DataDestinationList />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete [Ok OAuth] Sheets' }));
+
+    const reportsLink = await screen.findByRole('link', { name: '17 Reports' });
+    const url = new URL(reportsLink.getAttribute('href') ?? '', 'http://localhost');
+
+    expect(url.pathname).toBe('/ui/project-1/data-marts/reports');
+    expect(JSON.parse(url.searchParams.get('filters') ?? '[]')).toEqual([
+      { f: 'destination', o: 'eq', v: ['[Ok OAuth] Sheets'] },
+    ]);
+    await waitFor(() => {
+      expect(dataDestinationService.getDataDestinationImpact).toHaveBeenCalledWith('destination-1');
+    });
+  });
+});

--- a/apps/web/src/features/data-destination/list/components/DataDestinationList/DataDestinationList.tsx
+++ b/apps/web/src/features/data-destination/list/components/DataDestinationList/DataDestinationList.tsx
@@ -22,6 +22,14 @@ interface DataDestinationListProps {
   onCreateSheetClose?: () => void;
 }
 
+function buildReportsDestinationFilterPath(destinationTitle: string) {
+  const params = new URLSearchParams({
+    filters: JSON.stringify([{ f: 'destination', o: 'eq', v: [destinationTitle] }]),
+  });
+
+  return `/data-marts/reports?${params.toString()}`;
+}
+
 export const DataDestinationList = ({
   isCreateSheetInitiallyOpen = false,
   onCreateSheetClose,
@@ -219,7 +227,7 @@ export const DataDestinationList = ({
               <span className='block'>
                 <strong>&ldquo;{blocked.impact.destinationTitle}&rdquo;</strong> is referenced by{' '}
                 <Link
-                  to={scope('/data-marts')}
+                  to={scope(buildReportsDestinationFilterPath(blocked.impact.destinationTitle))}
                   className='text-primary hover:underline'
                   onClick={() => {
                     setBlocked(null);

--- a/apps/web/src/features/data-marts/insights/model/templates/services/insight-templates.service.test.ts
+++ b/apps/web/src/features/data-marts/insights/model/templates/services/insight-templates.service.test.ts
@@ -75,4 +75,32 @@ describe('InsightTemplatesService', () => {
     });
     expect(result).toEqual(response);
   });
+
+  it('fetches all project-wide insight templates when pagination is omitted', async () => {
+    const firstInsight = { id: 'insight-1', title: 'Insight 1' };
+    const secondInsight = { id: 'insight-101', title: 'Insight 101' };
+    (apiClient.get as any)
+      .mockResolvedValueOnce({
+        data: {
+          insights: Array.from({ length: 100 }, (_, index) => ({
+            id: `insight-${index + 1}`,
+            title: `Insight ${index + 1}`,
+          })),
+        },
+      })
+      .mockResolvedValueOnce({ data: { insights: [secondInsight] } });
+
+    const result = await service.getProjectInsightTemplates();
+
+    expect(apiClient.get).toHaveBeenCalledTimes(2);
+    expect(apiClient.get).toHaveBeenNthCalledWith(1, '/data-marts/insight-templates', {
+      params: { limit: 100, offset: 0 },
+    });
+    expect(apiClient.get).toHaveBeenNthCalledWith(2, '/data-marts/insight-templates', {
+      params: { limit: 100, offset: 100 },
+    });
+    expect(result.insights).toHaveLength(101);
+    expect(result.insights[0]).toEqual(firstInsight);
+    expect(result.insights[100]).toEqual(secondInsight);
+  });
 });

--- a/apps/web/src/features/data-marts/insights/model/templates/services/insight-templates.service.ts
+++ b/apps/web/src/features/data-marts/insights/model/templates/services/insight-templates.service.ts
@@ -11,6 +11,8 @@ import type {
   UpdateInsightTemplateRequestDto,
 } from '../types/insight-templates.dto';
 
+const PROJECT_INSIGHT_TEMPLATES_FETCH_PAGE_SIZE = 100;
+
 export class InsightTemplatesService extends ApiService {
   constructor() {
     super('/data-marts');
@@ -21,12 +23,33 @@ export class InsightTemplatesService extends ApiService {
   }
 
   async getProjectInsightTemplates(
-    limit = 100,
-    offset = 0
+    limit?: number,
+    offset?: number
   ): Promise<ProjectInsightTemplateListResponseDto> {
+    if (limit === undefined && offset === undefined) {
+      const insights: ProjectInsightTemplateListResponseDto['insights'] = [];
+      let nextOffset = 0;
+      let fetchedCount: number;
+
+      do {
+        const response = await this.get<ProjectInsightTemplateListResponseDto>(
+          '/insight-templates',
+          {
+            limit: PROJECT_INSIGHT_TEMPLATES_FETCH_PAGE_SIZE,
+            offset: nextOffset,
+          }
+        );
+        insights.push(...response.insights);
+        fetchedCount = response.insights.length;
+        nextOffset += PROJECT_INSIGHT_TEMPLATES_FETCH_PAGE_SIZE;
+      } while (fetchedCount === PROJECT_INSIGHT_TEMPLATES_FETCH_PAGE_SIZE);
+
+      return { insights };
+    }
+
     return this.get<ProjectInsightTemplateListResponseDto>('/insight-templates', {
-      limit,
-      offset,
+      limit: limit ?? PROJECT_INSIGHT_TEMPLATES_FETCH_PAGE_SIZE,
+      offset: offset ?? 0,
     });
   }
 

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditSheet/EmailReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditSheet/EmailReportEditSheet.tsx
@@ -21,6 +21,7 @@ import { useIntercomLauncher } from '../../../../../../shared/hooks/useIntercomL
 interface EmailReportEditSheetProps {
   isOpen: boolean;
   onClose: () => void;
+  onSubmitSuccess?: () => void | Promise<void>;
   initialReport?: DataMartReport;
   mode: ReportFormMode;
   preSelectedDestination?: DataDestination | null;
@@ -39,6 +40,7 @@ interface EmailReportEditSheetProps {
 export function EmailReportEditSheet({
   isOpen,
   onClose,
+  onSubmitSuccess,
   initialReport,
   mode,
   preSelectedDestination,
@@ -76,8 +78,9 @@ export function EmailReportEditSheet({
         duration: Infinity,
       });
     }
+    void onSubmitSuccess?.();
     baseHandleFormSubmitSuccess();
-  }, [baseHandleFormSubmitSuccess, projectId, dataMartId, pathname]);
+  }, [baseHandleFormSubmitSuccess, dataMartId, onSubmitSuccess, pathname, projectId]);
 
   useIntercomLauncher(isOpen);
 

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
@@ -17,6 +17,7 @@ import { useIntercomLauncher } from '../../../../../../shared/hooks/useIntercomL
 interface GoogleSheetsReportEditSheetProps {
   isOpen: boolean;
   onClose: () => void;
+  onSubmitSuccess?: () => void | Promise<void>;
   initialReport?: DataMartReport;
   mode: ReportFormMode;
   preSelectedDestination?: DataDestination | null;
@@ -25,6 +26,7 @@ interface GoogleSheetsReportEditSheetProps {
 export function GoogleSheetsReportEditSheet({
   isOpen,
   onClose,
+  onSubmitSuccess,
   initialReport,
   mode,
   preSelectedDestination,
@@ -67,7 +69,10 @@ export function GoogleSheetsReportEditSheet({
               initialReport={initialReport}
               mode={mode}
               onDirtyChange={handleFormDirtyChange}
-              onSubmit={handleFormSubmitSuccess}
+              onSubmit={() => {
+                void onSubmitSuccess?.();
+                handleFormSubmitSuccess();
+              }}
               onCancel={handleClose}
               preSelectedDestination={preSelectedDestination}
             />

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
@@ -17,6 +17,7 @@ import { useIntercomLauncher } from '../../../../../../shared/hooks/useIntercomL
 interface LookerStudioReportEditSheetProps {
   isOpen: boolean;
   onClose: () => void;
+  onSubmitSuccess?: () => void | Promise<void>;
   initialReport?: DataMartReport;
   mode: ReportFormMode;
   preSelectedDestination?: DataDestination | null;
@@ -25,6 +26,7 @@ interface LookerStudioReportEditSheetProps {
 export function LookerStudioReportEditSheet({
   isOpen,
   onClose,
+  onSubmitSuccess,
   initialReport,
   mode,
   preSelectedDestination,
@@ -65,7 +67,10 @@ export function LookerStudioReportEditSheet({
               initialReport={initialReport}
               mode={mode}
               onDirtyChange={handleFormDirtyChange}
-              onSubmit={handleFormSubmitSuccess}
+              onSubmit={() => {
+                void onSubmitSuccess?.();
+                handleFormSubmitSuccess();
+              }}
               onCancel={handleClose}
               preSelectedDestination={preSelectedDestination}
             />

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/ReportEditSheetRenderer.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/ReportEditSheetRenderer.tsx
@@ -10,6 +10,7 @@ interface ReportEditSheetRendererProps {
   destination: DataDestination;
   isOpen: boolean;
   onClose: () => void;
+  onSubmitSuccess?: () => void | Promise<void>;
   mode: ReportFormMode;
   initialReport?: DataMartReport | null;
 }
@@ -22,6 +23,7 @@ export function ReportEditSheetRenderer({
   destination,
   isOpen,
   onClose,
+  onSubmitSuccess,
   mode,
   initialReport,
 }: ReportEditSheetRendererProps) {
@@ -31,6 +33,7 @@ export function ReportEditSheetRenderer({
         <GoogleSheetsReportEditSheet
           isOpen={isOpen}
           onClose={onClose}
+          onSubmitSuccess={onSubmitSuccess}
           mode={mode}
           preSelectedDestination={destination}
           initialReport={initialReport ?? undefined}
@@ -41,6 +44,7 @@ export function ReportEditSheetRenderer({
         <LookerStudioReportEditSheet
           isOpen={isOpen}
           onClose={onClose}
+          onSubmitSuccess={onSubmitSuccess}
           mode={mode}
           preSelectedDestination={destination}
           initialReport={initialReport ?? undefined}
@@ -54,6 +58,7 @@ export function ReportEditSheetRenderer({
         <EmailReportEditSheet
           isOpen={isOpen}
           onClose={onClose}
+          onSubmitSuccess={onSubmitSuccess}
           mode={mode}
           preSelectedDestination={destination}
           initialReport={initialReport ?? undefined}

--- a/apps/web/src/features/data-marts/reports/shared/services/report.service.test.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/report.service.test.ts
@@ -20,10 +20,22 @@ describe('ReportService', () => {
     (apiClient.get as any).mockResolvedValue({ data: [] });
   });
 
-  it('fetches project reports without pagination when no pagination parameters are provided', async () => {
-    await service.getReportsByProject();
+  it('fetches all project reports when pagination is omitted', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({ id: `report-${index + 1}` }));
+    const secondPage = [{ id: 'report-101' }];
+    (apiClient.get as any)
+      .mockResolvedValueOnce({ data: firstPage })
+      .mockResolvedValueOnce({ data: secondPage });
 
-    expect(apiClient.get).toHaveBeenCalledWith('/reports/', { params: undefined });
+    const result = await service.getReportsByProject();
+
+    expect(apiClient.get).toHaveBeenNthCalledWith(1, '/reports/', {
+      params: { limit: 100, offset: 0 },
+    });
+    expect(apiClient.get).toHaveBeenNthCalledWith(2, '/reports/', {
+      params: { limit: 100, offset: 100 },
+    });
+    expect(result).toEqual([...firstPage, ...secondPage]);
   });
 
   it('fetches project reports with limit-only pagination', async () => {
@@ -46,7 +58,7 @@ describe('ReportService', () => {
     await service.getReportsByProject(undefined, 200);
 
     expect(apiClient.get).toHaveBeenCalledWith('/reports/', {
-      params: { offset: 200 },
+      params: { limit: 100, offset: 200 },
     });
   });
 });

--- a/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
@@ -2,6 +2,8 @@ import { ApiService } from '../../../../../services';
 import type { CreateReportRequestDto, ReportResponseDto, UpdateReportRequestDto } from './types';
 import type { AxiosRequestConfig } from '../../../../../app/api';
 
+const PROJECT_REPORTS_FETCH_PAGE_SIZE = 100;
+
 /**
  * Report Service
  * Specializes in report operations using the generic ApiService
@@ -69,13 +71,32 @@ export class ReportService extends ApiService {
    * @returns Promise with list of reports
    */
   async getReportsByProject(limit?: number, offset?: number): Promise<ReportResponseDto[]> {
-    const params =
-      limit === undefined && offset === undefined
-        ? undefined
-        : {
-            ...(limit !== undefined ? { limit } : {}),
-            ...(offset !== undefined ? { offset } : {}),
-          };
+    if (limit === undefined && offset === undefined) {
+      const reports: ReportResponseDto[] = [];
+      let nextOffset = 0;
+      let fetchedCount: number;
+
+      do {
+        const response = await this.get<ReportResponseDto[]>('/', {
+          limit: PROJECT_REPORTS_FETCH_PAGE_SIZE,
+          offset: nextOffset,
+        });
+        reports.push(...response);
+        fetchedCount = response.length;
+        nextOffset += PROJECT_REPORTS_FETCH_PAGE_SIZE;
+      } while (fetchedCount === PROJECT_REPORTS_FETCH_PAGE_SIZE);
+
+      return reports;
+    }
+
+    const params = {
+      ...(limit !== undefined
+        ? { limit }
+        : offset !== undefined
+          ? { limit: PROJECT_REPORTS_FETCH_PAGE_SIZE }
+          : {}),
+      ...(offset !== undefined ? { offset } : {}),
+    };
 
     return this.get<ReportResponseDto[]>('/', params);
   }

--- a/apps/web/src/features/data-marts/scheduled-triggers/services/scheduled-trigger.service.test.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/services/scheduled-trigger.service.test.ts
@@ -31,4 +31,31 @@ describe('ScheduledTriggerService', () => {
     });
     expect(result).toEqual(response);
   });
+
+  it('fetches all project-wide scheduled triggers when pagination is omitted', async () => {
+    const firstTrigger = { id: 'trigger-1' };
+    const secondPageTrigger = { id: 'trigger-101' };
+    (apiClient.get as any)
+      .mockResolvedValueOnce({
+        data: {
+          triggers: Array.from({ length: 100 }, (_, index) => ({
+            id: `trigger-${index + 1}`,
+          })),
+        },
+      })
+      .mockResolvedValueOnce({ data: { triggers: [secondPageTrigger] } });
+
+    const result = await service.getProjectScheduledTriggers();
+
+    expect(apiClient.get).toHaveBeenCalledTimes(2);
+    expect(apiClient.get).toHaveBeenNthCalledWith(1, '/data-marts/scheduled-triggers', {
+      params: { limit: 100, offset: 0 },
+    });
+    expect(apiClient.get).toHaveBeenNthCalledWith(2, '/data-marts/scheduled-triggers', {
+      params: { limit: 100, offset: 100 },
+    });
+    expect(result.triggers).toHaveLength(101);
+    expect(result.triggers[0]).toEqual(firstTrigger);
+    expect(result.triggers[100]).toEqual(secondPageTrigger);
+  });
 });

--- a/apps/web/src/features/data-marts/scheduled-triggers/services/scheduled-trigger.service.ts
+++ b/apps/web/src/features/data-marts/scheduled-triggers/services/scheduled-trigger.service.ts
@@ -7,6 +7,8 @@ import type {
   UpdateScheduledTriggerRequestApiDto,
 } from '../model/api';
 
+const PROJECT_SCHEDULED_TRIGGERS_FETCH_PAGE_SIZE = 100;
+
 /**
  * Scheduled Trigger Service
  * Specializes in scheduled trigger operations using the generic ApiService
@@ -32,12 +34,33 @@ export class ScheduledTriggerService extends ApiService {
    * Fetch scheduled triggers across all accessible data marts in the current project.
    */
   async getProjectScheduledTriggers(
-    limit = 100,
-    offset = 0
+    limit?: number,
+    offset?: number
   ): Promise<ProjectScheduledTriggerListResponseApiDto> {
+    if (limit === undefined && offset === undefined) {
+      const triggers: ProjectScheduledTriggerListResponseApiDto['triggers'] = [];
+      let nextOffset = 0;
+      let fetchedCount: number;
+
+      do {
+        const response = await this.get<ProjectScheduledTriggerListResponseApiDto>(
+          '/scheduled-triggers',
+          {
+            limit: PROJECT_SCHEDULED_TRIGGERS_FETCH_PAGE_SIZE,
+            offset: nextOffset,
+          }
+        );
+        triggers.push(...response.triggers);
+        fetchedCount = response.triggers.length;
+        nextOffset += PROJECT_SCHEDULED_TRIGGERS_FETCH_PAGE_SIZE;
+      } while (fetchedCount === PROJECT_SCHEDULED_TRIGGERS_FETCH_PAGE_SIZE);
+
+      return { triggers };
+    }
+
     return this.get<ProjectScheduledTriggerListResponseApiDto>('/scheduled-triggers', {
-      limit,
-      offset,
+      limit: limit ?? PROJECT_SCHEDULED_TRIGGERS_FETCH_PAGE_SIZE,
+      offset: offset ?? 0,
     });
   }
 

--- a/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.test.tsx
@@ -40,7 +40,7 @@ describe('DataMartInsightsPage', () => {
     insightTemplatesServiceMock.deleteInsightTemplate.mockResolvedValue(undefined);
   });
 
-  it('loads project insights by 100 and shows their Data Mart context', async () => {
+  it('loads all project insights and shows their Data Mart context', async () => {
     vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
       insights: [buildInsightTemplateResponse()],
     });
@@ -54,7 +54,29 @@ describe('DataMartInsightsPage', () => {
       '/ui/project-1/data-marts/dm-1/insights-v2'
     );
     expect(screen.getByRole('button', { name: 'Toggle columns' })).toBeInTheDocument();
-    expect(insightTemplatesService.getProjectInsightTemplates).toHaveBeenCalledWith(100, 0);
+    expect(insightTemplatesService.getProjectInsightTemplates).toHaveBeenCalledWith();
+  });
+
+  it('uses table pagination over the full insights list', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: Array.from({ length: 16 }, (_, index) =>
+        buildInsightTemplateResponse({
+          id: `insight-${index + 1}`,
+          title: `Insight ${index + 1}`,
+        })
+      ),
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Insight 1')).toBeInTheDocument();
+    expect(screen.getByText('1–15 of 16 rows')).toBeInTheDocument();
+    expect(screen.queryByText('Insight 16')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+
+    expect(await screen.findByText('Insight 16')).toBeInTheDocument();
+    expect(screen.getByText('16–16 of 16 rows')).toBeInTheDocument();
   });
 
   it('shows Data Mart as the first table column', async () => {
@@ -238,24 +260,21 @@ describe('DataMartInsightsPage', () => {
     expect(screen.queryByRole('button', { name: 'Insight actions' })).not.toBeInTheDocument();
   });
 
-  it('loads additional insight pages when project search is active', async () => {
-    vi.mocked(insightTemplatesService.getProjectInsightTemplates)
-      .mockResolvedValueOnce({
-        insights: Array.from({ length: 100 }, (_, index) =>
+  it('searches across the full loaded insights list without fetching another page', async () => {
+    vi.mocked(insightTemplatesService.getProjectInsightTemplates).mockResolvedValueOnce({
+      insights: [
+        ...Array.from({ length: 15 }, (_, index) =>
           buildInsightTemplateResponse({
             id: `insight-${index + 1}`,
             title: `Insight ${index + 1}`,
           })
         ),
-      })
-      .mockResolvedValueOnce({
-        insights: [
-          buildInsightTemplateResponse({
-            id: 'insight-needle',
-            title: 'Needle Insight',
-          }),
-        ],
-      });
+        buildInsightTemplateResponse({
+          id: 'insight-needle',
+          title: 'Needle Insight',
+        }),
+      ],
+    });
 
     renderPage();
 
@@ -266,7 +285,7 @@ describe('DataMartInsightsPage', () => {
     });
 
     expect(await screen.findByText('Needle Insight')).toBeInTheDocument();
-    expect(insightTemplatesService.getProjectInsightTemplates).toHaveBeenCalledWith(100, 100);
+    expect(insightTemplatesService.getProjectInsightTemplates).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.tsx
+++ b/apps/web/src/pages/data-marts/insights/DataMartInsightsPage.tsx
@@ -1,9 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import type { ColumnDef } from '@tanstack/react-table';
-import { RefreshCw } from 'lucide-react';
 import { toast } from 'react-hot-toast';
-import { Button } from '@owox/ui/components/button';
 import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
 import { extractApiError } from '../../../app/api';
 import { InsightRowActionsCell } from '../../../features/data-marts/insights/components/InsightRowActionsCell';
@@ -32,7 +30,7 @@ import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
 import { ProjectDataMartTitleLink } from '../shared/ProjectDataMartTitleLink';
 import { formatDateShort, trackEvent } from '../../../utils';
 
-const PROJECT_INSIGHTS_PAGE_SIZE = 100;
+const PROJECT_INSIGHTS_PAGE_SIZE = 15;
 const PROJECT_INSIGHTS_TABLE_ID = 'project-insights-table';
 
 type ProjectInsightFilterKey = 'dataMart' | 'insight' | 'createdBy';
@@ -85,47 +83,27 @@ export default function DataMartInsightsPage() {
   const { scope } = useProjectRoute();
   const [insights, setInsights] = useState<ProjectInsightTemplateEntity[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [hasMoreInsightsToLoad, setHasMoreInsightsToLoad] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [deletingInsight, setDeletingInsight] = useState<ProjectInsightTemplateEntity | null>(null);
 
-  const loadInsights = useCallback(async (offset = 0) => {
-    const isInitialLoad = offset === 0;
-    if (isInitialLoad) {
-      setIsLoading(true);
-    } else {
-      setIsLoadingMore(true);
-    }
+  const loadInsights = useCallback(async () => {
+    setIsLoading(true);
     setError(null);
 
     try {
-      const response = await insightTemplatesService.getProjectInsightTemplates(
-        PROJECT_INSIGHTS_PAGE_SIZE,
-        offset
-      );
-      const nextInsights = mapProjectInsightTemplateListFromDto(response);
-      setInsights(currentInsights =>
-        isInitialLoad ? nextInsights : [...currentInsights, ...nextInsights]
-      );
-      setHasMoreInsightsToLoad(nextInsights.length >= PROJECT_INSIGHTS_PAGE_SIZE);
+      const response = await insightTemplatesService.getProjectInsightTemplates();
+      setInsights(mapProjectInsightTemplateListFromDto(response));
     } catch (caught) {
       setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart insights');
     } finally {
       setIsLoading(false);
-      setIsLoadingMore(false);
     }
   }, []);
 
   useEffect(() => {
-    void loadInsights(0);
+    void loadInsights();
   }, [loadInsights]);
-
-  const loadMoreInsights = useCallback(async () => {
-    if (isLoadingMore || !hasMoreInsightsToLoad) return;
-    await loadInsights(insights.length);
-  }, [hasMoreInsightsToLoad, insights.length, isLoadingMore, loadInsights]);
 
   const handleConfirmDelete = useCallback(() => {
     void (async () => {
@@ -170,24 +148,6 @@ export default function DataMartInsightsPage() {
     urlParam: 'filters',
     config: filtersConfig,
   });
-
-  const shouldLoadAllInsightsForQuery =
-    searchQuery.trim().length > 0 || appliedState.filters.length > 0;
-
-  useEffect(() => {
-    if (!shouldLoadAllInsightsForQuery || !hasMoreInsightsToLoad || isLoading || isLoadingMore) {
-      return;
-    }
-
-    void loadInsights(insights.length);
-  }, [
-    hasMoreInsightsToLoad,
-    insights.length,
-    isLoading,
-    isLoadingMore,
-    loadInsights,
-    shouldLoadAllInsightsForQuery,
-  ]);
 
   const filteredInsights = useMemo(
     () =>
@@ -339,27 +299,6 @@ export default function DataMartInsightsPage() {
                 </div>
               )}
             />
-
-            {hasMoreInsightsToLoad && (
-              <div className='flex justify-center pt-4 pb-6'>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  onClick={() => void loadMoreInsights()}
-                  disabled={isLoadingMore}
-                  className='flex items-center gap-2'
-                >
-                  {isLoadingMore ? (
-                    <>
-                      <RefreshCw className='h-4 w-4 animate-spin' />
-                      Loading...
-                    </>
-                  ) : (
-                    'Load More'
-                  )}
-                </Button>
-              </div>
-            )}
           </div>
         )}
       </div>

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
@@ -13,7 +13,9 @@ import {
 import { ReportConditionEnum } from '../../../features/data-marts/reports/shared/enums/report-condition.enum';
 import type { ReportResponseDto } from '../../../features/data-marts/reports/shared/services';
 import { reportService } from '../../../features/data-marts/reports/shared/services';
+import { mapReportDtoToEntity } from '../../../features/data-marts/reports/shared/model/mappers';
 import DataMartReportsPage from './DataMartReportsPage';
+import { mergeReportPagePreservingRows } from './DataMartReportsPage.utils';
 
 const reportServiceMock = vi.hoisted(() => ({
   getReportsByProject: vi.fn(),
@@ -63,9 +65,13 @@ vi.mock(
       ReportEditSheetRenderer: ({
         isOpen,
         initialReport,
+        onClose,
+        onSubmitSuccess,
       }: {
         isOpen: boolean;
         initialReport?: { title: string } | null;
+        onClose: () => void;
+        onSubmitSuccess?: () => void | Promise<void>;
       }) => {
         const { dataMart } = useDataMartContext();
         useReportContext();
@@ -73,6 +79,18 @@ vi.mock(
         return isOpen ? (
           <div role='dialog' aria-label='Report edit sheet'>
             Editing report {initialReport?.title} for {dataMart?.title} via {dataMart?.storage.type}
+            <button type='button' onClick={onClose}>
+              Close report edit sheet
+            </button>
+            <button
+              type='button'
+              onClick={() => {
+                void onSubmitSuccess?.();
+                onClose();
+              }}
+            >
+              Submit report edit sheet
+            </button>
           </div>
         ) : null;
       },
@@ -108,7 +126,38 @@ describe('DataMartReportsPage', () => {
     vi.useRealTimers();
   });
 
-  it('loads project reports by 100 and shows their Data Mart context', async () => {
+  it('preserves unchanged report row objects during silent page refreshes', () => {
+    const unchangedReport = mapReportDtoToEntity(
+      buildReportResponse({ id: 'report-1', title: 'Unchanged Report' })
+    );
+    const changedReport = mapReportDtoToEntity(
+      buildReportResponse({ id: 'report-2', title: 'Pending Report' })
+    );
+    const oldTailReport = mapReportDtoToEntity(
+      buildReportResponse({ id: 'report-3', title: 'Loaded Tail Report' })
+    );
+    const nextUnchangedReport = mapReportDtoToEntity(
+      buildReportResponse({ id: 'report-1', title: 'Unchanged Report' })
+    );
+    const nextChangedReport = mapReportDtoToEntity(
+      buildReportResponse({
+        id: 'report-2',
+        title: 'Pending Report',
+        lastRunStatus: ReportStatusEnum.RUNNING,
+      })
+    );
+
+    const mergedReports = mergeReportPagePreservingRows(
+      [unchangedReport, changedReport, oldTailReport],
+      [nextUnchangedReport, nextChangedReport]
+    );
+
+    expect(mergedReports[0]).toBe(unchangedReport);
+    expect(mergedReports[1]).toBe(nextChangedReport);
+    expect(mergedReports[2]).toBe(oldTailReport);
+  });
+
+  it('loads all project reports and shows their Data Mart context', async () => {
     vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([buildReportResponse()]);
 
     renderPage();
@@ -122,7 +171,29 @@ describe('DataMartReportsPage', () => {
     expect(screen.getByText('Email')).toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'Success' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Toggle columns' })).toBeInTheDocument();
-    expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 0);
+    expect(reportService.getReportsByProject).toHaveBeenCalledWith();
+  });
+
+  it('uses table pagination over the full reports list', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce(
+      Array.from({ length: 16 }, (_, index) =>
+        buildReportResponse({
+          id: `report-${index + 1}`,
+          title: `Report ${index + 1}`,
+        })
+      )
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('Report 1')).toBeInTheDocument();
+    expect(screen.getByText('1–15 of 16 rows')).toBeInTheDocument();
+    expect(screen.queryByText('Report 16')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+
+    expect(await screen.findByText('Report 16')).toBeInTheDocument();
+    expect(screen.getByText('16–16 of 16 rows')).toBeInTheDocument();
   });
 
   it('shows Data Mart as the first table column', async () => {
@@ -269,6 +340,37 @@ describe('DataMartReportsPage', () => {
     );
   });
 
+  it('closes the report edit sheet without reloading the project reports list', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([buildReportResponse()]);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByText('Daily Sales Report'));
+    fireEvent.click(screen.getByRole('button', { name: 'Close report edit sheet' }));
+
+    expect(screen.queryByRole('dialog', { name: 'Report edit sheet' })).not.toBeInTheDocument();
+    expect(reportService.getReportsByProject).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads the project reports list after a report edit submit succeeds', async () => {
+    vi.mocked(reportService.getReportsByProject)
+      .mockResolvedValueOnce([buildReportResponse()])
+      .mockResolvedValueOnce([
+        buildReportResponse({
+          title: 'Updated Daily Sales Report',
+        }),
+      ]);
+
+    renderPage();
+
+    fireEvent.click(await screen.findByText('Daily Sales Report'));
+    fireEvent.click(screen.getByRole('button', { name: 'Submit report edit sheet' }));
+
+    await waitFor(() => {
+      expect(reportService.getReportsByProject).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it('does not open the report edit sheet when the caller cannot edit report config', async () => {
     vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
       buildReportResponse({ canEditConfig: false }),
@@ -385,7 +487,7 @@ describe('DataMartReportsPage', () => {
     expect(reportService.runReport).not.toHaveBeenCalled();
   });
 
-  it('polls project reports while any loaded report is still running', async () => {
+  it('polls project reports while any visible report is still running', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.mocked(reportService.getReportsByProject).mockResolvedValue([
       buildReportResponse({
@@ -406,11 +508,34 @@ describe('DataMartReportsPage', () => {
     vi.useRealTimers();
   });
 
+  it('does not poll project reports when a running report is outside the visible page', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(reportService.getReportsByProject).mockResolvedValue(
+      Array.from({ length: 16 }, (_, index) =>
+        buildReportResponse({
+          id: `report-${index + 1}`,
+          title: `Report ${index + 1}`,
+          lastRunStatus: index === 15 ? ReportStatusEnum.RUNNING : ReportStatusEnum.SUCCESS,
+        })
+      )
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('Report 1')).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(reportService.getReportsByProject).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
+  });
+
   it('keeps already loaded report pages during silent polling', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.mocked(reportService.getReportsByProject)
       .mockResolvedValueOnce(
-        Array.from({ length: 100 }, (_, index) =>
+        Array.from({ length: 16 }, (_, index) =>
           buildReportResponse({
             id: `report-${index + 1}`,
             title: `Report ${index + 1}`,
@@ -418,13 +543,6 @@ describe('DataMartReportsPage', () => {
           })
         )
       )
-      .mockResolvedValueOnce([
-        buildReportResponse({
-          id: 'report-101',
-          title: 'Loaded Second Page Report',
-          lastRunStatus: ReportStatusEnum.SUCCESS,
-        }),
-      ])
       .mockResolvedValueOnce([
         buildReportResponse({
           id: 'report-1',
@@ -436,41 +554,33 @@ describe('DataMartReportsPage', () => {
     renderPage();
 
     expect(await screen.findByText('Report 1')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Load More' }));
-    await waitFor(() => {
-      expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 100);
-    });
-    fireEvent.change(screen.getByPlaceholderText('Search'), {
-      target: { value: 'Loaded Second' },
-    });
-    expect(await screen.findByText('Loaded Second Page Report')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Load More' })).not.toBeInTheDocument();
 
     await vi.advanceTimersByTimeAsync(5000);
 
-    expect(await screen.findByText('Loaded Second Page Report')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Report 16' },
+    });
+    expect(await screen.findByText('Report 16')).toBeInTheDocument();
+    expect(reportService.getReportsByProject).toHaveBeenCalledWith();
     expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 0);
-    expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 100);
 
     vi.useRealTimers();
   });
 
-  it('loads additional report pages when project search is active', async () => {
-    vi.mocked(reportService.getReportsByProject)
-      .mockResolvedValueOnce(
-        Array.from({ length: 100 }, (_, index) =>
-          buildReportResponse({
-            id: `report-${index + 1}`,
-            title: `Report ${index + 1}`,
-          })
-        )
-      )
-      .mockResolvedValueOnce([
+  it('searches across the full loaded reports list without fetching another page', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      ...Array.from({ length: 15 }, (_, index) =>
         buildReportResponse({
-          id: 'report-needle',
-          title: 'Needle Report',
-        }),
-      ]);
+          id: `report-${index + 1}`,
+          title: `Report ${index + 1}`,
+        })
+      ),
+      buildReportResponse({
+        id: 'report-needle',
+        title: 'Needle Report',
+      }),
+    ]);
 
     renderPage();
 
@@ -481,7 +591,7 @@ describe('DataMartReportsPage', () => {
     });
 
     expect(await screen.findByText('Needle Report')).toBeInTheDocument();
-    expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 100);
+    expect(reportService.getReportsByProject).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
 import type { ColumnDef } from '@tanstack/react-table';
-import { RefreshCw } from 'lucide-react';
-import { Button } from '@owox/ui/components/button';
 import RelativeTime from '@owox/ui/components/common/relative-time';
 import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
 import { extractApiError } from '../../../app/api';
@@ -40,8 +38,10 @@ import {
 import { buildProjectDataMartContextValue } from '../shared/projectDataMartContext';
 import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
 import { ProjectDataMartTitleLink } from '../shared/ProjectDataMartTitleLink';
+import { mergeReportPagePreservingRows } from './DataMartReportsPage.utils';
 
-const PROJECT_REPORTS_PAGE_SIZE = 100;
+const PROJECT_REPORTS_TABLE_PAGE_SIZE = 15;
+const PROJECT_REPORTS_FETCH_PAGE_SIZE = 100;
 const PROJECT_REPORTS_TABLE_ID = 'project-reports-table';
 
 type ProjectReportFilterKey =
@@ -166,9 +166,7 @@ export default function DataMartReportsPage() {
   const { scope } = useProjectRoute();
   const [reports, setReports] = useState<DataMartReport[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [hasMoreReportsToLoad, setHasMoreReportsToLoad] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const {
     isOpen: isReportEditSheetOpen,
@@ -178,87 +176,51 @@ export default function DataMartReportsPage() {
     handleCloseModal,
   } = useReportSidesheet();
 
-  const loadReports = useCallback(async (offset = 0, options?: { silent?: boolean }) => {
-    const isInitialLoad = offset === 0;
-    const isSilent = options?.silent === true;
+  const loadReports = useCallback(
+    async (options?: { silent?: boolean; firstPageOnly?: boolean }) => {
+      const isSilent = options?.silent === true;
 
-    if (isInitialLoad && !isSilent) {
-      setIsLoading(true);
-    } else if (!isInitialLoad) {
-      setIsLoadingMore(true);
-    }
-
-    if (!isSilent) {
-      setError(null);
-    }
-
-    try {
-      const response = await reportService.getReportsByProject(PROJECT_REPORTS_PAGE_SIZE, offset);
-      const nextReports = response.map(mapReportDtoToEntity);
-      setReports(currentReports => {
-        if (!isInitialLoad) {
-          return [...currentReports, ...nextReports];
-        }
-
-        if (!isSilent) {
-          return nextReports;
-        }
-
-        const nextReportIds = new Set(nextReports.map(report => report.id));
-        const loadedOlderReports = currentReports.filter(report => !nextReportIds.has(report.id));
-        return [...nextReports, ...loadedOlderReports];
-      });
-
-      if (!isInitialLoad || !isSilent) {
-        setHasMoreReportsToLoad(nextReports.length >= PROJECT_REPORTS_PAGE_SIZE);
-      }
-    } catch (caught) {
       if (!isSilent) {
-        setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart reports');
+        setIsLoading(true);
+        setError(null);
       }
-    } finally {
-      if (isInitialLoad && !isSilent) {
-        setIsLoading(false);
-      } else if (!isInitialLoad) {
-        setIsLoadingMore(false);
+
+      try {
+        const response = options?.firstPageOnly
+          ? await reportService.getReportsByProject(PROJECT_REPORTS_FETCH_PAGE_SIZE, 0)
+          : await reportService.getReportsByProject();
+        const nextReports = response.map(mapReportDtoToEntity);
+        setReports(currentReports => {
+          if (!isSilent) {
+            return nextReports;
+          }
+
+          return mergeReportPagePreservingRows(currentReports, nextReports);
+        });
+      } catch (caught) {
+        if (!isSilent) {
+          setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart reports');
+        }
+      } finally {
+        if (!isSilent) {
+          setIsLoading(false);
+        }
       }
-    }
-  }, []);
-
-  useEffect(() => {
-    void loadReports(0);
-  }, [loadReports]);
-
-  const loadMoreReports = useCallback(async () => {
-    if (isLoadingMore || !hasMoreReportsToLoad) return;
-    await loadReports(reports.length);
-  }, [hasMoreReportsToLoad, isLoadingMore, loadReports, reports.length]);
-
-  const handleCloseReportEditSheet = useCallback(() => {
-    handleCloseModal();
-    void loadReports(0);
-  }, [handleCloseModal, loadReports]);
-
-  const handleReportActionComplete = useCallback(async () => {
-    await loadReports(0);
-  }, [loadReports]);
-
-  const hasRunningReports = useMemo(
-    () => reports.some(report => report.lastRunStatus === ReportStatusEnum.RUNNING),
-    [reports]
+    },
+    []
   );
 
   useEffect(() => {
-    if (!hasRunningReports || isLoadingMore) return;
+    void loadReports();
+  }, [loadReports]);
 
-    const intervalId = window.setInterval(() => {
-      void loadReports(0, { silent: true });
-    }, 5000);
+  const handleCloseReportEditSheet = useCallback(() => {
+    handleCloseModal();
+  }, [handleCloseModal]);
 
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [hasRunningReports, isLoadingMore, loadReports]);
+  const handleReportActionComplete = useCallback(async () => {
+    await loadReports();
+  }, [loadReports]);
 
   const reportDataMartContextValue = useMemo(
     () => (editingReport ? buildProjectDataMartContextValue(editingReport.dataMart) : null),
@@ -273,24 +235,6 @@ export default function DataMartReportsPage() {
     urlParam: 'filters',
     config: filtersConfig,
   });
-
-  const shouldLoadAllReportsForQuery =
-    searchQuery.trim().length > 0 || appliedState.filters.length > 0;
-
-  useEffect(() => {
-    if (!shouldLoadAllReportsForQuery || !hasMoreReportsToLoad || isLoading || isLoadingMore) {
-      return;
-    }
-
-    void loadReports(reports.length, { silent: true });
-  }, [
-    hasMoreReportsToLoad,
-    isLoading,
-    isLoadingMore,
-    loadReports,
-    reports.length,
-    shouldLoadAllReportsForQuery,
-  ]);
 
   const filteredReports = useMemo(
     () =>
@@ -444,9 +388,25 @@ export default function DataMartReportsPage() {
     columns,
     storageKeyPrefix: 'project-data-mart-reports',
     defaultSortingColumn: 'lastRunDate',
-    defaultPageSize: PROJECT_REPORTS_PAGE_SIZE,
+    defaultPageSize: PROJECT_REPORTS_TABLE_PAGE_SIZE,
     enableRowSelection: false,
   });
+
+  const hasRunningVisibleReports = table
+    .getRowModel()
+    .rows.some(row => row.original.lastRunStatus === ReportStatusEnum.RUNNING);
+
+  useEffect(() => {
+    if (!hasRunningVisibleReports) return;
+
+    const intervalId = window.setInterval(() => {
+      void loadReports({ silent: true, firstPageOnly: true });
+    }, 5000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [hasRunningVisibleReports, loadReports]);
 
   return (
     <ReportsProvider>
@@ -497,27 +457,6 @@ export default function DataMartReportsPage() {
                   }
                 }}
               />
-
-              {hasMoreReportsToLoad && (
-                <div className='flex justify-center pt-4 pb-6'>
-                  <Button
-                    variant='outline'
-                    size='sm'
-                    onClick={() => void loadMoreReports()}
-                    disabled={isLoadingMore}
-                    className='flex items-center gap-2'
-                  >
-                    {isLoadingMore ? (
-                      <>
-                        <RefreshCw className='h-4 w-4 animate-spin' />
-                        Loading...
-                      </>
-                    ) : (
-                      'Load More'
-                    )}
-                  </Button>
-                </div>
-              )}
             </div>
           )}
         </div>
@@ -528,6 +467,7 @@ export default function DataMartReportsPage() {
               destination={editingReport.dataDestination}
               isOpen={isReportEditSheetOpen}
               onClose={handleCloseReportEditSheet}
+              onSubmitSuccess={handleReportActionComplete}
               mode={reportEditMode}
               initialReport={editingReport}
             />

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.utils.ts
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.utils.ts
@@ -1,0 +1,26 @@
+import type { DataMartReport } from '../../../features/data-marts/reports/shared/model/types/data-mart-report';
+
+function areReportSnapshotsEqual(left: DataMartReport, right: DataMartReport) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function mergeReportPagePreservingRows(
+  currentReports: DataMartReport[],
+  nextReports: DataMartReport[]
+) {
+  const currentReportsById = new Map(currentReports.map(report => [report.id, report]));
+  const nextReportIds = new Set(nextReports.map(report => report.id));
+  const refreshedReports = nextReports.map(nextReport => {
+    const currentReport = currentReportsById.get(nextReport.id);
+    return currentReport && areReportSnapshotsEqual(currentReport, nextReport)
+      ? currentReport
+      : nextReport;
+  });
+  const loadedOlderReports = currentReports.filter(report => !nextReportIds.has(report.id));
+  const mergedReports = [...refreshedReports, ...loadedOlderReports];
+  const hasChanges =
+    mergedReports.length !== currentReports.length ||
+    mergedReports.some((report, index) => report !== currentReports[index]);
+
+  return hasChanges ? mergedReports : currentReports;
+}

--- a/apps/web/src/pages/data-marts/runs/DataMartRunsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/runs/DataMartRunsPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -67,6 +67,7 @@ describe('DataMartRunsPage', () => {
       'href',
       '/ui/project-1/data-marts'
     );
+    expect(dataMartService.getProjectDataMartRuns).toHaveBeenCalledWith(50, 0, undefined);
   });
 
   afterEach(() => {
@@ -129,7 +130,7 @@ describe('DataMartRunsPage', () => {
     });
 
     expect(dataMartService.getProjectDataMartRuns).toHaveBeenCalledTimes(2);
-    expect(dataMartService.getProjectDataMartRuns).toHaveBeenLastCalledWith(100, 0, {
+    expect(dataMartService.getProjectDataMartRuns).toHaveBeenLastCalledWith(50, 0, {
       skipLoadingIndicator: true,
     });
 
@@ -139,6 +140,30 @@ describe('DataMartRunsPage', () => {
     });
 
     expect(dataMartService.getProjectDataMartRuns).toHaveBeenCalledTimes(2);
+  });
+
+  it('loads the next run history batch with a 50-run offset', async () => {
+    vi.mocked(dataMartService.getProjectDataMartRuns)
+      .mockResolvedValueOnce({
+        runs: Array.from({ length: 50 }, (_, index) =>
+          buildProjectRun({
+            id: `run-${index + 1}`,
+            status: DataMartRunStatus.SUCCESS,
+          })
+        ),
+      })
+      .mockResolvedValueOnce({
+        runs: [buildProjectRun({ id: 'run-51', status: DataMartRunStatus.SUCCESS })],
+      });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Load More' }));
+
+    await waitFor(() => {
+      expect(dataMartService.getProjectDataMartRuns).toHaveBeenCalledTimes(2);
+    });
+    expect(dataMartService.getProjectDataMartRuns).toHaveBeenLastCalledWith(50, 50, undefined);
   });
 });
 
@@ -150,9 +175,9 @@ function renderPage() {
   );
 }
 
-function buildProjectRun({ status }: { status: DataMartRunStatus }) {
+function buildProjectRun({ id = 'run-1', status }: { id?: string; status: DataMartRunStatus }) {
   return {
-    id: 'run-1',
+    id,
     dataMartId: 'dm-1',
     status,
     createdAt: '2026-06-05T10:00:00.000Z',

--- a/apps/web/src/pages/data-marts/runs/DataMartRunsPage.tsx
+++ b/apps/web/src/pages/data-marts/runs/DataMartRunsPage.tsx
@@ -14,7 +14,7 @@ import { getConnectorInfoByName } from '../../../features/connectors/shared/util
 import { useProjectRoute } from '../../../shared/hooks';
 import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
 
-const PROJECT_RUNS_PAGE_SIZE = 100;
+const PROJECT_RUNS_PAGE_SIZE = 50;
 
 export default function DataMartRunsPage() {
   const { scope } = useProjectRoute();

--- a/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.test.tsx
+++ b/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.test.tsx
@@ -75,7 +75,30 @@ describe('DataMartSchedulesPage', () => {
     expect(await screen.findByText('Run Target')).toBeInTheDocument();
     expect(await screen.findByText('Daily Sales Report')).toBeInTheDocument();
     expect(await screen.findByRole('button', { name: 'Toggle columns' })).toBeInTheDocument();
-    expect(scheduledTriggerService.getProjectScheduledTriggers).toHaveBeenCalledWith(100, 0);
+    expect(scheduledTriggerService.getProjectScheduledTriggers).toHaveBeenCalledWith();
+  });
+
+  it('uses table pagination over the full triggers list', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: Array.from({ length: 16 }, (_, index) =>
+        buildProjectReportTrigger({
+          id: `trigger-${index + 1}`,
+          reportId: `report-${index + 1}`,
+          reportTitle: `Report ${index + 1}`,
+        })
+      ),
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Report 1')).toBeInTheDocument();
+    expect(screen.getByText('1–15 of 16 rows')).toBeInTheDocument();
+    expect(screen.queryByText('Report 16')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+
+    expect(await screen.findByText('Report 16')).toBeInTheDocument();
+    expect(screen.getByText('16–16 of 16 rows')).toBeInTheDocument();
   });
 
   it('shows Data Mart as the first table column', async () => {
@@ -298,26 +321,23 @@ describe('DataMartSchedulesPage', () => {
     expect(connectorIcon).toHaveAttribute('src', 'data:image/png;base64,facebook-logo');
   });
 
-  it('loads additional trigger pages when project search is active', async () => {
-    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers)
-      .mockResolvedValueOnce({
-        triggers: Array.from({ length: 100 }, (_, index) =>
+  it('searches across the full loaded triggers list without fetching another page', async () => {
+    vi.mocked(scheduledTriggerService.getProjectScheduledTriggers).mockResolvedValueOnce({
+      triggers: [
+        ...Array.from({ length: 15 }, (_, index) =>
           buildProjectReportTrigger({
             id: `trigger-${index + 1}`,
             reportId: `report-${index + 1}`,
             reportTitle: `Report ${index + 1}`,
           })
         ),
-      })
-      .mockResolvedValueOnce({
-        triggers: [
-          buildProjectReportTrigger({
-            id: 'trigger-needle',
-            reportId: 'report-needle',
-            reportTitle: 'Needle Trigger Target',
-          }),
-        ],
-      });
+        buildProjectReportTrigger({
+          id: 'trigger-needle',
+          reportId: 'report-needle',
+          reportTitle: 'Needle Trigger Target',
+        }),
+      ],
+    });
 
     renderPage();
 
@@ -328,7 +348,7 @@ describe('DataMartSchedulesPage', () => {
     });
 
     expect(await screen.findByText('Needle Trigger Target')).toBeInTheDocument();
-    expect(scheduledTriggerService.getProjectScheduledTriggers).toHaveBeenCalledWith(100, 100);
+    expect(scheduledTriggerService.getProjectScheduledTriggers).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.tsx
+++ b/apps/web/src/pages/data-marts/schedules/DataMartSchedulesPage.tsx
@@ -1,9 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import type { ColumnDef } from '@tanstack/react-table';
-import { RefreshCw } from 'lucide-react';
 import { Badge } from '@owox/ui/components/badge';
-import { Button } from '@owox/ui/components/button';
 import RelativeTime from '@owox/ui/components/common/relative-time';
 import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
 import { extractApiError } from '../../../app/api';
@@ -47,7 +45,7 @@ import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
 import { ProjectDataMartTitleLink } from '../shared/ProjectDataMartTitleLink';
 import { ProjectScheduledTriggerEditSheet } from './ProjectScheduledTriggerEditSheet';
 
-const DATA_MART_SCHEDULES_PAGE_SIZE = 100;
+const DATA_MART_SCHEDULES_PAGE_SIZE = 15;
 const PROJECT_SCHEDULED_TRIGGERS_TABLE_ID = 'project-scheduled-triggers-table';
 
 type ProjectScheduledTriggerFilterKey =
@@ -160,64 +158,44 @@ function DataMartSchedulesPageContent() {
   const { connectors, fetchAvailableConnectors } = useConnector();
   const [triggers, setTriggers] = useState<ProjectScheduledTrigger[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [hasMoreTriggersToLoad, setHasMoreTriggersToLoad] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [editingTrigger, setEditingTrigger] = useState<ProjectScheduledTrigger | null>(null);
 
-  const loadTriggers = useCallback(async (offset = 0) => {
-    const isInitialLoad = offset === 0;
-    if (isInitialLoad) {
-      setIsLoading(true);
-    } else {
-      setIsLoadingMore(true);
-    }
+  const loadTriggers = useCallback(async () => {
+    setIsLoading(true);
     setError(null);
 
     try {
-      const response = await scheduledTriggerService.getProjectScheduledTriggers(
-        DATA_MART_SCHEDULES_PAGE_SIZE,
-        offset
-      );
-      const nextTriggers = ScheduledTriggerMapper.mapProjectFromDtoList(response);
-      setTriggers(currentTriggers =>
-        isInitialLoad ? nextTriggers : [...currentTriggers, ...nextTriggers]
-      );
-      setHasMoreTriggersToLoad(nextTriggers.length >= DATA_MART_SCHEDULES_PAGE_SIZE);
+      const response = await scheduledTriggerService.getProjectScheduledTriggers();
+      setTriggers(ScheduledTriggerMapper.mapProjectFromDtoList(response));
     } catch (caught) {
       setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart triggers');
     } finally {
       setIsLoading(false);
-      setIsLoadingMore(false);
     }
   }, []);
 
   useEffect(() => {
-    void loadTriggers(0);
+    void loadTriggers();
   }, [loadTriggers]);
 
   useEffect(() => {
     void fetchAvailableConnectors();
   }, [fetchAvailableConnectors]);
 
-  const loadMoreTriggers = useCallback(async () => {
-    if (isLoadingMore || !hasMoreTriggersToLoad) return;
-    await loadTriggers(triggers.length);
-  }, [hasMoreTriggersToLoad, isLoadingMore, loadTriggers, triggers.length]);
-
   const handleCloseTriggerEditSheet = useCallback(() => {
     setEditingTrigger(null);
   }, []);
 
   const handleTriggerSaved = useCallback(async () => {
-    await loadTriggers(0);
+    await loadTriggers();
   }, [loadTriggers]);
 
   const handleDeleteTrigger = useCallback(
     async (trigger: ProjectScheduledTrigger) => {
       await scheduledTriggerService.deleteScheduledTrigger(trigger.dataMart.id, trigger.id);
-      await loadTriggers(0);
+      await loadTriggers();
     },
     [loadTriggers]
   );
@@ -238,24 +216,6 @@ function DataMartSchedulesPageContent() {
     urlParam: 'filters',
     config: filtersConfig,
   });
-
-  const shouldLoadAllTriggersForQuery =
-    searchQuery.trim().length > 0 || appliedState.filters.length > 0;
-
-  useEffect(() => {
-    if (!shouldLoadAllTriggersForQuery || !hasMoreTriggersToLoad || isLoading || isLoadingMore) {
-      return;
-    }
-
-    void loadTriggers(triggers.length);
-  }, [
-    hasMoreTriggersToLoad,
-    isLoading,
-    isLoadingMore,
-    loadTriggers,
-    shouldLoadAllTriggersForQuery,
-    triggers.length,
-  ]);
 
   const filteredTriggers = useMemo(
     () =>
@@ -495,27 +455,6 @@ function DataMartSchedulesPageContent() {
                 }
               }}
             />
-
-            {hasMoreTriggersToLoad && (
-              <div className='flex justify-center pt-4 pb-6'>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  onClick={() => void loadMoreTriggers()}
-                  disabled={isLoadingMore}
-                  className='flex items-center gap-2'
-                >
-                  {isLoadingMore ? (
-                    <>
-                      <RefreshCw className='h-4 w-4 animate-spin' />
-                      Loading...
-                    </>
-                  ) : (
-                    'Load More'
-                  )}
-                </Button>
-              </div>
-            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Load Reports, Insights, and Triggers lists page-by-page from the API while keeping table pagination at 15 rows.
- Refresh Reports without refetching on side sheet close, and poll only running reports from the visible page.
- Set Run History fetch batches to 50.
- Fix the broken Reports link in the "Cannot delete destination" popup so it opens the new Reports page filtered by destination.

## Verification
- npm run lint -w @owox/web
- npm run type-check -w @owox/web
- npm run format:check -w @owox/web
- npm run test -w @owox/web -- src/features/data-destination/list/components/DataDestinationList/DataDestinationList.test.tsx src/features/data-marts/insights/shared/services/insight-templates.service.test.ts src/features/data-marts/reports/shared/services/report.service.test.ts src/features/data-marts/schedules/shared/services/scheduled-trigger.service.test.ts src/pages/data-marts/insights/DataMartInsightsPage.test.tsx src/pages/data-marts/reports/DataMartReportsPage.test.tsx src/pages/data-marts/runs/DataMartRunsPage.test.tsx src/pages/data-marts/schedules/DataMartSchedulesPage.test.tsx