### PR TITLE
fix(web): serve connector OAuth callback pages via SPA fallback

### DIFF
--- a/.changeset/oauth-connector-callback-routing.md
+++ b/.changeset/oauth-connector-callback-routing.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Reliable OAuth sign-in for ad platform connectors
+
+Previously, signing in to connectors that use OAuth (such as Microsoft Ads, TikTok, LinkedIn, and Google Ads) could end with a "Not Found" error right after authorizing with the provider, because the connector's callback page was routed to the backend instead of the web app. Now these callback pages load correctly and the sign-in flow completes, so the connector gets connected as expected. This affects both self-hosted and cloud deployments.

--- a/apps/owox/src/web/static-config.ts
+++ b/apps/owox/src/web/static-config.ts
@@ -14,7 +14,15 @@ export interface StaticAssetsOptions {
   packageName?: string;
 }
 
-const DEFAULT_EXCLUDED_ROUTES = ['/api', '/.well-known', '/oauth', '/mcp'];
+const DEFAULT_EXCLUDED_ROUTES = [
+  '/api',
+  '/.well-known',
+  '/oauth/authorize',
+  '/oauth/token',
+  '/oauth/register',
+  '/oauth/jwks',
+  '/mcp',
+];
 
 /**
  * Configures Express application to serve static web interface files

--- a/apps/owox/test/web/static-config.test.ts
+++ b/apps/owox/test/web/static-config.test.ts
@@ -143,4 +143,65 @@ describe('setupWebStaticAssets', () => {
       );
     });
   });
+
+  // Guards the split between backend OAuth endpoints (MCP/IDP authorization
+  // server + discovery) and front-end OAuth connector callback pages. Both
+  // live under `/oauth/*`, so the exclude list must be specific enough to keep
+  // the backend endpoints routed to NestJS while letting connector callback
+  // pages fall through to the SPA. Re-broadening the excludes to `/oauth` (the
+  // regression this guards) breaks every connector sign-in; dropping a backend
+  // endpoint from the list breaks MCP OAuth.
+  describe('OAuth route exclusions (MCP/IDP backend vs connector callbacks)', () => {
+    beforeEach(() => {
+      // No backend handlers are registered here, so if the SPA fallback wrongly
+      // catches a backend route it returns index.html (200) instead of a 404.
+      const configured = setupWebStaticAssets(app);
+      expect(configured, '@owox/web must be built for these tests').to.be.true;
+    });
+
+    // Must stay routed to the NestJS backend (never served the SPA shell).
+    // Mirrors apps/backend/src/idp/oauth + ee/mcp metadata controllers.
+    const backendOnlyRoutes = [
+      '/oauth/authorize',
+      '/oauth/token',
+      '/oauth/register',
+      '/oauth/jwks',
+      '/.well-known/oauth-protected-resource',
+      '/.well-known/oauth-authorization-server',
+      '/.well-known/openid-configuration',
+      '/mcp',
+      '/mcp/.well-known/oauth-protected-resource',
+    ];
+
+    for (const route of backendOnlyRoutes) {
+      it(`must NOT serve the SPA shell for backend route ${route}`, async () => {
+        const response = await request(app).get(route);
+
+        expect(response.status, route).to.equal(404);
+        expect(response.text, route).not.to.contain('<div id="root"></div>');
+      });
+    }
+
+    // Connector OAuth callback pages are front-end routes and MUST be served
+    // the SPA shell so React Router can capture the auth code. Mirrors
+    // apps/web/src/routes/oauth.routes.tsx.
+    const connectorCallbackRoutes = [
+      '/oauth/microsoft-ads/callback',
+      '/oauth/google/callback',
+      '/oauth/google-ads/callback',
+      '/oauth/tiktok/callback',
+      '/oauth/linkedin-ads/callback',
+      '/oauth/linkedin-pages/callback',
+    ];
+
+    for (const route of connectorCallbackRoutes) {
+      it(`must serve the SPA shell for connector callback ${route}`, async () => {
+        const response = await request(app).get(route);
+
+        expect(response.status, route).to.equal(200);
+        expect(response.headers['content-type'], route).to.match(/text\/html/);
+        expect(response.text, route).to.contain('<div id="root"></div>');
+      });
+    }
+  });
 });


### PR DESCRIPTION
# Problem

Signing in to any connector that uses OAuth (Microsoft Ads, Google Ads, TikTok, LinkedIn) failed at the final step: after the user authorized with the provider, the browser was redirected to a callback page such as `/oauth/microsoft-ads/callback` and got a NestJS `404 Not Found` (`Cannot GET /oauth/microsoft-ads/callback`) instead of the app. The callback pages are front-end (SPA) routes, but the web server's SPA fallback excluded the entire `/oauth` prefix from serving `index.html`, so every `/oauth/*` request fell through to the backend, which only serves `/api/*`. The broad exclusion was originally added to keep the MCP/IDP OAuth authorization-server endpoints routed to the backend, but it unintentionally swallowed the connector callback pages too. This affected both self-hosted and cloud deployments.

# Solution

Narrow the SPA-fallback exclusion list from the catch-all `/oauth` to only the specific backend OAuth endpoints, so connector callback pages once again fall through to the SPA while MCP/IDP OAuth keeps working.

- Updated `DEFAULT_EXCLUDED_ROUTES` in `apps/owox/src/web/static-config.ts` to exclude `/oauth/authorize`, `/oauth/token`, `/oauth/register`, and `/oauth/jwks` instead of all of `/oauth`. These four mirror the IDP OAuth controllers (`apps/backend/src/idp/oauth/controllers/*`); discovery metadata stays covered by the unchanged `/.well-known` and `/mcp` excludes.
- Connector callback paths (`/oauth/<provider>/callback`) no longer match any exclusion, so they are served `index.html` and React Router can capture the auth code.
- Added a regression test that asserts both directions of the split, so re-broadening to `/oauth` (which breaks connector sign-in) or dropping a backend endpoint (which breaks MCP OAuth) fails CI.

# Changes

- Replaced the `/oauth` catch-all in `DEFAULT_EXCLUDED_ROUTES` with the explicit backend endpoints `/oauth/authorize`, `/oauth/token`, `/oauth/register`, `/oauth/jwks`.
- Added tests in `apps/owox/test/web/static-config.test.ts` verifying MCP/IDP backend OAuth and discovery endpoints are not served the SPA shell, while connector callback pages are.
- Added a changeset (`owox`, minor) describing the restored OAuth connector sign-in.