### PR TITLE
feat(web): Add drag-and-drop support for service account JSON inputs

### DIFF
--- a/.changeset/service-account-json-drag-and-drop.md
+++ b/.changeset/service-account-json-drag-and-drop.md
@@ -1,0 +1,7 @@
+---
+"owox": minor
+---
+
+# Drag-and-drop support for service account JSON inputs
+
+Added drag-and-drop support for service account JSON files on credentials textareas. Users can now drop their credential files directly to populate the field, with JSON validation, file size limits, and user-friendly error feedback.

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleSheetsFields.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleSheetsFields.tsx
@@ -7,7 +7,8 @@ import {
   FormLabel,
   FormMessage,
 } from '@owox/ui/components/form';
-import { Textarea } from '@owox/ui/components/textarea';
+import { FileDropTextarea } from '@owox/ui/components/file-drop-textarea';
+import { toast } from 'react-hot-toast';
 import { useState, useEffect } from 'react';
 import { type UseFormReturn } from 'react-hook-form';
 import { type DataDestinationFormData, DataDestinationType } from '../../../shared';
@@ -262,11 +263,20 @@ export function GoogleSheetsFields({ form }: GoogleSheetsFieldsProps) {
                         </button>
                       </div>
                     ) : (
-                      <Textarea
+                      <FileDropTextarea
                         {...field}
                         className='min-h-[150px] font-mono'
                         rows={8}
-                        placeholder='Paste your service account JSON here'
+                        placeholder='Paste your service account JSON here or drag & drop the file'
+                        onFileRead={content => {
+                          form.setValue('credentials.serviceAccount', content, {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          });
+                        }}
+                        onFileReject={error => {
+                          toast.error(error);
+                        }}
                       />
                     )}
                   </FormControl>

--- a/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/GoogleBigQueryFields.tsx
+++ b/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/GoogleBigQueryFields.tsx
@@ -20,7 +20,8 @@ import GoogleBigQueryLocationDescription from './FormDescriptions/GoogleBigQuery
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { Button } from '@owox/ui/components/button';
 import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
-import { Textarea } from '@owox/ui/components/textarea';
+import { FileDropTextarea } from '@owox/ui/components/file-drop-textarea';
+import { toast } from 'react-hot-toast';
 import { useState, useEffect } from 'react';
 import { getServiceAccountLink } from '../../../../../utils/google-cloud-utils';
 import { GoogleOAuthConnectButton, storageOAuthApi } from '../../../../../features/google-oauth';
@@ -269,11 +270,20 @@ export const GoogleBigQueryFields = ({ form }: GoogleBigQueryFieldsProps) => {
                           </TooltipContent>
                         </Tooltip>
                       ) : (
-                        <Textarea
+                        <FileDropTextarea
                           {...field}
                           className='min-h-[150px] font-mono'
                           rows={8}
-                          placeholder='Paste your service account JSON here'
+                          placeholder='Paste your service account JSON here or drag & drop the file'
+                          onFileRead={content => {
+                            form.setValue('credentials.serviceAccount', content, {
+                              shouldDirty: true,
+                              shouldValidate: true,
+                            });
+                          }}
+                          onFileReject={error => {
+                            toast.error(error);
+                          }}
                         />
                       )}
                     </FormControl>

--- a/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/LegacyGoogleBigQueryFields.tsx
+++ b/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/LegacyGoogleBigQueryFields.tsx
@@ -11,7 +11,8 @@ import {
 } from '@owox/ui/components/form';
 import { Input } from '@owox/ui/components/input';
 import { Tabs, TabsList, TabsTrigger } from '@owox/ui/components/tabs';
-import { Textarea } from '@owox/ui/components/textarea';
+import { FileDropTextarea } from '@owox/ui/components/file-drop-textarea';
+import { toast } from 'react-hot-toast';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { useState, useEffect } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
@@ -276,11 +277,20 @@ export const LegacyGoogleBigQueryFields = ({ form }: LegacyGoogleBigQueryFieldsP
                           </TooltipContent>
                         </Tooltip>
                       ) : (
-                        <Textarea
+                        <FileDropTextarea
                           {...field}
                           className='min-h-[150px] font-mono'
                           rows={8}
-                          placeholder='Paste your service account JSON here'
+                          placeholder='Paste your service account JSON here or drag & drop the file'
+                          onFileRead={content => {
+                            form.setValue('credentials.serviceAccount', content, {
+                              shouldDirty: true,
+                              shouldValidate: true,
+                            });
+                          }}
+                          onFileReject={error => {
+                            toast.error(error);
+                          }}
                         />
                       )}
                     </FormControl>

--- a/packages/ui/src/components/file-drop-textarea.tsx
+++ b/packages/ui/src/components/file-drop-textarea.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { Textarea } from './textarea.js';
+import { cn } from '@owox/ui/lib/utils';
+import { FileDown } from 'lucide-react';
+
+interface FileDropTextareaProps extends React.ComponentProps<'textarea'> {
+  onFileRead?: (content: string) => void;
+  onFileReject?: (message: string) => void;
+  allowedExtensions?: string[];
+}
+
+const FileDropTextarea = React.forwardRef<HTMLTextAreaElement, FileDropTextareaProps>(
+  ({ className, onFileRead, onFileReject, allowedExtensions = ['.json'], ...props }, ref) => {
+    const [isDragging, setIsDragging] = React.useState(false);
+
+    const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setIsDragging(true);
+    };
+
+    const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setIsDragging(false);
+    };
+
+    const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setIsDragging(false);
+
+      const file = e.dataTransfer.files[0];
+      if (file) {
+        const fileName = file.name.toLowerCase();
+        const isValidExtension = allowedExtensions.some(ext => fileName.endsWith(ext));
+
+        if (isValidExtension) {
+          const reader = new FileReader();
+          reader.onload = event => {
+            const text = event.target?.result;
+            if (typeof text === 'string') {
+              if (fileName.endsWith('.json')) {
+                try {
+                  JSON.parse(text);
+                } catch {
+                  if (onFileReject) {
+                    onFileReject('File is not a valid JSON');
+                  }
+                  return;
+                }
+              }
+              if (onFileRead) {
+                onFileRead(text);
+              }
+            }
+          };
+          reader.onerror = () => {
+            if (onFileReject) {
+              onFileReject('Failed to read file');
+            }
+          };
+          reader.readAsText(file);
+        } else {
+          if (onFileReject) {
+            onFileReject(
+              `Invalid file type. Only ${allowedExtensions.join(', ')} files are allowed.`
+            );
+          }
+        }
+      }
+    };
+
+    return (
+      <div
+        className='relative w-full'
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        <Textarea
+          ref={ref}
+          className={cn(isDragging && 'border-primary ring-primary/20 ring-[3px]', className)}
+          {...props}
+        />
+        {isDragging && (
+          <div className='bg-background/80 border-primary animate-in fade-in pointer-events-none absolute inset-0 flex flex-col items-center justify-center rounded-md border-2 border-dashed backdrop-blur-[2px] duration-100'>
+            <FileDown className='text-primary mb-2 h-8 w-8 animate-bounce' />
+            <span className='text-foreground text-sm font-medium'>Drop JSON file here</span>
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+FileDropTextarea.displayName = 'FileDropTextarea';
+
+export { FileDropTextarea };

--- a/packages/ui/src/components/file-drop-textarea.tsx
+++ b/packages/ui/src/components/file-drop-textarea.tsx
@@ -13,6 +13,16 @@ const FileDropTextarea = React.forwardRef<HTMLTextAreaElement, FileDropTextareaP
   ({ className, onFileRead, onFileReject, allowedExtensions = ['.json'], ...props }, ref) => {
     const [isDragging, setIsDragging] = React.useState(false);
 
+    React.useEffect(() => {
+      const preventDefault = (e: DragEvent) => e.preventDefault();
+      window.addEventListener('dragover', preventDefault);
+      window.addEventListener('drop', preventDefault);
+      return () => {
+        window.removeEventListener('dragover', preventDefault);
+        window.removeEventListener('drop', preventDefault);
+      };
+    }, []);
+
     const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
       e.preventDefault();
       setIsDragging(true);
@@ -20,6 +30,7 @@ const FileDropTextarea = React.forwardRef<HTMLTextAreaElement, FileDropTextareaP
 
     const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
       e.preventDefault();
+      if (e.currentTarget.contains(e.relatedTarget as Node)) return;
       setIsDragging(false);
     };
 
@@ -27,8 +38,23 @@ const FileDropTextarea = React.forwardRef<HTMLTextAreaElement, FileDropTextareaP
       e.preventDefault();
       setIsDragging(false);
 
+      if (e.dataTransfer.files.length > 1) {
+        if (onFileReject) {
+          onFileReject('Only one file can be dropped at a time.');
+        }
+        return;
+      }
+
       const file = e.dataTransfer.files[0];
       if (file) {
+        const maxFileSize = 1 * 1024 * 1024; // 1MB
+        if (file.size > maxFileSize) {
+          if (onFileReject) {
+            onFileReject('File is too large. Max allowed size is 1MB.');
+          }
+          return;
+        }
+
         const fileName = file.name.toLowerCase();
         const isValidExtension = allowedExtensions.some(ext => fileName.endsWith(ext));
 
@@ -37,9 +63,25 @@ const FileDropTextarea = React.forwardRef<HTMLTextAreaElement, FileDropTextareaP
           reader.onload = event => {
             const text = event.target?.result;
             if (typeof text === 'string') {
-              if (fileName.endsWith('.json')) {
+              const checkJson =
+                allowedExtensions.some(ext => ext.toLowerCase() === '.json') &&
+                fileName.endsWith('.json');
+              if (checkJson) {
                 try {
-                  JSON.parse(text);
+                  const parsed = JSON.parse(text);
+                  const isServiceAccount =
+                    parsed &&
+                    parsed.type === 'service_account' &&
+                    parsed.project_id &&
+                    parsed.private_key &&
+                    parsed.client_email;
+
+                  if (!isServiceAccount) {
+                    if (onFileReject) {
+                      onFileReject('File is not a valid Google Service Account JSON');
+                    }
+                    return;
+                  }
                 } catch {
                   if (onFileReject) {
                     onFileReject('File is not a valid JSON');
@@ -74,6 +116,7 @@ const FileDropTextarea = React.forwardRef<HTMLTextAreaElement, FileDropTextareaP
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
+        onDragEnd={() => setIsDragging(false)}
       >
         <Textarea
           ref={ref}


### PR DESCRIPTION
## Description

Currently, users have to manually open their Google Service Account JSON files, copy the raw JSON content, and paste it into the credentials textarea. This PR simplifies the onboarding flow by allowing users to drag and drop their service account JSON file directly onto the input field.

## Key Changes

- **Reusable Component**: Created `FileDropTextarea` in `@owox/ui` with drag-and-drop event listeners (`onDragOver`, `onDragLeave`, `onDrop`) and local file reading using `FileReader`.
- **Validation**: Added client-side verification to ensure that only files with `.json` extensions are accepted and that their content is valid JSON. Fails gracefully with user-friendly toast notifications.
- **UX/UI Improvements**: Added a styled glassmorphic overlay with backdrop blur and a bouncing `FileDown` icon to indicate when a file is hovered over the textarea.
- **Forms Integration**: Integrated `FileDropTextarea` in `GoogleSheetsFields.tsx`, `GoogleBigQueryFields.tsx`, and `LegacyGoogleBigQueryFields.tsx`.

<img width="1200" height="1051" alt="drag_over_overlay" src="https://github.com/user-attachments/assets/279a58eb-9a26-4ac7-945f-342003938348" />

## Verification

- Verified that ESLint and Prettier formatting checks pass successfully.
- Verified that all unit tests (`npm run test`) pass.
- Verified that `@owox/web` compiles successfully.