### PR TITLE
feat(mcp): expose data mart description in list_data_marts tool

### DIFF
--- a/apps/backend/src/data-marts/dto/domain/data-mart-list-item.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/data-mart-list-item.dto.ts
@@ -14,6 +14,7 @@ export class DataMartListItemDto {
     public readonly storageTitle: string,
     public readonly createdAt: Date,
     public readonly modifiedAt: Date,
+    public readonly description: string | null = null,
     public readonly definitionType?: DataMartDefinitionType,
     public readonly definition?: DataMartDefinition,
     public readonly triggersCount: number = 0,

--- a/apps/backend/src/data-marts/dto/presentation/data-mart-list-item-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-mart-list-item-response-api.dto.ts
@@ -19,6 +19,9 @@ export class DataMartListItemResponseApiDto {
   @ApiProperty()
   storage: DataMartListItemStorageApiDto;
 
+  @ApiProperty({ example: 'Data mart description', nullable: true })
+  description: string | null;
+
   @ApiProperty({ enum: DataMartDefinitionType, example: DataMartDefinitionType.SQL })
   definitionType?: DataMartDefinitionType;
 

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.spec.ts
@@ -20,7 +20,8 @@ describe('McpDataMartsFacadeImpl', () => {
             DataStorageType.GOOGLE_BIGQUERY,
             'BigQuery',
             new Date('2026-06-01T10:00:00.000Z'),
-            new Date('2026-06-10T10:00:00.000Z')
+            new Date('2026-06-10T10:00:00.000Z'),
+            'Mock Description'
           ),
         ],
         total: 1,
@@ -48,7 +49,7 @@ describe('McpDataMartsFacadeImpl', () => {
         {
           id: 'dm_1',
           title: 'Orders',
-          description: null,
+          description: 'Mock Description',
           status: DataMartStatus.PUBLISHED,
           updatedAt: '2026-06-10T10:00:00.000Z',
         },

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.ts
@@ -20,7 +20,7 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
       dataMarts: result.items.map(item => ({
         id: item.id,
         title: item.title,
-        description: null,
+        description: item.description,
         status: item.status,
         updatedAt: item.modifiedAt.toISOString(),
       })),

--- a/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
@@ -289,6 +289,7 @@ export class DataMartMapper {
       entity.storage.title || toHumanReadable(entity.storage.type),
       entity.createdAt,
       entity.modifiedAt,
+      entity.description ?? null,
       entity.definitionType,
       entity.definition,
       counters.triggersCount,
@@ -308,6 +309,7 @@ export class DataMartMapper {
       title: dto.title,
       status: dto.status,
       storage: { type: dto.storageType, title: dto.storageTitle },
+      description: dto.description,
       definitionType: dto.definitionType,
       connectorSourceName:
         dto.definitionType === DataMartDefinitionType.CONNECTOR && dto.definition

--- a/apps/backend/src/data-marts/services/data-mart.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart.service.ts
@@ -78,6 +78,7 @@ export class DataMartService {
         'dm.id',
         'dm.title',
         'dm.status',
+        'dm.description',
         'dm.definitionType',
         'dm.createdById',
         'dm.createdAt',


### PR DESCRIPTION
## What

The MCP `list_data_marts` tool now returns each data mart's real `description` instead of always returning an empty/`null` value.

## Changes

- `data-mart.service.ts` — add `dm.description` to the data mart list query select.
- `data-mart-list-item.dto.ts` — add `description` to the list-item domain DTO.
- `data-mart.mapper.ts` — map `entity.description` into the list-item DTO and the REST list response.
- `data-mart-list-item-response-api.dto.ts` — expose `description` on the REST list response.
- `mcp-data-marts.facade.impl.ts` — return `item.description` (was hardcoded `null`).
- `mcp-data-marts.facade.impl.spec.ts` — update expectations.

## Impact on non-MCP parts

Additive only. The REST list endpoint now also includes a new `description` field; no existing field/behavior changed. The `list_data_marts` tool coerces `null` → `""`, so data marts without a description stay safe.

## Testing

- Unit test for the MCP facade passes.
- Typecheck clean for the changed production files (pre-existing spec mock-typing errors are unrelated).
- e2e not run (per request).