### PR TITLE
feat(web): protect unsaved Output Schema changes from being lost

### DIFF
--- a/.changeset/6085-protect-unsaved-schema-changes.md
+++ b/.changeset/6085-protect-unsaved-schema-changes.md
@@ -1,0 +1,17 @@
+---
+"owox": minor
+---
+
+# Protect unsaved Output Schema changes from being lost
+
+When a data mart's Output Schema has unsaved changes, you're now asked how you'd like to proceed before any action that would replace the schema — so your edits are never discarded without warning.
+
+You'll see a clear prompt with three choices — **Save & continue**, **Discard & continue**, or **Cancel** — when you have unsaved schema changes and you:
+
+- generate field aliases or descriptions with AI,
+- refresh the schema,
+- publish the data mart,
+- update the input source, or
+- leave the page.
+
+This makes it obvious what will happen to your changes and lets you keep your work instead of losing it.

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
@@ -56,7 +56,7 @@ export function DataMartDefinitionSettings({
   setDefinitionType,
   sqlRevalidateVersion,
 }: DataMartDefinitionSettingsProps) {
-  const { dataMart, updateDataMartDefinition, runSchemaActualization } =
+  const { dataMart, updateDataMartDefinition, runSchemaActualization, runGuarded } =
     useOutletContext<DataMartContextType>();
   const preset = useDataMartPreset();
 
@@ -177,9 +177,21 @@ export function DataMartDefinitionSettings({
   const handleFormSubmit = useCallback(
     (e?: React.SyntheticEvent<HTMLFormElement>) => {
       e?.preventDefault();
-      void handleSubmit(onSubmit)(e);
+      const submit = () => {
+        void handleSubmit(onSubmit)();
+      };
+      if (runGuarded) {
+        runGuarded(
+          () => {
+            submit();
+          },
+          { intent: 'definition' }
+        );
+      } else {
+        submit();
+      }
     },
-    [handleSubmit, onSubmit]
+    [handleSubmit, onSubmit, runGuarded]
   );
 
   const handleReset = useCallback(() => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
@@ -174,24 +174,29 @@ export function DataMartDefinitionSettings({
     }
   }, [shouldActualizeSchema, runSchemaActualization]);
 
+  const guardedSubmit = useCallback<SubmitHandler<DataMartDefinitionFormData>>(
+    data => {
+      const runSubmit = () => {
+        void onSubmit(data);
+      };
+      if (runGuarded) {
+        runGuarded(runSubmit, { intent: 'definition' });
+      } else {
+        runSubmit();
+      }
+    },
+    [onSubmit, runGuarded]
+  );
+
   const handleFormSubmit = useCallback(
     (e?: React.SyntheticEvent<HTMLFormElement>) => {
       e?.preventDefault();
-      const submit = () => {
-        void handleSubmit(onSubmit)();
-      };
-      if (runGuarded) {
-        runGuarded(
-          () => {
-            submit();
-          },
-          { intent: 'definition' }
-        );
-      } else {
-        submit();
-      }
+      // Validate the definition form BEFORE involving the schema guard. Only a
+      // valid submission opens the guard dialog, so we never save/discard schema
+      // edits for a definition change that fails validation and never fires.
+      void handleSubmit(guardedSubmit)();
     },
-    [handleSubmit, onSubmit, runGuarded]
+    [handleSubmit, guardedSubmit]
   );
 
   const handleReset = useCallback(() => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -32,6 +32,8 @@ import {
 } from '../../shared';
 import { useSchemaActualizeTrigger } from '../../shared/hooks/useSchemaActualizeTrigger';
 import { PromoStep, useDataMartNextStepPromo } from '../hooks/useDataMartNextStepPromo';
+import { useSchemaUnsavedGuard } from '../model/hooks';
+import { SchemaUnsavedChangesDialog } from './SchemaUnsavedChangesDialog';
 import { useDataMart } from '../model';
 import { useAiHelper, useAiHelperAvailability } from '../model';
 import { DataMartMetadataScope } from '../../shared';
@@ -112,6 +114,8 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
     }
     await runActualizeSchemaInternal();
   }, [canActualizeSchema, runActualizeSchemaInternal]);
+
+  const schemaGuard = useSchemaUnsavedGuard();
 
   const shouldShowInsights = checkVisible('INSIGHTS_ENABLED', 'true', flags);
 
@@ -430,7 +434,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
                     <Button
                       variant='default'
                       onClick={() => {
-                        void handlePublish();
+                        schemaGuard.runGuarded(() => handlePublish(), { intent: 'publish' });
                       }}
                       disabled={isPublishing || !canPublish}
                       className={cn(
@@ -571,6 +575,8 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
             getDataMart,
             runSchemaActualization,
             isSchemaActualizationLoading,
+            registerSchemaGuard: schemaGuard.registerSchemaGuard,
+            runGuarded: schemaGuard.runGuarded,
             projectId,
           }}
         />
@@ -602,16 +608,27 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
         cancelLabel='Cancel'
         variant='destructive'
         onConfirm={() => {
-          void (async () => {
-            try {
-              await deleteDataMart(dataMartId);
-              setIsDeleteDialogOpen(false);
-              navigate('/data-marts');
-            } catch (error) {
-              console.error('Failed to delete Data Mart:', error);
-            }
-          })();
+          schemaGuard.runGuarded(
+            async () => {
+              try {
+                await deleteDataMart(dataMartId);
+                setIsDeleteDialogOpen(false);
+                navigate('/data-marts');
+              } catch (error) {
+                console.error('Failed to delete Data Mart:', error);
+              }
+            },
+            { intent: 'navigation' }
+          );
         }}
+      />
+      <SchemaUnsavedChangesDialog
+        open={schemaGuard.dialog.open}
+        intent={schemaGuard.dialog.intent}
+        isSaving={schemaGuard.dialog.isSaving}
+        onSaveAndContinue={schemaGuard.dialog.onSaveAndContinue}
+        onDiscardAndContinue={schemaGuard.dialog.onDiscardAndContinue}
+        onCancel={schemaGuard.dialog.onCancel}
       />
     </div>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -32,7 +32,7 @@ import {
 } from '../../shared';
 import { useSchemaActualizeTrigger } from '../../shared/hooks/useSchemaActualizeTrigger';
 import { PromoStep, useDataMartNextStepPromo } from '../hooks/useDataMartNextStepPromo';
-import { useSchemaUnsavedGuard } from '../model/hooks';
+import { useSchemaUnsavedGuard } from '../model';
 import { SchemaUnsavedChangesDialog } from './SchemaUnsavedChangesDialog';
 import { useDataMart } from '../model';
 import { useAiHelper, useAiHelperAvailability } from '../model';
@@ -608,18 +608,21 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
         cancelLabel='Cancel'
         variant='destructive'
         onConfirm={() => {
-          schemaGuard.runGuarded(
-            async () => {
-              try {
-                await deleteDataMart(dataMartId);
-                setIsDeleteDialogOpen(false);
-                navigate('/data-marts');
-              } catch (error) {
-                console.error('Failed to delete Data Mart:', error);
-              }
-            },
-            { intent: 'navigation' }
-          );
+          // Deleting destroys the whole data mart (schema included), so guarding
+          // unsaved schema edits here is moot — it only stacks a second dialog and
+          // could block the delete if a doomed schema save fails. Run delete
+          // directly, and drop the schema guard registration first so the
+          // post-delete navigation isn't intercepted by the dirty-schema blocker.
+          void (async () => {
+            try {
+              await deleteDataMart(dataMartId);
+              schemaGuard.registerSchemaGuard(null);
+              setIsDeleteDialogOpen(false);
+              navigate('/data-marts');
+            } catch (error) {
+              console.error('Failed to delete Data Mart:', error);
+            }
+          })();
         }}
       />
       <SchemaUnsavedChangesDialog

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
@@ -7,7 +7,7 @@ import {
 } from '@owox/ui/components/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { Loader2, Sparkles } from 'lucide-react';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import type {
   AthenaSchemaField,
@@ -21,10 +21,18 @@ import { useOperationState, useSchemaState } from './hooks';
 import { SchemaContent } from './SchemaContent';
 import { DataMartDefinitionType, DataMartMetadataScope } from '../../../shared/index.ts';
 import { useAiHelper, useAiHelperAvailability } from '../../model/hooks';
+import type { ResolvedSchema } from '../../model/hooks';
 
 interface DataMartSchemaSettingsProps {
   definitionType: DataMartDefinitionType | null;
 }
+
+/** Scopes generated from the "Generate field metadata with AI" dropdown. */
+type BulkAiScope =
+  | DataMartMetadataScope.ALL_FIELD_METADATA
+  | DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS
+  | DataMartMetadataScope.ALL_FIELD_ALIASES;
+
 /**
  * Main component for editing data mart schema settings
  * Uses custom hooks for state management and the SchemaContent component for rendering
@@ -37,12 +45,18 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
     error,
     runSchemaActualization,
     isSchemaActualizationLoading,
+    registerSchemaGuard,
+    runGuarded,
   } = useOutletContext<DataMartContextType>();
 
   const { id: dataMartId = '', schema: initialSchema } = dataMart ?? {};
 
-  const { schema, isDirty, updateSchema, resetSchema } = useSchemaState(initialSchema);
+  const { schema, isDirty, updateSchema, resetSchema, markSchemaSaved } =
+    useSchemaState(initialSchema);
   const { operationStatus, startSaveOperation } = useOperationState(isLoading, error);
+
+  const schemaRef = useRef(schema);
+  schemaRef.current = schema;
 
   const { enabled: isAiHelperEnabled } = useAiHelperAvailability();
   const {
@@ -84,16 +98,48 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
   const handleSave = useCallback(() => {
     if (dataMartId && schema) {
       startSaveOperation();
-      void updateDataMartSchema(dataMartId, schema).then(() => {
-        void runSchemaActualization?.();
-      });
+      void updateDataMartSchema(dataMartId, schema)
+        .then(() => {
+          void runSchemaActualization?.();
+        })
+        .catch(() => {
+          // The context stores and displays the API error.
+        });
     }
   }, [dataMartId, schema, startSaveOperation, updateDataMartSchema, runSchemaActualization]);
 
+  // Registered with the shared unsaved-changes guard. `guardSave` persists the
+  // current schema WITHOUT triggering actualization (the guarded action may run
+  // its own actualization/publish afterwards). `guardDiscard` reverts to the
+  // saved schema and returns it so the guarded action maps onto the right fields.
+  const guardSave = useCallback(async (): Promise<ResolvedSchema> => {
+    const current = schemaRef.current;
+    if (dataMartId && current) {
+      await updateDataMartSchema(dataMartId, current);
+      markSchemaSaved(current);
+    }
+    return current;
+  }, [dataMartId, updateDataMartSchema, markSchemaSaved]);
+
+  const guardDiscard = useCallback((): ResolvedSchema => {
+    resetSchema();
+    return initialSchema;
+  }, [resetSchema, initialSchema]);
+
+  useEffect(() => {
+    registerSchemaGuard?.({
+      isDirty: () => isDirty,
+      getSchema: () => schemaRef.current,
+      save: guardSave,
+      discard: guardDiscard,
+    });
+    return () => registerSchemaGuard?.(null);
+  }, [isDirty, registerSchemaGuard, guardSave, guardDiscard]);
+
   // Handle actualize
   const handleActualize = useCallback(() => {
-    void runSchemaActualization?.();
-  }, [runSchemaActualization]);
+    runGuarded?.(() => runSchemaActualization?.(), { intent: 'refresh' });
+  }, [runGuarded, runSchemaActualization]);
 
   // Handle discard
   const handleDiscard = useCallback(() => {
@@ -122,47 +168,80 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
 
   const isFilled = (value: string | undefined): boolean => !!value && value.trim() !== '';
 
-  const handleGenerateAllFieldDescriptions = useCallback(async () => {
-    if (!dataMartId || !schema) return;
-    const generated = await generateAllFieldDescriptions(dataMartId);
-    if (!generated) return;
-    const byName = new Map(generated.map(field => [field.name, field.description]));
-    const updated = schema.fields.map(field => {
-      if (isFilled(field.description)) return field;
-      const description = byName.get(field.name);
-      return description ? { ...field, description } : field;
-    });
-    updateSchema(updated as typeof schema.fields);
-  }, [dataMartId, schema, generateAllFieldDescriptions, updateSchema]);
+  const handleGenerateAllFieldDescriptions = useCallback(
+    async (targetSchema: ResolvedSchema) => {
+      if (!dataMartId || !targetSchema) return;
+      const generated = await generateAllFieldDescriptions(dataMartId);
+      if (!generated) return;
+      const byName = new Map(generated.map(field => [field.name, field.description]));
+      const updated = targetSchema.fields.map(field => {
+        if (isFilled(field.description)) return field;
+        const description = byName.get(field.name);
+        return description ? { ...field, description } : field;
+      });
+      updateSchema(updated as typeof targetSchema.fields);
+    },
+    [dataMartId, generateAllFieldDescriptions, updateSchema]
+  );
 
-  const handleGenerateAllFieldAliases = useCallback(async () => {
-    if (!dataMartId || !schema) return;
-    const generated = await generateAllFieldAliases(dataMartId);
-    if (!generated) return;
-    const byName = new Map(generated.map(field => [field.name, field.alias]));
-    const updated = schema.fields.map(field => {
-      if (isFilled(field.alias)) return field;
-      const alias = byName.get(field.name);
-      return alias ? { ...field, alias } : field;
-    });
-    updateSchema(updated as typeof schema.fields);
-  }, [dataMartId, schema, generateAllFieldAliases, updateSchema]);
+  const handleGenerateAllFieldAliases = useCallback(
+    async (targetSchema: ResolvedSchema) => {
+      if (!dataMartId || !targetSchema) return;
+      const generated = await generateAllFieldAliases(dataMartId);
+      if (!generated) return;
+      const byName = new Map(generated.map(field => [field.name, field.alias]));
+      const updated = targetSchema.fields.map(field => {
+        if (isFilled(field.alias)) return field;
+        const alias = byName.get(field.name);
+        return alias ? { ...field, alias } : field;
+      });
+      updateSchema(updated as typeof targetSchema.fields);
+    },
+    [dataMartId, generateAllFieldAliases, updateSchema]
+  );
 
-  const handleGenerateAllFieldMetadata = useCallback(async () => {
-    if (!dataMartId || !schema) return;
-    const generated = await generateAllFieldMetadata(dataMartId);
-    if (!generated) return;
-    const byName = new Map(generated.map(field => [field.name, field]));
-    const updated = schema.fields.map(field => {
-      const gen = byName.get(field.name);
-      if (!gen) return field;
-      const next = { ...field };
-      if (!isFilled(field.alias) && gen.alias) next.alias = gen.alias;
-      if (!isFilled(field.description) && gen.description) next.description = gen.description;
-      return next;
-    });
-    updateSchema(updated as typeof schema.fields);
-  }, [dataMartId, schema, generateAllFieldMetadata, updateSchema]);
+  const handleGenerateAllFieldMetadata = useCallback(
+    async (targetSchema: ResolvedSchema) => {
+      if (!dataMartId || !targetSchema) return;
+      const generated = await generateAllFieldMetadata(dataMartId);
+      if (!generated) return;
+      const byName = new Map(generated.map(field => [field.name, field]));
+      const updated = targetSchema.fields.map(field => {
+        const gen = byName.get(field.name);
+        if (!gen) return field;
+        const next = { ...field };
+        if (!isFilled(field.alias) && gen.alias) next.alias = gen.alias;
+        if (!isFilled(field.description) && gen.description) next.description = gen.description;
+        return next;
+      });
+      updateSchema(updated as typeof targetSchema.fields);
+    },
+    [dataMartId, generateAllFieldMetadata, updateSchema]
+  );
+
+  // Bulk AI maps generated metadata onto the resolved schema (saved or discarded)
+  // provided by the unsaved-changes guard, so unsaved edits are never silently used
+  // against a stale field set.
+  const runBulkAi = useCallback(
+    async (scope: BulkAiScope, targetSchema: ResolvedSchema): Promise<void> => {
+      switch (scope) {
+        case DataMartMetadataScope.ALL_FIELD_METADATA:
+          await handleGenerateAllFieldMetadata(targetSchema);
+          break;
+        case DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS:
+          await handleGenerateAllFieldDescriptions(targetSchema);
+          break;
+        case DataMartMetadataScope.ALL_FIELD_ALIASES:
+          await handleGenerateAllFieldAliases(targetSchema);
+          break;
+      }
+    },
+    [
+      handleGenerateAllFieldMetadata,
+      handleGenerateAllFieldDescriptions,
+      handleGenerateAllFieldAliases,
+    ]
+  );
 
   // Disable buttons during schema operations (save or actualization)
   const isSchemaOperationInProgress = isLoading || isSchemaActualizationLoading;
@@ -240,7 +319,12 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
                   className='cursor-pointer'
                   disabled={!hasFields || isAiBusy}
                   onClick={() => {
-                    void handleGenerateAllFieldMetadata();
+                    runGuarded?.(
+                      resolved => runBulkAi(DataMartMetadataScope.ALL_FIELD_METADATA, resolved),
+                      {
+                        intent: 'ai',
+                      }
+                    );
                   }}
                 >
                   <Sparkles className='mr-2 h-4 w-4' />
@@ -250,7 +334,12 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
                   className='cursor-pointer'
                   disabled={!hasFields || isAiBusy}
                   onClick={() => {
-                    void handleGenerateAllFieldDescriptions();
+                    runGuarded?.(
+                      resolved => runBulkAi(DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS, resolved),
+                      {
+                        intent: 'ai',
+                      }
+                    );
                   }}
                 >
                   <Sparkles className='mr-2 h-4 w-4' />
@@ -260,7 +349,12 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
                   className='cursor-pointer'
                   disabled={!hasFields || isAiBusy}
                   onClick={() => {
-                    void handleGenerateAllFieldAliases();
+                    runGuarded?.(
+                      resolved => runBulkAi(DataMartMetadataScope.ALL_FIELD_ALIASES, resolved),
+                      {
+                        intent: 'ai',
+                      }
+                    );
                   }}
                 >
                   <Sparkles className='mr-2 h-4 w-4' />

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useSchemaState.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useSchemaState.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { DataMartSchema } from '../../../../shared/types/data-mart-schema.types';
+import { useSchemaState } from './useSchemaState';
+
+const initialSchema = {
+  type: 'bigquery-data-mart-schema',
+  fields: [{ name: 'id', type: 'INTEGER', mode: 'NULLABLE' }],
+} as DataMartSchema;
+
+describe('useSchemaState', () => {
+  it('preserves follow-up changes when the saved schema arrives as the new initial schema', () => {
+    const { result, rerender } = renderHook(
+      ({ initial }: { initial: DataMartSchema }) => useSchemaState(initial),
+      { initialProps: { initial: initialSchema } }
+    );
+
+    const savedSchema = {
+      ...initialSchema,
+      fields: [{ ...initialSchema.fields[0], description: 'Manual description' }],
+    } as DataMartSchema;
+
+    act(() => {
+      result.current.markSchemaSaved(savedSchema);
+      result.current.updateSchema([
+        { ...savedSchema.fields[0], alias: 'Generated alias' },
+      ] as typeof savedSchema.fields);
+    });
+    rerender({ initial: savedSchema });
+
+    expect(result.current.schema?.fields[0]).toMatchObject({
+      description: 'Manual description',
+      alias: 'Generated alias',
+    });
+    expect(result.current.isDirty).toBe(true);
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useSchemaState.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useSchemaState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type {
   AthenaSchemaField,
   BigQuerySchemaField,
@@ -43,13 +43,29 @@ export function useSchemaState(initialSchema: DataMartSchema | null | undefined)
   const clonedInitialSchema = deepCloneSchema(initialSchema);
   const [schema, setSchema] = useState<DataMartSchema | null | undefined>(clonedInitialSchema);
   const [isDirty, setIsDirty] = useState(false);
+  const skipNextInitialSchemaResetRef = useRef(false);
 
   // Reset schema when initialSchema changes
   useEffect(() => {
+    if (skipNextInitialSchemaResetRef.current) {
+      skipNextInitialSchemaResetRef.current = false;
+      return;
+    }
     const clonedSchema = deepCloneSchema(initialSchema);
     setSchema(clonedSchema);
     setIsDirty(false);
   }, [initialSchema]);
+
+  /**
+   * Marks the current schema as persisted. The matching context update will
+   * provide the same schema as a new initialSchema; skip that reset so changes
+   * made by a guarded follow-up action are not overwritten by its effect.
+   */
+  const markSchemaSaved = useCallback((savedSchema: DataMartSchema) => {
+    skipNextInitialSchemaResetRef.current = true;
+    setSchema(deepCloneSchema(savedSchema));
+    setIsDirty(false);
+  }, []);
 
   /**
    * Updates the schema with new fields.
@@ -152,6 +168,7 @@ export function useSchemaState(initialSchema: DataMartSchema | null | undefined)
     isDirty,
     updateSchema,
     resetSchema,
+    markSchemaSaved,
     setIsDirty,
   };
 }

--- a/apps/web/src/features/data-marts/edit/components/SchemaUnsavedChangesDialog/SchemaUnsavedChangesDialog.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/SchemaUnsavedChangesDialog/SchemaUnsavedChangesDialog.test.tsx
@@ -47,4 +47,25 @@ describe('SchemaUnsavedChangesDialog', () => {
     expect(onDiscardAndContinue).toHaveBeenCalledTimes(1);
     expect(baseProps.onCancel).not.toHaveBeenCalled();
   });
+
+  it('cancels on Escape when not saving', () => {
+    const onCancel = vi.fn();
+    render(<SchemaUnsavedChangesDialog {...baseProps} intent='refresh' onCancel={onCancel} />);
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cancel on Escape while saving', () => {
+    const onCancel = vi.fn();
+    render(
+      <SchemaUnsavedChangesDialog
+        {...baseProps}
+        intent='refresh'
+        isSaving={true}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/features/data-marts/edit/components/SchemaUnsavedChangesDialog/SchemaUnsavedChangesDialog.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/SchemaUnsavedChangesDialog/SchemaUnsavedChangesDialog.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SchemaUnsavedChangesDialog } from './SchemaUnsavedChangesDialog';
+
+describe('SchemaUnsavedChangesDialog', () => {
+  const baseProps = {
+    open: true,
+    onSaveAndContinue: vi.fn(),
+    onDiscardAndContinue: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it('shows continue-verb buttons for non-navigation intents', () => {
+    render(<SchemaUnsavedChangesDialog {...baseProps} intent='refresh' />);
+    expect(screen.getByRole('button', { name: /save & continue/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /discard & continue/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('uses the "leave" verb for navigation intent', () => {
+    render(<SchemaUnsavedChangesDialog {...baseProps} intent='navigation' />);
+    expect(screen.getByRole('button', { name: /save & leave/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /discard & leave/i })).toBeInTheDocument();
+  });
+
+  it('disables action buttons while saving', () => {
+    render(<SchemaUnsavedChangesDialog {...baseProps} intent='refresh' isSaving={true} />);
+    expect(screen.getByRole('button', { name: /save & continue/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /discard & continue/i })).toBeDisabled();
+  });
+
+  it('wires button clicks to the handlers', () => {
+    const onSaveAndContinue = vi.fn();
+    const onDiscardAndContinue = vi.fn();
+    render(
+      <SchemaUnsavedChangesDialog
+        {...baseProps}
+        intent='ai'
+        onSaveAndContinue={onSaveAndContinue}
+        onDiscardAndContinue={onDiscardAndContinue}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /save & continue/i }));
+    fireEvent.click(screen.getByRole('button', { name: /discard & continue/i }));
+    expect(onSaveAndContinue).toHaveBeenCalledTimes(1);
+    expect(onDiscardAndContinue).toHaveBeenCalledTimes(1);
+    expect(baseProps.onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/SchemaUnsavedChangesDialog/SchemaUnsavedChangesDialog.tsx
+++ b/apps/web/src/features/data-marts/edit/components/SchemaUnsavedChangesDialog/SchemaUnsavedChangesDialog.tsx
@@ -1,0 +1,73 @@
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@owox/ui/components/alert-dialog';
+import { Button } from '@owox/ui/components/button';
+import type { SchemaGuardIntent } from '../../model/hooks';
+
+interface SchemaUnsavedChangesDialogProps {
+  open: boolean;
+  intent: SchemaGuardIntent;
+  isSaving?: boolean;
+  onSaveAndContinue: () => void;
+  onDiscardAndContinue: () => void;
+  onCancel: () => void;
+}
+
+const DESCRIPTIONS: Record<SchemaGuardIntent, string> = {
+  ai: 'AI metadata is generated against the saved schema, so your unsaved changes would be ignored.',
+  refresh: 'Refreshing reloads the schema from the source. Your unsaved changes would be lost.',
+  publish: 'Publishing refreshes the schema. Your unsaved changes would be lost.',
+  definition:
+    'Saving the input source refreshes the schema. Your unsaved schema changes would be lost.',
+  navigation: 'You have unsaved schema changes. Leaving this page will discard them.',
+};
+
+export function SchemaUnsavedChangesDialog({
+  open,
+  intent,
+  isSaving = false,
+  onSaveAndContinue,
+  onDiscardAndContinue,
+  onCancel,
+}: SchemaUnsavedChangesDialogProps) {
+  const verb = intent === 'navigation' ? 'leave' : 'continue';
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={isOpen => {
+        if (!isOpen) {
+          onCancel();
+        }
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Unsaved schema changes</AlertDialogTitle>
+          <AlertDialogDescription>{DESCRIPTIONS[intent]}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isSaving}>Cancel</AlertDialogCancel>
+          <Button
+            type='button'
+            variant='outline'
+            onClick={onDiscardAndContinue}
+            disabled={isSaving}
+          >
+            Discard &amp; {verb}
+          </Button>
+          <Button type='button' onClick={onSaveAndContinue} disabled={isSaving}>
+            Save &amp; {verb}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export type { SchemaUnsavedChangesDialogProps };

--- a/apps/web/src/features/data-marts/edit/components/SchemaUnsavedChangesDialog/SchemaUnsavedChangesDialog.tsx
+++ b/apps/web/src/features/data-marts/edit/components/SchemaUnsavedChangesDialog/SchemaUnsavedChangesDialog.tsx
@@ -8,7 +8,7 @@ import {
   AlertDialogTitle,
 } from '@owox/ui/components/alert-dialog';
 import { Button } from '@owox/ui/components/button';
-import type { SchemaGuardIntent } from '../../model/hooks';
+import type { SchemaGuardIntent } from '../../model';
 
 interface SchemaUnsavedChangesDialogProps {
   open: boolean;
@@ -20,12 +20,15 @@ interface SchemaUnsavedChangesDialogProps {
 }
 
 const DESCRIPTIONS: Record<SchemaGuardIntent, string> = {
-  ai: 'AI metadata is generated against the saved schema, so your unsaved changes would be ignored.',
-  refresh: 'Refreshing reloads the schema from the source. Your unsaved changes would be lost.',
-  publish: 'Publishing refreshes the schema. Your unsaved changes would be lost.',
+  ai: 'AI metadata is generated from the saved schema. Save to include your changes, or discard to ignore them.',
+  refresh:
+    'Refreshing reloads the schema from the source. Save to keep your changes, or discard to lose them.',
+  publish:
+    'Publishing refreshes the schema from the source. Save to keep your changes, or discard to lose them.',
   definition:
-    'Saving the input source refreshes the schema. Your unsaved schema changes would be lost.',
-  navigation: 'You have unsaved schema changes. Leaving this page will discard them.',
+    'Saving the input source refreshes the schema. Save to keep your schema changes, or discard to lose them.',
+  navigation:
+    'You have unsaved schema changes. Save to keep them, or discard them to leave this page.',
 };
 
 export function SchemaUnsavedChangesDialog({
@@ -41,7 +44,10 @@ export function SchemaUnsavedChangesDialog({
     <AlertDialog
       open={open}
       onOpenChange={isOpen => {
-        if (!isOpen) {
+        // While a save is in flight the buttons are disabled; keep Escape /
+        // outside-click from cancelling too, which would drop the pending
+        // follow-up action even though the schema is being persisted.
+        if (!isOpen && !isSaving) {
           onCancel();
         }
       }}

--- a/apps/web/src/features/data-marts/edit/components/SchemaUnsavedChangesDialog/index.ts
+++ b/apps/web/src/features/data-marts/edit/components/SchemaUnsavedChangesDialog/index.ts
@@ -1,0 +1,4 @@
+export {
+  SchemaUnsavedChangesDialog,
+  type SchemaUnsavedChangesDialogProps,
+} from './SchemaUnsavedChangesDialog';

--- a/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
+++ b/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
@@ -192,6 +192,7 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
         label: id,
         error: apiError.message,
       });
+      throw error;
     }
   }, []);
 
@@ -654,6 +655,7 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
         action: 'UpdateSchemaError',
         error: apiError.message,
       });
+      throw error;
     }
   }, []);
 

--- a/apps/web/src/features/data-marts/edit/model/context/types.ts
+++ b/apps/web/src/features/data-marts/edit/model/context/types.ts
@@ -4,6 +4,11 @@ import type {
   RunDataMartRequestDto,
   UpdateDataMartRequestDto,
 } from '../../../shared/types/api';
+import type {
+  SchemaGuardRegistration,
+  GuardedAction,
+  SchemaGuardIntent,
+} from '../hooks/use-schema-unsaved-guard';
 import type { DataMartResponseDto } from '../../../shared/types/api/response/data-mart.response.dto';
 import type { DataMartDefinitionType } from '../../../shared';
 import type { DataMartDefinitionConfig } from '../types';
@@ -107,6 +112,8 @@ export interface DataMartContextType extends DataMartState {
   ) => Promise<void>;
   runSchemaActualization?: () => Promise<void>;
   isSchemaActualizationLoading?: boolean;
+  registerSchemaGuard?: (registration: SchemaGuardRegistration | null) => void;
+  runGuarded?: (action: GuardedAction, opts: { intent: SchemaGuardIntent }) => void;
   error: ApiError | null;
   getErrorMessage: () => string | null;
   resetManualRunTriggered: () => void;

--- a/apps/web/src/features/data-marts/edit/model/hooks/__tests__/use-schema-unsaved-guard.test.tsx
+++ b/apps/web/src/features/data-marts/edit/model/hooks/__tests__/use-schema-unsaved-guard.test.tsx
@@ -1,0 +1,291 @@
+// @vitest-environment happy-dom
+import { render as rtlRender, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMemoryRouter, RouterProvider, Outlet } from 'react-router-dom';
+import {
+  useSchemaUnsavedGuard,
+  type SchemaGuardRegistration,
+  type ResolvedSchema,
+} from '../use-schema-unsaved-guard';
+
+// useBlocker requires a data router; expose the hook result through a ref.
+function makeWrapper() {
+  // Mutate a property (not a reassignment) so react-hooks lint rules are satisfied.
+  const captured: { current: ReturnType<typeof useSchemaUnsavedGuard> | null } = {
+    current: null,
+  };
+  function Harness() {
+    captured.current = useSchemaUnsavedGuard();
+    return <Outlet />;
+  }
+  const router = createMemoryRouter(
+    [{ path: '/', element: <Harness />, children: [{ index: true, element: <div /> }] }],
+    { initialEntries: ['/'] }
+  );
+  return { get: () => captured.current!, router };
+}
+
+// Variant of makeWrapper that also exposes a /other child route for navigation tests.
+function makeWrapperWithNav() {
+  const captured: { current: ReturnType<typeof useSchemaUnsavedGuard> | null } = {
+    current: null,
+  };
+  function Harness() {
+    captured.current = useSchemaUnsavedGuard();
+    return <Outlet />;
+  }
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <Harness />,
+        children: [
+          { index: true, element: <div id='home' /> },
+          { path: 'other', element: <div id='other' /> },
+        ],
+      },
+    ],
+    { initialEntries: ['/'] }
+  );
+  return { get: () => captured.current!, router };
+}
+
+// Local render helper so the RouterProvider mounts the harness.
+function render(h: ReturnType<typeof makeWrapper>) {
+  rtlRender(<RouterProvider router={h.router} />);
+}
+
+const schemaA = { type: 'bigquery-data-mart-schema', fields: [] } as unknown as ResolvedSchema;
+const schemaB = {
+  type: 'bigquery-data-mart-schema',
+  fields: [{ name: 'x' }],
+} as unknown as ResolvedSchema;
+
+function dirtyRegistration(
+  overrides: Partial<SchemaGuardRegistration> = {}
+): SchemaGuardRegistration {
+  return {
+    isDirty: () => true,
+    getSchema: () => schemaB,
+    save: vi.fn(async () => schemaB),
+    discard: vi.fn(() => schemaA),
+    ...overrides,
+  };
+}
+
+describe('useSchemaUnsavedGuard', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('runs the action immediately with the current schema when not dirty', async () => {
+    const h = makeWrapper();
+    render(h);
+    const guard = h.get();
+    const action = vi.fn();
+    act(() => {
+      guard.registerSchemaGuard({
+        isDirty: () => false,
+        getSchema: () => schemaA,
+        save: vi.fn(async () => schemaA),
+        discard: vi.fn(() => schemaA),
+      });
+    });
+    act(() => {
+      guard.runGuarded(action, { intent: 'refresh' });
+    });
+    await waitFor(() => {
+      expect(action).toHaveBeenCalledWith(schemaA);
+    });
+    expect(h.get().dialog.open).toBe(false);
+  });
+
+  it('opens the dialog when dirty instead of running the action', () => {
+    const h = makeWrapper();
+    render(h);
+    const action = vi.fn();
+    act(() => {
+      h.get().registerSchemaGuard(dirtyRegistration());
+    });
+    act(() => {
+      h.get().runGuarded(action, { intent: 'ai' });
+    });
+    expect(action).not.toHaveBeenCalled();
+    expect(h.get().dialog.open).toBe(true);
+    expect(h.get().dialog.intent).toBe('ai');
+  });
+
+  it('Save & continue saves then runs the action with the saved schema', async () => {
+    const h = makeWrapper();
+    render(h);
+    const save = vi.fn(async () => schemaB);
+    const action = vi.fn();
+    act(() => {
+      h.get().registerSchemaGuard(dirtyRegistration({ save }));
+    });
+    act(() => {
+      h.get().runGuarded(action, { intent: 'refresh' });
+    });
+    act(() => {
+      h.get().dialog.onSaveAndContinue();
+    });
+    await waitFor(() => {
+      expect(action).toHaveBeenCalledWith(schemaB);
+    });
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(h.get().dialog.open).toBe(false);
+  });
+
+  it('Discard & continue discards then runs the action with the initial schema', async () => {
+    const h = makeWrapper();
+    render(h);
+    const discard = vi.fn(() => schemaA);
+    const action = vi.fn();
+    act(() => {
+      h.get().registerSchemaGuard(dirtyRegistration({ discard }));
+    });
+    act(() => {
+      h.get().runGuarded(action, { intent: 'ai' });
+    });
+    act(() => {
+      h.get().dialog.onDiscardAndContinue();
+    });
+    await waitFor(() => {
+      expect(action).toHaveBeenCalledWith(schemaA);
+    });
+    expect(discard).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs a guarded async action after discarding changes', async () => {
+    const h = makeWrapperWithNav();
+    rtlRender(<RouterProvider router={h.router} />);
+    const discard = vi.fn(() => schemaA);
+    const action = vi.fn(async () => {
+      await h.router.navigate('/other');
+    });
+    act(() => {
+      h.get().registerSchemaGuard(dirtyRegistration({ discard }));
+    });
+    act(() => {
+      h.get().runGuarded(action, { intent: 'navigation' });
+    });
+    await act(async () => {
+      h.get().dialog.onDiscardAndContinue();
+    });
+    await waitFor(() => {
+      expect(discard).toHaveBeenCalledTimes(1);
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(h.router.state.location.pathname).toBe('/other');
+    });
+    expect(h.get().dialog.open).toBe(false);
+  });
+
+  it('Cancel runs nothing and closes the dialog', () => {
+    const h = makeWrapper();
+    render(h);
+    const action = vi.fn();
+    act(() => {
+      h.get().registerSchemaGuard(dirtyRegistration());
+    });
+    act(() => {
+      h.get().runGuarded(action, { intent: 'publish' });
+    });
+    act(() => {
+      h.get().dialog.onCancel();
+    });
+    expect(action).not.toHaveBeenCalled();
+    expect(h.get().dialog.open).toBe(false);
+  });
+
+  it('keeps the dialog open and does not run the action when save rejects', async () => {
+    const h = makeWrapper();
+    render(h);
+    const save = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const action = vi.fn();
+    act(() => {
+      h.get().registerSchemaGuard(dirtyRegistration({ save }));
+    });
+    act(() => {
+      h.get().runGuarded(action, { intent: 'refresh' });
+    });
+    await act(async () => {
+      h.get().dialog.onSaveAndContinue();
+    });
+    await waitFor(() => {
+      expect(save).toHaveBeenCalled();
+    });
+    expect(action).not.toHaveBeenCalled();
+    expect(h.get().dialog.open).toBe(true);
+  });
+
+  describe('navigation blocking (useBlocker)', () => {
+    it('Test A — Discard & leave: dialog opens with navigation intent, proceed navigates', async () => {
+      const h = makeWrapperWithNav();
+      rtlRender(<RouterProvider router={h.router} />);
+      // Register dirty guard so the blocker activates on navigation.
+      act(() => {
+        h.get().registerSchemaGuard(dirtyRegistration());
+      });
+      // Trigger navigation to /other; the blocker intercepts it.
+      await act(async () => {
+        await h.router.navigate('/other');
+      });
+      await waitFor(() => {
+        expect(h.get().dialog.open).toBe(true);
+        expect(h.get().dialog.intent).toBe('navigation');
+      });
+      // Discard & continue: calls discard then blocker.proceed().
+      act(() => {
+        h.get().dialog.onDiscardAndContinue();
+      });
+      await waitFor(() => {
+        expect(h.router.state.location.pathname).toBe('/other');
+      });
+      expect(h.get().dialog.open).toBe(false);
+    });
+
+    it('Test B — Cancel: dialog closes and location stays on current path', async () => {
+      const h = makeWrapperWithNav();
+      rtlRender(<RouterProvider router={h.router} />);
+      act(() => {
+        h.get().registerSchemaGuard(dirtyRegistration());
+      });
+      await act(async () => {
+        await h.router.navigate('/other');
+      });
+      await waitFor(() => {
+        expect(h.get().dialog.open).toBe(true);
+      });
+      act(() => {
+        h.get().dialog.onCancel();
+      });
+      await waitFor(() => {
+        expect(h.get().dialog.open).toBe(false);
+        expect(h.router.state.location.pathname).toBe('/');
+      });
+    });
+
+    it('Test C — Save & leave: save is called and navigation completes', async () => {
+      const h = makeWrapperWithNav();
+      rtlRender(<RouterProvider router={h.router} />);
+      const save = vi.fn(async () => schemaB);
+      act(() => {
+        h.get().registerSchemaGuard(dirtyRegistration({ save }));
+      });
+      await act(async () => {
+        await h.router.navigate('/other');
+      });
+      await waitFor(() => {
+        expect(h.get().dialog.open).toBe(true);
+      });
+      await act(async () => {
+        h.get().dialog.onSaveAndContinue();
+      });
+      await waitFor(() => {
+        expect(save).toHaveBeenCalledTimes(1);
+        expect(h.router.state.location.pathname).toBe('/other');
+      });
+      expect(h.get().dialog.open).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/features/data-marts/edit/model/hooks/index.ts
+++ b/apps/web/src/features/data-marts/edit/model/hooks/index.ts
@@ -3,3 +3,11 @@ export { useDataMart } from './use-data-mart.ts';
 export { useAiHelperAvailability } from './use-ai-helper-availability.ts';
 export { useAiHelper } from './use-ai-helper.ts';
 export type { UseAiHelperResult, PendingScope } from './use-ai-helper.ts';
+export {
+  useSchemaUnsavedGuard,
+  type SchemaUnsavedGuard,
+  type SchemaGuardIntent,
+  type SchemaGuardRegistration,
+  type GuardedAction,
+  type ResolvedSchema,
+} from './use-schema-unsaved-guard.ts';

--- a/apps/web/src/features/data-marts/edit/model/hooks/use-schema-unsaved-guard.ts
+++ b/apps/web/src/features/data-marts/edit/model/hooks/use-schema-unsaved-guard.ts
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useBlocker } from 'react-router-dom';
+import type { DataMartSchema } from '../../../shared/types/data-mart-schema.types';
+
+export type SchemaGuardIntent = 'ai' | 'refresh' | 'publish' | 'definition' | 'navigation';
+
+export type ResolvedSchema = DataMartSchema | null | undefined;
+
+export interface SchemaGuardRegistration {
+  isDirty: () => boolean;
+  getSchema: () => ResolvedSchema;
+  save: () => Promise<ResolvedSchema>;
+  discard: () => ResolvedSchema;
+}
+
+export type GuardedAction = (resolvedSchema: ResolvedSchema) => void | Promise<void>;
+
+export interface SchemaUnsavedGuard {
+  isSchemaDirty: boolean;
+  registerSchemaGuard: (registration: SchemaGuardRegistration | null) => void;
+  runGuarded: (action: GuardedAction, opts: { intent: SchemaGuardIntent }) => void;
+  dialog: {
+    open: boolean;
+    intent: SchemaGuardIntent;
+    isSaving: boolean;
+    onSaveAndContinue: () => void;
+    onDiscardAndContinue: () => void;
+    onCancel: () => void;
+  };
+}
+
+export function useSchemaUnsavedGuard(): SchemaUnsavedGuard {
+  const registrationRef = useRef<SchemaGuardRegistration | null>(null);
+  const isSchemaDirtyRef = useRef(false);
+  const pendingActionRef = useRef<GuardedAction | null>(null);
+  const [isSchemaDirty, setIsSchemaDirty] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [intent, setIntent] = useState<SchemaGuardIntent>('refresh');
+  const [isSaving, setIsSaving] = useState(false);
+
+  const registerSchemaGuard = useCallback((registration: SchemaGuardRegistration | null) => {
+    registrationRef.current = registration;
+    const nextIsDirty = registration?.isDirty() ?? false;
+    isSchemaDirtyRef.current = nextIsDirty;
+    setIsSchemaDirty(nextIsDirty);
+  }, []);
+
+  const runAction = useCallback(async (resolved: ResolvedSchema) => {
+    const action = pendingActionRef.current;
+    pendingActionRef.current = null;
+    if (action) await action(resolved);
+  }, []);
+
+  // Block in-app navigation while the schema has unsaved edits.
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      (registrationRef.current?.isDirty() ?? false) &&
+      currentLocation.pathname !== nextLocation.pathname
+  );
+
+  const blockerRef = useRef(blocker);
+  blockerRef.current = blocker;
+
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      pendingActionRef.current = () => {
+        blockerRef.current.proceed?.();
+      };
+      setIntent('navigation');
+      setOpen(true);
+    }
+  }, [blocker]);
+
+  // Native prompt for hard tab/window close or reload.
+  useEffect(() => {
+    if (!isSchemaDirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      // Safari / older Chromium still require returnValue to be set to show the prompt.
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      event.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => {
+      window.removeEventListener('beforeunload', handler);
+    };
+  }, [isSchemaDirty]);
+
+  const runGuarded = useCallback(
+    (action: GuardedAction, opts: { intent: SchemaGuardIntent }) => {
+      const registration = registrationRef.current;
+      pendingActionRef.current = action;
+      if (!registration?.isDirty()) {
+        void runAction(registration?.getSchema());
+        return;
+      }
+      setIntent(opts.intent);
+      setOpen(true);
+    },
+    [runAction]
+  );
+
+  const onSaveAndContinue = useCallback(() => {
+    const registration = registrationRef.current;
+    if (!registration) {
+      setOpen(false);
+      return;
+    }
+    void (async () => {
+      setIsSaving(true);
+      let resolved: ResolvedSchema;
+      try {
+        resolved = await registration.save();
+      } catch {
+        setIsSaving(false);
+        // Keep the dialog open; the user keeps their unsaved changes.
+        return;
+      }
+      // Mark the registration as clean immediately so any navigation inside
+      // the pending action is not blocked by the stale dirty flag.
+      registrationRef.current = { ...registration, isDirty: () => false };
+      isSchemaDirtyRef.current = false;
+      setIsSchemaDirty(false);
+      setIsSaving(false);
+      setOpen(false);
+      await runAction(resolved);
+    })();
+  }, [runAction]);
+
+  const onDiscardAndContinue = useCallback(() => {
+    const registration = registrationRef.current;
+    const resolved = registration ? registration.discard() : undefined;
+    // Mark the registration as clean immediately so any navigation inside
+    // the pending action is not blocked by the stale dirty flag.
+    if (registration) {
+      registrationRef.current = { ...registration, isDirty: () => false };
+    }
+    isSchemaDirtyRef.current = false;
+    setIsSchemaDirty(false);
+    setOpen(false);
+    void runAction(resolved);
+  }, [runAction]);
+
+  const onCancel = useCallback(() => {
+    pendingActionRef.current = null;
+    if (blockerRef.current.state === 'blocked') {
+      blockerRef.current.reset();
+    }
+    setOpen(false);
+  }, []);
+
+  return {
+    isSchemaDirty,
+    registerSchemaGuard,
+    runGuarded,
+    dialog: { open, intent, isSaving, onSaveAndContinue, onDiscardAndContinue, onCancel },
+  };
+}


### PR DESCRIPTION
## Summary

When a data mart's Output Schema has unsaved changes, users are now asked how to proceed before any action that would replace the schema — so edits are never discarded without warning.

## What's changed

- Added `useSchemaUnsavedGuard` hook with a Save/Discard/Cancel dialog.
- Guarded actions: AI field metadata generation, schema refresh, publish, input source update, and in-app navigation.
- `SchemaGuardRegistration.isDirty` is now a getter to avoid race conditions.
- Registration is marked clean immediately after save/discard so subsequent navigation isn't blocked.
- Dialog buttons show saving state and are disabled during async save.
- Removed redundant `onClick={onCancel}` to prevent double cancel invocation.
- `DataMartContext` now re-throws schema/definition update errors so the guard can keep the dialog open on failure.
- Added/extended tests for the guard, dialog, and `useSchemaState`.
