### PR TITLE
fix(docker): pin base image to node:22.22.3-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:22-slim
+# Pinned to a specific patch: the floating `node:22-slim` tag shipped Node 22.23.0,
+# whose http.Agent regression (https://github.com/nodejs/node/issues/63989) breaks node-fetch@2/gaxios@6 with
+# "Premature close", taking down C2C auth. Bump deliberately after verifying the fix.
+FROM node:22.22.3-slim
 ARG version=latest
 RUN npm install -g owox@${version} && npm cache clean --force
 ENV NODE_OPTIONS="--no-deprecation"


### PR DESCRIPTION
## Summary

Pin the production base image from the floating `node:22-slim` tag to `node:22.22.3-slim`.

## Why

`Dockerfile` used `FROM node:22-slim`, which floats to the latest 22.x at build time. Two production builds two hours apart resolved different Node versions:

| Build | Node | `node-fetch@2.7.0` → Google token endpoint |
|---|---|---|
| `0.28.0-next-20260618134433` | **22.22.3** | 30/30 OK |
| `0.28.0-next-20260618160300` | **22.23.0** | 0/30 — all `Premature close` |

Node **22.23.0** carries the `http.Agent` regression tracked in [nodejs/node#63989](https://github.com/nodejs/node/issues/63989): reused keep-alive sockets fail with `ERR_STREAM_PREMATURE_CLOSE` on chunked/gzip HTTPS responses, breaking the `node-fetch@2` / `gaxios@6` stack.

`@owox/internal-helpers`' `ImpersonatedIdTokenFetcher` uses `google-auth-library@9.15.1` → `gaxios@6.7.1` → `node-fetch@2.7.0` for every token call. On the 22.23.0 image it could no longer mint C2C ID tokens, which took down `app.owox.com` ↔ integrated-backend auth (sign-in, `/oauth/token`, `/api/data-marts`, `/api/members/*`, `/mcp`) in production on 2026-06-18 — **with no code change**. The image diff confirmed it: the two images' npm dependency trees are identical (1014/1022 packages; only the 8 `@owox/*` packages differ), so the Node version was the only variable.

## Fix

Pin to the last known-good patch (`22.22.3`). Bumps should be deliberate and verified.

## Follow-ups (separate PRs)

- Move `@owox/internal-helpers` to `google-auth-library@^10` (gaxios 7 on native `fetch`/undici) to drop the fragile `node-fetch@2` entirely — durable fix independent of the open upstream Node issue.
- Re-enable `npm-shrinkwrap.json` generation for `owox` before publish (currently disabled, `publish.yml`) so transitive deps are locked in the published artifact instead of floating at build time.
- Unpin / bump once nodejs/node#63989 ships a fix.