### PR TITLE
Stop advertising owox CLI as importable package

### DIFF
--- a/apps/owox/package.json
+++ b/apps/owox/package.json
@@ -62,7 +62,6 @@
     "athena"
   ],
   "license": "ELv2",
-  "main": "dist/index.js",
   "type": "module",
   "oclif": {
     "bin": "owox",
@@ -98,6 +97,5 @@
     "pretest": "oclif manifest",
     "test": "mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif readme && git add README.md"
-  },
-  "types": "dist/index.d.ts"
+  }
 }

--- a/apps/owox/src/index.ts
+++ b/apps/owox/src/index.ts
@@ -1,1 +1,0 @@
-export { run } from '@oclif/core';


### PR DESCRIPTION
## Summary

- remove the `main` and `types` package entrypoints from `owox`
- delete the unused `src/index.ts` re-export that made `owox` look importable
- keep the CLI `bin` entrypoint and publish allowlist unchanged

## Why

`owox` is an app-level CLI package, not a supported library API. It should be used through the `owox` binary, not through `import "owox"`.

The package previously advertised a TypeScript entrypoint via `types: "dist/index.d.ts"`, but did not publish declaration files. Instead of publishing declarations for an accidental import surface, this change removes the import contract entirely.

## Validation

- confirmed `bin.owox` still points to `./bin/run.js`
- confirmed `main` and `types` are no longer present in `apps/owox/package.json`
- `npm --cache /tmp/owox-npm-cache pack --dry-run --ignore-scripts --json ./apps/owox`
- `git diff --check HEAD~1..HEAD`