### PR TITLE
web(table-filters): set default table filter operator to is

### DIFF
--- a/.changeset/table-filters-default-is-condition.md
+++ b/.changeset/table-filters-default-is-condition.md
@@ -1,0 +1,5 @@
+---
+"owox": minor
+---
+
+Set default table filter operator to `is` for fields supporting both `contains` and `is`. Reset the operator when switching filter fields to ensure the new default takes effect.

--- a/apps/web/src/shared/components/TableFilters/FiltersForm.tsx
+++ b/apps/web/src/shared/components/TableFilters/FiltersForm.tsx
@@ -11,7 +11,7 @@ import {
 import { Button } from '@owox/ui/components/button';
 import { Plus, X } from 'lucide-react';
 import type { FilterConfigItem, FilterOperator, FiltersState } from './types';
-import { isFilterRowValid } from './filter-utils';
+import { getDefaultFilterOperator, isFilterRowValid } from './filter-utils';
 import { SelectValueControl, InputValueControl } from './index';
 
 /* ---------------------------------------------------------------------------
@@ -165,15 +165,17 @@ function FilterBlock({
     [config, usedFieldIds, selectedFieldId]
   );
 
-  // Auto-set first operator when field changes
+  // Auto-set the default operator when field changes.
   useEffect(() => {
     if (!selectedFieldId) return;
     const currentOperator = watch(opPath);
     if (currentOperator) return;
 
-    const firstOp = config.find(c => c.id === selectedFieldId)?.operators[0];
-    if (firstOp) {
-      setValue(opPath, firstOp, { shouldDirty: true, shouldTouch: true });
+    const defaultOperator = getDefaultFilterOperator(
+      config.find(c => c.id === selectedFieldId)?.operators ?? []
+    );
+    if (defaultOperator) {
+      setValue(opPath, defaultOperator, { shouldDirty: true, shouldTouch: true });
     }
   }, [selectedFieldId, config, opPath, setValue, watch]);
 

--- a/apps/web/src/shared/components/TableFilters/FiltersForm.tsx
+++ b/apps/web/src/shared/components/TableFilters/FiltersForm.tsx
@@ -217,6 +217,7 @@ function FilterBlock({
                     onValueChange={v => {
                       field.onChange(v);
                       setValue(valPath, []);
+                      setValue(opPath, '');
                     }}
                   >
                     <SelectTrigger className='w-full'>

--- a/apps/web/src/shared/components/TableFilters/filter-utils.test.ts
+++ b/apps/web/src/shared/components/TableFilters/filter-utils.test.ts
@@ -9,6 +9,7 @@ describe('getDefaultFilterOperator', () => {
   it('keeps the first configured operator when the field does not offer both contains and is', () => {
     expect(getDefaultFilterOperator(['contains', 'not_contains'])).toBe('contains');
     expect(getDefaultFilterOperator(['neq', 'eq'])).toBe('neq');
+    expect(getDefaultFilterOperator(['eq', 'neq'])).toBe('eq');
   });
 
   it('returns undefined when no operators are configured', () => {

--- a/apps/web/src/shared/components/TableFilters/filter-utils.test.ts
+++ b/apps/web/src/shared/components/TableFilters/filter-utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getDefaultFilterOperator } from './filter-utils';
+
+describe('getDefaultFilterOperator', () => {
+  it('defaults to is when both contains and is are available', () => {
+    expect(getDefaultFilterOperator(['contains', 'not_contains', 'eq', 'neq'])).toBe('eq');
+  });
+
+  it('keeps the first configured operator when the field does not offer both contains and is', () => {
+    expect(getDefaultFilterOperator(['contains', 'not_contains'])).toBe('contains');
+    expect(getDefaultFilterOperator(['neq', 'eq'])).toBe('neq');
+  });
+
+  it('returns undefined when no operators are configured', () => {
+    expect(getDefaultFilterOperator([])).toBeUndefined();
+  });
+});

--- a/apps/web/src/shared/components/TableFilters/filter-utils.ts
+++ b/apps/web/src/shared/components/TableFilters/filter-utils.ts
@@ -1,6 +1,16 @@
-import type { FiltersState } from './types';
+import type { FilterOperator, FiltersState } from './types';
 
 export type FilterAccessors<K extends string, T> = Record<K, (row: T) => unknown>;
+
+export function getDefaultFilterOperator(
+  operators: readonly FilterOperator[]
+): FilterOperator | undefined {
+  if (operators.includes('contains') && operators.includes('eq')) {
+    return 'eq';
+  }
+
+  return operators[0];
+}
 
 /**
  * A filter row is valid when all three fields are filled and at least one value


### PR DESCRIPTION
## Summary

Changed shared table filters so fields that support both `contains` and `is` now default to `is`.

## Why

For fields with a fixed option list, users usually want to select an exact value from the dropdown. When `contains` was selected by default, the value control switched to a free-text input and users had to manually change the condition to `is` before selecting from the list.

## What changed

- Added shared default operator selection for table filters.
- If a filter field supports both `contains` and `is` (`eq` internally), the default operator is now `is`.
- Fields that do not offer both operators keep their existing first configured operator as the default.
- Added regression tests for the default operator selection.

## Validation

- `npm --workspace apps/web test -- filter-utils.test.ts`
- `npm --workspace apps/web run lint -- src/shared/components/TableFilters/FiltersForm.tsx src/shared/components/TableFilters/filter-utils.ts src/shared/components/TableFilters/filter-utils.test.ts`