### PR TITLE
feat(mcp): add list_destinations MCP tool

### DIFF
--- a/.changeset/6706-mcp-list-destinations-tool.md
+++ b/.changeset/6706-mcp-list-destinations-tool.md
@@ -1,0 +1,9 @@
+---
+"owox": minor
+---
+
+# Add a list_destinations MCP tool
+
+AI assistants connected to OWOX over MCP can now list the destinations available in your active project. Each entry includes its name, type (Google Sheets, Looker Studio, Slack, Email, Microsoft Teams, or Google Chat), and owner — so the assistant can pick the right target before creating a report on your behalf.
+
+Only destinations you can access are returned, and destinations that aren't currently usable are omitted.

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -52,6 +52,8 @@ import { SyncLegacyGcpStoragesForProjectService } from './use-cases/legacy-data-
 import { ListDataMartsService } from './use-cases/list-data-marts.service';
 import { MCP_DATA_MARTS_FACADE } from './facades/mcp-data-marts.facade';
 import { McpDataMartsFacadeImpl } from './facades/mcp-data-marts.facade.impl';
+import { MCP_DATA_DESTINATIONS_FACADE } from './facades/mcp-data-destinations.facade';
+import { McpDataDestinationsFacadeImpl } from './facades/mcp-data-destinations.facade.impl';
 import { ListDataMartsByConnectorNameService } from './use-cases/list-data-marts-by-connector-name.service';
 import { ListProjectDataMartRunsService } from './use-cases/list-project-data-mart-runs.service';
 import { ListProjectInsightTemplatesService } from './use-cases/list-project-insight-templates.service';
@@ -502,6 +504,10 @@ import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-m
       provide: MCP_DATA_MARTS_FACADE,
       useClass: McpDataMartsFacadeImpl,
     },
+    {
+      provide: MCP_DATA_DESTINATIONS_FACADE,
+      useClass: McpDataDestinationsFacadeImpl,
+    },
     ListDataMartsByConnectorNameService,
     GetDataMartService,
     ListDataMartRunsService,
@@ -794,7 +800,12 @@ import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-m
     HttpDataColumnResolver,
     HttpDataColumnValidator,
   ],
-  exports: [MCP_DATA_MARTS_FACADE, ContextAccessService, AdvancedSearchIndexSyncService],
+  exports: [
+    MCP_DATA_MARTS_FACADE,
+    MCP_DATA_DESTINATIONS_FACADE,
+    ContextAccessService,
+    AdvancedSearchIndexSyncService,
+  ],
 })
 export class DataMartsModule {
   configure(consumer: MiddlewareConsumer) {

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.spec.ts
@@ -1,0 +1,165 @@
+jest.mock('../use-cases/list-data-destinations.service', () => ({
+  ListDataDestinationsService: jest.fn(),
+}));
+
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
+import { DataDestinationDto } from '../dto/domain/data-destination.dto';
+import { UserProjectionDto } from '../../idp/dto/domain/user-projection.dto';
+import type { ListDataDestinationsService } from '../use-cases/list-data-destinations.service';
+import { McpDataDestinationsFacadeImpl } from './mcp-data-destinations.facade.impl';
+
+function buildDestination(overrides: {
+  id: string;
+  title: string;
+  type: DataDestinationType;
+  createdByUser?: UserProjectionDto | null;
+  ownerUsers?: UserProjectionDto[];
+  availableForUse?: boolean;
+}): DataDestinationDto {
+  return new DataDestinationDto(
+    overrides.id,
+    overrides.title,
+    overrides.type,
+    'project-1',
+    new Date('2026-06-01T10:00:00.000Z'),
+    new Date('2026-06-02T10:00:00.000Z'),
+    null,
+    overrides.createdByUser ?? null,
+    overrides.ownerUsers ?? [],
+    overrides.availableForUse ?? true
+  );
+}
+
+describe('McpDataDestinationsFacadeImpl', () => {
+  it('lists destinations using project-member context and maps the DTO', async () => {
+    const listDataDestinationsService = {
+      run: jest.fn().mockResolvedValue([
+        buildDestination({
+          id: 'dest_1',
+          title: 'Marketing Sheet',
+          type: DataDestinationType.GOOGLE_SHEETS,
+          createdByUser: new UserProjectionDto('user-1', 'Ann', 'ann@owox.com'),
+        }),
+        buildDestination({
+          id: 'dest_2',
+          title: 'Ops Teams',
+          type: DataDestinationType.MS_TEAMS,
+          createdByUser: null,
+        }),
+      ]),
+    } as unknown as jest.Mocked<ListDataDestinationsService>;
+
+    const facade = new McpDataDestinationsFacadeImpl(listDataDestinationsService);
+
+    const result = await facade.listDestinations({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+    });
+
+    expect(listDataDestinationsService.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        userId: 'user-1',
+        roles: ['viewer'],
+      })
+    );
+    expect(result).toEqual({
+      destinations: [
+        { id: 'dest_1', name: 'Marketing Sheet', type: 'google_sheets', owner: 'ann@owox.com' },
+        { id: 'dest_2', name: 'Ops Teams', type: 'teams', owner: null },
+      ],
+    });
+  });
+
+  it('maps every destination type to the lowercase MCP vocabulary', async () => {
+    const listDataDestinationsService = {
+      run: jest
+        .fn()
+        .mockResolvedValue([
+          buildDestination({ id: '1', title: 'gs', type: DataDestinationType.GOOGLE_SHEETS }),
+          buildDestination({ id: '2', title: 'ls', type: DataDestinationType.LOOKER_STUDIO }),
+          buildDestination({ id: '3', title: 'em', type: DataDestinationType.EMAIL }),
+          buildDestination({ id: '4', title: 'sl', type: DataDestinationType.SLACK }),
+          buildDestination({ id: '5', title: 'tm', type: DataDestinationType.MS_TEAMS }),
+          buildDestination({ id: '6', title: 'gc', type: DataDestinationType.GOOGLE_CHAT }),
+        ]),
+    } as unknown as jest.Mocked<ListDataDestinationsService>;
+
+    const facade = new McpDataDestinationsFacadeImpl(listDataDestinationsService);
+
+    const result = await facade.listDestinations({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: [],
+    });
+
+    expect(result.destinations.map(d => d.type)).toEqual([
+      'google_sheets',
+      'looker_studio',
+      'email',
+      'slack',
+      'teams',
+      'google_chat',
+    ]);
+  });
+
+  it('filters out destinations that are not available for use', async () => {
+    const listDataDestinationsService = {
+      run: jest.fn().mockResolvedValue([
+        buildDestination({
+          id: 'usable',
+          title: 'Usable',
+          type: DataDestinationType.GOOGLE_SHEETS,
+          availableForUse: true,
+        }),
+        buildDestination({
+          id: 'broken',
+          title: 'Broken',
+          type: DataDestinationType.GOOGLE_SHEETS,
+          availableForUse: false,
+        }),
+      ]),
+    } as unknown as jest.Mocked<ListDataDestinationsService>;
+
+    const facade = new McpDataDestinationsFacadeImpl(listDataDestinationsService);
+
+    const result = await facade.listDestinations({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: [],
+    });
+
+    expect(result.destinations.map(d => d.id)).toEqual(['usable']);
+  });
+
+  it('prefers an assigned owner over the creator, falling back to the creator', async () => {
+    const listDataDestinationsService = {
+      run: jest.fn().mockResolvedValue([
+        buildDestination({
+          id: 'owned',
+          title: 'Owned',
+          type: DataDestinationType.GOOGLE_SHEETS,
+          createdByUser: new UserProjectionDto('creator', 'Creator', 'creator@owox.com'),
+          ownerUsers: [new UserProjectionDto('owner', 'Owner', 'owner@owox.com')],
+        }),
+        buildDestination({
+          id: 'creator-only',
+          title: 'Creator only',
+          type: DataDestinationType.GOOGLE_SHEETS,
+          createdByUser: new UserProjectionDto('creator', 'Creator', 'creator@owox.com'),
+        }),
+      ]),
+    } as unknown as jest.Mocked<ListDataDestinationsService>;
+
+    const facade = new McpDataDestinationsFacadeImpl(listDataDestinationsService);
+
+    const result = await facade.listDestinations({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: [],
+    });
+
+    expect(result.destinations.map(d => d.owner)).toEqual(['owner@owox.com', 'creator@owox.com']);
+  });
+});

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.spec.ts
@@ -133,21 +133,22 @@ describe('McpDataDestinationsFacadeImpl', () => {
     expect(result.destinations.map(d => d.id)).toEqual(['usable']);
   });
 
-  it('prefers an assigned owner over the creator, falling back to the creator', async () => {
+  it('reports the creator as owner, ignoring the unordered owners relation', async () => {
     const listDataDestinationsService = {
       run: jest.fn().mockResolvedValue([
         buildDestination({
-          id: 'owned',
-          title: 'Owned',
+          id: 'with-creator',
+          title: 'With creator',
           type: DataDestinationType.GOOGLE_SHEETS,
           createdByUser: new UserProjectionDto('creator', 'Creator', 'creator@owox.com'),
           ownerUsers: [new UserProjectionDto('owner', 'Owner', 'owner@owox.com')],
         }),
         buildDestination({
-          id: 'creator-only',
-          title: 'Creator only',
+          id: 'no-creator',
+          title: 'No creator',
           type: DataDestinationType.GOOGLE_SHEETS,
-          createdByUser: new UserProjectionDto('creator', 'Creator', 'creator@owox.com'),
+          createdByUser: null,
+          ownerUsers: [new UserProjectionDto('owner', 'Owner', 'owner@owox.com')],
         }),
       ]),
     } as unknown as jest.Mocked<ListDataDestinationsService>;
@@ -160,6 +161,6 @@ describe('McpDataDestinationsFacadeImpl', () => {
       roles: [],
     });
 
-    expect(result.destinations.map(d => d.owner)).toEqual(['owner@owox.com', 'creator@owox.com']);
+    expect(result.destinations.map(d => d.owner)).toEqual(['creator@owox.com', null]);
   });
 });

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
@@ -36,9 +36,10 @@ export class McpDataDestinationsFacadeImpl implements McpDataDestinationsFacade 
           id: destination.id,
           name: destination.title,
           type: DESTINATION_TYPE_MAP[destination.type],
-          // Prefer an assigned owner; fall back to the creator when a
-          // destination has no explicit owner.
-          owner: (destination.ownerUsers[0] ?? destination.createdByUser)?.email ?? null,
+          // Report the creator as the owner. The `owners` relation has no stable
+          // ordering, so picking one of potentially several owners would be
+          // non-deterministic; the creator is a single, stable value.
+          owner: destination.createdByUser?.email ?? null,
         })),
     };
   }

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
+import { ListDataDestinationsCommand } from '../dto/domain/list-data-destinations.command';
+import { ListDataDestinationsService } from '../use-cases/list-data-destinations.service';
+import {
+  McpDataDestinationsFacade,
+  McpDestinationType,
+  McpListDestinationsRequest,
+  McpListDestinationsResponse,
+} from './mcp-data-destinations.facade';
+
+const DESTINATION_TYPE_MAP: Record<DataDestinationType, McpDestinationType> = {
+  [DataDestinationType.GOOGLE_SHEETS]: 'google_sheets',
+  [DataDestinationType.LOOKER_STUDIO]: 'looker_studio',
+  [DataDestinationType.EMAIL]: 'email',
+  [DataDestinationType.SLACK]: 'slack',
+  [DataDestinationType.MS_TEAMS]: 'teams',
+  [DataDestinationType.GOOGLE_CHAT]: 'google_chat',
+};
+
+@Injectable()
+export class McpDataDestinationsFacadeImpl implements McpDataDestinationsFacade {
+  constructor(private readonly listDataDestinationsService: ListDataDestinationsService) {}
+
+  async listDestinations(
+    request: McpListDestinationsRequest
+  ): Promise<McpListDestinationsResponse> {
+    const items = await this.listDataDestinationsService.run(
+      new ListDataDestinationsCommand(request.projectId, request.userId, request.roles)
+    );
+
+    return {
+      destinations: items
+        .filter(destination => destination.availableForUse)
+        .map(destination => ({
+          id: destination.id,
+          name: destination.title,
+          type: DESTINATION_TYPE_MAP[destination.type],
+          // Prefer an assigned owner; fall back to the creator when a
+          // destination has no explicit owner.
+          owner: (destination.ownerUsers[0] ?? destination.createdByUser)?.email ?? null,
+        })),
+    };
+  }
+}

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.ts
@@ -1,0 +1,39 @@
+export const MCP_DATA_DESTINATIONS_FACADE = Symbol('MCP_DATA_DESTINATIONS_FACADE');
+
+export interface McpListDestinationsRequest {
+  projectId: string;
+  userId: string;
+  roles: string[];
+}
+
+/**
+ * Canonical MCP destination-type vocabulary and single source of truth. The
+ * `McpDestinationType` union, the `DESTINATION_TYPE_MAP` target type, and the
+ * tool's output `z.enum` are all derived from this tuple, so they cannot drift
+ * out of sync (a rename here updates every consumer at once).
+ */
+export const MCP_DESTINATION_TYPES = [
+  'google_sheets',
+  'looker_studio',
+  'email',
+  'slack',
+  'teams',
+  'google_chat',
+] as const;
+
+export type McpDestinationType = (typeof MCP_DESTINATION_TYPES)[number];
+
+export interface McpDestinationListItem {
+  id: string;
+  name: string;
+  type: McpDestinationType;
+  owner: string | null;
+}
+
+export interface McpListDestinationsResponse {
+  destinations: McpDestinationListItem[];
+}
+
+export interface McpDataDestinationsFacade {
+  listDestinations(request: McpListDestinationsRequest): Promise<McpListDestinationsResponse>;
+}

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -105,6 +105,7 @@ describe('ListDataMartsTool', () => {
       'ListDataMartsTool',
       'SearchDataMartsTool',
       'GetProjectContextTool',
+      'ListDestinationsTool',
     ]);
     expect(registry.getTool('list_data_marts')).toBeDefined();
     expect(registry.getTool('query_data_mart')).toBeUndefined();

--- a/apps/backend/src/ee/mcp/tools/list-destinations.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/list-destinations.tool.spec.ts
@@ -1,0 +1,77 @@
+import type { McpDataDestinationsFacade } from '../../../data-marts/facades/mcp-data-destinations.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import { McpToolRegistry } from './mcp-tool.registry';
+import { ListDestinationsTool } from './list-destinations.tool';
+import { MCP_TOOL_PROVIDER_CLASSES } from './mcp-tool.providers';
+
+describe('ListDestinationsTool', () => {
+  const context: McpAuthContext = {
+    clientId: 'mcp-client-1',
+    userId: 'user-1',
+    projectId: 'project-1',
+    roles: ['viewer'],
+    resource: 'https://mcp.owox.com/mcp',
+    scopes: ['mcp:read'],
+    authFlow: 'mcp',
+  };
+
+  it('lists destinations using token project-member context', async () => {
+    const facade = {
+      listDestinations: jest.fn().mockResolvedValue({
+        destinations: [
+          { id: 'dest_1', name: 'Marketing Sheet', type: 'google_sheets', owner: 'ann@owox.com' },
+        ],
+      }),
+    } as unknown as jest.Mocked<McpDataDestinationsFacade>;
+    const tool = new ListDestinationsTool(facade);
+
+    const structuredContent = {
+      destinations: [
+        { id: 'dest_1', name: 'Marketing Sheet', type: 'google_sheets', owner: 'ann@owox.com' },
+      ],
+    };
+
+    await expect(tool.handler({}, context)).resolves.toEqual({
+      structuredContent,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+    });
+    expect(facade.listDestinations).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+    });
+  });
+
+  it('rejects unexpected input', () => {
+    const tool = new ListDestinationsTool({} as McpDataDestinationsFacade);
+
+    expect(() => tool.parseInput({ project_id: 'another-project' })).toThrow();
+  });
+
+  it('is registered with read-only metadata and the right scope', () => {
+    const registry = new McpToolRegistry([
+      new ListDestinationsTool({} as McpDataDestinationsFacade),
+    ]);
+
+    expect(new ListDestinationsTool({} as McpDataDestinationsFacade)).toMatchObject({
+      name: 'list_destinations',
+      requiredScopes: ['mcp:read'],
+      outputSchema: expect.objectContaining({
+        destinations: expect.any(Object),
+      }),
+      annotations: {
+        title: 'List Destinations',
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    });
+    expect(MCP_TOOL_PROVIDER_CLASSES.map(tool => tool.name)).toContain('ListDestinationsTool');
+    expect(registry.getTool('list_destinations')).toBeDefined();
+  });
+});

--- a/apps/backend/src/ee/mcp/tools/list-destinations.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/list-destinations.tool.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import type { McpScope } from '@owox/idp-protocol';
+import {
+  MCP_DATA_DESTINATIONS_FACADE,
+  MCP_DESTINATION_TYPES,
+  type McpDataDestinationsFacade,
+} from '../../../data-marts/facades/mcp-data-destinations.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import type { McpToolDefinition, McpToolResult } from './mcp-tool.definition';
+
+type ListDestinationsInput = Record<string, never>;
+
+@Injectable()
+export class ListDestinationsTool implements McpToolDefinition<ListDestinationsInput> {
+  readonly name = 'list_destinations';
+  readonly description =
+    'List destinations in the active OWOX project to target when creating a report.';
+  readonly zodSchema = {};
+  readonly outputSchema = {
+    destinations: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        type: z.enum(MCP_DESTINATION_TYPES),
+        owner: z.string().nullable(),
+      })
+    ),
+  };
+  readonly annotations = {
+    title: 'List Destinations',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: false,
+  };
+  readonly requiredScopes: McpScope[] = ['mcp:read'];
+
+  private readonly inputSchema = z.object({}).strict();
+
+  constructor(
+    @Inject(MCP_DATA_DESTINATIONS_FACADE)
+    private readonly destinations: McpDataDestinationsFacade
+  ) {}
+
+  parseInput(input: unknown): ListDestinationsInput {
+    return this.inputSchema.parse(input);
+  }
+
+  async handler(input: ListDestinationsInput, context: McpAuthContext): Promise<McpToolResult> {
+    this.parseInput(input);
+
+    const result = await this.destinations.listDestinations({
+      projectId: context.projectId,
+      userId: context.userId,
+      roles: context.roles,
+    });
+
+    const structuredContent = { destinations: result.destinations };
+
+    return {
+      structuredContent,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+    };
+  }
+}

--- a/apps/backend/src/ee/mcp/tools/list-destinations.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/list-destinations.tool.ts
@@ -9,14 +9,16 @@ import {
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import type { McpToolDefinition, McpToolResult } from './mcp-tool.definition';
 
-type ListDestinationsInput = Record<string, never>;
+const inputSchema = z.object({}).strict();
+
+type ListDestinationsInput = z.infer<typeof inputSchema>;
 
 @Injectable()
 export class ListDestinationsTool implements McpToolDefinition<ListDestinationsInput> {
   readonly name = 'list_destinations';
   readonly description =
     'List destinations in the active OWOX project to target when creating a report.';
-  readonly zodSchema = {};
+  readonly zodSchema = inputSchema.shape;
   readonly outputSchema = {
     destinations: z.array(
       z.object({
@@ -35,15 +37,13 @@ export class ListDestinationsTool implements McpToolDefinition<ListDestinationsI
   };
   readonly requiredScopes: McpScope[] = ['mcp:read'];
 
-  private readonly inputSchema = z.object({}).strict();
-
   constructor(
     @Inject(MCP_DATA_DESTINATIONS_FACADE)
     private readonly destinations: McpDataDestinationsFacade
   ) {}
 
   parseInput(input: unknown): ListDestinationsInput {
-    return this.inputSchema.parse(input);
+    return inputSchema.parse(input);
   }
 
   async handler(input: ListDestinationsInput, context: McpAuthContext): Promise<McpToolResult> {

--- a/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
@@ -1,5 +1,6 @@
 import type { Provider, Type } from '@nestjs/common';
 import { ListDataMartsTool } from './data-mart-catalog.tool';
+import { ListDestinationsTool } from './list-destinations.tool';
 import { MCP_TOOL_DEFINITIONS, type McpToolDefinition } from './mcp-tool.definition';
 import { GetProjectContextTool } from './project-context.tool';
 import { SearchDataMartsTool } from './search-data-marts.tool';
@@ -8,6 +9,7 @@ export const MCP_TOOL_PROVIDER_CLASSES: Array<Type<McpToolDefinition>> = [
   ListDataMartsTool,
   SearchDataMartsTool,
   GetProjectContextTool,
+  ListDestinationsTool,
 ];
 
 export const MCP_TOOL_DEFINITIONS_PROVIDER: Provider = {

--- a/docs/getting-started/setup-guide/mcp.md
+++ b/docs/getting-started/setup-guide/mcp.md
@@ -110,7 +110,7 @@ To switch projects, disconnect, then reconnect and sign in again, choosing the p
 
 ## Available tools
 
-Once connected, the MCP server exposes two read-only tools. Both require the `mcp:read` scope, which the client requests during authorization.
+Once connected, the MCP server exposes four read-only tools. They all require the `mcp:read` scope, which the client requests during authorization.
 
 ### `get_project_context`
 
@@ -147,6 +147,37 @@ Use this tool to discover available data marts before running queries or buildin
 
 The list reflects your access: it includes only the data marts your [project role](../../project/roles-and-permissions.md) permits you to see. If a data mart you expect is missing, check your role in that project.
 
+### `get_relevant_data_marts_by_prompt`
+
+Finds the data marts most relevant to a natural-language question, ranked by relevance. Use it to discover which data marts can answer a specific question without listing the whole project.
+
+**Returns** an array of matching data mart objects:
+
+| Field | Description |
+| --- | --- |
+| `id` | Data mart identifier |
+| `title` | Data mart name |
+| `description` | Data mart description |
+| `url` | Link to open the data mart in OWOX Data Marts |
+| `relevance_score` | How closely the data mart matches your question |
+
+Only non-draft data marts visible to your [project role](../../project/roles-and-permissions.md) are returned.
+
+### `list_destinations`
+
+Lists the destinations in the current project — such as Google Sheets, Looker Studio, or messaging destinations — so the assistant knows where a report could be sent.
+
+**Returns** an array of destination objects:
+
+| Field | Description |
+| --- | --- |
+| `id` | Destination identifier |
+| `name` | Destination name |
+| `type` | Destination type (for example `google_sheets`, `looker_studio`, `slack`, `email`, `teams`, `google_chat`) |
+| `owner` | The user who created the destination |
+
+The list reflects your access: it includes only the destinations your [project role](../../project/roles-and-permissions.md) permits you to use.
+
 ## How to use it: example prompts
 
 Once the OWOX server is connected, just ask your assistant in plain language. You do not need to name the tools — the assistant calls them for you. Try prompts like:
@@ -156,8 +187,9 @@ Once the OWOX server is connected, just ask your assistant in plain language. Yo
 - "Which of my data marts were updated most recently?"
 - "Do I have any data marts about Facebook Ads? Show their descriptions."
 - "Give me a one-line summary of each data mart and what it is for."
+- "Which destinations can I send a report to?"
 
-> **What these tools can and cannot do:** They let the assistant discover your project and your data marts — titles, descriptions, status, roles, and when each was last updated. They do **not** run queries against the data inside a data mart or return its rows. Use them to find and understand what is available, then open the data mart in OWOX Data Marts to work with the data itself.
+> **What these tools can and cannot do:** They let the assistant discover your project, your data marts (titles, descriptions, status, and when each was last updated), and the destinations available for reports. They do **not** run queries against the data inside a data mart or return its rows. Use them to find and understand what is available, then open the data mart in OWOX Data Marts to work with the data itself.
 >
 > **What is shared with your AI provider:** To answer your prompts, the metadata above (project and data-mart names, descriptions, status, and your roles) is sent to the AI provider behind your client, such as Anthropic for Claude or OpenAI for ChatGPT. The data stored in your data marts is never sent. Connect OWOX only to clients your organization permits to receive this information.
 


### PR DESCRIPTION
## Summary

Adds a `list_destinations` MCP tool (PRD §15.15) so an AI assistant connected to OWOX over MCP can see the destinations in the active project and pick a target before creating a report. This is the first of the report/destination MCP tools; today the MCP surface only had read tools for data marts.

Read-only, requires the `mcp:read` scope, and is **free** (no credits consumed).

## What changed

- **New MCP tool** `ListDestinationsTool` (`ee/mcp/tools/list-destinations.tool.ts`) — no input params; output `{ destinations: [{ id, name, type, owner }] }`; `readOnlyHint: true`.
- **New facade** `McpDataDestinationsFacade` (+ impl, + DI symbol) wrapping the existing `ListDataDestinationsService` — registered and exported from `DataMartsModule`. No business logic reimplemented.
- **Registration** in `MCP_TOOL_PROVIDER_CLASSES`; updated the provider-list assertion in `data-mart-catalog.tool.spec.ts`.

## Design notes

- **`type`** is mapped to the lowercase MCP vocabulary via an exhaustive `Record<DataDestinationType, …>` (`MS_TEAMS → teams`, `GOOGLE_CHAT → google_chat`), so any future destination type fails the build until it's mapped.
- **`owner`** is derived from the destination creator's email.
- Destinations with `availableForUse === false` are omitted (the tool exists to pick a target for `add_report`).
- Row-level visibility is delegated to the existing permission model — the user only sees destinations they can access.

## Testing

- Unit tests for the facade (command args, type mapping for all 6 types, owner fallback, `availableForUse` filter) and the tool (output shape, `.strict()` input rejection, scope/annotations, registry).
- `nest build` (type-check, incl. the exhaustive `Record`), eslint, and the full MCP module suite — all green.
- Verified live in **Claude Desktop** (via `mcp-remote`) against a local `IDP_PROVIDER=owox-better-auth` server: the tool appears and returns the project's destinations.

## Out of scope / follow-ups

Sibling MCP report tools (`get_data_mart_reports`, `add_report`, `update_report`, `delete_report`) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)