### PR TITLE
feat(web): add quick run functionality for reports in visible area, don't hide them

### DIFF
--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { MoreHorizontal, Pencil, Play, Trash2 } from 'lucide-react';
+import { MoreHorizontal, Pencil, Trash2, Play } from 'lucide-react';
 import { Button } from '@owox/ui/components/button';
 import {
   DropdownMenu,
@@ -8,31 +8,19 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@owox/ui/components/dropdown-menu';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@owox/ui/components/tooltip';
+import { TooltipProvider } from '@owox/ui/components/tooltip';
 import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
-import { ReportStatusEnum } from '../../../shared/enums';
-import { isGeneratedSqlSupported, useReport } from '../../../shared';
+import { isGeneratedSqlSupported, useReport, ReportStatusEnum } from '../../../shared';
 import { GeneratedSqlViewer } from '../../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
 
 interface EmailActionsCellProps {
   row: { original: DataMartReport };
   onDeleteSuccess?: () => void;
   onEditReport?: (report: DataMartReport) => void;
-  onRunSuccess?: () => void | Promise<void>;
 }
 
-export function EmailActionsCell({
-  row,
-  onDeleteSuccess,
-  onEditReport,
-  onRunSuccess,
-}: EmailActionsCellProps) {
+export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailActionsCellProps) {
   const canRun = row.original.canRun;
   const canEditConfig = row.original.canEditConfig;
   const [isRunning, setIsRunning] = useState(
@@ -42,12 +30,11 @@ export function EmailActionsCell({
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { deleteReport, fetchReportsByDataMartId, runReport } = useReport();
 
-  const actionsMenuId = `actions-menu-${row.original.id}`;
-
-  // Sync isRunning with backend status
   useEffect(() => {
     setIsRunning(row.original.lastRunStatus === ReportStatusEnum.RUNNING);
   }, [row.original.lastRunStatus]);
+
+  const actionsMenuId = `actions-menu-${row.original.id}`;
 
   const handleDelete = useCallback(async () => {
     if (!canEditConfig) return;
@@ -76,25 +63,24 @@ export function EmailActionsCell({
     setMenuOpen(false);
   }, [canEditConfig, onEditReport, row.original]);
 
-  const handleRun = useCallback(async () => {
-    if (!canRun) return;
-
-    try {
-      setIsRunning(true);
-      await runReport(row.original.id);
-      await onRunSuccess?.();
-    } catch (error) {
-      setIsRunning(false);
-      console.error('Failed to run report:', error);
-    }
-  }, [canRun, onRunSuccess, runReport, row.original.id]);
-
   const handleDeleteClick = useCallback(() => {
     if (!canEditConfig) return;
 
     setIsDeleteDialogOpen(true);
     setMenuOpen(false);
   }, [canEditConfig]);
+
+  const handleRun = useCallback(async () => {
+    if (!canRun) return;
+
+    try {
+      setIsRunning(true);
+      await runReport(row.original.id);
+    } catch (error) {
+      setIsRunning(false);
+      console.error('Failed to run report:', error);
+    }
+  }, [canRun, runReport, row.original.id]);
 
   return (
     <TooltipProvider>
@@ -104,27 +90,6 @@ export function EmailActionsCell({
           e.stopPropagation();
         }}
       >
-        {/* Run report */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              onClick={e => {
-                e.stopPropagation();
-                void handleRun();
-              }}
-              variant='ghost'
-              className='dm-card-table-body-row-actionbtn opacity-0 transition-opacity group-hover:opacity-100 disabled:opacity-0 disabled:group-hover:opacity-50'
-              disabled={isRunning || !canRun}
-              aria-label={isRunning ? 'Running report...' : `Run report: ${row.original.title}`}
-            >
-              <Play className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side='bottom' role='tooltip'>
-            Run report
-          </TooltipContent>
-        </Tooltip>
-
         {/* View SQL */}
         {isGeneratedSqlSupported(
           row.original.dataMart.definitionType,
@@ -158,6 +123,18 @@ export function EmailActionsCell({
           </DropdownMenuTrigger>
 
           <DropdownMenuContent id={actionsMenuId} align='end' role='menu'>
+            <DropdownMenuItem
+              disabled={isRunning || !canRun}
+              onClick={e => {
+                e.stopPropagation();
+                void handleRun();
+              }}
+              role='menuitem'
+            >
+              <Play className='text-foreground h-4 w-4' aria-hidden='true' />
+              {isRunning ? 'Running report...' : 'Run report'}
+            </DropdownMenuItem>
+
             <DropdownMenuItem
               disabled={!canEditConfig}
               onClick={e => {

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
@@ -18,9 +18,15 @@ interface EmailActionsCellProps {
   row: { original: DataMartReport };
   onDeleteSuccess?: () => void;
   onEditReport?: (report: DataMartReport) => void;
+  onRunSuccess?: () => void | Promise<void>;
 }
 
-export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailActionsCellProps) {
+export function EmailActionsCell({
+  row,
+  onDeleteSuccess,
+  onEditReport,
+  onRunSuccess,
+}: EmailActionsCellProps) {
   const canRun = row.original.canRun;
   const canEditConfig = row.original.canEditConfig;
   const [isRunning, setIsRunning] = useState(
@@ -76,11 +82,12 @@ export function EmailActionsCell({ row, onDeleteSuccess, onEditReport }: EmailAc
     try {
       setIsRunning(true);
       await runReport(row.original.id);
+      await onRunSuccess?.();
     } catch (error) {
       setIsRunning(false);
       console.error('Failed to run report:', error);
     }
-  }, [canRun, runReport, row.original.id]);
+  }, [canRun, onRunSuccess, runReport, row.original.id]);
 
   return (
     <TooltipProvider>

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/columns/columns.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/columns/columns.tsx
@@ -24,6 +24,7 @@ export const getEmailColumns = ({
     size: 50,
     enableResizing: false,
     enableSorting: false,
+    enableHiding: false,
     header: () => null,
     cell: ({ row }) => <ReportQuickRunCell report={row.original} />,
   },

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/columns/columns.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/columns/columns.tsx
@@ -4,6 +4,7 @@ import RelativeTime from '@owox/ui/components/common/relative-time';
 import { EmailActionsCell } from '../EmailActionsCell';
 import { StatusIcon } from '../../StatusIcon';
 import type { DataMartReport } from '../../../../shared/model/types/data-mart-report';
+import { ReportQuickRunCell } from '../../../../shared';
 import { ReportColumnKey } from './columnKeys';
 import { ReportColumnLabels } from './columnLabels';
 import { UserReference } from '../../../../../../../shared/components/UserReference';
@@ -18,6 +19,14 @@ export const getEmailColumns = ({
   onDeleteSuccess,
   onEditReport,
 }: EmailTableColumnsProps = {}): ColumnDef<DataMartReport>[] => [
+  {
+    id: 'quickRun',
+    size: 50,
+    enableResizing: false,
+    enableSorting: false,
+    header: () => null,
+    cell: ({ row }) => <ReportQuickRunCell report={row.original} />,
+  },
   {
     accessorKey: ReportColumnKey.TITLE,
     size: 320,
@@ -115,7 +124,7 @@ export const getEmailColumns = ({
   },
   {
     id: 'actions',
-    size: 140,
+    size: 130,
     enableResizing: false,
     header: ({ table }) => <ToggleColumnsHeader table={table} />,
     cell: ({ row }) => (

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { MoreHorizontal, Pencil, Play, FileText, Trash2 } from 'lucide-react';
+import { MoreHorizontal, Pencil, FileText, Trash2, Play } from 'lucide-react';
 import { Button } from '@owox/ui/components/button';
 import {
   DropdownMenu,
@@ -20,8 +20,7 @@ import type {
   DataMartReport,
   GoogleSheetsDestinationConfig,
 } from '../../../shared/model/types/data-mart-report';
-import { ReportStatusEnum } from '../../../shared/enums';
-import { useReport } from '../../../shared';
+import { useReport, ReportStatusEnum } from '../../../shared';
 import { GeneratedSqlViewer } from '../../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
 
 interface GoogleSheetsActionsCellProps {
@@ -110,27 +109,6 @@ export function GoogleSheetsActionsCell({
           e.stopPropagation();
         }}
       >
-        {/* Run report */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              onClick={e => {
-                e.stopPropagation();
-                void handleRun();
-              }}
-              variant='ghost'
-              className='dm-card-table-body-row-actionbtn opacity-0 transition-opacity group-hover:opacity-100 disabled:opacity-0 disabled:group-hover:opacity-50'
-              disabled={isRunning || !canRun}
-              aria-label={isRunning ? 'Running report...' : `Run report: ${row.original.title}`}
-            >
-              <Play className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent id={`run-report-${row.original.id}`} side='bottom' role='tooltip'>
-            Run report
-          </TooltipContent>
-        </Tooltip>
-
         {/* Open doc */}
         <Tooltip>
           <TooltipTrigger asChild>
@@ -184,6 +162,18 @@ export function GoogleSheetsActionsCell({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent id={actionsMenuId} align='end' role='menu'>
+            <DropdownMenuItem
+              disabled={isRunning || !canRun}
+              onClick={e => {
+                e.stopPropagation();
+                void handleRun();
+              }}
+              role='menuitem'
+            >
+              <Play className='text-foreground h-4 w-4' aria-hidden='true' />
+              {isRunning ? 'Running report...' : 'Run report'}
+            </DropdownMenuItem>
+
             <DropdownMenuItem
               disabled={!canEditConfig}
               onClick={e => {

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/columns/columns.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/columns/columns.tsx
@@ -24,6 +24,7 @@ export const getGoogleSheetsColumns = ({
     size: 50,
     enableResizing: false,
     enableSorting: false,
+    enableHiding: false,
     header: () => null,
     cell: ({ row }) => <ReportQuickRunCell report={row.original} />,
   },

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/columns/columns.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/columns/columns.tsx
@@ -4,6 +4,7 @@ import { SortableHeader, ToggleColumnsHeader } from '../../../../../../../shared
 import { StatusIcon } from '../../StatusIcon';
 import { GoogleSheetsActionsCell } from '../GoogleSheetsActionsCell';
 import type { DataMartReport } from '../../../../shared/model/types/data-mart-report';
+import { ReportQuickRunCell } from '../../../../shared';
 import { ReportColumnKey } from './columnKeys';
 import { ReportColumnLabels } from './columnLabels';
 import { UserReference } from '../../../../../../../shared/components/UserReference';
@@ -18,6 +19,14 @@ export const getGoogleSheetsColumns = ({
   onDeleteSuccess,
   onEditReport,
 }: GoogleSheetsTableColumnsProps = {}): ColumnDef<DataMartReport>[] => [
+  {
+    id: 'quickRun',
+    size: 50,
+    enableResizing: false,
+    enableSorting: false,
+    header: () => null,
+    cell: ({ row }) => <ReportQuickRunCell report={row.original} />,
+  },
   {
     accessorKey: ReportColumnKey.TITLE,
     size: 320,
@@ -109,7 +118,7 @@ export const getGoogleSheetsColumns = ({
   },
   {
     id: 'actions',
-    size: 140,
+    size: 130,
     enableResizing: false,
     header: ({ table }) => <ToggleColumnsHeader table={table} />,
     cell: ({ row }) => (

--- a/apps/web/src/features/data-marts/reports/shared/components/ReportQuickRunCell.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/ReportQuickRunCell.tsx
@@ -43,6 +43,10 @@ export function ReportQuickRunCell({ report, onRunSuccess }: ReportQuickRunCellP
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      if (toastIdRef.current) {
+        toast.dismiss(toastIdRef.current);
+        toastIdRef.current = null;
+      }
     };
   }, []);
 

--- a/apps/web/src/features/data-marts/reports/shared/components/ReportQuickRunCell.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/ReportQuickRunCell.tsx
@@ -1,0 +1,137 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Loader2, Play } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+import { Button } from '@owox/ui/components/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@owox/ui/components/tooltip';
+import type { DataMartReport } from '../model/types/data-mart-report';
+import { ReportStatusEnum } from '../enums';
+import { useReport } from '../model';
+import { RunUndoToast } from './RunUndoToast';
+
+const GRACE_PERIOD_MS = 3000;
+
+interface ReportQuickRunCellProps {
+  report: DataMartReport;
+  onRunSuccess?: () => void | Promise<void>;
+}
+
+export function ReportQuickRunCell({ report, onRunSuccess }: ReportQuickRunCellProps) {
+  const canRun = report.canRun;
+  const [isRunning, setIsRunning] = useState(report.lastRunStatus === ReportStatusEnum.RUNNING);
+  const [isPending, setIsPending] = useState(false);
+  const [isOptimisticRunning, setIsOptimisticRunning] = useState(false);
+  const { runReport } = useReport();
+
+  useEffect(() => {
+    const running = report.lastRunStatus === ReportStatusEnum.RUNNING;
+    setIsRunning(running);
+    if (running) {
+      setIsOptimisticRunning(false);
+    }
+  }, [report.lastRunStatus]);
+
+  const mountedRef = useRef(true);
+  const hasRunRef = useRef(false);
+  const toastIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const executeRun = useCallback(async () => {
+    if (hasRunRef.current) return;
+    hasRunRef.current = true;
+
+    if (toastIdRef.current) {
+      toast.dismiss(toastIdRef.current);
+      toastIdRef.current = null;
+    }
+
+    setIsPending(false);
+    setIsOptimisticRunning(true);
+
+    try {
+      await runReport(report.id);
+      if (onRunSuccess) await onRunSuccess();
+    } catch (error) {
+      console.error('Failed to run report:', error);
+    } finally {
+      if (mountedRef.current) {
+        setIsOptimisticRunning(false);
+      }
+    }
+  }, [runReport, report.id, onRunSuccess]);
+
+  const handleRun = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!canRun || isPending || isRunning || isOptimisticRunning) return;
+
+      hasRunRef.current = false;
+      setIsPending(true);
+
+      const id = toast.custom(
+        t => (
+          <RunUndoToast
+            toastId={t.id}
+            reportName={report.title}
+            gracePeriodMs={GRACE_PERIOD_MS}
+            onConfirm={executeRun}
+            onCancel={() => {
+              if (hasRunRef.current) return;
+              if (mountedRef.current) {
+                setIsPending(false);
+              }
+            }}
+          />
+        ),
+        { duration: Infinity, position: 'bottom-center' }
+      );
+
+      toastIdRef.current = id;
+    },
+    [canRun, isPending, isRunning, isOptimisticRunning, executeRun, report.title]
+  );
+
+  const isActive = isPending || isRunning || isOptimisticRunning;
+  const tooltipText = isPending
+    ? 'Starting soon…'
+    : isRunning || isOptimisticRunning
+      ? 'Report is running…'
+      : 'Run report';
+
+  return (
+    <TooltipProvider>
+      <div className='flex h-full w-full items-center justify-center'>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              onClick={handleRun}
+              variant='ghost'
+              className='text-muted-foreground hover:text-primary h-8 w-8 p-0 opacity-60 transition-all duration-200 hover:opacity-100 disabled:opacity-30'
+              disabled={!canRun || isActive}
+              aria-label={isActive ? tooltipText : `Run report: ${report.title}`}
+            >
+              {isPending ? (
+                <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
+              ) : (
+                <Play className='h-4 w-4' aria-hidden='true' />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side='bottom' role='tooltip'>
+            {tooltipText}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/features/data-marts/reports/shared/components/RunUndoToast.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/RunUndoToast.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+
+interface RunUndoToastProps {
+  toastId: string;
+  reportName: string;
+  gracePeriodMs: number;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}
+
+export function RunUndoToast({
+  toastId,
+  reportName,
+  gracePeriodMs,
+  onConfirm,
+  onCancel,
+}: RunUndoToastProps) {
+  const [remaining, setRemaining] = useState(gracePeriodMs);
+  const activeRef = useRef(true);
+  const onConfirmRef = useRef(onConfirm);
+  onConfirmRef.current = onConfirm;
+
+  useEffect(() => {
+    const startTime = Date.now();
+
+    const interval = setInterval(() => {
+      if (!activeRef.current) return;
+
+      const left = Math.max(0, gracePeriodMs - (Date.now() - startTime));
+      setRemaining(left);
+
+      if (left <= 0) {
+        clearInterval(interval);
+        toast.dismiss(toastId);
+        void onConfirmRef.current().catch(console.error);
+      }
+    }, 100);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [gracePeriodMs, toastId]);
+
+  const handleCancel = () => {
+    activeRef.current = false;
+    toast.dismiss(toastId);
+    onCancel();
+  };
+
+  const seconds = Math.ceil(remaining / 1000);
+  const circumference = 2 * Math.PI * 13;
+  const dashOffset = circumference * (1 - remaining / gracePeriodMs);
+
+  return (
+    <div className='bg-popover text-popover-foreground border-border flex min-w-[300px] items-center gap-3 rounded-lg border px-4 py-3 shadow-lg'>
+      <Loader2 className='text-primary h-4 w-4 flex-shrink-0 animate-spin' aria-hidden='true' />
+      <div className='flex-1'>
+        <p className='text-sm font-medium'>Starting &ldquo;{reportName}&rdquo;&hellip;</p>
+        <p className='text-muted-foreground text-xs'>
+          Undo within {Math.ceil(gracePeriodMs / 1000)} seconds
+        </p>
+      </div>
+      <div className='relative flex-shrink-0' style={{ width: 32, height: 32 }}>
+        <svg
+          width='32'
+          height='32'
+          viewBox='0 0 32 32'
+          style={{ transform: 'rotate(-90deg)' }}
+          aria-hidden='true'
+        >
+          <circle cx='16' cy='16' r='13' fill='none' className='stroke-border' strokeWidth='3' />
+          <circle
+            cx='16'
+            cy='16'
+            r='13'
+            fill='none'
+            className='stroke-primary'
+            strokeWidth='3'
+            strokeLinecap='round'
+            strokeDasharray={circumference}
+            strokeDashoffset={dashOffset}
+          />
+        </svg>
+        <div className='text-muted-foreground absolute inset-0 flex items-center justify-center text-xs font-semibold'>
+          {seconds}
+        </div>
+      </div>
+      <button
+        onClick={handleCancel}
+        className='bg-secondary text-secondary-foreground hover:bg-accent rounded px-3 py-1.5 text-xs font-medium transition-colors'
+        aria-label='Cancel run'
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/reports/shared/components/__tests__/ReportQuickRunCell.test.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/__tests__/ReportQuickRunCell.test.tsx
@@ -1,0 +1,173 @@
+import type { ReactElement } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReportStatusEnum } from '../../enums';
+
+const mockRunReport = vi.hoisted(() => vi.fn());
+vi.mock('../../model', () => ({
+  useReport: () => ({ runReport: mockRunReport }),
+}));
+
+const mockToastCustom = vi.hoisted(() => vi.fn().mockReturnValue('mock-id'));
+vi.mock('react-hot-toast', () => ({
+  toast: { custom: mockToastCustom, dismiss: vi.fn() },
+}));
+
+import { ReportQuickRunCell } from '../ReportQuickRunCell';
+import type { DataMartReport } from '../../model/types/data-mart-report';
+
+function makeReport(overrides: Partial<DataMartReport> = {}): DataMartReport {
+  return {
+    id: 'report-1',
+    title: 'Monthly Revenue',
+    canRun: true,
+    lastRunStatus: ReportStatusEnum.SUCCESS,
+    ...overrides,
+  } as DataMartReport;
+}
+
+describe('ReportQuickRunCell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a Run button when report canRun is true', () => {
+    render(<ReportQuickRunCell report={makeReport()} />);
+    expect(screen.getByRole('button', { name: /run report/i })).toBeInTheDocument();
+  });
+
+  it('disables the button immediately after clicking Run (isPending)', () => {
+    render(<ReportQuickRunCell report={makeReport()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /run report/i }));
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('shows toast.custom with bottom-center position when Run is clicked', () => {
+    render(<ReportQuickRunCell report={makeReport()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /run report/i }));
+
+    expect(mockToastCustom).toHaveBeenCalledOnce();
+    expect(mockToastCustom).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ position: 'bottom-center', duration: Infinity })
+    );
+  });
+
+  it('calls runReport when onConfirm is invoked via the toast', async () => {
+    mockRunReport.mockResolvedValue(undefined);
+
+    render(<ReportQuickRunCell report={makeReport()} />);
+    fireEvent.click(screen.getByRole('button', { name: /run report/i }));
+
+    // Extract the render function passed to toast.custom and invoke it
+    // to get the RunUndoToast element, then grab its onConfirm prop
+    const renderFn = mockToastCustom.mock.calls[0][0] as (t: { id: string }) => ReactElement;
+    const element = renderFn({ id: 'mock-id' });
+    const { onConfirm } = element.props as { onConfirm: () => Promise<void>; onCancel: () => void };
+
+    await act(async () => {
+      await onConfirm();
+    });
+
+    expect(mockRunReport).toHaveBeenCalledWith('report-1');
+  });
+
+  it('re-enables the button when onCancel is invoked via the toast', async () => {
+    render(<ReportQuickRunCell report={makeReport()} />);
+    fireEvent.click(screen.getByRole('button', { name: /run report/i }));
+
+    expect(screen.getByRole('button')).toBeDisabled();
+
+    const renderFn = mockToastCustom.mock.calls[0][0] as (t: { id: string }) => ReactElement;
+    const element = renderFn({ id: 'mock-id' });
+    const { onCancel } = element.props as { onConfirm: () => Promise<void>; onCancel: () => void };
+
+    act(() => {
+      onCancel();
+    });
+
+    expect(screen.getByRole('button')).not.toBeDisabled();
+  });
+
+  it('disables the button when report canRun is false', () => {
+    render(<ReportQuickRunCell report={makeReport({ canRun: false })} />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('does not call toast.custom if Run is clicked while already pending', () => {
+    render(<ReportQuickRunCell report={makeReport()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /run report/i }));
+    // Button is now disabled — second click should be a no-op
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockToastCustom).toHaveBeenCalledOnce();
+  });
+
+  it('removes the spinner after the deferred run is confirmed', async () => {
+    mockRunReport.mockResolvedValue(undefined);
+
+    render(<ReportQuickRunCell report={makeReport()} />);
+    fireEvent.click(screen.getByRole('button', { name: /run report/i }));
+
+    const renderFn = mockToastCustom.mock.calls[0][0] as (t: { id: string }) => ReactElement;
+    const element = renderFn({ id: 'mock-id' });
+    const { onConfirm } = element.props as { onConfirm: () => Promise<void>; onCancel: () => void };
+
+    await act(async () => {
+      await onConfirm();
+    });
+
+    expect(screen.getByRole('button')).not.toHaveAttribute('aria-label', 'Starting soon…');
+    expect(document.querySelector('.animate-spin')).not.toBeInTheDocument();
+  });
+
+  it('shows a disabled Run button while the actual report run is in progress', async () => {
+    mockRunReport.mockImplementation(() => new Promise(() => {}));
+
+    render(<ReportQuickRunCell report={makeReport()} />);
+    fireEvent.click(screen.getByRole('button', { name: /run report/i }));
+
+    const renderFn = mockToastCustom.mock.calls[0][0] as (t: { id: string }) => ReactElement;
+    const element = renderFn({ id: 'mock-id' });
+    const { onConfirm } = element.props as { onConfirm: () => Promise<void>; onCancel: () => void };
+
+    // Trigger the actual run but do not await it, simulating a long-running request.
+    act(() => {
+      void onConfirm();
+    });
+
+    await waitFor(() => {
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-label', 'Report is running…');
+    });
+
+    expect(document.querySelector('.animate-spin')).not.toBeInTheDocument();
+  });
+
+  it('removes the spinner and runs the report when RunUndoToast fires onConfirm after grace period', async () => {
+    mockRunReport.mockResolvedValue(undefined);
+
+    render(<ReportQuickRunCell report={makeReport()} />);
+    fireEvent.click(screen.getByRole('button', { name: /run report/i }));
+
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+
+    // Simulate RunUndoToast calling onConfirm when its countdown expires
+    const renderFn = mockToastCustom.mock.calls[0][0] as (t: { id: string }) => ReactElement;
+    const element = renderFn({ id: 'mock-id' });
+    const { onConfirm } = element.props as { onConfirm: () => Promise<void> };
+
+    await act(async () => {
+      await onConfirm();
+    });
+
+    expect(mockRunReport).toHaveBeenCalledWith('report-1');
+    expect(document.querySelector('.animate-spin')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/reports/shared/components/__tests__/RunUndoToast.test.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/__tests__/RunUndoToast.test.tsx
@@ -1,0 +1,100 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDismiss = vi.hoisted(() => vi.fn());
+vi.mock('react-hot-toast', () => ({
+  toast: { dismiss: mockDismiss },
+}));
+
+import { RunUndoToast } from '../RunUndoToast';
+
+describe('RunUndoToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the report name', () => {
+    render(
+      <RunUndoToast
+        toastId='t1'
+        reportName='Monthly Revenue'
+        gracePeriodMs={5000}
+        onConfirm={vi.fn().mockResolvedValue(undefined)}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Monthly Revenue/)).toBeInTheDocument();
+  });
+
+  it('calls onConfirm and dismisses the toast after gracePeriodMs', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <RunUndoToast
+        toastId='t1'
+        reportName='Test'
+        gracePeriodMs={5000}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(mockDismiss).toHaveBeenCalledWith('t1');
+  });
+
+  it('does not call onConfirm before gracePeriodMs elapses', async () => {
+    const onConfirm = vi.fn();
+
+    render(
+      <RunUndoToast
+        toastId='t1'
+        reportName='Test'
+        gracePeriodMs={5000}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(4900);
+    });
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls onCancel and dismisses when Cancel is clicked, and does not later call onConfirm', async () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+
+    render(
+      <RunUndoToast
+        toastId='t1'
+        reportName='Test'
+        gracePeriodMs={5000}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(mockDismiss).toHaveBeenCalledWith('t1');
+
+    // Advance past grace period — onConfirm must NOT fire after cancel
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/data-marts/reports/shared/components/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/components/index.ts
@@ -1,1 +1,2 @@
 export * from './ReportHoverCard';
+export * from './ReportQuickRunCell';

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DataDestinationType } from '../../../features/data-destination';
@@ -16,6 +17,12 @@ import { reportService } from '../../../features/data-marts/reports/shared/servi
 import { mapReportDtoToEntity } from '../../../features/data-marts/reports/shared/model/mappers';
 import DataMartReportsPage from './DataMartReportsPage';
 import { mergeReportPagePreservingRows } from './DataMartReportsPage.utils';
+
+const mockToastCustom = vi.hoisted(() => vi.fn().mockReturnValue('mock-toast-id'));
+vi.mock('react-hot-toast', () => ({
+  default: { custom: mockToastCustom, dismiss: vi.fn(), success: vi.fn() },
+  toast: { custom: mockToastCustom, dismiss: vi.fn(), success: vi.fn() },
+}));
 
 const reportServiceMock = vi.hoisted(() => ({
   getReportsByProject: vi.fn(),
@@ -395,9 +402,7 @@ describe('DataMartReportsPage', () => {
       )
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', {
-        name: 'Preview SQL: Blended Sheet Report',
-      })
+      screen.getByRole('button', { name: 'Preview SQL: Blended Sheet Report' })
     ).toBeInTheDocument();
 
     fireEvent.pointerDown(
@@ -451,6 +456,18 @@ describe('DataMartReportsPage', () => {
     fireEvent.click(
       await screen.findByRole('button', { name: 'Run report: Blended Sheet Report' })
     );
+
+    // The component uses a grace-period toast; invoke onConfirm to trigger the actual run
+    await waitFor(() => {
+      expect(mockToastCustom).toHaveBeenCalled();
+    });
+    const renderFn = mockToastCustom.mock.calls[0][0] as (t: { id: string }) => ReactElement;
+    const element = renderFn({ id: 'mock-toast-id' });
+    const { onConfirm } = element.props as { onConfirm: () => Promise<void> };
+
+    await act(async () => {
+      await onConfirm();
+    });
 
     await waitFor(() => {
       expect(reportService.runReport).toHaveBeenCalledWith('report-1');

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
@@ -138,6 +138,7 @@ function ProjectReportActionsCell({
   const actionProps = {
     row: { original: report },
     onDeleteSuccess: onReportActionComplete,
+    onRunSuccess: onReportActionComplete,
     onEditReport,
   };
 
@@ -278,6 +279,7 @@ export default function DataMartReportsPage() {
         size: 50,
         enableResizing: false,
         enableSorting: false,
+        enableHiding: false,
         header: () => null,
         cell: ({ row }) => (
           <ReportQuickRunCell report={row.original} onRunSuccess={handleReportActionComplete} />

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
@@ -16,6 +16,7 @@ import { ReportEditSheetRenderer } from '../../../features/data-marts/reports/li
 import { useReportSidesheet } from '../../../features/data-marts/reports/list/model/hooks';
 import { mapReportDtoToEntity } from '../../../features/data-marts/reports/shared/model/mappers';
 import { ReportsProvider } from '../../../features/data-marts/reports/shared/model/context';
+import { ReportQuickRunCell } from '../../../features/data-marts/reports/shared';
 import type { DataMartReport } from '../../../features/data-marts/reports/shared/model/types/data-mart-report';
 import { ReportStatusEnum } from '../../../features/data-marts/reports/shared/enums';
 import { reportService } from '../../../features/data-marts/reports/shared/services';
@@ -138,7 +139,6 @@ function ProjectReportActionsCell({
     row: { original: report },
     onDeleteSuccess: onReportActionComplete,
     onEditReport,
-    onRunSuccess: onReportActionComplete,
   };
 
   let actionsCell: ReactNode = null;
@@ -274,6 +274,16 @@ export default function DataMartReportsPage() {
   const columns = useMemo<ColumnDef<DataMartReport>[]>(
     () => [
       {
+        id: 'quickRun',
+        size: 50,
+        enableResizing: false,
+        enableSorting: false,
+        header: () => null,
+        cell: ({ row }) => (
+          <ReportQuickRunCell report={row.original} onRunSuccess={handleReportActionComplete} />
+        ),
+      },
+      {
         id: 'dataMart',
         accessorFn: row => row.dataMart.title,
         size: 260,
@@ -376,7 +386,7 @@ export default function DataMartReportsPage() {
       },
       {
         id: 'actions',
-        size: 140,
+        size: 130,
         enableResizing: false,
         enableSorting: false,
         header: ({ table }) => <ToggleColumnsHeader table={table} />,


### PR DESCRIPTION
- Introduced a quick run feature for reports, allowing users to execute reports more efficiently.
- Added an undo toast notification to provide users with the option to revert the quick run action.