### PR TITLE
fix(backend): exclude disconnected fields from AI Helper sample query

### DIFF
--- a/.changeset/ai-helper-skip-disconnected-fields.md
+++ b/.changeset/ai-helper-skip-disconnected-fields.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Skip disconnected fields in AI Helper sample-data query
+
+Fix AI Helper alias/description generation failing with `Unrecognized name: <field>` when a data mart's Output Schema contains a field marked Disconnected ("Field is not connected to the data source"). The 30-row sample query no longer selects disconnected fields — they exist in the schema but not in the underlying table/view, so the storage rejected the whole query — and the sample fetch is skipped entirely when no connected fields remain. Hidden-for-reporting fields are intentionally kept, since the AI may still generate an alias or description for them.

--- a/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.spec.ts
+++ b/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.spec.ts
@@ -1,0 +1,145 @@
+import { GenerateDataMartMetadataOrchestratorService } from './generate-data-mart-metadata.orchestrator.service';
+import { DataMartMetadataScope, GenerateDataMartMetadataRequest } from './ai-insights-types';
+import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
+import { DataMartSchemaFieldStatus } from '../data-storage-types/enums/data-mart-schema-field-status.enum';
+import { DataMart } from '../entities/data-mart.entity';
+
+describe('GenerateDataMartMetadataOrchestratorService', () => {
+  const METADATA_SAMPLE_ROW_LIMIT = 30;
+
+  const buildSchema = (
+    fields: Array<{
+      name: string;
+      status: DataMartSchemaFieldStatus;
+      isHiddenForReporting?: boolean;
+    }>
+  ) => ({
+    type: 'bigquery-data-mart-schema',
+    fields: fields.map(f => ({
+      name: f.name,
+      type: 'STRING',
+      status: f.status,
+      isHiddenForReporting: f.isHiddenForReporting ?? false,
+    })),
+  });
+
+  const createService = (schema: unknown) => {
+    const dataMart = {
+      id: 'dm-1',
+      projectId: 'proj-1',
+      definitionType: DataMartDefinitionType.SQL,
+      title: 'Test Mart',
+      description: 'desc',
+      schema,
+    } as unknown as DataMart;
+
+    const dataMartService = {
+      actualizeSchemaIfExpired: jest.fn().mockResolvedValue(dataMart),
+    };
+    const dataMartSampleDataService = {
+      sampleColumns: jest.fn().mockResolvedValue({ columns: [], rows: [] }),
+    };
+    const definitionValidatorFacade = {
+      checkIsValid: jest.fn().mockResolvedValue(undefined),
+    };
+    const generateDataMartMetadataAgent = {
+      run: jest.fn().mockResolvedValue({ fields: [] }),
+    };
+
+    const service = new GenerateDataMartMetadataOrchestratorService(
+      dataMartService as never,
+      dataMartSampleDataService as never,
+      definitionValidatorFacade as never,
+      generateDataMartMetadataAgent as never,
+      {} as never,
+      {} as never
+    );
+
+    return { service, dataMartSampleDataService, generateDataMartMetadataAgent };
+  };
+
+  const request: GenerateDataMartMetadataRequest = {
+    dataMartId: 'dm-1',
+    projectId: 'proj-1',
+    scope: DataMartMetadataScope.ALL_FIELD_METADATA,
+    useSample: true,
+  };
+
+  it('excludes DISCONNECTED fields from the sample query', async () => {
+    const schema = buildSchema([
+      { name: 'campaign', status: DataMartSchemaFieldStatus.CONNECTED },
+      { name: 'country', status: DataMartSchemaFieldStatus.CONNECTED },
+      { name: 'clicks', status: DataMartSchemaFieldStatus.CONNECTED },
+      { name: 'impressions', status: DataMartSchemaFieldStatus.DISCONNECTED },
+    ]);
+    const { service, dataMartSampleDataService } = createService(schema);
+
+    await service.run(request);
+
+    expect(dataMartSampleDataService.sampleColumns).toHaveBeenCalledWith(
+      'dm-1',
+      'proj-1',
+      ['campaign', 'country', 'clicks'],
+      undefined,
+      METADATA_SAMPLE_ROW_LIMIT
+    );
+  });
+
+  it('keeps isHiddenForReporting fields in the sample query (AI may still alias/describe them)', async () => {
+    const schema = buildSchema([
+      { name: 'campaign', status: DataMartSchemaFieldStatus.CONNECTED },
+      {
+        name: 'internal_id',
+        status: DataMartSchemaFieldStatus.CONNECTED,
+        isHiddenForReporting: true,
+      },
+      { name: 'clicks', status: DataMartSchemaFieldStatus.CONNECTED },
+    ]);
+    const { service, dataMartSampleDataService } = createService(schema);
+
+    await service.run(request);
+
+    expect(dataMartSampleDataService.sampleColumns).toHaveBeenCalledWith(
+      'dm-1',
+      'proj-1',
+      ['campaign', 'internal_id', 'clicks'],
+      undefined,
+      METADATA_SAMPLE_ROW_LIMIT
+    );
+  });
+
+  it('keeps CONNECTED_WITH_DEFINITION_MISMATCH fields in the sample query', async () => {
+    const schema = buildSchema([
+      { name: 'campaign', status: DataMartSchemaFieldStatus.CONNECTED },
+      { name: 'clicks', status: DataMartSchemaFieldStatus.CONNECTED_WITH_DEFINITION_MISMATCH },
+    ]);
+    const { service, dataMartSampleDataService } = createService(schema);
+
+    await service.run(request);
+
+    expect(dataMartSampleDataService.sampleColumns).toHaveBeenCalledWith(
+      'dm-1',
+      'proj-1',
+      ['campaign', 'clicks'],
+      undefined,
+      METADATA_SAMPLE_ROW_LIMIT
+    );
+  });
+
+  it('skips the sample fetch when every field is DISCONNECTED', async () => {
+    const schema = buildSchema([
+      { name: 'campaign', status: DataMartSchemaFieldStatus.DISCONNECTED },
+      { name: 'impressions', status: DataMartSchemaFieldStatus.DISCONNECTED },
+    ]);
+    const { service, dataMartSampleDataService, generateDataMartMetadataAgent } =
+      createService(schema);
+
+    await service.run(request);
+
+    expect(dataMartSampleDataService.sampleColumns).not.toHaveBeenCalled();
+    expect(generateDataMartMetadataAgent.run).toHaveBeenCalledWith(
+      expect.objectContaining({ sampleColumns: null, sampleRows: null }),
+      expect.anything()
+    );
+  });
+});

--- a/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
+++ b/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
@@ -5,6 +5,7 @@ import { ToolRegistry } from '../../common/ai-insights/agent/tool-registry';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { DataMartDefinitionValidatorFacade } from '../data-storage-types/facades/data-mart-definition-validator-facade.service';
 import type { DataMartSchema } from '../data-storage-types/data-mart-schema.type';
+import { DataMartSchemaFieldStatus } from '../data-storage-types/enums/data-mart-schema-field-status.enum';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { DataMartService } from '../services/data-mart.service';
 import { DataMartSampleDataService } from '../services/data-mart-sample-data.service';
@@ -73,19 +74,28 @@ export class GenerateDataMartMetadataOrchestratorService {
     let sampleColumns: string[] | null = null;
     let sampleRows: QueryRow[] | null = null;
     if (request.useSample) {
-      const schemaColumns = schema.fields.map(f => f.name);
-      const sample = await this.dataMartSampleDataService.sampleColumns(
-        request.dataMartId,
-        request.projectId,
-        schemaColumns,
-        undefined,
-        METADATA_SAMPLE_ROW_LIMIT
-      );
-      sampleColumns = sample.columns;
-      sampleRows = sample.rows.map(row => this.toQueryRow(sample.columns, row));
-      this.logger.log(
-        `Fetched ${sample.rows.length} sample row(s) across ${sample.columns.length} column(s) for data mart ${request.dataMartId}`
-      );
+      // DISCONNECTED fields aren't in the underlying table/view, so selecting them fails the query.
+      const schemaColumns = schema.fields
+        .filter(f => f.status !== DataMartSchemaFieldStatus.DISCONNECTED)
+        .map(f => f.name);
+      if (schemaColumns.length === 0) {
+        this.logger.warn(
+          `Skipping sample fetch for data mart ${request.dataMartId}: no connected schema fields`
+        );
+      } else {
+        const sample = await this.dataMartSampleDataService.sampleColumns(
+          request.dataMartId,
+          request.projectId,
+          schemaColumns,
+          undefined,
+          METADATA_SAMPLE_ROW_LIMIT
+        );
+        sampleColumns = sample.columns;
+        sampleRows = sample.rows.map(row => this.toQueryRow(sample.columns, row));
+        this.logger.log(
+          `Fetched ${sample.rows.length} sample row(s) across ${sample.columns.length} column(s) for data mart ${request.dataMartId}`
+        );
+      }
     }
 
     const sharedContext: SharedAgentContext = {

--- a/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
+++ b/apps/backend/src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.ts
@@ -5,7 +5,7 @@ import { ToolRegistry } from '../../common/ai-insights/agent/tool-registry';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { DataMartDefinitionValidatorFacade } from '../data-storage-types/facades/data-mart-definition-validator-facade.service';
 import type { DataMartSchema } from '../data-storage-types/data-mart-schema.type';
-import { DataMartSchemaFieldStatus } from '../data-storage-types/enums/data-mart-schema-field-status.enum';
+import { isConnected } from '../data-storage-types/data-mart-schema.utils';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { DataMartService } from '../services/data-mart.service';
 import { DataMartSampleDataService } from '../services/data-mart-sample-data.service';
@@ -74,10 +74,8 @@ export class GenerateDataMartMetadataOrchestratorService {
     let sampleColumns: string[] | null = null;
     let sampleRows: QueryRow[] | null = null;
     if (request.useSample) {
-      // DISCONNECTED fields aren't in the underlying table/view, so selecting them fails the query.
-      const schemaColumns = schema.fields
-        .filter(f => f.status !== DataMartSchemaFieldStatus.DISCONNECTED)
-        .map(f => f.name);
+      // Disconnected fields aren't in the underlying table/view, so selecting them fails the query.
+      const schemaColumns = schema.fields.filter(isConnected).map(f => f.name);
       if (schemaColumns.length === 0) {
         this.logger.warn(
           `Skipping sample fetch for data mart ${request.dataMartId}: no connected schema fields`

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-headers-generator.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-headers-generator.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataMartSchemaFieldStatus } from '../../enums/data-mart-schema-field-status.enum';
+import { isConnected } from '../../data-mart-schema.utils';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { ReportHeadersGenerator } from '../../interfaces/report-headers-generator.interface';
 import { DataMartSchema } from '../../data-mart-schema.type';
@@ -41,7 +41,7 @@ export class BigQueryReportHeadersGenerator implements ReportHeadersGenerator {
     const fieldHeaders: ReportDataHeader[] = [];
     const fullPath = parentPath ? `${parentPath}.${field.name}` : field.name;
 
-    if (field.status === DataMartSchemaFieldStatus.DISCONNECTED) {
+    if (!isConnected(field)) {
       return fieldHeaders;
     }
 

--- a/apps/backend/src/data-marts/data-storage-types/data-mart-schema.utils.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-mart-schema.utils.spec.ts
@@ -1,0 +1,22 @@
+import { isConnected } from './data-mart-schema.utils';
+import { DataMartSchemaFieldStatus } from './enums/data-mart-schema-field-status.enum';
+import type { DataMartSchemaField } from './data-mart-schema.type';
+
+describe('isConnected', () => {
+  const field = (status: DataMartSchemaFieldStatus): DataMartSchemaField =>
+    ({ name: 'f', type: 'STRING', status }) as unknown as DataMartSchemaField;
+
+  it('treats CONNECTED as present in the source', () => {
+    expect(isConnected(field(DataMartSchemaFieldStatus.CONNECTED))).toBe(true);
+  });
+
+  it('treats CONNECTED_WITH_DEFINITION_MISMATCH as present in the source', () => {
+    expect(isConnected(field(DataMartSchemaFieldStatus.CONNECTED_WITH_DEFINITION_MISMATCH))).toBe(
+      true
+    );
+  });
+
+  it('treats DISCONNECTED as gone from the source', () => {
+    expect(isConnected(field(DataMartSchemaFieldStatus.DISCONNECTED))).toBe(false);
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/data-mart-schema.utils.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-mart-schema.utils.ts
@@ -7,6 +7,16 @@ import { Injectable } from '@nestjs/common';
 import { DataStoragePublicCredentialsFactory } from './factories/data-storage-public-credentials.factory';
 import { DataStorageCredentialsPublic } from '../dto/presentation/data-storage-response-api.dto';
 
+/**
+ * A field is "connected" when it still exists in the data source — i.e. its status is not
+ * DISCONNECTED (CONNECTED and CONNECTED_WITH_DEFINITION_MISMATCH both mean the column is
+ * present). Keeping this in one place means a future status that also signals "gone from
+ * the source" only needs handling here.
+ */
+export function isConnected(field: DataMartSchemaField): boolean {
+  return field.status !== DataMartSchemaFieldStatus.DISCONNECTED;
+}
+
 // A hidden-for-reporting or DISCONNECTED node prunes its whole subtree; container
 // nodes count as referenceable paths alongside their nested `a.b` leaves.
 export function collectSchemaFieldPaths(
@@ -23,7 +33,7 @@ export function collectSchemaFieldPathTypes(
   const result: { name: string; type: string }[] = [];
   for (const field of fields) {
     if (field.isHiddenForReporting) continue;
-    if (field.status === DataMartSchemaFieldStatus.DISCONNECTED) continue;
+    if (!isConnected(field)) continue;
     const fullName = prefix ? `${prefix}.${field.name}` : field.name;
     result.push({ name: fullName, type: String(field.type) });
     if ('fields' in field && field.fields?.length) {

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/flat-report-headers-generator.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/flat-report-headers-generator.ts
@@ -1,5 +1,5 @@
 import { DataMartSchema } from '../data-mart-schema.type';
-import { DataMartSchemaFieldStatus } from '../enums/data-mart-schema-field-status.enum';
+import { isConnected } from '../data-mart-schema.utils';
 import { DataStorageType } from '../enums/data-storage-type.enum';
 import { ReportDataHeader } from '../../dto/domain/report-data-header.dto';
 import { ReportHeadersGenerator } from './report-headers-generator.interface';
@@ -20,10 +20,7 @@ export abstract class FlatReportHeadersGenerator implements ReportHeadersGenerat
     }
 
     return dataMartSchema.fields
-      .filter(
-        field =>
-          field.status !== DataMartSchemaFieldStatus.DISCONNECTED && !field.isHiddenForReporting
-      )
+      .filter(field => isConnected(field) && !field.isHiddenForReporting)
       .map(field => new ReportDataHeader(field.name, field.alias, field.description, field.type));
   }
 }


### PR DESCRIPTION
## What changed

AI Helper alias/description generation (`POST /api/data-marts/:id/ai-helper/triggers/:triggerId`) failed when a data mart's **Output Schema** contained a field with status **Disconnected** ("Field is not connected to the data source").

`GenerateDataMartMetadataOrchestratorService` built the 30-row sample query from **every** schema field:

```ts
const schemaColumns = schema.fields.map(f => f.name);
```

A `DISCONNECTED` field exists in the saved schema but not in the underlying table/view, so the storage rejected the whole query. On BigQuery:

```
Unrecognized name: impressions at [1:41]
SELECT `campaign`, `country`, `clicks`, `impressions` FROM `...view...` LIMIT 30
```

This PR filters disconnected fields out of the sample query, and skips the sample fetch entirely when no connected fields remain (which would otherwise emit an empty `SELECT ... FROM`):

```ts
const schemaColumns = schema.fields
  .filter(f => f.status !== DataMartSchemaFieldStatus.DISCONNECTED)
  .map(f => f.name);
```

## Why

The `DISCONNECTED` status exists to mark schema fields no longer present in the data source. The sample query is the one place that selects raw columns from the live view, so it must respect that status — every other schema consumer already excludes disconnected fields (e.g. `collectSchemaFieldPaths`, the report header generators).

`isHiddenForReporting` fields are **intentionally kept**: they are real source columns, and the user may still want the AI to generate an alias/description for them. Unlike the report header/SQL generators, this path is not producing report output, so it does not filter them.

## Testing

- New `generate-data-mart-metadata.orchestrator.service.spec.ts` — 4 cases: disconnected fields excluded, `CONNECTED_WITH_DEFINITION_MISMATCH` kept, hidden-for-reporting kept, and the all-disconnected skip path (no sample fetch; agent receives `sampleColumns: null`).
- `jest src/data-marts/ai-insights/generate-data-mart-metadata.orchestrator.service.spec.ts`: **4 passed**.
- `eslint` + `prettier` clean (also enforced by the pre-commit lint-staged hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
