### PR TITLE
feat(mcp): add display titles to data-mart-catalog and project-context tools

### DIFF
--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -87,6 +87,7 @@ describe('ListDataMartsTool', () => {
         data_marts: expect.any(Object),
       }),
       annotations: {
+        title: 'List Data Marts',
         readOnlyHint: true,
         destructiveHint: false,
         openWorldHint: false,

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.ts
@@ -27,6 +27,7 @@ export class ListDataMartsTool implements McpToolDefinition<ListDataMartsInput> 
     ),
   };
   readonly annotations = {
+    title: 'List Data Marts',
     readOnlyHint: true,
     destructiveHint: false,
     openWorldHint: false,

--- a/apps/backend/src/ee/mcp/tools/project-context.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/project-context.tool.spec.ts
@@ -84,6 +84,7 @@ describe('GetProjectContextTool', () => {
         project_switching: expect.any(Object),
       }),
       annotations: {
+        title: 'Get Project Context',
         readOnlyHint: true,
         destructiveHint: false,
         openWorldHint: false,

--- a/apps/backend/src/ee/mcp/tools/project-context.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/project-context.tool.ts
@@ -27,6 +27,7 @@ export class GetProjectContextTool implements McpToolDefinition<GetProjectContex
     project_switching: z.string(),
   };
   readonly annotations = {
+    title: 'Get Project Context',
     readOnlyHint: true,
     destructiveHint: false,
     openWorldHint: false,


### PR DESCRIPTION
## What

Added human-readable `title` to the `annotations` of the `list_data_marts` and `get_project_context` MCP tools.

## Why

The `title` annotation is an optional MCP hint that lets clients show a friendly tool name in their UI instead of falling back to the raw tool `name` (e.g. `list_data_marts`).

## Changes

- `data-mart-catalog.tool.ts` — `title: 'List Data Marts'`
- `project-context.tool.ts` — `title: 'Get Project Context'`
- Updated both `.spec.ts` files to assert the new `title` in `annotations`

## Tests

`npx jest` for both tool specs — 6 passed.