### PR TITLE
fix(data-marts): suffix the display alias of aggregated columns

### DIFF
--- a/apps/backend/src/data-marts/data-storage-types/utils/report-data-headers.utils.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/utils/report-data-headers.utils.spec.ts
@@ -5,6 +5,7 @@ import { BigQueryFieldType } from '../bigquery/enums/bigquery-field-type.enum';
 import {
   ROW_COUNT_LABEL,
   UNIQUE_COUNT_LABEL,
+  aggregatedColumnAlias,
   aggregatedColumnLabel,
 } from '../../dto/schemas/aggregation-labels';
 import { BigQueryClauseRenderer } from '../bigquery/services/bigquery-clause-renderer';
@@ -218,6 +219,48 @@ describe('resolveReportDataHeaders', () => {
       );
       const aggregated = out.find(h => h.aggregateFunction === 'SUM');
       expect(aggregated?.storageFieldType).toBe(BigQueryFieldType.FLOAT);
+    });
+
+    it('an aliased aggregated column suffixes the DISPLAY alias too (sheet header keeps `| <FUNC>`)', () => {
+      // Regression: the sheet writer renders `alias || name`. If only the name gets the
+      // suffix, an aliased metric shows a bare `<alias>` and drops `| <FUNC>`; with two
+      // functions both columns would collide on the same header.
+      const aliased = [
+        new ReportDataHeader('channel', undefined, undefined, BigQueryFieldType.STRING),
+        new ReportDataHeader('revenue', 'Revenue', undefined, BigQueryFieldType.INTEGER),
+      ];
+      const out = resolveReportDataHeaders(
+        aliased,
+        {
+          columnFilter: ['channel', 'revenue'],
+          aggregationConfig: [
+            { column: 'revenue', function: 'SUM' },
+            { column: 'revenue', function: 'AVG' },
+          ],
+        },
+        BQ
+      );
+      const sum = out.find(h => h.name === aggregatedColumnLabel('revenue', 'SUM'));
+      const avg = out.find(h => h.name === aggregatedColumnLabel('revenue', 'AVG'));
+      expect(sum?.alias).toBe(aggregatedColumnAlias('Revenue', 'SUM'));
+      expect(avg?.alias).toBe(aggregatedColumnAlias('Revenue', 'AVG'));
+      // Distinct display labels — no header collision.
+      expect(sum?.alias).not.toBe(avg?.alias);
+      // A non-aggregated dimension keeps its plain (here: absent) alias.
+      expect(out.find(h => h.name === 'channel')?.alias).toBeUndefined();
+    });
+
+    it('an aggregated column with NO alias leaves the alias undefined (writer falls back to name)', () => {
+      const out = resolveReportDataHeaders(
+        native,
+        {
+          columnFilter: ['channel', 'revenue'],
+          aggregationConfig: [{ column: 'revenue', function: 'SUM' }],
+        },
+        BQ
+      );
+      const revenue = out.find(h => h.name === aggregatedColumnLabel('revenue', 'SUM'));
+      expect(revenue?.alias).toBeUndefined();
     });
 
     it('an unknown aggregated column (no native/blended header) yields undefined type, not a forced lie', () => {

--- a/apps/backend/src/data-marts/data-storage-types/utils/report-data-headers.utils.ts
+++ b/apps/backend/src/data-marts/data-storage-types/utils/report-data-headers.utils.ts
@@ -5,6 +5,7 @@ import { computeEffectiveType, integerTypeFor } from '../field-aggregation';
 import {
   ROW_COUNT_LABEL,
   UNIQUE_COUNT_LABEL,
+  aggregatedColumnAlias,
   aggregatedColumnLabel,
   aggregationFunctionsForColumn,
 } from '../../dto/schemas/aggregation-labels';
@@ -77,7 +78,10 @@ export function resolveReportDataHeaders(
         fn =>
           new ReportDataHeader(
             aggregatedColumnLabel(header.name, fn),
-            header.alias,
+            // The display alias must carry the function suffix too, else the sheet writer's
+            // `alias || name` renders a bare `<alias>` — dropping `| <FUNC>` and colliding
+            // when one aliased column carries several functions.
+            header.alias ? aggregatedColumnAlias(header.alias, fn) : undefined,
             header.description,
             // Type can only be derived when the base column type is known (it is for native
             // and blended headers; unknown SQL-override columns stay untyped).

--- a/apps/backend/src/data-marts/dto/schemas/aggregation-labels.spec.ts
+++ b/apps/backend/src/data-marts/dto/schemas/aggregation-labels.spec.ts
@@ -1,5 +1,6 @@
 import {
   ROW_COUNT_LABEL,
+  aggregatedColumnAlias,
   aggregatedColumnLabel,
   aggregateFunctionLabel,
 } from './aggregation-labels';
@@ -23,6 +24,16 @@ describe('aggregation-labels', () => {
   it('aggregatedColumnLabel sanitizes dots in a nested/struct column path', () => {
     expect(aggregatedColumnLabel('metrics.revenue', 'SUM')).toBe('metrics_revenue | SUM');
     expect(aggregatedColumnLabel('a.b.c', 'COUNT_DISTINCT')).toBe('a_b_c | COUNTUNIQUE');
+  });
+
+  it('aggregatedColumnAlias appends the same function suffix to a display alias', () => {
+    expect(aggregatedColumnAlias('Revenue', 'SUM')).toBe('Revenue | SUM');
+    expect(aggregatedColumnAlias('Revenue', 'AVG')).toBe('Revenue | AVG');
+  });
+
+  // Unlike the SQL-facing label, the alias is display-only: dots are legal and must survive.
+  it('aggregatedColumnAlias does NOT sanitize dots in the display alias', () => {
+    expect(aggregatedColumnAlias('Revenue v2.0', 'SUM')).toBe('Revenue v2.0 | SUM');
   });
 
   it('aggregateFunctionLabel maps every function to a human-readable Title Case label', () => {

--- a/apps/backend/src/data-marts/dto/schemas/aggregation-labels.ts
+++ b/apps/backend/src/data-marts/dto/schemas/aggregation-labels.ts
@@ -76,6 +76,17 @@ export function aggregatedColumnLabel(column: string, fn: ReportAggregateFunctio
 }
 
 /**
+ * Display label `<alias> | <TOKEN>` for an aggregated column that carries a user alias.
+ * Mirrors the suffix of `aggregatedColumnLabel` so an aliased metric reads consistently with a
+ * non-aliased one (whose display falls back to the `name`, i.e. `<column> | <TOKEN>`). The alias
+ * is NOT sanitized — it is a display string, not a SQL identifier, so it has no dot/legality
+ * constraint (and mangling it would corrupt the header the user chose).
+ */
+export function aggregatedColumnAlias(alias: string, fn: ReportAggregateFunction): string {
+  return `${alias} | ${REPORT_AGGREGATE_FUNCTION_TOKENS[fn]}`;
+}
+
+/**
  * The aggregation functions applied to a column, in rule order. A column may carry
  * more than one (each producing its own output column). The SQL renderer and the
  * header resolver MUST both expand a column through this same helper so the per-column


### PR DESCRIPTION
## Problem
When a report column has an **Alias**, aggregated headers written to Google Sheets
dropped the `| <FUNC>` suffix — the cell showed a bare `<Alias>` instead of
`<Alias> | SUM`. Two functions on one aliased column also collided on the same
header, which corrupts the `OWOX_COLUMNS` refresh diff.

## Root cause
`resolveReportDataHeaders` expands an aggregated column into one header per
function. It suffixed only the `name` (SQL alias / row-mapping key), leaving the
display `alias` untouched. The Google Sheets writer renders `alias || name`, so an
aliased metric fell through to the bare alias. Without an alias it fell back to the
suffixed `name`, which is why the bug only showed with aliases.

## Fix
- Add `aggregatedColumnAlias(alias, fn)` → `<alias> | <TOKEN>` (display-only, no dot
  sanitization — the alias is a label, not a SQL identifier).
- Apply it when expanding aggregated headers; empty/absent alias stays `undefined`
  so the writer keeps falling back to the suffixed `name`.

Centralised in the header resolver, so all consumers (Google Sheets, HTTP Data API
`title`, Looker `label`) are fixed at once.

## Tests
- New regression cases: aliased single/multi-function suffixing, no-collision, no-alias
  fallback, and dots-not-sanitized on the display alias.
- `aggregation-labels` + `report-data-headers.utils` specs — 29 passed;
  google-sheets writer + run-report — 162 passed; `nest build` clean.
