### PR TITLE
fix(mcp): add search data marts tool title

### DIFF
--- a/apps/backend/src/ee/mcp/tools/search-data-marts.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/search-data-marts.tool.spec.ts
@@ -111,6 +111,7 @@ describe('SearchDataMartsTool', () => {
         data_marts: expect.any(Object),
       }),
       annotations: {
+        title: 'Find Relevant Data Marts by Prompt',
         readOnlyHint: true,
         destructiveHint: false,
         openWorldHint: false,

--- a/apps/backend/src/ee/mcp/tools/search-data-marts.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/search-data-marts.tool.ts
@@ -41,6 +41,7 @@ export class SearchDataMartsTool implements McpToolDefinition<SearchDataMartsInp
     ),
   };
   readonly annotations = {
+    title: 'Find Relevant Data Marts by Prompt',
     readOnlyHint: true,
     destructiveHint: false,
     openWorldHint: false,


### PR DESCRIPTION
Summary: Add a user-facing title annotation to get_relevant_data_marts_by_prompt and cover it in SearchDataMartsTool spec. Tests: npm test -w @owox/backend -- ee/mcp/tools