### PR TITLE
fix(idp): accept null avatar in MCP OAuth token payload

### DIFF
--- a/packages/idp-owox-better-auth/src/client/IdentityOwoxClient.mcpOAuth.test.ts
+++ b/packages/idp-owox-better-auth/src/client/IdentityOwoxClient.mcpOAuth.test.ts
@@ -161,6 +161,33 @@ describe('IdentityOwoxClient MCP OAuth flow', () => {
     expect(result?.clientId).toBe('mcp-client');
   });
 
+  it('verifies an MCP access token whose payload has a null avatar', async () => {
+    httpMock.post.mockResolvedValue({
+      data: {
+        active: true,
+        payload: {
+          clientId: 'mcp-client',
+          userId: 'user-1',
+          projectId: 'project-1',
+          roles: ['viewer'],
+          avatar: null,
+          resource: 'https://mcp.owox.com/mcp',
+          scopes: ['mcp:read'],
+          authFlow: 'mcp',
+        },
+      },
+    });
+
+    const result = await createClient().verifyMcpAccessToken({
+      token: 'access-token',
+      resource: 'https://mcp.owox.com/mcp',
+      requiredScopes: ['mcp:read'],
+    });
+
+    expect(result?.projectId).toBe('project-1');
+    expect(result?.avatar).toBeUndefined();
+  });
+
   it('gets one project for a user through C2C backchannel', async () => {
     httpMock.get.mockResolvedValue({
       data: {

--- a/packages/idp-protocol/src/types/oauth-schema.test.ts
+++ b/packages/idp-protocol/src/types/oauth-schema.test.ts
@@ -85,6 +85,23 @@ describe('MCP OAuth protocol schemas', () => {
     ).toThrow();
   });
 
+  it('accepts a null avatar from the identity service and normalizes it to undefined', () => {
+    const payload = McpTokenPayloadSchema.parse({
+      clientId: 'mcp-client-1',
+      userId: 'user-1',
+      projectId: 'project-1',
+      email: 'user@example.com',
+      avatar: null,
+      roles: ['viewer'],
+      resource: 'https://mcp.owox.com/mcp',
+      scopes: ['mcp:read'],
+      authFlow: 'mcp',
+    });
+
+    expect(payload.avatar).toBeUndefined();
+    expect(payload.projectId).toBe('project-1');
+  });
+
   it('requires project-member context before issuing an authorization code', () => {
     const context = McpOAuthProjectMemberContextSchema.parse({
       userId: 'user-1',

--- a/packages/idp-protocol/src/types/oauth.ts
+++ b/packages/idp-protocol/src/types/oauth.ts
@@ -33,7 +33,14 @@ export const McpOAuthProjectMemberContextSchema = z.object({
   projectId: z.string().min(1),
   email: z.string().email().optional(),
   fullName: z.string().optional(),
-  avatar: z.string().url().optional(),
+  // The identity service sends `null` when the user has no avatar (or has
+  // restricted it); accept it and normalize to `undefined` so downstream
+  // consumers keep a `string | undefined` shape.
+  avatar: z
+    .string()
+    .url()
+    .nullish()
+    .transform(value => value ?? undefined),
   roles: z.array(RoleEnum).min(1),
 });
 export type McpOAuthProjectMemberContext = z.infer<typeof McpOAuthProjectMemberContextSchema>;


### PR DESCRIPTION
## Problem

Users could not connect the OWOX Data Marts (ODM) MCP server from Claude. The OAuth flow (authorize + token exchange) succeeded and the project was selected, but on returning to Claude they got:

> Your account was authorized, but ODM returned an error when connecting.

The failure was on the first MCP call (`POST /mcp`, method `initialize`), which returned **HTTP 500**.

## Root cause

`McpAuthGuard` verifies the bearer token via `IdentityOwoxClient.verifyMcpAccessToken`, which parses the identity service response with `McpTokenPayloadSchema`. The `avatar` field was declared as:

```ts
avatar: z.string().url().optional()
```

`.optional()` accepts `undefined` but **not `null`**. The identity service returns `avatar: null` when the user has no avatar (or restricted it), producing a `ZodError`:

```
ZodError: [{ "expected": "string", "received": "null", "path": ["payload","avatar"] }]
  at IdentityOwoxClient.verifyMcpAccessToken (...)
  at McpAuthGuard.canActivate (...)
```

Because the verify path throws (instead of returning `null`) and the error is not an `UnauthorizedException`, it fell through to the global filter as HTTP 500 — surfaced in Claude as "ODM returned an error when connecting".

## Fix

In `packages/idp-protocol/src/types/oauth.ts`, accept `null` and normalize it to `undefined` so the output type stays `string | undefined` and no downstream code changes:

```ts
avatar: z.string().url().nullish().transform(value => value ?? undefined)
```

## Tests

- `oauth-schema.test.ts` — `McpTokenPayloadSchema` accepts `avatar: null` and normalizes to `undefined`.
- `IdentityOwoxClient.mcpOAuth.test.ts` — regression on the exact `verifyMcpAccessToken` path with `payload.avatar = null`.

`@owox/idp-protocol` 17/17 and `@owox/idp-owox-better-auth` mcpOAuth tests green; backend typecheck shows no new production errors.

## Notes / follow-ups (not in this PR)

- `McpAuthGuard` still maps any other `verifyToken` failure to HTTP 500 instead of 401 — worth hardening separately.
- `PayloadSchema` (`models.ts`) and `email`/`fullName` in the MCP context use the same strict `.optional()` and could exhibit the same null issue (lower risk: JWT claims usually omit absent fields rather than emit explicit `null`).