### PR TITLE
Support Microsoft Ads refresh token rotation

### DIFF
--- a/.changeset/microsoft-ads-refresh-token-rotation.md
+++ b/.changeset/microsoft-ads-refresh-token-rotation.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Microsoft Ads refresh token rotation
+
+Persist rotated Microsoft Ads refresh tokens returned by Microsoft OAuth responses without overwriting the original user-provided refresh token.

--- a/apps/backend/src/data-marts/connector-types/connector-message/schemas/connector-message.schema.ts
+++ b/apps/backend/src/data-marts/connector-types/connector-message/schemas/connector-message.schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { MessageLogSchema } from './types/message-log.schema';
 import { MessageStatusSchema } from './types/message-status.schema';
 import { MessageStateSchema } from './types/message-state.schema';
+import { MessageCredentialsUpdateSchema } from './types/message-credentials-update.schema';
 import { MessageRequestedDateSchema } from './types/message-requested-date.schema';
 import { MessageWarningSchema } from './types/message-warning.schema';
 import { MessageUnknownSchema } from './types/message-unknown.schema';
@@ -14,6 +15,7 @@ export const ConnectorMessageSchema = z
     MessageLogSchema,
     MessageStatusSchema,
     MessageStateSchema,
+    MessageCredentialsUpdateSchema,
     MessageRequestedDateSchema,
     MessageWarningSchema,
     MessageUnknownSchema,
@@ -31,6 +33,10 @@ export const ConnectorMessageSchema = z
 
         case ConnectorMessageType.STATE: {
           return `[STATE] ${data.date}`;
+        }
+
+        case ConnectorMessageType.CREDENTIALS_UPDATE: {
+          return `[CREDENTIALS] ${Object.keys(data.credentials).join(', ')}`;
         }
 
         case ConnectorMessageType.REQUESTED_DATE: {

--- a/apps/backend/src/data-marts/connector-types/connector-message/schemas/types/message-credentials-update.schema.ts
+++ b/apps/backend/src/data-marts/connector-types/connector-message/schemas/types/message-credentials-update.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { ConnectorMessageType } from '../../../enums/connector-message-type-enum';
+
+export const MessageCredentialsUpdateSchema = z.object({
+  type: z.literal(ConnectorMessageType.CREDENTIALS_UPDATE),
+  at: z.string(),
+  credentials: z.record(z.string(), z.unknown()),
+});
+
+export type MessageCredentialsUpdate = z.infer<typeof MessageCredentialsUpdateSchema>;

--- a/apps/backend/src/data-marts/connector-types/connector-message/services/connector-message-parser.service.spec.ts
+++ b/apps/backend/src/data-marts/connector-types/connector-message/services/connector-message-parser.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { ConnectorMessageType } from '../../enums/connector-message-type-enum';
 import { ConnectorMessageParserService } from './connector-message-parser.service';
 
@@ -29,5 +30,26 @@ describe('ConnectorMessageParserService', () => {
     expect(result.type).toBe(ConnectorMessageType.UNKNOWN);
     expect(result.toFormattedString()).toContain('[REDACTED updateCredentials message]');
     expect(result.toFormattedString()).not.toContain('secret-token');
+  });
+
+  it('redacts parsed json when credential content appears under another message type', () => {
+    const service = createService();
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+    try {
+      const result = service.parse(
+        JSON.stringify({
+          type: ConnectorMessageType.LOG,
+          message: 'hello',
+          credentials: { generated_refresh_token: 'secret-token' },
+        })
+      );
+
+      expect(result.type).toBe(ConnectorMessageType.UNKNOWN);
+      expect(JSON.stringify(warnSpy.mock.calls)).toContain('[REDACTED updateCredentials message]');
+      expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('secret-token');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/apps/backend/src/data-marts/connector-types/connector-message/services/connector-message-parser.service.spec.ts
+++ b/apps/backend/src/data-marts/connector-types/connector-message/services/connector-message-parser.service.spec.ts
@@ -1,0 +1,33 @@
+import { ConnectorMessageType } from '../../enums/connector-message-type-enum';
+import { ConnectorMessageParserService } from './connector-message-parser.service';
+
+describe('ConnectorMessageParserService', () => {
+  const createService = () => new ConnectorMessageParserService();
+
+  it('redacts malformed credential update messages parsed as unknown', () => {
+    const service = createService();
+
+    const result = service.parse(
+      '{"type":"updateCredentials","credentials":{"generated_refresh_token":"secret-token"'
+    );
+
+    expect(result.type).toBe(ConnectorMessageType.UNKNOWN);
+    expect(result.toFormattedString()).toContain('[REDACTED updateCredentials message]');
+    expect(result.toFormattedString()).not.toContain('secret-token');
+  });
+
+  it('redacts schema-invalid credential update messages parsed as unknown', () => {
+    const service = createService();
+
+    const result = service.parse(
+      JSON.stringify({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        credentials: { generated_refresh_token: 'secret-token' },
+      })
+    );
+
+    expect(result.type).toBe(ConnectorMessageType.UNKNOWN);
+    expect(result.toFormattedString()).toContain('[REDACTED updateCredentials message]');
+    expect(result.toFormattedString()).not.toContain('secret-token');
+  });
+});

--- a/apps/backend/src/data-marts/connector-types/connector-message/services/connector-message-parser.service.ts
+++ b/apps/backend/src/data-marts/connector-types/connector-message/services/connector-message-parser.service.ts
@@ -51,18 +51,34 @@ export class ConnectorMessageParserService {
   }
 
   private redactCredentialUpdateJson(value: unknown): unknown {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    if (!value || typeof value !== 'object') {
       return value;
+    }
+
+    if (!this.hasCredentialUpdateContent(value)) {
+      return value;
+    }
+
+    return '[REDACTED updateCredentials message]';
+  }
+
+  private hasCredentialUpdateContent(value: unknown): boolean {
+    if (!value || typeof value !== 'object') {
+      return false;
+    }
+
+    if (Array.isArray(value)) {
+      return value.some(item => this.hasCredentialUpdateContent(item));
     }
 
     const objectValue = value as Record<string, unknown>;
-    if (objectValue.type !== ConnectorMessageType.CREDENTIALS_UPDATE) {
-      return value;
+    if (
+      objectValue.type === ConnectorMessageType.CREDENTIALS_UPDATE ||
+      Object.prototype.hasOwnProperty.call(objectValue, GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD)
+    ) {
+      return true;
     }
 
-    return {
-      ...objectValue,
-      credentials: '[REDACTED]',
-    };
+    return Object.values(objectValue).some(item => this.hasCredentialUpdateContent(item));
   }
 }

--- a/apps/backend/src/data-marts/connector-types/connector-message/services/connector-message-parser.service.ts
+++ b/apps/backend/src/data-marts/connector-types/connector-message/services/connector-message-parser.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConnectorMessage, ConnectorMessageSchema } from '../schemas/connector-message.schema';
 import { ConnectorMessageType } from '../../enums/connector-message-type-enum';
+// @ts-expect-error - Package lacks TypeScript declarations
+import { Core } from '@owox/connectors';
+
+const { GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD } = Core;
 
 @Injectable()
 export class ConnectorMessageParserService {
@@ -12,8 +16,8 @@ export class ConnectorMessageParserService {
       const parsedMessage = ConnectorMessageSchema.safeParse(asJson);
       if (!parsedMessage.success) {
         this.logger.warn(`Schema validation failed for message:`, {
-          message: message,
-          parsedJson: asJson,
+          message: this.redactCredentialUpdateMessage(message),
+          parsedJson: this.redactCredentialUpdateJson(asJson),
           errors: parsedMessage.error.errors,
         });
         return this.parseAsUnknown(message);
@@ -25,11 +29,40 @@ export class ConnectorMessageParserService {
   }
 
   private parseAsUnknown(message: string): ConnectorMessage {
+    const safeMessage = this.redactCredentialUpdateMessage(message).trim();
+
     return {
       type: ConnectorMessageType.UNKNOWN,
       at: new Date().toISOString(),
-      message: message.trim(),
-      toFormattedString: () => `[UNKNOWN] ${message.trim()}`,
+      message: safeMessage,
+      toFormattedString: () => `[UNKNOWN] ${safeMessage}`,
+    };
+  }
+
+  private redactCredentialUpdateMessage(message: string): string {
+    if (
+      !message.includes('updateCredentials') &&
+      !message.includes(GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD)
+    ) {
+      return message;
+    }
+
+    return '[REDACTED updateCredentials message]';
+  }
+
+  private redactCredentialUpdateJson(value: unknown): unknown {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return value;
+    }
+
+    const objectValue = value as Record<string, unknown>;
+    if (objectValue.type !== ConnectorMessageType.CREDENTIALS_UPDATE) {
+      return value;
+    }
+
+    return {
+      ...objectValue,
+      credentials: '[REDACTED]',
     };
   }
 }

--- a/apps/backend/src/data-marts/connector-types/enums/connector-message-type-enum.ts
+++ b/apps/backend/src/data-marts/connector-types/enums/connector-message-type-enum.ts
@@ -3,6 +3,7 @@ export enum ConnectorMessageType {
   IS_IN_PROGRESS = 'isInProgress',
   STATUS = 'updateCurrentStatus',
   STATE = 'updateLastImportDate',
+  CREDENTIALS_UPDATE = 'updateCredentials',
   REQUESTED_DATE = 'updateLastRequstedDate',
   WARNING = 'addWarningToCurrentStatus',
   UNKNOWN = 'unknown',

--- a/apps/backend/src/data-marts/services/connector/connector-credential-injector.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-credential-injector.service.spec.ts
@@ -144,6 +144,34 @@ describe('ConnectorCredentialInjectorService', () => {
       );
     });
 
+    it('injects generated refresh token from externalized secrets', async () => {
+      const { service, connectorSourceCredentialsService, connectorSecretService } =
+        createService();
+      const config = { _secrets_id: 'secret-1', field1: 'value1' };
+      const secrets = {
+        'AuthType.oauth2.RefreshToken': 'original-refresh-token',
+        generated_refresh_token: 'generated-refresh-token',
+      };
+
+      (connectorSourceCredentialsService.getCredentialsById as jest.Mock).mockResolvedValue({
+        id: 'secret-1',
+        projectId: 'proj-1',
+        credentials: secrets,
+      });
+      (connectorSecretService.injectSecretsAtPaths as jest.Mock).mockImplementation(
+        () => undefined
+      );
+
+      const result = await service.injectSecrets(config, 'proj-1');
+
+      expect(result.GeneratedRefreshToken).toBe('generated-refresh-token');
+      expect(result).not.toHaveProperty('generated_refresh_token');
+      expect(connectorSecretService.injectSecretsAtPaths).toHaveBeenCalledWith(
+        expect.objectContaining({ field1: 'value1' }),
+        { 'AuthType.oauth2.RefreshToken': 'original-refresh-token' }
+      );
+    });
+
     it('returns config when secrets entity not found', async () => {
       const { service, connectorSourceCredentialsService } = createService();
       const config = { _secrets_id: 'missing-secret', field1: 'value1' };

--- a/apps/backend/src/data-marts/services/connector/connector-credential-injector.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-credential-injector.service.spec.ts
@@ -47,7 +47,10 @@ describe('ConnectorCredentialInjectorService', () => {
         id: 'cred-1',
         projectId: 'proj-1',
         connectorName: 'TestConnector',
-        credentials: { accessToken: 'token123' },
+        credentials: {
+          accessToken: 'token123',
+          generated_refresh_token: 'generated-refresh-token',
+        },
       });
       (connectorSourceCredentialsService.isExpired as jest.Mock).mockResolvedValue(false);
       (connectorService.getItemByFieldPath as jest.Mock).mockResolvedValue({
@@ -59,6 +62,10 @@ describe('ConnectorCredentialInjectorService', () => {
       const authType = result.AuthType as Record<string, Record<string, unknown>>;
       expect(authType.oauth2).not.toHaveProperty('_source_credential_id');
       expect(authType.oauth2.AccessToken).toBe('token123');
+      expect(authType.oauth2.GeneratedRefreshToken).toEqual({
+        value: 'generated-refresh-token',
+      });
+      expect(authType.oauth2).not.toHaveProperty('generated_refresh_token');
     });
 
     it('returns config unchanged when credential not found', async () => {
@@ -96,7 +103,10 @@ describe('ConnectorCredentialInjectorService', () => {
         id: 'cred-1',
         projectId: 'proj-1',
         connectorName: 'TestConnector',
-        credentials: { accessToken: 'token123' },
+        credentials: {
+          accessToken: 'token123',
+          generated_refresh_token: 'generated-refresh-token',
+        },
       });
       (connectorSourceCredentialsService.isExpired as jest.Mock).mockResolvedValue(false);
       (connectorService.getItemByFieldPath as jest.Mock).mockResolvedValue({
@@ -106,6 +116,8 @@ describe('ConnectorCredentialInjectorService', () => {
       const result = await service.injectOAuthCredentials(config, 'TestConnector', 'proj-1');
 
       expect(result.accessToken).toBe('token123');
+      expect(result.GeneratedRefreshToken).toEqual({ value: 'generated-refresh-token' });
+      expect(result).not.toHaveProperty('generated_refresh_token');
       expect(result).not.toHaveProperty('_source_credential_id');
     });
   });
@@ -164,7 +176,7 @@ describe('ConnectorCredentialInjectorService', () => {
 
       const result = await service.injectSecrets(config, 'proj-1');
 
-      expect(result.GeneratedRefreshToken).toBe('generated-refresh-token');
+      expect(result.GeneratedRefreshToken).toEqual({ value: 'generated-refresh-token' });
       expect(result).not.toHaveProperty('generated_refresh_token');
       expect(connectorSecretService.injectSecretsAtPaths).toHaveBeenCalledWith(
         expect.objectContaining({ field1: 'value1' }),

--- a/apps/backend/src/data-marts/services/connector/connector-credential-injector.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-credential-injector.service.ts
@@ -4,6 +4,8 @@ import { ConnectorSourceCredentialsService } from './connector-source-credential
 import { ConnectorService } from './connector.service';
 import { ConnectorSecretService } from './connector-secret.service';
 
+const GENERATED_REFRESH_TOKEN_FIELD = 'generated_refresh_token';
+
 @Injectable()
 export class ConnectorCredentialInjectorService {
   private readonly logger = new Logger(ConnectorCredentialInjectorService.name);
@@ -91,12 +93,24 @@ export class ConnectorCredentialInjectorService {
           this.logger.warn(
             `No mapping found for OAuth field ${currentPath}. Using credentials directly.`
           );
-          return { ...restObj, ...credentialsEntity.credentials };
+          const { [GENERATED_REFRESH_TOKEN_FIELD]: generatedRefreshToken, ...credentials } =
+            credentialsEntity.credentials;
+          return {
+            ...restObj,
+            ...credentials,
+            ...(typeof generatedRefreshToken === 'string' && generatedRefreshToken
+              ? { GeneratedRefreshToken: generatedRefreshToken }
+              : {}),
+          };
         }
 
         const resolvedConfig: Record<string, unknown> = {};
         for (const [key, mappingConfig] of Object.entries(mapping)) {
           resolvedConfig[key] = this.resolveMapping(mappingConfig, credentialsEntity.credentials);
+        }
+        const generatedRefreshToken = credentialsEntity.credentials[GENERATED_REFRESH_TOKEN_FIELD];
+        if (typeof generatedRefreshToken === 'string' && generatedRefreshToken) {
+          resolvedConfig.GeneratedRefreshToken = generatedRefreshToken;
         }
 
         return { ...restObj, ...resolvedConfig };
@@ -205,8 +219,13 @@ export class ConnectorCredentialInjectorService {
 
       const { _secrets_id: _, ...restConfig } = config;
       const result = JSON.parse(JSON.stringify(restConfig)) as Record<string, unknown>;
+      const { [GENERATED_REFRESH_TOKEN_FIELD]: generatedRefreshToken, ...credentials } =
+        secretsEntity.credentials;
 
-      this.connectorSecretService.injectSecretsAtPaths(result, secretsEntity.credentials);
+      this.connectorSecretService.injectSecretsAtPaths(result, credentials);
+      if (typeof generatedRefreshToken === 'string' && generatedRefreshToken) {
+        result.GeneratedRefreshToken = generatedRefreshToken;
+      }
 
       return result;
     } catch (error) {

--- a/apps/backend/src/data-marts/services/connector/connector-credential-injector.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-credential-injector.service.ts
@@ -3,8 +3,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConnectorSourceCredentialsService } from './connector-source-credentials.service';
 import { ConnectorService } from './connector.service';
 import { ConnectorSecretService } from './connector-secret.service';
+// @ts-expect-error - Package lacks TypeScript declarations
+import { Core } from '@owox/connectors';
 
-const GENERATED_REFRESH_TOKEN_FIELD = 'generated_refresh_token';
+const { GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD, GENERATED_REFRESH_TOKEN_CONFIG_FIELD } = Core;
 
 @Injectable()
 export class ConnectorCredentialInjectorService {
@@ -93,13 +95,15 @@ export class ConnectorCredentialInjectorService {
           this.logger.warn(
             `No mapping found for OAuth field ${currentPath}. Using credentials directly.`
           );
-          const { [GENERATED_REFRESH_TOKEN_FIELD]: generatedRefreshToken, ...credentials } =
-            credentialsEntity.credentials;
+          const {
+            [GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD]: generatedRefreshToken,
+            ...credentials
+          } = credentialsEntity.credentials;
           return {
             ...restObj,
             ...credentials,
             ...(typeof generatedRefreshToken === 'string' && generatedRefreshToken
-              ? { GeneratedRefreshToken: generatedRefreshToken }
+              ? { [GENERATED_REFRESH_TOKEN_CONFIG_FIELD]: { value: generatedRefreshToken } }
               : {}),
           };
         }
@@ -108,9 +112,12 @@ export class ConnectorCredentialInjectorService {
         for (const [key, mappingConfig] of Object.entries(mapping)) {
           resolvedConfig[key] = this.resolveMapping(mappingConfig, credentialsEntity.credentials);
         }
-        const generatedRefreshToken = credentialsEntity.credentials[GENERATED_REFRESH_TOKEN_FIELD];
+        const generatedRefreshToken =
+          credentialsEntity.credentials[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
         if (typeof generatedRefreshToken === 'string' && generatedRefreshToken) {
-          resolvedConfig.GeneratedRefreshToken = generatedRefreshToken;
+          resolvedConfig[GENERATED_REFRESH_TOKEN_CONFIG_FIELD] = {
+            value: generatedRefreshToken,
+          };
         }
 
         return { ...restObj, ...resolvedConfig };
@@ -219,12 +226,14 @@ export class ConnectorCredentialInjectorService {
 
       const { _secrets_id: _, ...restConfig } = config;
       const result = JSON.parse(JSON.stringify(restConfig)) as Record<string, unknown>;
-      const { [GENERATED_REFRESH_TOKEN_FIELD]: generatedRefreshToken, ...credentials } =
+      const { [GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD]: generatedRefreshToken, ...credentials } =
         secretsEntity.credentials;
 
       this.connectorSecretService.injectSecretsAtPaths(result, credentials);
       if (typeof generatedRefreshToken === 'string' && generatedRefreshToken) {
-        result.GeneratedRefreshToken = generatedRefreshToken;
+        result[GENERATED_REFRESH_TOKEN_CONFIG_FIELD] = {
+          value: generatedRefreshToken,
+        };
       }
 
       return result;

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -133,6 +133,7 @@ describe('ConnectorExecutorService', () => {
 
     const connectorSourceCredentialsService = {
       updateCredentialFields: jest.fn().mockResolvedValue(undefined),
+      getCredentialsById: jest.fn().mockResolvedValue(null),
     } as unknown as ConnectorSourceCredentialsService;
 
     const service = new ConnectorExecutorService(
@@ -521,6 +522,47 @@ describe('ConnectorExecutorService', () => {
       'cred-1',
       'proj-1',
       { generated_refresh_token: 'latest-token' }
+    );
+  });
+
+  it('passes the pre-run generated refresh token snapshot when saving credential updates', async () => {
+    const {
+      service,
+      processSpawner,
+      connectorSourceCredentialsService,
+      emitMessage,
+      emitSuccessMessage,
+    } = createService();
+    const dataMart = createDataMart();
+    getFirstSourceConfig(dataMart)._secrets_id = 'cred-1';
+    (connectorSourceCredentialsService.getCredentialsById as jest.Mock).mockResolvedValue({
+      id: 'cred-1',
+      projectId: 'proj-1',
+      credentials: { generated_refresh_token: 'old-token' },
+    });
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'new-token' },
+      });
+      emitSuccessMessage();
+      return Promise.resolve();
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    expect(connectorSourceCredentialsService.getCredentialsById).toHaveBeenCalledWith('cred-1');
+    expect(
+      (connectorSourceCredentialsService.getCredentialsById as jest.Mock).mock
+        .invocationCallOrder[0]
+    ).toBeLessThan((processSpawner.spawnConnector as jest.Mock).mock.invocationCallOrder[0]);
+    expect(connectorSourceCredentialsService.updateCredentialFields).toHaveBeenCalledWith(
+      'cred-1',
+      'proj-1',
+      { generated_refresh_token: 'new-token' },
+      { generated_refresh_token: 'old-token' }
     );
   });
 

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -19,6 +19,7 @@ import { ConnectorProcessSpawnerService } from './connector-process-spawner.serv
 import { ConnectorStorageConfigService } from './connector-storage-config.service';
 import { ConnectorSourceConfigService } from './connector-source-config.service';
 import { ConnectorCredentialInjectorService } from './connector-credential-injector.service';
+import { ConnectorSourceCredentialsService } from './connector-source-credentials.service';
 import { ConnectorOutputCaptureService } from '../../connector-types/connector-message/services/connector-output-capture.service';
 import { ConnectorStateService } from '../../connector-types/connector-message/services/connector-state.service';
 import { ConsumptionTrackingService } from '../consumption-tracking.service';
@@ -129,6 +130,10 @@ describe('ConnectorExecutorService', () => {
       actualizeSchema: jest.fn().mockResolvedValue(undefined),
     } as unknown as DataMartService;
 
+    const connectorSourceCredentialsService = {
+      updateCredentialFields: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ConnectorSourceCredentialsService;
+
     const service = new ConnectorExecutorService(
       dataMartRunRepository,
       processSpawner,
@@ -142,7 +147,8 @@ describe('ConnectorExecutorService', () => {
       systemTimeService,
       eventDispatcher as unknown as OwoxEventDispatcher,
       projectBalanceService,
-      dataMartService
+      dataMartService,
+      connectorSourceCredentialsService
     );
 
     return {

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -18,6 +18,7 @@ import { ConnectorProcessSpawnerService } from './connector-process-spawner.serv
 import { ConnectorStorageConfigService } from './connector-storage-config.service';
 import { ConnectorSourceConfigService } from './connector-source-config.service';
 import { ConnectorCredentialInjectorService } from './connector-credential-injector.service';
+import { ConnectorSourceCredentialsService } from './connector-source-credentials.service';
 import { ConnectorOutputCaptureService } from '../../connector-types/connector-message/services/connector-output-capture.service';
 import { ConnectorStateService } from '../../connector-types/connector-message/services/connector-state.service';
 import { ConsumptionTrackingService } from '../consumption-tracking.service';
@@ -113,6 +114,10 @@ describe('ConnectorExecutorService', () => {
       actualizeSchema: jest.fn().mockResolvedValue(undefined),
     } as unknown as DataMartService;
 
+    const connectorSourceCredentialsService = {
+      updateCredentialFields: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ConnectorSourceCredentialsService;
+
     const service = new ConnectorExecutorService(
       dataMartRunRepository,
       processSpawner,
@@ -126,7 +131,8 @@ describe('ConnectorExecutorService', () => {
       systemTimeService,
       eventDispatcher as unknown as OwoxEventDispatcher,
       projectBalanceService,
-      dataMartService
+      dataMartService,
+      connectorSourceCredentialsService
     );
 
     return {

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -439,8 +439,7 @@ describe('ConnectorExecutorService', () => {
       connectorSourceCredentialsService,
       emitMessage,
       emitSuccessMessage,
-    } =
-      createService();
+    } = createService();
     const dataMart = createDataMart();
     getFirstSourceConfig(dataMart)._secrets_id = 'cred-1';
 
@@ -497,8 +496,7 @@ describe('ConnectorExecutorService', () => {
       connectorSourceCredentialsService,
       emitMessage,
       emitSuccessMessage,
-    } =
-      createService();
+    } = createService();
     const dataMart = createDataMart();
     getFirstSourceConfig(dataMart)._secrets_id = 'cred-1';
 
@@ -533,8 +531,7 @@ describe('ConnectorExecutorService', () => {
       connectorSourceCredentialsService,
       emitMessage,
       emitSuccessMessage,
-    } =
-      createService();
+    } = createService();
     const dataMart = createDataMart();
     const sourceConfig = getFirstSourceConfig(dataMart);
     sourceConfig._secrets_id = 'secrets-cred';
@@ -566,8 +563,7 @@ describe('ConnectorExecutorService', () => {
       connectorSourceCredentialsService,
       emitMessage,
       emitSuccessMessage,
-    } =
-      createService();
+    } = createService();
     const dataMart = createDataMart();
     getFirstSourceConfig(dataMart).AuthType = {
       oauth2: { _source_credential_id: 'oauth-cred' },
@@ -636,8 +632,7 @@ describe('ConnectorExecutorService', () => {
       connectorSourceCredentialsService,
       emitMessage,
       emitSuccessMessage,
-    } =
-      createService();
+    } = createService();
     const dataMart = createDataMart();
 
     (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
@@ -662,8 +657,7 @@ describe('ConnectorExecutorService', () => {
       connectorSourceCredentialsService,
       emitMessage,
       emitSuccessMessage,
-    } =
-      createService();
+    } = createService();
     const dataMart = createDataMart();
     getFirstSourceConfig(dataMart)._secrets_id = 'cred-1';
 

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -11,6 +11,7 @@ jest.mock('@owox/connectors', () => ({
       IMPORT_DONE: 3,
       ERROR: 5,
     },
+    GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD: 'generated_refresh_token',
   },
 }));
 
@@ -168,6 +169,8 @@ describe('ConnectorExecutorService', () => {
       dataMartService,
       emitSuccessMessage,
       emitInProgressMessage,
+      connectorSourceCredentialsService,
+      emitMessage: (message: unknown) => capturedOnMessage?.(message),
     };
   };
 
@@ -199,6 +202,14 @@ describe('ConnectorExecutorService', () => {
       runType: 'MANUAL',
       ...overrides,
     }) as unknown as DataMartRun;
+
+  const getFirstSourceConfig = (dataMart: DataMart): Record<string, unknown> => {
+    const definition = dataMart.definition as {
+      connector: { source: { configuration: Array<Record<string, unknown>> } };
+    };
+
+    return definition.connector.source.configuration[0];
+  };
 
   it('executes successfully and updates status to SUCCESS', async () => {
     const { service, dataMartRunRepository, consumptionTracker, eventDispatcher, dataMartService } =
@@ -419,5 +430,316 @@ describe('ConnectorExecutorService', () => {
       'run-1'
     );
     expect(eventDispatcher.publishExternal).toHaveBeenCalled();
+  });
+
+  it('only saves allowed credential updates from connector messages', async () => {
+    const {
+      service,
+      processSpawner,
+      connectorSourceCredentialsService,
+      emitMessage,
+      emitSuccessMessage,
+    } =
+      createService();
+    const dataMart = createDataMart();
+    getFirstSourceConfig(dataMart)._secrets_id = 'cred-1';
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: {
+          generated_refresh_token: 'generated-refresh-token',
+          'AuthType.oauth2.RefreshToken': 'should-not-be-saved',
+        },
+      });
+      emitSuccessMessage();
+      return Promise.resolve();
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    expect(connectorSourceCredentialsService.updateCredentialFields).toHaveBeenCalledWith(
+      'cred-1',
+      'proj-1',
+      { generated_refresh_token: 'generated-refresh-token' }
+    );
+  });
+
+  it('saves credential updates even when connector run fails after token rotation', async () => {
+    const { service, processSpawner, connectorSourceCredentialsService, emitMessage } =
+      createService();
+    const dataMart = createDataMart();
+    getFirstSourceConfig(dataMart)._secrets_id = 'cred-1';
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'generated-refresh-token' },
+      });
+      return Promise.reject(new Error('storage failed'));
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    expect(connectorSourceCredentialsService.updateCredentialFields).toHaveBeenCalledWith(
+      'cred-1',
+      'proj-1',
+      { generated_refresh_token: 'generated-refresh-token' }
+    );
+  });
+
+  it('saves the latest accumulated credential update', async () => {
+    const {
+      service,
+      processSpawner,
+      connectorSourceCredentialsService,
+      emitMessage,
+      emitSuccessMessage,
+    } =
+      createService();
+    const dataMart = createDataMart();
+    getFirstSourceConfig(dataMart)._secrets_id = 'cred-1';
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'first-token' },
+      });
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'latest-token' },
+      });
+      emitSuccessMessage();
+      return Promise.resolve();
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    expect(connectorSourceCredentialsService.updateCredentialFields).toHaveBeenCalledWith(
+      'cred-1',
+      'proj-1',
+      { generated_refresh_token: 'latest-token' }
+    );
+  });
+
+  it('uses nested _source_credential_id before stale _secrets_id when saving credential updates', async () => {
+    const {
+      service,
+      processSpawner,
+      connectorSourceCredentialsService,
+      emitMessage,
+      emitSuccessMessage,
+    } =
+      createService();
+    const dataMart = createDataMart();
+    const sourceConfig = getFirstSourceConfig(dataMart);
+    sourceConfig._secrets_id = 'secrets-cred';
+    sourceConfig.AuthType = { oauth2: { _source_credential_id: 'oauth-cred' } };
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'generated-refresh-token' },
+      });
+      emitSuccessMessage();
+      return Promise.resolve();
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    expect(connectorSourceCredentialsService.updateCredentialFields).toHaveBeenCalledWith(
+      'oauth-cred',
+      'proj-1',
+      { generated_refresh_token: 'generated-refresh-token' }
+    );
+  });
+
+  it('uses nested _source_credential_id when _secrets_id is missing', async () => {
+    const {
+      service,
+      processSpawner,
+      connectorSourceCredentialsService,
+      emitMessage,
+      emitSuccessMessage,
+    } =
+      createService();
+    const dataMart = createDataMart();
+    getFirstSourceConfig(dataMart).AuthType = {
+      oauth2: { _source_credential_id: 'oauth-cred' },
+    };
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'generated-refresh-token' },
+      });
+      emitSuccessMessage();
+      return Promise.resolve();
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    expect(connectorSourceCredentialsService.updateCredentialFields).toHaveBeenCalledWith(
+      'oauth-cred',
+      'proj-1',
+      { generated_refresh_token: 'generated-refresh-token' }
+    );
+  });
+
+  it('uses refreshed credential id when saving credential updates', async () => {
+    const {
+      service,
+      processSpawner,
+      connectorSourceCredentialsService,
+      credentialInjector,
+      emitMessage,
+      emitSuccessMessage,
+    } = createService();
+    const dataMart = createDataMart();
+    getFirstSourceConfig(dataMart).AuthType = {
+      oauth2: { _source_credential_id: 'old-oauth-cred' },
+    };
+    (credentialInjector.refreshCredentialsForConfig as jest.Mock).mockResolvedValue({
+      _id: 'cfg-1',
+      AuthType: { oauth2: { _source_credential_id: 'new-oauth-cred' } },
+    });
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'generated-refresh-token' },
+      });
+      emitSuccessMessage();
+      return Promise.resolve();
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    expect(connectorSourceCredentialsService.updateCredentialFields).toHaveBeenCalledWith(
+      'new-oauth-cred',
+      'proj-1',
+      { generated_refresh_token: 'generated-refresh-token' }
+    );
+  });
+
+  it('skips credential updates for legacy inline configs without credential reference', async () => {
+    const {
+      service,
+      processSpawner,
+      connectorSourceCredentialsService,
+      emitMessage,
+      emitSuccessMessage,
+    } =
+      createService();
+    const dataMart = createDataMart();
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'generated-refresh-token' },
+      });
+      emitSuccessMessage();
+      return Promise.resolve();
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    expect(connectorSourceCredentialsService.updateCredentialFields).not.toHaveBeenCalled();
+  });
+
+  it('ignores invalid generated refresh token values from connector messages', async () => {
+    const {
+      service,
+      processSpawner,
+      connectorSourceCredentialsService,
+      emitMessage,
+      emitSuccessMessage,
+    } =
+      createService();
+    const dataMart = createDataMart();
+    getFirstSourceConfig(dataMart)._secrets_id = 'cred-1';
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'x'.repeat(4097) },
+      });
+      emitSuccessMessage();
+      return Promise.resolve();
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    expect(connectorSourceCredentialsService.updateCredentialFields).not.toHaveBeenCalled();
+  });
+
+  it('marks run failed when saving credential updates fails', async () => {
+    const {
+      service,
+      processSpawner,
+      connectorSourceCredentialsService,
+      emitMessage,
+      emitSuccessMessage,
+      dataMartRunRepository,
+    } = createService();
+    const dataMart = createDataMart();
+    getFirstSourceConfig(dataMart)._secrets_id = 'cred-1';
+    (connectorSourceCredentialsService.updateCredentialFields as jest.Mock).mockRejectedValue(
+      new Error('save failed')
+    );
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'generated-refresh-token' },
+      });
+      emitSuccessMessage();
+      return Promise.resolve();
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    const finalRunUpdate = (dataMartRunRepository.update as jest.Mock).mock.calls
+      .map(call => call[1])
+      .find(update => update.status === DataMartRunStatus.FAILED);
+
+    expect(finalRunUpdate).toBeDefined();
+    expect(JSON.stringify(finalRunUpdate.errors)).toContain(
+      'Failed to update connector credentials: save failed'
+    );
+  });
+
+  it('does not persist generated refresh token in run logs', async () => {
+    const { service, processSpawner, dataMartRunRepository, emitMessage, emitSuccessMessage } =
+      createService();
+    const dataMart = createDataMart();
+    getFirstSourceConfig(dataMart)._secrets_id = 'cred-1';
+
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(() => {
+      emitMessage({
+        type: ConnectorMessageType.CREDENTIALS_UPDATE,
+        at: new Date().toISOString(),
+        credentials: { generated_refresh_token: 'secret-token' },
+      });
+      emitSuccessMessage();
+      return Promise.resolve();
+    });
+
+    await service.executeInBackground(dataMart, createRun(), null);
+
+    const persistedRunUpdates = (dataMartRunRepository.update as jest.Mock).mock.calls.map(
+      call => call[1]
+    );
+    expect(JSON.stringify(persistedRunUpdates)).not.toContain('secret-token');
   });
 });

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -29,6 +29,7 @@ import { ConnectorProcessSpawnerService } from './connector-process-spawner.serv
 import { ConnectorStorageConfigService } from './connector-storage-config.service';
 import { ConnectorSourceConfigService } from './connector-source-config.service';
 import { ConnectorCredentialInjectorService } from './connector-credential-injector.service';
+import { ConnectorSourceCredentialsService } from './connector-source-credentials.service';
 import { addMessageToArray } from './connector-message.utils';
 
 interface ConfigurationExecutionResult {
@@ -56,7 +57,8 @@ export class ConnectorExecutorService {
     private readonly systemTimeService: SystemTimeService,
     private readonly eventDispatcher: OwoxEventDispatcher,
     private readonly projectBalanceService: ProjectBalanceService,
-    private readonly dataMartService: DataMartService
+    private readonly dataMartService: DataMartService,
+    private readonly connectorSourceCredentialsService: ConnectorSourceCredentialsService
   ) {}
 
   async executeInBackground(
@@ -221,6 +223,7 @@ export class ConnectorExecutorService {
       const configLogs: ConnectorMessage[] = [];
       const configErrors: ConnectorMessage[] = [];
       let success = false;
+      let credentialUpdates: Record<string, unknown> | undefined;
 
       const logCaptureConfig = this.connectorOutputCaptureService.createCapture(
         (message: ConnectorMessage) => {
@@ -254,6 +257,9 @@ export class ConnectorExecutorService {
                     }
                   );
                 });
+              break;
+            case ConnectorMessageType.CREDENTIALS_UPDATE:
+              credentialUpdates = { ...(credentialUpdates ?? {}), ...message.credentials };
               break;
             case ConnectorMessageType.STATUS:
               if (message.status === Core.EXECUTION_STATUS.ERROR) {
@@ -327,6 +333,16 @@ export class ConnectorExecutorService {
         );
 
         if (success) {
+          if (credentialUpdates) {
+            await this.saveConnectorCredentials(
+              config as Record<string, unknown>,
+              credentialUpdates,
+              dataMart,
+              runId,
+              configId
+            );
+          }
+
           this.logger.log(`Configuration ${configIndex + 1} completed successfully`, {
             dataMartId: dataMart.id,
             projectId: dataMart.projectId,
@@ -363,6 +379,88 @@ export class ConnectorExecutorService {
     }
 
     return configurationResults;
+  }
+
+  private async saveConnectorCredentials(
+    config: Record<string, unknown>,
+    credentials: Record<string, unknown>,
+    dataMart: DataMart,
+    runId: string,
+    configId: string
+  ): Promise<void> {
+    try {
+      const credentialId = this.getCredentialIdForConfig(config);
+      if (!credentialId) {
+        this.logger.warn(`Cannot update connector credentials: no credential reference found`, {
+          dataMartId: dataMart.id,
+          projectId: dataMart.projectId,
+          runId,
+          configId,
+          credentialKeys: Object.keys(credentials),
+        });
+        return;
+      }
+
+      await this.connectorSourceCredentialsService.updateCredentialFields(
+        credentialId,
+        dataMart.projectId,
+        credentials
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Failed to update connector credentials: ${errorMessage}`,
+        (error as Error)?.stack,
+        {
+          dataMartId: dataMart.id,
+          projectId: dataMart.projectId,
+          runId,
+          configId,
+          error: errorMessage,
+          credentialKeys: Object.keys(credentials),
+        }
+      );
+    }
+  }
+
+  private getCredentialIdForConfig(config: Record<string, unknown>): string | undefined {
+    const secretsId = config._secrets_id;
+    if (typeof secretsId === 'string' && secretsId) {
+      return secretsId;
+    }
+
+    return this.findSourceCredentialId(config);
+  }
+
+  private findSourceCredentialId(value: unknown): string | undefined {
+    if (!value || typeof value !== 'object') {
+      return undefined;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const credentialId = this.findSourceCredentialId(item);
+        if (credentialId) {
+          return credentialId;
+        }
+      }
+      return undefined;
+    }
+
+    const obj = value as Record<string, unknown>;
+    const credentialId = obj._source_credential_id;
+    if (typeof credentialId === 'string' && credentialId) {
+      return credentialId;
+    }
+
+    for (const item of Object.values(obj)) {
+      const nestedCredentialId = this.findSourceCredentialId(item);
+      if (nestedCredentialId) {
+        return nestedCredentialId;
+      }
+    }
+
+    return undefined;
   }
 
   private async updateRunStatus(

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -5,8 +5,9 @@ import { Repository } from 'typeorm';
 // @ts-expect-error - Package lacks TypeScript declarations
 import { Core } from '@owox/connectors';
 
-const { ConfigDto } = Core;
+const { ConfigDto, GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD } = Core;
 type ConfigDto = InstanceType<typeof Core.ConfigDto>;
+const GENERATED_REFRESH_TOKEN_MAX_LENGTH = 4096;
 
 import { ConnectorDefinition as DataMartConnectorDefinition } from '../../dto/schemas/data-mart-table-definitions/connector-definition.schema';
 import { DataMart } from '../../entities/data-mart.entity';
@@ -228,6 +229,7 @@ export class ConnectorExecutorService {
       const configErrors: ConnectorMessage[] = [];
       let success = false;
       let credentialUpdates: Record<string, unknown> | undefined;
+      let configForCredentialUpdates = config as Record<string, unknown>;
 
       const logCaptureConfig = this.connectorOutputCaptureService.createCapture(
         (message: ConnectorMessage) => {
@@ -316,6 +318,7 @@ export class ConnectorExecutorService {
           connector.source.name,
           config as Record<string, unknown>
         );
+        configForCredentialUpdates = refreshedConfig;
 
         const configState = await this.connectorStateService.getState(dataMart.id, configId);
 
@@ -345,16 +348,6 @@ export class ConnectorExecutorService {
         );
 
         if (success) {
-          if (credentialUpdates) {
-            await this.saveConnectorCredentials(
-              config as Record<string, unknown>,
-              credentialUpdates,
-              dataMart,
-              runId,
-              configId
-            );
-          }
-
           this.logger.log(`Configuration ${configIndex + 1} completed successfully`, {
             dataMartId: dataMart.id,
             projectId: dataMart.projectId,
@@ -401,6 +394,27 @@ export class ConnectorExecutorService {
           }
         );
       } finally {
+        if (credentialUpdates) {
+          try {
+            await this.saveConnectorCredentials(
+              configForCredentialUpdates,
+              credentialUpdates,
+              dataMart,
+              runId,
+              configId
+            );
+          } catch (error) {
+            success = false;
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            const credentialErrorMessage = `Failed to update connector credentials: ${errorMessage}`;
+            addMessageToArray(configErrors, {
+              type: ConnectorMessageType.ERROR,
+              at: this.systemTimeService.now().toISOString(),
+              error: credentialErrorMessage,
+              toFormattedString: () => `[ERROR] ${credentialErrorMessage}`,
+            });
+          }
+        }
         configurationResults.push({ configIndex, success, logs: configLogs, errors: configErrors });
       }
     }
@@ -416,9 +430,28 @@ export class ConnectorExecutorService {
     configId: string
   ): Promise<void> {
     try {
+      const credentialUpdates = this.getAllowedCredentialUpdates(credentials);
+      const droppedCredentialKeys = Object.keys(credentials).filter(
+        key => !(key in credentialUpdates)
+      );
+
+      if (droppedCredentialKeys.length > 0) {
+        this.logger.warn(`Dropped unsupported connector credential updates`, {
+          dataMartId: dataMart.id,
+          projectId: dataMart.projectId,
+          runId,
+          configId,
+          credentialKeys: droppedCredentialKeys,
+        });
+      }
+
+      if (Object.keys(credentialUpdates).length === 0) {
+        return;
+      }
+
       const credentialId = this.getCredentialIdForConfig(config);
       if (!credentialId) {
-        this.logger.warn(`Cannot update connector credentials: no credential reference found`, {
+        this.logger.debug(`Skipping connector credential update: no credential reference found`, {
           dataMartId: dataMart.id,
           projectId: dataMart.projectId,
           runId,
@@ -431,7 +464,7 @@ export class ConnectorExecutorService {
       await this.connectorSourceCredentialsService.updateCredentialFields(
         credentialId,
         dataMart.projectId,
-        credentials
+        credentialUpdates
       );
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -447,16 +480,38 @@ export class ConnectorExecutorService {
           credentialKeys: Object.keys(credentials),
         }
       );
+      throw error;
     }
   }
 
+  private getAllowedCredentialUpdates(
+    credentials: Record<string, unknown>
+  ): Record<string, string> {
+    const generatedRefreshToken = credentials[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
+
+    if (
+      typeof generatedRefreshToken !== 'string' ||
+      generatedRefreshToken.length === 0 ||
+      generatedRefreshToken.length > GENERATED_REFRESH_TOKEN_MAX_LENGTH
+    ) {
+      return {};
+    }
+
+    return { [GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD]: generatedRefreshToken };
+  }
+
   private getCredentialIdForConfig(config: Record<string, unknown>): string | undefined {
+    const sourceCredentialId = this.findSourceCredentialId(config);
+    if (sourceCredentialId) {
+      return sourceCredentialId;
+    }
+
     const secretsId = config._secrets_id;
     if (typeof secretsId === 'string' && secretsId) {
       return secretsId;
     }
 
-    return this.findSourceCredentialId(config);
+    return undefined;
   }
 
   private findSourceCredentialId(value: unknown): string | undefined {

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -29,6 +29,7 @@ import { ConnectorProcessSpawnerService } from './connector-process-spawner.serv
 import { ConnectorStorageConfigService } from './connector-storage-config.service';
 import { ConnectorSourceConfigService } from './connector-source-config.service';
 import { ConnectorCredentialInjectorService } from './connector-credential-injector.service';
+import { ConnectorSourceCredentialsService } from './connector-source-credentials.service';
 import { addMessageToArray } from './connector-message.utils';
 
 interface ConfigurationExecutionResult {
@@ -56,7 +57,8 @@ export class ConnectorExecutorService {
     private readonly systemTimeService: SystemTimeService,
     private readonly eventDispatcher: OwoxEventDispatcher,
     private readonly projectBalanceService: ProjectBalanceService,
-    private readonly dataMartService: DataMartService
+    private readonly dataMartService: DataMartService,
+    private readonly connectorSourceCredentialsService: ConnectorSourceCredentialsService
   ) {}
 
   async executeInBackground(
@@ -225,6 +227,7 @@ export class ConnectorExecutorService {
       const configLogs: ConnectorMessage[] = [];
       const configErrors: ConnectorMessage[] = [];
       let success = false;
+      let credentialUpdates: Record<string, unknown> | undefined;
 
       const logCaptureConfig = this.connectorOutputCaptureService.createCapture(
         (message: ConnectorMessage) => {
@@ -258,6 +261,9 @@ export class ConnectorExecutorService {
                     }
                   );
                 });
+              break;
+            case ConnectorMessageType.CREDENTIALS_UPDATE:
+              credentialUpdates = { ...(credentialUpdates ?? {}), ...message.credentials };
               break;
             case ConnectorMessageType.STATUS:
               if (message.status === Core.EXECUTION_STATUS.ERROR) {
@@ -339,6 +345,16 @@ export class ConnectorExecutorService {
         );
 
         if (success) {
+          if (credentialUpdates) {
+            await this.saveConnectorCredentials(
+              config as Record<string, unknown>,
+              credentialUpdates,
+              dataMart,
+              runId,
+              configId
+            );
+          }
+
           this.logger.log(`Configuration ${configIndex + 1} completed successfully`, {
             dataMartId: dataMart.id,
             projectId: dataMart.projectId,
@@ -390,6 +406,88 @@ export class ConnectorExecutorService {
     }
 
     return configurationResults;
+  }
+
+  private async saveConnectorCredentials(
+    config: Record<string, unknown>,
+    credentials: Record<string, unknown>,
+    dataMart: DataMart,
+    runId: string,
+    configId: string
+  ): Promise<void> {
+    try {
+      const credentialId = this.getCredentialIdForConfig(config);
+      if (!credentialId) {
+        this.logger.warn(`Cannot update connector credentials: no credential reference found`, {
+          dataMartId: dataMart.id,
+          projectId: dataMart.projectId,
+          runId,
+          configId,
+          credentialKeys: Object.keys(credentials),
+        });
+        return;
+      }
+
+      await this.connectorSourceCredentialsService.updateCredentialFields(
+        credentialId,
+        dataMart.projectId,
+        credentials
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(
+        `Failed to update connector credentials: ${errorMessage}`,
+        (error as Error)?.stack,
+        {
+          dataMartId: dataMart.id,
+          projectId: dataMart.projectId,
+          runId,
+          configId,
+          error: errorMessage,
+          credentialKeys: Object.keys(credentials),
+        }
+      );
+    }
+  }
+
+  private getCredentialIdForConfig(config: Record<string, unknown>): string | undefined {
+    const secretsId = config._secrets_id;
+    if (typeof secretsId === 'string' && secretsId) {
+      return secretsId;
+    }
+
+    return this.findSourceCredentialId(config);
+  }
+
+  private findSourceCredentialId(value: unknown): string | undefined {
+    if (!value || typeof value !== 'object') {
+      return undefined;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const credentialId = this.findSourceCredentialId(item);
+        if (credentialId) {
+          return credentialId;
+        }
+      }
+      return undefined;
+    }
+
+    const obj = value as Record<string, unknown>;
+    const credentialId = obj._source_credential_id;
+    if (typeof credentialId === 'string' && credentialId) {
+      return credentialId;
+    }
+
+    for (const item of Object.values(obj)) {
+      const nestedCredentialId = this.findSourceCredentialId(item);
+      if (nestedCredentialId) {
+        return nestedCredentialId;
+      }
+    }
+
+    return undefined;
   }
 
   private isSuccessfulConnectorStatus(status: number): boolean {

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -230,6 +230,7 @@ export class ConnectorExecutorService {
       let success = false;
       let credentialUpdates: Record<string, unknown> | undefined;
       let configForCredentialUpdates = config as Record<string, unknown>;
+      let expectedCredentialValues: Record<string, unknown> | undefined;
 
       const logCaptureConfig = this.connectorOutputCaptureService.createCapture(
         (message: ConnectorMessage) => {
@@ -319,6 +320,12 @@ export class ConnectorExecutorService {
           config as Record<string, unknown>
         );
         configForCredentialUpdates = refreshedConfig;
+        expectedCredentialValues = await this.getExpectedCredentialValues(
+          refreshedConfig,
+          dataMart,
+          runId,
+          configId
+        );
 
         const configState = await this.connectorStateService.getState(dataMart.id, configId);
 
@@ -399,6 +406,7 @@ export class ConnectorExecutorService {
             await this.saveConnectorCredentials(
               configForCredentialUpdates,
               credentialUpdates,
+              expectedCredentialValues,
               dataMart,
               runId,
               configId
@@ -425,6 +433,7 @@ export class ConnectorExecutorService {
   private async saveConnectorCredentials(
     config: Record<string, unknown>,
     credentials: Record<string, unknown>,
+    expectedCredentialValues: Record<string, unknown> | undefined,
     dataMart: DataMart,
     runId: string,
     configId: string
@@ -461,11 +470,20 @@ export class ConnectorExecutorService {
         return;
       }
 
-      await this.connectorSourceCredentialsService.updateCredentialFields(
-        credentialId,
-        dataMart.projectId,
-        credentialUpdates
-      );
+      if (expectedCredentialValues) {
+        await this.connectorSourceCredentialsService.updateCredentialFields(
+          credentialId,
+          dataMart.projectId,
+          credentialUpdates,
+          expectedCredentialValues
+        );
+      } else {
+        await this.connectorSourceCredentialsService.updateCredentialFields(
+          credentialId,
+          dataMart.projectId,
+          credentialUpdates
+        );
+      }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(
@@ -481,6 +499,43 @@ export class ConnectorExecutorService {
         }
       );
       throw error;
+    }
+  }
+
+  private async getExpectedCredentialValues(
+    config: Record<string, unknown>,
+    dataMart: DataMart,
+    runId: string,
+    configId: string
+  ): Promise<Record<string, unknown> | undefined> {
+    const credentialId = this.getCredentialIdForConfig(config);
+    if (!credentialId) {
+      return undefined;
+    }
+
+    try {
+      const credentials =
+        await this.connectorSourceCredentialsService.getCredentialsById(credentialId);
+
+      if (!credentials || credentials.projectId !== dataMart.projectId) {
+        return undefined;
+      }
+
+      return {
+        [GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD]:
+          credentials.credentials?.[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD],
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to snapshot connector credentials before execution`, {
+        dataMartId: dataMart.id,
+        projectId: dataMart.projectId,
+        runId,
+        configId,
+        credentialId,
+        error: errorMessage,
+      });
+      return undefined;
     }
   }
 

--- a/apps/backend/src/data-marts/services/connector/connector-process-spawner.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-process-spawner.service.spec.ts
@@ -188,13 +188,77 @@ describe('ConnectorProcessSpawnerService', () => {
       }
     );
 
-    mockProcess.emitStdout('hello stdout');
-    mockProcess.emitStderr('hello stderr');
+    mockProcess.emitStdout('hello stdout\n');
+    mockProcess.emitStderr('hello stderr\n');
 
     expect(onStdout).toHaveBeenCalledWith('hello stdout');
     expect(onStderr).toHaveBeenCalledWith('hello stderr');
 
     mockProcess.emit('close', 0, null);
     await promise;
+  });
+
+  it('buffers stdout chunks until a full line is available', async () => {
+    const { service } = createService();
+    const mockProcess = createMockProcess();
+    (spawn as unknown as jest.Mock).mockReturnValue(mockProcess);
+
+    const onStdout = jest.fn();
+    const configMock = { toObject: () => ({}) };
+    const runConfigMock = { toObject: () => ({}) };
+
+    const promise = service.spawnConnector(
+      'dm-1',
+      'run-1',
+      configMock as unknown,
+      runConfigMock as unknown,
+      {
+        logCapture: { onStdout },
+      }
+    );
+
+    mockProcess.emitStdout('{"type":"updateCred');
+    expect(onStdout).not.toHaveBeenCalled();
+
+    mockProcess.emitStdout('entials","credentials":{"generated_refresh_token":"secret-token"}}\n');
+
+    expect(onStdout).toHaveBeenCalledWith(
+      '{"type":"updateCredentials","credentials":{"generated_refresh_token":"secret-token"}}'
+    );
+
+    mockProcess.emit('close', 0, null);
+    await promise;
+  });
+
+  it('flushes incomplete stdout and stderr lines when process closes', async () => {
+    const { service } = createService();
+    const mockProcess = createMockProcess();
+    (spawn as unknown as jest.Mock).mockReturnValue(mockProcess);
+
+    const onStdout = jest.fn();
+    const onStderr = jest.fn();
+    const configMock = { toObject: () => ({}) };
+    const runConfigMock = { toObject: () => ({}) };
+
+    const promise = service.spawnConnector(
+      'dm-1',
+      'run-1',
+      configMock as unknown,
+      runConfigMock as unknown,
+      {
+        logCapture: { onStdout, onStderr },
+      }
+    );
+
+    mockProcess.emitStdout('tail stdout');
+    mockProcess.emitStderr('tail stderr');
+    expect(onStdout).not.toHaveBeenCalled();
+    expect(onStderr).not.toHaveBeenCalled();
+
+    mockProcess.emit('close', 0, null);
+
+    await promise;
+    expect(onStdout).toHaveBeenCalledWith('tail stdout');
+    expect(onStderr).toHaveBeenCalledWith('tail stderr');
   });
 });

--- a/apps/backend/src/data-marts/services/connector/connector-process-spawner.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-process-spawner.service.spec.ts
@@ -76,6 +76,36 @@ describe('ConnectorProcessSpawnerService', () => {
     mockProcess.emit('close', 0, null);
 
     await expect(promise).resolves.toBeUndefined();
+    expect(spawn).toHaveBeenCalledWith(
+      'node',
+      expect.any(Array),
+      expect.objectContaining({ stdio: 'pipe' })
+    );
+  });
+
+  it('drains piped output even without logCapture callbacks', async () => {
+    const { service } = createService();
+    const mockProcess = createMockProcess();
+    (spawn as unknown as jest.Mock).mockReturnValue(mockProcess);
+
+    const configMock = { toObject: () => ({}) };
+    const runConfigMock = { toObject: () => ({}) };
+
+    const promise = service.spawnConnector(
+      'dm-1',
+      'run-1',
+      configMock as unknown,
+      runConfigMock as unknown,
+      {}
+    );
+
+    mockProcess.emitStdout('uncaptured stdout\n');
+    mockProcess.emitStderr('uncaptured stderr\n');
+    mockProcess.emit('close', 0, null);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(mockProcess.stdout.on).toHaveBeenCalledWith('data', expect.any(Function));
+    expect(mockProcess.stderr.on).toHaveBeenCalledWith('data', expect.any(Function));
   });
 
   it('rejects when process exits with non-zero code', async () => {
@@ -260,5 +290,38 @@ describe('ConnectorProcessSpawnerService', () => {
     await promise;
     expect(onStdout).toHaveBeenCalledWith('tail stdout');
     expect(onStderr).toHaveBeenCalledWith('tail stderr');
+  });
+
+  it('redacts oversized stdout and stderr lines instead of forwarding raw content', async () => {
+    const { service } = createService();
+    const mockProcess = createMockProcess();
+    (spawn as unknown as jest.Mock).mockReturnValue(mockProcess);
+
+    const onStdout = jest.fn();
+    const onStderr = jest.fn();
+    const configMock = { toObject: () => ({}) };
+    const runConfigMock = { toObject: () => ({}) };
+    const oversizedSecretLine = `${'x'.repeat(1024 * 1024)}secret-token`;
+    const truncationMarker = '[TRUNCATED connector output line: exceeded 1048576 bytes]';
+
+    const promise = service.spawnConnector(
+      'dm-1',
+      'run-1',
+      configMock as unknown,
+      runConfigMock as unknown,
+      {
+        logCapture: { onStdout, onStderr },
+      }
+    );
+
+    mockProcess.emitStdout(oversizedSecretLine);
+    mockProcess.emitStderr(oversizedSecretLine);
+    mockProcess.emit('close', 0, null);
+
+    await promise;
+    expect(onStdout).toHaveBeenCalledWith(truncationMarker);
+    expect(onStderr).toHaveBeenCalledWith(truncationMarker);
+    expect(JSON.stringify(onStdout.mock.calls)).not.toContain('secret-token');
+    expect(JSON.stringify(onStderr.mock.calls)).not.toContain('secret-token');
   });
 });

--- a/apps/backend/src/data-marts/services/connector/connector-process-spawner.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-process-spawner.service.ts
@@ -32,6 +32,7 @@ export class ConnectorProcessSpawnerService {
         onStderr?: (message: string) => void;
       } | null = null;
       let onSpawn: ((pid: number | undefined) => void) | null = null;
+      let flushCapturedOutput: (() => void) | null = null;
 
       if (stdio && typeof stdio === 'object' && stdio.logCapture) {
         logCapture = stdio.logCapture;
@@ -72,19 +73,29 @@ export class ConnectorProcessSpawnerService {
       }
 
       if (logCapture && node.stdout && node.stderr) {
+        const stdoutBuffer = this.createLineBuffer(message => logCapture?.onStdout?.(message));
+        const stderrBuffer = this.createLineBuffer(message => logCapture?.onStderr?.(message));
+
         node.stdout.on('data', data => {
-          const message = data.toString();
-          if (logCapture.onStdout) {
-            logCapture.onStdout(message);
-          }
+          stdoutBuffer.push(data.toString());
         });
 
         node.stderr.on('data', data => {
-          const message = data.toString();
-          if (logCapture.onStderr) {
-            logCapture.onStderr(message);
-          }
+          stderrBuffer.push(data.toString());
         });
+
+        node.stdout.on('end', () => {
+          stdoutBuffer.flush();
+        });
+
+        node.stderr.on('end', () => {
+          stderrBuffer.flush();
+        });
+
+        flushCapturedOutput = () => {
+          stdoutBuffer.flush();
+          stderrBuffer.flush();
+        };
       }
 
       if (signal) {
@@ -112,6 +123,8 @@ export class ConnectorProcessSpawnerService {
       }
 
       node.on('close', (code, closeSignal) => {
+        flushCapturedOutput?.();
+
         if (code === 0) {
           resolve();
           return;
@@ -141,5 +154,33 @@ export class ConnectorProcessSpawnerService {
         reject(error);
       });
     });
+  }
+
+  private createLineBuffer(onLine: (message: string) => void): {
+    push: (chunk: string) => void;
+    flush: () => void;
+  } {
+    let buffer = '';
+
+    const emit = (line: string): void => {
+      onLine(line.endsWith('\r') ? line.slice(0, -1) : line);
+    };
+
+    return {
+      push: (chunk: string): void => {
+        buffer += chunk;
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+        lines.forEach(emit);
+      },
+      flush: (): void => {
+        if (!buffer) {
+          return;
+        }
+
+        emit(buffer);
+        buffer = '';
+      },
+    };
   }
 }

--- a/apps/backend/src/data-marts/services/connector/connector-process-spawner.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-process-spawner.service.ts
@@ -8,6 +8,9 @@ import { Core } from '@owox/connectors';
 type ConfigDto = InstanceType<typeof Core.ConfigDto>;
 type RunConfigDto = InstanceType<typeof Core.RunConfigDto>;
 
+const MAX_CAPTURED_LINE_LENGTH = 1024 * 1024;
+const TRUNCATED_OUTPUT_LINE = '[TRUNCATED connector output line: exceeded 1048576 bytes]';
+
 @Injectable()
 export class ConnectorProcessSpawnerService {
   private readonly logger = new Logger(ConnectorProcessSpawnerService.name);
@@ -26,7 +29,7 @@ export class ConnectorProcessSpawnerService {
     signal?: AbortSignal
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      let spawnStdio: 'inherit' | 'pipe' | Array<string | number> = 'inherit';
+      const spawnStdio = 'pipe' as const;
       let logCapture: {
         onStdout?: (message: string) => void;
         onStderr?: (message: string) => void;
@@ -36,10 +39,10 @@ export class ConnectorProcessSpawnerService {
 
       if (stdio && typeof stdio === 'object' && stdio.logCapture) {
         logCapture = stdio.logCapture;
-        spawnStdio = 'pipe';
-        if (typeof stdio.onSpawn === 'function') {
-          onSpawn = stdio.onSpawn;
-        }
+      }
+
+      if (stdio && typeof stdio === 'object' && typeof stdio.onSpawn === 'function') {
+        onSpawn = stdio.onSpawn;
       }
 
       const env = {
@@ -72,7 +75,7 @@ export class ConnectorProcessSpawnerService {
         }
       }
 
-      if (logCapture && node.stdout && node.stderr) {
+      if (node.stdout && node.stderr) {
         const stdoutBuffer = this.createLineBuffer(message => logCapture?.onStdout?.(message));
         const stderrBuffer = this.createLineBuffer(message => logCapture?.onStderr?.(message));
 
@@ -161,6 +164,7 @@ export class ConnectorProcessSpawnerService {
     flush: () => void;
   } {
     let buffer = '';
+    let discardingOversizedLine = false;
 
     const emit = (line: string): void => {
       onLine(line.endsWith('\r') ? line.slice(0, -1) : line);
@@ -168,12 +172,41 @@ export class ConnectorProcessSpawnerService {
 
     return {
       push: (chunk: string): void => {
-        buffer += chunk;
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
-        lines.forEach(emit);
+        const parts = chunk.split('\n');
+
+        parts.forEach((part, index) => {
+          const isLastPart = index === parts.length - 1;
+
+          if (discardingOversizedLine) {
+            if (!isLastPart) {
+              discardingOversizedLine = false;
+              buffer = '';
+            }
+            return;
+          }
+
+          if (buffer.length + part.length > MAX_CAPTURED_LINE_LENGTH) {
+            emit(TRUNCATED_OUTPUT_LINE);
+            buffer = '';
+            discardingOversizedLine = isLastPart;
+            return;
+          }
+
+          buffer += part;
+
+          if (!isLastPart) {
+            emit(buffer);
+            buffer = '';
+          }
+        });
       },
       flush: (): void => {
+        if (discardingOversizedLine) {
+          discardingOversizedLine = false;
+          buffer = '';
+          return;
+        }
+
         if (!buffer) {
           return;
         }

--- a/apps/backend/src/data-marts/services/connector/connector-secret.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-secret.service.spec.ts
@@ -81,6 +81,22 @@ describe('ConnectorSecretService', () => {
       const masked = await service.mask(def);
       expect(masked).toBe(def);
     });
+
+    it('removes generated refresh token even when it is not a spec secret field', async () => {
+      const { service } = createService([]);
+      const def = makeDefinition([
+        {
+          _id: 'a',
+          AccountIDs: '33',
+          generated_refresh_token: 'generated-refresh-token',
+        },
+      ]);
+
+      const masked = await service.mask(def);
+      const cfg = masked!.connector.source.configuration as Array<Record<string, unknown>>;
+
+      expect(cfg[0]).not.toHaveProperty('generated_refresh_token');
+    });
   });
 
   describe('mergeDefinitionSecrets', () => {
@@ -143,6 +159,27 @@ describe('ConnectorSecretService', () => {
       const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
       expect(cfg[0].AccessToken).toBe(SECRET_MASK);
       expect(cfg[0]._id).toBe('y');
+    });
+
+    it('drops stale _secrets_id when an item switches to OAuth credentials', async () => {
+      const { service, credentialsService } = createService(['RefreshToken']);
+      const previous = makeDefinition([
+        { _id: 'a', _secrets_id: 'manual-secrets-id', RefreshToken: SECRET_MASK },
+      ]);
+      const incoming = makeDefinition([
+        {
+          _id: 'a',
+          AuthType: { oauth2: { _source_credential_id: 'oauth-cred' } },
+        },
+      ]);
+
+      const merged = await service.mergeDefinitionSecrets(incoming, previous);
+      const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
+      const authType = cfg[0].AuthType as Record<string, Record<string, unknown>>;
+
+      expect(cfg[0]).not.toHaveProperty('_secrets_id');
+      expect(authType.oauth2._source_credential_id).toBe('oauth-cred');
+      expect(credentialsService.getCredentialsById).not.toHaveBeenCalled();
     });
   });
 
@@ -405,6 +442,30 @@ describe('ConnectorSecretService', () => {
     });
   });
 
+  describe('extractAndSaveSecrets', () => {
+    it('removes generated refresh token from OAuth configs skipped by secret extraction', async () => {
+      const { service } = createService(['RefreshToken']);
+      const definition = makeDefinition([
+        {
+          _id: 'config-1',
+          AuthType: { oauth2: { _source_credential_id: 'oauth-cred' } },
+          generated_refresh_token: 'generated-refresh-token',
+        },
+      ]);
+
+      const processed = await service.extractAndSaveSecrets(
+        'dm-1',
+        'proj-1',
+        'FacebookMarketing',
+        definition,
+        'user-1'
+      );
+      const cfg = processed.connector.source.configuration as Array<Record<string, unknown>>;
+
+      expect(cfg[0]).not.toHaveProperty('generated_refresh_token');
+    });
+  });
+
   describe('mergeDefinitionSecretsFromSource', () => {
     it('copies secrets from correct source configurations using _copiedFrom.configId metadata', async () => {
       const { service } = createService(['AccessToken']);
@@ -479,6 +540,45 @@ describe('ConnectorSecretService', () => {
 
       expect(authType.oauth2.RefreshToken).toBe('stored-refresh-token');
       expect(cfg[0].generated_refresh_token).toBe('generated-refresh-token');
+    });
+
+    it('does not inline generated refresh token into copied OAuth configs', async () => {
+      const { service, credentialsService } = createService(['RefreshToken']);
+
+      (credentialsService.getCredentialsByIds as jest.Mock).mockResolvedValue(
+        new Map([
+          [
+            'secrets-1',
+            {
+              id: 'secrets-1',
+              credentials: {
+                'AuthType.oauth2.RefreshToken': 'stored-refresh-token',
+                generated_refresh_token: 'generated-refresh-token',
+              },
+            },
+          ],
+        ])
+      );
+
+      const sourceDefinition = makeDefinition([
+        {
+          _id: 'source-id-1',
+          _secrets_id: 'secrets-1',
+          AuthType: { oauth2: { _source_credential_id: 'oauth-cred' } },
+        },
+      ]);
+
+      const incoming = makeDefinition([
+        {
+          AuthType: { oauth2: { _source_credential_id: 'oauth-cred' } },
+          _copiedFrom: { configId: 'source-id-1' },
+        },
+      ]);
+
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
+
+      expect(cfg[0]).not.toHaveProperty('generated_refresh_token');
     });
 
     it('throws error when connector types do not match', async () => {

--- a/apps/backend/src/data-marts/services/connector/connector-secret.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-secret.service.spec.ts
@@ -443,6 +443,37 @@ describe('ConnectorSecretService', () => {
   });
 
   describe('extractAndSaveSecrets', () => {
+    it('externalizes and removes generated refresh token even when connector has no secret fields', async () => {
+      const { service, credentialsService } = createService([]);
+      const definition = makeDefinition([
+        {
+          _id: 'config-1',
+          AccountIDs: '123',
+          generated_refresh_token: 'generated-refresh-token',
+        },
+      ]);
+
+      const processed = await service.extractAndSaveSecrets(
+        'dm-1',
+        'proj-1',
+        'FacebookMarketing',
+        definition,
+        'user-1'
+      );
+      const cfg = processed.connector.source.configuration as Array<Record<string, unknown>>;
+
+      expect(credentialsService.createSecretsForConfig).toHaveBeenCalledWith(
+        'proj-1',
+        'FacebookMarketing',
+        'dm-1',
+        'config-1',
+        { generated_refresh_token: 'generated-refresh-token' },
+        'user-1'
+      );
+      expect(cfg[0]).not.toHaveProperty('generated_refresh_token');
+      expect(cfg[0]._secrets_id).toBe('mock-secrets-id');
+    });
+
     it('removes generated refresh token from OAuth configs skipped by secret extraction', async () => {
       const { service } = createService(['RefreshToken']);
       const definition = makeDefinition([
@@ -540,6 +571,43 @@ describe('ConnectorSecretService', () => {
 
       expect(authType.oauth2.RefreshToken).toBe('stored-refresh-token');
       expect(cfg[0].generated_refresh_token).toBe('generated-refresh-token');
+    });
+
+    it('does not copy source generated refresh token when incoming copied refresh token changes', async () => {
+      const { service, credentialsService } = createService(['RefreshToken']);
+
+      (credentialsService.getCredentialsByIds as jest.Mock).mockResolvedValue(
+        new Map([
+          [
+            'secrets-1',
+            {
+              id: 'secrets-1',
+              credentials: {
+                'AuthType.oauth2.RefreshToken': 'stored-refresh-token',
+                generated_refresh_token: 'generated-refresh-token',
+              },
+            },
+          ],
+        ])
+      );
+
+      const sourceDefinition = makeDefinition([
+        { _id: 'source-id-1', _secrets_id: 'secrets-1', AuthType: { oauth2: {} } },
+      ]);
+
+      const incoming = makeDefinition([
+        {
+          AuthType: { oauth2: { RefreshToken: 'new-refresh-token' } },
+          _copiedFrom: { configId: 'source-id-1' },
+        },
+      ]);
+
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
+      const authType = cfg[0].AuthType as Record<string, Record<string, unknown>>;
+
+      expect(authType.oauth2.RefreshToken).toBe('new-refresh-token');
+      expect(cfg[0]).not.toHaveProperty('generated_refresh_token');
     });
 
     it('does not inline generated refresh token into copied OAuth configs', async () => {

--- a/apps/backend/src/data-marts/services/connector/connector-secret.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-secret.service.spec.ts
@@ -444,6 +444,43 @@ describe('ConnectorSecretService', () => {
       expect(cfg[1]._id).not.toBe('source-id-3');
     });
 
+    it('copies source secrets from externalized secrets', async () => {
+      const { service, credentialsService } = createService(['RefreshToken']);
+
+      (credentialsService.getCredentialsByIds as jest.Mock).mockResolvedValue(
+        new Map([
+          [
+            'secrets-1',
+            {
+              id: 'secrets-1',
+              credentials: {
+                'AuthType.oauth2.RefreshToken': 'stored-refresh-token',
+                generated_refresh_token: 'generated-refresh-token',
+              },
+            },
+          ],
+        ])
+      );
+
+      const sourceDefinition = makeDefinition([
+        { _id: 'source-id-1', _secrets_id: 'secrets-1', AuthType: { oauth2: {} } },
+      ]);
+
+      const incoming = makeDefinition([
+        {
+          AuthType: { oauth2: { RefreshToken: SECRET_MASK } },
+          _copiedFrom: { configId: 'source-id-1' },
+        },
+      ]);
+
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
+      const authType = cfg[0].AuthType as Record<string, Record<string, unknown>>;
+
+      expect(authType.oauth2.RefreshToken).toBe('stored-refresh-token');
+      expect(cfg[0].generated_refresh_token).toBe('generated-refresh-token');
+    });
+
     it('throws error when connector types do not match', async () => {
       const { service } = createService(['AccessToken']);
 

--- a/apps/backend/src/data-marts/services/connector/connector-secret.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-secret.service.ts
@@ -180,6 +180,54 @@ export class ConnectorSecretService {
     return false;
   }
 
+  private getGeneratedRefreshTokenValue(value: unknown): string | undefined {
+    if (!value || typeof value !== 'object') {
+      return undefined;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const nestedValue = this.getGeneratedRefreshTokenValue(item);
+        if (nestedValue) {
+          return nestedValue;
+        }
+      }
+      return undefined;
+    }
+
+    for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+      if (
+        key === GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD &&
+        typeof nestedValue === 'string' &&
+        nestedValue
+      ) {
+        return nestedValue;
+      }
+
+      const nestedGeneratedRefreshToken = this.getGeneratedRefreshTokenValue(nestedValue);
+      if (nestedGeneratedRefreshToken) {
+        return nestedGeneratedRefreshToken;
+      }
+    }
+
+    return undefined;
+  }
+
+  private removeGeneratedRefreshTokenRecursively(value: unknown): void {
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach(item => this.removeGeneratedRefreshTokenRecursively(item));
+      return;
+    }
+
+    const obj = value as Record<string, unknown>;
+    delete obj[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
+    Object.values(obj).forEach(item => this.removeGeneratedRefreshTokenRecursively(item));
+  }
+
   /**
    * Injects secrets back into a configuration object at their original paths.
    * Paths are dot-separated strings like "AuthType.oauth2.RefreshToken".
@@ -240,9 +288,12 @@ export class ConnectorSecretService {
     userId?: string
   ): Promise<ConnectorDefinition> {
     const secretFieldNames = await this.getAllSecretFieldNames(connectorName);
+    const hasGeneratedRefreshToken = this.hasGeneratedRefreshTokenRecursively(
+      definition.connector.source.configuration
+    );
 
-    // If no secrets in spec, return definition as-is
-    if (secretFieldNames.size === 0) {
+    // If no secrets in spec and no runtime-generated secrets, return definition as-is
+    if (secretFieldNames.size === 0 && !hasGeneratedRefreshToken) {
       return definition;
     }
 
@@ -252,22 +303,24 @@ export class ConnectorSecretService {
         const configId = configItem._id as string;
 
         if (!configId) {
+          this.removeGeneratedRefreshTokenRecursively(configItem);
           return configItem;
         }
 
         // Skip items that use OAuth flow (they have _source_credential_id anywhere)
         // OAuth secrets are managed separately
         if (this.hasSourceCredentialIdRecursively(configItem)) {
-          delete configItem[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
+          this.removeGeneratedRefreshTokenRecursively(configItem);
           return configItem;
         }
 
         // Recursively extract secret values with their paths
         const secrets = this.extractSecretsRecursively(configItem, secretFieldNames);
-        const generatedRefreshToken = configItem[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
-        if (typeof generatedRefreshToken === 'string' && generatedRefreshToken) {
+        const generatedRefreshToken = this.getGeneratedRefreshTokenValue(configItem);
+        if (generatedRefreshToken) {
           secrets[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD] = generatedRefreshToken;
         }
+        this.removeGeneratedRefreshTokenRecursively(configItem);
 
         // If no secrets found, return as-is
         if (Object.keys(secrets).length === 0) {
@@ -320,7 +373,6 @@ export class ConnectorSecretService {
 
         // Remove secret values from configuration (recursively)
         this.removeSecretsRecursively(configItem, secretFieldNames);
-        delete configItem[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
 
         return configItem;
       })
@@ -768,7 +820,8 @@ export class ConnectorSecretService {
       if (
         typeof generatedRefreshToken === 'string' &&
         generatedRefreshToken &&
-        !this.hasSourceCredentialIdRecursively(mergedItem)
+        !this.hasSourceCredentialIdRecursively(mergedItem) &&
+        this.hasSameRefreshToken(sourceConfigWithSecrets, mergedItem)
       ) {
         mergedItem[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD] = generatedRefreshToken;
       }
@@ -786,5 +839,49 @@ export class ConnectorSecretService {
         },
       },
     } as ConnectorDefinition;
+  }
+
+  private hasSameRefreshToken(
+    sourceConfig: Record<string, unknown>,
+    mergedConfig: unknown
+  ): boolean {
+    const sourceRefreshToken = this.getRefreshTokenValue(sourceConfig);
+    const mergedRefreshToken = this.getRefreshTokenValue(mergedConfig);
+
+    return (
+      typeof sourceRefreshToken === 'string' &&
+      sourceRefreshToken !== '' &&
+      !this.isSecretMask(sourceRefreshToken) &&
+      mergedRefreshToken === sourceRefreshToken
+    );
+  }
+
+  private getRefreshTokenValue(value: unknown): unknown {
+    if (!value || typeof value !== 'object') {
+      return undefined;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const nestedValue = this.getRefreshTokenValue(item);
+        if (nestedValue !== undefined) {
+          return nestedValue;
+        }
+      }
+      return undefined;
+    }
+
+    for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+      if (key === 'refresh_token' || key === 'RefreshToken' || key.endsWith('.RefreshToken')) {
+        return nestedValue;
+      }
+
+      const nestedRefreshToken = this.getRefreshTokenValue(nestedValue);
+      if (nestedRefreshToken !== undefined) {
+        return nestedRefreshToken;
+      }
+    }
+
+    return undefined;
   }
 }

--- a/apps/backend/src/data-marts/services/connector/connector-secret.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-secret.service.ts
@@ -7,6 +7,7 @@ import { ConnectorSourceCredentialsService } from './connector-source-credential
 import { Core } from '@owox/connectors';
 
 export const SECRET_MASK = '**********' as const;
+const GENERATED_REFRESH_TOKEN_FIELD = 'generated_refresh_token';
 
 @Injectable()
 /**
@@ -167,6 +168,10 @@ export class ConnectorSecretService {
    */
   injectSecretsAtPaths(obj: Record<string, unknown>, secrets: Record<string, unknown>): void {
     for (const [path, value] of Object.entries(secrets)) {
+      if (path === GENERATED_REFRESH_TOKEN_FIELD) {
+        continue;
+      }
+
       const parts = path.split('.');
       let current = obj;
 
@@ -237,6 +242,10 @@ export class ConnectorSecretService {
 
         // Recursively extract secret values with their paths
         const secrets = this.extractSecretsRecursively(configItem, secretFieldNames);
+        const generatedRefreshToken = configItem[GENERATED_REFRESH_TOKEN_FIELD];
+        if (typeof generatedRefreshToken === 'string' && generatedRefreshToken) {
+          secrets[GENERATED_REFRESH_TOKEN_FIELD] = generatedRefreshToken;
+        }
 
         // If no secrets found, return as-is
         if (Object.keys(secrets).length === 0) {
@@ -289,6 +298,7 @@ export class ConnectorSecretService {
 
         // Remove secret values from configuration (recursively)
         this.removeSecretsRecursively(configItem, secretFieldNames);
+        delete configItem[GENERATED_REFRESH_TOKEN_FIELD];
 
         return configItem;
       })
@@ -482,6 +492,10 @@ export class ConnectorSecretService {
    */
   private injectMasksAtPaths(obj: Record<string, unknown>, secrets: Record<string, unknown>): void {
     for (const path of Object.keys(secrets)) {
+      if (path === GENERATED_REFRESH_TOKEN_FIELD) {
+        continue;
+      }
+
       const parts = path.split('.');
 
       // Navigate to the parent object, creating intermediate objects if needed
@@ -670,6 +684,11 @@ export class ConnectorSecretService {
     }
 
     const secretFieldNames = await this.getAllSecretFieldNames(incoming.connector.source.name);
+    const sourceSecretsIds = sourceDefinition.connector.source.configuration
+      .map(item => (item as Record<string, unknown>)._secrets_id as string | undefined)
+      .filter((id): id is string => !!id);
+    const sourceSecretsMap =
+      await this.connectorSourceCredentialsService.getCredentialsByIds(sourceSecretsIds);
 
     const mergedConfiguration = incoming.connector.source.configuration.map(incomingItem => {
       const itemWithMetadata = incomingItem as Record<string, unknown> & {
@@ -693,14 +712,28 @@ export class ConnectorSecretService {
         );
       }
 
+      const sourceConfigWithSecrets = JSON.parse(JSON.stringify(sourceConfig)) as Record<
+        string,
+        unknown
+      >;
+      const secretsId = sourceConfigWithSecrets._secrets_id as string | undefined;
+      const secretsEntity = secretsId ? sourceSecretsMap.get(secretsId) : undefined;
+      const generatedRefreshToken = secretsEntity?.credentials?.[GENERATED_REFRESH_TOKEN_FIELD];
+      if (secretsEntity?.credentials) {
+        this.injectSecretsAtPaths(sourceConfigWithSecrets, secretsEntity.credentials);
+      }
+
       const mergedItem = this.mergeSecretsRecursively(
         incomingItem,
-        sourceConfig,
+        sourceConfigWithSecrets,
         secretFieldNames
       ) as Record<string, unknown>;
 
       delete mergedItem._copiedFrom;
       mergedItem._id = randomUUID();
+      if (typeof generatedRefreshToken === 'string' && generatedRefreshToken) {
+        mergedItem[GENERATED_REFRESH_TOKEN_FIELD] = generatedRefreshToken;
+      }
 
       return mergedItem;
     });

--- a/apps/backend/src/data-marts/services/connector/connector-secret.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-secret.service.ts
@@ -7,7 +7,7 @@ import { ConnectorSourceCredentialsService } from './connector-source-credential
 import { Core } from '@owox/connectors';
 
 export const SECRET_MASK = '**********' as const;
-const GENERATED_REFRESH_TOKEN_FIELD = 'generated_refresh_token';
+const { GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD } = Core;
 
 @Injectable()
 /**
@@ -159,6 +159,27 @@ export class ConnectorSecretService {
     return false;
   }
 
+  private hasGeneratedRefreshTokenRecursively(obj: unknown): boolean {
+    if (!obj || typeof obj !== 'object') {
+      return false;
+    }
+
+    if (Array.isArray(obj)) {
+      return obj.some(item => this.hasGeneratedRefreshTokenRecursively(item));
+    }
+
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      if (key === GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD) {
+        return true;
+      }
+      if (this.hasGeneratedRefreshTokenRecursively(value)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   /**
    * Injects secrets back into a configuration object at their original paths.
    * Paths are dot-separated strings like "AuthType.oauth2.RefreshToken".
@@ -168,7 +189,7 @@ export class ConnectorSecretService {
    */
   injectSecretsAtPaths(obj: Record<string, unknown>, secrets: Record<string, unknown>): void {
     for (const [path, value] of Object.entries(secrets)) {
-      if (path === GENERATED_REFRESH_TOKEN_FIELD) {
+      if (path === GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD) {
         continue;
       }
 
@@ -237,14 +258,15 @@ export class ConnectorSecretService {
         // Skip items that use OAuth flow (they have _source_credential_id anywhere)
         // OAuth secrets are managed separately
         if (this.hasSourceCredentialIdRecursively(configItem)) {
+          delete configItem[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
           return configItem;
         }
 
         // Recursively extract secret values with their paths
         const secrets = this.extractSecretsRecursively(configItem, secretFieldNames);
-        const generatedRefreshToken = configItem[GENERATED_REFRESH_TOKEN_FIELD];
+        const generatedRefreshToken = configItem[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
         if (typeof generatedRefreshToken === 'string' && generatedRefreshToken) {
-          secrets[GENERATED_REFRESH_TOKEN_FIELD] = generatedRefreshToken;
+          secrets[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD] = generatedRefreshToken;
         }
 
         // If no secrets found, return as-is
@@ -298,7 +320,7 @@ export class ConnectorSecretService {
 
         // Remove secret values from configuration (recursively)
         this.removeSecretsRecursively(configItem, secretFieldNames);
-        delete configItem[GENERATED_REFRESH_TOKEN_FIELD];
+        delete configItem[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
 
         return configItem;
       })
@@ -333,6 +355,7 @@ export class ConnectorSecretService {
     }
 
     const maskedItem = { ...(item as Record<string, unknown>) };
+    delete maskedItem[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
 
     // If this item has _source_credential_id, don't mask OAuth-related fields
     // because the actual secrets are stored separately in ConnectorSourceCredentials
@@ -442,7 +465,10 @@ export class ConnectorSecretService {
     if (!definition) return definition;
 
     const secretFieldNames = await this.getAllSecretFieldNames(definition.connector.source.name);
-    if (secretFieldNames.size === 0) {
+    const hasGeneratedRefreshToken = this.hasGeneratedRefreshTokenRecursively(
+      definition.connector.source.configuration
+    );
+    if (secretFieldNames.size === 0 && !hasGeneratedRefreshToken) {
       return definition;
     }
 
@@ -492,7 +518,7 @@ export class ConnectorSecretService {
    */
   private injectMasksAtPaths(obj: Record<string, unknown>, secrets: Record<string, unknown>): void {
     for (const path of Object.keys(secrets)) {
-      if (path === GENERATED_REFRESH_TOKEN_FIELD) {
+      if (path === GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD) {
         continue;
       }
 
@@ -530,7 +556,8 @@ export class ConnectorSecretService {
    * If there are no secret fields in the specification — returns the incoming definition as is.
    *
    * If previous item has `_secrets_id`, loads secrets from the credentials table
-   * and merges them with incoming values. The `_secrets_id` is preserved in the result.
+   * and merges them with incoming values. The `_secrets_id` is preserved in the result
+   * unless the incoming item now uses OAuth credentials.
    *
    * @param incoming New definition coming from the client
    * @param previous Previously stored definition used as a source of truth for secrets
@@ -546,6 +573,11 @@ export class ConnectorSecretService {
     const mergedConfiguration = await Promise.all(
       incoming.connector.source.configuration.map(async item => {
         const incomingItem = (item || {}) as Record<string, unknown>;
+        const usesSourceCredentials = this.hasSourceCredentialIdRecursively(incomingItem);
+
+        if (usesSourceCredentials) {
+          delete incomingItem._secrets_id;
+        }
 
         const itemId = incomingItem._id;
         if (typeof itemId !== 'string' || itemId.length === 0) {
@@ -565,7 +597,7 @@ export class ConnectorSecretService {
         // If previous item has externalized secrets, load them for merging
         let previousWithSecrets = previousItem;
         const secretsId = previousItem._secrets_id as string | undefined;
-        if (secretsId) {
+        if (secretsId && !usesSourceCredentials) {
           const secretsEntity =
             await this.connectorSourceCredentialsService.getCredentialsById(secretsId);
           if (secretsEntity) {
@@ -718,7 +750,8 @@ export class ConnectorSecretService {
       >;
       const secretsId = sourceConfigWithSecrets._secrets_id as string | undefined;
       const secretsEntity = secretsId ? sourceSecretsMap.get(secretsId) : undefined;
-      const generatedRefreshToken = secretsEntity?.credentials?.[GENERATED_REFRESH_TOKEN_FIELD];
+      const generatedRefreshToken =
+        secretsEntity?.credentials?.[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
       if (secretsEntity?.credentials) {
         this.injectSecretsAtPaths(sourceConfigWithSecrets, secretsEntity.credentials);
       }
@@ -731,8 +764,13 @@ export class ConnectorSecretService {
 
       delete mergedItem._copiedFrom;
       mergedItem._id = randomUUID();
-      if (typeof generatedRefreshToken === 'string' && generatedRefreshToken) {
-        mergedItem[GENERATED_REFRESH_TOKEN_FIELD] = generatedRefreshToken;
+      delete mergedItem[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
+      if (
+        typeof generatedRefreshToken === 'string' &&
+        generatedRefreshToken &&
+        !this.hasSourceCredentialIdRecursively(mergedItem)
+      ) {
+        mergedItem[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD] = generatedRefreshToken;
       }
 
       return mergedItem;

--- a/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.spec.ts
@@ -149,6 +149,32 @@ describe('ConnectorSourceCredentialsService', () => {
       expect(result.credentials).toEqual({ newKey: 'newValue' });
     });
 
+    it('keeps generated refresh token when regular secrets are updated', async () => {
+      const { service, repository } = createService();
+      const existing = {
+        id: 'cred-1',
+        projectId: 'proj-1',
+        credentials: {
+          'AuthType.oauth2.RefreshToken': 'old-refresh-token',
+          generated_refresh_token: 'generated-refresh-token',
+        },
+      } as unknown as ConnectorSourceCredentials;
+      (repository.findOne as jest.Mock).mockResolvedValue(existing);
+
+      await service.updateSecretsForConfig('cred-1', 'proj-1', {
+        'AuthType.oauth2.RefreshToken': 'old-refresh-token',
+      });
+
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credentials: {
+            'AuthType.oauth2.RefreshToken': 'old-refresh-token',
+            generated_refresh_token: 'generated-refresh-token',
+          },
+        })
+      );
+    });
+
     it('throws when entity not found', async () => {
       const { service, repository } = createService();
       (repository.findOne as jest.Mock).mockResolvedValue(null);
@@ -170,6 +196,35 @@ describe('ConnectorSourceCredentialsService', () => {
       await expect(
         service.updateSecretsForConfig('cred-1', 'proj-1', { key: 'val' })
       ).rejects.toThrow('Unauthorized: secrets do not belong to this project');
+    });
+  });
+
+  describe('updateCredentialFields', () => {
+    it('adds generated refresh token without changing original refresh token fields', async () => {
+      const { service, repository } = createService();
+      const existing = {
+        id: 'cred-1',
+        projectId: 'proj-1',
+        credentials: {
+          'AuthType.oauth2.RefreshToken': 'old-refresh-token',
+          'AuthType.oauth2.ClientSecret': 'client-secret',
+        },
+      } as unknown as ConnectorSourceCredentials;
+      (repository.findOne as jest.Mock).mockResolvedValue(existing);
+
+      await service.updateCredentialFields('cred-1', 'proj-1', {
+        generated_refresh_token: 'generated-refresh-token',
+      });
+
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credentials: {
+            'AuthType.oauth2.RefreshToken': 'old-refresh-token',
+            'AuthType.oauth2.ClientSecret': 'client-secret',
+            generated_refresh_token: 'generated-refresh-token',
+          },
+        })
+      );
     });
   });
 

--- a/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.spec.ts
@@ -3,7 +3,7 @@ import { ConnectorSourceCredentialsService } from './connector-source-credential
 import { ConnectorSourceCredentials } from '../../entities/connector-source-credentials.entity';
 
 describe('ConnectorSourceCredentialsService', () => {
-  const createService = () => {
+  const createService = (databaseType = 'better-sqlite3') => {
     const queryBuilder = {
       update: jest.fn().mockReturnThis(),
       set: jest.fn().mockReturnThis(),
@@ -19,6 +19,9 @@ describe('ConnectorSourceCredentialsService', () => {
       find: jest.fn(),
       softDelete: jest.fn().mockResolvedValue(undefined),
       createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+      manager: {
+        connection: { options: { type: databaseType } },
+      },
     } as unknown as Repository<ConnectorSourceCredentials>;
 
     const service = new ConnectorSourceCredentialsService(repository);
@@ -267,6 +270,102 @@ describe('ConnectorSourceCredentialsService', () => {
         expect.objectContaining({ generatedRefreshToken: 'generated-refresh-token' })
       );
       expect(repository.save).not.toHaveBeenCalled();
+    });
+
+    it('guards generated refresh token updates using sqlite JSON extraction', async () => {
+      const { service, repository, queryBuilder } = createService('better-sqlite3');
+      const existing = {
+        id: 'cred-1',
+        projectId: 'proj-1',
+        credentials: { generated_refresh_token: 'old-token' },
+      } as unknown as ConnectorSourceCredentials;
+      (repository.findOne as jest.Mock).mockResolvedValueOnce(existing).mockResolvedValueOnce({
+        ...existing,
+        credentials: { generated_refresh_token: 'new-token' },
+      });
+
+      await service.updateCredentialFields(
+        'cred-1',
+        'proj-1',
+        { generated_refresh_token: 'new-token' },
+        { generated_refresh_token: 'old-token' }
+      );
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        "JSON_EXTRACT(credentials, '$.generated_refresh_token') = :expectedGeneratedRefreshToken"
+      );
+      expect(queryBuilder.setParameters).toHaveBeenCalledWith(
+        expect.objectContaining({ expectedGeneratedRefreshToken: 'old-token' })
+      );
+    });
+
+    it('guards generated refresh token updates using mysql JSON extraction', async () => {
+      const { service, repository, queryBuilder } = createService('mysql');
+      const existing = {
+        id: 'cred-1',
+        projectId: 'proj-1',
+        credentials: { generated_refresh_token: 'old-token' },
+      } as unknown as ConnectorSourceCredentials;
+      (repository.findOne as jest.Mock).mockResolvedValueOnce(existing).mockResolvedValueOnce({
+        ...existing,
+        credentials: { generated_refresh_token: 'new-token' },
+      });
+
+      await service.updateCredentialFields(
+        'cred-1',
+        'proj-1',
+        { generated_refresh_token: 'new-token' },
+        { generated_refresh_token: 'old-token' }
+      );
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        "JSON_UNQUOTE(JSON_EXTRACT(credentials, '$.generated_refresh_token')) = :expectedGeneratedRefreshToken"
+      );
+    });
+
+    it('returns existing credentials without failing when guarded update is stale', async () => {
+      const { service, repository, queryBuilder } = createService();
+      const existing = {
+        id: 'cred-1',
+        projectId: 'proj-1',
+        credentials: { generated_refresh_token: 'newer-token' },
+      } as unknown as ConnectorSourceCredentials;
+      (queryBuilder.execute as jest.Mock).mockResolvedValueOnce({ affected: 0 });
+      (repository.findOne as jest.Mock).mockResolvedValueOnce(existing);
+
+      const result = await service.updateCredentialFields(
+        'cred-1',
+        'proj-1',
+        { generated_refresh_token: 'older-token' },
+        { generated_refresh_token: 'old-token' }
+      );
+
+      expect(result).toBe(existing);
+      expect(repository.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    it('guards generated refresh token updates against an absent current value', async () => {
+      const { service, repository, queryBuilder } = createService();
+      const existing = {
+        id: 'cred-1',
+        projectId: 'proj-1',
+        credentials: {},
+      } as unknown as ConnectorSourceCredentials;
+      (repository.findOne as jest.Mock).mockResolvedValueOnce(existing).mockResolvedValueOnce({
+        ...existing,
+        credentials: { generated_refresh_token: 'new-token' },
+      });
+
+      await service.updateCredentialFields(
+        'cred-1',
+        'proj-1',
+        { generated_refresh_token: 'new-token' },
+        { generated_refresh_token: undefined }
+      );
+
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+        "JSON_EXTRACT(credentials, '$.generated_refresh_token') IS NULL"
+      );
     });
   });
 

--- a/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.spec.ts
@@ -4,18 +4,26 @@ import { ConnectorSourceCredentials } from '../../entities/connector-source-cred
 
 describe('ConnectorSourceCredentialsService', () => {
   const createService = () => {
+    const queryBuilder = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      setParameters: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
     const repository = {
       create: jest.fn().mockImplementation(data => data),
       save: jest.fn().mockImplementation(data => Promise.resolve({ ...data, id: 'cred-1' })),
       findOne: jest.fn(),
       find: jest.fn(),
       softDelete: jest.fn().mockResolvedValue(undefined),
-      createQueryBuilder: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
     } as unknown as Repository<ConnectorSourceCredentials>;
 
     const service = new ConnectorSourceCredentialsService(repository);
 
-    return { service, repository };
+    return { service, repository, queryBuilder };
   };
 
   describe('createCredentials', () => {
@@ -127,14 +135,13 @@ describe('ConnectorSourceCredentialsService', () => {
 
   describe('updateSecretsForConfig', () => {
     it('updates credentials when found and projectId matches', async () => {
-      const { service, repository } = createService();
+      const { service, repository, queryBuilder } = createService();
       const existing = {
         id: 'cred-1',
         projectId: 'proj-1',
         credentials: { oldKey: 'oldValue' },
       } as unknown as ConnectorSourceCredentials;
-      (repository.findOne as jest.Mock).mockResolvedValue(existing);
-      (repository.save as jest.Mock).mockResolvedValue({
+      (repository.findOne as jest.Mock).mockResolvedValueOnce(existing).mockResolvedValueOnce({
         ...existing,
         credentials: { newKey: 'newValue' },
       });
@@ -143,14 +150,16 @@ describe('ConnectorSourceCredentialsService', () => {
         newKey: 'newValue',
       });
 
-      expect(repository.save).toHaveBeenCalledWith(
-        expect.objectContaining({ credentials: { newKey: 'newValue' } })
+      expect(queryBuilder.set).toHaveBeenCalledWith({ credentials: expect.any(Function) });
+      expect(queryBuilder.setParameters).toHaveBeenCalledWith(
+        expect.objectContaining({ credentials: JSON.stringify({ newKey: 'newValue' }) })
       );
+      expect(repository.save).not.toHaveBeenCalled();
       expect(result.credentials).toEqual({ newKey: 'newValue' });
     });
 
     it('keeps generated refresh token when regular secrets are updated', async () => {
-      const { service, repository } = createService();
+      const { service, repository, queryBuilder } = createService();
       const existing = {
         id: 'cred-1',
         projectId: 'proj-1',
@@ -159,20 +168,51 @@ describe('ConnectorSourceCredentialsService', () => {
           generated_refresh_token: 'generated-refresh-token',
         },
       } as unknown as ConnectorSourceCredentials;
-      (repository.findOne as jest.Mock).mockResolvedValue(existing);
+      (repository.findOne as jest.Mock).mockResolvedValueOnce(existing).mockResolvedValueOnce({
+        ...existing,
+        credentials: {
+          'AuthType.oauth2.RefreshToken': 'old-refresh-token',
+          generated_refresh_token: 'generated-refresh-token',
+        },
+      });
 
       await service.updateSecretsForConfig('cred-1', 'proj-1', {
         'AuthType.oauth2.RefreshToken': 'old-refresh-token',
       });
 
-      expect(repository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          credentials: {
-            'AuthType.oauth2.RefreshToken': 'old-refresh-token',
-            generated_refresh_token: 'generated-refresh-token',
-          },
-        })
-      );
+      const credentialsExpression = (
+        queryBuilder.set as jest.Mock
+      ).mock.calls[0][0].credentials() as string;
+      expect(credentialsExpression).toContain('JSON_EXTRACT(credentials');
+      expect(repository.save).not.toHaveBeenCalled();
+    });
+
+    it('drops generated refresh token when original refresh token changes', async () => {
+      const { service, repository, queryBuilder } = createService();
+      const existing = {
+        id: 'cred-1',
+        projectId: 'proj-1',
+        credentials: {
+          'AuthType.oauth2.RefreshToken': 'old-refresh-token',
+          generated_refresh_token: 'generated-refresh-token',
+        },
+      } as unknown as ConnectorSourceCredentials;
+      (repository.findOne as jest.Mock).mockResolvedValueOnce(existing).mockResolvedValueOnce({
+        ...existing,
+        credentials: {
+          'AuthType.oauth2.RefreshToken': 'new-refresh-token',
+        },
+      });
+
+      await service.updateSecretsForConfig('cred-1', 'proj-1', {
+        'AuthType.oauth2.RefreshToken': 'new-refresh-token',
+      });
+
+      const credentialsExpression = (
+        queryBuilder.set as jest.Mock
+      ).mock.calls[0][0].credentials() as string;
+      expect(credentialsExpression).toBe(':credentials');
+      expect(repository.save).not.toHaveBeenCalled();
     });
 
     it('throws when entity not found', async () => {
@@ -201,7 +241,7 @@ describe('ConnectorSourceCredentialsService', () => {
 
   describe('updateCredentialFields', () => {
     it('adds generated refresh token without changing original refresh token fields', async () => {
-      const { service, repository } = createService();
+      const { service, repository, queryBuilder } = createService();
       const existing = {
         id: 'cred-1',
         projectId: 'proj-1',
@@ -210,21 +250,23 @@ describe('ConnectorSourceCredentialsService', () => {
           'AuthType.oauth2.ClientSecret': 'client-secret',
         },
       } as unknown as ConnectorSourceCredentials;
-      (repository.findOne as jest.Mock).mockResolvedValue(existing);
+      (repository.findOne as jest.Mock).mockResolvedValueOnce(existing).mockResolvedValueOnce({
+        ...existing,
+        credentials: {
+          ...existing.credentials,
+          generated_refresh_token: 'generated-refresh-token',
+        },
+      });
 
       await service.updateCredentialFields('cred-1', 'proj-1', {
         generated_refresh_token: 'generated-refresh-token',
       });
 
-      expect(repository.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          credentials: {
-            'AuthType.oauth2.RefreshToken': 'old-refresh-token',
-            'AuthType.oauth2.ClientSecret': 'client-secret',
-            generated_refresh_token: 'generated-refresh-token',
-          },
-        })
+      expect(queryBuilder.set).toHaveBeenCalledWith({ credentials: expect.any(Function) });
+      expect(queryBuilder.setParameters).toHaveBeenCalledWith(
+        expect.objectContaining({ generatedRefreshToken: 'generated-refresh-token' })
       );
+      expect(repository.save).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.ts
@@ -228,7 +228,8 @@ export class ConnectorSourceCredentialsService {
   async updateCredentialFields(
     id: string,
     projectId: string,
-    updates: Record<string, unknown>
+    updates: Record<string, unknown>,
+    expectedCurrentValues?: Record<string, unknown>
   ): Promise<ConnectorSourceCredentials> {
     const generatedRefreshToken = updates[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
     if (typeof generatedRefreshToken !== 'string') {
@@ -246,7 +247,7 @@ export class ConnectorSourceCredentialsService {
       throw new Error(`Unauthorized: credentials do not belong to this project`);
     }
 
-    await this.connectorSourceCredentialsRepository
+    const queryBuilder = this.connectorSourceCredentialsRepository
       .createQueryBuilder()
       .update(ConnectorSourceCredentials)
       .set({
@@ -260,8 +261,35 @@ export class ConnectorSourceCredentialsService {
       })
       .where('id = :id', { id })
       .andWhere('projectId = :projectId', { projectId })
-      .setParameters({ generatedRefreshToken })
-      .execute();
+      .setParameters({ generatedRefreshToken });
+
+    if (
+      expectedCurrentValues &&
+      Object.prototype.hasOwnProperty.call(
+        expectedCurrentValues,
+        GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD
+      )
+    ) {
+      const expectedGeneratedRefreshToken =
+        expectedCurrentValues[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
+      const generatedRefreshTokenExpression = this.getJsonExtractTextExpression(
+        'credentials',
+        `$.${GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD}`
+      );
+
+      if (typeof expectedGeneratedRefreshToken === 'string') {
+        queryBuilder
+          .andWhere(`${generatedRefreshTokenExpression} = :expectedGeneratedRefreshToken`)
+          .setParameters({ expectedGeneratedRefreshToken });
+      } else {
+        queryBuilder.andWhere(`${generatedRefreshTokenExpression} IS NULL`);
+      }
+    }
+
+    const updateResult = await queryBuilder.execute();
+    if (updateResult.affected === 0) {
+      return existing;
+    }
 
     const updated = await this.getCredentialsById(id);
 
@@ -273,6 +301,30 @@ export class ConnectorSourceCredentialsService {
           [GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD]: generatedRefreshToken,
         },
       }
+    );
+  }
+
+  private getJsonExtractTextExpression(column: string, path: string): string {
+    const databaseType = this.getDatabaseType();
+
+    if (databaseType === 'mysql' || databaseType === 'mariadb') {
+      return `JSON_UNQUOTE(JSON_EXTRACT(${column}, '${path}'))`;
+    }
+
+    return `JSON_EXTRACT(${column}, '${path}')`;
+  }
+
+  private getDatabaseType(): string | undefined {
+    const repository = this
+      .connectorSourceCredentialsRepository as Repository<ConnectorSourceCredentials> & {
+      manager?: {
+        connection?: { options?: { type?: string } };
+        dataSource?: { options?: { type?: string } };
+      };
+    };
+
+    return (
+      repository.manager?.connection?.options?.type ?? repository.manager?.dataSource?.options?.type
     );
   }
 

--- a/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.ts
@@ -2,6 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { ConnectorSourceCredentials } from '../../entities/connector-source-credentials.entity';
+// @ts-expect-error - Package lacks TypeScript declarations
+import { Core } from '@owox/connectors';
+
+const { GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD } = Core;
+const SECRET_MASK = '**********';
 
 @Injectable()
 export class ConnectorSourceCredentialsService {
@@ -209,14 +214,15 @@ export class ConnectorSourceCredentialsService {
       throw new Error(`Unauthorized: secrets do not belong to this project`);
     }
 
-    existing.credentials = {
-      ...secrets,
-      ...(existing.credentials.generated_refresh_token !== undefined &&
-      secrets.generated_refresh_token === undefined
-        ? { generated_refresh_token: existing.credentials.generated_refresh_token }
-        : {}),
-    };
-    return await this.connectorSourceCredentialsRepository.save(existing);
+    const shouldPreserveGeneratedRefreshToken = this.shouldPreserveGeneratedRefreshToken(
+      existing.credentials,
+      secrets
+    );
+
+    await this.updateCredentialsJson(id, projectId, secrets, shouldPreserveGeneratedRefreshToken);
+    const updated = await this.getCredentialsById(id);
+
+    return updated ?? { ...existing, credentials: secrets };
   }
 
   async updateCredentialFields(
@@ -224,8 +230,14 @@ export class ConnectorSourceCredentialsService {
     projectId: string,
     updates: Record<string, unknown>
   ): Promise<ConnectorSourceCredentials> {
-    const existing = await this.getCredentialsById(id);
+    const generatedRefreshToken = updates[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD];
+    if (typeof generatedRefreshToken !== 'string') {
+      throw new Error(
+        `Only ${GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD} can be updated by field update`
+      );
+    }
 
+    const existing = await this.getCredentialsById(id);
     if (!existing) {
       throw new Error(`ConnectorSourceCredentials with id ${id} not found`);
     }
@@ -234,8 +246,92 @@ export class ConnectorSourceCredentialsService {
       throw new Error(`Unauthorized: credentials do not belong to this project`);
     }
 
-    existing.credentials = { ...existing.credentials, ...updates };
-    return await this.connectorSourceCredentialsRepository.save(existing);
+    await this.connectorSourceCredentialsRepository
+      .createQueryBuilder()
+      .update(ConnectorSourceCredentials)
+      .set({
+        credentials: () => {
+          return `JSON_SET(
+            credentials,
+            '$.${GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD}',
+            :generatedRefreshToken
+          )`;
+        },
+      })
+      .where('id = :id', { id })
+      .andWhere('projectId = :projectId', { projectId })
+      .setParameters({ generatedRefreshToken })
+      .execute();
+
+    const updated = await this.getCredentialsById(id);
+
+    return (
+      updated ?? {
+        ...existing,
+        credentials: {
+          ...existing.credentials,
+          [GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD]: generatedRefreshToken,
+        },
+      }
+    );
+  }
+
+  private async updateCredentialsJson(
+    id: string,
+    projectId: string,
+    credentials: Record<string, unknown>,
+    preserveGeneratedRefreshToken: boolean
+  ): Promise<void> {
+    const serializedCredentials = JSON.stringify(credentials);
+    const generatedRefreshTokenPath = `$.${GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD}`;
+    const credentialsExpression = preserveGeneratedRefreshToken
+      ? `CASE
+          WHEN JSON_EXTRACT(credentials, '${generatedRefreshTokenPath}') IS NOT NULL
+          THEN JSON_SET(
+            :credentials,
+            '${generatedRefreshTokenPath}',
+            JSON_EXTRACT(credentials, '${generatedRefreshTokenPath}')
+          )
+          ELSE :credentials
+        END`
+      : ':credentials';
+
+    await this.connectorSourceCredentialsRepository
+      .createQueryBuilder()
+      .update(ConnectorSourceCredentials)
+      .set({ credentials: () => credentialsExpression })
+      .where('id = :id', { id })
+      .andWhere('projectId = :projectId', { projectId })
+      .setParameters({ credentials: serializedCredentials })
+      .execute();
+  }
+
+  private shouldPreserveGeneratedRefreshToken(
+    existingCredentials: Record<string, unknown>,
+    incomingSecrets: Record<string, unknown>
+  ): boolean {
+    if (incomingSecrets[GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD] !== undefined) {
+      return false;
+    }
+
+    const incomingRefreshToken = this.getRefreshTokenValue(incomingSecrets);
+    if (!this.isRefreshTokenValue(incomingRefreshToken)) {
+      return true;
+    }
+
+    return incomingRefreshToken === this.getRefreshTokenValue(existingCredentials);
+  }
+
+  private getRefreshTokenValue(credentials: Record<string, unknown>): unknown {
+    const refreshTokenEntry = Object.entries(credentials).find(([key]) => {
+      return key === 'refresh_token' || key === 'RefreshToken' || key.endsWith('.RefreshToken');
+    });
+
+    return refreshTokenEntry?.[1];
+  }
+
+  private isRefreshTokenValue(value: unknown): value is string {
+    return typeof value === 'string' && value !== '' && value !== SECRET_MASK;
   }
 
   /**

--- a/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-source-credentials.service.ts
@@ -209,7 +209,32 @@ export class ConnectorSourceCredentialsService {
       throw new Error(`Unauthorized: secrets do not belong to this project`);
     }
 
-    existing.credentials = secrets;
+    existing.credentials = {
+      ...secrets,
+      ...(existing.credentials.generated_refresh_token !== undefined &&
+      secrets.generated_refresh_token === undefined
+        ? { generated_refresh_token: existing.credentials.generated_refresh_token }
+        : {}),
+    };
+    return await this.connectorSourceCredentialsRepository.save(existing);
+  }
+
+  async updateCredentialFields(
+    id: string,
+    projectId: string,
+    updates: Record<string, unknown>
+  ): Promise<ConnectorSourceCredentials> {
+    const existing = await this.getCredentialsById(id);
+
+    if (!existing) {
+      throw new Error(`ConnectorSourceCredentials with id ${id} not found`);
+    }
+
+    if (existing.projectId !== projectId) {
+      throw new Error(`Unauthorized: credentials do not belong to this project`);
+    }
+
+    existing.credentials = { ...existing.credentials, ...updates };
     return await this.connectorSourceCredentialsRepository.save(existing);
   }
 

--- a/apps/backend/src/data-marts/services/connector/connector.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector.service.spec.ts
@@ -64,6 +64,8 @@ jest.mock('@owox/connectors', () => ({
     CONFIG_ATTRIBUTES: {
       OAUTH_FLOW: 'OAUTH_FLOW',
     },
+    GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD: 'generated_refresh_token',
+    GENERATED_REFRESH_TOKEN_CONFIG_FIELD: 'GeneratedRefreshToken',
   },
 }));
 

--- a/packages/connectors/src/Configs/NodeJs/NodeJsConfig.js
+++ b/packages/connectors/src/Configs/NodeJs/NodeJsConfig.js
@@ -129,6 +129,22 @@ class NodeJsConfig extends AbstractConfig {
         })
       );
     }
+
+    /**
+     * Emit runtime credential updates through the Node.js structured transport.
+     *
+     * @param {Object} credentials - Credential fields to update in the host runtime
+     */
+    updateCredentials(credentials) {
+      const at = new Date();
+      console.log(
+        JSON.stringify({
+          type: 'updateCredentials',
+          at: at.toISOString().split('T')[0] + ' ' + at.toISOString().split('T')[1].split('.')[0],
+          credentials,
+        })
+      );
+    }
   
     /**
      * Check if the connector is currently in progress

--- a/packages/connectors/src/Constants/CredentialConstants.js
+++ b/packages/connectors/src/Constants/CredentialConstants.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+var GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD = 'generated_refresh_token';
+var GENERATED_REFRESH_TOKEN_CONFIG_FIELD = 'GeneratedRefreshToken';

--- a/packages/connectors/src/Core/AbstractConfig.js
+++ b/packages/connectors/src/Core/AbstractConfig.js
@@ -273,6 +273,12 @@ class AbstractConfig {
     }
     //----------------------------------------------------------------
 
+  //---- updateCredentials -------------------------------------------
+    updateCredentials() {
+      // No-op by default: only runtimes with a structured transport need to emit this.
+    }
+    //----------------------------------------------------------------
+
   //---- trimValue ---------------------------------------------------
     /**
      * Automatically trim whitespace for string values

--- a/packages/connectors/src/Sources/MicrosoftAds/Source.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Source.js
@@ -261,15 +261,17 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
   async getAccessToken() {
     const tokenUrl = "https://login.microsoftonline.com/common/oauth2/v2.0/token";
     const scopes = [
-      'https://ads.microsoft.com/msads.manage', // New scope
-      'https://ads.microsoft.com/ads.manage'    // Old scope
+      'https://ads.microsoft.com/msads.manage offline_access', // New scope
+      'https://ads.microsoft.com/ads.manage offline_access'    // Old scope
     ];
 
     for (const scope of scopes) {
       try {
         const clientId = this.config.AuthType?.items?.ClientId?.value || this.config.ClientID?.value || process.env.OAUTH_MICROSOFT_ADS_CLIENT_ID;
         const clientSecret = this.config.AuthType?.items?.ClientSecret?.value || this.config.ClientSecret?.value || process.env.OAUTH_MICROSOFT_ADS_CLIENT_SECRET;
-        const refreshToken = this.config.AuthType?.items?.RefreshToken?.value || this.config.RefreshToken?.value;
+        const originalRefreshToken = this.config.AuthType?.items?.RefreshToken?.value || this.config.RefreshToken?.value;
+        const generatedRefreshToken = this.config.AuthType?.items?.GeneratedRefreshToken?.value || this.config.GeneratedRefreshToken?.value;
+        const refreshToken = generatedRefreshToken || originalRefreshToken;
 
         const form = {
           client_id: clientId,
@@ -298,6 +300,10 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
         }
 
         this.config.AccessToken = { value: json.access_token };
+        if (json.refresh_token) {
+          this._setGeneratedRefreshToken(json.refresh_token);
+          this._updateCredentials({ generated_refresh_token: json.refresh_token });
+        }
         this.config.logMessage(`Successfully obtained access token with scope (${scope})`);
         return;
       } catch (error) {
@@ -308,6 +314,22 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
         this.config.logMessage(`Scope ${scope} failed, trying next scope...`);
       }
     }
+  }
+
+  _setGeneratedRefreshToken(refreshToken) {
+    this.config.GeneratedRefreshToken = {
+      ...(this.config.GeneratedRefreshToken || {}),
+      value: refreshToken,
+    };
+  }
+
+  _updateCredentials(credentials) {
+    const at = new Date();
+    console.log(JSON.stringify({
+      type: 'updateCredentials',
+      at: at.toISOString().split('T')[0] + ' ' + at.toISOString().split('T')[1].split('.')[0],
+      credentials,
+    }));
   }
 
   _getDeveloperToken() {

--- a/packages/connectors/src/Sources/MicrosoftAds/Source.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Source.js
@@ -265,71 +265,85 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
       'https://ads.microsoft.com/ads.manage offline_access'    // Old scope
     ];
 
+    const clientId = this.config.AuthType?.items?.ClientId?.value || this.config.ClientID?.value || process.env.OAUTH_MICROSOFT_ADS_CLIENT_ID;
+    const clientSecret = this.config.AuthType?.items?.ClientSecret?.value || this.config.ClientSecret?.value || process.env.OAUTH_MICROSOFT_ADS_CLIENT_SECRET;
+    const originalRefreshToken = this.config.AuthType?.items?.RefreshToken?.value || this.config.RefreshToken?.value;
+    const generatedRefreshToken =
+      this.config[GENERATED_REFRESH_TOKEN_CONFIG_FIELD]?.value ||
+      this.config.AuthType?.items?.[GENERATED_REFRESH_TOKEN_CONFIG_FIELD]?.value;
+    const refreshTokens = generatedRefreshToken && originalRefreshToken && generatedRefreshToken !== originalRefreshToken
+      ? [generatedRefreshToken, originalRefreshToken]
+      : [generatedRefreshToken || originalRefreshToken];
+
     for (const scope of scopes) {
-      try {
-        const clientId = this.config.AuthType?.items?.ClientId?.value || this.config.ClientID?.value || process.env.OAUTH_MICROSOFT_ADS_CLIENT_ID;
-        const clientSecret = this.config.AuthType?.items?.ClientSecret?.value || this.config.ClientSecret?.value || process.env.OAUTH_MICROSOFT_ADS_CLIENT_SECRET;
-        const originalRefreshToken = this.config.AuthType?.items?.RefreshToken?.value || this.config.RefreshToken?.value;
-        const generatedRefreshToken = this.config.AuthType?.items?.GeneratedRefreshToken?.value || this.config.GeneratedRefreshToken?.value;
-        const refreshToken = generatedRefreshToken || originalRefreshToken;
+      for (const [refreshTokenIndex, refreshToken] of refreshTokens.entries()) {
+        try {
+          const form = {
+            client_id: clientId,
+            scope: scope,
+            refresh_token: refreshToken,
+            grant_type: 'refresh_token',
+            client_secret: clientSecret
+          };
 
-        const form = {
-          client_id: clientId,
-          scope: scope,
-          refresh_token: refreshToken,
-          grant_type: 'refresh_token',
-          client_secret: clientSecret
-        };
+          const options = {
+            method: 'post',
+            contentType: 'application/x-www-form-urlencoded',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            payload: form,
+            body: Object.entries(form)
+              .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+              .join('&') // TODO: body is for Node.js; refactor to centralize JSON option creation
+          };
 
-        const options = {
-          method: 'post',
-          contentType: 'application/x-www-form-urlencoded',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          payload: form,
-          body: Object.entries(form)
-            .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
-            .join('&') // TODO: body is for Node.js; refactor to centralize JSON option creation
-        };
+          const resp = await HttpUtils.fetch(tokenUrl, options);
+          const text = await resp.getContentText();
+          const json = JSON.parse(text);
 
-        const resp = await HttpUtils.fetch(tokenUrl, options);
-        const text = await resp.getContentText();
-        const json = JSON.parse(text);
+          if (json.error) {
+            throw new Error(`Token error: ${json.error} - ${json.error_description}`);
+          }
 
-        if (json.error) {
-          throw new Error(`Token error: ${json.error} - ${json.error_description}`);
+          this.config.AccessToken = { value: json.access_token };
+          if (json.refresh_token) {
+            this._setGeneratedRefreshToken(json.refresh_token);
+            this.config.updateCredentials({
+              [GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD]: json.refresh_token,
+            });
+          }
+          this.config.logMessage(`Successfully obtained access token with scope (${scope})`);
+          return;
+        } catch (error) {
+          const isInvalidGrant = error.message?.includes('invalid_grant') || error.message?.includes('70000');
+          const canTryOriginalRefreshToken = isInvalidGrant &&
+            refreshTokenIndex === 0 &&
+            generatedRefreshToken &&
+            originalRefreshToken &&
+            generatedRefreshToken !== originalRefreshToken;
+
+          if (canTryOriginalRefreshToken) {
+            this.config.logMessage(
+              'Generated Microsoft Ads refresh token failed, trying original refresh token...'
+            );
+            continue;
+          }
+
+          // If it's not an invalid_grant error or we're on the last scope, throw the error
+          if (!isInvalidGrant || scope === scopes[scopes.length - 1]) {
+            throw error;
+          }
+          this.config.logMessage(`Scope ${scope} failed, trying next scope...`);
+          break;
         }
-
-        this.config.AccessToken = { value: json.access_token };
-        if (json.refresh_token) {
-          this._setGeneratedRefreshToken(json.refresh_token);
-          this._updateCredentials({ generated_refresh_token: json.refresh_token });
-        }
-        this.config.logMessage(`Successfully obtained access token with scope (${scope})`);
-        return;
-      } catch (error) {
-        // If it's not an invalid_grant error or we're on the last scope, throw the error
-        if (!error.message?.includes('invalid_grant') && !error.message?.includes('70000') || scope === scopes[scopes.length - 1]) {
-          throw error;
-        }
-        this.config.logMessage(`Scope ${scope} failed, trying next scope...`);
       }
     }
   }
 
   _setGeneratedRefreshToken(refreshToken) {
-    this.config.GeneratedRefreshToken = {
-      ...(this.config.GeneratedRefreshToken || {}),
+    this.config[GENERATED_REFRESH_TOKEN_CONFIG_FIELD] = {
+      ...(this.config[GENERATED_REFRESH_TOKEN_CONFIG_FIELD] || {}),
       value: refreshToken,
     };
-  }
-
-  _updateCredentials(credentials) {
-    const at = new Date();
-    console.log(JSON.stringify({
-      type: 'updateCredentials',
-      at: at.toISOString().split('T')[0] + ' ' + at.toISOString().split('T')[1].split('.')[0],
-      credentials,
-    }));
   }
 
   _getDeveloperToken() {

--- a/packages/connectors/src/Sources/MicrosoftAds/Source.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Source.js
@@ -314,7 +314,10 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
           this.config.logMessage(`Successfully obtained access token with scope (${scope})`);
           return;
         } catch (error) {
-          const isInvalidGrant = error.message?.includes('invalid_grant') || error.message?.includes('70000');
+          const errorMessage = error.message || '';
+          const isInvalidGrant = errorMessage.includes('invalid_grant') || errorMessage.includes('70000');
+          const isInvalidScope = errorMessage.includes('invalid_scope') || errorMessage.includes('70011');
+          const canTryNextScope = isInvalidGrant || isInvalidScope;
           const canTryOriginalRefreshToken = isInvalidGrant &&
             refreshTokenIndex === 0 &&
             generatedRefreshToken &&
@@ -328,8 +331,8 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
             continue;
           }
 
-          // If it's not an invalid_grant error or we're on the last scope, throw the error
-          if (!isInvalidGrant || scope === scopes[scopes.length - 1]) {
+          // If it is not a recoverable token/scope error or we're on the last scope, throw the error
+          if (!canTryNextScope || scope === scopes[scopes.length - 1]) {
             throw error;
           }
           this.config.logMessage(`Scope ${scope} failed, trying next scope...`);


### PR DESCRIPTION
- Added Microsoft Ads refresh token rotation support.
- When Microsoft returns a new refresh token, the connector sends it through `updateCredentials`.
- Backend stores the rotated token as `generated_refresh_token` in `connector_source_credentials`.
- The original user-provided refresh token is not overwritten.
- On the next run, backend injects `generated_refresh_token` as runtime-only `GeneratedRefreshToken`, and Microsoft Ads uses it before falling back to the original refresh token.
- Added backend handling for connector `updateCredentials` messages with an allowlist: only `generated_refresh_token` can be saved from runtime messages.
- Saved rotated tokens even if the connector run fails after token refresh.
- Preserved/copied `generated_refresh_token` for externalized secret configs, but kept it hidden from API responses.
- Runtime token persistence requires `_secrets_id` or `_source_credential_id`; legacy inline configs without credential references are skipped quietly.