### PR TITLE
feat(mcp): add update_report MCP tool

### DIFF
--- a/.changeset/6701-mcp-update-report.md
+++ b/.changeset/6701-mcp-update-report.md
@@ -1,0 +1,9 @@
+---
+"owox": minor
+---
+
+# Add an update_report MCP tool
+
+AI assistants connected to OWOX over MCP can now update an existing report: rename it and/or change which data mart fields it exports. Everything you don't mention — destination, filters, sorting, owners, schedules — stays exactly as it was.
+
+Only reports you're allowed to edit can be updated.

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
@@ -537,6 +537,11 @@ describe('McpReportsFacadeImpl.updateReport', () => {
     expect(updateReportService.run).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'report-1',
+        // Authorization inputs must be forwarded verbatim — UpdateReportService
+        // derives mutate-access decisions from them.
+        projectId: 'project-1',
+        userId: 'user-1',
+        roles: ['editor'],
         title: 'New name',
         dataDestinationId: 'dest-1',
         destinationConfig: currentReport.destinationConfig,
@@ -550,6 +555,16 @@ describe('McpReportsFacadeImpl.updateReport', () => {
       })
     );
     expect(result).toEqual({ report_id: 'report-1', status: 'updated' });
+  });
+
+  it('rejects a call with nothing to update before touching any service', async () => {
+    const { facade, getReportService, updateReportService } = buildUpdateFacade();
+
+    await expect(facade.updateReport(updateRequest)).rejects.toThrow(
+      'Nothing to update: provide fields and/or name'
+    );
+    expect(getReportService.run).not.toHaveBeenCalled();
+    expect(updateReportService.run).not.toHaveBeenCalled();
   });
 
   it('replaces the column selection while preserving the name and filters', async () => {

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
@@ -9,6 +9,8 @@ jest.mock('../use-cases/google-sheets/create-google-sheet-document.service', () 
   CreateGoogleSheetDocumentService: jest.fn(),
 }));
 jest.mock('../services/data-mart.service', () => ({ DataMartService: jest.fn() }));
+jest.mock('../use-cases/get-report.service', () => ({ GetReportService: jest.fn() }));
+jest.mock('../use-cases/update-report.service', () => ({ UpdateReportService: jest.fn() }));
 jest.mock('../services/output-controls-validator.service', () => ({
   OutputControlsValidatorService: jest.fn(),
 }));
@@ -31,6 +33,8 @@ import type { CreateGoogleSheetDocumentService } from '../use-cases/google-sheet
 import type { AccessDecisionService } from '../services/access-decision';
 import type { DataMartService } from '../services/data-mart.service';
 import type { OutputControlsValidatorService } from '../services/output-controls-validator.service';
+import type { GetReportService } from '../use-cases/get-report.service';
+import type { UpdateReportService } from '../use-cases/update-report.service';
 import { McpReportsFacadeImpl } from './mcp-reports.facade.impl';
 
 function buildReport(overrides: {
@@ -108,6 +112,12 @@ function buildFacade(reports: ReportDto[], triggers: DataMartScheduledTrigger[])
   const outputControlsValidator = {
     validateForReport: jest.fn().mockResolvedValue(undefined),
   } as unknown as jest.Mocked<OutputControlsValidatorService>;
+  const getReportService = {
+    run: jest.fn(),
+  } as unknown as jest.Mocked<GetReportService>;
+  const updateReportService = {
+    run: jest.fn(),
+  } as unknown as jest.Mocked<UpdateReportService>;
   const facade = new McpReportsFacadeImpl(
     listReportsByDataMartService,
     scheduledTriggerService,
@@ -115,7 +125,9 @@ function buildFacade(reports: ReportDto[], triggers: DataMartScheduledTrigger[])
     createGoogleSheetDocumentService,
     dataMartService,
     accessDecisionService,
-    outputControlsValidator
+    outputControlsValidator,
+    getReportService,
+    updateReportService
   );
   return {
     facade,
@@ -126,6 +138,8 @@ function buildFacade(reports: ReportDto[], triggers: DataMartScheduledTrigger[])
     dataMartService,
     accessDecisionService,
     outputControlsValidator,
+    getReportService,
+    updateReportService,
   };
 }
 
@@ -475,5 +489,110 @@ describe('McpReportsFacadeImpl.addReport', () => {
       'Destination is not a Google Sheets destination'
     );
     expect(createReportService.run).not.toHaveBeenCalled();
+  });
+});
+
+describe('McpReportsFacadeImpl.updateReport', () => {
+  const updateRequest = {
+    reportId: 'report-1',
+    projectId: 'project-1',
+    userId: 'user-1',
+    roles: ['editor'],
+  };
+
+  const currentReport = {
+    id: 'report-1',
+    title: 'Old name',
+    dataDestinationAccess: { id: 'dest-1' },
+    destinationConfig: { type: 'google-sheets-config', spreadsheetId: 'ss-1', sheetId: 0 },
+    columnConfig: ['channel', 'revenue'],
+    filterConfig: [{ column: 'channel', operator: 'eq', value: 'ads' }],
+    sortConfig: [{ column: 'revenue', direction: 'DESC' }],
+    limitConfig: 100,
+    aggregationConfig: { groupBy: ['channel'] },
+    dateTruncConfig: { column: 'date', unit: 'month' },
+    uniqueCountConfig: undefined,
+  } as unknown as ReportDto;
+
+  function buildUpdateFacade() {
+    const built = buildFacade([], []);
+    built.getReportService.run.mockResolvedValue(currentReport);
+    built.updateReportService.run.mockResolvedValue(currentReport);
+    return built;
+  }
+
+  it('renames the report while preserving every other setting', async () => {
+    const { facade, getReportService, updateReportService } = buildUpdateFacade();
+
+    const result = await facade.updateReport({ ...updateRequest, name: 'New name' });
+
+    expect(getReportService.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'report-1',
+        projectId: 'project-1',
+        userId: 'user-1',
+        roles: ['editor'],
+      })
+    );
+    expect(updateReportService.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'report-1',
+        title: 'New name',
+        dataDestinationId: 'dest-1',
+        destinationConfig: currentReport.destinationConfig,
+        ownerIds: undefined,
+        columnConfig: ['channel', 'revenue'],
+        filterConfig: currentReport.filterConfig,
+        sortConfig: currentReport.sortConfig,
+        limitConfig: 100,
+        aggregationConfig: currentReport.aggregationConfig,
+        dateTruncConfig: currentReport.dateTruncConfig,
+      })
+    );
+    expect(result).toEqual({ report_id: 'report-1', status: 'updated' });
+  });
+
+  it('replaces the column selection while preserving the name and filters', async () => {
+    const { facade, updateReportService } = buildUpdateFacade();
+
+    await facade.updateReport({ ...updateRequest, fields: ['channel'] });
+
+    expect(updateReportService.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Old name',
+        columnConfig: ['channel'],
+        filterConfig: currentReport.filterConfig,
+      })
+    );
+  });
+
+  it('maps fields ["*"] to no column projection', async () => {
+    const { facade, updateReportService } = buildUpdateFacade();
+
+    await facade.updateReport({ ...updateRequest, fields: ['*'] });
+
+    expect(updateReportService.run).toHaveBeenCalledWith(
+      expect.objectContaining({ columnConfig: null })
+    );
+  });
+
+  it('applies name and fields together', async () => {
+    const { facade, updateReportService } = buildUpdateFacade();
+
+    await facade.updateReport({ ...updateRequest, name: 'New name', fields: ['channel'] });
+
+    expect(updateReportService.run).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'New name', columnConfig: ['channel'] })
+    );
+  });
+
+  it('does not update when loading the current report fails', async () => {
+    const { facade, getReportService, updateReportService } = buildUpdateFacade();
+    getReportService.run.mockRejectedValue(new Error('Report with ID report-1 not found'));
+
+    await expect(facade.updateReport({ ...updateRequest, name: 'New name' })).rejects.toThrow(
+      'not found'
+    );
+    expect(updateReportService.run).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
 import { DataMartStatus } from '../enums/data-mart-status.enum';
@@ -55,6 +55,12 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
   ) {}
 
   async updateReport(request: McpUpdateReportRequest): Promise<McpUpdateReportResult> {
+    // The facade is a public interface, so the "at least one change" invariant
+    // is enforced here as well, not only by the tool-layer input schema.
+    if (request.fields === undefined && request.name === undefined) {
+      throw new BadRequestException('Nothing to update: provide fields and/or name');
+    }
+
     // UpdateReportCommand carries the FULL report state and the service
     // overwrites every output control, so merge the partial MCP input into the
     // current report. Keeping the current destination id skips the destination
@@ -73,7 +79,9 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
         current.dataDestinationAccess.id,
         current.destinationConfig,
         undefined,
-        request.fields ? this.toColumnConfig(request.fields) : (current.columnConfig ?? null),
+        request.fields !== undefined
+          ? this.toColumnConfig(request.fields)
+          : (current.columnConfig ?? null),
         current.filterConfig ?? null,
         current.sortConfig ?? null,
         current.limitConfig ?? null,

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
@@ -6,10 +6,14 @@ import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled
 import { GoogleSheetsConfigType } from '../data-destination-types/google-sheets/schemas/google-sheets-config.schema';
 import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data-mart.command';
 import { CreateReportCommand } from '../dto/domain/create-report.command';
+import { GetReportCommand } from '../dto/domain/get-report.command';
+import { UpdateReportCommand } from '../dto/domain/update-report.command';
 import { CreateGoogleSheetDocumentCommand } from '../dto/domain/google-sheets/create-google-sheet-document.command';
 import { ReportColumnConfig } from '../dto/schemas/report-column-config.schema';
 import { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
 import { CreateReportService } from '../use-cases/create-report.service';
+import { GetReportService } from '../use-cases/get-report.service';
+import { UpdateReportService } from '../use-cases/update-report.service';
 import { CreateGoogleSheetDocumentService } from '../use-cases/google-sheets/create-google-sheet-document.service';
 import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
 import { DataMartService } from '../services/data-mart.service';
@@ -23,6 +27,8 @@ import {
   McpGetDataMartReportsResponse,
   McpReportScheduleItem,
   McpReportsFacade,
+  McpUpdateReportRequest,
+  McpUpdateReportResult,
 } from './mcp-reports.facade';
 
 /**
@@ -43,8 +49,42 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
     private readonly createGoogleSheetDocumentService: CreateGoogleSheetDocumentService,
     private readonly dataMartService: DataMartService,
     private readonly accessDecisionService: AccessDecisionService,
-    private readonly outputControlsValidator: OutputControlsValidatorService
+    private readonly outputControlsValidator: OutputControlsValidatorService,
+    private readonly getReportService: GetReportService,
+    private readonly updateReportService: UpdateReportService
   ) {}
+
+  async updateReport(request: McpUpdateReportRequest): Promise<McpUpdateReportResult> {
+    // UpdateReportCommand carries the FULL report state and the service
+    // overwrites every output control, so merge the partial MCP input into the
+    // current report. Keeping the current destination id skips the destination
+    // re-auth path, and leaving ownerIds undefined keeps owners untouched.
+    const current = await this.getReportService.run(
+      new GetReportCommand(request.reportId, request.projectId, request.userId, request.roles)
+    );
+
+    await this.updateReportService.run(
+      new UpdateReportCommand(
+        request.reportId,
+        request.projectId,
+        request.userId,
+        request.roles,
+        request.name ?? current.title,
+        current.dataDestinationAccess.id,
+        current.destinationConfig,
+        undefined,
+        request.fields ? this.toColumnConfig(request.fields) : (current.columnConfig ?? null),
+        current.filterConfig ?? null,
+        current.sortConfig ?? null,
+        current.limitConfig ?? null,
+        current.aggregationConfig ?? null,
+        current.dateTruncConfig ?? null,
+        current.uniqueCountConfig
+      )
+    );
+
+    return { report_id: request.reportId, status: 'updated' };
+  }
 
   async addReport(request: McpAddReportRequest): Promise<McpAddReportResult> {
     const columnConfig = this.toColumnConfig(request.fields);

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
@@ -71,6 +71,22 @@ export interface McpAddReportResult {
   shared_with_requester?: boolean;
 }
 
+export interface McpUpdateReportRequest {
+  reportId: string;
+  /** Replacement column selection; `['*']` (or containing `'*'`) selects every field. Omit to keep the current selection. */
+  fields?: string[];
+  /** New report name. Omit to keep the current name. */
+  name?: string;
+  projectId: string;
+  userId: string;
+  roles: string[];
+}
+
+export interface McpUpdateReportResult {
+  report_id: string;
+  status: 'updated';
+}
+
 export interface McpReportsFacade {
   getDataMartReports(request: McpGetDataMartReportsRequest): Promise<McpGetDataMartReportsResponse>;
   /**
@@ -79,4 +95,11 @@ export interface McpReportsFacade {
    * rejected by the underlying document-creation service.
    */
   addReport(request: McpAddReportRequest): Promise<McpAddReportResult>;
+  /**
+   * Partially updates a report (name and/or column selection). The domain
+   * update command requires the full report state, so the facade loads the
+   * current report and merges the requested changes into it; everything else
+   * (destination, filters, sorting, owners, …) is preserved as-is.
+   */
+  updateReport(request: McpUpdateReportRequest): Promise<McpUpdateReportResult>;
 }

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
@@ -100,6 +100,8 @@ export interface McpReportsFacade {
    * update command requires the full report state, so the facade loads the
    * current report and merges the requested changes into it; everything else
    * (destination, filters, sorting, owners, …) is preserved as-is.
+   * At least one of `fields`/`name` must be provided — a call with neither is
+   * rejected by the implementation, independent of the tool-layer validation.
    */
   updateReport(request: McpUpdateReportRequest): Promise<McpUpdateReportResult>;
 }

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -117,6 +117,7 @@ describe('ListDataMartsTool', () => {
       'DeleteReportRunScheduleTool',
       'QueryDataMartTool',
       'AddReportTool',
+      'UpdateReportTool',
     ]);
     expect(registry.getTool('list_data_marts')).toBeDefined();
     expect(registry.getTool('query_data_mart')).toBeUndefined();

--- a/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
@@ -12,6 +12,7 @@ import { GetProjectContextTool } from './project-context.tool';
 import { QueryDataMartTool } from './query-data-mart.tool';
 import { SearchDataMartsTool } from './search-data-marts.tool';
 import { UpdateReportRunScheduleTool } from './update-report-run-schedule.tool';
+import { UpdateReportTool } from './update-report.tool';
 
 export const MCP_TOOL_PROVIDER_CLASSES: Array<Type<McpToolDefinition>> = [
   ListDataMartsTool,
@@ -26,6 +27,7 @@ export const MCP_TOOL_PROVIDER_CLASSES: Array<Type<McpToolDefinition>> = [
   DeleteReportRunScheduleTool,
   QueryDataMartTool,
   AddReportTool,
+  UpdateReportTool,
 ];
 
 export const MCP_TOOL_DEFINITIONS_PROVIDER: Provider = {

--- a/apps/backend/src/ee/mcp/tools/update-report.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/update-report.tool.spec.ts
@@ -1,0 +1,82 @@
+import type { McpReportsFacade } from '../../../data-marts/facades/mcp-reports.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import { McpToolRegistry } from './mcp-tool.registry';
+import { UpdateReportTool } from './update-report.tool';
+import { MCP_TOOL_PROVIDER_CLASSES } from './mcp-tool.providers';
+
+describe('UpdateReportTool', () => {
+  const context: McpAuthContext = {
+    clientId: 'mcp-client-1',
+    userId: 'user-1',
+    projectId: 'project-1',
+    email: 'ann@owox.com',
+    roles: ['editor'],
+    resource: 'https://mcp.owox.com/mcp',
+    scopes: ['mcp:write'],
+    authFlow: 'mcp',
+  };
+
+  it('updates a report and returns the minimal PRD shape', async () => {
+    const facade = {
+      updateReport: jest.fn().mockResolvedValue({ report_id: 'report-1', status: 'updated' }),
+    } as unknown as jest.Mocked<McpReportsFacade>;
+    const tool = new UpdateReportTool(facade);
+
+    const structuredContent = { report_id: 'report-1', status: 'updated' };
+
+    await expect(
+      tool.handler({ report_id: 'report-1', name: 'New name', fields: ['channel'] }, context)
+    ).resolves.toEqual({
+      structuredContent,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+    });
+    expect(facade.updateReport).toHaveBeenCalledWith({
+      reportId: 'report-1',
+      fields: ['channel'],
+      name: 'New name',
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['editor'],
+    });
+  });
+
+  it('requires at least one change and rejects malformed input', () => {
+    const tool = new UpdateReportTool({} as McpReportsFacade);
+
+    expect(() => tool.parseInput({ report_id: 'report-1' })).toThrow(
+      'Provide at least one of fields or name'
+    );
+    expect(() => tool.parseInput({ name: 'New name' })).toThrow();
+    expect(() => tool.parseInput({ report_id: 'report-1', fields: [] })).toThrow();
+    expect(() => tool.parseInput({ report_id: 'report-1', name: 'x', extra: true })).toThrow();
+  });
+
+  it('trims the new name and rejects whitespace-only names', () => {
+    const tool = new UpdateReportTool({} as McpReportsFacade);
+
+    expect(tool.parseInput({ report_id: 'report-1', name: '  New name  ' }).name).toBe('New name');
+    expect(() => tool.parseInput({ report_id: 'report-1', name: '   ' })).toThrow();
+  });
+
+  it('is registered as a write tool with the mcp:write scope', () => {
+    const registry = new McpToolRegistry([new UpdateReportTool({} as McpReportsFacade)]);
+
+    expect(new UpdateReportTool({} as McpReportsFacade)).toMatchObject({
+      name: 'update_report',
+      requiredScopes: ['mcp:write'],
+      annotations: {
+        title: 'Update Report',
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    });
+    expect(MCP_TOOL_PROVIDER_CLASSES.map(tool => tool.name)).toContain('UpdateReportTool');
+    expect(registry.getTool('update_report')).toBeDefined();
+  });
+});

--- a/apps/backend/src/ee/mcp/tools/update-report.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/update-report.tool.ts
@@ -18,8 +18,15 @@ const baseInputSchema = z
       .array(z.string().min(1))
       .min(1)
       .optional()
-      .describe("Replacement column selection, or ['*'] for every field; omit to keep current"),
-    name: z.string().trim().min(1).optional().describe('New report name; omit to keep current'),
+      .describe(
+        "Replacement column selection, e.g. ['field_name_1', 'field_name_2'], or ['*'] for every field; omit to keep current. At least one of fields/name is required."
+      ),
+    name: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe('New report name; omit to keep current. At least one of fields/name is required.'),
   })
   .strict();
 
@@ -36,11 +43,11 @@ type UpdateReportInput = z.infer<typeof inputSchema>;
 export class UpdateReportTool implements McpToolDefinition<UpdateReportInput> {
   readonly name = 'update_report';
   readonly description =
-    'Update an existing report: rename it and/or replace which data mart fields it exports. Anything not provided stays unchanged.';
+    'Update an existing report: rename it and/or replace which data mart fields it exports. Provide at least one of name or fields; anything not provided stays unchanged.';
   readonly zodSchema = baseInputSchema.shape;
   readonly outputSchema = {
-    report_id: z.string(),
-    status: z.literal('updated'),
+    report_id: z.string().describe('Id of the updated report'),
+    status: z.literal('updated').describe("Always 'updated' on success"),
   };
   readonly annotations = {
     title: 'Update Report',

--- a/apps/backend/src/ee/mcp/tools/update-report.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/update-report.tool.ts
@@ -1,0 +1,76 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import type { McpScope } from '@owox/idp-protocol';
+import {
+  MCP_REPORTS_FACADE,
+  type McpReportsFacade,
+} from '../../../data-marts/facades/mcp-reports.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import { jsonToolResult, type McpToolDefinition, type McpToolResult } from './mcp-tool.definition';
+
+// The raw shape (exposed to MCP clients) has both change fields optional; the
+// parsed schema additionally requires at least one of them, since an update
+// with nothing to change is a caller mistake worth surfacing.
+const baseInputSchema = z
+  .object({
+    report_id: z.string().min(1),
+    fields: z
+      .array(z.string().min(1))
+      .min(1)
+      .optional()
+      .describe("Replacement column selection, or ['*'] for every field; omit to keep current"),
+    name: z.string().trim().min(1).optional().describe('New report name; omit to keep current'),
+  })
+  .strict();
+
+const inputSchema = baseInputSchema.refine(
+  input => input.fields !== undefined || input.name !== undefined,
+  {
+    message: 'Provide at least one of fields or name to update',
+  }
+);
+
+type UpdateReportInput = z.infer<typeof inputSchema>;
+
+@Injectable()
+export class UpdateReportTool implements McpToolDefinition<UpdateReportInput> {
+  readonly name = 'update_report';
+  readonly description =
+    'Update an existing report: rename it and/or replace which data mart fields it exports. Anything not provided stays unchanged.';
+  readonly zodSchema = baseInputSchema.shape;
+  readonly outputSchema = {
+    report_id: z.string(),
+    status: z.literal('updated'),
+  };
+  readonly annotations = {
+    title: 'Update Report',
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: false,
+  };
+  readonly requiredScopes: McpScope[] = ['mcp:write'];
+
+  constructor(
+    @Inject(MCP_REPORTS_FACADE)
+    private readonly reports: McpReportsFacade
+  ) {}
+
+  parseInput(input: unknown): UpdateReportInput {
+    return inputSchema.parse(input);
+  }
+
+  async handler(input: UpdateReportInput, context: McpAuthContext): Promise<McpToolResult> {
+    const { report_id, fields, name } = this.parseInput(input);
+
+    const result = await this.reports.updateReport({
+      reportId: report_id,
+      fields,
+      name,
+      projectId: context.projectId,
+      userId: context.userId,
+      roles: context.roles,
+    });
+
+    return jsonToolResult({ report_id: result.report_id, status: result.status });
+  }
+}


### PR DESCRIPTION
## Summary

Adds an `update_report` MCP tool (PRD §15.10, task #6701): an AI assistant connected over MCP can partially update an existing report — rename it and/or replace which data mart fields it exports. Everything not mentioned stays exactly as it was.

Write tool (`mcp:write`, `readOnlyHint: false`), free per the PRD billing model.

> **Stacked on #1381** (`add_report`), which is stacked on #1377 (`get_data_mart_reports`) — all three extend the same `McpReportsFacade`. GitHub will retarget as the stack merges.

## What changed

- **New MCP tool** `UpdateReportTool` (`ee/mcp/tools/update-report.tool.ts`) — input `{ report_id, fields?, name? }` (at least one of `fields`/`name` required; `name` trimmed; `fields: ['*']` = all columns); output exactly the PRD shape `{ report_id, status: 'updated' }`.
- **`McpReportsFacade.updateReport`** — load-then-merge over the existing domain services; nothing reimplemented.

## Design notes

- **Load-then-merge is the core.** `UpdateReportCommand` carries the *full* report state and `UpdateReportService` overwrites every output control, while the PRD input is a partial PATCH. The facade therefore loads the current report via `GetReportService` (which also enforces SEE access and 404s cleanly before any mutation) and merges the requested changes into a full command.
- **What is preserved, and how:** destination id is passed unchanged (so the service skips its destination re-auth path), `destinationConfig`, `filterConfig`, `sortConfig`, `limitConfig`, `aggregationConfig`, `dateTruncConfig`, `uniqueCountConfig` are passed through from the current report, and `ownerIds` stays `undefined` — `UpdateReportService` only touches owners when `ownerIds !== undefined`, so ownership is untouched.
- **Authorization** is delegated to the domain services: `GetReportService` checks SEE, `UpdateReportService` checks mutate access, validates the column selection (`OutputControlsValidatorService`) and invalidates the report data cache when configs change. No external side effects here, so no pre-flight duplication is needed (unlike `add_report`).
- **Scope, consistent with the rest of the MCP track:** `slices`/`filters` and `description` are deferred (PRD filter vocabulary doesn't map 1:1 onto the domain filter model; `description` has no field on the Report entity). Schedules are not touched — they belong to the dedicated schedule tools (#1378), per the "MCP mirrors ODM" team decision.
- Input schema detail: the client-facing `zodSchema` exposes the raw shape (both change fields optional); the server-side parse additionally enforces "at least one of `fields`/`name`" with a clear message, since a no-op update is a caller mistake worth surfacing to the LLM.

## Testing

- Facade: rename-only preserves columns/filters/sort/limit/aggregations/destination/owners; fields-only preserves the title; `['*']` → no projection; name+fields together; get-failure short-circuits (no update call).
- Tool: happy path payload/output, at-least-one-change refine, strict input, name trimming + whitespace-only rejection, `mcp:write` scope + annotations, registry.
- `npx jest src/data-marts/facades src/ee/mcp/tools` — 60 tests, 12 suites green; `nest build` and eslint clean.

## Out of scope / follow-ups

- `delete_report` MCP tool — last one on this track.
- `slices`/`filters` input support — shared design with the future `query_data_mart` filter vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
