### PR TITLE
web(reports) set default report filter operator to is

### DIFF
--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
@@ -12,6 +12,7 @@ import type { FilterRule, RelativeDatePreset } from '../../../shared/types/outpu
 import {
   type FilterOperator,
   operatorsForType,
+  defaultOperatorForType,
   isNumberType,
   isDateType,
   isTimeType,
@@ -148,7 +149,7 @@ export function FilterValueEditor({
   onChange,
 }: FilterValueEditorProps) {
   const operators = operatorsForType(fieldType);
-  const fallbackOp = operators[0]?.value ?? 'eq';
+  const fallbackOp = defaultOperatorForType(fieldType);
 
   const [state, setState] = useState<EditorState>(() => getInitialState(initialRule, fallbackOp));
 

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  defaultOperatorForType,
   operatorsForType,
   isFilterableType,
   isNumberType,
@@ -136,5 +137,22 @@ describe('operatorsForType', () => {
       expect(operatorsForType(t)).toEqual([]);
       expect(isFilterableType(t)).toBe(false);
     }
+  });
+});
+
+describe('defaultOperatorForType', () => {
+  it('uses "is" when a string-like type supports both contains and is', () => {
+    for (const t of ['STRING', 'VARCHAR', 'CHAR', 'TEXT', 'BPCHAR']) {
+      expect(defaultOperatorForType(t)).toBe('eq');
+    }
+  });
+
+  it('keeps the first supported operator for types without contains', () => {
+    expect(defaultOperatorForType('INTEGER')).toBe('eq');
+    expect(defaultOperatorForType('BOOLEAN')).toBe('is_true');
+  });
+
+  it('falls back to "is" for unknown unfilterable types', () => {
+    expect(defaultOperatorForType('JSON')).toBe('eq');
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-operators.ts
@@ -156,6 +156,17 @@ export function isFilterableType(fieldType: string): boolean {
   return operatorsForType(fieldType).length > 0;
 }
 
+export function defaultOperatorForType(fieldType: string): FilterOperator {
+  const operators = operatorsForType(fieldType);
+  const values = operators.map(o => o.value);
+
+  if (values.includes('contains') && values.includes('eq')) {
+    return 'eq';
+  }
+
+  return operators[0]?.value ?? 'eq';
+}
+
 // Shared so FilterValueEditor parses values with the SAME type sets — a number
 // column must emit a JS number, not a string (Athena quotes strings, breaking a
 // `bigint > '10'` comparison); a date column keeps its string for the backend cast.


### PR DESCRIPTION
 ## Summary

  Changed the default condition for report filters in the Column Picker from `contains` to `is` when both conditions are available.

  ## Why

  For string-like fields, users usually need to pick an exact value from the dropdown. Previously, the default `contains` condition showed a text input, so users had to manually switch to `is` before selecting a value from the list.

  ## What changed

  - Added explicit default operator selection for report filter fields.
  - When a field supports both `contains` and `is`, the default is now `is` (`eq` internally).
  - Existing saved filters are not changed.
  - This affects report filter and slice setup in the Column Picker.