### PR TITLE
fix(backend): clearer error messages for resource access

### DIFF
--- a/.changeset/clearer-error-messages.md
+++ b/.changeset/clearer-error-messages.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Clearer error messages for resource access
+
+Error messages returned by the API when access is denied or a resource is not found now use product names instead of internal class names. "Data Mart", "Data Storage", and "Data Destination" replace the former `DataMart`, `DataStorage`, and `DataDestination` identifiers, and role references now read "Technical User" and "Project Admin" instead of "editor" and "admin".

--- a/apps/backend/src/data-marts/services/context/context-access.service.ts
+++ b/apps/backend/src/data-marts/services/context/context-access.service.ts
@@ -55,7 +55,7 @@ export class ContextAccessService {
 
       if (!isTechOwnerWithEditorRole) {
         throw new ForbiddenException(
-          'Only Data Mart Technical Owners with editor role or admins can manage data mart contexts'
+          'Only Data Mart Technical Owners with Technical User role or Project Admins can manage Data Mart contexts'
         );
       }
     }
@@ -90,7 +90,7 @@ export class ContextAccessService {
 
       if (!isOwnerWithEditorRole) {
         throw new ForbiddenException(
-          'Only Storage Owners with editor role or admins can manage storage contexts'
+          'Only Data Storage Owners with Technical User role or Project Admins can manage Data Storage contexts'
         );
       }
     }
@@ -123,7 +123,7 @@ export class ContextAccessService {
 
       if (ownerStatus !== OwnerStatus.OWNER) {
         throw new ForbiddenException(
-          'Only Destination Owners or admins can manage destination contexts'
+          'Only Data Destination Owners or Project Admins can manage Data Destination contexts'
         );
       }
     }

--- a/apps/backend/src/data-marts/services/context/context-access.service.ts
+++ b/apps/backend/src/data-marts/services/context/context-access.service.ts
@@ -55,7 +55,7 @@ export class ContextAccessService {
 
       if (!isTechOwnerWithEditorRole) {
         throw new ForbiddenException(
-          'Only DM Technical Owners with editor role or admins can manage data mart contexts'
+          'Only Data Mart Technical Owners with editor role or admins can manage data mart contexts'
         );
       }
     }

--- a/apps/backend/src/data-marts/services/data-destination.service.ts
+++ b/apps/backend/src/data-marts/services/data-destination.service.ts
@@ -18,7 +18,7 @@ export class DataDestinationService {
 
     if (!entity) {
       throw new NotFoundException(
-        `DataDestination with id ${id} and projectId ${projectId} not found`
+        `Data Destination with id ${id} and projectId ${projectId} not found`
       );
     }
 

--- a/apps/backend/src/data-marts/services/data-mart.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart.service.ts
@@ -42,7 +42,7 @@ export class DataMartService {
     });
 
     if (!entity) {
-      throw new NotFoundException(`DataMart with id ${id} and projectId ${projectId} not found`);
+      throw new NotFoundException(`Data Mart with id ${id} and projectId ${projectId} not found`);
     }
 
     return entity;

--- a/apps/backend/src/data-marts/services/data-storage.service.ts
+++ b/apps/backend/src/data-marts/services/data-storage.service.ts
@@ -17,7 +17,9 @@ export class DataStorageService {
     });
 
     if (!entity) {
-      throw new NotFoundException(`DataStorage with id ${id} and projectId ${projectId} not found`);
+      throw new NotFoundException(
+        `Data Storage with id ${id} and projectId ${projectId} not found`
+      );
     }
 
     return entity;


### PR DESCRIPTION
# Problem

Backend `NotFoundException` and `ForbiddenException` messages used internal class name conventions (`DataMart`, `DataStorage`, `DataDestination`, `DM`) and raw role codes (`editor`, `admin`) instead of the product names shown in the UI and documentation. A developer or API consumer receiving a 403 or 404 would see unfamiliar identifiers that don't match anything in the product interface, making errors harder to understand and act on.

# Solution

Replaced all affected message strings with product-facing names. Entity names now match the UI vocabulary (`Data Mart`, `Data Storage`, `Data Destination`), and role references use the documented names (`Technical User`, `Project Admin`) rather than internal codes. No logic, HTTP status codes, or behavior was changed — only the human-readable message strings.