### PR TITLE
fix(web): update Data Studio doc link and fix stale "Looker Studio" labels

### DIFF
--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/descriptions/LookerStudioDescription.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/descriptions/LookerStudioDescription.tsx
@@ -21,7 +21,7 @@ export default function LookerStudioDescription() {
         </p>
         <ExternalAnchor
           className='p-0'
-          href='https://docs.owox.com/docs/destinations/supported-destinations/looker-studio/?utm_source=owox_data_marts&utm_medium=destination_enity&utm_campaign=tooltip'
+          href='https://docs.owox.com/docs/destinations/supported-destinations/data-studio/?utm_source=owox_data_marts&utm_medium=destination_entity&utm_campaign=tooltip'
         >
           Learn more
         </ExternalAnchor>

--- a/packages/idp-owox-better-auth/src/core/onboarding-constants.ts
+++ b/packages/idp-owox-better-auth/src/core/onboarding-constants.ts
@@ -57,7 +57,7 @@ export interface OnboardingOption {
 
 export const USE_CASE_OPTIONS: OnboardingOption[] = [
   { value: USE_CASE_ANSWER.SYNC_DWH_SHEETS, label: 'Sync live DWH data into Sheets' },
-  { value: USE_CASE_ANSWER.SYNC_DWH_LOOKER, label: 'Sync live DWH data to Looker Studio' },
+  { value: USE_CASE_ANSWER.SYNC_DWH_LOOKER, label: 'Sync live DWH data to Data Studio' },
   { value: USE_CASE_ANSWER.AI_INSIGHTS, label: 'Deliver AI Insights to Slack / Teams / Email' },
   {
     value: USE_CASE_ANSWER.IMPORT_EXTERNAL_DWH,


### PR DESCRIPTION
# Problem

The "Learn more" link in the Data Studio destination tooltip pointed to a now-broken docs URL (`/looker-studio/`) and contained a typo in the UTM parameter (`destination_enity`). Additionally, the onboarding use-case selector still displayed the old product name "Looker Studio" instead of "Data Studio", creating an inconsistent user-facing experience.

# Solution

Updated the two affected user-facing strings to align with the current "Data Studio" branding:
- Fixed the `href` in `LookerStudioDescription` to point to the correct docs path (`/data-studio/`) and corrected the UTM typo (`destination_entity`)
- Updated the onboarding option label in `onboarding-constants.ts` to say "Data Studio" instead of "Looker Studio"

No logic changes — purely display text and URL corrections.

# Changes

- Updated "Learn more" doc link in `LookerStudioDescription.tsx` from `/looker-studio/` to `/data-studio/`
- Fixed UTM typo `destination_enity` → `destination_entity` in the same link
- Replaced label `'Sync live DWH data to Looker Studio'` with `'Sync live DWH data to Data Studio'` in `onboarding-constants.ts`