### PR TITLE
fix(backend): escape identifiers in data mart sample-data SQL

### DIFF
--- a/.changeset/escape-identifiers-in-sample-data-sql.md
+++ b/.changeset/escape-identifiers-in-sample-data-sql.md
@@ -1,0 +1,7 @@
+---
+'owox': patch
+---
+
+# Escape table and column identifiers in AI Helper sample-data SQL
+
+Fix AI Helper metadata generation (and the `SAMPLE_TABLE_DATA` AI tool) failing with `Syntax error: Expected end of input but got "-"` for data marts whose fully qualified table name contains dashes (for example `my-project.dataset.my-table-name`). The sample-data SQL now escapes the table reference and column names per storage type via a new `IdentifierEscaperFacade`, following the existing TypeResolver + Facade pattern and reusing the per-storage identifier escaping utilities.

--- a/.changeset/escape-identifiers-in-sample-data-sql.md
+++ b/.changeset/escape-identifiers-in-sample-data-sql.md
@@ -1,5 +1,5 @@
 ---
-'owox': patch
+'owox': minor
 ---
 
 # Escape table and column identifiers in AI Helper sample-data SQL

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-identifier.escaper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-identifier.escaper.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { IdentifierEscaper } from '../../interfaces/identifier-escaper.interface';
+import { escapeAthenaIdentifier } from '../utils/athena-identifier.utils';
+
+@Injectable()
+export class AthenaIdentifierEscaper implements IdentifierEscaper {
+  readonly type = DataStorageType.AWS_ATHENA;
+
+  escapeIdentifier(identifier: string): string {
+    return escapeAthenaIdentifier(identifier);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-identifier.escaper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-identifier.escaper.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { IdentifierEscaper } from '../../interfaces/identifier-escaper.interface';
+import { escapeBigQueryIdentifier } from '../utils/bigquery-identifier.utils';
+
+@Injectable()
+export class BigQueryIdentifierEscaper implements IdentifierEscaper {
+  readonly type = DataStorageType.GOOGLE_BIGQUERY;
+
+  escapeIdentifier(identifier: string): string {
+    return escapeBigQueryIdentifier(identifier);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-identifier.escaper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/legacy/legacy-bigquery-identifier.escaper.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../../enums/data-storage-type.enum';
+import { IdentifierEscaper } from '../../../interfaces/identifier-escaper.interface';
+import { escapeBigQueryIdentifier } from '../../utils/bigquery-identifier.utils';
+
+@Injectable()
+export class LegacyBigQueryIdentifierEscaper implements IdentifierEscaper {
+  readonly type = DataStorageType.LEGACY_GOOGLE_BIGQUERY;
+
+  escapeIdentifier(identifier: string): string {
+    return escapeBigQueryIdentifier(identifier);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-facades.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-facades.ts
@@ -8,6 +8,7 @@ import { ReportHeadersGeneratorFacade } from './facades/report-headers-generator
 import { SqlDryRunExecutorFacade } from './facades/sql-dry-run-executor.facade';
 import { SqlRunExecutorFacade } from './facades/sql-run-executor.facade';
 import { CreateViewExecutorFacade } from './facades/create-view-executor.facade';
+import { IdentifierEscaperFacade } from './facades/identifier-escaper.facade';
 
 export const dataStorageFacadesProviders = [
   DataStorageAccessValidatorFacade,
@@ -20,4 +21,5 @@ export const dataStorageFacadesProviders = [
   SqlRunExecutorFacade,
   CreateViewExecutorFacade,
   BlendedQueryBuilderFacade,
+  IdentifierEscaperFacade,
 ];

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
@@ -7,6 +7,7 @@ import { AthenaCreateViewExecutor } from './athena/services/athena-create-view.e
 import { AthenaDataMartSchemaParser } from './athena/services/athena-data-mart-schema.parser';
 import { AthenaDataMartSchemaProvider } from './athena/services/athena-data-mart-schema.provider';
 import { AthenaDataMartValidator } from './athena/services/athena-datamart.validator';
+import { AthenaIdentifierEscaper } from './athena/services/athena-identifier.escaper';
 import { AthenaQueryBuilder } from './athena/services/athena-query.builder';
 import { AthenaReportHeadersGenerator } from './athena/services/athena-report-headers-generator.service';
 import { AthenaReportReader } from './athena/services/athena-report-reader.service';
@@ -24,6 +25,7 @@ import { BigQueryCreateViewExecutor } from './bigquery/services/bigquery-create-
 import { BigQueryDataMartSchemaParser } from './bigquery/services/bigquery-data-mart-schema.parser';
 import { BigQueryDataMartSchemaProvider } from './bigquery/services/bigquery-data-mart-schema.provider';
 import { BigQueryDataMartValidator } from './bigquery/services/bigquery-datamart.validator';
+import { BigQueryIdentifierEscaper } from './bigquery/services/bigquery-identifier.escaper';
 import { BigQueryQueryBuilder } from './bigquery/services/bigquery-query.builder';
 import { BigQueryReportHeadersGenerator } from './bigquery/services/bigquery-report-headers-generator.service';
 import { BigQueryReportReader } from './bigquery/services/bigquery-report-reader.service';
@@ -36,6 +38,7 @@ import { LegacyBigQueryCreateViewExecutor } from './bigquery/services/legacy/leg
 import { LegacyBigQueryDataMartSchemaParser } from './bigquery/services/legacy/legacy-bigquery-data-mart-schema.parser';
 import { LegacyBigQueryDataMartSchemaProvider } from './bigquery/services/legacy/legacy-bigquery-data-mart-schema.provider';
 import { LegacyBigQueryDataMartValidator } from './bigquery/services/legacy/legacy-bigquery-datamart.validator';
+import { LegacyBigQueryIdentifierEscaper } from './bigquery/services/legacy/legacy-bigquery-identifier.escaper';
 import { LegacyBigQueryQueryBuilder } from './bigquery/services/legacy/legacy-bigquery-query.builder';
 import { LegacyBigQueryReportHeadersGenerator } from './bigquery/services/legacy/legacy-bigquery-report-headers-generator.service';
 import { LegacyBigQueryReportReader } from './bigquery/services/legacy/legacy-bigquery-report-reader.service';
@@ -53,6 +56,7 @@ import { DatabricksCreateViewExecutor } from './databricks/services/databricks-c
 import { DatabricksDataMartSchemaParser } from './databricks/services/databricks-data-mart-schema.parser';
 import { DatabricksDataMartSchemaProvider } from './databricks/services/databricks-data-mart-schema.provider';
 import { DatabricksDataMartValidator } from './databricks/services/databricks-datamart.validator';
+import { DatabricksIdentifierEscaper } from './databricks/services/databricks-identifier.escaper';
 import { DatabricksQueryBuilder } from './databricks/services/databricks-query.builder';
 import { DatabricksReportHeadersGenerator } from './databricks/services/databricks-report-headers-generator.service';
 import { DatabricksReportReader } from './databricks/services/databricks-report-reader.service';
@@ -75,6 +79,7 @@ import { DataMartSchemaMerger } from './interfaces/data-mart-schema-merger.inter
 import { DataMartSchemaParser } from './interfaces/data-mart-schema-parser.interface';
 import { DataMartSchemaProvider } from './interfaces/data-mart-schema-provider.interface';
 import { DataMartValidator } from './interfaces/data-mart-validator.interface';
+import { IdentifierEscaper } from './interfaces/identifier-escaper.interface';
 import { DataStorageAccessValidator } from './interfaces/data-storage-access-validator.interface';
 import { DataStorageErrorMapper } from './interfaces/data-storage-error-mapper.interface';
 import { DataStorageReportReader } from './interfaces/data-storage-report-reader.interface';
@@ -87,6 +92,7 @@ import { RedshiftCreateViewExecutor } from './redshift/services/redshift-create-
 import { RedshiftDataMartSchemaParser } from './redshift/services/redshift-data-mart-schema.parser';
 import { RedshiftDataMartSchemaProvider } from './redshift/services/redshift-data-mart-schema.provider';
 import { RedshiftDataMartValidator } from './redshift/services/redshift-datamart.validator';
+import { RedshiftIdentifierEscaper } from './redshift/services/redshift-identifier.escaper';
 import { RedshiftQueryBuilder } from './redshift/services/redshift-query.builder';
 import { RedshiftReportHeadersGenerator } from './redshift/services/redshift-report-headers-generator.service';
 import { RedshiftReportReader } from './redshift/services/redshift-report-reader.service';
@@ -102,6 +108,7 @@ import { SnowflakeCreateViewExecutor } from './snowflake/services/snowflake-crea
 import { SnowflakeDataMartSchemaParser } from './snowflake/services/snowflake-data-mart-schema.parser';
 import { SnowflakeDataMartSchemaProvider } from './snowflake/services/snowflake-data-mart-schema.provider';
 import { SnowflakeDataMartValidator } from './snowflake/services/snowflake-datamart.validator';
+import { SnowflakeIdentifierEscaper } from './snowflake/services/snowflake-identifier.escaper';
 import { SnowflakeQueryBuilder } from './snowflake/services/snowflake-query.builder';
 import { SnowflakeReportHeadersGenerator } from './snowflake/services/snowflake-report-headers-generator.service';
 import { SnowflakeReportReader } from './snowflake/services/snowflake-report-reader.service';
@@ -127,6 +134,7 @@ export const REPORT_HEADERS_GENERATOR_RESOLVER = Symbol('REPORT_HEADERS_GENERATO
 export const SQL_DRY_RUN_EXECUTOR_RESOLVER = Symbol('SQL_DRY_RUN_EXECUTOR_RESOLVER');
 export const SQL_RUN_EXECUTOR_RESOLVER = Symbol('SQL_RUN_EXECUTOR_RESOLVER');
 export const CREATE_VIEW_EXECUTOR_RESOLVER = Symbol('CREATE_VIEW_EXECUTOR_RESOLVER');
+export const IDENTIFIER_ESCAPER_RESOLVER = Symbol('IDENTIFIER_ESCAPER_RESOLVER');
 
 const accessValidatorProviders = [
   BigQueryAccessValidator,
@@ -232,6 +240,14 @@ const createViewExecutorProviders = [
   RedshiftCreateViewExecutor,
   DatabricksCreateViewExecutor,
 ];
+const identifierEscaperProviders = [
+  BigQueryIdentifierEscaper,
+  LegacyBigQueryIdentifierEscaper,
+  AthenaIdentifierEscaper,
+  SnowflakeIdentifierEscaper,
+  RedshiftIdentifierEscaper,
+  DatabricksIdentifierEscaper,
+];
 const publicCredentialsProviders = [
   DataStoragePublicCredentialsFactory,
   DataStorageCredentialsUtils,
@@ -265,6 +281,7 @@ export const dataStorageResolverProviders = [
   ...sqlDryRunExecutorProviders,
   ...sqlRunExecutorProviders,
   ...createViewExecutorProviders,
+  ...identifierEscaperProviders,
   ...publicCredentialsProviders,
   ...legacyBigQueryProviders,
   ...blendedQueryBuilderProviders,
@@ -346,6 +363,12 @@ export const dataStorageResolverProviders = [
     useFactory: (...executors: CreateViewExecutor[]) =>
       new TypeResolver<DataStorageType, CreateViewExecutor>(executors),
     inject: createViewExecutorProviders,
+  },
+  {
+    provide: IDENTIFIER_ESCAPER_RESOLVER,
+    useFactory: (...escapers: IdentifierEscaper[]) =>
+      new TypeResolver<DataStorageType, IdentifierEscaper>(escapers),
+    inject: identifierEscaperProviders,
   },
   {
     provide: BLENDED_QUERY_BUILDER_RESOLVER,

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-identifier.escaper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-identifier.escaper.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { IdentifierEscaper } from '../../interfaces/identifier-escaper.interface';
+import { escapeDatabricksIdentifier } from '../utils/databricks-identifier.utils';
+
+@Injectable()
+export class DatabricksIdentifierEscaper implements IdentifierEscaper {
+  readonly type = DataStorageType.DATABRICKS;
+
+  escapeIdentifier(identifier: string): string {
+    return escapeDatabricksIdentifier(identifier);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/facades/identifier-escaper.facade.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/facades/identifier-escaper.facade.spec.ts
@@ -1,0 +1,48 @@
+import { TypeResolver } from '../../../common/resolver/type-resolver';
+import { AthenaIdentifierEscaper } from '../athena/services/athena-identifier.escaper';
+import { BigQueryIdentifierEscaper } from '../bigquery/services/bigquery-identifier.escaper';
+import { LegacyBigQueryIdentifierEscaper } from '../bigquery/services/legacy/legacy-bigquery-identifier.escaper';
+import { DatabricksIdentifierEscaper } from '../databricks/services/databricks-identifier.escaper';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+import { IdentifierEscaper } from '../interfaces/identifier-escaper.interface';
+import { RedshiftIdentifierEscaper } from '../redshift/services/redshift-identifier.escaper';
+import { SnowflakeIdentifierEscaper } from '../snowflake/services/snowflake-identifier.escaper';
+import { IdentifierEscaperFacade } from './identifier-escaper.facade';
+
+describe('IdentifierEscaperFacade', () => {
+  const facade = new IdentifierEscaperFacade(
+    new TypeResolver<DataStorageType, IdentifierEscaper>([
+      new BigQueryIdentifierEscaper(),
+      new LegacyBigQueryIdentifierEscaper(),
+      new AthenaIdentifierEscaper(),
+      new SnowflakeIdentifierEscaper(),
+      new RedshiftIdentifierEscaper(),
+      new DatabricksIdentifierEscaper(),
+    ])
+  );
+
+  const fqn = 'test-project.TestDataset.dashed-table-name';
+
+  it.each([
+    [DataStorageType.GOOGLE_BIGQUERY, '`test-project`.`TestDataset`.`dashed-table-name`'],
+    [DataStorageType.LEGACY_GOOGLE_BIGQUERY, '`test-project`.`TestDataset`.`dashed-table-name`'],
+    [DataStorageType.AWS_ATHENA, '"test-project"."TestDataset"."dashed-table-name"'],
+    [DataStorageType.AWS_REDSHIFT, '"test-project"."TestDataset"."dashed-table-name"'],
+    [DataStorageType.DATABRICKS, '`test-project`.`TestDataset`.`dashed-table-name`'],
+    [DataStorageType.SNOWFLAKE, 'test-project."TestDataset"."dashed-table-name"'],
+  ])('escapes a dashed fully qualified name for %s', async (type, expected) => {
+    await expect(facade.escapeIdentifier(type, fqn)).resolves.toBe(expected);
+  });
+
+  it('does not double-quote already escaped parts', async () => {
+    await expect(
+      facade.escapeIdentifier(DataStorageType.GOOGLE_BIGQUERY, '`test-project`.TestDataset.`table`')
+    ).resolves.toBe('`test-project`.`TestDataset`.`table`');
+  });
+
+  it('throws for an unregistered storage type', async () => {
+    await expect(facade.escapeIdentifier('UNKNOWN' as DataStorageType, fqn)).rejects.toThrow(
+      'No component found for type'
+    );
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/facades/identifier-escaper.facade.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/facades/identifier-escaper.facade.spec.ts
@@ -29,9 +29,15 @@ describe('IdentifierEscaperFacade', () => {
     [DataStorageType.AWS_ATHENA, '"test-project"."TestDataset"."dashed-table-name"'],
     [DataStorageType.AWS_REDSHIFT, '"test-project"."TestDataset"."dashed-table-name"'],
     [DataStorageType.DATABRICKS, '`test-project`.`TestDataset`.`dashed-table-name`'],
-    [DataStorageType.SNOWFLAKE, 'test-project."TestDataset"."dashed-table-name"'],
+    [DataStorageType.SNOWFLAKE, '"test-project"."TestDataset"."dashed-table-name"'],
   ])('escapes a dashed fully qualified name for %s', async (type, expected) => {
     await expect(facade.escapeIdentifier(type, fqn)).resolves.toBe(expected);
+  });
+
+  it('keeps a valid unquoted Snowflake database part unquoted', async () => {
+    await expect(
+      facade.escapeIdentifier(DataStorageType.SNOWFLAKE, 'test_db.TestDataset.dashed-table-name')
+    ).resolves.toBe('test_db."TestDataset"."dashed-table-name"');
   });
 
   it('does not double-quote already escaped parts', async () => {

--- a/apps/backend/src/data-marts/data-storage-types/facades/identifier-escaper.facade.ts
+++ b/apps/backend/src/data-marts/data-storage-types/facades/identifier-escaper.facade.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { TypeResolver } from '../../../common/resolver/type-resolver';
+import { IDENTIFIER_ESCAPER_RESOLVER } from '../data-storage-providers';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+import { IdentifierEscaper } from '../interfaces/identifier-escaper.interface';
+
+@Injectable()
+export class IdentifierEscaperFacade {
+  constructor(
+    @Inject(IDENTIFIER_ESCAPER_RESOLVER)
+    private readonly resolver: TypeResolver<DataStorageType, IdentifierEscaper>
+  ) {}
+
+  async escapeIdentifier(type: DataStorageType, identifier: string): Promise<string> {
+    const escaper = await this.resolver.resolve(type);
+    return escaper.escapeIdentifier(identifier);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/identifier-escaper.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/identifier-escaper.interface.ts
@@ -1,0 +1,6 @@
+import { TypedComponent } from '../../../common/resolver/typed-component.resolver';
+import { DataStorageType } from '../enums/data-storage-type.enum';
+
+export interface IdentifierEscaper extends TypedComponent<DataStorageType> {
+  escapeIdentifier(identifier: string): string;
+}

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-identifier.escaper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-identifier.escaper.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { IdentifierEscaper } from '../../interfaces/identifier-escaper.interface';
+import { escapeRedshiftIdentifier } from '../utils/redshift-identifier.utils';
+
+@Injectable()
+export class RedshiftIdentifierEscaper implements IdentifierEscaper {
+  readonly type = DataStorageType.AWS_REDSHIFT;
+
+  escapeIdentifier(identifier: string): string {
+    return escapeRedshiftIdentifier(identifier);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-identifier.escaper.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-identifier.escaper.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { IdentifierEscaper } from '../../interfaces/identifier-escaper.interface';
+import { escapeSnowflakeIdentifier } from '../utils/snowflake-identifier.utils';
+
+@Injectable()
+export class SnowflakeIdentifierEscaper implements IdentifierEscaper {
+  readonly type = DataStorageType.SNOWFLAKE;
+
+  escapeIdentifier(identifier: string): string {
+    return escapeSnowflakeIdentifier(identifier);
+  }
+}

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/utils/snowflake-identifier.utils.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/utils/snowflake-identifier.utils.spec.ts
@@ -50,6 +50,29 @@ describe('snowflake-identifier.utils', () => {
         'database."my-schema"."my_table"'
       );
     });
+
+    it('should quote a database name that is not a valid unquoted identifier', () => {
+      expect(escapeSnowflakeIdentifier('my-db.schema.table')).toBe('"my-db"."schema"."table"');
+      expect(escapeSnowflakeIdentifier('"my-db".schema.table')).toBe('"my-db"."schema"."table"');
+    });
+
+    it('should never pass embedded double quotes through raw', () => {
+      // unpaired quote is dropped by part splitting; the output stays fully quoted
+      expect(escapeSnowflakeIdentifier('col"name')).toBe('"col"."name"');
+      // paired quotes inside a part are escaped by doubling
+      expect(escapeSnowflakeIdentifier('"col" name')).toBe('"""col"" name"');
+    });
+
+    it('should fail closed on inputs with more than three parts', () => {
+      expect(escapeSnowflakeIdentifier('a.b.c.d')).toBe('"a"."b"."c"."d"');
+    });
+
+    it('should neutralize SQL breakout attempts instead of returning them raw', () => {
+      expect(escapeSnowflakeIdentifier('a.b.c.d FROM sensitive_table --')).toBe(
+        '"a"."b"."c"."d FROM sensitive_table --"'
+      );
+      expect(escapeSnowflakeIdentifier('"x" FROM y --"')).toBe('"""x"" FROM y --"');
+    });
   });
 
   describe('escapeSnowflakeSchema', () => {
@@ -67,6 +90,10 @@ describe('snowflake-identifier.utils', () => {
 
     it('should handle case-sensitive schema names', () => {
       expect(escapeSnowflakeSchema('database', '"MySchema"')).toBe('database."MySchema"');
+    });
+
+    it('should quote a database name that is not a valid unquoted identifier', () => {
+      expect(escapeSnowflakeSchema('my-db', 'schema')).toBe('"my-db"."schema"');
     });
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/utils/snowflake-identifier.utils.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/utils/snowflake-identifier.utils.ts
@@ -1,21 +1,41 @@
 /**
- * Helper function to quote a single identifier part if not already quoted
+ * Pattern for identifiers Snowflake accepts unquoted (letters, digits, '_' and '$',
+ * not starting with a digit). Anything else must be double-quoted to be safe.
+ */
+const UNQUOTED_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_$]*$/;
+
+/**
+ * Helper function to quote a single identifier part.
+ * Already-quoted parts are unwrapped first to avoid double-quoting,
+ * and embedded double quotes are escaped by doubling them.
  * @param part - The identifier part to quote
  * @returns The quoted identifier part
  */
 function quoteIdentifierPart(part: string): string {
-  if (part.startsWith('"') && part.endsWith('"')) {
-    return part;
-  }
-  return `"${part}"`;
+  const inner =
+    part.length >= 2 && part.startsWith('"') && part.endsWith('"') ? part.slice(1, -1) : part;
+  return `"${inner.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Unquotes the database part only when the result is a valid unquoted Snowflake
+ * identifier (Snowflake normalizes it to uppercase). Otherwise the part is kept
+ * safely quoted — never returned raw.
+ */
+function unquoteDatabasePart(part: string): string {
+  const inner =
+    part.length >= 2 && part.startsWith('"') && part.endsWith('"') ? part.slice(1, -1) : part;
+  return UNQUOTED_IDENTIFIER_PATTERN.test(inner) ? inner : quoteIdentifierPart(part);
 }
 
 /**
  * Escapes Snowflake identifiers by wrapping schema and table in double quotes
- * to preserve case sensitivity. Database name is left unquoted as Snowflake
- * normalizes it to uppercase.
+ * to preserve case sensitivity. The database name is left unquoted (Snowflake
+ * normalizes it to uppercase) only when it is a valid unquoted identifier.
  *
- * If parts are already quoted, they won't be quoted again to avoid double-quoting.
+ * Fails closed: inputs that are not a 1-3 part identifier (or contain characters
+ * that are unsafe unquoted) have every part quoted with embedded double quotes
+ * escaped, so the result is always a quoted identifier rather than raw SQL.
  *
  * @param identifier - Can be a single identifier or a fully qualified name (e.g., "database.schema.table")
  * @returns Escaped identifier with schema and table wrapped in double quotes
@@ -25,6 +45,8 @@ function quoteIdentifierPart(part: string): string {
  * escapeSnowflakeIdentifier('schema.table') // => "schema"."table"
  * escapeSnowflakeIdentifier('database.schema.table') // => database."schema"."table"
  * escapeSnowflakeIdentifier('database."SCHEMA"."TABLE"') // => database."SCHEMA"."TABLE"
+ * escapeSnowflakeIdentifier('my-db.schema.table') // => "my-db"."schema"."table"
+ * escapeSnowflakeIdentifier('a.b.c.d FROM x --') // => "a"."b"."c"."d FROM x --"
  */
 export function escapeSnowflakeIdentifier(identifier: string): string {
   if (!identifier) {
@@ -33,29 +55,21 @@ export function escapeSnowflakeIdentifier(identifier: string): string {
 
   const parts = identifier.match(/(?:[^."]+|"[^"]*")+/g) || [];
 
-  if (parts.length === 1) {
-    return quoteIdentifierPart(parts[0]);
-  }
-
-  if (parts.length === 2) {
-    return `${quoteIdentifierPart(parts[0])}.${quoteIdentifierPart(parts[1])}`;
+  if (parts.length === 0) {
+    return quoteIdentifierPart(identifier);
   }
 
   if (parts.length === 3) {
-    const database =
-      parts[0].startsWith('"') && parts[0].endsWith('"') ? parts[0].slice(1, -1) : parts[0];
-
-    return `${database}.${quoteIdentifierPart(parts[1])}.${quoteIdentifierPart(parts[2])}`;
+    return `${unquoteDatabasePart(parts[0])}.${quoteIdentifierPart(parts[1])}.${quoteIdentifierPart(parts[2])}`;
   }
 
-  // Fallback for unexpected format
-  return identifier;
+  return parts.map(quoteIdentifierPart).join('.');
 }
 
 /**
  * Escapes Snowflake schema identifier (database.schema format)
- * Only quotes the schema part, leaving database unquoted.
- * If schema is already quoted, it won't be quoted again.
+ * Only quotes the schema part, leaving database unquoted when it is a valid
+ * unquoted identifier (otherwise it is quoted as well).
  *
  * @param database - Database name
  * @param schema - Schema name
@@ -66,8 +80,5 @@ export function escapeSnowflakeIdentifier(identifier: string): string {
  * escapeSnowflakeSchema('database', '"SCHEMA"') // => database."SCHEMA"
  */
 export function escapeSnowflakeSchema(database: string, schema: string): string {
-  const dbName =
-    database.startsWith('"') && database.endsWith('"') ? database.slice(1, -1) : database;
-
-  return `${dbName}.${quoteIdentifierPart(schema)}`;
+  return `${unquoteDatabasePart(database)}.${quoteIdentifierPart(schema)}`;
 }

--- a/apps/backend/src/data-marts/services/data-mart-sample-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-sample-data.service.spec.ts
@@ -1,5 +1,6 @@
 import { TypeResolver } from '../../common/resolver/type-resolver';
 import { BigQueryIdentifierEscaper } from '../data-storage-types/bigquery/services/bigquery-identifier.escaper';
+import { SnowflakeIdentifierEscaper } from '../data-storage-types/snowflake/services/snowflake-identifier.escaper';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { IdentifierEscaperFacade } from '../data-storage-types/facades/identifier-escaper.facade';
 import { IdentifierEscaper } from '../data-storage-types/interfaces/identifier-escaper.interface';
@@ -7,17 +8,17 @@ import { DataMart } from '../entities/data-mart.entity';
 import { DataMartSampleDataService } from './data-mart-sample-data.service';
 
 describe('DataMartSampleDataService', () => {
-  const createDataMart = (): DataMart =>
+  const createDataMart = (storageType: DataStorageType): DataMart =>
     ({
       id: 'data-mart-1',
       projectId: 'project-1',
       storage: {
-        type: DataStorageType.GOOGLE_BIGQUERY,
+        type: storageType,
       },
     }) as unknown as DataMart;
 
-  const createService = () => {
-    const dataMart = createDataMart();
+  const createService = (storageType = DataStorageType.GOOGLE_BIGQUERY) => {
+    const dataMart = createDataMart(storageType);
     const dataMartService = {
       getByIdAndProjectId: jest.fn().mockResolvedValue(dataMart),
     };
@@ -28,7 +29,10 @@ describe('DataMartSampleDataService', () => {
       resolveTableName: jest.fn().mockResolvedValue('test-project.TestDataset.dashed-table-name'),
     };
     const identifierEscaperFacade = new IdentifierEscaperFacade(
-      new TypeResolver<DataStorageType, IdentifierEscaper>([new BigQueryIdentifierEscaper()])
+      new TypeResolver<DataStorageType, IdentifierEscaper>([
+        new BigQueryIdentifierEscaper(),
+        new SnowflakeIdentifierEscaper(),
+      ])
     );
 
     return {
@@ -72,6 +76,18 @@ describe('DataMartSampleDataService', () => {
       expect.anything(),
       'SELECT `report_date`, `amount` FROM `test-project`.`TestDataset`.`another-dashed-table` LIMIT 10',
       { limit: 10 }
+    );
+  });
+
+  it('neutralizes SQL breakout attempts in Snowflake column names', async () => {
+    const { service, dataMart, dataMartSqlTableService } = createService(DataStorageType.SNOWFLAKE);
+
+    await service.sampleColumns('data-mart-1', 'project-1', ['a.b.c.d FROM sensitive_table --']);
+
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      dataMart,
+      'SELECT "a"."b"."c"."d FROM sensitive_table --" FROM "test-project"."TestDataset"."dashed-table-name" LIMIT 5',
+      { limit: 5 }
     );
   });
 });

--- a/apps/backend/src/data-marts/services/data-mart-sample-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-sample-data.service.spec.ts
@@ -1,0 +1,77 @@
+import { TypeResolver } from '../../common/resolver/type-resolver';
+import { BigQueryIdentifierEscaper } from '../data-storage-types/bigquery/services/bigquery-identifier.escaper';
+import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
+import { IdentifierEscaperFacade } from '../data-storage-types/facades/identifier-escaper.facade';
+import { IdentifierEscaper } from '../data-storage-types/interfaces/identifier-escaper.interface';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataMartSampleDataService } from './data-mart-sample-data.service';
+
+describe('DataMartSampleDataService', () => {
+  const createDataMart = (): DataMart =>
+    ({
+      id: 'data-mart-1',
+      projectId: 'project-1',
+      storage: {
+        type: DataStorageType.GOOGLE_BIGQUERY,
+      },
+    }) as unknown as DataMart;
+
+  const createService = () => {
+    const dataMart = createDataMart();
+    const dataMartService = {
+      getByIdAndProjectId: jest.fn().mockResolvedValue(dataMart),
+    };
+    const dataMartSqlTableService = {
+      executeSqlToTable: jest.fn().mockResolvedValue({ columns: [], rows: [] }),
+    };
+    const dataMartTableReferenceService = {
+      resolveTableName: jest.fn().mockResolvedValue('test-project.TestDataset.dashed-table-name'),
+    };
+    const identifierEscaperFacade = new IdentifierEscaperFacade(
+      new TypeResolver<DataStorageType, IdentifierEscaper>([new BigQueryIdentifierEscaper()])
+    );
+
+    return {
+      service: new DataMartSampleDataService(
+        dataMartService as never,
+        dataMartSqlTableService as never,
+        dataMartTableReferenceService as never,
+        identifierEscaperFacade
+      ),
+      dataMart,
+      dataMartSqlTableService,
+      dataMartTableReferenceService,
+    };
+  };
+
+  it('escapes a dashed table name and columns in the generated SQL', async () => {
+    const { service, dataMart, dataMartSqlTableService } = createService();
+
+    await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
+
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      dataMart,
+      'SELECT `report_date` FROM `test-project`.`TestDataset`.`dashed-table-name` LIMIT 5',
+      { limit: 5 }
+    );
+  });
+
+  it('escapes an explicitly provided fully qualified table name without resolving it', async () => {
+    const { service, dataMartSqlTableService, dataMartTableReferenceService } = createService();
+
+    await service.sampleColumns(
+      'data-mart-1',
+      'project-1',
+      ['report_date', 'amount'],
+      'test-project.TestDataset.another-dashed-table',
+      10
+    );
+
+    expect(dataMartTableReferenceService.resolveTableName).not.toHaveBeenCalled();
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      expect.anything(),
+      'SELECT `report_date`, `amount` FROM `test-project`.`TestDataset`.`another-dashed-table` LIMIT 10',
+      { limit: 10 }
+    );
+  });
+});

--- a/apps/backend/src/data-marts/services/data-mart-sample-data.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-sample-data.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { IdentifierEscaperFacade } from '../data-storage-types/facades/identifier-escaper.facade';
 import { DataMartService } from './data-mart.service';
 import { DataMartSqlTableService } from './data-mart-sql-table.service';
 import { DataMartTableReferenceService } from './data-mart-table-reference.service';
@@ -13,7 +14,8 @@ export class DataMartSampleDataService {
   constructor(
     private readonly dataMartService: DataMartService,
     private readonly dataMartSqlTableService: DataMartSqlTableService,
-    private readonly dataMartTableReferenceService: DataMartTableReferenceService
+    private readonly dataMartTableReferenceService: DataMartTableReferenceService,
+    private readonly identifierEscaperFacade: IdentifierEscaperFacade
   ) {}
 
   async sampleColumns(
@@ -29,8 +31,12 @@ export class DataMartSampleDataService {
       fullyQualifiedTableName ??
       (await this.dataMartTableReferenceService.resolveTableName(dataMartId, projectId));
 
-    const columnList = columns.join(', ');
-    const sql = `SELECT ${columnList} FROM ${fqn} LIMIT ${limit}`;
+    const storageType = dataMart.storage.type;
+    const escapedColumns = await Promise.all(
+      columns.map(column => this.identifierEscaperFacade.escapeIdentifier(storageType, column))
+    );
+    const escapedFqn = await this.identifierEscaperFacade.escapeIdentifier(storageType, fqn);
+    const sql = `SELECT ${escapedColumns.join(', ')} FROM ${escapedFqn} LIMIT ${limit}`;
 
     const result = await this.dataMartSqlTableService.executeSqlToTable(dataMart, sql, { limit });
 


### PR DESCRIPTION
## What changed

`DataMartSampleDataService.sampleColumns()` built its sampling query by interpolating the raw fully qualified table name and column names into SQL:

```ts
const sql = `SELECT ${columnList} FROM ${fqn} LIMIT ${limit}`;
```

For data marts whose table path contains dashes (e.g. `my-project.dataset.my-table-name`), BigQuery rejects the query with `Syntax error: Expected end of input but got "-"`, which breaks AI Helper metadata generation (`POST /data-marts/:id/ai-helper/triggers`) and the `SAMPLE_TABLE_DATA` AI tool.

This PR adds identifier escaping to that query, following the existing storage-type component pattern (interface → per-storage implementations → `TypeResolver` → facade):

- `IdentifierEscaper` interface (`TypedComponent<DataStorageType>`)
- Six thin implementations delegating to the existing per-storage escaping utils (`escapeBigQueryIdentifier`, `escapeAthenaIdentifier`, `escapeSnowflakeIdentifier`, `escapeRedshiftIdentifier`, `escapeDatabricksIdentifier`)
- `IDENTIFIER_ESCAPER_RESOLVER` registered in `data-storage-providers.ts`
- `IdentifierEscaperFacade` registered in `data-storage-facades.ts`
- `DataMartSampleDataService` now escapes both the table reference and the column list per the data mart's storage type, so the generated SQL becomes ``SELECT `report_date` FROM `my-project`.`dataset`.`my-table-name` LIMIT 5``

## Why

Every other SQL construction path (query builders for all storage types) already escapes identifiers; this service was the only exception. Escaping the column list also stops LLM-supplied tool arguments from being interpolated into SQL unquoted.

## Notes for reviewers

- The escapers handle already-quoted parts without double-quoting, so pre-escaped FQNs from the AI prefetch context remain safe.
- `resolveTableName()` intentionally stays unescaped — its raw output is also used outside SQL (LLM context, report composers).
- Known same-class issue left out of scope: the `${DATA_MART_TABLE}` macro replacement in `data-mart-sql-table.service.ts` also inserts the raw name, but needs double-quoting protection for user SQL that already wraps the macro in backticks; planned as a follow-up.

## Testing

- New `identifier-escaper.facade.spec.ts`: dashed FQN escaping per storage type (incl. Snowflake's unquoted database part), no double-quoting, unknown-type error.
- New `data-mart-sample-data.service.spec.ts`: generated SQL is fully escaped for resolved and explicitly passed table names.
- `jest src/data-marts`: 3268 passed; the 2 failures in `project-list-sql-dialects.spec.ts` reproduce on a clean tree without these changes (pre-existing parser issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)