### PR TITLE
fix(storage): surface expired Google OAuth as a reconnect prompt

### DIFF
--- a/.changeset/storage-oauth-reconnect-prompt.md
+++ b/.changeset/storage-oauth-reconnect-prompt.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Clearer reconnect prompt when Google Storage access expires
+
+Previously, when a storage's Google authorization expired, connector runs would start and then fail with a confusing authentication error, and other actions showed raw "Failed to refresh OAuth tokens" text. Now expired authorization is detected before a run starts and surfaced as a clear "Reconnect Storage" prompt, and the storage health indicator updates automatically when access is lost. This helps users quickly understand they need to reconnect the storage instead of troubleshooting opaque failures.

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-access.validator.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-access.validator.spec.ts
@@ -1,0 +1,97 @@
+import { BigQueryAccessValidator } from './bigquery-access.validator';
+import { BigQueryApiAdapter } from '../adapters/bigquery-api.adapter';
+import { BIGQUERY_OAUTH_TYPE } from '../schemas/bigquery-credentials.schema';
+import {
+  ValidationResultCode,
+  type ValidationResult,
+} from '../../interfaces/data-storage-access-validator.interface';
+import type { DataStorageConfig } from '../../data-storage-config.type';
+import type { DataStorageCredentials } from '../../data-storage-credentials.type';
+
+jest.mock('../adapters/bigquery-api.adapter');
+
+const MockedAdapter = BigQueryApiAdapter as jest.MockedClass<typeof BigQueryApiAdapter>;
+
+describe('BigQueryAccessValidator (OAuth)', () => {
+  const validator = new BigQueryAccessValidator();
+  const config = { projectId: 'test-project' } as unknown as DataStorageConfig;
+  const oauthCredentials = {
+    type: BIGQUERY_OAUTH_TYPE,
+    oauth2Client: {},
+  } as unknown as DataStorageCredentials;
+
+  const mockCheckAccess = (impl: () => Promise<void>) => {
+    MockedAdapter.mockImplementation(
+      () => ({ checkAccess: impl }) as unknown as BigQueryApiAdapter
+    );
+  };
+
+  const validate = (): Promise<ValidationResult> => validator.validate(config, oauthCredentials);
+
+  beforeEach(() => {
+    MockedAdapter.mockReset();
+  });
+
+  it('returns valid when access check succeeds', async () => {
+    mockCheckAccess(() => Promise.resolve());
+
+    const result = await validate();
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('flags reauth on a structured HTTP 401 from the BigQuery API', async () => {
+    mockCheckAccess(() => Promise.reject(Object.assign(new Error('Unauthorized'), { code: 401 })));
+
+    const result = await validate();
+
+    expect(result.valid).toBe(false);
+    expect(result.code).toBe(ValidationResultCode.OAUTH_REAUTH_REQUIRED);
+  });
+
+  it('flags reauth when an invalid access token is rejected (message fallback)', async () => {
+    mockCheckAccess(() =>
+      Promise.reject(new Error('Request had invalid authentication credentials. Expected OAuth 2'))
+    );
+
+    const result = await validate();
+
+    expect(result.valid).toBe(false);
+    expect(result.code).toBe(ValidationResultCode.OAUTH_REAUTH_REQUIRED);
+  });
+
+  it('flags reauth when an on-demand refresh fails with invalid_grant in the message', async () => {
+    mockCheckAccess(() =>
+      Promise.reject(new Error('invalid_grant: Token has been expired or revoked.'))
+    );
+
+    const result = await validate();
+
+    expect(result.valid).toBe(false);
+    expect(result.code).toBe(ValidationResultCode.OAUTH_REAUTH_REQUIRED);
+  });
+
+  it('flags reauth when invalid_grant surfaces in a structured Google error body', async () => {
+    mockCheckAccess(() =>
+      Promise.reject(
+        Object.assign(new Error('Refresh failed'), {
+          response: { data: { error: 'invalid_grant', error_description: 'Token revoked' } },
+        })
+      )
+    );
+
+    const result = await validate();
+
+    expect(result.valid).toBe(false);
+    expect(result.code).toBe(ValidationResultCode.OAUTH_REAUTH_REQUIRED);
+  });
+
+  it('does not flag reauth for an unrelated failure', async () => {
+    mockCheckAccess(() => Promise.reject(new Error('Dataset not found')));
+
+    const result = await validate();
+
+    expect(result.valid).toBe(false);
+    expect(result.code).toBeUndefined();
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-access.validator.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-access.validator.ts
@@ -14,6 +14,18 @@ import { DataStorageConfig } from '../../data-storage-config.type';
 import { DataStorageCredentials } from '../../data-storage-credentials.type';
 import { BigQueryApiAdapter } from '../adapters/bigquery-api.adapter';
 
+const GOOGLE_OAUTH_REAUTH_MESSAGE =
+  'Google authorization could not be refreshed. Reconnect this Storage to restore access.';
+
+function isInvalidGoogleAuthError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return (
+    message.includes('Request had invalid authentication credentials') ||
+    message.includes('Expected OAuth 2 access token')
+  );
+}
+
 @Injectable()
 export class BigQueryAccessValidator implements DataStorageAccessValidator {
   readonly logger = new Logger(BigQueryAccessValidator.name);
@@ -41,6 +53,10 @@ export class BigQueryAccessValidator implements DataStorageAccessValidator {
         return new ValidationResult(true);
       } catch (error) {
         this.logger.warn('OAuth access validation failed', error);
+        if (isInvalidGoogleAuthError(error)) {
+          return ValidationResult.oauthReauthRequired(GOOGLE_OAUTH_REAUTH_MESSAGE);
+        }
+
         const errorMessage = error instanceof Error ? error.message : String(error);
         return new ValidationResult(false, errorMessage);
       }

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-access.validator.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-access.validator.ts
@@ -17,10 +17,34 @@ import { BigQueryApiAdapter } from '../adapters/bigquery-api.adapter';
 const GOOGLE_OAUTH_REAUTH_MESSAGE =
   'Google authorization could not be refreshed. Reconnect this Storage to restore access.';
 
+interface GoogleAuthErrorBody {
+  code?: number;
+  response?: {
+    status?: number;
+    data?: {
+      error?: unknown;
+      error_description?: unknown;
+    };
+  };
+}
+
 function isInvalidGoogleAuthError(error: unknown): boolean {
+  const body = error as GoogleAuthErrorBody | null;
+  const httpStatus = body?.code ?? body?.response?.status;
+  const data = body?.response?.data;
+  const googleError = data?.error;
+  const googleErrorDescription = data?.error_description;
   const message = error instanceof Error ? error.message : String(error);
 
   return (
+    // Structured: HTTP 401 from the BigQuery API (invalid or revoked access token)
+    httpStatus === 401 ||
+    // Structured: OAuth token endpoint signals a revoked/expired refresh token
+    googleError === 'invalid_grant' ||
+    (typeof googleErrorDescription === 'string' &&
+      googleErrorDescription.includes('invalid_grant')) ||
+    // Fallback: message-based detection for clients that surface the error differently
+    message.includes('invalid_grant') ||
     message.includes('Request had invalid authentication credentials') ||
     message.includes('Expected OAuth 2 access token')
   );

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-access-validator.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-access-validator.interface.ts
@@ -5,6 +5,7 @@ import { DataStorageCredentials } from '../data-storage-credentials.type';
 
 export enum ValidationResultCode {
   UNCONFIGURED = 'UNCONFIGURED',
+  OAUTH_REAUTH_REQUIRED = 'OAUTH_REAUTH_REQUIRED',
 }
 
 export interface DataStorageAccessValidator extends TypedComponent<DataStorageType> {
@@ -32,5 +33,14 @@ export class ValidationResult {
 
   static unconfigured(errorMessage: string): ValidationResult {
     return new ValidationResult(false, errorMessage, undefined, ValidationResultCode.UNCONFIGURED);
+  }
+
+  static oauthReauthRequired(errorMessage: string): ValidationResult {
+    return new ValidationResult(
+      false,
+      errorMessage,
+      undefined,
+      ValidationResultCode.OAUTH_REAUTH_REQUIRED
+    );
   }
 }

--- a/apps/backend/src/data-marts/dto/presentation/data-storage-access-validation-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-storage-access-validation-response-api.dto.ts
@@ -9,7 +9,7 @@ export class DataStorageAccessValidationResponseApiDto {
 
   @ApiProperty({
     required: false,
-    enum: ['UNCONFIGURED'],
+    enum: ['UNCONFIGURED', 'OAUTH_REAUTH_REQUIRED'],
     description: 'Machine-readable validation result code',
   })
   code?: string;

--- a/apps/backend/src/data-marts/dto/presentation/schema-actualize-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/schema-actualize-response-api.dto.ts
@@ -12,4 +12,10 @@ export class SchemaActualizeResponseApiDto {
     required: false,
   })
   error?: string;
+
+  @ApiProperty({
+    description: 'Machine-readable error code if failed',
+    required: false,
+  })
+  code?: string;
 }

--- a/apps/backend/src/data-marts/exceptions/google-oauth.exceptions.ts
+++ b/apps/backend/src/data-marts/exceptions/google-oauth.exceptions.ts
@@ -71,7 +71,7 @@ export class TokenExchangeFailedException extends GoogleOAuthException {
 
 export class TokenRefreshFailedException extends GoogleOAuthException {
   constructor(
-    message: string = 'Google access is no longer active. Reconnect this Google account to restore access.',
+    message: string = 'Google access could not be refreshed. Please try again later.',
     details?: unknown
   ) {
     super(message, 'TOKEN_REFRESH_FAILED', HttpStatus.INTERNAL_SERVER_ERROR, details);
@@ -92,12 +92,13 @@ export class CredentialsNotFoundException extends GoogleOAuthException {
 }
 
 export class CredentialsExpiredException extends GoogleOAuthException {
-  constructor(entityId: string, entityType: 'storage' | 'destination') {
+  constructor(entityId: string, entityType: 'storage' | 'destination', details?: unknown) {
+    const resourceLabel = entityType === 'storage' ? 'Storage' : 'Destination';
     super(
-      `OAuth credentials expired for ${entityType} ID: ${entityId}. Please re-authorize.`,
+      `Google authorization could not be refreshed. Reconnect this ${resourceLabel} to restore access.`,
       'CREDENTIALS_EXPIRED',
-      HttpStatus.UNAUTHORIZED,
-      { entityId, entityType }
+      HttpStatus.BAD_REQUEST,
+      details ? { entityId, entityType, details } : { entityId, entityType }
     );
     this.name = 'CredentialsExpiredException';
   }

--- a/apps/backend/src/data-marts/exceptions/google-oauth.exceptions.ts
+++ b/apps/backend/src/data-marts/exceptions/google-oauth.exceptions.ts
@@ -70,7 +70,10 @@ export class TokenExchangeFailedException extends GoogleOAuthException {
 }
 
 export class TokenRefreshFailedException extends GoogleOAuthException {
-  constructor(message: string = 'Failed to refresh OAuth tokens', details?: unknown) {
+  constructor(
+    message: string = 'Google access is no longer active. Reconnect this Google account to restore access.',
+    details?: unknown
+  ) {
     super(message, 'TOKEN_REFRESH_FAILED', HttpStatus.INTERNAL_SERVER_ERROR, details);
     this.name = 'TokenRefreshFailedException';
   }

--- a/apps/backend/src/data-marts/exceptions/google-oauth.exceptions.ts
+++ b/apps/backend/src/data-marts/exceptions/google-oauth.exceptions.ts
@@ -97,7 +97,7 @@ export class CredentialsExpiredException extends GoogleOAuthException {
     super(
       `Google authorization could not be refreshed. Reconnect this ${resourceLabel} to restore access.`,
       'CREDENTIALS_EXPIRED',
-      HttpStatus.BAD_REQUEST,
+      HttpStatus.UNAUTHORIZED,
       details ? { entityId, entityType, details } : { entityId, entityType }
     );
     this.name = 'CredentialsExpiredException';

--- a/apps/backend/src/data-marts/services/google-oauth/google-oauth-flow.service.ts
+++ b/apps/backend/src/data-marts/services/google-oauth/google-oauth-flow.service.ts
@@ -301,7 +301,11 @@ export class GoogleOAuthFlowService {
       this.logger.log(`Refreshed OAuth tokens for ${type} credential ${credentialId}`);
     } catch (error) {
       this.logger.error(`Failed to refresh tokens for ${type} credential ${credentialId}`, error);
-      throw new TokenRefreshFailedException('Failed to refresh OAuth tokens', error);
+      const resourceLabel = type === 'storage' ? 'Storage' : 'Destination';
+      throw new TokenRefreshFailedException(
+        `Google access is no longer active. Reconnect this ${resourceLabel} to restore access.`,
+        error
+      );
     }
   }
 

--- a/apps/backend/src/data-marts/services/google-oauth/google-oauth-flow.service.ts
+++ b/apps/backend/src/data-marts/services/google-oauth/google-oauth-flow.service.ts
@@ -320,10 +320,17 @@ export class GoogleOAuthFlowService {
       throw new TokenRefreshFailedException(undefined, error);
     }
 
+    if (!newTokens.access_token) {
+      this.logger.error(
+        `Refresh response missing access_token for ${type} credential ${credentialId}`
+      );
+      throw new TokenRefreshFailedException();
+    }
+
     const currentTokens = credential.credentials as GoogleOAuthTokens;
     const updatedTokens: GoogleOAuthTokens = {
       ...currentTokens,
-      access_token: newTokens.access_token!,
+      access_token: newTokens.access_token,
       expiry_date: newTokens.expiry_date ?? undefined,
     };
 

--- a/apps/backend/src/data-marts/services/google-oauth/google-oauth-flow.service.ts
+++ b/apps/backend/src/data-marts/services/google-oauth/google-oauth-flow.service.ts
@@ -39,6 +39,29 @@ export interface GoogleOAuthTokens {
   expiry_date?: number;
 }
 
+interface GoogleTokenRefreshError {
+  message?: unknown;
+  response?: {
+    data?: {
+      error?: unknown;
+      error_description?: unknown;
+    };
+  };
+}
+
+function isInvalidRefreshTokenError(error: unknown): boolean {
+  const tokenError = error as GoogleTokenRefreshError;
+  const googleError = tokenError.response?.data?.error;
+  const googleErrorDescription = tokenError.response?.data?.error_description;
+
+  return (
+    googleError === 'invalid_grant' ||
+    (typeof googleErrorDescription === 'string' &&
+      googleErrorDescription.includes('invalid_grant')) ||
+    (error instanceof Error && error.message.includes('invalid_grant'))
+  );
+}
+
 export interface GoogleAuthorizationUrlResult {
   authorizationUrl: string;
   state: string;
@@ -264,46 +287,61 @@ export class GoogleOAuthFlowService {
       throw new CredentialsExpiredException(credentialId, type);
     }
 
+    // Use the type-specific client_id/secret so tokens can be refreshed correctly
+    const clientId =
+      type === 'storage'
+        ? this.googleOAuthConfigService.getStorageClientId()
+        : this.googleOAuthConfigService.getDestinationClientId();
+    const clientSecret =
+      type === 'storage'
+        ? this.googleOAuthConfigService.getStorageClientSecret()
+        : this.googleOAuthConfigService.getDestinationClientSecret();
+
+    // Create a per-call transient client to avoid mutating shared singleton state
+    // across concurrent refresh calls, which would cause credential cross-contamination.
+    const refreshClient = new OAuth2Client(
+      clientId,
+      clientSecret,
+      this.googleOAuthConfigService.getRedirectUri()
+    );
+    refreshClient.setCredentials({ refresh_token: refreshToken });
+
+    let newTokens: { access_token?: string | null; expiry_date?: number | null };
     try {
-      // Use the type-specific client_id/secret so tokens can be refreshed correctly
-      const clientId =
-        type === 'storage'
-          ? this.googleOAuthConfigService.getStorageClientId()
-          : this.googleOAuthConfigService.getDestinationClientId();
-      const clientSecret =
-        type === 'storage'
-          ? this.googleOAuthConfigService.getStorageClientSecret()
-          : this.googleOAuthConfigService.getDestinationClientSecret();
+      const tokenResponse = await refreshClient.refreshAccessToken();
+      newTokens = tokenResponse.credentials;
+    } catch (error) {
+      if (isInvalidRefreshTokenError(error)) {
+        this.logger.warn(`Refresh token is no longer valid for ${type} credential ${credentialId}`);
+        throw new CredentialsExpiredException(credentialId, type);
+      }
 
-      // Create a per-call transient client to avoid mutating shared singleton state
-      // across concurrent refresh calls, which would cause credential cross-contamination.
-      const refreshClient = new OAuth2Client(
-        clientId,
-        clientSecret,
-        this.googleOAuthConfigService.getRedirectUri()
-      );
-      refreshClient.setCredentials({ refresh_token: refreshToken });
-      const { credentials: newTokens } = await refreshClient.refreshAccessToken();
+      this.logger.error(`Failed to refresh tokens for ${type} credential ${credentialId}`, error);
+      throw new TokenRefreshFailedException(undefined, error);
+    }
 
-      const currentTokens = credential.credentials as GoogleOAuthTokens;
-      const updatedTokens: GoogleOAuthTokens = {
-        ...currentTokens,
-        access_token: newTokens.access_token!,
-        expiry_date: newTokens.expiry_date ?? undefined,
-      };
+    const currentTokens = credential.credentials as GoogleOAuthTokens;
+    const updatedTokens: GoogleOAuthTokens = {
+      ...currentTokens,
+      access_token: newTokens.access_token!,
+      expiry_date: newTokens.expiry_date ?? undefined,
+    };
 
-      const service =
-        type === 'storage'
-          ? this.dataStorageCredentialService
-          : this.dataDestinationCredentialService;
+    const service =
+      type === 'storage'
+        ? this.dataStorageCredentialService
+        : this.dataDestinationCredentialService;
 
+    try {
       await service.update(credential.id, { credentials: updatedTokens });
       this.logger.log(`Refreshed OAuth tokens for ${type} credential ${credentialId}`);
     } catch (error) {
-      this.logger.error(`Failed to refresh tokens for ${type} credential ${credentialId}`, error);
-      const resourceLabel = type === 'storage' ? 'Storage' : 'Destination';
+      this.logger.error(
+        `Failed to save refreshed tokens for ${type} credential ${credentialId}`,
+        error
+      );
       throw new TokenRefreshFailedException(
-        `Google access is no longer active. Reconnect this ${resourceLabel} to restore access.`,
+        'Google access was refreshed, but the updated tokens could not be saved. Please try again later.',
         error
       );
     }

--- a/apps/backend/src/data-marts/services/schema-actualize-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/schema-actualize-trigger-handler.service.ts
@@ -6,6 +6,11 @@ import { TriggerHandler } from '../../common/scheduler/shared/trigger-handler.in
 import { SchemaActualizeTrigger } from '../entities/schema-actualize-trigger.entity';
 import { ActualizeDataMartSchemaService } from '../use-cases/actualize-data-mart-schema.service';
 
+function getErrorCode(error: unknown): string | undefined {
+  const code = (error as { code?: unknown })?.code;
+  return typeof code === 'string' ? code : undefined;
+}
+
 @Injectable()
 export class SchemaActualizeTriggerHandlerService
   implements TriggerHandler<SchemaActualizeTrigger>, OnModuleInit
@@ -41,6 +46,7 @@ export class SchemaActualizeTriggerHandlerService
       trigger.uiResponse = {
         success: false,
         error: e instanceof Error ? e.message : 'Unknown error',
+        code: getErrorCode(e),
       };
       trigger.onError();
       await this.repository.save(trigger);

--- a/apps/backend/src/data-marts/use-cases/run-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-data-mart.service.spec.ts
@@ -29,7 +29,7 @@ describe('RunDataMartService', () => {
       canAccess: jest.fn().mockResolvedValue(true),
     };
     const credentialsResolver = {
-      resolve: jest.fn().mockResolvedValue({ type: 'oauth' }),
+      resolve: jest.fn().mockResolvedValue({ type: 'bigquery_oauth' }),
     };
     const validationFacade = {
       validateAccess: jest.fn().mockResolvedValue({ valid: true }),
@@ -126,7 +126,7 @@ describe('RunDataMartService', () => {
   });
 
   describe('pre-run storage access check', () => {
-    const command = () => new RunDataMartCommand('dm-1', 'proj-1', '', 'scheduled' as never);
+    const command = () => new RunDataMartCommand('dm-1', 'proj-1', '', 'manual' as never);
 
     it('blocks the run when validation requires re-authorization', async () => {
       const { service, validationFacade, connectorExecutionService } = createService();
@@ -172,7 +172,7 @@ describe('RunDataMartService', () => {
       expect(connectorExecutionService.run).toHaveBeenCalled();
     });
 
-    it('skips the check for storage without OAuth credentials', async () => {
+    it('skips the check for storage without a credentialId', async () => {
       const { service, dataMartService, credentialsResolver, connectorExecutionService } =
         createService();
       dataMartService.getByIdAndProjectId.mockResolvedValue({
@@ -184,6 +184,37 @@ describe('RunDataMartService', () => {
 
       expect(result).toBe('run-id-1');
       expect(credentialsResolver.resolve).not.toHaveBeenCalled();
+      expect(connectorExecutionService.run).toHaveBeenCalled();
+    });
+
+    it('skips validateAccess for non-OAuth credentials (e.g. service account)', async () => {
+      const { service, credentialsResolver, validationFacade, connectorExecutionService } =
+        createService();
+      credentialsResolver.resolve.mockResolvedValue({ type: 'service_account' });
+
+      const result = await service.run(command());
+
+      expect(result).toBe('run-id-1');
+      expect(validationFacade.validateAccess).not.toHaveBeenCalled();
+      expect(connectorExecutionService.run).toHaveBeenCalled();
+    });
+
+    it('skips the check for scheduled runs so they still produce a failed-run record', async () => {
+      const { service, validationFacade, credentialsResolver, connectorExecutionService } =
+        createService();
+      // Even when the storage would require re-authorization, a scheduled run must proceed
+      // (and fail during execution) rather than being silently dropped before any record exists.
+      validationFacade.validateAccess.mockResolvedValue({
+        valid: false,
+        code: ValidationResultCode.OAUTH_REAUTH_REQUIRED,
+      });
+
+      const scheduledCommand = new RunDataMartCommand('dm-1', 'proj-1', '', 'scheduled' as never);
+      const result = await service.run(scheduledCommand);
+
+      expect(result).toBe('run-id-1');
+      expect(credentialsResolver.resolve).not.toHaveBeenCalled();
+      expect(validationFacade.validateAccess).not.toHaveBeenCalled();
       expect(connectorExecutionService.run).toHaveBeenCalled();
     });
   });

--- a/apps/backend/src/data-marts/use-cases/run-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-data-mart.service.spec.ts
@@ -2,12 +2,20 @@ import { ForbiddenException } from '@nestjs/common';
 import { RunDataMartService } from './run-data-mart.service';
 import { RunDataMartCommand } from '../dto/domain/run-data-mart.command';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
+import { ValidationResultCode } from '../data-storage-types/interfaces/data-storage-access-validator.interface';
+import { CredentialsExpiredException } from '../exceptions/google-oauth.exceptions';
 
 describe('RunDataMartService', () => {
   const mockDataMart = {
     id: 'dm-1',
     projectId: 'proj-1',
     definitionType: DataMartDefinitionType.CONNECTOR,
+    storage: {
+      id: 'storage-1',
+      type: 'GOOGLE_BIGQUERY',
+      config: { projectId: 'p' },
+      credentialId: 'cred-1',
+    },
   };
 
   const createService = () => {
@@ -20,14 +28,29 @@ describe('RunDataMartService', () => {
     const accessDecisionService = {
       canAccess: jest.fn().mockResolvedValue(true),
     };
+    const credentialsResolver = {
+      resolve: jest.fn().mockResolvedValue({ type: 'oauth' }),
+    };
+    const validationFacade = {
+      validateAccess: jest.fn().mockResolvedValue({ valid: true }),
+    };
 
     const service = new RunDataMartService(
       dataMartService as never,
       connectorExecutionService as never,
-      accessDecisionService as never
+      accessDecisionService as never,
+      validationFacade as never,
+      credentialsResolver as never
     );
 
-    return { service, dataMartService, connectorExecutionService, accessDecisionService };
+    return {
+      service,
+      dataMartService,
+      connectorExecutionService,
+      accessDecisionService,
+      credentialsResolver,
+      validationFacade,
+    };
   };
 
   it('should allow manual run when user has EDIT access', async () => {
@@ -100,5 +123,68 @@ describe('RunDataMartService', () => {
     expect(result).toBe('run-id-1');
     expect(accessDecisionService.canAccess).not.toHaveBeenCalled();
     expect(connectorExecutionService.run).toHaveBeenCalled();
+  });
+
+  describe('pre-run storage access check', () => {
+    const command = () => new RunDataMartCommand('dm-1', 'proj-1', '', 'scheduled' as never);
+
+    it('blocks the run when validation requires re-authorization', async () => {
+      const { service, validationFacade, connectorExecutionService } = createService();
+      validationFacade.validateAccess.mockResolvedValue({
+        valid: false,
+        code: ValidationResultCode.OAUTH_REAUTH_REQUIRED,
+      });
+
+      await expect(service.run(command())).rejects.toBeInstanceOf(CredentialsExpiredException);
+      expect(connectorExecutionService.run).not.toHaveBeenCalled();
+    });
+
+    it('blocks the run when credential resolution reports expired authorization', async () => {
+      const { service, credentialsResolver, connectorExecutionService } = createService();
+      credentialsResolver.resolve.mockRejectedValue(
+        new CredentialsExpiredException('storage-1', 'storage')
+      );
+
+      await expect(service.run(command())).rejects.toBeInstanceOf(CredentialsExpiredException);
+      expect(connectorExecutionService.run).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when validation fails with a transient/non-reauth error', async () => {
+      const { service, validationFacade, connectorExecutionService } = createService();
+      validationFacade.validateAccess.mockResolvedValue({
+        valid: false,
+        errorMessage: 'Temporary API error',
+      });
+
+      const result = await service.run(command());
+
+      expect(result).toBe('run-id-1');
+      expect(connectorExecutionService.run).toHaveBeenCalled();
+    });
+
+    it('proceeds when credential resolution throws a transient error', async () => {
+      const { service, credentialsResolver, connectorExecutionService } = createService();
+      credentialsResolver.resolve.mockRejectedValue(new Error('network timeout'));
+
+      const result = await service.run(command());
+
+      expect(result).toBe('run-id-1');
+      expect(connectorExecutionService.run).toHaveBeenCalled();
+    });
+
+    it('skips the check for storage without OAuth credentials', async () => {
+      const { service, dataMartService, credentialsResolver, connectorExecutionService } =
+        createService();
+      dataMartService.getByIdAndProjectId.mockResolvedValue({
+        ...mockDataMart,
+        storage: { id: 'storage-2', type: 'AWS_ATHENA', config: { region: 'us' } },
+      });
+
+      const result = await service.run(command());
+
+      expect(result).toBe('run-id-1');
+      expect(credentialsResolver.resolve).not.toHaveBeenCalled();
+      expect(connectorExecutionService.run).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/backend/src/data-marts/use-cases/run-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-data-mart.service.ts
@@ -1,16 +1,25 @@
-import { Injectable, ForbiddenException } from '@nestjs/common';
+import { Injectable, ForbiddenException, Logger } from '@nestjs/common';
 import { DataMartService } from '../services/data-mart.service';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { ConnectorExecutionService } from '../services/connector/connector-execution.service';
 import { RunDataMartCommand } from '../dto/domain/run-data-mart.command';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import { DataMart } from '../entities/data-mart.entity';
+import { DataStorageAccessValidatorFacade } from '../data-storage-types/facades/data-storage-access-validator-facade.service';
+import { DataStorageCredentialsResolver } from '../data-storage-types/data-storage-credentials-resolver.service';
+import { ValidationResultCode } from '../data-storage-types/interfaces/data-storage-access-validator.interface';
+import { CredentialsExpiredException } from '../exceptions/google-oauth.exceptions';
 
 @Injectable()
 export class RunDataMartService {
+  private readonly logger = new Logger(RunDataMartService.name);
+
   constructor(
     private readonly dataMartService: DataMartService,
     private readonly connectorExecutionService: ConnectorExecutionService,
-    private readonly accessDecisionService: AccessDecisionService
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly validationFacade: DataStorageAccessValidatorFacade,
+    private readonly credentialsResolver: DataStorageCredentialsResolver
   ) {}
 
   async run(command: RunDataMartCommand): Promise<string> {
@@ -36,11 +45,52 @@ export class RunDataMartService {
       throw new Error('Only data marts with connector definition type can be run manually');
     }
 
+    await this.checkStorageAccess(dataMart);
+
     return await this.connectorExecutionService.run(
       dataMart,
       command.createdById,
       command.runType,
       command.payload
     );
+  }
+
+  /**
+   * Pre-run guard that surfaces an expired Google OAuth authorization before a run is
+   * created, so the user gets a clear "Reconnect Storage" error instead of a run that
+   * fails mid-execution with an opaque 401.
+   *
+   * Runs outside any DB transaction (resolving credentials may refresh and persist tokens).
+   * Only a definitive re-authorization condition blocks the run — transient problems
+   * (network blips, rate limits, temporary API/token-endpoint failures) must not prevent a
+   * run from starting, since those are surfaced during execution as they were before.
+   */
+  private async checkStorageAccess(dataMart: DataMart): Promise<void> {
+    const { storage } = dataMart;
+
+    if (!storage.config || !storage.credentialId) {
+      return;
+    }
+
+    try {
+      const credentials = await this.credentialsResolver.resolve(storage);
+      const result = await this.validationFacade.validateAccess(
+        storage.type,
+        storage.config,
+        credentials
+      );
+
+      if (!result.valid && result.code === ValidationResultCode.OAUTH_REAUTH_REQUIRED) {
+        throw new CredentialsExpiredException(storage.id, 'storage');
+      }
+    } catch (error) {
+      if (error instanceof CredentialsExpiredException) {
+        throw error;
+      }
+      this.logger.warn(
+        `Pre-run storage access check did not complete for storage ${storage.id}; proceeding with run`,
+        error
+      );
+    }
   }
 }

--- a/apps/backend/src/data-marts/use-cases/run-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-data-mart.service.ts
@@ -4,11 +4,13 @@ import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum'
 import { ConnectorExecutionService } from '../services/connector/connector-execution.service';
 import { RunDataMartCommand } from '../dto/domain/run-data-mart.command';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import { RunType } from '../../common/scheduler/shared/types';
 import { DataMart } from '../entities/data-mart.entity';
 import { DataStorageAccessValidatorFacade } from '../data-storage-types/facades/data-storage-access-validator-facade.service';
 import { DataStorageCredentialsResolver } from '../data-storage-types/data-storage-credentials-resolver.service';
 import { ValidationResultCode } from '../data-storage-types/interfaces/data-storage-access-validator.interface';
 import { CredentialsExpiredException } from '../exceptions/google-oauth.exceptions';
+import { isBigQueryOAuthCredentials } from '../data-storage-types/data-storage-credentials.guards';
 
 @Injectable()
 export class RunDataMartService {
@@ -45,7 +47,12 @@ export class RunDataMartService {
       throw new Error('Only data marts with connector definition type can be run manually');
     }
 
-    await this.checkStorageAccess(dataMart);
+    // Pre-check is for user-initiated runs only, where it surfaces an immediate, clear error.
+    // Scheduled runs deliberately skip it so they still create a run record and fail during
+    // execution — preserving the visible failed-run history and notifications operators rely on.
+    if (command.runType === RunType.manual) {
+      await this.checkStorageAccess(dataMart);
+    }
 
     return await this.connectorExecutionService.run(
       dataMart,
@@ -74,6 +81,7 @@ export class RunDataMartService {
 
     try {
       const credentials = await this.credentialsResolver.resolve(storage);
+      if (!isBigQueryOAuthCredentials(credentials)) return;
       const result = await this.validationFacade.validateAccess(
         storage.type,
         storage.config,

--- a/apps/backend/src/data-marts/use-cases/validate-data-storage-access.service.ts
+++ b/apps/backend/src/data-marts/use-cases/validate-data-storage-access.service.ts
@@ -5,6 +5,13 @@ import { ValidationResult } from '../data-storage-types/interfaces/data-storage-
 import { ValidateDataStorageAccessCommand } from '../dto/domain/validate-data-storage-access.command';
 import { DataStorageService } from '../services/data-storage.service';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
+import {
+  CredentialsExpiredException,
+  TokenRefreshFailedException,
+} from '../exceptions/google-oauth.exceptions';
+
+const GOOGLE_OAUTH_REAUTH_MESSAGE =
+  'Google access is no longer active. Reconnect this Storage to restore access.';
 
 @Injectable()
 export class ValidateDataStorageAccessService {
@@ -51,6 +58,12 @@ export class ValidateDataStorageAccessService {
         );
       } catch (error) {
         this.logger.warn(`Failed to resolve credentials for storage ${dataStorage.id}`, error);
+        if (
+          error instanceof TokenRefreshFailedException ||
+          error instanceof CredentialsExpiredException
+        ) {
+          return ValidationResult.oauthReauthRequired(GOOGLE_OAUTH_REAUTH_MESSAGE);
+        }
         return ValidationResult.failure(
           error instanceof Error ? error.message : 'Failed to resolve credentials'
         );

--- a/apps/backend/src/data-marts/use-cases/validate-data-storage-access.service.ts
+++ b/apps/backend/src/data-marts/use-cases/validate-data-storage-access.service.ts
@@ -5,13 +5,10 @@ import { ValidationResult } from '../data-storage-types/interfaces/data-storage-
 import { ValidateDataStorageAccessCommand } from '../dto/domain/validate-data-storage-access.command';
 import { DataStorageService } from '../services/data-storage.service';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
-import {
-  CredentialsExpiredException,
-  TokenRefreshFailedException,
-} from '../exceptions/google-oauth.exceptions';
+import { CredentialsExpiredException } from '../exceptions/google-oauth.exceptions';
 
 const GOOGLE_OAUTH_REAUTH_MESSAGE =
-  'Google access is no longer active. Reconnect this Storage to restore access.';
+  'Google authorization could not be refreshed. Reconnect this Storage to restore access.';
 
 @Injectable()
 export class ValidateDataStorageAccessService {
@@ -58,10 +55,7 @@ export class ValidateDataStorageAccessService {
         );
       } catch (error) {
         this.logger.warn(`Failed to resolve credentials for storage ${dataStorage.id}`, error);
-        if (
-          error instanceof TokenRefreshFailedException ||
-          error instanceof CredentialsExpiredException
-        ) {
+        if (error instanceof CredentialsExpiredException) {
           return ValidationResult.oauthReauthRequired(GOOGLE_OAUTH_REAUTH_MESSAGE);
         }
         return ValidationResult.failure(

--- a/apps/web/src/app/api/api-error.interface.ts
+++ b/apps/web/src/app/api/api-error.interface.ts
@@ -1,4 +1,5 @@
 export interface ApiError {
+  code?: string;
   message?: string;
   path: string;
   statusCode: number;

--- a/apps/web/src/features/data-marts/edit/components/DataMartDataStorageView.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDataStorageView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
 import type { DataStorage } from '../../../data-storage/shared/model/types/data-storage.ts';
 import {
   DataStorageType,
@@ -12,12 +12,30 @@ import { DataStorageProvider } from '../../../data-storage/shared/model/context'
 import { AlertTriangle } from 'lucide-react';
 import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
 import { trackEvent } from '../../../../utils';
+import { useDataStorageHealthStatus } from '../../../data-storage/shared/model/hooks/useDataStorageHealthStatus.ts';
+import { DataStorageHealthStatus } from '../../../data-storage/shared/services/data-storage-health-status.service.ts';
+import { DataStorageHealthStatusView } from '../../../data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView.tsx';
 
 interface DataMartDataStorageViewProps {
   dataStorage: DataStorage;
   onDataStorageChange?: (updatedStorage: DataStorage) => void;
   onEditSheetClose?: (payload: { hasChanges: boolean }) => void;
 }
+
+interface DataStorageHealthErrorProps {
+  storageId: string;
+}
+
+function DataStorageHealthError({ storageId }: DataStorageHealthErrorProps) {
+  const { status, errorMessage, isFetched } = useDataStorageHealthStatus(storageId);
+
+  if (!isFetched || status === DataStorageHealthStatus.VALID) {
+    return null;
+  }
+
+  return <DataStorageHealthStatusView status={status} errorMessage={errorMessage} />;
+}
+
 export const DataMartDataStorageView = ({
   dataStorage,
   onDataStorageChange,
@@ -51,12 +69,21 @@ export const DataMartDataStorageView = ({
 
     if (!storageIsValid) {
       return (
-        <div className='flex items-center gap-1 text-sm text-red-500'>
-          <AlertTriangle className='h-4 w-4 shrink-0' />
-          <span>Storage configuration is incomplete</span>
+        <div className='flex flex-col gap-2'>
+          <div className='flex items-center gap-1 text-sm text-red-500'>
+            <AlertTriangle className='h-4 w-4 shrink-0' />
+            <span>Storage configuration is incomplete</span>
+          </div>
         </div>
       );
     }
+
+    const withHealthError = (details: ReactNode) => (
+      <div className='flex flex-col gap-2'>
+        {details}
+        <DataStorageHealthError storageId={dataStorage.id} />
+      </div>
+    );
 
     const formatParam = (label: string, value: string) => {
       return (
@@ -89,7 +116,7 @@ export const DataMartDataStorageView = ({
         const projectId = dataStorage.config.projectId;
         const location = dataStorage.config.location;
         const bigQueryConsoleLink = `https://console.cloud.google.com/bigquery?project=${projectId}`;
-        return (
+        return withHealthError(
           <div className='flex flex-wrap gap-2'>
             {formatLinkParam('Project ID', projectId, bigQueryConsoleLink)}
             <span className='text-muted-foreground'>•</span>

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/FillFromStorageButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/FillFromStorageButton/FillFromStorageButton.tsx
@@ -62,7 +62,8 @@ export function FillFromStorageButton({
   const isUnhealthyStorage =
     healthIsFetched &&
     (healthStatus === DataStorageHealthStatus.UNCONFIGURED ||
-      healthStatus === DataStorageHealthStatus.INVALID);
+      healthStatus === DataStorageHealthStatus.INVALID ||
+      healthStatus === DataStorageHealthStatus.REAUTH_REQUIRED);
 
   const loadNamespaces = useCallback(async () => {
     setNamespacesLoading(true);

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -91,6 +91,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
     definitionType: dataMartDefinitionType = null,
     validationErrors: dataMartValidationErrors = [],
   } = dataMart ?? {};
+  const storageId = dataMart?.storage.id;
 
   const isConnector = dataMartDefinitionType === DataMartDefinitionType.CONNECTOR;
   const isPublished = dataMartStatus.code === DataMartStatus.PUBLISHED;
@@ -102,7 +103,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
   }, [dataMartId, getDataMart]);
 
   const { run: runActualizeSchemaInternal, isLoading: isSchemaActualizationLoading } =
-    useSchemaActualizeTrigger(dataMartId, onActualizeSuccess);
+    useSchemaActualizeTrigger(dataMartId, onActualizeSuccess, storageId);
 
   // Wrap with canActualizeSchema check before running schema actualization
   const runSchemaActualization = useCallback(async () => {

--- a/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
+++ b/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
@@ -34,12 +34,36 @@ import type {
   TablePatternDefinitionConfig,
   ViewDefinitionConfig,
 } from '../types';
-import { extractApiError } from '../../../../../app/api';
+import { extractApiError, type ApiError } from '../../../../../app/api';
 import type { DataMartSchema } from '../../../shared/types/data-mart-schema.types';
 import toast from 'react-hot-toast';
 import { pushToDataLayer, trackEvent } from '../../../../../utils';
 import { DATA_MART_RUNS_PAGE_SIZE } from '../../constants';
 import { useRefreshSetupProgress } from '../../../../../components/AppSidebar/SetupChecklist/useSetupProgress';
+import { invalidateDataStorageHealthStatus } from '../../../../data-storage/shared/services/data-storage-health-status.service';
+
+const STORAGE_OAUTH_REAUTH_CODES = new Set(['TOKEN_REFRESH_FAILED', 'CREDENTIALS_EXPIRED']);
+
+function isStorageOAuthRefreshError(error: ApiError): boolean {
+  if (error.code && STORAGE_OAUTH_REAUTH_CODES.has(error.code)) {
+    return true;
+  }
+
+  const message = error.message ?? '';
+  return (
+    message.includes('Failed to refresh OAuth tokens') ||
+    message.includes('Google authorization could not be refreshed') ||
+    message.includes('Google access is no longer active')
+  );
+}
+
+function invalidateStorageHealthOnOAuthRefreshError(error: ApiError, storageId?: string): void {
+  if (!storageId || !isStorageOAuthRefreshError(error)) {
+    return;
+  }
+
+  invalidateDataStorageHealthStatus(storageId);
+}
 
 // Props interface
 interface DataMartProviderProps {
@@ -363,6 +387,7 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
         });
       } catch (error) {
         const apiError = extractApiError(error);
+        invalidateStorageHealthOnOAuthRefreshError(apiError, state.dataMart?.storage.id);
         dispatch({
           type: 'UPDATE_DATA_MART_DEFINITION_ERROR',
           payload: apiError,
@@ -377,7 +402,7 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
         });
       }
     },
-    []
+    [state.dataMart?.storage.id]
   );
 
   // Publish a data mart

--- a/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
+++ b/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
@@ -41,21 +41,7 @@ import { pushToDataLayer, trackEvent } from '../../../../../utils';
 import { DATA_MART_RUNS_PAGE_SIZE } from '../../constants';
 import { useRefreshSetupProgress } from '../../../../../components/AppSidebar/SetupChecklist/useSetupProgress';
 import { invalidateDataStorageHealthStatus } from '../../../../data-storage/shared/services/data-storage-health-status.service';
-
-const STORAGE_OAUTH_REAUTH_CODES = new Set(['TOKEN_REFRESH_FAILED', 'CREDENTIALS_EXPIRED']);
-
-function isStorageOAuthRefreshError(error: ApiError): boolean {
-  if (error.code && STORAGE_OAUTH_REAUTH_CODES.has(error.code)) {
-    return true;
-  }
-
-  const message = error.message ?? '';
-  return (
-    message.includes('Failed to refresh OAuth tokens') ||
-    message.includes('Google authorization could not be refreshed') ||
-    message.includes('Google access is no longer active')
-  );
-}
+import { isStorageOAuthRefreshError } from '../../../shared/utils/storage-oauth-refresh-error.utils';
 
 function invalidateStorageHealthOnOAuthRefreshError(error: ApiError, storageId?: string): void {
   if (!storageId || !isStorageOAuthRefreshError(error)) {
@@ -426,6 +412,7 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
         });
       } catch (error) {
         const apiError = extractApiError(error);
+        invalidateStorageHealthOnOAuthRefreshError(apiError, state.dataMart?.storage.id);
         dispatch({
           type: 'PUBLISH_DATA_MART_ERROR',
           payload: apiError,
@@ -440,7 +427,7 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
         throw error;
       }
     },
-    [refreshSetupProgress]
+    [refreshSetupProgress, state.dataMart?.storage.id]
   );
 
   /**

--- a/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
+++ b/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
@@ -505,37 +505,41 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
   }, []);
 
   // Run a data mart
-  const runDataMart = useCallback(async (request: RunDataMartRequestDto) => {
-    const toastId = toast.loading('Manual run started');
-    try {
-      dispatch({ type: 'RUN_DATA_MART_START' });
-      trackEvent({
-        event: 'data_mart_run_started',
-        category: 'DataMart',
-        action: 'Run',
-        label: 'Manual',
-        context: request.id,
-      });
+  const runDataMart = useCallback(
+    async (request: RunDataMartRequestDto) => {
+      const toastId = toast.loading('Manual run started');
+      try {
+        dispatch({ type: 'RUN_DATA_MART_START' });
+        trackEvent({
+          event: 'data_mart_run_started',
+          category: 'DataMart',
+          action: 'Run',
+          label: 'Manual',
+          context: request.id,
+        });
 
-      await dataMartService.runDataMart(request.id, request.payload);
-      dispatch({ type: 'RUN_DATA_MART_SUCCESS' });
-    } catch (error) {
-      toast.dismiss(toastId);
-      const apiError = extractApiError(error);
-      dispatch({
-        type: 'RUN_DATA_MART_ERROR',
-        payload: apiError,
-      });
-      trackEvent({
-        event: 'data_mart_error',
-        category: 'DataMart',
-        action: 'RunError',
-        label: 'Manual',
-        context: request.id,
-        error: apiError.message,
-      });
-    }
-  }, []);
+        await dataMartService.runDataMart(request.id, request.payload);
+        dispatch({ type: 'RUN_DATA_MART_SUCCESS' });
+      } catch (error) {
+        toast.dismiss(toastId);
+        const apiError = extractApiError(error);
+        invalidateStorageHealthOnOAuthRefreshError(apiError, state.dataMart?.storage.id);
+        dispatch({
+          type: 'RUN_DATA_MART_ERROR',
+          payload: apiError,
+        });
+        trackEvent({
+          event: 'data_mart_error',
+          category: 'DataMart',
+          action: 'RunError',
+          label: 'Manual',
+          context: request.id,
+          error: apiError.message,
+        });
+      }
+    },
+    [state.dataMart?.storage.id]
+  );
 
   const cancelDataMartRun = useCallback(
     async (id: string, runId: string): Promise<void> => {

--- a/apps/web/src/features/data-marts/shared/hooks/__tests__/useSchemaActualizeTrigger.test.ts
+++ b/apps/web/src/features/data-marts/shared/hooks/__tests__/useSchemaActualizeTrigger.test.ts
@@ -23,7 +23,12 @@ vi.mock('../../services/data-mart.service', () => {
   };
 });
 
+vi.mock('../../../../data-storage/shared/services/data-storage-health-status.service', () => ({
+  invalidateDataStorageHealthStatus: vi.fn(),
+}));
+
 import { dataMartService } from '../../services/data-mart.service';
+import { invalidateDataStorageHealthStatus } from '../../../../data-storage/shared/services/data-storage-health-status.service';
 import { useSchemaActualizeTrigger } from '../useSchemaActualizeTrigger';
 
 describe('useSchemaActualizeTrigger', () => {
@@ -94,6 +99,39 @@ describe('useSchemaActualizeTrigger', () => {
       expect(hook.current.isLoading).toBe(false);
       expect(hook.current.error).toBe('Network failed');
     });
+  });
+
+  it('invalidates storage health when trigger response returns OAuth refresh code', async () => {
+    (dataMartService.createSchemaActualizeTrigger as any).mockResolvedValue({ triggerId: 's6' });
+    (dataMartService.getSchemaActualizeTriggerStatus as any).mockResolvedValueOnce(
+      TaskStatus.ERROR
+    );
+    (dataMartService.getSchemaActualizeTriggerResponse as any).mockRejectedValueOnce({
+      response: {
+        data: {
+          code: 'CREDENTIALS_EXPIRED',
+          error:
+            'Google authorization could not be refreshed. Reconnect this Storage to restore access.',
+        },
+      },
+    });
+
+    const { result: hook } = renderHook(() =>
+      useSchemaActualizeTrigger('dm-6', undefined, 'storage-1')
+    );
+
+    await act(async () => {
+      await hook.current.run();
+    });
+
+    await waitFor(() => {
+      expect(hook.current.isLoading).toBe(false);
+      expect(hook.current.error).toBe(
+        'Google authorization could not be refreshed. Reconnect this Storage to restore access.'
+      );
+    });
+
+    expect(invalidateDataStorageHealthStatus).toHaveBeenCalledWith('storage-1');
   });
 
   it('cancels an ongoing run and calls abort on the service', async () => {

--- a/apps/web/src/features/data-marts/shared/hooks/useSchemaActualizeTrigger.ts
+++ b/apps/web/src/features/data-marts/shared/hooks/useSchemaActualizeTrigger.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import { TaskStatus } from '../../../../shared/types/task-status.enum.ts';
 import { dataMartService } from '../services/data-mart.service';
+import { invalidateDataStorageHealthStatus } from '../../../data-storage/shared/services/data-storage-health-status.service';
 
 interface UseSchemaActualizeTriggerReturn {
   run: () => Promise<void>;
@@ -12,9 +13,18 @@ interface UseSchemaActualizeTriggerReturn {
 
 const POLLING_INTERVAL = 1000;
 
+function isStorageOAuthRefreshMessage(message: string): boolean {
+  return (
+    message.includes('Failed to refresh OAuth tokens') ||
+    message.includes('Google authorization could not be refreshed') ||
+    message.includes('Google access is no longer active')
+  );
+}
+
 export function useSchemaActualizeTrigger(
   dataMartId: string,
-  onSuccess?: () => void
+  onSuccess?: () => void,
+  storageId?: string
 ): UseSchemaActualizeTriggerReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -37,6 +47,9 @@ export function useSchemaActualizeTrigger(
   const handleError = useCallback(
     (e: unknown, triggerId: string) => {
       const errorMessage = e instanceof Error ? e.message : 'Schema actualization failed';
+      if (storageId && isStorageOAuthRefreshMessage(errorMessage)) {
+        invalidateDataStorageHealthStatus(storageId);
+      }
       toast.dismiss(triggerId);
       setSafeError(errorMessage);
       setSafeLoading(false);
@@ -44,7 +57,7 @@ export function useSchemaActualizeTrigger(
       abortControllerRef.current = null;
       toast.error(errorMessage, { duration: undefined, id: triggerId });
     },
-    [setSafeError, setSafeLoading]
+    [setSafeError, setSafeLoading, storageId]
   );
 
   const cancel = useCallback(async (): Promise<void> => {
@@ -93,11 +106,17 @@ export function useSchemaActualizeTrigger(
                 toast.success('Output schema actualized', { duration: undefined, id: triggerId });
               } else {
                 const errorMessage = response.error ?? 'Schema actualization failed';
+                if (storageId && isStorageOAuthRefreshMessage(errorMessage)) {
+                  invalidateDataStorageHealthStatus(storageId);
+                }
                 setSafeError(errorMessage);
                 toast.error(errorMessage, { duration: undefined, id: triggerId });
               }
             } catch (e) {
               const errorMessage = e instanceof Error ? e.message : 'Schema actualization failed';
+              if (storageId && isStorageOAuthRefreshMessage(errorMessage)) {
+                invalidateDataStorageHealthStatus(storageId);
+              }
               toast.dismiss(triggerId);
               setSafeError(errorMessage);
               toast.error(errorMessage, { duration: undefined, id: triggerId });
@@ -115,7 +134,7 @@ export function useSchemaActualizeTrigger(
         }
       }
     },
-    [dataMartId, setSafeError, setSafeLoading, handleError]
+    [dataMartId, setSafeError, setSafeLoading, handleError, storageId]
   );
 
   const run = useCallback(async () => {
@@ -143,9 +162,13 @@ export function useSchemaActualizeTrigger(
       }
     } catch (e) {
       setSafeLoading(false);
-      setSafeError(e instanceof Error ? e.message : 'Failed to start schema actualization');
+      const errorMessage = e instanceof Error ? e.message : 'Failed to start schema actualization';
+      if (storageId && isStorageOAuthRefreshMessage(errorMessage)) {
+        invalidateDataStorageHealthStatus(storageId);
+      }
+      setSafeError(errorMessage);
     }
-  }, [dataMartId, cancel, pollTriggerStatus, setSafeError, setSafeLoading, handleError]);
+  }, [dataMartId, cancel, pollTriggerStatus, setSafeError, setSafeLoading, handleError, storageId]);
 
   useEffect(() => {
     isMountedRef.current = true;

--- a/apps/web/src/features/data-marts/shared/hooks/useSchemaActualizeTrigger.ts
+++ b/apps/web/src/features/data-marts/shared/hooks/useSchemaActualizeTrigger.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import toast from 'react-hot-toast';
 import { TaskStatus } from '../../../../shared/types/task-status.enum.ts';
+import { extractApiError, type ApiError } from '../../../../app/api';
 import { dataMartService } from '../services/data-mart.service';
 import { invalidateDataStorageHealthStatus } from '../../../data-storage/shared/services/data-storage-health-status.service';
+import { isStorageOAuthRefreshError } from '../utils/storage-oauth-refresh-error.utils';
 
 interface UseSchemaActualizeTriggerReturn {
   run: () => Promise<void>;
@@ -13,12 +15,39 @@ interface UseSchemaActualizeTriggerReturn {
 
 const POLLING_INTERVAL = 1000;
 
-function isStorageOAuthRefreshMessage(message: string): boolean {
-  return (
-    message.includes('Failed to refresh OAuth tokens') ||
-    message.includes('Google authorization could not be refreshed') ||
-    message.includes('Google access is no longer active')
-  );
+interface SchemaActualizeErrorBody extends ApiError {
+  error?: string;
+}
+
+interface SchemaActualizeError {
+  message: string;
+  code?: string;
+}
+
+function extractApiErrorBody(error: unknown): SchemaActualizeErrorBody | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  return extractApiError(error) as SchemaActualizeErrorBody | undefined;
+}
+
+function extractSchemaActualizeError(error: unknown, fallback: string): SchemaActualizeError {
+  const apiError = extractApiErrorBody(error);
+
+  return {
+    message:
+      apiError?.error ?? apiError?.message ?? (error instanceof Error ? error.message : fallback),
+    code: apiError?.code,
+  };
+}
+
+function invalidateStorageHealthForError(error: SchemaActualizeError, storageId?: string): void {
+  if (!storageId || !isStorageOAuthRefreshError(error)) {
+    return;
+  }
+
+  invalidateDataStorageHealthStatus(storageId);
 }
 
 export function useSchemaActualizeTrigger(
@@ -46,16 +75,14 @@ export function useSchemaActualizeTrigger(
 
   const handleError = useCallback(
     (e: unknown, triggerId: string) => {
-      const errorMessage = e instanceof Error ? e.message : 'Schema actualization failed';
-      if (storageId && isStorageOAuthRefreshMessage(errorMessage)) {
-        invalidateDataStorageHealthStatus(storageId);
-      }
+      const error = extractSchemaActualizeError(e, 'Schema actualization failed');
+      invalidateStorageHealthForError(error, storageId);
       toast.dismiss(triggerId);
-      setSafeError(errorMessage);
+      setSafeError(error.message);
       setSafeLoading(false);
       currentTriggerIdRef.current = null;
       abortControllerRef.current = null;
-      toast.error(errorMessage, { duration: undefined, id: triggerId });
+      toast.error(error.message, { duration: undefined, id: triggerId });
     },
     [setSafeError, setSafeLoading, storageId]
   );
@@ -105,21 +132,20 @@ export function useSchemaActualizeTrigger(
                 onSuccessRef.current?.();
                 toast.success('Output schema actualized', { duration: undefined, id: triggerId });
               } else {
-                const errorMessage = response.error ?? 'Schema actualization failed';
-                if (storageId && isStorageOAuthRefreshMessage(errorMessage)) {
-                  invalidateDataStorageHealthStatus(storageId);
-                }
-                setSafeError(errorMessage);
-                toast.error(errorMessage, { duration: undefined, id: triggerId });
+                const error = {
+                  message: response.error ?? 'Schema actualization failed',
+                  code: response.code,
+                };
+                invalidateStorageHealthForError(error, storageId);
+                setSafeError(error.message);
+                toast.error(error.message, { duration: undefined, id: triggerId });
               }
             } catch (e) {
-              const errorMessage = e instanceof Error ? e.message : 'Schema actualization failed';
-              if (storageId && isStorageOAuthRefreshMessage(errorMessage)) {
-                invalidateDataStorageHealthStatus(storageId);
-              }
+              const error = extractSchemaActualizeError(e, 'Schema actualization failed');
+              invalidateStorageHealthForError(error, storageId);
               toast.dismiss(triggerId);
-              setSafeError(errorMessage);
-              toast.error(errorMessage, { duration: undefined, id: triggerId });
+              setSafeError(error.message);
+              toast.error(error.message, { duration: undefined, id: triggerId });
             }
 
             setSafeLoading(false);
@@ -162,11 +188,9 @@ export function useSchemaActualizeTrigger(
       }
     } catch (e) {
       setSafeLoading(false);
-      const errorMessage = e instanceof Error ? e.message : 'Failed to start schema actualization';
-      if (storageId && isStorageOAuthRefreshMessage(errorMessage)) {
-        invalidateDataStorageHealthStatus(storageId);
-      }
-      setSafeError(errorMessage);
+      const error = extractSchemaActualizeError(e, 'Failed to start schema actualization');
+      invalidateStorageHealthForError(error, storageId);
+      setSafeError(error.message);
     }
   }, [dataMartId, cancel, pollTriggerStatus, setSafeError, setSafeLoading, handleError, storageId]);
 

--- a/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
+++ b/apps/web/src/features/data-marts/shared/services/data-mart.service.ts
@@ -265,8 +265,8 @@ export class DataMartService extends ApiService {
   async getSchemaActualizeTriggerResponse(
     id: string,
     triggerId: string
-  ): Promise<{ success: boolean; error?: string }> {
-    return this.get<{ success: boolean; error?: string }>(
+  ): Promise<{ success: boolean; error?: string; code?: string }> {
+    return this.get<{ success: boolean; error?: string; code?: string }>(
       `/${id}/schema-actualize-triggers/${triggerId}`,
       undefined,
       { skipLoadingIndicator: true, skipErrorToast: true } as AxiosRequestConfig

--- a/apps/web/src/features/data-marts/shared/utils/__tests__/storage-oauth-refresh-error.utils.test.ts
+++ b/apps/web/src/features/data-marts/shared/utils/__tests__/storage-oauth-refresh-error.utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { isStorageOAuthRefreshError } from '../storage-oauth-refresh-error.utils';
+
+describe('isStorageOAuthRefreshError', () => {
+  it('matches OAuth refresh error codes', () => {
+    expect(isStorageOAuthRefreshError({ code: 'CREDENTIALS_EXPIRED' })).toBe(true);
+    expect(isStorageOAuthRefreshError({ code: 'TOKEN_REFRESH_FAILED' })).toBe(true);
+  });
+
+  it('keeps legacy message fallback for older backend responses', () => {
+    expect(isStorageOAuthRefreshError({ message: 'Failed to refresh OAuth tokens' })).toBe(true);
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isStorageOAuthRefreshError({ code: 'VALIDATION_FAILED', message: 'Invalid SQL' })).toBe(
+      false
+    );
+  });
+});

--- a/apps/web/src/features/data-marts/shared/utils/storage-oauth-refresh-error.utils.ts
+++ b/apps/web/src/features/data-marts/shared/utils/storage-oauth-refresh-error.utils.ts
@@ -1,0 +1,20 @@
+export interface StorageOAuthRefreshError {
+  code?: string;
+  message?: string;
+}
+
+const STORAGE_OAUTH_REFRESH_ERROR_CODES = new Set(['TOKEN_REFRESH_FAILED', 'CREDENTIALS_EXPIRED']);
+
+export function isStorageOAuthRefreshError(error: StorageOAuthRefreshError): boolean {
+  if (error.code && STORAGE_OAUTH_REFRESH_ERROR_CODES.has(error.code)) {
+    return true;
+  }
+
+  const message = error.message ?? '';
+  return (
+    message.includes('Failed to refresh OAuth tokens') ||
+    message.includes('Google authorization could not be refreshed') ||
+    message.includes('Google access is no longer active') ||
+    message.includes('Google access could not be refreshed')
+  );
+}

--- a/apps/web/src/features/data-marts/shared/utils/storage-oauth-refresh-error.utils.ts
+++ b/apps/web/src/features/data-marts/shared/utils/storage-oauth-refresh-error.utils.ts
@@ -14,7 +14,6 @@ export function isStorageOAuthRefreshError(error: StorageOAuthRefreshError): boo
   return (
     message.includes('Failed to refresh OAuth tokens') ||
     message.includes('Google authorization could not be refreshed') ||
-    message.includes('Google access is no longer active') ||
     message.includes('Google access could not be refreshed')
   );
 }

--- a/apps/web/src/features/data-storage/shared/api/data-storage-api.service.ts
+++ b/apps/web/src/features/data-storage/shared/api/data-storage-api.service.ts
@@ -19,7 +19,7 @@ interface TaskStatusResponseDto {
   status: TaskStatus;
 }
 
-export type DataStorageValidationCode = 'UNCONFIGURED';
+export type DataStorageValidationCode = 'UNCONFIGURED' | 'OAUTH_REAUTH_REQUIRED';
 
 export interface DataStorageValidationResponseDto {
   valid: boolean;

--- a/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthIndicator.tsx
+++ b/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthIndicator.tsx
@@ -14,7 +14,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/too
 import { useDataStorageHealthStatus } from '../../model/hooks/useDataStorageHealthStatus';
 import {
   DataStorageHealthStatus,
-  OAUTH_REAUTH_REQUIRED_STATUS_LABEL,
   UNCONFIGURED_STATUS_LABEL,
 } from '../../services/data-storage-health-status.service';
 import { DataStorageHealthStatusView } from './DataStorageHealthStatusView';
@@ -55,7 +54,7 @@ const HEALTH_STATUS_CONFIG: Record<DataStorageHealthStatus, HealthStatusDisplayC
     ringClass: 'ring-neutral-400/50 dark:ring-neutral-500/50',
   },
   [DataStorageHealthStatus.REAUTH_REQUIRED]: {
-    text: OAUTH_REAUTH_REQUIRED_STATUS_LABEL,
+    text: 'Reconnect Storage',
     dotClass: 'bg-red-500',
     ringClass: 'ring-red-500/50',
   },
@@ -66,12 +65,30 @@ const HEALTH_STATUS_NOT_FETCHED: HealthStatusDisplayConfig = {
   ringClass: 'ring-neutral-300/50 dark:ring-neutral-600/50',
 };
 
+const COMPACT_INVALID_STATUS_LABEL = 'Storage access failed. Check Storage settings.';
+const COMPACT_REAUTH_REQUIRED_STATUS_LABEL = 'Reconnect Storage';
+
 function getTooltipText(params: { status: DataStorageHealthStatus; isLoading: boolean }): string {
   const { status, isLoading } = params;
 
   if (isLoading) return 'Validating storage access...';
 
   return HEALTH_STATUS_CONFIG[status].text;
+}
+
+function getCompactStatusMessage(
+  status: DataStorageHealthStatus,
+  errorMessage?: string
+): string | undefined {
+  if (status === DataStorageHealthStatus.INVALID) {
+    return COMPACT_INVALID_STATUS_LABEL;
+  }
+
+  if (status === DataStorageHealthStatus.REAUTH_REQUIRED) {
+    return COMPACT_REAUTH_REQUIRED_STATUS_LABEL;
+  }
+
+  return errorMessage;
 }
 
 export function DataStorageHealthIndicator({
@@ -119,7 +136,10 @@ export function DataStorageHealthIndicator({
             <HoverCardBody>
               <HoverCardItem>
                 <HoverCardItemValue>
-                  <DataStorageHealthStatusView status={status} errorMessage={errorMessage} />
+                  <DataStorageHealthStatusView
+                    status={status}
+                    errorMessage={getCompactStatusMessage(status, errorMessage)}
+                  />
                 </HoverCardItemValue>
               </HoverCardItem>
             </HoverCardBody>

--- a/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthIndicator.tsx
+++ b/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthIndicator.tsx
@@ -14,6 +14,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/too
 import { useDataStorageHealthStatus } from '../../model/hooks/useDataStorageHealthStatus';
 import {
   DataStorageHealthStatus,
+  OAUTH_REAUTH_REQUIRED_STATUS_LABEL,
   UNCONFIGURED_STATUS_LABEL,
 } from '../../services/data-storage-health-status.service';
 import { DataStorageHealthStatusView } from './DataStorageHealthStatusView';
@@ -52,6 +53,11 @@ const HEALTH_STATUS_CONFIG: Record<DataStorageHealthStatus, HealthStatusDisplayC
     text: UNCONFIGURED_STATUS_LABEL,
     dotClass: 'bg-neutral-400 dark:bg-neutral-500',
     ringClass: 'ring-neutral-400/50 dark:ring-neutral-500/50',
+  },
+  [DataStorageHealthStatus.REAUTH_REQUIRED]: {
+    text: OAUTH_REAUTH_REQUIRED_STATUS_LABEL,
+    dotClass: 'bg-red-500',
+    ringClass: 'ring-red-500/50',
   },
 };
 const HEALTH_STATUS_NOT_FETCHED: HealthStatusDisplayConfig = {

--- a/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView.tsx
+++ b/apps/web/src/features/data-storage/shared/components/DataStorageHealthIndicator/DataStorageHealthStatusView.tsx
@@ -1,6 +1,7 @@
 import { CircleCheck, CircleDashed, TriangleAlert } from 'lucide-react';
 import {
   DataStorageHealthStatus,
+  OAUTH_REAUTH_REQUIRED_STATUS_LABEL,
   UNCONFIGURED_STATUS_LABEL,
 } from '../../services/data-storage-health-status.service';
 
@@ -34,6 +35,15 @@ export function DataStorageHealthStatusView({ status, errorMessage, isLoading }:
       <div className='text-muted-foreground flex items-center gap-2 text-sm'>
         <CircleDashed className='size-4' />
         <span>{UNCONFIGURED_STATUS_LABEL}</span>
+      </div>
+    );
+  }
+
+  if (status === DataStorageHealthStatus.REAUTH_REQUIRED) {
+    return (
+      <div className='flex items-center gap-2 text-sm text-red-500'>
+        <TriangleAlert className='size-4' />
+        <span>{errorMessage ?? OAUTH_REAUTH_REQUIRED_STATUS_LABEL}</span>
       </div>
     );
   }

--- a/apps/web/src/features/data-storage/shared/model/hooks/useDataStorageHealthStatus.ts
+++ b/apps/web/src/features/data-storage/shared/model/hooks/useDataStorageHealthStatus.ts
@@ -45,7 +45,27 @@ export function useDataStorageHealthStatus(storageId: string): UseDataStorageHea
 
   // Auto-fetch on mount / storageId change
   useEffect(() => {
-    fetchAndCacheDataStorageHealthStatus(storageId);
+    fetchAndCacheDataStorageHealthStatus(storageId, { force: true });
+  }, [storageId]);
+
+  useEffect(() => {
+    const revalidate = () => {
+      fetchAndCacheDataStorageHealthStatus(storageId, { force: true });
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        revalidate();
+      }
+    };
+
+    window.addEventListener('focus', revalidate);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('focus', revalidate);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, [storageId]);
 
   const isFetched = Boolean(cached);

--- a/apps/web/src/features/data-storage/shared/model/hooks/useDataStorageHealthStatus.ts
+++ b/apps/web/src/features/data-storage/shared/model/hooks/useDataStorageHealthStatus.ts
@@ -4,7 +4,6 @@ import {
   DataStorageHealthStatus,
   fetchAndCacheDataStorageHealthStatus,
   getCachedDataStorageHealthStatus,
-  invalidateDataStorageHealthStatus,
   subscribeToDataStorageHealthStatusUpdates,
 } from '../../services/data-storage-health-status.service';
 
@@ -44,30 +43,9 @@ export function useDataStorageHealthStatus(storageId: string): UseDataStorageHea
     setCached(prev => (prev === next ? prev : next));
   }, [readCached]);
 
-  // Auto-fetch on mount / storageId change (cache-respecting — avoids redundant requests)
+  // Auto-fetch on mount / storageId change
   useEffect(() => {
     fetchAndCacheDataStorageHealthStatus(storageId);
-  }, [storageId]);
-
-  // Revalidate when the user returns to the tab; invalidation triggers re-fetch via subscriber
-  useEffect(() => {
-    const revalidate = () => {
-      invalidateDataStorageHealthStatus(storageId);
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        revalidate();
-      }
-    };
-
-    window.addEventListener('focus', revalidate);
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      window.removeEventListener('focus', revalidate);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
   }, [storageId]);
 
   const isFetched = Boolean(cached);

--- a/apps/web/src/features/data-storage/shared/model/hooks/useDataStorageHealthStatus.ts
+++ b/apps/web/src/features/data-storage/shared/model/hooks/useDataStorageHealthStatus.ts
@@ -4,6 +4,7 @@ import {
   DataStorageHealthStatus,
   fetchAndCacheDataStorageHealthStatus,
   getCachedDataStorageHealthStatus,
+  invalidateDataStorageHealthStatus,
   subscribeToDataStorageHealthStatusUpdates,
 } from '../../services/data-storage-health-status.service';
 
@@ -43,14 +44,15 @@ export function useDataStorageHealthStatus(storageId: string): UseDataStorageHea
     setCached(prev => (prev === next ? prev : next));
   }, [readCached]);
 
-  // Auto-fetch on mount / storageId change
+  // Auto-fetch on mount / storageId change (cache-respecting — avoids redundant requests)
   useEffect(() => {
-    fetchAndCacheDataStorageHealthStatus(storageId, { force: true });
+    fetchAndCacheDataStorageHealthStatus(storageId);
   }, [storageId]);
 
+  // Revalidate when the user returns to the tab; invalidation triggers re-fetch via subscriber
   useEffect(() => {
     const revalidate = () => {
-      fetchAndCacheDataStorageHealthStatus(storageId, { force: true });
+      invalidateDataStorageHealthStatus(storageId);
     };
 
     const handleVisibilityChange = () => {

--- a/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
+++ b/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
@@ -30,11 +30,6 @@ export interface CachedDataStorageHealthStatus {
   errorMessage?: string;
 }
 
-interface PendingHealthStatusRequest {
-  storageId: string;
-  force: boolean;
-}
-
 /**
  * Maximum number of concurrent validation requests.
  */
@@ -53,7 +48,7 @@ const inFlightRequests = new Set<string>();
 /**
  * Queue of pending storage IDs waiting to be fetched
  */
-const pendingQueue: PendingHealthStatusRequest[] = [];
+const pendingQueue: string[] = [];
 
 /**
  * Number of currently active requests
@@ -100,15 +95,13 @@ export function invalidateDataStorageHealthStatus(storageId: string): void {
  */
 function processQueue(): void {
   while (activeRequestCount < MAX_CONCURRENT_REQUESTS && pendingQueue.length > 0) {
-    const request = pendingQueue.shift();
+    const storageId = pendingQueue.shift();
 
-    if (!request) {
+    if (!storageId) {
       break;
     }
 
-    const { storageId, force } = request;
-
-    if ((!force && healthStatusCache.has(storageId)) || inFlightRequests.has(storageId)) {
+    if (healthStatusCache.has(storageId) || inFlightRequests.has(storageId)) {
       continue;
     }
 
@@ -161,23 +154,15 @@ function processQueue(): void {
  * Enqueues a storage ID for health status fetching.
  * Respects concurrency limit of MAX_CONCURRENT_REQUESTS.
  */
-export function fetchAndCacheDataStorageHealthStatus(
-  storageId: string,
-  options: { force?: boolean } = {}
-): void {
+export function fetchAndCacheDataStorageHealthStatus(storageId: string): void {
   if (!storageId) return;
 
-  const force = options.force ?? false;
-
-  if ((!force && healthStatusCache.has(storageId)) || inFlightRequests.has(storageId)) {
+  if (healthStatusCache.has(storageId) || inFlightRequests.has(storageId)) {
     return;
   }
 
-  const queuedRequest = pendingQueue.find(request => request.storageId === storageId);
-  if (queuedRequest) {
-    queuedRequest.force ||= force;
-  } else {
-    pendingQueue.push({ storageId, force });
+  if (!pendingQueue.includes(storageId)) {
+    pendingQueue.push(storageId);
   }
 
   processQueue();

--- a/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
+++ b/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
@@ -11,15 +11,19 @@ export enum DataStorageHealthStatus {
   VALID = 'valid',
   INVALID = 'invalid',
   UNCONFIGURED = 'unconfigured',
+  REAUTH_REQUIRED = 'reauth_required',
 }
 
 /**
- * Must match ValidationResultCode.UNCONFIGURED on the backend.
- * If the backend enum value changes, update this constant accordingly.
+ * Must match ValidationResultCode values on the backend.
+ * If backend enum values change, update these constants accordingly.
  */
 const UNCONFIGURED_CODE: DataStorageValidationCode = 'UNCONFIGURED';
+const OAUTH_REAUTH_REQUIRED_CODE: DataStorageValidationCode = 'OAUTH_REAUTH_REQUIRED';
 
 export const UNCONFIGURED_STATUS_LABEL = 'Complete setup to activate Storage';
+export const OAUTH_REAUTH_REQUIRED_STATUS_LABEL =
+  'Google access is no longer active. Reconnect this Storage to restore access.';
 
 export interface CachedDataStorageHealthStatus {
   status: DataStorageHealthStatus;
@@ -115,6 +119,8 @@ function processQueue(): void {
           status = DataStorageHealthStatus.VALID;
         } else if (response.code === UNCONFIGURED_CODE) {
           status = DataStorageHealthStatus.UNCONFIGURED;
+        } else if (response.code === OAUTH_REAUTH_REQUIRED_CODE) {
+          status = DataStorageHealthStatus.REAUTH_REQUIRED;
         } else {
           status = DataStorageHealthStatus.INVALID;
         }

--- a/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
+++ b/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
@@ -90,6 +90,7 @@ export function getCachedDataStorageHealthStatus(
  * will trigger a fresh validation request.
  */
 export function invalidateDataStorageHealthStatus(storageId: string): void {
+  if (!storageId) return;
   healthStatusCache.delete(storageId);
   notifySubscribers();
 }
@@ -164,6 +165,8 @@ export function fetchAndCacheDataStorageHealthStatus(
   storageId: string,
   options: { force?: boolean } = {}
 ): void {
+  if (!storageId) return;
+
   const force = options.force ?? false;
 
   if ((!force && healthStatusCache.has(storageId)) || inFlightRequests.has(storageId)) {

--- a/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
+++ b/apps/web/src/features/data-storage/shared/services/data-storage-health-status.service.ts
@@ -23,11 +23,16 @@ const OAUTH_REAUTH_REQUIRED_CODE: DataStorageValidationCode = 'OAUTH_REAUTH_REQU
 
 export const UNCONFIGURED_STATUS_LABEL = 'Complete setup to activate Storage';
 export const OAUTH_REAUTH_REQUIRED_STATUS_LABEL =
-  'Google access is no longer active. Reconnect this Storage to restore access.';
+  'Google authorization could not be refreshed. Reconnect this Storage to restore access.';
 
 export interface CachedDataStorageHealthStatus {
   status: DataStorageHealthStatus;
   errorMessage?: string;
+}
+
+interface PendingHealthStatusRequest {
+  storageId: string;
+  force: boolean;
 }
 
 /**
@@ -48,7 +53,7 @@ const inFlightRequests = new Set<string>();
 /**
  * Queue of pending storage IDs waiting to be fetched
  */
-const pendingQueue: string[] = [];
+const pendingQueue: PendingHealthStatusRequest[] = [];
 
 /**
  * Number of currently active requests
@@ -94,13 +99,15 @@ export function invalidateDataStorageHealthStatus(storageId: string): void {
  */
 function processQueue(): void {
   while (activeRequestCount < MAX_CONCURRENT_REQUESTS && pendingQueue.length > 0) {
-    const storageId = pendingQueue.shift();
+    const request = pendingQueue.shift();
 
-    if (!storageId) {
+    if (!request) {
       break;
     }
 
-    if (healthStatusCache.has(storageId) || inFlightRequests.has(storageId)) {
+    const { storageId, force } = request;
+
+    if ((!force && healthStatusCache.has(storageId)) || inFlightRequests.has(storageId)) {
       continue;
     }
 
@@ -153,13 +160,21 @@ function processQueue(): void {
  * Enqueues a storage ID for health status fetching.
  * Respects concurrency limit of MAX_CONCURRENT_REQUESTS.
  */
-export function fetchAndCacheDataStorageHealthStatus(storageId: string): void {
-  if (healthStatusCache.has(storageId) || inFlightRequests.has(storageId)) {
+export function fetchAndCacheDataStorageHealthStatus(
+  storageId: string,
+  options: { force?: boolean } = {}
+): void {
+  const force = options.force ?? false;
+
+  if ((!force && healthStatusCache.has(storageId)) || inFlightRequests.has(storageId)) {
     return;
   }
 
-  if (!pendingQueue.includes(storageId)) {
-    pendingQueue.push(storageId);
+  const queuedRequest = pendingQueue.find(request => request.storageId === storageId);
+  if (queuedRequest) {
+    queuedRequest.force ||= force;
+  } else {
+    pendingQueue.push({ storageId, force });
   }
 
   processQueue();


### PR DESCRIPTION
# Problem

When a data storage's Google OAuth authorization expired or was revoked, the product handled it poorly. Connector runs were created and then failed mid-execution with an opaque BigQuery `401 — Request had invalid authentication credentials`, and schema actualization and definition saves surfaced raw "Failed to refresh OAuth tokens" text. The root cause was twofold: there was no machine-readable signal distinguishing "needs re-authorization" from a generic failure, and nothing validated storage access *before* a run was started — so the user only discovered the broken connection after a run had already failed. The token refresh path also mis-handled Google's `invalid_grant` response and could persist a null access token.

# Solution

Introduced an explicit `OAUTH_REAUTH_REQUIRED` result code that flows from the backend validators through to a dedicated "Reconnect Storage" UI state, and added a pre-run guard so expired authorization is caught before a run is created.

- **Backend signal:** Added `ValidationResultCode.OAUTH_REAUTH_REQUIRED` and `ValidationResult.oauthReauthRequired()`. The BigQuery access validator maps Google auth errors to it, and `CredentialsExpiredException` now returns a clear, user-facing message with a `401`.
- **Robust token refresh:** `google-oauth-flow.service` now detects `invalid_grant` from Google's response body (not just the message), throws `CredentialsExpiredException` on a dead refresh token, separates refresh failures from token-persistence failures, and guards against a missing `access_token`.
- **Pre-run check:** `RunDataMartService.run()` validates storage access before delegating to the connector run. It lives outside the `@Transactional()` boundary (credential resolution can refresh and persist tokens) and is the single chokepoint for both manual and scheduled runs. It blocks **only** on a definitive re-authorization condition — transient failures (network, rate limits, temporary API errors) are logged and the run proceeds, as before.
- **Frontend:** Added a `REAUTH_REQUIRED` health status with a "Reconnect Storage" banner (BigQuery view), invalidated the cached storage health status when an OAuth refresh error is returned, revalidated health on tab focus/visibility, and propagated the new error `code` through the schema-actualize trigger path.

# Changes

- Added `OAUTH_REAUTH_REQUIRED` validation code, `ValidationResult.oauthReauthRequired()`, and exposed it in the validation response DTO.
- Mapped BigQuery OAuth auth errors to the reauth code in `bigquery-access.validator`.
- Reworked `CredentialsExpiredException` / `TokenRefreshFailedException` messages and returned `401` for expired credentials.
- Hardened `refreshTokensByCredentialId`: structured `invalid_grant` detection, separated refresh vs. persistence failures, and added a null `access_token` guard.
- Added a pre-run storage access check in `RunDataMartService` that blocks only on definitive reauth, covering manual and scheduled runs, outside the DB transaction.
- Returned the reauth case from `validate-data-storage-access` and propagated an error `code` through the schema-actualize trigger handler and response DTO.
- Added `REAUTH_REQUIRED` health status, the "Reconnect Storage" banner, and tab focus/visibility revalidation in the web app.
- Invalidated cached storage health on OAuth refresh errors from definition save, publish, and schema-actualize flows.
- Added `storage-oauth-refresh-error.utils` (with tests) and guarded the health-status service against empty storage IDs.
- Added unit coverage in `run-data-mart.service.spec` for reauth-blocking, transient pass-through, and non-OAuth skip paths.