### PR TITLE
feat(web): move report quick actions to the title column

### DIFF
--- a/.changeset/6723-report-table-buttons-improvements.md
+++ b/.changeset/6723-report-table-buttons-improvements.md
@@ -1,0 +1,12 @@
+---
+'owox': minor
+---
+
+# Improved the reports table UX by making frequently used actions easier to discover and access
+
+- Moved **Open document** and **Preview SQL** actions next to the report title.
+- Kept the **More actions** menu in the actions column.
+- Added tooltips for truncated report titles.
+- Extracted reusable report action components for better consistency across report tables.
+
+This update improves discoverability and provides faster access to common report actions while keeping the table layout clean and consistent.

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
@@ -123,7 +123,7 @@ export function GeneratedSqlViewer({
                 type='button'
                 variant='ghost'
                 className={cn(
-                  'dm-card-table-body-row-actionbtn w-6 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100',
+                  'dm-card-table-body-row-actionbtn !h-6 !w-6 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100',
                   className
                 )}
                 aria-label={ariaLabel}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { cn } from '@owox/ui/lib/utils';
 import { Editor } from '@monaco-editor/react';
 import { useTheme } from 'next-themes';
 import { Copy, FileCode2, Loader2 } from 'lucide-react';
@@ -40,6 +41,7 @@ interface GeneratedSqlViewerProps {
    * action icon variant.
    */
   reportTitle?: string;
+  className?: string;
 }
 
 /**
@@ -50,6 +52,7 @@ export function GeneratedSqlViewer({
   dataMartId,
   variant = 'action-icon',
   reportTitle,
+  className,
 }: GeneratedSqlViewerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [sql, setSql] = useState<string | null>(null);
@@ -119,7 +122,10 @@ export function GeneratedSqlViewer({
               <Button
                 type='button'
                 variant='ghost'
-                className='dm-card-table-body-row-actionbtn cursor-pointer opacity-0 transition-opacity group-hover:opacity-100'
+                className={cn(
+                  'dm-card-table-body-row-actionbtn w-6 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100',
+                  className
+                )}
                 aria-label={ariaLabel}
                 onClick={e => {
                   e.stopPropagation();

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailActionsCell.tsx
@@ -8,11 +8,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@owox/ui/components/dropdown-menu';
-import { TooltipProvider } from '@owox/ui/components/tooltip';
 import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
-import { isGeneratedSqlSupported, useReport, ReportStatusEnum } from '../../../shared';
-import { GeneratedSqlViewer } from '../../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
+import { useReport, ReportStatusEnum } from '../../../shared';
 
 interface EmailActionsCellProps {
   row: { original: DataMartReport };
@@ -29,18 +27,20 @@ export function EmailActionsCell({
 }: EmailActionsCellProps) {
   const canRun = row.original.canRun;
   const canEditConfig = row.original.canEditConfig;
+
   const [isRunning, setIsRunning] = useState(
     row.original.lastRunStatus === ReportStatusEnum.RUNNING
   );
   const [menuOpen, setMenuOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
   const { deleteReport, fetchReportsByDataMartId, runReport } = useReport();
+
+  const actionsMenuId = `actions-menu-${row.original.id}`;
 
   useEffect(() => {
     setIsRunning(row.original.lastRunStatus === ReportStatusEnum.RUNNING);
   }, [row.original.lastRunStatus]);
-
-  const actionsMenuId = `actions-menu-${row.original.id}`;
 
   const handleDelete = useCallback(async () => {
     if (!canEditConfig) return;
@@ -90,106 +90,88 @@ export function EmailActionsCell({
   }, [canRun, onRunSuccess, runReport, row.original.id]);
 
   return (
-    <TooltipProvider>
-      <div
-        className='flex justify-end gap-1'
-        onClick={e => {
-          e.stopPropagation();
+    <div
+      className='flex justify-end'
+      onClick={e => {
+        e.stopPropagation();
+      }}
+    >
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant='ghost'
+            className={`dm-card-table-body-row-actionbtn opacity-0 transition-opacity ${
+              menuOpen ? 'opacity-100' : 'group-hover:opacity-100'
+            }`}
+            aria-label={`Actions for report: ${row.original.title}`}
+            aria-haspopup='true'
+            aria-expanded={menuOpen}
+            aria-controls={actionsMenuId}
+          >
+            <MoreHorizontal className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
+          </Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent id={actionsMenuId} align='end' role='menu'>
+          <DropdownMenuItem
+            disabled={isRunning || !canRun}
+            onClick={e => {
+              e.stopPropagation();
+              void handleRun();
+            }}
+            role='menuitem'
+          >
+            <Play className='text-foreground h-4 w-4' aria-hidden='true' />
+            {isRunning ? 'Running report...' : 'Run report'}
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            disabled={!canEditConfig}
+            onClick={e => {
+              e.stopPropagation();
+              handleEdit();
+            }}
+            role='menuitem'
+          >
+            <Pencil className='text-foreground h-4 w-4' aria-hidden='true' />
+            Edit report
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuItem
+            disabled={!canEditConfig}
+            onClick={e => {
+              e.stopPropagation();
+              handleDeleteClick();
+            }}
+            role='menuitem'
+            aria-label={`Delete report: ${row.original.title}`}
+          >
+            <Trash2 className='h-4 w-4 text-red-600' aria-hidden='true' />
+            <span className='text-red-600'>Delete report</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ConfirmationDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        title='Delete Report'
+        description={
+          <p className='break-words'>
+            Are you sure you want to delete "
+            <span className='font-semibold [overflow-wrap:anywhere]'>{row.original.title}</span>
+            "? This action cannot be undone.
+          </p>
+        }
+        confirmLabel='Delete'
+        cancelLabel='Cancel'
+        onConfirm={() => {
+          void handleDelete();
         }}
-      >
-        {/* View SQL */}
-        {isGeneratedSqlSupported(
-          row.original.dataMart.definitionType,
-          row.original.dataMart.storage.type
-        ) && (
-          <GeneratedSqlViewer
-            reportId={row.original.id}
-            dataMartId={row.original.dataMart.id}
-            reportTitle={row.original.title}
-          />
-        )}
-
-        {/* More actions */}
-        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant='ghost'
-              className={`dm-card-table-body-row-actionbtn opacity-0 transition-opacity ${
-                menuOpen ? 'opacity-100' : 'group-hover:opacity-100'
-              }`}
-              aria-label={`Actions for report: ${row.original.title}`}
-              aria-haspopup='true'
-              aria-expanded={menuOpen}
-              aria-controls={actionsMenuId}
-            >
-              <MoreHorizontal
-                className='dm-card-table-body-row-actionbtn-icon'
-                aria-hidden='true'
-              />
-            </Button>
-          </DropdownMenuTrigger>
-
-          <DropdownMenuContent id={actionsMenuId} align='end' role='menu'>
-            <DropdownMenuItem
-              disabled={isRunning || !canRun}
-              onClick={e => {
-                e.stopPropagation();
-                void handleRun();
-              }}
-              role='menuitem'
-            >
-              <Play className='text-foreground h-4 w-4' aria-hidden='true' />
-              {isRunning ? 'Running report...' : 'Run report'}
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              disabled={!canEditConfig}
-              onClick={e => {
-                e.stopPropagation();
-                handleEdit();
-              }}
-              role='menuitem'
-            >
-              <Pencil className='text-foreground h-4 w-4' aria-hidden='true' />
-              Edit report
-            </DropdownMenuItem>
-
-            <DropdownMenuSeparator />
-
-            <DropdownMenuItem
-              disabled={!canEditConfig}
-              onClick={e => {
-                e.stopPropagation();
-                handleDeleteClick();
-              }}
-              role='menuitem'
-              aria-label={`Delete report: ${row.original.title}`}
-            >
-              <Trash2 className='h-4 w-4 text-red-600' aria-hidden='true' />
-              <span className='text-red-600'>Delete report</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        <ConfirmationDialog
-          open={isDeleteDialogOpen}
-          onOpenChange={setIsDeleteDialogOpen}
-          title='Delete Report'
-          description={
-            <p className='break-words'>
-              Are you sure you want to delete "
-              <span className='font-semibold [overflow-wrap:anywhere]'>{row.original.title}</span>"?
-              This action cannot be undone.
-            </p>
-          }
-          confirmLabel='Delete'
-          cancelLabel='Cancel'
-          onConfirm={() => {
-            void handleDelete();
-          }}
-          variant='destructive'
-        />
-      </div>
-    </TooltipProvider>
+        variant='destructive'
+      />
+    </div>
   );
 }

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailReportTitleCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailReportTitleCell.tsx
@@ -1,0 +1,21 @@
+import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
+import {
+  ReportGeneratedSqlAction,
+  ReportTitleCell,
+  reportTitleCellQuickActionClassName,
+} from '../../../shared/components';
+
+interface EmailReportTitleCellProps {
+  report: DataMartReport;
+}
+
+export function EmailReportTitleCell({ report }: EmailReportTitleCellProps) {
+  return (
+    <ReportTitleCell
+      title={report.title}
+      actions={
+        <ReportGeneratedSqlAction report={report} className={reportTitleCellQuickActionClassName} />
+      }
+    />
+  );
+}

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/columns/columns.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/columns/columns.tsx
@@ -9,6 +9,7 @@ import { ReportColumnKey } from './columnKeys';
 import { ReportColumnLabels } from './columnLabels';
 import { UserReference } from '../../../../../../../shared/components/UserReference';
 import { UserAvatarGroup } from '../../../../../../../shared/components/UserAvatarGroup';
+import { EmailReportTitleCell } from '../EmailReportTitleCell';
 
 interface EmailTableColumnsProps {
   onDeleteSuccess?: () => void;
@@ -21,7 +22,7 @@ export const getEmailColumns = ({
 }: EmailTableColumnsProps = {}): ColumnDef<DataMartReport>[] => [
   {
     id: 'quickRun',
-    size: 50,
+    size: 40,
     enableResizing: false,
     enableSorting: false,
     enableHiding: false,
@@ -38,7 +39,7 @@ export const getEmailColumns = ({
     header: ({ column }) => (
       <SortableHeader column={column}>{ReportColumnLabels[ReportColumnKey.TITLE]}</SortableHeader>
     ),
-    cell: ({ row }) => row.original.title,
+    cell: ({ row }) => <EmailReportTitleCell report={row.original} />,
   },
   {
     accessorKey: ReportColumnKey.LAST_RUN_DATE,
@@ -125,7 +126,7 @@ export const getEmailColumns = ({
   },
   {
     id: 'actions',
-    size: 130,
+    size: 50,
     enableResizing: false,
     header: ({ table }) => <ToggleColumnsHeader table={table} />,
     cell: ({ row }) => (

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/index.ts
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/index.ts
@@ -1,3 +1,4 @@
 export { EmailReportsTable } from './EmailReportsTable';
 export { getEmailColumns } from './columns';
 export { EmailActionsCell } from './EmailActionsCell';
+export { EmailReportTitleCell } from './EmailReportTitleCell';

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsActionsCell.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import { MoreHorizontal, Pencil, FileText, Trash2, Play } from 'lucide-react';
+import { MoreHorizontal, Pencil, Trash2, Play } from 'lucide-react';
 import { Button } from '@owox/ui/components/button';
 import {
   DropdownMenu,
@@ -8,20 +8,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@owox/ui/components/dropdown-menu';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@owox/ui/components/tooltip';
 import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
-import { getGoogleSheetTabUrl, isGeneratedSqlSupported } from '../../../shared';
-import type {
-  DataMartReport,
-  GoogleSheetsDestinationConfig,
-} from '../../../shared/model/types/data-mart-report';
+import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
 import { useReport, ReportStatusEnum } from '../../../shared';
-import { GeneratedSqlViewer } from '../../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
 
 interface GoogleSheetsActionsCellProps {
   row: { original: DataMartReport };
@@ -102,124 +91,87 @@ export function GoogleSheetsActionsCell({
   }, [canEditConfig]);
 
   return (
-    <TooltipProvider>
-      <div
-        className='flex justify-end gap-1'
-        onClick={e => {
-          e.stopPropagation();
+    <div
+      className='flex justify-end'
+      onClick={e => {
+        e.stopPropagation();
+      }}
+    >
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant='ghost'
+            className={`dm-card-table-body-row-actionbtn opacity-0 transition-opacity ${
+              menuOpen ? 'opacity-100' : 'group-hover:opacity-100'
+            }`}
+            aria-label={`Actions for report: ${row.original.title}`}
+            aria-haspopup='true'
+            aria-expanded={menuOpen}
+            aria-controls={actionsMenuId}
+          >
+            <MoreHorizontal className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent id={actionsMenuId} align='end' role='menu'>
+          <DropdownMenuItem
+            disabled={isRunning || !canRun}
+            onClick={e => {
+              e.stopPropagation();
+              void handleRun();
+            }}
+            role='menuitem'
+          >
+            <Play className='text-foreground h-4 w-4' aria-hidden='true' />
+            {isRunning ? 'Running report...' : 'Run report'}
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            disabled={!canEditConfig}
+            onClick={e => {
+              e.stopPropagation();
+              handleEdit();
+            }}
+            role='menuitem'
+          >
+            <Pencil className='text-foreground h-4 w-4' aria-hidden='true' />
+            Edit report
+          </DropdownMenuItem>
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuItem
+            disabled={!canEditConfig}
+            onClick={e => {
+              e.stopPropagation();
+              handleDeleteClick();
+            }}
+            role='menuitem'
+            aria-label={`Delete report: ${row.original.title}`}
+          >
+            <Trash2 className='h-4 w-4 text-red-600' aria-hidden='true' />
+            <span className='text-red-600'>Delete report</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ConfirmationDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        title='Delete Report'
+        description={
+          <p className='break-words'>
+            Are you sure you want to delete "
+            <span className='font-semibold [overflow-wrap:anywhere]'>{row.original.title}</span>
+            "? This action cannot be undone.
+          </p>
+        }
+        confirmLabel='Delete'
+        cancelLabel='Cancel'
+        onConfirm={() => {
+          void handleDelete();
         }}
-      >
-        {/* Open doc */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <a
-              href={getGoogleSheetTabUrl(
-                (row.original.destinationConfig as GoogleSheetsDestinationConfig).spreadsheetId,
-                (row.original.destinationConfig as GoogleSheetsDestinationConfig).sheetId
-              )}
-              className='dm-card-table-body-row-actionbtn inline-flex items-center justify-center rounded-md px-3 opacity-0 transition-opacity group-hover:opacity-100'
-              target='_blank'
-              rel='noopener noreferrer'
-              onClick={e => {
-                e.stopPropagation();
-              }}
-            >
-              <FileText className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
-            </a>
-          </TooltipTrigger>
-          <TooltipContent id={`run-report-${row.original.id}`} side='bottom' role='tooltip'>
-            Open document
-          </TooltipContent>
-        </Tooltip>
-
-        {/* View SQL */}
-        {isGeneratedSqlSupported(
-          row.original.dataMart.definitionType,
-          row.original.dataMart.storage.type
-        ) && (
-          <GeneratedSqlViewer
-            reportId={row.original.id}
-            dataMartId={row.original.dataMart.id}
-            reportTitle={row.original.title}
-          />
-        )}
-
-        {/* More actions */}
-        <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant='ghost'
-              className={`dm-card-table-body-row-actionbtn opacity-0 transition-opacity ${menuOpen ? 'opacity-100' : 'group-hover:opacity-100'}`}
-              aria-label={`Actions for report: ${row.original.title}`}
-              aria-haspopup='true'
-              aria-expanded={menuOpen}
-              aria-controls={actionsMenuId}
-            >
-              <MoreHorizontal
-                className='dm-card-table-body-row-actionbtn-icon'
-                aria-hidden='true'
-              />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent id={actionsMenuId} align='end' role='menu'>
-            <DropdownMenuItem
-              disabled={isRunning || !canRun}
-              onClick={e => {
-                e.stopPropagation();
-                void handleRun();
-              }}
-              role='menuitem'
-            >
-              <Play className='text-foreground h-4 w-4' aria-hidden='true' />
-              {isRunning ? 'Running report...' : 'Run report'}
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              disabled={!canEditConfig}
-              onClick={e => {
-                e.stopPropagation();
-                handleEdit();
-              }}
-              role='menuitem'
-            >
-              <Pencil className='text-foreground h-4 w-4' aria-hidden='true' />
-              Edit report
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              disabled={!canEditConfig}
-              onClick={e => {
-                e.stopPropagation();
-                handleDeleteClick();
-              }}
-              role='menuitem'
-              aria-label={`Delete report: ${row.original.title}`}
-            >
-              <Trash2 className='h-4 w-4 text-red-600' aria-hidden='true' />
-              <span className='text-red-600'>Delete report</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        <ConfirmationDialog
-          open={isDeleteDialogOpen}
-          onOpenChange={setIsDeleteDialogOpen}
-          title='Delete Report'
-          description={
-            <p className='break-words'>
-              Are you sure you want to delete "
-              <span className='font-semibold [overflow-wrap:anywhere]'>{row.original.title}</span>"?
-              This action cannot be undone.
-            </p>
-          }
-          confirmLabel='Delete'
-          cancelLabel='Cancel'
-          onConfirm={() => {
-            void handleDelete();
-          }}
-          variant='destructive'
-        />
-      </div>
-    </TooltipProvider>
+        variant='destructive'
+      />
+    </div>
   );
 }

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsReportTitleCell.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsReportTitleCell.tsx
@@ -1,0 +1,31 @@
+import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
+import {
+  ReportGeneratedSqlAction,
+  ReportOpenDocumentAction,
+  ReportTitleCell,
+  reportTitleCellQuickActionClassName,
+} from '../../../shared/components';
+
+interface GoogleSheetsReportTitleCellProps {
+  report: DataMartReport;
+}
+
+export function GoogleSheetsReportTitleCell({ report }: GoogleSheetsReportTitleCellProps) {
+  return (
+    <ReportTitleCell
+      title={report.title}
+      actions={
+        <>
+          <ReportOpenDocumentAction
+            report={report}
+            className={reportTitleCellQuickActionClassName}
+          />
+          <ReportGeneratedSqlAction
+            report={report}
+            className={reportTitleCellQuickActionClassName}
+          />
+        </>
+      }
+    />
+  );
+}

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/columns/columns.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/columns/columns.tsx
@@ -9,6 +9,7 @@ import { ReportColumnKey } from './columnKeys';
 import { ReportColumnLabels } from './columnLabels';
 import { UserReference } from '../../../../../../../shared/components/UserReference';
 import { UserAvatarGroup } from '../../../../../../../shared/components/UserAvatarGroup/UserAvatarGroup';
+import { GoogleSheetsReportTitleCell } from '../GoogleSheetsReportTitleCell';
 
 interface GoogleSheetsTableColumnsProps {
   onDeleteSuccess?: () => void;
@@ -21,7 +22,7 @@ export const getGoogleSheetsColumns = ({
 }: GoogleSheetsTableColumnsProps = {}): ColumnDef<DataMartReport>[] => [
   {
     id: 'quickRun',
-    size: 50,
+    size: 40,
     enableResizing: false,
     enableSorting: false,
     enableHiding: false,
@@ -38,7 +39,7 @@ export const getGoogleSheetsColumns = ({
     header: ({ column }) => (
       <SortableHeader column={column}>{ReportColumnLabels[ReportColumnKey.TITLE]}</SortableHeader>
     ),
-    cell: ({ row }) => row.original.title,
+    cell: ({ row }) => <GoogleSheetsReportTitleCell report={row.original} />,
   },
   {
     accessorKey: ReportColumnKey.LAST_RUN_DATE,
@@ -119,7 +120,7 @@ export const getGoogleSheetsColumns = ({
   },
   {
     id: 'actions',
-    size: 130,
+    size: 50,
     enableResizing: false,
     header: ({ table }) => <ToggleColumnsHeader table={table} />,
     cell: ({ row }) => (

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/index.ts
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/index.ts
@@ -1,3 +1,4 @@
 export { GoogleSheetsReportsTable } from './GoogleSheetsReportsTable';
 export { getGoogleSheetsColumns } from './columns';
 export { GoogleSheetsActionsCell } from './GoogleSheetsActionsCell';
+export { GoogleSheetsReportTitleCell } from './GoogleSheetsReportTitleCell';

--- a/apps/web/src/features/data-marts/reports/shared/components/ReportGeneratedSqlAction.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/ReportGeneratedSqlAction.tsx
@@ -1,0 +1,23 @@
+import { GeneratedSqlViewer } from '../../../edit/components/ReportColumnPicker/GeneratedSqlViewer';
+import { isGeneratedSqlSupported } from '../utils';
+import type { DataMartReport } from '../model/types/data-mart-report';
+
+interface ReportGeneratedSqlActionProps {
+  report: DataMartReport;
+  className?: string;
+}
+
+export function ReportGeneratedSqlAction({ report, className }: ReportGeneratedSqlActionProps) {
+  if (!isGeneratedSqlSupported(report.dataMart.definitionType, report.dataMart.storage.type)) {
+    return null;
+  }
+
+  return (
+    <GeneratedSqlViewer
+      reportId={report.id}
+      dataMartId={report.dataMart.id}
+      reportTitle={report.title}
+      className={className}
+    />
+  );
+}

--- a/apps/web/src/features/data-marts/reports/shared/components/ReportOpenDocumentAction.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/ReportOpenDocumentAction.tsx
@@ -7,10 +7,11 @@ import {
   TooltipTrigger,
 } from '@owox/ui/components/tooltip';
 
+import { DataDestinationType } from '../../../../data-destination/shared';
 import { getGoogleSheetTabUrl } from '../utils';
-import type {
-  DataMartReport,
-  GoogleSheetsDestinationConfig,
+import {
+  isGoogleSheetsDestinationConfig,
+  type DataMartReport,
 } from '../model/types/data-mart-report';
 
 interface ReportOpenDocumentActionProps {
@@ -19,16 +20,28 @@ interface ReportOpenDocumentActionProps {
 }
 
 export function ReportOpenDocumentAction({ report, className }: ReportOpenDocumentActionProps) {
-  const destinationConfig = report.destinationConfig as GoogleSheetsDestinationConfig;
+  if (report.dataDestination.type !== DataDestinationType.GOOGLE_SHEETS) {
+    return null;
+  }
+
+  if (!isGoogleSheetsDestinationConfig(report.destinationConfig)) {
+    return null;
+  }
+
+  const { spreadsheetId, sheetId } = report.destinationConfig;
+
+  if (!spreadsheetId || !sheetId) {
+    return null;
+  }
 
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
           <a
-            href={getGoogleSheetTabUrl(destinationConfig.spreadsheetId, destinationConfig.sheetId)}
+            href={getGoogleSheetTabUrl(spreadsheetId, sheetId)}
             className={cn(
-              'dm-card-table-body-row-actionbtn inline-flex h-6 w-6 items-center justify-center rounded-md',
+              'dm-card-table-body-row-actionbtn inline-flex !h-6 !w-6 items-center justify-center rounded-md',
               className
             )}
             aria-label={`Open document: ${report.title}`}

--- a/apps/web/src/features/data-marts/reports/shared/components/ReportOpenDocumentAction.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/ReportOpenDocumentAction.tsx
@@ -1,0 +1,51 @@
+import { FileText } from 'lucide-react';
+import { cn } from '@owox/ui/lib/utils';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@owox/ui/components/tooltip';
+
+import { getGoogleSheetTabUrl } from '../utils';
+import type {
+  DataMartReport,
+  GoogleSheetsDestinationConfig,
+} from '../model/types/data-mart-report';
+
+interface ReportOpenDocumentActionProps {
+  report: DataMartReport;
+  className?: string;
+}
+
+export function ReportOpenDocumentAction({ report, className }: ReportOpenDocumentActionProps) {
+  const destinationConfig = report.destinationConfig as GoogleSheetsDestinationConfig;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <a
+            href={getGoogleSheetTabUrl(destinationConfig.spreadsheetId, destinationConfig.sheetId)}
+            className={cn(
+              'dm-card-table-body-row-actionbtn inline-flex h-6 w-6 items-center justify-center rounded-md',
+              className
+            )}
+            aria-label={`Open document: ${report.title}`}
+            target='_blank'
+            rel='noopener noreferrer'
+            onClick={e => {
+              e.stopPropagation();
+            }}
+          >
+            <FileText className='dm-card-table-body-row-actionbtn-icon' aria-hidden='true' />
+          </a>
+        </TooltipTrigger>
+
+        <TooltipContent side='bottom' role='tooltip'>
+          Open document
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/features/data-marts/reports/shared/components/ReportQuickRunCell.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/ReportQuickRunCell.tsx
@@ -120,14 +120,14 @@ export function ReportQuickRunCell({ report, onRunSuccess }: ReportQuickRunCellP
             <Button
               onClick={handleRun}
               variant='ghost'
-              className='text-muted-foreground hover:text-primary h-8 w-8 p-0 opacity-60 transition-all duration-200 hover:opacity-100 disabled:opacity-30'
+              className='dm-card-table-body-row-actionbtn cursor-pointer transition-all disabled:opacity-30'
               disabled={!canRun || isActive}
               aria-label={isActive ? tooltipText : `Run report: ${report.title}`}
             >
               {isPending ? (
                 <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
               ) : (
-                <Play className='h-4 w-4' aria-hidden='true' />
+                <Play className='text-muted-foreground h-4 w-4' aria-hidden='true' />
               )}
             </Button>
           </TooltipTrigger>

--- a/apps/web/src/features/data-marts/reports/shared/components/ReportTitleCell.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/ReportTitleCell.tsx
@@ -7,7 +7,7 @@ import {
 } from '@owox/ui/components/tooltip';
 
 export const reportTitleCellQuickActionClassName =
-  'pointer-events-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100';
+  'pointer-events-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100';
 
 interface ReportTitleCellProps {
   title: string;

--- a/apps/web/src/features/data-marts/reports/shared/components/ReportTitleCell.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/ReportTitleCell.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@owox/ui/components/tooltip';
+
+export const reportTitleCellQuickActionClassName =
+  'pointer-events-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100';
+
+interface ReportTitleCellProps {
+  title: string;
+  actions?: ReactNode;
+}
+
+export function ReportTitleCell({ title, actions }: ReportTitleCellProps) {
+  return (
+    <div className='flex items-center gap-2'>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className='min-w-0 truncate'>{title}</span>
+          </TooltipTrigger>
+
+          <TooltipContent side='bottom'>{title}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+
+      {actions && (
+        <div
+          className='flex flex-shrink-0 items-center'
+          onClick={e => {
+            e.stopPropagation();
+          }}
+        >
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/reports/shared/components/__tests__/ReportOpenDocumentAction.test.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/__tests__/ReportOpenDocumentAction.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DestinationTypeConfigEnum } from '../..';
+import type {
+  DataMartReport,
+  GoogleSheetsDestinationConfig,
+} from '../../model/types/data-mart-report';
+import { getGoogleSheetTabUrl } from '../../utils';
+import { ReportOpenDocumentAction } from '../ReportOpenDocumentAction';
+
+function makeReport(overrides: Partial<DataMartReport> = {}): DataMartReport {
+  return {
+    id: 'report-1',
+    title: 'Monthly Revenue',
+    destinationConfig: {
+      type: DestinationTypeConfigEnum.GOOGLE_SHEETS_CONFIG,
+      spreadsheetId: 'spreadsheet-123',
+      sheetId: '456',
+    } satisfies GoogleSheetsDestinationConfig,
+    ...overrides,
+  } as DataMartReport;
+}
+
+describe('ReportOpenDocumentAction', () => {
+  it('renders a link to the Google Sheets document', () => {
+    render(<ReportOpenDocumentAction report={makeReport()} />);
+
+    const link = screen.getByRole('link', {
+      name: /open document: monthly revenue/i,
+    });
+
+    expect(link).toHaveAttribute('href', getGoogleSheetTabUrl('spreadsheet-123', '456'));
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/apps/web/src/features/data-marts/reports/shared/components/__tests__/ReportOpenDocumentAction.test.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/__tests__/ReportOpenDocumentAction.test.tsx
@@ -38,4 +38,60 @@ describe('ReportOpenDocumentAction', () => {
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
+
+  it('does not render for non-Google Sheets reports', () => {
+    render(
+      <ReportOpenDocumentAction
+        report={makeReport({
+          dataDestination: {
+            type: DataDestinationType.LOOKER_STUDIO,
+          } as DataMartReport['dataDestination'],
+        })}
+      />
+    );
+
+    expect(
+      screen.queryByRole('link', {
+        name: /open document/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render when the destination configuration is not Google Sheets', () => {
+    render(
+      <ReportOpenDocumentAction
+        report={makeReport({
+          destinationConfig: {
+            type: DestinationTypeConfigEnum.EMAIL_CONFIG,
+          } as DataMartReport['destinationConfig'],
+        })}
+      />
+    );
+
+    expect(
+      screen.queryByRole('link', {
+        name: /open document/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render when the Google Sheets configuration is incomplete', () => {
+    render(
+      <ReportOpenDocumentAction
+        report={makeReport({
+          destinationConfig: {
+            type: DestinationTypeConfigEnum.GOOGLE_SHEETS_CONFIG,
+            spreadsheetId: '',
+            sheetId: '456',
+          },
+        })}
+      />
+    );
+
+    expect(
+      screen.queryByRole('link', {
+        name: /open document/i,
+      })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/data-marts/reports/shared/components/__tests__/ReportOpenDocumentAction.test.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/__tests__/ReportOpenDocumentAction.test.tsx
@@ -8,11 +8,15 @@ import type {
 } from '../../model/types/data-mart-report';
 import { getGoogleSheetTabUrl } from '../../utils';
 import { ReportOpenDocumentAction } from '../ReportOpenDocumentAction';
+import { DataDestinationType } from '../../../../../data-destination/shared/enums/data-destination-type.enum';
 
 function makeReport(overrides: Partial<DataMartReport> = {}): DataMartReport {
   return {
     id: 'report-1',
     title: 'Monthly Revenue',
+    dataDestination: {
+      type: DataDestinationType.GOOGLE_SHEETS,
+    } as DataMartReport['dataDestination'],
     destinationConfig: {
       type: DestinationTypeConfigEnum.GOOGLE_SHEETS_CONFIG,
       spreadsheetId: 'spreadsheet-123',

--- a/apps/web/src/features/data-marts/reports/shared/components/__tests__/ReportTitleCell.test.tsx
+++ b/apps/web/src/features/data-marts/reports/shared/components/__tests__/ReportTitleCell.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ReportTitleCell } from '../ReportTitleCell';
+
+describe('ReportTitleCell', () => {
+  it('renders the report title', () => {
+    render(<ReportTitleCell title='Monthly Revenue' />);
+
+    expect(screen.getByText('Monthly Revenue')).toBeInTheDocument();
+  });
+
+  it('renders quick actions when provided', () => {
+    render(
+      <ReportTitleCell
+        title='Monthly Revenue'
+        actions={<button type='button'>Open document</button>}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Open document' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/reports/shared/components/index.ts
+++ b/apps/web/src/features/data-marts/reports/shared/components/index.ts
@@ -1,2 +1,5 @@
 export * from './ReportHoverCard';
 export * from './ReportQuickRunCell';
+export * from './ReportGeneratedSqlAction';
+export * from './ReportOpenDocumentAction';
+export * from './ReportTitleCell';

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.test.tsx
@@ -20,8 +20,8 @@ import { mergeReportPagePreservingRows } from './DataMartReportsPage.utils';
 
 const mockToastCustom = vi.hoisted(() => vi.fn().mockReturnValue('mock-toast-id'));
 vi.mock('react-hot-toast', () => ({
-  default: { custom: mockToastCustom, dismiss: vi.fn(), success: vi.fn() },
-  toast: { custom: mockToastCustom, dismiss: vi.fn(), success: vi.fn() },
+  default: { custom: mockToastCustom, dismiss: vi.fn(), success: vi.fn(), error: vi.fn() },
+  toast: { custom: mockToastCustom, dismiss: vi.fn(), success: vi.fn(), error: vi.fn() },
 }));
 
 const reportServiceMock = vi.hoisted(() => ({
@@ -417,6 +417,46 @@ describe('DataMartReportsPage', () => {
 
     expect(await screen.findByText('Edit report')).toBeInTheDocument();
     expect(screen.getByText('Delete report')).toBeInTheDocument();
+  });
+
+  it('does not open the report edit sheet when Open document is clicked', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildGoogleSheetsReportResponse({
+        title: 'Blended Sheet Report',
+        columnConfig: ['joined_field'],
+      }),
+    ]);
+
+    const { container } = renderPage();
+
+    await screen.findByText('Blended Sheet Report');
+
+    fireEvent.click(
+      container.querySelector(
+        'a[href="https://docs.google.com/spreadsheets/d/spreadsheet-1/edit#gid=123"]'
+      )!
+    );
+
+    expect(screen.queryByRole('dialog', { name: 'Report edit sheet' })).not.toBeInTheDocument();
+  });
+
+  it('does not open the report edit sheet when Preview SQL is clicked', async () => {
+    vi.mocked(reportService.getReportsByProject).mockResolvedValueOnce([
+      buildGoogleSheetsReportResponse({
+        title: 'Blended Sheet Report',
+        columnConfig: ['joined_field'],
+      }),
+    ]);
+
+    renderPage();
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Preview SQL: Blended Sheet Report',
+      })
+    );
+
+    expect(screen.queryByRole('dialog', { name: 'Report edit sheet' })).not.toBeInTheDocument();
   });
 
   it('renders notification report row actions like the Data Mart reports tab', async () => {

--- a/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
+++ b/apps/web/src/pages/data-marts/reports/DataMartReportsPage.tsx
@@ -40,6 +40,12 @@ import { buildProjectDataMartContextValue } from '../shared/projectDataMartConte
 import { ProjectDataMartEmptyState } from '../shared/ProjectDataMartEmptyState';
 import { ProjectDataMartTitleLink } from '../shared/ProjectDataMartTitleLink';
 import { mergeReportPagePreservingRows } from './DataMartReportsPage.utils';
+import {
+  ReportGeneratedSqlAction,
+  ReportOpenDocumentAction,
+  ReportTitleCell,
+  reportTitleCellQuickActionClassName,
+} from '../../../features/data-marts/reports/shared/components';
 
 const PROJECT_REPORTS_TABLE_PAGE_SIZE = 15;
 const PROJECT_REPORTS_TABLE_ID = 'project-reports-table';
@@ -118,6 +124,38 @@ function buildProjectReportFilters(
       }),
     },
   ];
+}
+
+function ProjectReportTitleCell({ report }: { report: DataMartReport }) {
+  let quickActions: ReactNode = null;
+
+  switch (report.dataDestination.type) {
+    case DataDestinationType.GOOGLE_SHEETS:
+      quickActions = (
+        <>
+          <ReportOpenDocumentAction
+            report={report}
+            className={reportTitleCellQuickActionClassName}
+          />
+          <ReportGeneratedSqlAction
+            report={report}
+            className={reportTitleCellQuickActionClassName}
+          />
+        </>
+      );
+      break;
+
+    case DataDestinationType.EMAIL:
+    case DataDestinationType.SLACK:
+    case DataDestinationType.GOOGLE_CHAT:
+    case DataDestinationType.MS_TEAMS:
+      quickActions = (
+        <ReportGeneratedSqlAction report={report} className={reportTitleCellQuickActionClassName} />
+      );
+      break;
+  }
+
+  return <ReportTitleCell title={report.title} actions={quickActions} />;
 }
 
 interface ProjectReportActionsCellProps {
@@ -308,7 +346,7 @@ export default function DataMartReportsPage() {
           if (!title) {
             return <span className='text-muted-foreground'>—</span>;
           }
-          return <div className='overflow-hidden text-ellipsis'>{title}</div>;
+          return <ProjectReportTitleCell report={row.original} />;
         },
       },
       {
@@ -388,7 +426,7 @@ export default function DataMartReportsPage() {
       },
       {
         id: 'actions',
-        size: 130,
+        size: 50,
         enableResizing: false,
         enableSorting: false,
         header: ({ table }) => <ToggleColumnsHeader table={table} />,


### PR DESCRIPTION
# Improved the reports table UX by making frequently used actions easier to discover and access

- Moved **Open document** and **Preview SQL** actions next to the report title.
- Kept the **More actions** menu in the actions column.
- Added tooltips for truncated report titles.
- Extracted reusable report action components for better consistency across report tables.

This update improves discoverability and provides faster access to common report actions while keeping the table layout clean and consistent.

<img width="954" height="636" alt="Recording 2026-07-05 204824" src="https://github.com/user-attachments/assets/7340e584-8ace-446a-9e2e-19685786aafa" />
