### PR TITLE
feat(mcp): add get_data_mart_reports MCP tool

### DIFF
--- a/.changeset/6699-mcp-get-data-mart-reports.md
+++ b/.changeset/6699-mcp-get-data-mart-reports.md
@@ -1,9 +1,9 @@
 ---
-"owox": minor
+'owox': minor
 ---
 
 # Add a get_data_mart_reports MCP tool
 
-AI assistants connected to OWOX over MCP can now list the reports tied to a data mart. Each report includes its destination, owner, schedule (as a cron expression), when it last ran, and whether it is active, paused, or errored — so you can review your reports without leaving the assistant.
+AI assistants connected to OWOX over MCP can now list the reports tied to a data mart. Each report includes its destination, owner, all of its run schedules (a report can have several, each with a cron expression, timezone, and active flag), when it last ran, and the status of that last run — so you can review your reports without leaving the assistant.
 
 Only reports on data marts you have access to are returned.

--- a/.changeset/6699-mcp-get-data-mart-reports.md
+++ b/.changeset/6699-mcp-get-data-mart-reports.md
@@ -1,0 +1,9 @@
+---
+"owox": minor
+---
+
+# Add a get_data_mart_reports MCP tool
+
+AI assistants connected to OWOX over MCP can now list the reports tied to a data mart. Each report includes its destination, owner, schedule (as a cron expression), when it last ran, and whether it is active, paused, or errored — so you can review your reports without leaving the assistant.
+
+Only reports on data marts you have access to are returned.

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -54,6 +54,8 @@ import { MCP_DATA_MARTS_FACADE } from './facades/mcp-data-marts.facade';
 import { McpDataMartsFacadeImpl } from './facades/mcp-data-marts.facade.impl';
 import { MCP_DATA_DESTINATIONS_FACADE } from './facades/mcp-data-destinations.facade';
 import { McpDataDestinationsFacadeImpl } from './facades/mcp-data-destinations.facade.impl';
+import { MCP_REPORTS_FACADE } from './facades/mcp-reports.facade';
+import { McpReportsFacadeImpl } from './facades/mcp-reports.facade.impl';
 import { ListDataMartsByConnectorNameService } from './use-cases/list-data-marts-by-connector-name.service';
 import { ListProjectDataMartRunsService } from './use-cases/list-project-data-mart-runs.service';
 import { ListProjectInsightTemplatesService } from './use-cases/list-project-insight-templates.service';
@@ -510,6 +512,10 @@ import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-m
       provide: MCP_DATA_DESTINATIONS_FACADE,
       useClass: McpDataDestinationsFacadeImpl,
     },
+    {
+      provide: MCP_REPORTS_FACADE,
+      useClass: McpReportsFacadeImpl,
+    },
     ListDataMartsByConnectorNameService,
     GetDataMartService,
     ListDataMartRunsService,
@@ -807,6 +813,7 @@ import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-m
   exports: [
     MCP_DATA_MARTS_FACADE,
     MCP_DATA_DESTINATIONS_FACADE,
+    MCP_REPORTS_FACADE,
     ContextAccessService,
     AdvancedSearchIndexSyncService,
   ],

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
@@ -1,22 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
 import { ListDataDestinationsCommand } from '../dto/domain/list-data-destinations.command';
 import { ListDataDestinationsService } from '../use-cases/list-data-destinations.service';
+import { toMcpDestinationType } from './mcp-destination-type';
 import {
   McpDataDestinationsFacade,
-  McpDestinationType,
   McpListDestinationsRequest,
   McpListDestinationsResponse,
 } from './mcp-data-destinations.facade';
-
-const DESTINATION_TYPE_MAP: Record<DataDestinationType, McpDestinationType> = {
-  [DataDestinationType.GOOGLE_SHEETS]: 'google_sheets',
-  [DataDestinationType.LOOKER_STUDIO]: 'looker_studio',
-  [DataDestinationType.EMAIL]: 'email',
-  [DataDestinationType.SLACK]: 'slack',
-  [DataDestinationType.MS_TEAMS]: 'teams',
-  [DataDestinationType.GOOGLE_CHAT]: 'google_chat',
-};
 
 @Injectable()
 export class McpDataDestinationsFacadeImpl implements McpDataDestinationsFacade {
@@ -35,7 +25,7 @@ export class McpDataDestinationsFacadeImpl implements McpDataDestinationsFacade 
         .map(destination => ({
           id: destination.id,
           name: destination.title,
-          type: DESTINATION_TYPE_MAP[destination.type],
+          type: toMcpDestinationType(destination.type),
           // Report the creator as the owner. The `owners` relation has no stable
           // ordering, so picking one of potentially several owners would be
           // non-deterministic; the creator is a single, stable value.

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.ts
@@ -1,3 +1,5 @@
+import type { McpDestinationType } from './mcp-destination-type';
+
 export const MCP_DATA_DESTINATIONS_FACADE = Symbol('MCP_DATA_DESTINATIONS_FACADE');
 
 export interface McpListDestinationsRequest {
@@ -5,23 +7,6 @@ export interface McpListDestinationsRequest {
   userId: string;
   roles: string[];
 }
-
-/**
- * Canonical MCP destination-type vocabulary and single source of truth. The
- * `McpDestinationType` union, the `DESTINATION_TYPE_MAP` target type, and the
- * tool's output `z.enum` are all derived from this tuple, so they cannot drift
- * out of sync (a rename here updates every consumer at once).
- */
-export const MCP_DESTINATION_TYPES = [
-  'google_sheets',
-  'looker_studio',
-  'email',
-  'slack',
-  'teams',
-  'google_chat',
-] as const;
-
-export type McpDestinationType = (typeof MCP_DESTINATION_TYPES)[number];
 
 export interface McpDestinationListItem {
   id: string;

--- a/apps/backend/src/data-marts/facades/mcp-destination-type.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-destination-type.spec.ts
@@ -1,0 +1,24 @@
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
+import { MCP_DESTINATION_TYPES, toMcpDestinationType } from './mcp-destination-type';
+
+describe('toMcpDestinationType', () => {
+  it('maps every destination type to the MCP vocabulary', () => {
+    const mapped = Object.values(DataDestinationType).map(type => toMcpDestinationType(type));
+
+    expect(mapped).toEqual([
+      'google_sheets',
+      'looker_studio',
+      'email',
+      'slack',
+      'teams',
+      'google_chat',
+    ]);
+    expect([...MCP_DESTINATION_TYPES].sort()).toEqual([...mapped].sort());
+  });
+
+  it('fails loudly on a value outside the enum instead of leaking undefined', () => {
+    expect(() => toMcpDestinationType('SOMETHING_NEW' as DataDestinationType)).toThrow(
+      'Unsupported destination type for MCP: SOMETHING_NEW'
+    );
+  });
+});

--- a/apps/backend/src/data-marts/facades/mcp-destination-type.ts
+++ b/apps/backend/src/data-marts/facades/mcp-destination-type.ts
@@ -1,0 +1,36 @@
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
+
+/**
+ * Canonical MCP destination-type vocabulary and single source of truth. The
+ * `McpDestinationType` union, the `DESTINATION_TYPE_MAP` target type, and every
+ * tool's output `z.enum` are derived from this tuple, so they cannot drift out
+ * of sync (a rename here updates every consumer at once).
+ */
+export const MCP_DESTINATION_TYPES = [
+  'google_sheets',
+  'looker_studio',
+  'email',
+  'slack',
+  'teams',
+  'google_chat',
+] as const;
+
+export type McpDestinationType = (typeof MCP_DESTINATION_TYPES)[number];
+
+const DESTINATION_TYPE_MAP: Record<DataDestinationType, McpDestinationType> = {
+  [DataDestinationType.GOOGLE_SHEETS]: 'google_sheets',
+  [DataDestinationType.LOOKER_STUDIO]: 'looker_studio',
+  [DataDestinationType.EMAIL]: 'email',
+  [DataDestinationType.SLACK]: 'slack',
+  [DataDestinationType.MS_TEAMS]: 'teams',
+  [DataDestinationType.GOOGLE_CHAT]: 'google_chat',
+};
+
+/**
+ * Maps a domain `DataDestinationType` to the lowercase MCP vocabulary exposed to
+ * clients. The `Record` is exhaustive over the enum, so a new destination type
+ * fails the build until it is mapped here.
+ */
+export function toMcpDestinationType(type: DataDestinationType): McpDestinationType {
+  return DESTINATION_TYPE_MAP[type];
+}

--- a/apps/backend/src/data-marts/facades/mcp-destination-type.ts
+++ b/apps/backend/src/data-marts/facades/mcp-destination-type.ts
@@ -29,8 +29,14 @@ const DESTINATION_TYPE_MAP: Record<DataDestinationType, McpDestinationType> = {
 /**
  * Maps a domain `DataDestinationType` to the lowercase MCP vocabulary exposed to
  * clients. The `Record` is exhaustive over the enum, so a new destination type
- * fails the build until it is mapped here.
+ * fails the build until it is mapped here; the runtime guard covers values that
+ * bypass the compiler (e.g. a raw DB string outside the enum), which would
+ * otherwise leak `undefined` into an MCP response.
  */
 export function toMcpDestinationType(type: DataDestinationType): McpDestinationType {
-  return DESTINATION_TYPE_MAP[type];
+  const mapped = DESTINATION_TYPE_MAP[type];
+  if (!mapped) {
+    throw new Error(`Unsupported destination type for MCP: ${type}`);
+  }
+  return mapped;
 }

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
@@ -121,6 +121,7 @@ describe('McpReportsFacadeImpl', () => {
     expect(result.reports).toEqual([
       {
         report_id: 'r1',
+        data_mart_id: 'dm-1',
         name: 'Weekly revenue',
         destination_id: 'dest-99',
         destination_type: 'teams',

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
@@ -171,6 +171,21 @@ describe('McpReportsFacadeImpl', () => {
     ]);
   });
 
+  it('orders schedules with equal creation time by id, independent of row order', async () => {
+    const sharedCreatedAt = new Date('2026-01-01T00:00:00.000Z');
+    const { facade } = buildFacade(
+      [buildReport({ id: 'r1' })],
+      [
+        buildTrigger({ id: 'trigger-b', reportId: 'r1', createdAt: sharedCreatedAt }),
+        buildTrigger({ id: 'trigger-a', reportId: 'r1', createdAt: sharedCreatedAt }),
+      ]
+    );
+
+    const result = await facade.getDataMartReports(request);
+
+    expect(result.reports[0].schedules.map(s => s.trigger_id)).toEqual(['trigger-a', 'trigger-b']);
+  });
+
   it('reports an unscheduled report with an empty schedules list', async () => {
     const { facade } = buildFacade([buildReport({ id: 'r1' })], []);
 

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
@@ -40,18 +40,26 @@ function buildReport(overrides: {
 }
 
 function buildTrigger(overrides: {
+  id?: string;
   reportId: string;
   cron?: string;
+  timeZone?: string;
   isActive?: boolean;
   type?: ScheduledTriggerType;
   createdAt?: Date;
+  nextRunTimestamp?: Date | null;
+  lastRunTimestamp?: Date | null;
 }): DataMartScheduledTrigger {
   return {
+    id: overrides.id ?? `trigger-${overrides.reportId}`,
     type: overrides.type ?? ScheduledTriggerType.REPORT_RUN,
     triggerConfig: { type: 'scheduled-report-run-config', reportId: overrides.reportId },
     isActive: overrides.isActive ?? true,
     cronExpression: overrides.cron ?? '0 9 * * 1',
+    timeZone: overrides.timeZone ?? 'UTC',
     createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00.000Z'),
+    nextRunTimestamp: overrides.nextRunTimestamp ?? null,
+    lastRunTimestamp: overrides.lastRunTimestamp ?? null,
   } as unknown as DataMartScheduledTrigger;
 }
 
@@ -87,7 +95,17 @@ describe('McpReportsFacadeImpl', () => {
           lastRunStatus: ReportRunStatus.SUCCESS,
         }),
       ],
-      [buildTrigger({ reportId: 'r1', cron: '0 9 * * 1', isActive: true })]
+      [
+        buildTrigger({
+          id: 'trigger-1',
+          reportId: 'r1',
+          cron: '0 9 * * 1',
+          timeZone: 'Europe/Kyiv',
+          isActive: true,
+          nextRunTimestamp: new Date('2026-06-15T06:00:00.000Z'),
+          lastRunTimestamp: new Date('2026-06-08T06:00:00.000Z'),
+        }),
+      ]
     );
 
     const result = await facade.getDataMartReports(request);
@@ -107,42 +125,67 @@ describe('McpReportsFacadeImpl', () => {
         destination_id: 'dest-99',
         destination_type: 'teams',
         owner: 'ann@owox.com',
-        schedule: '0 9 * * 1',
+        schedules: [
+          {
+            trigger_id: 'trigger-1',
+            cron_expression: '0 9 * * 1',
+            time_zone: 'Europe/Kyiv',
+            is_active: true,
+            next_run_at: '2026-06-15T06:00:00.000Z',
+            last_run_at: '2026-06-08T06:00:00.000Z',
+          },
+        ],
         last_run_at: '2026-06-10T10:00:00.000Z',
-        status: 'active',
+        last_run_status: ReportRunStatus.SUCCESS,
       },
     ]);
   });
 
-  it('derives status and schedule across the trigger/last-run matrix', async () => {
+  it('returns every schedule of a report, ordered by creation time', async () => {
     const { facade } = buildFacade(
+      [buildReport({ id: 'r1' })],
       [
-        buildReport({ id: 'no-trigger', lastRunStatus: ReportRunStatus.SUCCESS }),
-        buildReport({ id: 'paused', lastRunStatus: ReportRunStatus.SUCCESS }),
-        buildReport({ id: 'active', lastRunStatus: ReportRunStatus.SUCCESS }),
-        buildReport({ id: 'errored', lastRunStatus: ReportRunStatus.ERROR }),
-      ],
-      [
-        buildTrigger({ reportId: 'paused', cron: '0 8 * * *', isActive: false }),
-        buildTrigger({ reportId: 'active', cron: '0 9 * * *', isActive: true }),
-        buildTrigger({ reportId: 'errored', cron: '0 7 * * *', isActive: true }),
+        buildTrigger({
+          id: 'newer',
+          reportId: 'r1',
+          cron: '0 9 * * *',
+          isActive: true,
+          createdAt: new Date('2026-02-01T00:00:00.000Z'),
+        }),
+        buildTrigger({
+          id: 'older-disabled',
+          reportId: 'r1',
+          cron: '0 8 * * *',
+          isActive: false,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
       ]
     );
 
     const result = await facade.getDataMartReports(request);
-    const byId = Object.fromEntries(result.reports.map(r => [r.report_id, r]));
 
-    expect(byId['no-trigger']).toMatchObject({ schedule: null, status: 'paused' });
-    // A disabled schedule is still reported, but the status is paused.
-    expect(byId['paused']).toMatchObject({ schedule: '0 8 * * *', status: 'paused' });
-    expect(byId['active']).toMatchObject({ schedule: '0 9 * * *', status: 'active' });
-    // A failed last run wins over an otherwise-active schedule.
-    expect(byId['errored']).toMatchObject({ schedule: '0 7 * * *', status: 'error' });
+    // A disabled schedule is still reported (is_active: false), nothing is collapsed.
+    expect(result.reports[0].schedules).toEqual([
+      expect.objectContaining({ trigger_id: 'older-disabled', is_active: false }),
+      expect.objectContaining({ trigger_id: 'newer', is_active: true }),
+    ]);
+  });
+
+  it('reports an unscheduled report with an empty schedules list', async () => {
+    const { facade } = buildFacade([buildReport({ id: 'r1' })], []);
+
+    const result = await facade.getDataMartReports(request);
+
+    expect(result.reports[0]).toMatchObject({
+      schedules: [],
+      last_run_at: null,
+      last_run_status: null,
+    });
   });
 
   it('ignores connector triggers and triggers targeting other reports', async () => {
     const { facade } = buildFacade(
-      [buildReport({ id: 'r1', lastRunStatus: ReportRunStatus.SUCCESS })],
+      [buildReport({ id: 'r1' })],
       [
         buildTrigger({ reportId: 'r1', type: ScheduledTriggerType.CONNECTOR_RUN, isActive: true }),
         buildTrigger({ reportId: 'other-report', cron: '0 1 * * *', isActive: true }),
@@ -151,21 +194,25 @@ describe('McpReportsFacadeImpl', () => {
 
     const result = await facade.getDataMartReports(request);
 
-    expect(result.reports[0]).toMatchObject({ schedule: null, status: 'paused' });
+    expect(result.reports[0].schedules).toEqual([]);
   });
 
-  it('prefers an active trigger deterministically when a report has several', async () => {
+  it('passes the last run status through unchanged', async () => {
     const { facade } = buildFacade(
-      [buildReport({ id: 'r1', lastRunStatus: ReportRunStatus.SUCCESS })],
       [
-        buildTrigger({ reportId: 'r1', cron: 'inactive-cron', isActive: false }),
-        buildTrigger({ reportId: 'r1', cron: 'active-cron', isActive: true }),
-      ]
+        buildReport({ id: 'ok', lastRunStatus: ReportRunStatus.SUCCESS }),
+        buildReport({ id: 'failed', lastRunStatus: ReportRunStatus.ERROR }),
+        buildReport({ id: 'never-ran' }),
+      ],
+      []
     );
 
     const result = await facade.getDataMartReports(request);
+    const byId = Object.fromEntries(result.reports.map(r => [r.report_id, r]));
 
-    expect(result.reports[0]).toMatchObject({ schedule: 'active-cron', status: 'active' });
+    expect(byId['ok'].last_run_status).toBe(ReportRunStatus.SUCCESS);
+    expect(byId['failed'].last_run_status).toBe(ReportRunStatus.ERROR);
+    expect(byId['never-ran'].last_run_status).toBeNull();
   });
 
   it('returns an empty list without querying triggers when there are no reports', async () => {
@@ -178,10 +225,7 @@ describe('McpReportsFacadeImpl', () => {
   });
 
   it('returns owner null when the report has no creator', async () => {
-    const { facade } = buildFacade(
-      [buildReport({ id: 'r1', createdByEmail: null, lastRunStatus: ReportRunStatus.SUCCESS })],
-      []
-    );
+    const { facade } = buildFacade([buildReport({ id: 'r1', createdByEmail: null })], []);
 
     const result = await facade.getDataMartReports(request);
 

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
@@ -1,0 +1,190 @@
+jest.mock('../use-cases/list-reports-by-data-mart.service', () => ({
+  ListReportsByDataMartService: jest.fn(),
+}));
+jest.mock('../services/scheduled-trigger.service', () => ({
+  ScheduledTriggerService: jest.fn(),
+}));
+
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
+import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
+import { ReportRunStatus } from '../enums/report-run-status.enum';
+import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { ReportDto } from '../dto/domain/report.dto';
+import type { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
+import type { ScheduledTriggerService } from '../services/scheduled-trigger.service';
+import { McpReportsFacadeImpl } from './mcp-reports.facade.impl';
+
+function buildReport(overrides: {
+  id: string;
+  title?: string;
+  destinationId?: string;
+  destinationType?: DataDestinationType;
+  createdByEmail?: string | null;
+  lastRunAt?: Date;
+  lastRunStatus?: ReportRunStatus;
+}): ReportDto {
+  return {
+    id: overrides.id,
+    title: overrides.title ?? `Report ${overrides.id}`,
+    dataDestinationAccess: {
+      id: overrides.destinationId ?? 'dest-1',
+      type: overrides.destinationType ?? DataDestinationType.GOOGLE_SHEETS,
+    },
+    createdByUser:
+      overrides.createdByEmail === null
+        ? null
+        : { email: overrides.createdByEmail ?? 'creator@owox.com' },
+    lastRunAt: overrides.lastRunAt,
+    lastRunStatus: overrides.lastRunStatus,
+  } as unknown as ReportDto;
+}
+
+function buildTrigger(overrides: {
+  reportId: string;
+  cron?: string;
+  isActive?: boolean;
+  type?: ScheduledTriggerType;
+  createdAt?: Date;
+}): DataMartScheduledTrigger {
+  return {
+    type: overrides.type ?? ScheduledTriggerType.REPORT_RUN,
+    triggerConfig: { type: 'scheduled-report-run-config', reportId: overrides.reportId },
+    isActive: overrides.isActive ?? true,
+    cronExpression: overrides.cron ?? '0 9 * * 1',
+    createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00.000Z'),
+  } as unknown as DataMartScheduledTrigger;
+}
+
+function buildFacade(reports: ReportDto[], triggers: DataMartScheduledTrigger[]) {
+  const listReportsByDataMartService = {
+    run: jest.fn().mockResolvedValue(reports),
+  } as unknown as jest.Mocked<ListReportsByDataMartService>;
+  const scheduledTriggerService = {
+    getAllByDataMartIdAndProjectId: jest.fn().mockResolvedValue(triggers),
+  } as unknown as jest.Mocked<ScheduledTriggerService>;
+  const facade = new McpReportsFacadeImpl(listReportsByDataMartService, scheduledTriggerService);
+  return { facade, listReportsByDataMartService, scheduledTriggerService };
+}
+
+const request = {
+  dataMartId: 'dm-1',
+  projectId: 'project-1',
+  userId: 'user-1',
+  roles: ['viewer'],
+};
+
+describe('McpReportsFacadeImpl', () => {
+  it('maps a scheduled report to the MCP shape', async () => {
+    const { facade, listReportsByDataMartService } = buildFacade(
+      [
+        buildReport({
+          id: 'r1',
+          title: 'Weekly revenue',
+          destinationId: 'dest-99',
+          destinationType: DataDestinationType.MS_TEAMS,
+          createdByEmail: 'ann@owox.com',
+          lastRunAt: new Date('2026-06-10T10:00:00.000Z'),
+          lastRunStatus: ReportRunStatus.SUCCESS,
+        }),
+      ],
+      [buildTrigger({ reportId: 'r1', cron: '0 9 * * 1', isActive: true })]
+    );
+
+    const result = await facade.getDataMartReports(request);
+
+    expect(listReportsByDataMartService.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataMartId: 'dm-1',
+        projectId: 'project-1',
+        userId: 'user-1',
+        roles: ['viewer'],
+      })
+    );
+    expect(result.reports).toEqual([
+      {
+        report_id: 'r1',
+        name: 'Weekly revenue',
+        destination_id: 'dest-99',
+        destination_type: 'teams',
+        owner: 'ann@owox.com',
+        schedule: '0 9 * * 1',
+        last_run_at: '2026-06-10T10:00:00.000Z',
+        status: 'active',
+      },
+    ]);
+  });
+
+  it('derives status and schedule across the trigger/last-run matrix', async () => {
+    const { facade } = buildFacade(
+      [
+        buildReport({ id: 'no-trigger', lastRunStatus: ReportRunStatus.SUCCESS }),
+        buildReport({ id: 'paused', lastRunStatus: ReportRunStatus.SUCCESS }),
+        buildReport({ id: 'active', lastRunStatus: ReportRunStatus.SUCCESS }),
+        buildReport({ id: 'errored', lastRunStatus: ReportRunStatus.ERROR }),
+      ],
+      [
+        buildTrigger({ reportId: 'paused', cron: '0 8 * * *', isActive: false }),
+        buildTrigger({ reportId: 'active', cron: '0 9 * * *', isActive: true }),
+        buildTrigger({ reportId: 'errored', cron: '0 7 * * *', isActive: true }),
+      ]
+    );
+
+    const result = await facade.getDataMartReports(request);
+    const byId = Object.fromEntries(result.reports.map(r => [r.report_id, r]));
+
+    expect(byId['no-trigger']).toMatchObject({ schedule: null, status: 'paused' });
+    // A disabled schedule is still reported, but the status is paused.
+    expect(byId['paused']).toMatchObject({ schedule: '0 8 * * *', status: 'paused' });
+    expect(byId['active']).toMatchObject({ schedule: '0 9 * * *', status: 'active' });
+    // A failed last run wins over an otherwise-active schedule.
+    expect(byId['errored']).toMatchObject({ schedule: '0 7 * * *', status: 'error' });
+  });
+
+  it('ignores connector triggers and triggers targeting other reports', async () => {
+    const { facade } = buildFacade(
+      [buildReport({ id: 'r1', lastRunStatus: ReportRunStatus.SUCCESS })],
+      [
+        buildTrigger({ reportId: 'r1', type: ScheduledTriggerType.CONNECTOR_RUN, isActive: true }),
+        buildTrigger({ reportId: 'other-report', cron: '0 1 * * *', isActive: true }),
+      ]
+    );
+
+    const result = await facade.getDataMartReports(request);
+
+    expect(result.reports[0]).toMatchObject({ schedule: null, status: 'paused' });
+  });
+
+  it('prefers an active trigger deterministically when a report has several', async () => {
+    const { facade } = buildFacade(
+      [buildReport({ id: 'r1', lastRunStatus: ReportRunStatus.SUCCESS })],
+      [
+        buildTrigger({ reportId: 'r1', cron: 'inactive-cron', isActive: false }),
+        buildTrigger({ reportId: 'r1', cron: 'active-cron', isActive: true }),
+      ]
+    );
+
+    const result = await facade.getDataMartReports(request);
+
+    expect(result.reports[0]).toMatchObject({ schedule: 'active-cron', status: 'active' });
+  });
+
+  it('returns an empty list without querying triggers when there are no reports', async () => {
+    const { facade, scheduledTriggerService } = buildFacade([], []);
+
+    const result = await facade.getDataMartReports(request);
+
+    expect(result).toEqual({ reports: [] });
+    expect(scheduledTriggerService.getAllByDataMartIdAndProjectId).not.toHaveBeenCalled();
+  });
+
+  it('returns owner null when the report has no creator', async () => {
+    const { facade } = buildFacade(
+      [buildReport({ id: 'r1', createdByEmail: null, lastRunStatus: ReportRunStatus.SUCCESS })],
+      []
+    );
+
+    const result = await facade.getDataMartReports(request);
+
+    expect(result.reports[0].owner).toBeNull();
+  });
+});

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
@@ -1,0 +1,117 @@
+import { Injectable } from '@nestjs/common';
+import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
+import { ReportRunStatus } from '../enums/report-run-status.enum';
+import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data-mart.command';
+import { ReportDto } from '../dto/domain/report.dto';
+import { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
+import { ScheduledTriggerService } from '../services/scheduled-trigger.service';
+import { toMcpDestinationType } from './mcp-destination-type';
+import {
+  McpGetDataMartReportsRequest,
+  McpGetDataMartReportsResponse,
+  McpReportStatus,
+  McpReportsFacade,
+} from './mcp-reports.facade';
+
+@Injectable()
+export class McpReportsFacadeImpl implements McpReportsFacade {
+  constructor(
+    private readonly listReportsByDataMartService: ListReportsByDataMartService,
+    private readonly scheduledTriggerService: ScheduledTriggerService
+  ) {}
+
+  async getDataMartReports(
+    request: McpGetDataMartReportsRequest
+  ): Promise<McpGetDataMartReportsResponse> {
+    const reports = await this.listReportsByDataMartService.run(
+      new ListReportsByDataMartCommand(
+        request.dataMartId,
+        request.projectId,
+        request.userId,
+        request.roles
+      )
+    );
+
+    // No reports (or the data mart is not visible → empty list): skip the trigger query.
+    if (reports.length === 0) {
+      return { reports: [] };
+    }
+
+    const triggerByReportId = await this.loadReportTriggers(request.dataMartId, request.projectId);
+
+    return {
+      reports: reports.map(report => {
+        const trigger = triggerByReportId.get(report.id);
+        return {
+          report_id: report.id,
+          name: report.title,
+          destination_id: report.dataDestinationAccess.id,
+          destination_type: toMcpDestinationType(report.dataDestinationAccess.type),
+          // Report the creator as the owner (consistent with list_destinations):
+          // the owners relation has no stable ordering.
+          owner: report.createdByUser?.email ?? null,
+          schedule: trigger?.cronExpression ?? null,
+          last_run_at: report.lastRunAt?.toISOString() ?? null,
+          status: this.deriveStatus(report, trigger),
+        };
+      }),
+    };
+  }
+
+  /**
+   * Loads the data mart's schedule triggers once and indexes the REPORT_RUN ones
+   * by their target report. When a report has more than one trigger, an active
+   * trigger wins and ties break on the earliest creation, so the resulting
+   * schedule and status are deterministic rather than dependent on row order.
+   */
+  private async loadReportTriggers(
+    dataMartId: string,
+    projectId: string
+  ): Promise<Map<string, DataMartScheduledTrigger>> {
+    const triggers = await this.scheduledTriggerService.getAllByDataMartIdAndProjectId(
+      dataMartId,
+      projectId
+    );
+
+    const byReportId = new Map<string, DataMartScheduledTrigger>();
+    for (const trigger of triggers) {
+      if (trigger.type !== ScheduledTriggerType.REPORT_RUN) {
+        continue;
+      }
+      const reportId = trigger.triggerConfig?.reportId;
+      if (!reportId) {
+        continue;
+      }
+      const existing = byReportId.get(reportId);
+      if (!existing || this.preferredTrigger(trigger, existing) === trigger) {
+        byReportId.set(reportId, trigger);
+      }
+    }
+    return byReportId;
+  }
+
+  private preferredTrigger(
+    a: DataMartScheduledTrigger,
+    b: DataMartScheduledTrigger
+  ): DataMartScheduledTrigger {
+    if (a.isActive !== b.isActive) {
+      return a.isActive ? a : b;
+    }
+    return a.createdAt <= b.createdAt ? a : b;
+  }
+
+  private deriveStatus(
+    report: ReportDto,
+    trigger: DataMartScheduledTrigger | undefined
+  ): McpReportStatus {
+    if (report.lastRunStatus === ReportRunStatus.ERROR) {
+      return 'error';
+    }
+    if (trigger?.isActive) {
+      return 'active';
+    }
+    // No schedule, or the schedule is turned off.
+    return 'paused';
+  }
+}

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
@@ -1,16 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
-import { ReportRunStatus } from '../enums/report-run-status.enum';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
 import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data-mart.command';
-import { ReportDto } from '../dto/domain/report.dto';
 import { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
 import { ScheduledTriggerService } from '../services/scheduled-trigger.service';
 import { toMcpDestinationType } from './mcp-destination-type';
 import {
   McpGetDataMartReportsRequest,
   McpGetDataMartReportsResponse,
-  McpReportStatus,
+  McpReportScheduleItem,
   McpReportsFacade,
 } from './mcp-reports.facade';
 
@@ -38,43 +36,42 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
       return { reports: [] };
     }
 
-    const triggerByReportId = await this.loadReportTriggers(request.dataMartId, request.projectId);
+    const triggersByReportId = await this.loadReportTriggers(request.dataMartId, request.projectId);
 
     return {
-      reports: reports.map(report => {
-        const trigger = triggerByReportId.get(report.id);
-        return {
-          report_id: report.id,
-          name: report.title,
-          destination_id: report.dataDestinationAccess.id,
-          destination_type: toMcpDestinationType(report.dataDestinationAccess.type),
-          // Report the creator as the owner (consistent with list_destinations):
-          // the owners relation has no stable ordering.
-          owner: report.createdByUser?.email ?? null,
-          schedule: trigger?.cronExpression ?? null,
-          last_run_at: report.lastRunAt?.toISOString() ?? null,
-          status: this.deriveStatus(report, trigger),
-        };
-      }),
+      reports: reports.map(report => ({
+        report_id: report.id,
+        name: report.title,
+        destination_id: report.dataDestinationAccess.id,
+        destination_type: toMcpDestinationType(report.dataDestinationAccess.type),
+        // Report the creator as the owner (consistent with list_destinations):
+        // the owners relation has no stable ordering.
+        owner: report.createdByUser?.email ?? null,
+        schedules: (triggersByReportId.get(report.id) ?? []).map(trigger =>
+          this.toScheduleItem(trigger)
+        ),
+        last_run_at: report.lastRunAt?.toISOString() ?? null,
+        last_run_status: report.lastRunStatus ?? null,
+      })),
     };
   }
 
   /**
-   * Loads the data mart's schedule triggers once and indexes the REPORT_RUN ones
-   * by their target report. When a report has more than one trigger, an active
-   * trigger wins and ties break on the earliest creation, so the resulting
-   * schedule and status are deterministic rather than dependent on row order.
+   * Loads the data mart's schedule triggers once and groups the REPORT_RUN ones
+   * by their target report. A report can have any number of schedules; they are
+   * all returned, ordered by creation time so the output is deterministic
+   * rather than dependent on DB row order.
    */
   private async loadReportTriggers(
     dataMartId: string,
     projectId: string
-  ): Promise<Map<string, DataMartScheduledTrigger>> {
+  ): Promise<Map<string, DataMartScheduledTrigger[]>> {
     const triggers = await this.scheduledTriggerService.getAllByDataMartIdAndProjectId(
       dataMartId,
       projectId
     );
 
-    const byReportId = new Map<string, DataMartScheduledTrigger>();
+    const byReportId = new Map<string, DataMartScheduledTrigger[]>();
     for (const trigger of triggers) {
       if (trigger.type !== ScheduledTriggerType.REPORT_RUN) {
         continue;
@@ -83,35 +80,27 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
       if (!reportId) {
         continue;
       }
-      const existing = byReportId.get(reportId);
-      if (!existing || this.preferredTrigger(trigger, existing) === trigger) {
-        byReportId.set(reportId, trigger);
+      const reportTriggers = byReportId.get(reportId);
+      if (reportTriggers) {
+        reportTriggers.push(trigger);
+      } else {
+        byReportId.set(reportId, [trigger]);
       }
+    }
+    for (const reportTriggers of byReportId.values()) {
+      reportTriggers.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
     }
     return byReportId;
   }
 
-  private preferredTrigger(
-    a: DataMartScheduledTrigger,
-    b: DataMartScheduledTrigger
-  ): DataMartScheduledTrigger {
-    if (a.isActive !== b.isActive) {
-      return a.isActive ? a : b;
-    }
-    return a.createdAt <= b.createdAt ? a : b;
-  }
-
-  private deriveStatus(
-    report: ReportDto,
-    trigger: DataMartScheduledTrigger | undefined
-  ): McpReportStatus {
-    if (report.lastRunStatus === ReportRunStatus.ERROR) {
-      return 'error';
-    }
-    if (trigger?.isActive) {
-      return 'active';
-    }
-    // No schedule, or the schedule is turned off.
-    return 'paused';
+  private toScheduleItem(trigger: DataMartScheduledTrigger): McpReportScheduleItem {
+    return {
+      trigger_id: trigger.id,
+      cron_expression: trigger.cronExpression,
+      time_zone: trigger.timeZone,
+      is_active: trigger.isActive,
+      next_run_at: trigger.nextRunTimestamp?.toISOString() ?? null,
+      last_run_at: trigger.lastRunTimestamp?.toISOString() ?? null,
+    };
   }
 }

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
@@ -88,7 +88,11 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
       }
     }
     for (const reportTriggers of byReportId.values()) {
-      reportTriggers.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+      // The id tie-break keeps the order stable when several triggers share a
+      // creation timestamp (e.g. batch-created) — DB row order is not reliable.
+      reportTriggers.sort(
+        (a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id)
+      );
     }
     return byReportId;
   }

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
@@ -41,6 +41,7 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
     return {
       reports: reports.map(report => ({
         report_id: report.id,
+        data_mart_id: request.dataMartId,
         name: report.title,
         destination_id: report.dataDestinationAccess.id,
         destination_type: toMcpDestinationType(report.dataDestinationAccess.type),
@@ -88,6 +89,10 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
       }
     }
     for (const reportTriggers of byReportId.values()) {
+      // Oldest-first is purely a stable chronological presentation — the order
+      // carries no precedence semantics (schedules are equal peers; a newer
+      // trigger is an additional schedule, not an override of an older one).
+      // `createdAt` is the trigger's creation time and never changes on update.
       // The id tie-break keeps the order stable when several triggers share a
       // creation timestamp (e.g. batch-created) — DB row order is not reliable.
       reportTriggers.sort(

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
@@ -28,6 +28,8 @@ export interface McpReportScheduleItem {
 
 export interface McpReportListItem {
   report_id: string;
+  /** Id of the parent data mart, echoed so each item is self-describing. */
+  data_mart_id: string;
   name: string;
   destination_id: string;
   destination_type: McpDestinationType;

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
@@ -1,0 +1,35 @@
+import type { McpDestinationType } from './mcp-destination-type';
+
+export const MCP_REPORTS_FACADE = Symbol('MCP_REPORTS_FACADE');
+
+export interface McpGetDataMartReportsRequest {
+  dataMartId: string;
+  projectId: string;
+  userId: string;
+  roles: string[];
+}
+
+export type McpReportStatus = 'active' | 'paused' | 'error';
+
+export const MCP_REPORT_STATUSES = ['active', 'paused', 'error'] as const;
+
+export interface McpReportListItem {
+  report_id: string;
+  name: string;
+  destination_id: string;
+  destination_type: McpDestinationType;
+  owner: string | null;
+  /** Cron expression of the report's active schedule, or `null` when unscheduled. */
+  schedule: string | null;
+  /** ISO 8601 timestamp of the last run, or `null` when the report never ran. */
+  last_run_at: string | null;
+  status: McpReportStatus;
+}
+
+export interface McpGetDataMartReportsResponse {
+  reports: McpReportListItem[];
+}
+
+export interface McpReportsFacade {
+  getDataMartReports(request: McpGetDataMartReportsRequest): Promise<McpGetDataMartReportsResponse>;
+}

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
@@ -1,3 +1,4 @@
+import type { ReportRunStatus } from '../enums/report-run-status.enum';
 import type { McpDestinationType } from './mcp-destination-type';
 
 export const MCP_REPORTS_FACADE = Symbol('MCP_REPORTS_FACADE');
@@ -9,9 +10,21 @@ export interface McpGetDataMartReportsRequest {
   roles: string[];
 }
 
-export type McpReportStatus = 'active' | 'paused' | 'error';
-
-export const MCP_REPORT_STATUSES = ['active', 'paused', 'error'] as const;
+/**
+ * One REPORT_RUN scheduled trigger of a report. A report can have any number
+ * of schedules; the field vocabulary matches the report-run-schedule MCP tools,
+ * so `trigger_id` can be passed to them directly.
+ */
+export interface McpReportScheduleItem {
+  trigger_id: string;
+  cron_expression: string;
+  time_zone: string;
+  is_active: boolean;
+  /** ISO 8601 timestamp of the next scheduled run, or `null`. */
+  next_run_at: string | null;
+  /** ISO 8601 timestamp of the trigger's last run, or `null` when it never ran. */
+  last_run_at: string | null;
+}
 
 export interface McpReportListItem {
   report_id: string;
@@ -19,11 +32,12 @@ export interface McpReportListItem {
   destination_id: string;
   destination_type: McpDestinationType;
   owner: string | null;
-  /** Cron expression of the report's active schedule, or `null` when unscheduled. */
-  schedule: string | null;
-  /** ISO 8601 timestamp of the last run, or `null` when the report never ran. */
+  /** All REPORT_RUN schedules of the report; empty when unscheduled. */
+  schedules: McpReportScheduleItem[];
+  /** ISO 8601 timestamp of the report's last run, or `null` when it never ran. */
   last_run_at: string | null;
-  status: McpReportStatus;
+  /** Status of the report's last run, or `null` when it never ran. */
+  last_run_status: ReportRunStatus | null;
 }
 
 export interface McpGetDataMartReportsResponse {

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -106,6 +106,7 @@ describe('ListDataMartsTool', () => {
       'SearchDataMartsTool',
       'GetProjectContextTool',
       'ListDestinationsTool',
+      'GetDataMartReportsTool',
     ]);
     expect(registry.getTool('list_data_marts')).toBeDefined();
     expect(registry.getTool('query_data_mart')).toBeUndefined();

--- a/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.spec.ts
@@ -19,6 +19,7 @@ describe('GetDataMartReportsTool', () => {
     const reports = [
       {
         report_id: 'r1',
+        data_mart_id: 'dm-1',
         name: 'Weekly revenue',
         destination_id: 'dest-1',
         destination_type: 'google_sheets' as const,

--- a/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.spec.ts
@@ -23,9 +23,18 @@ describe('GetDataMartReportsTool', () => {
         destination_id: 'dest-1',
         destination_type: 'google_sheets' as const,
         owner: 'ann@owox.com',
-        schedule: '0 9 * * 1',
+        schedules: [
+          {
+            trigger_id: 'trigger-1',
+            cron_expression: '0 9 * * 1',
+            time_zone: 'Europe/Kyiv',
+            is_active: true,
+            next_run_at: '2026-06-15T06:00:00.000Z',
+            last_run_at: '2026-06-08T06:00:00.000Z',
+          },
+        ],
         last_run_at: '2026-06-10T10:00:00.000Z',
-        status: 'active' as const,
+        last_run_status: 'SUCCESS' as const,
       },
     ];
     const facade = {

--- a/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.spec.ts
@@ -1,0 +1,81 @@
+import type { McpReportsFacade } from '../../../data-marts/facades/mcp-reports.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import { McpToolRegistry } from './mcp-tool.registry';
+import { GetDataMartReportsTool } from './get-data-mart-reports.tool';
+import { MCP_TOOL_PROVIDER_CLASSES } from './mcp-tool.providers';
+
+describe('GetDataMartReportsTool', () => {
+  const context: McpAuthContext = {
+    clientId: 'mcp-client-1',
+    userId: 'user-1',
+    projectId: 'project-1',
+    roles: ['viewer'],
+    resource: 'https://mcp.owox.com/mcp',
+    scopes: ['mcp:read'],
+    authFlow: 'mcp',
+  };
+
+  it('lists a data mart reports using token project-member context', async () => {
+    const reports = [
+      {
+        report_id: 'r1',
+        name: 'Weekly revenue',
+        destination_id: 'dest-1',
+        destination_type: 'google_sheets' as const,
+        owner: 'ann@owox.com',
+        schedule: '0 9 * * 1',
+        last_run_at: '2026-06-10T10:00:00.000Z',
+        status: 'active' as const,
+      },
+    ];
+    const facade = {
+      getDataMartReports: jest.fn().mockResolvedValue({ reports }),
+    } as unknown as jest.Mocked<McpReportsFacade>;
+    const tool = new GetDataMartReportsTool(facade);
+
+    const structuredContent = { reports };
+
+    await expect(tool.handler({ data_mart_id: 'dm-1' }, context)).resolves.toEqual({
+      structuredContent,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+    });
+    expect(facade.getDataMartReports).toHaveBeenCalledWith({
+      dataMartId: 'dm-1',
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+    });
+  });
+
+  it('requires data_mart_id and rejects unexpected input', () => {
+    const tool = new GetDataMartReportsTool({} as McpReportsFacade);
+
+    expect(() => tool.parseInput({})).toThrow();
+    expect(() => tool.parseInput({ data_mart_id: 'dm-1', extra: true })).toThrow();
+  });
+
+  it('is registered with read-only metadata and the right scope', () => {
+    const registry = new McpToolRegistry([new GetDataMartReportsTool({} as McpReportsFacade)]);
+
+    expect(new GetDataMartReportsTool({} as McpReportsFacade)).toMatchObject({
+      name: 'get_data_mart_reports',
+      requiredScopes: ['mcp:read'],
+      outputSchema: expect.objectContaining({
+        reports: expect.any(Object),
+      }),
+      annotations: {
+        title: 'Get Data Mart Reports',
+        readOnlyHint: true,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    });
+    expect(MCP_TOOL_PROVIDER_CLASSES.map(tool => tool.name)).toContain('GetDataMartReportsTool');
+    expect(registry.getTool('get_data_mart_reports')).toBeDefined();
+  });
+});

--- a/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.ts
@@ -2,9 +2,9 @@ import { Inject, Injectable } from '@nestjs/common';
 import { z } from 'zod';
 import type { McpScope } from '@owox/idp-protocol';
 import { MCP_DESTINATION_TYPES } from '../../../data-marts/facades/mcp-destination-type';
+import { ReportRunStatus } from '../../../data-marts/enums/report-run-status.enum';
 import {
   MCP_REPORTS_FACADE,
-  MCP_REPORT_STATUSES,
   type McpReportsFacade,
 } from '../../../data-marts/facades/mcp-reports.facade';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
@@ -18,7 +18,7 @@ type GetDataMartReportsInput = z.infer<typeof inputSchema>;
 export class GetDataMartReportsTool implements McpToolDefinition<GetDataMartReportsInput> {
   readonly name = 'get_data_mart_reports';
   readonly description =
-    'List the reports tied to a data mart in the active OWOX project, including each report destination, schedule, and status.';
+    'List the reports tied to a data mart in the active OWOX project, including each report destination, run schedules (a report can have any number of schedule triggers), and last run status.';
   readonly zodSchema = inputSchema.shape;
   readonly outputSchema = {
     reports: z.array(
@@ -28,9 +28,18 @@ export class GetDataMartReportsTool implements McpToolDefinition<GetDataMartRepo
         destination_id: z.string(),
         destination_type: z.enum(MCP_DESTINATION_TYPES),
         owner: z.string().nullable(),
-        schedule: z.string().nullable(),
+        schedules: z.array(
+          z.object({
+            trigger_id: z.string(),
+            cron_expression: z.string(),
+            time_zone: z.string(),
+            is_active: z.boolean(),
+            next_run_at: z.string().nullable(),
+            last_run_at: z.string().nullable(),
+          })
+        ),
         last_run_at: z.string().nullable(),
-        status: z.enum(MCP_REPORT_STATUSES),
+        last_run_status: z.nativeEnum(ReportRunStatus).nullable(),
       })
     ),
   };

--- a/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.ts
@@ -24,6 +24,7 @@ export class GetDataMartReportsTool implements McpToolDefinition<GetDataMartRepo
     reports: z.array(
       z.object({
         report_id: z.string(),
+        data_mart_id: z.string(),
         name: z.string(),
         destination_id: z.string(),
         destination_type: z.enum(MCP_DESTINATION_TYPES),

--- a/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/get-data-mart-reports.tool.ts
@@ -1,0 +1,76 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import type { McpScope } from '@owox/idp-protocol';
+import { MCP_DESTINATION_TYPES } from '../../../data-marts/facades/mcp-destination-type';
+import {
+  MCP_REPORTS_FACADE,
+  MCP_REPORT_STATUSES,
+  type McpReportsFacade,
+} from '../../../data-marts/facades/mcp-reports.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import type { McpToolDefinition, McpToolResult } from './mcp-tool.definition';
+
+const inputSchema = z.object({ data_mart_id: z.string().min(1) }).strict();
+
+type GetDataMartReportsInput = z.infer<typeof inputSchema>;
+
+@Injectable()
+export class GetDataMartReportsTool implements McpToolDefinition<GetDataMartReportsInput> {
+  readonly name = 'get_data_mart_reports';
+  readonly description =
+    'List the reports tied to a data mart in the active OWOX project, including each report destination, schedule, and status.';
+  readonly zodSchema = inputSchema.shape;
+  readonly outputSchema = {
+    reports: z.array(
+      z.object({
+        report_id: z.string(),
+        name: z.string(),
+        destination_id: z.string(),
+        destination_type: z.enum(MCP_DESTINATION_TYPES),
+        owner: z.string().nullable(),
+        schedule: z.string().nullable(),
+        last_run_at: z.string().nullable(),
+        status: z.enum(MCP_REPORT_STATUSES),
+      })
+    ),
+  };
+  readonly annotations = {
+    title: 'Get Data Mart Reports',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: false,
+  };
+  readonly requiredScopes: McpScope[] = ['mcp:read'];
+
+  constructor(
+    @Inject(MCP_REPORTS_FACADE)
+    private readonly reports: McpReportsFacade
+  ) {}
+
+  parseInput(input: unknown): GetDataMartReportsInput {
+    return inputSchema.parse(input);
+  }
+
+  async handler(input: GetDataMartReportsInput, context: McpAuthContext): Promise<McpToolResult> {
+    const { data_mart_id } = this.parseInput(input);
+
+    const result = await this.reports.getDataMartReports({
+      dataMartId: data_mart_id,
+      projectId: context.projectId,
+      userId: context.userId,
+      roles: context.roles,
+    });
+
+    const structuredContent = { reports: result.reports };
+
+    return {
+      structuredContent,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+    };
+  }
+}

--- a/apps/backend/src/ee/mcp/tools/list-destinations.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/list-destinations.tool.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 import type { McpScope } from '@owox/idp-protocol';
 import {
   MCP_DATA_DESTINATIONS_FACADE,
-  MCP_DESTINATION_TYPES,
   type McpDataDestinationsFacade,
 } from '../../../data-marts/facades/mcp-data-destinations.facade';
+import { MCP_DESTINATION_TYPES } from '../../../data-marts/facades/mcp-destination-type';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import type { McpToolDefinition, McpToolResult } from './mcp-tool.definition';
 

--- a/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
@@ -1,5 +1,6 @@
 import type { Provider, Type } from '@nestjs/common';
 import { ListDataMartsTool } from './data-mart-catalog.tool';
+import { GetDataMartReportsTool } from './get-data-mart-reports.tool';
 import { ListDestinationsTool } from './list-destinations.tool';
 import { MCP_TOOL_DEFINITIONS, type McpToolDefinition } from './mcp-tool.definition';
 import { GetProjectContextTool } from './project-context.tool';
@@ -10,6 +11,7 @@ export const MCP_TOOL_PROVIDER_CLASSES: Array<Type<McpToolDefinition>> = [
   SearchDataMartsTool,
   GetProjectContextTool,
   ListDestinationsTool,
+  GetDataMartReportsTool,
 ];
 
 export const MCP_TOOL_DEFINITIONS_PROVIDER: Provider = {


### PR DESCRIPTION
## Summary

Adds a `get_data_mart_reports` MCP tool (PRD §15.8) that lists the reports tied to a data mart in the active project, so an AI assistant can review a data mart's reports — their destination, owner, run schedules, last run, and its status — without leaving the chat. Read-only, requires the `mcp:read` scope, and is **free** (no credits).

Second of the report/destination MCP tools, after `list_destinations` (#1376).

## What changed

- **New MCP tool** `GetDataMartReportsTool` (`ee/mcp/tools/get-data-mart-reports.tool.ts`) — input `{ data_mart_id }`; output `{ reports: [{ report_id, name, destination_id, destination_type, owner, schedules, last_run_at, last_run_status }] }`; `readOnlyHint: true`.
- **New facade** `McpReportsFacade` (+ impl, + DI symbol), wrapping the existing `ListReportsByDataMartService`. Registered and exported from `DataMartsModule`. No business logic reimplemented.
- **Shared destination-type module** `facades/mcp-destination-type.ts` — extracts the `DataDestinationType → MCP vocabulary` mapping that `list_destinations` introduced, so both tools map from one source (no drift). `list_destinations` is refactored to use it (behavior unchanged).

## Design notes

- **A report's schedules are exposed as-is, all of them.** A report can have any number of `REPORT_RUN` triggers and the product does not enforce a single-schedule rule, so the tool does not pretend there is one: each report carries a `schedules` array with one item per trigger — `{ trigger_id, cron_expression, time_zone, is_active, next_run_at, last_run_at }` — ordered by trigger creation time (deterministic rather than dependent on DB row order), empty when the report is unscheduled. The field vocabulary matches the report-run-schedule tools from #1378, so `trigger_id` values can be passed to `update_report_run_schedule` / `delete_report_run_schedule` directly.
- **`last_run_status`** is the report's own `lastRunStatus` (`SUCCESS` / `ERROR` / `RUNNING` / `CANCELLED` / `RESTRICTED`), passed through verbatim rather than folded into a derived status. `null` when the report never ran.
- The facade loads the data mart's triggers once (`ScheduledTriggerService.getAllByDataMartIdAndProjectId`) and groups `REPORT_RUN` triggers by `triggerConfig.reportId`.
- **`owner`** is the report creator's email — consistent with `list_destinations` (the owners relation has no stable ordering).
- Row-level access is delegated to `ListReportsByDataMartService` (checks `DATA_MART.SEE`; returns an empty list for a data mart you cannot see).

## Testing

- Facade unit tests: field mapping (including per-schedule fields); multi-trigger reports return every schedule ordered by creation time, disabled ones included; unscheduled reports get an empty `schedules` array; connector and other-report triggers are ignored; `last_run_status` pass-through (`SUCCESS` / `ERROR` / never ran → `null`); empty-reports short-circuit (no trigger query); and `owner` null.
- Tool unit tests: output shape, input validation (`data_mart_id` required, `.strict()` rejects extras), scope/annotations, registry.
- `nest build` (type-check), eslint, prettier, and the full MCP + facades suites — all green (52 tests).

## Out of scope / follow-ups

Sibling report tools (`add_report`, `update_report`, `delete_report`) are tracked separately. Schedule management itself (create/update/delete of report run schedules) is #1378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)