### PR TITLE
test(backend): update google sheet tests to include retry policy

### DIFF
--- a/packages/test-utils/src/helpers/google-sheets-test-sheet.ts
+++ b/packages/test-utils/src/helpers/google-sheets-test-sheet.ts
@@ -23,6 +23,37 @@ const TITLE_MAX_LENGTH = 80;
 const RANDOM_SUFFIX_BYTES = 3;
 
 /**
+ * Retry policy for the test's direct Sheets API calls.
+ *
+ * The whole suite runs as a single service account, so every read/write counts
+ * against one user's per-minute Sheets quota (default 60 read + 60 write per
+ * minute per user). On a fast CI runner the assertion reads bunch up and burst
+ * past that window, surfacing as HTTP 429 `Quota exceeded ... Read requests per
+ * minute per user`. Locally the higher network latency spaces calls out enough
+ * to stay under the limit, which is why this only bites in CI.
+ *
+ * googleapis' default backoff (3 tries, ~1–4s) is far too short to outlast a
+ * per-minute quota window, so we retry 429/5xx more times with a longer capped
+ * delay (~2,4,8,16,30,30s ≈ 90s total) — enough for the sliding window to free
+ * up budget. Only 429/5xx are retried; a 429 is rejected before the request
+ * applies, so retrying writes is safe.
+ */
+const SHEETS_RETRY_CONFIG = {
+  retry: 6,
+  retryDelay: 2000,
+  maxRetryDelay: 30_000,
+  httpMethodsToRetry: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'],
+  statusCodesToRetry: [
+    [429, 429],
+    [500, 599],
+  ],
+  onRetryAttempt: (err: { message?: string }) => {
+    // eslint-disable-next-line no-console
+    console.warn(`Retrying Sheets API call after error: ${err?.message ?? 'unknown error'}`);
+  },
+};
+
+/**
  * Provisions a brand-new ephemeral sheet inside the shared test spreadsheet.
  *
  * Title shape: `it-{Date.now()}-{rand}-{slug(baseName)}` — the timestamp +
@@ -49,7 +80,7 @@ export async function createTestSheet(
     key: credentials.private_key,
     scopes: ['https://www.googleapis.com/auth/spreadsheets'],
   });
-  const sheets = google.sheets({ version: 'v4', auth });
+  const sheets = google.sheets({ version: 'v4', auth, retryConfig: SHEETS_RETRY_CONFIG });
 
   const sheetTitle = buildSheetTitle(baseName);
   const addRes = await sheets.spreadsheets.batchUpdate({


### PR DESCRIPTION
## Summary

Makes the `google-sheets-column-preservation` integration suite reliable in the scheduled **Integration Tests (Real DB)** workflow. The suite already existed and passed locally, but was effectively dormant in CI (credential-gated → silently skipped) and, once wired up, failed on two CI-only conditions: a cold-boot hook timeout and Google Sheets API rate limiting. This PR fixes both so the suite runs green on a fresh runner.

## Background / root cause

Enabling the suite in CI surfaced a chain of issues, fixed in order:

1. **Silently skipping** — the suite is gated on `GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON` + `TEST_GOOGLE_SPREADSHEET_ID`; without them every test skips and the job stays green but tests nothing. (Resolved by adding the two repository secrets — see *Operational notes*.)
2. **`beforeAll` timeout** — once secrets were present, `createTestApp()` (cold NestJS + TypeORM bootstrap) exceeded the default 60s hook budget on a fresh CI runner, failing all 13 tests at the hook.
3. **Sheets API 429** — with the app booting, 12/13 tests passed; the suite then hit `Quota exceeded … Read requests per minute per user`. The whole suite runs as a single service account, so every assertion read/write counts against one user's per-minute Sheets quota (default 60/min). On a fast runner the calls burst past that window; local runs stay under it only thanks to higher network latency.

## Changes

- **`apps/backend/test/integration/google-sheets-column-preservation.integration.ts`** — raise the `beforeAll` hook timeout `60s → 180s`, matching the existing `report-run-real` / `http-data-real` suites that also boot the app.
- **`packages/test-utils/src/helpers/google-sheets-test-sheet.ts`** — add a `retryConfig` to the test's Sheets client (used only by this suite). Retries `429` and `5xx` with capped exponential backoff (~2→30s per attempt, 6 attempts) so a per-minute quota window can free up. Default googleapis backoff (3 tries, ~1–4s) is too short to outlast a per-minute quota; a `429` is rejected before the request applies, so retrying writes is safe.

## Testing

- **Local:** full suite green — `13 passed`.
- **CI (before retry fix):** `12 passed, 1 failed` — the only failure was the Sheets `429`, which the retry config addresses.
- Will confirm green end-to-end via `workflow_dispatch` from the PR branch.

## Operational notes (no code)

- Requires repository secrets `GOOGLE_SHEETS_SERVICE_ACCOUNT_JSON` and `TEST_GOOGLE_SPREADSHEET_ID`. The Sheets credential can reuse the existing BigQuery service account (Sheets API enabled on the project + **Editor** on the test spreadsheet); the test spreadsheet is owned by the shared `bi.dev@owox.com` account.
- The suite runs only on **schedule** (08:00 / 16:00 Kyiv) and manual `workflow_dispatch` — never on PRs (real credentials, ~5 min run).
- Expected, non-actionable log noise: one `ERROR … intentional integration-test failure` line (the by-design failed-refresh test) and occasional `Retrying Sheets API call …` warnings when backoff engages.

🤖 Generated with [[Claude Code](https://claude.com/claude-code)](https://claude.com/claude-code)