### PR TITLE
refactor(backend): allow saving data mart definition without storage validation

### DIFF
--- a/apps/backend/src/data-marts/use-cases/actualize-data-mart-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/actualize-data-mart-schema.service.spec.ts
@@ -1,0 +1,81 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { ActualizeDataMartSchemaService } from './actualize-data-mart-schema.service';
+import { ActualizeDataMartSchemaCommand } from '../dto/domain/actualize-data-mart-schema.command';
+import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
+
+describe('ActualizeDataMartSchemaService', () => {
+  const createService = (options: { isValid: boolean } = { isValid: true }) => {
+    const dataMart = {
+      id: 'dm-1',
+      projectId: 'proj-1',
+      definitionType: DataMartDefinitionType.TABLE,
+      definition: { tableName: 'my_table' },
+    };
+
+    const dataMartService = {
+      getByIdAndProjectId: jest.fn().mockResolvedValue(dataMart),
+      actualizeSchemaInEntity: jest.fn().mockResolvedValue(undefined),
+      save: jest.fn().mockResolvedValue(dataMart),
+    };
+
+    const definitionValidatorFacade = {
+      checkIsValid: jest.fn().mockImplementation(() => {
+        if (!options.isValid) {
+          throw new BusinessViolationException('Storage validation failed');
+        }
+        return Promise.resolve();
+      }),
+    };
+
+    const mapper = {
+      toDomainDto: jest.fn().mockReturnValue({ id: 'dm-1' }),
+    };
+
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(true),
+    };
+
+    const service = new ActualizeDataMartSchemaService(
+      dataMartService as any,
+      definitionValidatorFacade as any,
+      mapper as any,
+      accessDecisionService as any
+    );
+
+    return { service, dataMartService, definitionValidatorFacade, dataMart };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should actualize schema successfully when storage validation succeeds', async () => {
+    const { service, dataMartService, definitionValidatorFacade, dataMart } = createService({
+      isValid: true,
+    });
+    const command = new ActualizeDataMartSchemaCommand('dm-1', 'proj-1', 'user-1', ['editor']);
+
+    const result = await service.run(command);
+
+    expect(definitionValidatorFacade.checkIsValid).toHaveBeenCalledWith(dataMart);
+    expect(dataMartService.actualizeSchemaInEntity).toHaveBeenCalledWith(dataMart);
+    expect(dataMartService.save).toHaveBeenCalledWith(dataMart);
+    expect(result).toEqual({ id: 'dm-1' });
+  });
+
+  it('should reject schema actualization when storage validation fails', async () => {
+    const { service, dataMartService } = createService({
+      isValid: false,
+    });
+    const command = new ActualizeDataMartSchemaCommand('dm-1', 'proj-1', 'user-1', ['editor']);
+
+    await expect(service.run(command)).rejects.toThrow(BusinessViolationException);
+    expect(dataMartService.actualizeSchemaInEntity).not.toHaveBeenCalled();
+    expect(dataMartService.save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/publish-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-mart.service.spec.ts
@@ -1,0 +1,92 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { PublishDataMartService } from './publish-data-mart.service';
+import { PublishDataMartCommand } from '../dto/domain/publish-data-mart.command';
+import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
+
+describe('PublishDataMartService', () => {
+  const createService = (options: { isValid: boolean } = { isValid: true }) => {
+    const dataMart = {
+      id: 'dm-1',
+      projectId: 'proj-1',
+      status: DataMartStatus.DRAFT,
+      definitionType: DataMartDefinitionType.TABLE,
+      definition: { tableName: 'my_table' },
+      createdById: 'user-1',
+    };
+
+    const dataMartService = {
+      getByIdAndProjectId: jest.fn().mockResolvedValue(dataMart),
+      save: jest.fn().mockResolvedValue(dataMart),
+    };
+
+    const definitionValidatorFacade = {
+      checkIsValid: jest.fn().mockImplementation(() => {
+        if (!options.isValid) {
+          throw new BusinessViolationException('Storage validation failed');
+        }
+        return Promise.resolve();
+      }),
+    };
+
+    const mapper = {
+      toDomainDto: jest.fn().mockReturnValue({ id: 'dm-1', status: DataMartStatus.PUBLISHED }),
+    };
+
+    const eventDispatcher = {
+      publish: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(true),
+    };
+
+    const connectorExecutionService = {
+      run: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const service = new PublishDataMartService(
+      dataMartService as any,
+      definitionValidatorFacade as any,
+      mapper as any,
+      eventDispatcher as any,
+      accessDecisionService as any,
+      connectorExecutionService as any
+    );
+
+    return { service, dataMartService, definitionValidatorFacade, dataMart };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should publish successfully when storage validation succeeds', async () => {
+    const { service, dataMartService, definitionValidatorFacade, dataMart } = createService({
+      isValid: true,
+    });
+    const command = new PublishDataMartCommand('dm-1', 'proj-1', 'user-1', ['editor'], 'user-1');
+
+    const result = await service.run(command);
+
+    expect(definitionValidatorFacade.checkIsValid).toHaveBeenCalledWith(dataMart);
+    expect(dataMart.status).toBe(DataMartStatus.PUBLISHED);
+    expect(dataMartService.save).toHaveBeenCalledWith(dataMart);
+    expect(result.status).toBe(DataMartStatus.PUBLISHED);
+  });
+
+  it('should reject publish when storage validation fails', async () => {
+    const { service, dataMartService } = createService({
+      isValid: false,
+    });
+    const command = new PublishDataMartCommand('dm-1', 'proj-1', 'user-1', ['editor'], 'user-1');
+
+    await expect(service.run(command)).rejects.toThrow(BusinessViolationException);
+    expect(dataMartService.save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.spec.ts
@@ -1,0 +1,110 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+import { ForbiddenException } from '@nestjs/common';
+import { UpdateDataMartDefinitionService } from './update-data-mart-definition.service';
+import { UpdateDataMartDefinitionCommand } from '../dto/domain/update-data-mart-definition.command';
+import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
+import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
+
+describe('UpdateDataMartDefinitionService', () => {
+  const createService = () => {
+    const dataMart = {
+      id: 'dm-1',
+      projectId: 'proj-1',
+      storage: { id: 'storage-1', type: DataStorageType.GOOGLE_BIGQUERY },
+      definitionType: undefined as DataMartDefinitionType | undefined,
+      definition: undefined as any,
+    };
+
+    const dataMartService = {
+      getByIdAndProjectId: jest.fn().mockResolvedValue(dataMart),
+      save: jest.fn().mockResolvedValue(dataMart),
+    };
+    const mapper = {
+      toDomainDto: jest.fn().mockReturnValue({ id: 'dm-1' }),
+    };
+    const connectorSecretService = {
+      mergeDefinitionSecretsFromSource: jest.fn(),
+      mergeDefinitionSecrets: jest.fn(),
+      extractAndSaveSecrets: jest.fn(),
+      deleteOrphanedSecrets: jest.fn(),
+    };
+    const legacyDataMartsService = {
+      updateQuery: jest.fn(),
+    };
+    const accessDecisionService = {
+      canAccess: jest.fn().mockResolvedValue(true),
+    };
+    const eventDispatcher = {
+      publishExternal: jest.fn(),
+    };
+
+    const service = new UpdateDataMartDefinitionService(
+      dataMartService as any,
+      mapper as any,
+      connectorSecretService as any,
+      legacyDataMartsService as any,
+      accessDecisionService as any,
+      eventDispatcher as any
+    );
+
+    return { service, dataMartService, accessDecisionService, dataMart };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    DataMartDefinitionType.TABLE,
+    DataMartDefinitionType.VIEW,
+    DataMartDefinitionType.TABLE_PATTERN,
+  ])(
+    'should succeed when saving a %s definition type without performing storage validation',
+    async definitionType => {
+      const { service, dataMartService, dataMart } = createService();
+      const definition = {
+        tableName: 'my_table',
+      };
+      const command = new UpdateDataMartDefinitionCommand(
+        'dm-1',
+        'proj-1',
+        definitionType,
+        definition,
+        undefined,
+        undefined,
+        'user-1',
+        ['editor']
+      );
+
+      const result = await service.run(command);
+
+      expect(dataMartService.getByIdAndProjectId).toHaveBeenCalledWith('dm-1', 'proj-1');
+      expect(dataMart.definitionType).toBe(definitionType);
+      expect(dataMart.definition).toBe(definition);
+      expect(dataMartService.save).toHaveBeenCalledWith(dataMart);
+      expect(result).toEqual({ id: 'dm-1' });
+    }
+  );
+
+  it('should throw ForbiddenException when user has no edit access to data mart', async () => {
+    const { service, accessDecisionService } = createService();
+    accessDecisionService.canAccess.mockResolvedValue(false);
+
+    const command = new UpdateDataMartDefinitionCommand(
+      'dm-1',
+      'proj-1',
+      DataMartDefinitionType.TABLE,
+      { tableName: 'my_table' },
+      undefined,
+      undefined,
+      'user-1',
+      ['editor']
+    );
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.ts
@@ -2,7 +2,6 @@ import { Injectable, ForbiddenException } from '@nestjs/common';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { OwoxEventDispatcher } from '../../common/event-dispatcher/owox-event-dispatcher';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
-import { DataMartDefinitionValidatorFacade } from '../data-storage-types/facades/data-mart-definition-validator-facade.service';
 import { DataMartDto } from '../dto/domain/data-mart.dto';
 import { UpdateDataMartDefinitionCommand } from '../dto/domain/update-data-mart-definition.command';
 import { ConnectorDefinition } from '../dto/schemas/data-mart-table-definitions/connector-definition.schema';
@@ -20,7 +19,6 @@ import { AccessDecisionService, EntityType, Action } from '../services/access-de
 export class UpdateDataMartDefinitionService {
   constructor(
     private readonly dataMartService: DataMartService,
-    private readonly definitionValidatorFacade: DataMartDefinitionValidatorFacade,
     private readonly mapper: DataMartMapper,
     private readonly connectorSecretService: ConnectorSecretService,
     private readonly legacyDataMartsService: LegacyDataMartsService,
@@ -126,13 +124,6 @@ export class UpdateDataMartDefinitionService {
       );
     } else {
       dataMart.definition = command.definition;
-    }
-
-    if (
-      dataMart.definitionType !== DataMartDefinitionType.SQL &&
-      dataMart.definitionType !== DataMartDefinitionType.CONNECTOR
-    ) {
-      await this.definitionValidatorFacade.checkIsValid(dataMart);
     }
 
     await this.dataMartService.save(dataMart);


### PR DESCRIPTION
### Description
Currently, saving a data mart definition of type `VIEW`, `TABLE`, or `TABLE_PATTERN` is blocked if the associated storage is not fully configured or valid. This PR bypasses this validation during the definition saving stage (`UpdateDataMartDefinitionService`), allowing users to save their definition drafts regardless of the storage status.

### Changes
- Removed `definitionValidatorFacade` injection and `checkIsValid` check from `UpdateDataMartDefinitionService`.
- Validation still runs on publishing (`PublishDataMartService`), schema actualization (`ActualizeDataMartSchemaService`), and metadata generation.

### Testing
- Executed and passed backend e2e tests.
