### PR TITLE
feat(data-marts): output controls for Snowflake data marts (filters, …

### DIFF
--- a/.changeset/snowflake-output-controls.md
+++ b/.changeset/snowflake-output-controls.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Add output controls for Snowflake data marts
+
+Add report-level output controls (filters, slices, sort, limit) for Snowflake data marts. Filter values are inlined as escaped SQL literals (Snowflake-correct backslash + quote escaping); substring matchers use CONTAINS/STARTSWITH/ENDSWITH (not LIKE) so user `%`/`_` stay literal, and regex uses `REGEXP_INSTR(...) > 0` for partial matching; date/time comparisons are CAST to the column type. Works for the web app and the Google Sheets extension.

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -28,9 +28,11 @@ jobs:
             pattern: athena.integration
           - name: Redshift
             pattern: redshift.integration
+          - name: Snowflake
+            pattern: snowflake.integration
           - name: Databricks
             pattern: databricks.integration
-          - name: HTTP Data (Athena + BigQuery + Redshift + Databricks)
+          - name: HTTP Data (Athena + BigQuery + Redshift + Databricks + Snowflake)
             pattern: http-data-real
           - name: Report read (Athena)
             pattern: report-run-real
@@ -75,6 +77,14 @@ jobs:
           REDSHIFT_REGION: ${{ secrets.REDSHIFT_REGION }}
           REDSHIFT_WORKGROUP_NAME: ${{ secrets.REDSHIFT_WORKGROUP_NAME }}
           REDSHIFT_DATABASE: ${{ secrets.REDSHIFT_DATABASE }}
+          # Snowflake (PASSWORD auth = PAT in the password field; the account needs a
+          # network policy that permits GitHub Actions runners, or the auth will fail)
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
+          SNOWFLAKE_USERNAME: ${{ secrets.SNOWFLAKE_USERNAME }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
+          SNOWFLAKE_SCHEMA: ${{ secrets.SNOWFLAKE_SCHEMA }}
           # Databricks (PERSONAL_ACCESS_TOKEN auth; catalog + schema host the seed table)
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
@@ -115,6 +115,7 @@ import { SnowflakeReportReader } from './snowflake/services/snowflake-report-rea
 import { SnowflakeSchemaMerger } from './snowflake/services/snowflake-schema-merger';
 import { SnowflakeSqlDryRunExecutor } from './snowflake/services/snowflake-sql-dry-run.executor';
 import { SnowflakeBlendedQueryBuilder } from './snowflake/services/snowflake-blended-query-builder';
+import { SnowflakeClauseRenderer } from './snowflake/services/snowflake-clause-renderer';
 import { SnowflakeSqlRunExecutor } from './snowflake/services/snowflake-sql-run.executor';
 import { SnowflakeStorageErrorMapper } from './snowflake/services/snowflake-storage-error.mapper';
 
@@ -259,6 +260,7 @@ const blendedQueryBuilderProviders = [
   AthenaClauseRenderer,
   RedshiftClauseRenderer,
   DatabricksClauseRenderer,
+  SnowflakeClauseRenderer,
   BigQueryBlendedQueryBuilder,
   SnowflakeBlendedQueryBuilder,
   RedshiftBlendedQueryBuilder,

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
@@ -168,7 +168,7 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     const selectClause = selectParts.length > 0 ? selectParts.join(',\n  ') : '*';
 
     const body =
-      `SELECT\n  ${selectClause}\nFROM main` +
+      `SELECT\n  ${selectClause}\nFROM ${this.quoteIdentifier('main')}` +
       (joinParts.length > 0 ? '\n' + joinParts.join('\n') : '');
 
     const qualifyColumn = this.buildColumnQualifier(outputAliasToRoot);
@@ -204,7 +204,7 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       if (rootAlias) {
         return `${this.quoteIdentifier(rootAlias)}.${this.quoteIdentifier(column)}`;
       }
-      return `main.${this.quoteFieldRef(column)}`;
+      return `${this.quoteIdentifier('main')}.${this.quoteFieldRef(column)}`;
     };
   }
 
@@ -497,7 +497,7 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       if (rootAlias && !hiddenOutputAliases.has(col)) {
         parts.push(`${this.quoteIdentifier(rootAlias)}.${this.quoteIdentifier(col)}`);
       } else {
-        parts.push(`main.${this.quoteFieldRef(col)}`);
+        parts.push(`${this.quoteIdentifier('main')}.${this.quoteFieldRef(col)}`);
       }
     }
     return parts;

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotImplementedException } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import {
   createBuildContext,
@@ -7,6 +6,7 @@ import {
   makeRelationship,
 } from '../../interfaces/__fixtures__/blended-query-builder-fixtures';
 import { SnowflakeBlendedQueryBuilder } from './snowflake-blended-query-builder';
+import { SnowflakeClauseRenderer } from './snowflake-clause-renderer';
 import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
 
 const buildContext = createBuildContext('mydb."myschema"."customers"');
@@ -16,7 +16,7 @@ describe('SnowflakeBlendedQueryBuilder', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SnowflakeBlendedQueryBuilder],
+      providers: [SnowflakeBlendedQueryBuilder, SnowflakeClauseRenderer],
     }).compile();
 
     builder = module.get(SnowflakeBlendedQueryBuilder);
@@ -43,7 +43,9 @@ describe('SnowflakeBlendedQueryBuilder', () => {
 
     const { sql } = builder.buildBlendedQuery(buildContext([chain], ['order_names']));
 
-    expect(sql).toContain("LISTAGG(CAST(order_name AS VARCHAR), ', ') AS order_names");
+    expect(sql).toContain(
+      'LISTAGG(CAST("order_name" AS VARCHAR), \', \') WITHIN GROUP (ORDER BY "order_name") AS "order_names"'
+    );
     expect(sql).not.toContain('STRING_AGG');
     expect(sql).not.toContain('ARRAY_JOIN');
     expect(sql).not.toContain('COLLECT_LIST');
@@ -66,7 +68,7 @@ describe('SnowflakeBlendedQueryBuilder', () => {
 
     const { sql } = builder.buildBlendedQuery(buildContext([chain], ['unique_customers']));
 
-    expect(sql).toContain('COUNT(DISTINCT customer_id) AS unique_customers');
+    expect(sql).toContain('COUNT(DISTINCT "customer_id") AS "unique_customers"');
   });
 
   it('uses " (double-quote) quoting for identifiers', () => {
@@ -95,6 +97,31 @@ describe('SnowflakeBlendedQueryBuilder', () => {
     expect(sql).not.toMatch(/`Product's`/);
   });
 
+  it('always quotes simple lowercase identifiers (Snowflake folds unquoted to UPPERCASE)', () => {
+    // The base builder returns simple names bare — safe for lowercase-folding engines but
+    // NOT Snowflake: a bare `campaign_id` resolves to CAMPAIGN_ID and misses the lowercase
+    // column the OWOX connector creates (as quoted) → "invalid identifier".
+    const chain = makeChain({
+      relationship: makeRelationship(),
+      targetTableReference: 'mydb."myschema"."orders"',
+      parentAlias: 'main',
+      blendedFields: [
+        {
+          targetFieldName: 'campaign_id',
+          outputAlias: 'campaign_ids',
+          isHidden: false,
+          aggregateFunction: 'STRING_AGG',
+        },
+      ],
+    });
+
+    const { sql } = builder.buildBlendedQuery(buildContext([chain], ['campaign_ids']));
+
+    expect(sql).toContain('LISTAGG(CAST("campaign_id" AS VARCHAR)');
+    expect(sql).toContain('AS "campaign_ids"');
+    expect(sql).not.toContain('CAST(campaign_id AS'); // never bare
+  });
+
   it('uses COUNT function correctly', () => {
     const chain = makeChain({
       relationship: makeRelationship(),
@@ -112,54 +139,101 @@ describe('SnowflakeBlendedQueryBuilder', () => {
 
     const { sql } = builder.buildBlendedQuery(buildContext([chain], ['order_count']));
 
-    expect(sql).toContain('COUNT(order_id) AS order_count');
+    expect(sql).toContain('COUNT("order_id") AS "order_count"');
   });
 });
 
-describe('SnowflakeBlendedQueryBuilder — output controls guard', () => {
-  const builder = new SnowflakeBlendedQueryBuilder();
-  const baseContext: BlendedQueryContext = {
-    mainTableReference: 'mydb."myschema"."customers"',
-    mainDataMartTitle: 'M',
-    mainDataMartUrl: 'http://x',
-    chains: [],
-    columns: ['a'],
-  };
+describe('SnowflakeBlendedQueryBuilder — output controls', () => {
+  let builder: SnowflakeBlendedQueryBuilder;
 
-  it('throws NotImplemented when filters are non-empty', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
-        filters: [{ column: 'a', operator: 'eq', value: 1 }],
-      })
-    ).toThrow(NotImplementedException);
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SnowflakeBlendedQueryBuilder, SnowflakeClauseRenderer],
+    }).compile();
+    builder = module.get(SnowflakeBlendedQueryBuilder);
   });
 
-  it('throws NotImplemented when sort is non-empty', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
-        sort: [{ column: 'a', direction: 'asc' }],
-      })
-    ).toThrow(NotImplementedException);
+  function ctx(over: Partial<BlendedQueryContext>): BlendedQueryContext {
+    return {
+      mainTableReference: 'mydb."myschema"."customers"',
+      mainDataMartTitle: 'M',
+      mainDataMartUrl: 'http://x',
+      chains: [],
+      columns: ['a'],
+      ...over,
+    };
+  }
+
+  it('applies a post-join filter as an inlined literal predicate with no bound params', () => {
+    const { sql, params } = builder.buildBlendedQuery(
+      ctx({ filters: [{ column: 'a', operator: 'eq', value: 1 }] })
+    );
+    expect(sql).toContain('WHERE "main"."a" = 1');
+    expect(params).toEqual([]);
   });
 
-  it('throws NotImplemented when limit is set', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
-        limit: 100,
-      })
-    ).toThrow(NotImplementedException);
+  it('quotes the main CTE alias consistently in its definition AND references', () => {
+    // Snowflake folds a bare `main` to MAIN, which cannot resolve the lowercase-quoted
+    // "main" CTE. The definition (always quoted) and every reference (FROM / qualifier)
+    // must use the same "main" form, or blended OC reports fail at runtime.
+    const { sql } = builder.buildBlendedQuery(
+      ctx({ filters: [{ column: 'a', operator: 'eq', value: 1 }] })
+    );
+    expect(sql).toContain('"main" AS (');
+    expect(sql).toContain('FROM "main"');
+    expect(sql).not.toContain('FROM main');
   });
 
-  it('throws NotImplemented on pre-join filters (slices)', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
+  it('uses CONTAINS for string contains operator (no ? / @p placeholders)', () => {
+    const { sql, params } = builder.buildBlendedQuery(
+      ctx({ filters: [{ column: 'status', operator: 'contains', value: 'active' }] })
+    );
+    expect(sql).toContain('CONTAINS("main"."status", \'active\')');
+    expect(sql).not.toMatch(/[?]|@p\d/);
+    expect(params).toEqual([]);
+  });
+
+  it('renders ORDER BY and LIMIT', () => {
+    const { sql } = builder.buildBlendedQuery(
+      ctx({ sort: [{ column: 'a', direction: 'desc' }], limit: 10 })
+    );
+    expect(sql).toContain('ORDER BY "main"."a" DESC');
+    expect(sql).toContain('LIMIT 10');
+  });
+
+  it('multiple post-join filters combine with AND (inlined, no params)', () => {
+    const { sql, params } = builder.buildBlendedQuery(
+      ctx({
+        columns: ['a'],
+        filters: [
+          { column: 'a', operator: 'eq', value: 'x', placement: 'post-join' },
+          { column: 'a', operator: 'neq', value: 'y', placement: 'post-join' },
+        ],
+      })
+    );
+    expect(sql).toContain('WHERE "main"."a" = \'x\' AND "main"."a" <> \'y\'');
+    expect(params).toEqual([]);
+  });
+
+  it('inlines a pre-join slice filter as a literal inside the subsidiary raw CTE with no params', () => {
+    const chain = makeChain({
+      relationship: makeRelationship({
+        targetAlias: 'users',
+        joinConditions: [{ sourceFieldName: 'user_id', targetFieldName: 'user_id' }],
+      }),
+      targetTableReference: 'mydb."myschema"."users"',
+      parentAlias: 'main',
+      blendedFields: [
+        { targetFieldName: 'role', outputAlias: 'role', isHidden: true, aggregateFunction: 'MAX' },
+      ],
+    });
+    const { sql, params } = builder.buildBlendedQuery(
+      ctx({
+        chains: [chain],
+        columns: ['a'],
         filters: [
           {
-            column: 'userRole',
+            column: 'role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
@@ -167,6 +241,17 @@ describe('SnowflakeBlendedQueryBuilder — output controls guard', () => {
           },
         ],
       })
-    ).toThrow(NotImplementedException);
+    );
+    // The inlined literal predicate must appear inside the subsidiary raw CTE.
+    const rawCteStart = sql.indexOf('"users_raw" AS (');
+    const predicatePos = sql.indexOf('"role" = \'admin\'');
+    const outerSelectPos = sql.lastIndexOf('\nSELECT\n');
+    expect(rawCteStart).toBeGreaterThanOrEqual(0);
+    expect(predicatePos).toBeGreaterThan(rawCteStart);
+    expect(predicatePos).toBeLessThan(outerSelectPos);
+    // The outer WHERE must not reference the pre-join column
+    expect(sql).not.toContain('"main"."role"');
+    // Snowflake uses inlined literals — no bound params
+    expect(params).toEqual([]);
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.ts
@@ -2,17 +2,32 @@ import { Injectable } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
 import { SqlClauseRenderer } from '../../utils/sql-clause-renderer';
+import { SnowflakeClauseRenderer } from './snowflake-clause-renderer';
 
 @Injectable()
 export class SnowflakeBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
   readonly type = DataStorageType.SNOWFLAKE;
   protected readonly identifierQuoteChar = '"';
 
-  protected get clauseRenderer(): SqlClauseRenderer | null {
-    return null;
+  constructor(private readonly _renderer: SnowflakeClauseRenderer) {
+    super();
+  }
+
+  protected get clauseRenderer(): SqlClauseRenderer {
+    return this._renderer;
+  }
+
+  // Snowflake folds UNQUOTED identifiers to UPPERCASE, so the base class's bare return
+  // for simple names would miss the lowercase columns the OWOX connector creates (as
+  // quoted). Always quote — case-stable, and consistent with the non-blended builder.
+  protected quoteIdentifier(name: string): string {
+    const q = this.identifierQuoteChar;
+    return `${q}${name.split(q).join(q + q)}${q}`;
   }
 
   protected buildStringAgg(fieldName: string): string {
-    return `LISTAGG(CAST(${fieldName} AS VARCHAR), ', ')`;
+    // WITHIN GROUP (ORDER BY) makes the concatenation deterministic — Snowflake allows
+    // omitting it (Redshift requires it), but a stable order matches the Redshift sibling.
+    return `LISTAGG(CAST(${fieldName} AS VARCHAR), ', ') WITHIN GROUP (ORDER BY ${fieldName})`;
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-clause-renderer.spec.ts
@@ -1,0 +1,152 @@
+import { SnowflakeClauseRenderer } from './snowflake-clause-renderer';
+import { FilterRule } from '../../../dto/schemas/filter-config.schema';
+
+function where(renderer: SnowflakeClauseRenderer, rule: FilterRule, type?: string) {
+  return renderer.renderWhere([rule], undefined, 'p', type ? () => type : undefined).sql;
+}
+
+describe('SnowflakeClauseRenderer', () => {
+  const r = new SnowflakeClauseRenderer();
+
+  it('renders comparison operators with inlined literals and no params', () => {
+    const out = r.renderWhere([{ column: 'age', operator: 'gte', value: 18 }]);
+    expect(out.sql).toBe('\nWHERE "age" >= 18');
+    expect(out.params).toEqual([]);
+  });
+
+  it('escapes single quotes AND backslashes in string literals (Snowflake treats \\ as escape)', () => {
+    expect(where(r, { column: 'name', operator: 'eq', value: "O'Brien" })).toBe(
+      `\nWHERE "name" = 'O''Brien'`
+    );
+    expect(where(r, { column: 'path', operator: 'eq', value: 'a\\b' })).toBe(
+      `\nWHERE "path" = 'a\\\\b'`
+    );
+  });
+
+  it('uses string built-ins (not LIKE) so %/_ stay literal', () => {
+    expect(where(r, { column: 'name', operator: 'contains', value: '50%_x' })).toBe(
+      `\nWHERE CONTAINS("name", '50%_x')`
+    );
+    expect(where(r, { column: 'name', operator: 'starts_with', value: 'a' })).toBe(
+      `\nWHERE STARTSWITH("name", 'a')`
+    );
+    expect(where(r, { column: 'name', operator: 'ends_with', value: 'z' })).toBe(
+      `\nWHERE ENDSWITH("name", 'z')`
+    );
+    expect(where(r, { column: 'name', operator: 'not_contains', value: 'x' })).toBe(
+      `\nWHERE NOT CONTAINS("name", 'x')`
+    );
+    expect(where(r, { column: 'name', operator: 'regex', value: '^a.*' })).toBe(
+      `\nWHERE REGEXP_INSTR("name", '^a.*') > 0`
+    );
+    expect(where(r, { column: 'name', operator: 'not_regex', value: '^a.*' })).toBe(
+      `\nWHERE REGEXP_INSTR("name", '^a.*') = 0`
+    );
+    // `^alp` is the semantically meaningful case: Snowflake RLIKE/REGEXP_LIKE would
+    // full-anchor it and NOT match `alpha`; REGEXP_INSTR>0 is partial (live-verified).
+    expect(where(r, { column: 'name', operator: 'regex', value: '^alp' })).toBe(
+      `\nWHERE REGEXP_INSTR("name", '^alp') > 0`
+    );
+  });
+
+  it('inlines a malicious filter VALUE as a single escaped literal (no breakout)', () => {
+    // Option B inlines every value, so the value is an injection surface too — both the
+    // `lit` path (eq) and the `text` path (contains) must neutralize it.
+    expect(where(r, { column: 'name', operator: 'eq', value: "x' OR '1'='1" })).toBe(
+      `\nWHERE "name" = 'x'' OR ''1''=''1'`
+    );
+    expect(where(r, { column: 'name', operator: 'contains', value: "a') OR 1=1 --" })).toBe(
+      `\nWHERE CONTAINS("name", 'a'') OR 1=1 --')`
+    );
+  });
+
+  it('wraps date/time value comparisons in a defensive CAST to the column type', () => {
+    expect(
+      where(r, { column: 'created_at', operator: 'gte', value: '2024-01-01' }, 'TIMESTAMP')
+    ).toBe(`\nWHERE "created_at" >= CAST('2024-01-01' AS TIMESTAMP)`);
+    expect(
+      where(
+        r,
+        { column: 'd', operator: 'between', value: { from: '2024-01-01', to: '2024-02-01' } },
+        'DATE'
+      )
+    ).toBe(`\nWHERE "d" BETWEEN CAST('2024-01-01' AS DATE) AND CAST('2024-02-01' AS DATE)`);
+    expect(where(r, { column: 't', operator: 'gte', value: '08:00:00' }, 'TIME')).toBe(
+      `\nWHERE "t" >= CAST('08:00:00' AS TIME)`
+    );
+    expect(where(r, { column: 'age', operator: 'gte', value: 18 }, 'INTEGER')).toBe(
+      `\nWHERE "age" >= 18`
+    );
+  });
+
+  it('renders bool / null / empty operators', () => {
+    expect(where(r, { column: 'ok', operator: 'is_true' })).toBe(`\nWHERE "ok" = TRUE`);
+    expect(where(r, { column: 'ok', operator: 'is_false' })).toBe(`\nWHERE "ok" = FALSE`);
+    expect(where(r, { column: 'x', operator: 'is_null' })).toBe(`\nWHERE "x" IS NULL`);
+    expect(where(r, { column: 'x', operator: 'is_not_null' })).toBe(`\nWHERE "x" IS NOT NULL`);
+    expect(where(r, { column: 's', operator: 'is_empty' })).toBe(
+      `\nWHERE ("s" IS NULL OR "s" = '')`
+    );
+    expect(where(r, { column: 's', operator: 'is_not_empty' })).toBe(
+      `\nWHERE ("s" IS NOT NULL AND "s" <> '')`
+    );
+    expect(where(r, { column: 'n', operator: 'neq', value: 1 })).toBe(`\nWHERE "n" <> 1`);
+  });
+
+  it('renders relative_date presets as half-open ranges with upper bounds', () => {
+    expect(where(r, { column: 'd', operator: 'relative_date', value: { kind: 'today' } })).toBe(
+      `\nWHERE "d" >= CURRENT_DATE AND "d" < DATEADD(day, 1, CURRENT_DATE)`
+    );
+    expect(
+      where(r, { column: 'd', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } })
+    ).toBe(`\nWHERE "d" >= DATEADD(day, -7, CURRENT_DATE) AND "d" < DATEADD(day, 1, CURRENT_DATE)`);
+    expect(
+      where(r, { column: 'd', operator: 'relative_date', value: { kind: 'this_month' } })
+    ).toBe(
+      `\nWHERE "d" >= DATE_TRUNC('month', CURRENT_DATE) AND "d" < DATEADD(month, 1, DATE_TRUNC('month', CURRENT_DATE))`
+    );
+    expect(where(r, { column: 'd', operator: 'relative_date', value: { kind: 'yesterday' } })).toBe(
+      `\nWHERE "d" >= DATEADD(day, -1, CURRENT_DATE) AND "d" < CURRENT_DATE`
+    );
+    expect(
+      where(r, { column: 'd', operator: 'relative_date', value: { kind: 'last_n_months', n: 3 } })
+    ).toBe(
+      `\nWHERE "d" >= DATEADD(month, -3, CURRENT_DATE) AND "d" < DATEADD(day, 1, CURRENT_DATE)`
+    );
+    expect(
+      where(r, { column: 'd', operator: 'relative_date', value: { kind: 'last_month' } })
+    ).toBe(
+      `\nWHERE "d" >= DATE_TRUNC('month', DATEADD(month, -1, CURRENT_DATE)) AND "d" < DATE_TRUNC('month', CURRENT_DATE)`
+    );
+    expect(where(r, { column: 'd', operator: 'relative_date', value: { kind: 'this_year' } })).toBe(
+      `\nWHERE "d" >= DATE_TRUNC('year', CURRENT_DATE) AND "d" < DATEADD(year, 1, DATE_TRUNC('year', CURRENT_DATE))`
+    );
+  });
+
+  it('safely quotes malicious column names (no breakout via dots or payloads)', () => {
+    // A 4+-part / payload-laden column name must stay fully inside quoted identifiers and
+    // never break out of the WHERE clause. escapeSnowflakeIdentifier returns 4+-part names
+    // RAW; this renderer uses the robust shared escaper instead.
+    expect(where(r, { column: 'a.b.c.d OR 1=1 --', operator: 'is_null' })).toBe(
+      `\nWHERE "a"."b"."c"."d OR 1=1 --" IS NULL`
+    );
+    expect(where(r, { column: `c'; DROP TABLE x; --`, operator: 'is_null' })).toBe(
+      `\nWHERE "c'; DROP TABLE x; --" IS NULL`
+    );
+  });
+
+  it('rejects non-finite numbers and negative/non-integer relative_date n', () => {
+    expect(() => r.renderWhere([{ column: 'x', operator: 'gt', value: Infinity }])).toThrow(
+      /Non-finite/
+    );
+    expect(() =>
+      r.renderWhere([
+        {
+          column: 'd',
+          operator: 'relative_date',
+          value: { kind: 'last_n_days', n: -1 },
+        } as FilterRule,
+      ])
+    ).toThrow(/Invalid relative_date n/);
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-clause-renderer.ts
@@ -1,0 +1,161 @@
+import { Injectable } from '@nestjs/common';
+import { RenderedClause, SqlClauseRenderer } from '../../utils/sql-clause-renderer';
+import { FilterRule } from '../../../dto/schemas/filter-config.schema';
+import { createIdentifierEscaper } from '../../utils/identifier-escaper.utils';
+
+// Column references (filter/sort columns) are user-controlled (`FilterRule.column` is
+// only `z.string().min(1)`), so they MUST go through the robust shared escaper that
+// quotes every dotted part and doubles inner quotes — NOT `escapeSnowflakeIdentifier`,
+// which is FQN-oriented (leaves the database part unquoted for 3-part names), so it is
+// wrong for arbitrary user column refs that need every dotted part quoted.
+const escapeColumnIdentifier = createIdentifierEscaper({ quoteChar: '"' });
+
+/**
+ * Formats a value as a Snowflake SQL literal. The Snowflake renderer inlines every
+ * value (params: []), so this escaping is the ONLY injection barrier. Snowflake
+ * interprets backslash escape sequences in single-quoted string literals, so a literal
+ * backslash must be doubled BEFORE single quotes are doubled (BigQuery-style, NOT
+ * Redshift's quote-only escaping).
+ */
+function formatSnowflakeLiteral(value: string | number | boolean | null): string {
+  if (value === null) return 'NULL';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Non-finite numeric filter value: ${String(value)}`);
+    }
+    return String(value);
+  }
+  if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "''")}'`;
+}
+
+/**
+ * Snowflake renderer (option B). Inlines every value as a literal — fragments always
+ * return params: []. Substring/affix matchers use CONTAINS/STARTSWITH/ENDSWITH (never
+ * LIKE) so user %/_ stay literal; regex uses REGEXP_INSTR>0 (partial match). Date/time
+ * value comparisons get a defensive CAST to the column type — kept explicit even though the
+ * live integration confirmed Snowflake also coerces a bare literal (explicit > implicit).
+ */
+@Injectable()
+export class SnowflakeClauseRenderer extends SqlClauseRenderer {
+  // The normalized SnowflakeFieldType vocabulary (TIMESTAMP_NTZ/LTZ/TZ, DATETIME all
+  // collapse to TIMESTAMP upstream via parseSnowflakeFieldType) — so these three suffice.
+  private static readonly DATE_CAST_TYPES = new Set(['DATE', 'TIME', 'TIMESTAMP']);
+
+  protected quoteIdentifier(name: string): string {
+    return escapeColumnIdentifier(name);
+  }
+
+  protected validateFragment(clause: RenderedClause): void {
+    if (clause.params.length !== 0) {
+      throw new Error(
+        `SnowflakeClauseRenderer must inline all values, but a fragment emitted ` +
+          `${clause.params.length} param(s): "${clause.sql}".`
+      );
+    }
+  }
+
+  private litCast(value: string | number | boolean | null, columnType?: string): string {
+    const l = formatSnowflakeLiteral(value);
+    return columnType && SnowflakeClauseRenderer.DATE_CAST_TYPES.has(columnType)
+      ? `CAST(${l} AS ${columnType})`
+      : l;
+  }
+
+  protected renderFilterFragment(
+    rule: FilterRule,
+    _paramName: string,
+    col: string,
+    columnType?: string
+  ): RenderedClause {
+    const lit = (v: string | number | boolean | null): string => this.litCast(v, columnType);
+    const text = (v: string | number | boolean | null): string => formatSnowflakeLiteral(String(v));
+    switch (rule.operator) {
+      case 'eq':
+        return { sql: `${col} = ${lit(rule.value)}`, params: [] };
+      case 'neq':
+        return { sql: `${col} <> ${lit(rule.value)}`, params: [] };
+      case 'gt':
+        return { sql: `${col} > ${lit(rule.value)}`, params: [] };
+      case 'lt':
+        return { sql: `${col} < ${lit(rule.value)}`, params: [] };
+      case 'gte':
+        return { sql: `${col} >= ${lit(rule.value)}`, params: [] };
+      case 'lte':
+        return { sql: `${col} <= ${lit(rule.value)}`, params: [] };
+      case 'contains':
+        return { sql: `CONTAINS(${col}, ${text(rule.value)})`, params: [] };
+      case 'not_contains':
+        return { sql: `NOT CONTAINS(${col}, ${text(rule.value)})`, params: [] };
+      case 'starts_with':
+        return { sql: `STARTSWITH(${col}, ${text(rule.value)})`, params: [] };
+      case 'ends_with':
+        return { sql: `ENDSWITH(${col}, ${text(rule.value)})`, params: [] };
+      case 'regex':
+        // RLIKE/REGEXP_LIKE full-anchor the string in Snowflake; REGEXP_INSTR(...)>0 gives
+        // the partial-match semantics the other storages (Athena/BQ/Redshift) use.
+        return { sql: `REGEXP_INSTR(${col}, ${text(rule.value)}) > 0`, params: [] };
+      case 'not_regex':
+        return { sql: `REGEXP_INSTR(${col}, ${text(rule.value)}) = 0`, params: [] };
+      case 'is_empty':
+        return { sql: `(${col} IS NULL OR ${col} = '')`, params: [] };
+      case 'is_not_empty':
+        return { sql: `(${col} IS NOT NULL AND ${col} <> '')`, params: [] };
+      case 'is_null':
+        return { sql: `${col} IS NULL`, params: [] };
+      case 'is_not_null':
+        return { sql: `${col} IS NOT NULL`, params: [] };
+      case 'is_true':
+        return { sql: `${col} = TRUE`, params: [] };
+      case 'is_false':
+        return { sql: `${col} = FALSE`, params: [] };
+      case 'between':
+        return {
+          sql: `${col} BETWEEN ${lit(rule.value.from)} AND ${lit(rule.value.to)}`,
+          params: [],
+        };
+      case 'relative_date':
+        return { sql: this.renderRelativeDate(col, rule.value), params: [] };
+    }
+  }
+
+  private renderRelativeDate(
+    col: string,
+    preset: Extract<FilterRule, { operator: 'relative_date' }>['value']
+  ): string {
+    if ('n' in preset && (!Number.isInteger(preset.n) || preset.n < 0)) {
+      throw new Error(`Invalid relative_date n: ${String(preset.n)}`);
+    }
+    switch (preset.kind) {
+      case 'today':
+        return `${col} >= CURRENT_DATE AND ${col} < DATEADD(day, 1, CURRENT_DATE)`;
+      case 'yesterday':
+        return `${col} >= DATEADD(day, -1, CURRENT_DATE) AND ${col} < CURRENT_DATE`;
+      case 'last_n_days':
+        return (
+          `${col} >= DATEADD(day, -${preset.n}, CURRENT_DATE)` +
+          ` AND ${col} < DATEADD(day, 1, CURRENT_DATE)`
+        );
+      case 'last_n_months':
+        return (
+          `${col} >= DATEADD(month, -${preset.n}, CURRENT_DATE)` +
+          ` AND ${col} < DATEADD(day, 1, CURRENT_DATE)`
+        );
+      case 'this_month':
+        return (
+          `${col} >= DATE_TRUNC('month', CURRENT_DATE)` +
+          ` AND ${col} < DATEADD(month, 1, DATE_TRUNC('month', CURRENT_DATE))`
+        );
+      case 'last_month':
+        return (
+          `${col} >= DATE_TRUNC('month', DATEADD(month, -1, CURRENT_DATE))` +
+          ` AND ${col} < DATE_TRUNC('month', CURRENT_DATE)`
+        );
+      case 'this_year':
+        return (
+          `${col} >= DATE_TRUNC('year', CURRENT_DATE)` +
+          ` AND ${col} < DATEADD(year, 1, DATE_TRUNC('year', CURRENT_DATE))`
+        );
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-query.builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-query.builder.spec.ts
@@ -1,31 +1,68 @@
-import { NotImplementedException } from '@nestjs/common';
 import { SnowflakeQueryBuilder } from './snowflake-query.builder';
+import { SnowflakeClauseRenderer } from './snowflake-clause-renderer';
+import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
 
-describe('SnowflakeQueryBuilder — output controls guard', () => {
-  const builder = new SnowflakeQueryBuilder();
-  const tableDef = { type: 'table', fullyQualifiedName: 'mydb.tbl' } as any;
+const tableDef = {
+  definitionType: 'TABLE',
+  fullyQualifiedName: 'db.sc.events',
+} as unknown as DataMartDefinition;
 
-  it('throws NotImplemented when filters are non-empty', () => {
-    expect(() =>
-      builder.buildQuery(tableDef, {
-        filters: [{ column: 'a', operator: 'eq', value: 1 }],
-      })
-    ).toThrow(NotImplementedException);
+const sqlDef = {
+  definitionType: 'SQL',
+  sqlQuery: 'SELECT id, created_at FROM raw',
+} as unknown as DataMartDefinition;
+
+function build() {
+  return new SnowflakeQueryBuilder(new SnowflakeClauseRenderer());
+}
+
+describe('SnowflakeQueryBuilder', () => {
+  it('builds a plain SELECT with no output controls', () => {
+    const sql = build().buildQuery(tableDef, {});
+    expect(sql).toBe('SELECT * FROM db."sc"."events"');
   });
 
-  it('throws NotImplemented when sort is non-empty', () => {
-    expect(() =>
-      builder.buildQuery(tableDef, {
-        sort: [{ column: 'a', direction: 'asc' }],
-      })
-    ).toThrow(NotImplementedException);
+  it('applies filters, sort and limit via the clause renderer', () => {
+    const sql = build().buildQuery(tableDef, {
+      columns: ['id', 'created_at'],
+      filters: [{ column: 'created_at', operator: 'gte', value: '2024-01-01' }],
+      sort: [{ column: 'id', direction: 'desc' }],
+      limit: 100,
+      columnTypes: new Map([['created_at', 'TIMESTAMP']]),
+    });
+    expect(sql).toContain('SELECT "id", "created_at" FROM db."sc"."events"');
+    expect(sql).toContain(`WHERE "created_at" >= CAST('2024-01-01' AS TIMESTAMP)`);
+    expect(sql).toContain('ORDER BY "id" DESC');
+    expect(sql).toContain('LIMIT 100');
   });
 
-  it('still works without output controls (limit-only legacy path)', () => {
-    expect(builder.buildQuery(tableDef, { limit: 0 })).toBeDefined();
+  it('safely quotes a malicious column name in the SELECT list', () => {
+    const sql = build().buildQuery(tableDef, { columns: ['a.b.c.d OR 1=1 --'] });
+    expect(sql).toBe('SELECT "a"."b"."c"."d OR 1=1 --" FROM db."sc"."events"');
   });
 
-  it('still works without options', () => {
-    expect(builder.buildQuery(tableDef)).toBeDefined();
+  it('uses mainTableReference as the FROM for a SQL-def mart with output controls', () => {
+    const sql = build().buildQuery(sqlDef, {
+      filters: [{ column: 'id', operator: 'gt', value: 0 }],
+      mainTableReference: 'db."sc"."view_x"',
+    });
+    expect(sql).toContain('FROM db."sc"."view_x"');
+    expect(sql).not.toContain('SELECT id, created_at FROM raw');
+    expect(sql).toContain('WHERE "id" > 0');
+  });
+
+  it('wraps the raw SQL when no mainTableReference is supplied', () => {
+    const sql = build().buildQuery(sqlDef, {
+      filters: [{ column: 'id', operator: 'gt', value: 0 }],
+    });
+    expect(sql).toContain('FROM (SELECT id, created_at FROM raw)');
+  });
+
+  it('still throws for table-pattern definitions', () => {
+    const patternDef = {
+      definitionType: 'TABLE_PATTERN',
+      pattern: 'ev_',
+    } as unknown as DataMartDefinition;
+    expect(() => build().buildQuery(patternDef, { limit: 1 })).toThrow();
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-query.builder.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
 import {
   isConnectorDefinition,
@@ -12,55 +12,113 @@ import {
   DataMartQueryBuilder,
   DataMartQueryOptions,
 } from '../../interfaces/data-mart-query-builder.interface';
+import { FilterRule } from '../../../dto/schemas/filter-config.schema';
+import { createIdentifierEscaper } from '../../utils/identifier-escaper.utils';
 import { escapeSnowflakeIdentifier } from '../utils/snowflake-identifier.utils';
+import { SnowflakeClauseRenderer } from './snowflake-clause-renderer';
+
+// User-controlled output-control column names use the robust shared escaper (quotes every
+// dotted part, doubles inner quotes). Table FQNs in FROM keep escapeSnowflakeIdentifier
+// (Snowflake leaves the database part unquoted).
+const escapeColumnIdentifier = createIdentifierEscaper({ quoteChar: '"' });
 
 @Injectable()
 export class SnowflakeQueryBuilder implements DataMartQueryBuilder {
   readonly type = DataStorageType.SNOWFLAKE;
 
+  constructor(private readonly clauseRenderer: SnowflakeClauseRenderer) {}
+
   buildQuery(definition: DataMartDefinition, queryOptions?: DataMartQueryOptions): string {
-    if ((queryOptions?.filters?.length ?? 0) > 0 || (queryOptions?.sort?.length ?? 0) > 0) {
-      throw new NotImplementedException(
-        `Output controls not yet supported for storage type ${this.type}`
+    const hasOutputControls =
+      (queryOptions?.filters?.length ?? 0) > 0 ||
+      (queryOptions?.sort?.length ?? 0) > 0 ||
+      queryOptions?.limit != null;
+
+    const selectList = this.buildSelectList(queryOptions?.columns);
+
+    if (!hasOutputControls) {
+      return this.buildPlainQuery(definition, selectList, queryOptions);
+    }
+
+    const fromClause = this.resolveFromClauseWithOutputControls(definition, queryOptions);
+    const columnTypes = queryOptions?.columnTypes;
+    const resolveColumnType = columnTypes
+      ? (rule: FilterRule) => columnTypes.get(rule.column)
+      : undefined;
+    const where = this.clauseRenderer.renderWhere(
+      queryOptions?.filters ?? [],
+      undefined,
+      'p',
+      resolveColumnType
+    );
+    const orderBy = this.clauseRenderer.renderOrderBy(queryOptions?.sort ?? []);
+    const limit = this.clauseRenderer.renderLimit(queryOptions?.limit ?? null);
+
+    // Snowflake inlines every literal — no path carries bound params. Fail fast if a
+    // fragment ever emitted one (the reader rejects parameterized sqlOverride).
+    const paramCount = where.params.length + orderBy.params.length + limit.params.length;
+    if (paramCount > 0) {
+      throw new Error(
+        `SnowflakeQueryBuilder expected zero bound params (literals are inlined) but got ${paramCount}`
       );
     }
-    const selectList = this.buildSelectList(queryOptions?.columns);
-    let query: string;
 
+    return `SELECT ${selectList} FROM ${fromClause}${where.sql}${orderBy.sql}${limit.sql}`;
+  }
+
+  private buildPlainQuery(
+    definition: DataMartDefinition,
+    selectList: string,
+    queryOptions?: DataMartQueryOptions
+  ): string {
     if (isTableDefinition(definition) || isViewDefinition(definition)) {
-      query = `SELECT ${selectList} FROM ${escapeSnowflakeIdentifier(definition.fullyQualifiedName)}`;
-    } else if (isConnectorDefinition(definition)) {
-      query = `SELECT ${selectList} FROM ${escapeSnowflakeIdentifier(definition.connector.storage.fullyQualifiedName)}`;
-    } else if (isSqlDefinition(definition)) {
+      return `SELECT ${selectList} FROM ${escapeSnowflakeIdentifier(definition.fullyQualifiedName)}`;
+    }
+    if (isConnectorDefinition(definition)) {
+      return `SELECT ${selectList} FROM ${escapeSnowflakeIdentifier(definition.connector.storage.fullyQualifiedName)}`;
+    }
+    if (isSqlDefinition(definition)) {
       if (queryOptions?.columns?.length) {
         const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
-        query = `SELECT ${selectList} FROM (${cleanQuery})`;
-      } else {
-        query = definition.sqlQuery;
+        return `SELECT ${selectList} FROM (${cleanQuery})`;
       }
-    } else if (isTablePatternDefinition(definition)) {
-      // Snowflake doesn't support table patterns like BigQuery
-      // This would need to be implemented differently, possibly using INFORMATION_SCHEMA
+      return definition.sqlQuery;
+    }
+    if (isTablePatternDefinition(definition)) {
       throw new Error('Table pattern definitions are not supported for Snowflake');
-    } else {
-      throw new Error('Invalid data mart definition');
     }
+    throw new Error('Invalid data mart definition');
+  }
 
-    if (queryOptions?.limit !== undefined && queryOptions.limit !== null) {
-      if (!Number.isInteger(queryOptions.limit) || queryOptions.limit < 0) {
-        throw new Error(`Invalid LIMIT value: ${String(queryOptions.limit)}`);
+  private resolveFromClauseWithOutputControls(
+    definition: DataMartDefinition,
+    options?: DataMartQueryOptions
+  ): string {
+    if (isTableDefinition(definition) || isViewDefinition(definition)) {
+      return escapeSnowflakeIdentifier(definition.fullyQualifiedName);
+    }
+    if (isConnectorDefinition(definition)) {
+      return escapeSnowflakeIdentifier(definition.connector.storage.fullyQualifiedName);
+    }
+    if (isSqlDefinition(definition)) {
+      // Prefer the pre-materialized view the composer resolves (mirrors Redshift); fall
+      // back to wrapping the raw SQL when no reference was supplied.
+      if (options?.mainTableReference) {
+        return options.mainTableReference;
       }
-      const cleanQuery = query.trim().endsWith(';') ? query.trim().slice(0, -1) : query.trim();
-      query = `SELECT * FROM (${cleanQuery}) LIMIT ${queryOptions.limit}`;
+      const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
+      return `(${cleanQuery})`;
     }
-
-    return query;
+    if (isTablePatternDefinition(definition)) {
+      throw new Error('Table pattern definitions are not supported for Snowflake');
+    }
+    throw new Error('Invalid data mart definition');
   }
 
   private buildSelectList(columns?: string[]): string {
     if (!columns || columns.length === 0) {
       return '*';
     }
-    return columns.map(col => escapeSnowflakeIdentifier(col)).join(', ');
+    return columns.map(col => escapeColumnIdentifier(col)).join(', ');
   }
 }

--- a/apps/backend/src/data-marts/services/output-controls-capability.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-capability.service.spec.ts
@@ -10,8 +10,8 @@ describe('OutputControlsCapabilityService', () => {
   it('supports AWS_ATHENA', () => {
     expect(svc.isSupported(DataStorageType.AWS_ATHENA)).toBe(true);
   });
-  it('returns false for Snowflake', () => {
-    expect(svc.isSupported(DataStorageType.SNOWFLAKE)).toBe(false);
+  it('supports Snowflake', () => {
+    expect(svc.isSupported(DataStorageType.SNOWFLAKE)).toBe(true);
   });
   it('supports AWS_REDSHIFT', () => {
     expect(svc.isSupported(DataStorageType.AWS_REDSHIFT)).toBe(true);

--- a/apps/backend/src/data-marts/services/output-controls-capability.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-capability.service.ts
@@ -10,6 +10,7 @@ export class OutputControlsCapabilityService {
     DataStorageType.AWS_ATHENA,
     DataStorageType.AWS_REDSHIFT,
     DataStorageType.DATABRICKS,
+    DataStorageType.SNOWFLAKE,
   ]);
 
   isSupported(type: DataStorageType): boolean {

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -144,8 +144,8 @@ export class ReportSqlComposerService {
       case DataStorageType.LEGACY_GOOGLE_BIGQUERY:
         return { sql: inlineBigQueryNamedParams(composed.sql, composed.params) };
       default:
-        // Redshift inlines all literals and produces no params (early-returned above).
-        // Athena (positional ?) and BigQuery (named @p) are the only current param
+        // Redshift and Snowflake inline all literals and produce no params (early-returned
+        // above). Athena (positional ?) and BigQuery (named @p) are the only current param
         // producers. This guard catches a future dialect added with output controls
         // before its inliner is wired, rather than emit SQL with unbound parameters.
         throw new BusinessViolationException(

--- a/apps/backend/test/integration/http-data-real.integration.ts
+++ b/apps/backend/test/integration/http-data-real.integration.ts
@@ -19,6 +19,8 @@ import { DatabricksApiAdapter } from 'src/data-marts/data-storage-types/databric
 import { DatabricksCredentials } from 'src/data-marts/data-storage-types/databricks/schemas/databricks-credentials.schema';
 import { DatabricksConfig } from 'src/data-marts/data-storage-types/databricks/schemas/databricks-config.schema';
 import { DatabricksAuthMethod } from 'src/data-marts/data-storage-types/databricks/enums/databricks-auth-method.enum';
+import { SnowflakeApiAdapter } from 'src/data-marts/data-storage-types/snowflake/adapters/snowflake-api.adapter';
+import { SnowflakeAuthMethod } from 'src/data-marts/data-storage-types/snowflake/enums/snowflake-auth-method.enum';
 import { STREAM_BATCH_SIZE } from 'src/data-marts/services/http-data/http-data.constants';
 
 /**
@@ -137,6 +139,39 @@ if (!DB_CREDENTIALS_AVAILABLE) {
 }
 
 const describeIfDbCredentials = DB_CREDENTIALS_AVAILABLE ? describe : describe.skip;
+// ---------------------------------------------------------------------------
+// Snowflake env vars / credential gate
+// ---------------------------------------------------------------------------
+const SNOWFLAKE_ACCOUNT = process.env.SNOWFLAKE_ACCOUNT;
+const SNOWFLAKE_WAREHOUSE = process.env.SNOWFLAKE_WAREHOUSE;
+const SNOWFLAKE_USERNAME = process.env.SNOWFLAKE_USERNAME;
+const SNOWFLAKE_PASSWORD = process.env.SNOWFLAKE_PASSWORD;
+const SNOWFLAKE_DATABASE = process.env.SNOWFLAKE_DATABASE;
+const SNOWFLAKE_SCHEMA = process.env.SNOWFLAKE_SCHEMA;
+
+const SNOWFLAKE_CREDENTIALS_AVAILABLE = !!(
+  SNOWFLAKE_ACCOUNT &&
+  SNOWFLAKE_WAREHOUSE &&
+  SNOWFLAKE_USERNAME &&
+  SNOWFLAKE_PASSWORD &&
+  SNOWFLAKE_DATABASE &&
+  SNOWFLAKE_SCHEMA
+);
+
+if (!SNOWFLAKE_CREDENTIALS_AVAILABLE) {
+  const sfMissing: string[] = [];
+  if (!SNOWFLAKE_ACCOUNT) sfMissing.push('SNOWFLAKE_ACCOUNT');
+  if (!SNOWFLAKE_WAREHOUSE) sfMissing.push('SNOWFLAKE_WAREHOUSE');
+  if (!SNOWFLAKE_USERNAME) sfMissing.push('SNOWFLAKE_USERNAME');
+  if (!SNOWFLAKE_PASSWORD) sfMissing.push('SNOWFLAKE_PASSWORD');
+  if (!SNOWFLAKE_DATABASE) sfMissing.push('SNOWFLAKE_DATABASE');
+  if (!SNOWFLAKE_SCHEMA) sfMissing.push('SNOWFLAKE_SCHEMA');
+  console.log(
+    `Skipping HTTP Data real Snowflake integration tests: missing env vars: ${sfMissing.join(', ')}`
+  );
+}
+
+const describeIfSnowflakeCredentials = SNOWFLAKE_CREDENTIALS_AVAILABLE ? describe : describe.skip;
 
 // ---------------------------------------------------------------------------
 // Shared NestJS app — ONE instance for the entire file.
@@ -152,7 +187,8 @@ const NEED_APP =
   ATHENA_CREDENTIALS_AVAILABLE ||
   BQ_CREDENTIALS_AVAILABLE ||
   RS_CREDENTIALS_AVAILABLE ||
-  DB_CREDENTIALS_AVAILABLE;
+  DB_CREDENTIALS_AVAILABLE ||
+  SNOWFLAKE_CREDENTIALS_AVAILABLE;
 
 if (NEED_APP) {
   beforeAll(async () => {
@@ -971,6 +1007,211 @@ describeIfDbCredentials('HTTP Data API real-data (live Databricks)', () => {
       `column=id&column=name` +
         `&filter=${dbB64([{ column: 'id', operator: 'between', value: { from: 2, to: 3 } }])}` +
         `&sort=${dbB64([{ column: 'id', direction: 'asc' }])}`
+    );
+    expect(rows.map(r => Number(r.id))).toEqual([2, 3]);
+  }, 120000);
+});
+
+describeIfSnowflakeCredentials('HTTP Data API real-data (live Snowflake)', () => {
+  let sfDataMartId: string;
+
+  let sfAdapter: SnowflakeApiAdapter;
+  let sfFullyQualifiedName: string;
+
+  const SF_TEST_TABLE_SUFFIX = `http_data_real_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+  // -------------------------------------------------------------------------
+  // beforeAll: seed real Snowflake table + build credentialed storage + mart
+  // via HTTP API (uses sharedAgent — no second createTestApp() call)
+  // -------------------------------------------------------------------------
+  beforeAll(async () => {
+    sfAdapter = new SnowflakeApiAdapter(
+      {
+        authMethod: SnowflakeAuthMethod.PASSWORD,
+        username: SNOWFLAKE_USERNAME!,
+        password: SNOWFLAKE_PASSWORD!,
+      },
+      {
+        account: SNOWFLAKE_ACCOUNT!,
+        warehouse: SNOWFLAKE_WAREHOUSE!,
+      }
+    );
+
+    // FQN uses QUOTED lowercase table suffix so "id"/"name" etc. match.
+    sfFullyQualifiedName = `${SNOWFLAKE_DATABASE}.${SNOWFLAKE_SCHEMA}."${SF_TEST_TABLE_SUFFIX}"`;
+
+    // Establish the connection BEFORE the pre-cleanup try/catch (Snowflake SDK
+    // transitions to StateDisconnected on any connect failure, which cannot be
+    // retried — failing here loudly is correct).
+    await sfAdapter.checkAccess();
+
+    // --- Step 1: Pre-cleanup in case a previous run crashed ---
+    try {
+      await sfAdapter.executeQuery(`DROP TABLE IF EXISTS ${sfFullyQualifiedName}`);
+    } catch {
+      // ignore — table may not exist on first run
+    }
+
+    // --- Step 2: Seed a real (permanent) Snowflake table ---
+    // QUOTED lowercase column names: Snowflake folds unquoted identifiers to UPPERCASE;
+    // the clause renderer emits `"id"` (lowercase), so column names must be lowercase-quoted.
+    await sfAdapter.executeQuery(
+      `CREATE TABLE ${sfFullyQualifiedName} ` +
+        `("id" INTEGER, "name" VARCHAR(100), "active" BOOLEAN, "created_at" TIMESTAMP_NTZ)`
+    );
+    await sfAdapter.executeQuery(
+      `INSERT INTO ${sfFullyQualifiedName} ("id", "name", "active", "created_at") VALUES ` +
+        `(1, 'alpha',    TRUE,  TIMESTAMP_NTZ '2024-01-01 00:00:00'), ` +
+        `(2, 'beta',     FALSE, TIMESTAMP_NTZ '2024-02-01 00:00:00'), ` +
+        `(3, 'gamma',    TRUE,  TIMESTAMP_NTZ '2024-03-01 00:00:00'), ` +
+        `(4, 'alphabet', TRUE,  TIMESTAMP_NTZ '2024-04-01 00:00:00')`
+    );
+
+    // --- Step 3: Create credentialed Snowflake storage via HTTP API ---
+    const storageCreateRes = await sharedAgent
+      .post('/api/data-storages')
+      .set(AUTH_HEADER)
+      .send({ type: 'SNOWFLAKE' });
+    if (storageCreateRes.status !== 201) {
+      console.error('SF storage create failed:', JSON.stringify(storageCreateRes.body, null, 2));
+    }
+    expect(storageCreateRes.status).toBe(201);
+    const sfStorageId: string = storageCreateRes.body.id;
+
+    const storageUpdateRes = await sharedAgent
+      .put(`/api/data-storages/${sfStorageId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'sf-real',
+        config: {
+          account: SNOWFLAKE_ACCOUNT!,
+          warehouse: SNOWFLAKE_WAREHOUSE!,
+        },
+        credentials: {
+          authMethod: SnowflakeAuthMethod.PASSWORD,
+          username: SNOWFLAKE_USERNAME!,
+          password: SNOWFLAKE_PASSWORD!,
+        },
+      });
+    if (storageUpdateRes.status !== 200) {
+      console.error('SF storage update failed:', JSON.stringify(storageUpdateRes.body, null, 2));
+    }
+    expect(storageUpdateRes.status).toBe(200);
+
+    // --- Step 4: Create data mart ---
+    const dataMartCreateRes = await sharedAgent
+      .post('/api/data-marts')
+      .set(AUTH_HEADER)
+      .send({ title: 'real-sf-test-mart', storageId: sfStorageId });
+    if (dataMartCreateRes.status !== 201) {
+      console.error('SF data mart create failed:', JSON.stringify(dataMartCreateRes.body, null, 2));
+    }
+    expect(dataMartCreateRes.status).toBe(201);
+    sfDataMartId = dataMartCreateRes.body.id;
+
+    // --- Step 5: Set TABLE definition (pointing at the real seeded table) ---
+    const defRes = await sharedAgent
+      .put(`/api/data-marts/${sfDataMartId}/definition`)
+      .set(AUTH_HEADER)
+      .send({
+        definitionType: 'TABLE',
+        definition: { fullyQualifiedName: sfFullyQualifiedName },
+      });
+    if (defRes.status !== 200) {
+      console.error('SF definition set failed:', JSON.stringify(defRes.body, null, 2));
+    }
+    expect(defRes.status).toBe(200);
+
+    // --- Step 6: Publish (reads real schema from Snowflake) ---
+    const publishRes = await sharedAgent
+      .put(`/api/data-marts/${sfDataMartId}/publish`)
+      .set(AUTH_HEADER);
+    if (publishRes.status !== 200) {
+      console.error('SF publish failed:', JSON.stringify(publishRes.body, null, 2));
+    }
+    expect(publishRes.status).toBe(200);
+  }, 180000);
+
+  // -------------------------------------------------------------------------
+  // afterAll: drop Snowflake table + destroy adapter
+  // -------------------------------------------------------------------------
+  afterAll(async () => {
+    try {
+      await sfAdapter.executeQuery(`DROP TABLE IF EXISTS ${sfFullyQualifiedName}`);
+    } catch (error) {
+      console.warn('Failed to drop Snowflake test table during teardown:', error);
+    }
+    try {
+      await sfAdapter.destroy();
+    } catch (error) {
+      console.warn('Failed to destroy Snowflake adapter during teardown:', error);
+    }
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // Helpers scoped to Snowflake block
+  // -------------------------------------------------------------------------
+  async function fetchSfNdjson(qs: string): Promise<Record<string, unknown>[]> {
+    const res = await sharedAgent
+      .get(`/api/external/http-data/data-marts/${sfDataMartId}.ndjson${qs ? '?' + qs : ''}`)
+      .set(AUTH_HEADER);
+    if (res.status !== 200) {
+      console.error('fetchSfNdjson failed:', res.status, JSON.stringify(res.body, null, 2));
+      console.error('Response text:', res.text?.slice(0, 500));
+    }
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('application/x-ndjson');
+    return res.text
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l));
+  }
+
+  const sfB64 = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url');
+
+  // -------------------------------------------------------------------------
+  // Test A — WITHOUT output controls (streams all real rows)
+  // -------------------------------------------------------------------------
+  it('streams all real rows from Snowflake without output controls', async () => {
+    const rows = await fetchSfNdjson('column=id&column=name&column=active');
+    expect(rows).toHaveLength(4);
+
+    // Coerce id to string for safe lookup (Snowflake may return numbers).
+    const byId = Object.fromEntries(rows.map(r => [String(r.id), r]));
+    expect(byId['1'].name).toBe('alpha');
+    expect(byId['2'].name).toBe('beta');
+    expect(byId['4'].name).toBe('alphabet');
+  }, 120000);
+
+  // -------------------------------------------------------------------------
+  // Test B — WITH output controls (filter/sort/limit on real Snowflake data)
+  // -------------------------------------------------------------------------
+  it('applies eq filter on real Snowflake data', async () => {
+    const rows = await fetchSfNdjson(
+      `column=id&column=name&filter=${sfB64([{ column: 'name', operator: 'eq', value: 'alpha' }])}`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('alpha');
+  }, 120000);
+
+  it('applies contains + sort desc + limit on real Snowflake data', async () => {
+    // Both 'alpha' (id=1) and 'alphabet' (id=4) contain 'alpha'.
+    // sort desc by id + limit 1 → id=4 ('alphabet').
+    const rows = await fetchSfNdjson(
+      `column=id&column=name` +
+        `&filter=${sfB64([{ column: 'name', operator: 'contains', value: 'alpha' }])}` +
+        `&sort=${sfB64([{ column: 'id', direction: 'desc' }])}` +
+        `&limit=1`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('alphabet');
+  }, 120000);
+
+  it('applies a numeric between filter on real Snowflake data', async () => {
+    const rows = await fetchSfNdjson(
+      `column=id&column=name` +
+        `&filter=${sfB64([{ column: 'id', operator: 'between', value: { from: 2, to: 3 } }])}` +
+        `&sort=${sfB64([{ column: 'id', direction: 'asc' }])}`
     );
     expect(rows.map(r => Number(r.id))).toEqual([2, 3]);
   }, 120000);

--- a/apps/backend/test/integration/snowflake.integration.ts
+++ b/apps/backend/test/integration/snowflake.integration.ts
@@ -1,0 +1,484 @@
+import { SnowflakeApiAdapter } from 'src/data-marts/data-storage-types/snowflake/adapters/snowflake-api.adapter';
+import { SnowflakeCredentials } from 'src/data-marts/data-storage-types/snowflake/schemas/snowflake-credentials.schema';
+import { SnowflakeConfig } from 'src/data-marts/data-storage-types/snowflake/schemas/snowflake-config.schema';
+import { SnowflakeAuthMethod } from 'src/data-marts/data-storage-types/snowflake/enums/snowflake-auth-method.enum';
+import { SnowflakeClauseRenderer } from 'src/data-marts/data-storage-types/snowflake/services/snowflake-clause-renderer';
+import { SnowflakeQueryBuilder } from 'src/data-marts/data-storage-types/snowflake/services/snowflake-query.builder';
+import { TableDefinition } from 'src/data-marts/dto/schemas/data-mart-table-definitions/table-definition.schema';
+import { DataMartQueryOptions } from 'src/data-marts/data-storage-types/interfaces/data-mart-query-builder.interface';
+
+/**
+ * Snowflake Integration Tests
+ *
+ * Live integration suite that runs against a REAL Snowflake account.
+ * Every test in this file sends SQL to the actual cluster — nothing here
+ * is mocked. The suite finalises two open design decisions:
+ *
+ *   §0 PROBE 1 — Backslash round-trip: does the renderer's `\`→`\\` doubling
+ *      produce a correct match for the stored literal `a\b`?
+ *
+ *   §0 PROBE 2 — CAST necessity: does Snowflake accept a bare quoted string
+ *      literal in comparisons against TIMESTAMP_NTZ columns WITHOUT a CAST?
+ *
+ * Required environment variables (loaded from .env.tests):
+ *   SNOWFLAKE_ACCOUNT    — Snowflake account identifier
+ *   SNOWFLAKE_WAREHOUSE  — Warehouse to use
+ *   SNOWFLAKE_USERNAME   — Login username
+ *   SNOWFLAKE_PASSWORD   — Login password
+ *   SNOWFLAKE_DATABASE   — Database containing the test schema
+ *   SNOWFLAKE_SCHEMA     — Schema in which the test table is created
+ */
+
+const SNOWFLAKE_ACCOUNT = process.env.SNOWFLAKE_ACCOUNT;
+const SNOWFLAKE_WAREHOUSE = process.env.SNOWFLAKE_WAREHOUSE;
+const SNOWFLAKE_USERNAME = process.env.SNOWFLAKE_USERNAME;
+const SNOWFLAKE_PASSWORD = process.env.SNOWFLAKE_PASSWORD;
+const SNOWFLAKE_DATABASE = process.env.SNOWFLAKE_DATABASE;
+const SNOWFLAKE_SCHEMA = process.env.SNOWFLAKE_SCHEMA;
+
+const SNOWFLAKE_CREDENTIALS_AVAILABLE = !!(
+  SNOWFLAKE_ACCOUNT &&
+  SNOWFLAKE_WAREHOUSE &&
+  SNOWFLAKE_USERNAME &&
+  SNOWFLAKE_PASSWORD &&
+  SNOWFLAKE_DATABASE &&
+  SNOWFLAKE_SCHEMA
+);
+
+if (!SNOWFLAKE_CREDENTIALS_AVAILABLE) {
+  const missing: string[] = [];
+  if (!SNOWFLAKE_ACCOUNT) missing.push('SNOWFLAKE_ACCOUNT');
+  if (!SNOWFLAKE_WAREHOUSE) missing.push('SNOWFLAKE_WAREHOUSE');
+  if (!SNOWFLAKE_USERNAME) missing.push('SNOWFLAKE_USERNAME');
+  if (!SNOWFLAKE_PASSWORD) missing.push('SNOWFLAKE_PASSWORD');
+  if (!SNOWFLAKE_DATABASE) missing.push('SNOWFLAKE_DATABASE');
+  if (!SNOWFLAKE_SCHEMA) missing.push('SNOWFLAKE_SCHEMA');
+  console.log(`Skipping Snowflake integration tests: missing env vars: ${missing.join(', ')}`);
+}
+
+const describeIfSnowflakeCredentials = SNOWFLAKE_CREDENTIALS_AVAILABLE ? describe : describe.skip;
+
+// ---------------------------------------------------------------------------
+// Operator matrix + design-decision probes
+// ---------------------------------------------------------------------------
+// Seed rows:
+//   id  name        amount   status    date_col             ts_col (non-midnight for rows 1,6)
+//    1  alpha         10.0   active    today                today@13:45
+//    2  beta          20.0   inactive  yesterday            yesterday@00:00
+//    3  O'Brien       30.0   active    -40 days             -40d@00:00
+//    4  100%          40.0   inactive  -400 days (last yr)  -400d@00:00
+//    5  a\b           50.0   active    +13 months (next yr) next_year@00:00
+//    6  gamma          0.0   active    today                today@13:45
+//
+// Row 5: future-dated for this_year / this_month upper-bound exclusion.
+// Rows 1,6: today at 13:45 for relative_date non-midnight timestamp check.
+// Row 3: O'Brien for single-quote round-trip safety.
+// Row 4: 100% for wildcard-literal (CONTAINS, not LIKE) safety.
+// Row 5: a\b for backslash escape probe (§0 PROBE 1).
+
+// Date.now() + Math.random() are allowed in integration test files (not workflow scripts).
+const MATRIX_TABLE_SUFFIX = `sf_matrix_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const MATRIX_FQN = `${SNOWFLAKE_DATABASE}.${SNOWFLAKE_SCHEMA}."${MATRIX_TABLE_SUFFIX}"`;
+
+describeIfSnowflakeCredentials(
+  'Snowflake — backslash probe, CAST-necessity probe, operator matrix',
+  () => {
+    let adapter: SnowflakeApiAdapter;
+
+    const builder = new SnowflakeQueryBuilder(new SnowflakeClauseRenderer());
+    const definition: TableDefinition = {
+      get fullyQualifiedName() {
+        return MATRIX_FQN;
+      },
+    };
+
+    async function runFilter(
+      queryOptions: DataMartQueryOptions
+    ): Promise<Array<Record<string, unknown>>> {
+      const sql = builder.buildQuery(definition, queryOptions) as string;
+      return adapter.executeQueryAndFetchAll(sql);
+    }
+
+    function ids(rows: Array<Record<string, unknown>>): string[] {
+      return rows.map(r => String(r.id ?? r.ID ?? '')).sort((a, b) => Number(a) - Number(b));
+    }
+
+    beforeAll(async () => {
+      const credentials: SnowflakeCredentials = {
+        authMethod: SnowflakeAuthMethod.PASSWORD,
+        username: SNOWFLAKE_USERNAME!,
+        password: SNOWFLAKE_PASSWORD!,
+      };
+      const config: SnowflakeConfig = {
+        account: SNOWFLAKE_ACCOUNT!,
+        warehouse: SNOWFLAKE_WAREHOUSE!,
+      };
+      adapter = new SnowflakeApiAdapter(credentials, config);
+
+      // Establish the connection BEFORE the pre-cleanup try/catch. The Snowflake SDK
+      // transitions a connection to the fatal StateDisconnected if connect() fails,
+      // and a subsequent try/catch around executeQuery would silently swallow that
+      // connection error, leaving the adapter permanently unusable.
+      await adapter.checkAccess();
+
+      // Pre-cleanup in case of a previous crash
+      try {
+        await adapter.executeQuery(`DROP TABLE IF EXISTS ${MATRIX_FQN}`);
+      } catch {
+        // ignore — table may not exist on first run
+      }
+
+      // QUOTED lowercase column names: Snowflake folds unquoted identifiers to
+      // UPPERCASE. The clause renderer emits `"id"` (lowercase), so the CREATE
+      // must also use quoted lowercase column names to prevent a casing mismatch.
+      await adapter.executeQuery(`
+        CREATE TABLE ${MATRIX_FQN} (
+          "id"       INTEGER,
+          "name"     VARCHAR(100),
+          "amount"   NUMBER(10,2),
+          "status"   VARCHAR(20),
+          "date_col" DATE,
+          "ts_col"   TIMESTAMP_NTZ,
+          "time_col" TIME
+        )
+      `);
+
+      // Insert seed rows.
+      // Row 5 stores name = a\b (one literal backslash). The renderer emits `'a\\b'` in
+      // SQL (doubled backslash); the seed must emit the SAME `'a\\b'` so the round-trip
+      // matches — hence 'a\\\\b' here (a JS template literal collapses \\\\ → \\).
+      await adapter.executeQuery(`
+        INSERT INTO ${MATRIX_FQN}
+          ("id", "name", "amount", "status", "date_col", "ts_col", "time_col")
+        VALUES
+          (1, 'alpha',    10.00, 'active',
+            CURRENT_DATE,
+            DATEADD(minute, 825, CAST(CURRENT_DATE AS TIMESTAMP_NTZ)),
+            '13:45:00'),
+          (2, 'beta',     20.00, 'inactive',
+            DATEADD(day, -1, CURRENT_DATE),
+            CAST(DATEADD(day, -1, CURRENT_DATE) AS TIMESTAMP_NTZ),
+            '09:00:00'),
+          (3, 'O''Brien', 30.00, 'active',
+            DATEADD(day, -40, CURRENT_DATE),
+            CAST(DATEADD(day, -40, CURRENT_DATE) AS TIMESTAMP_NTZ),
+            '00:00:00'),
+          (4, '100%',     40.00, 'inactive',
+            DATEADD(day, -400, CURRENT_DATE),
+            CAST(DATEADD(day, -400, CURRENT_DATE) AS TIMESTAMP_NTZ),
+            '23:59:00'),
+          (5, 'a\\\\b',    50.00, 'active',
+            DATEADD(month, 13, CURRENT_DATE),
+            CAST(DATEADD(month, 13, CURRENT_DATE) AS TIMESTAMP_NTZ),
+            '12:00:00'),
+          (6, 'gamma',     0.00, 'active',
+            CURRENT_DATE,
+            DATEADD(minute, 825, CAST(CURRENT_DATE AS TIMESTAMP_NTZ)),
+            '13:45:00')
+      `);
+    }, 120000);
+
+    afterAll(async () => {
+      try {
+        await adapter.executeQuery(`DROP TABLE IF EXISTS ${MATRIX_FQN}`);
+      } catch (error) {
+        console.warn('Failed to drop Snowflake matrix test table:', error);
+      }
+      try {
+        await adapter.destroy();
+      } catch (error) {
+        console.warn('Failed to destroy Snowflake adapter:', error);
+      }
+    }, 60000);
+
+    // -------------------------------------------------------------------------
+    // §0 PROBE 1 — Backslash round-trip
+    // -------------------------------------------------------------------------
+    // Row 5 stores name = 'a\b' (one literal backslash).
+    // The renderer doubles backslashes → emits `'a\\b'` in SQL.
+    // Snowflake interprets `\\` as a single `\`, so the WHERE matches row 5.
+    // If escaping is wrong the result count is 0 and we fail loudly.
+
+    it('§0 PROBE 1 — backslash round-trip: eq "a\\b" → row 5 (count must be 1)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'eq', value: 'a\\b' }],
+      });
+      console.log(
+        `[§0 PROBE 1] backslash eq match count: ${rows.length} ` +
+          `(expected 1 — renderer's \\\\ doubling must match the stored literal a\\b)`
+      );
+      if (rows.length !== 1) {
+        throw new Error(
+          `§0 PROBE 1 FAILED: expected 1 row for eq "a\\b" but got ${rows.length}. ` +
+            `This means backslash escaping is wrong in the SnowflakeClauseRenderer.`
+        );
+      }
+      expect(rows.length).toBe(1);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // §0 PROBE 2 — CAST necessity (DECISION: keep the CAST, it is defensive-only)
+    // -------------------------------------------------------------------------
+    // Snowflake accepts BOTH the renderer's CAST(...) form AND a bare string literal in a
+    // TIMESTAMP_NTZ comparison (it coerces). The defensive CAST is therefore kept for
+    // explicitness, not necessity. This is now asserted, not just logged.
+
+    it('§0 PROBE 2 — CAST is defensive-only: both CAST and bare-literal date comparisons work', async () => {
+      // First — run what the renderer already emits (with CAST). This must work.
+      const withCastRows = await runFilter({
+        filters: [{ column: 'ts_col', operator: 'gte', value: '2020-01-01' }],
+        columnTypes: new Map([['ts_col', 'TIMESTAMP']]),
+      });
+      console.log(
+        `[§0 PROBE 2] renderer's CAST form: ${withCastRows.length} rows returned, no error`
+      );
+
+      // Second — probe the bare-literal form directly (no CAST), to determine
+      // whether the defensive CAST is strictly required or just defensive.
+      let bareResult: 'works' | 'errors' = 'works';
+      let bareCount = 0;
+      try {
+        const bareRows = await adapter.executeQueryAndFetchAll(
+          `SELECT * FROM ${MATRIX_FQN} WHERE "ts_col" >= '2020-01-01'`
+        );
+        bareCount = bareRows.length;
+        bareResult = 'works';
+      } catch {
+        bareResult = 'errors';
+      }
+      console.log(
+        `[§0 PROBE 2] bare-literal date comparison on TIMESTAMP_NTZ: ${bareResult}` +
+          (bareResult === 'works' ? ` (${bareCount} rows)` : '')
+      );
+      console.log(`[CAST NECESSITY] bare-literal date comparison: ${bareResult}`);
+      // The renderer's CAST form must return rows...
+      expect(withCastRows.length).toBeGreaterThan(0);
+      // ...and the bare-literal form must ALSO work, proving Snowflake coerces and the
+      // defensive CAST is explicit-not-required (the finalized §0 decision).
+      expect(bareResult).toBe('works');
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // Operator matrix
+    // -------------------------------------------------------------------------
+
+    it('eq on name → row 1 (alpha)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'eq', value: 'alpha' }],
+      });
+      expect(ids(rows)).toEqual(['1']);
+    }, 30000);
+
+    it('neq on status: not "active" → rows 2,4 (inactive)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'status', operator: 'neq', value: 'active' }],
+      });
+      expect(ids(rows)).toEqual(['2', '4']);
+    }, 30000);
+
+    it('gt: amount > 20 → rows 3,4,5 (30,40,50)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'amount', operator: 'gt', value: 20 }],
+      });
+      expect(ids(rows)).toEqual(['3', '4', '5']);
+    }, 30000);
+
+    it('lt: amount < 20 → rows 1,6 (10,0)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'amount', operator: 'lt', value: 20 }],
+      });
+      expect(ids(rows)).toEqual(['1', '6']);
+    }, 30000);
+
+    it('gte: amount >= 20 → rows 2,3,4,5 (20,30,40,50)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'amount', operator: 'gte', value: 20 }],
+      });
+      expect(ids(rows)).toEqual(['2', '3', '4', '5']);
+    }, 30000);
+
+    it('lte: amount <= 20 → rows 1,2,6 (10,20,0)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'amount', operator: 'lte', value: 20 }],
+      });
+      expect(ids(rows)).toEqual(['1', '2', '6']);
+    }, 30000);
+
+    it('contains "alph" on name → row 1 (alpha)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'contains', value: 'alph' }],
+      });
+      expect(ids(rows)).toEqual(['1']);
+    }, 30000);
+
+    it('not_contains "eta" on name → rows 1,3,4,5,6 (all except beta)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'not_contains', value: 'eta' }],
+      });
+      expect(ids(rows)).toEqual(['1', '3', '4', '5', '6']);
+    }, 30000);
+
+    it('starts_with "al" on name → row 1 (alpha)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'starts_with', value: 'al' }],
+      });
+      expect(ids(rows)).toEqual(['1']);
+    }, 30000);
+
+    it('ends_with "a" on name → rows 1,2,6 (alpha,beta,gamma all end in "a")', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'ends_with', value: 'a' }],
+      });
+      expect(ids(rows)).toEqual(['1', '2', '6']);
+    }, 30000);
+
+    it('regex: name REGEXP_INSTR "^alp" → row 1 (partial match)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'regex', value: '^alp' }],
+      });
+      expect(ids(rows)).toEqual(['1']);
+    }, 30000);
+
+    it('not_regex: name NOT REGEXP_INSTR "^alp" → rows 2,3,4,5,6', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'not_regex', value: '^alp' }],
+      });
+      expect(ids(rows)).toEqual(['2', '3', '4', '5', '6']);
+    }, 30000);
+
+    it('is_empty: no empty-name rows → 0 rows', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'is_empty' }],
+      });
+      expect(rows).toHaveLength(0);
+    }, 30000);
+
+    it('is_not_empty: all 6 rows have non-empty names', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'is_not_empty' }],
+      });
+      expect(rows).toHaveLength(6);
+    }, 30000);
+
+    it('is_null: no NULLs in seed → 0 rows', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'is_null' }],
+      });
+      expect(rows).toHaveLength(0);
+    }, 30000);
+
+    it('is_not_null: all 6 rows', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'is_not_null' }],
+      });
+      expect(rows).toHaveLength(6);
+    }, 30000);
+
+    it('between: amount BETWEEN 20 AND 30 → rows 2,3', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'amount', operator: 'between', value: { from: 20, to: 30 } }],
+      });
+      expect(ids(rows)).toEqual(['2', '3']);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // relative_date today on non-midnight TIMESTAMP_NTZ column
+    // -------------------------------------------------------------------------
+    // Rows 1 and 6 have ts_col = today at 13:45. The half-open range
+    // `>= CURRENT_DATE AND < DATEADD(day,1,CURRENT_DATE)` covers the full day.
+
+    it('relative_date today on ts_col (13:45, non-midnight) → rows 1,6', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'ts_col', operator: 'relative_date', value: { kind: 'today' } }],
+      });
+      expect(ids(rows)).toEqual(['1', '6']);
+    }, 30000);
+
+    it('relative_date today on date_col → rows 1,6', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'date_col', operator: 'relative_date', value: { kind: 'today' } }],
+      });
+      expect(ids(rows)).toEqual(['1', '6']);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // this_year / this_month upper-bound exclusion
+    // -------------------------------------------------------------------------
+    // Row 5 (date_col = DATEADD(month,13,CURRENT_DATE)) is always next year.
+    // this_year upper bound = DATEADD(year,1,DATE_TRUNC('year',CURRENT_DATE)) — excludes row 5.
+    // Row 4 (-400 days) is always last year — also excluded.
+
+    it('relative_date this_year excludes future-dated row 5 and last-year row 4', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'date_col', operator: 'relative_date', value: { kind: 'this_year' } }],
+      });
+      const resultIds = ids(rows);
+      expect(resultIds).not.toContain('5');
+      expect(resultIds).not.toContain('4');
+      expect(resultIds).toContain('1');
+      expect(resultIds).toContain('6');
+      console.log(`[this_year] rows returned: [${resultIds.join(',')}]`);
+    }, 30000);
+
+    it('relative_date this_month excludes future-dated row 5', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'date_col', operator: 'relative_date', value: { kind: 'this_month' } }],
+      });
+      const resultIds = ids(rows);
+      expect(resultIds).not.toContain('5');
+      console.log(`[this_month] rows returned: [${resultIds.join(',')}]`);
+    }, 30000);
+
+    it('relative_date last_n_days(7): rows 1,2,6 (future row 5 excluded)', async () => {
+      const rows = await runFilter({
+        filters: [
+          { column: 'date_col', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
+        ],
+      });
+      expect(ids(rows)).toEqual(['1', '2', '6']);
+    }, 30000);
+
+    it('relative_date last_n_months(3): rows 1,2,3,6 (future row 5 excluded)', async () => {
+      const rows = await runFilter({
+        filters: [
+          {
+            column: 'date_col',
+            operator: 'relative_date',
+            value: { kind: 'last_n_months', n: 3 },
+          },
+        ],
+      });
+      expect(ids(rows)).toEqual(['1', '2', '3', '6']);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // Wildcard-literal safety
+    // -------------------------------------------------------------------------
+
+    it('SAFETY contains "100%" on name → only row 4 (% is not a wildcard in CONTAINS)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'contains', value: '100%' }],
+      });
+      expect(ids(rows)).toEqual(['4']);
+    }, 30000);
+
+    it('SAFETY eq "O\'Brien" → row 3 (single-quote doubling round-trip)', async () => {
+      const rows = await runFilter({
+        filters: [{ column: 'name', operator: 'eq', value: "O'Brien" }],
+      });
+      expect(ids(rows)).toEqual(['3']);
+    }, 30000);
+
+    // -------------------------------------------------------------------------
+    // Sort + limit
+    // -------------------------------------------------------------------------
+
+    it('sort by amount DESC + limit 2 → rows 5,4 (amounts 50,40)', async () => {
+      const rows = await runFilter({
+        sort: [{ column: 'amount', direction: 'desc' }],
+        limit: 2,
+      });
+      expect(rows.map(r => String(r.id ?? r.ID ?? ''))).toEqual(['5', '4']);
+    }, 30000);
+  }
+);

--- a/apps/backend/test/output-controls-snowflake-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-snowflake-emission.e2e-spec.ts
@@ -1,0 +1,235 @@
+import { INestApplication } from '@nestjs/common';
+import * as crypto from 'crypto';
+import * as supertest from 'supertest';
+import {
+  createTestApp,
+  closeTestApp,
+  StorageBuilder,
+  DataMartBuilder,
+  DataDestinationBuilder,
+  ReportBuilder,
+  AUTH_HEADER,
+  signLookerPayload,
+  mockGoogleJwkFetch,
+  restoreGoogleJwkFetch,
+} from '@owox/test-utils';
+import { DataStorageType } from '../src/data-marts/data-storage-types/enums/data-storage-type.enum';
+import { DataDestinationType } from '../src/data-marts/data-destination-types/enums/data-destination-type.enum';
+import { DataMartDefinitionValidatorFacade } from '../src/data-marts/data-storage-types/facades/data-mart-definition-validator-facade.service';
+import { DataMartSchemaProviderFacade } from '../src/data-marts/data-storage-types/facades/data-mart-schema-provider.facade';
+import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../src/data-marts/data-storage-types/data-storage-providers';
+import { ReportDataHeader } from '../src/data-marts/dto/domain/report-data-header.dto';
+import { ReportDataBatch } from '../src/data-marts/dto/domain/report-data-batch.dto';
+import { ReportDataDescription } from '../src/data-marts/dto/domain/report-data-description.dto';
+import { SnowflakeFieldType } from '../src/data-marts/data-storage-types/snowflake/enums/snowflake-field-type.enum';
+
+// HTTP-layer e2e for Snowflake output-controls SQL emission. ONE app + ONE Snowflake
+// report (date filter on a TIMESTAMP column) drives two assertions to keep the
+// e2e suite fast — booting createTestApp() is the dominant cost:
+//
+//   1. GET /generated-sql emits a CAST-wrapped literal — Snowflake renderer (option B)
+//      inlines all values and applies a defensive CAST for date/time columns.
+//   2. POST /looker/get-data runs the REAL ReportDataCacheService (only the storage
+//      reader is a spy), proving resolvePrepareOptions() composes + forwards the inlined
+//      SQL with no bound params into sqlOverride / sqlOverrideParams.
+//
+// The publish-time validator is stubbed (orthogonal — it dry-runs live Snowflake);
+// everything else (composer → builder → renderer, types from the persisted schema)
+// runs for real.
+
+const HEADERS: ReportDataHeader[] = [
+  new ReportDataHeader('id', 'id', undefined, SnowflakeFieldType.INTEGER),
+  new ReportDataHeader('created_at', 'created_at', undefined, SnowflakeFieldType.TIMESTAMP),
+];
+
+// Real ReportDataCacheService → spyReader.prepareReportData(report, options).
+// We assert the options it captured.
+const spyReader = {
+  prepareReportData: jest.fn().mockResolvedValue(new ReportDataDescription(HEADERS, 1)),
+  readReportDataBatch: jest
+    .fn()
+    .mockResolvedValue(new ReportDataBatch([['1', '2024-02-01']], null)),
+  finalize: jest.fn().mockResolvedValue(undefined),
+  getState: jest.fn().mockReturnValue(null),
+  initFromState: jest.fn().mockResolvedValue(undefined),
+  getType: jest.fn().mockReturnValue(DataStorageType.SNOWFLAKE),
+};
+
+const mockSchemaProviderFacade = {
+  getActualDataMartSchema: jest.fn().mockResolvedValue({
+    type: 'snowflake-data-mart-schema',
+    fields: HEADERS.map(h => ({
+      name: h.name,
+      type: h.storageFieldType,
+      status: 'CONNECTED',
+      isPrimaryKey: false,
+    })),
+  }),
+};
+
+describe('Output controls — Snowflake SQL emission (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+  let destinationId: string;
+  let destinationSecretKey: string;
+  let reportId: string;
+
+  const postLooker = (path: string, payload: unknown): supertest.Test =>
+    agent.post(path).set('Content-Type', 'application/jwt').send(signLookerPayload(payload));
+
+  beforeAll(async () => {
+    mockGoogleJwkFetch();
+
+    const testApp = await createTestApp([
+      {
+        provide: DataMartDefinitionValidatorFacade,
+        useValue: { checkIsValid: async () => undefined },
+      },
+      { provide: DataMartSchemaProviderFacade, useValue: mockSchemaProviderFacade },
+      {
+        provide: DATA_STORAGE_REPORT_READER_RESOLVER,
+        useValue: { resolve: async () => spyReader },
+      },
+    ]);
+    app = testApp.app;
+    agent = testApp.agent;
+
+    const storageRes = await agent
+      .post('/api/data-storages')
+      .set(AUTH_HEADER)
+      .send(new StorageBuilder().withType(DataStorageType.SNOWFLAKE).build());
+    expect(storageRes.status).toBe(201);
+    const storageId = storageRes.body.id;
+
+    const dmRes = await agent
+      .post('/api/data-marts')
+      .set(AUTH_HEADER)
+      .send(new DataMartBuilder().withStorageId(storageId).build());
+    expect(dmRes.status).toBe(201);
+    const dataMartId = dmRes.body.id;
+
+    await agent
+      .put(`/api/data-marts/${dataMartId}/definition`)
+      .set(AUTH_HEADER)
+      .send({ definitionType: 'TABLE', definition: { fullyQualifiedName: 'db.sc.events' } });
+
+    await agent
+      .put(`/api/data-marts/${dataMartId}/schema`)
+      .set(AUTH_HEADER)
+      .send({
+        schema: {
+          type: 'snowflake-data-mart-schema',
+          fields: [
+            { name: 'id', type: 'INTEGER', status: 'CONNECTED', isPrimaryKey: false },
+            { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
+          ],
+        },
+      });
+
+    expect((await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER)).status).toBe(
+      200
+    );
+    await agent
+      .put(`/api/data-storages/${storageId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForUse: true, availableForMaintenance: true });
+    await agent
+      .put(`/api/data-marts/${dataMartId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForReporting: true, availableForMaintenance: true });
+
+    const destRes = await agent
+      .post('/api/data-destinations')
+      .set(AUTH_HEADER)
+      .send(
+        new DataDestinationBuilder()
+          .withType(DataDestinationType.LOOKER_STUDIO)
+          .withCredentials({ type: 'looker-studio-credentials' })
+          .build()
+      );
+    expect(destRes.status).toBe(201);
+    destinationId = destRes.body.id;
+    await agent
+      .put(`/api/data-destinations/${destinationId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForUse: true, availableForMaintenance: true });
+
+    // The Looker report lookup INNER JOINs storage.credential — seed one and a config.
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const backendRoot = require.resolve('@owox/backend/package.json');
+    const backendDir = require('path').dirname(backendRoot);
+    const { DataSource } = require(require.resolve('typeorm', { paths: [backendDir] }));
+    /* eslint-enable @typescript-eslint/no-require-imports */
+    const dataSource = app.get(DataSource);
+    const credentialId = crypto.randomUUID();
+    await dataSource.query(
+      `INSERT INTO data_storage_credentials (id, projectId, type, credentials, createdAt, modifiedAt)
+       VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      [
+        credentialId,
+        '0',
+        'snowflake_password',
+        JSON.stringify({ authMethod: 'PASSWORD', username: 'u', password: 'p' }),
+      ]
+    );
+    await dataSource.query(`UPDATE data_storage SET config = ?, credentialId = ? WHERE id = ?`, [
+      JSON.stringify({ account: 'acc', warehouse: 'wh' }),
+      credentialId,
+      storageId,
+    ]);
+
+    destinationSecretKey = (
+      await agent.get(`/api/data-destinations/${destinationId}`).set(AUTH_HEADER)
+    ).body.credentials.destinationSecretKey;
+
+    const reportRes = await agent
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send(
+        new ReportBuilder().withDataMartId(dataMartId).withDataDestinationId(destinationId).build()
+      );
+    expect(reportRes.status).toBe(201);
+    reportId = reportRes.body.id;
+
+    const putRes = await agent
+      .put(`/api/reports/${reportId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Looker Snowflake date filter',
+        dataDestinationId: destinationId,
+        destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        columnConfig: ['id', 'created_at'],
+        filterConfig: [{ column: 'created_at', operator: 'gte', value: '2024-01-01' }],
+      });
+    expect(putRes.status).toBe(200);
+  }, 120_000);
+
+  afterAll(async () => {
+    restoreGoogleJwkFetch();
+    await closeTestApp(app);
+  });
+
+  it('GET /generated-sql inlines the date literal with a defensive CAST', async () => {
+    const res = await agent.get(`/api/reports/${reportId}/generated-sql`).set(AUTH_HEADER);
+    expect(res.status).toBe(200);
+    expect(res.body.sql).toContain(`"created_at" >= CAST('2024-01-01' AS TIMESTAMP)`);
+    expect(res.body.sql).not.toContain('?');
+    expect(res.body.sql).not.toContain('@p');
+  });
+
+  it('forwards composed SQL as a non-parameterized sqlOverride to the cached reader', async () => {
+    const res = await postLooker('/api/external/looker/get-data', {
+      connectionConfig: { deploymentUrl: 'http://localhost', destinationId, destinationSecretKey },
+      request: {
+        configParams: { destinationId, reportId },
+        scriptParams: { sampleExtraction: true },
+        fields: [{ name: 'id' }, { name: 'created_at' }],
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(spyReader.prepareReportData).toHaveBeenCalled();
+    const options = spyReader.prepareReportData.mock.calls[0][1];
+    expect(options.sqlOverride).toContain(`"created_at" >= CAST('2024-01-01' AS TIMESTAMP)`);
+    expect(options.sqlOverrideParams ?? []).toEqual([]);
+  });
+});

--- a/apps/web/src/features/data-marts/shared/utils/output-controls-support.test.ts
+++ b/apps/web/src/features/data-marts/shared/utils/output-controls-support.test.ts
@@ -23,8 +23,11 @@ describe('supportsOutputControls', () => {
     expect(supportsOutputControls(DataStorageType.DATABRICKS)).toBe(true);
   });
 
+  it('returns true for Snowflake', () => {
+    expect(supportsOutputControls(DataStorageType.SNOWFLAKE)).toBe(true);
+  });
+
   it('returns false for not-yet-supported storages', () => {
-    expect(supportsOutputControls(DataStorageType.SNOWFLAKE)).toBe(false);
     expect(supportsOutputControls(DataStorageType.AZURE_SYNAPSE)).toBe(false);
   });
 });

--- a/apps/web/src/features/data-marts/shared/utils/output-controls-support.ts
+++ b/apps/web/src/features/data-marts/shared/utils/output-controls-support.ts
@@ -7,6 +7,7 @@ const SUPPORTED: ReadonlySet<DataStorageType> = new Set([
   DataStorageType.AWS_ATHENA,
   DataStorageType.AWS_REDSHIFT,
   DataStorageType.DATABRICKS,
+  DataStorageType.SNOWFLAKE,
 ]);
 
 export function supportsOutputControls(type: DataStorageType): boolean {


### PR DESCRIPTION
…slices, sort, limit)

Adds filters / column slices / sort / limit to Snowflake reports, matching the Athena/BigQuery/Redshift feature already shipped. Uses "option B": the clause renderer inlines every value as a SQL literal (params always empty), so there is no bound-param plumbing and composeStatic's empty-params early-return covers it.

Snowflake-specific choices, all live-verified against a real account (28/28 integration):
- CONTAINS/STARTSWITH/ENDSWITH (never LIKE) so user %/_ stay literal
- REGEXP_INSTR(col, pat) > 0 for regex (RLIKE/REGEXP_LIKE full-anchor in Snowflake)
- backslash-first literal escaping (Snowflake honors backslash escape sequences)
- defensive CAST(<lit> AS DATE|TIME|TIMESTAMP) for date-typed comparisons
- LISTAGG(...) WITHIN GROUP (ORDER BY) for deterministic blended STRING_AGG
- two identifier escapers: the robust shared escaper for user-controlled column refs (injection-safe), the FQN-aware escaper for table names (hardened to throw on 4+-part input instead of returning raw)

Capability + web/extension mirrors updated; renderer/builder/blended unit specs, SQL-emission e2e, and a credential-gated live integration suite added. The live suite (snowflake.integration + the Snowflake block in http-data-real) is wired into the scheduled CI matrix in test-integration.yml; it skips green until the SNOWFLAKE_* secrets are configured. Changeset included.