### PR TITLE
fix(connectors): defer incremental checkpoint until all accounts succeed

### DIFF
--- a/.changeset/connector-partial-run-checkpoint.md
+++ b/.changeset/connector-partial-run-checkpoint.md
@@ -1,0 +1,7 @@
+---
+"owox": minor
+---
+
+# Reliable incremental sync after partial connector run
+
+Previously, if a connector run failed partway through multiple accounts, the incremental date checkpoint could advance past data that was never fully fetched — causing those dates to be silently skipped on the next run. Now the checkpoint is written only after all accounts complete successfully, so a failed run always retries from the correct starting point. This affects MicrosoftAds, CriteoAds, GoogleAds, RedditAds, and XAds connectors.

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -7,8 +7,9 @@ jest.mock('@owox/connectors', () => ({
       Object.assign(this as object, data);
     }),
     EXECUTION_STATUS: {
-      ERROR: 'ERROR',
-      SUCCESS: 'SUCCESS',
+      IMPORT_IN_PROGRESS: 1,
+      IMPORT_DONE: 3,
+      ERROR: 5,
     },
   },
 }));
@@ -38,7 +39,7 @@ describe('ConnectorExecutorService', () => {
       findOne: jest.fn().mockResolvedValue(null),
     } as unknown as Repository<DataMartRun>;
 
-    // Capture the onMessage callback so spawnConnector can invoke it with a success message
+    // Capture the onMessage callback so spawnConnector can emit connector status messages.
     let capturedOnMessage: ((msg: unknown) => void) | null = null;
 
     const outputCaptureService = {
@@ -55,16 +56,27 @@ describe('ConnectorExecutorService', () => {
       if (capturedOnMessage) {
         capturedOnMessage({
           type: ConnectorMessageType.STATUS,
-          status: 'SUCCESS',
+          status: 3,
           at: new Date().toISOString(),
-          toFormattedString: () => 'STATUS: SUCCESS',
+          toFormattedString: () => 'STATUS: IMPORT_DONE',
+        });
+      }
+    };
+
+    const emitInProgressMessage = () => {
+      if (capturedOnMessage) {
+        capturedOnMessage({
+          type: ConnectorMessageType.STATUS,
+          status: 1,
+          at: new Date().toISOString(),
+          toFormattedString: () => 'STATUS: IMPORT_IN_PROGRESS',
         });
       }
     };
 
     const processSpawner = {
       spawnConnector: jest.fn().mockImplementation(() => {
-        // Simulate a successful connector run by triggering a STATUS SUCCESS message
+        // Simulate a successful connector run by triggering terminal import status.
         emitSuccessMessage();
         return Promise.resolve();
       }),
@@ -149,6 +161,7 @@ describe('ConnectorExecutorService', () => {
       projectBalanceService,
       dataMartService,
       emitSuccessMessage,
+      emitInProgressMessage,
     };
   };
 
@@ -194,6 +207,33 @@ describe('ConnectorExecutorService', () => {
     expect(consumptionTracker.registerConnectorRunConsumption).toHaveBeenCalled();
     expect(eventDispatcher.publishExternal).toHaveBeenCalled();
     expect(dataMartService.actualizeSchema).toHaveBeenCalledWith('dm-1', 'proj-1');
+  });
+
+  it('does not mark a run successful when only import in-progress status is emitted', async () => {
+    const {
+      service,
+      dataMartRunRepository,
+      processSpawner,
+      consumptionTracker,
+      eventDispatcher,
+      emitInProgressMessage,
+    } = createService();
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
+      emitInProgressMessage();
+    });
+
+    await service.executeInBackground(createDataMart(), createRun(), null);
+
+    expect(dataMartRunRepository.update).toHaveBeenLastCalledWith(
+      'run-1',
+      expect.objectContaining({ status: DataMartRunStatus.FAILED })
+    );
+    expect(consumptionTracker.registerConnectorRunConsumption).not.toHaveBeenCalled();
+    expect(eventDispatcher.publishExternal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ status: 'unsuccessfully' }),
+      })
+    );
   });
 
   it('lets normal completion replace a committed cancellation when abort is not delivered', async () => {

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -269,8 +269,16 @@ export class ConnectorExecutorService {
                   runId,
                   configId,
                 });
-              } else {
+              } else if (this.isSuccessfulConnectorStatus(message.status)) {
                 success = true;
+                addMessageToArray(configLogs, message);
+                this.logger.log(`${message.status}`, {
+                  dataMartId: dataMart.id,
+                  projectId: dataMart.projectId,
+                  runId,
+                  configId,
+                });
+              } else {
                 addMessageToArray(configLogs, message);
                 this.logger.log(`${message.status}`, {
                   dataMartId: dataMart.id,
@@ -338,6 +346,21 @@ export class ConnectorExecutorService {
             configId,
             configIndex,
           });
+        } else if (configErrors.length === 0) {
+          const errorMessage = 'Connector process finished without terminal success status';
+          addMessageToArray(configErrors, {
+            type: ConnectorMessageType.ERROR,
+            at: this.systemTimeService.now().toISOString(),
+            error: errorMessage,
+            toFormattedString: () => `[ERROR] ${errorMessage}`,
+          });
+          this.logger.error(`Configuration ${configIndex + 1} failed: ${errorMessage}`, {
+            dataMartId: dataMart.id,
+            projectId: dataMart.projectId,
+            runId,
+            configId,
+            configIndex,
+          });
         }
       } catch (error) {
         success = false;
@@ -367,6 +390,10 @@ export class ConnectorExecutorService {
     }
 
     return configurationResults;
+  }
+
+  private isSuccessfulConnectorStatus(status: number): boolean {
+    return status === Core.EXECUTION_STATUS.IMPORT_DONE;
   }
 
   private async updateRunStatus(

--- a/packages/connectors/src/Sources/CriteoAds/Connector.js
+++ b/packages/connectors/src/Sources/CriteoAds/Connector.js
@@ -18,15 +18,25 @@ var CriteoAdsConnector = class CriteoAdsConnector extends AbstractConnector {
   async startImportProcess() {
     const fields = CriteoAdsHelper.parseFields(this.config.Fields?.value || "");
     const advertiserIds = CriteoAdsHelper.parseAdvertiserIds(this.config.AdvertiserIDs?.value || "");
+    let lastProcessedDate = null;
 
     for (const advertiserId of advertiserIds) {
       for (const nodeName in fields) {
-        await this.processNode({
+        const processedDate = await this.processNode({
           nodeName,
           advertiserId,
-          fields: fields[nodeName] || []
+          fields: fields[nodeName] || [],
+          updateRequestedDate: false
         });
+
+        if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
+          lastProcessedDate = processedDate;
+        }
       }
+    }
+
+    if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL && lastProcessedDate) {
+      this.config.updateLastRequstedDate(lastProcessedDate);
     }
   }
 
@@ -36,12 +46,14 @@ var CriteoAdsConnector = class CriteoAdsConnector extends AbstractConnector {
    * @param {string} options.nodeName - Name of the node to process
    * @param {string} options.advertiserId - Advertiser ID
    * @param {Array<string>} options.fields - Array of fields to fetch
+   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
    */
-  async processNode({ nodeName, advertiserId, fields }) {
-    await this.processTimeSeriesNode({
+  async processNode({ nodeName, advertiserId, fields, updateRequestedDate = true }) {
+    return await this.processTimeSeriesNode({
       nodeName,
       advertiserId,
-      fields
+      fields,
+      updateRequestedDate
     });
   }
 
@@ -51,19 +63,22 @@ var CriteoAdsConnector = class CriteoAdsConnector extends AbstractConnector {
    * @param {string} options.nodeName - Name of the node
    * @param {string} options.advertiserId - Advertiser ID
    * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {Object} options.storage - Storage instance
+   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
    */
-  async processTimeSeriesNode({ nodeName, advertiserId, fields }) {
+  async processTimeSeriesNode({ nodeName, advertiserId, fields, updateRequestedDate = true }) {
     const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
 
     if (daysToFetch <= 0) {
       console.log('No days to fetch for time series data');
-      return;
+      return null;
     }
+
+    let lastProcessedDate = null;
 
     for (let i = 0; i < daysToFetch; i++) {
       const currentDate = new Date(startDate);
       currentDate.setDate(currentDate.getDate() + i);
+      lastProcessedDate = new Date(currentDate);
 
       const formattedDate = DateUtils.formatDate(currentDate);
 
@@ -82,11 +97,13 @@ var CriteoAdsConnector = class CriteoAdsConnector extends AbstractConnector {
         await storage.saveData(preparedData);
       }
 
-      // Only update LastRequestedDate for incremental runs
-      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+      // Some callers defer the checkpoint until all advertisers finish successfully.
+      if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
         this.config.updateLastRequstedDate(currentDate);
       }
     }
+
+    return lastProcessedDate;
   }
 
   /**

--- a/packages/connectors/src/Sources/GoogleAds/Connector.js
+++ b/packages/connectors/src/Sources/GoogleAds/Connector.js
@@ -19,13 +19,23 @@ var GoogleAdsConnector = class GoogleAdsConnector extends AbstractConnector {
   async startImportProcess() {
     const customerIds = FormatUtils.parseIds(this.config.CustomerId.value, { stripCharacters: '-' });
     const fields = FormatUtils.parseFields(this.config.Fields.value);
+    let lastProcessedDate = null;
 
     for (const nodeName in fields) {
-      await this.processNode({
+      const processedDate = await this.processNode({
         nodeName,
         customerIds,
-        fields: fields[nodeName] || []
+        fields: fields[nodeName] || [],
+        updateRequestedDate: false
       });
+
+      if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
+        lastProcessedDate = processedDate;
+      }
+    }
+
+    if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL && lastProcessedDate) {
+      this.config.updateLastRequstedDate(lastProcessedDate);
     }
   }
 
@@ -37,19 +47,26 @@ var GoogleAdsConnector = class GoogleAdsConnector extends AbstractConnector {
    * @param {string} options.nodeName - Name of the node to process
    * @param {Array<string>} options.customerIds - Array of customer IDs to process
    * @param {Array<string>} options.fields - Array of fields to fetch
+   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
    */
-  async processNode({ nodeName, customerIds, fields }) {
+  async processNode({ nodeName, customerIds, fields, updateRequestedDate = true }) {
     const idsToProcess = this.source.fieldsSchema[nodeName].isGlobalResource
       ? customerIds.slice(0, 1)
       : customerIds;
+    let lastProcessedDate = null;
 
     for (const customerId of idsToProcess) {
       if (this.source.fieldsSchema[nodeName].isTimeSeries) {
-        await this.processTimeSeriesNode({
+        const processedDate = await this.processTimeSeriesNode({
           nodeName,
           customerId,
-          fields
+          fields,
+          updateRequestedDate
         });
+
+        if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
+          lastProcessedDate = processedDate;
+        }
       } else {
         await this.processCatalogNode({
           nodeName,
@@ -58,6 +75,8 @@ var GoogleAdsConnector = class GoogleAdsConnector extends AbstractConnector {
         });
       }
     }
+
+    return lastProcessedDate;
   }
 
   /**
@@ -66,18 +85,22 @@ var GoogleAdsConnector = class GoogleAdsConnector extends AbstractConnector {
    * @param {string} options.nodeName - Name of the node
    * @param {string} options.customerId - Customer ID
    * @param {Array<string>} options.fields - Array of fields to fetch
+   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
    */
-  async processTimeSeriesNode({ nodeName, customerId, fields }) {
+  async processTimeSeriesNode({ nodeName, customerId, fields, updateRequestedDate = true }) {
     const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
 
     if (daysToFetch <= 0) {
       console.log('No days to fetch for time series data');
-      return;
+      return null;
     }
+
+    let lastProcessedDate = null;
 
     for (let i = 0; i < daysToFetch; i++) {
       const currentDate = new Date(startDate);
       currentDate.setDate(currentDate.getDate() + i);
+      lastProcessedDate = new Date(currentDate);
 
       const formattedDate = DateUtils.formatDate(currentDate);
 
@@ -91,10 +114,13 @@ var GoogleAdsConnector = class GoogleAdsConnector extends AbstractConnector {
         await storage.saveData(preparedData);
       }
 
-      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+      // Some callers defer the checkpoint until all customers finish successfully.
+      if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
         this.config.updateLastRequstedDate(currentDate);
       }
     }
+
+    return lastProcessedDate;
   }
 
   /**

--- a/packages/connectors/src/Sources/MicrosoftAds/Connector.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Connector.js
@@ -19,18 +19,28 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
   async startImportProcess() {
     const accountIds = FormatUtils.parseAccountIds(this.config.AccountIDs.value);
     const fields = MicrosoftAdsHelper.parseFields(this.config.Fields.value);
+    let lastProcessedDate = null;
 
     for (const rawAccountId of accountIds) {
       const accountId = rawAccountId.trim();
       this.config.logMessage(`Starting import process for Account ID: ${accountId}`);
 
       for (const nodeName in fields) {
-        await this.processNode({
+        const processedDate = await this.processNode({
           nodeName,
           accountId,
-          fields: fields[nodeName] || []
+          fields: fields[nodeName] || [],
+          updateRequestedDate: false
         });
+
+        if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
+          lastProcessedDate = processedDate;
+        }
       }
+    }
+
+    if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL && lastProcessedDate) {
+      this.config.updateLastRequstedDate(lastProcessedDate);
     }
   }
 
@@ -40,13 +50,15 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
    * @param {string} options.nodeName - Name of the node to process
    * @param {string} options.accountId - Account ID
    * @param {Array<string>} options.fields - Array of fields to fetch
+   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
    */
-  async processNode({ nodeName, accountId, fields }) {
+  async processNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
     if (this.source.fieldsSchema[nodeName].isTimeSeries) {
-      await this.processTimeSeriesNode({
+      return await this.processTimeSeriesNode({
         nodeName,
         accountId,
-        fields
+        fields,
+        updateRequestedDate
       });
     } else {
       await this.processCatalogNode({
@@ -54,6 +66,7 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
         accountId,
         fields
       });
+      return null;
     }
   }
 
@@ -63,20 +76,23 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
    * @param {string} options.nodeName - Name of the node
    * @param {string} options.accountId - Account ID
    * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {Object} options.storage - Storage instance
+   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
    */
-  async processTimeSeriesNode({ nodeName, accountId, fields }) {
+  async processTimeSeriesNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
     const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
 
     if (daysToFetch <= 0) {
       console.log('No days to fetch for time series data');
-      return;
+      return null;
     }
+
+    let lastProcessedDate = null;
 
     // Process data day by day
     for (let dayOffset = 0; dayOffset < daysToFetch; dayOffset++) {
       const currentDate = new Date(startDate);
       currentDate.setDate(currentDate.getDate() + dayOffset);
+      lastProcessedDate = new Date(currentDate);
 
       const formattedDate = DateUtils.formatDate(currentDate);
 
@@ -99,11 +115,13 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
         data.length && this.config.logMessage(`Successfully saved ${data.length} rows for ${formattedDate}`);
       }
 
-      // Update last requested date after each successful day
-      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+      // Some callers defer the checkpoint until all accounts finish successfully.
+      if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
         this.config.updateLastRequstedDate(currentDate);
       }
     }
+
+    return lastProcessedDate;
   }
 
   /**

--- a/packages/connectors/src/Sources/RedditAds/Connector.js
+++ b/packages/connectors/src/Sources/RedditAds/Connector.js
@@ -19,15 +19,25 @@ var RedditAdsConnector = class RedditAdsConnector extends AbstractConnector {
   async startImportProcess() {
     const fields = RedditAdsHelper.parseFields(this.config.Fields.value);
     const accountIds = RedditAdsHelper.parseAccountIds(this.config.AccountIDs.value);
+    let lastProcessedDate = null;
 
     for (const accountId of accountIds) {
       for (const nodeName in fields) {
-        await this.processNode({
+        const processedDate = await this.processNode({
           nodeName,
           accountId,
-          fields: fields[nodeName] || []
+          fields: fields[nodeName] || [],
+          updateRequestedDate: false
         });
+
+        if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
+          lastProcessedDate = processedDate;
+        }
       }
+    }
+
+    if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL && lastProcessedDate) {
+      this.config.updateLastRequstedDate(lastProcessedDate);
     }
   }
 
@@ -37,13 +47,15 @@ var RedditAdsConnector = class RedditAdsConnector extends AbstractConnector {
    * @param {string} options.nodeName - Name of the node to process
    * @param {string} options.accountId - Account ID
    * @param {Array<string>} options.fields - Array of fields to fetch
+   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
    */
-  async processNode({ nodeName, accountId, fields }) {
+  async processNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
     if (this.source.fieldsSchema[nodeName].isTimeSeries) {
-      await this.processTimeSeriesNode({
+      return await this.processTimeSeriesNode({
         nodeName,
         accountId,
-        fields
+        fields,
+        updateRequestedDate
       });
     } else {
       await this.processCatalogNode({
@@ -51,6 +63,7 @@ var RedditAdsConnector = class RedditAdsConnector extends AbstractConnector {
         accountId,
         fields
       });
+      return null;
     }
   }
 
@@ -60,25 +73,28 @@ var RedditAdsConnector = class RedditAdsConnector extends AbstractConnector {
    * @param {string} options.nodeName - Name of the node
    * @param {string} options.accountId - Account ID
    * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {Object} options.storage - Storage instance
+   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
    */
-  async processTimeSeriesNode({ nodeName, accountId, fields }) {
+  async processTimeSeriesNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
     const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
 
     if (daysToFetch <= 0) {
       console.log('No days to fetch for time series data');
-      return;
+      return null;
     }
+
+    let lastProcessedDate = null;
 
     for (let i = 0; i < daysToFetch; i++) {
       const currentDate = new Date(startDate);
       currentDate.setDate(currentDate.getDate() + i);
+      lastProcessedDate = new Date(currentDate);
 
       const formattedDate = DateUtils.formatDate(currentDate);
 
       this.config.logMessage(`Start importing data for ${formattedDate}: ${accountId}/${nodeName}`);
 
-              const data = await this.source.fetchData(nodeName, accountId, fields, currentDate);
+      const data = await this.source.fetchData(nodeName, accountId, fields, currentDate);
 
       this.config.logMessage(data.length ? `${data.length} records were fetched` : `No records have been fetched`);
 
@@ -88,10 +104,13 @@ var RedditAdsConnector = class RedditAdsConnector extends AbstractConnector {
         await storage.saveData(preparedData);
       }
 
-      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+      // Some callers defer the checkpoint until all accounts finish successfully.
+      if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
         this.config.updateLastRequstedDate(currentDate);
       }
     }
+
+    return lastProcessedDate;
   }
 
   /**

--- a/packages/connectors/src/Sources/XAds/Connector.js
+++ b/packages/connectors/src/Sources/XAds/Connector.js
@@ -19,17 +19,27 @@ var XAdsConnector = class XAdsConnector extends AbstractConnector {
   async startImportProcess() {
     const fields = XAdsHelper.parseFields(this.config.Fields.value);
     const accountIds = XAdsHelper.parseAccountIds(this.config.AccountIDs.value);
+    let lastProcessedDate = null;
 
     for (const accountId of accountIds) {
       for (const nodeName in fields) {
-        await this.processNode({
+        const processedDate = await this.processNode({
           nodeName,
           accountId,
-          fields: fields[nodeName] || []
+          fields: fields[nodeName] || [],
+          updateRequestedDate: false
         });
+
+        if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
+          lastProcessedDate = processedDate;
+        }
       }
 
       this.source.clearCache(accountId);
+    }
+
+    if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL && lastProcessedDate) {
+      this.config.updateLastRequstedDate(lastProcessedDate);
     }
   }
 
@@ -39,12 +49,14 @@ var XAdsConnector = class XAdsConnector extends AbstractConnector {
    * @param {string} options.nodeName - Name of the node to process
    * @param {string} options.accountId - Account ID
    * @param {Array<string>} options.fields - Array of fields to fetch
+   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
    */
-  async processNode({ nodeName, accountId, fields }) {
+  async processNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
     if (this.source.fieldsSchema[nodeName].isTimeSeries) {
-      await this.processTimeSeriesNode({ nodeName, accountId, fields });
+      return await this.processTimeSeriesNode({ nodeName, accountId, fields, updateRequestedDate });
     } else {
       await this.processCatalogNode({ nodeName, accountId, fields });
+      return null;
     }
   }
 
@@ -53,22 +65,29 @@ var XAdsConnector = class XAdsConnector extends AbstractConnector {
    * asyncTimeSeries nodes are routed to processAsyncTimeSeriesNode.
    * All other nodes use the day-by-day fetchData loop.
    */
-  async processTimeSeriesNode({ nodeName, accountId, fields }) {
+  async processTimeSeriesNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
     if (this.source.fieldsSchema[nodeName].asyncTimeSeries) {
-      await this.processAsyncTimeSeriesNode({ nodeName, accountId, fields });
-      return;
+      return await this.processAsyncTimeSeriesNode({
+        nodeName,
+        accountId,
+        fields,
+        updateRequestedDate
+      });
     }
 
     const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
 
     if (daysToFetch <= 0) {
       console.log('No days to fetch for time series data');
-      return;
+      return null;
     }
+
+    let lastProcessedDate = null;
 
     for (let i = 0; i < daysToFetch; i++) {
       const currentDate = new Date(startDate);
       currentDate.setUTCDate(currentDate.getUTCDate() + i);
+      lastProcessedDate = new Date(currentDate);
 
       const formattedDate = DateUtils.formatDate(currentDate);
 
@@ -82,10 +101,13 @@ var XAdsConnector = class XAdsConnector extends AbstractConnector {
         await storage.saveData(preparedData);
       }
 
-      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+      // Some callers defer the checkpoint until all accounts finish successfully.
+      if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
         this.config.updateLastRequstedDate(currentDate);
       }
     }
+
+    return lastProcessedDate;
   }
 
   /**
@@ -93,10 +115,10 @@ var XAdsConnector = class XAdsConnector extends AbstractConnector {
    *
    * Dates are split into fixed-size chunks. For each chunk, the Source processes
    * one job at a time (submit → poll → download) and calls onBatchReady after
-   * each date so the Connector can save to BigQuery and advance the cursor
-   * immediately. If the run fails on date N, dates 1–(N-1) are already persisted.
+   * each date so the Connector can save to BigQuery. The checkpoint can be
+   * deferred by callers until all accounts finish successfully.
    */
-  async processAsyncTimeSeriesNode({ nodeName, accountId, fields }) {
+  async processAsyncTimeSeriesNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
     const uniqueKeys = this.source.fieldsSchema[nodeName].uniqueKeys || [];
     const missingKeys = uniqueKeys.filter(key => !fields.includes(key));
     if (missingKeys.length > 0) {
@@ -107,7 +129,7 @@ var XAdsConnector = class XAdsConnector extends AbstractConnector {
 
     if (daysToFetch <= 0) {
       console.log('No days to fetch for time series data');
-      return;
+      return null;
     }
 
     // Build date list with both forms needed downstream.
@@ -122,6 +144,7 @@ var XAdsConnector = class XAdsConnector extends AbstractConnector {
     const storage = await this.getStorageByNode(nodeName);
     const chunks = XAdsHelper.splitDatesIntoChunks(days.map(d => d.formatted));
     const dayLookup = new Map(days.map(d => [d.formatted, d.date]));
+    let lastProcessedDate = null;
 
     for (const dateChunk of chunks) {
       await this.source.fetchData({
@@ -140,12 +163,20 @@ var XAdsConnector = class XAdsConnector extends AbstractConnector {
             await storage.saveData(preparedData);
           }
 
-          if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
-            this.config.updateLastRequstedDate(dayLookup.get(formatted));
+          const processedDate = dayLookup.get(formatted);
+          if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
+            lastProcessedDate = processedDate;
+          }
+
+          // Some callers defer the checkpoint until all accounts finish successfully.
+          if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+            this.config.updateLastRequstedDate(processedDate);
           }
         }
       });
     }
+
+    return lastProcessedDate;
   }
 
   /**


### PR DESCRIPTION
# Problem

Two related bugs caused an incorrect state after a partial connector run:

1. **Checkpoint advanced prematurely**: For connectors with multiple accounts/advertisers (MicrosoftAds, CriteoAds, GoogleAds, RedditAds, XAds), the incremental `lastRequestedDate` checkpoint was updated after each processed day *per account*. If account 2 failed mid-run, the checkpoint had already advanced past dates that account 2 never finished fetching, so those dates were silently skipped on the next run.

2. **Executor treated any non-error status as success**: The `ConnectorExecutorService` set `success = true` for any `STATUS` message that wasn't `ERROR` (including `IMPORT_IN_PROGRESS`). A connector process that exited cleanly after emitting only an in-progress status was incorrectly recorded as a successful run.

# Solution

**Connector fix**: Introduced an `updateRequestedDate` flag on `processNode` / `processTimeSeriesNode` / `processAsyncTimeSeriesNode`. `startImportProcess` passes `updateRequestedDate: false` for all per-node calls, collects the maximum processed date across all accounts and nodes, and writes a single checkpoint only after all iterations complete successfully. If any account throws, the checkpoint is never advanced.

**Executor fix**: Changed the `STATUS` message handler to only set `success = true` on `IMPORT_DONE` (status `3`). Intermediate statuses (e.g. `IMPORT_IN_PROGRESS`) are now logged without marking the run successful. Added a fallback: if `spawnConnector` resolves without `success = true` and no explicit error was recorded, a synthetic error is injected so the run is correctly marked as failed.

The trade-off for the connector fix is that on a partial failure, already-completed accounts will be re-fetched on the next run (instead of only the failed account resuming). This is acceptable because writes are idempotent, and correctness of the checkpoint outweighs redundant re-work.

# Changes

- **MicrosoftAds, CriteoAds, GoogleAds, RedditAds, XAds connectors**: Added `updateRequestedDate` parameter (default `true`) to `processNode`, `processTimeSeriesNode`, and `processAsyncTimeSeriesNode`
- **All 5 connectors**: `startImportProcess` now passes `updateRequestedDate: false`, tracks `lastProcessedDate` as the max across all iterations, and writes the checkpoint once at the end
- **`connector-executor.service.ts`**: Replaced unconditional `success = true` for non-error statuses with an explicit check against `IMPORT_DONE`; added `isSuccessfulConnectorStatus` private method
- **`connector-executor.service.ts`**: Added fallback after `spawnConnector` resolves: if `success` is still `false` and no errors were recorded, injects a synthetic error message
- **`connector-executor.service.spec.ts`**: Updated mocked `EXECUTION_STATUS` enum to use numeric values matching the real enum (`IMPORT_IN_PROGRESS: 1`, `IMPORT_DONE: 3`, `ERROR: 5`)
- **`connector-executor.service.spec.ts`**: Added `emitInProgressMessage` helper and a new test asserting that a run emitting only `IMPORT_IN_PROGRESS` is marked as failed