### PR TITLE
feat(data-marts): output controls for Legacy Google BigQuery data marts

### DIFF
--- a/.changeset/legacy-bigquery-output-controls.md
+++ b/.changeset/legacy-bigquery-output-controls.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Add output controls for Legacy Google BigQuery data marts
+
+Add report-level output controls (filters, slices, sort, limit) for Legacy Google BigQuery data marts, reaching parity with the standard Google BigQuery storage. Reuses the BigQuery SQL renderer and adapter, so filtered/sorted/limited reports — including the generated-SQL preview and the Looker Studio cached path — now work for legacy BigQuery marts in both the web app and the Google Sheets extension.

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-blended-query-builder.ts
@@ -6,7 +6,7 @@ import { BigQueryClauseRenderer } from './bigquery-clause-renderer';
 
 @Injectable()
 export class BigQueryBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
-  readonly type = DataStorageType.GOOGLE_BIGQUERY;
+  readonly type: DataStorageType = DataStorageType.GOOGLE_BIGQUERY;
   protected readonly identifierQuoteChar = '`';
 
   constructor(private readonly _renderer: BigQueryClauseRenderer) {

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-blended-query-builder.spec.ts
@@ -1,0 +1,43 @@
+import { DataStorageType } from '../../../enums/data-storage-type.enum';
+import {
+  createBuildContext,
+  makeChain,
+  makeRelationship,
+} from '../../../interfaces/__fixtures__/blended-query-builder-fixtures';
+import { LegacyBigQueryBlendedQueryBuilder } from './legacy-bigquery-blended-query-builder';
+import { BigQueryClauseRenderer } from '../bigquery-clause-renderer';
+
+const buildContext = createBuildContext('`project`.`dataset`.`customers`');
+
+describe('LegacyBigQueryBlendedQueryBuilder', () => {
+  let builder: LegacyBigQueryBlendedQueryBuilder;
+
+  beforeEach(() => {
+    builder = new LegacyBigQueryBlendedQueryBuilder(new BigQueryClauseRenderer());
+  });
+
+  it('should have type LEGACY_GOOGLE_BIGQUERY', () => {
+    expect(builder.type).toBe(DataStorageType.LEGACY_GOOGLE_BIGQUERY);
+  });
+
+  it('uses STRING_AGG(CAST(... AS STRING)) and backtick quoting (BigQuery dialect)', () => {
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: '`project`.`dataset`.`orders`',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'order_name',
+          outputAlias: 'order_names',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const { sql } = builder.buildBlendedQuery(buildContext([chain], ['order_names']));
+
+    expect(sql).toContain("STRING_AGG(CAST(order_name AS STRING), ', ') AS order_names");
+    expect(sql).not.toContain('LISTAGG');
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-blended-query-builder.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../../enums/data-storage-type.enum';
+import { BigQueryBlendedQueryBuilder } from '../bigquery-blended-query-builder';
+
+/**
+ * Legacy BigQuery uses the identical BigQuery SQL dialect, adapter and renderer as
+ * {@link BigQueryBlendedQueryBuilder}; only the storage-type discriminator differs so
+ * the blended TypeResolver can route LEGACY_GOOGLE_BIGQUERY marts to it.
+ */
+@Injectable()
+export class LegacyBigQueryBlendedQueryBuilder extends BigQueryBlendedQueryBuilder {
+  readonly type: DataStorageType = DataStorageType.LEGACY_GOOGLE_BIGQUERY;
+}

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-query.builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-query.builder.spec.ts
@@ -1,0 +1,96 @@
+import { DataStorageType } from '../../../enums/data-storage-type.enum';
+import { BigQueryClauseRenderer } from '../bigquery-clause-renderer';
+import { LegacyBigQueryQueryBuilder } from './legacy-bigquery-query.builder';
+import { LegacyBigQuerySqlPreprocessor } from './legacy-bigquery-sql-preprocessor.service';
+import { isQueryBuildResult } from '../../../interfaces/data-mart-query-builder.interface';
+import { DataMartDefinition } from '../../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
+
+const sqlDefinition = {
+  definitionType: 'SQL',
+  sqlQuery: 'SELECT id, created_at FROM source_table',
+} as unknown as DataMartDefinition;
+
+const tableDefinition = {
+  definitionType: 'TABLE',
+  fullyQualifiedName: 'proj.ds.table',
+} as unknown as DataMartDefinition;
+
+const viewRef = '`proj`.`ds`.`view_x`';
+
+function makeBuilder(prepared = 'SELECT id, created_at FROM parsed_table') {
+  const preprocessor = {
+    prepare: jest.fn().mockResolvedValue(prepared),
+  } as unknown as LegacyBigQuerySqlPreprocessor;
+  const builder = new LegacyBigQueryQueryBuilder(preprocessor, new BigQueryClauseRenderer());
+  return { builder, preprocessor };
+}
+
+describe('LegacyBigQueryQueryBuilder', () => {
+  it('has type LEGACY_GOOGLE_BIGQUERY', () => {
+    const { builder } = makeBuilder();
+    expect(builder.type).toBe(DataStorageType.LEGACY_GOOGLE_BIGQUERY);
+  });
+
+  it('returns preprocessed raw SQL when no output controls are present', async () => {
+    const { builder, preprocessor } = makeBuilder();
+    const result = await builder.buildQuery(sqlDefinition, {});
+    expect(result).toBe('SELECT id, created_at FROM parsed_table');
+    expect(preprocessor.prepare).toHaveBeenCalledWith('SELECT id, created_at FROM source_table');
+  });
+
+  it('delegates to the BigQuery output-controls path (wraps the view) when filters are present', async () => {
+    const { builder, preprocessor } = makeBuilder();
+    const result = await builder.buildQuery(sqlDefinition, {
+      filters: [{ column: 'created_at', operator: 'gte', value: '2024-01-01' }],
+      mainTableReference: viewRef,
+      columnTypes: new Map([['created_at', 'TIMESTAMP']]),
+    });
+    expect(isQueryBuildResult(result)).toBe(true);
+    if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
+    expect(result.sql).toContain(viewRef);
+    expect(result.sql).toContain('CAST(@p0 AS TIMESTAMP)');
+    expect(result.params).toEqual([{ name: 'p0', value: '2024-01-01' }]);
+    expect(preprocessor.prepare).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the output-controls path for a sort-only report', async () => {
+    const { builder, preprocessor } = makeBuilder();
+    const result = await builder.buildQuery(sqlDefinition, {
+      sort: [{ column: 'created_at', direction: 'desc' }],
+      mainTableReference: viewRef,
+    });
+    expect(isQueryBuildResult(result)).toBe(true);
+    if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
+    expect(result.sql).toContain(viewRef);
+    expect(result.sql).toContain('ORDER BY');
+    expect(preprocessor.prepare).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the output-controls path for a limit-only report', async () => {
+    const { builder, preprocessor } = makeBuilder();
+    const result = await builder.buildQuery(sqlDefinition, {
+      limit: 100,
+      mainTableReference: viewRef,
+    });
+    expect(isQueryBuildResult(result)).toBe(true);
+    if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
+    expect(result.sql).toContain(viewRef);
+    expect(result.sql).toContain('LIMIT 100');
+    expect(preprocessor.prepare).not.toHaveBeenCalled();
+  });
+
+  it('projects a column subset over the preprocessed SQL when no output controls are present', async () => {
+    const { builder, preprocessor } = makeBuilder();
+    const result = await builder.buildQuery(sqlDefinition, { columns: ['id', 'created_at'] });
+    expect(result).toBe('SELECT `id`, `created_at` FROM (SELECT id, created_at FROM parsed_table)');
+    expect(preprocessor.prepare).toHaveBeenCalledWith('SELECT id, created_at FROM source_table');
+  });
+
+  it('throws for a non-SQL definition with no output controls (legacy marts are SQL-only)', async () => {
+    const { builder, preprocessor } = makeBuilder();
+    await expect(builder.buildQuery(tableDefinition, {})).rejects.toThrow(
+      'Invalid data mart definition'
+    );
+    expect(preprocessor.prepare).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-query.builder.ts
@@ -2,13 +2,18 @@ import { Injectable } from '@nestjs/common';
 import { DataMartDefinition } from '../../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
 import { isSqlDefinition } from '../../../../dto/schemas/data-mart-table-definitions/data-mart-definition.guards';
 import { DataStorageType } from '../../../enums/data-storage-type.enum';
+import {
+  DataMartQueryOptions,
+  QueryBuildResult,
+} from '../../../interfaces/data-mart-query-builder.interface';
+import { escapeBigQueryIdentifier } from '../../utils/bigquery-identifier.utils';
 import { BigQueryClauseRenderer } from '../bigquery-clause-renderer';
 import { BigQueryQueryBuilder } from '../bigquery-query.builder';
 import { LegacyBigQuerySqlPreprocessor } from './legacy-bigquery-sql-preprocessor.service';
 
 @Injectable()
 export class LegacyBigQueryQueryBuilder extends BigQueryQueryBuilder {
-  readonly type = DataStorageType.LEGACY_GOOGLE_BIGQUERY;
+  readonly type: DataStorageType = DataStorageType.LEGACY_GOOGLE_BIGQUERY;
 
   constructor(
     private readonly preprocessor: LegacyBigQuerySqlPreprocessor,
@@ -17,11 +22,36 @@ export class LegacyBigQueryQueryBuilder extends BigQueryQueryBuilder {
     super(clauseRenderer);
   }
 
-  async buildQuery(definition: DataMartDefinition): Promise<string> {
-    if (isSqlDefinition(definition)) {
-      return this.preprocessor.prepare(definition.sqlQuery);
-    } else {
+  async buildQuery(
+    definition: DataMartDefinition,
+    queryOptions?: DataMartQueryOptions
+  ): Promise<string | QueryBuildResult> {
+    const hasOutputControls =
+      (queryOptions?.filters?.length ?? 0) > 0 ||
+      (queryOptions?.sort?.length ?? 0) > 0 ||
+      queryOptions?.limit != null;
+
+    // Output controls reference the materialized BQ view (mainTableReference), which is
+    // already ODM-preprocessed at view-creation time, so the parent BigQuery builder does
+    // the right thing and the legacy preprocessor must NOT re-run on this path.
+    if (hasOutputControls) {
+      return super.buildQuery(definition, queryOptions);
+    }
+
+    if (!isSqlDefinition(definition)) {
       throw new Error('Invalid data mart definition');
     }
+
+    // Non-OC path: the legacy SQL must be ODM-preprocessed first (no view exists until
+    // output controls trigger one). A column subset wraps the preprocessed SQL exactly as
+    // BigQueryQueryBuilder does for native SQL marts, so the projection is honored in the
+    // generated-SQL preview and copy-as-data-mart rather than silently dropped.
+    const preparedSql = await this.preprocessor.prepare(definition.sqlQuery);
+    if (!queryOptions?.columns?.length) {
+      return preparedSql;
+    }
+    const cleanQuery = preparedSql.trim().replace(/;\s*$/, '');
+    const selectList = queryOptions.columns.map(col => escapeBigQueryIdentifier(col)).join(', ');
+    return `SELECT ${selectList} FROM (${cleanQuery})`;
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
@@ -44,6 +44,7 @@ import { LegacyBigQuerySqlDryRunExecutor } from './bigquery/services/legacy/lega
 import { LegacyBigQuerySqlPreprocessor } from './bigquery/services/legacy/legacy-bigquery-sql-preprocessor.service';
 import { LegacyBigQuerySqlRunExecutor } from './bigquery/services/legacy/legacy-bigquery-sql-run.executor';
 import { LegacyBigQueryStorageErrorMapper } from './bigquery/services/legacy/legacy-bigquery-storage-error.mapper';
+import { LegacyBigQueryBlendedQueryBuilder } from './bigquery/services/legacy/legacy-bigquery-blended-query-builder';
 import { BigQueryStorageResourceBrowser } from './bigquery/services/bigquery-storage-resource-browser.service';
 import { DataStorageCredentialsUtils } from './data-mart-schema.utils';
 import { DatabricksApiAdapterFactory } from './databricks/adapters/databricks-api-adapter.factory';
@@ -245,6 +246,7 @@ const blendedQueryBuilderProviders = [
   RedshiftBlendedQueryBuilder,
   AthenaBlendedQueryBuilder,
   DatabricksBlendedQueryBuilder,
+  LegacyBigQueryBlendedQueryBuilder,
 ];
 
 export const dataStorageResolverProviders = [

--- a/apps/backend/src/data-marts/services/output-controls-capability.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-capability.service.spec.ts
@@ -19,7 +19,7 @@ describe('OutputControlsCapabilityService', () => {
   it('returns false for Databricks', () => {
     expect(svc.isSupported(DataStorageType.DATABRICKS)).toBe(false);
   });
-  it('returns false for legacy BigQuery', () => {
-    expect(svc.isSupported(DataStorageType.LEGACY_GOOGLE_BIGQUERY)).toBe(false);
+  it('supports legacy BigQuery', () => {
+    expect(svc.isSupported(DataStorageType.LEGACY_GOOGLE_BIGQUERY)).toBe(true);
   });
 });

--- a/apps/backend/src/data-marts/services/output-controls-capability.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-capability.service.ts
@@ -6,6 +6,7 @@ export class OutputControlsCapabilityService {
   // Source of truth — keep frontend mirrors (web + extension output-controls-support.ts) in sync.
   private readonly supported: ReadonlySet<DataStorageType> = new Set([
     DataStorageType.GOOGLE_BIGQUERY,
+    DataStorageType.LEGACY_GOOGLE_BIGQUERY,
     DataStorageType.AWS_ATHENA,
     DataStorageType.AWS_REDSHIFT,
   ]);

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
@@ -778,6 +778,39 @@ describe('ReportSqlComposerService', () => {
       );
     });
 
+    it('inlines named @params into literals for Legacy BigQuery (shares the BigQuery branch)', async () => {
+      const queryBuilderFacade = {
+        buildQuery: jest.fn().mockResolvedValue({
+          sql: 'SELECT * FROM t WHERE `d` = CAST(@p0 AS DATE)',
+          params: [{ name: 'p0', value: '2024-01-01' }],
+        }),
+      };
+      const blendedDataService = {
+        resolveBlendingDecision: jest
+          .fn()
+          .mockResolvedValue({ needsBlending: false, columnFilter: ['d'] }),
+      };
+      const composer = new ReportSqlComposerService(
+        blendedDataService as never,
+        queryBuilderFacade as never,
+        { resolveTableName: jest.fn().mockResolvedValue('p.d.t') } as never,
+        { isSupported: jest.fn().mockReturnValue(true) } as never
+      );
+      const report = {
+        filterConfig: [{ column: 'd', operator: 'gte', value: '2024-01-01' }],
+        dataMart: {
+          id: 'm',
+          projectId: 'p',
+          storage: { type: DataStorageType.LEGACY_GOOGLE_BIGQUERY },
+          definition: { type: 'sql', sqlQuery: 'SELECT * FROM t' },
+        },
+      } as never;
+
+      const { sql } = await composer.composeStatic(report, { userId: 'u1', roles: ['admin'] });
+      expect(sql).not.toContain('@p');
+      expect(sql).toBe("SELECT * FROM t WHERE `d` = CAST('2024-01-01' AS DATE)");
+    });
+
     it('returns SQL unchanged when there are no params (sort/limit-only or no controls)', async () => {
       const queryBuilderFacade = { buildQuery: jest.fn().mockResolvedValue('SELECT * FROM t') };
       const blendedDataService = {

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -140,6 +140,7 @@ export class ReportSqlComposerService {
       case DataStorageType.AWS_ATHENA:
         return { sql: inlineAthenaPositionalParams(composed.sql, composed.params) };
       case DataStorageType.GOOGLE_BIGQUERY:
+      case DataStorageType.LEGACY_GOOGLE_BIGQUERY:
         return { sql: inlineBigQueryNamedParams(composed.sql, composed.params) };
       default:
         // Redshift inlines all literals and produces no params (early-returned above).

--- a/apps/backend/test/output-controls-legacy-bq-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-legacy-bq-emission.e2e-spec.ts
@@ -1,0 +1,301 @@
+import { INestApplication } from '@nestjs/common';
+import * as crypto from 'crypto';
+import * as supertest from 'supertest';
+import {
+  createTestApp,
+  closeTestApp,
+  DataMartBuilder,
+  DataDestinationBuilder,
+  ReportBuilder,
+  AUTH_HEADER,
+  signLookerPayload,
+  mockGoogleJwkFetch,
+  restoreGoogleJwkFetch,
+} from '@owox/test-utils';
+import { DataStorageType } from '../src/data-marts/data-storage-types/enums/data-storage-type.enum';
+import { DataDestinationType } from '../src/data-marts/data-destination-types/enums/data-destination-type.enum';
+import { DataMartDefinitionValidatorFacade } from '../src/data-marts/data-storage-types/facades/data-mart-definition-validator-facade.service';
+import { DataMartSchemaProviderFacade } from '../src/data-marts/data-storage-types/facades/data-mart-schema-provider.facade';
+import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../src/data-marts/data-storage-types/data-storage-providers';
+import { DataMartTableReferenceService } from '../src/data-marts/services/data-mart-table-reference.service';
+import { LegacyDataMartsService } from '../src/data-marts/services/legacy-data-marts/legacy-data-marts.service';
+import { ReportDataHeader } from '../src/data-marts/dto/domain/report-data-header.dto';
+import { ReportDataBatch } from '../src/data-marts/dto/domain/report-data-batch.dto';
+import { ReportDataDescription } from '../src/data-marts/dto/domain/report-data-description.dto';
+import { BigQueryFieldType } from '../src/data-marts/data-storage-types/bigquery/enums/bigquery-field-type.enum';
+
+// HTTP-layer e2e for Legacy BigQuery output-controls SQL emission. ONE app +
+// ONE Legacy BigQuery report (date filter on a TIMESTAMP column) drives two
+// assertions to keep the e2e suite fast — booting createTestApp() is the
+// dominant cost:
+//
+//   1. GET /generated-sql inlines the date literal into a BigQuery CAST.
+//   2. POST /looker/get-data runs the REAL ReportDataCacheService (only the
+//      storage reader is a spy), proving resolvePrepareOptions() composes +
+//      forwards bound params instead of dropping output controls.
+//
+// The publish-time validator, LegacyDataMartsService, and
+// DataMartTableReferenceService are stubbed (all require live BigQuery/ODM
+// service); everything else (composer → builder → renderer, types from the
+// persisted schema) runs for real.
+//
+// LEGACY_GOOGLE_BIGQUERY storage cannot be created via the POST /api/data-storages
+// endpoint (CreateDataStorageService rejects it), so we seed it directly via SQL.
+
+const HEADERS: ReportDataHeader[] = [
+  new ReportDataHeader('id', 'id', undefined, BigQueryFieldType.INTEGER),
+  new ReportDataHeader('created_at', 'created_at', undefined, BigQueryFieldType.TIMESTAMP),
+];
+
+// Real ReportDataCacheService → spyReader.prepareReportData(report, options).
+// We assert the options it captured.
+const spyReader = {
+  prepareReportData: jest.fn().mockResolvedValue(new ReportDataDescription(HEADERS, 1)),
+  readReportDataBatch: jest
+    .fn()
+    .mockResolvedValue(new ReportDataBatch([['1', '2024-02-01']], null)),
+  finalize: jest.fn().mockResolvedValue(undefined),
+  getState: jest.fn().mockReturnValue(null),
+  initFromState: jest.fn().mockResolvedValue(undefined),
+  getType: jest.fn().mockReturnValue(DataStorageType.LEGACY_GOOGLE_BIGQUERY),
+};
+
+const mockSchemaProviderFacade = {
+  getActualDataMartSchema: jest.fn().mockResolvedValue({
+    type: 'bigquery-data-mart-schema',
+    fields: HEADERS.map(h => ({
+      name: h.name,
+      type: h.storageFieldType,
+      mode: 'NULLABLE',
+      status: 'CONNECTED',
+      isPrimaryKey: false,
+    })),
+  }),
+};
+
+describe('Output controls — Legacy BigQuery SQL emission (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+  let destinationId: string;
+  let destinationSecretKey: string;
+  let reportId: string;
+
+  const postLooker = (path: string, payload: unknown): supertest.Test =>
+    agent.post(path).set('Content-Type', 'application/jwt').send(signLookerPayload(payload));
+
+  beforeAll(async () => {
+    mockGoogleJwkFetch();
+
+    const testApp = await createTestApp([
+      {
+        provide: DataMartDefinitionValidatorFacade,
+        useValue: { checkIsValid: async () => undefined },
+      },
+      { provide: DataMartSchemaProviderFacade, useValue: mockSchemaProviderFacade },
+      {
+        provide: DATA_STORAGE_REPORT_READER_RESOLVER,
+        useValue: { resolve: async () => spyReader },
+      },
+      {
+        provide: DataMartTableReferenceService,
+        useValue: {
+          resolveTableName: async () => '`test-project`.`ds`.`view_legacy`',
+          ensureSqlViewIsUpToDate: async () => '`test-project`.`ds`.`view_legacy`',
+        },
+      },
+      {
+        provide: LegacyDataMartsService,
+        useValue: {
+          createDataMart: jest.fn().mockResolvedValue({ id: crypto.randomUUID() }),
+          updateQuery: jest.fn().mockResolvedValue(undefined),
+          updateTitle: jest.fn().mockResolvedValue(undefined),
+          updateDescription: jest.fn().mockResolvedValue(undefined),
+          deleteDataMart: jest.fn().mockResolvedValue(undefined),
+          parseQuery: jest.fn().mockImplementation((q: string) => Promise.resolve(q)),
+          isDataMartIdLooksLikeLegacy: jest.fn().mockReturnValue(false),
+        },
+      },
+    ]);
+    app = testApp.app;
+    agent = testApp.agent;
+
+    // LEGACY_GOOGLE_BIGQUERY storage cannot be created via POST /api/data-storages.
+    // Seed it directly in SQLite, mirroring the data_storage table columns.
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const backendRoot = require.resolve('@owox/backend/package.json');
+    const backendDir = require('path').dirname(backendRoot);
+    const { DataSource } = require(require.resolve('typeorm', { paths: [backendDir] }));
+    /* eslint-enable @typescript-eslint/no-require-imports */
+    const dataSource = app.get(DataSource);
+    const storageId = crypto.randomUUID();
+    await dataSource.query(
+      `INSERT INTO data_storage
+         (id, type, projectId, title, config, credentialId, availableForUse, availableForMaintenance, createdById, createdAt, modifiedAt)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      [
+        storageId,
+        DataStorageType.LEGACY_GOOGLE_BIGQUERY,
+        '0',
+        'Legacy BQ Test Storage',
+        JSON.stringify({ projectId: 'test-project' }),
+        null,
+        1,
+        0,
+        '0',
+      ]
+    );
+
+    const dmRes = await agent
+      .post('/api/data-marts')
+      .set(AUTH_HEADER)
+      .send(new DataMartBuilder().withStorageId(storageId).build());
+    expect(dmRes.status).toBe(201);
+    const dataMartId = dmRes.body.id;
+
+    await agent
+      .put(`/api/data-marts/${dataMartId}/definition`)
+      .set(AUTH_HEADER)
+      .send({
+        definitionType: 'SQL',
+        definition: { sqlQuery: 'SELECT id, created_at FROM events' },
+      });
+
+    await agent
+      .put(`/api/data-marts/${dataMartId}/schema`)
+      .set(AUTH_HEADER)
+      .send({
+        schema: {
+          type: 'bigquery-data-mart-schema',
+          fields: [
+            {
+              name: 'id',
+              type: 'INTEGER',
+              mode: 'NULLABLE',
+              status: 'CONNECTED',
+              isPrimaryKey: false,
+            },
+            {
+              name: 'created_at',
+              type: 'TIMESTAMP',
+              mode: 'NULLABLE',
+              status: 'CONNECTED',
+              isPrimaryKey: false,
+            },
+          ],
+        },
+      });
+
+    expect((await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER)).status).toBe(
+      200
+    );
+    await agent
+      .put(`/api/data-storages/${storageId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForUse: true, availableForMaintenance: true });
+    await agent
+      .put(`/api/data-marts/${dataMartId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForReporting: true, availableForMaintenance: true });
+
+    const destRes = await agent
+      .post('/api/data-destinations')
+      .set(AUTH_HEADER)
+      .send(
+        new DataDestinationBuilder()
+          .withType(DataDestinationType.LOOKER_STUDIO)
+          .withCredentials({ type: 'looker-studio-credentials' })
+          .build()
+      );
+    expect(destRes.status).toBe(201);
+    destinationId = destRes.body.id;
+    await agent
+      .put(`/api/data-destinations/${destinationId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForUse: true, availableForMaintenance: true });
+
+    // The Looker report lookup INNER JOINs storage.credential — seed one and link it.
+    const credentialId = crypto.randomUUID();
+    await dataSource.query(
+      `INSERT INTO data_storage_credentials (id, projectId, type, credentials, createdAt, modifiedAt)
+       VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      [
+        credentialId,
+        '0',
+        'google_service_account',
+        JSON.stringify({
+          type: 'service_account',
+          project_id: 'test-project',
+          private_key_id: 'key-id',
+          private_key:
+            '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7\n-----END PRIVATE KEY-----\n',
+          client_email: 'test@test-project.iam.gserviceaccount.com',
+          client_id: '123456789',
+          auth_uri: 'https://accounts.google.com/o/oauth2/auth',
+          token_uri: 'https://oauth2.googleapis.com/token',
+          auth_provider_x509_cert_url: 'https://www.googleapis.com/oauth2/v1/certs',
+          client_x509_cert_url:
+            'https://www.googleapis.com/robot/v1/metadata/x509/test%40test-project.iam.gserviceaccount.com',
+        }),
+      ]
+    );
+    await dataSource.query(`UPDATE data_storage SET config = ?, credentialId = ? WHERE id = ?`, [
+      JSON.stringify({ projectId: 'test-project' }),
+      credentialId,
+      storageId,
+    ]);
+
+    destinationSecretKey = (
+      await agent.get(`/api/data-destinations/${destinationId}`).set(AUTH_HEADER)
+    ).body.credentials.destinationSecretKey;
+
+    const reportRes = await agent
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send(
+        new ReportBuilder().withDataMartId(dataMartId).withDataDestinationId(destinationId).build()
+      );
+    expect(reportRes.status).toBe(201);
+    reportId = reportRes.body.id;
+
+    const putRes = await agent
+      .put(`/api/reports/${reportId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Looker Legacy BigQuery date filter',
+        dataDestinationId: destinationId,
+        destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        columnConfig: ['id', 'created_at'],
+        filterConfig: [{ column: 'created_at', operator: 'gte', value: '2024-01-01' }],
+      });
+    expect(putRes.status).toBe(200);
+  }, 120_000);
+
+  afterAll(async () => {
+    restoreGoogleJwkFetch();
+    await closeTestApp(app);
+  });
+
+  it('GET /generated-sql inlines the date literal into CAST (BigQuery)', async () => {
+    const res = await agent.get(`/api/reports/${reportId}/generated-sql`).set(AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.body.sql).toContain('`test-project`.`ds`.`view_legacy`');
+    expect(res.body.sql).toContain("`created_at` >= CAST('2024-01-01' AS TIMESTAMP)");
+    expect(res.body.sql).not.toContain('@p');
+  });
+
+  it('carries composed output-controls SQL + bound params into the cached reader', async () => {
+    const res = await postLooker('/api/external/looker/get-data', {
+      connectionConfig: { deploymentUrl: 'http://localhost', destinationId, destinationSecretKey },
+      request: {
+        configParams: { destinationId, reportId },
+        scriptParams: { sampleExtraction: true },
+        fields: [{ name: 'id' }, { name: 'created_at' }],
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(spyReader.prepareReportData).toHaveBeenCalled();
+    const options = spyReader.prepareReportData.mock.calls[0][1];
+    expect(options.sqlOverride).toContain('`created_at` >= CAST(@p0 AS TIMESTAMP)');
+    expect(options.sqlOverrideParams).toEqual([{ name: 'p0', value: '2024-01-01' }]);
+  });
+});

--- a/apps/web/src/features/data-marts/shared/utils/output-controls-support.test.ts
+++ b/apps/web/src/features/data-marts/shared/utils/output-controls-support.test.ts
@@ -11,8 +11,8 @@ describe('supportsOutputControls', () => {
     expect(supportsOutputControls(DataStorageType.AWS_ATHENA)).toBe(true);
   });
 
-  it('returns false for legacy BigQuery', () => {
-    expect(supportsOutputControls(DataStorageType.LEGACY_GOOGLE_BIGQUERY)).toBe(false);
+  it('returns true for legacy BigQuery', () => {
+    expect(supportsOutputControls(DataStorageType.LEGACY_GOOGLE_BIGQUERY)).toBe(true);
   });
 
   it('returns true for Redshift', () => {

--- a/apps/web/src/features/data-marts/shared/utils/output-controls-support.ts
+++ b/apps/web/src/features/data-marts/shared/utils/output-controls-support.ts
@@ -3,6 +3,7 @@ import { DataStorageType } from '../../../data-storage/shared/model/types/data-s
 // Mirror of backend OutputControlsCapabilityService — keep in sync.
 const SUPPORTED: ReadonlySet<DataStorageType> = new Set([
   DataStorageType.GOOGLE_BIGQUERY,
+  DataStorageType.LEGACY_GOOGLE_BIGQUERY,
   DataStorageType.AWS_ATHENA,
   DataStorageType.AWS_REDSHIFT,
 ]);


### PR DESCRIPTION
## What

Adds report-level output controls (filters, slices, sort, limit) for **Legacy Google BigQuery** data marts, bringing them to parity with standard Google BigQuery.

## Why

Legacy BigQuery was the last BigQuery-family storage without output controls — filtered/sorted/limited reports were rejected for these marts. Since legacy BigQuery is the same BigQuery SQL dialect/adapter/renderer (its services are thin subclasses), enabling it is mostly wiring rather than new dialect logic.

## How

- **Blended builder** — new `LegacyBigQueryBlendedQueryBuilder` (subclass of the BigQuery one; only the storage-type discriminator differs), registered in `blendedQueryBuilderProviders`. As a side effect this also enables blended legacy reports in general (previously there was no builder to resolve for the type).
- **Non-blended path** — `LegacyBigQueryQueryBuilder.buildQuery` now delegates to the BigQuery output-controls path when controls are present (wrapping the published BQ view via `mainTableReference`); the legacy ODM preprocessor stays on the non-OC raw-SQL path. On that path a column subset is now projected over the preprocessed SQL, matching native BigQuery (previously dropped silently).
- **Capability + static SQL** — `LEGACY_GOOGLE_BIGQUERY` added to the output-controls capability set and to the `composeStatic` inline branch (reuses `inlineBigQueryNamedParams`). The web capability mirror is updated; the BE↔FE contract test keeps them in sync.
- Base `BigQueryBlendedQueryBuilder.type` is annotated as `DataStorageType` so the subclass can override the discriminator.

Escaping and parameter binding are unchanged — they reuse the already-shipped, live-verified BigQuery renderer/adapter (`@p` named params, `CAST(@p AS <type>)` for date/time columns), so there is no new SQL-injection surface.

## Testing

- **Unit** — blended builder; `buildQuery` output-controls delegation incl. sort-only, limit-only, column projection and the SQL-only-definition guard; capability; `composeStatic` legacy branch.
- **e2e** — `output-controls-legacy-bq-emission`: generated-SQL inline preview + Looker cached param-forwarding path.
- Backend `nest build` clean, full unit suite green, web `tsc -b` clean.

## Scope / non-goals

- No live integration test (legacy ODM API + legacy creds): the SQL emission is byte-identical to the live-verified BigQuery path.
- No changes to the legacy ODM preprocessor, the ODM contract, or non-OC behaviour.
- Snowflake / Databricks output controls are separate follow-ups.

## Companion

The Google Sheets extension capability mirror is a separate PR in the `google-sheets-extension` repo.
