### PR TITLE
fix(release-pr): push release branch with explicit remote

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -53,4 +53,4 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git add .
           git commit -m "chore: fix changelog headings and update package-lock.json"
-          git push
+          git push origin HEAD


### PR DESCRIPTION
## Problem

The `release-pr` job failed on the latest `main` push ([run](https://github.com/OWOX/owox-data-marts/actions/runs/27347134359/job/80798741619)):

```
[changeset-release/main c1cbcdb3f] chore: fix changelog headings and update package-lock.json
fatal: The current branch changeset-release/main has no upstream branch.
##[error]Process completed with exit code 128.
```

The `Commit fixed changelogs` step uses a bare `git push`. That only works when `changeset-release/main` already exists on the remote (the local checkout tracks `origin`). When the branch is created **fresh** — i.e. the first changeset after a release PR is merged, which consumes all changesets and deletes the branch — the local branch has no upstream and `git push` exits 128.

This is why the job is green while a release PR is being accumulated (#1305, #1306, #1307, #1310) but red on the first changeset of the next cycle (#1312). It is unrelated to the dependency change in #1312.

## Effect

Release PR #1313 was created by `changesets/action`, but the follow-up commit `c1cbcdb3f` (changelog-heading fixes + `npm run clean:reinstall` lockfile sync) failed to push, so #1313 is missing its lockfile update.

## Fix

`git push` → `git push origin HEAD`, which works for both freshly-created and existing `changeset-release/main` branches.

After merge, the next push to `main` re-runs `release-pr` and updates #1313 with the missing commit.