### PR TITLE
Handle disconnected report columns and output controls

### DIFF
--- a/.changeset/fail-fast-orphaned-report-columns.md
+++ b/.changeset/fail-fast-orphaned-report-columns.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Fail fast on disconnected report columns and output controls
+
+Fail fast with a clear error when a report references columns that can no longer be resolved against the data mart schema or its joined data marts setup (for example, after a joined data mart alias was renamed, a relationship was removed, a field disappeared from the schema or was hidden for reporting, or a joined field was hidden in the joined data marts setup). Previously such orphaned references leaked into the generated blended SQL as main data mart columns and failed in the storage with a cryptic "Unrecognized name" error — and selecting a field hidden in the blend setup silently dropped it from the final SELECT while report headers still promised it; now the report run and SQL preview reject them upfront, listing the offending columns. Filter, sort, and slice references to disconnected or hidden fields are rejected by the output-controls validation as well.
+
+The report column picker now also surfaces stale selected columns, filters, and slices in a "Disconnected columns" block at the top of the list (styled like the existing no-access block), so selected stale columns can be unchecked and stale filter/slice rules can be removed to make the report runnable again. Sort-only stale references stay in the Output Controls menu, where stale filters, slices, and sorts are highlighted in red. The Output Controls button now shows the controls count and switches the badge to red when any output control references a disconnected field. Rule popups on disconnected and no-access rows now share one view-and-remove layout that lists the existing filter and slice rules without add or edit controls.

--- a/apps/backend/src/data-marts/data-storage-types/data-mart-schema.type.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-mart-schema.type.ts
@@ -14,3 +14,4 @@ export const DataMartSchemaSchema = z.discriminatedUnion('type', [
 ]);
 
 export type DataMartSchema = z.infer<typeof DataMartSchemaSchema>;
+export type DataMartSchemaField = DataMartSchema['fields'][number];

--- a/apps/backend/src/data-marts/data-storage-types/data-mart-schema.utils.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-mart-schema.utils.ts
@@ -1,10 +1,37 @@
 import { z } from 'zod';
 import { DataStorageCredentials } from './data-storage-credentials.type';
+import type { DataMartSchemaField } from './data-mart-schema.type';
 import { DataMartSchemaFieldStatus } from './enums/data-mart-schema-field-status.enum';
 import { DataStorageType } from './enums/data-storage-type.enum';
 import { Injectable } from '@nestjs/common';
 import { DataStoragePublicCredentialsFactory } from './factories/data-storage-public-credentials.factory';
 import { DataStorageCredentialsPublic } from '../dto/presentation/data-storage-response-api.dto';
+
+// A hidden-for-reporting or DISCONNECTED node prunes its whole subtree; container
+// nodes count as referenceable paths alongside their nested `a.b` leaves.
+export function collectSchemaFieldPaths(
+  fields: readonly DataMartSchemaField[],
+  prefix = ''
+): string[] {
+  return collectSchemaFieldPathTypes(fields, prefix).map(field => field.name);
+}
+
+export function collectSchemaFieldPathTypes(
+  fields: readonly DataMartSchemaField[],
+  prefix = ''
+): { name: string; type: string }[] {
+  const result: { name: string; type: string }[] = [];
+  for (const field of fields) {
+    if (field.isHiddenForReporting) continue;
+    if (field.status === DataMartSchemaFieldStatus.DISCONNECTED) continue;
+    const fullName = prefix ? `${prefix}.${field.name}` : field.name;
+    result.push({ name: fullName, type: String(field.type) });
+    if ('fields' in field && field.fields?.length) {
+      result.push(...collectSchemaFieldPathTypes(field.fields, fullName));
+    }
+  }
+  return result;
+}
 
 export function createBaseFieldSchemaForType<T extends z.ZodTypeAny>(schemaFieldType: T) {
   const typedSchema = z

--- a/apps/backend/src/data-marts/errors/disconnected-report-columns.error.ts
+++ b/apps/backend/src/data-marts/errors/disconnected-report-columns.error.ts
@@ -1,0 +1,16 @@
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+
+export function throwDisconnectedReportColumnsError(
+  dataMartId: string,
+  unknownColumns: string[]
+): never {
+  const uniqueUnknownColumns = Array.from(new Set(unknownColumns));
+  const list = uniqueUnknownColumns.map(column => `"${column}"`).join(', ');
+
+  throw new BusinessViolationException(
+    `Cannot build report SQL, report references columns that are disconnected from the current ` +
+      `data mart schema or joined data marts setup: ${list}. ` +
+      `Update the report column selection, or restore the previous schema or joined data marts setup to reconnect them.`,
+    { unknownColumns: uniqueUnknownColumns, dataMartId }
+  );
+}

--- a/apps/backend/src/data-marts/errors/disconnected-report-columns.error.ts
+++ b/apps/backend/src/data-marts/errors/disconnected-report-columns.error.ts
@@ -8,9 +8,9 @@ export function throwDisconnectedReportColumnsError(
   const list = uniqueUnknownColumns.map(column => `"${column}"`).join(', ');
 
   throw new BusinessViolationException(
-    `Cannot build report SQL, report references columns that are disconnected from the current ` +
-      `data mart schema or joined data marts setup: ${list}. ` +
-      `Update the report column selection, or restore the previous schema or joined data marts setup to reconnect them.`,
+    `Cannot build report SQL. Disconnected columns: ${list}. ` +
+      `They are missing from the current Data Mart output schema. ` +
+      `Uncheck them to remove them from the report, or contact your analyst to restore the schema.`,
     { unknownColumns: uniqueUnknownColumns, dataMartId }
   );
 }

--- a/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
@@ -1645,5 +1645,208 @@ describe('BlendedReportDataService', () => {
         expect(field.isHidden).toBe(false);
       });
     });
+
+    describe('resolveBlendingDecision — orphaned column references', () => {
+      function makeMainSchema(fields: object[]): DataMart['schema'] {
+        return {
+          type: 'bigquery-data-mart-schema',
+          fields,
+        } as unknown as DataMart['schema'];
+      }
+
+      function nativeField(name: string, overrides: object = {}): object {
+        return { name, type: 'STRING', status: 'CONNECTED', ...overrides };
+      }
+
+      function mockChains(): void {
+        relationshipService.findBySourceDataMartId.mockResolvedValue([
+          {
+            id: 'rel-0',
+            targetAlias: 'alias_0',
+            sourceDataMart: { id: 'dm-1' },
+            targetDataMart: { id: 'dm-target-0', title: 'Target DM 0' },
+            joinConditions: [],
+          } as unknown as DataMartRelationship,
+        ]);
+        tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
+        blendedQueryBuilderFacade.buildBlendedQuery.mockResolvedValue('SELECT ...');
+      }
+
+      it('throws BusinessViolationException listing columns missing from both native schema and blended fields', async () => {
+        const report = makeReport({
+          columnConfig: ['date', 'page__pageGroup', 'page_hash__pageGroup', 'page_hash__pagePath'],
+        });
+        report.dataMart.schema = makeMainSchema([nativeField('date'), nativeField('sessionId')]);
+
+        blendableSchemaService.computeBlendableSchema.mockResolvedValue(
+          makeBlendableSchema(['page__pageGroup'])
+        );
+
+        await expect(
+          service.resolveBlendingDecision(report, { userId: 'user-1', roles: ['admin'] })
+        ).rejects.toMatchObject({
+          message: expect.stringContaining('"page_hash__pageGroup", "page_hash__pagePath"'),
+          errorDetails: {
+            unknownColumns: ['page_hash__pageGroup', 'page_hash__pagePath'],
+            dataMartId: 'dm-1',
+          },
+        });
+
+        expect(blendedQueryBuilderFacade.buildBlendedQuery).not.toHaveBeenCalled();
+      });
+
+      it('throws for orphaned references even when no valid blended column is selected (native path)', async () => {
+        const report = makeReport({ columnConfig: ['date', 'page_hash__pageGroup'] });
+        report.dataMart.schema = makeMainSchema([nativeField('date')]);
+
+        blendableSchemaService.computeBlendableSchema.mockResolvedValue(
+          makeBlendableSchema(['page__pageGroup'])
+        );
+
+        await expect(
+          service.resolveBlendingDecision(report, { userId: 'user-1', roles: ['admin'] })
+        ).rejects.toMatchObject({
+          errorDetails: { unknownColumns: ['page_hash__pageGroup'] },
+        });
+      });
+
+      it('accepts nested struct paths and struct containers', async () => {
+        const report = makeReport({
+          columnConfig: ['date', 'user', 'user.email', 'blended_field'],
+        });
+        report.dataMart.schema = makeMainSchema([
+          nativeField('date'),
+          nativeField('user', { type: 'RECORD', fields: [nativeField('email')] }),
+        ]);
+
+        blendableSchemaService.computeBlendableSchema.mockResolvedValue(
+          makeBlendableSchema(['blended_field'])
+        );
+        mockChains();
+
+        const result = await service.resolveBlendingDecision(report, {
+          userId: 'user-1',
+          roles: ['admin'],
+        });
+
+        expect(result.needsBlending).toBe(true);
+        expect(blendedQueryBuilderFacade.buildBlendedQuery).toHaveBeenCalled();
+      });
+
+      it('passes recursive native field types to the blended query builder for nested post-join controls', async () => {
+        const report = makeReport({
+          columnConfig: ['user.created_at', 'blended_field'],
+          filterConfig: [
+            {
+              column: 'user.created_at',
+              operator: 'relative_date',
+              value: { kind: 'last_n_days', n: 7 },
+            },
+          ],
+          sortConfig: [{ column: 'user.created_at', direction: 'asc' }],
+        });
+        report.dataMart.schema = makeMainSchema([
+          nativeField('user', { type: 'RECORD', fields: [nativeField('created_at')] }),
+        ]);
+
+        const schema = makeBlendableSchema(['blended_field']);
+        schema.nativeFields = [
+          {
+            name: 'user',
+            type: 'RECORD',
+            status: 'CONNECTED',
+            fields: [{ name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED' }],
+          },
+        ] as never;
+        blendableSchemaService.computeBlendableSchema.mockResolvedValue(schema);
+        mockChains();
+
+        await service.resolveBlendingDecision(report, {
+          userId: 'user-1',
+          roles: ['admin'],
+        });
+
+        const [, context] = blendedQueryBuilderFacade.buildBlendedQuery.mock.calls[0];
+        expect(context!.columnTypes?.postJoin?.get('user.created_at')).toBe('TIMESTAMP');
+      });
+
+      it('treats hidden-for-reporting native fields as no longer available', async () => {
+        const report = makeReport({
+          columnConfig: ['date', 'secret', 'user.hidden_child', 'blended_field'],
+        });
+        report.dataMart.schema = makeMainSchema([
+          nativeField('date'),
+          nativeField('secret', { isHiddenForReporting: true }),
+          nativeField('user', {
+            type: 'RECORD',
+            fields: [nativeField('hidden_child', { isHiddenForReporting: true })],
+          }),
+        ]);
+
+        blendableSchemaService.computeBlendableSchema.mockResolvedValue(
+          makeBlendableSchema(['blended_field'])
+        );
+
+        await expect(
+          service.resolveBlendingDecision(report, { userId: 'user-1', roles: ['admin'] })
+        ).rejects.toMatchObject({
+          errorDetails: { unknownColumns: ['secret', 'user.hidden_child'] },
+        });
+      });
+
+      it('treats blended fields hidden in the joined data marts setup as no longer available', async () => {
+        const report = makeReport({
+          columnConfig: ['date', 'alias__hidden_field', 'blended_field'],
+        });
+        report.dataMart.schema = makeMainSchema([nativeField('date')]);
+
+        const schema = makeBlendableSchema(['blended_field', 'alias__hidden_field']);
+        schema.blendedFields[1].isHidden = true;
+        blendableSchemaService.computeBlendableSchema.mockResolvedValue(schema);
+        mockChains();
+
+        await expect(
+          service.resolveBlendingDecision(report, { userId: 'user-1', roles: ['admin'] })
+        ).rejects.toMatchObject({
+          errorDetails: { unknownColumns: ['alias__hidden_field'] },
+        });
+
+        expect(blendedQueryBuilderFacade.buildBlendedQuery).not.toHaveBeenCalled();
+      });
+
+      it('treats DISCONNECTED native fields as no longer available', async () => {
+        const report = makeReport({ columnConfig: ['date', 'legacy', 'blended_field'] });
+        report.dataMart.schema = makeMainSchema([
+          nativeField('date'),
+          nativeField('legacy', { status: 'DISCONNECTED' }),
+        ]);
+
+        blendableSchemaService.computeBlendableSchema.mockResolvedValue(
+          makeBlendableSchema(['blended_field'])
+        );
+
+        await expect(
+          service.resolveBlendingDecision(report, { userId: 'user-1', roles: ['admin'] })
+        ).rejects.toMatchObject({
+          errorDetails: { unknownColumns: ['legacy'] },
+        });
+      });
+
+      it('skips the check when the data mart schema is not actualized', async () => {
+        const report = makeReport({ columnConfig: ['whatever_unknown', 'blended_field'] });
+
+        blendableSchemaService.computeBlendableSchema.mockResolvedValue(
+          makeBlendableSchema(['blended_field'])
+        );
+        mockChains();
+
+        const result = await service.resolveBlendingDecision(report, {
+          userId: 'user-1',
+          roles: ['admin'],
+        });
+
+        expect(result.needsBlending).toBe(true);
+      });
+    });
   });
 });

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -20,11 +20,17 @@ import { DataStorageType } from '../data-storage-types/enums/data-storage-type.e
 import { StorageFieldType } from '../dto/domain/storage-field-type';
 import { computeEffectiveType } from '../data-storage-types/field-aggregation';
 import { BlendingDecision } from '../dto/domain/blending-decision.dto';
+import { DataMart } from '../entities/data-mart.entity';
 import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
+import {
+  collectSchemaFieldPaths,
+  collectSchemaFieldPathTypes,
+} from '../data-storage-types/data-mart-schema.utils';
 import { PublicOriginService } from '../../common/config/public-origin.service';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { buildDataMartUrl } from '../../common/helpers/data-mart-url.helper';
 import { UserProjectionsFetcherService } from './user-projections-fetcher.service';
+import { throwDisconnectedReportColumnsError } from '../errors/disconnected-report-columns.error';
 
 @Injectable()
 export class BlendedReportDataService {
@@ -107,6 +113,8 @@ export class BlendedReportDataService {
     );
 
     const blendedFieldsByName = new Map(blendableSchema.blendedFields.map(f => [f.name, f]));
+    this.assertNoOrphanedColumnReferences(dataMart, columnConfig, blendedFieldsByName);
+
     const referencedColumns = new Set<string>([
       ...columnConfig,
       ...postJoinFilterColumns,
@@ -194,7 +202,9 @@ export class BlendedReportDataService {
   // blended output aliases; pre-join slices target subsidiary raw columns by aliasPath.
   private buildBlendedColumnTypes(blendableSchema: BlendableSchemaDto): BlendedColumnTypes {
     const postJoin = new Map<string, string>();
-    for (const nf of blendableSchema.nativeFields) postJoin.set(nf.name, String(nf.type));
+    for (const nf of collectSchemaFieldPathTypes(blendableSchema.nativeFields)) {
+      postJoin.set(nf.name, nf.type);
+    }
     for (const bf of blendableSchema.blendedFields) postJoin.set(bf.name, bf.type);
 
     const preJoin = new Map<string, Map<string, string>>();
@@ -345,6 +355,32 @@ export class BlendedReportDataService {
     this.assertNoChainCollisions(chains);
 
     return chains;
+  }
+
+  // Blended column refs are flat `<aliasPath>__<field>` strings; an alias rename or
+  // relationship removal orphans them, and unmatched names would otherwise be projected
+  // as native main columns — producing a cryptic storage error instead of this one.
+  // Hidden fields are equally unavailable: schema-hidden ones are excluded from
+  // reporting by definition, and blend-hidden ones are dropped from the final SELECT
+  // while their data headers are still emitted — selecting either must fail here.
+  private assertNoOrphanedColumnReferences(
+    dataMart: DataMart,
+    columnConfig: string[],
+    blendedFieldsByName: ReadonlyMap<string, BlendedFieldDto>
+  ): void {
+    const schemaFields = dataMart.schema?.fields ?? [];
+    if (schemaFields.length === 0) return;
+
+    const nativeNames = new Set(collectSchemaFieldPaths(schemaFields));
+
+    const unknownColumns = columnConfig.filter(col => {
+      if (nativeNames.has(col)) return false;
+      const blendedField = blendedFieldsByName.get(col);
+      return !blendedField || blendedField.isHidden;
+    });
+    if (unknownColumns.length === 0) return;
+
+    throwDisconnectedReportColumnsError(dataMart.id, unknownColumns);
   }
 
   private async assertAllRequestedSourcesAccessible(

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-sets.util.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-sets.util.ts
@@ -1,34 +1,13 @@
 import { BlendableSchemaDto } from '../../dto/domain/blendable-schema.dto';
-import { DataMartSchemaFieldStatus } from '../../data-storage-types/enums/data-mart-schema-field-status.enum';
+import { collectSchemaFieldPaths } from '../../data-storage-types/data-mart-schema.utils';
 
 export interface ReportingColumns {
   native: string[];
   blended: string[];
 }
 
-interface NativeSchemaField {
-  name: string;
-  status?: string;
-  isHiddenForReporting?: boolean;
-  fields?: NativeSchemaField[];
-}
-
 export function nativeColumnNames(schema: BlendableSchemaDto): string[] {
-  return collectNative(schema.nativeFields as unknown as NativeSchemaField[]);
-}
-
-function collectNative(fields: NativeSchemaField[], prefix = ''): string[] {
-  const result: string[] = [];
-  for (const field of fields) {
-    if (field.isHiddenForReporting) continue;
-    if (field.status === DataMartSchemaFieldStatus.DISCONNECTED) continue;
-    const fullName = prefix ? `${prefix}.${field.name}` : field.name;
-    result.push(fullName);
-    if (field.fields && field.fields.length > 0) {
-      result.push(...collectNative(field.fields, fullName));
-    }
-  }
-  return result;
+  return collectSchemaFieldPaths(schema.nativeFields);
 }
 
 // Must stay in sync with the web ReportColumnPicker visibility predicate.

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -16,9 +16,8 @@ describe('OutputControlsValidatorService', () => {
   ) => {
     expect(caught).toBeInstanceOf(BusinessViolationException);
     const error = caught as BusinessViolationException;
-    expect(error.message).toContain(
-      'Cannot build report SQL, report references columns that are disconnected'
-    );
+    expect(error.message).toContain('Cannot build report SQL. Disconnected columns:');
+    expect(error.message).toContain('They are missing from the current Data Mart output schema.');
     for (const column of unknownColumns) {
       expect(error.message).toContain(`"${column}"`);
     }

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -4,9 +4,26 @@ import { BigQueryFieldType } from '../data-storage-types/bigquery/enums/bigquery
 import { AthenaFieldType } from '../data-storage-types/athena/enums/athena-field-type.enum';
 import { RedshiftFieldType } from '../data-storage-types/redshift/enums/redshift-field-type.enum';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 
 describe('OutputControlsValidatorService', () => {
   const svc = new OutputControlsValidatorService(undefined as never, undefined as never);
+
+  const expectDisconnectedColumnsError = (
+    caught: unknown,
+    unknownColumns: string[],
+    dataMartId = 'dm-1'
+  ) => {
+    expect(caught).toBeInstanceOf(BusinessViolationException);
+    const error = caught as BusinessViolationException;
+    expect(error.message).toContain(
+      'Cannot build report SQL, report references columns that are disconnected'
+    );
+    for (const column of unknownColumns) {
+      expect(error.message).toContain(`"${column}"`);
+    }
+    expect(error.errorDetails).toEqual({ unknownColumns, dataMartId });
+  };
 
   describe('validateFilters (post-join)', () => {
     const fieldTypes = new Map<string, string>([
@@ -210,7 +227,9 @@ describe('OutputControlsValidatorService', () => {
         homeFieldTypes,
         knownPaths
       );
-      expect(errors).toEqual([{ code: 'FILTER_ALIAS_PATH_UNKNOWN', aliasPath: 'orgs' }]);
+      expect(errors).toEqual([
+        { code: 'FILTER_ALIAS_PATH_UNKNOWN', aliasPath: 'orgs', column: 'x' },
+      ]);
     });
 
     it('rejects unknown column inside known aliasPath (includes aliasPath in payload)', () => {
@@ -296,7 +315,9 @@ describe('OutputControlsValidatorService', () => {
         new Map(),
         excluded
       );
-      expect(errors).toEqual([{ code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath: 'users' }]);
+      expect(errors).toEqual([
+        { code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath: 'users', column: 'userRole' },
+      ]);
     });
 
     it('post-join rule without placement defaults to post-join lookup (does not need knownPaths)', () => {
@@ -339,14 +360,23 @@ describe('OutputControlsValidatorService', () => {
       isSupported: jest.fn().mockReturnValue(supported),
     });
 
+    type TestNativeField = {
+      name: string;
+      type: string;
+      status?: string;
+      isHiddenForReporting?: boolean;
+      fields?: TestNativeField[];
+    };
+
     const makeBlendableSchemaService = (
-      nativeFields: { name: string; type: string }[] = [],
+      nativeFields: TestNativeField[] = [],
       extras: {
         blendedFields?: {
           name?: string;
           aliasPath?: string;
           originalFieldName?: string;
           type: string;
+          isHidden?: boolean;
         }[];
         availableSources?: { aliasPath: string; isIncluded?: boolean }[];
       } = {}
@@ -460,7 +490,216 @@ describe('OutputControlsValidatorService', () => {
       expect(schemaSvc.computeBlendableSchema).not.toHaveBeenCalled();
     });
 
-    it('throws BadRequestException with FILTER_COLUMN_UNKNOWN for unknown filter column', async () => {
+    it('accepts filters and sorts on visible nested native paths', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([
+        {
+          name: 'user',
+          type: 'RECORD',
+          status: 'CONNECTED',
+          fields: [{ name: 'email', type: 'STRING', status: 'CONNECTED' }],
+        },
+      ]);
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      await expect(
+        validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: ['user.email'],
+          filterConfig: [{ column: 'user.email', operator: 'eq', value: 'a@example.com' }],
+          sortConfig: [{ column: 'user.email', direction: 'asc' }],
+          limitConfig: null,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('lists DISCONNECTED native fields used by filters in the disconnected-columns error', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([
+        { name: 'date', type: 'DATE', status: 'CONNECTED' },
+        { name: 'legacy', type: 'STRING', status: 'DISCONNECTED' },
+      ]);
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      let caught: unknown;
+      try {
+        await validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: ['date'],
+          filterConfig: [{ column: 'legacy', operator: 'eq', value: 'x' }],
+          sortConfig: null,
+          limitConfig: null,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        });
+      } catch (e) {
+        caught = e;
+      }
+
+      expectDisconnectedColumnsError(caught, ['legacy']);
+    });
+
+    it('lists hidden blended fields used by post-join filters in the disconnected-columns error', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService(
+        [{ name: 'date', type: 'DATE', status: 'CONNECTED' }],
+        {
+          blendedFields: [
+            { name: 'b__visible', aliasPath: 'b', type: 'STRING' },
+            { name: 'b__hidden', aliasPath: 'b', type: 'STRING', isHidden: true },
+          ],
+          availableSources: [{ aliasPath: 'b', isIncluded: true }],
+        }
+      );
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      let caught: unknown;
+      try {
+        await validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: ['date', 'b__visible'],
+          filterConfig: [
+            { column: 'b__hidden', operator: 'eq', value: 'x' },
+            { column: 'b__visible', operator: 'eq', value: 'y' },
+          ],
+          sortConfig: null,
+          limitConfig: null,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        });
+      } catch (e) {
+        caught = e;
+      }
+
+      expectDisconnectedColumnsError(caught, ['b__hidden']);
+    });
+
+    it('lists hidden blended fields used by pre-join slices as aliasPath.column', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService(
+        [{ name: 'date', type: 'DATE', status: 'CONNECTED' }],
+        {
+          blendedFields: [
+            { name: 'b__visible', aliasPath: 'b', originalFieldName: 'visible', type: 'STRING' },
+            {
+              name: 'b__hidden',
+              aliasPath: 'b',
+              originalFieldName: 'hidden',
+              type: 'STRING',
+              isHidden: true,
+            },
+          ],
+          availableSources: [{ aliasPath: 'b', isIncluded: true }],
+        }
+      );
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      let caught: unknown;
+      try {
+        await validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: ['date', 'b__visible'],
+          filterConfig: [
+            { column: 'hidden', operator: 'eq', value: 'x', placement: 'pre-join', aliasPath: 'b' },
+            {
+              column: 'visible',
+              operator: 'eq',
+              value: 'y',
+              placement: 'pre-join',
+              aliasPath: 'b',
+            },
+          ],
+          sortConfig: null,
+          limitConfig: null,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        });
+      } catch (e) {
+        caught = e;
+      }
+
+      expectDisconnectedColumnsError(caught, ['b.hidden']);
+    });
+
+    it('lists a DISCONNECTED native field used by sort when columnConfig is null', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([
+        { name: 'date', type: 'DATE', status: 'CONNECTED' },
+        { name: 'legacy', type: 'STRING', status: 'DISCONNECTED' },
+      ]);
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      let caught: unknown;
+      try {
+        await validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: null,
+          filterConfig: null,
+          sortConfig: [{ column: 'legacy', direction: 'asc' }],
+          limitConfig: null,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        });
+      } catch (e) {
+        caught = e;
+      }
+
+      expectDisconnectedColumnsError(caught, ['legacy']);
+    });
+
+    it('lists a DISCONNECTED sort field even when stale columnConfig still selects it', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([
+        { name: 'date', type: 'DATE', status: 'CONNECTED' },
+        { name: 'legacy', type: 'STRING', status: 'DISCONNECTED' },
+      ]);
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      let caught: unknown;
+      try {
+        await validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: ['legacy'],
+          filterConfig: null,
+          sortConfig: [{ column: 'legacy', direction: 'asc' }],
+          limitConfig: null,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        });
+      } catch (e) {
+        caught = e;
+      }
+
+      expectDisconnectedColumnsError(caught, ['legacy']);
+    });
+
+    it('lists an unknown post-join filter column in the disconnected-columns error', async () => {
       const capabilitySvc = makeCapabilityService(true);
       const schemaSvc = makeBlendableSchemaService([
         { name: 'amount', type: BigQueryFieldType.INTEGER },
@@ -470,7 +709,7 @@ describe('OutputControlsValidatorService', () => {
         schemaSvc as never
       );
 
-      let caught: BadRequestException | undefined;
+      let caught: unknown;
       try {
         await validator.validateForReport({
           storageType: supportedStorageType,
@@ -483,12 +722,10 @@ describe('OutputControlsValidatorService', () => {
           accessor: { userId: 'user-1', roles: ['admin'] },
         });
       } catch (e) {
-        caught = e as BadRequestException;
+        caught = e;
       }
 
-      expect(caught).toBeDefined();
-      const response = caught!.getResponse() as { details: { errors: { code: string }[] } };
-      expect(response.details.errors[0].code).toBe('FILTER_COLUMN_UNKNOWN');
+      expectDisconnectedColumnsError(caught, ['missing']);
     });
 
     it('throws BadRequestException with INVALID_OPERATOR_FOR_TYPE for regex on INTEGER', async () => {
@@ -741,7 +978,7 @@ describe('OutputControlsValidatorService', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('throws FILTER_ALIAS_PATH_UNKNOWN when pre-join filter aliasPath is not in blendableSchema', async () => {
+    it('lists a pre-join filter on an unknown aliasPath as aliasPath.column', async () => {
       const capabilitySvc = makeCapabilityService(true);
       const schemaSvc = makeBlendableSchemaService([], {
         blendedFields: [
@@ -754,7 +991,7 @@ describe('OutputControlsValidatorService', () => {
         schemaSvc as never
       );
 
-      let caught: BadRequestException | undefined;
+      let caught: unknown;
       try {
         await validator.validateForReport({
           storageType: supportedStorageType,
@@ -769,12 +1006,10 @@ describe('OutputControlsValidatorService', () => {
           accessor: { userId: 'user-1', roles: ['admin'] },
         });
       } catch (e) {
-        caught = e as BadRequestException;
+        caught = e;
       }
 
-      expect(caught).toBeDefined();
-      const response = caught!.getResponse() as { details: { errors: { code: string }[] } };
-      expect(response.details.errors[0].code).toBe('FILTER_ALIAS_PATH_UNKNOWN');
+      expectDisconnectedColumnsError(caught, ['orgs.x']);
     });
 
     it('rejects pre-join filter when columnConfig is null/empty (PRE_JOIN_FILTERS_REQUIRE_COLUMN_CONFIG)', async () => {
@@ -1369,7 +1604,7 @@ describe('OutputControlsValidatorService', () => {
   describe('buildKnownPaths via validateForReport', () => {
     const supportedStorageType = DataStorageType.GOOGLE_BIGQUERY;
 
-    it('emits FILTER_ALIAS_PATH_NOT_INCLUDED when source.isIncluded === false', async () => {
+    it('lists a pre-join filter on an excluded source as aliasPath.column', async () => {
       const capabilitySvc = { isSupported: jest.fn().mockReturnValue(true) };
       const schemaSvc = {
         computeBlendableSchema: jest.fn().mockResolvedValue({
@@ -1385,7 +1620,7 @@ describe('OutputControlsValidatorService', () => {
         schemaSvc as never
       );
 
-      let caught: BadRequestException | undefined;
+      let caught: unknown;
       try {
         await validator.validateForReport({
           storageType: supportedStorageType,
@@ -1406,12 +1641,10 @@ describe('OutputControlsValidatorService', () => {
           accessor: { userId: 'user-1', roles: ['admin'] },
         });
       } catch (e) {
-        caught = e as BadRequestException;
+        caught = e;
       }
 
-      expect(caught).toBeDefined();
-      const response = caught!.getResponse() as { details: { errors: { code: string }[] } };
-      expect(response.details.errors[0].code).toBe('FILTER_ALIAS_PATH_NOT_INCLUDED');
+      expectDisconnectedColumnsError(caught, ['users.userRole']);
     });
 
     it('included sources still accept pre-join filters on their columns (no false positive)', async () => {

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -436,6 +436,28 @@ describe('OutputControlsValidatorService', () => {
       expect(schemaSvc.computeBlendableSchema).not.toHaveBeenCalled();
     });
 
+    it('does not classify output controls as disconnected before schema actualization', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService();
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      await expect(
+        validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: ['not_yet_actualized'],
+          filterConfig: [{ column: 'not_yet_actualized', operator: 'eq', value: 'x' }],
+          sortConfig: [{ column: 'not_yet_actualized', direction: 'asc' }],
+          limitConfig: null,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        })
+      ).resolves.toBeUndefined();
+    });
+
     it('throws BadRequestException with OUTPUT_CONTROLS_NOT_SUPPORTED for unsupported storage', async () => {
       const capabilitySvc = makeCapabilityService(false);
       const schemaSvc = makeBlendableSchemaService();

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.ts
@@ -271,43 +271,48 @@ export class OutputControlsValidatorService {
         args.accessor
       );
 
-      const homeFieldTypes = new Map<string, string>();
-      const knownOutputColumns = new Set<string>();
-      const connectedNativeNames: string[] = [];
-      for (const native of collectSchemaFieldPathTypes(blendableSchema.nativeFields)) {
-        homeFieldTypes.set(native.name, native.type);
-        knownOutputColumns.add(native.name);
-        connectedNativeNames.push(native.name);
-      }
-      for (const blended of blendableSchema.blendedFields) {
-        if (blended.isHidden) continue;
-        homeFieldTypes.set(blended.name, blended.type);
-        knownOutputColumns.add(blended.name);
-      }
+      const hasActualizedSchema =
+        blendableSchema.nativeFields.length > 0 || blendableSchema.blendedFields.length > 0;
 
-      if (parsedFilters.length > 0) {
-        const { knownPaths, excludedPaths } = this.buildKnownPaths(blendableSchema);
-        errors.push(
-          ...this.validateFilters(parsedFilters, homeFieldTypes, knownPaths, excludedPaths)
+      if (hasActualizedSchema) {
+        const homeFieldTypes = new Map<string, string>();
+        const knownOutputColumns = new Set<string>();
+        const connectedNativeNames: string[] = [];
+        for (const native of collectSchemaFieldPathTypes(blendableSchema.nativeFields)) {
+          homeFieldTypes.set(native.name, native.type);
+          knownOutputColumns.add(native.name);
+          connectedNativeNames.push(native.name);
+        }
+        for (const blended of blendableSchema.blendedFields) {
+          if (blended.isHidden) continue;
+          homeFieldTypes.set(blended.name, blended.type);
+          knownOutputColumns.add(blended.name);
+        }
+
+        if (parsedFilters.length > 0) {
+          const { knownPaths, excludedPaths } = this.buildKnownPaths(blendableSchema);
+          errors.push(
+            ...this.validateFilters(parsedFilters, homeFieldTypes, knownPaths, excludedPaths)
+          );
+        }
+        if (parsedSort.length > 0) {
+          // With no explicit columnConfig the projection is `SELECT *` over the home
+          // mart's NATIVE fields only — blended output aliases are NOT projected, and
+          // the blended run path rejects output controls without an explicit column
+          // selection. Validate sort against that same native-only set so a sort on a
+          // blended column is caught here at save time instead of failing at run time.
+          const selectedSet = new Set(args.columnConfig ?? connectedNativeNames);
+          errors.push(...this.validateSort(parsedSort, selectedSet));
+        }
+
+        const disconnectedOutputControlRefs = this.collectDisconnectedOutputControlRefs(
+          errors,
+          parsedSort,
+          knownOutputColumns
         );
-      }
-      if (parsedSort.length > 0) {
-        // With no explicit columnConfig the projection is `SELECT *` over the home
-        // mart's NATIVE fields only — blended output aliases are NOT projected, and
-        // the blended run path rejects output controls without an explicit column
-        // selection. Validate sort against that same native-only set so a sort on a
-        // blended column is caught here at save time instead of failing at run time.
-        const selectedSet = new Set(args.columnConfig ?? connectedNativeNames);
-        errors.push(...this.validateSort(parsedSort, selectedSet));
-      }
-
-      const disconnectedOutputControlRefs = this.collectDisconnectedOutputControlRefs(
-        errors,
-        parsedSort,
-        knownOutputColumns
-      );
-      if (disconnectedOutputControlRefs.length > 0) {
-        throwDisconnectedReportColumnsError(args.dataMartId, disconnectedOutputControlRefs);
+        if (disconnectedOutputControlRefs.length > 0) {
+          throwDisconnectedReportColumnsError(args.dataMartId, disconnectedOutputControlRefs);
+        }
       }
     }
 
@@ -362,8 +367,6 @@ export class OutputControlsValidatorService {
     for (const error of errors) {
       switch (error.code) {
         case 'FILTER_COLUMN_UNKNOWN':
-          refs.push(this.formatFilterRef(error.column, error.aliasPath));
-          break;
         case 'FILTER_ALIAS_PATH_UNKNOWN':
         case 'FILTER_ALIAS_PATH_NOT_INCLUDED':
           refs.push(this.formatFilterRef(error.column, error.aliasPath));

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.ts
@@ -4,6 +4,8 @@ import { SortConfig, SortConfigSchema, SortRule } from '../dto/schemas/sort-conf
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { OutputControlsCapabilityService } from './output-controls-capability.service';
 import { BlendableSchemaAccessor, BlendableSchemaService } from './blendable-schema.service';
+import { throwDisconnectedReportColumnsError } from '../errors/disconnected-report-columns.error';
+import { collectSchemaFieldPathTypes } from '../data-storage-types/data-mart-schema.utils';
 
 export type ValidationError =
   | { code: 'FILTER_COLUMN_UNKNOWN'; column: string; aliasPath?: string }
@@ -16,8 +18,8 @@ export type ValidationError =
     }
   | { code: 'INVALID_REGEX_PATTERN'; column: string; pattern: string; aliasPath?: string }
   | { code: 'SORT_COLUMN_NOT_SELECTED'; column: string }
-  | { code: 'FILTER_ALIAS_PATH_UNKNOWN'; aliasPath: string }
-  | { code: 'FILTER_ALIAS_PATH_NOT_INCLUDED'; aliasPath: string }
+  | { code: 'FILTER_ALIAS_PATH_UNKNOWN'; aliasPath: string; column: string }
+  | { code: 'FILTER_ALIAS_PATH_NOT_INCLUDED'; aliasPath: string; column: string }
   | { code: 'PRE_JOIN_FILTERS_REQUIRE_COLUMN_CONFIG' };
 
 const STRING_TYPES = new Set(['STRING', 'VARCHAR', 'CHAR', 'TEXT', 'BPCHAR']);
@@ -139,12 +141,12 @@ export class OutputControlsValidatorService {
       if (rule.placement === 'pre-join') {
         const aliasPath = rule.aliasPath!;
         if (excludedPaths?.has(aliasPath)) {
-          errors.push({ code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath });
+          errors.push({ code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath, column: rule.column });
           continue;
         }
         const subsidiaryTypes = knownPaths?.get(aliasPath);
         if (!subsidiaryTypes) {
-          errors.push({ code: 'FILTER_ALIAS_PATH_UNKNOWN', aliasPath });
+          errors.push({ code: 'FILTER_ALIAS_PATH_UNKNOWN', aliasPath, column: rule.column });
           continue;
         }
         const type = subsidiaryTypes.get(rule.column);
@@ -270,11 +272,17 @@ export class OutputControlsValidatorService {
       );
 
       const homeFieldTypes = new Map<string, string>();
-      for (const native of blendableSchema.nativeFields) {
+      const knownOutputColumns = new Set<string>();
+      const connectedNativeNames: string[] = [];
+      for (const native of collectSchemaFieldPathTypes(blendableSchema.nativeFields)) {
         homeFieldTypes.set(native.name, native.type);
+        knownOutputColumns.add(native.name);
+        connectedNativeNames.push(native.name);
       }
       for (const blended of blendableSchema.blendedFields) {
+        if (blended.isHidden) continue;
         homeFieldTypes.set(blended.name, blended.type);
+        knownOutputColumns.add(blended.name);
       }
 
       if (parsedFilters.length > 0) {
@@ -289,10 +297,17 @@ export class OutputControlsValidatorService {
         // the blended run path rejects output controls without an explicit column
         // selection. Validate sort against that same native-only set so a sort on a
         // blended column is caught here at save time instead of failing at run time.
-        const selectedSet = new Set(
-          args.columnConfig ?? blendableSchema.nativeFields.map(f => f.name)
-        );
+        const selectedSet = new Set(args.columnConfig ?? connectedNativeNames);
         errors.push(...this.validateSort(parsedSort, selectedSet));
+      }
+
+      const disconnectedOutputControlRefs = this.collectDisconnectedOutputControlRefs(
+        errors,
+        parsedSort,
+        knownOutputColumns
+      );
+      if (disconnectedOutputControlRefs.length > 0) {
+        throwDisconnectedReportColumnsError(args.dataMartId, disconnectedOutputControlRefs);
       }
     }
 
@@ -306,7 +321,12 @@ export class OutputControlsValidatorService {
 
   private buildKnownPaths(blendableSchema: {
     availableSources: { aliasPath: string; isIncluded?: boolean }[];
-    blendedFields: { aliasPath: string; originalFieldName: string; type: string }[];
+    blendedFields: {
+      aliasPath: string;
+      originalFieldName: string;
+      type: string;
+      isHidden?: boolean;
+    }[];
   }): { knownPaths: Map<string, Map<string, string>>; excludedPaths: Set<string> } {
     const knownPaths = new Map<string, Map<string, string>>();
     const excludedPaths = new Set<string>();
@@ -321,6 +341,7 @@ export class OutputControlsValidatorService {
     }
     for (const field of blendableSchema.blendedFields) {
       if (excludedPaths.has(field.aliasPath)) continue;
+      if (field.isHidden) continue;
       let fields = knownPaths.get(field.aliasPath);
       if (!fields) {
         fields = new Map();
@@ -329,5 +350,37 @@ export class OutputControlsValidatorService {
       fields.set(field.originalFieldName, field.type);
     }
     return { knownPaths, excludedPaths };
+  }
+
+  private collectDisconnectedOutputControlRefs(
+    errors: ValidationError[],
+    sort: SortRule[],
+    knownOutputColumns: ReadonlySet<string>
+  ): string[] {
+    const refs: string[] = [];
+
+    for (const error of errors) {
+      switch (error.code) {
+        case 'FILTER_COLUMN_UNKNOWN':
+          refs.push(this.formatFilterRef(error.column, error.aliasPath));
+          break;
+        case 'FILTER_ALIAS_PATH_UNKNOWN':
+        case 'FILTER_ALIAS_PATH_NOT_INCLUDED':
+          refs.push(this.formatFilterRef(error.column, error.aliasPath));
+          break;
+      }
+    }
+
+    for (const rule of sort) {
+      if (!knownOutputColumns.has(rule.column)) {
+        refs.push(rule.column);
+      }
+    }
+
+    return Array.from(new Set(refs));
+  }
+
+  private formatFilterRef(column: string, aliasPath?: string): string {
+    return aliasPath ? `${aliasPath}.${column}` : column;
   }
 }

--- a/apps/backend/src/data-marts/services/report-data-cache.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.spec.ts
@@ -2,6 +2,7 @@ import { ReportDataCacheService } from './report-data-cache.service';
 import { Report } from '../entities/report.entity';
 import { BlendingDecision } from '../dto/domain/blending-decision.dto';
 import { PrepareReportDataOptions } from '../data-storage-types/interfaces/data-storage-report-reader.interface';
+import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 
 /**
  * Regression coverage for the Looker Studio cached-reader path: it must carry
@@ -48,7 +49,6 @@ describe('ReportDataCacheService — output controls on the cached path', () => 
       cacheRepository as never,
       readerResolver as never,
       blendedReportDataService as never,
-      {} as never,
       reportSqlComposerService as never
     );
 
@@ -109,5 +109,86 @@ describe('ReportDataCacheService — output controls on the cached path', () => 
     const opts = optionsPassedToReader(reader);
     expect(opts.sqlOverride).toBeUndefined();
     expect(opts.sqlOverrideParams).toBeUndefined();
+  });
+});
+
+/**
+ * The cleanup path must release external cached artifacts only where persisted
+ * state can be finalized without starting a fresh read. Athena has S3 result
+ * files to remove; other storages are deleted without reader restoration because
+ * their current restore path either finalizes as a no-op or starts a new query.
+ */
+describe('ReportDataCacheService — cleanup finalize path', () => {
+  const setupCleanup = (storageType = DataStorageType.AWS_ATHENA) => {
+    const reader = {
+      prepareReportData: jest.fn().mockResolvedValue({ dataHeaders: [] }),
+      initFromState: jest.fn().mockResolvedValue(undefined),
+      finalize: jest.fn().mockResolvedValue(undefined),
+    };
+    const entry = {
+      id: 'cache-1',
+      storageType,
+      readerState: { outputBucket: 'bucket', outputPrefix: 'prefix' },
+      dataDescription: { dataHeaders: [] },
+      report: {
+        id: 'rep-1',
+        dataMart: { id: 'dm-1', projectId: 'proj-1', storage: { type: storageType } },
+      } as unknown as Report,
+    };
+    const cacheRepository = {
+      find: jest.fn().mockResolvedValue([entry]),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+    const readerResolver = { resolve: jest.fn().mockResolvedValue(reader) };
+    const blendedReportDataService = { resolveBlendingDecision: jest.fn() };
+
+    const service = new ReportDataCacheService(
+      cacheRepository as never,
+      readerResolver as never,
+      blendedReportDataService as never,
+      {} as never
+    );
+
+    return { service, reader, entry, cacheRepository, readerResolver, blendedReportDataService };
+  };
+
+  it('finalizes from cached state without resolving a fresh blending decision', async () => {
+    const { service, reader, entry, cacheRepository, blendedReportDataService } = setupCleanup();
+
+    await service.invalidateByReportId('rep-1');
+
+    expect(blendedReportDataService.resolveBlendingDecision).not.toHaveBeenCalled();
+    expect(reader.prepareReportData).toHaveBeenCalledWith(entry.report, {});
+    expect(reader.initFromState).toHaveBeenCalledWith(
+      entry.readerState,
+      entry.dataDescription.dataHeaders
+    );
+    expect(reader.finalize).toHaveBeenCalledTimes(1);
+    expect(cacheRepository.delete).toHaveBeenCalled();
+  });
+
+  it.each([
+    DataStorageType.DATABRICKS,
+    DataStorageType.SNOWFLAKE,
+    DataStorageType.GOOGLE_BIGQUERY,
+    DataStorageType.AWS_REDSHIFT,
+  ])('deletes %s entries without restoring a reader during cleanup', async storageType => {
+    const { service, cacheRepository, readerResolver, blendedReportDataService } =
+      setupCleanup(storageType);
+
+    await service.invalidateByReportId('rep-1');
+
+    expect(blendedReportDataService.resolveBlendingDecision).not.toHaveBeenCalled();
+    expect(readerResolver.resolve).not.toHaveBeenCalled();
+    expect(cacheRepository.delete).toHaveBeenCalled();
+  });
+
+  it('still deletes entries when finalize itself fails', async () => {
+    const { service, reader, cacheRepository } = setupCleanup();
+    reader.finalize.mockRejectedValue(new Error('storage unavailable'));
+
+    await service.invalidateByReportId('rep-1');
+
+    expect(cacheRepository.delete).toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/data-marts/services/report-data-cache.service.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.ts
@@ -13,13 +13,9 @@ import { CachedReaderData } from '../dto/domain/cached-reader-data.dto';
 import { Report } from '../entities/report.entity';
 import { isLookerStudioConnectorConfig } from '../data-destination-types/data-destination-config.guards';
 import { ReportDataCache } from '../entities/report-data-cache.entity';
-import {
-  BlendableSchemaAccessor,
-  resolveBlendableSchemaAccessor,
-} from './blendable-schema.service';
+import { BlendableSchemaAccessor } from './blendable-schema.service';
 import { BlendedReportDataService } from './blended-report-data.service';
 import { BlendingDecision } from '../dto/domain/blending-decision.dto';
-import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
 import { ReportSqlComposerService } from './report-sql-composer.service';
 
 /**
@@ -37,7 +33,6 @@ export class ReportDataCacheService {
     @Inject(DATA_STORAGE_REPORT_READER_RESOLVER)
     private readonly readerResolver: TypeResolver<DataStorageType, DataStorageReportReader>,
     private readonly blendedReportDataService: BlendedReportDataService,
-    private readonly idpProjectionsFacade: IdpProjectionsFacade,
     private readonly reportSqlComposerService: ReportSqlComposerService
   ) {}
 
@@ -49,8 +44,7 @@ export class ReportDataCacheService {
    */
   private async resolvePrepareOptions(
     report: Report,
-    accessor: BlendableSchemaAccessor,
-    composeOutputControls = true
+    accessor: BlendableSchemaAccessor
   ): Promise<{ options: PrepareReportDataOptions; decision: BlendingDecision }> {
     const decision = await this.blendedReportDataService.resolveBlendingDecision(report, accessor);
 
@@ -60,8 +54,8 @@ export class ReportDataCacheService {
     // Non-blended reports with output controls must compose their filter/sort/limit
     // SQL + bound params here, exactly as RunReportService does — otherwise this
     // (Looker Studio) cached-reader path drops them, and Athena's positional `?`
-    // placeholders execute unbound. The cleanup path only finalizes, never executes.
-    if (composeOutputControls && !decision.needsBlending && this.hasOutputControls(report)) {
+    // placeholders execute unbound.
+    if (!decision.needsBlending && this.hasOutputControls(report)) {
       const composed = await this.reportSqlComposerService.compose(report, accessor, decision);
       sqlOverride = composed.sql;
       sqlOverrideParams = composed.params;
@@ -85,27 +79,6 @@ export class ReportDataCacheService {
       report.limitConfig != null
     );
   }
-
-  private resolveCreatorAccessor(report: Report): Promise<BlendableSchemaAccessor> {
-    return resolveBlendableSchemaAccessor(
-      this.idpProjectionsFacade,
-      report.dataMart.projectId,
-      report.createdById
-    );
-  }
-
-  /**
-   * Sentinel accessor used by the cache-cleanup path only. Reader.finalize
-   * must not be skipped just because the creator was removed from the
-   * project, but we still need a valid BlendableSchemaAccessor to resolve
-   * prepare options. The admin role bypasses USE/SEE checks so resource
-   * cleanup never blocks on user membership; this constant is private to
-   * the cleanup path and never reaches user-driven read flows.
-   */
-  private readonly cleanupAccessor: BlendableSchemaAccessor = {
-    userId: '__cache-cleanup__',
-    roles: ['admin'],
-  };
 
   /**
    * Gets cached reader or creates new one if cache miss
@@ -235,19 +208,29 @@ export class ReportDataCacheService {
   }
 
   /**
-   * Finalizes expired cache entry by creating reader and calling finalize
+   * Finalizes expired cache entry by creating reader and calling finalize.
+   *
+   * Athena is currently the only reader with external cached artifacts that can be
+   * finalized safely from persisted state (S3 result files). Other readers either
+   * finalize as a no-op or need prepareReportData to start a fresh query/cursor
+   * before initFromState, so cleanup must not restore them just to delete the cache row.
    */
   private async finalizeExpiredCacheEntry(cacheEntry: ReportDataCache): Promise<void> {
     try {
-      if (cacheEntry.readerState) {
-        const { options } = await this.resolvePrepareOptions(
-          cacheEntry.report,
-          this.cleanupAccessor,
-          false
-        );
-        const reader = await this.restoreReaderFromCache(cacheEntry, cacheEntry.report, options);
-        await reader.finalize();
+      if (!cacheEntry.readerState) {
+        this.logger.debug(`No reader state to finalize for cache entry ${cacheEntry.id}`);
+        return;
       }
+
+      if (cacheEntry.storageType !== DataStorageType.AWS_ATHENA) {
+        this.logger.debug(
+          `Skipping reader finalization for cache entry ${cacheEntry.id}: ${cacheEntry.storageType} has no cleanup-safe cached-state finalizer`
+        );
+        return;
+      }
+
+      const reader = await this.restoreReaderFromCache(cacheEntry, cacheEntry.report, {});
+      await reader.finalize();
       this.logger.debug(`Successfully finalized reader for cache entry ${cacheEntry.id}`);
     } catch (error) {
       this.logger.error(
@@ -271,9 +254,9 @@ export class ReportDataCacheService {
   }
 
   /**
-   * Restores reader from cached state. Callers supply pre-resolved prepare
-   * options so the blending resolution is reused between the public-path
-   * (read) and cleanup-path (finalize) without a duplicate lookup.
+   * Restores reader from cached state. The read path supplies resolved prepare
+   * options; the cleanup path passes empty options because the cached state
+   * carries everything finalize needs.
    */
   private async restoreReaderFromCache(
     cachedData: ReportDataCache,

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
@@ -7,6 +7,7 @@ import { AthenaQueryBuilder } from '../data-storage-types/athena/services/athena
 import { AthenaClauseRenderer } from '../data-storage-types/athena/services/athena-clause-renderer';
 import { isQueryBuildResult } from '../data-storage-types/interfaces/data-mart-query-builder.interface';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 
 describe('ReportSqlComposerService', () => {
   const buildReport = (overrides: Partial<Report> = {}): Report =>
@@ -201,6 +202,59 @@ describe('ReportSqlComposerService', () => {
       })
     );
     expect(result).toEqual({ sql: 'SELECT 1', params: [{ name: 'p0', value: 1 }] });
+  });
+
+  it('passes recursive native field types to QueryBuilder for nested output controls', async () => {
+    const queryBuilderFacade = {
+      buildQuery: jest.fn().mockResolvedValue({ sql: 'SELECT 1', params: [] }),
+    };
+    const blendedDataService = {
+      resolveBlendingDecision: jest.fn().mockResolvedValue({
+        needsBlending: false,
+        columnFilter: ['user.created_at'],
+      }),
+    };
+    const tableReferenceService = { resolveTableName: jest.fn().mockResolvedValue('p.d.view_x') };
+    const capabilityService = { isSupported: jest.fn().mockReturnValue(true) };
+    const composer = new ReportSqlComposerService(
+      blendedDataService as never,
+      queryBuilderFacade as never,
+      tableReferenceService as never,
+      capabilityService as never
+    );
+    const filterConfig = [
+      {
+        column: 'user.created_at',
+        operator: 'relative_date',
+        value: { kind: 'last_n_days', n: 7 },
+      },
+    ];
+    const report = {
+      filterConfig,
+      sortConfig: [{ column: 'user.created_at', direction: 'asc' }],
+      limitConfig: null,
+      dataMart: {
+        id: 'm',
+        projectId: 'p',
+        storage: { type: 'GOOGLE_BIGQUERY' },
+        definition: { type: 'sql', sqlQuery: 'SELECT 1' },
+        schema: {
+          fields: [
+            {
+              name: 'user',
+              type: 'RECORD',
+              status: 'CONNECTED',
+              fields: [{ name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED' }],
+            },
+          ],
+        },
+      },
+    } as never;
+
+    await composer.compose(report, { userId: 'user-1', roles: ['admin'] });
+
+    const options = queryBuilderFacade.buildQuery.mock.calls[0][2];
+    expect(options.columnTypes.get('user.created_at')).toBe('TIMESTAMP');
   });
 
   it('does not resolve mainTableReference when no output controls', async () => {
@@ -523,31 +577,29 @@ describe('ReportSqlComposerService', () => {
         },
       }) as never;
 
-    it('filter on a column no longer in the schema (renamed/excluded) surfaces as 400 BadRequestException with FILTER_COLUMN_UNKNOWN', async () => {
+    it('filter on a column no longer in the schema (renamed/excluded) surfaces as 400 BusinessViolationException with unknownColumns', async () => {
       // Simulates: report was saved with a filter on "old_column"; the data mart
       // schema was later updated and "old_column" was renamed / excluded.  The
-      // validator running inside resolveBlendingDecision raises a structured 400.
-      const schemaDriftError = new BadRequestException({
-        message: 'Output controls validation failed',
-        details: {
-          errors: [{ code: 'FILTER_COLUMN_UNKNOWN', column: 'old_column' }],
-        },
-      });
+      // validator running inside resolveBlendingDecision raises the same structured
+      // 400 used for disconnected selected columns.
+      const schemaDriftError = new BusinessViolationException(
+        'Cannot build report SQL, report references columns that are disconnected from the current data mart schema or joined data marts setup: "old_column".',
+        { unknownColumns: ['old_column'], dataMartId: 'dm-athena' }
+      );
       const service = makeAthenaComposerWithValidationError(schemaDriftError);
 
       const report = athenaReport([{ column: 'old_column', operator: 'eq', value: 'stale' }]);
 
-      // Must re-throw the BadRequestException (400), not a generic Error (500).
+      // Must re-throw the BusinessViolationException (mapped to HTTP 400), not a generic Error (500).
       await expect(service.compose(report, { userId: 'u1', roles: ['viewer'] })).rejects.toThrow(
-        BadRequestException
+        BusinessViolationException
       );
       await expect(
         service.compose(report, { userId: 'u1', roles: ['viewer'] })
       ).rejects.toMatchObject({
-        response: {
-          details: {
-            errors: [{ code: 'FILTER_COLUMN_UNKNOWN', column: 'old_column' }],
-          },
+        errorDetails: {
+          unknownColumns: ['old_column'],
+          dataMartId: 'dm-athena',
         },
       });
     });
@@ -593,10 +645,10 @@ describe('ReportSqlComposerService', () => {
     });
 
     it('queryBuilderFacade is never called when schema-drift validation fails', async () => {
-      const schemaDriftError = new BadRequestException({
-        message: 'Output controls validation failed',
-        details: { errors: [{ code: 'FILTER_COLUMN_UNKNOWN', column: 'stale' }] },
-      });
+      const schemaDriftError = new BusinessViolationException(
+        'Cannot build report SQL, report references columns that are disconnected from the current data mart schema or joined data marts setup: "stale".',
+        { unknownColumns: ['stale'], dataMartId: 'dm-athena' }
+      );
       const blendedReportDataService = {
         resolveBlendingDecision: jest.fn().mockRejectedValue(schemaDriftError),
       };
@@ -616,7 +668,7 @@ describe('ReportSqlComposerService', () => {
           userId: 'u1',
           roles: ['viewer'],
         })
-      ).rejects.toThrow(BadRequestException);
+      ).rejects.toThrow(BusinessViolationException);
 
       expect(queryBuilderFacade.buildQuery).not.toHaveBeenCalled();
     });

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
@@ -583,7 +583,7 @@ describe('ReportSqlComposerService', () => {
       // validator running inside resolveBlendingDecision raises the same structured
       // 400 used for disconnected selected columns.
       const schemaDriftError = new BusinessViolationException(
-        'Cannot build report SQL, report references columns that are disconnected from the current data mart schema or joined data marts setup: "old_column".',
+        'Cannot build report SQL. Disconnected columns: "old_column". They are missing from the current Data Mart output schema. Uncheck them to remove them from the report, or contact your analyst to restore the schema.',
         { unknownColumns: ['old_column'], dataMartId: 'dm-athena' }
       );
       const service = makeAthenaComposerWithValidationError(schemaDriftError);
@@ -646,7 +646,7 @@ describe('ReportSqlComposerService', () => {
 
     it('queryBuilderFacade is never called when schema-drift validation fails', async () => {
       const schemaDriftError = new BusinessViolationException(
-        'Cannot build report SQL, report references columns that are disconnected from the current data mart schema or joined data marts setup: "stale".',
+        'Cannot build report SQL. Disconnected columns: "stale". They are missing from the current Data Mart output schema. Uncheck them to remove them from the report, or contact your analyst to restore the schema.',
         { unknownColumns: ['stale'], dataMartId: 'dm-athena' }
       );
       const blendedReportDataService = {

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -12,6 +12,7 @@ import { DataStorageType } from '../data-storage-types/enums/data-storage-type.e
 import { inlineAthenaPositionalParams } from '../data-storage-types/athena/adapters/athena-execution-parameters.utils';
 import { inlineBigQueryNamedParams } from '../data-storage-types/bigquery/adapters/bigquery-execution-parameters.utils';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { collectSchemaFieldPathTypes } from '../data-storage-types/data-mart-schema.utils';
 
 @Injectable()
 export class ReportSqlComposerService {
@@ -94,7 +95,7 @@ export class ReportSqlComposerService {
     // persisted schema (same native fields the validator types against).
     const schemaFields = dataMart.schema?.fields ?? [];
     const columnTypes: ReadonlyMap<string, string> | undefined = schemaFields.length
-      ? new Map(schemaFields.map((f): [string, string] => [f.name, String(f.type)]))
+      ? new Map(collectSchemaFieldPathTypes(schemaFields).map(f => [f.name, f.type]))
       : undefined;
 
     const queryResult = await this.queryBuilderFacade.buildQuery(

--- a/apps/backend/test/blended-output-controls.e2e-spec.ts
+++ b/apps/backend/test/blended-output-controls.e2e-spec.ts
@@ -90,6 +90,15 @@ describe('Blended output controls full-flow (e2e)', () => {
     return res.body as Record<string, unknown>;
   }
 
+  function expectDisconnectedColumns(res: supertest.Response, unknownColumns: string[]): void {
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain('report references columns that are disconnected');
+    expect(res.body.errorDetails).toEqual({
+      unknownColumns,
+      dataMartId: prereqs.mainDataMartId,
+    });
+  }
+
   // ── Group 1: Baseline ─────────────────────────────────────────────────────
 
   describe('1. Baseline', () => {
@@ -316,8 +325,7 @@ describe('Blended output controls full-flow (e2e)', () => {
           },
         ],
       });
-      expect(res.status).toBe(400);
-      expect(JSON.stringify(res.body)).toContain('FILTER_ALIAS_PATH_UNKNOWN');
+      expectDisconnectedColumns(res, ['nonexistent_alias.something']);
     });
 
     it('rejects pre-join filter with aliasPath="main" (home mart not slicable)', async () => {
@@ -356,9 +364,7 @@ describe('Blended output controls full-flow (e2e)', () => {
           },
         ],
       });
-      expect(res.status).toBe(400);
-      const body = JSON.stringify(res.body);
-      expect(body).toContain('FILTER_COLUMN_UNKNOWN');
+      expectDisconnectedColumns(res, ['users.no_such_column']);
     });
 
     it('rejects operator/type mismatch on pre-join (regex on INTEGER native field)', async () => {
@@ -428,8 +434,7 @@ describe('Blended output controls full-flow (e2e)', () => {
         columnConfig: ['event_id'],
         filterConfig: [{ column: 'no_such_native', operator: 'eq', value: 'X' }],
       });
-      expect(res.status).toBe(400);
-      expect(JSON.stringify(res.body)).toContain('FILTER_COLUMN_UNKNOWN');
+      expectDisconnectedColumns(res, ['no_such_native']);
     });
   });
 
@@ -521,8 +526,7 @@ describe('Blended output controls full-flow (e2e)', () => {
       const sqlRes = await agent
         .get(`/api/reports/${prereqs.reportId}/generated-sql`)
         .set(AUTH_HEADER);
-      expect(sqlRes.status).toBe(400);
-      expect(JSON.stringify(sqlRes.body)).toContain('FILTER_ALIAS_PATH_NOT_INCLUDED');
+      expectDisconnectedColumns(sqlRes, ['users.role']);
 
       const restore = await agent
         .put(`/api/data-marts/${prereqs.mainDataMartId}/blended-fields-config`)

--- a/apps/backend/test/blended-output-controls.e2e-spec.ts
+++ b/apps/backend/test/blended-output-controls.e2e-spec.ts
@@ -92,7 +92,10 @@ describe('Blended output controls full-flow (e2e)', () => {
 
   function expectDisconnectedColumns(res: supertest.Response, unknownColumns: string[]): void {
     expect(res.status).toBe(400);
-    expect(res.body.message).toContain('report references columns that are disconnected');
+    expect(res.body.message).toContain('Disconnected columns:');
+    expect(res.body.message).toContain(
+      'They are missing from the current Data Mart output schema.'
+    );
     expect(res.body.errorDetails).toEqual({
       unknownColumns,
       dataMartId: prereqs.mainDataMartId,

--- a/apps/backend/test/output-controls.e2e-spec.ts
+++ b/apps/backend/test/output-controls.e2e-spec.ts
@@ -29,7 +29,10 @@ describe('Output controls API (e2e)', () => {
 
   function expectDisconnectedColumns(res: supertest.Response, unknownColumns: string[]): void {
     expect(res.status).toBe(400);
-    expect(res.body.message).toContain('report references columns that are disconnected');
+    expect(res.body.message).toContain('Disconnected columns:');
+    expect(res.body.message).toContain(
+      'They are missing from the current Data Mart output schema.'
+    );
     expect(res.body.errorDetails).toEqual({ unknownColumns, dataMartId });
   }
 

--- a/apps/backend/test/output-controls.e2e-spec.ts
+++ b/apps/backend/test/output-controls.e2e-spec.ts
@@ -27,6 +27,12 @@ describe('Output controls API (e2e)', () => {
   let dataDestinationId: string;
   let reportId: string;
 
+  function expectDisconnectedColumns(res: supertest.Response, unknownColumns: string[]): void {
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain('report references columns that are disconnected');
+    expect(res.body.errorDetails).toEqual({ unknownColumns, dataMartId });
+  }
+
   beforeAll(async () => {
     const testApp = await createTestApp();
     app = testApp.app;
@@ -35,6 +41,20 @@ describe('Output controls API (e2e)', () => {
     const prereqs = await setupReportPrerequisites(agent);
     dataMartId = prereqs.dataMartId;
     dataDestinationId = prereqs.dataDestinationId;
+
+    const schemaRes = await agent
+      .put(`/api/data-marts/${dataMartId}/schema`)
+      .set(AUTH_HEADER)
+      .send({
+        schema: {
+          type: 'bigquery-data-mart-schema',
+          fields: [
+            { name: 'col_a', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+            { name: 'col_b', type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' },
+          ],
+        },
+      });
+    expect(schemaRes.status).toBe(200);
 
     // Seed baseline report. LOOKER_STUDIO destinations use a deterministic
     // UUID v5 derived from (dataMartId, dataDestinationId), so there can be
@@ -82,7 +102,7 @@ describe('Output controls API (e2e)', () => {
     });
   });
 
-  it('PUT rejects sort on non-selected column with SORT_COLUMN_NOT_SELECTED', async () => {
+  it('PUT rejects sort on existing non-selected column with SORT_COLUMN_NOT_SELECTED', async () => {
     const res = await agent
       .put(`/api/reports/${reportId}`)
       .set(AUTH_HEADER)
@@ -91,17 +111,14 @@ describe('Output controls API (e2e)', () => {
         dataDestinationId,
         destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
         columnConfig: ['col_a'],
-        sortConfig: [{ column: 'not_in_columns', direction: 'asc' }],
+        sortConfig: [{ column: 'col_b', direction: 'asc' }],
       });
 
     expect(res.status).toBe(400);
     expect(JSON.stringify(res.body)).toContain('SORT_COLUMN_NOT_SELECTED');
   });
 
-  it('PUT with filter on a column missing from the data mart schema reports FILTER_COLUMN_UNKNOWN', async () => {
-    // The seeded data mart has no schema actualized, so every filter column
-    // is unknown to BlendableSchemaService — this exercises the structured
-    // error path of the validator end-to-end.
+  it('PUT with filter on a column missing from the data mart schema reports disconnected columns', async () => {
     const res = await agent
       .put(`/api/reports/${reportId}`)
       .set(AUTH_HEADER)
@@ -113,8 +130,7 @@ describe('Output controls API (e2e)', () => {
         filterConfig: [{ column: 'definitely_does_not_exist', operator: 'is_empty' }],
       });
 
-    expect(res.status).toBe(400);
-    expect(JSON.stringify(res.body)).toContain('FILTER_COLUMN_UNKNOWN');
+    expectDisconnectedColumns(res, ['definitely_does_not_exist']);
   });
 
   it('PUT rejects limitConfig <= 0 via class-validator @IsPositive', async () => {
@@ -187,7 +203,7 @@ describe('Output controls API (e2e)', () => {
     expect(getRes.body.limitConfig).toBeNull();
   });
 
-  it('PUT pre-join filter on simple (non-joined) report → 400 FILTER_ALIAS_PATH_UNKNOWN', async () => {
+  it('PUT pre-join filter on simple report reports disconnected columns', async () => {
     const putRes = await agent
       .put(`/api/reports/${reportId}`)
       .set(AUTH_HEADER)
@@ -206,8 +222,7 @@ describe('Output controls API (e2e)', () => {
           },
         ],
       });
-    expect(putRes.status).toBe(400);
-    expect(JSON.stringify(putRes.body)).toContain('FILTER_ALIAS_PATH_UNKNOWN');
+    expectDisconnectedColumns(putRes, ['users.userRole']);
   });
 
   it('PUT pre-join filter with aliasPath="main" → 400 with Zod shape error', async () => {

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ActiveRulesPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ActiveRulesPopover.tsx
@@ -1,0 +1,131 @@
+import { type ReactNode } from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from '@owox/ui/components/popover';
+import { Button } from '@owox/ui/components/button';
+import { Label } from '@owox/ui/components/label';
+import { X } from 'lucide-react';
+import type { FilterRule } from '../../../shared/types/output-config';
+import { operatorLabelFor } from './output-controls-operators';
+import { summarizeFilterRule } from './filter-rule-summary';
+
+interface RuleListProps {
+  rules: readonly FilterRule[];
+  onRemoveAt: (index: number) => void;
+}
+
+export interface ActiveRulesPopoverProps {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  trigger: ReactNode;
+  column: string;
+  fieldType: string;
+  aliasPath?: string;
+  sliceColumn?: string;
+  filters?: RuleListProps;
+  slices?: RuleListProps;
+}
+
+export function ActiveRulesPopover({
+  open,
+  onOpenChange,
+  trigger,
+  column,
+  fieldType,
+  aliasPath,
+  sliceColumn,
+  filters,
+  slices,
+}: ActiveRulesPopoverProps) {
+  const slicesOnly = !filters?.rules.length && !!slices?.rules.length && aliasPath != null;
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent className='w-72 space-y-3'>
+        <div>
+          <Label>Column</Label>
+          <div className='font-mono text-xs'>
+            {slicesOnly ? (
+              <>
+                <span className='text-blue-600'>{aliasPath}</span>.{sliceColumn ?? column}
+              </>
+            ) : (
+              column
+            )}{' '}
+            <span className='text-muted-foreground'>({fieldType})</span>
+          </div>
+        </div>
+
+        {!!filters?.rules.length && (
+          <RuleSection
+            label='Active filters'
+            removeLabel='Remove filter'
+            fieldType={fieldType}
+            rules={filters.rules}
+            onRemoveAt={filters.onRemoveAt}
+          />
+        )}
+        {!!slices?.rules.length && (
+          <RuleSection
+            label='Active slices'
+            removeLabel='Remove slice'
+            fieldType={fieldType}
+            rules={slices.rules}
+            onRemoveAt={slices.onRemoveAt}
+          />
+        )}
+
+        <div className='flex justify-end'>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => {
+              onOpenChange(false);
+            }}
+          >
+            Close
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface RuleSectionProps extends RuleListProps {
+  label: string;
+  removeLabel: string;
+  fieldType: string;
+}
+
+function RuleSection({ label, removeLabel, fieldType, rules, onRemoveAt }: RuleSectionProps) {
+  return (
+    <div className='space-y-1'>
+      <Label>{label}</Label>
+      <div className='space-y-1'>
+        {rules.map((rule, idx) => {
+          const valueStr = summarizeFilterRule(rule);
+          return (
+            <div
+              key={idx}
+              className='bg-muted/40 flex items-center gap-2 rounded px-2 py-1 text-xs'
+            >
+              <span className='flex-1 truncate font-mono' title={valueStr}>
+                <b>{operatorLabelFor(rule.operator, fieldType)}</b>
+                {valueStr && <>: {valueStr}</>}
+              </span>
+              <Button
+                variant='ghost'
+                size='sm'
+                className='h-6 w-6 p-0'
+                onClick={() => {
+                  onRemoveAt(idx);
+                }}
+                aria-label={removeLabel}
+              >
+                <X className='h-3 w-3' />
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
@@ -22,6 +22,7 @@ export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProp
   const opLabel = operatorLabelFor(rule.operator, resolvedType);
   const valueText = summarizeFilterRule(rule);
   const isPreJoin = rule.placement === 'pre-join' && !!rule.aliasPath;
+  const displayColumn = isPreJoin ? `${rule.aliasPath}.${rule.column}` : rule.column;
 
   return (
     <div
@@ -31,7 +32,7 @@ export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProp
       )}
     >
       <div className='min-w-0 flex-1'>
-        <div className='flex items-center gap-1 truncate font-mono text-xs' title={rule.column}>
+        <div className='flex items-center gap-1 truncate font-mono text-xs' title={displayColumn}>
           {isOrphaned && (
             <span
               className='inline-flex items-center text-red-600'
@@ -41,18 +42,27 @@ export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProp
               <AlertTriangle className='h-3 w-3' />
             </span>
           )}
-          {isPreJoin && (
-            <span
-              className='inline-flex items-center gap-1 text-blue-600'
-              title='Pre-join filter (slice)'
-            >
+          {isPreJoin && isOrphaned ? (
+            <span className='inline-flex items-center gap-1 text-red-700 dark:text-red-300'>
               <Layers className='h-3 w-3' />
-              <span>{rule.aliasPath}.</span>
+              <span className='line-through'>{displayColumn}</span>
             </span>
+          ) : (
+            <>
+              {isPreJoin && (
+                <span
+                  className='inline-flex items-center gap-1 text-blue-600'
+                  title='Pre-join filter (slice)'
+                >
+                  <Layers className='h-3 w-3' />
+                  <span>{rule.aliasPath}.</span>
+                </span>
+              )}
+              <span className={cn(isOrphaned && 'text-red-700 line-through dark:text-red-300')}>
+                {rule.column}
+              </span>
+            </>
           )}
-          <span className={cn(isOrphaned && 'text-red-700 line-through dark:text-red-300')}>
-            {rule.column}
-          </span>
         </div>
         <div className='truncate font-mono text-[11px]'>
           <span className='text-foreground/70 font-medium'>{opLabel}</span>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsButton.tsx
@@ -1,4 +1,5 @@
 import { SlidersHorizontal } from 'lucide-react';
+import { Badge } from '@owox/ui/components/badge';
 import { Button } from '@owox/ui/components/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { cn } from '@owox/ui/lib/utils';
@@ -7,9 +8,17 @@ interface OutputSettingsButtonProps {
   active: boolean;
   open: boolean;
   onClick: () => void;
+  count?: number;
+  hasDisconnectedControls?: boolean;
 }
 
-export function OutputSettingsButton({ active, open, onClick }: OutputSettingsButtonProps) {
+export function OutputSettingsButton({
+  active,
+  open,
+  onClick,
+  count,
+  hasDisconnectedControls = false,
+}: OutputSettingsButtonProps) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -20,9 +29,20 @@ export function OutputSettingsButton({ active, open, onClick }: OutputSettingsBu
           aria-label='Output controls'
           aria-expanded={open}
           onClick={onClick}
-          className='h-6 w-6 p-0'
+          className='relative h-6 w-6 p-0'
         >
           <SlidersHorizontal className={cn('h-3.5 w-3.5', active && 'text-blue-500')} />
+          {typeof count === 'number' && count > 0 && (
+            <Badge
+              variant={hasDisconnectedControls ? 'destructive' : 'default'}
+              aria-label={
+                hasDisconnectedControls ? 'Disconnected output controls' : 'Output controls count'
+              }
+              className='pointer-events-none absolute -top-1.5 -right-1.5 flex h-4 w-4 items-center justify-center rounded-full p-0 text-[8px] leading-none'
+            >
+              {count}
+            </Badge>
+          )}
         </Button>
       </TooltipTrigger>
       <TooltipContent>Output controls</TooltipContent>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { OutputSettingsDropdown } from './OutputSettingsDropdown';
+import type { OutputConfig } from '../../../shared/types/output-config';
+
+vi.mock('@owox/ui/components/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('OutputSettingsDropdown disconnected controls', () => {
+  it('marks stale filters, slices, and sort rules as disconnected rows', () => {
+    const value: OutputConfig = {
+      filterConfig: [
+        { column: 'ghost_filter', operator: 'eq', value: 'x' },
+        {
+          column: 'ghost_slice',
+          operator: 'eq',
+          value: 'y',
+          placement: 'pre-join',
+          aliasPath: 'old',
+        },
+      ],
+      sortConfig: [{ column: 'ghost_sort', direction: 'asc' }],
+      limitConfig: null,
+    };
+
+    render(
+      <OutputSettingsDropdown
+        value={value}
+        onChange={() => {}}
+        allColumns={[{ name: 'native_one', type: 'STRING' }]}
+        selectedColumns={[{ name: 'native_one', type: 'STRING' }]}
+        joinedSources={[]}
+      />
+    );
+
+    expect(screen.getByText('ghost_filter')).toHaveClass('line-through');
+    expect(screen.getByText('old.ghost_slice')).toHaveClass('line-through');
+    expect(screen.queryByText('ghost_slice')).not.toBeInTheDocument();
+    expect(screen.getByText('ghost_sort')).toHaveClass('line-through');
+    expect(screen.getAllByLabelText('Column not found in schema')).toHaveLength(3);
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
@@ -44,4 +44,34 @@ describe('OutputSettingsDropdown disconnected controls', () => {
     expect(screen.getByText('ghost_sort')).toHaveClass('line-through');
     expect(screen.getAllByLabelText('Column not found in schema')).toHaveLength(3);
   });
+
+  it('shows readable operator labels for stale filters and slices without a known field type', () => {
+    const value: OutputConfig = {
+      filterConfig: [
+        { column: 'ghost_filter', operator: 'gte', value: 10 },
+        {
+          column: 'ghost_slice',
+          operator: 'gte',
+          value: 20,
+          placement: 'pre-join',
+          aliasPath: 'old',
+        },
+      ],
+      sortConfig: [],
+      limitConfig: null,
+    };
+
+    render(
+      <OutputSettingsDropdown
+        value={value}
+        onChange={() => {}}
+        allColumns={[]}
+        selectedColumns={[]}
+        joinedSources={[]}
+      />
+    );
+
+    expect(screen.getAllByText('greater than or equal')).toHaveLength(2);
+    expect(screen.queryByText('gte')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
@@ -92,7 +92,7 @@ export function OutputSettingsDropdown({
     });
   };
 
-  const hasJoinedSources = (joinedSources ?? []).length > 0;
+  const hasSlicesSection = (joinedSources ?? []).length > 0 || preJoinIndexed.length > 0;
 
   return (
     <div className='space-y-4 p-3'>
@@ -103,7 +103,7 @@ export function OutputSettingsDropdown({
         onUpdateAt={onUpdateAt}
         onRemoveAt={onRemoveAt}
       />
-      {hasJoinedSources && (
+      {hasSlicesSection && (
         <SlicesSection
           indexedRules={preJoinIndexed}
           joinedSources={joinedSources ?? []}
@@ -395,6 +395,7 @@ interface SortSectionProps {
 
 function SortSection({ sort, selectedColumns, onChange }: SortSectionProps) {
   const sortColumns = new Set(sort.map(s => s.column));
+  const selectedColumnSet = new Set(selectedColumns);
   const available = selectedColumns.filter(c => !sortColumns.has(c));
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
@@ -455,6 +456,7 @@ function SortSection({ sort, selectedColumns, onChange }: SortSectionProps) {
             <SortRow
               rule={rule}
               index={index}
+              isOrphaned={!selectedColumnSet.has(rule.column)}
               onChange={next => {
                 const updated = [...sort];
                 updated[index] = next;

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 import { ReportColumnPicker } from './ReportColumnPicker';
 import { BLENDABLE_SCHEMA_QUERY_KEY } from '../../../shared/hooks/blendable-schema-query-key';
 import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
@@ -10,6 +10,7 @@ import type {
   BlendableSchema,
   BlendedField,
 } from '../../../shared/types/relationship.types';
+import { DataStorageType } from '../../../../data-storage/shared/model/types/data-storage-type.enum';
 
 vi.mock('../../../shared/services/data-mart-relationship.service', () => ({
   dataMartRelationshipService: {
@@ -65,7 +66,11 @@ function buildSchema(overrides: Partial<BlendableSchema> = {}): BlendableSchema 
   };
 }
 
-function renderPicker(schema: BlendableSchema, value: string[] | null) {
+function renderPicker(
+  schema: BlendableSchema,
+  value: string[] | null,
+  props: Partial<ComponentProps<typeof ReportColumnPicker>> = {}
+) {
   vi.mocked(dataMartRelationshipService.getBlendableSchema).mockResolvedValue(schema);
 
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -77,7 +82,7 @@ function renderPicker(schema: BlendableSchema, value: string[] | null) {
 
   const onChange = vi.fn();
   const utils = render(
-    <ReportColumnPicker dataMartId={DATA_MART_ID} value={value} onChange={onChange} />,
+    <ReportColumnPicker dataMartId={DATA_MART_ID} value={value} onChange={onChange} {...props} />,
     { wrapper }
   );
   return { ...utils, onChange, client };
@@ -225,5 +230,374 @@ describe('ReportColumnPicker access flag', () => {
 
     expect(screen.queryByText('Joined DM')).not.toBeInTheDocument();
     expect(screen.queryByText('only')).not.toBeInTheDocument();
+  });
+});
+
+describe('ReportColumnPicker unresolved columns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lists selected columns missing from the schema in a Disconnected columns block', () => {
+    const schema = buildSchema({
+      blendedFields: [buildBlendedField({ name: 'page__pageGroup' })],
+      availableSources: [buildAvailableSource()],
+    });
+
+    renderPicker(schema, ['native_one', 'page_hash__pageGroup', 'page_hash__pagePath']);
+
+    const block = screen.getByText('Disconnected columns').closest('div[class*="border"]');
+    expect(block).not.toBeNull();
+    expect(within(block as HTMLElement).getByText('page_hash__pageGroup')).toBeInTheDocument();
+    expect(within(block as HTMLElement).getByText('page_hash__pagePath')).toBeInTheDocument();
+  });
+
+  it('removes an unresolved column from the report when its checkbox is unchecked', () => {
+    const schema = buildSchema();
+
+    const { onChange } = renderPicker(schema, ['native_one', 'gone__field']);
+
+    const row = screen.getByText('gone__field').closest('label');
+    expect(row).not.toBeNull();
+    fireEvent.click(within(row!).getByRole('checkbox'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(['native_one']);
+  });
+
+  it('does not render the block when every selected column resolves against the schema', () => {
+    const schema = buildSchema({
+      blendedFields: [buildBlendedField({ name: 'b__some_field' })],
+      availableSources: [buildAvailableSource()],
+    });
+
+    renderPicker(schema, ['native_one', 'b__some_field']);
+
+    expect(screen.queryByText('Disconnected columns')).not.toBeInTheDocument();
+  });
+
+  it('treats hidden-for-reporting nested native fields as disconnected', () => {
+    const schema = buildSchema({
+      nativeFields: [
+        { name: 'native_one', type: 'STRING' },
+        {
+          name: 'user',
+          type: 'RECORD',
+          fields: [
+            { name: 'email', type: 'STRING' },
+            { name: 'secret_child', type: 'STRING', isHiddenForReporting: true },
+          ],
+        },
+      ] as unknown[],
+    });
+
+    renderPicker(schema, ['native_one', 'user.email', 'user.secret_child']);
+
+    const block = screen.getByText('Disconnected columns').closest('div[class*="border"]');
+    expect(block).not.toBeNull();
+    expect(within(block as HTMLElement).getByText('user.secret_child')).toBeInTheDocument();
+    expect(within(block as HTMLElement).queryByText('user.email')).not.toBeInTheDocument();
+    expect(screen.getAllByText('user.secret_child')).toHaveLength(1);
+  });
+
+  it('treats DISCONNECTED native fields as disconnected columns', () => {
+    const schema = buildSchema({
+      nativeFields: [
+        { name: 'native_one', type: 'STRING' },
+        { name: 'legacy', type: 'STRING', status: 'DISCONNECTED' },
+      ] as unknown[],
+    });
+
+    renderPicker(schema, ['native_one', 'legacy']);
+
+    const block = screen.getByText('Disconnected columns').closest('div[class*="border"]');
+    expect(block).not.toBeNull();
+    expect(within(block as HTMLElement).getByText('legacy')).toBeInTheDocument();
+    expect(screen.getAllByText('legacy')).toHaveLength(1);
+  });
+
+  it('treats blended fields hidden in the joined data marts setup as disconnected', () => {
+    const schema = buildSchema({
+      blendedFields: [
+        buildBlendedField({
+          name: 'b__hidden_field',
+          originalFieldName: 'hidden_field',
+          isHidden: true,
+        }),
+        buildBlendedField({ name: 'b__visible_field', originalFieldName: 'visible_field' }),
+      ],
+      availableSources: [buildAvailableSource()],
+    });
+
+    renderPicker(schema, ['native_one', 'b__hidden_field', 'b__visible_field']);
+
+    const block = screen.getByText('Disconnected columns').closest('div[class*="border"]');
+    expect(block).not.toBeNull();
+    expect(within(block as HTMLElement).getByText('b__hidden_field')).toBeInTheDocument();
+    expect(within(block as HTMLElement).queryByText('b__visible_field')).not.toBeInTheDocument();
+  });
+
+  it('does not treat excluded-source blended fields as unresolved', () => {
+    const schema = buildSchema({
+      blendedFields: [
+        buildBlendedField({
+          name: 'c__excluded_field',
+          originalFieldName: 'excluded_field',
+          aliasPath: 'c',
+          targetAlias: 'c',
+          sourceRelationshipId: 'rel-c',
+          sourceDataMartId: 'dm-c',
+        }),
+      ],
+      availableSources: [
+        buildAvailableSource({
+          aliasPath: 'c',
+          relationshipId: 'rel-c',
+          dataMartId: 'dm-c',
+          isIncluded: false,
+        }),
+      ],
+    });
+
+    renderPicker(schema, ['native_one', 'c__excluded_field']);
+
+    expect(screen.queryByText('Disconnected columns')).not.toBeInTheDocument();
+  });
+
+  it('shows a filter-only reference to a missing column as a disconnected row with its filter', () => {
+    const schema = buildSchema();
+    vi.mocked(dataMartRelationshipService.getBlendableSchema).mockResolvedValue(schema);
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData([BLENDABLE_SCHEMA_QUERY_KEY, DATA_MART_ID], schema);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    render(
+      <ReportColumnPicker
+        dataMartId={DATA_MART_ID}
+        storageType={DataStorageType.GOOGLE_BIGQUERY}
+        value={['native_one']}
+        onChange={() => {}}
+        outputConfig={{
+          filterConfig: [{ column: 'ghost__col', operator: 'eq', value: 'x' }] as never,
+          sortConfig: [],
+          limitConfig: null,
+        }}
+        onOutputConfigChange={() => {}}
+      />,
+      { wrapper }
+    );
+
+    const block = screen.getByText('Disconnected columns').closest('div[class*="border"]');
+    expect(block).not.toBeNull();
+    expect(screen.getByLabelText('Disconnected output controls')).toHaveTextContent('1');
+    const row = within(block as HTMLElement)
+      .getByText('ghost__col')
+      .closest('label');
+    expect(row).not.toBeNull();
+    const checkbox = within(row as HTMLElement).getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+    expect(checkbox).toBeDisabled();
+    expect(
+      within(row as HTMLElement).getByRole('button', { name: 'Manage filters and slices' })
+    ).toBeInTheDocument();
+  });
+
+  it('keeps a sort-only reference out of disconnected columns and removable in output settings', () => {
+    const schema = buildSchema();
+    vi.mocked(dataMartRelationshipService.getBlendableSchema).mockResolvedValue(schema);
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData([BLENDABLE_SCHEMA_QUERY_KEY, DATA_MART_ID], schema);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const onOutputConfigChange = vi.fn();
+
+    render(
+      <ReportColumnPicker
+        dataMartId={DATA_MART_ID}
+        storageType={DataStorageType.GOOGLE_BIGQUERY}
+        value={['native_one']}
+        onChange={() => {}}
+        outputConfig={{
+          filterConfig: [],
+          sortConfig: [{ column: 'ghost__sort', direction: 'asc' }],
+          limitConfig: null,
+        }}
+        onOutputConfigChange={onOutputConfigChange}
+      />,
+      { wrapper }
+    );
+
+    expect(screen.queryByText('Disconnected columns')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Disconnected output controls')).toHaveTextContent('1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Output controls' }));
+
+    expect(screen.getByText('ghost__sort')).toBeInTheDocument();
+    expect(screen.getByLabelText('Column not found in schema')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove sort' }));
+
+    expect(onOutputConfigChange).toHaveBeenCalledWith({
+      filterConfig: [],
+      sortConfig: [],
+      limitConfig: null,
+    });
+  });
+
+  it('flags filters on hidden blended fields as disconnected but not filters on known columns', () => {
+    const schema = buildSchema({
+      blendedFields: [
+        buildBlendedField({
+          name: 'b__hidden_field',
+          originalFieldName: 'hidden_field',
+          isHidden: true,
+        }),
+      ],
+      availableSources: [buildAvailableSource()],
+    });
+    vi.mocked(dataMartRelationshipService.getBlendableSchema).mockResolvedValue(schema);
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData([BLENDABLE_SCHEMA_QUERY_KEY, DATA_MART_ID], schema);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    render(
+      <ReportColumnPicker
+        dataMartId={DATA_MART_ID}
+        storageType={DataStorageType.GOOGLE_BIGQUERY}
+        value={['native_one']}
+        onChange={() => {}}
+        outputConfig={{
+          filterConfig: [
+            { column: 'b__hidden_field', operator: 'eq', value: 'x' },
+            { column: 'native_one', operator: 'eq', value: 'y' },
+          ] as never,
+          sortConfig: [],
+          limitConfig: null,
+        }}
+        onOutputConfigChange={() => {}}
+      />,
+      { wrapper }
+    );
+
+    const block = screen.getByText('Disconnected columns').closest('div[class*="border"]');
+    expect(block).not.toBeNull();
+    expect(within(block as HTMLElement).getByText('b__hidden_field')).toBeInTheDocument();
+    expect(within(block as HTMLElement).queryByText('native_one')).not.toBeInTheDocument();
+  });
+
+  it('flags pre-join slices on hidden joined fields as disconnected with the slice removable', () => {
+    const schema = buildSchema({
+      blendedFields: [
+        buildBlendedField({
+          name: 'b__hidden_field',
+          originalFieldName: 'hidden_field',
+          isHidden: true,
+        }),
+        buildBlendedField({ name: 'b__visible_field', originalFieldName: 'visible_field' }),
+      ],
+      availableSources: [buildAvailableSource()],
+    });
+    vi.mocked(dataMartRelationshipService.getBlendableSchema).mockResolvedValue(schema);
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData([BLENDABLE_SCHEMA_QUERY_KEY, DATA_MART_ID], schema);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    render(
+      <ReportColumnPicker
+        dataMartId={DATA_MART_ID}
+        storageType={DataStorageType.GOOGLE_BIGQUERY}
+        value={['native_one', 'b__visible_field']}
+        onChange={() => {}}
+        outputConfig={{
+          filterConfig: [
+            {
+              column: 'hidden_field',
+              operator: 'eq',
+              value: 'x',
+              placement: 'pre-join',
+              aliasPath: 'b',
+            },
+            {
+              column: 'visible_field',
+              operator: 'eq',
+              value: 'y',
+              placement: 'pre-join',
+              aliasPath: 'b',
+            },
+          ] as never,
+          sortConfig: [],
+          limitConfig: null,
+        }}
+        onOutputConfigChange={() => {}}
+      />,
+      { wrapper }
+    );
+
+    const block = screen.getByText('Disconnected columns').closest('div[class*="border"]');
+    expect(block).not.toBeNull();
+    const row = within(block as HTMLElement)
+      .getByText('b.hidden_field')
+      .closest('label');
+    expect(row).not.toBeNull();
+    const checkbox = within(row as HTMLElement).getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+    expect(checkbox).toBeDisabled();
+    expect(
+      within(row as HTMLElement).getByRole('button', { name: 'Manage filters and slices' })
+    ).toBeInTheDocument();
+    expect(within(block as HTMLElement).queryByText('b.visible_field')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Disconnected output controls')).toHaveTextContent('2');
+  });
+
+  it('shows a neutral output controls count when all controls resolve', () => {
+    const schema = buildSchema();
+
+    renderPicker(schema, ['native_one'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: {
+        filterConfig: [{ column: 'native_one', operator: 'eq', value: 'ok' }] as never,
+        sortConfig: [],
+        limitConfig: null,
+      },
+      onOutputConfigChange: () => {},
+    });
+
+    expect(screen.getByLabelText('Output controls count')).toHaveTextContent('1');
+    expect(screen.queryByLabelText('Disconnected output controls')).not.toBeInTheDocument();
+  });
+
+  it('counts unresolved columns in both selected and total', () => {
+    const schema = buildSchema();
+    vi.mocked(dataMartRelationshipService.getBlendableSchema).mockResolvedValue(schema);
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData([BLENDABLE_SCHEMA_QUERY_KEY, DATA_MART_ID], schema);
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+
+    const onCountChange = vi.fn();
+    render(
+      <ReportColumnPicker
+        dataMartId={DATA_MART_ID}
+        value={['native_one', 'gone__field']}
+        onChange={() => {}}
+        onCountChange={onCountChange}
+      />,
+      { wrapper }
+    );
+
+    expect(onCountChange).toHaveBeenLastCalledWith({ selected: 2, total: 2 });
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
@@ -577,6 +577,30 @@ describe('ReportColumnPicker unresolved columns', () => {
     expect(screen.queryByLabelText('Disconnected output controls')).not.toBeInTheDocument();
   });
 
+  it('does not mark output controls on inaccessible but known blended fields as disconnected', () => {
+    const schema = buildSchema({
+      blendedFields: [buildBlendedField({ name: 'b__field', originalFieldName: 'field' })],
+      availableSources: [buildAvailableSource({ isAccessibleForReporting: false })],
+    });
+
+    renderPicker(schema, ['native_one'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: {
+        filterConfig: [
+          { column: 'b__field', operator: 'eq', value: 'x' },
+          { column: 'field', operator: 'eq', value: 'y', placement: 'pre-join', aliasPath: 'b' },
+        ] as never,
+        sortConfig: [],
+        limitConfig: null,
+      },
+      onOutputConfigChange: () => {},
+    });
+
+    expect(screen.getByLabelText('Output controls count')).toHaveTextContent('2');
+    expect(screen.queryByLabelText('Disconnected output controls')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disconnected columns')).not.toBeInTheDocument();
+  });
+
   it('counts unresolved columns in both selected and total', () => {
     const schema = buildSchema();
     vi.mocked(dataMartRelationshipService.getBlendableSchema).mockResolvedValue(schema);

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -871,9 +871,12 @@ export function ReportColumnPicker({
                   />
                 </TooltipTrigger>
                 <TooltipContent side='top' className='max-w-xs'>
-                  These columns are disconnected from the current data mart schema or joined data
-                  marts setup. Uncheck them or remove their filters, or restore the previous schema
-                  or joined data marts setup to reconnect them.
+                  <div className='space-y-1'>
+                    <p>
+                      They are missing from the current Data Mart output schema. Uncheck them to
+                      remove them from the report, or contact your analyst to restore the schema.
+                    </p>
+                  </div>
                 </TooltipContent>
               </Tooltip>
             </div>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -6,7 +6,8 @@ import { Button } from '@owox/ui/components/button';
 import { Checkbox } from '@owox/ui/components/checkbox';
 import { Collapsible, CollapsibleContent } from '@owox/ui/components/collapsible';
 import { Switch } from '@owox/ui/components/switch';
-import { AlertTriangle, ChevronDown, ChevronRight } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { AlertTriangle, ChevronDown, ChevronRight, TriangleAlert } from 'lucide-react';
 import { Skeleton } from '@owox/ui/components/skeleton';
 import { NoAccessIndicator } from '../DataMartRelationships/NoAccessIndicator';
 import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
@@ -32,12 +33,18 @@ interface NativeField {
   type?: string;
   alias?: string;
   description?: string;
+  isHiddenForReporting?: boolean;
+  status?: string;
   fields?: NativeField[];
 }
 
+// Must stay in sync with the backend collectSchemaFieldPaths walker: hidden and
+// DISCONNECTED nodes (with their subtrees) are unavailable for reporting, so they
+// are excluded from the list and surface in the Disconnected columns block instead.
 function flattenNativeFields(fields: NativeField[], prefix = ''): NativeField[] {
   const result: NativeField[] = [];
   for (const field of fields) {
+    if (field.isHiddenForReporting || field.status === 'DISCONNECTED') continue;
     const fullName = prefix ? `${prefix}.${field.name}` : field.name;
     result.push({
       name: fullName,
@@ -375,6 +382,61 @@ export function ReportColumnPicker({
     [includedBlendedFields]
   );
 
+  // Excluded-source blended fields still resolve on the backend, but fields hidden
+  // in the joined data marts setup are rejected by the report-run orphan check —
+  // they must surface as disconnected alongside names absent from the schema.
+  const knownFieldNames = useMemo(() => {
+    const names = new Set(nativeFields.map(f => f.name));
+    for (const field of schema?.blendedFields ?? []) {
+      if (!field.isHidden) names.add(field.name);
+    }
+    return names;
+  }, [nativeFields, schema]);
+
+  const unresolvedColumns = useMemo(
+    () => (schema ? effectiveValue.filter(name => !knownFieldNames.has(name)) : []),
+    [schema, effectiveValue, knownFieldNames]
+  );
+
+  const unresolvedFilterOnlyColumns = useMemo(() => {
+    if (!schema) return [];
+    const names: string[] = [];
+    const seen = new Set<string>();
+    for (const rule of effectiveOutputConfig.filterConfig) {
+      if (rule.placement === 'pre-join') continue;
+      if (knownFieldNames.has(rule.column) || effectiveValueSet.has(rule.column)) continue;
+      if (seen.has(rule.column)) continue;
+      seen.add(rule.column);
+      names.push(rule.column);
+    }
+    return names;
+  }, [schema, effectiveOutputConfig.filterConfig, knownFieldNames, effectiveValueSet]);
+
+  const unresolvedSlices = useMemo(() => {
+    if (!schema) return [];
+    const visibleSliceKeys = new Set<string>();
+    const typeByKey = new Map<string, string>();
+    for (const f of schema.blendedFields) {
+      const key = `${f.aliasPath}\0${f.originalFieldName}`;
+      if (!f.isHidden) visibleSliceKeys.add(key);
+      if (f.type) typeByKey.set(key, f.type);
+    }
+    const seen = new Set<string>();
+    const result: { aliasPath: string; column: string; fieldType?: string }[] = [];
+    for (const rule of effectiveOutputConfig.filterConfig) {
+      if (rule.placement !== 'pre-join' || !rule.aliasPath) continue;
+      const key = `${rule.aliasPath}\0${rule.column}`;
+      if (visibleSliceKeys.has(key) || seen.has(key)) continue;
+      seen.add(key);
+      result.push({
+        aliasPath: rule.aliasPath,
+        column: rule.column,
+        fieldType: typeByKey.get(key),
+      });
+    }
+    return result;
+  }, [schema, effectiveOutputConfig.filterConfig]);
+
   const valueRef = useRef(effectiveValue);
   valueRef.current = effectiveValue;
 
@@ -436,7 +498,7 @@ export function ReportColumnPicker({
   const selectedBlendedCount = effectiveValue.filter(name =>
     includedBlendedNamesSet.has(name)
   ).length;
-  const selectedFieldsCount = selectedNativeCount + selectedBlendedCount;
+  const selectedFieldsCount = selectedNativeCount + selectedBlendedCount + unresolvedColumns.length;
   const accessibleBlendedNamesSet = useMemo(
     () => new Set(accessibleBlendedFieldNames),
     [accessibleBlendedFieldNames]
@@ -448,7 +510,8 @@ export function ReportColumnPicker({
       ).length,
     [effectiveValue, includedBlendedNamesSet, accessibleBlendedNamesSet]
   );
-  const totalFieldsCount = selectableFieldNames.length + selectedInaccessibleBlendedCount;
+  const totalFieldsCount =
+    selectableFieldNames.length + selectedInaccessibleBlendedCount + unresolvedColumns.length;
 
   useEffect(() => {
     onCountChange?.({ selected: selectedFieldsCount, total: totalFieldsCount });
@@ -486,16 +549,17 @@ export function ReportColumnPicker({
     return map;
   }, [effectiveOutputConfig.filterConfig]);
 
+  // Hidden blended fields included so disconnected filter rows show their real type.
   const fieldTypeByName = useMemo<Map<string, string>>(() => {
     const map = new Map<string, string>();
     for (const f of nativeFields) {
       if (f.type) map.set(f.name, f.type);
     }
-    for (const f of includedBlendedFields) {
+    for (const f of schema?.blendedFields ?? []) {
       if (f.type) map.set(f.name, f.type);
     }
     return map;
-  }, [nativeFields, includedBlendedFields]);
+  }, [nativeFields, schema]);
 
   const filterableTypeFor = useCallback(
     (fieldName: string): string | undefined => {
@@ -556,7 +620,7 @@ export function ReportColumnPicker({
     }
     for (const field of schema.blendedFields) {
       const entry = byPath.get(field.aliasPath);
-      if (!entry || !field.type) continue;
+      if (!entry || !field.type || field.isHidden) continue;
       entry.columns.push({ name: field.originalFieldName, type: field.type });
     }
     for (const entry of byPath.values()) {
@@ -587,6 +651,54 @@ export function ReportColumnPicker({
     () => dropdownColumns.filter(c => effectiveValueSet.has(c.name)),
     [dropdownColumns, effectiveValueSet]
   );
+
+  const controlsCount = useMemo(() => {
+    return (
+      effectiveOutputConfig.filterConfig.length +
+      effectiveOutputConfig.sortConfig.length +
+      (effectiveOutputConfig.limitConfig != null ? 1 : 0)
+    );
+  }, [effectiveOutputConfig]);
+
+  const dropdownColumnNames = useMemo(() => {
+    return new Set(dropdownColumns.map(c => c.name));
+  }, [dropdownColumns]);
+
+  const selectedDropdownColumnNames = useMemo(() => {
+    return new Set(selectedDropdownColumns.map(c => c.name));
+  }, [selectedDropdownColumns]);
+
+  const joinedColumnKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const source of joinedSources) {
+      for (const column of source.columns) {
+        keys.add(`${source.aliasPath}\0${column.name}`);
+      }
+    }
+    return keys;
+  }, [joinedSources]);
+
+  const hasDisconnectedOutputControls = useMemo(() => {
+    for (const rule of effectiveOutputConfig.filterConfig) {
+      if (rule.placement === 'pre-join') {
+        if (!rule.aliasPath || !joinedColumnKeys.has(`${rule.aliasPath}\0${rule.column}`)) {
+          return true;
+        }
+      } else if (!dropdownColumnNames.has(rule.column)) {
+        return true;
+      }
+    }
+
+    return effectiveOutputConfig.sortConfig.some(
+      rule => !selectedDropdownColumnNames.has(rule.column)
+    );
+  }, [
+    effectiveOutputConfig.filterConfig,
+    effectiveOutputConfig.sortConfig,
+    dropdownColumnNames,
+    joinedColumnKeys,
+    selectedDropdownColumnNames,
+  ]);
 
   const referencedFieldNames = useMemo(() => {
     const names = new Set<string>();
@@ -693,6 +805,8 @@ export function ReportColumnPicker({
           {outputControlsAvailable && (
             <OutputSettingsButton
               active={hasAnyOutputControls(effectiveOutputConfig)}
+              count={controlsCount}
+              hasDisconnectedControls={hasDisconnectedOutputControls}
               open={settingsOpen}
               onClick={() => {
                 setSettingsOpen(o => !o);
@@ -739,6 +853,91 @@ export function ReportColumnPicker({
           selectedNativeCount === 0 ? 'border-destructive' : 'border-border'
         )}
       >
+        {(unresolvedColumns.length > 0 ||
+          unresolvedFilterOnlyColumns.length > 0 ||
+          unresolvedSlices.length > 0) && (
+          <div className='border-destructive bg-destructive/10 rounded border'>
+            <div className='flex items-start gap-1.5 px-1 py-1'>
+              <div className='min-w-0 flex-1'>
+                <span className='text-destructive truncate text-xs font-semibold'>
+                  Disconnected columns
+                </span>
+              </div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <TriangleAlert
+                    className='text-destructive mt-0.5 size-4 shrink-0'
+                    aria-label='About disconnected columns'
+                  />
+                </TooltipTrigger>
+                <TooltipContent side='top' className='max-w-xs'>
+                  These columns are disconnected from the current data mart schema or joined data
+                  marts setup. Uncheck them or remove their filters, or restore the previous schema
+                  or joined data marts setup to reconnect them.
+                </TooltipContent>
+              </Tooltip>
+            </div>
+            {[
+              ...unresolvedColumns.map(name => ({ name, selected: true })),
+              ...unresolvedFilterOnlyColumns.map(name => ({ name, selected: false })),
+            ].map(({ name, selected }) => {
+              const columnFilters = filtersByColumn.get(name) ?? EMPTY_COLUMN_FILTERS;
+              return (
+                <label
+                  key={name}
+                  className='group hover:bg-destructive/20 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
+                >
+                  <Checkbox
+                    checked={selected}
+                    disabled={!selected}
+                    onCheckedChange={() => {
+                      if (selected) toggleField(name, false);
+                    }}
+                  />
+                  <span className='font-mono text-xs'>{name}</span>
+                  {outputControlsAvailable && columnFilters.rules.length > 0 && (
+                    <RowFilterIcon
+                      column={name}
+                      fieldType={fieldTypeByName.get(name) ?? 'STRING'}
+                      activeRules={columnFilters.rules}
+                      onRemoveAt={localIndex => {
+                        handleRemoveFilterAt(columnFilters.indices[localIndex]);
+                      }}
+                    />
+                  )}
+                </label>
+              );
+            })}
+            {unresolvedSlices.map(({ aliasPath, column, fieldType }) => {
+              const sliceKey = `${aliasPath}\0${column}`;
+              const slices = preJoinByAliasPathColumn.get(sliceKey) ?? EMPTY_COLUMN_FILTERS;
+              return (
+                <label
+                  key={sliceKey}
+                  className='group hover:bg-destructive/20 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
+                >
+                  <Checkbox checked={false} disabled />
+                  <span className='font-mono text-xs'>{`${aliasPath}.${column}`}</span>
+                  {outputControlsAvailable && slices.rules.length > 0 && (
+                    <RowFilterIcon
+                      column={column}
+                      fieldType={fieldType ?? 'STRING'}
+                      activeRules={EMPTY_COLUMN_FILTERS.rules}
+                      onRemoveAt={() => undefined}
+                      sliceIconProps={{
+                        aliasPath,
+                        originalFieldName: column,
+                        existingSlices: slices.rules,
+                        existingSliceIndices: slices.indices,
+                        onRemoveSliceAt: handleRemoveFilterAt,
+                      }}
+                    />
+                  )}
+                </label>
+              );
+            })}
+          </div>
+        )}
         {visibleNativeFields.length === 0 && (
           <p className='text-muted-foreground px-1 text-xs'>No fields available.</p>
         )}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -412,13 +412,19 @@ export function ReportColumnPicker({
     return names;
   }, [schema, effectiveOutputConfig.filterConfig, knownFieldNames, effectiveValueSet]);
 
+  const knownSliceKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const f of schema?.blendedFields ?? []) {
+      if (!f.isHidden) keys.add(`${f.aliasPath}\0${f.originalFieldName}`);
+    }
+    return keys;
+  }, [schema]);
+
   const unresolvedSlices = useMemo(() => {
     if (!schema) return [];
-    const visibleSliceKeys = new Set<string>();
     const typeByKey = new Map<string, string>();
     for (const f of schema.blendedFields) {
       const key = `${f.aliasPath}\0${f.originalFieldName}`;
-      if (!f.isHidden) visibleSliceKeys.add(key);
       if (f.type) typeByKey.set(key, f.type);
     }
     const seen = new Set<string>();
@@ -426,7 +432,7 @@ export function ReportColumnPicker({
     for (const rule of effectiveOutputConfig.filterConfig) {
       if (rule.placement !== 'pre-join' || !rule.aliasPath) continue;
       const key = `${rule.aliasPath}\0${rule.column}`;
-      if (visibleSliceKeys.has(key) || seen.has(key)) continue;
+      if (knownSliceKeys.has(key) || seen.has(key)) continue;
       seen.add(key);
       result.push({
         aliasPath: rule.aliasPath,
@@ -435,7 +441,7 @@ export function ReportColumnPicker({
       });
     }
     return result;
-  }, [schema, effectiveOutputConfig.filterConfig]);
+  }, [schema, effectiveOutputConfig.filterConfig, knownSliceKeys]);
 
   const valueRef = useRef(effectiveValue);
   valueRef.current = effectiveValue;
@@ -660,44 +666,26 @@ export function ReportColumnPicker({
     );
   }, [effectiveOutputConfig]);
 
-  const dropdownColumnNames = useMemo(() => {
-    return new Set(dropdownColumns.map(c => c.name));
-  }, [dropdownColumns]);
-
-  const selectedDropdownColumnNames = useMemo(() => {
-    return new Set(selectedDropdownColumns.map(c => c.name));
-  }, [selectedDropdownColumns]);
-
-  const joinedColumnKeys = useMemo(() => {
-    const keys = new Set<string>();
-    for (const source of joinedSources) {
-      for (const column of source.columns) {
-        keys.add(`${source.aliasPath}\0${column.name}`);
-      }
-    }
-    return keys;
-  }, [joinedSources]);
-
   const hasDisconnectedOutputControls = useMemo(() => {
     for (const rule of effectiveOutputConfig.filterConfig) {
       if (rule.placement === 'pre-join') {
-        if (!rule.aliasPath || !joinedColumnKeys.has(`${rule.aliasPath}\0${rule.column}`)) {
+        if (!rule.aliasPath || !knownSliceKeys.has(`${rule.aliasPath}\0${rule.column}`)) {
           return true;
         }
-      } else if (!dropdownColumnNames.has(rule.column)) {
+      } else if (!knownFieldNames.has(rule.column)) {
         return true;
       }
     }
 
     return effectiveOutputConfig.sortConfig.some(
-      rule => !selectedDropdownColumnNames.has(rule.column)
+      rule => !effectiveValueSet.has(rule.column) || !knownFieldNames.has(rule.column)
     );
   }, [
     effectiveOutputConfig.filterConfig,
     effectiveOutputConfig.sortConfig,
-    dropdownColumnNames,
-    joinedColumnKeys,
-    selectedDropdownColumnNames,
+    knownFieldNames,
+    knownSliceKeys,
+    effectiveValueSet,
   ]);
 
   const referencedFieldNames = useMemo(() => {

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RowFilterIcon } from './RowFilterIcon';
+import type { FilterRule } from '../../../shared/types/output-config';
+
+// Render popover content unconditionally — the popup open state lives inside
+// RowFilterIcon, and these tests assert which popup variant gets mounted.
+vi.mock('@owox/ui/components/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@owox/ui/components/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <select>{children}</select>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+const filterRule = { column: 'ghost__col', operator: 'eq', value: 'x' } as FilterRule;
+const sliceRule = {
+  column: 'hidden_field',
+  operator: 'eq',
+  value: 'y',
+  placement: 'pre-join',
+  aliasPath: 'b',
+} as FilterRule;
+
+describe('RowFilterIcon — remove-only popup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a view-and-remove popup without tabs or editor for orphaned slices', () => {
+    const onRemoveSliceAt = vi.fn();
+    render(
+      <RowFilterIcon
+        column='hidden_field'
+        fieldType='INTEGER'
+        activeRules={[]}
+        onRemoveAt={() => undefined}
+        sliceIconProps={{
+          aliasPath: 'b',
+          originalFieldName: 'hidden_field',
+          existingSlices: [sliceRule],
+          existingSliceIndices: [3],
+          onRemoveSliceAt,
+        }}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Filter' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Slice' })).not.toBeInTheDocument();
+    expect(screen.getByText('Active slices')).toBeInTheDocument();
+    expect(screen.queryByText('Active filters')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^(Apply|Add)$/ })).not.toBeInTheDocument();
+    expect(document.querySelector('input[type="text"]')).toBeNull();
+    expect(screen.getByText('b')).toBeInTheDocument();
+    expect(screen.getByText('(INTEGER)')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove slice' }));
+    expect(onRemoveSliceAt).toHaveBeenCalledWith(3);
+  });
+
+  it('renders a view-and-remove popup listing filters without the value editor', () => {
+    const onRemoveAt = vi.fn();
+    render(
+      <RowFilterIcon
+        column='ghost__col'
+        fieldType='STRING'
+        activeRules={[filterRule]}
+        onRemoveAt={onRemoveAt}
+      />
+    );
+
+    expect(screen.getByText('Active filters')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Filter' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Slice' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^(Apply|Add)$/ })).not.toBeInTheDocument();
+    expect(document.querySelector('input[type="text"]')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove filter' }));
+    expect(onRemoveAt).toHaveBeenCalledWith(0);
+  });
+
+  it('shows filters and slices together without tabs for no-access rows (nothing editable)', () => {
+    render(
+      <RowFilterIcon
+        column='b__field'
+        fieldType='STRING'
+        activeRules={[filterRule]}
+        onRemoveAt={() => undefined}
+        sliceIconProps={{
+          aliasPath: 'b',
+          originalFieldName: 'field',
+          existingSlices: [sliceRule],
+          existingSliceIndices: [1],
+          onRemoveSliceAt: () => undefined,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Active filters')).toBeInTheDocument();
+    expect(screen.getByText('Active slices')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Filter' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Slice' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+
+  it('keeps the tabbed editor popover when adding is allowed', () => {
+    render(
+      <RowFilterIcon
+        column='b__field'
+        fieldType='STRING'
+        activeRules={[]}
+        onAdd={() => undefined}
+        onRemoveAt={() => undefined}
+        sliceIconProps={{
+          aliasPath: 'b',
+          originalFieldName: 'field',
+          existingSlices: [],
+          existingSliceIndices: [],
+          onAddSlice: () => undefined,
+          onRemoveSliceAt: () => undefined,
+        }}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Filter' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Slice' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^(Apply|Add)$/ })).toBeInTheDocument();
+  });
+
+  it('keeps the plain filter editor popover when only filters are editable', () => {
+    render(
+      <RowFilterIcon
+        column='native_one'
+        fieldType='STRING'
+        activeRules={[]}
+        onAdd={() => undefined}
+        onRemoveAt={() => undefined}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /^(Apply|Add)$/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Filter } from 'lucide-react';
 import { cn } from '@owox/ui/lib/utils';
+import { ActiveRulesPopover } from './ActiveRulesPopover';
 import { FilterEditorPopover } from './FilterEditorPopover';
 import { FilterOrSliceEditorPopover } from './FilterOrSliceEditorPopover';
 import type { FilterRule } from '../../../shared/types/output-config';
@@ -12,8 +13,7 @@ interface SliceIconProps {
   existingSlices: readonly FilterRule[];
   /**
    * Add a pre-join FilterRule (placement+aliasPath already set by the popover).
-   * Omit for remove-only mode (the slice tab is hidden and existing slices
-   * can only be cleared).
+   * Omit when adding slices is not allowed.
    */
   onAddSlice?: (rule: FilterRule) => void;
   onRemoveSliceAt: (globalIndex: number) => void;
@@ -80,9 +80,7 @@ export function RowFilterIcon({
   };
   const replaceSliceAt = sliceIconProps?.onReplaceSliceAt;
   const addSlice = sliceIconProps?.onAddSlice;
-  // Surface the slice tab whenever we can either add a slice or clear an
-  // existing one — otherwise the remove path inside an inaccessible group
-  // disappears together with the add path.
+  const canEdit = !!onAdd || !!onReplaceAt || !!addSlice || !!replaceSliceAt;
   const sliceTabAvailable =
     !!sliceIconProps && (!!addSlice || sliceIconProps.existingSlices.length > 0);
   const handleSliceApply = sliceTabAvailable
@@ -113,6 +111,32 @@ export function RowFilterIcon({
       )}
     </button>
   );
+
+  // Nothing editable (disconnected / no-access rows) — stale references can only be cleared.
+  if (!canEdit) {
+    return (
+      <ActiveRulesPopover
+        open={open}
+        onOpenChange={setOpen}
+        trigger={trigger}
+        column={column}
+        fieldType={fieldType}
+        aliasPath={sliceIconProps?.aliasPath}
+        sliceColumn={sliceIconProps?.originalFieldName}
+        filters={{ rules: activeRules, onRemoveAt }}
+        slices={
+          sliceIconProps
+            ? {
+                rules: sliceIconProps.existingSlices,
+                onRemoveAt: localIdx => {
+                  sliceIconProps.onRemoveSliceAt(sliceIconProps.existingSliceIndices[localIdx]);
+                },
+              }
+            : undefined
+        }
+      />
+    );
+  }
 
   if (sliceIconProps && handleSliceApply) {
     return (

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/SortRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/SortRow.tsx
@@ -1,6 +1,7 @@
 import type { HTMLAttributes } from 'react';
 import { Button } from '@owox/ui/components/button';
-import { ArrowDown, ArrowUp, GripVertical, X } from 'lucide-react';
+import { AlertTriangle, ArrowDown, ArrowUp, GripVertical, X } from 'lucide-react';
+import { cn } from '@owox/ui/lib/utils';
 import type { SortRule } from '../../../shared/types/output-config';
 
 interface SortRowProps {
@@ -9,16 +10,30 @@ interface SortRowProps {
   onChange: (next: SortRule) => void;
   onRemove: () => void;
   dragHandleProps?: HTMLAttributes<HTMLSpanElement>;
+  isOrphaned?: boolean;
 }
 
-export function SortRow({ rule, index, onChange, onRemove, dragHandleProps }: SortRowProps) {
+export function SortRow({
+  rule,
+  index,
+  onChange,
+  onRemove,
+  dragHandleProps,
+  isOrphaned = false,
+}: SortRowProps) {
   const toggleDirection = () => {
+    if (isOrphaned) return;
     onChange({ ...rule, direction: rule.direction === 'asc' ? 'desc' : 'asc' });
   };
   const ArrowIcon = rule.direction === 'asc' ? ArrowUp : ArrowDown;
 
   return (
-    <div className='bg-muted/40 flex items-center gap-2 rounded px-2 py-1.5'>
+    <div
+      className={cn(
+        'flex items-center gap-2 rounded px-2 py-1.5',
+        isOrphaned ? 'bg-red-50 dark:bg-red-950/30' : 'bg-muted/40'
+      )}
+    >
       <span
         {...dragHandleProps}
         className='text-muted-foreground cursor-grab'
@@ -27,14 +42,29 @@ export function SortRow({ rule, index, onChange, onRemove, dragHandleProps }: So
         <GripVertical className='h-4 w-4' />
       </span>
       <span className='text-muted-foreground w-4 text-xs tabular-nums'>{index + 1}</span>
-      <span className='flex-1 truncate font-mono text-xs' title={rule.column}>
-        {rule.column}
+      <span className='flex min-w-0 flex-1 items-center gap-1 truncate font-mono text-xs'>
+        {isOrphaned && (
+          <span
+            className='inline-flex items-center text-red-600'
+            title='This column is no longer available for sorting. Remove this rule or restore the column.'
+            aria-label='Column not found in schema'
+          >
+            <AlertTriangle className='h-3 w-3' />
+          </span>
+        )}
+        <span
+          className={cn('truncate', isOrphaned && 'text-red-700 line-through dark:text-red-300')}
+          title={rule.column}
+        >
+          {rule.column}
+        </span>
       </span>
       <Button
         variant='ghost'
         size='sm'
         className='text-muted-foreground hover:text-foreground h-6 gap-1 px-1.5 text-[11px]'
         onClick={toggleDirection}
+        disabled={isOrphaned}
         aria-label={`Toggle direction (currently ${rule.direction})`}
       >
         <ArrowIcon className='h-4 w-4' />

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.ts
@@ -102,6 +102,29 @@ const BOOLEAN_OPERATORS: OperatorMeta[] = [
   { value: 'is_not_null', label: 'is not null', shortLabel: '¬∅' },
 ];
 
+const FALLBACK_OPERATOR_LABELS: Record<FilterOperator, string> = {
+  eq: 'is',
+  neq: 'is not',
+  contains: 'contains',
+  not_contains: "doesn't contain",
+  starts_with: 'starts with',
+  ends_with: 'ends with',
+  is_empty: 'is empty',
+  is_not_empty: 'is not empty',
+  is_null: 'is null',
+  is_not_null: 'is not null',
+  regex: 'matches regex',
+  not_regex: "doesn't match regex",
+  gt: 'greater than',
+  lt: 'less than',
+  gte: 'greater than or equal',
+  lte: 'less than or equal',
+  between: 'between',
+  is_true: 'is true',
+  is_false: 'is false',
+  relative_date: 'relative',
+};
+
 // Same comparison operators as dates minus relative_date (calendar-only presets).
 // "at"-framed labels read naturally for a time of day, which has no calendar date
 // to be "on" / "on or after".
@@ -148,5 +171,5 @@ export function isTimeType(fieldType: string): boolean {
 
 export function operatorLabelFor(operator: FilterOperator, fieldType: string): string {
   const meta = operatorsForType(fieldType).find(o => o.value === operator);
-  return meta?.label ?? operator;
+  return meta?.label ?? FALLBACK_OPERATOR_LABELS[operator];
 }


### PR DESCRIPTION
## Summary

- Fail fast when a report references disconnected or hidden selected columns/output controls instead of letting stale references leak into generated SQL or fail later in storage with a cryptic error.
- Reuse recursive schema path collection for native fields so nested native report fields stay supported while disconnected/hidden schema subtrees are pruned consistently.
- Surface stale selected columns, filter-only references, and slices in the Report Column Picker disconnected block so they can be removed from the picker.
- Keep sort-only stale references in the Output Controls menu and highlight stale filters, slices, and sorts there in red.
- Add a red Output Controls badge/count when any filter, slice, or sort references a disconnected field, matching the unresolved state in the menu.
- Share the remove-only active-rules popover between disconnected and no-access rows so stale filter/slice rules can be reviewed and removed without add/edit controls.
- Tighten cache invalidation cleanup so it does not prepare a fresh blended reader while deleting cache entries.

## Related

- Google Sheets extension sync PR: https://github.com/OWOX/google-sheets-extension/pull/21

## Screenshots

Add screenshots of the updated Report Column Picker / Output Controls UI before moving this PR out of draft.

| State | Screenshot |
| --- | --- |
| Disconnected columns block | <img width="601" height="318" alt="CleanShot 2026-06-11 at 00 00 20" src="https://github.com/user-attachments/assets/2ed8cc50-1b44-4ba5-a367-2a222df6c913" /> |
| Output Controls red badge and menu | <img width="589" height="620" alt="CleanShot 2026-06-11 at 00 35 39" src="https://github.com/user-attachments/assets/39674db3-2913-45c4-92e7-9d6ca3905af5" /> |
| Stale slice/filter remove-only popover | <img width="589" height="269" alt="CleanShot 2026-06-11 at 00 36 21" src="https://github.com/user-attachments/assets/5a8cc6d7-6735-4891-b4ea-9f6fc215b8d9" /> |

## Test Plan

- [x] `npm test -w @owox/backend -- output-controls-validator.service.spec.ts blended-report-data.service.spec.ts report-sql-composer.service.spec.ts report-data-cache.service.spec.ts`
- [x] `npm test -w @owox/web -- ReportColumnPicker.test.tsx OutputSettingsDropdown.test.tsx RowFilterIcon.test.tsx`
- [x] `npm run test:e2e -w @owox/backend -- --shard=1/3 --runInBand`
- [x] `npm run test:e2e -w @owox/backend -- --shard=2/3 --runInBand`
- [x] `npm run test:e2e -w @owox/backend -- --shard=3/3 --runInBand`
- [x] `npx eslint ...` for touched backend files
- [x] `npx eslint ...` for touched web ReportColumnPicker files
- [x] `npx tsc -p tsconfig.build.json --noEmit --incremental false`
- [x] `npm run type-check -w @owox/web`
- [x] `npx prettier --check ...` for touched backend/web/changeset files
- [x] `git diff --check`
