### PR TITLE
fix(web): surface validation errors hidden in collapsed form sections

### DIFF
--- a/.changeset/report-form-invalid-submit-guard.md
+++ b/.changeset/report-form-invalid-submit-guard.md
@@ -1,0 +1,7 @@
+---
+"owox": minor
+---
+
+# Surface validation errors hidden in collapsed form sections
+
+Improved form validation UX so submitting a form opens collapsed sections that contain invalid fields and focuses the first validation error.

--- a/apps/web/e2e/selectors/testids.ts
+++ b/apps/web/e2e/selectors/testids.ts
@@ -54,6 +54,9 @@ export const TESTIDS = {
   notifToggle: 'notifToggle',
   notifEditSheet: 'notifEditSheet',
 
+  // Form validation
+  formSectionErrorIndicator: 'form-section-error-indicator',
+
   // FloatingPopover domain
   floatingPopoverClose: 'floatingPopoverClose',
 

--- a/apps/web/e2e/specs/storage.spec.ts
+++ b/apps/web/e2e/specs/storage.spec.ts
@@ -232,6 +232,48 @@ describeIfCredentials(['AWS_ACCESS_KEY_ID', 'AWS_REGION'], 'Athena Config Save',
 });
 
 // ---------------------------------------------------------------------------
+// STOR-08: Collapsed section with errors auto-opens on failed submit
+// ---------------------------------------------------------------------------
+
+test.describe('Storage Form — Collapsed Section Validation', () => {
+  test('auto-opens collapsed General section and shows error indicator on failed submit', async ({
+    page,
+    apiHelpers,
+  }) => {
+    await apiHelpers.createStorage('GOOGLE_BIGQUERY');
+    await page.goto('/ui/0/data-storages');
+    await expect(page.getByTestId(TESTIDS.storageListPage)).toBeVisible();
+
+    await page.getByRole('button', { name: 'Open menu' }).first().click();
+    await page.getByRole('menuitem', { name: 'Edit' }).click();
+    await expect(page.getByTestId(TESTIDS.storageEditForm)).toBeVisible();
+
+    const form = page.getByTestId(TESTIDS.storageEditForm);
+    const titleInput = form.getByLabel('Title');
+
+    // Clear title to create a validation error inside "General"
+    await titleInput.click();
+    await titleInput.fill('');
+
+    // Collapse the "General" section
+    await form.getByRole('button', { name: /general/i }).click();
+    await expect(titleInput).not.toBeVisible();
+
+    // Submit with a collapsed section that contains errors
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    // Section must auto-open and expose the invalid field
+    await expect(titleInput).toBeVisible({ timeout: 3000 });
+
+    // Error indicator must appear in at least one section header (General, and possibly others)
+    await expect(form.getByTestId(TESTIDS.formSectionErrorIndicator).first()).toBeVisible();
+
+    // Inline validation message must be visible
+    await expect(form.getByText('Title is required')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // STOR-06: Delete storage with confirmation dialog
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/DataDestinationForm.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/DataDestinationForm.tsx
@@ -39,7 +39,7 @@ import {
   AccordionTrigger,
 } from '@owox/ui/components/accordion';
 
-import { createFormPayload } from '../../../../../utils';
+import { createFormPayload, focusFirstInvalidField } from '../../../../../utils';
 import { COPY_SOURCE_CREDENTIAL_PLACEHOLDER } from '../../../../../shared/utils/credential-identity-utils';
 import {
   DataDestinationType,
@@ -220,7 +220,7 @@ export function DataDestinationForm({
     <Form {...form}>
       <AppForm
         onSubmit={e => {
-          void form.handleSubmit(handleSubmit)(e);
+          void form.handleSubmit(handleSubmit, focusFirstInvalidField)(e);
         }}
       >
         <FormLayout>

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
@@ -1013,7 +1013,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
             </FormLayout>
             <ReportFormActions
               mode={mode}
-              isSubmitting={isSubmitting}
+              isSubmitting={isSubmitting || form.formState.isSubmitting}
               isDirty={isDirty}
               triggersDirty={triggersDirty}
               ownersDirty={ownersDirty}

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useEffect, useMemo, useState, useRef } from 'react';
 import { useOwnerState } from '../../../../../../shared/hooks/useOwnerState';
+import { focusFirstInvalidField } from '../../../../../../utils';
 import { UserReference } from '../../../../../../shared/components/UserReference/UserReference';
 import { useUser } from '../../../../../idp/hooks/useAuthState';
 import { useNavigate, Link } from 'react-router-dom';
@@ -220,7 +221,6 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
 
     const {
       isDirty,
-      isValid,
       reset,
       form,
       isSubmitting,
@@ -391,7 +391,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
             ref={ref}
             noValidate
             onSubmit={e => {
-              void form.handleSubmit(handleFormSubmit)(e);
+              void form.handleSubmit(handleFormSubmit, focusFirstInvalidField)(e);
             }}
           >
             <FormLayout>
@@ -911,30 +911,54 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
                 title='Report Columns'
                 tooltip='Select which columns to include in the report'
                 titleAdornment={<ReportColumnsCountBadge count={columnsCount} />}
+                fields={['columnConfig', 'filterConfig', 'sortConfig', 'limitConfig']}
               >
-                {dataMart?.id && (
-                  <div className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
-                    <ReportColumnPicker
-                      dataMartId={dataMart.id}
-                      storageType={dataMart.storage.type}
-                      value={form.watch('columnConfig')}
-                      onChange={value => {
-                        form.setValue('columnConfig', value, { shouldDirty: true });
-                      }}
-                      outputConfig={{
-                        filterConfig: form.watch('filterConfig') ?? [],
-                        sortConfig: form.watch('sortConfig') ?? [],
-                        limitConfig: form.watch('limitConfig') ?? null,
-                      }}
-                      onOutputConfigChange={config => {
-                        form.setValue('filterConfig', config.filterConfig, { shouldDirty: true });
-                        form.setValue('sortConfig', config.sortConfig, { shouldDirty: true });
-                        form.setValue('limitConfig', config.limitConfig, { shouldDirty: true });
-                      }}
-                      onCountChange={setColumnsCount}
-                    />
-                  </div>
-                )}
+                <FormField
+                  control={form.control}
+                  name='columnConfig'
+                  render={() => (
+                    <FormItem>
+                      {dataMart?.id && (
+                        <FormControl>
+                          <div
+                            className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'
+                            tabIndex={-1}
+                          >
+                            <ReportColumnPicker
+                              dataMartId={dataMart.id}
+                              storageType={dataMart.storage.type}
+                              value={form.watch('columnConfig')}
+                              onChange={value => {
+                                form.setValue('columnConfig', value, {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                              }}
+                              outputConfig={{
+                                filterConfig: form.watch('filterConfig') ?? [],
+                                sortConfig: form.watch('sortConfig') ?? [],
+                                limitConfig: form.watch('limitConfig') ?? null,
+                              }}
+                              onOutputConfigChange={config => {
+                                form.setValue('filterConfig', config.filterConfig, {
+                                  shouldDirty: true,
+                                });
+                                form.setValue('sortConfig', config.sortConfig, {
+                                  shouldDirty: true,
+                                });
+                                form.setValue('limitConfig', config.limitConfig, {
+                                  shouldDirty: true,
+                                });
+                              }}
+                              onCountChange={setColumnsCount}
+                            />
+                          </div>
+                        </FormControl>
+                      )}
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
               </FormSection>
 
               <FormSection title='Automate Report Runs'>
@@ -991,11 +1015,10 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
               mode={mode}
               isSubmitting={isSubmitting}
               isDirty={isDirty}
-              isValid={isValid}
               triggersDirty={triggersDirty}
               ownersDirty={ownersDirty}
               runAfterSaveRef={runAfterSaveRef}
-              onSubmit={() => void form.handleSubmit(handleFormSubmit)()}
+              onSubmit={() => void form.handleSubmit(handleFormSubmit, focusFirstInvalidField)()}
               onCancel={onCancel}
             />
           </AppForm>

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useEffect, useState, useRef } from 'react';
 import { useOwnerState } from '../../../../../../shared/hooks';
+import { focusFirstInvalidField } from '../../../../../../utils';
 import { UserReference } from '../../../../../../shared/components/UserReference';
 import { useUser } from '../../../../../idp';
 import { Input } from '@owox/ui/components/input';
@@ -154,7 +155,6 @@ export const GoogleSheetsReportEditForm = forwardRef<
 
     const {
       isDirty,
-      isValid,
       reset,
       form,
       isSubmitting,
@@ -242,7 +242,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
           id={formId}
           ref={ref}
           noValidate
-          onSubmit={e => void form.handleSubmit(handleFormSubmit)(e)}
+          onSubmit={e => void form.handleSubmit(handleFormSubmit, focusFirstInvalidField)(e)}
         >
           <FormLayout>
             <FormSection title='General'>
@@ -430,30 +430,54 @@ export const GoogleSheetsReportEditForm = forwardRef<
               title='Report Columns'
               tooltip='Select which columns to include in the report'
               titleAdornment={<ReportColumnsCountBadge count={columnsCount} />}
+              fields={['columnConfig', 'filterConfig', 'sortConfig', 'limitConfig']}
             >
-              {dataMart?.id && (
-                <div className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
-                  <ReportColumnPicker
-                    dataMartId={dataMart.id}
-                    storageType={dataMart.storage.type}
-                    value={form.watch('columnConfig')}
-                    onChange={value => {
-                      form.setValue('columnConfig', value, { shouldDirty: true });
-                    }}
-                    outputConfig={{
-                      filterConfig: form.watch('filterConfig') ?? [],
-                      sortConfig: form.watch('sortConfig') ?? [],
-                      limitConfig: form.watch('limitConfig') ?? null,
-                    }}
-                    onOutputConfigChange={config => {
-                      form.setValue('filterConfig', config.filterConfig, { shouldDirty: true });
-                      form.setValue('sortConfig', config.sortConfig, { shouldDirty: true });
-                      form.setValue('limitConfig', config.limitConfig, { shouldDirty: true });
-                    }}
-                    onCountChange={setColumnsCount}
-                  />
-                </div>
-              )}
+              <FormField
+                control={form.control}
+                name='columnConfig'
+                render={() => (
+                  <FormItem>
+                    {dataMart?.id && (
+                      <FormControl>
+                        <div
+                          className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'
+                          tabIndex={-1}
+                        >
+                          <ReportColumnPicker
+                            dataMartId={dataMart.id}
+                            storageType={dataMart.storage.type}
+                            value={form.watch('columnConfig')}
+                            onChange={value => {
+                              form.setValue('columnConfig', value, {
+                                shouldDirty: true,
+                                shouldValidate: true,
+                              });
+                            }}
+                            outputConfig={{
+                              filterConfig: form.watch('filterConfig') ?? [],
+                              sortConfig: form.watch('sortConfig') ?? [],
+                              limitConfig: form.watch('limitConfig') ?? null,
+                            }}
+                            onOutputConfigChange={config => {
+                              form.setValue('filterConfig', config.filterConfig, {
+                                shouldDirty: true,
+                              });
+                              form.setValue('sortConfig', config.sortConfig, {
+                                shouldDirty: true,
+                              });
+                              form.setValue('limitConfig', config.limitConfig, {
+                                shouldDirty: true,
+                              });
+                            }}
+                            onCountChange={setColumnsCount}
+                          />
+                        </div>
+                      </FormControl>
+                    )}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </FormSection>
             <FormSection title='Automate Report Runs'>
               {dataMart?.id ? (
@@ -505,11 +529,10 @@ export const GoogleSheetsReportEditForm = forwardRef<
             mode={mode}
             isSubmitting={isSubmitting}
             isDirty={isDirty}
-            isValid={isValid}
             triggersDirty={triggersDirty}
             ownersDirty={ownersDirty}
             runAfterSaveRef={runAfterSaveRef}
-            onSubmit={() => void form.handleSubmit(handleFormSubmit)()}
+            onSubmit={() => void form.handleSubmit(handleFormSubmit, focusFirstInvalidField)()}
             onCancel={onCancel}
           />
         </AppForm>

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -527,7 +527,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
 
           <ReportFormActions
             mode={mode}
-            isSubmitting={isSubmitting}
+            isSubmitting={isSubmitting || form.formState.isSubmitting}
             isDirty={isDirty}
             triggersDirty={triggersDirty}
             ownersDirty={ownersDirty}

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useEffect, useState } from 'react';
 import { useOwnerState } from '../../../../../../shared/hooks';
+import { focusFirstInvalidField } from '../../../../../../utils';
 import { UserReference } from '../../../../../../shared/components/UserReference';
 import { useUser } from '../../../../../idp';
 
@@ -116,7 +117,6 @@ export const LookerStudioReportEditForm = forwardRef<
 
     const {
       isDirty,
-      isValid,
       reset,
       form,
       isSubmitting,
@@ -174,7 +174,7 @@ export const LookerStudioReportEditForm = forwardRef<
           id={formId}
           ref={ref}
           noValidate
-          onSubmit={e => void form.handleSubmit(handleFormSubmit)(e)}
+          onSubmit={e => void form.handleSubmit(handleFormSubmit, focusFirstInvalidField)(e)}
         >
           <FormLayout>
             <FormSection title='Cache Configuration'>
@@ -219,42 +219,69 @@ export const LookerStudioReportEditForm = forwardRef<
               title='Report Columns'
               tooltip='Select which columns to include in the report'
               titleAdornment={<ReportColumnsCountBadge count={columnsCount} />}
+              fields={['columnConfig', 'filterConfig', 'sortConfig', 'limitConfig']}
             >
-              {dataMart?.id && (
-                <div className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'>
-                  <ReportColumnPicker
-                    dataMartId={dataMart.id}
-                    storageType={dataMart.storage.type}
-                    value={form.watch('columnConfig')}
-                    onChange={value => {
-                      form.setValue('columnConfig', value, { shouldDirty: true });
-                    }}
-                    outputConfig={{
-                      filterConfig: form.watch('filterConfig') ?? [],
-                      sortConfig: form.watch('sortConfig') ?? [],
-                      limitConfig: form.watch('limitConfig') ?? null,
-                    }}
-                    onOutputConfigChange={config => {
-                      form.setValue('filterConfig', config.filterConfig, { shouldDirty: true });
-                      form.setValue('sortConfig', config.sortConfig, { shouldDirty: true });
-                      form.setValue('limitConfig', config.limitConfig, { shouldDirty: true });
-                    }}
-                    onCountChange={setColumnsCount}
-                  />
-                  {mode === ReportFormMode.EDIT &&
-                    initialReport?.id &&
-                    dataMart.id &&
-                    isGeneratedSqlSupported(dataMart.definitionType, dataMart.storage.type) && (
-                      <div className='pt-1'>
-                        <GeneratedSqlViewer
-                          reportId={initialReport.id}
-                          dataMartId={dataMart.id}
-                          variant='outline-button'
-                        />
-                      </div>
+              <FormField
+                control={form.control}
+                name='columnConfig'
+                render={() => (
+                  <FormItem>
+                    {dataMart?.id && (
+                      <FormControl>
+                        <div
+                          className='border-border space-y-3 rounded-md border-b bg-white px-4 py-3 dark:border-transparent dark:bg-white/4'
+                          tabIndex={-1}
+                        >
+                          <ReportColumnPicker
+                            dataMartId={dataMart.id}
+                            storageType={dataMart.storage.type}
+                            value={form.watch('columnConfig')}
+                            onChange={value => {
+                              form.setValue('columnConfig', value, {
+                                shouldDirty: true,
+                                shouldValidate: true,
+                              });
+                            }}
+                            outputConfig={{
+                              filterConfig: form.watch('filterConfig') ?? [],
+                              sortConfig: form.watch('sortConfig') ?? [],
+                              limitConfig: form.watch('limitConfig') ?? null,
+                            }}
+                            onOutputConfigChange={config => {
+                              form.setValue('filterConfig', config.filterConfig, {
+                                shouldDirty: true,
+                              });
+                              form.setValue('sortConfig', config.sortConfig, {
+                                shouldDirty: true,
+                              });
+                              form.setValue('limitConfig', config.limitConfig, {
+                                shouldDirty: true,
+                              });
+                            }}
+                            onCountChange={setColumnsCount}
+                          />
+                          {mode === ReportFormMode.EDIT &&
+                            initialReport?.id &&
+                            dataMart.id &&
+                            isGeneratedSqlSupported(
+                              dataMart.definitionType,
+                              dataMart.storage.type
+                            ) && (
+                              <div className='pt-1'>
+                                <GeneratedSqlViewer
+                                  reportId={initialReport.id}
+                                  dataMartId={dataMart.id}
+                                  variant='outline-button'
+                                />
+                              </div>
+                            )}
+                        </div>
+                      </FormControl>
                     )}
-                </div>
-              )}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </FormSection>
 
             <FormSection title='Ownership'>
@@ -295,11 +322,10 @@ export const LookerStudioReportEditForm = forwardRef<
               type='submit'
               className='w-full'
               aria-label={mode === ReportFormMode.CREATE ? 'Create' : 'Save changes'}
-              // `disabled` logic is duplicated intentionally and needs to be synchronized manually
-              disabled={
-                isSubmitting ||
-                (mode === ReportFormMode.CREATE ? !isValid : !isDirty && !ownersDirty)
-              }
+              // In CREATE mode the button stays clickable even while the form is
+              // invalid: submitting surfaces validation errors instead of leaving
+              // the user with a disabled button and no hint about what is missing.
+              disabled={isSubmitting || (mode === ReportFormMode.EDIT && !isDirty && !ownersDirty)}
             >
               {isSubmitting
                 ? mode === ReportFormMode.CREATE

--- a/apps/web/src/features/data-marts/reports/edit/components/shared/ReportFormActions.test.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/shared/ReportFormActions.test.tsx
@@ -60,4 +60,67 @@ describe('ReportFormActions', () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
+
+  it('releases the primary submit guard after an invalid submit cycle', () => {
+    const onSubmit = vi.fn();
+    const runAfterSaveRef = { current: false };
+    const { rerender } = render(
+      <form
+        onSubmit={event => {
+          event.preventDefault();
+          onSubmit();
+        }}
+      >
+        <ReportFormActions
+          mode={ReportFormMode.CREATE}
+          isSubmitting={false}
+          isDirty={false}
+          triggersDirty={false}
+          runAfterSaveRef={runAfterSaveRef}
+          onSubmit={vi.fn()}
+        />
+      </form>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create & Run report' }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <form
+        onSubmit={event => {
+          event.preventDefault();
+          onSubmit();
+        }}
+      >
+        <ReportFormActions
+          mode={ReportFormMode.CREATE}
+          isSubmitting={true}
+          isDirty={false}
+          triggersDirty={false}
+          runAfterSaveRef={runAfterSaveRef}
+          onSubmit={vi.fn()}
+        />
+      </form>
+    );
+    rerender(
+      <form
+        onSubmit={event => {
+          event.preventDefault();
+          onSubmit();
+        }}
+      >
+        <ReportFormActions
+          mode={ReportFormMode.CREATE}
+          isSubmitting={false}
+          isDirty={false}
+          triggersDirty={false}
+          runAfterSaveRef={runAfterSaveRef}
+          onSubmit={vi.fn()}
+        />
+      </form>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create & Run report' }));
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/src/features/data-marts/reports/edit/components/shared/ReportFormActions.test.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/shared/ReportFormActions.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { ReportFormMode } from '../../../shared';
+import { ReportFormActions } from './ReportFormActions';
+
+function renderActions(props: Partial<Parameters<typeof ReportFormActions>[0]> = {}) {
+  return render(
+    <ReportFormActions
+      mode={ReportFormMode.CREATE}
+      isSubmitting={false}
+      isDirty={false}
+      triggersDirty={false}
+      runAfterSaveRef={{ current: false }}
+      onSubmit={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+describe('ReportFormActions', () => {
+  it('keeps the primary button clickable in CREATE mode so submit can surface validation errors', () => {
+    renderActions({ mode: ReportFormMode.CREATE });
+
+    expect(screen.getByRole('button', { name: 'Create & Run report' })).toBeEnabled();
+  });
+
+  it('disables the primary button while submitting', () => {
+    renderActions({ mode: ReportFormMode.CREATE, isSubmitting: true });
+
+    expect(screen.getByRole('button', { name: 'Create & Run report' })).toBeDisabled();
+  });
+
+  it('disables the primary button in EDIT mode when nothing changed', () => {
+    renderActions({ mode: ReportFormMode.EDIT });
+
+    expect(screen.getByRole('button', { name: 'Save changes to report' })).toBeDisabled();
+  });
+
+  it('enables the primary button in EDIT mode when the form is dirty', () => {
+    renderActions({ mode: ReportFormMode.EDIT, isDirty: true });
+
+    expect(screen.getByRole('button', { name: 'Save changes to report' })).toBeEnabled();
+  });
+
+  it('prevents double-submit via dropdown before isSubmitting prop updates', async () => {
+    const onSubmit = vi.fn();
+    renderActions({ mode: ReportFormMode.CREATE, onSubmit });
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'More actions' }));
+    const item1 = await within(document.body).findByText('Create new report');
+    fireEvent.click(item1);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    // isSubmitting prop is still false — simulate the race window
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'More actions' }));
+    await waitFor(() => within(document.body).findByText('Create new report'));
+    const item2 = within(document.body).getByText('Create new report');
+    fireEvent.click(item2);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/data-marts/reports/edit/components/shared/ReportFormActions.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/shared/ReportFormActions.tsx
@@ -9,13 +9,13 @@ import {
 } from '@owox/ui/components/dropdown-menu';
 import { ChevronDown } from 'lucide-react';
 import { ReportFormMode } from '../../../shared';
+import { useRef, useEffect } from 'react';
 import type { RefObject } from 'react';
 
 export interface ReportFormActionsProps {
   mode: ReportFormMode;
   isSubmitting: boolean;
   isDirty: boolean;
-  isValid: boolean;
   triggersDirty: boolean;
   ownersDirty?: boolean;
   runAfterSaveRef: RefObject<boolean>;
@@ -27,16 +27,27 @@ export const ReportFormActions = ({
   mode,
   isSubmitting,
   isDirty,
-  isValid,
   triggersDirty,
   ownersDirty = false,
   runAfterSaveRef,
   onSubmit,
   onCancel,
 }: ReportFormActionsProps) => {
+  // Guards against double-submit during the window between the first click and
+  // the parent updating isSubmitting to true (async resolver latency).
+  const submitPendingRef = useRef(false);
+  useEffect(() => {
+    if (!isSubmitting) {
+      submitPendingRef.current = false;
+    }
+  }, [isSubmitting]);
+
+  // In CREATE mode the button stays clickable even while the form is invalid:
+  // submitting runs validation, which opens collapsed sections with errors and
+  // focuses the first invalid field. Disabling on !isValid would leave the user
+  // with no hint about what is missing.
   const disabledPrimary =
-    isSubmitting ||
-    (mode === ReportFormMode.CREATE ? !isValid : !(isDirty || triggersDirty || ownersDirty));
+    isSubmitting || (mode === ReportFormMode.EDIT && !(isDirty || triggersDirty || ownersDirty));
 
   const primaryLabel =
     mode === ReportFormMode.CREATE ? 'Create & Run report' : 'Save changes to report';
@@ -56,7 +67,12 @@ export const ReportFormActions = ({
           type='submit'
           disabled={disabledPrimary}
           className='flex-1'
-          onClick={() => {
+          onClick={e => {
+            if (submitPendingRef.current) {
+              e.preventDefault();
+              return;
+            }
+            submitPendingRef.current = true;
             // For CREATE: run after save. For EDIT: don't run
             runAfterSaveRef.current = mode === ReportFormMode.CREATE;
           }}
@@ -82,6 +98,8 @@ export const ReportFormActions = ({
           <DropdownMenuContent align='end' side='top'>
             <DropdownMenuItem
               onClick={() => {
+                if (submitPendingRef.current || isSubmitting) return;
+                submitPendingRef.current = true;
                 // For CREATE: don't run. For EDIT: run after save
                 runAfterSaveRef.current = mode === ReportFormMode.EDIT;
                 onSubmit();

--- a/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useEmailReportForm.test.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useEmailReportForm.test.ts
@@ -20,7 +20,7 @@ vi.mock('../../../../../data-marts/reports/shared/model/hooks/useReport', () => 
 }));
 
 import { useReport } from '../../../../../data-marts/reports/shared/model/hooks/useReport';
-import { useEmailReportForm } from '../useEmailReportForm';
+import { useEmailReportForm, EmailReportEditFormSchema } from '../useEmailReportForm';
 import { ReportFormMode, TemplateSourceTypeEnum } from '../../../shared';
 import { DestinationTypeConfigEnum } from '../../../shared/enums/destination-type-config.enum';
 import { ReportConditionEnum } from '../../../shared/enums/report-condition.enum';
@@ -94,6 +94,43 @@ beforeEach(() => {
   setupUseReportMock();
   mockCreateReport.mockResolvedValue(buildReport({ id: 'created-1' }));
   mockUpdateReport.mockResolvedValue(buildReport({ id: 'updated-1' }));
+});
+
+const validEmailFormData = {
+  title: 'Test Report',
+  dataDestinationId: 'dest-1',
+  reportCondition: ReportConditionEnum.ALWAYS,
+  subject: 'Weekly',
+  templateSourceType: TemplateSourceTypeEnum.CUSTOM_MESSAGE,
+  messageTemplate: 'Hello',
+  columnConfig: ['col_a'],
+  filterConfig: null,
+  sortConfig: null,
+  limitConfig: null,
+};
+
+describe('EmailReportEditFormSchema — columnConfig validation', () => {
+  it('rejects an empty array with the expected message', async () => {
+    const result = await EmailReportEditFormSchema.safeParseAsync({
+      ...validEmailFormData,
+      columnConfig: [],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues.find(i => i.path.includes('columnConfig'))?.message;
+      expect(msg).toBe('At least one column must be selected');
+    }
+  });
+
+  it('accepts null (no columns configured yet)', async () => {
+    const result = await EmailReportEditFormSchema.safeParseAsync({
+      ...validEmailFormData,
+      columnConfig: null,
+    });
+
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('useEmailReportForm — defaults', () => {

--- a/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useGoogleSheetsReportForm.test.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useGoogleSheetsReportForm.test.ts
@@ -22,7 +22,10 @@ vi.mock('../../../../../data-marts/reports/shared/model/hooks/useReport', () => 
 }));
 
 import { useReport } from '../../../../../data-marts/reports/shared/model/hooks/useReport';
-import { useGoogleSheetsReportForm } from '../useGoogleSheetsReportForm';
+import {
+  useGoogleSheetsReportForm,
+  GoogleSheetsReportEditFormSchema,
+} from '../useGoogleSheetsReportForm';
 import { ReportFormMode } from '../../../shared';
 import { DestinationTypeConfigEnum } from '../../../shared/enums/destination-type-config.enum';
 import { DataStorageType } from '../../../../../data-storage/shared/model/types/data-storage-type.enum';
@@ -93,6 +96,40 @@ beforeEach(() => {
   setupUseReportMock();
   mockCreateReport.mockResolvedValue(buildReport({ id: 'created-1' }));
   mockUpdateReport.mockResolvedValue(buildReport({ id: 'updated-1' }));
+});
+
+const validGoogleSheetsFormData = {
+  title: 'Test Report',
+  documentUrl: VALID_SHEETS_URL,
+  dataDestinationId: 'dest-1',
+  columnConfig: ['col_a'],
+  filterConfig: null,
+  sortConfig: null,
+  limitConfig: null,
+};
+
+describe('GoogleSheetsReportEditFormSchema — columnConfig validation', () => {
+  it('rejects an empty array with the expected message', async () => {
+    const result = await GoogleSheetsReportEditFormSchema.safeParseAsync({
+      ...validGoogleSheetsFormData,
+      columnConfig: [],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues.find(i => i.path.includes('columnConfig'))?.message;
+      expect(msg).toBe('At least one column must be selected');
+    }
+  });
+
+  it('accepts null (no columns configured yet)', async () => {
+    const result = await GoogleSheetsReportEditFormSchema.safeParseAsync({
+      ...validGoogleSheetsFormData,
+      columnConfig: null,
+    });
+
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('useGoogleSheetsReportForm — defaults', () => {

--- a/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useLookerStudioReportForm.test.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useLookerStudioReportForm.test.ts
@@ -20,7 +20,10 @@ vi.mock('../../../../../data-marts/reports/shared/model/hooks/useReport', () => 
 }));
 
 import { useReport } from '../../../../../data-marts/reports/shared/model/hooks/useReport';
-import { useLookerStudioReportForm } from '../useLookerStudioReportForm';
+import {
+  useLookerStudioReportForm,
+  lookerStudioReportFormSchema,
+} from '../useLookerStudioReportForm';
 import { DestinationTypeConfigEnum } from '../../../shared/enums/destination-type-config.enum';
 import { DataStorageType } from '../../../../../data-storage/shared/model/types/data-storage-type.enum';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
@@ -87,6 +90,38 @@ beforeEach(() => {
   setupUseReportMock();
   mockCreateReport.mockResolvedValue(buildReport({ id: 'created-1' }));
   mockUpdateReport.mockResolvedValue(buildReport({ id: 'updated-1' }));
+});
+
+const validLookerStudioFormData = {
+  cacheLifetime: 300,
+  columnConfig: ['col_a'],
+  filterConfig: null,
+  sortConfig: null,
+  limitConfig: null,
+};
+
+describe('lookerStudioReportFormSchema — columnConfig validation', () => {
+  it('rejects an empty array with the expected message', async () => {
+    const result = await lookerStudioReportFormSchema.safeParseAsync({
+      ...validLookerStudioFormData,
+      columnConfig: [],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msg = result.error.issues.find(i => i.path.includes('columnConfig'))?.message;
+      expect(msg).toBe('At least one column must be selected');
+    }
+  });
+
+  it('accepts null (no columns configured yet)', async () => {
+    const result = await lookerStudioReportFormSchema.safeParseAsync({
+      ...validLookerStudioFormData,
+      columnConfig: null,
+    });
+
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('useLookerStudioReportForm — defaults', () => {

--- a/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/DataStorageForm.tsx
+++ b/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/DataStorageForm.tsx
@@ -1,4 +1,3 @@
-import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@owox/ui/components/button';
 import {
   AppForm,
@@ -29,7 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@owox/ui/components/select';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import type { CredentialIdentity } from '../../../../../shared/types/credential-identity';
 import { OwnersSection } from '../../../../../shared/components/OwnersSection/OwnersSection';
@@ -43,14 +42,13 @@ import { useIsAdmin } from '../../../../idp/hooks/useRole';
 import type { UserProjection } from '../../../../../shared/types';
 import { UserReference } from '../../../../../shared/components/UserReference/UserReference';
 import { CopyCredentialContext } from '../../model/context/copy-credential-context';
-import { createFormPayload } from '../../../../../utils/form-utils';
-import { COPY_SOURCE_CREDENTIAL_PLACEHOLDER } from '../../../../../shared/utils/credential-identity-utils';
+import { createDataStorageFormResolver } from '../../model/data-storage-form-resolver';
+import { createFormPayload, focusFirstInvalidField } from '../../../../../utils/form-utils';
 import {
   type DataStorageFormData,
   type GoogleBigQueryFormData,
   type LegacyGoogleBigQueryFormData,
   DataStorageHealthIndicator,
-  dataStorageSchema,
   DataStorageStatus,
   DataStorageType,
 } from '../../../shared';
@@ -92,8 +90,15 @@ export function DataStorageForm({
   onCancel,
   onDirtyChange,
 }: DataStorageFormProps) {
+  // The resolver reads this ref so credential validation is bypassed while
+  // the user copies credentials from another storage (fields are hidden then).
+  const copySourceSelectedRef = useRef(false);
+  const resolver = useMemo(
+    () => createDataStorageFormResolver(() => copySourceSelectedRef.current),
+    []
+  );
   const form = useForm<DataStorageFormData>({
-    resolver: zodResolver(dataStorageSchema),
+    resolver,
     defaultValues: initialData,
   });
 
@@ -148,29 +153,17 @@ export function DataStorageForm({
   const handleSourceSelect = useCallback(
     (id: string, title: string, identity: CredentialIdentity | null) => {
       setSelectedSource({ id, title, identity });
-      // For Google types, set a placeholder credentialId so Zod validation passes.
-      // Non-Google types don't have credentialId in their schemas, so we skip this.
-      // Credentials are copied server-side via sourceStorageId; the placeholder is
-      // stripped from the payload in handleSubmit.
-      const currentType = form.getValues('type');
-      if (
-        currentType === DataStorageType.GOOGLE_BIGQUERY ||
-        currentType === DataStorageType.LEGACY_GOOGLE_BIGQUERY
-      ) {
-        form.setValue('credentials.credentialId', COPY_SOURCE_CREDENTIAL_PLACEHOLDER, {
-          shouldDirty: false,
-          shouldValidate: true,
-        });
-      }
+      copySourceSelectedRef.current = true;
+      // Credentials now come from the source storage; drop stale field errors
+      form.clearErrors('credentials');
     },
     [form]
   );
 
   const handleSourceClear = useCallback(() => {
     setSelectedSource(null);
-    // Restore credential field to its original value from initialData
-    form.resetField('credentials.credentialId');
-  }, [form]);
+    copySourceSelectedRef.current = false;
+  }, []);
 
   const {
     watch,
@@ -231,12 +224,16 @@ export function DataStorageForm({
       <AppForm
         data-testid='storageEditForm'
         onSubmit={e => {
-          void form.handleSubmit(handleSubmit)(e);
+          void form.handleSubmit(handleSubmit, focusFirstInvalidField)(e);
         }}
         noValidate
       >
         <FormLayout>
-          <FormSection title='General' defaultOpen={!isLegacyGoogleBigQuery}>
+          <FormSection
+            title='General'
+            defaultOpen={!isLegacyGoogleBigQuery}
+            fields={['title', 'type']}
+          >
             {storageId && (
               <FormItem>
                 <DataStorageHealthIndicator storageId={storageId} />

--- a/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/RedshiftFields.tsx
+++ b/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/RedshiftFields.tsx
@@ -86,63 +86,71 @@ export const RedshiftFields = ({ form }: RedshiftFieldsProps) => {
           )}
         />
 
-        <FormField
-          control={form.control}
-          name='config.connectionType'
-          render={({ field }) => {
-            const connectionType =
-              (field.value as RedshiftConnectionType | undefined) ??
-              RedshiftConnectionType.SERVERLESS;
-            return (
-              <FormItem>
-                <div className='flex items-center justify-between'>
-                  <FormLabel
-                    tooltip={
-                      connectionType === RedshiftConnectionType.SERVERLESS
-                        ? 'Workgroup name for Redshift Serverless'
-                        : 'Cluster identifier for provisioned Redshift cluster'
-                    }
-                  >
-                    {connectionType === RedshiftConnectionType.SERVERLESS
-                      ? 'Workgroup Name'
-                      : 'Cluster Identifier'}
-                  </FormLabel>
-                  <Tabs value={connectionType} onValueChange={field.onChange}>
-                    <TabsList>
-                      <TabsTrigger value={RedshiftConnectionType.SERVERLESS}>
-                        Serverless
-                      </TabsTrigger>
-                      <TabsTrigger value={RedshiftConnectionType.PROVISIONED}>
-                        Provisioned
-                      </TabsTrigger>
-                    </TabsList>
-                  </Tabs>
-                </div>
-                <FormControl>
-                  {connectionType === RedshiftConnectionType.SERVERLESS ? (
-                    <Input
-                      {...form.register('config.workgroupName')}
-                      placeholder='Enter workgroup name'
-                    />
-                  ) : (
-                    <Input
-                      {...form.register('config.clusterIdentifier')}
-                      placeholder='Enter cluster identifier'
-                    />
-                  )}
-                </FormControl>
-                <FormDescription>
-                  {connectionType === RedshiftConnectionType.SERVERLESS ? (
+        {(() => {
+          const connectionType =
+            (form.watch('config.connectionType') as RedshiftConnectionType | undefined) ??
+            RedshiftConnectionType.SERVERLESS;
+          const tabs = (
+            <Tabs
+              value={connectionType}
+              onValueChange={value => {
+                form.setValue('config.connectionType', value as RedshiftConnectionType, {
+                  shouldDirty: true,
+                });
+              }}
+            >
+              <TabsList>
+                <TabsTrigger value={RedshiftConnectionType.SERVERLESS}>Serverless</TabsTrigger>
+                <TabsTrigger value={RedshiftConnectionType.PROVISIONED}>Provisioned</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          );
+          return connectionType === RedshiftConnectionType.SERVERLESS ? (
+            <FormField
+              control={form.control}
+              name='config.workgroupName'
+              render={({ field }) => (
+                <FormItem>
+                  <div className='flex items-center justify-between'>
+                    <FormLabel tooltip='Workgroup name for Redshift Serverless'>
+                      Workgroup Name
+                    </FormLabel>
+                    {tabs}
+                  </div>
+                  <FormControl>
+                    <Input {...field} placeholder='Enter workgroup name' />
+                  </FormControl>
+                  <FormDescription>
                     <RedshiftWorkgroupDescription />
-                  ) : (
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          ) : (
+            <FormField
+              control={form.control}
+              name='config.clusterIdentifier'
+              render={({ field }) => (
+                <FormItem>
+                  <div className='flex items-center justify-between'>
+                    <FormLabel tooltip='Cluster identifier for provisioned Redshift cluster'>
+                      Cluster Identifier
+                    </FormLabel>
+                    {tabs}
+                  </div>
+                  <FormControl>
+                    <Input {...field} placeholder='Enter cluster identifier' />
+                  </FormControl>
+                  <FormDescription>
                     <RedshiftClusterDescription />
-                  )}
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            );
-          }}
-        />
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          );
+        })()}
 
         <FormField
           control={form.control}

--- a/apps/web/src/features/data-storage/edit/model/data-storage-form-resolver.test.ts
+++ b/apps/web/src/features/data-storage/edit/model/data-storage-form-resolver.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { DataStorageType, type DataStorageFormData } from '../../shared';
+import { RedshiftConnectionType } from '../../shared/model/types/credentials';
+import { createDataStorageFormResolver } from './data-storage-form-resolver';
+
+const resolverOptions = {
+  fields: {},
+  shouldUseNativeValidation: false,
+} as const;
+
+// Only types present in the dataStorageSchema discriminated union
+// (e.g. AZURE_SYNAPSE is "coming soon" and has no schema yet).
+const validConfigByType = {
+  [DataStorageType.GOOGLE_BIGQUERY]: { projectId: 'my-project', location: 'US' },
+  [DataStorageType.LEGACY_GOOGLE_BIGQUERY]: { projectId: 'my-project', location: 'US' },
+  [DataStorageType.AWS_ATHENA]: { region: 'us-east-1', outputBucket: 'my-bucket' },
+  [DataStorageType.SNOWFLAKE]: { account: 'my-account', warehouse: 'my-warehouse' },
+  [DataStorageType.AWS_REDSHIFT]: {
+    connectionType: RedshiftConnectionType.SERVERLESS,
+    region: 'us-east-1',
+    database: 'my-db',
+    workgroupName: 'my-workgroup',
+  },
+  [DataStorageType.DATABRICKS]: { host: 'my-host', httpPath: '/sql/1.0' },
+};
+
+type SchemaBackedType = keyof typeof validConfigByType;
+
+function buildValues(type: SchemaBackedType) {
+  // The resolver receives raw form values at runtime, which may not yet
+  // satisfy the schema (that is exactly what it validates).
+  return {
+    title: 'My storage',
+    type,
+    credentials: {},
+    config: validConfigByType[type],
+  } as unknown as DataStorageFormData;
+}
+
+describe('createDataStorageFormResolver', () => {
+  it.each(Object.keys(validConfigByType) as SchemaBackedType[])(
+    'passes validation for %s with empty credentials while copying from another storage',
+    async type => {
+      const resolver = createDataStorageFormResolver(() => true);
+
+      const result = await resolver(buildValues(type), undefined, resolverOptions);
+
+      expect(result.errors).toEqual({});
+    }
+  );
+
+  it('keeps requiring credentials when no copy source is selected', async () => {
+    const resolver = createDataStorageFormResolver(() => false);
+
+    const result = await resolver(
+      buildValues(DataStorageType.AWS_REDSHIFT),
+      undefined,
+      resolverOptions
+    );
+
+    expect(result.errors).toHaveProperty('credentials');
+  });
+
+  it('does not report credential errors for AZURE_SYNAPSE when copying from another storage', async () => {
+    const resolver = createDataStorageFormResolver(() => true);
+
+    const result = await resolver(
+      {
+        title: 'My storage',
+        type: DataStorageType.AZURE_SYNAPSE,
+        credentials: {},
+        config: {},
+      } as unknown as DataStorageFormData,
+      undefined,
+      resolverOptions
+    );
+
+    expect(result.errors).not.toHaveProperty('credentials');
+  });
+
+  it('still reports errors on non-credential fields while copying', async () => {
+    const resolver = createDataStorageFormResolver(() => true);
+
+    const result = await resolver(
+      { ...buildValues(DataStorageType.AWS_REDSHIFT), title: '' },
+      undefined,
+      resolverOptions
+    );
+
+    expect(result.errors).toHaveProperty('title');
+    expect(result.errors).not.toHaveProperty('credentials');
+  });
+
+  it('strips credentials from returned values when copy source is selected', async () => {
+    const resolver = createDataStorageFormResolver(() => true);
+
+    const result = await resolver(
+      buildValues(DataStorageType.AWS_REDSHIFT),
+      undefined,
+      resolverOptions
+    );
+
+    expect(result.values).not.toHaveProperty('credentials');
+  });
+});

--- a/apps/web/src/features/data-storage/edit/model/data-storage-form-resolver.ts
+++ b/apps/web/src/features/data-storage/edit/model/data-storage-form-resolver.ts
@@ -1,0 +1,80 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { Resolver } from 'react-hook-form';
+import { COPY_SOURCE_CREDENTIAL_PLACEHOLDER } from '../../../../shared/utils/credential-identity-utils';
+import { dataStorageSchema, type DataStorageFormData, DataStorageType } from '../../shared';
+import { SnowflakeAuthMethod, DatabricksAuthMethod } from '../../shared/model/types/credentials';
+
+/**
+ * Schema-satisfying credentials for the "Copy From" flow. The values are never
+ * sent to the server: handleSubmit strips credentials from the payload when a
+ * copy source is selected and the server copies them via sourceStorageId.
+ */
+function buildCopySourcePlaceholderCredentials(
+  type: DataStorageType | undefined
+): DataStorageFormData['credentials'] | undefined {
+  switch (type) {
+    case DataStorageType.GOOGLE_BIGQUERY:
+    case DataStorageType.LEGACY_GOOGLE_BIGQUERY:
+      return { credentialId: COPY_SOURCE_CREDENTIAL_PLACEHOLDER };
+    case DataStorageType.AWS_ATHENA:
+    case DataStorageType.AWS_REDSHIFT:
+      return {
+        accessKeyId: COPY_SOURCE_CREDENTIAL_PLACEHOLDER,
+        secretAccessKey: COPY_SOURCE_CREDENTIAL_PLACEHOLDER,
+      };
+    case DataStorageType.SNOWFLAKE:
+      return {
+        authMethod: SnowflakeAuthMethod.PASSWORD,
+        username: COPY_SOURCE_CREDENTIAL_PLACEHOLDER,
+        password: COPY_SOURCE_CREDENTIAL_PLACEHOLDER,
+      };
+    case DataStorageType.DATABRICKS:
+      return {
+        authMethod: DatabricksAuthMethod.PERSONAL_ACCESS_TOKEN,
+        token: COPY_SOURCE_CREDENTIAL_PLACEHOLDER,
+      };
+    case DataStorageType.AZURE_SYNAPSE:
+      // No Zod schema yet — credentials aren't validated, so no placeholder needed.
+      return undefined;
+    case undefined:
+      return undefined;
+    default: {
+      // If TypeScript errors here, a new DataStorageType was added without a case above.
+      const _exhaustive: never = type;
+      void _exhaustive;
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Form resolver for the Data Storage form.
+ *
+ * @param isCopySourceSelected returns true while the user copies credentials
+ * from another storage ("Copy From"). In that state the credential inputs are
+ * hidden and the real credentials are copied server-side via sourceStorageId,
+ * so credential validation must be bypassed.
+ */
+export function createDataStorageFormResolver(
+  isCopySourceSelected: () => boolean
+): Resolver<DataStorageFormData> {
+  const baseResolver = zodResolver(dataStorageSchema);
+  return async (values, context, options) => {
+    const copying = isCopySourceSelected();
+    const placeholderCredentials = copying
+      ? buildCopySourcePlaceholderCredentials(values.type)
+      : undefined;
+    const effectiveValues = placeholderCredentials
+      ? ({ ...values, credentials: placeholderCredentials } as DataStorageFormData)
+      : values;
+    const result = await baseResolver(effectiveValues, context, options);
+    if (copying) {
+      const { credentials: _stripped, ...rest } = result.values as DataStorageFormData & {
+        credentials?: unknown;
+      };
+      void _stripped;
+      return { ...result, values: rest as unknown as DataStorageFormData };
+    }
+    return result;
+  };
+}

--- a/apps/web/src/features/data-storage/edit/model/data-storage-form-resolver.ts
+++ b/apps/web/src/features/data-storage/edit/model/data-storage-form-resolver.ts
@@ -73,7 +73,12 @@ export function createDataStorageFormResolver(
         credentials?: unknown;
       };
       void _stripped;
-      return { ...result, values: rest as unknown as DataStorageFormData };
+      // Build the return explicitly to avoid spreading a union (which produces a
+      // type incompatible with ResolverResult's discriminated union).
+      if (Object.keys(result.errors).length === 0) {
+        return { values: rest as unknown as DataStorageFormData, errors: {} };
+      }
+      return { values: {}, errors: result.errors };
     }
     return result;
   };

--- a/apps/web/src/shared/components/FormSection/FormSection.test.tsx
+++ b/apps/web/src/shared/components/FormSection/FormSection.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Tests for the validation-aware FormSection from @owox/ui.
+ * The ui package has no test runner, so the tests live here in apps/web,
+ * which already depends on @owox/ui and has vitest configured.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormSection,
+} from '@owox/ui/components/form';
+
+const schema = z.object({
+  title: z.string().min(1, 'Title is required'),
+});
+
+type TestFormData = z.infer<typeof schema>;
+
+function TestForm({
+  defaultOpen = true,
+  sectionFields,
+  sectionName,
+}: {
+  defaultOpen?: boolean;
+  sectionFields?: string[];
+  sectionName?: string;
+}) {
+  const form = useForm<TestFormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { title: '' },
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        noValidate
+        onSubmit={e => {
+          void form.handleSubmit(() => {
+            /* valid submit is a no-op */
+          })(e);
+        }}
+      >
+        <FormSection
+          title='General'
+          defaultOpen={defaultOpen}
+          fields={sectionFields}
+          name={sectionName}
+        >
+          <FormField
+            control={form.control}
+            name='title'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Title</FormLabel>
+                <FormControl>
+                  <input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </FormSection>
+        <button type='submit'>Save</button>
+      </form>
+    </Form>
+  );
+}
+
+describe('FormSection validation awareness', () => {
+  it('reopens a user-collapsed section and shows the message when submit fails validation inside it', async () => {
+    render(<TestForm />);
+
+    // Field is visible while the section is open
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+
+    // User collapses the section — content unmounts
+    fireEvent.click(screen.getByRole('button', { name: /general/i }));
+    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument();
+
+    // Submit with an empty required field
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    // The section must reopen and the validation message must be visible
+    expect(await screen.findByText('Title is required')).toBeInTheDocument();
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+  });
+
+  it('opens a section that starts collapsed when its declared fields have errors', async () => {
+    render(<TestForm defaultOpen={false} sectionFields={['title']} />);
+
+    // Starts collapsed — the field never mounted
+    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('Title is required')).toBeInTheDocument();
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+  });
+
+  it('shows an error indicator in the section header after a failed submit', async () => {
+    render(<TestForm />);
+
+    expect(screen.queryByTestId('form-section-error-indicator')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByText('Title is required');
+
+    expect(await screen.findByTestId('form-section-error-indicator')).toBeInTheDocument();
+  });
+
+  it('does not overwrite the persisted user preference when auto-opening', async () => {
+    localStorage.removeItem('form-section-general');
+    render(<TestForm sectionName='general' />);
+
+    // User collapses the named section — preference is persisted
+    fireEvent.click(screen.getByRole('button', { name: /general/i }));
+    expect(localStorage.getItem('form-section-general')).toBe('false');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByText('Title is required');
+
+    // Section auto-opened, but the stored preference must stay untouched
+    expect(localStorage.getItem('form-section-general')).toBe('false');
+    localStorage.removeItem('form-section-general');
+  });
+
+  it('lets the user re-collapse the section after an auto-open until the next submit', async () => {
+    render(<TestForm />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByText('Title is required');
+
+    // User collapses the auto-opened section — it must stay collapsed
+    fireEvent.click(screen.getByRole('button', { name: /general/i }));
+    expect(screen.queryByText('Title is required')).not.toBeInTheDocument();
+
+    // The next submit attempt reopens it again
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByText('Title is required')).toBeInTheDocument();
+  });
+
+  it('renders without crashing outside a react-hook-form context', () => {
+    render(
+      <FormSection title='Standalone'>
+        <div>Plain content</div>
+      </FormSection>
+    );
+
+    expect(screen.getByText('Plain content')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/utils/form-utils.test.tsx
+++ b/apps/web/src/utils/form-utils.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormSection,
+} from '@owox/ui/components/form';
+import { focusFirstInvalidField } from './form-utils';
+
+const schema = z.object({
+  title: z.string().min(1, 'Title is required'),
+});
+
+type TestFormData = z.infer<typeof schema>;
+
+function TestForm() {
+  const form = useForm<TestFormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { title: '' },
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        noValidate
+        onSubmit={e => {
+          void form.handleSubmit(() => {
+            /* valid submit is a no-op */
+          }, focusFirstInvalidField)(e);
+        }}
+      >
+        <FormSection title='General'>
+          <FormField
+            control={form.control}
+            name='title'
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Title</FormLabel>
+                <FormControl>
+                  <input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </FormSection>
+        <button type='submit'>Save</button>
+      </form>
+    </Form>
+  );
+}
+
+describe('focusFirstInvalidField', () => {
+  it('focuses the first element marked aria-invalid once the next frames are painted', async () => {
+    render(
+      <div>
+        <input aria-label='Valid' />
+        <input aria-label='Broken' aria-invalid='true' />
+      </div>
+    );
+
+    focusFirstInvalidField();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Broken')).toHaveFocus();
+    });
+  });
+
+  it('focuses the first invalid element scoped inside the event target form if target is provided', async () => {
+    render(
+      <div>
+        <form data-testid='first-form'>
+          <input aria-label='Input in first form' aria-invalid='true' />
+        </form>
+        <form data-testid='second-form'>
+          <input aria-label='Input in second form' aria-invalid='true' />
+        </form>
+      </div>
+    );
+
+    const secondForm = screen.getByTestId('second-form');
+    focusFirstInvalidField({}, { target: secondForm });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Input in second form')).toHaveFocus();
+    });
+    expect(screen.getByLabelText('Input in first form')).not.toHaveFocus();
+  });
+
+  it('focuses the first invalid field after a failed submit, once collapsed sections reopen', async () => {
+    render(<TestForm />);
+
+    // User collapses the section, so the invalid field is unmounted at submit time
+    fireEvent.click(screen.getByRole('button', { name: /general/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await screen.findByText('Title is required');
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Title')).toHaveFocus();
+    });
+  });
+});

--- a/apps/web/src/utils/form-utils.ts
+++ b/apps/web/src/utils/form-utils.ts
@@ -6,3 +6,31 @@
 export function createFormPayload<T>(data: T): T {
   return JSON.parse(JSON.stringify(data)) as T;
 }
+
+/**
+ * Focuses and scrolls to the first form control marked invalid.
+ * Pass as the onInvalid handler to react-hook-form's handleSubmit.
+ * Collapsed FormSections auto-open on a failed submit, so the invalid field
+ * may not be mounted yet when this is called — react-hook-form's built-in
+ * shouldFocusError runs too early for such fields. Polls a few frames until
+ * the field appears, then gives up silently if none ever does.
+ */
+const MAX_FOCUS_ATTEMPTS = 20; // ~333 ms at 60 fps
+
+export function focusFirstInvalidField(_errors?: unknown, event?: { target?: unknown }): void {
+  let attemptsLeft = MAX_FOCUS_ATTEMPTS;
+  const container = event?.target instanceof HTMLElement ? event.target : document;
+  const tryFocus = () => {
+    const element = container.querySelector('[aria-invalid="true"]');
+    if (element instanceof HTMLElement) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      element.focus({ preventScroll: true });
+      return;
+    }
+    attemptsLeft--;
+    if (attemptsLeft > 0) {
+      requestAnimationFrame(tryFocus);
+    }
+  };
+  requestAnimationFrame(tryFocus);
+}

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -16,7 +16,7 @@ import {
 import { cn } from '@owox/ui/lib/utils';
 import { Label } from '@owox/ui/components/label';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
-import { ChevronRight, Info } from 'lucide-react';
+import { ChevronRight, CircleAlert, Info } from 'lucide-react';
 import {
   Collapsible,
   CollapsibleTrigger,
@@ -37,8 +37,16 @@ type FormFieldContextValue<
 
 const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
 
+type FormSectionContextValue = {
+  registerFieldName: (name: string) => void;
+};
+
+const FormSectionContext = React.createContext<FormSectionContextValue | null>(null);
+
 /**
  * FormField wraps react-hook-form Controller and provides field context.
+ * It also reports its field name to the enclosing FormSection so the section
+ * can track validation errors of its fields even while collapsed.
  */
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
@@ -46,6 +54,13 @@ const FormField = <
 >({
   ...props
 }: ControllerProps<TFieldValues, TName>) => {
+  const sectionContext = React.useContext(FormSectionContext);
+  const { name } = props;
+
+  React.useEffect(() => {
+    sectionContext?.registerFieldName(name);
+  }, [sectionContext, name]);
+
   return (
     <FormFieldContext.Provider value={{ name: props.name }}>
       <Controller {...props} />
@@ -281,6 +296,13 @@ interface FormSectionProps {
   defaultOpen?: boolean;
   collapsible?: boolean;
   name?: string;
+  /**
+   * Form field names whose validation errors belong to this section.
+   * FormFields rendered inside the section register themselves automatically;
+   * pass this only for sections that may start collapsed, since their fields
+   * never mount and cannot self-register.
+   */
+  fields?: string[];
 }
 
 const SECTION_STORAGE_PREFIX = 'form-section-';
@@ -308,6 +330,30 @@ function FormSectionTooltip({ tooltip }: { tooltip: React.ReactNode | string }) 
   );
 }
 
+/**
+ * Subscribes to the validation state of the given fields and reports it to
+ * the enclosing FormSection. Rendered as a separate component so FormSection
+ * itself works outside a react-hook-form context.
+ */
+function FormSectionErrorObserver({
+  fields,
+  onErrorStateChange,
+}: {
+  fields: string[];
+  onErrorStateChange: (hasError: boolean, submitCount: number) => void;
+}) {
+  const { getFieldState } = useFormContext();
+  const formState = useFormState({ name: fields });
+  const hasError = fields.some(field => getFieldState(field, formState).invalid);
+  const { submitCount } = formState;
+
+  React.useEffect(() => {
+    onErrorStateChange(hasError, submitCount);
+  }, [hasError, submitCount, onErrorStateChange]);
+
+  return null;
+}
+
 function FormSection({
   title,
   description,
@@ -318,6 +364,7 @@ function FormSection({
   defaultOpen = true,
   collapsible = true,
   name,
+  fields,
 }: FormSectionProps) {
   const getInitialState = () => {
     if (name) {
@@ -347,7 +394,43 @@ function FormSection({
     [name]
   );
 
-  const content = <div className='flex flex-col gap-2'>{children}</div>;
+  // null outside a react-hook-form context — error tracking is disabled there
+  const formContext = useFormContext() as ReturnType<typeof useFormContext> | null;
+
+  // Names are sticky: a field that mounted at least once keeps counting toward
+  // the section's error state even after the section collapses and unmounts it.
+  const [registeredFieldNames, setRegisteredFieldNames] = React.useState<string[]>([]);
+  const registerFieldName = React.useCallback((fieldName: string) => {
+    setRegisteredFieldNames(prev => (prev.includes(fieldName) ? prev : [...prev, fieldName]));
+  }, []);
+  const sectionContextValue = React.useMemo(() => ({ registerFieldName }), [registerFieldName]);
+
+  const watchedFields = React.useMemo(() => {
+    const merged = [...(fields ?? []), ...registeredFieldNames];
+    return [...new Set(merged)];
+  }, [fields, registeredFieldNames]);
+
+  const [hasError, setHasError] = React.useState(false);
+  const handledSubmitCount = React.useRef(0);
+  const handleErrorStateChange = React.useCallback((nextHasError: boolean, submitCount: number) => {
+    setHasError(nextHasError);
+    if (nextHasError && submitCount > handledSubmitCount.current) {
+      handledSubmitCount.current = submitCount;
+      // Open directly (not via handleOpenChange) so the auto-open does not
+      // overwrite the user's persisted open/closed preference in localStorage.
+      setIsOpen(true);
+    }
+  }, []);
+
+  const errorObserver = formContext && watchedFields.length > 0 && (
+    <FormSectionErrorObserver fields={watchedFields} onErrorStateChange={handleErrorStateChange} />
+  );
+
+  const content = (
+    <FormSectionContext.Provider value={sectionContextValue}>
+      <div className='flex flex-col gap-2'>{children}</div>
+    </FormSectionContext.Provider>
+  );
 
   // Non-collapsible section
   if (!collapsible) {
@@ -382,6 +465,7 @@ function FormSection({
       data-slot='form-section'
       className='flex flex-col gap-2'
     >
+      {errorObserver}
       {title && (
         <div className='group flex items-center justify-between'>
           <CollapsibleTrigger asChild>
@@ -393,6 +477,18 @@ function FormSection({
                 {title}
               </span>
               {titleAdornment}
+              {hasError && (
+                <>
+                  <CircleAlert
+                    data-testid='form-section-error-indicator'
+                    // -mt-px optically centers the icon against the uppercase
+                    // title: caps sit slightly above the line-box center.
+                    className='text-destructive -mt-px size-3.5 shrink-0'
+                    aria-hidden='true'
+                  />
+                  <span className='sr-only'>This section contains validation errors</span>
+                </>
+              )}
               <ChevronRight
                 className={cn(
                   'text-foreground/75 h-3.5 w-3.5 transition-transform duration-200',


### PR DESCRIPTION
## Problem

In the Storage, Destination, and Report forms, required fields with validation
errors could sit inside a collapsed accordion section. Clicking **Save** then
failed silently: react-hook-form kept the errors on unmounted fields, no message
was rendered, and the built-in focus on the invalid field could not work. Two
adjacent issues made it worse:

- **Copy credentials from another storage** always failed validation for
  non-Google storage types (Athena, Redshift, Snowflake, Databricks), because
  the hidden credential fields were still required by the schema — with nowhere
  to display the errors.
- The **Create & Run report** button was disabled while the form was invalid,
  leaving the user with a dead button and no hint about what was missing.

## Changes

### `packages/ui` — `FormSection`
- Sections track their fields automatically (every `FormField` rendered inside
  registers itself via context); sections that may start collapsed can declare
  them explicitly with the new optional `fields` prop.
- On a failed submit, a collapsed section containing errors auto-opens once per
  submit attempt — the user can re-collapse it, and their persisted (localStorage)
  preference is never overwritten.
- A red `CircleAlert` indicator (optically centered with the uppercase title)
  appears in the section header while it contains errors, with an `sr-only`
  description for screen readers.

### `apps/web` — forms
- New `focusFirstInvalidField` helper is wired as the `onInvalid` handler in all
  five forms (Storage, Destination, Google Sheets / Email / Looker Studio
  reports): it polls a few frames until the reopened section mounts the invalid
  field, then scrolls to it and focuses it.
- New `createDataStorageFormResolver` bypasses credential validation while a
  copy source is selected (the credentials are stripped from the payload and
  copied server-side via `sourceStorageId`), replacing the previous
  Google-only placeholder hack — Copy From now works for every storage type.
- Report create buttons (`ReportFormActions` and the Looker Studio form) no
  longer disable on `!isValid` in CREATE mode, so submitting reveals the
  validation errors. EDIT mode behavior (disabled until dirty) is unchanged.
- The Report Columns section now participates in validation: it declares its
  fields, the picker is wrapped in `FormField`/`FormControl` (aria-invalid +
  scroll target), and the error clears immediately once a column is selected
  again.

## Testing
- Unit tests cover the new behavior: `FormSection` auto-open, the focus helper,
  the storage form resolver for all storage types, and `ReportFormActions`
  disabled states.
- `tsc -b` and ESLint clean.
- Verified manually end-to-end in the running app: section auto-open + focus on
  Storage save, Copy From on a new Redshift storage (success toast), report
  creation with collapsed General section, and the Report Columns error flow.
