### PR TITLE
Fix search indexing sort memory exhaustion

### DIFF
--- a/.changeset/add-search-functionality.md
+++ b/.changeset/add-search-functionality.md
@@ -1,0 +1,7 @@
+---
+"owox": minor
+---
+
+# Add search functionality
+
+Add search functionality for finding project data marts, storages, and destinations from the project search index.

--- a/.changeset/fix-search-indexing-sort-memory.md
+++ b/.changeset/fix-search-indexing-sort-memory.md
@@ -1,0 +1,7 @@
+---
+"owox": minor
+---
+
+# Optimize search indexing pagination to avoid MySQL sort-buffer exhaustion
+
+Reduce the row width involved in search-index pagination queries so MySQL does not need to filesort large JSON/text payloads while indexing data marts, storages, and destinations. Storage and destination indexing now page narrow key rows before hydrating credential data, while data-mart indexing uses a narrower projection and an order that aligns with the existing `idx_dm_project_deleted_created` composite index.

--- a/.changeset/fix-search-indexing-sort-memory.md
+++ b/.changeset/fix-search-indexing-sort-memory.md
@@ -1,7 +1,0 @@
----
-"owox": minor
----
-
-# Optimize search indexing pagination to avoid MySQL sort-buffer exhaustion
-
-Reduce the row width involved in search-index pagination queries so MySQL does not need to filesort large JSON/text payloads while indexing data marts, storages, and destinations. Storage and destination indexing now page narrow key rows before hydrating credential data, while data-mart indexing uses a narrower projection and an order that aligns with the existing `idx_dm_project_deleted_created` composite index.

--- a/apps/backend/src/data-marts/search/catalog/typeorm-data-mart-catalog.adapter.spec.ts
+++ b/apps/backend/src/data-marts/search/catalog/typeorm-data-mart-catalog.adapter.spec.ts
@@ -172,6 +172,72 @@ describe('TypeOrmDataMartCatalogAdapter', () => {
       expect(page.descriptors).toHaveLength(2);
       expect(page.nextCursor).not.toBeNull();
     });
+
+    it('paginates by createdAt DESC and id ASC to match the existing data_mart index', async () => {
+      const storage = await seedStorage();
+      const firstTie = await seedMart(storage, {
+        title: 'First Tie',
+        status: DataMartStatus.PUBLISHED,
+      });
+      const secondTie = await seedMart(storage, {
+        title: 'Second Tie',
+        status: DataMartStatus.PUBLISHED,
+      });
+      const older = await seedMart(storage, { title: 'Older', status: DataMartStatus.PUBLISHED });
+
+      await martRepo.query('UPDATE data_mart SET createdAt = ? WHERE id IN (?, ?)', [
+        '2024-01-02 00:00:00',
+        firstTie.id,
+        secondTie.id,
+      ]);
+      await martRepo.query('UPDATE data_mart SET createdAt = ? WHERE id = ?', [
+        '2024-01-01 00:00:00',
+        older.id,
+      ]);
+
+      const sameTimestampIds = [firstTie.id, secondTie.id].sort();
+
+      const page1 = await adapter.listSearchablePage('proj-1', null, 2);
+      expect(page1.descriptors.map(d => d.entityId)).toEqual(sameTimestampIds);
+      expect(page1.nextCursor).not.toBeNull();
+
+      const page2 = await adapter.listSearchablePage('proj-1', page1.nextCursor, 2);
+      expect(page2.descriptors.map(d => d.entityId)).toEqual([older.id]);
+      expect(page2.nextCursor).toBeNull();
+    });
+
+    it('keeps the keyset page query narrow by disabling eager relation loading', async () => {
+      const storage = await seedStorage();
+      await seedMart(storage, { title: 'A', status: DataMartStatus.PUBLISHED });
+      await seedMart(storage, { title: 'B', status: DataMartStatus.PUBLISHED });
+
+      const findSpy = jest.spyOn(martRepo, 'find');
+
+      try {
+        await adapter.listSearchablePage('proj-1', null, 1);
+
+        expect(findSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            select: expect.objectContaining({
+              id: true,
+              projectId: true,
+              title: true,
+              description: true,
+              schema: true,
+              status: true,
+              createdAt: true,
+              modifiedAt: true,
+            }),
+            loadEagerRelations: false,
+            order: { createdAt: 'DESC', id: 'ASC' },
+            take: 1,
+          })
+        );
+        expect(findSpy.mock.calls[0][0]).not.toHaveProperty('relations');
+      } finally {
+        findSpy.mockRestore();
+      }
+    });
   });
 
   describe('loadSearchable', () => {

--- a/apps/backend/src/data-marts/search/catalog/typeorm-data-mart-catalog.adapter.spec.ts
+++ b/apps/backend/src/data-marts/search/catalog/typeorm-data-mart-catalog.adapter.spec.ts
@@ -206,7 +206,7 @@ describe('TypeOrmDataMartCatalogAdapter', () => {
       expect(page2.nextCursor).toBeNull();
     });
 
-    it('keeps the keyset page query narrow by disabling eager relation loading', async () => {
+    it('loads the keyset page before hydrating searchable mart fields', async () => {
       const storage = await seedStorage();
       await seedMart(storage, { title: 'A', status: DataMartStatus.PUBLISHED });
       await seedMart(storage, { title: 'B', status: DataMartStatus.PUBLISHED });
@@ -216,7 +216,18 @@ describe('TypeOrmDataMartCatalogAdapter', () => {
       try {
         await adapter.listSearchablePage('proj-1', null, 1);
 
-        expect(findSpy).toHaveBeenCalledWith(
+        expect(findSpy).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            select: { id: true, createdAt: true },
+            loadEagerRelations: false,
+            order: { createdAt: 'DESC', id: 'ASC' },
+            take: 1,
+          })
+        );
+        expect(findSpy.mock.calls[0][0]).not.toHaveProperty('relations');
+        expect(findSpy).toHaveBeenNthCalledWith(
+          2,
           expect.objectContaining({
             select: expect.objectContaining({
               id: true,
@@ -225,15 +236,17 @@ describe('TypeOrmDataMartCatalogAdapter', () => {
               description: true,
               schema: true,
               status: true,
-              createdAt: true,
               modifiedAt: true,
             }),
             loadEagerRelations: false,
-            order: { createdAt: 'DESC', id: 'ASC' },
-            take: 1,
           })
         );
-        expect(findSpy.mock.calls[0][0]).not.toHaveProperty('relations');
+        expect(findSpy.mock.calls[1][0]).not.toHaveProperty('take');
+        expect(findSpy.mock.calls[1][0]).not.toHaveProperty('order');
+        expect(findSpy.mock.calls[1][0]).not.toHaveProperty('relations');
+        expect(findSpy.mock.calls[1][0].where).toEqual(
+          expect.objectContaining({ projectId: 'proj-1' })
+        );
       } finally {
         findSpy.mockRestore();
       }

--- a/apps/backend/src/data-marts/search/catalog/typeorm-data-mart-catalog.adapter.ts
+++ b/apps/backend/src/data-marts/search/catalog/typeorm-data-mart-catalog.adapter.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOptionsWhere, IsNull, MoreThan, Raw, Repository } from 'typeorm';
+import { In, IsNull, Repository } from 'typeorm';
 import { DataMart } from '../../entities/data-mart.entity';
 import { DataMartRelationship } from '../../entities/data-mart-relationship.entity';
 import { DataMartStatus } from '../../enums/data-mart-status.enum';
@@ -12,7 +12,7 @@ import type {
   SearchableDataMart,
 } from './data-mart-catalog.port';
 import type { PageCursor, SearchablePage } from '../sources/indexable-source.port';
-import { nextPageCursor } from '../sources/indexable-source.port';
+import { buildKeysetWhere, nextPageCursor } from '../sources/indexable-source.port';
 import { buildDataMartScoringDescriptor } from './data-mart-scoring-descriptor.builder';
 
 type SchemaFieldLike = {
@@ -29,40 +29,22 @@ type SearchableDataMartProjection = Pick<
   'id' | 'projectId' | 'title' | 'description' | 'schema' | 'status' | 'modifiedAt'
 >;
 
-type SearchableDataMartPageRow = SearchableDataMartProjection & Pick<DataMart, 'createdAt'>;
+type SearchableDataMartPageRow = Pick<DataMart, 'id' | 'createdAt'>;
 
-const DATA_MART_SEARCHABLE_PAGE_SELECT = {
+const DATA_MART_SEARCHABLE_SELECT = {
   id: true,
   projectId: true,
   title: true,
   description: true,
   schema: true,
   status: true,
-  createdAt: true,
   modifiedAt: true,
+} satisfies Record<keyof SearchableDataMartProjection, true>;
+
+const DATA_MART_SEARCHABLE_PAGE_SELECT = {
+  id: true,
+  createdAt: true,
 } satisfies Record<keyof SearchableDataMartPageRow, true>;
-
-function buildDataMartSearchPageWhere(
-  projectId: string,
-  cursor: PageCursor | null
-): FindOptionsWhere<DataMart> | FindOptionsWhere<DataMart>[] {
-  const baseWhere: FindOptionsWhere<DataMart> = { projectId, deletedAt: IsNull() };
-  if (!cursor) return baseWhere;
-
-  return [
-    {
-      ...baseWhere,
-      createdAt: Raw(alias => `${alias} < :createdBefore`, {
-        createdBefore: cursor.createdAt,
-      }),
-    },
-    {
-      ...baseWhere,
-      createdAt: Raw(alias => `${alias} = :createdAt`, { createdAt: cursor.createdAt }),
-      id: MoreThan(cursor.id),
-    },
-  ];
-}
 
 function collectFieldLabels(fields: SchemaFieldLike[]): string[] {
   const labels: string[] = [];
@@ -117,21 +99,33 @@ export class TypeOrmDataMartCatalogAdapter implements DataMartCatalogPort {
     cursor: PageCursor | null,
     limit: number
   ): Promise<SearchablePage> {
-    const where = buildDataMartSearchPageWhere(projectId, cursor);
+    const where = buildKeysetWhere<DataMart>({ projectId, deletedAt: IsNull() }, cursor, 'DESC');
 
-    const marts: SearchableDataMartPageRow[] = await this.dataMartRepo.find({
+    const pageRows: SearchableDataMartPageRow[] = await this.dataMartRepo.find({
       where,
       select: DATA_MART_SEARCHABLE_PAGE_SELECT,
       loadEagerRelations: false,
+      // Keep this aligned with idx_dm_project_deleted_created for a covering page query.
       order: { createdAt: 'DESC', id: 'ASC' },
       take: limit,
     });
-    if (marts.length === 0) return { descriptors: [], nextCursor: null };
+    if (pageRows.length === 0) return { descriptors: [], nextCursor: null };
 
-    const martIds = marts.map(m => m.id);
-    const searchableMarts = marts.map(mart => this.toSearchable(mart));
+    const pageIds = pageRows.map(m => m.id);
+    const marts: SearchableDataMartProjection[] = await this.dataMartRepo.find({
+      // Re-check scope in case a mart changes between page selection and hydration.
+      where: { id: In(pageIds), projectId, deletedAt: IsNull() },
+      select: DATA_MART_SEARCHABLE_SELECT,
+      loadEagerRelations: false,
+    });
+    const martById = new Map(marts.map(mart => [mart.id, mart]));
+    const searchableMarts = pageIds
+      .map(id => martById.get(id))
+      .filter((mart): mart is SearchableDataMartProjection => mart !== undefined)
+      .map(mart => this.toSearchable(mart));
+    const searchableMartIds = searchableMarts.map(m => m.id);
 
-    const edges = await this.listOutboundEdgesFor(martIds);
+    const edges = await this.listOutboundEdgesFor(searchableMartIds);
     const outboundEdgesBySourceId = new Map<string, RelationshipEdge[]>();
     for (const edge of edges) {
       const existing = outboundEdgesBySourceId.get(edge.sourceDataMartId) ?? [];
@@ -139,7 +133,9 @@ export class TypeOrmDataMartCatalogAdapter implements DataMartCatalogPort {
       outboundEdgesBySourceId.set(edge.sourceDataMartId, existing);
     }
 
-    const targetIds = edges.map(e => e.targetDataMartId).filter(id => !martIds.includes(id));
+    const targetIds = edges
+      .map(e => e.targetDataMartId)
+      .filter(id => !searchableMartIds.includes(id));
     const uniqueTargetIds = [...new Set(targetIds)];
     const targetMarts: SearchableDataMart[] = [];
     if (uniqueTargetIds.length > 0) {
@@ -162,7 +158,7 @@ export class TypeOrmDataMartCatalogAdapter implements DataMartCatalogPort {
       buildDataMartScoringDescriptor(mart, outboundEdgesBySourceId, martsById)
     );
 
-    return { descriptors, nextCursor: nextPageCursor(marts, limit) };
+    return { descriptors, nextCursor: nextPageCursor(pageRows, limit) };
   }
 
   async loadSearchable(entityId: string): Promise<SearchableDataMart | null> {

--- a/apps/backend/src/data-marts/search/catalog/typeorm-data-mart-catalog.adapter.ts
+++ b/apps/backend/src/data-marts/search/catalog/typeorm-data-mart-catalog.adapter.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { IsNull, Repository } from 'typeorm';
+import { FindOptionsWhere, IsNull, MoreThan, Raw, Repository } from 'typeorm';
 import { DataMart } from '../../entities/data-mart.entity';
 import { DataMartRelationship } from '../../entities/data-mart-relationship.entity';
 import { DataMartStatus } from '../../enums/data-mart-status.enum';
@@ -12,7 +12,7 @@ import type {
   SearchableDataMart,
 } from './data-mart-catalog.port';
 import type { PageCursor, SearchablePage } from '../sources/indexable-source.port';
-import { buildKeysetWhere, nextPageCursor } from '../sources/indexable-source.port';
+import { nextPageCursor } from '../sources/indexable-source.port';
 import { buildDataMartScoringDescriptor } from './data-mart-scoring-descriptor.builder';
 
 type SchemaFieldLike = {
@@ -23,6 +23,46 @@ type SchemaFieldLike = {
   isHiddenForReporting?: boolean;
   fields?: SchemaFieldLike[];
 };
+
+type SearchableDataMartProjection = Pick<
+  DataMart,
+  'id' | 'projectId' | 'title' | 'description' | 'schema' | 'status' | 'modifiedAt'
+>;
+
+type SearchableDataMartPageRow = SearchableDataMartProjection & Pick<DataMart, 'createdAt'>;
+
+const DATA_MART_SEARCHABLE_PAGE_SELECT = {
+  id: true,
+  projectId: true,
+  title: true,
+  description: true,
+  schema: true,
+  status: true,
+  createdAt: true,
+  modifiedAt: true,
+} satisfies Record<keyof SearchableDataMartPageRow, true>;
+
+function buildDataMartSearchPageWhere(
+  projectId: string,
+  cursor: PageCursor | null
+): FindOptionsWhere<DataMart> | FindOptionsWhere<DataMart>[] {
+  const baseWhere: FindOptionsWhere<DataMart> = { projectId, deletedAt: IsNull() };
+  if (!cursor) return baseWhere;
+
+  return [
+    {
+      ...baseWhere,
+      createdAt: Raw(alias => `${alias} < :createdBefore`, {
+        createdBefore: cursor.createdAt,
+      }),
+    },
+    {
+      ...baseWhere,
+      createdAt: Raw(alias => `${alias} = :createdAt`, { createdAt: cursor.createdAt }),
+      id: MoreThan(cursor.id),
+    },
+  ];
+}
 
 function collectFieldLabels(fields: SchemaFieldLike[]): string[] {
   const labels: string[] = [];
@@ -77,11 +117,13 @@ export class TypeOrmDataMartCatalogAdapter implements DataMartCatalogPort {
     cursor: PageCursor | null,
     limit: number
   ): Promise<SearchablePage> {
-    const where = buildKeysetWhere<DataMart>({ projectId, deletedAt: IsNull() }, cursor);
+    const where = buildDataMartSearchPageWhere(projectId, cursor);
 
-    const marts = await this.dataMartRepo.find({
+    const marts: SearchableDataMartPageRow[] = await this.dataMartRepo.find({
       where,
-      order: { createdAt: 'ASC', id: 'ASC' },
+      select: DATA_MART_SEARCHABLE_PAGE_SELECT,
+      loadEagerRelations: false,
+      order: { createdAt: 'DESC', id: 'ASC' },
       take: limit,
     });
     if (marts.length === 0) return { descriptors: [], nextCursor: null };
@@ -134,7 +176,7 @@ export class TypeOrmDataMartCatalogAdapter implements DataMartCatalogPort {
     return this.toSearchable(mart);
   }
 
-  private toSearchable(mart: DataMart): SearchableDataMart {
+  private toSearchable(mart: SearchableDataMartProjection): SearchableDataMart {
     return {
       id: mart.id,
       projectId: mart.projectId,

--- a/apps/backend/src/data-marts/search/sources/data-destination.source.spec.ts
+++ b/apps/backend/src/data-marts/search/sources/data-destination.source.spec.ts
@@ -462,6 +462,39 @@ describe('DataDestinationIndexableSource', () => {
       const allIds = [first.descriptors[0].entityId, second.descriptors[0].entityId];
       expect(new Set(allIds)).toEqual(new Set([d1.id, d2.id]));
     });
+
+    it('loads the keyset page before joining credential data', async () => {
+      await seedDestination({ title: 'D1' });
+      await seedDestination({ title: 'D2' });
+
+      const findSpy = jest.spyOn(destinationRepo, 'find');
+
+      try {
+        await source.listSearchablePage('proj-1', null, 1);
+
+        expect(findSpy).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            select: { id: true, createdAt: true },
+            loadEagerRelations: false,
+            order: { createdAt: 'ASC', id: 'ASC' },
+            take: 1,
+          })
+        );
+        expect(findSpy.mock.calls[0][0]).not.toHaveProperty('relations');
+        expect(findSpy).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            relations: { credential: true },
+            loadEagerRelations: false,
+          })
+        );
+        expect(findSpy.mock.calls[1][0]).not.toHaveProperty('take');
+        expect(findSpy.mock.calls[1][0]).not.toHaveProperty('order');
+      } finally {
+        findSpy.mockRestore();
+      }
+    });
   });
 
   describe('listProjectIds', () => {

--- a/apps/backend/src/data-marts/search/sources/data-destination.source.ts
+++ b/apps/backend/src/data-marts/search/sources/data-destination.source.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { IsNull, Repository } from 'typeorm';
+import { In, IsNull, Repository } from 'typeorm';
 import { SearchableEntityType } from '../../../common/search/search.facade';
 import { DataDestination } from '../../entities/data-destination.entity';
 import {
@@ -110,15 +110,41 @@ export class DataDestinationIndexableSource implements IndexableSource {
   ): Promise<SearchablePage> {
     const where = buildKeysetWhere<DataDestination>({ projectId, deletedAt: IsNull() }, cursor);
 
-    const destinations = await this.destinationRepo.find({
+    const pageRows = await this.destinationRepo.find({
       where,
-      relations: { credential: true },
+      select: { id: true, createdAt: true },
+      loadEagerRelations: false,
       order: { createdAt: 'ASC', id: 'ASC' },
       take: limit,
     });
-    const descriptors = destinations.map(d => toDescriptor(d));
+    if (pageRows.length === 0) return { descriptors: [], nextCursor: null };
 
-    return { descriptors, nextCursor: nextPageCursor(destinations, limit) };
+    const pageIds = pageRows.map(destination => destination.id);
+    const destinations = await this.destinationRepo.find({
+      where: { id: In(pageIds), projectId, deletedAt: IsNull() },
+      select: {
+        id: true,
+        title: true,
+        type: true,
+        projectId: true,
+        credentialId: true,
+        modifiedAt: true,
+        credential: {
+          id: true,
+          identity: true,
+          credentials: true,
+        },
+      },
+      relations: { credential: true },
+      loadEagerRelations: false,
+    });
+    const destinationById = new Map(destinations.map(destination => [destination.id, destination]));
+    const descriptors = pageIds
+      .map(id => destinationById.get(id))
+      .filter((destination): destination is DataDestination => destination !== undefined)
+      .map(toDescriptor);
+
+    return { descriptors, nextCursor: nextPageCursor(pageRows, limit) };
   }
 
   async listProjectIds(): Promise<string[]> {

--- a/apps/backend/src/data-marts/search/sources/data-destination.source.ts
+++ b/apps/backend/src/data-marts/search/sources/data-destination.source.ts
@@ -121,6 +121,7 @@ export class DataDestinationIndexableSource implements IndexableSource {
 
     const pageIds = pageRows.map(destination => destination.id);
     const destinations = await this.destinationRepo.find({
+      // Re-check scope in case a destination changes between page selection and hydration.
       where: { id: In(pageIds), projectId, deletedAt: IsNull() },
       select: {
         id: true,

--- a/apps/backend/src/data-marts/search/sources/data-storage.source.spec.ts
+++ b/apps/backend/src/data-marts/search/sources/data-storage.source.spec.ts
@@ -367,6 +367,39 @@ describe('DataStorageIndexableSource', () => {
       const allIds = [first.descriptors[0].entityId, second.descriptors[0].entityId];
       expect(new Set(allIds)).toEqual(new Set([s1.id, s2.id]));
     });
+
+    it('loads the keyset page before joining credential data', async () => {
+      await seedStorage({ title: 'S1' });
+      await seedStorage({ title: 'S2' });
+
+      const findSpy = jest.spyOn(storageRepo, 'find');
+
+      try {
+        await source.listSearchablePage('proj-1', null, 1);
+
+        expect(findSpy).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            select: { id: true, createdAt: true },
+            loadEagerRelations: false,
+            order: { createdAt: 'ASC', id: 'ASC' },
+            take: 1,
+          })
+        );
+        expect(findSpy.mock.calls[0][0]).not.toHaveProperty('relations');
+        expect(findSpy).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            relations: { credential: true },
+            loadEagerRelations: false,
+          })
+        );
+        expect(findSpy.mock.calls[1][0]).not.toHaveProperty('take');
+        expect(findSpy.mock.calls[1][0]).not.toHaveProperty('order');
+      } finally {
+        findSpy.mockRestore();
+      }
+    });
   });
 
   describe('listProjectIds', () => {

--- a/apps/backend/src/data-marts/search/sources/data-storage.source.ts
+++ b/apps/backend/src/data-marts/search/sources/data-storage.source.ts
@@ -113,6 +113,7 @@ export class DataStorageIndexableSource implements IndexableSource {
 
     const pageIds = pageRows.map(storage => storage.id);
     const storages = await this.dataStorageRepo.find({
+      // Re-check scope in case a storage changes between page selection and hydration.
       where: { id: In(pageIds), projectId, deletedAt: IsNull() },
       select: {
         id: true,

--- a/apps/backend/src/data-marts/search/sources/data-storage.source.ts
+++ b/apps/backend/src/data-marts/search/sources/data-storage.source.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { IsNull, Repository } from 'typeorm';
+import { In, IsNull, Repository } from 'typeorm';
 import { SearchableEntityType } from '../../../common/search/search.facade';
 import { DataStorage } from '../../entities/data-storage.entity';
 import {
@@ -102,15 +102,40 @@ export class DataStorageIndexableSource implements IndexableSource {
   ): Promise<SearchablePage> {
     const where = buildKeysetWhere<DataStorage>({ projectId, deletedAt: IsNull() }, cursor);
 
-    const storages = await this.dataStorageRepo.find({
+    const pageRows = await this.dataStorageRepo.find({
       where,
-      relations: { credential: true },
+      select: { id: true, createdAt: true },
+      loadEagerRelations: false,
       order: { createdAt: 'ASC', id: 'ASC' },
       take: limit,
     });
-    const descriptors = storages.map(toDescriptor);
+    if (pageRows.length === 0) return { descriptors: [], nextCursor: null };
 
-    return { descriptors, nextCursor: nextPageCursor(storages, limit) };
+    const pageIds = pageRows.map(storage => storage.id);
+    const storages = await this.dataStorageRepo.find({
+      where: { id: In(pageIds), projectId, deletedAt: IsNull() },
+      select: {
+        id: true,
+        type: true,
+        projectId: true,
+        title: true,
+        credentialId: true,
+        modifiedAt: true,
+        credential: {
+          id: true,
+          identity: true,
+        },
+      },
+      relations: { credential: true },
+      loadEagerRelations: false,
+    });
+    const storageById = new Map(storages.map(storage => [storage.id, storage]));
+    const descriptors = pageIds
+      .map(id => storageById.get(id))
+      .filter((storage): storage is DataStorage => storage !== undefined)
+      .map(toDescriptor);
+
+    return { descriptors, nextCursor: nextPageCursor(pageRows, limit) };
   }
 
   async listProjectIds(): Promise<string[]> {

--- a/apps/backend/src/data-marts/search/sources/indexable-source.port.ts
+++ b/apps/backend/src/data-marts/search/sources/indexable-source.port.ts
@@ -35,14 +35,23 @@ export function toCursorTimestamp(createdAt: Date): string {
 }
 
 type KeysetRow = { createdAt: Date; id: string };
+type CreatedAtSortDirection = 'ASC' | 'DESC';
 
 export function buildKeysetWhere<T extends KeysetRow>(
   baseWhere: FindOptionsWhere<T>,
-  cursor: PageCursor | null
+  cursor: PageCursor | null,
+  createdAtDirection: CreatedAtSortDirection = 'ASC'
 ): FindOptionsWhere<T> | FindOptionsWhere<T>[] {
   if (!cursor) return baseWhere;
+  const createdAtComparison = createdAtDirection === 'DESC' ? '<' : '>';
+
   return [
-    { ...baseWhere, createdAt: Raw(alias => `${alias} > :cAfter`, { cAfter: cursor.createdAt }) },
+    {
+      ...baseWhere,
+      createdAt: Raw(alias => `${alias} ${createdAtComparison} :cBoundary`, {
+        cBoundary: cursor.createdAt,
+      }),
+    },
     {
       ...baseWhere,
       createdAt: Raw(alias => `${alias} = :cAt`, { cAt: cursor.createdAt }),


### PR DESCRIPTION
## Summary

- Narrow search-indexing pagination queries so MySQL does not sort wide JSON/text payloads while building the search index.
- Split data-storage and data-destination indexing into a narrow keyset page query followed by bounded credential hydration.
- Adjust data-mart pagination to `createdAt DESC, id ASC` so it can use the existing `idx_dm_project_deleted_created` composite index instead of adding another data-mart pagination index.
- Add regression coverage for the new pagination shapes and include an `owox` changeset.

## Why

The production failure came from TypeORM building ordered queries over wide rows and eager relation joins. On MySQL this can force a filesort over large JSON/text payloads and hit `ER_OUT_OF_SORTMEMORY` / `Out of sort memory`.

For storages and destinations, the sorted query now only carries `{ id, createdAt }`; the wider credential data is loaded after the page boundary is known. For data marts, the query still needs `schema` to build embeddings, so the change narrows the selected fields, disables eager relation loading, and intentionally orders by `createdAt DESC, id ASC` to match the existing data-mart composite index.

## Verification

- `npm test -w @owox/backend -- data-mart.source data-storage.source data-destination.source typeorm-data-mart-catalog.adapter --runInBand`
- `npm test -w @owox/backend -- advanced-search --runInBand`
- `npx tsc -p apps/backend/tsconfig.build.json --noEmit`
- `git diff --check`