### PR TITLE
feat(data-marts): output controls for Databricks data marts (filters,…

### DIFF
--- a/.changeset/databricks-output-controls.md
+++ b/.changeset/databricks-output-controls.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Add output controls for Databricks data marts
+
+Add report-level output controls (filters, slices, sort, limit) for Databricks data
+marts. Filter values are inlined as escaped SQL literals (Spark-correct backslash + quote
+escaping); substring matchers use `contains`/`startswith`/`endswith` and regex uses
+`RLIKE` so user `%`/`_` stay literal; date/time comparisons are cast to the column type.
+Works for the web app and the Google Sheets extension.

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -28,7 +28,9 @@ jobs:
             pattern: athena.integration
           - name: Redshift
             pattern: redshift.integration
-          - name: HTTP Data (Athena + BigQuery)
+          - name: Databricks
+            pattern: databricks.integration
+          - name: HTTP Data (Athena + BigQuery + Redshift + Databricks)
             pattern: http-data-real
           - name: Report read (Athena)
             pattern: report-run-real
@@ -73,6 +75,12 @@ jobs:
           REDSHIFT_REGION: ${{ secrets.REDSHIFT_REGION }}
           REDSHIFT_WORKGROUP_NAME: ${{ secrets.REDSHIFT_WORKGROUP_NAME }}
           REDSHIFT_DATABASE: ${{ secrets.REDSHIFT_DATABASE }}
+          # Databricks (PERSONAL_ACCESS_TOKEN auth; catalog + schema host the seed table)
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_HTTP_PATH: ${{ secrets.DATABRICKS_HTTP_PATH }}
+          DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          DATABRICKS_CATALOG: ${{ secrets.DATABRICKS_CATALOG }}
+          DATABRICKS_SCHEMA: ${{ secrets.DATABRICKS_SCHEMA }}
           # Google Sheets
           GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON }}
           TEST_GOOGLE_SPREADSHEET_ID: ${{ secrets.TEST_GOOGLE_SPREADSHEET_ID }}

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
@@ -59,6 +59,7 @@ import { DatabricksReportReader } from './databricks/services/databricks-report-
 import { DatabricksSchemaMerger } from './databricks/services/databricks-schema-merger';
 import { DatabricksSqlDryRunExecutor } from './databricks/services/databricks-sql-dry-run.executor';
 import { DatabricksBlendedQueryBuilder } from './databricks/services/databricks-blended-query-builder';
+import { DatabricksClauseRenderer } from './databricks/services/databricks-clause-renderer';
 import { DatabricksSqlRunExecutor } from './databricks/services/databricks-sql-run.executor';
 import { DatabricksStorageErrorMapper } from './databricks/services/databricks-storage-error.mapper';
 import { DataStorageType } from './enums/data-storage-type.enum';
@@ -241,6 +242,7 @@ const blendedQueryBuilderProviders = [
   BigQueryClauseRenderer,
   AthenaClauseRenderer,
   RedshiftClauseRenderer,
+  DatabricksClauseRenderer,
   BigQueryBlendedQueryBuilder,
   SnowflakeBlendedQueryBuilder,
   RedshiftBlendedQueryBuilder,

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotImplementedException } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import {
   createBuildContext,
@@ -7,6 +6,7 @@ import {
   makeRelationship,
 } from '../../interfaces/__fixtures__/blended-query-builder-fixtures';
 import { DatabricksBlendedQueryBuilder } from './databricks-blended-query-builder';
+import { DatabricksClauseRenderer } from './databricks-clause-renderer';
 import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
 
 const buildContext = createBuildContext('`catalog`.`schema`.`customers`');
@@ -16,7 +16,7 @@ describe('DatabricksBlendedQueryBuilder', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DatabricksBlendedQueryBuilder],
+      providers: [DatabricksBlendedQueryBuilder, DatabricksClauseRenderer],
     }).compile();
 
     builder = module.get(DatabricksBlendedQueryBuilder);
@@ -118,50 +118,72 @@ describe('DatabricksBlendedQueryBuilder', () => {
   });
 });
 
-describe('DatabricksBlendedQueryBuilder — output controls guard', () => {
-  const builder = new DatabricksBlendedQueryBuilder();
-  const baseContext: BlendedQueryContext = {
-    mainTableReference: '`catalog`.`schema`.`customers`',
-    mainDataMartTitle: 'M',
-    mainDataMartUrl: 'http://x',
-    chains: [],
-    columns: ['a'],
-  };
+describe('DatabricksBlendedQueryBuilder — output controls', () => {
+  let builder: DatabricksBlendedQueryBuilder;
 
-  it('throws NotImplemented when filters are non-empty', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
-        filters: [{ column: 'a', operator: 'eq', value: 1 }],
-      })
-    ).toThrow(NotImplementedException);
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DatabricksBlendedQueryBuilder, DatabricksClauseRenderer],
+    }).compile();
+    builder = module.get(DatabricksBlendedQueryBuilder);
   });
 
-  it('throws NotImplemented when sort is non-empty', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
-        sort: [{ column: 'a', direction: 'asc' }],
-      })
-    ).toThrow(NotImplementedException);
+  function ctx(over: Partial<BlendedQueryContext>): BlendedQueryContext {
+    return {
+      mainTableReference: '`catalog`.`schema`.`customers`',
+      mainDataMartTitle: 'M',
+      mainDataMartUrl: 'http://x',
+      chains: [],
+      columns: ['a'],
+      ...over,
+    };
+  }
+
+  it('applies a post-join filter as an inlined literal predicate with no bound params', () => {
+    const { sql, params } = builder.buildBlendedQuery(
+      ctx({ filters: [{ column: 'a', operator: 'eq', value: 1 }] })
+    );
+    // Spark is case-insensitive, so simple post-join columns stay bare (main.a, not main.`a`).
+    expect(sql).toContain('WHERE main.a = 1');
+    expect(params).toEqual([]);
   });
 
-  it('throws NotImplemented when limit is set', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
-        limit: 100,
-      })
-    ).toThrow(NotImplementedException);
+  it('uses contains for the string contains operator (no ? / @p placeholders)', () => {
+    const { sql, params } = builder.buildBlendedQuery(
+      ctx({ filters: [{ column: 'status', operator: 'contains', value: 'active' }] })
+    );
+    expect(sql).toContain("contains(main.status, 'active')");
+    expect(sql).not.toMatch(/[?]|@p\d/);
+    expect(params).toEqual([]);
   });
 
-  it('throws NotImplemented on pre-join filters (slices)', () => {
-    expect(() =>
-      builder.buildBlendedQuery({
-        ...baseContext,
+  it('renders ORDER BY and LIMIT', () => {
+    const { sql } = builder.buildBlendedQuery(
+      ctx({ sort: [{ column: 'a', direction: 'desc' }], limit: 10 })
+    );
+    expect(sql).toContain('ORDER BY main.a DESC');
+    expect(sql).toContain('LIMIT 10');
+  });
+
+  it('inlines a pre-join slice filter as a literal inside the subsidiary raw CTE with no params', () => {
+    const chain = makeChain({
+      relationship: makeRelationship({
+        targetAlias: 'users',
+        joinConditions: [{ sourceFieldName: 'user_id', targetFieldName: 'user_id' }],
+      }),
+      targetTableReference: '`catalog`.`schema`.`users`',
+      parentAlias: 'main',
+      blendedFields: [
+        { targetFieldName: 'role', outputAlias: 'role', isHidden: true, aggregateFunction: 'MAX' },
+      ],
+    });
+    const { sql, params } = builder.buildBlendedQuery(
+      ctx({
+        chains: [chain],
+        columns: ['a'],
         filters: [
           {
-            column: 'userRole',
+            column: 'role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
@@ -169,6 +191,16 @@ describe('DatabricksBlendedQueryBuilder — output controls guard', () => {
           },
         ],
       })
-    ).toThrow(NotImplementedException);
+    );
+    // The inlined predicate must sit inside the subsidiary raw CTE, before the outer SELECT.
+    // Spark is case-insensitive so the simple alias/column stay bare (users_raw, role).
+    const rawCteStart = sql.indexOf('users_raw AS (');
+    const predicatePos = sql.indexOf("role = 'admin'");
+    const outerSelectPos = sql.lastIndexOf('\nSELECT\n');
+    expect(rawCteStart).toBeGreaterThanOrEqual(0);
+    expect(predicatePos).toBeGreaterThan(rawCteStart);
+    expect(predicatePos).toBeLessThan(outerSelectPos);
+    expect(sql).not.toContain('main.role');
+    expect(params).toEqual([]);
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.ts
@@ -2,16 +2,24 @@ import { Injectable } from '@nestjs/common';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { AbstractBlendedQueryBuilder } from '../../interfaces/abstract-blended-query-builder';
 import { SqlClauseRenderer } from '../../utils/sql-clause-renderer';
+import { DatabricksClauseRenderer } from './databricks-clause-renderer';
 
 @Injectable()
 export class DatabricksBlendedQueryBuilder extends AbstractBlendedQueryBuilder {
   readonly type = DataStorageType.DATABRICKS;
   protected readonly identifierQuoteChar = '`';
 
-  protected get clauseRenderer(): SqlClauseRenderer | null {
-    return null;
+  constructor(private readonly _renderer: DatabricksClauseRenderer) {
+    super();
   }
 
+  protected get clauseRenderer(): SqlClauseRenderer {
+    return this._renderer;
+  }
+
+  // Spark is case-insensitive for identifier resolution and backticks do NOT make an
+  // identifier case-sensitive (unlike Snowflake) — so the base's bare return for simple
+  // names is safe; no quoteIdentifier override needed.
   protected buildStringAgg(fieldName: string): string {
     return `CONCAT_WS(', ', COLLECT_LIST(CAST(${fieldName} AS STRING)))`;
   }

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-clause-renderer.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-clause-renderer.spec.ts
@@ -1,0 +1,148 @@
+import { DatabricksClauseRenderer } from './databricks-clause-renderer';
+import { FilterRule } from '../../../dto/schemas/filter-config.schema';
+
+function where(renderer: DatabricksClauseRenderer, rule: FilterRule, type?: string) {
+  return renderer.renderWhere([rule], undefined, 'p', type ? () => type : undefined).sql;
+}
+
+describe('DatabricksClauseRenderer', () => {
+  const r = new DatabricksClauseRenderer();
+
+  it('renders comparison operators with inlined literals and no params', () => {
+    const out = r.renderWhere([{ column: 'age', operator: 'gte', value: 18 }]);
+    expect(out.sql).toBe('\nWHERE `age` >= 18');
+    expect(out.params).toEqual([]);
+    expect(where(r, { column: 'age', operator: 'gt', value: 18 })).toBe('\nWHERE `age` > 18');
+    expect(where(r, { column: 'age', operator: 'lt', value: 18 })).toBe('\nWHERE `age` < 18');
+    expect(where(r, { column: 'age', operator: 'lte', value: 18 })).toBe('\nWHERE `age` <= 18');
+  });
+
+  it('safely escapes malicious column names (no breakout via dots or payloads)', () => {
+    // The column name is user-controlled (FilterRule.column is only z.string().min(1)); it
+    // must stay fully inside backtick-quoted identifiers and never break out of the clause.
+    expect(where(r, { column: 'a.b.c.d OR 1=1 --', operator: 'is_null' })).toBe(
+      '\nWHERE `a`.`b`.`c`.`d OR 1=1 --` IS NULL'
+    );
+    expect(where(r, { column: "c'; DROP TABLE x; --", operator: 'is_null' })).toBe(
+      "\nWHERE `c'; DROP TABLE x; --` IS NULL"
+    );
+  });
+
+  it('escapes single quotes AND backslashes (Spark treats \\ as an escape char)', () => {
+    expect(where(r, { column: 'name', operator: 'eq', value: "O'Brien" })).toBe(
+      "\nWHERE `name` = 'O''Brien'"
+    );
+    expect(where(r, { column: 'path', operator: 'eq', value: 'a\\b' })).toBe(
+      "\nWHERE `path` = 'a\\\\b'"
+    );
+  });
+
+  it('inlines a malicious filter VALUE as a single escaped literal (no breakout)', () => {
+    expect(where(r, { column: 'name', operator: 'eq', value: "x' OR '1'='1" })).toBe(
+      "\nWHERE `name` = 'x'' OR ''1''=''1'"
+    );
+  });
+
+  it('uses Spark string built-ins (not LIKE) so %/_ stay literal', () => {
+    expect(where(r, { column: 'name', operator: 'contains', value: '50%_x' })).toBe(
+      "\nWHERE contains(`name`, '50%_x')"
+    );
+    expect(where(r, { column: 'name', operator: 'starts_with', value: 'a' })).toBe(
+      "\nWHERE startswith(`name`, 'a')"
+    );
+    expect(where(r, { column: 'name', operator: 'ends_with', value: 'z' })).toBe(
+      "\nWHERE endswith(`name`, 'z')"
+    );
+    expect(where(r, { column: 'name', operator: 'not_contains', value: 'x' })).toBe(
+      "\nWHERE NOT contains(`name`, 'x')"
+    );
+    expect(where(r, { column: 'name', operator: 'regex', value: '^a.*' })).toBe(
+      "\nWHERE `name` RLIKE '^a.*'"
+    );
+    expect(where(r, { column: 'name', operator: 'not_regex', value: '^a.*' })).toBe(
+      "\nWHERE NOT (`name` RLIKE '^a.*')"
+    );
+    // A regex metacharacter survives the string-literal layer: the backslash is doubled so
+    // Spark unescapes it back to `\d` for RLIKE (live-verified — matched the digit row).
+    expect(where(r, { column: 'name', operator: 'regex', value: '\\d+' })).toBe(
+      "\nWHERE `name` RLIKE '\\\\d+'"
+    );
+  });
+
+  it('wraps date/time value comparisons in a defensive CAST to the column type', () => {
+    expect(
+      where(r, { column: 'created_at', operator: 'gte', value: '2024-01-01' }, 'TIMESTAMP')
+    ).toBe("\nWHERE `created_at` >= CAST('2024-01-01' AS TIMESTAMP)");
+    expect(where(r, { column: 'ts', operator: 'eq', value: '2024-01-01' }, 'TIMESTAMP_NTZ')).toBe(
+      "\nWHERE `ts` = CAST('2024-01-01' AS TIMESTAMP_NTZ)"
+    );
+    expect(
+      where(
+        r,
+        { column: 'd', operator: 'between', value: { from: '2024-01-01', to: '2024-02-01' } },
+        'DATE'
+      )
+    ).toBe("\nWHERE `d` BETWEEN CAST('2024-01-01' AS DATE) AND CAST('2024-02-01' AS DATE)");
+    // Non-date columns get no cast.
+    expect(where(r, { column: 'age', operator: 'gte', value: 18 }, 'INT')).toBe(
+      '\nWHERE `age` >= 18'
+    );
+  });
+
+  it('renders bool / null / empty operators', () => {
+    expect(where(r, { column: 'ok', operator: 'is_true' })).toBe('\nWHERE `ok` = TRUE');
+    expect(where(r, { column: 'ok', operator: 'is_false' })).toBe('\nWHERE `ok` = FALSE');
+    expect(where(r, { column: 'x', operator: 'is_null' })).toBe('\nWHERE `x` IS NULL');
+    expect(where(r, { column: 'x', operator: 'is_not_null' })).toBe('\nWHERE `x` IS NOT NULL');
+    expect(where(r, { column: 's', operator: 'is_empty' })).toBe(
+      "\nWHERE (`s` IS NULL OR `s` = '')"
+    );
+    expect(where(r, { column: 's', operator: 'is_not_empty' })).toBe(
+      "\nWHERE (`s` IS NOT NULL AND `s` <> '')"
+    );
+    expect(where(r, { column: 'n', operator: 'neq', value: 1 })).toBe('\nWHERE `n` <> 1');
+  });
+
+  it('renders relative_date presets as half-open ranges with upper bounds', () => {
+    expect(where(r, { column: 'd', operator: 'relative_date', value: { kind: 'today' } })).toBe(
+      '\nWHERE `d` >= CURRENT_DATE AND `d` < date_add(CURRENT_DATE, 1)'
+    );
+    expect(where(r, { column: 'd', operator: 'relative_date', value: { kind: 'yesterday' } })).toBe(
+      '\nWHERE `d` >= date_add(CURRENT_DATE, -1) AND `d` < CURRENT_DATE'
+    );
+    expect(
+      where(r, { column: 'd', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } })
+    ).toBe('\nWHERE `d` >= date_add(CURRENT_DATE, -7) AND `d` < date_add(CURRENT_DATE, 1)');
+    expect(
+      where(r, { column: 'd', operator: 'relative_date', value: { kind: 'last_n_months', n: 3 } })
+    ).toBe('\nWHERE `d` >= add_months(CURRENT_DATE, -3) AND `d` < date_add(CURRENT_DATE, 1)');
+    expect(
+      where(r, { column: 'd', operator: 'relative_date', value: { kind: 'this_month' } })
+    ).toBe(
+      "\nWHERE `d` >= trunc(CURRENT_DATE, 'MONTH') AND `d` < add_months(trunc(CURRENT_DATE, 'MONTH'), 1)"
+    );
+    expect(
+      where(r, { column: 'd', operator: 'relative_date', value: { kind: 'last_month' } })
+    ).toBe(
+      "\nWHERE `d` >= add_months(trunc(CURRENT_DATE, 'MONTH'), -1) AND `d` < trunc(CURRENT_DATE, 'MONTH')"
+    );
+    expect(where(r, { column: 'd', operator: 'relative_date', value: { kind: 'this_year' } })).toBe(
+      "\nWHERE `d` >= trunc(CURRENT_DATE, 'YEAR') AND `d` < add_months(trunc(CURRENT_DATE, 'YEAR'), 12)"
+    );
+  });
+
+  it('rejects non-finite numbers and negative/non-integer relative_date n', () => {
+    expect(() => r.renderWhere([{ column: 'x', operator: 'gt', value: Infinity }])).toThrow(
+      /Non-finite/
+    );
+    expect(() =>
+      r.renderWhere([
+        {
+          column: 'd',
+          operator: 'relative_date',
+          value: { kind: 'last_n_days', n: -1 },
+        } as FilterRule,
+      ])
+    ).toThrow(/Invalid relative_date n/);
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-clause-renderer.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-clause-renderer.ts
@@ -1,0 +1,157 @@
+import { Injectable } from '@nestjs/common';
+import { RenderedClause, SqlClauseRenderer } from '../../utils/sql-clause-renderer';
+import { FilterRule } from '../../../dto/schemas/filter-config.schema';
+import { escapeDatabricksIdentifier } from '../utils/databricks-identifier.utils';
+
+/**
+ * Formats a value as a Databricks (Spark SQL) literal. The renderer inlines every value
+ * (params: []), so this escaping is the ONLY injection barrier. Spark interprets backslash
+ * escape sequences in single-quoted string literals, so a literal backslash must be doubled
+ * BEFORE single quotes are doubled (BigQuery/Snowflake-style, NOT Redshift's quote-only).
+ * The same backslash-doubling also lets a user's regex metacharacter (`\d`) survive the
+ * string-literal layer into RLIKE.
+ */
+function formatDatabricksLiteral(value: string | number | boolean | null): string {
+  if (value === null) return 'NULL';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Non-finite numeric filter value: ${String(value)}`);
+    }
+    return String(value);
+  }
+  if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE';
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "''")}'`;
+}
+
+/**
+ * Databricks renderer (option B). Inlines every value as a literal — fragments always
+ * return params: []. Substring/affix matchers use Spark `contains`/`startswith`/`endswith`
+ * (never LIKE) so user %/_ stay literal; regex uses infix `RLIKE` (Spark partial match).
+ * Date/time value comparisons get a defensive CAST to the column type.
+ */
+@Injectable()
+export class DatabricksClauseRenderer extends SqlClauseRenderer {
+  // Databricks date/time types that take a defensive CAST around the inlined literal.
+  private static readonly DATE_CAST_TYPES = new Set(['DATE', 'TIMESTAMP', 'TIMESTAMP_NTZ']);
+
+  protected quoteIdentifier(name: string): string {
+    return escapeDatabricksIdentifier(name);
+  }
+
+  protected validateFragment(clause: RenderedClause): void {
+    if (clause.params.length !== 0) {
+      throw new Error(
+        `DatabricksClauseRenderer must inline all values, but a fragment emitted ` +
+          `${clause.params.length} param(s): "${clause.sql}".`
+      );
+    }
+  }
+
+  private litCast(value: string | number | boolean | null, columnType?: string): string {
+    const l = formatDatabricksLiteral(value);
+    return columnType && DatabricksClauseRenderer.DATE_CAST_TYPES.has(columnType)
+      ? `CAST(${l} AS ${columnType})`
+      : l;
+  }
+
+  protected renderFilterFragment(
+    rule: FilterRule,
+    _paramName: string,
+    col: string,
+    columnType?: string
+  ): RenderedClause {
+    const lit = (v: string | number | boolean | null): string => this.litCast(v, columnType);
+    // Text operators are validator-restricted to string columns: always a string literal.
+    const text = (v: string | number | boolean | null): string =>
+      formatDatabricksLiteral(String(v));
+    switch (rule.operator) {
+      case 'eq':
+        return { sql: `${col} = ${lit(rule.value)}`, params: [] };
+      case 'neq':
+        return { sql: `${col} <> ${lit(rule.value)}`, params: [] };
+      case 'gt':
+        return { sql: `${col} > ${lit(rule.value)}`, params: [] };
+      case 'lt':
+        return { sql: `${col} < ${lit(rule.value)}`, params: [] };
+      case 'gte':
+        return { sql: `${col} >= ${lit(rule.value)}`, params: [] };
+      case 'lte':
+        return { sql: `${col} <= ${lit(rule.value)}`, params: [] };
+      case 'contains':
+        return { sql: `contains(${col}, ${text(rule.value)})`, params: [] };
+      case 'not_contains':
+        return { sql: `NOT contains(${col}, ${text(rule.value)})`, params: [] };
+      case 'starts_with':
+        return { sql: `startswith(${col}, ${text(rule.value)})`, params: [] };
+      case 'ends_with':
+        return { sql: `endswith(${col}, ${text(rule.value)})`, params: [] };
+      case 'regex':
+        // Spark RLIKE is partial-match (Java find() semantics), unlike Snowflake's
+        // full-anchored RLIKE — so `^prefix` works like the other storages. Live-verified.
+        return { sql: `${col} RLIKE ${text(rule.value)}`, params: [] };
+      case 'not_regex':
+        return { sql: `NOT (${col} RLIKE ${text(rule.value)})`, params: [] };
+      case 'is_empty':
+        return { sql: `(${col} IS NULL OR ${col} = '')`, params: [] };
+      case 'is_not_empty':
+        return { sql: `(${col} IS NOT NULL AND ${col} <> '')`, params: [] };
+      case 'is_null':
+        return { sql: `${col} IS NULL`, params: [] };
+      case 'is_not_null':
+        return { sql: `${col} IS NOT NULL`, params: [] };
+      case 'is_true':
+        return { sql: `${col} = TRUE`, params: [] };
+      case 'is_false':
+        return { sql: `${col} = FALSE`, params: [] };
+      case 'between':
+        return {
+          sql: `${col} BETWEEN ${lit(rule.value.from)} AND ${lit(rule.value.to)}`,
+          params: [],
+        };
+      case 'relative_date':
+        return { sql: this.renderRelativeDate(col, rule.value), params: [] };
+    }
+  }
+
+  private renderRelativeDate(
+    col: string,
+    preset: Extract<FilterRule, { operator: 'relative_date' }>['value']
+  ): string {
+    // `n` is inlined into SQL; re-assert the integer locally (the injection barrier must
+    // not live solely in the zod schema on the request path).
+    if ('n' in preset && (!Number.isInteger(preset.n) || preset.n < 0)) {
+      throw new Error(`Invalid relative_date n: ${String(preset.n)}`);
+    }
+    switch (preset.kind) {
+      case 'today':
+        return `${col} >= CURRENT_DATE AND ${col} < date_add(CURRENT_DATE, 1)`;
+      case 'yesterday':
+        return `${col} >= date_add(CURRENT_DATE, -1) AND ${col} < CURRENT_DATE`;
+      case 'last_n_days':
+        return (
+          `${col} >= date_add(CURRENT_DATE, -${preset.n})` +
+          ` AND ${col} < date_add(CURRENT_DATE, 1)`
+        );
+      case 'last_n_months':
+        return (
+          `${col} >= add_months(CURRENT_DATE, -${preset.n})` +
+          ` AND ${col} < date_add(CURRENT_DATE, 1)`
+        );
+      case 'this_month':
+        return (
+          `${col} >= trunc(CURRENT_DATE, 'MONTH')` +
+          ` AND ${col} < add_months(trunc(CURRENT_DATE, 'MONTH'), 1)`
+        );
+      case 'last_month':
+        return (
+          `${col} >= add_months(trunc(CURRENT_DATE, 'MONTH'), -1)` +
+          ` AND ${col} < trunc(CURRENT_DATE, 'MONTH')`
+        );
+      case 'this_year':
+        return (
+          `${col} >= trunc(CURRENT_DATE, 'YEAR')` +
+          ` AND ${col} < add_months(trunc(CURRENT_DATE, 'YEAR'), 12)`
+        );
+    }
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-query.builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-query.builder.spec.ts
@@ -15,8 +15,20 @@ describe('DatabricksQueryBuilder', () => {
   });
 
   it('wraps a SQL definition with limit (legacy schema-probe path), trailing semicolon stripped', () => {
-    expect(build().buildQuery(sqlDef, { limit: 0 })).toBe('SELECT * FROM (SELECT 1)\nLIMIT 0');
-    expect(build().buildQuery(sqlDef, { limit: 10 })).toBe('SELECT * FROM (SELECT 1)\nLIMIT 10');
+    expect(build().buildQuery(sqlDef, { limit: 0 })).toBe(
+      'SELECT * FROM (SELECT 1) AS subq\nLIMIT 0'
+    );
+    expect(build().buildQuery(sqlDef, { limit: 10 })).toBe(
+      'SELECT * FROM (SELECT 1) AS subq\nLIMIT 10'
+    );
+  });
+
+  it('wraps the raw SQL as an aliased subquery when no mainTableReference is supplied (SQL def + filters)', () => {
+    const sql = build().buildQuery(sqlDef, {
+      filters: [{ column: 'a', operator: 'eq', value: 1 }],
+    });
+    expect(sql).toContain('FROM (SELECT 1) AS subq');
+    expect(sql).toContain('WHERE `a` = 1');
   });
 
   it('applies filters, sort and limit via the clause renderer', () => {

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-query.builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-query.builder.spec.ts
@@ -1,59 +1,53 @@
-import { NotImplementedException } from '@nestjs/common';
 import { DatabricksQueryBuilder } from './databricks-query.builder';
+import { DatabricksClauseRenderer } from './databricks-clause-renderer';
+import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
+
+const sqlDef = { sqlQuery: 'SELECT 1;' } as unknown as DataMartDefinition;
+const tableDef = { fullyQualifiedName: 'cat.sch.events' } as unknown as DataMartDefinition;
+
+function build() {
+  return new DatabricksQueryBuilder(new DatabricksClauseRenderer());
+}
 
 describe('DatabricksQueryBuilder', () => {
-  const builder = new DatabricksQueryBuilder();
-
-  it('wraps SQL definitions with limit and strips trailing semicolon', () => {
-    const query = builder.buildQuery(
-      {
-        type: 'SQL',
-        sqlQuery: 'SELECT 1;',
-      } as never,
-      { limit: 0 }
-    );
-
-    expect(query).toBe('SELECT * FROM (SELECT 1) LIMIT 0');
+  it('builds a plain SELECT with no output controls', () => {
+    expect(build().buildQuery(tableDef, {})).toBe('SELECT * FROM `cat`.`sch`.`events`');
   });
 
-  it('wraps SQL definitions with limit without changing valid queries', () => {
-    const query = builder.buildQuery(
-      {
-        type: 'SQL',
-        sqlQuery: 'SELECT 1',
-      } as never,
-      { limit: 10 }
-    );
-
-    expect(query).toBe('SELECT * FROM (SELECT 1) LIMIT 10');
-  });
-});
-
-describe('DatabricksQueryBuilder — output controls guard', () => {
-  const builder = new DatabricksQueryBuilder();
-  const tableDef = { type: 'table', fullyQualifiedName: 'catalog.schema.tbl' } as any;
-
-  it('throws NotImplemented when filters are non-empty', () => {
-    expect(() =>
-      builder.buildQuery(tableDef, {
-        filters: [{ column: 'a', operator: 'eq', value: 1 }],
-      })
-    ).toThrow(NotImplementedException);
+  it('wraps a SQL definition with limit (legacy schema-probe path), trailing semicolon stripped', () => {
+    expect(build().buildQuery(sqlDef, { limit: 0 })).toBe('SELECT * FROM (SELECT 1)\nLIMIT 0');
+    expect(build().buildQuery(sqlDef, { limit: 10 })).toBe('SELECT * FROM (SELECT 1)\nLIMIT 10');
   });
 
-  it('throws NotImplemented when sort is non-empty', () => {
-    expect(() =>
-      builder.buildQuery(tableDef, {
-        sort: [{ column: 'a', direction: 'asc' }],
-      })
-    ).toThrow(NotImplementedException);
+  it('applies filters, sort and limit via the clause renderer', () => {
+    const sql = build().buildQuery(tableDef, {
+      columns: ['id', 'created_at'],
+      filters: [{ column: 'created_at', operator: 'gte', value: '2024-01-01' }],
+      sort: [{ column: 'id', direction: 'desc' }],
+      limit: 100,
+      columnTypes: new Map([['created_at', 'TIMESTAMP']]),
+    });
+    expect(sql).toContain('SELECT `id`, `created_at` FROM `cat`.`sch`.`events`');
+    expect(sql).toContain("WHERE `created_at` >= CAST('2024-01-01' AS TIMESTAMP)");
+    expect(sql).toContain('ORDER BY `id` DESC');
+    expect(sql).toContain('LIMIT 100');
   });
 
-  it('still works without output controls (limit-only legacy path)', () => {
-    expect(builder.buildQuery(tableDef, { limit: 0 })).toBeDefined();
+  it('prefers mainTableReference as the FROM for SQL definitions under output controls', () => {
+    const sql = build().buildQuery(sqlDef, {
+      filters: [{ column: 'a', operator: 'eq', value: 1 }],
+      mainTableReference: 'cat.sch.my_view',
+    });
+    expect(sql).toContain('FROM cat.sch.my_view');
+    expect(sql).toContain('WHERE `a` = 1');
   });
 
   it('still works without options', () => {
-    expect(builder.buildQuery(tableDef)).toBeDefined();
+    expect(build().buildQuery(tableDef)).toBeDefined();
+  });
+
+  it('throws for table-pattern definitions under output controls', () => {
+    const patternDef = { pattern: 'ev_' } as unknown as DataMartDefinition;
+    expect(() => build().buildQuery(patternDef, { limit: 1 })).toThrow();
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-query.builder.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
 import {
   isConnectorDefinition,
@@ -12,52 +12,108 @@ import {
   DataMartQueryBuilder,
   DataMartQueryOptions,
 } from '../../interfaces/data-mart-query-builder.interface';
+import { FilterRule } from '../../../dto/schemas/filter-config.schema';
 import {
   escapeDatabricksIdentifier,
   escapeFullyQualifiedIdentifier,
 } from '../utils/databricks-identifier.utils';
+import { DatabricksClauseRenderer } from './databricks-clause-renderer';
 
 @Injectable()
 export class DatabricksQueryBuilder implements DataMartQueryBuilder {
   readonly type = DataStorageType.DATABRICKS;
 
+  constructor(private readonly clauseRenderer: DatabricksClauseRenderer) {}
+
   buildQuery(definition: DataMartDefinition, queryOptions?: DataMartQueryOptions): string {
-    if ((queryOptions?.filters?.length ?? 0) > 0 || (queryOptions?.sort?.length ?? 0) > 0) {
-      throw new NotImplementedException(
-        `Output controls not yet supported for storage type ${this.type}`
+    const hasOutputControls =
+      (queryOptions?.filters?.length ?? 0) > 0 ||
+      (queryOptions?.sort?.length ?? 0) > 0 ||
+      queryOptions?.limit != null;
+
+    const selectList = this.buildSelectList(queryOptions?.columns);
+
+    if (!hasOutputControls) {
+      return this.buildPlainQuery(definition, selectList, queryOptions);
+    }
+
+    const fromClause = this.resolveFromClauseWithOutputControls(definition, queryOptions);
+    const columnTypes = queryOptions?.columnTypes;
+    const resolveColumnType = columnTypes
+      ? (rule: FilterRule) => columnTypes.get(rule.column)
+      : undefined;
+    const where = this.clauseRenderer.renderWhere(
+      queryOptions?.filters ?? [],
+      undefined,
+      'p',
+      resolveColumnType
+    );
+    const orderBy = this.clauseRenderer.renderOrderBy(queryOptions?.sort ?? []);
+    const limit = this.clauseRenderer.renderLimit(queryOptions?.limit ?? null);
+
+    // Databricks inlines every literal — no path carries bound params. Fail fast if a
+    // fragment ever emitted one (the reader rejects parameterized sqlOverride).
+    const paramCount = where.params.length + orderBy.params.length + limit.params.length;
+    if (paramCount > 0) {
+      throw new Error(
+        `DatabricksQueryBuilder expected zero bound params (literals are inlined) but got ${paramCount}`
       );
     }
-    const selectList = this.buildSelectList(queryOptions?.columns);
-    let query: string;
 
+    return `SELECT ${selectList} FROM ${fromClause}${where.sql}${orderBy.sql}${limit.sql}`;
+  }
+
+  private buildPlainQuery(
+    definition: DataMartDefinition,
+    selectList: string,
+    queryOptions?: DataMartQueryOptions
+  ): string {
     if (isTableDefinition(definition) || isViewDefinition(definition)) {
       const parts = definition.fullyQualifiedName.split('.');
-      query = `SELECT ${selectList} FROM ${escapeFullyQualifiedIdentifier(parts)}`;
-    } else if (isConnectorDefinition(definition)) {
+      return `SELECT ${selectList} FROM ${escapeFullyQualifiedIdentifier(parts)}`;
+    }
+    if (isConnectorDefinition(definition)) {
       const parts = definition.connector.storage.fullyQualifiedName.split('.');
-      query = `SELECT ${selectList} FROM ${escapeFullyQualifiedIdentifier(parts)}`;
-    } else if (isSqlDefinition(definition)) {
+      return `SELECT ${selectList} FROM ${escapeFullyQualifiedIdentifier(parts)}`;
+    }
+    if (isSqlDefinition(definition)) {
       if (queryOptions?.columns?.length) {
         const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
-        query = `SELECT ${selectList} FROM (${cleanQuery})`;
-      } else {
-        query = definition.sqlQuery.trim();
+        return `SELECT ${selectList} FROM (${cleanQuery})`;
       }
-    } else if (isTablePatternDefinition(definition)) {
+      return definition.sqlQuery.trim();
+    }
+    if (isTablePatternDefinition(definition)) {
       throw new Error('Table pattern definitions are not supported for Databricks');
-    } else {
-      throw new Error('Invalid data mart definition');
     }
+    throw new Error('Invalid data mart definition');
+  }
 
-    if (queryOptions?.limit !== undefined && queryOptions.limit !== null) {
-      if (!Number.isInteger(queryOptions.limit) || queryOptions.limit < 0) {
-        throw new Error(`Invalid LIMIT value: ${String(queryOptions.limit)}`);
+  private resolveFromClauseWithOutputControls(
+    definition: DataMartDefinition,
+    options?: DataMartQueryOptions
+  ): string {
+    if (isTableDefinition(definition) || isViewDefinition(definition)) {
+      return escapeFullyQualifiedIdentifier(definition.fullyQualifiedName.split('.'));
+    }
+    if (isConnectorDefinition(definition)) {
+      return escapeFullyQualifiedIdentifier(
+        definition.connector.storage.fullyQualifiedName.split('.')
+      );
+    }
+    if (isSqlDefinition(definition)) {
+      // Prefer the pre-materialized view the composer resolves (mirrors Snowflake/Redshift);
+      // fall back to wrapping the raw SQL when no reference was supplied (e.g. schema probe).
+      if (options?.mainTableReference) {
+        return options.mainTableReference;
       }
-      const cleanQuery = query.endsWith(';') ? query.slice(0, -1) : query;
-      query = `SELECT * FROM (${cleanQuery}) LIMIT ${queryOptions.limit}`;
+      const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
+      return `(${cleanQuery})`;
     }
-
-    return query;
+    if (isTablePatternDefinition(definition)) {
+      throw new Error('Table pattern definitions are not supported for Databricks');
+    }
+    throw new Error('Invalid data mart definition');
   }
 
   private buildSelectList(columns?: string[]): string {

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-query.builder.ts
@@ -79,7 +79,7 @@ export class DatabricksQueryBuilder implements DataMartQueryBuilder {
     if (isSqlDefinition(definition)) {
       if (queryOptions?.columns?.length) {
         const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
-        return `SELECT ${selectList} FROM (${cleanQuery})`;
+        return `SELECT ${selectList} FROM (${cleanQuery}) AS subq`;
       }
       return definition.sqlQuery.trim();
     }
@@ -108,7 +108,9 @@ export class DatabricksQueryBuilder implements DataMartQueryBuilder {
         return options.mainTableReference;
       }
       const cleanQuery = definition.sqlQuery.trim().replace(/;\s*$/, '');
-      return `(${cleanQuery})`;
+      // Alias the derived table (mirrors the Redshift sibling). Spark tolerates an
+      // unaliased subquery, but `AS subq` keeps the dialect builders uniform.
+      return `(${cleanQuery}) AS subq`;
     }
     if (isTablePatternDefinition(definition)) {
       throw new Error('Table pattern definitions are not supported for Databricks');

--- a/apps/backend/src/data-marts/services/output-controls-capability.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-capability.service.spec.ts
@@ -16,8 +16,8 @@ describe('OutputControlsCapabilityService', () => {
   it('supports AWS_REDSHIFT', () => {
     expect(svc.isSupported(DataStorageType.AWS_REDSHIFT)).toBe(true);
   });
-  it('returns false for Databricks', () => {
-    expect(svc.isSupported(DataStorageType.DATABRICKS)).toBe(false);
+  it('supports Databricks', () => {
+    expect(svc.isSupported(DataStorageType.DATABRICKS)).toBe(true);
   });
   it('supports legacy BigQuery', () => {
     expect(svc.isSupported(DataStorageType.LEGACY_GOOGLE_BIGQUERY)).toBe(true);

--- a/apps/backend/src/data-marts/services/output-controls-capability.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-capability.service.ts
@@ -9,6 +9,7 @@ export class OutputControlsCapabilityService {
     DataStorageType.LEGACY_GOOGLE_BIGQUERY,
     DataStorageType.AWS_ATHENA,
     DataStorageType.AWS_REDSHIFT,
+    DataStorageType.DATABRICKS,
   ]);
 
   isSupported(type: DataStorageType): boolean {

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -131,6 +131,46 @@ describe('OutputControlsValidatorService', () => {
       expect(errors).toEqual([]);
     });
 
+    it('treats Databricks INT as a number type (comparison allowed, relative_date rejected)', () => {
+      const types = new Map<string, string>([['n', 'INT']]);
+      expect(
+        svc.validateFilters(
+          [{ column: 'n', operator: 'gte', value: 1, placement: 'post-join' }],
+          types
+        )
+      ).toEqual([]);
+      const bad = svc.validateFilters(
+        [
+          {
+            column: 'n',
+            operator: 'relative_date',
+            value: { kind: 'today' },
+            placement: 'post-join',
+          },
+        ],
+        types
+      );
+      expect(bad).toHaveLength(1);
+      expect(bad[0].code).toBe('INVALID_OPERATOR_FOR_TYPE');
+    });
+
+    it('treats Databricks TIMESTAMP_NTZ as a date type (relative_date allowed)', () => {
+      const types = new Map<string, string>([['t', 'TIMESTAMP_NTZ']]);
+      expect(
+        svc.validateFilters(
+          [
+            {
+              column: 't',
+              operator: 'relative_date',
+              value: { kind: 'today' },
+              placement: 'post-join',
+            },
+          ],
+          types
+        )
+      ).toEqual([]);
+    });
+
     it('accepts gt on NUMERIC types (INTEGER/FLOAT/NUMERIC/BIGNUMERIC)', () => {
       const types = new Map<string, string>([
         ['i', BigQueryFieldType.INTEGER],

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.ts
@@ -23,6 +23,7 @@ export type ValidationError =
 const STRING_TYPES = new Set(['STRING', 'VARCHAR', 'CHAR', 'TEXT', 'BPCHAR']);
 const NUMBER_TYPES = new Set([
   'INTEGER',
+  'INT',
   'BIGINT',
   'SMALLINT',
   'TINYINT',
@@ -40,6 +41,7 @@ const DATE_TYPES = new Set([
   'TIMESTAMP',
   'TIMESTAMP WITH TIME ZONE',
   'TIMESTAMPTZ',
+  'TIMESTAMP_NTZ',
 ]);
 // Time-of-day types are kept separate from DATE/TIMESTAMP: relative_date renders
 // `current_date` / `date_add(..., current_date)` predicates that are meaningless

--- a/apps/backend/test/integration/README.md
+++ b/apps/backend/test/integration/README.md
@@ -50,6 +50,17 @@ ATHENA_OUTPUT_BUCKET=my-athena-results-bucket
 # Athena database name (must already exist — create via: CREATE DATABASE name)
 ATHENA_DATABASE=my_test_database
 
+# === Databricks ===
+# Workspace host (with https://) of the SQL warehouse
+DATABRICKS_HOST=https://dbc-xxxxxxxx.cloud.databricks.com
+# SQL warehouse HTTP path (Warehouse → Connection details → HTTP path)
+DATABRICKS_HTTP_PATH=/sql/1.0/warehouses/abcdef1234567890
+# Personal access token (User Settings → Developer → Access tokens)
+DATABRICKS_TOKEN=dapi...
+# Catalog + schema that host the seed table (the token needs CREATE/DROP TABLE there)
+DATABRICKS_CATALOG=main
+DATABRICKS_SCHEMA=default
+
 # === Google Sheets ===
 # JSON string of a GCP service account key with Google Sheets API access
 # (Editor role on TEST_GOOGLE_SPREADSHEET_ID — sheet add/delete requires Editor).
@@ -79,6 +90,12 @@ TEST_GOOGLE_SPREADSHEET_ID=your_spreadsheet_id_here
 - `athena:StartQueryExecution`, `athena:GetQueryExecution`, `athena:GetQueryResults`
 - `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket` (on output bucket)
 - `glue:GetTable`, `glue:CreateTable`, `glue:DeleteTable`, `glue:GetDatabase` (on Glue catalog)
+
+**Databricks token:**
+
+- `CREATE TABLE` / `DROP TABLE` on `DATABRICKS_CATALOG`.`DATABRICKS_SCHEMA` (the suite
+  seeds and drops its own table)
+- `SELECT` on that schema; the SQL warehouse must be running (or auto-start enabled)
 
 ## CI Setup (GitHub Actions)
 
@@ -113,6 +130,12 @@ quotes — not even for the JSON ones).
 | `ATHENA_DATABASE`                  | Athena        | Existing Athena database (create once via `CREATE DATABASE …`)                                                      |
 | `GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON` | Google Sheets | Full GCP service-account key JSON, **Editor**-shared on the test spreadsheet                                       |
 | `TEST_GOOGLE_SPREADSHEET_ID`       | Google Sheets | The spreadsheet ID (the long token in its URL)                                                                       |
+
+Redshift (`REDSHIFT_REGION`, `REDSHIFT_WORKGROUP_NAME`, `REDSHIFT_DATABASE`) reuses the
+Athena `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`. Databricks needs five DATABRICKS\_-prefixed
+secrets: `DATABRICKS_HOST`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_TOKEN`, `DATABRICKS_CATALOG`,
+`DATABRICKS_SCHEMA`. As with every other suite, a job whose secrets are missing just skips
+(green), so they can be added independently.
 
 `NODE_ENV`, `TEST_GOOGLE_SHEET_ID` (`'0'`) and `TEST_GOOGLE_SHEET_ID_2` (`'1'`)
 are **not** secrets — they are hard-coded in the workflow, nothing to add.

--- a/apps/backend/test/integration/README.md
+++ b/apps/backend/test/integration/README.md
@@ -51,8 +51,8 @@ ATHENA_OUTPUT_BUCKET=my-athena-results-bucket
 ATHENA_DATABASE=my_test_database
 
 # === Databricks ===
-# Workspace host (with https://) of the SQL warehouse
-DATABRICKS_HOST=https://dbc-xxxxxxxx.cloud.databricks.com
+# Workspace host — HOSTNAME ONLY, no https:// (passed straight to DBSQLClient.connect({ host }))
+DATABRICKS_HOST=dbc-xxxxxxxx.cloud.databricks.com
 # SQL warehouse HTTP path (Warehouse → Connection details → HTTP path)
 DATABRICKS_HTTP_PATH=/sql/1.0/warehouses/abcdef1234567890
 # Personal access token (User Settings → Developer → Access tokens)

--- a/apps/backend/test/integration/databricks.integration.ts
+++ b/apps/backend/test/integration/databricks.integration.ts
@@ -1,0 +1,406 @@
+import { DatabricksApiAdapter } from 'src/data-marts/data-storage-types/databricks/adapters/databricks-api.adapter';
+import { DatabricksCredentials } from 'src/data-marts/data-storage-types/databricks/schemas/databricks-credentials.schema';
+import { DatabricksConfig } from 'src/data-marts/data-storage-types/databricks/schemas/databricks-config.schema';
+import { DatabricksAuthMethod } from 'src/data-marts/data-storage-types/databricks/enums/databricks-auth-method.enum';
+import { DatabricksQueryBuilder } from 'src/data-marts/data-storage-types/databricks/services/databricks-query.builder';
+import { DatabricksClauseRenderer } from 'src/data-marts/data-storage-types/databricks/services/databricks-clause-renderer';
+import { TableDefinition } from 'src/data-marts/dto/schemas/data-mart-table-definitions/table-definition.schema';
+
+// Live Databricks integration for output controls (option B — the renderer inlines every
+// literal). Proves the renderer/builder SQL executes against a real Databricks SQL warehouse
+// and returns the expected rows, and finalizes the two live-only design questions:
+//   (a) backslash round-trip — Spark interprets `\` as a string-literal escape (like
+//       BigQuery/Snowflake), so the renderer doubles it; the seed must double it TWICE more
+//       to land a single backslash in storage (a JS template literal eats one level).
+//   (b) regex anchoring — Spark `RLIKE` is PARTIAL match (Java find()), unlike Snowflake's
+//       full-anchored RLIKE; the `^alp` → 'alpha' case is the only test that proves it.
+//   (c) CAST necessity — the renderer emits a defensive CAST; a bare-literal probe confirms
+//       Spark also coerces (so the cast is defensive-only).
+//
+// Required env (all DATABRICKS_-prefixed):
+//   DATABRICKS_HOST      — workspace host, e.g. https://dbc-xxxx.cloud.databricks.com
+//   DATABRICKS_HTTP_PATH — SQL warehouse HTTP path, e.g. /sql/1.0/warehouses/abc123
+//   DATABRICKS_TOKEN     — personal access token
+//   DATABRICKS_CATALOG   — catalog for the seed table (e.g. main)
+//   DATABRICKS_SCHEMA    — schema for the seed table (e.g. default)
+
+const DATABRICKS_HOST = process.env.DATABRICKS_HOST;
+const DATABRICKS_HTTP_PATH = process.env.DATABRICKS_HTTP_PATH;
+const DATABRICKS_TOKEN = process.env.DATABRICKS_TOKEN;
+const DATABRICKS_CATALOG = process.env.DATABRICKS_CATALOG;
+const DATABRICKS_SCHEMA = process.env.DATABRICKS_SCHEMA;
+
+const DATABRICKS_CREDENTIALS_AVAILABLE = !!(
+  DATABRICKS_HOST &&
+  DATABRICKS_HTTP_PATH &&
+  DATABRICKS_TOKEN &&
+  DATABRICKS_CATALOG &&
+  DATABRICKS_SCHEMA
+);
+
+if (!DATABRICKS_CREDENTIALS_AVAILABLE) {
+  const missing: string[] = [];
+  if (!DATABRICKS_HOST) missing.push('DATABRICKS_HOST');
+  if (!DATABRICKS_HTTP_PATH) missing.push('DATABRICKS_HTTP_PATH');
+  if (!DATABRICKS_TOKEN) missing.push('DATABRICKS_TOKEN');
+  if (!DATABRICKS_CATALOG) missing.push('DATABRICKS_CATALOG');
+  if (!DATABRICKS_SCHEMA) missing.push('DATABRICKS_SCHEMA');
+  console.warn(`Skipping Databricks integration tests — missing env: ${missing.join(', ')}`);
+}
+
+const describeIfCredentials = DATABRICKS_CREDENTIALS_AVAILABLE ? describe : describe.skip;
+
+function makeAdapter(): DatabricksApiAdapter {
+  const credentials: DatabricksCredentials = {
+    authMethod: DatabricksAuthMethod.PERSONAL_ACCESS_TOKEN,
+    token: DATABRICKS_TOKEN!,
+  };
+  const config: DatabricksConfig = {
+    host: DATABRICKS_HOST!,
+    httpPath: DATABRICKS_HTTP_PATH!,
+  };
+  return new DatabricksApiAdapter(credentials, config);
+}
+
+describeIfCredentials('Databricks Integration Tests — access', () => {
+  let adapter: DatabricksApiAdapter;
+
+  beforeAll(() => {
+    adapter = makeAdapter();
+  });
+
+  afterAll(async () => {
+    await adapter.destroy();
+  });
+
+  it('checkAccess succeeds with valid credentials', async () => {
+    await expect(adapter.checkAccess()).resolves.not.toThrow();
+  }, 60000);
+
+  it('executeDryRunQuery validates good SQL and rejects bad SQL', async () => {
+    const ok = await adapter.executeDryRunQuery('SELECT 1');
+    expect(ok.isValid).toBe(true);
+    const bad = await adapter.executeDryRunQuery('SELEKT * FORM nope');
+    expect(bad.isValid).toBe(false);
+  }, 60000);
+});
+
+// ---------------------------------------------------------------------------
+// Design-decision probes + operator matrix (own seed table)
+// ---------------------------------------------------------------------------
+// Seed rows:
+//   id  name        amount  status    date_col              ts_col (non-midnight rows 1,6)
+//    1  alpha         10.0  active    today                 today@13:45
+//    2  beta          20.0  inactive  yesterday             yesterday@00:00
+//    3  O'Brien       30.0  active    -40 days              -40d@00:00
+//    4  100%          40.0  inactive  -400 days (last yr)   -400d@00:00
+//    5  a\b           50.0  active    +13 months (next yr)  next_year@00:00
+//    6  gamma          0.0  active    today                 today@13:45
+//
+// Row 5: future-dated for this_year / this_month upper-bound exclusion AND the
+//        backslash round-trip probe. Rows 1,6: today@13:45 for the non-midnight check.
+// Row 3: O'Brien for single-quote round-trip. Row 4: 100% for wildcard-literal safety
+//        and the `\d` regex-class probe.
+
+const MATRIX_SUFFIX = `db_oc_matrix_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const MATRIX_FQN = `${DATABRICKS_CATALOG}.${DATABRICKS_SCHEMA}.${MATRIX_SUFFIX}`;
+const QUALIFIED = `\`${DATABRICKS_CATALOG}\`.\`${DATABRICKS_SCHEMA}\`.\`${MATRIX_SUFFIX}\``;
+
+describeIfCredentials('Databricks — date/time coercion, escaping, regex, operator matrix', () => {
+  let adapter: DatabricksApiAdapter;
+
+  const builder = new DatabricksQueryBuilder(new DatabricksClauseRenderer());
+  const definition: TableDefinition = {
+    get fullyQualifiedName() {
+      return MATRIX_FQN;
+    },
+  };
+  const columnTypes = new Map<string, string>([
+    ['date_col', 'DATE'],
+    ['ts_col', 'TIMESTAMP'],
+    ['ts_ntz_col', 'TIMESTAMP_NTZ'],
+  ]);
+
+  async function runFilter(
+    queryOptions: Parameters<DatabricksQueryBuilder['buildQuery']>[1]
+  ): Promise<Array<Record<string, unknown>>> {
+    const sql = builder.buildQuery(definition, { columnTypes, ...queryOptions });
+    return adapter.executeQueryAndFetchAll(sql);
+  }
+
+  function ids(rows: Array<Record<string, unknown>>): string[] {
+    return rows.map(r => String(r.id)).sort((a, b) => Number(a) - Number(b));
+  }
+
+  beforeAll(async () => {
+    adapter = makeAdapter();
+
+    try {
+      await adapter.executeQuery(`DROP TABLE IF EXISTS ${QUALIFIED}`);
+    } catch {
+      // ignore — table may not exist on first run
+    }
+
+    await adapter.executeQuery(`
+      CREATE TABLE ${QUALIFIED} (
+        id          INT,
+        name        STRING,
+        amount      DECIMAL(10,2),
+        status      STRING,
+        date_col    DATE,
+        ts_col      TIMESTAMP,
+        ts_ntz_col  TIMESTAMP_NTZ
+      ) USING DELTA
+    `);
+
+    // Row 5 name: a JS template literal collapses `\\\\` (4) → `\\` (2) in the SQL text,
+    // and Spark then unescapes `\\` → `\`, so the stored value is exactly `a\b` (one
+    // backslash) — matching what the renderer emits for the filter value `a\b`.
+    await adapter.executeQuery(`
+      INSERT INTO ${QUALIFIED}
+        (id, name, amount, status, date_col, ts_col, ts_ntz_col)
+      VALUES
+        (1, 'alpha',   10.00, 'active',
+          current_date,
+          cast(current_date as timestamp) + interval 825 minute,
+          cast(cast(current_date as timestamp) + interval 825 minute as timestamp_ntz)),
+        (2, 'beta',    20.00, 'inactive',
+          date_add(current_date, -1),
+          cast(date_add(current_date, -1) as timestamp),
+          cast(date_add(current_date, -1) as timestamp_ntz)),
+        (3, 'O''Brien',30.00, 'active',
+          date_add(current_date, -40),
+          cast(date_add(current_date, -40) as timestamp),
+          cast(date_add(current_date, -40) as timestamp_ntz)),
+        (4, '100%',    40.00, 'inactive',
+          date_add(current_date, -400),
+          cast(date_add(current_date, -400) as timestamp),
+          cast(date_add(current_date, -400) as timestamp_ntz)),
+        (5, 'a\\\\b',  50.00, 'active',
+          add_months(current_date, 13),
+          cast(add_months(current_date, 13) as timestamp),
+          cast(add_months(current_date, 13) as timestamp_ntz)),
+        (6, 'gamma',    0.00, 'active',
+          current_date,
+          cast(current_date as timestamp) + interval 825 minute,
+          cast(cast(current_date as timestamp) + interval 825 minute as timestamp_ntz))
+    `);
+  }, 180000);
+
+  afterAll(async () => {
+    try {
+      await adapter.executeQuery(`DROP TABLE IF EXISTS ${QUALIFIED}`);
+    } catch (error) {
+      console.warn('Failed to drop Databricks matrix test table:', error);
+    } finally {
+      await adapter.destroy();
+    }
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // PROBE (a): backslash round-trip
+  // -------------------------------------------------------------------------
+  it('PROBE backslash round-trip: eq "a\\\\b" matches the seeded backslash row', async () => {
+    const rows = await runFilter({ filters: [{ column: 'name', operator: 'eq', value: 'a\\b' }] });
+    console.log(`[ESCAPING] backslash eq match count: ${rows.length} (expect 1)`);
+    expect(ids(rows)).toEqual(['5']);
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // PROBE (c): CAST necessity — does Spark coerce a bare string literal?
+  // -------------------------------------------------------------------------
+  it('PROBE bare-literal date coercion: WHERE date_col >= bare string executes', async () => {
+    const rows = await adapter.executeQueryAndFetchAll(
+      `SELECT id FROM ${QUALIFIED} WHERE date_col >= '2020-01-01'`
+    );
+    console.log(`[COERCION] bare-literal date predicate → ${rows.length} rows, no error`);
+    expect(rows.length).toBeGreaterThan(0);
+  }, 60000);
+
+  it('DATE gte/between with the defensive CAST returns rows', async () => {
+    const gte = await runFilter({
+      filters: [{ column: 'date_col', operator: 'gte', value: '2020-01-01' }],
+    });
+    expect(gte.length).toBeGreaterThan(0);
+    const between = await runFilter({
+      filters: [
+        {
+          column: 'date_col',
+          operator: 'between',
+          value: { from: '2020-01-01', to: '2035-12-31' },
+        },
+      ],
+    });
+    expect(between.length).toBeGreaterThan(0);
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // relative_date on a non-midnight TIMESTAMP column (half-open range)
+  // -------------------------------------------------------------------------
+  it('relative_date today on ts_col (13:45, non-midnight) → rows 1,6', async () => {
+    const rows = await runFilter({
+      filters: [{ column: 'ts_col', operator: 'relative_date', value: { kind: 'today' } }],
+    });
+    expect(ids(rows)).toEqual(['1', '6']);
+  }, 60000);
+
+  it('relative_date today on date_col → rows 1,6', async () => {
+    const rows = await runFilter({
+      filters: [{ column: 'date_col', operator: 'relative_date', value: { kind: 'today' } }],
+    });
+    expect(ids(rows)).toEqual(['1', '6']);
+  }, 60000);
+
+  it('relative_date this_year excludes future row 5 and last-year row 4', async () => {
+    const rows = await runFilter({
+      filters: [{ column: 'date_col', operator: 'relative_date', value: { kind: 'this_year' } }],
+    });
+    const resultIds = ids(rows);
+    expect(resultIds).not.toContain('5');
+    expect(resultIds).not.toContain('4');
+    expect(resultIds).toContain('1');
+    expect(resultIds).toContain('6');
+  }, 60000);
+
+  it('relative_date this_month excludes future-dated row 5', async () => {
+    const rows = await runFilter({
+      filters: [{ column: 'date_col', operator: 'relative_date', value: { kind: 'this_month' } }],
+    });
+    expect(ids(rows)).not.toContain('5');
+  }, 60000);
+
+  it('relative_date last_n_days(7) → rows 1,2,6 (upper bound excludes future row 5)', async () => {
+    const rows = await runFilter({
+      filters: [
+        { column: 'date_col', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
+      ],
+    });
+    expect(ids(rows)).toEqual(['1', '2', '6']);
+  }, 60000);
+
+  it('relative_date last_n_months(3) → rows 1,2,3,6 (future row 5 excluded)', async () => {
+    const rows = await runFilter({
+      filters: [
+        { column: 'date_col', operator: 'relative_date', value: { kind: 'last_n_months', n: 3 } },
+      ],
+    });
+    expect(ids(rows)).toEqual(['1', '2', '3', '6']);
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // Operator matrix
+  // -------------------------------------------------------------------------
+  it('eq on name → row 1 (alpha)', async () => {
+    expect(
+      ids(await runFilter({ filters: [{ column: 'name', operator: 'eq', value: 'alpha' }] }))
+    ).toEqual(['1']);
+  }, 60000);
+
+  it('neq on status: not "active" → rows 2,4', async () => {
+    expect(
+      ids(await runFilter({ filters: [{ column: 'status', operator: 'neq', value: 'active' }] }))
+    ).toEqual(['2', '4']);
+  }, 60000);
+
+  it('gt: amount > 20 → rows 3,4,5', async () => {
+    expect(
+      ids(await runFilter({ filters: [{ column: 'amount', operator: 'gt', value: 20 }] }))
+    ).toEqual(['3', '4', '5']);
+  }, 60000);
+
+  it('lte: amount <= 20 → rows 1,2,6', async () => {
+    expect(
+      ids(await runFilter({ filters: [{ column: 'amount', operator: 'lte', value: 20 }] }))
+    ).toEqual(['1', '2', '6']);
+  }, 60000);
+
+  it('contains "alph" → row 1', async () => {
+    expect(
+      ids(await runFilter({ filters: [{ column: 'name', operator: 'contains', value: 'alph' }] }))
+    ).toEqual(['1']);
+  }, 60000);
+
+  it('not_contains "eta" → rows 1,3,4,5,6', async () => {
+    expect(
+      ids(
+        await runFilter({ filters: [{ column: 'name', operator: 'not_contains', value: 'eta' }] })
+      )
+    ).toEqual(['1', '3', '4', '5', '6']);
+  }, 60000);
+
+  it('starts_with "al" → row 1', async () => {
+    expect(
+      ids(await runFilter({ filters: [{ column: 'name', operator: 'starts_with', value: 'al' }] }))
+    ).toEqual(['1']);
+  }, 60000);
+
+  it('ends_with "a" → rows 1,2,6', async () => {
+    expect(
+      ids(await runFilter({ filters: [{ column: 'name', operator: 'ends_with', value: 'a' }] }))
+    ).toEqual(['1', '2', '6']);
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // PROBE (b): regex anchoring — Spark RLIKE must be PARTIAL match
+  // -------------------------------------------------------------------------
+  it('regex "^alp" → row 1 (Spark RLIKE is partial; ^ anchors to start, not full string)', async () => {
+    const rows = await runFilter({
+      filters: [{ column: 'name', operator: 'regex', value: '^alp' }],
+    });
+    console.log(`[REGEX] ^alp match ids: [${ids(rows).join(',')}] (expect [1])`);
+    expect(ids(rows)).toEqual(['1']);
+  }, 60000);
+
+  it('not_regex "^alp" → rows 2,3,4,5,6', async () => {
+    expect(
+      ids(await runFilter({ filters: [{ column: 'name', operator: 'not_regex', value: '^alp' }] }))
+    ).toEqual(['2', '3', '4', '5', '6']);
+  }, 60000);
+
+  it('regex "\\\\d" (digit class) → row 4 (100%) — backslash survives into RLIKE', async () => {
+    const rows = await runFilter({
+      filters: [{ column: 'name', operator: 'regex', value: '\\d' }],
+    });
+    console.log(`[REGEX] \\d match ids: [${ids(rows).join(',')}] (expect [4])`);
+    expect(ids(rows)).toEqual(['4']);
+  }, 60000);
+
+  it('is_not_empty → all 6 rows', async () => {
+    expect(
+      (await runFilter({ filters: [{ column: 'name', operator: 'is_not_empty' }] })).length
+    ).toBe(6);
+  }, 60000);
+
+  it('between: amount BETWEEN 20 AND 30 → rows 2,3', async () => {
+    expect(
+      ids(
+        await runFilter({
+          filters: [{ column: 'amount', operator: 'between', value: { from: 20, to: 30 } }],
+        })
+      )
+    ).toEqual(['2', '3']);
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // Wildcard-literal + quote safety
+  // -------------------------------------------------------------------------
+  it('SAFETY contains "100%" → only row 4 (% is not a LIKE wildcard)', async () => {
+    expect(
+      ids(await runFilter({ filters: [{ column: 'name', operator: 'contains', value: '100%' }] }))
+    ).toEqual(['4']);
+  }, 60000);
+
+  it('SAFETY eq "O\'Brien" → row 3 (single-quote doubling round-trip)', async () => {
+    expect(
+      ids(await runFilter({ filters: [{ column: 'name', operator: 'eq', value: "O'Brien" }] }))
+    ).toEqual(['3']);
+  }, 60000);
+
+  // -------------------------------------------------------------------------
+  // Sort + limit
+  // -------------------------------------------------------------------------
+  it('sort by amount DESC + limit 2 → rows 5,4 (amounts 50,40)', async () => {
+    const rows = await runFilter({ sort: [{ column: 'amount', direction: 'desc' }], limit: 2 });
+    expect(rows.map(r => String(r.id))).toEqual(['5', '4']);
+  }, 60000);
+});

--- a/apps/backend/test/integration/databricks.integration.ts
+++ b/apps/backend/test/integration/databricks.integration.ts
@@ -18,7 +18,7 @@ import { TableDefinition } from 'src/data-marts/dto/schemas/data-mart-table-defi
 //       Spark also coerces (so the cast is defensive-only).
 //
 // Required env (all DATABRICKS_-prefixed):
-//   DATABRICKS_HOST      — workspace host, e.g. https://dbc-xxxx.cloud.databricks.com
+//   DATABRICKS_HOST      — workspace host, HOSTNAME ONLY (no https://), e.g. dbc-xxxx.cloud.databricks.com
 //   DATABRICKS_HTTP_PATH — SQL warehouse HTTP path, e.g. /sql/1.0/warehouses/abc123
 //   DATABRICKS_TOKEN     — personal access token
 //   DATABRICKS_CATALOG   — catalog for the seed table (e.g. main)

--- a/apps/backend/test/integration/http-data-real.integration.ts
+++ b/apps/backend/test/integration/http-data-real.integration.ts
@@ -15,6 +15,10 @@ import { RedshiftApiAdapter } from 'src/data-marts/data-storage-types/redshift/a
 import { RedshiftCredentials } from 'src/data-marts/data-storage-types/redshift/schemas/redshift-credentials.schema';
 import { RedshiftConfig } from 'src/data-marts/data-storage-types/redshift/schemas/redshift-config.schema';
 import { RedshiftConnectionType } from 'src/data-marts/data-storage-types/redshift/enums/redshift-connection-type.enum';
+import { DatabricksApiAdapter } from 'src/data-marts/data-storage-types/databricks/adapters/databricks-api.adapter';
+import { DatabricksCredentials } from 'src/data-marts/data-storage-types/databricks/schemas/databricks-credentials.schema';
+import { DatabricksConfig } from 'src/data-marts/data-storage-types/databricks/schemas/databricks-config.schema';
+import { DatabricksAuthMethod } from 'src/data-marts/data-storage-types/databricks/enums/databricks-auth-method.enum';
 import { STREAM_BATCH_SIZE } from 'src/data-marts/services/http-data/http-data.constants';
 
 /**
@@ -112,6 +116,29 @@ if (!RS_CREDENTIALS_AVAILABLE) {
 const describeIfRsCredentials = RS_CREDENTIALS_AVAILABLE ? describe : describe.skip;
 
 // ---------------------------------------------------------------------------
+// Databricks env vars / credential gate (all DATABRICKS_-prefixed)
+// ---------------------------------------------------------------------------
+const DATABRICKS_HOST = process.env.DATABRICKS_HOST;
+const DATABRICKS_HTTP_PATH = process.env.DATABRICKS_HTTP_PATH;
+const DATABRICKS_TOKEN = process.env.DATABRICKS_TOKEN;
+const DATABRICKS_CATALOG = process.env.DATABRICKS_CATALOG;
+const DATABRICKS_SCHEMA = process.env.DATABRICKS_SCHEMA;
+
+const DB_CREDENTIALS_AVAILABLE = !!(
+  DATABRICKS_HOST &&
+  DATABRICKS_HTTP_PATH &&
+  DATABRICKS_TOKEN &&
+  DATABRICKS_CATALOG &&
+  DATABRICKS_SCHEMA
+);
+
+if (!DB_CREDENTIALS_AVAILABLE) {
+  console.log('Skipping HTTP Data real Databricks integration tests: DATABRICKS_* config not set');
+}
+
+const describeIfDbCredentials = DB_CREDENTIALS_AVAILABLE ? describe : describe.skip;
+
+// ---------------------------------------------------------------------------
 // Shared NestJS app — ONE instance for the entire file.
 // Both describe blocks share the same SQLite :memory: app to avoid the
 // TypeORM / typeorm-transactional DataSource singleton conflict that arises
@@ -122,7 +149,10 @@ let sharedAgent: supertest.Agent;
 
 // Create the shared app if at least one credential set is present.
 const NEED_APP =
-  ATHENA_CREDENTIALS_AVAILABLE || BQ_CREDENTIALS_AVAILABLE || RS_CREDENTIALS_AVAILABLE;
+  ATHENA_CREDENTIALS_AVAILABLE ||
+  BQ_CREDENTIALS_AVAILABLE ||
+  RS_CREDENTIALS_AVAILABLE ||
+  DB_CREDENTIALS_AVAILABLE;
 
 if (NEED_APP) {
   beforeAll(async () => {
@@ -767,6 +797,180 @@ describeIfRsCredentials('HTTP Data API real-data (live Redshift)', () => {
       `column=id&column=name` +
         `&filter=${rsB64([{ column: 'id', operator: 'between', value: { from: 2, to: 3 } }])}` +
         `&sort=${rsB64([{ column: 'id', direction: 'asc' }])}`
+    );
+    expect(rows.map(r => Number(r.id))).toEqual([2, 3]);
+  }, 120000);
+});
+
+// =============================================================================
+// DATABRICKS BLOCK — full-stack HTTP Data API against a live Databricks SQL
+// warehouse (TABLE-def mart, stream + output controls). Mirrors the RS block.
+// =============================================================================
+
+describeIfDbCredentials('HTTP Data API real-data (live Databricks)', () => {
+  let dbDataMartId: string;
+
+  let dbAdapter: DatabricksApiAdapter;
+  let dbFullyQualifiedName: string;
+
+  const DB_TEST_TABLE_SUFFIX = `http_data_real_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+  beforeAll(async () => {
+    const dbCredentials: DatabricksCredentials = {
+      authMethod: DatabricksAuthMethod.PERSONAL_ACCESS_TOKEN,
+      token: DATABRICKS_TOKEN!,
+    };
+    const dbConfig: DatabricksConfig = {
+      host: DATABRICKS_HOST!,
+      httpPath: DATABRICKS_HTTP_PATH!,
+    };
+    dbAdapter = new DatabricksApiAdapter(dbCredentials, dbConfig);
+
+    dbFullyQualifiedName = `${DATABRICKS_CATALOG}.${DATABRICKS_SCHEMA}.${DB_TEST_TABLE_SUFFIX}`;
+    const qualified = `\`${DATABRICKS_CATALOG}\`.\`${DATABRICKS_SCHEMA}\`.\`${DB_TEST_TABLE_SUFFIX}\``;
+
+    // --- Step 1: Pre-cleanup in case a previous run crashed ---
+    try {
+      await dbAdapter.executeQuery(`DROP TABLE IF EXISTS ${qualified}`);
+    } catch {
+      // ignore — table may not exist on first run
+    }
+
+    // --- Step 2: Seed a real (permanent) Databricks table ---
+    await dbAdapter.executeQuery(
+      `CREATE TABLE ${qualified} ` +
+        `(id INT, name STRING, active BOOLEAN, created_at TIMESTAMP) USING DELTA`
+    );
+    await dbAdapter.executeQuery(
+      `INSERT INTO ${qualified} (id, name, active, created_at) VALUES
+        (1, 'alpha',    true,  TIMESTAMP '2024-01-01 00:00:00'),
+        (2, 'beta',     false, TIMESTAMP '2024-02-01 00:00:00'),
+        (3, 'gamma',    true,  TIMESTAMP '2024-03-01 00:00:00'),
+        (4, 'alphabet', true,  TIMESTAMP '2024-04-01 00:00:00')`
+    );
+
+    // --- Step 3: Create credentialed Databricks storage via HTTP API ---
+    const storageCreateRes = await sharedAgent
+      .post('/api/data-storages')
+      .set(AUTH_HEADER)
+      .send({ type: 'DATABRICKS' });
+    if (storageCreateRes.status !== 201) {
+      console.error('DB storage create failed:', JSON.stringify(storageCreateRes.body, null, 2));
+    }
+    expect(storageCreateRes.status).toBe(201);
+    const dbStorageId: string = storageCreateRes.body.id;
+
+    const storageUpdateRes = await sharedAgent
+      .put(`/api/data-storages/${dbStorageId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'db-real',
+        config: { host: DATABRICKS_HOST!, httpPath: DATABRICKS_HTTP_PATH! },
+        credentials: { authMethod: 'PERSONAL_ACCESS_TOKEN', token: DATABRICKS_TOKEN! },
+      });
+    if (storageUpdateRes.status !== 200) {
+      console.error('DB storage update failed:', JSON.stringify(storageUpdateRes.body, null, 2));
+    }
+    expect(storageUpdateRes.status).toBe(200);
+
+    // --- Step 4: Create data mart ---
+    const dataMartCreateRes = await sharedAgent
+      .post('/api/data-marts')
+      .set(AUTH_HEADER)
+      .send({ title: 'real-db-test-mart', storageId: dbStorageId });
+    if (dataMartCreateRes.status !== 201) {
+      console.error('DB data mart create failed:', JSON.stringify(dataMartCreateRes.body, null, 2));
+    }
+    expect(dataMartCreateRes.status).toBe(201);
+    dbDataMartId = dataMartCreateRes.body.id;
+
+    // --- Step 5: Set TABLE definition (pointing at the real seeded table) ---
+    const defRes = await sharedAgent
+      .put(`/api/data-marts/${dbDataMartId}/definition`)
+      .set(AUTH_HEADER)
+      .send({
+        definitionType: 'TABLE',
+        definition: { fullyQualifiedName: dbFullyQualifiedName },
+      });
+    if (defRes.status !== 200) {
+      console.error('DB definition set failed:', JSON.stringify(defRes.body, null, 2));
+    }
+    expect(defRes.status).toBe(200);
+
+    // --- Step 6: Publish (reads real schema from Databricks) ---
+    const publishRes = await sharedAgent
+      .put(`/api/data-marts/${dbDataMartId}/publish`)
+      .set(AUTH_HEADER);
+    if (publishRes.status !== 200) {
+      console.error('DB publish failed:', JSON.stringify(publishRes.body, null, 2));
+    }
+    expect(publishRes.status).toBe(200);
+  }, 180000);
+
+  afterAll(async () => {
+    try {
+      const qualified = `\`${DATABRICKS_CATALOG}\`.\`${DATABRICKS_SCHEMA}\`.\`${DB_TEST_TABLE_SUFFIX}\``;
+      await dbAdapter.executeQuery(`DROP TABLE IF EXISTS ${qualified}`);
+    } catch (error) {
+      console.warn('Failed to drop Databricks test table during teardown:', error);
+    } finally {
+      await dbAdapter.destroy();
+    }
+  }, 60000);
+
+  async function fetchDbNdjson(qs: string): Promise<Record<string, unknown>[]> {
+    const res = await sharedAgent
+      .get(`/api/external/http-data/data-marts/${dbDataMartId}.ndjson${qs ? '?' + qs : ''}`)
+      .set(AUTH_HEADER);
+    if (res.status !== 200) {
+      console.error('fetchDbNdjson failed:', res.status, JSON.stringify(res.body, null, 2));
+      console.error('Response text:', res.text?.slice(0, 500));
+    }
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('application/x-ndjson');
+    return res.text
+      .split('\n')
+      .filter(Boolean)
+      .map(l => JSON.parse(l));
+  }
+
+  const dbB64 = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url');
+
+  it('streams all real rows from Databricks without output controls', async () => {
+    const rows = await fetchDbNdjson('column=id&column=name&column=active');
+    expect(rows).toHaveLength(4);
+    const byId = Object.fromEntries(rows.map(r => [String(r.id), r]));
+    expect(byId['1'].name).toBe('alpha');
+    expect(byId['2'].name).toBe('beta');
+    expect(byId['4'].name).toBe('alphabet');
+  }, 120000);
+
+  it('applies eq filter on real Databricks data', async () => {
+    const rows = await fetchDbNdjson(
+      `column=id&column=name&filter=${dbB64([{ column: 'name', operator: 'eq', value: 'alpha' }])}`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('alpha');
+  }, 120000);
+
+  it('applies contains + sort desc + limit on real Databricks data', async () => {
+    // Both 'alpha' (id=1) and 'alphabet' (id=4) contain 'alpha'.
+    // sort desc by id + limit 1 → id=4 ('alphabet').
+    const rows = await fetchDbNdjson(
+      `column=id&column=name` +
+        `&filter=${dbB64([{ column: 'name', operator: 'contains', value: 'alpha' }])}` +
+        `&sort=${dbB64([{ column: 'id', direction: 'desc' }])}` +
+        `&limit=1`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('alphabet');
+  }, 120000);
+
+  it('applies a numeric between filter on real Databricks data', async () => {
+    const rows = await fetchDbNdjson(
+      `column=id&column=name` +
+        `&filter=${dbB64([{ column: 'id', operator: 'between', value: { from: 2, to: 3 } }])}` +
+        `&sort=${dbB64([{ column: 'id', direction: 'asc' }])}`
     );
     expect(rows.map(r => Number(r.id))).toEqual([2, 3]);
   }, 120000);

--- a/apps/backend/test/output-controls-databricks-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-databricks-emission.e2e-spec.ts
@@ -1,0 +1,247 @@
+import { INestApplication } from '@nestjs/common';
+import * as crypto from 'crypto';
+import * as supertest from 'supertest';
+import {
+  createTestApp,
+  closeTestApp,
+  StorageBuilder,
+  DataMartBuilder,
+  DataDestinationBuilder,
+  ReportBuilder,
+  AUTH_HEADER,
+  signLookerPayload,
+  mockGoogleJwkFetch,
+  restoreGoogleJwkFetch,
+} from '@owox/test-utils';
+import { DataStorageType } from '../src/data-marts/data-storage-types/enums/data-storage-type.enum';
+import { DataDestinationType } from '../src/data-marts/data-destination-types/enums/data-destination-type.enum';
+import { DataMartDefinitionValidatorFacade } from '../src/data-marts/data-storage-types/facades/data-mart-definition-validator-facade.service';
+import { DataMartSchemaProviderFacade } from '../src/data-marts/data-storage-types/facades/data-mart-schema-provider.facade';
+import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../src/data-marts/data-storage-types/data-storage-providers';
+import { ReportDataHeader } from '../src/data-marts/dto/domain/report-data-header.dto';
+import { ReportDataBatch } from '../src/data-marts/dto/domain/report-data-batch.dto';
+import { ReportDataDescription } from '../src/data-marts/dto/domain/report-data-description.dto';
+import { DatabricksFieldType } from '../src/data-marts/data-storage-types/databricks/enums/databricks-field-type.enum';
+
+// HTTP-layer e2e for Databricks output-controls SQL emission. ONE app + ONE Databricks
+// report (date filter on a TIMESTAMP column) drives two assertions to keep the e2e suite
+// fast — booting createTestApp() is the dominant cost:
+//
+//   1. GET /generated-sql emits a defensive CAST('2024-01-01' AS TIMESTAMP) (no bound
+//      params — option B inlines every literal).
+//   2. POST /looker/get-data runs the REAL ReportDataCacheService (only the storage reader
+//      is a spy), proving resolvePrepareOptions() composes + forwards the inlined SQL with
+//      no bound params into sqlOverride / sqlOverrideParams.
+//
+// The publish-time validator is stubbed (orthogonal — it dry-runs live Databricks);
+// everything else (composer → builder → renderer, types from the persisted schema) runs
+// for real.
+
+const HEADERS: ReportDataHeader[] = [
+  new ReportDataHeader('id', 'id', undefined, DatabricksFieldType.INT),
+  new ReportDataHeader('created_at', 'created_at', undefined, DatabricksFieldType.TIMESTAMP),
+];
+
+// Real ReportDataCacheService → spyReader.prepareReportData(report, options).
+// We assert the options it captured.
+const spyReader = {
+  prepareReportData: jest.fn().mockResolvedValue(new ReportDataDescription(HEADERS, 1)),
+  readReportDataBatch: jest
+    .fn()
+    .mockResolvedValue(new ReportDataBatch([['1', '2024-02-01']], null)),
+  finalize: jest.fn().mockResolvedValue(undefined),
+  getState: jest.fn().mockReturnValue(null),
+  initFromState: jest.fn().mockResolvedValue(undefined),
+  getType: jest.fn().mockReturnValue(DataStorageType.DATABRICKS),
+};
+
+const mockSchemaProviderFacade = {
+  getActualDataMartSchema: jest.fn().mockResolvedValue({
+    type: 'databricks-data-mart-schema',
+    table: 'cat.sch.events',
+    fields: HEADERS.map(h => ({
+      name: h.name,
+      type: h.storageFieldType,
+      status: 'CONNECTED',
+      isPrimaryKey: false,
+    })),
+  }),
+};
+
+describe('Output controls — Databricks SQL emission (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+  let destinationId: string;
+  let destinationSecretKey: string;
+  let reportId: string;
+
+  const postLooker = (path: string, payload: unknown): supertest.Test =>
+    agent.post(path).set('Content-Type', 'application/jwt').send(signLookerPayload(payload));
+
+  beforeAll(async () => {
+    mockGoogleJwkFetch();
+
+    const testApp = await createTestApp([
+      {
+        provide: DataMartDefinitionValidatorFacade,
+        useValue: { checkIsValid: async () => undefined },
+      },
+      { provide: DataMartSchemaProviderFacade, useValue: mockSchemaProviderFacade },
+      {
+        provide: DATA_STORAGE_REPORT_READER_RESOLVER,
+        useValue: { resolve: async () => spyReader },
+      },
+    ]);
+    app = testApp.app;
+    agent = testApp.agent;
+
+    const storageRes = await agent
+      .post('/api/data-storages')
+      .set(AUTH_HEADER)
+      .send(new StorageBuilder().withType(DataStorageType.DATABRICKS).build());
+    expect(storageRes.status).toBe(201);
+    const storageId = storageRes.body.id;
+
+    const dmRes = await agent
+      .post('/api/data-marts')
+      .set(AUTH_HEADER)
+      .send(new DataMartBuilder().withStorageId(storageId).build());
+    expect(dmRes.status).toBe(201);
+    const dataMartId = dmRes.body.id;
+
+    await agent
+      .put(`/api/data-marts/${dataMartId}/definition`)
+      .set(AUTH_HEADER)
+      .send({ definitionType: 'TABLE', definition: { fullyQualifiedName: 'cat.sch.events' } });
+
+    await agent
+      .put(`/api/data-marts/${dataMartId}/schema`)
+      .set(AUTH_HEADER)
+      .send({
+        schema: {
+          type: 'databricks-data-mart-schema',
+          table: 'cat.sch.events',
+          fields: [
+            { name: 'id', type: 'INT', status: 'CONNECTED', isPrimaryKey: false },
+            { name: 'created_at', type: 'TIMESTAMP', status: 'CONNECTED', isPrimaryKey: false },
+          ],
+        },
+      });
+
+    expect((await agent.put(`/api/data-marts/${dataMartId}/publish`).set(AUTH_HEADER)).status).toBe(
+      200
+    );
+    await agent
+      .put(`/api/data-storages/${storageId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForUse: true, availableForMaintenance: true });
+    await agent
+      .put(`/api/data-marts/${dataMartId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForReporting: true, availableForMaintenance: true });
+
+    const destRes = await agent
+      .post('/api/data-destinations')
+      .set(AUTH_HEADER)
+      .send(
+        new DataDestinationBuilder()
+          .withType(DataDestinationType.LOOKER_STUDIO)
+          .withCredentials({ type: 'looker-studio-credentials' })
+          .build()
+      );
+    expect(destRes.status).toBe(201);
+    destinationId = destRes.body.id;
+    await agent
+      .put(`/api/data-destinations/${destinationId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForUse: true, availableForMaintenance: true });
+
+    // The Looker report lookup INNER JOINs storage.credential — seed one and a config.
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const backendRoot = require.resolve('@owox/backend/package.json');
+    const backendDir = require('path').dirname(backendRoot);
+    const { DataSource } = require(require.resolve('typeorm', { paths: [backendDir] }));
+    /* eslint-enable @typescript-eslint/no-require-imports */
+    const dataSource = app.get(DataSource);
+    const credentialId = crypto.randomUUID();
+    await dataSource.query(
+      `INSERT INTO data_storage_credentials (id, projectId, type, credentials, createdAt, modifiedAt)
+       VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      [
+        credentialId,
+        '0',
+        'databricks_pat',
+        JSON.stringify({ authMethod: 'PERSONAL_ACCESS_TOKEN', token: 'test-token' }),
+      ]
+    );
+    await dataSource.query(`UPDATE data_storage SET config = ?, credentialId = ? WHERE id = ?`, [
+      JSON.stringify({
+        host: 'https://test.cloud.databricks.com',
+        httpPath: '/sql/1.0/warehouses/test',
+      }),
+      credentialId,
+      storageId,
+    ]);
+
+    destinationSecretKey = (
+      await agent.get(`/api/data-destinations/${destinationId}`).set(AUTH_HEADER)
+    ).body.credentials.destinationSecretKey;
+
+    const reportRes = await agent
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send(
+        new ReportBuilder().withDataMartId(dataMartId).withDataDestinationId(destinationId).build()
+      );
+    expect(reportRes.status).toBe(201);
+    reportId = reportRes.body.id;
+
+    const putRes = await agent
+      .put(`/api/reports/${reportId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Looker Databricks date filter',
+        dataDestinationId: destinationId,
+        destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        columnConfig: ['id', 'created_at'],
+        filterConfig: [{ column: 'created_at', operator: 'gte', value: '2024-01-01' }],
+      });
+    expect(putRes.status).toBe(200);
+  }, 120_000);
+
+  afterAll(async () => {
+    restoreGoogleJwkFetch();
+    await closeTestApp(app);
+  });
+
+  it('GET /generated-sql inlines the date value as a literal inside a defensive CAST', async () => {
+    const res = await agent.get(`/api/reports/${reportId}/generated-sql`).set(AUTH_HEADER);
+    expect(res.status).toBe(200);
+    // Databricks renderer inlines all values as literals — no bound params. Date/time
+    // comparisons get a defensive CAST to the column type.
+    expect(res.body.sql).toContain("`created_at` >= CAST('2024-01-01' AS TIMESTAMP)");
+    expect(res.body.sql).not.toContain('?');
+    expect(res.body.sql).not.toContain('@p');
+  });
+
+  it('carries composed output-controls SQL with no bound params into the cached reader', async () => {
+    const res = await postLooker('/api/external/looker/get-data', {
+      connectionConfig: { deploymentUrl: 'http://localhost', destinationId, destinationSecretKey },
+      request: {
+        configParams: { destinationId, reportId },
+        // Sample extraction still resolves the cached reader (our assertion target)
+        // but skips creating a report run + its async success handlers — faster, no noise.
+        scriptParams: { sampleExtraction: true },
+        fields: [{ name: 'id' }, { name: 'created_at' }],
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(spyReader.prepareReportData).toHaveBeenCalled();
+    const options = spyReader.prepareReportData.mock.calls[0][1];
+    expect(options.sqlOverride).toContain("`created_at` >= CAST('2024-01-01' AS TIMESTAMP)");
+    expect(options.sqlOverrideParams ?? []).toEqual([]);
+    expect(options.sqlOverride).not.toContain('?');
+    expect(options.sqlOverride).not.toContain('@p');
+  });
+});

--- a/apps/backend/test/output-controls-databricks-emission.e2e-spec.ts
+++ b/apps/backend/test/output-controls-databricks-emission.e2e-spec.ts
@@ -176,7 +176,7 @@ describe('Output controls — Databricks SQL emission (e2e)', () => {
     );
     await dataSource.query(`UPDATE data_storage SET config = ?, credentialId = ? WHERE id = ?`, [
       JSON.stringify({
-        host: 'https://test.cloud.databricks.com',
+        host: 'test.cloud.databricks.com',
         httpPath: '/sql/1.0/warehouses/test',
       }),
       credentialId,

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.test.ts
@@ -118,6 +118,19 @@ describe('operatorsForType', () => {
     });
   });
 
+  // Databricks emits INT (not INTEGER) and TIMESTAMP_NTZ, and has no standalone TIME type.
+  describe('Databricks type names', () => {
+    it('maps INT to number ops (comparison + between, no relative_date)', () => {
+      expect(opValues('INT')).toContain('between');
+      expect(opValues('INT')).not.toContain('relative_date');
+      expect(isNumberType('INT')).toBe(true);
+    });
+    it('maps TIMESTAMP_NTZ to date ops with relative_date', () => {
+      expect(opValues('TIMESTAMP_NTZ')).toContain('relative_date');
+      expect(isDateType('TIMESTAMP_NTZ')).toBe(true);
+    });
+  });
+
   it('returns no operators for unrecognised (complex/binary) types', () => {
     for (const t of ['ARRAY', 'MAP', 'STRUCT', 'JSON', 'VARBINARY', 'GEOGRAPHY']) {
       expect(operatorsForType(t)).toEqual([]);

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.ts
@@ -31,6 +31,7 @@ export interface OperatorMeta {
 const STRING_TYPES = new Set(['STRING', 'VARCHAR', 'CHAR', 'TEXT', 'BPCHAR']);
 const NUMBER_TYPES = new Set([
   'INTEGER',
+  'INT',
   'BIGINT',
   'SMALLINT',
   'TINYINT',
@@ -48,6 +49,7 @@ const DATE_TYPES = new Set([
   'TIMESTAMP',
   'TIMESTAMP WITH TIME ZONE',
   'TIMESTAMPTZ',
+  'TIMESTAMP_NTZ',
 ]);
 // Time-of-day types are kept out of DATE_TYPES: relative_date presets resolve to
 // calendar dates (current_date / date_add), which are meaningless for a column

--- a/apps/web/src/features/data-marts/shared/utils/output-controls-support.test.ts
+++ b/apps/web/src/features/data-marts/shared/utils/output-controls-support.test.ts
@@ -19,9 +19,12 @@ describe('supportsOutputControls', () => {
     expect(supportsOutputControls(DataStorageType.AWS_REDSHIFT)).toBe(true);
   });
 
+  it('returns true for Databricks', () => {
+    expect(supportsOutputControls(DataStorageType.DATABRICKS)).toBe(true);
+  });
+
   it('returns false for not-yet-supported storages', () => {
     expect(supportsOutputControls(DataStorageType.SNOWFLAKE)).toBe(false);
-    expect(supportsOutputControls(DataStorageType.DATABRICKS)).toBe(false);
     expect(supportsOutputControls(DataStorageType.AZURE_SYNAPSE)).toBe(false);
   });
 });

--- a/apps/web/src/features/data-marts/shared/utils/output-controls-support.ts
+++ b/apps/web/src/features/data-marts/shared/utils/output-controls-support.ts
@@ -6,6 +6,7 @@ const SUPPORTED: ReadonlySet<DataStorageType> = new Set([
   DataStorageType.LEGACY_GOOGLE_BIGQUERY,
   DataStorageType.AWS_ATHENA,
   DataStorageType.AWS_REDSHIFT,
+  DataStorageType.DATABRICKS,
 ]);
 
 export function supportsOutputControls(type: DataStorageType): boolean {


### PR DESCRIPTION
… slices, sort, limit)

Enable report-level output controls for the DATABRICKS storage — the last non-GBQ storage in the epic. Option B (same shape as Redshift/Snowflake): DatabricksClauseRenderer inlines every filter value as a SQL literal and always returns params: [], so there is no bound-param plumbing — the report reader (already option-B-ready), composeStatic (early- returns on empty params), and the adapter need no changes.

Per-dialect (Spark SQL): contains/startswith/endswith (never LIKE so %/_ stay literal), infix RLIKE (partial match), <> for neq, = TRUE/FALSE for bool, backslash-first literal escaping, and date_add/add_months/trunc for relative_date (half-open ranges, upper bounds on every preset). One robust backtick escaper for columns and FQNs; no quoteIdentifier override (Spark is case-insensitive). Defensive CAST(... AS DATE|TIMESTAMP|TIMESTAMP_NTZ).

Validator + web + extension type matrices gain INT and TIMESTAMP_NTZ (Databricks has no standalone TIME type). Capability + FE mirrors add DATABRICKS.

Verified: nest build, full backend unit suite, emission e2e (generated-sql + Looker cache path), web tsc + vitest, extension typecheck, and 31/31 LIVE integration (operator matrix
+ relative_date + escaping/regex/CAST probes + full HTTP Data API stack) against a real Databricks SQL warehouse. Live findings: Spark RLIKE is partial (no anchoring fix needed), CAST is defensive-only (Spark coerces bare literals), backslash round-trip confirmed.