### PR TITLE
feat(mcp): add add_report MCP tool

### DIFF
--- a/.changeset/6700-mcp-add-report.md
+++ b/.changeset/6700-mcp-add-report.md
@@ -1,0 +1,9 @@
+---
+"owox": minor
+---
+
+# Add an add_report MCP tool
+
+AI assistants connected to OWOX over MCP can now create a report that exports a data mart to a Google Sheets destination. A new Google Sheet is created automatically and the report is linked to it, so you get ready-to-open report and sheet links without leaving the assistant.
+
+You choose which fields to include (or all of them). The tool currently supports Google Sheets destinations.

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
@@ -4,14 +4,33 @@ jest.mock('../use-cases/list-reports-by-data-mart.service', () => ({
 jest.mock('../services/scheduled-trigger.service', () => ({
   ScheduledTriggerService: jest.fn(),
 }));
+jest.mock('../use-cases/create-report.service', () => ({ CreateReportService: jest.fn() }));
+jest.mock('../use-cases/google-sheets/create-google-sheet-document.service', () => ({
+  CreateGoogleSheetDocumentService: jest.fn(),
+}));
+jest.mock('../services/data-mart.service', () => ({ DataMartService: jest.fn() }));
+jest.mock('../services/output-controls-validator.service', () => ({
+  OutputControlsValidatorService: jest.fn(),
+}));
+jest.mock('../services/access-decision', () => ({
+  AccessDecisionService: jest.fn(),
+  EntityType: { DATA_MART: 'DATA_MART', DESTINATION: 'DESTINATION' },
+  Action: { USE: 'USE' },
+}));
 
 import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
 import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
 import { ReportRunStatus } from '../enums/report-run-status.enum';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
 import { ReportDto } from '../dto/domain/report.dto';
 import type { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
 import type { ScheduledTriggerService } from '../services/scheduled-trigger.service';
+import type { CreateReportService } from '../use-cases/create-report.service';
+import type { CreateGoogleSheetDocumentService } from '../use-cases/google-sheets/create-google-sheet-document.service';
+import type { AccessDecisionService } from '../services/access-decision';
+import type { DataMartService } from '../services/data-mart.service';
+import type { OutputControlsValidatorService } from '../services/output-controls-validator.service';
 import { McpReportsFacadeImpl } from './mcp-reports.facade.impl';
 
 function buildReport(overrides: {
@@ -70,8 +89,44 @@ function buildFacade(reports: ReportDto[], triggers: DataMartScheduledTrigger[])
   const scheduledTriggerService = {
     getAllByDataMartIdAndProjectId: jest.fn().mockResolvedValue(triggers),
   } as unknown as jest.Mocked<ScheduledTriggerService>;
-  const facade = new McpReportsFacadeImpl(listReportsByDataMartService, scheduledTriggerService);
-  return { facade, listReportsByDataMartService, scheduledTriggerService };
+  const createReportService = {
+    run: jest.fn(),
+  } as unknown as jest.Mocked<CreateReportService>;
+  const createGoogleSheetDocumentService = {
+    run: jest.fn(),
+  } as unknown as jest.Mocked<CreateGoogleSheetDocumentService>;
+  const dataMartService = {
+    getByIdAndProjectId: jest.fn().mockResolvedValue({
+      id: 'dm-1',
+      status: DataMartStatus.PUBLISHED,
+      storage: { type: 'GOOGLE_BIGQUERY' },
+    }),
+  } as unknown as jest.Mocked<DataMartService>;
+  const accessDecisionService = {
+    canAccess: jest.fn().mockResolvedValue(true),
+  } as unknown as jest.Mocked<AccessDecisionService>;
+  const outputControlsValidator = {
+    validateForReport: jest.fn().mockResolvedValue(undefined),
+  } as unknown as jest.Mocked<OutputControlsValidatorService>;
+  const facade = new McpReportsFacadeImpl(
+    listReportsByDataMartService,
+    scheduledTriggerService,
+    createReportService,
+    createGoogleSheetDocumentService,
+    dataMartService,
+    accessDecisionService,
+    outputControlsValidator
+  );
+  return {
+    facade,
+    listReportsByDataMartService,
+    scheduledTriggerService,
+    createReportService,
+    createGoogleSheetDocumentService,
+    dataMartService,
+    accessDecisionService,
+    outputControlsValidator,
+  };
 }
 
 const request = {
@@ -246,5 +301,179 @@ describe('McpReportsFacadeImpl', () => {
     const result = await facade.getDataMartReports(request);
 
     expect(result.reports[0].owner).toBeNull();
+  });
+});
+
+describe('McpReportsFacadeImpl.addReport', () => {
+  const addRequest = {
+    dataMartId: 'dm-1',
+    destinationId: 'dest-1',
+    fields: ['channel', 'revenue'],
+    name: 'Weekly revenue',
+    projectId: 'project-1',
+    userId: 'user-1',
+    userEmail: 'ann@owox.com',
+    roles: ['editor'],
+  };
+
+  it('pre-validates, auto-creates a sheet, then creates a report pointing at it', async () => {
+    const {
+      facade,
+      createGoogleSheetDocumentService,
+      createReportService,
+      accessDecisionService,
+      outputControlsValidator,
+    } = buildFacade([], []);
+    createGoogleSheetDocumentService.run.mockResolvedValue({ spreadsheetId: 'ss-1', sheetId: 0 });
+    createReportService.run.mockResolvedValue({
+      id: 'report-1',
+      createdByUser: { email: 'ann@owox.com' },
+    } as unknown as ReportDto);
+
+    const result = await facade.addReport(addRequest);
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      'DATA_MART',
+      'dm-1',
+      'USE',
+      'project-1'
+    );
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      'DESTINATION',
+      'dest-1',
+      'USE',
+      'project-1'
+    );
+    expect(outputControlsValidator.validateForReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storageType: 'GOOGLE_BIGQUERY',
+        dataMartId: 'dm-1',
+        projectId: 'project-1',
+        columnConfig: ['channel', 'revenue'],
+      })
+    );
+    expect(createGoogleSheetDocumentService.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationId: 'dest-1',
+        projectId: 'project-1',
+        title: 'Weekly revenue',
+        requestedByUserId: 'user-1',
+        userEmail: 'ann@owox.com',
+      })
+    );
+    expect(createReportService.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'project-1',
+        userId: 'user-1',
+        title: 'Weekly revenue',
+        dataMartId: 'dm-1',
+        dataDestinationId: 'dest-1',
+        destinationConfig: {
+          type: 'google-sheets-config',
+          spreadsheetId: 'ss-1',
+          sheetId: 0,
+        },
+        columnConfig: ['channel', 'revenue'],
+      })
+    );
+    expect(result).toEqual({
+      report_id: 'report-1',
+      owner: 'ann@owox.com',
+      status: 'created',
+      sheet_url: 'https://docs.google.com/spreadsheets/d/ss-1/edit#gid=0',
+    });
+  });
+
+  it('passes the placed-in-root and shared-with-requester flags through', async () => {
+    const { facade, createGoogleSheetDocumentService, createReportService } = buildFacade([], []);
+    createGoogleSheetDocumentService.run.mockResolvedValue({
+      spreadsheetId: 'ss-1',
+      sheetId: 0,
+      placedInRoot: true,
+      sharedWithRequester: false,
+    });
+    createReportService.run.mockResolvedValue({
+      id: 'report-1',
+      createdByUser: null,
+    } as unknown as ReportDto);
+
+    const result = await facade.addReport(addRequest);
+
+    expect(result).toMatchObject({ placed_in_root: true, shared_with_requester: false });
+  });
+
+  it('maps fields ["*"] to no column projection (all fields)', async () => {
+    const {
+      facade,
+      createGoogleSheetDocumentService,
+      createReportService,
+      outputControlsValidator,
+    } = buildFacade([], []);
+    createGoogleSheetDocumentService.run.mockResolvedValue({ spreadsheetId: 'ss-2', sheetId: 3 });
+    createReportService.run.mockResolvedValue({ id: 'report-2', createdByUser: null } as ReportDto);
+
+    await facade.addReport({ ...addRequest, fields: ['*'] });
+
+    expect(outputControlsValidator.validateForReport).toHaveBeenCalledWith(
+      expect.objectContaining({ columnConfig: null })
+    );
+    expect(createReportService.run).toHaveBeenCalledWith(
+      expect.objectContaining({ columnConfig: null })
+    );
+  });
+
+  it('rejects a non-published data mart before creating the sheet', async () => {
+    const { facade, createGoogleSheetDocumentService, dataMartService } = buildFacade([], []);
+    dataMartService.getByIdAndProjectId.mockResolvedValue({
+      id: 'dm-1',
+      status: 'DRAFT',
+      storage: { type: 'GOOGLE_BIGQUERY' },
+    } as never);
+
+    await expect(facade.addReport(addRequest)).rejects.toThrow('PUBLISHED');
+    expect(createGoogleSheetDocumentService.run).not.toHaveBeenCalled();
+  });
+
+  it('rejects a caller without data mart access before creating the sheet', async () => {
+    const { facade, createGoogleSheetDocumentService, accessDecisionService } = buildFacade([], []);
+    accessDecisionService.canAccess.mockResolvedValueOnce(false);
+
+    await expect(facade.addReport(addRequest)).rejects.toThrow('access to the DataMart');
+    expect(createGoogleSheetDocumentService.run).not.toHaveBeenCalled();
+  });
+
+  it('rejects a caller without destination access before creating the sheet', async () => {
+    const { facade, createGoogleSheetDocumentService, accessDecisionService } = buildFacade([], []);
+    accessDecisionService.canAccess.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await expect(facade.addReport(addRequest)).rejects.toThrow('access to the Destination');
+    expect(createGoogleSheetDocumentService.run).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid fields before creating the sheet', async () => {
+    const { facade, createGoogleSheetDocumentService, outputControlsValidator } = buildFacade(
+      [],
+      []
+    );
+    outputControlsValidator.validateForReport.mockRejectedValue(new Error('Unknown column'));
+
+    await expect(facade.addReport(addRequest)).rejects.toThrow('Unknown column');
+    expect(createGoogleSheetDocumentService.run).not.toHaveBeenCalled();
+  });
+
+  it('does not create the report when sheet creation fails', async () => {
+    const { facade, createGoogleSheetDocumentService, createReportService } = buildFacade([], []);
+    createGoogleSheetDocumentService.run.mockRejectedValue(
+      new Error('Destination is not a Google Sheets destination')
+    );
+
+    await expect(facade.addReport(addRequest)).rejects.toThrow(
+      'Destination is not a Google Sheets destination'
+    );
+    expect(createReportService.run).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
@@ -1,23 +1,165 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
 import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled-trigger-type.enum';
+import { GoogleSheetsConfigType } from '../data-destination-types/google-sheets/schemas/google-sheets-config.schema';
 import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data-mart.command';
+import { CreateReportCommand } from '../dto/domain/create-report.command';
+import { CreateGoogleSheetDocumentCommand } from '../dto/domain/google-sheets/create-google-sheet-document.command';
+import { ReportColumnConfig } from '../dto/schemas/report-column-config.schema';
 import { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
+import { CreateReportService } from '../use-cases/create-report.service';
+import { CreateGoogleSheetDocumentService } from '../use-cases/google-sheets/create-google-sheet-document.service';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+import { DataMartService } from '../services/data-mart.service';
+import { OutputControlsValidatorService } from '../services/output-controls-validator.service';
 import { ScheduledTriggerService } from '../services/scheduled-trigger.service';
 import { toMcpDestinationType } from './mcp-destination-type';
 import {
+  McpAddReportRequest,
+  McpAddReportResult,
   McpGetDataMartReportsRequest,
   McpGetDataMartReportsResponse,
   McpReportScheduleItem,
   McpReportsFacade,
 } from './mcp-reports.facade';
 
+/**
+ * Builds the shareable Google Sheets URL for a spreadsheet tab.
+ * Keep the format in sync with `getGoogleSheetTabUrl` in
+ * apps/web/src/features/data-marts/reports/shared/utils/google-sheets-url.utils.ts.
+ */
+function buildGoogleSheetUrl(spreadsheetId: string, sheetId: number): string {
+  return `https://docs.google.com/spreadsheets/d/${spreadsheetId}/edit#gid=${sheetId}`;
+}
+
 @Injectable()
 export class McpReportsFacadeImpl implements McpReportsFacade {
   constructor(
     private readonly listReportsByDataMartService: ListReportsByDataMartService,
-    private readonly scheduledTriggerService: ScheduledTriggerService
+    private readonly scheduledTriggerService: ScheduledTriggerService,
+    private readonly createReportService: CreateReportService,
+    private readonly createGoogleSheetDocumentService: CreateGoogleSheetDocumentService,
+    private readonly dataMartService: DataMartService,
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly outputControlsValidator: OutputControlsValidatorService
   ) {}
+
+  async addReport(request: McpAddReportRequest): Promise<McpAddReportResult> {
+    const columnConfig = this.toColumnConfig(request.fields);
+
+    // 1. Validate everything CreateReportService would reject BEFORE the
+    //    external side effect: sheet creation is not transactional, so a
+    //    failure after it would leave an orphaned document, and an
+    //    unauthorized caller must not be able to trigger it at all.
+    await this.assertCanCreateReport(request, columnConfig);
+
+    // 2. Auto-create the Google Sheet. This also validates that the destination
+    //    is a Google Sheets destination (it throws otherwise), so it doubles as
+    //    the guard against unsupported destination types.
+    const sheet = await this.createGoogleSheetDocumentService.run(
+      new CreateGoogleSheetDocumentCommand(
+        request.destinationId,
+        request.projectId,
+        request.name,
+        request.userId,
+        request.userEmail
+      )
+    );
+
+    // 3. Create the report pointing at the freshly-created sheet. Omitting
+    //    ownerIds makes the service default ownership to the requesting user.
+    const report = await this.createReportService.run(
+      new CreateReportCommand(
+        request.projectId,
+        request.userId,
+        request.name,
+        request.dataMartId,
+        request.destinationId,
+        {
+          type: GoogleSheetsConfigType,
+          spreadsheetId: sheet.spreadsheetId,
+          sheetId: sheet.sheetId,
+        },
+        undefined,
+        request.roles,
+        columnConfig
+      )
+    );
+
+    return {
+      report_id: report.id,
+      owner: report.createdByUser?.email ?? null,
+      status: 'created',
+      sheet_url: buildGoogleSheetUrl(sheet.spreadsheetId, sheet.sheetId),
+      placed_in_root: sheet.placedInRoot,
+      shared_with_requester: sheet.sharedWithRequester,
+    };
+  }
+
+  /**
+   * Pre-flight for addReport, mirroring the checks CreateReportService.run
+   * performs inside its transaction (kept deliberately in sync): the service
+   * re-validates afterwards, but by then the sheet already exists.
+   */
+  private async assertCanCreateReport(
+    request: McpAddReportRequest,
+    columnConfig: ReportColumnConfig
+  ): Promise<void> {
+    const dataMart = await this.dataMartService.getByIdAndProjectId(
+      request.dataMartId,
+      request.projectId
+    );
+    if (dataMart.status !== DataMartStatus.PUBLISHED) {
+      throw new BusinessViolationException(
+        `Cannot create report for data mart with status ${dataMart.status}. Data mart must be in PUBLISHED status.`
+      );
+    }
+
+    const canUseDataMart = await this.accessDecisionService.canAccess(
+      request.userId,
+      request.roles,
+      EntityType.DATA_MART,
+      request.dataMartId,
+      Action.USE,
+      request.projectId
+    );
+    if (!canUseDataMart) {
+      throw new ForbiddenException('You do not have access to the DataMart for this report');
+    }
+
+    const canUseDestination = await this.accessDecisionService.canAccess(
+      request.userId,
+      request.roles,
+      EntityType.DESTINATION,
+      request.destinationId,
+      Action.USE,
+      request.projectId
+    );
+    if (!canUseDestination) {
+      throw new ForbiddenException('You do not have access to the Destination for this report');
+    }
+
+    await this.outputControlsValidator.validateForReport({
+      storageType: dataMart.storage.type,
+      dataMartId: dataMart.id,
+      projectId: request.projectId,
+      columnConfig,
+      filterConfig: null,
+      sortConfig: null,
+      limitConfig: null,
+      aggregationConfig: null,
+      dateTruncConfig: null,
+      uniqueCountConfig: null,
+      accessor: { userId: request.userId, roles: request.roles },
+    });
+  }
+
+  /** `['*']` (or any list containing `'*'`) means "all fields" → no column projection. */
+  private toColumnConfig(fields: string[]): ReportColumnConfig {
+    return fields.includes('*') ? null : fields;
+  }
 
   async getDataMartReports(
     request: McpGetDataMartReportsRequest

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
@@ -46,6 +46,37 @@ export interface McpGetDataMartReportsResponse {
   reports: McpReportListItem[];
 }
 
+export interface McpAddReportRequest {
+  dataMartId: string;
+  destinationId: string;
+  /** Column names to include; `['*']` (or containing `'*'`) selects every field. */
+  fields: string[];
+  name: string;
+  projectId: string;
+  userId: string;
+  /** Requesting user email — the auto-created sheet is shared with them (best-effort). */
+  userEmail?: string;
+  roles: string[];
+}
+
+export interface McpAddReportResult {
+  report_id: string;
+  owner: string | null;
+  status: 'created';
+  /** Link to the auto-created Google Sheet. */
+  sheet_url: string;
+  /** True when the configured Drive folder could not be used and the sheet landed in the Drive root. */
+  placed_in_root?: boolean;
+  /** False when the created sheet could not be shared with the requesting user. */
+  shared_with_requester?: boolean;
+}
+
 export interface McpReportsFacade {
   getDataMartReports(request: McpGetDataMartReportsRequest): Promise<McpGetDataMartReportsResponse>;
+  /**
+   * Creates a report for a Google Sheets destination: auto-creates a new Sheet,
+   * then creates the report pointing at it. Non-Google-Sheets destinations are
+   * rejected by the underlying document-creation service.
+   */
+  addReport(request: McpAddReportRequest): Promise<McpAddReportResult>;
 }

--- a/apps/backend/src/ee/mcp/tools/add-report.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/add-report.tool.spec.ts
@@ -1,0 +1,125 @@
+import type { PublicOriginService } from '../../../common/config/public-origin.service';
+import type { McpReportsFacade } from '../../../data-marts/facades/mcp-reports.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import { McpToolRegistry } from './mcp-tool.registry';
+import { AddReportTool } from './add-report.tool';
+import { MCP_TOOL_PROVIDER_CLASSES } from './mcp-tool.providers';
+
+describe('AddReportTool', () => {
+  const context: McpAuthContext = {
+    clientId: 'mcp-client-1',
+    userId: 'user-1',
+    projectId: 'project-1',
+    email: 'ann@owox.com',
+    roles: ['editor'],
+    resource: 'https://mcp.owox.com/mcp',
+    scopes: ['mcp:write'],
+    authFlow: 'mcp',
+  };
+  const publicOrigin = {
+    getPublicOrigin: jest.fn(() => 'https://app.owox.com'),
+  } as unknown as jest.Mocked<PublicOriginService>;
+
+  const input = {
+    data_mart_id: 'dm-1',
+    destination_id: 'dest-1',
+    fields: ['channel', 'revenue'],
+    name: 'Weekly revenue',
+  };
+
+  it('creates a report and returns the report and sheet links', async () => {
+    const facade = {
+      addReport: jest.fn().mockResolvedValue({
+        report_id: 'report-1',
+        owner: 'ann@owox.com',
+        status: 'created',
+        sheet_url: 'https://docs.google.com/spreadsheets/d/ss-1/edit#gid=0',
+      }),
+    } as unknown as jest.Mocked<McpReportsFacade>;
+    const tool = new AddReportTool(facade, publicOrigin);
+
+    const structuredContent = {
+      report_id: 'report-1',
+      report_url: 'https://app.owox.com/ui/project-1/data-marts/dm-1/reports',
+      sheet_url: 'https://docs.google.com/spreadsheets/d/ss-1/edit#gid=0',
+      owner: 'ann@owox.com',
+      status: 'created',
+    };
+
+    await expect(tool.handler(input, context)).resolves.toEqual({
+      structuredContent,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+    });
+    expect(facade.addReport).toHaveBeenCalledWith({
+      dataMartId: 'dm-1',
+      destinationId: 'dest-1',
+      fields: ['channel', 'revenue'],
+      name: 'Weekly revenue',
+      projectId: 'project-1',
+      userId: 'user-1',
+      userEmail: 'ann@owox.com',
+      roles: ['editor'],
+    });
+  });
+
+  it('surfaces sheet placement and sharing warnings when present', async () => {
+    const facade = {
+      addReport: jest.fn().mockResolvedValue({
+        report_id: 'report-1',
+        owner: null,
+        status: 'created',
+        sheet_url: 'https://docs.google.com/spreadsheets/d/ss-1/edit#gid=0',
+        placed_in_root: true,
+        shared_with_requester: false,
+      }),
+    } as unknown as jest.Mocked<McpReportsFacade>;
+    const tool = new AddReportTool(facade, publicOrigin);
+
+    const result = await tool.handler(input, context);
+
+    expect(result.structuredContent).toMatchObject({
+      placed_in_root: true,
+      shared_with_requester: false,
+    });
+    expect((result.content[0] as { text: string }).text).toContain(
+      '"shared_with_requester": false'
+    );
+  });
+
+  it('validates required input and rejects unexpected keys', () => {
+    const tool = new AddReportTool({} as McpReportsFacade, publicOrigin);
+
+    expect(() => tool.parseInput({ destination_id: 'd', fields: ['*'], name: 'x' })).toThrow();
+    expect(() => tool.parseInput({ ...input, fields: [] })).toThrow();
+    expect(() => tool.parseInput({ ...input, extra: true })).toThrow();
+  });
+
+  it('trims the report name and rejects whitespace-only names', () => {
+    const tool = new AddReportTool({} as McpReportsFacade, publicOrigin);
+
+    expect(tool.parseInput({ ...input, name: '  Weekly revenue  ' }).name).toBe('Weekly revenue');
+    expect(() => tool.parseInput({ ...input, name: '   ' })).toThrow();
+  });
+
+  it('is registered as a write tool with the mcp:write scope', () => {
+    const registry = new McpToolRegistry([new AddReportTool({} as McpReportsFacade, publicOrigin)]);
+
+    expect(new AddReportTool({} as McpReportsFacade, publicOrigin)).toMatchObject({
+      name: 'add_report',
+      requiredScopes: ['mcp:write'],
+      annotations: {
+        title: 'Add Report',
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    });
+    expect(MCP_TOOL_PROVIDER_CLASSES.map(tool => tool.name)).toContain('AddReportTool');
+    expect(registry.getTool('add_report')).toBeDefined();
+  });
+});

--- a/apps/backend/src/ee/mcp/tools/add-report.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/add-report.tool.ts
@@ -1,0 +1,108 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import type { McpScope } from '@owox/idp-protocol';
+import { PublicOriginService } from '../../../common/config/public-origin.service';
+import {
+  MCP_REPORTS_FACADE,
+  type McpReportsFacade,
+} from '../../../data-marts/facades/mcp-reports.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import type { McpToolDefinition, McpToolResult } from './mcp-tool.definition';
+import { buildReportsUiPath, joinPublicOrigin } from './data-mart-ui-path';
+
+const inputSchema = z
+  .object({
+    data_mart_id: z.string().min(1),
+    destination_id: z.string().min(1),
+    fields: z
+      .array(z.string().min(1))
+      .min(1)
+      .describe("Column names to include, or ['*'] for every field"),
+    name: z.string().trim().min(1),
+  })
+  .strict();
+
+type AddReportInput = z.infer<typeof inputSchema>;
+
+@Injectable()
+export class AddReportTool implements McpToolDefinition<AddReportInput> {
+  readonly name = 'add_report';
+  readonly description =
+    'Create a report that exports a data mart to a Google Sheets destination. A new Google Sheet is created automatically and the report is linked to it. Returns the report and sheet links.';
+  readonly zodSchema = inputSchema.shape;
+  readonly outputSchema = {
+    report_id: z.string(),
+    report_url: z.string(),
+    sheet_url: z.string(),
+    owner: z.string().nullable(),
+    status: z.literal('created'),
+    placed_in_root: z
+      .boolean()
+      .optional()
+      .describe(
+        'True when the configured Drive folder could not be used and the sheet was created in the Drive root instead.'
+      ),
+    shared_with_requester: z
+      .boolean()
+      .optional()
+      .describe(
+        'False when the sheet could not be shared with you; opening the link may require requesting access.'
+      ),
+  };
+  readonly annotations = {
+    title: 'Add Report',
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: false,
+  };
+  readonly requiredScopes: McpScope[] = ['mcp:write'];
+
+  constructor(
+    @Inject(MCP_REPORTS_FACADE)
+    private readonly reports: McpReportsFacade,
+    private readonly publicOriginService: PublicOriginService
+  ) {}
+
+  parseInput(input: unknown): AddReportInput {
+    return inputSchema.parse(input);
+  }
+
+  async handler(input: AddReportInput, context: McpAuthContext): Promise<McpToolResult> {
+    const { data_mart_id, destination_id, fields, name } = this.parseInput(input);
+
+    const result = await this.reports.addReport({
+      dataMartId: data_mart_id,
+      destinationId: destination_id,
+      fields,
+      name,
+      projectId: context.projectId,
+      userId: context.userId,
+      userEmail: context.email,
+      roles: context.roles,
+    });
+
+    const publicOrigin = this.publicOriginService.getPublicOrigin();
+    const structuredContent = {
+      report_id: result.report_id,
+      report_url: joinPublicOrigin(
+        publicOrigin,
+        buildReportsUiPath(context.projectId, data_mart_id)
+      ),
+      sheet_url: result.sheet_url,
+      owner: result.owner,
+      status: result.status,
+      placed_in_root: result.placed_in_root,
+      shared_with_requester: result.shared_with_requester,
+    };
+
+    return {
+      structuredContent,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+    };
+  }
+}

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -108,6 +108,7 @@ describe('ListDataMartsTool', () => {
       'GetProjectContextTool',
       'ListDestinationsTool',
       'GetDataMartReportsTool',
+      'AddReportTool',
     ]);
     expect(registry.getTool('list_data_marts')).toBeDefined();
     expect(registry.getTool('query_data_mart')).toBeUndefined();

--- a/apps/backend/src/ee/mcp/tools/data-mart-ui-path.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-ui-path.ts
@@ -2,6 +2,10 @@ export function buildDataMartUiPath(projectId: string, dataMartId: string): stri
   return `/ui/${encodeURIComponent(projectId)}/data-marts/${encodeURIComponent(dataMartId)}/data-setup`;
 }
 
+export function buildReportsUiPath(projectId: string, dataMartId: string): string {
+  return `/ui/${encodeURIComponent(projectId)}/data-marts/${encodeURIComponent(dataMartId)}/reports`;
+}
+
 export function joinPublicOrigin(publicOrigin: string, path: string): string {
   return new URL(path, `${publicOrigin.replace(/\/+$/, '')}/`).toString();
 }

--- a/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
@@ -1,4 +1,5 @@
 import type { Provider, Type } from '@nestjs/common';
+import { AddReportTool } from './add-report.tool';
 import { ListDataMartsTool } from './data-mart-catalog.tool';
 import { GetDataMartDetailsTool } from './data-mart-details.tool';
 import { GetDataMartReportsTool } from './get-data-mart-reports.tool';
@@ -14,6 +15,7 @@ export const MCP_TOOL_PROVIDER_CLASSES: Array<Type<McpToolDefinition>> = [
   GetProjectContextTool,
   ListDestinationsTool,
   GetDataMartReportsTool,
+  AddReportTool,
 ];
 
 export const MCP_TOOL_DEFINITIONS_PROVIDER: Provider = {


### PR DESCRIPTION
## Summary

Adds an `add_report` MCP tool (PRD §15.9, task #6700): an AI assistant connected over MCP can create a report that exports a data mart to a **Google Sheets** destination. A new Google Sheet is created automatically and the report is linked to it — the caller gets ready-to-open `report_url` and `sheet_url` back, without leaving the chat.

First **write** tool on the MCP surface (`mcp:write` scope, `readOnlyHint: false`). Free per the PRD billing model.

> **Stacked on #1377** (`get_data_mart_reports`) — it extends the same `McpReportsFacade`. GitHub will retarget this PR to `main` once #1377 merges.

## What changed

- **New MCP tool** `AddReportTool` (`ee/mcp/tools/add-report.tool.ts`) — input `{ data_mart_id, destination_id, fields, name }` (`fields: ['*']` = all columns; `name` is trimmed); output `{ report_id, report_url, sheet_url, owner, status: 'created', placed_in_root?, shared_with_requester? }`.
- **`McpReportsFacade.addReport`** orchestrates the existing domain services — nothing reimplemented:
  1. **Pre-flight validation** (see below),
  2. `CreateGoogleSheetDocumentService` mints the Sheet (synchronous; also rejects non-Google-Sheets destinations),
  3. `CreateReportService` creates the report pointing at it (`destinationConfig` built from the fresh `spreadsheetId`/`sheetId`).
- **Reports UI-path helper** `buildReportsUiPath` next to the existing data-mart path helper.

## Design notes

- **Validation runs BEFORE the external side effect.** Sheet creation is not transactional, so the facade pre-validates everything `CreateReportService` would reject — data mart `PUBLISHED`, `USE` access to the data mart **and** the destination, and the `fields` selection (`OutputControlsValidatorService`) — before any Google API call. Without this, a DRAFT data mart, a permissions miss, or a typo'd field name would orphan a real document in the destination owner's Drive (and MCP clients retry on error, multiplying orphans); an unauthorized caller could trigger file creation at all. This mirrors the REST path, where the controller enforces `Action.USE` before `createGoogleSheetDocument` ([data-destination.controller.ts:334](../blob/main/apps/backend/src/data-marts/controllers/data-destination.controller.ts)). The service still re-validates inside its transaction; the duplication is deliberate and commented.
- **`sheet_url` is synchronous** because the tool itself mints the sheet first — the `report.created` listener only stamps developer metadata and never produces the document.
- **Sharing/placement warnings are surfaced, not swallowed:** `placed_in_root` (configured Drive folder could not be used) and `shared_with_requester` (sheet could not be shared with the caller) pass through to the tool output with LLM-facing descriptions, so the assistant can warn the user instead of handing over a link that shows "Request access" — same signals the web UI warns about.
- **Google-Sheets-only v1** (product decision): other destination types are rejected with a clear error by the document-creation service. `slices`/`filters` and `description` from the PRD input are **deferred**: the PRD filter vocabulary doesn't map 1:1 onto the domain filter model yet, and half-mapping them would create reports that silently return wrong rows; `description` has no field on the Report entity.
- `owner` defaults to the requesting user (service default); `report_url` points at the data mart's reports tab (no per-report route exists in the web app).

## Review

A max-effort multi-agent code review ran on this branch (10 finder angles → adversarial verification → gap sweep). All confirmed findings are addressed in this PR: validation-before-side-effect ordering, destination `USE` parity with REST, surfaced sharing/placement flags, trimmed report name. One pre-existing perf item (eager `DataMart` hydration in `ScheduledTriggerService` queries) is tracked separately.

## Testing

- Facade: pre-validation rejection matrix (DRAFT mart / no mart access / no destination access / invalid fields — each asserting the sheet is **not** created), happy path incl. check→sheet→report ordering and command payloads, `['*']` → no column projection, flags passthrough, sheet-failure short-circuit, owner fallback.
- Tool: output shape incl. warning flags, strict input validation, name trimming and whitespace-only rejection, `mcp:write` scope + annotations, registry.
- `npx jest src/data-marts/facades src/ee/mcp/tools` — 51 tests, 11 suites green; `nest build` and eslint clean.
- Live-verified earlier in Claude Desktop via `mcp-remote` against a local `owox-better-auth` server (pre-fix version of the flow; the GS auto-creation path is the same one exercised by the web "Create document" button).

## Out of scope / follow-ups

- `update_report`, `delete_report` MCP tools (tracked separately).
- `slices`/`filters` input support — shared design with the future `query_data_mart` filter vocabulary.
- Lean trigger query (perf) in `ScheduledTriggerService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
