### PR TITLE
test(backend): stop Redshift integration timeouts from flaking on transient latency

### DIFF
--- a/apps/backend/test/integration/redshift.integration.ts
+++ b/apps/backend/test/integration/redshift.integration.ts
@@ -59,6 +59,13 @@ if (!REDSHIFT_CREDENTIALS_AVAILABLE) {
 
 const describeIfCredentials = REDSHIFT_CREDENTIALS_AVAILABLE ? describe : describe.skip;
 
+// The Serverless workgroup runs on minimal Base RPU (cost cap) and is hit
+// concurrently by the parallel http-data-real suite, so individual Data API
+// queries occasionally spike to ~30s+ under contention. Per-test timeouts now
+// inherit the global 60s (jest-integration.json) instead of a hardcoded 30s, and
+// we retry once so a single transient latency spike doesn't fail the whole run.
+jest.retryTimes(1, { logErrorsBeforeRetry: true });
+
 // ---------------------------------------------------------------------------
 // Access validation + dry-run
 // ---------------------------------------------------------------------------
@@ -87,7 +94,7 @@ describeIfCredentials('Redshift Integration Tests', () => {
   describe('Access Validation', () => {
     it('should accept valid credentials', async () => {
       await expect(adapter.checkAccess()).resolves.not.toThrow();
-    }, 30000);
+    });
 
     it('should reject invalid credentials', async () => {
       const invalidAdapter = new RedshiftApiAdapter(
@@ -95,17 +102,17 @@ describeIfCredentials('Redshift Integration Tests', () => {
         config
       );
       await expect(invalidAdapter.checkAccess()).rejects.toThrow();
-    }, 30000);
+    });
   });
 
   describe('SQL Dry Run', () => {
     it('should validate correct query via EXPLAIN', async () => {
       await expect(adapter.executeDryRunQuery('SELECT 1')).resolves.not.toThrow();
-    }, 30000);
+    });
 
     it('should reject invalid SQL syntax', async () => {
       await expect(adapter.executeDryRunQuery('SELEKT * FORM invalid')).rejects.toThrow();
-    }, 30000);
+    });
   });
 });
 
@@ -265,7 +272,7 @@ describeIfCredentials(
       // Asserts the seeded `a\b` row matched: backslash is literal (standard_conforming_strings
       // effectively ON), so `'`→`''` escaping is airtight. FAILS if a future cluster has scs=off.
       expect(rows.length).toBe(1);
-    }, 30000);
+    });
 
     // -------------------------------------------------------------------------
     // Design decision 2: date/time coercion (bare literal, no CAST)
@@ -282,7 +289,7 @@ describeIfCredentials(
       });
       console.log(`[COERCION] DATE gte bare string → ${rows.length} rows, no error`);
       expect(rows.length).toBeGreaterThan(0);
-    }, 30000);
+    });
 
     it('DATE: between bare string literals executes without error', async () => {
       const rows = await runFilter({
@@ -296,7 +303,7 @@ describeIfCredentials(
       });
       console.log(`[COERCION] DATE between bare strings → ${rows.length} rows, no error`);
       expect(rows.length).toBeGreaterThan(0);
-    }, 30000);
+    });
 
     it('TIMESTAMP: gte bare string literal executes without error', async () => {
       const rows = await runFilter({
@@ -304,7 +311,7 @@ describeIfCredentials(
       });
       console.log(`[COERCION] TIMESTAMP gte bare string → ${rows.length} rows, no error`);
       expect(rows.length).toBeGreaterThan(0);
-    }, 30000);
+    });
 
     it('TIMESTAMP: between bare string literals executes without error', async () => {
       const rows = await runFilter({
@@ -318,7 +325,7 @@ describeIfCredentials(
       });
       console.log(`[COERCION] TIMESTAMP between bare strings → ${rows.length} rows, no error`);
       expect(rows.length).toBeGreaterThan(0);
-    }, 30000);
+    });
 
     it('TIMESTAMPTZ: gte bare string literal executes without error', async () => {
       const rows = await runFilter({
@@ -326,7 +333,7 @@ describeIfCredentials(
       });
       console.log(`[COERCION] TIMESTAMPTZ gte bare string → ${rows.length} rows, no error`);
       expect(rows.length).toBeGreaterThan(0);
-    }, 30000);
+    });
 
     it('TIMESTAMPTZ: between bare string literals executes without error', async () => {
       const rows = await runFilter({
@@ -340,7 +347,7 @@ describeIfCredentials(
       });
       console.log(`[COERCION] TIMESTAMPTZ between bare strings → ${rows.length} rows, no error`);
       expect(rows.length).toBeGreaterThan(0);
-    }, 30000);
+    });
 
     it('TIME: gte bare string literal executes without error', async () => {
       const rows = await runFilter({
@@ -348,7 +355,7 @@ describeIfCredentials(
       });
       console.log(`[COERCION] TIME gte bare string → ${rows.length} rows, no error`);
       expect(rows.length).toBeGreaterThan(0);
-    }, 30000);
+    });
 
     it('TIME: between bare string literals executes without error', async () => {
       const rows = await runFilter({
@@ -362,7 +369,7 @@ describeIfCredentials(
       });
       console.log(`[COERCION] TIME between bare strings → ${rows.length} rows, no error`);
       expect(rows.length).toBeGreaterThan(0);
-    }, 30000);
+    });
 
     it('TIMETZ: gte bare string literal executes without error', async () => {
       const rows = await runFilter({
@@ -370,7 +377,7 @@ describeIfCredentials(
       });
       console.log(`[COERCION] TIMETZ gte bare string → ${rows.length} rows, no error`);
       expect(rows.length).toBeGreaterThan(0);
-    }, 30000);
+    });
 
     it('TIMETZ: between bare string literals executes without error', async () => {
       const rows = await runFilter({
@@ -384,7 +391,7 @@ describeIfCredentials(
       });
       console.log(`[COERCION] TIMETZ between bare strings → ${rows.length} rows, no error`);
       expect(rows.length).toBeGreaterThan(0);
-    }, 30000);
+    });
 
     // -------------------------------------------------------------------------
     // relative_date today on non-midnight TIMESTAMP column
@@ -398,14 +405,14 @@ describeIfCredentials(
         filters: [{ column: 'ts_col', operator: 'relative_date', value: { kind: 'today' } }],
       });
       expect(ids(rows)).toEqual(['1', '6']);
-    }, 30000);
+    });
 
     it('relative_date today on date_col → rows 1,6', async () => {
       const rows = await runFilter({
         filters: [{ column: 'date_col', operator: 'relative_date', value: { kind: 'today' } }],
       });
       expect(ids(rows)).toEqual(['1', '6']);
-    }, 30000);
+    });
 
     // -------------------------------------------------------------------------
     // this_year / this_month upper-bound exclusion
@@ -426,7 +433,7 @@ describeIfCredentials(
       expect(resultIds).toContain('1');
       expect(resultIds).toContain('6');
       console.log(`[this_year] rows returned: [${resultIds.join(',')}]`);
-    }, 30000);
+    });
 
     it('relative_date this_month excludes future-dated row 5', async () => {
       const rows = await runFilter({
@@ -435,7 +442,7 @@ describeIfCredentials(
       const resultIds = ids(rows);
       expect(resultIds).not.toContain('5');
       console.log(`[this_month] rows returned: [${resultIds.join(',')}]`);
-    }, 30000);
+    });
 
     // -------------------------------------------------------------------------
     // Operator matrix: every operator runs without error, returns sensible rows
@@ -447,49 +454,49 @@ describeIfCredentials(
         filters: [{ column: 'name', operator: 'eq', value: 'alpha' }],
       });
       expect(ids(rows)).toEqual(['1']);
-    }, 30000);
+    });
 
     it('neq on status: not "active" → rows 2,4 (inactive)', async () => {
       const rows = await runFilter({
         filters: [{ column: 'status', operator: 'neq', value: 'active' }],
       });
       expect(ids(rows)).toEqual(['2', '4']);
-    }, 30000);
+    });
 
     it('gt: amount > 20 → rows 3,4,5 (30,40,50)', async () => {
       const rows = await runFilter({
         filters: [{ column: 'amount', operator: 'gt', value: 20 }],
       });
       expect(ids(rows)).toEqual(['3', '4', '5']);
-    }, 30000);
+    });
 
     it('lt: amount < 20 → rows 1,6 (10,0)', async () => {
       const rows = await runFilter({
         filters: [{ column: 'amount', operator: 'lt', value: 20 }],
       });
       expect(ids(rows)).toEqual(['1', '6']);
-    }, 30000);
+    });
 
     it('gte: amount >= 20 → rows 2,3,4,5 (20,30,40,50)', async () => {
       const rows = await runFilter({
         filters: [{ column: 'amount', operator: 'gte', value: 20 }],
       });
       expect(ids(rows)).toEqual(['2', '3', '4', '5']);
-    }, 30000);
+    });
 
     it('lte: amount <= 20 → rows 1,2,6 (10,20,0)', async () => {
       const rows = await runFilter({
         filters: [{ column: 'amount', operator: 'lte', value: 20 }],
       });
       expect(ids(rows)).toEqual(['1', '2', '6']);
-    }, 30000);
+    });
 
     it('contains "alph" on name → row 1 (alpha)', async () => {
       const rows = await runFilter({
         filters: [{ column: 'name', operator: 'contains', value: 'alph' }],
       });
       expect(ids(rows)).toEqual(['1']);
-    }, 30000);
+    });
 
     it('not_contains "eta" on name → rows 1,3,4,5,6 (all except beta)', async () => {
       // beta(2) contains 'eta'; others do not
@@ -497,70 +504,70 @@ describeIfCredentials(
         filters: [{ column: 'name', operator: 'not_contains', value: 'eta' }],
       });
       expect(ids(rows)).toEqual(['1', '3', '4', '5', '6']);
-    }, 30000);
+    });
 
     it('starts_with "al" on name → row 1 (alpha)', async () => {
       const rows = await runFilter({
         filters: [{ column: 'name', operator: 'starts_with', value: 'al' }],
       });
       expect(ids(rows)).toEqual(['1']);
-    }, 30000);
+    });
 
     it('ends_with "a" on name → rows 1,2,6 (alpha,beta,gamma all end in "a")', async () => {
       const rows = await runFilter({
         filters: [{ column: 'name', operator: 'ends_with', value: 'a' }],
       });
       expect(ids(rows)).toEqual(['1', '2', '6']);
-    }, 30000);
+    });
 
     it('regex: name ~ "^alp" → row 1', async () => {
       const rows = await runFilter({
         filters: [{ column: 'name', operator: 'regex', value: '^alp' }],
       });
       expect(ids(rows)).toEqual(['1']);
-    }, 30000);
+    });
 
     it('not_regex: name !~ "^alp" → rows 2,3,4,5,6', async () => {
       const rows = await runFilter({
         filters: [{ column: 'name', operator: 'not_regex', value: '^alp' }],
       });
       expect(ids(rows)).toEqual(['2', '3', '4', '5', '6']);
-    }, 30000);
+    });
 
     it('is_empty: no empty-name rows → 0 rows', async () => {
       const rows = await runFilter({
         filters: [{ column: 'name', operator: 'is_empty' }],
       });
       expect(rows).toHaveLength(0);
-    }, 30000);
+    });
 
     it('is_not_empty: all 6 rows have non-empty names', async () => {
       const rows = await runFilter({
         filters: [{ column: 'name', operator: 'is_not_empty' }],
       });
       expect(rows).toHaveLength(6);
-    }, 30000);
+    });
 
     it('is_null: no NULLs in seed → 0 rows', async () => {
       const rows = await runFilter({
         filters: [{ column: 'name', operator: 'is_null' }],
       });
       expect(rows).toHaveLength(0);
-    }, 30000);
+    });
 
     it('is_not_null: all 6 rows', async () => {
       const rows = await runFilter({
         filters: [{ column: 'name', operator: 'is_not_null' }],
       });
       expect(rows).toHaveLength(6);
-    }, 30000);
+    });
 
     it('between: amount BETWEEN 20 AND 30 → rows 2,3', async () => {
       const rows = await runFilter({
         filters: [{ column: 'amount', operator: 'between', value: { from: 20, to: 30 } }],
       });
       expect(ids(rows)).toEqual(['2', '3']);
-    }, 30000);
+    });
 
     it('relative_date last_n_days(7): rows 1,2,6 (upper bound excludes future row 5)', async () => {
       const rows = await runFilter({
@@ -570,7 +577,7 @@ describeIfCredentials(
       });
       // last_n_days is bounded `< tomorrow`: future-dated row 5 (+13 months) is excluded.
       expect(ids(rows)).toEqual(['1', '2', '6']);
-    }, 30000);
+    });
 
     it('relative_date last_n_months(3): rows 1,2,3,6 (upper bound excludes future row 5)', async () => {
       const rows = await runFilter({
@@ -584,7 +591,7 @@ describeIfCredentials(
       });
       // last_n_months is bounded `< tomorrow`: future-dated row 5 is excluded; row 3 (-40d) stays.
       expect(ids(rows)).toEqual(['1', '2', '3', '6']);
-    }, 30000);
+    });
 
     // -------------------------------------------------------------------------
     // Wildcard-literal safety
@@ -595,14 +602,14 @@ describeIfCredentials(
         filters: [{ column: 'name', operator: 'contains', value: '100%' }],
       });
       expect(ids(rows)).toEqual(['4']);
-    }, 30000);
+    });
 
     it('SAFETY eq "O\'Brien" → row 3 (single-quote doubling round-trip)', async () => {
       const rows = await runFilter({
         filters: [{ column: 'name', operator: 'eq', value: "O'Brien" }],
       });
       expect(ids(rows)).toEqual(['3']);
-    }, 30000);
+    });
 
     // -------------------------------------------------------------------------
     // Sort + limit
@@ -614,7 +621,7 @@ describeIfCredentials(
         limit: 2,
       });
       expect(rows.map(r => r.id)).toEqual(['5', '4']);
-    }, 30000);
+    });
 
     // -------------------------------------------------------------------------
     // Aggregation (real GROUP BY / percentile / date-trunc / totals)


### PR DESCRIPTION
## Problem

The `Redshift` job in **Integration Tests (Real DB)** fails on roughly half of the
nightly scheduled runs. The failure signature is consistent and points to
environment latency, not a code bug:

- Always **1 test failed, 40 passed** — never a wrong result, always
  `thrown: "Exceeded timeout of 30000 ms for a test."` at ~30001 ms.
- The failing test **roams** between runs (`gt: amount > 20`, `relative_date today`,
  `TIMESTAMP: gte`, `DATE: between`, `TIMETZ: gte`, …) — whichever test happens to
  run during a latency spike gets killed at the 30s ceiling.
- Data API polling logs show queries intermittently taking ~30s to execute a
  trivial statement; latency climbs mid-run (e.g. `neq` took 17s, the next test
  timed out) and drops back to ~1.5s immediately after.

### Root cause

The Serverless workgroup runs on **minimal Base RPU** (cost cap) and is queried
**concurrently** by the parallel `http-data-real` suite (which also hits Redshift)
on a separate matrix runner. Under that contention, individual Data API queries
occasionally spike past the **hardcoded 30s per-test timeout** that every test in
`redshift.integration.ts` set explicitly — even though the suite's global timeout
in `jest-integration.json` is already 60s.

## Change

- Remove the hardcoded `30000` per-test timeout from all 41 tests so they inherit
  the **global 60s** from `jest-integration.json`. (The intentional longer
  timeouts — 60s/120s for seeding/heavy ops — are left untouched.)
- Add `jest.retryTimes(1, { logErrorsBeforeRetry: true })` so a single transient
  spike no longer fails the whole run, while still logging the original error.

No production code changes — test/CI reliability only.

## Notes

This addresses the symptom cheaply (no RPU spend). It does **not** remove the
underlying contention between the `Redshift` and `http-data-real` jobs; if 60s
still proves too tight on occasion, the follow-up is to serialize the two
Redshift-touching jobs via a shared concurrency group.
