### PR TITLE
feat(mcp): add OpenAI Apps domain-verification endpoint

### DIFF
--- a/.changeset/mcp-openai-apps-domain-verification.md
+++ b/.changeset/mcp-openai-apps-domain-verification.md
@@ -1,0 +1,7 @@
+---
+"owox": minor
+---
+
+# Add OpenAI Apps domain-verification endpoint for the MCP host
+
+Serve the OpenAI Apps verification token as `text/plain` (HTTP 200) at the origin-root well-known path `GET /.well-known/openai-apps-challenge`, so the OWOX MCP server can pass OpenAI's domain verification during app submission. The endpoint is public (no auth, served at the host root rather than under `/api`) and returns 404 until the token is configured via the new `MCP_OPENAI_APPS_CHALLENGE_TOKEN` environment variable.

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ PUBLIC_ORIGIN=
 # Example for Claude web: https://claude.ai
 # Default: empty
 MCP_DYNAMIC_CLIENT_ALLOWED_REDIRECT_ORIGINS=
+
+# OpenAI Apps domain-verification token. Served verbatim as text/plain at
+# https://<mcp-host>/.well-known/openai-apps-challenge (public, no auth). Supplied by
+# OpenAI in the app submission UI; leave empty to disable the endpoint (returns 404).
+# Default: empty
+MCP_OPENAI_APPS_CHALLENGE_TOKEN=
 # -------------------------------------------------------------------------------------------
 
 # --- @owox/backend variables ---------------------------------------------------------------

--- a/apps/backend/src/config/protocol-route-exclusions.config.ts
+++ b/apps/backend/src/config/protocol-route-exclusions.config.ts
@@ -5,6 +5,7 @@ export const PROTOCOL_ROUTE_EXCLUSIONS = [
   { path: '.well-known/oauth-protected-resource/(.*)', method: RequestMethod.ALL },
   { path: '.well-known/oauth-authorization-server', method: RequestMethod.ALL },
   { path: '.well-known/oauth-authorization-server/(.*)', method: RequestMethod.ALL },
+  { path: '.well-known/openai-apps-challenge', method: RequestMethod.ALL },
   { path: 'oauth/(.*)', method: RequestMethod.ALL },
   { path: 'mcp', method: RequestMethod.ALL },
   { path: 'mcp/(.*)', method: RequestMethod.ALL },

--- a/apps/backend/src/ee/mcp/config/mcp.config.ts
+++ b/apps/backend/src/ee/mcp/config/mcp.config.ts
@@ -32,6 +32,16 @@ export class McpConfigService {
     );
   }
 
+  /**
+   * Verification token for OpenAI Apps domain verification, served verbatim as
+   * `text/plain` at `/.well-known/openai-apps-challenge`. Provided by OpenAI when
+   * submitting the MCP app; configured via env so it can be rotated without a code
+   * change. Returns `undefined` when unset, in which case the endpoint responds 404.
+   */
+  get openaiAppsChallengeToken(): string | undefined {
+    return this.config.get<string>('MCP_OPENAI_APPS_CHALLENGE_TOKEN')?.trim() || undefined;
+  }
+
   get serverName(): string {
     return this.config.get<string>('MCP_SERVER_NAME') ?? 'owox-mcp';
   }

--- a/apps/backend/src/ee/mcp/controllers/mcp-metadata.controller.spec.ts
+++ b/apps/backend/src/ee/mcp/controllers/mcp-metadata.controller.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { McpConfigService } from '../config/mcp.config';
 import { McpMetadataController } from './mcp-metadata.controller';
@@ -32,5 +33,25 @@ describe('McpMetadataController', () => {
       scopes_supported: ['mcp:read', 'mcp:write'],
       resource_documentation: 'https://docs.dev.owox.com/mcp',
     });
+  });
+
+  it('returns the configured OpenAI Apps challenge token verbatim', () => {
+    const config = new McpConfigService({
+      get: jest.fn((key: string) =>
+        key === 'MCP_OPENAI_APPS_CHALLENGE_TOKEN' ? 'test-openai-apps-challenge-token' : undefined
+      ),
+    } as unknown as ConfigService);
+    const controller = new McpMetadataController(config);
+
+    expect(controller.getOpenaiAppsChallenge()).toBe('test-openai-apps-challenge-token');
+  });
+
+  it('responds with 404 when no OpenAI Apps challenge token is configured', () => {
+    const config = new McpConfigService({
+      get: jest.fn(() => undefined),
+    } as unknown as ConfigService);
+    const controller = new McpMetadataController(config);
+
+    expect(() => controller.getOpenaiAppsChallenge()).toThrow(NotFoundException);
   });
 });

--- a/apps/backend/src/ee/mcp/controllers/mcp-metadata.controller.ts
+++ b/apps/backend/src/ee/mcp/controllers/mcp-metadata.controller.ts
@@ -32,6 +32,7 @@ export class McpMetadataController {
    */
   @Get(OPENAI_APPS_CHALLENGE_PATH)
   @Header('Content-Type', 'text/plain; charset=utf-8')
+  @Header('Cache-Control', 'no-store')
   getOpenaiAppsChallenge(): string {
     const token = this.config.openaiAppsChallengeToken;
     if (!token) {

--- a/apps/backend/src/ee/mcp/controllers/mcp-metadata.controller.ts
+++ b/apps/backend/src/ee/mcp/controllers/mcp-metadata.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Header, NotFoundException } from '@nestjs/common';
 import { OAuthProtectedResourceMetadataSchema } from '@owox/idp-protocol';
 import { McpConfigService } from '../config/mcp.config';
 
@@ -7,6 +7,8 @@ const PROTECTED_RESOURCE_METADATA_PATHS = [
   '/.well-known/oauth-protected-resource/mcp',
   '/mcp/.well-known/oauth-protected-resource',
 ];
+
+const OPENAI_APPS_CHALLENGE_PATH = '/.well-known/openai-apps-challenge';
 
 @Controller()
 export class McpMetadataController {
@@ -20,5 +22,21 @@ export class McpMetadataController {
       scopes_supported: this.config.scopes,
       resource_documentation: this.config.resourceDocumentationUrl,
     });
+  }
+
+  /**
+   * OpenAI Apps domain verification. OpenAI pings this origin-root well-known URL
+   * and expects the verification token back as plain text with a 200. Public (no
+   * auth, no `/api` prefix — see PROTOCOL_ROUTE_EXCLUSIONS). Returns 404 until the
+   * token is configured so we never publish an empty challenge.
+   */
+  @Get(OPENAI_APPS_CHALLENGE_PATH)
+  @Header('Content-Type', 'text/plain; charset=utf-8')
+  getOpenaiAppsChallenge(): string {
+    const token = this.config.openaiAppsChallengeToken;
+    if (!token) {
+      throw new NotFoundException();
+    }
+    return token;
   }
 }

--- a/apps/backend/test/mcp-oauth.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth.e2e-spec.ts
@@ -101,6 +101,7 @@ describe('MCP OAuth discovery (e2e)', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers['content-type']).toContain('text/plain');
+    expect(response.headers['cache-control']).toBe('no-store');
     expect(response.text).toBe(challengeToken);
   });
 

--- a/apps/backend/test/mcp-oauth.e2e-spec.ts
+++ b/apps/backend/test/mcp-oauth.e2e-spec.ts
@@ -7,10 +7,13 @@ describe('MCP OAuth discovery (e2e)', () => {
   let agent: supertest.Agent;
   const originalMcpPublicBaseUrl = process.env.MCP_PUBLIC_BASE_URL;
   const originalOwoxAuthPublicBaseUrl = process.env.OWOX_AUTH_PUBLIC_BASE_URL;
+  const originalOpenaiAppsChallengeToken = process.env.MCP_OPENAI_APPS_CHALLENGE_TOKEN;
+  const challengeToken = 'test-openai-apps-challenge-token';
 
   beforeAll(async () => {
     process.env.MCP_PUBLIC_BASE_URL = 'https://mcp.owox.com';
     process.env.OWOX_AUTH_PUBLIC_BASE_URL = 'https://app.owox.com';
+    process.env.MCP_OPENAI_APPS_CHALLENGE_TOKEN = challengeToken;
     const testApp = await createTestApp();
     app = testApp.app;
     agent = testApp.agent;
@@ -29,6 +32,11 @@ describe('MCP OAuth discovery (e2e)', () => {
       delete process.env.OWOX_AUTH_PUBLIC_BASE_URL;
     } else {
       process.env.OWOX_AUTH_PUBLIC_BASE_URL = originalOwoxAuthPublicBaseUrl;
+    }
+    if (originalOpenaiAppsChallengeToken === undefined) {
+      delete process.env.MCP_OPENAI_APPS_CHALLENGE_TOKEN;
+    } else {
+      process.env.MCP_OPENAI_APPS_CHALLENGE_TOKEN = originalOpenaiAppsChallengeToken;
     }
   });
 
@@ -86,6 +94,20 @@ describe('MCP OAuth discovery (e2e)', () => {
         registration_endpoint: 'https://app.owox.com/oauth/register',
       });
     }
+  });
+
+  it('serves the OpenAI Apps domain-verification challenge token as text/plain at the origin-root well-known path', async () => {
+    const response = await agent.get('/.well-known/openai-apps-challenge');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toContain('text/plain');
+    expect(response.text).toBe(challengeToken);
+  });
+
+  it('does not expose the OpenAI Apps challenge under the /api prefix', async () => {
+    const response = await agent.get('/api/.well-known/openai-apps-challenge');
+
+    expect(response.status).toBe(404);
   });
 
   it('challenges unauthenticated MCP requests with protected resource metadata', async () => {


### PR DESCRIPTION
## Summary

Adds a public endpoint so the OWOX MCP server can pass **OpenAI Apps domain verification** during app submission. OpenAI pings an origin-root well-known URL on the MCP host and expects the verification token back as plain text with a 200.

- **Route:** `GET /.well-known/openai-apps-challenge` → returns the token as `text/plain` (HTTP 200), served at the **host root** (not under `/api`).
- **Public:** no auth — added to `PROTOCOL_ROUTE_EXCLUSIONS` so it bypasses the `/api` prefix, same as the existing OAuth well-known metadata routes.
- **Config-driven:** the token comes from the new `MCP_OPENAI_APPS_CHALLENGE_TOKEN` env var (rotatable without a code change). Returns **404** until the token is configured, so we never publish an empty challenge.

## Out of scope

This PR is **only** the domain-verification endpoint. The separate `GET /oauth/authorize` HTTP 500 seen in the ChatGPT Apps OAuth flow is **not** addressed here — its root cause is upstream in the Java Identity backend (`Data too long for column 'state'` when persisting the MCP OAuth authorization code for OpenAI's long relay `state`), which needs a fix in that repo.

## Testing

- Unit (`mcp-metadata.controller.spec.ts`): returns the configured token verbatim; responds 404 when unset.
- E2E (`mcp-oauth.e2e-spec.ts`): serves the token as `text/plain` at the origin-root path; confirms it is **not** exposed under `/api`.
- `eslint` clean; `tsc -b` introduces no new errors.

## Rollout (infra — required before OpenAI can verify)

- [ ] Set `MCP_OPENAI_APPS_CHALLENGE_TOKEN` (value from OpenAI's submission UI) in the production `mcp.owox.com` backend
- [ ] Deploy
- [ ] Ensure `/.well-known/openai-apps-challenge` is publicly reachable on the `mcp.owox.com` root (no auth / no WAF block)