### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/docs/destinations/manage-destinations.md
+++ b/docs/destinations/manage-destinations.md
@@ -23,7 +23,7 @@ To configure a new **Destination**:
 
 1. On the **Destinations** page, click **+ New Destination**.
 2. Choose a storage type option on the **Destination Type** dropdown list:
-    - [Google Sheets](supported-destinations/google-spreadsheets.md)
+    - [Google Sheets](supported-destinations/google-sheets.md)
     - [Data Studio](supported-destinations/data-studio.md)
     - [Email](supported-destinations/email.md)
     - [Slack](supported-destinations/slack.md)

--- a/docs/editions/appsscript-edition.md
+++ b/docs/editions/appsscript-edition.md
@@ -43,7 +43,7 @@ Whether you're an analyst at an agency, a startup, or in a huge enterprise, this
 
 ---
 
-This is the starting point for data connectivity, but we also have the **OWOX Data Marts** **[🌐 Cloud](https://app.owox.com?utm_source=github&utm_medium=referral&utm_campaign=appscriptreadme)** and **[Self-Hosted](./all-editions.md)** Editions.
+This is the starting point for data connectivity, but we also have the **OWOX Data Marts** **[🌐 Cloud](https://app.owox.com?utm_source=github&utm_medium=referral&utm_campaign=appscriptreadme)** and **[Self-Hosted](./self-managed-editions.md)** Editions.
 
 ## 🧰 How It Works
 

--- a/docs/getting-started/setup-guide/view-data-mart.md
+++ b/docs/getting-started/setup-guide/view-data-mart.md
@@ -94,7 +94,7 @@ You can also open the **Run History** tab to view execution logs, status, and ti
 
 - [Scheduling Reports Updates →](report-triggers.md)
 - [Adding More Report Destinations →](../../destinations/manage-destinations.md)
-- [Create Connector-Based Data Mart →](onnector-data-mart.md)
+- [Create Connector-Based Data Mart →](connector-data-mart.md)
 - [Create SQL-Based Data Mart →](sql-data-mart.md)
 - [Create Table-Based Data Mart →](table-data-mart.md)
 - [Create Pattern-Based Data Mart →](pattern-data-mart.md)

--- a/docs/templates/ga4bigquery/define-ga4-visitors.md
+++ b/docs/templates/ga4bigquery/define-ga4-visitors.md
@@ -13,7 +13,7 @@ This script standardizes visitor definition logic into a **single, reusable Data
 - First date seen
 - Last date seen
 - Count of total events
-- Geo, location, device, consent - are not included, as they are the part of the [sessions data mart](./ga4bigquery/define-GA4-sessions.md)
+- Geo, location, device, consent - are not included, as they are the part of the [sessions data mart](./define-GA4-sessions.md)
 
 Use this as the foundation for reporting in:
 


### PR DESCRIPTION
- Fix the Google Sheets destination documentation link.
- Update the Self-Hosted editions link.
- Correct the connector-based data mart setup guide link.
- Fix the GA4 visitors template link to the GA4 sessions data mart.