### PR TITLE
feat(data-marts): unified column identifiers for output control filters

### DIFF
--- a/.changeset/unified-column-identifiers.md
+++ b/.changeset/unified-column-identifiers.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Unified column identifiers for output control filters
+
+Slice (pre-join) filters now reference a column by the same fully qualified identifier as
+regular output filters — for example `category_details__item_event_count` — instead of a raw
+column name plus a separate `aliasPath`. This makes every filter, slice, and sort refer to a
+column the same way across the API and the Web/Extension report editor. Existing saved reports
+are migrated automatically, so no manual changes are needed.

--- a/apps/backend/src/data-marts/controllers/spec/report-openapi.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report-openapi.ts
@@ -127,7 +127,11 @@ export class ReportRelativeDateFilterValueApiDto {
 }
 
 export class ReportFilterRuleApiDto {
-  @ApiProperty({ minLength: 1 })
+  @ApiProperty({
+    minLength: 1,
+    description:
+      'Output column name. For slice filters (placement=pre-join), use the fully qualified blended column identifier, e.g. category_details__item_event_count.',
+  })
   column: string;
 
   @ApiProperty({
@@ -156,14 +160,6 @@ export class ReportFilterRuleApiDto {
     description: 'Use pre-join for slice filters. Omit for normal output filters.',
   })
   placement?: 'pre-join' | 'post-join';
-
-  @ApiPropertyOptional({
-    minLength: 1,
-    maxLength: 255,
-    pattern: '^[a-z0-9_]+(\\.[a-z0-9_]+)*$',
-    description: 'Required for slice filters when placement is pre-join.',
-  })
-  aliasPath?: string;
 }
 
 export class ReportSortRuleApiDto {
@@ -232,7 +228,8 @@ const commonReportRequestProperties = {
     nullable: true,
     maxItems: 50,
     items: { $ref: getSchemaPath(ReportFilterRuleApiDto) },
-    description: 'Output filters. Use placement=pre-join and aliasPath for slice filters.',
+    description:
+      'Output filters. Use placement=pre-join for slice filters (column = unified blended identifier).',
   },
   sortConfig: {
     type: 'array',

--- a/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
@@ -127,7 +127,10 @@ describe('ReportController OpenAPI', () => {
     );
     expect(filterRule.properties.value.oneOf).toHaveLength(3);
     expect(filterRule.properties.placement.enum).toEqual(['pre-join', 'post-join']);
-    expect(filterRule.properties.aliasPath.description).toContain('slice');
+    expect(filterRule.properties.aliasPath).toBeUndefined();
+    expect(filterRule.properties.column.description).toContain(
+      'category_details__item_event_count'
+    );
 
     expect(updateProperties.sortConfig).toMatchObject({
       type: 'array',

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-blended-query-builder.spec.ts
@@ -8,6 +8,7 @@ import {
 import { AthenaBlendedQueryBuilder } from './athena-blended-query-builder';
 import { AthenaClauseRenderer } from './athena-clause-renderer';
 import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
+import { buildBlendedFieldIndex } from '../../../services/blended-field-index';
 
 const buildContext = createBuildContext('"mydb"."customers"');
 
@@ -202,20 +203,26 @@ describe('AthenaBlendedQueryBuilder — output controls', () => {
         { targetFieldName: 'role', outputAlias: 'role', isHidden: true, aggregateFunction: 'MAX' },
       ],
     });
+    const fieldIndex = buildBlendedFieldIndex({
+      blendedFields: [
+        { name: 'users__role', aliasPath: 'users', originalFieldName: 'role', type: 'STRING' },
+      ],
+      availableSources: [{ aliasPath: 'users', isIncluded: true }],
+    } as never);
     const { params } = builder.buildBlendedQuery(
       ctx({
         chains: [chain],
         columns: ['a'],
         filters: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
           { column: 'a', operator: 'eq', value: 'post', placement: 'post-join' },
         ],
+        fieldIndex,
       })
     );
     // pre-join value first (lives inside the users_raw CTE), post-join value last.
@@ -253,20 +260,30 @@ describe('AthenaBlendedQueryBuilder — output controls', () => {
         },
       ],
     });
+    const fieldIndex = buildBlendedFieldIndex({
+      blendedFields: [
+        {
+          name: 'users__signup_date',
+          aliasPath: 'users',
+          originalFieldName: 'signup_date',
+          type: 'DATE',
+        },
+      ],
+      availableSources: [{ aliasPath: 'users', isIncluded: true }],
+    } as never);
     const { sql, params } = builder.buildBlendedQuery(
       ctx({
         chains: [chain],
         columns: ['a'],
         filters: [
           {
-            column: 'signup_date',
+            column: 'users__signup_date',
             operator: 'gte',
             value: '2024-01-01',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
-        columnTypes: { preJoin: new Map([['users', new Map([['signup_date', 'DATE']])]]) },
+        fieldIndex,
       })
     );
     expect(sql).toContain('signup_date >= CAST(? AS DATE)');

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-blended-query-builder-edge-cases.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-blended-query-builder-edge-cases.spec.ts
@@ -1,4 +1,5 @@
 import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
+import { buildBlendedFieldIndex } from '../../../services/blended-field-index';
 import {
   makeChain,
   makeRelationship,
@@ -122,6 +123,17 @@ describe('BigQueryBlendedQueryBuilder — SQL safety / quoting', () => {
       ],
     });
 
+    const fieldIndex = buildBlendedFieldIndex({
+      blendedFields: [
+        {
+          name: 'users__first name',
+          aliasPath: 'users',
+          originalFieldName: 'first name',
+          type: 'STRING',
+        },
+      ],
+      availableSources: [{ aliasPath: 'users', isIncluded: true }],
+    } as never);
     const ctx: BlendedQueryContext = {
       mainTableReference: '`project.dataset.events`',
       mainDataMartTitle: 'Events',
@@ -130,12 +142,12 @@ describe('BigQueryBlendedQueryBuilder — SQL safety / quoting', () => {
       columns: ['event_id', 'first_name_agg'],
       filters: [
         {
-          column: 'first name',
+          column: 'users__first name',
           operator: 'is_not_null',
           placement: 'pre-join',
-          aliasPath: 'users',
         },
       ],
+      fieldIndex,
     };
 
     const { sql } = builder.buildBlendedQuery(ctx);

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-blended-query-builder.spec.ts
@@ -8,6 +8,7 @@ import {
 import { DatabricksBlendedQueryBuilder } from './databricks-blended-query-builder';
 import { DatabricksClauseRenderer } from './databricks-clause-renderer';
 import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
+import { buildBlendedFieldIndex } from '../../../services/blended-field-index';
 
 const buildContext = createBuildContext('`catalog`.`schema`.`customers`');
 
@@ -177,19 +178,25 @@ describe('DatabricksBlendedQueryBuilder — output controls', () => {
         { targetFieldName: 'role', outputAlias: 'role', isHidden: true, aggregateFunction: 'MAX' },
       ],
     });
+    const fieldIndex = buildBlendedFieldIndex({
+      blendedFields: [
+        { name: 'users__role', aliasPath: 'users', originalFieldName: 'role', type: 'STRING' },
+      ],
+      availableSources: [{ aliasPath: 'users', isIncluded: true }],
+    } as never);
     const { sql, params } = builder.buildBlendedQuery(
       ctx({
         chains: [chain],
         columns: ['a'],
         filters: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
+        fieldIndex,
       })
     );
     // The inlined predicate must sit inside the subsidiary raw CTE, before the outer SELECT.

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
@@ -10,6 +10,7 @@ import { AbstractBlendedQueryBuilder } from './abstract-blended-query-builder';
 import { ResolvedRelationshipChain, BlendedQueryContext } from './blended-query-builder.interface';
 import { SqlClauseRenderer, SqlParameter } from '../utils/sql-clause-renderer';
 import { BigQueryClauseRenderer } from '../bigquery/services/bigquery-clause-renderer';
+import { buildBlendedFieldIndex } from '../../services/blended-field-index';
 
 // Uses backtick quoting and a plain STRING_AGG syntax (no CAST) so that SQL-shape
 // assertions stay readable — dialect-specific CASTs are covered by per-dialect specs.
@@ -1264,17 +1265,28 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
     }
 
     it('emits WHERE inside a leaf raw CTE for a single pre-join filter', () => {
+      const fieldIndex = buildBlendedFieldIndex({
+        blendedFields: [
+          {
+            name: 'users__userRole',
+            aliasPath: 'users',
+            originalFieldName: 'userRole',
+            type: 'STRING',
+          },
+        ],
+        availableSources: [{ aliasPath: 'users', isIncluded: true }],
+      } as never);
       const ctx: BlendedQueryContext = {
         ...buildContext([makeUsersChain()], ['users_email']),
         filters: [
           {
-            column: 'userRole',
+            column: 'users__userRole',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
+        fieldIndex,
       };
       const { sql, params } = builder.buildBlendedQuery(ctx);
       expect(sql).toMatch(/users_raw AS \([\s\S]+?WHERE\s+userRole\s*=\s*@s_users_0/);
@@ -1282,41 +1294,68 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
     });
 
     it('projects pre-join filter columns into the raw CTE even if not in columnConfig', () => {
+      const fieldIndex = buildBlendedFieldIndex({
+        blendedFields: [
+          {
+            name: 'users__userRole',
+            aliasPath: 'users',
+            originalFieldName: 'userRole',
+            type: 'STRING',
+          },
+        ],
+        availableSources: [{ aliasPath: 'users', isIncluded: true }],
+      } as never);
       const ctx: BlendedQueryContext = {
         ...buildContext([makeUsersChain()], ['users_email']),
         filters: [
           {
-            column: 'userRole',
+            column: 'users__userRole',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
+        fieldIndex,
       };
       const { sql } = builder.buildBlendedQuery(ctx);
       expect(sql).toMatch(/users_raw AS \([\s\S]*?userRole[\s\S]*?FROM/);
     });
 
     it('combines multiple pre-join filters on the same CTE with AND', () => {
+      const fieldIndex = buildBlendedFieldIndex({
+        blendedFields: [
+          {
+            name: 'users__userRole',
+            aliasPath: 'users',
+            originalFieldName: 'userRole',
+            type: 'STRING',
+          },
+          {
+            name: 'users__createdAt',
+            aliasPath: 'users',
+            originalFieldName: 'createdAt',
+            type: 'TIMESTAMP',
+          },
+        ],
+        availableSources: [{ aliasPath: 'users', isIncluded: true }],
+      } as never);
       const ctx: BlendedQueryContext = {
         ...buildContext([makeUsersChain()], ['users_email']),
         filters: [
           {
-            column: 'userRole',
+            column: 'users__userRole',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
           {
-            column: 'createdAt',
+            column: 'users__createdAt',
             operator: 'relative_date',
             value: { kind: 'last_n_days', n: 30 },
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
+        fieldIndex,
       };
       const { sql } = builder.buildBlendedQuery(ctx);
       expect(sql).toMatch(/WHERE[\s\S]+AND[\s\S]+DATE_SUB/);
@@ -1340,25 +1379,39 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
           },
         ],
       });
+      const fieldIndex = buildBlendedFieldIndex({
+        blendedFields: [
+          {
+            name: 'users__userRole',
+            aliasPath: 'users',
+            originalFieldName: 'userRole',
+            type: 'STRING',
+          },
+          { name: 'orgs__plan', aliasPath: 'orgs', originalFieldName: 'plan', type: 'STRING' },
+        ],
+        availableSources: [
+          { aliasPath: 'users', isIncluded: true },
+          { aliasPath: 'orgs', isIncluded: true },
+        ],
+      } as never);
       const ctx: BlendedQueryContext = {
         ...buildContext([makeUsersChain(), orgsChain], ['users_email', 'orgs_name']),
         filters: [
           { column: 'users_email', operator: 'contains', value: '@owox' },
           {
-            column: 'userRole',
+            column: 'users__userRole',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
           {
-            column: 'plan',
+            column: 'orgs__plan',
             operator: 'eq',
             value: 'pro',
             placement: 'pre-join',
-            aliasPath: 'orgs',
           },
         ],
+        fieldIndex,
       };
       const { params } = builder.buildBlendedQuery(ctx);
       const names = params.map(p => p.name).sort();
@@ -1366,17 +1419,28 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
     });
 
     it('quotes each segment of a dotted column (nested struct) in the pre-join WHERE', () => {
+      const fieldIndex = buildBlendedFieldIndex({
+        blendedFields: [
+          {
+            name: 'users__profile.country',
+            aliasPath: 'users',
+            originalFieldName: 'profile.country',
+            type: 'STRING',
+          },
+        ],
+        availableSources: [{ aliasPath: 'users', isIncluded: true }],
+      } as never);
       const ctx: BlendedQueryContext = {
         ...buildContext([makeUsersChain()], ['users_email']),
         filters: [
           {
-            column: 'profile.country',
+            column: 'users__profile.country',
             operator: 'eq',
             value: 'UA',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
+        fieldIndex,
       };
       const { sql } = builder.buildBlendedQuery(ctx);
       // M1 regression: nested struct paths must traverse as `profile.country`
@@ -1390,35 +1454,52 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
       expect(sql).not.toContain('`profile.country`');
     });
 
-    it('throws when a pre-join filter aliasPath does not resolve to any chain', () => {
+    it('throws when a pre-join filter column does not resolve in the field index', () => {
+      const fieldIndex = buildBlendedFieldIndex({
+        blendedFields: [
+          { name: 'users__email', aliasPath: 'users', originalFieldName: 'email', type: 'STRING' },
+        ],
+        availableSources: [{ aliasPath: 'users', isIncluded: true }],
+      } as never);
       const ctx: BlendedQueryContext = {
         ...buildContext([makeUsersChain()], ['users_email']),
         filters: [
           {
-            column: 'plan',
+            column: 'orgs__plan',
             operator: 'eq',
             value: 'pro',
             placement: 'pre-join',
-            aliasPath: 'orgs',
           },
         ],
+        fieldIndex,
       };
-      expect(() => builder.buildBlendedQuery(ctx)).toThrow(/aliasPath='orgs'/);
+      expect(() => builder.buildBlendedQuery(ctx)).toThrow(/column='orgs__plan'/);
     });
 
     it("post-join filters use the 'p' prefix so they never collide with pre-join 's_<cte>_' prefixes", () => {
+      const fieldIndex = buildBlendedFieldIndex({
+        blendedFields: [
+          {
+            name: 'users__userRole',
+            aliasPath: 'users',
+            originalFieldName: 'userRole',
+            type: 'STRING',
+          },
+        ],
+        availableSources: [{ aliasPath: 'users', isIncluded: true }],
+      } as never);
       const ctx: BlendedQueryContext = {
         ...buildContext([makeUsersChain()], ['customer_name', 'users_email']),
         filters: [
           { column: 'customer_name', operator: 'eq', value: 'X' },
           {
-            column: 'userRole',
+            column: 'users__userRole',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
+        fieldIndex,
       };
       const { sql, params } = builder.buildBlendedQuery(ctx);
       expect(sql).toContain('WHERE main.customer_name = @p0');
@@ -1450,12 +1531,23 @@ describe('AbstractBlendedQueryBuilder — output controls', () => {
       });
     }
 
-    type RuleInput = Omit<FilterRule, 'placement' | 'aliasPath'>;
+    type RuleInput = Omit<FilterRule, 'placement'>;
 
     function runWithRule(rule: RuleInput): { sql: string; params: SqlParameter[] } {
+      // Build a field index that maps the unified name to the users CTE.
+      // Column in rule is the raw field name; unified name = 'users__<column>'.
+      const rawColumn = rule.column;
+      const unifiedName = `users__${rawColumn}`;
+      const fieldIndex = buildBlendedFieldIndex({
+        blendedFields: [
+          { name: unifiedName, aliasPath: 'users', originalFieldName: rawColumn, type: 'STRING' },
+        ],
+        availableSources: [{ aliasPath: 'users', isIncluded: true }],
+      } as never);
       const ctx: BlendedQueryContext = {
         ...buildContext([makeUsersChain()], ['users_email']),
-        filters: [{ ...rule, placement: 'pre-join', aliasPath: 'users' } as FilterRule],
+        filters: [{ ...rule, column: unifiedName, placement: 'pre-join' } as FilterRule],
+        fieldIndex,
       };
       return builder.buildBlendedQuery(ctx);
     }
@@ -1620,17 +1712,23 @@ describe('AbstractBlendedQueryBuilder — pre-join filters on tricky tree shapes
       ],
     });
 
+    const fieldIndex = buildBlendedFieldIndex({
+      blendedFields: [
+        { name: 'b__b_status', aliasPath: 'b', originalFieldName: 'b_status', type: 'STRING' },
+      ],
+      availableSources: [{ aliasPath: 'b', isIncluded: true }],
+    } as never);
     const ctx: BlendedQueryContext = {
       ...buildContext([bChain, cChain], ['b_blend']),
       filters: [
         {
-          column: 'b_status',
+          column: 'b__b_status',
           operator: 'eq',
           value: 'active',
           placement: 'pre-join',
-          aliasPath: 'b',
         } as FilterRule,
       ],
+      fieldIndex,
     };
     const { sql } = builder.buildBlendedQuery(ctx);
 
@@ -1692,17 +1790,28 @@ describe('AbstractBlendedQueryBuilder — pre-join filters on tricky tree shapes
       ],
     });
 
+    const fieldIndex = buildBlendedFieldIndex({
+      blendedFields: [
+        {
+          name: 'a_b_c_d__d_status',
+          aliasPath: 'a.b.c.d',
+          originalFieldName: 'd_status',
+          type: 'STRING',
+        },
+      ],
+      availableSources: [{ aliasPath: 'a.b.c.d', isIncluded: true }],
+    } as never);
     const ctx: BlendedQueryContext = {
       ...buildContext([aChain, bChain, cChain, dChain], ['d_blend']),
       filters: [
         {
-          column: 'd_status',
+          column: 'a_b_c_d__d_status',
           operator: 'eq',
           value: 'live',
           placement: 'pre-join',
-          aliasPath: 'a.b.c.d',
         } as FilterRule,
       ],
+      fieldIndex,
     };
     const { sql } = builder.buildBlendedQuery(ctx);
 
@@ -1773,17 +1882,23 @@ describe('AbstractBlendedQueryBuilder — pre-join filters on tricky tree shapes
       ],
     });
 
+    const fieldIndex = buildBlendedFieldIndex({
+      blendedFields: [
+        { name: 'a_c__c_status', aliasPath: 'a.c', originalFieldName: 'c_status', type: 'STRING' },
+      ],
+      availableSources: [{ aliasPath: 'a.c', isIncluded: true }],
+    } as never);
     const ctx: BlendedQueryContext = {
       ...buildContext([aChain, acChain, bChain, bcChain], ['ac_blend', 'bc_blend']),
       filters: [
         {
-          column: 'c_status',
+          column: 'a_c__c_status',
           operator: 'eq',
           value: 'live',
           placement: 'pre-join',
-          aliasPath: 'a.c',
         } as FilterRule,
       ],
+      fieldIndex,
     };
     const { sql } = builder.buildBlendedQuery(ctx);
 
@@ -1815,16 +1930,27 @@ describe('AbstractBlendedQueryBuilder — pre-join filters on tricky tree shapes
       ],
     });
 
+    const fieldIndex = buildBlendedFieldIndex({
+      blendedFields: [
+        {
+          name: 'users__user_id',
+          aliasPath: 'users',
+          originalFieldName: 'user_id',
+          type: 'STRING',
+        },
+      ],
+      availableSources: [{ aliasPath: 'users', isIncluded: true }],
+    } as never);
     const ctx: BlendedQueryContext = {
       ...buildContext([usersChain], ['users_email']),
       filters: [
         {
-          column: 'user_id',
+          column: 'users__user_id',
           operator: 'is_not_null',
           placement: 'pre-join',
-          aliasPath: 'users',
         } as FilterRule,
       ],
+      fieldIndex,
     };
     const { sql } = builder.buildBlendedQuery(ctx);
 

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
@@ -1,6 +1,5 @@
 import { Logger, NotImplementedException } from '@nestjs/common';
 import {
-  BlendedColumnTypes,
   BlendedQueryBuilder,
   BlendedQueryContext,
   ResolvedRelationshipChain,
@@ -13,7 +12,7 @@ import {
   SqlClauseRenderer,
   SqlParameter,
 } from '../utils/sql-clause-renderer';
-import { FilterRule, aliasPathToCteName } from '../../dto/schemas/filter-config.schema';
+import { FilterRule } from '../../dto/schemas/filter-config.schema';
 
 interface BlendTreeNode {
   chain: ResolvedRelationshipChain;
@@ -89,7 +88,6 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
 
   buildBlendedQuery(context: BlendedQueryContext): { sql: string; params: SqlParameter[] } {
     const allFilters = context.filters ?? [];
-    const resolveColumnType = this.buildColumnTypeResolver(context.columnTypes);
 
     // Capability guard first — storages without a clauseRenderer can't honour any controls.
     const hasOutputControls =
@@ -103,26 +101,41 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
     const validCteNames = new Set(context.chains.map(c => c.cteName));
     const preJoinByCte = new Map<string, FilterRule[]>();
     const postJoinFilters: FilterRule[] = [];
+    // Maps each resolved pre-join rule object (identity key) to its column type,
+    // so resolveColumnType can serve pre-join casts without a separate type map.
+    const preJoinTypeByRule = new Map<FilterRule, string | undefined>();
     for (const rule of allFilters) {
       if (rule.placement === 'pre-join') {
-        // aliasPath presence and "main" exclusion enforced at schema level.
-        if (!rule.aliasPath) {
-          throw new Error('buildBlendedQuery: pre-join rule missing aliasPath (schema bug)');
-        }
-        const cteName = aliasPathToCteName(rule.aliasPath);
-        if (!validCteNames.has(cteName)) {
+        const f = context.fieldIndex?.get(rule.column);
+        if (!f) {
+          // Invariant: the validator must have rejected an unresolvable pre-join
+          // slice before reaching the builder. Reaching here means the unified
+          // column isn't a known blended field for this schema.
           throw new Error(
-            `buildBlendedQuery: pre-join filter aliasPath='${rule.aliasPath}' ` +
-              `does not resolve to any chain (cteName='${cteName}')`
+            `buildBlendedQuery: pre-join filter column='${rule.column}' is an unresolved blended column ` +
+              `(not present in the field index for this schema)`
           );
         }
-        const list = preJoinByCte.get(cteName) ?? [];
-        list.push(rule);
-        preJoinByCte.set(cteName, list);
+        if (!validCteNames.has(f.cteName)) {
+          throw new Error(
+            `buildBlendedQuery: pre-join filter column='${rule.column}' ` +
+              `resolves to cteName='${f.cteName}' which is not in any chain`
+          );
+        }
+        const internal: FilterRule = { ...rule, column: f.originalFieldName };
+        preJoinTypeByRule.set(internal, f.type);
+        const list = preJoinByCte.get(f.cteName) ?? [];
+        list.push(internal);
+        preJoinByCte.set(f.cteName, list);
       } else {
         postJoinFilters.push(rule);
       }
     }
+
+    const resolveColumnType: ColumnTypeResolver = rule =>
+      preJoinTypeByRule.has(rule)
+        ? preJoinTypeByRule.get(rule)
+        : context.columnTypes?.postJoin?.get(rule.column);
 
     const { mainTableReference, mainDataMartTitle, mainDataMartUrl, chains, columns } = context;
     const columnSet = new Set(columns);
@@ -184,18 +197,6 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       : { sql: '', params: [] as SqlParameter[] };
     const sql = `${withClause}\n\n${body}${where.sql}${orderBy.sql}${limit.sql}`;
     return { sql, params: [...cteParams, ...where.params, ...orderBy.params, ...limit.params] };
-  }
-
-  // Pre-join slices filter a subsidiary's raw columns (keyed by aliasPath); every
-  // other rule filters a final-SELECT column. Mirrors the validator's type lookup.
-  private buildColumnTypeResolver(
-    columnTypes: BlendedColumnTypes | undefined
-  ): ColumnTypeResolver | undefined {
-    if (!columnTypes) return undefined;
-    return rule =>
-      rule.placement === 'pre-join' && rule.aliasPath
-        ? columnTypes.preJoin?.get(rule.aliasPath)?.get(rule.column)
-        : columnTypes.postJoin?.get(rule.column);
   }
 
   private buildColumnQualifier(outputAliasToRoot: Map<string, string>): ColumnRefResolver {

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/blended-query-builder.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/blended-query-builder.interface.ts
@@ -23,14 +23,25 @@ export interface ResolvedRelationshipChain {
 }
 
 /**
- * Storage field types for filter columns, so positional dialects (Athena) can cast
- * date/time placeholders. Split because pre-join slices target a subsidiary CTE's
- * raw columns (keyed by aliasPath) while post-join filters target final-SELECT
- * columns (home native + blended output aliases).
+ * Storage field types for post-join filter columns (home native fields + blended
+ * output aliases), so positional dialects (Athena) can cast date/time placeholders.
+ * Pre-join slice types are resolved via the field index instead.
  */
 export interface BlendedColumnTypes {
   postJoin?: ReadonlyMap<string, string>;
-  preJoin?: ReadonlyMap<string, ReadonlyMap<string, string>>;
+}
+
+/**
+ * Flat resolution entry for one blended field, keyed by its unified name
+ * (`<aliasPath with dots→_>__<originalFieldName with dots→_>`). Single source of
+ * truth for resolving a unified column identifier back to the data it encodes.
+ */
+export interface BlendedFieldEntry {
+  aliasPath: string; // 'category.details'
+  cteName: string; // 'category_details'
+  originalFieldName: string; // 'item.event_count' (nested-struct dots preserved)
+  type: string;
+  isIncluded: boolean; // false when the source is excluded from reporting
 }
 
 export interface BlendedQueryContext {
@@ -43,6 +54,7 @@ export interface BlendedQueryContext {
   sort?: SortRule[];
   limit?: number | null;
   columnTypes?: BlendedColumnTypes;
+  fieldIndex?: ReadonlyMap<string, BlendedFieldEntry>;
 }
 
 export interface BlendedQueryBuilder {

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-blended-query-builder.spec.ts
@@ -8,6 +8,7 @@ import {
 import { RedshiftBlendedQueryBuilder } from './redshift-blended-query-builder';
 import { RedshiftClauseRenderer } from './redshift-clause-renderer';
 import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
+import { buildBlendedFieldIndex } from '../../../services/blended-field-index';
 
 const buildContext = createBuildContext('"myschema"."customers"');
 
@@ -159,19 +160,25 @@ describe('RedshiftBlendedQueryBuilder — output controls', () => {
         { targetFieldName: 'role', outputAlias: 'role', isHidden: true, aggregateFunction: 'MAX' },
       ],
     });
+    const fieldIndex = buildBlendedFieldIndex({
+      blendedFields: [
+        { name: 'users__role', aliasPath: 'users', originalFieldName: 'role', type: 'STRING' },
+      ],
+      availableSources: [{ aliasPath: 'users', isIncluded: true }],
+    } as never);
     const { sql, params } = builder.buildBlendedQuery(
       ctx({
         chains: [chain],
         columns: ['a'],
         filters: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
+        fieldIndex,
       })
     );
     // The inlined literal predicate must appear inside the subsidiary raw CTE.

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-blended-query-builder.spec.ts
@@ -8,6 +8,7 @@ import {
 import { SnowflakeBlendedQueryBuilder } from './snowflake-blended-query-builder';
 import { SnowflakeClauseRenderer } from './snowflake-clause-renderer';
 import { BlendedQueryContext } from '../../interfaces/blended-query-builder.interface';
+import { buildBlendedFieldIndex } from '../../../services/blended-field-index';
 
 const buildContext = createBuildContext('mydb."myschema"."customers"');
 
@@ -227,19 +228,25 @@ describe('SnowflakeBlendedQueryBuilder — output controls', () => {
         { targetFieldName: 'role', outputAlias: 'role', isHidden: true, aggregateFunction: 'MAX' },
       ],
     });
+    const fieldIndex = buildBlendedFieldIndex({
+      blendedFields: [
+        { name: 'users__role', aliasPath: 'users', originalFieldName: 'role', type: 'STRING' },
+      ],
+      availableSources: [{ aliasPath: 'users', isIncluded: true }],
+    } as never);
     const { sql, params } = builder.buildBlendedQuery(
       ctx({
         chains: [chain],
         columns: ['a'],
         filters: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
+        fieldIndex,
       })
     );
     // The inlined literal predicate must appear inside the subsidiary raw CTE.

--- a/apps/backend/src/data-marts/dto/schemas/filter-config.schema.spec.ts
+++ b/apps/backend/src/data-marts/dto/schemas/filter-config.schema.spec.ts
@@ -80,14 +80,13 @@ describe('FilterConfigSchema', () => {
   });
 });
 
-describe('FilterRuleSchema placement / aliasPath', () => {
+describe('FilterRuleSchema placement', () => {
   it('keeps placement undefined when omitted (downstream treats absence as post-join)', () => {
     const parsed = FilterRuleSchema.parse({ column: 'x', operator: 'eq', value: 1 });
     expect(parsed.placement).toBeUndefined();
-    expect(parsed.aliasPath).toBeUndefined();
   });
 
-  it('accepts explicit placement="post-join" without aliasPath', () => {
+  it('accepts explicit placement="post-join"', () => {
     const parsed = FilterRuleSchema.parse({
       column: 'x',
       operator: 'eq',
@@ -97,71 +96,37 @@ describe('FilterRuleSchema placement / aliasPath', () => {
     expect(parsed.placement).toBe('post-join');
   });
 
-  it('rejects placement="post-join" with aliasPath set', () => {
-    expect(() =>
-      FilterRuleSchema.parse({
-        column: 'x',
-        operator: 'eq',
-        value: 1,
-        placement: 'post-join',
-        aliasPath: 'users',
-      })
-    ).toThrow();
-  });
-
-  it('accepts placement="pre-join" with single-segment aliasPath and scalar rule', () => {
+  it('accepts placement="pre-join" with a unified column name and scalar rule', () => {
     const parsed = FilterRuleSchema.parse({
-      column: 'userRole',
+      column: 'users__userRole',
       operator: 'eq',
       value: 'admin',
       placement: 'pre-join',
-      aliasPath: 'users',
     });
     expect(parsed.placement).toBe('pre-join');
-    expect(parsed.aliasPath).toBe('users');
+    expect(parsed.column).toBe('users__userRole');
   });
 
-  it('accepts placement="pre-join" with dotted aliasPath and relative_date rule', () => {
+  it('accepts placement="pre-join" with a unified column name and relative_date rule', () => {
     expect(
       FilterRuleSchema.parse({
-        column: 'createdAt',
+        column: 'users_profiles__createdAt',
         operator: 'relative_date',
         value: { kind: 'last_n_days', n: 30 },
         placement: 'pre-join',
-        aliasPath: 'users.profiles',
       })
-    ).toMatchObject({ placement: 'pre-join', aliasPath: 'users.profiles' });
+    ).toMatchObject({ placement: 'pre-join', column: 'users_profiles__createdAt' });
   });
 
-  it('rejects placement="pre-join" without aliasPath', () => {
-    expect(() =>
+  it('accepts placement="pre-join" without additional metadata (validator resolves via index)', () => {
+    expect(
       FilterRuleSchema.parse({
-        column: 'x',
+        column: 'users__x',
         operator: 'eq',
         value: 1,
         placement: 'pre-join',
       })
-    ).toThrow();
-  });
-
-  it('rejects placement="pre-join" with aliasPath="main" (home mart not slicable)', () => {
-    expect(() =>
-      FilterRuleSchema.parse({
-        column: 'x',
-        operator: 'eq',
-        value: 1,
-        placement: 'pre-join',
-        aliasPath: 'main',
-      })
-    ).toThrow();
-  });
-
-  it('rejects aliasPath with uppercase / dashes / leading dot / trailing dot', () => {
-    const base = { column: 'x', operator: 'eq', value: 1, placement: 'pre-join' as const };
-    expect(() => FilterRuleSchema.parse({ ...base, aliasPath: 'Users' })).toThrow();
-    expect(() => FilterRuleSchema.parse({ ...base, aliasPath: 'users-table' })).toThrow();
-    expect(() => FilterRuleSchema.parse({ ...base, aliasPath: '.users' })).toThrow();
-    expect(() => FilterRuleSchema.parse({ ...base, aliasPath: 'users.' })).toThrow();
+    ).toMatchObject({ placement: 'pre-join', column: 'users__x' });
   });
 });
 

--- a/apps/backend/src/data-marts/dto/schemas/filter-config.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/filter-config.schema.ts
@@ -62,38 +62,11 @@ const FilterRuleBaseSchema = z.discriminatedUnion('operator', [
   }),
 ]);
 
-const AliasPathSchema = z.string().min(1).max(255).regex(ALIAS_PATH_REGEX);
-
 const PlacementExtrasSchema = z.object({
   placement: z.enum(['pre-join', 'post-join']).optional(),
-  aliasPath: AliasPathSchema.optional(),
 });
 
-export const FilterRuleSchema = z
-  .intersection(FilterRuleBaseSchema, PlacementExtrasSchema)
-  .superRefine((rule, ctx) => {
-    if (rule.placement === 'pre-join') {
-      if (!rule.aliasPath) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['aliasPath'],
-          message: 'aliasPath is required when placement is "pre-join"',
-        });
-      } else if (rule.aliasPath === 'main') {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['aliasPath'],
-          message: 'pre-join filter on the home data mart ("main") is not allowed',
-        });
-      }
-    } else if (rule.aliasPath != null) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['aliasPath'],
-        message: 'aliasPath is only valid when placement is "pre-join"',
-      });
-    }
-  });
+export const FilterRuleSchema = z.intersection(FilterRuleBaseSchema, PlacementExtrasSchema);
 
 export const FilterConfigSchema = z.array(FilterRuleSchema).nullable();
 

--- a/apps/backend/src/data-marts/services/blended-field-index.spec.ts
+++ b/apps/backend/src/data-marts/services/blended-field-index.spec.ts
@@ -1,0 +1,95 @@
+import { buildBlendedFieldIndex } from './blended-field-index';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+
+function schema(
+  blendedFields: Array<{
+    name: string;
+    aliasPath: string;
+    originalFieldName: string;
+    type: string;
+    isHidden?: boolean;
+  }>,
+  availableSources: Array<{ aliasPath: string; isIncluded?: boolean }> = []
+) {
+  return { blendedFields, availableSources } as never;
+}
+
+describe('buildBlendedFieldIndex', () => {
+  it('keys by unified name and preserves nested-struct dots in originalFieldName', () => {
+    const index = buildBlendedFieldIndex(
+      schema(
+        [
+          {
+            name: 'category_details__item_event_count',
+            aliasPath: 'category.details',
+            originalFieldName: 'item.event_count',
+            type: 'INTEGER',
+          },
+        ],
+        [{ aliasPath: 'category.details', isIncluded: true }]
+      )
+    );
+    expect(index.get('category_details__item_event_count')).toEqual({
+      aliasPath: 'category.details',
+      cteName: 'category_details',
+      originalFieldName: 'item.event_count',
+      type: 'INTEGER',
+      isIncluded: true,
+    });
+  });
+
+  it('marks fields of excluded sources as isIncluded=false but still indexes them', () => {
+    const index = buildBlendedFieldIndex(
+      schema(
+        [{ name: 'users__role', aliasPath: 'users', originalFieldName: 'role', type: 'STRING' }],
+        [{ aliasPath: 'users', isIncluded: false }]
+      )
+    );
+    expect(index.get('users__role')?.isIncluded).toBe(false);
+  });
+
+  it('omits hidden fields', () => {
+    const index = buildBlendedFieldIndex(
+      schema([
+        {
+          name: 'users__secret',
+          aliasPath: 'users',
+          originalFieldName: 'secret',
+          type: 'STRING',
+          isHidden: true,
+        },
+      ])
+    );
+    expect(index.has('users__secret')).toBe(false);
+  });
+
+  it('throws when two distinct (aliasPath, field) pairs fold to the same unified name', () => {
+    // Both fold to 'users__archived__role' because the `__` separator can appear
+    // inside an alias segment or a field name — last-write-wins would silently
+    // resolve a slice to the wrong column/CTE.
+    expect(() =>
+      buildBlendedFieldIndex(
+        schema(
+          [
+            {
+              name: 'users__archived__role',
+              aliasPath: 'users__archived',
+              originalFieldName: 'role',
+              type: 'STRING',
+            },
+            {
+              name: 'users__archived__role',
+              aliasPath: 'users',
+              originalFieldName: 'archived__role',
+              type: 'STRING',
+            },
+          ],
+          [
+            { aliasPath: 'users__archived', isIncluded: true },
+            { aliasPath: 'users', isIncluded: true },
+          ]
+        )
+      )
+    ).toThrow(BusinessViolationException);
+  });
+});

--- a/apps/backend/src/data-marts/services/blended-field-index.ts
+++ b/apps/backend/src/data-marts/services/blended-field-index.ts
@@ -1,0 +1,53 @@
+import { BlendableSchemaDto } from '../dto/domain/blendable-schema.dto';
+import { BlendedFieldEntry } from '../data-storage-types/interfaces/blended-query-builder.interface';
+import { aliasPathToCteName } from '../dto/schemas/filter-config.schema';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+
+/**
+ * Builds the flat resolution index from a blendable schema. Excluded sources'
+ * fields are indexed with `isIncluded: false` so the validator can tell
+ * "excluded" apart from "unknown". Hidden fields are omitted (cannot be sliced),
+ * matching the post-join `homeFieldTypes` map.
+ */
+export function buildBlendedFieldIndex(
+  schema: Pick<BlendableSchemaDto, 'blendedFields' | 'availableSources'>
+): Map<string, BlendedFieldEntry> {
+  const excluded = new Set<string>();
+  for (const source of schema.availableSources) {
+    if (source.isIncluded === false) excluded.add(source.aliasPath);
+  }
+
+  const index = new Map<string, BlendedFieldEntry>();
+  for (const field of schema.blendedFields) {
+    if (field.isHidden) continue;
+    // The `__` separator can appear inside an alias segment or a field name, so
+    // two distinct (aliasPath, originalFieldName) pairs can fold to the same
+    // unified name. Last-write-wins would silently resolve a slice to the wrong
+    // column/CTE — surface it as a user-fixable error instead, mirroring
+    // assertNoChainCollisions.
+    const existing = index.get(field.name);
+    if (existing) {
+      throw new BusinessViolationException(
+        `Ambiguous blended column name "${field.name}": it maps to both ` +
+          `aliasPath="${existing.aliasPath}" field="${existing.originalFieldName}" and ` +
+          `aliasPath="${field.aliasPath}" field="${field.originalFieldName}". ` +
+          `Rename one of the conflicting aliases or fields so each blended column has a unique name.`,
+        {
+          unifiedName: field.name,
+          conflicts: [
+            { aliasPath: existing.aliasPath, originalFieldName: existing.originalFieldName },
+            { aliasPath: field.aliasPath, originalFieldName: field.originalFieldName },
+          ],
+        }
+      );
+    }
+    index.set(field.name, {
+      aliasPath: field.aliasPath,
+      cteName: aliasPathToCteName(field.aliasPath),
+      originalFieldName: field.originalFieldName,
+      type: field.type,
+      isIncluded: !excluded.has(field.aliasPath),
+    });
+  }
+  return index;
+}

--- a/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.spec.ts
@@ -557,9 +557,14 @@ describe('BlendedReportDataService', () => {
       relationshipService.findBySourceDataMartId.mockResolvedValue([relAB, relAC]);
       tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
 
+      // Two blended fields share the same unified name ('shared_alias') across
+      // distinct aliasPaths — the field-index ambiguity guard now rejects this
+      // first, before the downstream chain outputAlias-collision check.
       await expect(
         service.resolveBlendingDecision(report, { userId: 'user-1', roles: ['admin'] })
-      ).rejects.toThrow(/outputAlias.+shared_alias.+collision|duplicate.+shared_alias/i);
+      ).rejects.toThrow(
+        /Ambiguous blended column name "shared_alias"|outputAlias.+shared_alias.+collision|duplicate.+shared_alias/i
+      );
     });
 
     it('disambiguates CTE names with parent path when two chains share the same targetAlias', async () => {
@@ -1479,6 +1484,58 @@ describe('BlendedReportDataService', () => {
         });
 
         expect(result.needsBlending).toBe(true);
+      });
+
+      it('rejects a pre-join slice targeting an EXCLUDED source on the run path', async () => {
+        // The save-time validator rejects slices on excluded sources, but the run
+        // path resolves slices through a fieldIndex that still includes excluded
+        // fields (isIncluded:false). This locks the run-path guard.
+        const report = makeReport({
+          columnConfig: ['b__field'],
+          filterConfig: [
+            { column: 'excluded__field', operator: 'eq', value: 'x', placement: 'pre-join' },
+          ] as any,
+        });
+
+        blendableSchemaService.computeBlendableSchema.mockResolvedValue({
+          nativeFields: [],
+          availableSources: [
+            makeAccessibleSource({ aliasPath: 'b', isAccessibleForReporting: true }),
+            makeAccessibleSource({
+              aliasPath: 'excluded',
+              title: 'Excluded DM',
+              dataMartId: 'dm-excluded',
+              relationshipId: 'rel-excluded',
+              isAccessibleForReporting: true,
+              isIncluded: false,
+            }),
+          ],
+          blendedFields: [makeField('b__field', 'b'), makeField('excluded__field', 'excluded')],
+        });
+
+        relationshipService.findBySourceDataMartId.mockResolvedValue([
+          {
+            id: 'rel-1',
+            targetAlias: 'b',
+            sourceDataMart: { id: 'dm-1' },
+            targetDataMart: { id: 'dm-target-1', title: 'Joined DM' },
+            joinConditions: [],
+          } as unknown as DataMartRelationship,
+        ]);
+        tableReferenceService.resolveTableName.mockResolvedValue('table_ref');
+        blendedQueryBuilderFacade.buildBlendedQuery.mockResolvedValue('SELECT ...');
+
+        await expect(
+          service.resolveBlendingDecision(report, { userId: 'user-1', roles: ['admin'] })
+        ).rejects.toMatchObject({
+          message: expect.stringContaining('excluded from reporting'),
+          errorDetails: {
+            excludedDataMartIds: ['dm-excluded'],
+            excludedAliasPaths: ['excluded'],
+          },
+        });
+
+        expect(blendedQueryBuilderFacade.buildBlendedQuery).not.toHaveBeenCalled();
       });
     });
 

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -31,6 +31,7 @@ import { BusinessViolationException } from '../../common/exceptions/business-vio
 import { buildDataMartUrl } from '../../common/helpers/data-mart-url.helper';
 import { UserProjectionsFetcherService } from './user-projections-fetcher.service';
 import { throwDisconnectedReportColumnsError } from '../errors/disconnected-report-columns.error';
+import { buildBlendedFieldIndex } from './blended-field-index';
 
 @Injectable()
 export class BlendedReportDataService {
@@ -63,16 +64,16 @@ export class BlendedReportDataService {
     });
 
     const postJoinFilterColumns: string[] = [];
-    const preJoinAliasPaths = new Set<string>();
+    const preJoinFilterColumns: string[] = [];
     for (const rule of report.filterConfig ?? []) {
-      if (rule.placement === 'pre-join' && rule.aliasPath) {
-        preJoinAliasPaths.add(rule.aliasPath);
+      if (rule.placement === 'pre-join') {
+        preJoinFilterColumns.push(rule.column);
       } else {
         postJoinFilterColumns.push(rule.column);
       }
     }
     const sortColumns = (report.sortConfig ?? []).map(s => s.column);
-    const hasPreJoinFilters = preJoinAliasPaths.size > 0;
+    const hasPreJoinFilters = preJoinFilterColumns.length > 0;
 
     if (columnConfig === null || columnConfig === undefined) {
       // Without an explicit column config the native projection is "all native
@@ -101,7 +102,7 @@ export class BlendedReportDataService {
         'Cannot build report SQL: blended output controls require an explicit column selection',
         {
           blendedFilterOrSortColumns: blendedRefs,
-          preJoinAliasPaths: Array.from(preJoinAliasPaths),
+          preJoinColumns: preJoinFilterColumns,
         }
       );
     }
@@ -110,6 +111,13 @@ export class BlendedReportDataService {
       dataMart.id,
       dataMart.projectId,
       accessor
+    );
+
+    const fieldIndex = buildBlendedFieldIndex(blendableSchema);
+    const preJoinAliasPaths = new Set<string>(
+      preJoinFilterColumns
+        .map(column => fieldIndex.get(column)?.aliasPath)
+        .filter((p): p is string => p != null)
     );
 
     const blendedFieldsByName = new Map(blendableSchema.blendedFields.map(f => [f.name, f]));
@@ -182,6 +190,7 @@ export class BlendedReportDataService {
         sort: report.sortConfig ?? undefined,
         limit: report.limitConfig ?? undefined,
         columnTypes: this.buildBlendedColumnTypes(blendableSchema),
+        fieldIndex,
       }
     );
     const blendedSql = isQueryBuildResult(blendedResult) ? blendedResult.sql : blendedResult;
@@ -197,26 +206,13 @@ export class BlendedReportDataService {
     };
   }
 
-  // Declared field types for the Athena placeholder casts, matching what the
-  // validator types filters against: post-join columns are home native fields +
-  // blended output aliases; pre-join slices target subsidiary raw columns by aliasPath.
   private buildBlendedColumnTypes(blendableSchema: BlendableSchemaDto): BlendedColumnTypes {
     const postJoin = new Map<string, string>();
     for (const nf of collectSchemaFieldPathTypes(blendableSchema.nativeFields)) {
       postJoin.set(nf.name, nf.type);
     }
     for (const bf of blendableSchema.blendedFields) postJoin.set(bf.name, bf.type);
-
-    const preJoin = new Map<string, Map<string, string>>();
-    for (const bf of blendableSchema.blendedFields) {
-      let cols = preJoin.get(bf.aliasPath);
-      if (!cols) {
-        cols = new Map();
-        preJoin.set(bf.aliasPath, cols);
-      }
-      cols.set(bf.originalFieldName, bf.type);
-    }
-    return { postJoin, preJoin };
+    return { postJoin };
   }
 
   private buildBlendedDataHeaders(
@@ -394,6 +390,27 @@ export class BlendedReportDataService {
     const neededPaths = this.collectNeededAliasPaths(requested, preJoinAliasPaths);
 
     const sourceByPath = new Map(availableSources.map(s => [s.aliasPath, s]));
+
+    // Defence-in-depth: the save-time validator rejects slices on excluded
+    // sources (FILTER_ALIAS_PATH_NOT_INCLUDED), but the run path resolves slices
+    // through a fieldIndex that still includes excluded fields (isIncluded:false).
+    // Refuse to build a slice against an excluded source here too.
+    const excluded: AvailableSourceDto[] = [];
+    for (const path of preJoinAliasPaths) {
+      const src = sourceByPath.get(path);
+      if (src && src.isIncluded === false) excluded.push(src);
+    }
+    if (excluded.length > 0) {
+      const titles = excluded.map(s => `"${s.title}"`).join(', ');
+      throw new BusinessViolationException(
+        `Cannot build report SQL: a pre-join filter targets data marts excluded from reporting: ${titles}`,
+        {
+          excludedDataMartIds: excluded.map(s => s.dataMartId),
+          excludedAliasPaths: excluded.map(s => s.aliasPath),
+        }
+      );
+    }
+
     const denied: AvailableSourceDto[] = [];
     for (const path of neededPaths) {
       const src = sourceByPath.get(path);

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -5,6 +5,7 @@ import { AthenaFieldType } from '../data-storage-types/athena/enums/athena-field
 import { RedshiftFieldType } from '../data-storage-types/redshift/enums/redshift-field-type.enum';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { buildBlendedFieldIndex } from './blended-field-index';
 
 describe('OutputControlsValidatorService', () => {
   const svc = new OutputControlsValidatorService(undefined as never, undefined as never);
@@ -231,141 +232,103 @@ describe('OutputControlsValidatorService', () => {
   });
 
   describe('validateFilters (pre-join)', () => {
-    const homeFieldTypes = new Map<string, string>();
-    const knownPaths = new Map<string, ReadonlyMap<string, string>>([
-      [
-        'users',
-        new Map([
-          ['userRole', BigQueryFieldType.STRING],
-          ['createdAt', BigQueryFieldType.TIMESTAMP],
-        ]),
+    const index = buildBlendedFieldIndex({
+      blendedFields: [
+        { name: 'users__role', aliasPath: 'users', originalFieldName: 'role', type: 'STRING' },
+        { name: 'orders__total', aliasPath: 'orders', originalFieldName: 'total', type: 'NUMERIC' },
       ],
-      ['users.profiles', new Map([['country', BigQueryFieldType.STRING]])],
-    ]);
+      availableSources: [
+        { aliasPath: 'users', isIncluded: true },
+        { aliasPath: 'orders', isIncluded: false },
+      ],
+    } as never);
 
-    it('accepts a known aliasPath + known column + valid operator', () => {
+    it('accepts a pre-join filter by unified name', () => {
       const errors = svc.validateFilters(
-        [
-          {
-            column: 'userRole',
-            operator: 'eq',
-            value: 'admin',
-            placement: 'pre-join',
-            aliasPath: 'users',
-          },
-        ],
-        homeFieldTypes,
-        knownPaths
+        [{ column: 'users__role', operator: 'eq', value: 'admin', placement: 'pre-join' }],
+        new Map(),
+        index
       );
       expect(errors).toEqual([]);
     });
 
-    it('rejects unknown aliasPath', () => {
+    it('reports unknown pre-join column as FILTER_COLUMN_UNKNOWN', () => {
       const errors = svc.validateFilters(
-        [{ column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'orgs' }],
-        homeFieldTypes,
-        knownPaths
+        [{ column: 'users__missing', operator: 'eq', value: 'x', placement: 'pre-join' }],
+        new Map(),
+        index
+      );
+      expect(errors).toEqual([{ code: 'FILTER_COLUMN_UNKNOWN', column: 'users__missing' }]);
+    });
+
+    it('reports excluded source as FILTER_ALIAS_PATH_NOT_INCLUDED', () => {
+      const errors = svc.validateFilters(
+        [{ column: 'orders__total', operator: 'gt', value: 1, placement: 'pre-join' }],
+        new Map(),
+        index
       );
       expect(errors).toEqual([
-        { code: 'FILTER_ALIAS_PATH_UNKNOWN', aliasPath: 'orgs', column: 'x' },
+        { code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath: 'orders', column: 'orders__total' },
       ]);
     });
 
-    it('rejects unknown column inside known aliasPath (includes aliasPath in payload)', () => {
+    it('rejects a home/native field used as a slice (no __ name → unknown)', () => {
       const errors = svc.validateFilters(
-        [
-          {
-            column: 'missing',
-            operator: 'eq',
-            value: 1,
-            placement: 'pre-join',
-            aliasPath: 'users',
-          },
-        ],
-        homeFieldTypes,
-        knownPaths
+        [{ column: 'native_field', operator: 'eq', value: 'x', placement: 'pre-join' }],
+        new Map([['native_field', 'STRING']]),
+        index
       );
-      expect(errors).toEqual([
-        { code: 'FILTER_COLUMN_UNKNOWN', column: 'missing', aliasPath: 'users' },
-      ]);
+      expect(errors).toEqual([{ code: 'FILTER_COLUMN_UNKNOWN', column: 'native_field' }]);
     });
 
-    it('rejects regex on INTEGER inside pre-join filter (carries aliasPath)', () => {
-      const pathsWithInt = new Map<string, ReadonlyMap<string, string>>([
-        ['users', new Map([['amount', BigQueryFieldType.INTEGER]])],
-      ]);
-      const errors = svc.validateFilters(
-        [
+    it('rejects invalid operator for type on pre-join column', () => {
+      const indexWithInt = buildBlendedFieldIndex({
+        blendedFields: [
           {
-            column: 'amount',
-            operator: 'regex',
-            value: '^1',
-            placement: 'pre-join',
+            name: 'users__amount',
             aliasPath: 'users',
+            originalFieldName: 'amount',
+            type: BigQueryFieldType.INTEGER,
           },
         ],
-        homeFieldTypes,
-        pathsWithInt
+        availableSources: [{ aliasPath: 'users', isIncluded: true }],
+      } as never);
+      const errors = svc.validateFilters(
+        [{ column: 'users__amount', operator: 'regex', value: '^1', placement: 'pre-join' }],
+        new Map(),
+        indexWithInt
       );
       expect(errors[0]).toMatchObject({
         code: 'INVALID_OPERATOR_FOR_TYPE',
-        column: 'amount',
+        column: 'users__amount',
         aliasPath: 'users',
       });
     });
 
     it('rejects malformed regex pattern inside pre-join filter (carries aliasPath)', () => {
       const errors = svc.validateFilters(
-        [
-          {
-            column: 'userRole',
-            operator: 'regex',
-            value: '[unclosed',
-            placement: 'pre-join',
-            aliasPath: 'users',
-          },
-        ],
-        homeFieldTypes,
-        knownPaths
+        [{ column: 'users__role', operator: 'regex', value: '[unclosed', placement: 'pre-join' }],
+        new Map(),
+        index
       );
       expect(errors).toEqual([
         {
           code: 'INVALID_REGEX_PATTERN',
-          column: 'userRole',
+          column: 'users__role',
           pattern: '[unclosed',
           aliasPath: 'users',
         },
       ]);
     });
 
-    it('rejects pre-join filter on excluded source', () => {
-      const excluded = new Set(['users']);
-      const errors = svc.validateFilters(
-        [
-          {
-            column: 'userRole',
-            operator: 'eq',
-            value: 'admin',
-            placement: 'pre-join',
-            aliasPath: 'users',
-          },
-        ],
-        homeFieldTypes,
-        new Map(),
-        excluded
-      );
-      expect(errors).toEqual([
-        { code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath: 'users', column: 'userRole' },
-      ]);
-    });
-
-    it('post-join rule without placement defaults to post-join lookup (does not need knownPaths)', () => {
+    it('post-join rule without placement defaults to post-join lookup (does not need fieldIndex)', () => {
       const homeTypes = new Map<string, string>([['name', BigQueryFieldType.STRING]]);
       const errors = svc.validateFilters(
         // No placement field — Zod default would set 'post-join'; raw call here
         // simulates a rule that was passed through unparsed.
         [{ column: 'name', operator: 'eq', value: 'X' } as never],
-        homeTypes
+        homeTypes,
+        new Map()
       );
       expect(errors).toEqual([]);
     });
@@ -649,7 +612,7 @@ describe('OutputControlsValidatorService', () => {
       expectDisconnectedColumnsError(caught, ['b__hidden']);
     });
 
-    it('lists hidden blended fields used by pre-join slices as aliasPath.column', async () => {
+    it('lists hidden blended fields used by pre-join slices as the unified column name', async () => {
       const capabilitySvc = makeCapabilityService(true);
       const schemaSvc = makeBlendableSchemaService(
         [{ name: 'date', type: 'DATE', status: 'CONNECTED' }],
@@ -680,14 +643,8 @@ describe('OutputControlsValidatorService', () => {
           projectId: 'proj-1',
           columnConfig: ['date', 'b__visible'],
           filterConfig: [
-            { column: 'hidden', operator: 'eq', value: 'x', placement: 'pre-join', aliasPath: 'b' },
-            {
-              column: 'visible',
-              operator: 'eq',
-              value: 'y',
-              placement: 'pre-join',
-              aliasPath: 'b',
-            },
+            { column: 'b__hidden', operator: 'eq', value: 'x', placement: 'pre-join' },
+            { column: 'b__visible', operator: 'eq', value: 'y', placement: 'pre-join' },
           ],
           sortConfig: null,
           limitConfig: null,
@@ -697,7 +654,7 @@ describe('OutputControlsValidatorService', () => {
         caught = e;
       }
 
-      expectDisconnectedColumnsError(caught, ['b.hidden']);
+      expectDisconnectedColumnsError(caught, ['b__hidden']);
     });
 
     it('lists a DISCONNECTED native field used by sort when columnConfig is null', async () => {
@@ -1039,11 +996,16 @@ describe('OutputControlsValidatorService', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('lists a pre-join filter on an unknown aliasPath as aliasPath.column', async () => {
+    it('lists a pre-join filter on an unknown unified column in the disconnected-columns error', async () => {
       const capabilitySvc = makeCapabilityService(true);
       const schemaSvc = makeBlendableSchemaService([], {
         blendedFields: [
-          { aliasPath: 'users', originalFieldName: 'userRole', type: BigQueryFieldType.STRING },
+          {
+            name: 'users__userRole',
+            aliasPath: 'users',
+            originalFieldName: 'userRole',
+            type: BigQueryFieldType.STRING,
+          },
         ],
         availableSources: [{ aliasPath: 'users' }],
       });
@@ -1059,9 +1021,7 @@ describe('OutputControlsValidatorService', () => {
           dataMartId: 'dm-1',
           projectId: 'proj-1',
           columnConfig: ['some_col'],
-          filterConfig: [
-            { column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'orgs' },
-          ],
+          filterConfig: [{ column: 'orgs__x', operator: 'eq', value: 1, placement: 'pre-join' }],
           sortConfig: null,
           limitConfig: null,
           accessor: { userId: 'user-1', roles: ['admin'] },
@@ -1070,7 +1030,7 @@ describe('OutputControlsValidatorService', () => {
         caught = e;
       }
 
-      expectDisconnectedColumnsError(caught, ['orgs.x']);
+      expectDisconnectedColumnsError(caught, ['orgs__x']);
     });
 
     it('rejects pre-join filter when columnConfig is null/empty (PRE_JOIN_FILTERS_REQUIRE_COLUMN_CONFIG)', async () => {
@@ -1080,7 +1040,12 @@ describe('OutputControlsValidatorService', () => {
       const capabilitySvc = makeCapabilityService(true);
       const schemaSvc = makeBlendableSchemaService([], {
         blendedFields: [
-          { aliasPath: 'users', originalFieldName: 'userRole', type: BigQueryFieldType.STRING },
+          {
+            name: 'users__userRole',
+            aliasPath: 'users',
+            originalFieldName: 'userRole',
+            type: BigQueryFieldType.STRING,
+          },
         ],
         availableSources: [{ aliasPath: 'users' }],
       });
@@ -1098,11 +1063,10 @@ describe('OutputControlsValidatorService', () => {
           columnConfig: null,
           filterConfig: [
             {
-              column: 'userRole',
+              column: 'users__userRole',
               operator: 'eq',
               value: 'admin',
               placement: 'pre-join',
-              aliasPath: 'users',
             },
           ],
           sortConfig: null,
@@ -1120,11 +1084,51 @@ describe('OutputControlsValidatorService', () => {
       ).toBe(true);
     });
 
-    it('resolves when pre-join filter aliasPath and column are valid', async () => {
+    it('treats a pre-join filter on a NON-actualized schema as disconnected (400, not skipped)', async () => {
+      // Schema not yet actualized (empty native + blended). The pre-join filter
+      // would otherwise be skipped here, then blow up at run time with a 500 in
+      // the builder. Surface it as a disconnected-columns error instead.
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([], {
+        blendedFields: [],
+        availableSources: [],
+      });
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      let caught: unknown;
+      try {
+        await validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: ['some_col'],
+          filterConfig: [
+            { column: 'users__role', operator: 'eq', value: 'admin', placement: 'pre-join' },
+          ],
+          sortConfig: null,
+          limitConfig: null,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        });
+      } catch (e) {
+        caught = e;
+      }
+
+      expectDisconnectedColumnsError(caught, ['users__role']);
+    });
+
+    it('resolves when pre-join filter unified column is valid', async () => {
       const capabilitySvc = makeCapabilityService(true);
       const schemaSvc = makeBlendableSchemaService([], {
         blendedFields: [
-          { aliasPath: 'users', originalFieldName: 'userRole', type: BigQueryFieldType.STRING },
+          {
+            name: 'users__userRole',
+            aliasPath: 'users',
+            originalFieldName: 'userRole',
+            type: BigQueryFieldType.STRING,
+          },
         ],
         availableSources: [{ aliasPath: 'users' }],
       });
@@ -1141,11 +1145,10 @@ describe('OutputControlsValidatorService', () => {
           columnConfig: ['some_col'],
           filterConfig: [
             {
-              column: 'userRole',
+              column: 'users__userRole',
               operator: 'eq',
               value: 'admin',
               placement: 'pre-join',
-              aliasPath: 'users',
             },
           ],
           sortConfig: null,
@@ -1662,16 +1665,21 @@ describe('OutputControlsValidatorService', () => {
     });
   });
 
-  describe('buildKnownPaths via validateForReport', () => {
+  describe('field index via validateForReport', () => {
     const supportedStorageType = DataStorageType.GOOGLE_BIGQUERY;
 
-    it('lists a pre-join filter on an excluded source as aliasPath.column', async () => {
+    it('lists a pre-join filter on an excluded source as the unified column', async () => {
       const capabilitySvc = { isSupported: jest.fn().mockReturnValue(true) };
       const schemaSvc = {
         computeBlendableSchema: jest.fn().mockResolvedValue({
           nativeFields: [],
           blendedFields: [
-            { aliasPath: 'users', originalFieldName: 'userRole', type: BigQueryFieldType.STRING },
+            {
+              name: 'users__userRole',
+              aliasPath: 'users',
+              originalFieldName: 'userRole',
+              type: BigQueryFieldType.STRING,
+            },
           ],
           availableSources: [{ aliasPath: 'users', isIncluded: false }],
         }),
@@ -1690,11 +1698,10 @@ describe('OutputControlsValidatorService', () => {
           columnConfig: ['some_col'],
           filterConfig: [
             {
-              column: 'userRole',
+              column: 'users__userRole',
               operator: 'eq',
               value: 'admin',
               placement: 'pre-join',
-              aliasPath: 'users',
             },
           ],
           sortConfig: null,
@@ -1705,7 +1712,7 @@ describe('OutputControlsValidatorService', () => {
         caught = e;
       }
 
-      expectDisconnectedColumnsError(caught, ['users.userRole']);
+      expectDisconnectedColumnsError(caught, ['users__userRole']);
     });
 
     it('included sources still accept pre-join filters on their columns (no false positive)', async () => {
@@ -1714,7 +1721,12 @@ describe('OutputControlsValidatorService', () => {
         computeBlendableSchema: jest.fn().mockResolvedValue({
           nativeFields: [],
           blendedFields: [
-            { aliasPath: 'users', originalFieldName: 'userRole', type: BigQueryFieldType.STRING },
+            {
+              name: 'users__userRole',
+              aliasPath: 'users',
+              originalFieldName: 'userRole',
+              type: BigQueryFieldType.STRING,
+            },
           ],
           availableSources: [{ aliasPath: 'users', isIncluded: true }],
         }),
@@ -1732,11 +1744,10 @@ describe('OutputControlsValidatorService', () => {
           columnConfig: ['some_col'],
           filterConfig: [
             {
-              column: 'userRole',
+              column: 'users__userRole',
               operator: 'eq',
               value: 'admin',
               placement: 'pre-join',
-              aliasPath: 'users',
             },
           ],
           sortConfig: null,

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.ts
@@ -6,6 +6,8 @@ import { OutputControlsCapabilityService } from './output-controls-capability.se
 import { BlendableSchemaAccessor, BlendableSchemaService } from './blendable-schema.service';
 import { throwDisconnectedReportColumnsError } from '../errors/disconnected-report-columns.error';
 import { collectSchemaFieldPathTypes } from '../data-storage-types/data-mart-schema.utils';
+import { buildBlendedFieldIndex } from './blended-field-index';
+import { BlendedFieldEntry } from '../data-storage-types/interfaces/blended-query-builder.interface';
 
 export type ValidationError =
   | { code: 'FILTER_COLUMN_UNKNOWN'; column: string; aliasPath?: string }
@@ -18,7 +20,7 @@ export type ValidationError =
     }
   | { code: 'INVALID_REGEX_PATTERN'; column: string; pattern: string; aliasPath?: string }
   | { code: 'SORT_COLUMN_NOT_SELECTED'; column: string }
-  | { code: 'FILTER_ALIAS_PATH_UNKNOWN'; aliasPath: string; column: string }
+  | { code: 'FILTER_ALIAS_PATH_UNKNOWN'; aliasPath: string; column: string } // retained for backward compatibility; no longer emitted by validateFilters
   | { code: 'FILTER_ALIAS_PATH_NOT_INCLUDED'; aliasPath: string; column: string }
   | { code: 'PRE_JOIN_FILTERS_REQUIRE_COLUMN_CONFIG' };
 
@@ -122,41 +124,28 @@ export class OutputControlsValidatorService {
     private readonly blendableSchemaService: BlendableSchemaService
   ) {}
 
-  /**
-   * Validates a list of filter rules against the blendable schema.
-   *
-   * - post-join rules (`placement === 'post-join'` or omitted): looked up in
-   *   `homeFieldTypes` (blended output aliases + home native fields).
-   * - pre-join rules (`placement === 'pre-join'`): looked up by `aliasPath` in
-   *   `knownPaths`, then by raw column name inside that path. Pre-join rules
-   *   targeting excluded sources or the home mart are rejected with dedicated
-   *   error codes so the FE can surface the right message.
-   */
   validateFilters(
     filters: FilterRule[],
     homeFieldTypes: Map<string, string>,
-    knownPaths?: ReadonlyMap<string, ReadonlyMap<string, string>>,
-    excludedPaths?: ReadonlySet<string>
+    fieldIndex: ReadonlyMap<string, BlendedFieldEntry> = new Map()
   ): ValidationError[] {
     const errors: ValidationError[] = [];
     for (const rule of filters) {
       if (rule.placement === 'pre-join') {
-        const aliasPath = rule.aliasPath!;
-        if (excludedPaths?.has(aliasPath)) {
-          errors.push({ code: 'FILTER_ALIAS_PATH_NOT_INCLUDED', aliasPath, column: rule.column });
+        const f = fieldIndex.get(rule.column);
+        if (!f) {
+          errors.push({ code: 'FILTER_COLUMN_UNKNOWN', column: rule.column });
           continue;
         }
-        const subsidiaryTypes = knownPaths?.get(aliasPath);
-        if (!subsidiaryTypes) {
-          errors.push({ code: 'FILTER_ALIAS_PATH_UNKNOWN', aliasPath, column: rule.column });
+        if (!f.isIncluded) {
+          errors.push({
+            code: 'FILTER_ALIAS_PATH_NOT_INCLUDED',
+            aliasPath: f.aliasPath,
+            column: rule.column,
+          });
           continue;
         }
-        const type = subsidiaryTypes.get(rule.column);
-        if (type === undefined) {
-          errors.push({ code: 'FILTER_COLUMN_UNKNOWN', column: rule.column, aliasPath });
-          continue;
-        }
-        this.validateRuleAgainstType(rule, type, aliasPath, errors);
+        this.validateRuleAgainstType(rule, f.type, f.aliasPath, errors);
       } else {
         const type = homeFieldTypes.get(rule.column);
         if (type === undefined) {
@@ -276,6 +265,19 @@ export class OutputControlsValidatorService {
       const hasActualizedSchema =
         blendableSchema.nativeFields.length > 0 || blendableSchema.blendedFields.length > 0;
 
+      if (!hasActualizedSchema) {
+        // A pre-join slice on a non-actualized schema can't be validated (no
+        // fields to resolve against) and would otherwise be skipped — the run
+        // path then hands the builder an empty fieldIndex and fails with a 500.
+        // Surface the slice columns as disconnected (a 400) instead.
+        const preJoinRefs = parsedFilters
+          .filter(r => r.placement === 'pre-join')
+          .map(r => r.column);
+        if (preJoinRefs.length > 0) {
+          throwDisconnectedReportColumnsError(args.dataMartId, preJoinRefs);
+        }
+      }
+
       if (hasActualizedSchema) {
         const homeFieldTypes = new Map<string, string>();
         const knownOutputColumns = new Set<string>();
@@ -292,10 +294,8 @@ export class OutputControlsValidatorService {
         }
 
         if (parsedFilters.length > 0) {
-          const { knownPaths, excludedPaths } = this.buildKnownPaths(blendableSchema);
-          errors.push(
-            ...this.validateFilters(parsedFilters, homeFieldTypes, knownPaths, excludedPaths)
-          );
+          const fieldIndex = buildBlendedFieldIndex(blendableSchema);
+          errors.push(...this.validateFilters(parsedFilters, homeFieldTypes, fieldIndex));
         }
         if (parsedSort.length > 0) {
           // With no explicit columnConfig the projection is `SELECT *` over the home
@@ -326,39 +326,6 @@ export class OutputControlsValidatorService {
     }
   }
 
-  private buildKnownPaths(blendableSchema: {
-    availableSources: { aliasPath: string; isIncluded?: boolean }[];
-    blendedFields: {
-      aliasPath: string;
-      originalFieldName: string;
-      type: string;
-      isHidden?: boolean;
-    }[];
-  }): { knownPaths: Map<string, Map<string, string>>; excludedPaths: Set<string> } {
-    const knownPaths = new Map<string, Map<string, string>>();
-    const excludedPaths = new Set<string>();
-    for (const source of blendableSchema.availableSources) {
-      if (source.isIncluded === false) {
-        excludedPaths.add(source.aliasPath);
-        continue;
-      }
-      if (!knownPaths.has(source.aliasPath)) {
-        knownPaths.set(source.aliasPath, new Map());
-      }
-    }
-    for (const field of blendableSchema.blendedFields) {
-      if (excludedPaths.has(field.aliasPath)) continue;
-      if (field.isHidden) continue;
-      let fields = knownPaths.get(field.aliasPath);
-      if (!fields) {
-        fields = new Map();
-        knownPaths.set(field.aliasPath, fields);
-      }
-      fields.set(field.originalFieldName, field.type);
-    }
-    return { knownPaths, excludedPaths };
-  }
-
   private collectDisconnectedOutputControlRefs(
     errors: ValidationError[],
     sort: SortRule[],
@@ -370,8 +337,11 @@ export class OutputControlsValidatorService {
       switch (error.code) {
         case 'FILTER_COLUMN_UNKNOWN':
         case 'FILTER_ALIAS_PATH_UNKNOWN':
-        case 'FILTER_ALIAS_PATH_NOT_INCLUDED':
           refs.push(this.formatFilterRef(error.column, error.aliasPath));
+          break;
+        case 'FILTER_ALIAS_PATH_NOT_INCLUDED':
+          // column is the unified name — use it directly as the disconnected ref.
+          refs.push(error.column);
           break;
       }
     }

--- a/apps/backend/src/migrations/1779200000000-migrate-prejoin-filter-to-unified-column.ts
+++ b/apps/backend/src/migrations/1779200000000-migrate-prejoin-filter-to-unified-column.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { Report } from '../data-marts/entities/report.entity';
+
+type Rule = Record<string, unknown>;
+
+export class MigratePreJoinFilterToUnifiedColumn1779200000000 implements MigrationInterface {
+  public readonly name = 'MigratePreJoinFilterToUnifiedColumn1779200000000';
+
+  private parse(value: unknown): Rule[] | undefined {
+    if (value == null) return undefined;
+    try {
+      const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+      return Array.isArray(parsed) ? (parsed as Rule[]) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // Folds a pre-join (slice) rule's aliasPath + raw column into the unified column
+  // identifier (`<aliasPath dots->_>__<column dots->_>`) and drops aliasPath. Returns
+  // true if anything changed. Inlined (not shared) so the migration stays self-contained.
+  private migrateRules(rules: Rule[]): boolean {
+    let changed = false;
+    for (const rule of rules) {
+      if (rule.placement === 'pre-join' && typeof rule.aliasPath === 'string') {
+        const aliasPath = rule.aliasPath;
+        const column = String(rule.column);
+        rule.column = `${aliasPath.replace(/\./g, '_')}__${column.replace(/\./g, '_')}`;
+        delete rule.aliasPath;
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const rows = await queryRunner.manager
+      .getRepository(Report)
+      .createQueryBuilder('r')
+      .select('r.id', 'id')
+      .addSelect('r.filterConfig', 'filterConfig')
+      .where('r.filterConfig IS NOT NULL')
+      .getRawMany<{ id: string; filterConfig: unknown }>();
+
+    for (const row of rows) {
+      const rules = this.parse(row.filterConfig);
+      if (!rules || !this.migrateRules(rules)) continue;
+      // Write goes through the filterConfig Zod column transformer — migrated rules are
+      // valid by construction (previously-valid rules with aliasPath removed). This also
+      // bumps version/modifiedAt, which is acceptable for a one-shot migration.
+      await queryRunner.manager
+        .getRepository(Report)
+        .createQueryBuilder()
+        .update()
+        .set({ filterConfig: rules as Report['filterConfig'] })
+        .where('id = :id', { id: row.id })
+        .execute();
+    }
+  }
+
+  // Forward-only: the unified name is lossy (nested-field dots collapse to '_'),
+  // so the reverse split cannot reliably reconstruct aliasPath + raw column. No-op.
+  public async down(_queryRunner: QueryRunner): Promise<void> {}
+}

--- a/apps/backend/test/blended-output-controls.e2e-spec.ts
+++ b/apps/backend/test/blended-output-controls.e2e-spec.ts
@@ -14,7 +14,8 @@ import { CreateViewCommand } from 'src/data-marts/dto/domain/create-view.command
 // Full-flow e2e: PUT /api/reports/:id → GET /api/reports/:id/generated-sql.
 // Exercises the entire pipeline (DTO → validator → entity persist → composer
 // → BigQuery blended builder) for both post-join filters and pre-join filters
-// (a.k.a. slices, expressed via FilterRule.placement='pre-join'+aliasPath).
+// (a.k.a. slices, expressed via FilterRule.placement='pre-join' with a unified
+// column identifier of the form '<aliasPath>__<rawColumn>').
 //
 // The 7 groups below mirror the contract that protects this feature end-to-end:
 //   1. Baseline — sanity check that an unfiltered report composes a blended-or-simple SELECT
@@ -154,11 +155,10 @@ describe('Blended output controls full-flow (e2e)', () => {
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
       });
@@ -179,17 +179,15 @@ describe('Blended output controls full-flow (e2e)', () => {
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
           {
-            column: 'is_active',
+            column: 'users__is_active',
             operator: 'is_true',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
       });
@@ -207,18 +205,16 @@ describe('Blended output controls full-flow (e2e)', () => {
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
           {
-            column: 'plan',
+            column: 'orgs__plan',
             operator: 'eq',
             value: 'pro',
             placement: 'pre-join',
-            aliasPath: 'orgs',
           },
         ],
       });
@@ -240,11 +236,10 @@ describe('Blended output controls full-flow (e2e)', () => {
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
       });
@@ -267,11 +262,10 @@ describe('Blended output controls full-flow (e2e)', () => {
         filterConfig: [
           { column: 'amount', operator: 'gt', value: 50 },
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
       });
@@ -293,11 +287,10 @@ describe('Blended output controls full-flow (e2e)', () => {
         filterConfig: [
           { column: 'amount', operator: 'gte', value: 1 },
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
         sortConfig: [{ column: 'amount', direction: 'desc' }],
@@ -315,43 +308,38 @@ describe('Blended output controls full-flow (e2e)', () => {
   // ── Group 5: Validation ──────────────────────────────────────────────────
 
   describe('5. Validation', () => {
-    it('rejects pre-join filter with aliasPath that does not resolve to any chain', async () => {
+    it('rejects pre-join filter with unified column not in any blended source', async () => {
       const res = await putReportConfig({
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'something',
+            column: 'nonexistent_alias__something',
             operator: 'eq',
             value: 'X',
             placement: 'pre-join',
-            aliasPath: 'nonexistent_alias',
           },
         ],
       });
-      expectDisconnectedColumns(res, ['nonexistent_alias.something']);
+      // Unknown unified name → FILTER_COLUMN_UNKNOWN → disconnected-columns error.
+      expectDisconnectedColumns(res, ['nonexistent_alias__something']);
     });
 
-    it('rejects pre-join filter with aliasPath="main" (home mart not slicable)', async () => {
+    it('rejects pre-join filter on home mart column (home mart not slicable)', async () => {
       const res = await putReportConfig({
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'event_id',
+            column: 'main__event_id',
             operator: 'eq',
             value: 'X',
             placement: 'pre-join',
-            aliasPath: 'main',
           },
         ],
       });
-      expect(res.status).toBe(400);
-      // Zod superRefine on FilterRuleSchema catches this BEFORE the validator
-      // service runs, so the response body carries the schema "invalid shape"
-      // path (`aliasPath`) — verified by absence of the schema-level success.
-      const body = JSON.stringify(res.body);
-      expect(
-        body.includes('FILTER_ALIAS_PATH_NOT_ALLOWED_ON_HOME') || body.includes('aliasPath')
-      ).toBe(true);
+      // "main" is not a registered blended source — the unified name is not in the
+      // field index, so the validator emits FILTER_COLUMN_UNKNOWN and the column
+      // is surfaced as disconnected. The home mart remains unslicable.
+      expectDisconnectedColumns(res, ['main__event_id']);
     });
 
     it('rejects pre-join filter with unknown raw column inside known aliasPath', async () => {
@@ -359,15 +347,16 @@ describe('Blended output controls full-flow (e2e)', () => {
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'no_such_column',
+            column: 'users__no_such_column',
             operator: 'eq',
             value: 'X',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
       });
-      expectDisconnectedColumns(res, ['users.no_such_column']);
+      // Unified name not in field index (users source exists but has no "no_such_column")
+      // → FILTER_COLUMN_UNKNOWN → disconnected-columns error.
+      expectDisconnectedColumns(res, ['users__no_such_column']);
     });
 
     it('rejects operator/type mismatch on pre-join (regex on INTEGER native field)', async () => {
@@ -375,11 +364,10 @@ describe('Blended output controls full-flow (e2e)', () => {
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'employee_count',
+            column: 'orgs__employee_count',
             operator: 'regex',
             value: '^1',
             placement: 'pre-join',
-            aliasPath: 'orgs',
           },
         ],
       });
@@ -397,11 +385,10 @@ describe('Blended output controls full-flow (e2e)', () => {
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
       });
@@ -449,11 +436,10 @@ describe('Blended output controls full-flow (e2e)', () => {
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'regex',
             value: '[unclosed',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
       });
@@ -503,11 +489,10 @@ describe('Blended output controls full-flow (e2e)', () => {
         columnConfig: ['event_id'],
         filterConfig: [
           {
-            column: 'role',
+            column: 'users__role',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
       });
@@ -529,7 +514,9 @@ describe('Blended output controls full-flow (e2e)', () => {
       const sqlRes = await agent
         .get(`/api/reports/${prereqs.reportId}/generated-sql`)
         .set(AUTH_HEADER);
-      expectDisconnectedColumns(sqlRes, ['users.role']);
+      // FILTER_ALIAS_PATH_NOT_INCLUDED pushes error.column (the unified name) as
+      // the disconnected ref — no dot notation in the new model.
+      expectDisconnectedColumns(sqlRes, ['users__role']);
 
       const restore = await agent
         .put(`/api/data-marts/${prereqs.mainDataMartId}/blended-fields-config`)

--- a/apps/backend/test/integration/athena.integration.ts
+++ b/apps/backend/test/integration/athena.integration.ts
@@ -12,6 +12,7 @@ import { TableDefinition } from 'src/data-marts/dto/schemas/data-mart-table-defi
 import { AthenaBlendedQueryBuilder } from 'src/data-marts/data-storage-types/athena/services/athena-blended-query-builder';
 import { BlendedQueryContext } from 'src/data-marts/data-storage-types/interfaces/blended-query-builder.interface';
 import { DataMartRelationship } from 'src/data-marts/entities/data-mart-relationship.entity';
+import { buildBlendedFieldIndex } from 'src/data-marts/services/blended-field-index';
 
 /**
  * Athena Integration Tests
@@ -706,8 +707,9 @@ AS SELECT * FROM (VALUES
 // Blended pre-join SLICE — proves a pre-join filter narrows a JOINED data mart
 // inside its `<alias>_raw` CTE on REAL Athena (separate seed: two tables).
 // ---------------------------------------------------------------------------
-// A "slice" is a FilterRule with placement:'pre-join' + aliasPath, injected as a
-// WHERE INSIDE the joined subsidiary mart's `<alias>_raw` CTE — BEFORE the JOIN.
+// A "slice" is a FilterRule with placement:'pre-join' identified by the unified
+// column name (<aliasPath>__<rawColumn>), injected as a WHERE INSIDE the joined
+// subsidiary mart's `<alias>_raw` CTE — BEFORE the JOIN.
 // This suite seeds two related tables and executes the builder's SQL on real
 // Athena to prove the join result is narrowed exactly as if the joined dimension
 // had been reduced upstream.
@@ -758,6 +760,12 @@ describeIfCredentials(
 
     // Build a BlendedQueryContext pointed at the REAL seeded tables.
     function blendContext(over: Partial<BlendedQueryContext> = {}): BlendedQueryContext {
+      const fieldIndex = buildBlendedFieldIndex({
+        blendedFields: [
+          { name: 'users__role', aliasPath: 'users', originalFieldName: 'role', type: 'STRING' },
+        ],
+        availableSources: [{ aliasPath: 'users', isIncluded: true }],
+      } as never);
       return {
         mainTableReference: `"${database}"."${BLEND_ORDERS_SUFFIX}"`,
         mainDataMartTitle: 'Orders',
@@ -781,6 +789,7 @@ describeIfCredentials(
           },
         ],
         columns: ['order_id', 'role'],
+        fieldIndex,
         ...over,
       };
     }
@@ -917,11 +926,10 @@ AS SELECT * FROM (VALUES
         blendContext({
           filters: [
             {
-              column: 'role',
+              column: 'users__role',
               operator: 'eq',
               value: 'admin',
               placement: 'pre-join',
-              aliasPath: 'users',
             },
           ],
         })
@@ -943,11 +951,10 @@ AS SELECT * FROM (VALUES
         blendContext({
           filters: [
             {
-              column: 'role',
+              column: 'users__role',
               operator: 'eq',
               value: 'admin',
               placement: 'pre-join',
-              aliasPath: 'users',
             },
             { column: 'role', operator: 'is_not_null', placement: 'post-join' },
           ],
@@ -966,11 +973,10 @@ AS SELECT * FROM (VALUES
         blendContext({
           filters: [
             {
-              column: 'role',
+              column: 'users__role',
               operator: 'eq',
               value: 'viewer',
               placement: 'pre-join',
-              aliasPath: 'users',
             },
             { column: 'role', operator: 'is_not_null', placement: 'post-join' },
           ],

--- a/apps/backend/test/integration/bigquery.integration.ts
+++ b/apps/backend/test/integration/bigquery.integration.ts
@@ -13,6 +13,7 @@ import { BlendedQueryContext } from 'src/data-marts/data-storage-types/interface
 import { DataMartRelationship } from 'src/data-marts/entities/data-mart-relationship.entity';
 import { DataStorageCredentialsResolver } from 'src/data-marts/data-storage-types/data-storage-credentials-resolver.service';
 import { TableDefinition } from 'src/data-marts/dto/schemas/data-mart-table-definitions/table-definition.schema';
+import { buildBlendedFieldIndex } from 'src/data-marts/services/blended-field-index';
 
 /**
  * BigQuery Integration Tests
@@ -652,6 +653,12 @@ describeIfCredentials(
     }
 
     function blendContext(over: Partial<BlendedQueryContext> = {}): BlendedQueryContext {
+      const fieldIndex = buildBlendedFieldIndex({
+        blendedFields: [
+          { name: 'users__role', aliasPath: 'users', originalFieldName: 'role', type: 'STRING' },
+        ],
+        availableSources: [{ aliasPath: 'users', isIncluded: true }],
+      } as never);
       return {
         mainTableReference: `\`${ordersFQN}\``,
         mainDataMartTitle: 'Orders',
@@ -675,6 +682,7 @@ describeIfCredentials(
           },
         ],
         columns: ['order_id', 'role'],
+        fieldIndex,
         ...over,
       };
     }
@@ -760,11 +768,10 @@ describeIfCredentials(
         blendContext({
           filters: [
             {
-              column: 'role',
+              column: 'users__role',
               operator: 'eq',
               value: 'admin',
               placement: 'pre-join',
-              aliasPath: 'users',
             },
           ],
         })
@@ -782,11 +789,10 @@ describeIfCredentials(
         blendContext({
           filters: [
             {
-              column: 'role',
+              column: 'users__role',
               operator: 'eq',
               value: 'admin',
               placement: 'pre-join',
-              aliasPath: 'users',
             },
             { column: 'role', operator: 'is_not_null', placement: 'post-join' },
           ],
@@ -801,11 +807,10 @@ describeIfCredentials(
         blendContext({
           filters: [
             {
-              column: 'role',
+              column: 'users__role',
               operator: 'eq',
               value: 'viewer',
               placement: 'pre-join',
-              aliasPath: 'users',
             },
             { column: 'role', operator: 'is_not_null', placement: 'post-join' },
           ],

--- a/apps/backend/test/integration/http-data-real.integration.ts
+++ b/apps/backend/test/integration/http-data-real.integration.ts
@@ -1061,10 +1061,10 @@ describeIfSnowflakeCredentials('HTTP Data API real-data (live Snowflake)', () =>
     );
     await sfAdapter.executeQuery(
       `INSERT INTO ${sfFullyQualifiedName} ("id", "name", "active", "created_at") VALUES ` +
-        `(1, 'alpha',    TRUE,  TIMESTAMP_NTZ '2024-01-01 00:00:00'), ` +
-        `(2, 'beta',     FALSE, TIMESTAMP_NTZ '2024-02-01 00:00:00'), ` +
-        `(3, 'gamma',    TRUE,  TIMESTAMP_NTZ '2024-03-01 00:00:00'), ` +
-        `(4, 'alphabet', TRUE,  TIMESTAMP_NTZ '2024-04-01 00:00:00')`
+        `(1, 'alpha',    TRUE,  '2024-01-01 00:00:00'::TIMESTAMP_NTZ), ` +
+        `(2, 'beta',     FALSE, '2024-02-01 00:00:00'::TIMESTAMP_NTZ), ` +
+        `(3, 'gamma',    TRUE,  '2024-03-01 00:00:00'::TIMESTAMP_NTZ), ` +
+        `(4, 'alphabet', TRUE,  '2024-04-01 00:00:00'::TIMESTAMP_NTZ)`
     );
 
     // --- Step 3: Create credentialed Snowflake storage via HTTP API ---

--- a/apps/backend/test/output-controls.e2e-spec.ts
+++ b/apps/backend/test/output-controls.e2e-spec.ts
@@ -217,18 +217,17 @@ describe('Output controls API (e2e)', () => {
         columnConfig: ['col_a'],
         filterConfig: [
           {
-            column: 'userRole',
+            column: 'users__userRole',
             operator: 'eq',
             value: 'admin',
             placement: 'pre-join',
-            aliasPath: 'users',
           },
         ],
       });
-    expectDisconnectedColumns(putRes, ['users.userRole']);
+    expectDisconnectedColumns(putRes, ['users__userRole']);
   });
 
-  it('PUT pre-join filter with aliasPath="main" → 400 with Zod shape error', async () => {
+  it('PUT pre-join filter on home mart column → 400 disconnected (home mart not slicable)', async () => {
     const res = await agent
       .put(`/api/reports/${reportId}`)
       .set(AUTH_HEADER)
@@ -237,14 +236,12 @@ describe('Output controls API (e2e)', () => {
         dataDestinationId,
         destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
         columnConfig: ['col_a'],
-        filterConfig: [
-          { column: 'x', operator: 'eq', value: 1, placement: 'pre-join', aliasPath: 'main' },
-        ],
+        filterConfig: [{ column: 'main__x', operator: 'eq', value: 1, placement: 'pre-join' }],
       });
-    expect(res.status).toBe(400);
-    // Owned by Zod superRefine — FE consumes the schema-level issue, not a validator code.
-    const body = JSON.stringify(res.body);
-    expect(body).toContain('pre-join filter on the home data mart');
+    // No Zod superRefine on aliasPath="main" in the new model — the unified column
+    // name "main__x" is simply not found in the blended field index, so it flows
+    // through as a disconnected column (FILTER_COLUMN_UNKNOWN path).
+    expectDisconnectedColumns(res, ['main__x']);
   });
 
   it('PUT rejects filterConfig with > 50 entries via @ArrayMaxSize(50)', async () => {

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ActiveRulesPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ActiveRulesPopover.tsx
@@ -18,7 +18,7 @@ export interface ActiveRulesPopoverProps {
   trigger: ReactNode;
   column: string;
   fieldType: string;
-  aliasPath?: string;
+  /** Unified blended-field name for display when showing slices. */
   sliceColumn?: string;
   filters?: RuleListProps;
   slices?: RuleListProps;
@@ -30,12 +30,11 @@ export function ActiveRulesPopover({
   trigger,
   column,
   fieldType,
-  aliasPath,
   sliceColumn,
   filters,
   slices,
 }: ActiveRulesPopoverProps) {
-  const slicesOnly = !filters?.rules.length && !!slices?.rules.length && aliasPath != null;
+  const slicesOnly = !filters?.rules.length && !!slices?.rules.length && sliceColumn != null;
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
@@ -43,13 +42,7 @@ export function ActiveRulesPopover({
         <div>
           <Label>Column</Label>
           <div className='font-mono text-xs'>
-            {slicesOnly ? (
-              <>
-                <span className='text-blue-600'>{aliasPath}</span>.{sliceColumn ?? column}
-              </>
-            ) : (
-              column
-            )}{' '}
+            {slicesOnly ? sliceColumn : column}{' '}
             <span className='text-muted-foreground'>({fieldType})</span>
           </div>
         </div>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.test.tsx
@@ -48,9 +48,8 @@ describe('FilterOrSliceEditorPopover — parallel drafts across tab switches', (
         open={true}
         onOpenChange={() => undefined}
         column='users__userRole'
-        sliceColumn='userRole'
+        sliceColumn='users__userRole'
         fieldType='STRING'
-        aliasPath='users'
         defaultTab='filter'
         trigger={<button>trigger</button>}
         filterProps={{
@@ -118,9 +117,8 @@ describe('FilterOrSliceEditorPopover — parallel drafts across tab switches', (
         open={true}
         onOpenChange={() => undefined}
         column='users__userRole'
-        sliceColumn='userRole'
+        sliceColumn='users__userRole'
         fieldType='STRING'
-        aliasPath='users'
         defaultTab='filter'
         trigger={<button>trigger</button>}
         filterProps={{ onApply: filterOnApply, existingRules: [] }}
@@ -144,7 +142,7 @@ describe('FilterOrSliceEditorPopover — parallel drafts across tab switches', (
     expect(sliceOnApply).not.toHaveBeenCalled();
   });
 
-  it('emits the Slice draft with placement="pre-join" + aliasPath injected when applied on Slice tab', () => {
+  it('emits the Slice draft with placement="pre-join" and unified column when applied on Slice tab', () => {
     const filterOnApply = vi.fn();
     const sliceOnApply = vi.fn();
 
@@ -153,9 +151,8 @@ describe('FilterOrSliceEditorPopover — parallel drafts across tab switches', (
         open={true}
         onOpenChange={() => undefined}
         column='users__userRole'
-        sliceColumn='userRole'
+        sliceColumn='users__userRole'
         fieldType='STRING'
-        aliasPath='users'
         defaultTab='slice'
         trigger={<button>trigger</button>}
         filterProps={{ onApply: filterOnApply, existingRules: [] }}
@@ -172,14 +169,14 @@ describe('FilterOrSliceEditorPopover — parallel drafts across tab switches', (
 
     expect(sliceOnApply).toHaveBeenCalledTimes(1);
     const emitted = sliceOnApply.mock.calls[0][0];
-    // Popover must inject placement + aliasPath; column is the raw slice column.
+    // Popover must inject placement and override column with the unified name.
     expect(emitted).toMatchObject({
-      column: 'userRole',
+      column: 'users__userRole',
       operator: 'eq',
       value: 'admin',
       placement: 'pre-join',
-      aliasPath: 'users',
     });
+    expect(emitted.aliasPath).toBeUndefined();
     expect(filterOnApply).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.tsx
@@ -28,7 +28,7 @@ export interface FilterOrSliceEditorPopoverProps {
   trigger: ReactNode;
   column: string;
   fieldType: string;
-  aliasPath?: string;
+  /** Unified blended-field name used as rule.column for pre-join rules. When absent, no slice tab. */
   sliceColumn?: string;
   filterProps: FilterOnlyProps;
   sliceProps?: SliceOnlyProps;
@@ -36,9 +36,9 @@ export interface FilterOrSliceEditorPopoverProps {
 }
 
 export function FilterOrSliceEditorPopover(props: FilterOrSliceEditorPopoverProps) {
-  const { aliasPath, sliceProps } = props;
+  const { sliceColumn, sliceProps } = props;
 
-  if (aliasPath == null || sliceProps == null) {
+  if (sliceColumn == null || sliceProps == null) {
     return (
       <FilterEditorPopover
         open={props.open}
@@ -51,18 +51,10 @@ export function FilterOrSliceEditorPopover(props: FilterOrSliceEditorPopoverProp
     );
   }
 
-  return (
-    <TabbedPopover
-      {...props}
-      aliasPath={aliasPath}
-      sliceProps={sliceProps}
-      sliceColumn={props.sliceColumn ?? props.column}
-    />
-  );
+  return <TabbedPopover {...props} sliceColumn={sliceColumn} sliceProps={sliceProps} />;
 }
 
 interface TabbedPopoverProps extends FilterOrSliceEditorPopoverProps {
-  aliasPath: string;
   sliceProps: SliceOnlyProps;
   sliceColumn: string;
 }
@@ -116,7 +108,7 @@ function TabbedPopover(props: TabbedPopoverProps) {
       const preJoinRule = {
         ...sliceDraft,
         placement: 'pre-join' as const,
-        aliasPath: props.aliasPath,
+        column: props.sliceColumn,
       } as FilterRule;
       props.sliceProps.onApply(preJoinRule);
     }
@@ -143,11 +135,6 @@ function TabbedPopover(props: TabbedPopoverProps) {
         <div>
           <Label>Column</Label>
           <div className='font-mono text-xs'>
-            {tab === 'slice' && (
-              <>
-                <span className='text-blue-600'>{props.aliasPath}</span>.
-              </>
-            )}
             {tab === 'slice' ? props.sliceColumn : props.column}{' '}
             <span className='text-muted-foreground'>({props.fieldType})</span>
           </div>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
@@ -62,7 +62,9 @@ export function FilterRow({
               title='Pre-join filter (slice)'
             >
               <Layers className='h-3 w-3' />
-              <span className={cn(isOrphaned && 'line-through')}>{displayLabel ?? rule.column}</span>
+              <span className={cn(isOrphaned && 'line-through')}>
+                {displayLabel ?? rule.column}
+              </span>
             </span>
           ) : (
             <span className={cn(isOrphaned && 'text-red-700 line-through dark:text-red-300')}>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
@@ -21,8 +21,8 @@ export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProp
   const resolvedType = fieldType ?? 'STRING';
   const opLabel = operatorLabelFor(rule.operator, resolvedType);
   const valueText = summarizeFilterRule(rule);
-  const isPreJoin = rule.placement === 'pre-join' && !!rule.aliasPath;
-  const displayColumn = isPreJoin ? `${rule.aliasPath}.${rule.column}` : rule.column;
+  const isPreJoin = rule.placement === 'pre-join';
+  const displayColumn = rule.column;
 
   return (
     <div
@@ -42,26 +42,21 @@ export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProp
               <AlertTriangle className='h-3 w-3' />
             </span>
           )}
-          {isPreJoin && isOrphaned ? (
-            <span className='inline-flex items-center gap-1 text-red-700 dark:text-red-300'>
+          {isPreJoin ? (
+            <span
+              className={cn(
+                'inline-flex items-center gap-1',
+                isOrphaned ? 'text-red-700 dark:text-red-300' : 'text-blue-600'
+              )}
+              title='Pre-join filter (slice)'
+            >
               <Layers className='h-3 w-3' />
-              <span className='line-through'>{displayColumn}</span>
+              <span className={cn(isOrphaned && 'line-through')}>{rule.column}</span>
             </span>
           ) : (
-            <>
-              {isPreJoin && (
-                <span
-                  className='inline-flex items-center gap-1 text-blue-600'
-                  title='Pre-join filter (slice)'
-                >
-                  <Layers className='h-3 w-3' />
-                  <span>{rule.aliasPath}.</span>
-                </span>
-              )}
-              <span className={cn(isOrphaned && 'text-red-700 line-through dark:text-red-300')}>
-                {rule.column}
-              </span>
-            </>
+            <span className={cn(isOrphaned && 'text-red-700 line-through dark:text-red-300')}>
+              {rule.column}
+            </span>
           )}
         </div>
         <div className='truncate font-mono text-[11px]'>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
@@ -17,11 +17,10 @@ describe('OutputSettingsDropdown disconnected controls', () => {
       filterConfig: [
         { column: 'ghost_filter', operator: 'eq', value: 'x' },
         {
-          column: 'ghost_slice',
+          column: 'users__ghost_slice',
           operator: 'eq',
           value: 'y',
           placement: 'pre-join',
-          aliasPath: 'old',
         },
       ],
       sortConfig: [{ column: 'ghost_sort', direction: 'asc' }],
@@ -39,8 +38,7 @@ describe('OutputSettingsDropdown disconnected controls', () => {
     );
 
     expect(screen.getByText('ghost_filter')).toHaveClass('line-through');
-    expect(screen.getByText('old.ghost_slice')).toHaveClass('line-through');
-    expect(screen.queryByText('ghost_slice')).not.toBeInTheDocument();
+    expect(screen.getByText('users__ghost_slice')).toHaveClass('line-through');
     expect(screen.getByText('ghost_sort')).toHaveClass('line-through');
     expect(screen.getAllByLabelText('Column not found in schema')).toHaveLength(3);
   });
@@ -50,11 +48,10 @@ describe('OutputSettingsDropdown disconnected controls', () => {
       filterConfig: [
         { column: 'ghost_filter', operator: 'gte', value: 10 },
         {
-          column: 'ghost_slice',
+          column: 'users__ghost_slice',
           operator: 'gte',
           value: 20,
           placement: 'pre-join',
-          aliasPath: 'old',
         },
       ],
       sortConfig: [],
@@ -73,5 +70,36 @@ describe('OutputSettingsDropdown disconnected controls', () => {
 
     expect(screen.getAllByText('greater than or equal')).toHaveLength(2);
     expect(screen.queryByText('gte')).not.toBeInTheDocument();
+  });
+
+  it('renders the Add slice picker when joined sources are available', () => {
+    // Emission contract (pre-join placement, unified column id, no aliasPath) is
+    // asserted in FilterOrSliceEditorPopover.test.tsx ("emits the Slice draft" test).
+    // The Select mock here strips onValueChange, so driving the full add flow would
+    // require a separate mock strategy that duplicates that coverage without adding value.
+    const onChange = vi.fn();
+    const value: OutputConfig = {
+      filterConfig: [],
+      sortConfig: [],
+      limitConfig: null,
+    };
+
+    render(
+      <OutputSettingsDropdown
+        value={value}
+        onChange={onChange}
+        allColumns={[]}
+        selectedColumns={[]}
+        joinedSources={[
+          {
+            aliasPath: 'users',
+            title: 'Users',
+            columns: [{ id: 'users__role', name: 'role', type: 'STRING' }],
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Add slice')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
@@ -136,7 +136,7 @@ interface IndexedFilterRule {
 
 // Bare index would let React drag deleted-row state onto its neighbour.
 function filterRowKey(rule: FilterRule, index: number): string {
-  return `${rule.placement ?? 'post'}|${rule.aliasPath ?? ''}|${rule.column}|${rule.operator}|${index}`;
+  return `${rule.placement ?? 'post'}|${rule.column}|${rule.operator}|${index}`;
 }
 
 interface FiltersSectionProps {
@@ -213,8 +213,9 @@ interface SlicesSectionProps {
 }
 
 interface PendingSliceColumn {
-  aliasPath: string;
-  column: string;
+  id: string; // unified name, stored on the rule
+  label: string; // raw name, for display
+  aliasPath: string; // for display only
   fieldType: string;
 }
 
@@ -230,13 +231,12 @@ function SlicesSection({
   const fieldTypeMap = new Map<string, string>();
   for (const src of joinedSources) {
     for (const col of src.columns) {
-      fieldTypeMap.set(`${src.aliasPath}\0${col.name}`, col.type);
+      fieldTypeMap.set(col.id, col.type);
     }
   }
 
   function fieldTypeFor(rule: FilterRule): string | null {
-    if (!rule.aliasPath) return null;
-    return fieldTypeMap.get(`${rule.aliasPath}\0${rule.column}`) ?? null;
+    return fieldTypeMap.get(rule.column) ?? null;
   }
 
   return (
@@ -249,12 +249,7 @@ function SlicesSection({
             rule={rule}
             fieldType={fieldTypeFor(rule)}
             onChange={next => {
-              // Re-stamp placement/aliasPath; FilterEditorPopover drops them.
-              onUpdateAt(index, {
-                ...next,
-                placement: 'pre-join',
-                aliasPath: rule.aliasPath,
-              } as FilterRule);
+              onUpdateAt(index, { ...next, placement: 'pre-join' } as FilterRule);
             }}
             onRemove={() => {
               onRemoveAt(index);
@@ -269,20 +264,16 @@ function SlicesSection({
             onOpenChange={isOpen => {
               if (!isOpen) setPending(null);
             }}
-            column={pending.column}
+            column={pending.id}
             fieldType={pending.fieldType}
             onApply={rule => {
-              onAdd({
-                ...rule,
-                placement: 'pre-join',
-                aliasPath: pending.aliasPath,
-              } as FilterRule);
+              onAdd({ ...rule, placement: 'pre-join', column: pending.id } as FilterRule);
               setPending(null);
             }}
             trigger={
               <Button variant='outline' size='sm' className='h-7 text-xs'>
                 <Plus className='mr-1 h-3 w-3' />
-                {pending.aliasPath}.{pending.column}
+                {pending.aliasPath}.{pending.label}
               </Button>
             }
           />
@@ -301,14 +292,13 @@ function AddSlicePicker({
   joinedSources: readonly JoinedSource[];
   onSelect: (pending: PendingSliceColumn) => void;
 }) {
-  // `\0` separator so a `.` in aliasPath/column doesn't collide.
   const items = joinedSources.flatMap(src =>
     src.columns
       .filter(col => isFilterableType(col.type))
       .map(col => ({
-        value: `${src.aliasPath}\0${col.name}`,
+        id: col.id,
+        label: col.name,
         aliasPath: src.aliasPath,
-        column: col.name,
         fieldType: col.type,
       }))
   );
@@ -321,13 +311,9 @@ function AddSlicePicker({
     <Select
       value=''
       onValueChange={val => {
-        const item = items.find(i => i.value === val);
+        const item = items.find(i => i.id === val);
         if (item) {
-          onSelect({
-            aliasPath: item.aliasPath,
-            column: item.column,
-            fieldType: item.fieldType,
-          });
+          onSelect(item);
         }
       }}
     >
@@ -339,9 +325,9 @@ function AddSlicePicker({
       </SelectTrigger>
       <SelectContent>
         {items.map(item => (
-          <SelectItem key={item.value} value={item.value}>
+          <SelectItem key={item.id} value={item.id}>
             <span className='font-mono'>
-              <span className='text-blue-600'>{item.aliasPath}</span>.{item.column}
+              <span className='text-blue-600'>{item.aliasPath}</span>.{item.label}
             </span>
             <span className='text-muted-foreground ml-2 text-xs'>({item.fieldType})</span>
           </SelectItem>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
@@ -522,20 +522,18 @@ describe('ReportColumnPicker unresolved columns', () => {
         outputConfig={{
           filterConfig: [
             {
-              column: 'hidden_field',
+              column: 'b__hidden_field',
               operator: 'eq',
               value: 'x',
               placement: 'pre-join',
-              aliasPath: 'b',
             },
             {
-              column: 'visible_field',
+              column: 'b__visible_field',
               operator: 'eq',
               value: 'y',
               placement: 'pre-join',
-              aliasPath: 'b',
             },
-          ] as never,
+          ],
           sortConfig: [],
           limitConfig: null,
         }}
@@ -547,7 +545,7 @@ describe('ReportColumnPicker unresolved columns', () => {
     const block = screen.getByText('Disconnected columns').closest('div[class*="border"]');
     expect(block).not.toBeNull();
     const row = within(block as HTMLElement)
-      .getByText('b.hidden_field')
+      .getByText('b__hidden_field')
       .closest('label');
     expect(row).not.toBeNull();
     const checkbox = within(row as HTMLElement).getByRole('checkbox');
@@ -556,7 +554,7 @@ describe('ReportColumnPicker unresolved columns', () => {
     expect(
       within(row as HTMLElement).getByRole('button', { name: 'Manage filters and slices' })
     ).toBeInTheDocument();
-    expect(within(block as HTMLElement).queryByText('b.visible_field')).not.toBeInTheDocument();
+    expect(within(block as HTMLElement).queryByText('b__visible_field')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Disconnected output controls')).toHaveTextContent('2');
   });
 
@@ -588,8 +586,8 @@ describe('ReportColumnPicker unresolved columns', () => {
       outputConfig: {
         filterConfig: [
           { column: 'b__field', operator: 'eq', value: 'x' },
-          { column: 'field', operator: 'eq', value: 'y', placement: 'pre-join', aliasPath: 'b' },
-        ] as never,
+          { column: 'b__field', operator: 'eq', value: 'y', placement: 'pre-join' },
+        ],
         sortConfig: [],
         limitConfig: null,
       },

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -232,8 +232,7 @@ const BlendedFieldRow = memo(function BlendedFieldRow({
                 : undefined
             }
             sliceIconProps={{
-              aliasPath: field.aliasPath,
-              originalFieldName: field.originalFieldName,
+              unifiedFieldName: field.name,
               existingSlices: preJoinSlices.rules,
               existingSliceIndices: preJoinSlices.indices,
               onAddSlice: effectiveAddFilter,
@@ -313,7 +312,6 @@ function BlendedGroupItem({
       </button>
       <CollapsibleContent>
         {group.visibleFields.map(field => {
-          const sliceKey = `${field.aliasPath}\0${field.originalFieldName}`;
           return (
             <BlendedFieldRow
               key={field.name}
@@ -325,7 +323,7 @@ function BlendedGroupItem({
               onAddFilter={onAddFilter}
               onRemoveFilterAt={onRemoveFilterAt}
               onReplaceFilterAt={onReplaceFilterAt}
-              preJoinSlices={preJoinByAliasPathColumn?.get(sliceKey) ?? EMPTY_COLUMN_FILTERS}
+              preJoinSlices={preJoinByAliasPathColumn?.get(field.name) ?? EMPTY_COLUMN_FILTERS}
               hoverClassName={inaccessible ? 'hover:bg-destructive/20' : undefined}
               removeOnly={inaccessible}
             />
@@ -415,29 +413,26 @@ export function ReportColumnPicker({
   const knownSliceKeys = useMemo(() => {
     const keys = new Set<string>();
     for (const f of schema?.blendedFields ?? []) {
-      if (!f.isHidden) keys.add(`${f.aliasPath}\0${f.originalFieldName}`);
+      if (!f.isHidden) keys.add(f.name);
     }
     return keys;
   }, [schema]);
 
   const unresolvedSlices = useMemo(() => {
     if (!schema) return [];
-    const typeByKey = new Map<string, string>();
+    const typeByName = new Map<string, string>();
     for (const f of schema.blendedFields) {
-      const key = `${f.aliasPath}\0${f.originalFieldName}`;
-      if (f.type) typeByKey.set(key, f.type);
+      if (f.type) typeByName.set(f.name, f.type);
     }
     const seen = new Set<string>();
-    const result: { aliasPath: string; column: string; fieldType?: string }[] = [];
+    const result: { column: string; fieldType?: string }[] = [];
     for (const rule of effectiveOutputConfig.filterConfig) {
-      if (rule.placement !== 'pre-join' || !rule.aliasPath) continue;
-      const key = `${rule.aliasPath}\0${rule.column}`;
-      if (knownSliceKeys.has(key) || seen.has(key)) continue;
-      seen.add(key);
+      if (rule.placement !== 'pre-join') continue;
+      if (knownSliceKeys.has(rule.column) || seen.has(rule.column)) continue;
+      seen.add(rule.column);
       result.push({
-        aliasPath: rule.aliasPath,
         column: rule.column,
-        fieldType: typeByKey.get(key),
+        fieldType: typeByName.get(rule.column),
       });
     }
     return result;
@@ -538,12 +533,12 @@ export function ReportColumnPicker({
     return map;
   }, [effectiveOutputConfig.filterConfig]);
 
-  // Pre-join filters (slices) keyed by aliasPath + raw column.
+  // Pre-join filters (slices) keyed by unified blended-field name (rule.column).
   const preJoinByAliasPathColumn = useMemo<Map<string, ColumnFilters>>(() => {
     const map = new Map<string, ColumnFilters>();
     effectiveOutputConfig.filterConfig.forEach((rule, idx) => {
-      if (rule.placement !== 'pre-join' || !rule.aliasPath) return;
-      const key = `${rule.aliasPath}\0${rule.column}`;
+      if (rule.placement !== 'pre-join') return;
+      const key = rule.column;
       const existing = map.get(key);
       if (existing) {
         existing.rules.push(rule);
@@ -614,7 +609,10 @@ export function ReportColumnPicker({
 
   const joinedSources = useMemo<JoinedSource[]>(() => {
     if (!schema) return [];
-    const byPath = new Map<string, JoinedSource & { columns: { name: string; type: string }[] }>();
+    const byPath = new Map<
+      string,
+      JoinedSource & { columns: { id: string; name: string; type: string }[] }
+    >();
     for (const source of schema.availableSources) {
       if (!source.isIncluded) continue;
       if (!source.isAccessibleForReporting) continue;
@@ -627,13 +625,13 @@ export function ReportColumnPicker({
     for (const field of schema.blendedFields) {
       const entry = byPath.get(field.aliasPath);
       if (!entry || !field.type || field.isHidden) continue;
-      entry.columns.push({ name: field.originalFieldName, type: field.type });
+      entry.columns.push({ id: field.name, name: field.originalFieldName, type: field.type });
     }
     for (const entry of byPath.values()) {
       const seen = new Set<string>();
       entry.columns = entry.columns.filter(c => {
-        if (seen.has(c.name)) return false;
-        seen.add(c.name);
+        if (seen.has(c.id)) return false;
+        seen.add(c.id);
         return true;
       });
     }
@@ -669,7 +667,7 @@ export function ReportColumnPicker({
   const hasDisconnectedOutputControls = useMemo(() => {
     for (const rule of effectiveOutputConfig.filterConfig) {
       if (rule.placement === 'pre-join') {
-        if (!rule.aliasPath || !knownSliceKeys.has(`${rule.aliasPath}\0${rule.column}`)) {
+        if (!knownSliceKeys.has(rule.column)) {
           return true;
         }
       } else if (!knownFieldNames.has(rule.column)) {
@@ -700,8 +698,8 @@ export function ReportColumnPicker({
   const referencedPreJoinKeys = useMemo(() => {
     const keys = new Set<string>();
     for (const rule of effectiveOutputConfig.filterConfig) {
-      if (rule.placement === 'pre-join' && rule.aliasPath) {
-        keys.add(`${rule.aliasPath}\0${rule.column}`);
+      if (rule.placement === 'pre-join') {
+        keys.add(rule.column);
       }
     }
     return keys;
@@ -727,9 +725,7 @@ export function ReportColumnPicker({
       }
       const isSelected = effectiveValueSet.has(field.name);
       const isReferenced =
-        isSelected ||
-        referencedFieldNames.has(field.name) ||
-        referencedPreJoinKeys.has(`${field.aliasPath}\0${field.originalFieldName}`);
+        isSelected || referencedFieldNames.has(field.name) || referencedPreJoinKeys.has(field.name);
       if (isSelected) group.selectedCount += 1;
       if (group.isAccessibleForReporting) {
         if (!showSelectedOnly || isReferenced) group.visibleFields.push(field);
@@ -899,16 +895,15 @@ export function ReportColumnPicker({
                 </label>
               );
             })}
-            {unresolvedSlices.map(({ aliasPath, column, fieldType }) => {
-              const sliceKey = `${aliasPath}\0${column}`;
-              const slices = preJoinByAliasPathColumn.get(sliceKey) ?? EMPTY_COLUMN_FILTERS;
+            {unresolvedSlices.map(({ column, fieldType }) => {
+              const slices = preJoinByAliasPathColumn.get(column) ?? EMPTY_COLUMN_FILTERS;
               return (
                 <label
-                  key={sliceKey}
+                  key={column}
                   className='group hover:bg-destructive/20 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
                 >
                   <Checkbox checked={false} disabled />
-                  <span className='font-mono text-xs'>{`${aliasPath}.${column}`}</span>
+                  <span className='font-mono text-xs'>{column}</span>
                   {outputControlsAvailable && slices.rules.length > 0 && (
                     <RowFilterIcon
                       column={column}
@@ -916,8 +911,7 @@ export function ReportColumnPicker({
                       activeRules={EMPTY_COLUMN_FILTERS.rules}
                       onRemoveAt={() => undefined}
                       sliceIconProps={{
-                        aliasPath,
-                        originalFieldName: column,
+                        unifiedFieldName: column,
                         existingSlices: slices.rules,
                         existingSliceIndices: slices.indices,
                         onRemoveSliceAt: handleRemoveFilterAt,

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.test.tsx
@@ -23,11 +23,10 @@ vi.mock('@owox/ui/components/select', () => ({
 
 const filterRule = { column: 'ghost__col', operator: 'eq', value: 'x' } as FilterRule;
 const sliceRule = {
-  column: 'hidden_field',
+  column: 'b__hidden_field',
   operator: 'eq',
   value: 'y',
   placement: 'pre-join',
-  aliasPath: 'b',
 } as FilterRule;
 
 describe('RowFilterIcon — remove-only popup', () => {
@@ -39,13 +38,12 @@ describe('RowFilterIcon — remove-only popup', () => {
     const onRemoveSliceAt = vi.fn();
     render(
       <RowFilterIcon
-        column='hidden_field'
+        column='b__hidden_field'
         fieldType='INTEGER'
         activeRules={[]}
         onRemoveAt={() => undefined}
         sliceIconProps={{
-          aliasPath: 'b',
-          originalFieldName: 'hidden_field',
+          unifiedFieldName: 'b__hidden_field',
           existingSlices: [sliceRule],
           existingSliceIndices: [3],
           onRemoveSliceAt,
@@ -59,7 +57,7 @@ describe('RowFilterIcon — remove-only popup', () => {
     expect(screen.queryByText('Active filters')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^(Apply|Add)$/ })).not.toBeInTheDocument();
     expect(document.querySelector('input[type="text"]')).toBeNull();
-    expect(screen.getByText('b')).toBeInTheDocument();
+    expect(screen.getByText('b__hidden_field')).toBeInTheDocument();
     expect(screen.getByText('(INTEGER)')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
 
@@ -97,8 +95,7 @@ describe('RowFilterIcon — remove-only popup', () => {
         activeRules={[filterRule]}
         onRemoveAt={() => undefined}
         sliceIconProps={{
-          aliasPath: 'b',
-          originalFieldName: 'field',
+          unifiedFieldName: 'b__field',
           existingSlices: [sliceRule],
           existingSliceIndices: [1],
           onRemoveSliceAt: () => undefined,
@@ -122,8 +119,7 @@ describe('RowFilterIcon — remove-only popup', () => {
         onAdd={() => undefined}
         onRemoveAt={() => undefined}
         sliceIconProps={{
-          aliasPath: 'b',
-          originalFieldName: 'field',
+          unifiedFieldName: 'b__field',
           existingSlices: [],
           existingSliceIndices: [],
           onAddSlice: () => undefined,

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
@@ -7,12 +7,12 @@ import { FilterOrSliceEditorPopover } from './FilterOrSliceEditorPopover';
 import type { FilterRule } from '../../../shared/types/output-config';
 
 interface SliceIconProps {
-  aliasPath: string;
-  originalFieldName: string;
-  /** Pre-join filters already active for this aliasPath+column combination. */
+  /** Unified blended-field name used as rule.column for pre-join rules. */
+  unifiedFieldName: string;
+  /** Pre-join filters already active for this unified column. */
   existingSlices: readonly FilterRule[];
   /**
-   * Add a pre-join FilterRule (placement+aliasPath already set by the popover).
+   * Add a pre-join FilterRule (placement already set by the popover).
    * Omit when adding slices is not allowed.
    */
   onAddSlice?: (rule: FilterRule) => void;
@@ -121,8 +121,7 @@ export function RowFilterIcon({
         trigger={trigger}
         column={column}
         fieldType={fieldType}
-        aliasPath={sliceIconProps?.aliasPath}
-        sliceColumn={sliceIconProps?.originalFieldName}
+        sliceColumn={sliceIconProps?.unifiedFieldName}
         filters={{ rules: activeRules, onRemoveAt }}
         slices={
           sliceIconProps
@@ -144,9 +143,8 @@ export function RowFilterIcon({
         open={open}
         onOpenChange={setOpen}
         column={column}
-        sliceColumn={sliceIconProps.originalFieldName}
+        sliceColumn={sliceIconProps.unifiedFieldName}
         fieldType={fieldType}
-        aliasPath={sliceIconProps.aliasPath}
         defaultTab={defaultTab}
         filterProps={{
           onApply: handleFilterApply,

--- a/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useEmailReportForm.test.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useEmailReportForm.test.ts
@@ -99,11 +99,10 @@ beforeEach(() => {
 describe('useEmailReportForm — defaults', () => {
   it('seeds output controls from initialReport (post+pre-join mix)', () => {
     const preJoinRule: FilterRule = {
-      column: 'plan',
+      column: 'orgs__plan',
       operator: 'eq',
       value: 'pro',
       placement: 'pre-join',
-      aliasPath: 'orgs',
     };
     const initial = buildReport({
       filterConfig: [{ column: 'col_a', operator: 'eq', value: 'X' }, preJoinRule],
@@ -132,11 +131,10 @@ describe('useEmailReportForm — submission', () => {
   it('UPDATE: builds CUSTOM_MESSAGE destinationConfig and forwards output controls', async () => {
     const initial = buildReport({ id: 'r-42' });
     const preJoinRule: FilterRule = {
-      column: 'country',
+      column: 'users__country',
       operator: 'neq',
       value: 'UA',
       placement: 'pre-join',
-      aliasPath: 'users',
     };
 
     const { result } = renderHook(() =>

--- a/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useGoogleSheetsReportForm.test.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useGoogleSheetsReportForm.test.ts
@@ -98,11 +98,10 @@ beforeEach(() => {
 describe('useGoogleSheetsReportForm — defaults', () => {
   it('seeds defaults from initialReport (title, columnConfig, all output controls)', () => {
     const preJoinRule: FilterRule = {
-      column: 'userRole',
+      column: 'users__userRole',
       operator: 'eq',
       value: 'admin',
       placement: 'pre-join',
-      aliasPath: 'users',
     };
     const postJoinRule: FilterRule = { column: 'revenue', operator: 'gt', value: 100 };
 
@@ -148,11 +147,10 @@ describe('useGoogleSheetsReportForm — defaults', () => {
 describe('useGoogleSheetsReportForm — submission', () => {
   it('CREATE: passes all output controls (including pre-join rule) to createReport', async () => {
     const preJoinRule: FilterRule = {
-      column: 'country',
+      column: 'users__country',
       operator: 'neq',
       value: 'UA',
       placement: 'pre-join',
-      aliasPath: 'users',
     };
 
     const { result } = renderHook(() =>

--- a/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useLookerStudioReportForm.test.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/__tests__/useLookerStudioReportForm.test.ts
@@ -92,11 +92,10 @@ beforeEach(() => {
 describe('useLookerStudioReportForm — defaults', () => {
   it('seeds output controls from initialReport (post+pre-join mix)', () => {
     const preJoinRule: FilterRule = {
-      column: 'plan',
+      column: 'orgs__plan',
       operator: 'eq',
       value: 'enterprise',
       placement: 'pre-join',
-      aliasPath: 'orgs',
     };
     const initial = buildReport({
       columnConfig: ['col_a', 'col_b'],
@@ -131,11 +130,10 @@ describe('useLookerStudioReportForm — defaults', () => {
 describe('useLookerStudioReportForm — submission', () => {
   it('UPDATE path: forwards output controls including pre-join rule', async () => {
     const preJoinRule: FilterRule = {
-      column: 'country',
+      column: 'users__country',
       operator: 'neq',
       value: 'UA',
       placement: 'pre-join',
-      aliasPath: 'users',
     };
     const initial = buildReport({ id: 'r-42' });
     const { result } = renderHook(() =>

--- a/apps/web/src/features/data-marts/shared/types/output-config.ts
+++ b/apps/web/src/features/data-marts/shared/types/output-config.ts
@@ -58,43 +58,12 @@ const FilterRuleBaseSchema = z.discriminatedUnion('operator', [
   }),
 ]);
 
-const ALIAS_PATH_REGEX = /^[a-z0-9_]+(\.[a-z0-9_]+)*$/;
-const AliasPathSchema = z.string().min(1).max(255).regex(ALIAS_PATH_REGEX);
-
 // Placement is optional — when absent, the rule is treated as 'post-join'.
-// Keeps backward compatibility with existing filterConfig rows that pre-date
-// this field and lets call sites construct plain rules without specifying
-// placement when post-join is the intended default.
 const PlacementExtrasSchema = z.object({
   placement: z.enum(['pre-join', 'post-join']).optional(),
-  aliasPath: AliasPathSchema.optional(),
 });
 
-export const FilterRuleSchema = z
-  .intersection(FilterRuleBaseSchema, PlacementExtrasSchema)
-  .superRefine((rule, ctx) => {
-    if (rule.placement === 'pre-join') {
-      if (!rule.aliasPath) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['aliasPath'],
-          message: 'aliasPath is required when placement is "pre-join"',
-        });
-      } else if (rule.aliasPath === 'main') {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['aliasPath'],
-          message: 'pre-join filter on the home data mart ("main") is not allowed',
-        });
-      }
-    } else if (rule.aliasPath != null) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['aliasPath'],
-        message: 'aliasPath is only valid when placement is "pre-join"',
-      });
-    }
-  });
+export const FilterRuleSchema = z.intersection(FilterRuleBaseSchema, PlacementExtrasSchema);
 
 export const SortRuleSchema = z.object({
   column: z.string().min(1),
@@ -106,6 +75,9 @@ export type SortRule = z.infer<typeof SortRuleSchema>;
 export type RelativeDatePreset = z.infer<typeof RelativeDatePresetSchema>;
 
 export interface JoinedSourceColumn {
+  /** Unified blended-field name stored on the rule, e.g. `category_details__item_event_count`. */
+  id: string;
+  /** Raw original field name, for friendly display in the slice picker. */
   name: string;
   type: string;
 }
@@ -134,6 +106,6 @@ export function hasAnyOutputControls(config: OutputConfig): boolean {
   );
 }
 
-export function isPreJoinFilter(rule: FilterRule): rule is FilterRule & { aliasPath: string } {
-  return rule.placement === 'pre-join' && !!rule.aliasPath;
+export function isPreJoinFilter(rule: FilterRule): boolean {
+  return rule.placement === 'pre-join';
 }


### PR DESCRIPTION
## Summary

Pre-join (slice) filters now reference a column by the **same fully qualified identifier** as post-join filters — e.g. `category_details__item_event_count` — instead of a raw column name plus a separate `aliasPath`. A single blended-field index resolves that unified name back to its source / CTE / raw column for both validation and SQL generation across all storages.

### DoD
- [x] Leave the fully qualified column name as-is (e.g. `category_details__item_event_count`)
- [x] Pre-join filter uses the same column format as post-join (no `aliasPath`)

## Why

Previously a slice identified a column with **two** fields (`column` = raw name + `aliasPath`), while post-join filters used the fully qualified blended name. The frontend also reconstructed composite keys (`aliasPath\0column`) in several places, so FE and BE could disagree on how a slice column is named. Unifying on the existing blended-field `name` removes that whole class of mismatch — every filter / slice / sort now refers to a column the same way, on both sides.

## Example

Stored slice rule, before → after:

```jsonc
// before — two fields carry the identifier
{ "column": "item_event_count", "aliasPath": "category.details", "placement": "pre-join", "operator": "gt", "value": 0 }

// after — one unified identifier, no aliasPath
{ "column": "category_details__item_event_count", "placement": "pre-join", "operator": "gt", "value": 0 }
```

Unified name format: `<aliasPath with dots→'_'>__<originalFieldName with dots→'_'>`.

## What changed

**Backend**
- New `buildBlendedFieldIndex` — one flat index `name → { aliasPath, cteName, originalFieldName, type, isIncluded }`; replaces the two parallel two-level maps (`buildKnownPaths` in the validator and `BlendedColumnTypes.preJoin`).
- Filter Zod schema **and** the hand-written OpenAPI DTO drop `aliasPath`.
- Validator + blended query builder resolve pre-join filters through the index (BigQuery, Athena/Trino, Snowflake, Redshift, Databricks). Emitted SQL is unchanged — the unified name resolves back to the raw column.
- Review hardening: collision guard in the index (two fields folding to the same unified name now throws instead of silently mis-resolving); a pre-join filter on a non-actualized schema returns **400** (was a 500); excluded-source slices are gated on the run path too.

**Frontend**
- Slice UI emits the unified identifier and no longer reconstructs composite keys client-side.

**Migration** — `1779200000000-migrate-prejoin-filter-to-unified-column`
- Converts stored reports: folds `aliasPath` + raw column into the unified name, drops `aliasPath`. Idempotent (already-unified rows are skipped).
- Self-contained: the transform is a private method and the file exports only the migration class (no shared helper).

## Migration notes (rolling deploy)

- This is a **data-shape change**, not pure expand-contract. During a rolling deploy, an old pod that runs a just-migrated report's slice would reject it (the old schema still expects `aliasPath`). Blast radius is **small and transient** — only reports that use slices (a new, low-usage feature), only during the deploy window. Recommendation: drain-then-migrate, or accept the transient window (the migration runs last).
- `down()` is intentionally a **no-op**: the unified name is lossy (nested-field dots collapse to `_`), so the reverse split can't reliably reconstruct `aliasPath` + raw column — there is no clean data rollback.

## Testing

- Backend unit (data-marts) + web suites green; `nest build` + `tsc -b` clean.
- e2e: `output-controls` + `blended-output-controls` 30/30 — acceptance, excluded-source / unknown-column rejection, disconnected-columns.
- Integration vs **real cloud**: Athena + BigQuery 92/92 (slices execute end-to-end); Snowflake / Redshift / Databricks output-controls.
- Migration round-trip (`up → down → up`, 96 migrations) **and** the actual JSON data transform verified on **both SQLite and MySQL** — including nested-struct dot handling and MySQL native JSON read/write of `filterConfig`.
- Changeset included (`'owox': minor`).