### PR TITLE
 fix(backend): optimize project-wide list queries

### DIFF
--- a/apps/backend/src/data-marts/services/data-mart-run.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.spec.ts
@@ -9,6 +9,7 @@ import { Report } from '../entities/report.entity';
 import { DataDestination } from '../entities/data-destination.entity';
 import { DataMartRunStatus } from '../enums/data-mart-run-status.enum';
 import { DataMartRunType } from '../enums/data-mart-run-type.enum';
+import { RoleScope } from '../enums/role-scope.enum';
 import { DataMartRunService, ReportRunContext } from './data-mart-run.service';
 
 function fakeDataMart(overrides: Partial<DataMart> = {}): DataMart {
@@ -73,9 +74,97 @@ function createService() {
   return { service, dataMartRunRepository, systemClock, eventDispatcher, saved };
 }
 
+function createQueryBuilderMock() {
+  const qb = {
+    innerJoin: jest.fn(),
+    where: jest.fn(),
+    andWhere: jest.fn(),
+    select: jest.fn(),
+    orderBy: jest.fn(),
+    addOrderBy: jest.fn(),
+    limit: jest.fn(),
+    offset: jest.fn(),
+    getRawMany: jest.fn(),
+    getMany: jest.fn(),
+  };
+
+  for (const method of [
+    'innerJoin',
+    'where',
+    'andWhere',
+    'select',
+    'orderBy',
+    'addOrderBy',
+    'limit',
+    'offset',
+  ] as const) {
+    qb[method].mockReturnValue(qb);
+  }
+
+  return qb;
+}
+
 const context: ReportRunContext = { createdById: 'user-1', runType: RunType.manual };
 
 describe('DataMartRunService', () => {
+  describe('listVisibleByProject', () => {
+    it('sorts only run IDs, loads full rows without ORDER BY, and restores page order', async () => {
+      const { service, dataMartRunRepository } = createService();
+      const firstRun = { id: 'run-1', dataMart: { id: 'dm-1', title: 'First' } } as DataMartRun;
+      const secondRun = {
+        id: 'run-2',
+        dataMart: { id: 'dm-2', title: 'Second' },
+      } as DataMartRun;
+
+      const pageQb = createQueryBuilderMock();
+      pageQb.getRawMany.mockResolvedValue([{ id: 'run-2' }, { id: 'run-1' }]);
+      const rowsQb = createQueryBuilderMock();
+      rowsQb.getMany.mockResolvedValue([firstRun, secondRun]);
+      (dataMartRunRepository.createQueryBuilder as jest.Mock)
+        .mockReturnValueOnce(pageQb)
+        .mockReturnValueOnce(rowsQb);
+
+      const result = await service.listVisibleByProject({
+        projectId: 'proj-1',
+        userId: 'admin-1',
+        roles: ['admin'],
+        roleScope: RoleScope.ENTIRE_PROJECT,
+        limit: 50,
+        offset: 100,
+      });
+
+      expect(pageQb.select).toHaveBeenCalledWith('run.id', 'id');
+      expect(pageQb.orderBy).toHaveBeenCalledWith('run.createdAt', 'DESC');
+      expect(pageQb.addOrderBy).toHaveBeenCalledWith('run.id', 'DESC');
+      expect(pageQb.limit).toHaveBeenCalledWith(50);
+      expect(pageQb.offset).toHaveBeenCalledWith(100);
+      expect(rowsQb.select).toHaveBeenCalledWith(['run', 'dataMart.id', 'dataMart.title']);
+      expect(rowsQb.where).toHaveBeenCalledWith('run.id IN (:...runIds)', {
+        runIds: ['run-2', 'run-1'],
+      });
+      expect(rowsQb.orderBy).not.toHaveBeenCalled();
+      expect(result).toEqual([secondRun, firstRun]);
+    });
+
+    it('does not issue the full-row query for an empty page', async () => {
+      const { service, dataMartRunRepository } = createService();
+      const pageQb = createQueryBuilderMock();
+      pageQb.getRawMany.mockResolvedValue([]);
+      (dataMartRunRepository.createQueryBuilder as jest.Mock).mockReturnValueOnce(pageQb);
+
+      await expect(
+        service.listVisibleByProject({
+          projectId: 'proj-1',
+          userId: 'admin-1',
+          roles: ['admin'],
+          roleScope: RoleScope.ENTIRE_PROJECT,
+        })
+      ).resolves.toEqual([]);
+
+      expect(dataMartRunRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('createAndMarkReportRunAsPending — reportDefinition outputConfig snapshot', () => {
     it('omits outputConfig from reportDefinition when the report has no filter/sort/limit', async () => {
       const { service, dataMartRunRepository } = createService();

--- a/apps/backend/src/data-marts/services/data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.ts
@@ -142,17 +142,13 @@ export class DataMartRunService {
   public async listVisibleByProject(
     options: ListVisibleProjectRunsOptions
   ): Promise<DataMartRun[]> {
-    const qb = this.dataMartRunRepository
+    const pageQb = this.dataMartRunRepository
       .createQueryBuilder('run')
-      .innerJoinAndSelect('run.dataMart', 'dataMart')
+      .innerJoin('run.dataMart', 'dataMart')
       .where('dataMart.projectId = :projectId', { projectId: options.projectId })
-      .andWhere('dataMart.deletedAt IS NULL')
-      .orderBy('run.createdAt', 'DESC')
-      .addOrderBy('run.id', 'DESC')
-      .take(options.limit ?? 20)
-      .skip(options.offset ?? 0);
+      .andWhere('dataMart.deletedAt IS NULL');
 
-    applyDataMartVisibilityFilter(qb, {
+    applyDataMartVisibilityFilter(pageQb, {
       dataMartAlias: 'dataMart',
       projectId: options.projectId,
       userId: options.userId,
@@ -160,7 +156,33 @@ export class DataMartRunService {
       roleScope: options.roleScope,
     });
 
-    return qb.getMany();
+    // Keep pagination sorting narrow. TypeORM's take/skip with a joined entity otherwise
+    // performs a second, wide ORDER BY over all JSON run and Data Mart columns.
+    const page = await pageQb
+      .select('run.id', 'id')
+      .orderBy('run.createdAt', 'DESC')
+      .addOrderBy('run.id', 'DESC')
+      .limit(options.limit ?? 20)
+      .offset(options.offset ?? 0)
+      .getRawMany<{ id: string }>();
+
+    const runIds = page.map(({ id }) => id);
+    if (runIds.length === 0) {
+      return [];
+    }
+
+    const runs = await this.dataMartRunRepository
+      .createQueryBuilder('run')
+      .innerJoin('run.dataMart', 'dataMart')
+      .select(['run', 'dataMart.id', 'dataMart.title'])
+      .where('run.id IN (:...runIds)', { runIds })
+      .getMany();
+
+    const runsById = new Map(runs.map(run => [run.id, run]));
+    return runIds.flatMap(id => {
+      const run = runsById.get(id);
+      return run ? [run] : [];
+    });
   }
 
   /**

--- a/apps/backend/src/data-marts/services/insight-template.service.spec.ts
+++ b/apps/backend/src/data-marts/services/insight-template.service.spec.ts
@@ -2,24 +2,28 @@ import { RoleScope } from '../enums/role-scope.enum';
 import { InsightTemplateService } from './insight-template.service';
 
 describe('InsightTemplateService', () => {
-  function createQueryBuilder(result: unknown[] = []) {
+  function createQueryBuilder(result: Array<{ id: string }> = []) {
     return {
-      innerJoinAndSelect: jest.fn().mockReturnThis(),
+      innerJoin: jest.fn().mockReturnThis(),
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
       addOrderBy: jest.fn().mockReturnThis(),
-      take: jest.fn().mockReturnThis(),
-      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue(result.map(item => ({ id: item.id }))),
       getMany: jest.fn().mockResolvedValue(result),
     };
   }
 
   it('lists project-visible insight templates with Data Mart visibility filtering and pagination', async () => {
-    const qb = createQueryBuilder([{ id: 'insight-template-1' }]);
+    const insightTemplate = { id: 'insight-template-1' };
+    const qb = createQueryBuilder([insightTemplate]);
+    const rowsQb = createQueryBuilder([insightTemplate]);
     const repository = {
-      createQueryBuilder: jest.fn().mockReturnValue(qb),
+      createQueryBuilder: jest.fn().mockReturnValueOnce(qb).mockReturnValueOnce(rowsQb),
     };
     const service = new InsightTemplateService(repository as never);
 
@@ -34,8 +38,8 @@ describe('InsightTemplateService', () => {
 
     expect(result).toEqual([{ id: 'insight-template-1' }]);
     expect(repository.createQueryBuilder).toHaveBeenCalledWith('insightTemplate');
-    expect(qb.innerJoinAndSelect).toHaveBeenCalledWith('insightTemplate.dataMart', 'dataMart');
-    expect(qb.leftJoinAndSelect).toHaveBeenCalledWith(
+    expect(qb.innerJoin).toHaveBeenCalledWith('insightTemplate.dataMart', 'dataMart');
+    expect(rowsQb.leftJoinAndSelect).toHaveBeenCalledWith(
       'insightTemplate.sourceEntities',
       'sourceEntities'
     );
@@ -50,8 +54,9 @@ describe('InsightTemplateService', () => {
       entireProjectScope: RoleScope.ENTIRE_PROJECT,
       projectId: 'project-1',
     });
-    expect(qb.take).toHaveBeenCalledWith(20);
-    expect(qb.skip).toHaveBeenCalledWith(40);
+    expect(qb.limit).toHaveBeenCalledWith(20);
+    expect(qb.offset).toHaveBeenCalledWith(40);
+    expect(rowsQb.orderBy).not.toHaveBeenCalled();
   });
 
   it('defaults project-visible insight template pagination to 100', async () => {
@@ -68,7 +73,7 @@ describe('InsightTemplateService', () => {
       roleScope: RoleScope.ENTIRE_PROJECT,
     });
 
-    expect(qb.take).toHaveBeenCalledWith(100);
-    expect(qb.skip).toHaveBeenCalledWith(0);
+    expect(qb.limit).toHaveBeenCalledWith(100);
+    expect(qb.offset).toHaveBeenCalledWith(0);
   });
 });

--- a/apps/backend/src/data-marts/services/insight-template.service.spec.ts
+++ b/apps/backend/src/data-marts/services/insight-template.service.spec.ts
@@ -43,6 +43,12 @@ describe('InsightTemplateService', () => {
       'insightTemplate.sourceEntities',
       'sourceEntities'
     );
+    expect(rowsQb.select).toHaveBeenCalledWith([
+      'insightTemplate',
+      'dataMart.id',
+      'dataMart.title',
+      'sourceEntities',
+    ]);
     expect(qb.where).toHaveBeenCalledWith('dataMart.projectId = :projectId', {
       projectId: 'project-1',
     });

--- a/apps/backend/src/data-marts/services/insight-template.service.ts
+++ b/apps/backend/src/data-marts/services/insight-template.service.ts
@@ -85,18 +85,13 @@ export class InsightTemplateService {
   async listVisibleByProject(
     options: ListVisibleProjectInsightTemplatesOptions
   ): Promise<InsightTemplate[]> {
-    const qb = this.repository
+    const pageQb = this.repository
       .createQueryBuilder('insightTemplate')
-      .innerJoinAndSelect('insightTemplate.dataMart', 'dataMart')
-      .leftJoinAndSelect('insightTemplate.sourceEntities', 'sourceEntities')
+      .innerJoin('insightTemplate.dataMart', 'dataMart')
       .where('dataMart.projectId = :projectId', { projectId: options.projectId })
-      .andWhere('dataMart.deletedAt IS NULL')
-      .orderBy('insightTemplate.modifiedAt', 'DESC')
-      .addOrderBy('insightTemplate.id', 'DESC')
-      .take(options.limit ?? 100)
-      .skip(options.offset ?? 0);
+      .andWhere('dataMart.deletedAt IS NULL');
 
-    applyDataMartVisibilityFilter(qb, {
+    applyDataMartVisibilityFilter(pageQb, {
       dataMartAlias: 'dataMart',
       projectId: options.projectId,
       userId: options.userId,
@@ -104,7 +99,33 @@ export class InsightTemplateService {
       roleScope: options.roleScope,
     });
 
-    return qb.getMany();
+    const page = await pageQb
+      .select('insightTemplate.id', 'id')
+      .orderBy('insightTemplate.modifiedAt', 'DESC')
+      .addOrderBy('insightTemplate.id', 'DESC')
+      .limit(options.limit ?? 100)
+      .offset(options.offset ?? 0)
+      .getRawMany<{ id: string }>();
+    const insightTemplateIds = page.map(({ id }) => id);
+    if (insightTemplateIds.length === 0) {
+      return [];
+    }
+
+    const insightTemplates = await this.repository
+      .createQueryBuilder('insightTemplate')
+      .innerJoin('insightTemplate.dataMart', 'dataMart')
+      .leftJoinAndSelect('insightTemplate.sourceEntities', 'sourceEntities')
+      .select(['insightTemplate', 'dataMart.id', 'dataMart.title'])
+      .where('insightTemplate.id IN (:...insightTemplateIds)', { insightTemplateIds })
+      .getMany();
+    const insightTemplatesById = new Map(
+      insightTemplates.map(insightTemplate => [insightTemplate.id, insightTemplate])
+    );
+
+    return insightTemplateIds.flatMap(id => {
+      const insightTemplate = insightTemplatesById.get(id);
+      return insightTemplate ? [insightTemplate] : [];
+    });
   }
 
   async updateTitleOnlyIfHasDefaultTitle(

--- a/apps/backend/src/data-marts/services/insight-template.service.ts
+++ b/apps/backend/src/data-marts/services/insight-template.service.ts
@@ -115,7 +115,7 @@ export class InsightTemplateService {
       .createQueryBuilder('insightTemplate')
       .innerJoin('insightTemplate.dataMart', 'dataMart')
       .leftJoinAndSelect('insightTemplate.sourceEntities', 'sourceEntities')
-      .select(['insightTemplate', 'dataMart.id', 'dataMart.title'])
+      .select(['insightTemplate', 'dataMart.id', 'dataMart.title', 'sourceEntities'])
       .where('insightTemplate.id IN (:...insightTemplateIds)', { insightTemplateIds })
       .getMany();
     const insightTemplatesById = new Map(

--- a/apps/backend/src/data-marts/services/scheduled-trigger.service.spec.ts
+++ b/apps/backend/src/data-marts/services/scheduled-trigger.service.spec.ts
@@ -1,0 +1,69 @@
+import { RoleScope } from '../enums/role-scope.enum';
+import { ScheduledTriggerService } from './scheduled-trigger.service';
+
+function createQueryBuilder() {
+  return {
+    innerJoin: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn(),
+    getMany: jest.fn(),
+  };
+}
+
+describe('ScheduledTriggerService', () => {
+  it('sorts only IDs and restores their order after loading trigger rows', async () => {
+    const pageQb = createQueryBuilder();
+    pageQb.getRawMany.mockResolvedValue([{ id: 'trigger-2' }, { id: 'trigger-1' }]);
+    const rowsQb = createQueryBuilder();
+    rowsQb.getMany.mockResolvedValue([{ id: 'trigger-1' }, { id: 'trigger-2' }]);
+    const repository = {
+      createQueryBuilder: jest.fn().mockReturnValueOnce(pageQb).mockReturnValueOnce(rowsQb),
+    };
+    const service = new ScheduledTriggerService(repository as never);
+
+    const result = await service.listVisibleByProject({
+      projectId: 'project-1',
+      userId: 'admin-1',
+      roles: ['admin'],
+      roleScope: RoleScope.ENTIRE_PROJECT,
+      limit: 20,
+      offset: 40,
+    });
+
+    expect(pageQb.select).toHaveBeenCalledWith('scheduledTrigger.id', 'id');
+    expect(pageQb.limit).toHaveBeenCalledWith(20);
+    expect(pageQb.offset).toHaveBeenCalledWith(40);
+    expect(rowsQb.select).toHaveBeenCalledWith([
+      'scheduledTrigger',
+      'dataMart.id',
+      'dataMart.title',
+      'dataMart.definition',
+    ]);
+    expect(rowsQb.orderBy).not.toHaveBeenCalled();
+    expect(result.map(trigger => trigger.id)).toEqual(['trigger-2', 'trigger-1']);
+  });
+
+  it('does not load full rows for an empty page', async () => {
+    const pageQb = createQueryBuilder();
+    pageQb.getRawMany.mockResolvedValue([]);
+    const repository = { createQueryBuilder: jest.fn().mockReturnValue(pageQb) };
+    const service = new ScheduledTriggerService(repository as never);
+
+    await expect(
+      service.listVisibleByProject({
+        projectId: 'project-1',
+        userId: 'admin-1',
+        roles: ['admin'],
+        roleScope: RoleScope.ENTIRE_PROJECT,
+      })
+    ).resolves.toEqual([]);
+
+    expect(repository.createQueryBuilder).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/data-marts/services/scheduled-trigger.service.ts
+++ b/apps/backend/src/data-marts/services/scheduled-trigger.service.ts
@@ -63,17 +63,13 @@ export class ScheduledTriggerService {
   async listVisibleByProject(
     options: ListVisibleProjectScheduledTriggersOptions
   ): Promise<DataMartScheduledTrigger[]> {
-    const qb = this.triggerRepository
+    const pageQb = this.triggerRepository
       .createQueryBuilder('scheduledTrigger')
-      .innerJoinAndSelect('scheduledTrigger.dataMart', 'dataMart')
+      .innerJoin('scheduledTrigger.dataMart', 'dataMart')
       .where('dataMart.projectId = :projectId', { projectId: options.projectId })
-      .andWhere('dataMart.deletedAt IS NULL')
-      .orderBy('scheduledTrigger.createdAt', 'DESC')
-      .addOrderBy('scheduledTrigger.id', 'DESC')
-      .take(options.limit ?? 20)
-      .skip(options.offset ?? 0);
+      .andWhere('dataMart.deletedAt IS NULL');
 
-    applyDataMartVisibilityFilter(qb, {
+    applyDataMartVisibilityFilter(pageQb, {
       dataMartAlias: 'dataMart',
       projectId: options.projectId,
       userId: options.userId,
@@ -81,7 +77,30 @@ export class ScheduledTriggerService {
       roleScope: options.roleScope,
     });
 
-    return qb.getMany();
+    const page = await pageQb
+      .select('scheduledTrigger.id', 'id')
+      .orderBy('scheduledTrigger.createdAt', 'DESC')
+      .addOrderBy('scheduledTrigger.id', 'DESC')
+      .limit(options.limit ?? 20)
+      .offset(options.offset ?? 0)
+      .getRawMany<{ id: string }>();
+    const triggerIds = page.map(({ id }) => id);
+    if (triggerIds.length === 0) {
+      return [];
+    }
+
+    const triggers = await this.triggerRepository
+      .createQueryBuilder('scheduledTrigger')
+      .innerJoin('scheduledTrigger.dataMart', 'dataMart')
+      .select(['scheduledTrigger', 'dataMart.id', 'dataMart.title', 'dataMart.definition'])
+      .where('scheduledTrigger.id IN (:...triggerIds)', { triggerIds })
+      .getMany();
+    const triggersById = new Map(triggers.map(trigger => [trigger.id, trigger]));
+
+    return triggerIds.flatMap(id => {
+      const trigger = triggersById.get(id);
+      return trigger ? [trigger] : [];
+    });
   }
 
   async deleteAllByDataMartIdAndProjectId(dataMartId: string, projectId: string): Promise<void> {

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.spec.ts
@@ -4,23 +4,29 @@ import { RoleScope } from '../enums/role-scope.enum';
 import { ListReportsByProjectService } from './list-reports-by-project.service';
 
 describe('ListReportsByProjectService', () => {
-  function createQueryBuilder(reports: unknown[]) {
+  function createQueryBuilder() {
     return {
+      innerJoin: jest.fn().mockReturnThis(),
       leftJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
       orderBy: jest.fn().mockReturnThis(),
       addOrderBy: jest.fn().mockReturnThis(),
-      take: jest.fn().mockReturnThis(),
-      skip: jest.fn().mockReturnThis(),
-      getMany: jest.fn().mockResolvedValue(reports),
+      limit: jest.fn().mockReturnThis(),
+      offset: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn(),
+      getMany: jest.fn(),
     };
   }
 
   function createService(reports = [buildReport()]) {
-    const qb = createQueryBuilder(reports);
+    const qb = createQueryBuilder();
+    qb.getRawMany.mockResolvedValue(reports.map(report => ({ id: report.id })));
+    const rowsQb = createQueryBuilder();
+    rowsQb.getMany.mockResolvedValue(reports);
     const reportRepository = {
-      createQueryBuilder: jest.fn().mockReturnValue(qb),
+      createQueryBuilder: jest.fn().mockReturnValueOnce(qb).mockReturnValueOnce(rowsQb),
     };
     const mapper = {
       toDomainDto: jest.fn(report => ({ id: report.id })),
@@ -53,6 +59,7 @@ describe('ListReportsByProjectService', () => {
     return {
       service,
       qb,
+      rowsQb,
       contextAccessService,
       reportAccessService,
       mapper,
@@ -63,12 +70,13 @@ describe('ListReportsByProjectService', () => {
     const { service, qb, contextAccessService, reportAccessService } = createService();
 
     await service.run(
-      new ListReportsByProjectCommand('project-1', 'user-1', ['viewer'], OwnerFilter.ALL, 25, 50)
+      new ListReportsByProjectCommand('project-1', 'user-1', ['viewer'], undefined, 25, 50)
     );
 
     expect(contextAccessService.getRoleScope).toHaveBeenCalledWith('user-1', 'project-1');
-    expect(qb.take).toHaveBeenCalledWith(25);
-    expect(qb.skip).toHaveBeenCalledWith(50);
+    expect(qb.select).toHaveBeenCalledWith('r.id', 'id');
+    expect(qb.limit).toHaveBeenCalledWith(25);
+    expect(qb.offset).toHaveBeenCalledWith(50);
     expect(qb.andWhere).toHaveBeenCalledWith(expect.stringContaining('data_mart_contexts'), {
       userId: 'user-1',
       isTrue: true,
@@ -92,8 +100,8 @@ describe('ListReportsByProjectService', () => {
     );
 
     expect(contextAccessService.getRoleScope).not.toHaveBeenCalled();
-    expect(qb.take).toHaveBeenCalledWith(10);
-    expect(qb.skip).toHaveBeenCalledWith(0);
+    expect(qb.limit).toHaveBeenCalledWith(10);
+    expect(qb.offset).toHaveBeenCalledWith(0);
     expect(qb.andWhere).not.toHaveBeenCalledWith(
       expect.stringContaining('data_mart_contexts'),
       expect.anything()
@@ -105,12 +113,29 @@ describe('ListReportsByProjectService', () => {
 
     await service.run(new ListReportsByProjectCommand('project-1', 'user-1', ['viewer']));
 
-    expect(qb.take).not.toHaveBeenCalled();
-    expect(qb.skip).not.toHaveBeenCalled();
+    expect(qb.limit).not.toHaveBeenCalled();
+    expect(qb.offset).not.toHaveBeenCalled();
+  });
+
+  it('loads wide report relations without SQL ordering and restores page order', async () => {
+    const first = buildReport({ id: 'report-1' });
+    const second = buildReport({ id: 'report-2' });
+    const { service, qb, rowsQb, mapper } = createService([second, first]);
+    qb.getRawMany.mockResolvedValue([{ id: 'report-1' }, { id: 'report-2' }]);
+
+    await service.run(
+      new ListReportsByProjectCommand('project-1', 'admin-1', ['admin'], undefined, 20, 0)
+    );
+
+    expect(rowsQb.where).toHaveBeenCalledWith('r.id IN (:...reportIds)', {
+      reportIds: ['report-1', 'report-2'],
+    });
+    expect(rowsQb.orderBy).not.toHaveBeenCalled();
+    expect(mapper.toDomainDto.mock.calls.map(call => call[0].id)).toEqual(['report-1', 'report-2']);
   });
 });
 
-function buildReport() {
+function buildReport(overrides: Record<string, unknown> = {}) {
   return {
     id: 'report-1',
     createdById: 'creator-1',
@@ -119,5 +144,6 @@ function buildReport() {
       id: 'dm-1',
       projectId: 'project-1',
     },
+    ...overrides,
   };
 }

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.spec.ts
@@ -1,5 +1,4 @@
 import { ListReportsByProjectCommand } from '../dto/domain/list-reports-by-project.command';
-import { OwnerFilter } from '../enums/owner-filter.enum';
 import { RoleScope } from '../enums/role-scope.enum';
 import { ListReportsByProjectService } from './list-reports-by-project.service';
 

--- a/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.ts
+++ b/apps/backend/src/data-marts/use-cases/list-reports-by-project.service.ts
@@ -30,17 +30,14 @@ export class ListReportsByProjectService {
       ? RoleScope.ENTIRE_PROJECT
       : await this.contextAccessService.getRoleScope(command.userId, command.projectId);
 
-    // Get all data reports for the project — filtered by DM visibility
-    let qb = this.reportRepository
+    // Select the ordered page without joining wide report relations or one-to-many owners.
+    let pageQb = this.reportRepository
       .createQueryBuilder('r')
-      .leftJoinAndSelect('r.dataMart', 'dataMart')
-      .leftJoinAndSelect('dataMart.storage', 'storage')
-      .leftJoinAndSelect('r.dataDestination', 'dataDestination')
-      .leftJoinAndSelect('r.owners', 'owners')
+      .innerJoin('r.dataMart', 'dataMart')
       .where('dataMart.projectId = :projectId', { projectId: command.projectId })
       .andWhere('dataMart.deletedAt IS NULL');
 
-    applyDataMartVisibilityFilter(qb, {
+    applyDataMartVisibilityFilter(pageQb, {
       dataMartAlias: 'dataMart',
       projectId: command.projectId,
       userId: command.userId,
@@ -49,24 +46,44 @@ export class ListReportsByProjectService {
     });
 
     if (command.ownerFilter === OwnerFilter.HAS_OWNERS) {
-      qb = qb.andWhere('EXISTS (SELECT 1 FROM report_owners o WHERE o.report_id = r.id)');
+      pageQb = pageQb.andWhere('EXISTS (SELECT 1 FROM report_owners o WHERE o.report_id = r.id)');
     } else if (command.ownerFilter === OwnerFilter.NO_OWNERS) {
-      qb = qb.andWhere('NOT EXISTS (SELECT 1 FROM report_owners o WHERE o.report_id = r.id)');
+      pageQb = pageQb.andWhere(
+        'NOT EXISTS (SELECT 1 FROM report_owners o WHERE o.report_id = r.id)'
+      );
     }
 
-    qb = qb.orderBy('r.createdAt', 'DESC').addOrderBy('r.id', 'DESC');
+    pageQb = pageQb.select('r.id', 'id').orderBy('r.createdAt', 'DESC').addOrderBy('r.id', 'DESC');
 
     if (command.limit !== undefined) {
-      qb = qb.take(command.limit);
+      pageQb = pageQb.limit(command.limit);
     }
 
     if (command.offset !== undefined) {
-      qb = qb.skip(command.offset);
+      pageQb = pageQb.offset(command.offset);
     }
 
-    const reports = await qb.getMany();
+    const page = await pageQb.getRawMany<{ id: string }>();
+    const reportIds = page.map(({ id }) => id);
+    if (reportIds.length === 0) {
+      return [];
+    }
 
-    const allUserIds = reports.flatMap(r => [
+    const reports = await this.reportRepository
+      .createQueryBuilder('r')
+      .leftJoinAndSelect('r.dataMart', 'dataMart')
+      .leftJoinAndSelect('dataMart.storage', 'storage')
+      .leftJoinAndSelect('r.dataDestination', 'dataDestination')
+      .leftJoinAndSelect('r.owners', 'owners')
+      .where('r.id IN (:...reportIds)', { reportIds })
+      .getMany();
+    const reportsById = new Map(reports.map(report => [report.id, report]));
+    const orderedReports = reportIds.flatMap(id => {
+      const report = reportsById.get(id);
+      return report ? [report] : [];
+    });
+
+    const allUserIds = orderedReports.flatMap(r => [
       ...(r.createdById ? [r.createdById] : []),
       ...r.ownerIds,
     ]);
@@ -74,7 +91,7 @@ export class ListReportsByProjectService {
       await this.userProjectionsFetcherService.fetchUserProjectionsList(allUserIds);
 
     const reportsWithCaps = await Promise.all(
-      reports.map(async report => {
+      orderedReports.map(async report => {
         const capabilities = await this.reportAccessService.computeCapabilitiesForReport(
           command.userId,
           command.roles,

--- a/apps/backend/src/data-marts/utils/project-list-sql-dialects.spec.ts
+++ b/apps/backend/src/data-marts/utils/project-list-sql-dialects.spec.ts
@@ -41,10 +41,7 @@ function buildProjectReportQuery(dataSource: DataSource, ownerFilter?: OwnerFilt
   const qb = dataSource
     .getRepository(Report)
     .createQueryBuilder('r')
-    .leftJoinAndSelect('r.dataMart', 'dataMart')
-    .leftJoinAndSelect('dataMart.storage', 'storage')
-    .leftJoinAndSelect('r.dataDestination', 'dataDestination')
-    .leftJoinAndSelect('r.owners', 'owners')
+    .innerJoin('r.dataMart', 'dataMart')
     .where('dataMart.projectId = :projectId', { projectId: 'project-1' })
     .andWhere('dataMart.deletedAt IS NULL');
 
@@ -56,20 +53,26 @@ function buildProjectReportQuery(dataSource: DataSource, ownerFilter?: OwnerFilt
     qb.andWhere('NOT EXISTS (SELECT 1 FROM report_owners o WHERE o.report_id = r.id)');
   }
 
-  return qb.orderBy('r.createdAt', 'DESC').addOrderBy('r.id', 'DESC').take(100).skip(0);
+  return qb
+    .select('r.id', 'id')
+    .orderBy('r.createdAt', 'DESC')
+    .addOrderBy('r.id', 'DESC')
+    .limit(100)
+    .offset(0);
 }
 
 function buildProjectRunQuery(dataSource: DataSource) {
   const qb = dataSource
     .getRepository(DataMartRun)
     .createQueryBuilder('run')
-    .innerJoinAndSelect('run.dataMart', 'dataMart')
+    .innerJoin('run.dataMart', 'dataMart')
     .where('dataMart.projectId = :projectId', { projectId: 'project-1' })
     .andWhere('dataMart.deletedAt IS NULL')
+    .select('run.id', 'id')
     .orderBy('run.createdAt', 'DESC')
     .addOrderBy('run.id', 'DESC')
-    .take(100)
-    .skip(0);
+    .limit(100)
+    .offset(0);
 
   return applyViewerVisibility(qb);
 }
@@ -78,13 +81,14 @@ function buildProjectScheduledTriggerQuery(dataSource: DataSource) {
   const qb = dataSource
     .getRepository(DataMartScheduledTrigger)
     .createQueryBuilder('scheduledTrigger')
-    .innerJoinAndSelect('scheduledTrigger.dataMart', 'dataMart')
+    .innerJoin('scheduledTrigger.dataMart', 'dataMart')
     .where('dataMart.projectId = :projectId', { projectId: 'project-1' })
     .andWhere('dataMart.deletedAt IS NULL')
+    .select('scheduledTrigger.id', 'id')
     .orderBy('scheduledTrigger.createdAt', 'DESC')
     .addOrderBy('scheduledTrigger.id', 'DESC')
-    .take(100)
-    .skip(0);
+    .limit(100)
+    .offset(0);
 
   return applyViewerVisibility(qb);
 }
@@ -93,14 +97,14 @@ function buildProjectInsightTemplateQuery(dataSource: DataSource) {
   const qb = dataSource
     .getRepository(InsightTemplate)
     .createQueryBuilder('insightTemplate')
-    .innerJoinAndSelect('insightTemplate.dataMart', 'dataMart')
-    .leftJoinAndSelect('insightTemplate.sourceEntities', 'sourceEntities')
+    .innerJoin('insightTemplate.dataMart', 'dataMart')
     .where('dataMart.projectId = :projectId', { projectId: 'project-1' })
     .andWhere('dataMart.deletedAt IS NULL')
+    .select('insightTemplate.id', 'id')
     .orderBy('insightTemplate.modifiedAt', 'DESC')
     .addOrderBy('insightTemplate.id', 'DESC')
-    .take(100)
-    .skip(0);
+    .limit(100)
+    .offset(0);
 
   return applyViewerVisibility(qb);
 }
@@ -134,7 +138,7 @@ describe('project Data Mart list SQL dialects', () => {
         }
       }
 
-      expect(buildProjectInsightTemplateQuery(dataSource).getSql()).toContain('sourceEntities');
+      expect(buildProjectInsightTemplateQuery(dataSource).getSql()).not.toContain('sourceEntities');
     }
   );
 });

--- a/apps/web/src/features/data-marts/reports/list/components/StatusIcon/StatusIcon.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/StatusIcon/StatusIcon.tsx
@@ -50,7 +50,10 @@ const fallbackStatusConfig = {
 
 export function StatusIcon({ status, error, className }: StatusIconProps) {
   if (!status) return null;
-  const config = statusConfig[status] ?? fallbackStatusConfig;
+  const config =
+    (statusConfig as Partial<Record<ReportStatusEnum, (typeof statusConfig)[ReportStatusEnum]>>)[
+      status
+    ] ?? fallbackStatusConfig;
   const { icon: Icon, color, label } = config;
 
   // Generate unique ID for tooltip

--- a/apps/web/src/features/data-marts/reports/list/components/StatusIcon/StatusIcon.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/StatusIcon/StatusIcon.tsx
@@ -4,7 +4,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@owox/ui/components/tooltip';
-import { CircleCheck, XCircle, Loader2 } from 'lucide-react';
+import { CircleCheck, XCircle, Loader2, CircleDashed } from 'lucide-react';
 import { cn } from '@owox/ui/lib/utils';
 import { ReportStatusEnum } from '../../../shared/enums/report-status.enum';
 
@@ -42,9 +42,15 @@ const statusConfig = {
   },
 } as const;
 
+const fallbackStatusConfig = {
+  icon: CircleDashed,
+  color: 'text-muted-foreground',
+  label: 'Unknown',
+} as const;
+
 export function StatusIcon({ status, error, className }: StatusIconProps) {
   if (!status) return null;
-  const config = statusConfig[status];
+  const config = statusConfig[status] ?? fallbackStatusConfig;
   const { icon: Icon, color, label } = config;
 
   // Generate unique ID for tooltip

--- a/apps/web/src/features/data-marts/reports/shared/models/report-status.model.ts
+++ b/apps/web/src/features/data-marts/reports/shared/models/report-status.model.ts
@@ -1,4 +1,4 @@
-import { CircleCheck, Loader2, XCircle } from 'lucide-react';
+import { CircleCheck, Loader2, XCircle, CircleDashed } from 'lucide-react';
 import type { AppIcon } from '../../../../../shared';
 import { ReportStatusEnum } from '../enums';
 
@@ -44,7 +44,14 @@ export const ReportStatusModel = {
   },
 
   getInfo(status: ReportStatusEnum): ReportStatusInfo {
-    return this.statuses[status];
+    return (
+      this.statuses[status] ?? {
+        status,
+        displayName: 'Unknown',
+        icon: CircleDashed,
+        color: 'text-muted-foreground',
+      }
+    );
   },
 
   getAllStatuses(): ReportStatusInfo[] {

--- a/apps/web/src/features/data-marts/reports/shared/models/report-status.model.ts
+++ b/apps/web/src/features/data-marts/reports/shared/models/report-status.model.ts
@@ -45,7 +45,7 @@ export const ReportStatusModel = {
 
   getInfo(status: ReportStatusEnum): ReportStatusInfo {
     return (
-      this.statuses[status] ?? {
+      (this.statuses as Partial<Record<ReportStatusEnum, ReportStatusInfo>>)[status] ?? {
         status,
         displayName: 'Unknown',
         icon: CircleDashed,

--- a/apps/web/src/shared/components/UserAvatar/UserAvatar.test.tsx
+++ b/apps/web/src/shared/components/UserAvatar/UserAvatar.test.tsx
@@ -1,0 +1,17 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { UserAvatar } from './UserAvatar.tsx';
+
+describe('UserAvatar', () => {
+  it('tries to load a new avatar after the previous URL fails', () => {
+    const { rerender } = render(
+      <UserAvatar avatar='broken-avatar' initials='JD' displayName='John Doe' />
+    );
+
+    fireEvent.error(screen.getByRole('img', { name: 'John Doe' }));
+    expect(screen.getByText('JD')).toBeInTheDocument();
+
+    rerender(<UserAvatar avatar='valid-avatar' initials='JD' displayName='John Doe' />);
+
+    expect(screen.getByRole('img', { name: 'John Doe' })).toHaveAttribute('src', 'valid-avatar');
+  });
+});

--- a/apps/web/src/shared/components/UserAvatar/UserAvatar.tsx
+++ b/apps/web/src/shared/components/UserAvatar/UserAvatar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { UserAvatarSize } from './UserAvatar.types.ts';
 
 export function UserAvatar({
@@ -11,6 +12,7 @@ export function UserAvatar({
   displayName: string;
   size?: UserAvatarSize;
 }) {
+  const [hasAvatarError, setHasAvatarError] = useState(false);
   let wrapperSizeClass, imageSizeClass, initialsSizeClass;
 
   switch (size) {
@@ -34,11 +36,14 @@ export function UserAvatar({
     <div
       className={`${wrapperSizeClass} flex aspect-square items-center justify-center rounded-full border bg-white dark:bg-white/10`}
     >
-      {avatar ? (
+      {avatar && !hasAvatarError ? (
         <img
           src={avatar}
           alt={displayName}
           className={`${imageSizeClass} rounded-full object-cover`}
+          onError={() => {
+            setHasAvatarError(true);
+          }}
         />
       ) : (
         <span className={`${initialsSizeClass} text-muted-foreground font-medium`}>{initials}</span>

--- a/apps/web/src/shared/components/UserAvatar/UserAvatar.tsx
+++ b/apps/web/src/shared/components/UserAvatar/UserAvatar.tsx
@@ -12,7 +12,7 @@ export function UserAvatar({
   displayName: string;
   size?: UserAvatarSize;
 }) {
-  const [hasAvatarError, setHasAvatarError] = useState(false);
+  const [failedAvatar, setFailedAvatar] = useState<string | null>(null);
   let wrapperSizeClass, imageSizeClass, initialsSizeClass;
 
   switch (size) {
@@ -36,13 +36,13 @@ export function UserAvatar({
     <div
       className={`${wrapperSizeClass} flex aspect-square items-center justify-center rounded-full border bg-white dark:bg-white/10`}
     >
-      {avatar && !hasAvatarError ? (
+      {avatar && avatar !== failedAvatar ? (
         <img
           src={avatar}
           alt={displayName}
           className={`${imageSizeClass} rounded-full object-cover`}
           onError={() => {
-            setHasAvatarError(true);
+            setFailedAvatar(avatar);
           }}
         />
       ) : (


### PR DESCRIPTION
## Summary

- reduce MySQL sort memory usage for project-wide Runs, Reports, Insights, and Triggers
- split pagination into a narrow ID query followed by full entity loading
- preserve the requested ordering after loading full entities
- handle unknown report statuses without crashing the Reports page
- fall back to user labels when avatar images fail to load

## Problem

Project-wide lists could fail with `Out of sort memory` because MySQL sorted wide rows containing JSON fields and joined entities.

The Reports page could also crash when it encountered an unknown status or an unavailable avatar image.

## Solution

Project-wide list queries now:

1. select, sort, and paginate only entity IDs
2. load complete entities and required relations in a separate query
3. restore the original page order in application code

Report rendering now provides fallbacks for unknown statuses and failed avatar requests.

## Testing

- Backend: 5 test suites, 22 tests passed
- Web Reports page: 25 tests passed
