### PR TITLE
feat(mcp): add delete_report MCP tool

### DIFF
--- a/.changeset/6703-mcp-delete-report.md
+++ b/.changeset/6703-mcp-delete-report.md
@@ -1,0 +1,9 @@
+---
+"owox": minor
+---
+
+# Add a delete_report MCP tool
+
+AI assistants connected to OWOX over MCP can now delete a report on your behalf. The report stops running and disappears from the project; the underlying data mart, destination, and any already-exported documents are not affected.
+
+The tool is marked as destructive so assistants ask for your confirmation before calling it, and only reports you're allowed to manage can be deleted.

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
@@ -11,6 +11,7 @@ jest.mock('../use-cases/google-sheets/create-google-sheet-document.service', () 
 jest.mock('../services/data-mart.service', () => ({ DataMartService: jest.fn() }));
 jest.mock('../use-cases/get-report.service', () => ({ GetReportService: jest.fn() }));
 jest.mock('../use-cases/update-report.service', () => ({ UpdateReportService: jest.fn() }));
+jest.mock('../use-cases/delete-report.service', () => ({ DeleteReportService: jest.fn() }));
 jest.mock('../services/output-controls-validator.service', () => ({
   OutputControlsValidatorService: jest.fn(),
 }));
@@ -35,6 +36,7 @@ import type { DataMartService } from '../services/data-mart.service';
 import type { OutputControlsValidatorService } from '../services/output-controls-validator.service';
 import type { GetReportService } from '../use-cases/get-report.service';
 import type { UpdateReportService } from '../use-cases/update-report.service';
+import type { DeleteReportService } from '../use-cases/delete-report.service';
 import { McpReportsFacadeImpl } from './mcp-reports.facade.impl';
 
 function buildReport(overrides: {
@@ -118,6 +120,9 @@ function buildFacade(reports: ReportDto[], triggers: DataMartScheduledTrigger[])
   const updateReportService = {
     run: jest.fn(),
   } as unknown as jest.Mocked<UpdateReportService>;
+  const deleteReportService = {
+    run: jest.fn(),
+  } as unknown as jest.Mocked<DeleteReportService>;
   const facade = new McpReportsFacadeImpl(
     listReportsByDataMartService,
     scheduledTriggerService,
@@ -127,7 +132,8 @@ function buildFacade(reports: ReportDto[], triggers: DataMartScheduledTrigger[])
     accessDecisionService,
     outputControlsValidator,
     getReportService,
-    updateReportService
+    updateReportService,
+    deleteReportService
   );
   return {
     facade,
@@ -140,6 +146,7 @@ function buildFacade(reports: ReportDto[], triggers: DataMartScheduledTrigger[])
     outputControlsValidator,
     getReportService,
     updateReportService,
+    deleteReportService,
   };
 }
 
@@ -609,5 +616,38 @@ describe('McpReportsFacadeImpl.updateReport', () => {
       'not found'
     );
     expect(updateReportService.run).not.toHaveBeenCalled();
+  });
+});
+
+describe('McpReportsFacadeImpl.deleteReport', () => {
+  const deleteRequest = {
+    reportId: 'report-1',
+    projectId: 'project-1',
+    userId: 'user-1',
+    roles: ['editor'],
+  };
+
+  it('deletes the report and synthesizes the confirmation shape', async () => {
+    const { facade, deleteReportService } = buildFacade([], []);
+    deleteReportService.run.mockResolvedValue(undefined);
+
+    const result = await facade.deleteReport(deleteRequest);
+
+    expect(deleteReportService.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'report-1',
+        projectId: 'project-1',
+        userId: 'user-1',
+        roles: ['editor'],
+      })
+    );
+    expect(result).toEqual({ report_id: 'report-1', status: 'deleted' });
+  });
+
+  it('propagates a not-found error instead of reporting success', async () => {
+    const { facade, deleteReportService } = buildFacade([], []);
+    deleteReportService.run.mockRejectedValue(new Error('Report with ID report-1 not found'));
+
+    await expect(facade.deleteReport(deleteRequest)).rejects.toThrow('not found');
   });
 });

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
@@ -6,12 +6,14 @@ import { ScheduledTriggerType } from '../scheduled-trigger-types/enums/scheduled
 import { GoogleSheetsConfigType } from '../data-destination-types/google-sheets/schemas/google-sheets-config.schema';
 import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data-mart.command';
 import { CreateReportCommand } from '../dto/domain/create-report.command';
+import { DeleteReportCommand } from '../dto/domain/delete-report.command';
 import { GetReportCommand } from '../dto/domain/get-report.command';
 import { UpdateReportCommand } from '../dto/domain/update-report.command';
 import { CreateGoogleSheetDocumentCommand } from '../dto/domain/google-sheets/create-google-sheet-document.command';
 import { ReportColumnConfig } from '../dto/schemas/report-column-config.schema';
 import { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
 import { CreateReportService } from '../use-cases/create-report.service';
+import { DeleteReportService } from '../use-cases/delete-report.service';
 import { GetReportService } from '../use-cases/get-report.service';
 import { UpdateReportService } from '../use-cases/update-report.service';
 import { CreateGoogleSheetDocumentService } from '../use-cases/google-sheets/create-google-sheet-document.service';
@@ -23,6 +25,8 @@ import { toMcpDestinationType } from './mcp-destination-type';
 import {
   McpAddReportRequest,
   McpAddReportResult,
+  McpDeleteReportRequest,
+  McpDeleteReportResult,
   McpGetDataMartReportsRequest,
   McpGetDataMartReportsResponse,
   McpReportScheduleItem,
@@ -51,8 +55,19 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
     private readonly accessDecisionService: AccessDecisionService,
     private readonly outputControlsValidator: OutputControlsValidatorService,
     private readonly getReportService: GetReportService,
-    private readonly updateReportService: UpdateReportService
+    private readonly updateReportService: UpdateReportService,
+    private readonly deleteReportService: DeleteReportService
   ) {}
+
+  async deleteReport(request: McpDeleteReportRequest): Promise<McpDeleteReportResult> {
+    // The service enforces not-found and mutate-access itself and returns
+    // void, so the confirmation shape is synthesized here.
+    await this.deleteReportService.run(
+      new DeleteReportCommand(request.reportId, request.projectId, request.userId, request.roles)
+    );
+
+    return { report_id: request.reportId, status: 'deleted' };
+  }
 
   async updateReport(request: McpUpdateReportRequest): Promise<McpUpdateReportResult> {
     // The facade is a public interface, so the "at least one change" invariant

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
@@ -87,6 +87,18 @@ export interface McpUpdateReportResult {
   status: 'updated';
 }
 
+export interface McpDeleteReportRequest {
+  reportId: string;
+  projectId: string;
+  userId: string;
+  roles: string[];
+}
+
+export interface McpDeleteReportResult {
+  report_id: string;
+  status: 'deleted';
+}
+
 export interface McpReportsFacade {
   getDataMartReports(request: McpGetDataMartReportsRequest): Promise<McpGetDataMartReportsResponse>;
   /**
@@ -104,4 +116,11 @@ export interface McpReportsFacade {
    * rejected by the implementation, independent of the tool-layer validation.
    */
   updateReport(request: McpUpdateReportRequest): Promise<McpUpdateReportResult>;
+  /**
+   * Deletes a report. Deleting an unknown id is a not-found error, not a
+   * no-op. The domain service returns void, so the result status is
+   * synthesized; external cleanup (e.g. Google Sheets metadata) runs
+   * asynchronously via the report.deleted event and is not awaited.
+   */
+  deleteReport(request: McpDeleteReportRequest): Promise<McpDeleteReportResult>;
 }

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -118,6 +118,7 @@ describe('ListDataMartsTool', () => {
       'QueryDataMartTool',
       'AddReportTool',
       'UpdateReportTool',
+      'DeleteReportTool',
     ]);
     expect(registry.getTool('list_data_marts')).toBeDefined();
     expect(registry.getTool('query_data_mart')).toBeUndefined();

--- a/apps/backend/src/ee/mcp/tools/delete-report.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/delete-report.tool.spec.ts
@@ -49,6 +49,15 @@ describe('DeleteReportTool', () => {
     expect(() => tool.parseInput({ report_id: 'report-1', extra: true })).toThrow();
   });
 
+  it('propagates facade errors instead of swallowing them', async () => {
+    const facade = {
+      deleteReport: jest.fn().mockRejectedValue(new Error('Report with ID report-1 not found')),
+    } as unknown as jest.Mocked<McpReportsFacade>;
+    const tool = new DeleteReportTool(facade);
+
+    await expect(tool.handler({ report_id: 'report-1' }, context)).rejects.toThrow('not found');
+  });
+
   it('is registered as a destructive write tool with the mcp:write scope', () => {
     const registry = new McpToolRegistry([new DeleteReportTool({} as McpReportsFacade)]);
 

--- a/apps/backend/src/ee/mcp/tools/delete-report.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/delete-report.tool.spec.ts
@@ -1,0 +1,68 @@
+import type { McpReportsFacade } from '../../../data-marts/facades/mcp-reports.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import { McpToolRegistry } from './mcp-tool.registry';
+import { DeleteReportTool } from './delete-report.tool';
+import { MCP_TOOL_PROVIDER_CLASSES } from './mcp-tool.providers';
+
+describe('DeleteReportTool', () => {
+  const context: McpAuthContext = {
+    clientId: 'mcp-client-1',
+    userId: 'user-1',
+    projectId: 'project-1',
+    email: 'ann@owox.com',
+    roles: ['editor'],
+    resource: 'https://mcp.owox.com/mcp',
+    scopes: ['mcp:write'],
+    authFlow: 'mcp',
+  };
+
+  it('deletes a report and returns the confirmation shape', async () => {
+    const facade = {
+      deleteReport: jest.fn().mockResolvedValue({ report_id: 'report-1', status: 'deleted' }),
+    } as unknown as jest.Mocked<McpReportsFacade>;
+    const tool = new DeleteReportTool(facade);
+
+    const structuredContent = { report_id: 'report-1', status: 'deleted' };
+
+    await expect(tool.handler({ report_id: 'report-1' }, context)).resolves.toEqual({
+      structuredContent,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(structuredContent, null, 2),
+        },
+      ],
+    });
+    expect(facade.deleteReport).toHaveBeenCalledWith({
+      reportId: 'report-1',
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['editor'],
+    });
+  });
+
+  it('requires report_id and rejects unexpected input', () => {
+    const tool = new DeleteReportTool({} as McpReportsFacade);
+
+    expect(() => tool.parseInput({})).toThrow();
+    expect(() => tool.parseInput({ report_id: '' })).toThrow();
+    expect(() => tool.parseInput({ report_id: 'report-1', extra: true })).toThrow();
+  });
+
+  it('is registered as a destructive write tool with the mcp:write scope', () => {
+    const registry = new McpToolRegistry([new DeleteReportTool({} as McpReportsFacade)]);
+
+    expect(new DeleteReportTool({} as McpReportsFacade)).toMatchObject({
+      name: 'delete_report',
+      requiredScopes: ['mcp:write'],
+      annotations: {
+        title: 'Delete Report',
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: false,
+      },
+    });
+    expect(MCP_TOOL_PROVIDER_CLASSES.map(tool => tool.name)).toContain('DeleteReportTool');
+    expect(registry.getTool('delete_report')).toBeDefined();
+  });
+});

--- a/apps/backend/src/ee/mcp/tools/delete-report.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/delete-report.tool.ts
@@ -19,8 +19,8 @@ export class DeleteReportTool implements McpToolDefinition<DeleteReportInput> {
     'Permanently delete a report by id. The report stops running and disappears from the project; the underlying data mart, destination, and any already-exported documents are not affected. This cannot be undone.';
   readonly zodSchema = inputSchema.shape;
   readonly outputSchema = {
-    report_id: z.string(),
-    status: z.literal('deleted'),
+    report_id: z.string().describe('Id of the deleted report'),
+    status: z.literal('deleted').describe("Always 'deleted' on success"),
   };
   readonly annotations = {
     title: 'Delete Report',

--- a/apps/backend/src/ee/mcp/tools/delete-report.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/delete-report.tool.ts
@@ -1,0 +1,54 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import type { McpScope } from '@owox/idp-protocol';
+import {
+  MCP_REPORTS_FACADE,
+  type McpReportsFacade,
+} from '../../../data-marts/facades/mcp-reports.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import { jsonToolResult, type McpToolDefinition, type McpToolResult } from './mcp-tool.definition';
+
+const inputSchema = z.object({ report_id: z.string().min(1) }).strict();
+
+type DeleteReportInput = z.infer<typeof inputSchema>;
+
+@Injectable()
+export class DeleteReportTool implements McpToolDefinition<DeleteReportInput> {
+  readonly name = 'delete_report';
+  readonly description =
+    'Permanently delete a report by id. The report stops running and disappears from the project; the underlying data mart, destination, and any already-exported documents are not affected. This cannot be undone.';
+  readonly zodSchema = inputSchema.shape;
+  readonly outputSchema = {
+    report_id: z.string(),
+    status: z.literal('deleted'),
+  };
+  readonly annotations = {
+    title: 'Delete Report',
+    readOnlyHint: false,
+    destructiveHint: true,
+    openWorldHint: false,
+  };
+  readonly requiredScopes: McpScope[] = ['mcp:write'];
+
+  constructor(
+    @Inject(MCP_REPORTS_FACADE)
+    private readonly reports: McpReportsFacade
+  ) {}
+
+  parseInput(input: unknown): DeleteReportInput {
+    return inputSchema.parse(input);
+  }
+
+  async handler(input: DeleteReportInput, context: McpAuthContext): Promise<McpToolResult> {
+    const { report_id } = this.parseInput(input);
+
+    const result = await this.reports.deleteReport({
+      reportId: report_id,
+      projectId: context.projectId,
+      userId: context.userId,
+      roles: context.roles,
+    });
+
+    return jsonToolResult({ report_id: result.report_id, status: result.status });
+  }
+}

--- a/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
@@ -4,6 +4,7 @@ import { AddReportTool } from './add-report.tool';
 import { ListDataMartsTool } from './data-mart-catalog.tool';
 import { GetDataMartDetailsTool } from './data-mart-details.tool';
 import { DeleteReportRunScheduleTool } from './delete-report-run-schedule.tool';
+import { DeleteReportTool } from './delete-report.tool';
 import { GetDataMartReportsTool } from './get-data-mart-reports.tool';
 import { ListDestinationsTool } from './list-destinations.tool';
 import { ListReportRunSchedulesTool } from './list-report-run-schedules.tool';
@@ -28,6 +29,7 @@ export const MCP_TOOL_PROVIDER_CLASSES: Array<Type<McpToolDefinition>> = [
   QueryDataMartTool,
   AddReportTool,
   UpdateReportTool,
+  DeleteReportTool,
 ];
 
 export const MCP_TOOL_DEFINITIONS_PROVIDER: Provider = {

--- a/docs/getting-started/setup-guide/mcp.md
+++ b/docs/getting-started/setup-guide/mcp.md
@@ -112,10 +112,10 @@ To switch projects, disconnect, then reconnect and sign in again, choosing the p
 
 ## Available tools
 
-Once connected, the MCP server exposes twelve tools across two scopes:
+Once connected, the MCP server exposes fourteen tools across two scopes:
 
 - **`mcp:read`** (requested by every connection): discovery and query tools — `get_project_context`, `list_data_marts`, `get_relevant_data_marts_by_prompt`, `get_data_mart_details_by_id`, `query_data_mart`, `list_destinations`, `get_data_mart_reports`, `list_report_run_schedules`. `query_data_mart` additionally queries a data mart's data — it returns data rows, records each call in Run History, and costs [credits](../billing/consumption-units.md) per call.
-- **`mcp:write`** (requested alongside `mcp:read`): tools that create or change reports and schedules — `add_report`, `create_report_run_schedule`, `update_report_run_schedule`, `delete_report_run_schedule`. Your MCP client may ask you to confirm before it calls one of these.
+- **`mcp:write`** (requested alongside `mcp:read`): tools that create or change reports and schedules — `add_report`, `update_report`, `delete_report`, `create_report_run_schedule`, `update_report_run_schedule`, `delete_report_run_schedule`. Your MCP client may ask you to confirm before it calls one of these.
 
 ### `get_project_context`
 
@@ -361,6 +361,44 @@ Unlike every other tool, this one reaches outside OWOX: it creates a file in Goo
 | `placed_in_root`            | `true` if the configured Drive folder could not be used, so the sheet was created in the Drive root |
 | `shared_with_requester`     | `false` if the sheet could not be shared with you — opening the link may require requesting access  |
 
+### `update_report` (requires `mcp:write`)
+
+Updates an existing report: renames it and/or replaces which data mart fields it exports. Anything not provided stays unchanged — the destination, filters, sorting, owners, and schedules are preserved as-is.
+
+**Input:**
+
+| Field       | Description                                                                       |
+| ----------- | --------------------------------------------------------------------------------- |
+| `report_id` | Report to update (from `get_data_mart_reports`)                                   |
+| `fields`    | Optional. Replacement column selection, or `["*"]` for every field                |
+| `name`      | Optional. New report name                                                          |
+
+At least one of `fields` / `name` must be provided.
+
+**Returns:**
+
+| Field       | Description        |
+| ----------- | ------------------ |
+| `report_id` | Report identifier  |
+| `status`    | `updated`          |
+
+### `delete_report` (requires `mcp:write`)
+
+Permanently deletes a report. The report stops running and disappears from the project; the underlying data mart, destination, and any already-exported documents are not affected. This cannot be undone, so your assistant asks for confirmation before calling it.
+
+**Input:**
+
+| Field       | Description                                     |
+| ----------- | ----------------------------------------------- |
+| `report_id` | Report to delete (from `get_data_mart_reports`) |
+
+**Returns:**
+
+| Field       | Description        |
+| ----------- | ------------------ |
+| `report_id` | Report identifier  |
+| `status`    | `deleted`          |
+
 ## How to use it: example prompts
 
 Once the OWOX server is connected, just ask your assistant in plain language. You do not need to name the tools — the assistant calls them for you. Try prompts like:
@@ -376,10 +414,12 @@ Once the OWOX server is connected, just ask your assistant in plain language. Yo
 - "Which destinations can I send a report to?"
 - "What reports and schedules already exist for the Sales data mart?"
 - "Export the Ads data mart to a new Google Sheet called 'Weekly Ads Report'."
+- "Rename that report to 'Q3 Ads Report' and keep only the campaign and spend fields."
 - "Schedule that report to run every Monday at 9am New York time."
 - "Turn off the schedule you just created."
+- "Delete the old 'Test export' report from the Sales data mart."
 
-> **What these tools can and cannot do:** They let the assistant discover your project, your data marts (titles, descriptions, status, when each was last updated, and field-level metadata for a selected data mart), and the destinations available for reports — and, with `query_data_mart`, run a bounded query and read the resulting data rows and totals. With your confirmation, the assistant can also create a report to a Google Sheets destination (`add_report`) and create, update, or delete that report's run schedules (`create_report_run_schedule`, `update_report_run_schedule`, `delete_report_run_schedule`) — these are the only actions that create or change anything. They cannot run arbitrary SQL — only structured queries built from the fields, filters, and aggregations described above — and cannot change a data mart, destination, or project itself.
+> **What these tools can and cannot do:** They let the assistant discover your project, your data marts (titles, descriptions, status, when each was last updated, and field-level metadata for a selected data mart), and the destinations available for reports — and, with `query_data_mart`, run a bounded query and read the resulting data rows and totals. With your confirmation, the assistant can also create a report to a Google Sheets destination (`add_report`), rename a report or change which fields it exports (`update_report`), delete a report (`delete_report`), and create, update, or delete a report's run schedules (`create_report_run_schedule`, `update_report_run_schedule`, `delete_report_run_schedule`) — these are the only actions that create or change anything. They cannot run arbitrary SQL — only structured queries built from the fields, filters, and aggregations described above — and cannot change a data mart, destination, or project itself.
 >
 > **What is shared with your AI provider:** To answer your prompts, data-mart metadata (project and data-mart names, descriptions, status, fields, and your roles) is sent to the AI provider behind your client, such as Anthropic for Claude or OpenAI for ChatGPT. In addition, whenever the assistant runs `query_data_mart`, the **resulting data rows and totals are sent** to that provider so it can answer with the data — only data you are permitted to query. Connect OWOX only to clients your organization permits to receive this information.
 


### PR DESCRIPTION
## Summary

Adds a `delete_report` MCP tool (PRD §15.12, task #6703): an AI assistant connected over MCP can delete a report. The report stops running and disappears from the project; the underlying data mart, destination, and any already-exported documents are not affected.

Destructive write tool: `mcp:write` scope, `readOnlyHint: false`, **`destructiveHint: true`** — MCP clients prompt the user for confirmation before calling it (and the annotation matters for the Anthropic connector-directory review, PRD §19). Free per the PRD billing model.

**This completes the report/destination MCP tool track** (`list_destinations` #1376 ✅, `get_data_mart_reports` #1377, `add_report` #1381, `update_report` #1382, `delete_report` — this PR).

> **Stacked on #1382** (`update_report`); full chain #1377 ← #1381 ← #1382 ← this. GitHub will retarget as the stack merges.

## What changed

- **New MCP tool** `DeleteReportTool` (`ee/mcp/tools/delete-report.tool.ts`) — input `{ report_id }`, output exactly the PRD shape `{ report_id, status: 'deleted' }`.
- **`McpReportsFacade.deleteReport`** — a thin delegation to the existing `DeleteReportService`; nothing reimplemented.

## Design notes

- **Authorization and existence checks stay in the domain:** `DeleteReportService` 404s on an unknown/foreign-project id and enforces mutate access (`ReportAccessService.checkMutateAccess`) before deleting. The facade adds nothing on top — deletion has no pre-side-effect hazard (unlike `add_report`).
- **Deleting an unknown id is a not-found error, not a no-op** — an LLM retrying a failed call gets an honest signal instead of a fabricated success.
- **The confirmation is synthesized:** the service returns `void`, so the facade builds `{ report_id, status: 'deleted' }` after the call succeeds.
- **External cleanup is async by design:** the service emits `report.deleted` (e.g. Google Sheets developer-metadata cleanup) after the DB delete; the tool response does not wait for it.

## Testing

- Facade: command payload + synthesized confirmation; not-found propagation (no fabricated success).
- Tool: happy path, strict input (`report_id` required, extras rejected), `mcp:write` + `destructiveHint: true` annotations, registry.
- `npx jest src/data-marts/facades src/ee/mcp/tools` — 65 tests, 13 suites green; `nest build` and eslint clean.

## Out of scope / follow-ups

- `query_data_mart` and destination-connect tools — the remaining PRD §15 surface, tracked separately.
- `run_report` / report-run-schedule tools live in #1378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
