### PR TITLE
fix: poll visible running reports by id

### DIFF
--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
@@ -487,9 +487,9 @@ describe('DataMartReportsPage', () => {
     expect(reportService.runReport).not.toHaveBeenCalled();
   });
 
-  it('polls project reports while any visible report is still running', async () => {
+  it('polls visible running reports by id', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    vi.mocked(reportService.getReportsByProject).mockResolvedValue([
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
       buildReportResponse({
         lastRunStatus: ReportStatusEnum.RUNNING,
       }),
@@ -502,8 +502,9 @@ describe('DataMartReportsPage', () => {
     await vi.advanceTimersByTimeAsync(5000);
 
     await waitFor(() => {
-      expect(reportService.getReportsByProject).toHaveBeenCalledTimes(2);
+      expect(reportService.getReportById).toHaveBeenCalledWith('report-1');
     });
+    expect(reportService.getReportsByProject).toHaveBeenCalledTimes(1);
 
     vi.useRealTimers();
   });
@@ -527,29 +528,61 @@ describe('DataMartReportsPage', () => {
     await vi.advanceTimersByTimeAsync(5000);
 
     expect(reportService.getReportsByProject).toHaveBeenCalledTimes(1);
+    expect(reportService.getReportById).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it('stops polling after a visible running report finishes', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildReportResponse({
+        lastRunStatus: ReportStatusEnum.RUNNING,
+      }),
+    ]);
+    vi.mocked(reportService.getReportById).mockResolvedValueOnce(
+      buildReportResponse({
+        lastRunStatus: ReportStatusEnum.SUCCESS,
+      })
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('Daily Sales Report')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'In progress' })).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await waitFor(() => {
+      expect(reportService.getReportById).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByRole('img', { name: 'Success' })).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(reportService.getReportById).toHaveBeenCalledTimes(1);
 
     vi.useRealTimers();
   });
 
   it('keeps already loaded report pages during silent polling', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    vi.mocked(reportService.getReportsByProject)
-      .mockResolvedValueOnce(
-        Array.from({ length: 16 }, (_, index) =>
-          buildReportResponse({
-            id: `report-${index + 1}`,
-            title: `Report ${index + 1}`,
-            lastRunStatus: index === 0 ? ReportStatusEnum.RUNNING : ReportStatusEnum.SUCCESS,
-          })
-        )
-      )
-      .mockResolvedValueOnce([
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce(
+      Array.from({ length: 16 }, (_, index) =>
         buildReportResponse({
-          id: 'report-1',
-          title: 'Report 1',
-          lastRunStatus: ReportStatusEnum.RUNNING,
-        }),
-      ]);
+          id: `report-${index + 1}`,
+          title: `Report ${index + 1}`,
+          lastRunStatus: index === 0 ? ReportStatusEnum.RUNNING : ReportStatusEnum.SUCCESS,
+        })
+      )
+    );
+    vi.mocked(reportService.getReportById).mockResolvedValueOnce(
+      buildReportResponse({
+        id: 'report-1',
+        title: 'Report 1',
+        lastRunStatus: ReportStatusEnum.RUNNING,
+      })
+    );
 
     renderPage();
 
@@ -563,7 +596,49 @@ describe('DataMartReportsPage', () => {
     });
     expect(await screen.findByText('Report 16')).toBeInTheDocument();
     expect(reportService.getReportsByProject).toHaveBeenCalledWith();
-    expect(reportService.getReportsByProject).toHaveBeenCalledWith(100, 0);
+    expect(reportService.getReportsByProject).toHaveBeenCalledTimes(1);
+    expect(reportService.getReportById).toHaveBeenCalledWith('report-1');
+
+    vi.useRealTimers();
+  });
+
+  it('refreshes visible running reports by id when they are outside the first API page', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce(
+      Array.from({ length: 105 }, (_, index) =>
+        buildReportResponse({
+          id: `report-${index + 1}`,
+          title: index === 104 ? 'Tail Running Report' : `Report ${index + 1}`,
+          lastRunStatus: index === 104 ? ReportStatusEnum.RUNNING : ReportStatusEnum.SUCCESS,
+        })
+      )
+    );
+    vi.mocked(reportService.getReportById).mockResolvedValueOnce(
+      buildReportResponse({
+        id: 'report-105',
+        title: 'Tail Running Report',
+        lastRunStatus: ReportStatusEnum.SUCCESS,
+      })
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('Report 1')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'Tail' },
+    });
+
+    expect(await screen.findByText('Tail Running Report')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'In progress' })).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await waitFor(() => {
+      expect(reportService.getReportById).toHaveBeenCalledWith('report-105');
+    });
+    expect(reportService.getReportsByProject).toHaveBeenCalledTimes(1);
+    expect(await screen.findByRole('img', { name: 'Success' })).toBeInTheDocument();
 
     vi.useRealTimers();
   });

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
@@ -41,7 +41,6 @@ import { ProjectDataMartTitleLink } from '../shared/ProjectDataMartTitleLink';
 import { mergeReportPagePreservingRows } from './DataMartReportsPage.utils';
 
 const PROJECT_REPORTS_TABLE_PAGE_SIZE = 15;
-const PROJECT_REPORTS_FETCH_PAGE_SIZE = 100;
 const PROJECT_REPORTS_TABLE_ID = 'project-reports-table';
 
 type ProjectReportFilterKey =
@@ -176,39 +175,49 @@ export default function DataMartReportsPage() {
     handleCloseModal,
   } = useReportSidesheet();
 
-  const loadReports = useCallback(
-    async (options?: { silent?: boolean; firstPageOnly?: boolean }) => {
-      const isSilent = options?.silent === true;
+  const loadReports = useCallback(async (options?: { silent?: boolean }) => {
+    const isSilent = options?.silent === true;
 
+    if (!isSilent) {
+      setIsLoading(true);
+      setError(null);
+    }
+
+    try {
+      const response = await reportService.getReportsByProject();
+      const nextReports = response.map(mapReportDtoToEntity);
+      setReports(currentReports => {
+        if (!isSilent) {
+          return nextReports;
+        }
+
+        return mergeReportPagePreservingRows(currentReports, nextReports);
+      });
+    } catch (caught) {
       if (!isSilent) {
-        setIsLoading(true);
-        setError(null);
+        setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart reports');
       }
-
-      try {
-        const response = options?.firstPageOnly
-          ? await reportService.getReportsByProject(PROJECT_REPORTS_FETCH_PAGE_SIZE, 0)
-          : await reportService.getReportsByProject();
-        const nextReports = response.map(mapReportDtoToEntity);
-        setReports(currentReports => {
-          if (!isSilent) {
-            return nextReports;
-          }
-
-          return mergeReportPagePreservingRows(currentReports, nextReports);
-        });
-      } catch (caught) {
-        if (!isSilent) {
-          setError(extractApiError(caught).message ?? 'Failed to fetch Data Mart reports');
-        }
-      } finally {
-        if (!isSilent) {
-          setIsLoading(false);
-        }
+    } finally {
+      if (!isSilent) {
+        setIsLoading(false);
       }
-    },
-    []
-  );
+    }
+  }, []);
+
+  const refreshReportsByIds = useCallback(async (reportIds: string[]) => {
+    const responses = await Promise.allSettled(
+      reportIds.map(reportId => reportService.getReportById(reportId))
+    );
+    const nextReports = responses.flatMap(response =>
+      response.status === 'fulfilled' ? [mapReportDtoToEntity(response.value)] : []
+    );
+
+    if (nextReports.length === 0) {
+      return;
+    }
+
+    setReports(currentReports => mergeReportPagePreservingRows(currentReports, nextReports));
+  }, []);
 
   useEffect(() => {
     void loadReports();
@@ -392,21 +401,25 @@ export default function DataMartReportsPage() {
     enableRowSelection: false,
   });
 
-  const hasRunningVisibleReports = table
+  const visibleRunningReportIds = table
     .getRowModel()
-    .rows.some(row => row.original.lastRunStatus === ReportStatusEnum.RUNNING);
+    .rows.filter(row => row.original.lastRunStatus === ReportStatusEnum.RUNNING)
+    .map(row => row.original.id);
+  const visibleRunningReportIdsKey = visibleRunningReportIds.join('\0');
 
   useEffect(() => {
-    if (!hasRunningVisibleReports) return;
+    if (!visibleRunningReportIdsKey) return;
+
+    const reportIds = visibleRunningReportIdsKey.split('\0');
 
     const intervalId = window.setInterval(() => {
-      void loadReports({ silent: true, firstPageOnly: true });
+      void refreshReportsByIds(reportIds);
     }, 5000);
 
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [hasRunningVisibleReports, loadReports]);
+  }, [refreshReportsByIds, visibleRunningReportIdsKey]);
 
   return (
     <ReportsProvider>

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.utils.ts
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.utils.ts
@@ -9,15 +9,20 @@ export function mergeReportPagePreservingRows(
   nextReports: DataMartReport[]
 ) {
   const currentReportsById = new Map(currentReports.map(report => [report.id, report]));
-  const nextReportIds = new Set(nextReports.map(report => report.id));
-  const refreshedReports = nextReports.map(nextReport => {
-    const currentReport = currentReportsById.get(nextReport.id);
-    return currentReport && areReportSnapshotsEqual(currentReport, nextReport)
-      ? currentReport
-      : nextReport;
+  const nextReportsById = new Map(nextReports.map(report => [report.id, report]));
+  const refreshedReports = currentReports.map(currentReport => {
+    const nextReport = nextReportsById.get(currentReport.id);
+    if (!nextReport) {
+      return currentReport;
+    }
+
+    return areReportSnapshotsEqual(currentReport, nextReport) ? currentReport : nextReport;
   });
-  const loadedOlderReports = currentReports.filter(report => !nextReportIds.has(report.id));
-  const mergedReports = [...refreshedReports, ...loadedOlderReports];
+  const appendedReports = nextReports.filter(nextReport => {
+    const currentReport = currentReportsById.get(nextReport.id);
+    return !currentReport;
+  });
+  const mergedReports = [...refreshedReports, ...appendedReports];
   const hasChanges =
     mergedReports.length !== currentReports.length ||
     mergedReports.some((report, index) => report !== currentReports[index]);


### PR DESCRIPTION
## Summary
- Replace Reports silent first-page polling with per-id refreshes for currently visible running report rows.
- Preserve loaded report order and unchanged row references during partial refreshes.
- Add regression coverage for hidden running rows, tail visible running rows, and polling stop after completion.

## Verification
- npm run test -w @owox/web -- src/pages/data-marts/reports/DataMartReportsPage.test.tsx
- npm run format:check -w @owox/web
- npm run type-check -w @owox/web
- npm run lint -w @owox/web