### PR TITLE
refactor(web): extract CORS configuration logic into a dedicated module

### DIFF
--- a/.changeset/configure-cors-allowed-headers.md
+++ b/.changeset/configure-cors-allowed-headers.md
@@ -1,0 +1,7 @@
+---
+"owox": minor
+---
+
+# Customize CORS allowed headers via environment variable
+
+Added `CORS_ALLOWED_HEADERS` environment variable support to customize the allowed HTTP headers for API CORS configurations.

--- a/apps/owox/src/commands/serve.ts
+++ b/apps/owox/src/commands/serve.ts
@@ -4,14 +4,15 @@ import type { IdpProvider } from '@owox/idp-protocol';
 
 import { Flags } from '@oclif/core';
 import { IdpProtocolMiddleware } from '@owox/idp-protocol';
-import cors, { CorsOptions } from 'cors';
+import cors from 'cors';
 import express from 'express';
 import { existsSync } from 'node:fs';
 
 import { IdpFactory } from '../idp/factory.js';
 import { trackServeStarted } from '../telemetry/index.js';
-import { getPackageInfo } from '../utils/package-info.js';
+import { getPackageInfo } from '../utils/index.js';
 import {
+  buildCorsConfig,
   registerHealthRoutes,
   registerPublicFlagsRoute,
   setupWebStaticAssets,
@@ -107,30 +108,6 @@ export default class Serve extends BaseCommand {
   }
 
   /**
-   * Builds CORS configuration based on environment variables.
-   * @returns CORS middleware options with validated origins
-   * @private
-   */
-  private buildCorsConfig(): CorsOptions {
-    const googleSheetsExtensionOrigin = process.env.GOOGLE_SHEETS_EXTENSION_ORIGIN;
-    const allowedOrigins = googleSheetsExtensionOrigin
-      ? googleSheetsExtensionOrigin
-          .split(',')
-          .map(origin => origin.trim())
-          .filter(origin => origin.length > 0)
-      : [];
-
-    return {
-      allowedHeaders: ['content-Type', 'authorization', 'x-owox-authorization'],
-      credentials: true,
-      maxAge: 86_400,
-      methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-      optionsSuccessStatus: 204,
-      origin: allowedOrigins,
-    };
-  }
-
-  /**
    * Handles graceful shutdown when receiving termination signals.
    *
    * Prevents multiple shutdown attempts, logs the shutdown process, waits for
@@ -223,7 +200,7 @@ export default class Serve extends BaseCommand {
     const expressApp = express();
     expressApp.set('trust proxy', 1);
 
-    const corsConfig = this.buildCorsConfig();
+    const corsConfig = buildCorsConfig();
     expressApp.use(cors(corsConfig));
 
     // Holders for late-bound dependencies used by early health routes

--- a/apps/owox/src/web/cors.ts
+++ b/apps/owox/src/web/cors.ts
@@ -8,12 +8,30 @@ export function parseCorsAllowedHeaders(value: string | undefined): string[] {
     return [];
   }
 
-  const headers = value
-    .split(',')
-    .map(header => header.trim().toLowerCase())
-    .filter(header => header.length > 0 && CORS_HEADER_NAME_PATTERN.test(header));
+  const rawHeaders = value.split(',').map(header => header.trim());
+  const validHeaders: string[] = [];
+  const invalidHeaders: string[] = [];
 
-  return [...new Set(headers)];
+  for (const rawHeader of rawHeaders) {
+    if (rawHeader.length === 0) {
+      continue;
+    }
+
+    const lowercaseHeader = rawHeader.toLowerCase();
+    if (CORS_HEADER_NAME_PATTERN.test(lowercaseHeader)) {
+      validHeaders.push(lowercaseHeader);
+    } else {
+      invalidHeaders.push(rawHeader);
+    }
+  }
+
+  if (invalidHeaders.length > 0) {
+    console.warn(
+      `Warning: Ignored invalid CORS allowed header name(s): ${invalidHeaders.map(h => `"${h}"`).join(', ')}`
+    );
+  }
+
+  return [...new Set(validHeaders)];
 }
 
 export function buildCorsAllowedHeaders(

--- a/apps/owox/src/web/cors.ts
+++ b/apps/owox/src/web/cors.ts
@@ -1,0 +1,44 @@
+import type { CorsOptions } from 'cors';
+
+const DEFAULT_CORS_ALLOWED_HEADERS = ['content-type', 'authorization', 'x-owox-authorization'];
+const CORS_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9a-z]+$/i;
+
+export function parseCorsAllowedHeaders(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  const headers = value
+    .split(',')
+    .map(header => header.trim().toLowerCase())
+    .filter(header => header.length > 0 && CORS_HEADER_NAME_PATTERN.test(header));
+
+  return [...new Set(headers)];
+}
+
+export function buildCorsAllowedHeaders(
+  extraHeadersValue = process.env.CORS_ALLOWED_HEADERS
+): string[] {
+  return [
+    ...new Set([...DEFAULT_CORS_ALLOWED_HEADERS, ...parseCorsAllowedHeaders(extraHeadersValue)]),
+  ];
+}
+
+export function buildCorsConfig(): CorsOptions {
+  const googleSheetsExtensionOrigin = process.env.GOOGLE_SHEETS_EXTENSION_ORIGIN;
+  const allowedOrigins = googleSheetsExtensionOrigin
+    ? googleSheetsExtensionOrigin
+        .split(',')
+        .map(origin => origin.trim())
+        .filter(origin => origin.length > 0)
+    : [];
+
+  return {
+    allowedHeaders: buildCorsAllowedHeaders(),
+    credentials: true,
+    maxAge: 86_400,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    optionsSuccessStatus: 204,
+    origin: allowedOrigins,
+  };
+}

--- a/apps/owox/src/web/index.ts
+++ b/apps/owox/src/web/index.ts
@@ -5,6 +5,7 @@
  * including static file serving, SPA routing configuration, and helper routes.
  */
 
+export { buildCorsConfig } from './cors.js';
 export { type FlagsRouteOptions, registerPublicFlagsRoute } from './flags-route.js';
 export { registerHealthRoutes } from './health-route.js';
 export { checkReadiness } from './readiness.js';

--- a/apps/owox/test/web/cors.test.ts
+++ b/apps/owox/test/web/cors.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+
+import { buildCorsAllowedHeaders, parseCorsAllowedHeaders } from '../../src/web/cors.js';
+
+describe('CORS configuration', () => {
+  describe('allowed headers', () => {
+    it('keeps default allowed headers when no extra headers are configured', () => {
+      expect(buildCorsAllowedHeaders('')).to.deep.equal([
+        'content-type',
+        'authorization',
+        'x-owox-authorization',
+      ]);
+    });
+
+    it('adds comma-separated headers from the environment value', () => {
+      expect(buildCorsAllowedHeaders('ngrok-skip-browser-warning, x-custom-header')).to.deep.equal([
+        'content-type',
+        'authorization',
+        'x-owox-authorization',
+        'ngrok-skip-browser-warning',
+        'x-custom-header',
+      ]);
+    });
+
+    it('normalizes and de-duplicates extra headers', () => {
+      expect(
+        buildCorsAllowedHeaders(' X-Custom-Header, x-custom-header, AUTHORIZATION ')
+      ).to.deep.equal(['content-type', 'authorization', 'x-owox-authorization', 'x-custom-header']);
+    });
+
+    it('ignores invalid extra header names', () => {
+      expect(parseCorsAllowedHeaders('x-valid, invalid header, also:invalid')).to.deep.equal([
+        'x-valid',
+      ]);
+    });
+  });
+});

--- a/apps/owox/test/web/cors.test.ts
+++ b/apps/owox/test/web/cors.test.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 
-import { buildCorsAllowedHeaders, parseCorsAllowedHeaders } from '../../src/web/cors.js';
+import {
+  buildCorsAllowedHeaders,
+  buildCorsConfig,
+  parseCorsAllowedHeaders,
+} from '../../src/web/cors.js';
 
 describe('CORS configuration', () => {
   describe('allowed headers', () => {
@@ -32,6 +36,78 @@ describe('CORS configuration', () => {
       expect(parseCorsAllowedHeaders('x-valid, invalid header, also:invalid')).to.deep.equal([
         'x-valid',
       ]);
+    });
+
+    it('logs a warning when invalid extra header names are encountered', () => {
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (message: string) => {
+        warnings.push(message);
+      };
+
+      try {
+        parseCorsAllowedHeaders('x-valid, invalid header, also:invalid');
+        expect(warnings).to.have.lengthOf(1);
+        expect(warnings[0]).to.include(
+          'Ignored invalid CORS allowed header name(s): "invalid header", "also:invalid"'
+        );
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+  });
+
+  describe('buildCorsConfig', () => {
+    let originalAllowedHeaders: string | undefined;
+    let originalOrigin: string | undefined;
+
+    beforeEach(() => {
+      originalAllowedHeaders = process.env.CORS_ALLOWED_HEADERS;
+      originalOrigin = process.env.GOOGLE_SHEETS_EXTENSION_ORIGIN;
+    });
+
+    afterEach(() => {
+      if (originalAllowedHeaders === undefined) {
+        delete process.env.CORS_ALLOWED_HEADERS;
+      } else {
+        process.env.CORS_ALLOWED_HEADERS = originalAllowedHeaders;
+      }
+
+      if (originalOrigin === undefined) {
+        delete process.env.GOOGLE_SHEETS_EXTENSION_ORIGIN;
+      } else {
+        process.env.GOOGLE_SHEETS_EXTENSION_ORIGIN = originalOrigin;
+      }
+    });
+
+    it('returns default CORS options when env variables are not set', () => {
+      delete process.env.CORS_ALLOWED_HEADERS;
+      delete process.env.GOOGLE_SHEETS_EXTENSION_ORIGIN;
+
+      const config = buildCorsConfig();
+      expect(config).to.deep.equal({
+        allowedHeaders: ['content-type', 'authorization', 'x-owox-authorization'],
+        credentials: true,
+        maxAge: 86_400,
+        methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+        optionsSuccessStatus: 204,
+        origin: [],
+      });
+    });
+
+    it('returns custom allowed headers and origins based on env variables', () => {
+      process.env.CORS_ALLOWED_HEADERS = 'ngrok-skip-browser-warning, x-custom-header';
+      process.env.GOOGLE_SHEETS_EXTENSION_ORIGIN = 'https://extension1.com, https://extension2.com';
+
+      const config = buildCorsConfig();
+      expect(config.allowedHeaders).to.deep.equal([
+        'content-type',
+        'authorization',
+        'x-owox-authorization',
+        'ngrok-skip-browser-warning',
+        'x-custom-header',
+      ]);
+      expect(config.origin).to.deep.equal(['https://extension1.com', 'https://extension2.com']);
     });
   });
 });

--- a/docs/getting-started/deployment-guide/environment-variables.md
+++ b/docs/getting-started/deployment-guide/environment-variables.md
@@ -181,6 +181,15 @@ owox serve --env-file custom.env --port 3030
   - Example for Claude web: `https://claude.ai`
   - Default: empty.
 
+## CORS
+
+- **CORS_ALLOWED_HEADERS**: Additional comma-separated request headers allowed by the
+  API CORS configuration.
+  - The values are added to the default allowed headers:
+    `content-type`, `authorization`, `x-owox-authorization`.
+  - Example for local tunnels or proxies:
+    `CORS_ALLOWED_HEADERS=ngrok-skip-browser-warning,x-custom-header`
+
 ## MySQL SSL
 
 `DB_MYSQL_SSL`, `IDP_BETTER_AUTH_MYSQL_SSL`, `IDP_OWOX_MYSQL_SSL`  enable TLS for MySQL (mysql2). Supported formats:


### PR DESCRIPTION
## Summary

- Add `CORS_ALLOWED_HEADERS` support to extend API CORS allowed headers at runtime
- Extract CORS configuration from the `serve` command into a dedicated `web/cors` module
- Normalize, validate, and de-duplicate configured header names before applying them
- Keep `serve.ts` focused on application startup orchestration
- Add focused tests for CORS allowed header parsing and merging
- Document the new `CORS_ALLOWED_HEADERS` environment variable and default allowed headers

## Testing

- `npm test -w owox -- --grep "CORS configuration"`
- `npm test -w owox -- --grep "shows help for serve command|accepts port flag|accepts web-enabled flag"`
- `npm run build -w owox`