### PR TITLE
fix: publish owox declaration files

### DIFF
--- a/apps/owox/package.json
+++ b/apps/owox/package.json
@@ -46,7 +46,13 @@
   "engines": {
     "node": ">=22.16.0"
   },
-  "files": ["./bin", "./dist/**/*.js", "./oclif.manifest.json", "./npm-shrinkwrap.json"],
+  "files": [
+    "./bin",
+    "./dist/**/*.js",
+    "./dist/**/*.d.ts",
+    "./oclif.manifest.json",
+    "./npm-shrinkwrap.json"
+  ],
   "homepage": "https://github.com/OWOX/owox-data-marts",
   "keywords": [
     "data-marts",
@@ -68,7 +74,9 @@
     "bin": "owox",
     "dirname": "owox",
     "commands": "./dist/commands",
-    "plugins": ["@oclif/plugin-help"],
+    "plugins": [
+      "@oclif/plugin-help"
+    ],
     "topicSeparator": " "
   },
   "repository": "OWOX/owox-data-marts",


### PR DESCRIPTION
## Summary
- include generated `dist/**/*.d.ts` files in the `owox` package publish allowlist
- keep existing JS, bin, manifest, and shrinkwrap publish entries unchanged

## Why
The package advertises `types: "dist/index.d.ts"` and the TypeScript config emits declarations, but the published `owox@0.27.1` tarball only includes `dist/**/*.js` because the package `files` allowlist excludes `.d.ts` files. TypeScript consumers resolve a missing declaration entrypoint.

## Validation
- `npm pack owox@0.27.1 --silent` confirmed `package/dist/index.js` exists and `package/dist/index.d.ts` is absent
- `node -e "const p=require('./apps/owox/package.json'); if(!p.files.includes('./dist/**/*.d.ts')) process.exit(1)"`
- `git diff --check`