### PR TITLE
feat(web): readable Output Control fields with search

### DIFF
--- a/.changeset/output-controls-readable-fields.md
+++ b/.changeset/output-controls-readable-fields.md
@@ -1,0 +1,13 @@
+---
+'owox': minor
+---
+
+# Readable field names and search in report Output Controls
+
+The Filters, Slices, and Sort pickers in a report's Output Controls now show the
+business-readable field name (its alias, or the column's leaf name), with the joined
+data mart name as a muted second line for blended fields, instead of only the raw
+nested column identifier. Hovering a field reveals its full path as a tree. Each picker
+is now searchable — start typing to filter the list by the readable name, the data mart
+name, or the technical field name. Long nested field names no longer overflow the
+sidebar, and the section info tooltips stay within view in narrow sidebars.

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ActiveRulesPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ActiveRulesPopover.tsx
@@ -18,6 +18,10 @@ export interface ActiveRulesPopoverProps {
   trigger: ReactNode;
   column: string;
   fieldType: string;
+  /** Business-readable field name shown in the header; falls back to `column`. */
+  displayLabel?: string;
+  /** Joined data mart name shown under the field name; absent for home-mart fields. */
+  dataMartName?: string;
   aliasPath?: string;
   sliceColumn?: string;
   filters?: RuleListProps;
@@ -30,6 +34,8 @@ export function ActiveRulesPopover({
   trigger,
   column,
   fieldType,
+  displayLabel,
+  dataMartName,
   aliasPath,
   sliceColumn,
   filters,
@@ -41,17 +47,10 @@ export function ActiveRulesPopover({
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent className='w-72 space-y-3'>
         <div>
-          <Label>Column</Label>
-          <div className='font-mono text-xs'>
-            {slicesOnly ? (
-              <>
-                <span className='text-blue-600'>{aliasPath}</span>.{sliceColumn ?? column}
-              </>
-            ) : (
-              column
-            )}{' '}
-            <span className='text-muted-foreground'>({fieldType})</span>
+          <div className='text-sm font-medium'>
+            {displayLabel ?? (slicesOnly ? (sliceColumn ?? column) : column)}
           </div>
+          {dataMartName && <div className='text-muted-foreground text-[11px]'>{dataMartName}</div>}
         </div>
 
         {!!filters?.rules.length && (

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldSearchPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldSearchPicker.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { FieldSearchPicker } from './FieldSearchPicker';
+
+// Radix Popover/Tooltip portals + cmdk Command manage their own state/portals.
+// Mock them to passthroughs so RTL can see the items and click them directly.
+vi.mock('@owox/ui/components/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@owox/ui/components/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+}));
+
+vi.mock('@owox/ui/components/command', () => ({
+  Command: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandInput: ({ placeholder }: { placeholder?: string }) => <input placeholder={placeholder} />,
+  CommandList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandItem: ({ children, onSelect }: { children: React.ReactNode; onSelect?: () => void }) => (
+    <div
+      role='option'
+      onClick={() => {
+        onSelect?.();
+      }}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+describe('FieldSearchPicker', () => {
+  it('hands back the raw value, not the label, when an item is chosen', () => {
+    const onSelect = vi.fn();
+    render(
+      <FieldSearchPicker
+        items={[
+          {
+            value: 'orders.product_revenue',
+            label: 'Product Revenue',
+            dataMartName: 'Orders',
+            path: ['orders', 'product_revenue'],
+          },
+        ]}
+        placeholder='Add filter'
+        onSelect={onSelect}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Product Revenue'));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('orders.product_revenue');
+  });
+
+  it('shows the joined data mart name as a second line', () => {
+    render(
+      <FieldSearchPicker
+        items={[
+          {
+            value: 'blended_users__email',
+            label: 'email',
+            dataMartName: 'Users',
+            path: ['orders', 'users', 'email'],
+          },
+        ]}
+        placeholder='Add filter'
+        onSelect={() => {}}
+      />
+    );
+
+    expect(screen.getByText('email')).toBeInTheDocument();
+    expect(screen.getByText('Users')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldSearchPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldSearchPicker.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+import { Button } from '@owox/ui/components/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@owox/ui/components/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@owox/ui/components/command';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+
+// Substring match over the readable field name, data-mart name, and the raw
+// field identifier (the item keywords) — so power users can still search by the
+// technical name. cmdk's default fuzzy scorer normalises the value, which makes
+// dotted-name search erratic.
+function commandFilter(value: string, search: string, keywords?: string[]): number {
+  const target = keywords?.join(' ') ?? value;
+  return target.toLowerCase().includes(search.toLowerCase()) ? 1 : 0;
+}
+
+export interface FieldPickerItem {
+  /** Stored identifier handed back on select. */
+  value: string;
+  /** Business-readable field name (line 1). */
+  label: string;
+  /** Joined data mart name (muted line 2); omit for home-mart fields. */
+  dataMartName?: string;
+  /** Full path segments, shown as a vertical tree on hover. */
+  path?: string[];
+}
+
+/** Vertical, indented path so a deep join chain never overflows the sidebar. */
+export function PathTree({ segments }: { segments: readonly string[] }) {
+  return (
+    <div className='font-mono text-[11px] leading-snug'>
+      {segments.map((seg, i) => (
+        <div key={i} style={{ paddingLeft: i * 12 }}>
+          {i > 0 && <span className='opacity-50'>› </span>}
+          {seg}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface FieldSearchPickerProps {
+  items: readonly FieldPickerItem[];
+  /** Trigger text, e.g. 'Add filter'. */
+  placeholder: string;
+  searchPlaceholder?: string;
+  onSelect: (value: string) => void;
+}
+
+export function FieldSearchPicker({
+  items,
+  placeholder,
+  searchPlaceholder = 'Search fields…',
+  onSelect,
+}: FieldSearchPickerProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen} modal={true}>
+      <PopoverTrigger asChild>
+        <Button
+          variant='outline'
+          size='sm'
+          className='text-muted-foreground h-7 w-full justify-start text-xs'
+          aria-expanded={open}
+          aria-haspopup='listbox'
+        >
+          <Plus className='mr-1 h-4 w-4' />
+          {placeholder}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align='start' className='w-[var(--radix-popover-trigger-width)] p-0'>
+        <Command filter={commandFilter}>
+          <CommandInput placeholder={searchPlaceholder} className='h-8' />
+          <CommandList>
+            <CommandEmpty>No fields found.</CommandEmpty>
+            {items.map(item => {
+              const content = (
+                <span className='flex min-w-0 flex-1 flex-col'>
+                  <span className='truncate'>{item.label}</span>
+                  {item.dataMartName && (
+                    <span className='text-muted-foreground truncate text-[11px]'>
+                      {item.dataMartName}
+                    </span>
+                  )}
+                </span>
+              );
+              const tree = item.path && item.path.length > 1 ? item.path : null;
+              return (
+                <CommandItem
+                  key={item.value}
+                  value={item.value}
+                  keywords={[item.label, item.dataMartName ?? '', item.value]}
+                  // Use the closure value, not cmdk's normalized arg.
+                  onSelect={() => {
+                    onSelect(item.value);
+                    setOpen(false);
+                  }}
+                >
+                  {tree ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>{content}</TooltipTrigger>
+                      <TooltipContent
+                        side='bottom'
+                        align='start'
+                        collisionPadding={8}
+                        className='max-w-[min(20rem,calc(100vw-1.5rem))]'
+                      >
+                        <PathTree segments={tree} />
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    content
+                  )}
+                </CommandItem>
+              );
+            })}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldSearchPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldSearchPicker.tsx
@@ -17,7 +17,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/too
 // dotted-name search erratic.
 function commandFilter(value: string, search: string, keywords?: string[]): number {
   const target = keywords?.join(' ') ?? value;
-  return target.toLowerCase().includes(search.toLowerCase()) ? 1 : 0;
+  return target.toLowerCase().includes(search.trim().toLowerCase()) ? 1 : 0;
 }
 
 export interface FieldPickerItem {

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldSearchPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldSearchPicker.tsx
@@ -95,7 +95,11 @@ export function FieldSearchPicker({
                 <CommandItem
                   key={item.value}
                   value={item.value}
-                  keywords={[item.label, item.dataMartName ?? '', item.value]}
+                  keywords={[
+                    item.label,
+                    item.value,
+                    ...(item.dataMartName ? [item.dataMartName] : []),
+                  ]}
                   // Use the closure value, not cmdk's normalized arg.
                   onSelect={() => {
                     onSelect(item.value);
@@ -103,7 +107,7 @@ export function FieldSearchPicker({
                   }}
                 >
                   {tree ? (
-                    <Tooltip>
+                    <Tooltip delayDuration={600}>
                       <TooltipTrigger asChild>{content}</TooltipTrigger>
                       <TooltipContent
                         side='bottom'

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterEditorPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterEditorPopover.tsx
@@ -14,6 +14,10 @@ export interface FilterEditorPopoverProps {
   trigger: ReactNode;
   column: string;
   fieldType: string;
+  /** Business-readable field name shown in the header; falls back to `column`. */
+  displayLabel?: string;
+  /** Joined data mart name shown under the field name; absent for home-mart fields. */
+  dataMartName?: string;
   initialRule?: FilterRule;
   onApply: (rule: FilterRule) => void;
   onCancel?: () => void;
@@ -69,10 +73,10 @@ export function FilterEditorPopover(props: FilterEditorPopoverProps) {
       <PopoverTrigger asChild>{props.trigger}</PopoverTrigger>
       <PopoverContent className='w-72 space-y-3'>
         <div>
-          <Label>Column</Label>
-          <div className='font-mono text-xs'>
-            {props.column} <span className='text-muted-foreground'>({props.fieldType})</span>
-          </div>
+          <div className='text-sm font-medium'>{props.displayLabel ?? props.column}</div>
+          {props.dataMartName && (
+            <div className='text-muted-foreground text-[11px]'>{props.dataMartName}</div>
+          )}
         </div>
 
         {hasExisting && (

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.tsx
@@ -28,6 +28,10 @@ export interface FilterOrSliceEditorPopoverProps {
   trigger: ReactNode;
   column: string;
   fieldType: string;
+  /** Business-readable field name shown in the header; falls back to `column`. */
+  displayLabel?: string;
+  /** Joined data mart name shown under the field name; absent for home-mart fields. */
+  dataMartName?: string;
   aliasPath?: string;
   sliceColumn?: string;
   filterProps: FilterOnlyProps;
@@ -46,6 +50,8 @@ export function FilterOrSliceEditorPopover(props: FilterOrSliceEditorPopoverProp
         trigger={props.trigger}
         column={props.column}
         fieldType={props.fieldType}
+        displayLabel={props.displayLabel}
+        dataMartName={props.dataMartName}
         {...props.filterProps}
       />
     );
@@ -141,16 +147,12 @@ function TabbedPopover(props: TabbedPopoverProps) {
       <PopoverTrigger asChild>{props.trigger}</PopoverTrigger>
       <PopoverContent className='w-72 space-y-3'>
         <div>
-          <Label>Column</Label>
-          <div className='font-mono text-xs'>
-            {tab === 'slice' && (
-              <>
-                <span className='text-blue-600'>{props.aliasPath}</span>.
-              </>
-            )}
-            {tab === 'slice' ? props.sliceColumn : props.column}{' '}
-            <span className='text-muted-foreground'>({props.fieldType})</span>
+          <div className='text-sm font-medium'>
+            {props.displayLabel ?? (tab === 'slice' ? props.sliceColumn : props.column)}
           </div>
+          {props.dataMartName && (
+            <div className='text-muted-foreground text-[11px]'>{props.dataMartName}</div>
+          )}
         </div>
 
         <TabToggle tab={tab} onChange={setTab} />

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
@@ -13,9 +13,20 @@ interface FilterRowProps {
   fieldType: string | null;
   onChange: (next: FilterRule) => void;
   onRemove: () => void;
+  /** Business-readable label; falls back to the raw column when absent. */
+  displayLabel?: string;
+  /** Joined data mart name (muted second line); absent for home-mart fields. */
+  dataMartName?: string;
 }
 
-export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProps) {
+export function FilterRow({
+  rule,
+  fieldType,
+  onChange,
+  onRemove,
+  displayLabel,
+  dataMartName,
+}: FilterRowProps) {
   const [editing, setEditing] = useState(false);
   const isOrphaned = fieldType === null;
   const resolvedType = fieldType ?? 'STRING';
@@ -50,20 +61,19 @@ export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProp
           ) : (
             <>
               {isPreJoin && (
-                <span
-                  className='inline-flex items-center gap-1 text-blue-600'
-                  title='Pre-join filter (slice)'
-                >
-                  <Layers className='h-3 w-3' />
-                  <span>{rule.aliasPath}.</span>
+                <span className='text-blue-600' title='Pre-join filter (slice)'>
+                  <Layers className='h-3 w-3 shrink-0' />
                 </span>
               )}
               <span className={cn(isOrphaned && 'text-red-700 line-through dark:text-red-300')}>
-                {rule.column}
+                {displayLabel ?? rule.column}
               </span>
             </>
           )}
         </div>
+        {!isOrphaned && dataMartName && (
+          <div className='text-muted-foreground truncate text-[11px]'>{dataMartName}</div>
+        )}
         <div className='truncate font-mono text-[11px]'>
           <span className='text-foreground/70 font-medium'>{opLabel}</span>
           {valueText && <span className='text-muted-foreground'> {valueText}</span>}
@@ -99,6 +109,8 @@ export function FilterRow({ rule, fieldType, onChange, onRemove }: FilterRowProp
           }
           column={rule.column}
           fieldType={resolvedType}
+          displayLabel={displayLabel}
+          dataMartName={dataMartName}
           initialRule={rule}
           onApply={onChange}
         />

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.invariant.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.invariant.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { FilterRule, OutputConfig } from '../../../shared/types/output-config';
+
+// The change is presentation-only: a picker shows a business label but must hand
+// back — and store — the RAW identifier. Stub the picker + editor so the test
+// drives the add-path wiring directly, without Radix/cmdk portals.
+vi.mock('./FieldSearchPicker', () => ({
+  FieldSearchPicker: ({
+    items,
+    placeholder,
+    onSelect,
+  }: {
+    items: { value: string; label: string }[];
+    placeholder: string;
+    onSelect: (value: string) => void;
+  }) => (
+    <div>
+      {items.map(item => (
+        <button
+          key={item.value}
+          onClick={() => {
+            onSelect(item.value);
+          }}
+        >
+          {`${placeholder}: ${item.label}`}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+// Stand in for the value editor: emit a rule carrying the `column` prop it was
+// given. If the wiring leaked a label into `column`, this rule would carry it.
+vi.mock('./FilterEditorPopover', () => ({
+  FilterEditorPopover: ({
+    column,
+    onApply,
+  }: {
+    column: string;
+    onApply: (rule: FilterRule) => void;
+  }) => (
+    <button
+      onClick={() => {
+        onApply({ column, operator: 'eq', value: 'x' });
+      }}
+    >
+      {`apply:${column}`}
+    </button>
+  ),
+}));
+
+import {
+  OutputSettingsDropdown,
+  type OutputSettingsDropdownColumn,
+} from './OutputSettingsDropdown';
+
+const EMPTY: OutputConfig = { filterConfig: [], sortConfig: [], limitConfig: null };
+
+// Alias differs from the raw name on purpose — that's where a leak would show.
+const productId: OutputSettingsDropdownColumn = {
+  name: 'orders.product_id',
+  type: 'STRING',
+  label: 'Product ID',
+};
+
+describe('OutputSettingsDropdown stored-identifier invariant', () => {
+  it('adding a filter stores the raw column name, not the business label', () => {
+    const onChange = vi.fn();
+    render(
+      <OutputSettingsDropdown
+        value={EMPTY}
+        onChange={onChange}
+        allColumns={[productId]}
+        selectedColumns={[]}
+        joinedSources={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Add filter: Product ID'));
+    fireEvent.click(screen.getByText('apply:orders.product_id'));
+
+    const cfg = onChange.mock.lastCall?.[0] as OutputConfig | undefined;
+    expect(cfg?.filterConfig).toHaveLength(1);
+    expect(cfg?.filterConfig[0].column).toBe('orders.product_id');
+    expect(cfg?.filterConfig[0].column).not.toBe('Product ID');
+  });
+
+  it('adding a slice stores the raw aliasPath + column, not the label', () => {
+    const onChange = vi.fn();
+    render(
+      <OutputSettingsDropdown
+        value={EMPTY}
+        onChange={onChange}
+        allColumns={[]}
+        selectedColumns={[]}
+        joinedSources={[
+          {
+            aliasPath: 'orders',
+            title: 'Orders',
+            dataMartName: 'Orders',
+            columns: [{ name: 'product_id', type: 'STRING', alias: 'Product ID' }],
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Add slice: Product ID'));
+    fireEvent.click(screen.getByText('apply:product_id'));
+
+    const cfg = onChange.mock.lastCall?.[0] as OutputConfig | undefined;
+    expect(cfg?.filterConfig).toHaveLength(1);
+    const rule = cfg?.filterConfig[0];
+    expect(rule?.column).toBe('product_id');
+    expect(rule?.aliasPath).toBe('orders');
+    expect(rule?.placement).toBe('pre-join');
+    expect(rule?.column).not.toBe('Product ID');
+  });
+
+  it('adding a sort stores the raw column name, not the business label', () => {
+    const onChange = vi.fn();
+    render(
+      <OutputSettingsDropdown
+        value={EMPTY}
+        onChange={onChange}
+        allColumns={[]}
+        selectedColumns={[productId]}
+        joinedSources={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Add sort by: Product ID'));
+
+    const cfg = onChange.mock.lastCall?.[0] as OutputConfig | undefined;
+    expect(cfg?.sortConfig).toHaveLength(1);
+    expect(cfg?.sortConfig[0].column).toBe('orders.product_id');
+    expect(cfg?.sortConfig[0].column).not.toBe('Product ID');
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
@@ -1,15 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
-import { OutputSettingsDropdown } from './OutputSettingsDropdown';
+import { describe, expect, it } from 'vitest';
+import {
+  OutputSettingsDropdown,
+  type OutputSettingsDropdownColumn,
+} from './OutputSettingsDropdown';
 import type { OutputConfig } from '../../../shared/types/output-config';
-
-vi.mock('@owox/ui/components/select', () => ({
-  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SelectTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
-  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
-  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
 
 describe('OutputSettingsDropdown disconnected controls', () => {
   it('marks stale filters, slices, and sort rules as disconnected rows', () => {
@@ -32,8 +27,8 @@ describe('OutputSettingsDropdown disconnected controls', () => {
       <OutputSettingsDropdown
         value={value}
         onChange={() => {}}
-        allColumns={[{ name: 'native_one', type: 'STRING' }]}
-        selectedColumns={[{ name: 'native_one', type: 'STRING' }]}
+        allColumns={[{ name: 'native_one', type: 'STRING', label: 'native_one' }]}
+        selectedColumns={[{ name: 'native_one', type: 'STRING', label: 'native_one' }]}
         joinedSources={[]}
       />
     );
@@ -73,5 +68,56 @@ describe('OutputSettingsDropdown disconnected controls', () => {
 
     expect(screen.getAllByText('greater than or equal')).toHaveLength(2);
     expect(screen.queryByText('gte')).not.toBeInTheDocument();
+  });
+});
+
+describe('OutputSettingsDropdown readable labels', () => {
+  const productId: OutputSettingsDropdownColumn = {
+    name: 'orders.product_id',
+    type: 'STRING',
+    label: 'Product ID',
+  };
+
+  it('shows the business label on a live filter chip, not the raw column', () => {
+    const value: OutputConfig = {
+      filterConfig: [{ column: 'orders.product_id', operator: 'eq', value: 'x' }],
+      sortConfig: [],
+      limitConfig: null,
+    };
+
+    render(
+      <OutputSettingsDropdown
+        value={value}
+        onChange={() => {}}
+        allColumns={[productId]}
+        selectedColumns={[productId]}
+        joinedSources={[]}
+      />
+    );
+
+    expect(screen.getByText('Product ID')).toBeInTheDocument();
+    // Raw column name stays in the title attribute, not the visible text.
+    expect(screen.queryByText('orders.product_id')).not.toBeInTheDocument();
+  });
+
+  it('shows the business label on a live sort chip, not the raw column', () => {
+    const value: OutputConfig = {
+      filterConfig: [],
+      sortConfig: [{ column: 'orders.product_id', direction: 'asc' }],
+      limitConfig: null,
+    };
+
+    render(
+      <OutputSettingsDropdown
+        value={value}
+        onChange={() => {}}
+        allColumns={[productId]}
+        selectedColumns={[productId]}
+        joinedSources={[]}
+      />
+    );
+
+    expect(screen.getByText('Product ID')).toBeInTheDocument();
+    expect(screen.queryByText('orders.product_id')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
@@ -2,14 +2,10 @@ import { useState, type DragEvent } from 'react';
 import { Button } from '@owox/ui/components/button';
 import { Info, Plus } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@owox/ui/components/select';
 import { cn } from '@owox/ui/lib/utils';
+import { FieldSearchPicker, type FieldPickerItem } from './FieldSearchPicker';
+import { fieldDisplayLabel } from './output-controls-display';
+import { makePreJoinKey } from './output-controls-utils';
 import type {
   FilterRule,
   JoinedSource,
@@ -34,7 +30,11 @@ function SectionHeader({ title, info }: { title: string; info: string }) {
             <Info className='size-3.5' aria-label={`About ${title}`} />
           </span>
         </TooltipTrigger>
-        <TooltipContent side='top' className='max-w-xs text-xs whitespace-pre-wrap normal-case'>
+        <TooltipContent
+          side='top'
+          collisionPadding={8}
+          className='max-w-[min(20rem,calc(100vw-1.5rem))] text-xs whitespace-pre-wrap normal-case'
+        >
           {info}
         </TooltipContent>
       </Tooltip>
@@ -56,6 +56,21 @@ const SECTION_INFO = {
 export interface OutputSettingsDropdownColumn {
   name: string;
   type: string;
+  /** Business-readable field name (alias or leaf of name). */
+  label: string;
+  /** Joined data mart name; absent for home-mart fields. */
+  dataMartName?: string;
+  /** Full path segments, shown as a tree on hover. */
+  path?: string[];
+}
+
+function columnToPickerItem(c: OutputSettingsDropdownColumn): FieldPickerItem {
+  return {
+    value: c.name,
+    label: c.label,
+    dataMartName: c.dataMartName,
+    path: c.path,
+  };
 }
 
 interface OutputSettingsDropdownProps {
@@ -114,7 +129,7 @@ export function OutputSettingsDropdown({
       )}
       <SortSection
         sort={value.sortConfig}
-        selectedColumns={selectedColumns.map(c => c.name)}
+        selectedColumns={selectedColumns}
         onChange={s => {
           onChange({ ...value, sortConfig: s });
         }}
@@ -139,6 +154,11 @@ function filterRowKey(rule: FilterRule, index: number): string {
   return `${rule.placement ?? 'post'}|${rule.aliasPath ?? ''}|${rule.column}|${rule.operator}|${index}`;
 }
 
+// FilterEditorPopover strips placement/aliasPath; re-stamp them for a slice.
+function toPreJoin(rule: FilterRule, aliasPath: string | undefined): FilterRule {
+  return { ...rule, placement: 'pre-join', aliasPath } as FilterRule;
+}
+
 interface FiltersSectionProps {
   indexedRules: IndexedFilterRule[];
   allColumns: readonly OutputSettingsDropdownColumn[];
@@ -157,6 +177,8 @@ function FiltersSection({
   const [pendingColumn, setPendingColumn] = useState<OutputSettingsDropdownColumn | null>(null);
   const filterableColumns = allColumns.filter(c => isFilterableType(c.type));
   const columnTypeMap = new Map(allColumns.map(c => [c.name, c.type]));
+  const labelByName = new Map(allColumns.map(c => [c.name, c.label]));
+  const dataMartByName = new Map(allColumns.map(c => [c.name, c.dataMartName]));
 
   return (
     <div>
@@ -167,6 +189,8 @@ function FiltersSection({
             key={filterRowKey(rule, index)}
             rule={rule}
             fieldType={columnTypeMap.get(rule.column) ?? null}
+            displayLabel={labelByName.get(rule.column)}
+            dataMartName={dataMartByName.get(rule.column)}
             onChange={next => {
               onUpdateAt(index, next);
             }}
@@ -185,6 +209,8 @@ function FiltersSection({
             }}
             column={pendingColumn.name}
             fieldType={pendingColumn.type}
+            displayLabel={pendingColumn.label}
+            dataMartName={pendingColumn.dataMartName}
             onApply={rule => {
               onAdd(rule);
               setPendingColumn(null);
@@ -192,7 +218,7 @@ function FiltersSection({
             trigger={
               <Button variant='outline' size='sm' className='h-7 text-xs'>
                 <Plus className='mr-1 h-3 w-3' />
-                {pendingColumn.name}
+                {pendingColumn.label}
               </Button>
             }
           />
@@ -216,6 +242,8 @@ interface PendingSliceColumn {
   aliasPath: string;
   column: string;
   fieldType: string;
+  label: string;
+  dataMartName?: string;
 }
 
 function SlicesSection({
@@ -228,15 +256,29 @@ function SlicesSection({
   const [pending, setPending] = useState<PendingSliceColumn | null>(null);
 
   const fieldTypeMap = new Map<string, string>();
+  const labelMap = new Map<string, string>();
+  const dataMartByAliasPath = new Map<string, string | undefined>();
   for (const src of joinedSources) {
+    dataMartByAliasPath.set(src.aliasPath, src.dataMartName);
     for (const col of src.columns) {
-      fieldTypeMap.set(`${src.aliasPath}\0${col.name}`, col.type);
+      fieldTypeMap.set(makePreJoinKey(src.aliasPath, col.name), col.type);
+      labelMap.set(makePreJoinKey(src.aliasPath, col.name), fieldDisplayLabel(col.alias, col.name));
     }
   }
 
   function fieldTypeFor(rule: FilterRule): string | null {
     if (!rule.aliasPath) return null;
-    return fieldTypeMap.get(`${rule.aliasPath}\0${rule.column}`) ?? null;
+    return fieldTypeMap.get(makePreJoinKey(rule.aliasPath, rule.column)) ?? null;
+  }
+
+  function labelFor(rule: FilterRule): string | undefined {
+    if (!rule.aliasPath) return undefined;
+    return labelMap.get(makePreJoinKey(rule.aliasPath, rule.column));
+  }
+
+  function dataMartFor(rule: FilterRule): string | undefined {
+    if (!rule.aliasPath) return undefined;
+    return dataMartByAliasPath.get(rule.aliasPath);
   }
 
   return (
@@ -248,13 +290,10 @@ function SlicesSection({
             key={filterRowKey(rule, index)}
             rule={rule}
             fieldType={fieldTypeFor(rule)}
+            displayLabel={labelFor(rule)}
+            dataMartName={dataMartFor(rule)}
             onChange={next => {
-              // Re-stamp placement/aliasPath; FilterEditorPopover drops them.
-              onUpdateAt(index, {
-                ...next,
-                placement: 'pre-join',
-                aliasPath: rule.aliasPath,
-              } as FilterRule);
+              onUpdateAt(index, toPreJoin(next, rule.aliasPath));
             }}
             onRemove={() => {
               onRemoveAt(index);
@@ -271,18 +310,16 @@ function SlicesSection({
             }}
             column={pending.column}
             fieldType={pending.fieldType}
+            displayLabel={pending.label}
+            dataMartName={pending.dataMartName}
             onApply={rule => {
-              onAdd({
-                ...rule,
-                placement: 'pre-join',
-                aliasPath: pending.aliasPath,
-              } as FilterRule);
+              onAdd(toPreJoin(rule, pending.aliasPath));
               setPending(null);
             }}
             trigger={
               <Button variant='outline' size='sm' className='h-7 text-xs'>
                 <Plus className='mr-1 h-3 w-3' />
-                {pending.aliasPath}.{pending.column}
+                {pending.aliasPath}.{pending.label}
               </Button>
             }
           />
@@ -301,53 +338,42 @@ function AddSlicePicker({
   joinedSources: readonly JoinedSource[];
   onSelect: (pending: PendingSliceColumn) => void;
 }) {
-  // `\0` separator so a `.` in aliasPath/column doesn't collide.
-  const items = joinedSources.flatMap(src =>
-    src.columns
-      .filter(col => isFilterableType(col.type))
-      .map(col => ({
-        value: `${src.aliasPath}\0${col.name}`,
+  const lookup = new Map<string, PendingSliceColumn>();
+  const items: FieldPickerItem[] = [];
+  for (const src of joinedSources) {
+    for (const col of src.columns) {
+      if (!isFilterableType(col.type)) continue;
+      const value = makePreJoinKey(src.aliasPath, col.name);
+      const label = fieldDisplayLabel(col.alias, col.name);
+      lookup.set(value, {
         aliasPath: src.aliasPath,
         column: col.name,
         fieldType: col.type,
-      }))
-  );
+        label,
+        dataMartName: src.dataMartName,
+      });
+      items.push({
+        value,
+        label,
+        dataMartName: src.dataMartName,
+        path: [...src.aliasPath.split('.'), col.name],
+      });
+    }
+  }
 
   if (items.length === 0) {
     return <span className='text-muted-foreground text-xs'>No filterable joined columns.</span>;
   }
 
   return (
-    <Select
-      value=''
-      onValueChange={val => {
-        const item = items.find(i => i.value === val);
-        if (item) {
-          onSelect({
-            aliasPath: item.aliasPath,
-            column: item.column,
-            fieldType: item.fieldType,
-          });
-        }
+    <FieldSearchPicker
+      items={items}
+      placeholder='Add slice'
+      onSelect={value => {
+        const pending = lookup.get(value);
+        if (pending) onSelect(pending);
       }}
-    >
-      <SelectTrigger className='text-muted-foreground h-7 w-full text-xs'>
-        <span className='flex flex-1 items-center gap-1 text-left'>
-          <Plus className='h-4 w-4' />
-          <SelectValue placeholder='Add slice' />
-        </span>
-      </SelectTrigger>
-      <SelectContent>
-        {items.map(item => (
-          <SelectItem key={item.value} value={item.value}>
-            <span className='font-mono'>
-              <span className='text-blue-600'>{item.aliasPath}</span>.{item.column}
-            </span>
-            <span className='text-muted-foreground ml-2 text-xs'>({item.fieldType})</span>
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    />
   );
 }
 
@@ -355,48 +381,36 @@ function AddFilterPicker({
   columns,
   onSelect,
 }: {
-  columns: OutputSettingsDropdownColumn[];
+  columns: readonly OutputSettingsDropdownColumn[];
   onSelect: (column: OutputSettingsDropdownColumn) => void;
 }) {
   if (columns.length === 0) {
     return <span className='text-muted-foreground text-xs'>No more filterable columns.</span>;
   }
   return (
-    <Select
-      value=''
-      onValueChange={name => {
+    <FieldSearchPicker
+      items={columns.map(columnToPickerItem)}
+      placeholder='Add filter'
+      onSelect={name => {
         const column = columns.find(c => c.name === name);
         if (column) onSelect(column);
       }}
-    >
-      <SelectTrigger className='text-muted-foreground h-7 w-full text-xs'>
-        <span className='flex flex-1 items-center gap-1 text-left'>
-          <Plus className='h-4 w-4' />
-          <SelectValue placeholder='Add filter' />
-        </span>
-      </SelectTrigger>
-      <SelectContent>
-        {columns.map(c => (
-          <SelectItem key={c.name} value={c.name}>
-            <span className='font-mono'>{c.name}</span>
-            <span className='text-muted-foreground ml-2 text-xs'>({c.type})</span>
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    />
   );
 }
 
 interface SortSectionProps {
   sort: SortRule[];
-  selectedColumns: string[];
+  selectedColumns: readonly OutputSettingsDropdownColumn[];
   onChange: (next: SortRule[]) => void;
 }
 
 function SortSection({ sort, selectedColumns, onChange }: SortSectionProps) {
   const sortColumns = new Set(sort.map(s => s.column));
-  const selectedColumnSet = new Set(selectedColumns);
-  const available = selectedColumns.filter(c => !sortColumns.has(c));
+  const selectedColumnSet = new Set(selectedColumns.map(c => c.name));
+  const labelByName = new Map(selectedColumns.map(c => [c.name, c.label]));
+  const dataMartByName = new Map(selectedColumns.map(c => [c.name, c.dataMartName]));
+  const available = selectedColumns.filter(c => !sortColumns.has(c.name));
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
@@ -457,6 +471,8 @@ function SortSection({ sort, selectedColumns, onChange }: SortSectionProps) {
               rule={rule}
               index={index}
               isOrphaned={!selectedColumnSet.has(rule.column)}
+              displayLabel={labelByName.get(rule.column)}
+              dataMartName={dataMartByName.get(rule.column)}
               onChange={next => {
                 const updated = [...sort];
                 updated[index] = next;
@@ -475,28 +491,15 @@ function SortSection({ sort, selectedColumns, onChange }: SortSectionProps) {
             All selected columns are already sorted.
           </span>
         ) : (
-          <Select
-            value=''
-            onValueChange={name => {
+          <FieldSearchPicker
+            items={available.map(columnToPickerItem)}
+            placeholder='Add sort by'
+            onSelect={name => {
               if (name && !sortColumns.has(name)) {
                 onChange([...sort, { column: name, direction: 'asc' }]);
               }
             }}
-          >
-            <SelectTrigger className='text-muted-foreground h-7 w-full text-xs'>
-              <span className='flex flex-1 items-center gap-1 text-left'>
-                <Plus className='h-4 w-4' />
-                <SelectValue placeholder='Add sort by' />
-              </span>
-            </SelectTrigger>
-            <SelectContent>
-              {available.map(name => (
-                <SelectItem key={name} value={name}>
-                  <span className='font-mono'>{name}</span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          />
         )}
       </div>
     </div>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
@@ -156,7 +156,7 @@ function filterRowKey(rule: FilterRule, index: number): string {
 
 // FilterEditorPopover strips placement/aliasPath; re-stamp them for a slice.
 function toPreJoin(rule: FilterRule, aliasPath: string | undefined): FilterRule {
-  return { ...rule, placement: 'pre-join', aliasPath } as FilterRule;
+  return { ...rule, placement: 'pre-join', aliasPath };
 }
 
 interface FiltersSectionProps {

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, type DragEvent } from 'react';
+import { useMemo, useState, type DragEvent } from 'react';
 import { Button } from '@owox/ui/components/button';
 import { Info, Plus } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
@@ -255,16 +255,22 @@ function SlicesSection({
 }: SlicesSectionProps) {
   const [pending, setPending] = useState<PendingSliceColumn | null>(null);
 
-  const fieldTypeMap = new Map<string, string>();
-  const labelMap = new Map<string, string>();
-  const dataMartByAliasPath = new Map<string, string | undefined>();
-  for (const src of joinedSources) {
-    dataMartByAliasPath.set(src.aliasPath, src.dataMartName);
-    for (const col of src.columns) {
-      fieldTypeMap.set(makePreJoinKey(src.aliasPath, col.name), col.type);
-      labelMap.set(makePreJoinKey(src.aliasPath, col.name), fieldDisplayLabel(col.alias, col.name));
+  const { fieldTypeMap, labelMap, dataMartByAliasPath } = useMemo(() => {
+    const fieldTypeMap = new Map<string, string>();
+    const labelMap = new Map<string, string>();
+    const dataMartByAliasPath = new Map<string, string | undefined>();
+    for (const src of joinedSources) {
+      dataMartByAliasPath.set(src.aliasPath, src.dataMartName);
+      for (const col of src.columns) {
+        fieldTypeMap.set(makePreJoinKey(src.aliasPath, col.name), col.type);
+        labelMap.set(
+          makePreJoinKey(src.aliasPath, col.name),
+          fieldDisplayLabel(col.alias, col.name)
+        );
+      }
     }
-  }
+    return { fieldTypeMap, labelMap, dataMartByAliasPath };
+  }, [joinedSources]);
 
   function fieldTypeFor(rule: FilterRule): string | null {
     if (!rule.aliasPath) return null;

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -19,12 +19,16 @@ import {
   hasAnyOutputControls,
   type FilterRule,
   type JoinedSource,
+  type JoinedSourceColumn,
   type OutputConfig,
 } from '../../../shared/types/output-config';
 import { supportsOutputControls } from '../../../shared/utils/output-controls-support';
 import { FieldInfoTooltip } from './FieldInfoTooltip';
 import { OutputSettingsButton } from './OutputSettingsButton';
 import { OutputSettingsDropdown } from './OutputSettingsDropdown';
+import type { OutputSettingsDropdownColumn } from './OutputSettingsDropdown';
+import { fieldDisplayLabel } from './output-controls-display';
+import { makePreJoinKey } from './output-controls-utils';
 import { RowFilterIcon } from './RowFilterIcon';
 import { isFilterableType } from './output-controls-operators';
 
@@ -127,20 +131,23 @@ const NativeFieldRow = memo(function NativeFieldRow({
   onReplaceFilterAt,
 }: NativeFieldRowProps) {
   return (
-    <label className='group hover:bg-muted/50 flex cursor-pointer items-center gap-2 rounded px-1 py-1'>
+    <label className='group hover:bg-muted/50 flex min-w-0 cursor-pointer items-center gap-2 rounded px-1 py-1'>
       <Checkbox
         checked={checked}
         onCheckedChange={c => {
           onToggleField(field.name, c === true);
         }}
       />
-      <span className='font-mono text-xs'>{field.alias ?? field.name}</span>
-      {field.type && <span className='text-muted-foreground text-xs'>({field.type})</span>}
+      <span className='min-w-0 truncate font-mono text-xs' title={field.name}>
+        {field.alias ?? field.name}
+      </span>
+      {field.type && <span className='text-muted-foreground shrink-0 text-xs'>({field.type})</span>}
       <FieldInfoTooltip text={field.description} compact />
       {filterableType && onAddFilter && onRemoveFilterAt && (
         <RowFilterIcon
           column={field.name}
           fieldType={filterableType}
+          displayLabel={fieldDisplayLabel(field.alias, field.name)}
           activeRules={columnFilters.rules}
           onAdd={onAddFilter}
           onRemoveAt={localIndex => {
@@ -197,7 +204,7 @@ const BlendedFieldRow = memo(function BlendedFieldRow({
   return (
     <label
       className={cn(
-        'group flex cursor-pointer items-center gap-2 rounded px-1 py-1',
+        'group flex min-w-0 cursor-pointer items-center gap-2 rounded px-1 py-1',
         hoverClassName
       )}
     >
@@ -208,8 +215,10 @@ const BlendedFieldRow = memo(function BlendedFieldRow({
           onToggleField(field.name, c === true);
         }}
       />
-      <span className='font-mono text-xs'>{field.alias || field.originalFieldName}</span>
-      {field.type && <span className='text-muted-foreground text-xs'>({field.type})</span>}
+      <span className='min-w-0 truncate font-mono text-xs' title={field.name}>
+        {field.alias || field.originalFieldName}
+      </span>
+      {field.type && <span className='text-muted-foreground shrink-0 text-xs'>({field.type})</span>}
       <FieldInfoTooltip text={field.description} compact />
       {filterableType &&
         onRemoveFilterAt &&
@@ -219,6 +228,8 @@ const BlendedFieldRow = memo(function BlendedFieldRow({
           <RowFilterIcon
             column={field.name}
             fieldType={filterableType}
+            displayLabel={fieldDisplayLabel(field.alias, field.originalFieldName)}
+            dataMartName={field.outputPrefix.trim() || field.sourceDataMartTitle}
             activeRules={columnFilters.rules}
             onAdd={effectiveAddFilter}
             onRemoveAt={localIndex => {
@@ -313,7 +324,7 @@ function BlendedGroupItem({
       </button>
       <CollapsibleContent>
         {group.visibleFields.map(field => {
-          const sliceKey = `${field.aliasPath}\0${field.originalFieldName}`;
+          const sliceKey = makePreJoinKey(field.aliasPath, field.originalFieldName);
           return (
             <BlendedFieldRow
               key={field.name}
@@ -415,7 +426,7 @@ export function ReportColumnPicker({
   const knownSliceKeys = useMemo(() => {
     const keys = new Set<string>();
     for (const f of schema?.blendedFields ?? []) {
-      if (!f.isHidden) keys.add(`${f.aliasPath}\0${f.originalFieldName}`);
+      if (!f.isHidden) keys.add(makePreJoinKey(f.aliasPath, f.originalFieldName));
     }
     return keys;
   }, [schema]);
@@ -424,14 +435,14 @@ export function ReportColumnPicker({
     if (!schema) return [];
     const typeByKey = new Map<string, string>();
     for (const f of schema.blendedFields) {
-      const key = `${f.aliasPath}\0${f.originalFieldName}`;
+      const key = makePreJoinKey(f.aliasPath, f.originalFieldName);
       if (f.type) typeByKey.set(key, f.type);
     }
     const seen = new Set<string>();
     const result: { aliasPath: string; column: string; fieldType?: string }[] = [];
     for (const rule of effectiveOutputConfig.filterConfig) {
       if (rule.placement !== 'pre-join' || !rule.aliasPath) continue;
-      const key = `${rule.aliasPath}\0${rule.column}`;
+      const key = makePreJoinKey(rule.aliasPath, rule.column);
       if (knownSliceKeys.has(key) || seen.has(key)) continue;
       seen.add(key);
       result.push({
@@ -543,7 +554,7 @@ export function ReportColumnPicker({
     const map = new Map<string, ColumnFilters>();
     effectiveOutputConfig.filterConfig.forEach((rule, idx) => {
       if (rule.placement !== 'pre-join' || !rule.aliasPath) return;
-      const key = `${rule.aliasPath}\0${rule.column}`;
+      const key = makePreJoinKey(rule.aliasPath, rule.column);
       const existing = map.get(key);
       if (existing) {
         existing.rules.push(rule);
@@ -614,7 +625,7 @@ export function ReportColumnPicker({
 
   const joinedSources = useMemo<JoinedSource[]>(() => {
     if (!schema) return [];
-    const byPath = new Map<string, JoinedSource & { columns: { name: string; type: string }[] }>();
+    const byPath = new Map<string, JoinedSource & { columns: JoinedSourceColumn[] }>();
     for (const source of schema.availableSources) {
       if (!source.isIncluded) continue;
       if (!source.isAccessibleForReporting) continue;
@@ -627,7 +638,8 @@ export function ReportColumnPicker({
     for (const field of schema.blendedFields) {
       const entry = byPath.get(field.aliasPath);
       if (!entry || !field.type || field.isHidden) continue;
-      entry.columns.push({ name: field.originalFieldName, type: field.type });
+      entry.dataMartName ??= field.outputPrefix.trim() || field.sourceDataMartTitle;
+      entry.columns.push({ name: field.originalFieldName, type: field.type, alias: field.alias });
     }
     for (const entry of byPath.values()) {
       const seen = new Set<string>();
@@ -640,15 +652,28 @@ export function ReportColumnPicker({
     return Array.from(byPath.values()).filter(s => s.columns.length > 0);
   }, [schema]);
 
-  const dropdownColumns = useMemo(() => {
-    const cols: { name: string; type: string }[] = [];
+  const dropdownColumns = useMemo<OutputSettingsDropdownColumn[]>(() => {
+    const cols: OutputSettingsDropdownColumn[] = [];
     for (const f of nativeFields) {
-      if (f.type) cols.push({ name: f.name, type: f.type });
+      if (f.type) {
+        cols.push({
+          name: f.name,
+          type: f.type,
+          label: fieldDisplayLabel(f.alias, f.name),
+          path: f.name.split('.'),
+        });
+      }
     }
     for (const f of includedBlendedFields) {
       if (!f.type) continue;
       if (!availableSourceByPath.get(f.aliasPath)?.isAccessibleForReporting) continue;
-      cols.push({ name: f.name, type: f.type });
+      cols.push({
+        name: f.name,
+        type: f.type,
+        label: fieldDisplayLabel(f.alias, f.originalFieldName),
+        dataMartName: f.outputPrefix.trim() || f.sourceDataMartTitle,
+        path: [...f.aliasPath.split('.'), f.originalFieldName],
+      });
     }
     return cols;
   }, [nativeFields, includedBlendedFields, availableSourceByPath]);
@@ -669,7 +694,7 @@ export function ReportColumnPicker({
   const hasDisconnectedOutputControls = useMemo(() => {
     for (const rule of effectiveOutputConfig.filterConfig) {
       if (rule.placement === 'pre-join') {
-        if (!rule.aliasPath || !knownSliceKeys.has(`${rule.aliasPath}\0${rule.column}`)) {
+        if (!rule.aliasPath || !knownSliceKeys.has(makePreJoinKey(rule.aliasPath, rule.column))) {
           return true;
         }
       } else if (!knownFieldNames.has(rule.column)) {
@@ -701,7 +726,7 @@ export function ReportColumnPicker({
     const keys = new Set<string>();
     for (const rule of effectiveOutputConfig.filterConfig) {
       if (rule.placement === 'pre-join' && rule.aliasPath) {
-        keys.add(`${rule.aliasPath}\0${rule.column}`);
+        keys.add(makePreJoinKey(rule.aliasPath, rule.column));
       }
     }
     return keys;
@@ -729,7 +754,7 @@ export function ReportColumnPicker({
       const isReferenced =
         isSelected ||
         referencedFieldNames.has(field.name) ||
-        referencedPreJoinKeys.has(`${field.aliasPath}\0${field.originalFieldName}`);
+        referencedPreJoinKeys.has(makePreJoinKey(field.aliasPath, field.originalFieldName));
       if (isSelected) group.selectedCount += 1;
       if (group.isAccessibleForReporting) {
         if (!showSelectedOnly || isReferenced) group.visibleFields.push(field);
@@ -900,7 +925,7 @@ export function ReportColumnPicker({
               );
             })}
             {unresolvedSlices.map(({ aliasPath, column, fieldType }) => {
-              const sliceKey = `${aliasPath}\0${column}`;
+              const sliceKey = makePreJoinKey(aliasPath, column);
               const slices = preJoinByAliasPathColumn.get(sliceKey) ?? EMPTY_COLUMN_FILTERS;
               return (
                 <label

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.test.tsx
@@ -59,8 +59,8 @@ describe('RowFilterIcon — remove-only popup', () => {
     expect(screen.queryByText('Active filters')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^(Apply|Add)$/ })).not.toBeInTheDocument();
     expect(document.querySelector('input[type="text"]')).toBeNull();
-    expect(screen.getByText('b')).toBeInTheDocument();
-    expect(screen.getByText('(INTEGER)')).toBeInTheDocument();
+    expect(screen.getByText('hidden_field')).toBeInTheDocument();
+    expect(screen.queryByText('(INTEGER)')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove slice' }));

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
@@ -24,6 +24,10 @@ interface SliceIconProps {
 interface RowFilterIconProps {
   column: string;
   fieldType: string;
+  /** Business-readable field name shown in popover headers; falls back to `column`. */
+  displayLabel?: string;
+  /** Joined data mart name shown under the field name; absent for home-mart fields. */
+  dataMartName?: string;
   activeRules: readonly FilterRule[];
   /** Omit to render the icon in remove-only mode (still shows count and exposes onRemoveAt). */
   onAdd?: (rule: FilterRule) => void;
@@ -35,6 +39,8 @@ interface RowFilterIconProps {
 export function RowFilterIcon({
   column,
   fieldType,
+  displayLabel,
+  dataMartName,
   activeRules,
   onAdd,
   onRemoveAt,
@@ -121,6 +127,8 @@ export function RowFilterIcon({
         trigger={trigger}
         column={column}
         fieldType={fieldType}
+        displayLabel={displayLabel}
+        dataMartName={dataMartName}
         aliasPath={sliceIconProps?.aliasPath}
         sliceColumn={sliceIconProps?.originalFieldName}
         filters={{ rules: activeRules, onRemoveAt }}
@@ -146,6 +154,8 @@ export function RowFilterIcon({
         column={column}
         sliceColumn={sliceIconProps.originalFieldName}
         fieldType={fieldType}
+        displayLabel={displayLabel}
+        dataMartName={dataMartName}
         aliasPath={sliceIconProps.aliasPath}
         defaultTab={defaultTab}
         filterProps={{
@@ -173,6 +183,8 @@ export function RowFilterIcon({
       onOpenChange={setOpen}
       column={column}
       fieldType={fieldType}
+      displayLabel={displayLabel}
+      dataMartName={dataMartName}
       onApply={handleFilterApply}
       initialRule={editFilter}
       existingRules={editFilter ? [] : activeRules}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/SortRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/SortRow.tsx
@@ -11,6 +11,10 @@ interface SortRowProps {
   onRemove: () => void;
   dragHandleProps?: HTMLAttributes<HTMLSpanElement>;
   isOrphaned?: boolean;
+  /** Business-readable label; falls back to the raw column when absent. */
+  displayLabel?: string;
+  /** Joined data mart name (muted second line); absent for home-mart fields. */
+  dataMartName?: string;
 }
 
 export function SortRow({
@@ -20,6 +24,8 @@ export function SortRow({
   onRemove,
   dragHandleProps,
   isOrphaned = false,
+  displayLabel,
+  dataMartName,
 }: SortRowProps) {
   const toggleDirection = () => {
     if (isOrphaned) return;
@@ -42,22 +48,27 @@ export function SortRow({
         <GripVertical className='h-4 w-4' />
       </span>
       <span className='text-muted-foreground w-4 text-xs tabular-nums'>{index + 1}</span>
-      <span className='flex min-w-0 flex-1 items-center gap-1 truncate font-mono text-xs'>
-        {isOrphaned && (
+      <span className='flex min-w-0 flex-1 flex-col justify-center truncate font-mono text-xs'>
+        <span className='flex items-center gap-1 truncate'>
+          {isOrphaned && (
+            <span
+              className='inline-flex items-center text-red-600'
+              title='This column is no longer available for sorting. Remove this rule or restore the column.'
+              aria-label='Column not found in schema'
+            >
+              <AlertTriangle className='h-3 w-3' />
+            </span>
+          )}
           <span
-            className='inline-flex items-center text-red-600'
-            title='This column is no longer available for sorting. Remove this rule or restore the column.'
-            aria-label='Column not found in schema'
+            className={cn('truncate', isOrphaned && 'text-red-700 line-through dark:text-red-300')}
+            title={rule.column}
           >
-            <AlertTriangle className='h-3 w-3' />
+            {displayLabel ?? rule.column}
           </span>
-        )}
-        <span
-          className={cn('truncate', isOrphaned && 'text-red-700 line-through dark:text-red-300')}
-          title={rule.column}
-        >
-          {rule.column}
         </span>
+        {!isOrphaned && dataMartName && (
+          <span className='text-muted-foreground truncate text-[11px]'>{dataMartName}</span>
+        )}
       </span>
       <Button
         variant='ghost'

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-display.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-display.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { fieldLeafName, fieldDisplayLabel } from './output-controls-display';
+
+describe('fieldLeafName', () => {
+  it('returns the last dotted segment', () => {
+    expect(fieldLeafName('orders.order_items.products.product_id')).toBe('product_id');
+  });
+  it('returns the whole name when there is no dot', () => {
+    expect(fieldLeafName('email')).toBe('email');
+  });
+});
+
+describe('fieldDisplayLabel', () => {
+  it('prefers a non-empty alias', () => {
+    expect(fieldDisplayLabel('Product ID', 'orders.x.product_id')).toBe('Product ID');
+  });
+  it('falls back to the leaf when alias is missing', () => {
+    expect(fieldDisplayLabel(undefined, 'orders.x.product_id')).toBe('product_id');
+  });
+  it('ignores a whitespace-only alias', () => {
+    expect(fieldDisplayLabel('   ', 'orders.x.product_id')).toBe('product_id');
+  });
+  it('handles a blended leaf basis (no dots)', () => {
+    expect(fieldDisplayLabel(undefined, 'product_id')).toBe('product_id');
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-display.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-display.ts
@@ -1,0 +1,15 @@
+/** Last dotted segment of a flattened field name: `a.b.c` → `c`. */
+export function fieldLeafName(name: string): string {
+  const i = name.lastIndexOf('.');
+  return i === -1 ? name : name.slice(i + 1);
+}
+
+/**
+ * Business-readable label for a field option. Prefers a human-set alias;
+ * otherwise the leaf of `basis` — the dotted path for native fields, or the
+ * already-leaf original field name for blended fields.
+ */
+export function fieldDisplayLabel(alias: string | undefined, basis: string): string {
+  const trimmed = alias?.trim() ?? '';
+  return trimmed !== '' ? trimmed : fieldLeafName(basis);
+}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-utils.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-utils.ts
@@ -1,0 +1,5 @@
+// `\0` cannot occur in aliasPath or column names, so it is a safe delimiter for
+// composite map keys / select values built from those two parts.
+export function makePreJoinKey(aliasPath: string, column: string): string {
+  return `${aliasPath}\0${column}`;
+}

--- a/apps/web/src/features/data-marts/shared/types/output-config.ts
+++ b/apps/web/src/features/data-marts/shared/types/output-config.ts
@@ -108,11 +108,15 @@ export type RelativeDatePreset = z.infer<typeof RelativeDatePresetSchema>;
 export interface JoinedSourceColumn {
   name: string;
   type: string;
+  /** Business-readable name of the joined column (presentation only). */
+  alias?: string;
 }
 
 export interface JoinedSource {
   aliasPath: string;
   title: string;
+  /** Display name of the joined data mart (join alias or its title). */
+  dataMartName?: string;
   columns: readonly JoinedSourceColumn[];
 }
 


### PR DESCRIPTION
## Summary
Makes report Output Control field names readable for business users, stops them overflowing the sidebar, and adds search to the field pickers.

- Filters / Slices / Sort pickers, the column picker, and active-rule chips now show a business-readable field name (alias → leaf) instead of the raw nested column identifier
- Blended fields get the joined data mart name as a muted second line; hovering a field reveals its full path as a tree
- Each picker is searchable — by readable name, data mart name, or the technical field name
- Long nested names truncate instead of overflowing; section info tooltips stay within view in narrow sidebars
- Filter/slice editor popover header shows the readable name as its heading
- Presentation only: stored identifiers (`FilterRule.column`, `aliasPath`, `SortRule.column`, slice keys) are unchanged

### Review follow-ups folded in
- Centralised the pre-join slice-key delimiter in a `makePreJoinKey` helper (one named home for the `\0` delimiter)
- `toPreJoin` helper replaces ad-hoc `as FilterRule` casts when re-stamping slice rules
- Added invariant tests proving the add-filter/slice/sort paths store the raw identifier, not the business label

## Test plan
- [x] `tsc -b` clean
- [x] `vitest` ReportColumnPicker — 105 passing (incl. new invariant tests)
- [x] Filters/Slices/Sort pickers show readable names + data mart line; search matches both readable and technical names
- [x] Long names don't overflow; hover shows the path tree
- [x] Existing filters/slices/sorts still apply correctly (stored identifiers intact)