### PR TITLE
feat(criteo): add report endpoints, configurable currency, API 2026-01

### DIFF
--- a/.changeset/criteo-new-endpoints-and-currency.md
+++ b/.changeset/criteo-new-endpoints-and-currency.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Criteo placement, category, and transaction reporting
+
+The Criteo connector now supports three new endpoints — placements, placement categories,
+and transactions — alongside the existing campaign statistics, plus extra statistics
+dimensions such as device, OS, and channel. You can also choose the reporting currency
+instead of always getting USD. Previously only campaign-level statistics were available;
+now you can break performance down by where ads ran and pull individual attributed orders.

--- a/packages/connectors/src/Sources/CriteoAds/Connector.js
+++ b/packages/connectors/src/Sources/CriteoAds/Connector.js
@@ -78,7 +78,7 @@ var CriteoAdsConnector = class CriteoAdsConnector extends AbstractConnector {
 
       if (data.length || this.config.CreateEmptyTables?.value) {
         const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
-        const storage = await this.getStorageByNode(nodeName);
+        const storage = await this.getStorageByNode(nodeName, fields);
         await storage.saveData(preparedData);
       }
 
@@ -92,9 +92,10 @@ var CriteoAdsConnector = class CriteoAdsConnector extends AbstractConnector {
   /**
    * Get storage instance for a node
    * @param {string} nodeName - Name of the node
+   * @param {Array<string>} fields - Fields selected for this node
    * @returns {Object} Storage instance
    */
-  async getStorageByNode(nodeName) {
+  async getStorageByNode(nodeName, fields = []) {
     if (!("storages" in this)) {
       this.storages = {};
     }
@@ -105,12 +106,10 @@ var CriteoAdsConnector = class CriteoAdsConnector extends AbstractConnector {
       }
 
       const uniqueFields = this.source.fieldsSchema[nodeName].uniqueKeys;
+      const storageConfig = this._buildStorageConfig({ nodeName, fields, uniqueFields });
 
       this.storages[nodeName] = new globalThis[this.storageName](
-        this.config.mergeParameters({
-          DestinationSheetName: { value: this.source.fieldsSchema[nodeName].destinationName },
-          DestinationTableName: { value: this.getDestinationName(nodeName, this.config, this.source.fieldsSchema[nodeName].destinationName) },
-        }),
+        storageConfig,
         uniqueFields,
         this.source.fieldsSchema[nodeName].fields,
         `${this.source.fieldsSchema[nodeName].description} ${this.source.fieldsSchema[nodeName].documentation}`
@@ -120,5 +119,35 @@ var CriteoAdsConnector = class CriteoAdsConnector extends AbstractConnector {
     }
 
     return this.storages[nodeName];
+  }
+
+  /**
+   * Build a storage-specific config without mutating the connector config.
+   * Storage parses Fields itself, so pass only the fields for the current node.
+   * @param {Object} options
+   * @param {string} options.nodeName
+   * @param {Array<string>} options.fields
+   * @param {Array<string>} options.uniqueFields
+   * @returns {Object}
+   * @private
+   */
+  _buildStorageConfig({ nodeName, fields, uniqueFields }) {
+    const scopedFields = [...fields];
+    for (const field of uniqueFields) {
+      if (!scopedFields.includes(field)) {
+        scopedFields.push(field);
+      }
+    }
+
+    const storageConfig = Object.assign(
+      Object.create(Object.getPrototypeOf(this.config)),
+      this.config
+    );
+
+    return storageConfig.mergeParameters({
+      DestinationSheetName: { value: this.source.fieldsSchema[nodeName].destinationName },
+      DestinationTableName: { value: this.getDestinationName(nodeName, this.config, this.source.fieldsSchema[nodeName].destinationName) },
+      Fields: { value: scopedFields.map(field => `${nodeName} ${field}`).join(", ") }
+    });
   }
 };

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/CriteoAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/CriteoAdsFieldsSchema.js
@@ -19,9 +19,9 @@ var CriteoAdsFieldsSchema = {
   placements: {
     overview: "Criteo Placements",
     description: "Performance metrics broken down by publisher placement.",
-    documentation: "https://developers.criteo.com/marketing-solutions/docs/placement-report",
+    documentation: "https://developers.criteo.com/marketing-solutions/docs/placement",
     fields: placementFields,
-    uniqueKeys: ["advertiserId", "adsetId", "Day", "environment", "placement"],
+    uniqueKeys: ["advertiserId", "adsetId", "day", "environment", "placement"],
     defaultFields: ["advertiserId", "adsetId", "adsetName", "environment", "placement", "clicks", "displays", "cost"],
     destinationName: "criteo_ads_placements",
     isTimeSeries: true,
@@ -30,9 +30,9 @@ var CriteoAdsFieldsSchema = {
   placement_categories: {
     overview: "Criteo Placement Categories",
     description: "Performance metrics broken down by content category and publisher domain. Web only.",
-    documentation: "https://developers.criteo.com/marketing-solutions/docs/placement-category-report",
+    documentation: "https://developers.criteo.com/marketing-solutions/docs/placement-category",
     fields: placementCategoryFields,
-    uniqueKeys: ["advertiserId", "Day", "category", "domain"],
+    uniqueKeys: ["advertiserId", "day", "category", "domain"],
     defaultFields: ["advertiserId", "category", "domain", "displays", "clicks", "salesPc30d"],
     destinationName: "criteo_ads_placement_categories",
     isTimeSeries: true,
@@ -43,8 +43,8 @@ var CriteoAdsFieldsSchema = {
     description: "Transaction-level data with individual order details attributed to Criteo ads.",
     documentation: "https://developers.criteo.com/marketing-solutions/docs/transaction-id-report",
     fields: transactionFields,
-    uniqueKeys: ["TransactionId"],
-    defaultFields: ["TransactionId", "TransactionDate", "AdvertiserId", "AdsetName", "EventType", "Amount", "Currency"],
+    uniqueKeys: ["transactionId"],
+    defaultFields: ["transactionId", "transactionDate", "advertiserId", "adsetName", "eventType", "amount", "currency"],
     destinationName: "criteo_ads_transactions",
     isTimeSeries: true
   }

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/CriteoAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/CriteoAdsFieldsSchema.js
@@ -15,5 +15,37 @@ var CriteoAdsFieldsSchema = {
     defaultFields: ["Clicks", "Displays", "AdvertiserCost", "Campaign", "Advertiser", "Adset", "Ad", "Currency"],
     destinationName: "criteo_ads_statistics",
     isTimeSeries: true
+  },
+  placements: {
+    overview: "Criteo Placements",
+    description: "Performance metrics broken down by publisher placement.",
+    documentation: "https://developers.criteo.com/marketing-solutions/docs/placement-report",
+    fields: placementFields,
+    uniqueKeys: ["advertiserId", "adsetId", "Day", "environment", "placement"],
+    defaultFields: ["advertiserId", "adsetId", "adsetName", "environment", "placement", "clicks", "displays", "cost"],
+    destinationName: "criteo_ads_placements",
+    isTimeSeries: true,
+    injectDay: true
+  },
+  placement_categories: {
+    overview: "Criteo Placement Categories",
+    description: "Performance metrics broken down by content category and publisher domain. Web only.",
+    documentation: "https://developers.criteo.com/marketing-solutions/docs/placement-category-report",
+    fields: placementCategoryFields,
+    uniqueKeys: ["advertiserId", "Day", "category", "domain"],
+    defaultFields: ["advertiserId", "category", "domain", "displays", "clicks", "salesPc30d"],
+    destinationName: "criteo_ads_placement_categories",
+    isTimeSeries: true,
+    injectDay: true
+  },
+  transactions: {
+    overview: "Criteo Transactions",
+    description: "Transaction-level data with individual order details attributed to Criteo ads.",
+    documentation: "https://developers.criteo.com/marketing-solutions/docs/transaction-id-report",
+    fields: transactionFields,
+    uniqueKeys: ["TransactionId"],
+    defaultFields: ["TransactionId", "TransactionDate", "AdvertiserId", "AdsetName", "EventType", "Amount", "Currency"],
+    destinationName: "criteo_ads_transactions",
+    isTimeSeries: true
   }
 };

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/CriteoAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/CriteoAdsFieldsSchema.js
@@ -29,11 +29,11 @@ var CriteoAdsFieldsSchema = {
   },
   placement_categories: {
     overview: "Criteo Placement Categories",
-    description: "Performance metrics broken down by content category and publisher domain. Web only.",
+    description: "Performance metrics broken down by content category.",
     documentation: "https://developers.criteo.com/marketing-solutions/docs/placement-category",
     fields: placementCategoryFields,
-    uniqueKeys: ["advertiserId", "day", "category", "domain"],
-    defaultFields: ["advertiserId", "category", "domain", "displays", "clicks", "salesPc30d"],
+    uniqueKeys: ["advertiserId", "day", "categoryId"],
+    defaultFields: ["advertiserId", "categoryId", "categoryName", "displays", "clicks", "salesPc30d"],
     destinationName: "criteo_ads_placement_categories",
     isTimeSeries: true,
     injectDay: true
@@ -41,9 +41,9 @@ var CriteoAdsFieldsSchema = {
   transactions: {
     overview: "Criteo Transactions",
     description: "Transaction-level data with individual order details attributed to Criteo ads.",
-    documentation: "https://developers.criteo.com/marketing-solutions/docs/transaction-id-report",
+    documentation: "https://developers.criteo.com/marketing-solutions/docs/transaction-ids",
     fields: transactionFields,
-    uniqueKeys: ["transactionId"],
+    uniqueKeys: ["advertiserId", "transactionId"],
     defaultFields: ["transactionId", "transactionDate", "advertiserId", "adsetName", "eventType", "amount", "currency"],
     destinationName: "criteo_ads_transactions",
     isTimeSeries: true

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/adStatisticsFields.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/adStatisticsFields.js
@@ -734,5 +734,55 @@ var adStatisticsFields = {
   'Currency': {
     'description': 'The currency of the advertiser cost.',
     'type': DATA_TYPES.STRING
+  },
+  'Device': {
+    'description': 'The device type on which the ad was served (e.g., Desktop, Tablet, Mobile).',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'Os': {
+    'description': 'The operating system of the device on which the ad was served.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'Channel': {
+    'description': 'The channel name through which the ad was served.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'ChannelId': {
+    'description': 'The unique identifier of the channel through which the ad was served.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'Category': {
+    'description': 'The product category name.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'CategoryId': {
+    'description': 'The unique identifier for the product category.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'Coupon': {
+    'description': 'The coupon or promotion name.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'CouponId': {
+    'description': 'The unique identifier for the coupon or promotion.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'MarketingObjective': {
+    'description': 'The marketing objective name (e.g., awareness, consideration, conversion).',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'MarketingObjectiveId': {
+    'description': 'The unique identifier for the marketing objective.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
   }
 };

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementCategoryFields.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementCategoryFields.js
@@ -11,15 +11,17 @@ var placementCategoryFields = {
     'type': DATA_TYPES.STRING,
     'fieldType': 'dimension'
   },
-  'category': {
+  'categoryId': {
+    'description': 'The unique identifier for the content category.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension',
+    'apiName': 'CategoryId'
+  },
+  'categoryName': {
     'description': 'The IAB content category of the publisher page where the ad was served.',
     'type': DATA_TYPES.STRING,
-    'fieldType': 'dimension'
-  },
-  'domain': {
-    'description': 'The publisher domain where the ad was served.',
-    'type': DATA_TYPES.STRING,
-    'fieldType': 'dimension'
+    'fieldType': 'dimension',
+    'apiName': 'CategoryName'
   },
   'day': {
     'description': 'The day of the placement category data (YYYY-MM-DD format).',

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementCategoryFields.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementCategoryFields.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+var placementCategoryFields = {
+  'advertiserId': {
+    'description': 'The unique identifier for the advertiser.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'category': {
+    'description': 'The IAB content category of the publisher page where the ad was served.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'domain': {
+    'description': 'The publisher domain where the ad was served.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'Day': {
+    'description': 'The day of the placement category data (YYYY-MM-DD format).',
+    'type': DATA_TYPES.DATE,
+    'fieldType': 'dimension'
+  },
+  'displays': {
+    'description': 'The number of ad impressions served in this category.',
+    'type': DATA_TYPES.INTEGER,
+    'fieldType': 'metric'
+  },
+  'clicks': {
+    'description': 'The number of clicks in this category.',
+    'type': DATA_TYPES.INTEGER,
+    'fieldType': 'metric'
+  },
+  'salesPc30d': {
+    'description': 'The number of transactions or conversions (30-day post-click).',
+    'type': DATA_TYPES.INTEGER,
+    'fieldType': 'metric'
+  },
+  'salesPv1d': {
+    'description': 'The number of transactions or conversions (1-day post-view).',
+    'type': DATA_TYPES.INTEGER,
+    'fieldType': 'metric'
+  }
+};

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementCategoryFields.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementCategoryFields.js
@@ -21,10 +21,9 @@ var placementCategoryFields = {
     'type': DATA_TYPES.STRING,
     'fieldType': 'dimension'
   },
-  'Day': {
+  'day': {
     'description': 'The day of the placement category data (YYYY-MM-DD format).',
-    'type': DATA_TYPES.DATE,
-    'fieldType': 'dimension'
+    'type': DATA_TYPES.DATE
   },
   'displays': {
     'description': 'The number of ad impressions served in this category.',

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementFields.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementFields.js
@@ -14,7 +14,8 @@ var placementFields = {
   'adsetId': {
     'description': 'The unique identifier for the adset.',
     'type': DATA_TYPES.STRING,
-    'fieldType': 'dimension'
+    'fieldType': 'dimension',
+    'apiName': 'adSetId'
   },
   'adsetName': {
     'description': 'The name of the adset.',

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementFields.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementFields.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+var placementFields = {
+  'advertiserId': {
+    'description': 'The unique identifier for the advertiser.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'adsetId': {
+    'description': 'The unique identifier for the adset.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'adsetName': {
+    'description': 'The name of the adset.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'environment': {
+    'description': 'The environment where the ad was served (e.g., web, app).',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'placement': {
+    'description': 'The publisher placement where the ad was served.',
+    'type': DATA_TYPES.STRING,
+    'fieldType': 'dimension'
+  },
+  'Day': {
+    'description': 'The day of the placement data (YYYY-MM-DD format).',
+    'type': DATA_TYPES.DATE,
+    'fieldType': 'dimension'
+  },
+  'clicks': {
+    'description': 'The number of clicks on this placement.',
+    'type': DATA_TYPES.INTEGER,
+    'fieldType': 'metric'
+  },
+  'displays': {
+    'description': 'The number of ad impressions served on this placement.',
+    'type': DATA_TYPES.INTEGER,
+    'fieldType': 'metric'
+  },
+  'cost': {
+    'description': 'Total money spent on this placement.',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  },
+  'salesPc30d': {
+    'description': 'The number of transactions or conversions (30-day post-click).',
+    'type': DATA_TYPES.INTEGER,
+    'fieldType': 'metric'
+  },
+  'salesPv1d': {
+    'description': 'The number of transactions or conversions (1-day post-view).',
+    'type': DATA_TYPES.INTEGER,
+    'fieldType': 'metric'
+  },
+  'revenuePc30d': {
+    'description': 'The revenue generated (30-day post-click).',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  },
+  'revenuePv1d': {
+    'description': 'The revenue generated (1-day post-view).',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  },
+  'cosPc30d': {
+    'description': 'The cost of sale (30-day post-click).',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  },
+  'cosPv1d': {
+    'description': 'The cost of sale (1-day post-view).',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  },
+  'roasPc30d': {
+    'description': 'The return on ad spend (30-day post-click).',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  },
+  'roasPv1d': {
+    'description': 'The return on ad spend (1-day post-view).',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  },
+  'cpoPc30d': {
+    'description': 'The cost per order (30-day post-click).',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  },
+  'cpoPv1d': {
+    'description': 'The cost per order (1-day post-view).',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  },
+  'cvrPc30d': {
+    'description': 'The conversion rate (30-day post-click).',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  },
+  'cvrPv1d': {
+    'description': 'The conversion rate (1-day post-view).',
+    'type': DATA_TYPES.NUMBER,
+    'fieldType': 'metric'
+  }
+};

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementFields.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/placementFields.js
@@ -22,7 +22,7 @@ var placementFields = {
     'fieldType': 'dimension'
   },
   'environment': {
-    'description': 'The environment where the ad was served (e.g., web, app).',
+    'description': 'The environment where the ad was served (Web, Android, iOS).',
     'type': DATA_TYPES.STRING,
     'fieldType': 'dimension'
   },
@@ -31,10 +31,9 @@ var placementFields = {
     'type': DATA_TYPES.STRING,
     'fieldType': 'dimension'
   },
-  'Day': {
+  'day': {
     'description': 'The day of the placement data (YYYY-MM-DD format).',
-    'type': DATA_TYPES.DATE,
-    'fieldType': 'dimension'
+    'type': DATA_TYPES.DATE
   },
   'clicks': {
     'description': 'The number of clicks on this placement.',

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/transactionFields.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/transactionFields.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) OWOX, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+var transactionFields = {
+  'TransactionId': {
+    'description': 'The unique identifier for the transaction.',
+    'type': DATA_TYPES.STRING
+  },
+  'TransactionDate': {
+    'description': 'The date and time when the transaction occurred.',
+    'type': DATA_TYPES.STRING
+  },
+  'AdvertiserId': {
+    'description': 'The unique identifier for the advertiser.',
+    'type': DATA_TYPES.STRING
+  },
+  'AdvertiserName': {
+    'description': 'The name of the advertiser.',
+    'type': DATA_TYPES.STRING
+  },
+  'AdsetName': {
+    'description': 'The name of the adset that drove the transaction.',
+    'type': DATA_TYPES.STRING
+  },
+  'EventType': {
+    'description': 'The type of event that triggered the attribution (click or display).',
+    'type': DATA_TYPES.STRING
+  },
+  'EventDate': {
+    'description': 'The date and time of the click or view event that drove the transaction.',
+    'type': DATA_TYPES.STRING
+  },
+  'AttributedTransaction': {
+    'description': 'Whether the transaction was attributed to a Criteo ad.',
+    'type': DATA_TYPES.BOOLEAN
+  },
+  'Currency': {
+    'description': 'The currency of the transaction amount.',
+    'type': DATA_TYPES.STRING
+  },
+  'Amount': {
+    'description': 'The transaction amount (order value).',
+    'type': DATA_TYPES.NUMBER
+  },
+  'CrossDeviceTransaction': {
+    'description': 'Whether the transaction occurred on a different device from the one where the ad was viewed.',
+    'type': DATA_TYPES.BOOLEAN
+  }
+};

--- a/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/transactionFields.js
+++ b/packages/connectors/src/Sources/CriteoAds/CriteoAdsAPIReference/transactionFields.js
@@ -5,49 +5,53 @@
  * file that was distributed with this source code.
  */
 
+// Note: the transactions report has a fixed schema and returns camelCase keys
+// (unlike statistics/placements, which echo back the PascalCase dimension names
+// requested). The keys below must match the response keys exactly so that
+// _filterBySchema keeps them.
 var transactionFields = {
-  'TransactionId': {
+  'transactionId': {
     'description': 'The unique identifier for the transaction.',
     'type': DATA_TYPES.STRING
   },
-  'TransactionDate': {
-    'description': 'The date and time when the transaction occurred.',
+  'transactionDate': {
+    'description': 'The date and time when the transaction occurred (MM/DD/YYYY HH:MM:SS).',
     'type': DATA_TYPES.STRING
   },
-  'AdvertiserId': {
+  'advertiserId': {
     'description': 'The unique identifier for the advertiser.',
     'type': DATA_TYPES.STRING
   },
-  'AdvertiserName': {
+  'advertiserName': {
     'description': 'The name of the advertiser.',
     'type': DATA_TYPES.STRING
   },
-  'AdsetName': {
+  'adsetName': {
     'description': 'The name of the adset that drove the transaction.',
     'type': DATA_TYPES.STRING
   },
-  'EventType': {
+  'eventType': {
     'description': 'The type of event that triggered the attribution (click or display).',
     'type': DATA_TYPES.STRING
   },
-  'EventDate': {
-    'description': 'The date and time of the click or view event that drove the transaction.',
+  'eventDate': {
+    'description': 'The date and time of the click or view event that drove the transaction (MM/DD/YYYY HH:MM:SS).',
     'type': DATA_TYPES.STRING
   },
-  'AttributedTransaction': {
-    'description': 'Whether the transaction was attributed to a Criteo ad.',
-    'type': DATA_TYPES.BOOLEAN
+  'attributedTransaction': {
+    'description': 'Whether the transaction was attributed to a Criteo ad (returned as "True" / "False").',
+    'type': DATA_TYPES.STRING
   },
-  'Currency': {
+  'currency': {
     'description': 'The currency of the transaction amount.',
     'type': DATA_TYPES.STRING
   },
-  'Amount': {
+  'amount': {
     'description': 'The transaction amount (order value).',
     'type': DATA_TYPES.NUMBER
   },
-  'CrossDeviceTransaction': {
-    'description': 'Whether the transaction occurred on a different device from the one where the ad was viewed.',
-    'type': DATA_TYPES.BOOLEAN
+  'crossDeviceTransaction': {
+    'description': 'Whether the transaction occurred on a different device from the one where the ad was viewed (returned as "Yes" / "No").',
+    'type': DATA_TYPES.STRING
   }
 };

--- a/packages/connectors/src/Sources/CriteoAds/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/CriteoAds/GETTING_STARTED.md
@@ -33,7 +33,11 @@ Before proceeding, please make sure that:
 
 ## Configure Data Import
 
-1. Choose one of the available **endpoints**.  
+1. Choose one of the available **endpoints**:
+    - **statistics** – campaign performance metrics (clicks, displays, cost, sales, ROAS, and more) by advertiser, campaign, adset, ad, and day.
+    - **placements** – performance metrics by publisher placement and environment (Web, Android, iOS).
+    - **placement_categories** – performance metrics by content category. Breakdown by publisher domain is not available in the Criteo `2026-01` API; use **placements** for placement-level detail.
+    - **transactions** – transaction-level data with individual order details attributed to Criteo ads. Returns rows only for periods with attributed conversions.
 2. Select the required **fields**.  
 3. Specify the **dataset** where the data will be stored (or leave the default).  
 4. Click **Finish**, then **Publish Data Mart**.

--- a/packages/connectors/src/Sources/CriteoAds/Helper.js
+++ b/packages/connectors/src/Sources/CriteoAds/Helper.js
@@ -12,11 +12,18 @@ var CriteoAdsHelper = {
    * @return {Object} Object with node names as keys and arrays of field names as values
    */
   parseFields(fieldsString) {
-    return fieldsString.split(", ").reduce((acc, pair) => {
-      let [key, value] = pair.split(" ");
-      (acc[key] = acc[key] || []).push(value.trim());
-      return acc;
-    }, {});
+    return String(fieldsString)
+      .split(',')
+      .map(pair => pair.trim())
+      .filter(Boolean)
+      .reduce((acc, pair) => {
+        const [key, value] = pair.split(/\s+/);
+        if (!key || !value) {
+          return acc;
+        }
+        (acc[key] = acc[key] || []).push(value.trim());
+        return acc;
+      }, {});
   },
 
   /**
@@ -27,6 +34,7 @@ var CriteoAdsHelper = {
   parseAdvertiserIds(advertiserIdsString) {
     return String(advertiserIdsString)
       .split(/[,;]\s*/)
-      .map(id => id.trim());
+      .map(id => id.trim())
+      .filter(Boolean);
   }
 };

--- a/packages/connectors/src/Sources/CriteoAds/README.md
+++ b/packages/connectors/src/Sources/CriteoAds/README.md
@@ -2,6 +2,19 @@
 
 The **Criteo Source** allows you to transfer raw data from Criteo advertising services. Use this data for in-depth analysis and reporting.
 
+## Available Endpoints
+
+| Endpoint | Description |
+| --- | --- |
+| `statistics` | Campaign performance metrics (clicks, displays, cost, sales, ROAS, and more) broken down by advertiser, campaign, adset, ad, day, and optional dimensions such as device, OS, and channel. |
+| `placements` | Performance metrics broken down by publisher placement and environment (Web, Android, iOS). |
+| `placement_categories` | Performance metrics broken down by content category. |
+| `transactions` | Transaction-level data with individual order details attributed to Criteo ads. |
+
+> **Note:** Breakdown by publisher **domain** is not available in the Criteo `2026-01` API.
+> For the closest equivalent, use the `placements` endpoint, which breaks performance down
+> by individual placement.
+
 ## Getting Started
 
 To begin, check out [**GETTING STARTED.md**](GETTING_STARTED.md) for step-by-step instructions.

--- a/packages/connectors/src/Sources/CriteoAds/Source.js
+++ b/packages/connectors/src/Sources/CriteoAds/Source.js
@@ -157,7 +157,7 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
    * @private
    */
   async _makeApiRequest(requestBody) {
-    const apiVersion = "2025-07";
+    const apiVersion = "2026-01";
     const apiUrl = `https://api.criteo.com/${apiVersion}/statistics/report`;
     const options = {
       method: 'post',

--- a/packages/connectors/src/Sources/CriteoAds/Source.js
+++ b/packages/connectors/src/Sources/CriteoAds/Source.js
@@ -5,6 +5,8 @@
  * file that was distributed with this source code.
  */
 
+const CRITEO_API_VERSION = "2026-01";
+
 var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
 
   constructor(configRange) {
@@ -60,6 +62,13 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
         description: "Your Criteo API Client Secret",
         attributes: [CONFIG_ATTRIBUTES.SECRET]
       },
+      Currency: {
+        requiredType: "string",
+        isRequired: true,
+        default: "USD",
+        label: "Currency",
+        description: "ISO 4217 code (e.g. USD, EUR). Supported currencies: developers.criteo.com/marketing-solutions/docs/campaign-statistics#currencies"
+      },
       CreateEmptyTables: {
         requiredType: "boolean",
         default: true,
@@ -86,8 +95,37 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
       case 'statistics':
         return await this._fetchStatistics({ accountId, fields, date });
 
+      case 'placements':
+        return await this._fetchPlacements({ accountId, fields, date });
+
+      case 'placement_categories':
+        return await this._fetchPlacementCategories({ accountId, fields, date });
+
+      case 'transactions':
+        return await this._fetchTransactions({ accountId, fields, date });
+
       default:
         throw new Error(`Unknown node: ${nodeName}`);
+    }
+  }
+
+  /**
+   * Ensure every unique key for a node is among the requested fields, so the API
+   * returns them and storage can dedupe correctly. Keys injected after fetch
+   * (e.g. 'day' for streams with injectDay) are exempt since they are not requested.
+   * @param {string} nodeName
+   * @param {Array<string>} fields
+   * @throws {Error} when a required unique key is missing
+   * @private
+   */
+  _validateUniqueKeys(nodeName, fields) {
+    const schema = this.fieldsSchema[nodeName];
+    const uniqueKeys = schema.uniqueKeys || [];
+    const injectedKeys = schema.injectDay ? ['day'] : [];
+    const missingKeys = uniqueKeys.filter(key => !injectedKeys.includes(key) && !fields.includes(key));
+
+    if (missingKeys.length > 0) {
+      throw new Error(`Missing required unique fields for endpoint '${nodeName}'. Missing fields: ${missingKeys.join(', ')}`);
     }
   }
 
@@ -101,21 +139,89 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
    * @private
    */
   async _fetchStatistics({ accountId, fields, date }) {
-    const uniqueKeys = this.fieldsSchema.statistics.uniqueKeys || [];
-    const missingKeys = uniqueKeys.filter(key => !fields.includes(key));
-    
-    if (missingKeys.length > 0) {
-      throw new Error(`Missing required unique fields for endpoint 'statistics'. Missing fields: ${missingKeys.join(', ')}`);
-    }
+    this._validateUniqueKeys('statistics', fields);
 
     await this.getAccessToken();
     
     const requestBody = this._buildStatisticsRequestBody({ accountId, fields, date });
-    const response = await this._makeApiRequest(requestBody);
+    const response = await this._makeApiRequest(`https://api.criteo.com/${CRITEO_API_VERSION}/statistics/report`, requestBody);
     const text = await response.getContentText();
     const jsonObject = JSON.parse(text);
-    
-    return this.parseApiResponse({ apiResponse: jsonObject, date, accountId, fields });
+
+    return this.parseApiResponse({ apiResponse: jsonObject, date, fields, nodeName: 'statistics' });
+  }
+
+  /**
+   * Fetching placement report data
+   * @param {Object} options
+   * @param {string} options.accountId
+   * @param {Array<string>} options.fields
+   * @param {Date} options.date
+   * @returns {Array<Object>}
+   * @private
+   */
+  async _fetchPlacements({ accountId, fields, date }) {
+    this._validateUniqueKeys('placements', fields);
+    await this.getAccessToken();
+    const requestBody = this._buildPlacementsRequestBody({ nodeName: 'placements', accountId, fields, date });
+    const apiUrl = `https://api.criteo.com/${CRITEO_API_VERSION}/placements/report`;
+    const response = await this._makeApiRequest(apiUrl, requestBody);
+    const text = await response.getContentText();
+    const jsonObject = JSON.parse(text);
+    return this.parseApiResponse({ apiResponse: jsonObject, date, fields, nodeName: 'placements' });
+  }
+
+  /**
+   * Fetching placement category report data
+   * @param {Object} options
+   * @param {string} options.accountId
+   * @param {Array<string>} options.fields
+   * @param {Date} options.date
+   * @returns {Array<Object>}
+   * @private
+   */
+  async _fetchPlacementCategories({ accountId, fields, date }) {
+    this._validateUniqueKeys('placement_categories', fields);
+    await this.getAccessToken();
+    const requestBody = this._buildPlacementCategoriesRequestBody({ accountId, date });
+    const apiUrl = `https://api.criteo.com/${CRITEO_API_VERSION}/categories/report`;
+    const response = await this._makeApiRequest(apiUrl, requestBody);
+    const text = await response.getContentText();
+    const jsonObject = JSON.parse(text);
+    return this.parseApiResponse({ apiResponse: jsonObject, date, fields, nodeName: 'placement_categories' });
+  }
+
+  /**
+   * Fetching transaction-level data
+   * @param {Object} options
+   * @param {string} options.accountId
+   * @param {Array<string>} options.fields
+   * @param {Date} options.date
+   * @returns {Array<Object>}
+   * @private
+   */
+  async _fetchTransactions({ accountId, fields, date }) {
+    this._validateUniqueKeys('transactions', fields);
+    await this.getAccessToken();
+    const formattedDate = DateUtils.formatDate(date);
+    const requestBody = {
+      data: [{
+        type: "report",
+        attributes: {
+          advertiserIds: accountId.toString(),
+          currency: this.config.Currency?.value || "USD",
+          timezone: "UTC",
+          format: "json",
+          startDate: formattedDate,
+          endDate: formattedDate
+        }
+      }]
+    };
+    const apiUrl = `https://api.criteo.com/${CRITEO_API_VERSION}/transactions/report`;
+    const response = await this._makeApiRequest(apiUrl, requestBody);
+    const text = await response.getContentText();
+    const jsonObject = JSON.parse(text);
+    return this.parseApiResponse({ apiResponse: jsonObject, date, fields, nodeName: 'transactions' });
   }
 
   /**
@@ -142,7 +248,7 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
       advertiserIds: accountId.toString(),
       timezone: "UTC",
       dimensions: dimensions,
-      currency: "USD", //@TODO currency in interface
+      currency: this.config.Currency?.value || "USD",
       format: "json",
       startDate: date,
       endDate: date,
@@ -151,14 +257,72 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
   }
 
   /**
-   * Make API request to statistics endpoint
+   * Build JSON:API request body for the placements/report endpoint.
+   * @param {Object} options
+   * @param {string} options.nodeName - 'placements'
+   * @param {string} options.accountId
+   * @param {Array<string>} options.fields
+   * @param {Date} options.date
+   * @returns {Object}
+   * @private
+   */
+  _buildPlacementsRequestBody({ nodeName, accountId, fields, date }) {
+    const fieldsSchema = this.fieldsSchema[nodeName].fields;
+    const formattedDate = DateUtils.formatDate(date);
+
+    const dimensions = fields.filter(f => fieldsSchema[f]?.fieldType === 'dimension');
+    const metrics = fields.filter(f => fieldsSchema[f]?.fieldType === 'metric');
+
+    return {
+      data: [{
+        type: "ReportOrder",
+        attributes: {
+          advertiserIds: accountId.toString(),
+          currency: this.config.Currency?.value || "USD",
+          timezone: "UTC",
+          dimensions,
+          metrics,
+          format: "json",
+          disclosed: "true",
+          startDate: formattedDate,
+          endDate: formattedDate
+        }
+      }]
+    };
+  }
+
+  /**
+   * Build request body for the categories/report endpoint.
+   * The category report has a fixed response schema, so requested fields are only
+   * applied when filtering the response before storage.
+   * @param {Object} options
+   * @param {string} options.accountId
+   * @param {Date} options.date
+   * @returns {Object}
+   * @private
+   */
+  _buildPlacementCategoriesRequestBody({ accountId, date }) {
+    const formattedDate = DateUtils.formatDate(date);
+
+    return {
+      data: {
+        startDate: formattedDate,
+        endDate: formattedDate,
+        advertiserIds: [accountId.toString()],
+        timezone: "UTC",
+        format: "json"
+      }
+    };
+  }
+
+  /**
+   * Make API request to a Criteo endpoint
+   * @param {string} url - Full API endpoint URL
    * @param {Object} requestBody - Request body
    * @returns {Object} - HTTP response
    * @private
    */
-  async _makeApiRequest(requestBody) {
-    const apiVersion = "2026-01";
-    const apiUrl = `https://api.criteo.com/${apiVersion}/statistics/report`;
+  async _makeApiRequest(url, requestBody) {
     const options = {
       method: 'post',
       headers: {
@@ -170,7 +334,7 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
       body: JSON.stringify(requestBody) // TODO: body is for Node.js; refactor to centralize JSON option creation
     };
 
-    const response = await this.urlFetchWithRetry(apiUrl, options);
+    const response = await this.urlFetchWithRetry(url, options);
     const responseCode = response.getResponseCode();
     
     if (responseCode === HTTP_STATUS.OK) {
@@ -248,19 +412,100 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
   }
 
   /**
-   * Parse API response and add date field
+   * Extract the row array from a Criteo report response, handling the known shapes:
+   *  - bare array: `[ {...}, ... ]`                         (statistics, categories)
+   *  - JSON:API envelope: `{ data: [ { attributes: { rows: [...] } } ] }`
+   *                                                          (placements)
+   *  - JSON:API per-row entries: `{ data: [ { attributes: { ...row } }, ... ] }`
+   *                                                          (transactions: one entry per row)
+   *  - legacy envelope: `{ Rows: [...] }`                    (kept for safety)
+   * @param {*} apiResponse - Parsed JSON response
+   * @returns {Array<Object>|null} Rows, or null when the shape is not recognized
+   * @private
+   */
+  _extractRows(apiResponse) {
+    if (Array.isArray(apiResponse)) {
+      return apiResponse;
+    }
+    if (Array.isArray(apiResponse?.Rows)) {
+      return apiResponse.Rows;
+    }
+    if (Array.isArray(apiResponse?.data)) {
+      const rows = [];
+      let unrecognizedEntries = false;
+      for (const entry of apiResponse.data) {
+        const attributes = entry?.attributes;
+        if (Array.isArray(attributes?.rows)) {
+          rows.push(...attributes.rows);
+        } else if (attributes && typeof attributes === 'object') {
+          // Entry without a rows container: attributes is the row itself.
+          rows.push(attributes);
+        } else {
+          unrecognizedEntries = true;
+        }
+      }
+      // `data` entries exist but none could be interpreted as rows:
+      // the envelope shape differs from what we expect — treat as unrecognized.
+      if (apiResponse.data.length > 0 && rows.length === 0 && unrecognizedEntries) {
+        return null;
+      }
+      return rows;
+    }
+    return null;
+  }
+
+  /**
+   * Describe an API response without logging row values or customer data.
+   * @param {*} apiResponse - Parsed JSON response
+   * @returns {string}
+   * @private
+   */
+  _describeApiResponseShape(apiResponse) {
+    if (Array.isArray(apiResponse)) {
+      return `array(length=${apiResponse.length})`;
+    }
+
+    if (apiResponse && typeof apiResponse === 'object') {
+      const keys = Object.keys(apiResponse);
+      const details = keys.map(key => {
+        const value = apiResponse[key];
+        if (Array.isArray(value)) {
+          return `${key}:array(length=${value.length})`;
+        }
+        if (value && typeof value === 'object') {
+          return `${key}:object(keys=${Object.keys(value).join(',')})`;
+        }
+        return `${key}:${typeof value}`;
+      });
+      return `object(keys=${keys.join(',')}; ${details.join('; ')})`;
+    }
+
+    return String(apiResponse === null ? 'null' : typeof apiResponse);
+  }
+
+  /**
+   * Parse API response, inject day for streams that need it, and filter by schema.
    * @param {Object} options - Parsing options
    * @param {Object} options.apiResponse - API response
-   * @param {Date} options.date - Date to add to each row
-   * @param {string} options.accountId - Account ID
+   * @param {Date} options.date - Date to inject if schema has injectDay
    * @param {Array<string>} options.fields - Fields to include in the result
+   * @param {string} options.nodeName - Schema node name
    * @returns {Array<Object>} - Parsed and enriched data
    */
-  parseApiResponse({ apiResponse, date, accountId, fields }) {
-    if (!apiResponse.Rows || !Array.isArray(apiResponse.Rows)) {
+  parseApiResponse({ apiResponse, date, fields, nodeName = 'statistics' }) {
+    let rows = this._extractRows(apiResponse);
+
+    if (rows === null) {
+      const responseShape = this._describeApiResponseShape(apiResponse);
+      this.config.logMessage(`Unexpected API response shape for '${nodeName}'; parsed 0 rows. Response shape: ${responseShape}`);
       return [];
     }
 
-    return this._filterBySchema(apiResponse.Rows, 'statistics', fields);
+    if (this.fieldsSchema[nodeName]?.injectDay) {
+      const dayStr = DateUtils.formatDate(date);
+      rows = rows.map(row => ({ ...row, day: dayStr }));
+    }
+
+    return this._filterBySchema(rows, nodeName, fields);
   }
 }

--- a/packages/connectors/src/Sources/CriteoAds/Source.js
+++ b/packages/connectors/src/Sources/CriteoAds/Source.js
@@ -6,6 +6,23 @@
  */
 
 const CRITEO_API_VERSION = "2026-01";
+// Source: Criteo v2026.01 Campaign Statistics docs, "Currencies" section.
+// Advisory only: membership produces a warning, not an error, because this
+// list drifts as Criteo adds currencies — the API is the authority.
+const CRITEO_SUPPORTED_CURRENCIES = new Set([
+  "EUR", "USD", "GBP", "CHF", "JPY", "BGN", "CZK", "DKK", "HUF", "LTL",
+  "PLN", "RON", "SEK", "NOK", "HRK", "RUB", "TRY", "AUD", "BRL", "CAD",
+  "CNY", "HKD", "IDR", "INR", "KRW", "MXN", "MYR", "NZD", "PHP", "SGD",
+  "THB", "ZAR", "ARS", "COP", "AED", "KZT", "SAR", "UAH", "EGP", "MAD",
+  "ILS", "BHD", "JOD", "KWD", "LBP", "OMR", "QAR", "NGN", "KES", "ALL",
+  "ETB", "BSD", "BDT", "BAM", "BWP", "MMK", "AFN", "BTN", "GEL", "GHS",
+  "GIP", "ISK", "KHR", "JMD", "LAK", "MKD", "MUR", "MNT", "NPR", "NAD",
+  "PKR", "RWF", "LKR", "SZL", "TZS", "TTD", "UGX", "ZMW", "BOB", "CRC",
+  "DOP", "GTQ", "HNL", "NIO", "PAB", "PYG", "PEN", "UYU", "VEF", "XAF",
+  "XOF", "HTG", "MGA", "DZD", "IQD", "LYD", "TND", "YER", "BND", "AOA",
+  "MZN", "AMD", "AZN", "KGS", "TJS", "UZS", "MDL", "RSD", "XPF", "MOP",
+  "VND", "TWD", "CLP"
+]);
 
 var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
 
@@ -67,7 +84,7 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
         isRequired: true,
         default: "USD",
         label: "Currency",
-        description: "ISO 4217 code (e.g. USD, EUR). Supported currencies: developers.criteo.com/marketing-solutions/docs/campaign-statistics#currencies"
+        description: "ISO 4217 code (e.g. USD, EUR). Supported currencies: https://developers.criteo.com/marketing-solutions/docs/campaign-statistics#currencies"
       },
       CreateEmptyTables: {
         requiredType: "boolean",
@@ -115,11 +132,16 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
    * (e.g. 'day' for streams with injectDay) are exempt since they are not requested.
    * @param {string} nodeName
    * @param {Array<string>} fields
-   * @throws {Error} when a required unique key is missing
+   * @throws {Error} when a field is unknown or a required unique key is missing
    * @private
    */
   _validateUniqueKeys(nodeName, fields) {
     const schema = this.fieldsSchema[nodeName];
+    const unknownFields = fields.filter(field => !Object.hasOwn(schema.fields, field));
+    if (unknownFields.length > 0) {
+      throw new Error(`Unknown fields for endpoint '${nodeName}': ${unknownFields.join(', ')}`);
+    }
+
     const uniqueKeys = schema.uniqueKeys || [];
     const injectedKeys = schema.injectDay ? ['day'] : [];
     const missingKeys = uniqueKeys.filter(key => !injectedKeys.includes(key) && !fields.includes(key));
@@ -127,6 +149,34 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
     if (missingKeys.length > 0) {
       throw new Error(`Missing required unique fields for endpoint '${nodeName}'. Missing fields: ${missingKeys.join(', ')}`);
     }
+  }
+
+  /**
+   * Normalize and validate the configured report currency before it reaches Criteo.
+   * Malformed codes fail fast; codes outside the known Criteo list only log a
+   * warning, since that list drifts and Criteo rejects unsupported codes with a
+   * clear API error anyway.
+   * @returns {string} ISO 4217 currency code
+   * @throws {Error} when Currency is not a three-letter ISO 4217 code
+   * @private
+   */
+  _getCurrency() {
+    if (this._currency) {
+      return this._currency;
+    }
+
+    const currency = String(this.config.Currency?.value || "USD").trim().toUpperCase();
+
+    if (!/^[A-Z]{3}$/.test(currency)) {
+      throw new Error(`Invalid Currency '${currency}'. Expected ISO 4217 code, e.g. USD.`);
+    }
+
+    if (!CRITEO_SUPPORTED_CURRENCIES.has(currency)) {
+      this.config.logMessage(`Currency '${currency}' is not in the known Criteo-supported list; passing it through. If the API rejects it, pick a supported code, e.g. USD, EUR, JPY.`);
+    }
+
+    this._currency = currency;
+    return currency;
   }
 
   /**
@@ -140,14 +190,12 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
    */
   async _fetchStatistics({ accountId, fields, date }) {
     this._validateUniqueKeys('statistics', fields);
-
     await this.getAccessToken();
-    
     const requestBody = this._buildStatisticsRequestBody({ accountId, fields, date });
-    const response = await this._makeApiRequest(`https://api.criteo.com/${CRITEO_API_VERSION}/statistics/report`, requestBody);
+    const apiUrl = `https://api.criteo.com/${CRITEO_API_VERSION}/statistics/report`;
+    const response = await this._makeApiRequest(apiUrl, requestBody);
     const text = await response.getContentText();
     const jsonObject = JSON.parse(text);
-
     return this.parseApiResponse({ apiResponse: jsonObject, date, fields, nodeName: 'statistics' });
   }
 
@@ -172,7 +220,10 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
   }
 
   /**
-   * Fetching placement category report data
+   * Fetching placement category report data.
+   * Uses the same /placements/report endpoint as the placements stream, with
+   * category dimensions: the dedicated categories endpoint does not exist in
+   * the 2026-01 OpenAPI spec and returns 404.
    * @param {Object} options
    * @param {string} options.accountId
    * @param {Array<string>} options.fields
@@ -183,8 +234,8 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
   async _fetchPlacementCategories({ accountId, fields, date }) {
     this._validateUniqueKeys('placement_categories', fields);
     await this.getAccessToken();
-    const requestBody = this._buildPlacementCategoriesRequestBody({ accountId, date });
-    const apiUrl = `https://api.criteo.com/${CRITEO_API_VERSION}/categories/report`;
+    const requestBody = this._buildPlacementsRequestBody({ nodeName: 'placement_categories', accountId, fields, date });
+    const apiUrl = `https://api.criteo.com/${CRITEO_API_VERSION}/placements/report`;
     const response = await this._makeApiRequest(apiUrl, requestBody);
     const text = await response.getContentText();
     const jsonObject = JSON.parse(text);
@@ -206,10 +257,10 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
     const formattedDate = DateUtils.formatDate(date);
     const requestBody = {
       data: [{
-        type: "report",
+        type: "Report",
         attributes: {
           advertiserIds: accountId.toString(),
-          currency: this.config.Currency?.value || "USD",
+          currency: this._getCurrency(),
           timezone: "UTC",
           format: "json",
           startDate: formattedDate,
@@ -235,31 +286,33 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
    */
   _buildStatisticsRequestBody({ accountId, fields, date }) {
     const fieldsSchema = this.fieldsSchema.statistics.fields;
-    
+    const formattedDate = DateUtils.formatDate(date);
+
     // Filter fields into dimensions and metrics based on fieldType
-    const dimensions = fields.filter(field => 
+    const dimensions = fields.filter(field =>
       fieldsSchema[field] && fieldsSchema[field].fieldType === 'dimension'
     );
-    const metrics = fields.filter(field => 
+    const metrics = fields.filter(field =>
       fieldsSchema[field] && fieldsSchema[field].fieldType === 'metric'
     );
-    
+
     return {
       advertiserIds: accountId.toString(),
       timezone: "UTC",
       dimensions: dimensions,
-      currency: this.config.Currency?.value || "USD",
+      currency: this._getCurrency(),
       format: "json",
-      startDate: date,
-      endDate: date,
+      startDate: formattedDate,
+      endDate: formattedDate,
       metrics: metrics
     };
   }
 
   /**
    * Build JSON:API request body for the placements/report endpoint.
+   * Used by both placements and placement_categories streams.
    * @param {Object} options
-   * @param {string} options.nodeName - 'placements'
+   * @param {string} options.nodeName - 'placements' or 'placement_categories'
    * @param {string} options.accountId
    * @param {Array<string>} options.fields
    * @param {Date} options.date
@@ -270,48 +323,26 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
     const fieldsSchema = this.fieldsSchema[nodeName].fields;
     const formattedDate = DateUtils.formatDate(date);
 
-    const dimensions = fields.filter(f => fieldsSchema[f]?.fieldType === 'dimension');
+    const dimensions = fields
+      .filter(f => fieldsSchema[f]?.fieldType === 'dimension')
+      .map(f => fieldsSchema[f].apiName || f);
     const metrics = fields.filter(f => fieldsSchema[f]?.fieldType === 'metric');
 
     return {
       data: [{
-        type: "ReportOrder",
+        type: "Report",
         attributes: {
           advertiserIds: accountId.toString(),
-          currency: this.config.Currency?.value || "USD",
+          currency: this._getCurrency(),
           timezone: "UTC",
           dimensions,
           metrics,
           format: "json",
-          disclosed: "true",
+          disclosed: true,
           startDate: formattedDate,
           endDate: formattedDate
         }
       }]
-    };
-  }
-
-  /**
-   * Build request body for the categories/report endpoint.
-   * The category report has a fixed response schema, so requested fields are only
-   * applied when filtering the response before storage.
-   * @param {Object} options
-   * @param {string} options.accountId
-   * @param {Date} options.date
-   * @returns {Object}
-   * @private
-   */
-  _buildPlacementCategoriesRequestBody({ accountId, date }) {
-    const formattedDate = DateUtils.formatDate(date);
-
-    return {
-      data: {
-        startDate: formattedDate,
-        endDate: formattedDate,
-        advertiserIds: [accountId.toString()],
-        timezone: "UTC",
-        format: "json"
-      }
     };
   }
 
@@ -334,15 +365,7 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
       body: JSON.stringify(requestBody) // TODO: body is for Node.js; refactor to centralize JSON option creation
     };
 
-    const response = await this.urlFetchWithRetry(url, options);
-    const responseCode = response.getResponseCode();
-    
-    if (responseCode === HTTP_STATUS.OK) {
-      return response;
-    } else {
-      const text = await response.getContentText();
-      throw new Error(`API Error (${responseCode}): ${text}`);
-    }
+    return await this.urlFetchWithRetry(url, options);
   }
 
   /**
@@ -372,13 +395,13 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
         .join('&'), // TODO: body is for Node.js; refactor to centralize JSON option creation
       muteHttpExceptions: true
     };
-    
+
     try {
       const response = await this.urlFetchWithRetry(tokenUrl, options);
       const text = await response.getContentText();
       const responseData = JSON.parse(text);
       const accessToken = responseData["access_token"];
-      
+
       this.config.AccessToken = {
         value: accessToken
       };
@@ -390,6 +413,10 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
 
   /**
    * Keep only requestedFields plus any schema-required keys.
+   * Response keys are matched to canonical schema field names case-insensitively,
+   * because Criteo's report responses echo field names in unpredictable casing
+   * (e.g. `AdvertiserId`, `adSetId`). This protects unique keys from being dropped
+   * — and dedup from silently breaking — when the API casing differs from the schema.
    * @param {Array<Object>} items
    * @param {string} nodeName
    * @param {Array<string>} requestedFields
@@ -399,12 +426,15 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
     const schema = this.fieldsSchema[nodeName];
     const requiredFields = new Set(schema.uniqueKeys || []);
     const keepFields = new Set([ ...requiredFields, ...requestedFields ]);
+    const keyResolver = this._buildKeyResolver(schema);
 
     return items.map(item => {
       const result = {};
       for (const key of Object.keys(item)) {
-        if (keepFields.has(key)) {
-          result[key] = item[key];
+        const canonicalKey = keyResolver[key.toLowerCase()] || key;
+        // An exact-case canonical key always wins over a differently-cased variant.
+        if (keepFields.has(canonicalKey) && (canonicalKey === key || !(canonicalKey in result))) {
+          result[canonicalKey] = item[key];
         }
       }
       return result;
@@ -412,10 +442,28 @@ var CriteoAdsSource = class CriteoAdsSource extends AbstractSource {
   }
 
   /**
+   * Build a case-insensitive map of response keys to canonical schema field names.
+   * Includes each canonical field name and any explicitly declared aliases.
+   * @param {Object} schema
+   * @returns {Object<string, string>} Map of lowercased response key to canonical field name
+   * @private
+   */
+  _buildKeyResolver(schema) {
+    const resolver = {};
+    for (const [fieldName, fieldConfig] of Object.entries(schema.fields || {})) {
+      resolver[fieldName.toLowerCase()] = fieldName;
+      for (const alias of fieldConfig.aliases || []) {
+        resolver[alias.toLowerCase()] = fieldName;
+      }
+    }
+    return resolver;
+  }
+
+  /**
    * Extract the row array from a Criteo report response, handling the known shapes:
-   *  - bare array: `[ {...}, ... ]`                         (statistics, categories)
+   *  - bare array: `[ {...}, ... ]`                         (statistics)
    *  - JSON:API envelope: `{ data: [ { attributes: { rows: [...] } } ] }`
-   *                                                          (placements)
+   *                                                          (placements, categories)
    *  - JSON:API per-row entries: `{ data: [ { attributes: { ...row } }, ... ] }`
    *                                                          (transactions: one entry per row)
    *  - legacy envelope: `{ Rows: [...] }`                    (kept for safety)


### PR DESCRIPTION
# Problem

The Criteo connector exposed only a single `statistics` endpoint, pinned to API version `2025-07`, with the reporting currency hardcoded to USD. Customers could not break performance down by publisher placement or content category, could not pull attributed transaction-level data, and always received cost/revenue figures in USD regardless of their account currency. The response parser also failed silently: any unrecognized response shape was treated as "no data", so a misconfigured stream produced a successful run with empty tables instead of an error.

# Solution

Three new report streams were added on top of the verified Criteo `2026-01` OpenAPI spec, with the API version centralized in a single constant. During live testing the documented endpoints turned out to diverge from the spec (the dedicated categories endpoint returns 404, response envelopes differ per endpoint, and field casing is inconsistent), so the integration was hardened structurally rather than per-case:

- `placement_categories` reuses the spec-confirmed `/placements/report` endpoint with category dimensions, since `/categories/report` does not exist in `2026-01`.
- Response parsing recognizes all observed envelope shapes (bare array, JSON:API `data[].attributes.rows`, per-row `data[].attributes`, legacy `Rows`) and logs a PII-free shape description instead of silently returning zero rows when the shape is unknown.
- Response keys are matched case-insensitively against the schema (with optional `apiName` for request-side mapping), so unique keys cannot be silently dropped by casing drift — which would otherwise corrupt storage dedup.
- Unique-key and unknown-field validation runs before every fetch, failing fast with a clear error.
- The new `Currency` config validates format as a hard error but treats the known-currency list as advisory (warning only), since the list drifts and the API is the authority.
- Storage config is now built per node without mutating the shared connector config, scoping fields to the current stream.

# Changes

- Added `placements`, `placement_categories`, and `transactions` streams with field schemas, unique keys, and default fields (`Source.js`, `CriteoAdsFieldsSchema.js`, `placementFields.js`, `placementCategoryFields.js`, `transactionFields.js`)
- Bumped the Criteo API version from `2025-07` to `2026-01` via a single `CRITEO_API_VERSION` constant
- Added 10 dimensions to the statistics stream: Device, Os, Channel/ChannelId, Category/CategoryId, Coupon/CouponId, MarketingObjective/MarketingObjectiveId (`adStatisticsFields.js`)
- Added a `Currency` config parameter (default USD) with ISO 4217 format validation and an advisory supported-currency warning, replacing the hardcoded USD
- Added multi-shape response-row extraction with a logged, value-free shape warning for unrecognized responses
- Added case-insensitive response-key normalization and request-side `apiName` mapping to protect unique keys from API casing inconsistencies
- Added pre-fetch validation of unknown fields and missing unique keys for all streams
- Generalized `_makeApiRequest` to accept the endpoint URL and removed its redundant status check (handled by `urlFetchWithRetry`)
- Scoped storage config per node with unique keys always included, without mutating the shared connector config (`Connector.js`)
- Hardened `parseFields`/`parseAdvertiserIds` against malformed separators and empty entries (`Helper.js`)
- Documented all four endpoints and the unavailability of domain-level breakdown in `2026-01` (`README.md`, `GETTING_STARTED.md`)
- Added changeset `criteo-new-endpoints-and-currency`