### PR TITLE
feat: record executed SQL on report runs and show it in Run History

### DIFF
--- a/.changeset/run-history-executed-sql.md
+++ b/.changeset/run-history-executed-sql.md
@@ -1,0 +1,13 @@
+---
+'owox': minor
+---
+
+# Run History shows the executed SQL for report runs
+
+Report runs now record the exact SQL that ran — with output controls (filters, sorting,
+limit) applied and filter parameter values inlined as literals, matching the generated-SQL
+preview — and surface it in Run History as a dedicated **Executed SQL** block.
+Previously the run only stored the raw Data Mart query, so the recorded SQL did not reflect
+the parameters used at run time. This covers report exports to Google Sheets, Email, Slack,
+Google Chat, and Microsoft Teams, as well as Looker Studio. The block appears only when the
+run actually applied output controls or blended SQL.

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.spec.ts
@@ -319,6 +319,73 @@ describe('LookerStudioConnectorApiService', () => {
         ).not.toHaveBeenCalled();
         expect(eventDispatcher.publishExternal).not.toHaveBeenCalled();
       });
+
+      it('records executionSqlQuery on the run when the cached reader provides it', async () => {
+        delete process.env.LOOKER_STREAMING_ENABLED;
+        const request = createMockRequest(false);
+        const res = createMockResponse();
+        const mockResult = { schema: [], rows: [], filtersApplied: [] };
+        const dataMartRun = { reportDefinition: { title: 'r' } as Record<string, unknown> };
+        const mockReportRun = {
+          markAsSuccess: jest.fn(),
+          markAsUnsuccessful: jest.fn(),
+          getReport: jest.fn().mockReturnValue(createMockReport()),
+          getReportId: jest.fn().mockReturnValue('report-1'),
+          getDataMartRun: jest.fn().mockReturnValue(dataMartRun),
+        };
+
+        reportRunService.create.mockResolvedValue(mockReportRun as any);
+        cacheService.getOrCreateCachedReader.mockResolvedValue({
+          fromCache: false,
+          reader: {},
+          dataDescription: { dataHeaders: [] },
+          executionSqlQuery: "SELECT a FROM t WHERE a = 'x'",
+        } as any);
+        dataService.getData.mockResolvedValue({
+          response: mockResult,
+          meta: { limitExceeded: false, rowsSent: 0, bytesSent: undefined, limitReason: undefined },
+        } as any);
+
+        await service.getDataStreaming(request, res as Response);
+
+        expect(dataMartRun.reportDefinition.executionSqlQuery).toBe(
+          "SELECT a FROM t WHERE a = 'x'"
+        );
+      });
+
+      it('carries executionSqlQuery on the run when limitExceeded causes markAsUnsuccessful', async () => {
+        delete process.env.LOOKER_STREAMING_ENABLED;
+        const request = createMockRequest(false);
+        const res = createMockResponse();
+        const mockResult = { schema: [], rows: [], filtersApplied: [] };
+        const dataMartRun = { reportDefinition: { title: 'r' } as Record<string, unknown> };
+        const mockReportRun = {
+          markAsSuccess: jest.fn(),
+          markAsUnsuccessful: jest.fn(),
+          getReport: jest.fn().mockReturnValue(createMockReport()),
+          getReportId: jest.fn().mockReturnValue('report-1'),
+          getDataMartRun: jest.fn().mockReturnValue(dataMartRun),
+        };
+
+        reportRunService.create.mockResolvedValue(mockReportRun as any);
+        cacheService.getOrCreateCachedReader.mockResolvedValue({
+          fromCache: false,
+          reader: {},
+          dataDescription: { dataHeaders: [] },
+          executionSqlQuery: "SELECT a FROM t WHERE a = 'x'",
+        } as any);
+        dataService.getData.mockResolvedValue({
+          response: mockResult,
+          meta: { limitExceeded: true, rowsSent: 1000000, bytesSent: 5, limitReason: 'row cap' },
+        } as any);
+
+        await service.getDataStreaming(request, res as Response);
+
+        expect(mockReportRun.markAsUnsuccessful).toHaveBeenCalled();
+        expect(dataMartRun.reportDefinition.executionSqlQuery).toBe(
+          "SELECT a FROM t WHERE a = 'x'"
+        );
+      });
     });
 
     describe('full extraction with streaming enabled', () => {
@@ -488,6 +555,41 @@ describe('LookerStudioConnectorApiService', () => {
           consumptionTrackingService.registerLookerReportRunConsumption
         ).not.toHaveBeenCalled();
         expect(eventDispatcher.publishExternal).not.toHaveBeenCalled();
+      });
+
+      it('records executionSqlQuery on the run when the cached reader provides it', async () => {
+        process.env.LOOKER_STREAMING_ENABLED = 'true';
+        const request = createMockRequest(false);
+        const res = createMockResponse();
+        const dataMartRun = { reportDefinition: { title: 'r' } as Record<string, unknown> };
+        const mockReportRun = {
+          markAsSuccess: jest.fn(),
+          markAsUnsuccessful: jest.fn(),
+          getReport: jest.fn().mockReturnValue(createMockReport()),
+          getReportId: jest.fn().mockReturnValue('report-1'),
+          getDataMartRun: jest.fn().mockReturnValue(dataMartRun),
+        };
+
+        reportRunService.create.mockResolvedValue(mockReportRun as any);
+        cacheService.getOrCreateCachedReader.mockResolvedValue({
+          fromCache: false,
+          reader: {},
+          dataDescription: { dataHeaders: [] },
+          executionSqlQuery: "SELECT a FROM t WHERE a = 'x'",
+        } as any);
+        dataService.prepareStreamingContext.mockResolvedValue({} as any);
+        dataService.streamData.mockResolvedValue({
+          rowCount: 100,
+          limitExceeded: false,
+          bytesWritten: 10,
+          limitReason: undefined,
+        } as any);
+
+        await service.getDataStreaming(request, res as Response);
+
+        expect(dataMartRun.reportDefinition.executionSqlQuery).toBe(
+          "SELECT a FROM t WHERE a = 'x'"
+        );
       });
 
       it('should handle errors before streaming starts', async () => {

--- a/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/looker-studio-connector/services/looker-studio-connector-api.service.ts
@@ -194,6 +194,8 @@ export class LookerStudioConnectorApiService {
       throw new InternalServerErrorException('Failed to create report run');
     }
 
+    this.recordExecutionSqlQuery(reportRun, cachedReader);
+
     const reportRunLogger = createReportRunLogger(this.systemTimeService);
     logBlendedSqlIfNeeded(cachedReader.blendingDecision, reportRunLogger);
 
@@ -368,6 +370,8 @@ export class LookerStudioConnectorApiService {
       throw new InternalServerErrorException('Failed to create report run');
     }
 
+    this.recordExecutionSqlQuery(reportRun, cachedReader);
+
     const reportRunLogger = createReportRunLogger(this.systemTimeService);
     logBlendedSqlIfNeeded(cachedReader.blendingDecision, reportRunLogger);
 
@@ -392,6 +396,25 @@ export class LookerStudioConnectorApiService {
     } catch (e) {
       await this.handleFailedReportRun(reportRun, e, reportRunLogger);
       throw e;
+    }
+  }
+
+  /**
+   * Copies the executed SQL (output controls applied + params inlined) onto the run
+   * record so Run History shows what actually ran. Called before the read in both the
+   * streaming and non-streaming paths so the value persists on success AND failure.
+   * No-op when there are no output controls / blending (executionSqlQuery undefined).
+   */
+  private recordExecutionSqlQuery(
+    reportRun: LookerStudioReportRun,
+    cachedReader: CachedReaderData
+  ): void {
+    if (!cachedReader.executionSqlQuery) {
+      return;
+    }
+    const dmRun = reportRun.getDataMartRun();
+    if (dmRun.reportDefinition) {
+      dmRun.reportDefinition.executionSqlQuery = cachedReader.executionSqlQuery;
     }
   }
 

--- a/apps/backend/src/data-marts/dto/domain/cached-reader-data.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/cached-reader-data.dto.ts
@@ -22,4 +22,11 @@ export interface CachedReaderData {
    * without re-running metadata lookups.
    */
   blendingDecision: BlendingDecision;
+
+  /**
+   * Executed SQL with output controls applied and params inlined as literals
+   * (same render as the generated-SQL preview). Undefined when the report has no
+   * output controls / blending. Copied onto the run record for Run History.
+   */
+  executionSqlQuery?: string;
 }

--- a/apps/backend/src/data-marts/dto/domain/report-like-read-plan.ts
+++ b/apps/backend/src/data-marts/dto/domain/report-like-read-plan.ts
@@ -15,3 +15,16 @@ export interface ReportLikeReadPlan {
 }
 
 export type ReportLike = Report | ReportLikeReadPlan;
+
+/**
+ * True when the report carries any output control — a filter, sort, or limit.
+ * Single source for this predicate (run / cache / compose / run-record paths) so the
+ * copies cannot drift.
+ */
+export function hasOutputControls(report: ReportLike): boolean {
+  return (
+    (report.filterConfig?.length ?? 0) > 0 ||
+    (report.sortConfig?.length ?? 0) > 0 ||
+    report.limitConfig != null
+  );
+}

--- a/apps/backend/src/data-marts/dto/presentation/data-mart-run-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-mart-run-response-api.dto.ts
@@ -57,7 +57,12 @@ export class DataMartRunResponseApiDto {
   reportId: string | null;
 
   @ApiProperty({
-    example: { title: 'Quarterly export', destination: { type: 'GOOGLE_SHEETS' } },
+    example: {
+      title: 'Quarterly export',
+      destination: { type: 'GOOGLE_SHEETS' },
+      executionSqlQuery:
+        "SELECT * FROM (SELECT * FROM `proj.ds.sales`) WHERE created_at >= DATE '2025-01-01'",
+    },
     required: false,
     nullable: true,
   })

--- a/apps/backend/src/data-marts/dto/schemas/data-mart-run/data-mart-run-report-definition.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/data-mart-run/data-mart-run-report-definition.schema.ts
@@ -19,6 +19,7 @@ export const DataMartRunReportDefinitionSchema = z.object({
   }),
   destinationConfig: DataDestinationConfigSchema,
   outputConfig: DataMartRunReportOutputConfigSchema.nullable().optional(),
+  executionSqlQuery: z.string().optional(),
 });
 
 export type DataMartRunReportDefinition = z.infer<typeof DataMartRunReportDefinitionSchema>;

--- a/apps/backend/src/data-marts/services/data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.ts
@@ -12,6 +12,7 @@ import { DataMart } from '../entities/data-mart.entity';
 import { Insight } from '../entities/insight.entity';
 import { InsightTemplate } from '../entities/insight-template.entity';
 import { Report } from '../entities/report.entity';
+import { hasOutputControls } from '../dto/domain/report-like-read-plan';
 import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
 import { DataMartRunType } from '../enums/data-mart-run-type.enum';
 import { RoleScope } from '../enums/role-scope.enum';
@@ -581,11 +582,7 @@ export class DataMartRunService {
   private createReportRunFromReport(report: Report, context: ReportRunContext): DataMartRun {
     const { id, title, dataMart, destinationConfig, dataDestination } = report;
 
-    const hasOutputControls =
-      (report.filterConfig?.length ?? 0) > 0 ||
-      (report.sortConfig?.length ?? 0) > 0 ||
-      report.limitConfig != null;
-    const outputConfig = hasOutputControls
+    const outputConfig = hasOutputControls(report)
       ? {
           filterConfig: report.filterConfig ?? undefined,
           sortConfig: report.sortConfig ?? undefined,

--- a/apps/backend/src/data-marts/services/report-data-cache.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.spec.ts
@@ -43,6 +43,7 @@ describe('ReportDataCacheService — output controls on the cached path', () => 
     };
     const reportSqlComposerService = {
       compose: jest.fn().mockResolvedValue(composeResult ?? { sql: 'unused' }),
+      inlineStaticSql: jest.fn((_storageType: unknown, sql: string) => sql),
     };
 
     const service = new ReportDataCacheService(
@@ -88,12 +89,16 @@ describe('ReportDataCacheService — output controls on the cached path', () => 
       filterConfig: [{ column: 'x', operator: 'eq', value: 'y' }],
     } as never);
 
-    await service.getOrCreateCachedReader(report, { userId: 'user-1', roles: ['editor'] } as never);
+    const cached = await service.getOrCreateCachedReader(report, {
+      userId: 'user-1',
+      roles: ['editor'],
+    } as never);
 
     expect(reportSqlComposerService.compose).not.toHaveBeenCalled();
     const opts = optionsPassedToReader(reader);
     expect(opts.sqlOverride).toBe(decision.blendedSql);
     expect(opts.sqlOverrideParams).toEqual(decision.params);
+    expect(cached.executionSqlQuery).toBeDefined();
   });
 
   it('leaves overrides undefined for a plain report with no output controls', async () => {
@@ -109,6 +114,71 @@ describe('ReportDataCacheService — output controls on the cached path', () => 
     const opts = optionsPassedToReader(reader);
     expect(opts.sqlOverride).toBeUndefined();
     expect(opts.sqlOverrideParams).toBeUndefined();
+  });
+
+  it('exposes executionSqlQuery (inlined static SQL) for an output-controls report', async () => {
+    const composed = { sql: 'SELECT a FROM t WHERE a = ?', params: [{ name: 'p0', value: 'x' }] };
+    const { service, reportSqlComposerService } = setup(
+      { needsBlending: false, columnFilter: ['a'] },
+      composed
+    );
+    reportSqlComposerService.inlineStaticSql.mockReturnValue("SELECT a FROM t WHERE a = 'x'");
+    const report = buildReport({
+      filterConfig: [{ column: 'a', operator: 'eq', value: 'x' }],
+    } as never);
+
+    const cached = await service.getOrCreateCachedReader(report, {
+      userId: 'user-1',
+      roles: ['editor'],
+    } as never);
+
+    expect(reportSqlComposerService.inlineStaticSql).toHaveBeenCalledWith(
+      'AWS_ATHENA',
+      composed.sql,
+      composed.params
+    );
+    expect(cached.executionSqlQuery).toBe("SELECT a FROM t WHERE a = 'x'");
+  });
+
+  it('leaves executionSqlQuery undefined for a plain report with no output controls', async () => {
+    const { service, reportSqlComposerService } = setup({
+      needsBlending: false,
+      columnFilter: ['a'],
+    });
+    const report = buildReport(); // no filter/sort/limit
+
+    const cached = await service.getOrCreateCachedReader(report, {
+      userId: 'user-1',
+      roles: ['editor'],
+    } as never);
+
+    expect(reportSqlComposerService.inlineStaticSql).not.toHaveBeenCalled();
+    expect(cached.executionSqlQuery).toBeUndefined();
+  });
+
+  it('exposes inlined executionSqlQuery for a blended report with params', async () => {
+    const blendedSql = 'WITH m AS (...) SELECT * FROM m WHERE x = ?';
+    const params = [{ name: 'p0', value: 'y' }];
+    const decision: BlendingDecision = { needsBlending: true, blendedSql, params };
+    const { service, reportSqlComposerService } = setup(decision);
+    reportSqlComposerService.inlineStaticSql.mockReturnValue(
+      "WITH m AS (...) SELECT * FROM m WHERE x = 'y'"
+    );
+    const report = buildReport({
+      filterConfig: [{ column: 'x', operator: 'eq', value: 'y' }],
+    } as never);
+
+    const cached = await service.getOrCreateCachedReader(report, {
+      userId: 'user-1',
+      roles: ['editor'],
+    } as never);
+
+    expect(reportSqlComposerService.inlineStaticSql).toHaveBeenCalledWith(
+      'AWS_ATHENA',
+      blendedSql,
+      params
+    );
+    expect(cached.executionSqlQuery).toBe("WITH m AS (...) SELECT * FROM m WHERE x = 'y'");
   });
 });
 

--- a/apps/backend/src/data-marts/services/report-data-cache.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.spec.ts
@@ -140,6 +140,28 @@ describe('ReportDataCacheService — output controls on the cached path', () => 
     expect(cached.executionSqlQuery).toBe("SELECT a FROM t WHERE a = 'x'");
   });
 
+  it('does not abort the fetch when recording executionSqlQuery throws (best-effort)', async () => {
+    const composed = { sql: 'SELECT a FROM t WHERE a = ?', params: [{ name: 'p0', value: 'x' }] };
+    const { service, reportSqlComposerService } = setup(
+      { needsBlending: false, columnFilter: ['a'] },
+      composed
+    );
+    reportSqlComposerService.inlineStaticSql.mockImplementation(() => {
+      throw new Error('no inliner for this dialect');
+    });
+    const report = buildReport({
+      filterConfig: [{ column: 'a', operator: 'eq', value: 'x' }],
+    } as never);
+
+    const cached = await service.getOrCreateCachedReader(report, {
+      userId: 'user-1',
+      roles: ['editor'],
+    } as never);
+
+    expect(reportSqlComposerService.inlineStaticSql).toHaveBeenCalled();
+    expect(cached.executionSqlQuery).toBeUndefined();
+  });
+
   it('leaves executionSqlQuery undefined for a plain report with no output controls', async () => {
     const { service, reportSqlComposerService } = setup({
       needsBlending: false,

--- a/apps/backend/src/data-marts/services/report-data-cache.service.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.ts
@@ -16,6 +16,7 @@ import { ReportDataCache } from '../entities/report-data-cache.entity';
 import { BlendableSchemaAccessor } from './blendable-schema.service';
 import { BlendedReportDataService } from './blended-report-data.service';
 import { BlendingDecision } from '../dto/domain/blending-decision.dto';
+import { hasOutputControls } from '../dto/domain/report-like-read-plan';
 import { ReportSqlComposerService } from './report-sql-composer.service';
 
 /**
@@ -55,7 +56,7 @@ export class ReportDataCacheService {
     // SQL + bound params here, exactly as RunReportService does — otherwise this
     // (Looker Studio) cached-reader path drops them, and Athena's positional `?`
     // placeholders execute unbound.
-    if (!decision.needsBlending && this.hasOutputControls(report)) {
+    if (!decision.needsBlending && hasOutputControls(report)) {
       const composed = await this.reportSqlComposerService.compose(report, accessor, decision);
       sqlOverride = composed.sql;
       sqlOverrideParams = composed.params;
@@ -70,14 +71,6 @@ export class ReportDataCacheService {
       },
       decision,
     };
-  }
-
-  private hasOutputControls(report: Report): boolean {
-    return (
-      (report.filterConfig?.length ?? 0) > 0 ||
-      (report.sortConfig?.length ?? 0) > 0 ||
-      report.limitConfig != null
-    );
   }
 
   /**

--- a/apps/backend/src/data-marts/services/report-data-cache.service.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.ts
@@ -112,6 +112,14 @@ export class ReportDataCacheService {
     const now = new Date();
     const { options, decision } = await this.resolvePrepareOptions(report, accessor);
 
+    const executionSqlQuery = options.sqlOverride
+      ? this.reportSqlComposerService.inlineStaticSql(
+          report.dataMart.storage.type,
+          options.sqlOverride,
+          options.sqlOverrideParams
+        )
+      : undefined;
+
     const cachedData = await this.cacheRepository.findOne({
       where: {
         report: { id: report.id },
@@ -130,10 +138,11 @@ export class ReportDataCacheService {
         dataDescription: cachedData.dataDescription,
         fromCache: true,
         blendingDecision: decision,
+        executionSqlQuery,
       };
     }
 
-    return this.createNewCachedReader(report, options, decision);
+    return { ...(await this.createNewCachedReader(report, options, decision)), executionSqlQuery };
   }
 
   private async createNewCachedReader(

--- a/apps/backend/src/data-marts/services/report-data-cache.service.ts
+++ b/apps/backend/src/data-marts/services/report-data-cache.service.ts
@@ -112,13 +112,24 @@ export class ReportDataCacheService {
     const now = new Date();
     const { options, decision } = await this.resolvePrepareOptions(report, accessor);
 
-    const executionSqlQuery = options.sqlOverride
-      ? this.reportSqlComposerService.inlineStaticSql(
+    // Best-effort: executionSqlQuery is display-only run-history metadata, so a failure
+    // to render it must never abort the data fetch.
+    let executionSqlQuery: string | undefined;
+    if (options.sqlOverride) {
+      try {
+        executionSqlQuery = this.reportSqlComposerService.inlineStaticSql(
           report.dataMart.storage.type,
           options.sqlOverride,
           options.sqlOverrideParams
-        )
-      : undefined;
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to record executionSqlQuery for report ${report.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+    }
 
     const cachedData = await this.cacheRepository.findOne({
       where: {

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
@@ -789,6 +789,53 @@ describe('ReportSqlComposerService', () => {
     });
   });
 
+  describe('inlineStaticSql', () => {
+    const composer = new ReportSqlComposerService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never
+    );
+
+    it('returns SQL unchanged when there are no params', () => {
+      expect(composer.inlineStaticSql(DataStorageType.AWS_ATHENA, 'SELECT 1')).toBe('SELECT 1');
+      expect(composer.inlineStaticSql(DataStorageType.GOOGLE_BIGQUERY, 'SELECT 1', [])).toBe(
+        'SELECT 1'
+      );
+    });
+
+    it('inlines positional ? to literals for Athena (quotes escaped)', () => {
+      const sql = composer.inlineStaticSql(
+        DataStorageType.AWS_ATHENA,
+        `SELECT * FROM t WHERE "name" = ? AND "amount" >= ?`,
+        [
+          { name: 'p0', value: "O'Brien" },
+          { name: 'p1', value: 50 },
+        ]
+      );
+      expect(sql).not.toContain('?');
+      expect(sql).toContain(`"name" = 'O''Brien'`);
+      expect(sql).toContain('"amount" >= 50');
+    });
+
+    it('inlines named @p to literals for BigQuery and Legacy BigQuery', () => {
+      const sql = 'SELECT * FROM t WHERE `d` = CAST(@p0 AS DATE)';
+      const params = [{ name: 'p0', value: '2024-01-01' }];
+      const bq = composer.inlineStaticSql(DataStorageType.GOOGLE_BIGQUERY, sql, params);
+      const legacy = composer.inlineStaticSql(DataStorageType.LEGACY_GOOGLE_BIGQUERY, sql, params);
+      expect(bq).toBe("SELECT * FROM t WHERE `d` = CAST('2024-01-01' AS DATE)");
+      expect(legacy).toBe(bq);
+    });
+
+    it('throws BusinessViolationException for a dialect with no inliner when params are present', () => {
+      expect(() =>
+        composer.inlineStaticSql(DataStorageType.SNOWFLAKE, 'SELECT * FROM t WHERE a = ?', [
+          { name: 'p0', value: 1 },
+        ])
+      ).toThrow(BusinessViolationException);
+    });
+  });
+
   describe('composeStatic — non-Athena dialects', () => {
     it('inlines named @params into literals for BigQuery (CAST wrapper makes date literals valid)', async () => {
       const queryBuilderFacade = {

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { DataMartQueryBuilderFacade } from '../data-storage-types/facades/data-mart-query-builder.facade';
 import { BlendingDecision } from '../dto/domain/blending-decision.dto';
-import { ReportLike } from '../dto/domain/report-like-read-plan';
+import { ReportLike, hasOutputControls } from '../dto/domain/report-like-read-plan';
 import { BlendableSchemaAccessor } from './blendable-schema.service';
 import { BlendedReportDataService } from './blended-report-data.service';
 import { isQueryBuildResult } from '../data-storage-types/interfaces/data-mart-query-builder.interface';
@@ -69,12 +69,7 @@ export class ReportSqlComposerService {
       throw new Error('Data Mart definition is not set.');
     }
 
-    const hasOutputControls =
-      (report.filterConfig?.length ?? 0) > 0 ||
-      (report.sortConfig?.length ?? 0) > 0 ||
-      report.limitConfig != null;
-
-    if (hasOutputControls && !this.capabilityService.isSupported(dataMart.storage.type)) {
+    if (hasOutputControls(report) && !this.capabilityService.isSupported(dataMart.storage.type)) {
       throw new BadRequestException({
         message: 'Output controls not yet supported for this storage type',
         details: {
@@ -84,7 +79,7 @@ export class ReportSqlComposerService {
     }
 
     let mainTableReference: string | undefined;
-    if (hasOutputControls) {
+    if (hasOutputControls(report)) {
       mainTableReference = await this.tableReferenceService.resolveTableName(
         dataMart.id,
         dataMart.projectId

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -136,21 +136,32 @@ export class ReportSqlComposerService {
     precomputedDecision?: BlendingDecision
   ): Promise<{ sql: string }> {
     const composed = await this.compose(report, accessor, precomputedDecision);
-    if (!composed.params?.length) return { sql: composed.sql };
-    switch (report.dataMart.storage.type) {
+    return {
+      sql: this.inlineStaticSql(report.dataMart.storage.type, composed.sql, composed.params),
+    };
+  }
+
+  /**
+   * Inlines bound parameters into a self-contained, runnable SQL string for paths
+   * with no parameter-binding channel: copied/persisted SQL, the generated-SQL
+   * preview, and the run-history record. Athena positional `?` and BigQuery named
+   * `@p` become literals (both dialects wrap value placeholders in a CAST so
+   * date/time literals stay valid). No params — sort/limit-only, relative_date, no
+   * controls, or literal-inlining dialects (Redshift/Snowflake/Databricks) — returns
+   * the SQL unchanged.
+   */
+  inlineStaticSql(storageType: DataStorageType, sql: string, params?: SqlParameter[]): string {
+    if (!params?.length) return sql;
+    switch (storageType) {
       case DataStorageType.AWS_ATHENA:
-        return { sql: inlineAthenaPositionalParams(composed.sql, composed.params) };
+        return inlineAthenaPositionalParams(sql, params);
       case DataStorageType.GOOGLE_BIGQUERY:
       case DataStorageType.LEGACY_GOOGLE_BIGQUERY:
-        return { sql: inlineBigQueryNamedParams(composed.sql, composed.params) };
+        return inlineBigQueryNamedParams(sql, params);
       default:
-        // Redshift and Snowflake inline all literals and produce no params (early-returned
-        // above). Athena (positional ?) and BigQuery (named @p) are the only current param
-        // producers. This guard catches a future dialect added with output controls
-        // before its inliner is wired, rather than emit SQL with unbound parameters.
         throw new BusinessViolationException(
           'Generating static SQL for a report with value filters is not supported for this storage type.',
-          { storageType: report.dataMart.storage.type }
+          { storageType }
         );
     }
   }

--- a/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
@@ -83,6 +83,11 @@ describe('RunReportService', () => {
       registerEmailBasedReportRunConsumption: jest.fn().mockResolvedValue(undefined),
     };
 
+    const reportSqlComposerService = {
+      compose: jest.fn().mockResolvedValue({ sql: 'SELECT 1' }),
+      inlineStaticSql: jest.fn().mockReturnValue('SELECT 1'),
+    };
+
     const service = new RunReportService(
       reportReaderResolver as never,
       reportWriterResolver as never,
@@ -96,7 +101,7 @@ describe('RunReportService', () => {
       reportRunTriggerService as never,
       reportAccessService as never,
       blendedReportDataService as never,
-      { compose: jest.fn().mockResolvedValue({ sql: 'SELECT 1' }) } as never,
+      reportSqlComposerService as never,
       { getProjectMemberOrThrow: jest.fn().mockResolvedValue({ role: 'admin' }) } as never,
       consumptionTrackingService as never
     );
@@ -114,6 +119,7 @@ describe('RunReportService', () => {
       reportAccessService,
       gracefulShutdownService,
       consumptionTrackingService,
+      reportSqlComposerService,
     };
   };
 
@@ -567,5 +573,190 @@ describe('RunReportService', () => {
     expect(writer.finalize).toHaveBeenCalledWith(undefined, {
       mainRowsTruncationInfo: null,
     });
+  });
+
+  it('stores reportDefinition.executionSqlQuery (inlined SQL) when output controls are present', async () => {
+    const {
+      service,
+      reportReaderResolver,
+      reportWriterResolver,
+      blendedReportDataService,
+      reportSqlComposerService,
+    } = createService();
+    const report = createReport(DataDestinationType.GOOGLE_SHEETS);
+    report.filterConfig = [{ column: 'a', operator: 'eq', value: 1 }] as never;
+    blendedReportDataService.resolveBlendingDecision.mockResolvedValue({ needsBlending: false });
+    reportSqlComposerService.compose.mockResolvedValue({
+      sql: 'SELECT * FROM t WHERE a = @p0',
+      params: [{ name: 'p0', value: 1 }],
+    });
+    reportSqlComposerService.inlineStaticSql.mockReturnValue('SELECT * FROM t WHERE a = 1');
+
+    const reader = createReader();
+    reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], undefined));
+    const writer = createWriter(DataDestinationType.GOOGLE_SHEETS);
+    reportReaderResolver.resolve.mockResolvedValue(reader);
+    reportWriterResolver.resolve.mockResolvedValue(writer);
+
+    const dataMartRun = createDataMartRun(report);
+    dataMartRun.reportDefinition = { title: 'Report' } as never;
+
+    await (
+      service as unknown as {
+        executeReport: (
+          report: Report,
+          accessor: { userId: string; roles: string[] },
+          signal?: AbortSignal,
+          logger?: unknown,
+          dataMartRun?: DataMartRun
+        ) => Promise<void>;
+      }
+    ).executeReport(
+      report,
+      { userId: 'user-1', roles: ['admin'] },
+      undefined,
+      undefined,
+      dataMartRun
+    );
+
+    expect(reportSqlComposerService.inlineStaticSql).toHaveBeenCalledWith(
+      DataStorageType.GOOGLE_BIGQUERY,
+      'SELECT * FROM t WHERE a = @p0',
+      [{ name: 'p0', value: 1 }]
+    );
+    expect(dataMartRun.reportDefinition!.executionSqlQuery).toBe('SELECT * FROM t WHERE a = 1');
+  });
+
+  it('persists executionSqlQuery on the run record even when the read fails', async () => {
+    const {
+      service,
+      reportReaderResolver,
+      reportWriterResolver,
+      blendedReportDataService,
+      reportRunService,
+      reportSqlComposerService,
+    } = createService();
+    const report = createReport(DataDestinationType.GOOGLE_SHEETS);
+    report.filterConfig = [{ column: 'a', operator: 'eq', value: 1 }] as never;
+    blendedReportDataService.resolveBlendingDecision.mockResolvedValue({ needsBlending: false });
+    reportSqlComposerService.compose.mockResolvedValue({
+      sql: 'SELECT * FROM t WHERE a = @p0',
+      params: [{ name: 'p0', value: 1 }],
+    });
+    reportSqlComposerService.inlineStaticSql.mockReturnValue('SELECT * FROM t WHERE a = 1');
+
+    const reader = createReader();
+    reader.prepareReportData.mockRejectedValue(new Error('storage 500'));
+    const writer = createWriter(DataDestinationType.GOOGLE_SHEETS);
+    reportReaderResolver.resolve.mockResolvedValue(reader);
+    reportWriterResolver.resolve.mockResolvedValue(writer);
+
+    const dataMartRun = createDataMartRun(report);
+    dataMartRun.reportDefinition = { title: 'Report' } as never;
+    const reportRun = ReportRun.create(report, dataMartRun);
+    reportRunService.loadByDataMartRunId.mockResolvedValue(reportRun);
+
+    await service.executeExistingRun('data-mart-run-1', 'project-1', 'user-1');
+
+    expect(reportRun.getDataMartRun().status).toBe(DataMartRunStatus.FAILED);
+    expect(reportRun.getDataMartRun().reportDefinition!.executionSqlQuery).toBe(
+      'SELECT * FROM t WHERE a = 1'
+    );
+    expect(reportRunService.finish).toHaveBeenCalled();
+  });
+
+  it('sets executionSqlQuery via inlineStaticSql using blendedSql when blending is needed', async () => {
+    const {
+      service,
+      reportReaderResolver,
+      reportWriterResolver,
+      blendedReportDataService,
+      reportSqlComposerService,
+    } = createService();
+    const report = createReport(DataDestinationType.GOOGLE_SHEETS);
+    report.filterConfig = [{ column: 'x', operator: 'eq', value: 'y' }] as never;
+
+    const blendedSql = 'WITH m AS (...) SELECT * FROM m WHERE x = @p0';
+    const params = [{ name: 'p0', value: 'y' }];
+    blendedReportDataService.resolveBlendingDecision.mockResolvedValue({
+      needsBlending: true,
+      blendedSql,
+      params,
+    });
+    reportSqlComposerService.inlineStaticSql.mockReturnValue(
+      "WITH m AS (...) SELECT * FROM m WHERE x = 'y'"
+    );
+
+    const reader = createReader();
+    reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], undefined));
+    const writer = createWriter(DataDestinationType.GOOGLE_SHEETS);
+    reportReaderResolver.resolve.mockResolvedValue(reader);
+    reportWriterResolver.resolve.mockResolvedValue(writer);
+
+    const dataMartRun = createDataMartRun(report);
+    dataMartRun.reportDefinition = { title: 'Report' } as never;
+
+    await (
+      service as unknown as {
+        executeReport: (
+          report: Report,
+          accessor: { userId: string; roles: string[] },
+          signal?: AbortSignal,
+          logger?: unknown,
+          dataMartRun?: DataMartRun
+        ) => Promise<void>;
+      }
+    ).executeReport(
+      report,
+      { userId: 'user-1', roles: ['admin'] },
+      undefined,
+      undefined,
+      dataMartRun
+    );
+
+    expect(reportSqlComposerService.inlineStaticSql).toHaveBeenCalledWith(
+      DataStorageType.GOOGLE_BIGQUERY,
+      blendedSql,
+      params
+    );
+    expect(dataMartRun.reportDefinition!.executionSqlQuery).toBe(
+      "WITH m AS (...) SELECT * FROM m WHERE x = 'y'"
+    );
+  });
+
+  it('does not set executionSqlQuery when there are no output controls or blending', async () => {
+    const { service, reportReaderResolver, reportWriterResolver, reportSqlComposerService } =
+      createService();
+    const report = createReport(DataDestinationType.GOOGLE_SHEETS);
+
+    const reader = createReader();
+    reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], undefined));
+    const writer = createWriter(DataDestinationType.GOOGLE_SHEETS);
+    reportReaderResolver.resolve.mockResolvedValue(reader);
+    reportWriterResolver.resolve.mockResolvedValue(writer);
+
+    const dataMartRun = createDataMartRun(report);
+    dataMartRun.reportDefinition = { title: 'Report' } as never;
+
+    await (
+      service as unknown as {
+        executeReport: (
+          report: Report,
+          accessor: { userId: string; roles: string[] },
+          signal?: AbortSignal,
+          logger?: unknown,
+          dataMartRun?: DataMartRun
+        ) => Promise<void>;
+      }
+    ).executeReport(
+      report,
+      { userId: 'user-1', roles: ['admin'] },
+      undefined,
+      undefined,
+      dataMartRun
+    );
+
+    expect(reportSqlComposerService.inlineStaticSql).not.toHaveBeenCalled();
+    expect(dataMartRun.reportDefinition!.executionSqlQuery).toBeUndefined();
   });
 });

--- a/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.spec.ts
@@ -627,6 +627,57 @@ describe('RunReportService', () => {
     expect(dataMartRun.reportDefinition!.executionSqlQuery).toBe('SELECT * FROM t WHERE a = 1');
   });
 
+  it('does not abort the run when recording executionSqlQuery throws (best-effort metadata)', async () => {
+    const {
+      service,
+      reportReaderResolver,
+      reportWriterResolver,
+      blendedReportDataService,
+      reportSqlComposerService,
+    } = createService();
+    const report = createReport(DataDestinationType.GOOGLE_SHEETS);
+    report.filterConfig = [{ column: 'a', operator: 'eq', value: 1 }] as never;
+    blendedReportDataService.resolveBlendingDecision.mockResolvedValue({ needsBlending: false });
+    reportSqlComposerService.compose.mockResolvedValue({
+      sql: 'SELECT * FROM t WHERE a = @p0',
+      params: [{ name: 'p0', value: 1 }],
+    });
+    reportSqlComposerService.inlineStaticSql.mockImplementation(() => {
+      throw new Error('no inliner for this dialect');
+    });
+
+    const reader = createReader();
+    reader.readReportDataBatch.mockResolvedValue(new ReportDataBatch([], undefined));
+    const writer = createWriter(DataDestinationType.GOOGLE_SHEETS);
+    reportReaderResolver.resolve.mockResolvedValue(reader);
+    reportWriterResolver.resolve.mockResolvedValue(writer);
+
+    const dataMartRun = createDataMartRun(report);
+    dataMartRun.reportDefinition = { title: 'Report' } as never;
+
+    // Awaiting throws if executeReport rejected — proves the run was NOT aborted.
+    await (
+      service as unknown as {
+        executeReport: (
+          report: Report,
+          accessor: { userId: string; roles: string[] },
+          signal?: AbortSignal,
+          logger?: unknown,
+          dataMartRun?: DataMartRun
+        ) => Promise<void>;
+      }
+    ).executeReport(
+      report,
+      { userId: 'user-1', roles: ['admin'] },
+      undefined,
+      undefined,
+      dataMartRun
+    );
+
+    expect(reader.prepareReportData).toHaveBeenCalled();
+    expect(dataMartRun.reportDefinition!.executionSqlQuery).toBeUndefined();
+  });
+
   it('persists executionSqlQuery on the run record even when the read fails', async () => {
     const {
       service,

--- a/apps/backend/src/data-marts/use-cases/run-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.ts
@@ -20,6 +20,7 @@ import { DataStorageReportReader } from '../data-storage-types/interfaces/data-s
 import { RunReportCommand } from '../dto/domain/run-report.command';
 import { RunType } from '../../common/scheduler/shared/types';
 import { DataMart } from '../entities/data-mart.entity';
+import { DataMartRun } from '../entities/data-mart-run.entity';
 import { Report } from '../entities/report.entity';
 import { ReportRun } from '../models/report-run.model';
 import { logBlendedSqlIfNeeded } from '../report-run-logging/log-blended-sql';
@@ -212,7 +213,8 @@ export class RunReportService {
     report: Report,
     accessor: BlendableSchemaAccessor,
     signal?: AbortSignal,
-    reportRunLogger?: ReportRunLogger
+    reportRunLogger?: ReportRunLogger,
+    dataMartRun?: DataMartRun
   ): Promise<ReportWriteFinalizeResult | undefined> {
     signal?.throwIfAborted();
     const { dataMart, dataDestination } = report;
@@ -253,6 +255,19 @@ export class RunReportService {
         const composed = await this.reportSqlComposerService.compose(report, accessor);
         sqlOverride = composed.sql;
         sqlOverrideParams = composed.params;
+      }
+
+      // Persist the exact executed SQL (output controls applied, params inlined as
+      // literals — same render as the generated-SQL preview) onto the run record so
+      // Run History can show it. Only when an override exists (output controls or
+      // blending); a plain report's executed SQL == the raw definition sqlQuery.
+      if (sqlOverride && dataMartRun?.reportDefinition) {
+        dataMartRun.reportDefinition.executionSqlQuery =
+          this.reportSqlComposerService.inlineStaticSql(
+            dataMart.storage.type,
+            sqlOverride,
+            sqlOverrideParams
+          );
       }
 
       const reportDataDescription = await reportReader.prepareReportData(report, {
@@ -332,7 +347,8 @@ export class RunReportService {
         reportRun.getReport(),
         accessor,
         signal,
-        reportRunLogger
+        reportRunLogger,
+        reportRun.getDataMartRun()
       );
       const { logs, errors } = reportRunLogger.asArrays();
       await this.handleReportRunSuccess(reportRun, logs, errors, finalizeResult);

--- a/apps/backend/src/data-marts/use-cases/run-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.ts
@@ -261,13 +261,23 @@ export class RunReportService {
       // literals — same render as the generated-SQL preview) onto the run record so
       // Run History can show it. Only when an override exists (output controls or
       // blending); a plain report's executed SQL == the raw definition sqlQuery.
+      // Best-effort: this is display-only run-history metadata, so a failure to render
+      // it must never abort an otherwise-successful run.
       if (sqlOverride && dataMartRun?.reportDefinition) {
-        dataMartRun.reportDefinition.executionSqlQuery =
-          this.reportSqlComposerService.inlineStaticSql(
-            dataMart.storage.type,
-            sqlOverride,
-            sqlOverrideParams
+        try {
+          dataMartRun.reportDefinition.executionSqlQuery =
+            this.reportSqlComposerService.inlineStaticSql(
+              dataMart.storage.type,
+              sqlOverride,
+              sqlOverrideParams
+            );
+        } catch (error) {
+          this.logger.warn(
+            `Failed to record executionSqlQuery for report ${report.id}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
           );
+        }
       }
 
       const reportDataDescription = await reportReader.prepareReportData(report, {

--- a/apps/backend/src/data-marts/use-cases/run-report.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-report.service.ts
@@ -18,6 +18,7 @@ import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../data-storage-types/data-
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { DataStorageReportReader } from '../data-storage-types/interfaces/data-storage-report-reader.interface';
 import { RunReportCommand } from '../dto/domain/run-report.command';
+import { hasOutputControls } from '../dto/domain/report-like-read-plan';
 import { RunType } from '../../common/scheduler/shared/types';
 import { DataMart } from '../entities/data-mart.entity';
 import { DataMartRun } from '../entities/data-mart-run.entity';
@@ -245,11 +246,7 @@ export class RunReportService {
       if (blendingDecision.needsBlending) {
         sqlOverride = blendingDecision.blendedSql;
         sqlOverrideParams = blendingDecision.params;
-      } else if (
-        (report.filterConfig?.length ?? 0) > 0 ||
-        (report.sortConfig?.length ?? 0) > 0 ||
-        report.limitConfig != null
-      ) {
+      } else if (hasOutputControls(report)) {
         // Non-blended report with output controls — compose the full SQL + params here so
         // the reader doesn't need to know about output-controls semantics.
         const composed = await this.reportSqlComposerService.compose(report, accessor);

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/ConfigurationView.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/ConfigurationView.tsx
@@ -66,13 +66,35 @@ export function ConfigurationView({
             </pre>
           </>
         )}
+        {reportDefinition?.executionSqlQuery != null && (
+          <>
+            <div className='mt-3 mb-3 flex items-center justify-between'>
+              <h4 className='text-foreground text-sm font-medium'>Executed SQL:</h4>
+              <CopyButton
+                text={reportDefinition.executionSqlQuery}
+                section='executionSql'
+                variant={CopyButtonVariant.DEFAULT}
+                copiedSection={copiedSection}
+                onCopy={handleCopy}
+              />
+            </div>
+            <pre className='bg-muted text-foreground overflow-x-auto rounded p-3 font-mono text-xs whitespace-pre-wrap dark:bg-white/3'>
+              {reportDefinition.executionSqlQuery}
+            </pre>
+          </>
+        )}
         {definitionRun != null && reportDefinition && (
           <>
             <h4 className='text-foreground mt-3 mb-3 text-sm font-medium'>Report definition:</h4>
             <pre className='bg-muted text-foreground overflow-x-auto rounded p-3 font-mono text-xs whitespace-pre-wrap dark:bg-white/3'>
               {JSON.stringify(
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                (({ outputConfig: _outputConfig, ...rest }) => rest)(reportDefinition),
+                // outputConfig and executionSqlQuery each render in their own block below,
+                // so exclude them from this raw dump to avoid showing them twice.
+                Object.fromEntries(
+                  Object.entries(reportDefinition).filter(
+                    ([key]) => key !== 'outputConfig' && key !== 'executionSqlQuery'
+                  )
+                ),
                 null,
                 2
               )}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/__tests__/ConfigurationView.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/__tests__/ConfigurationView.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { ConfigurationView } from '../ConfigurationView';
+
+const definitionRun = { sqlQuery: 'SELECT * FROM `t`' } as never;
+
+const reportDefinition = {
+  title: 'R',
+  destination: { id: 'd', title: 'D', type: 'GOOGLE_SHEETS' },
+  destinationConfig: { type: 'google-sheets-config' },
+  outputConfig: {
+    filterConfig: [{ column: 'report_date', operator: 'gte', value: '2026-01-01' }],
+  },
+  executionSqlQuery: "SELECT * FROM (SELECT * FROM `t`) WHERE report_date >= DATE '2026-01-01'",
+} as never;
+
+describe('ConfigurationView', () => {
+  it('renders executionSqlQuery in a dedicated Executed SQL block, not inside Configuration', () => {
+    const { container } = render(
+      <ConfigurationView
+        definitionRun={definitionRun}
+        reportDefinition={reportDefinition}
+        insightDefinition={null}
+        insightTemplateDefinition={null}
+        additionalParams={null}
+      />
+    );
+
+    const headings = Array.from(container.querySelectorAll('h4')).map(h => h.textContent);
+    const pres = Array.from(container.querySelectorAll('pre'));
+
+    // Dedicated, plain-text Executed SQL block (real newlines, not JSON-escaped).
+    expect(headings).toContain('Executed SQL:');
+    const execPre = pres.find(p =>
+      p.textContent.includes("WHERE report_date >= DATE '2026-01-01'")
+    );
+    expect(execPre).toBeDefined();
+
+    // Configuration block keeps the raw sqlQuery and does NOT carry executionSqlQuery.
+    const configPre = pres.find(p => p.textContent.includes('"sqlQuery"'));
+    expect(configPre).toBeDefined();
+    expect(configPre?.textContent).not.toContain('executionSqlQuery');
+
+    // Report definition block must not contain it either.
+    const reportDefPre = pres.find(p => p.textContent.includes('"title": "R"'));
+    expect(reportDefPre?.textContent).not.toContain('executionSqlQuery');
+  });
+
+  it('omits the Executed SQL block when executionSqlQuery is absent', () => {
+    const { container } = render(
+      <ConfigurationView
+        definitionRun={definitionRun}
+        reportDefinition={
+          { ...(reportDefinition as object), executionSqlQuery: undefined } as never
+        }
+        insightDefinition={null}
+        insightTemplateDefinition={null}
+        additionalParams={null}
+      />
+    );
+
+    const headings = Array.from(container.querySelectorAll('h4')).map(h => h.textContent);
+    expect(headings).not.toContain('Executed SQL:');
+
+    const configPre = container.querySelector('pre');
+    expect(configPre?.textContent).toContain('"sqlQuery"');
+    expect(configPre?.textContent).not.toContain('executionSqlQuery');
+  });
+});

--- a/apps/web/src/features/data-marts/edit/model/types/data-mart-run-report-definition.ts
+++ b/apps/web/src/features/data-marts/edit/model/types/data-mart-run-report-definition.ts
@@ -12,4 +12,5 @@ export interface DataMartRunReportDefinition {
   };
   destinationConfig: DataMartRunReportDestinationConfigDto;
   outputConfig?: DataMartRunReportOutputConfigDto | null;
+  executionSqlQuery?: string;
 }


### PR DESCRIPTION
## Summary

Report runs now capture the exact SQL that ran — output controls (filters, sorting, limit) applied and filter parameter values inlined as literals, identical to the generated-SQL preview — recorded on `reportDefinition.executionSqlQuery` and surfaced in Run History as a dedicated **Executed SQL** block.

Previously the run stored only the raw Data Mart query, so the recorded SQL did not reflect the parameters used at run time.

- Extracted a shared `ReportSqlComposerService.inlineStaticSql(...)` from `composeStatic`, so the run-history SQL is byte-identical to the generated-SQL preview.
- Wired into every run-creating path: push destinations (Google Sheets, Email, Slack, Google Chat, MS Teams) via `RunReportService.executeReport`, and Looker Studio (streaming + non-streaming) via `ReportDataCacheService` + `LookerStudioConnectorApiService` (deduped into one helper, set before the read so it persists on success **and** failure).
- Populated **only** when the run applied output controls or blended SQL.
- Frontend: a dedicated "Executed SQL" block in the Run History Configuration view, rendered as plain-text SQL.
- HTTP Data API path intentionally excluded (its run has no `reportDefinition`).

No DB migration (additive optional field on the existing `reportDefinition` JSON column) and no backfill — the field appears only on new runs.

## Test Plan

- [ ] Backend unit: `inlineStaticSql` (Athena/BigQuery inlining, no-params passthrough, unsupported-dialect throw); push + Looker paths set `executionSqlQuery` when controls present and omit it otherwise; failure-path persistence; blended-with-params consistency.
- [ ] Frontend unit: Executed SQL block renders when present, omitted when absent, not duplicated in other blocks.
- [ ] Manual: run a scheduled/manual report with a date filter → Run History → Configuration tab shows the **Executed SQL** block with the filter inlined.
- [ ] Manual: run a report with no output controls → no Executed SQL block.
- [ ] Manual: Looker Studio fetch with a filter → run record carries the executed SQL.

Verified locally: `nest build` ✅, web `tsc -b` + vite ✅, affected backend suites (89 tests) ✅, web ConfigurationView ✅.