### PR TITLE
fix(deps): deduplicate google-auth-library to fix release build

### DIFF
--- a/.changeset/dedupe-google-auth-library.md
+++ b/.changeset/dedupe-google-auth-library.md
@@ -1,0 +1,11 @@
+---
+'owox': patch
+---
+
+# Fix release build broken by duplicate google-auth-library
+
+A transitive dependency drift left two copies of `google-auth-library` (v10) in the
+tree — one hoisted at the root and a second pinned exactly by `googleapis-common` —
+which produced incompatible `OAuth2Client` types and broke the TypeScript build of the
+Google Sheets and BigQuery integrations. A scoped npm override now makes
+`googleapis-common` reuse the root copy, so the packages build and publish reliably again.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14471,9 +14471,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
-      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.2.tgz",
+      "integrity": "sha512-2V5j0dOfxv3iIngIWMnW1O6UPXpeoU70HJzUJGVth/+RURhDyq7SEWTD70Y2SkUB0MQonYYWpIX3f85P/I22+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -20460,38 +20460,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/googleapis-common/node_modules/gcp-metadata": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.3.tgz",
-      "integrity": "sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "7.1.3",
-        "google-logging-utils": "1.1.3",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/google-auth-library": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.0.0",
-        "gcp-metadata": "^8.0.0",
-        "google-logging-utils": "^1.0.0",
-        "gtoken": "^8.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/googleapis-common/node_modules/google-logging-utils": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
@@ -20499,19 +20467,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/gtoken": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-      "license": "MIT",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/googleapis-common/node_modules/https-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,9 @@
     "picomatch": "^4.0.4",
     "file-type": "^21.3.2",
     "thrift": "^0.23.0",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "googleapis-common": {
+      "google-auth-library": "^10.1.0"
+    }
   }
 }


### PR DESCRIPTION
## Problem

Commit [`1ad2615`](https://github.com/OWOX/owox-data-marts/commit/1ad2615635901bb72983a963ee08f7bcfc380205) ("Version Packages" #1250) turned ~15 CI checks red, all from **a single root cause**.

The `package-lock.json` regeneration floated the hoisted root `google-auth-library` to `10.7.0`, while `googleapis-common@8.0.2` pins it to exactly `10.5.0`. That left **two physical v10 copies** in the tree → two distinct `OAuth2Client` types → `error TS2345` in the backend:

- `apps/backend/.../google-sheets/adapters/google-sheets-api.adapter.ts` — `google.sheets({ version: 'v4', auth })`
- `apps/backend/.../bigquery/services/bigquery-storage-resource-browser.service.ts` — `google.bigquery({ version: 'v2', auth })`

The backend imports `OAuth2Client` directly from `google-auth-library` (root copy), but `googleapis` expects the type from `googleapis-common`'s nested copy. Since almost every job starts with `build:dep` (which compiles the backend), the single build error cascaded into the tests, linters, `publish`, and all E2E jobs.

## Fix

Scoped npm override in the root `package.json`:

```json
"googleapis-common": { "google-auth-library": "^10.1.0" }
```

`googleapis-common` now reuses the root copy. The `^10.1.0` range (rather than a pinned `10.7.0`) auto-tracks the root on future lockfile regenerations, so the tree stays deduplicated. The separate v9 cluster (`@google-cloud/logging`/`pubsub`, `google-gax` — all `9.15.1`) is left untouched.

In `package-lock.json`, the duplicate `google-auth-library@10.5.0` and its now-orphaned `gcp-metadata`/`gtoken` entries are removed (minimal diff).

## Verification

| Check | Result |
|---|---|
| `npm ci` (same as CI) | ✅ exit 0, `0 vulnerabilities` |
| Deduplication | ✅ single root `google-auth-library@10.7.0` |
| Backend build (`TS2345`) | ✅ gone |
| Full `owox` build (CI step repro) | ✅ exit 0 |

> ℹ️ `npm ls google-auth-library` will report `invalid` (the override intentionally violates `googleapis-common`'s exact pin) — cosmetic only; it does not affect `npm ci`/build/publish, and CI never runs a bare `npm ls`.