### PR TITLE
feat(mcp): add add_destination MCP tool

### DIFF
--- a/.changeset/6706-mcp-list-destinations-tool.md
+++ b/.changeset/6706-mcp-list-destinations-tool.md
@@ -4,6 +4,6 @@
 
 # Add a list_destinations MCP tool
 
-AI assistants connected to OWOX over MCP can now list the destinations available in your active project. Each entry includes its name, type (Google Sheets, Looker Studio, Slack, Email, Microsoft Teams, or Google Chat), and owner — so the assistant can pick the right target before creating a report on your behalf.
+AI assistants connected to OWOX over MCP can now list the destinations available in your active project. Each entry includes its name, type (Google Sheets, Looker Studio, Slack, Email, Microsoft Teams, or Google Chat), owner, and whether it's currently shared for use — so the assistant can pick the right target before creating a report on your behalf, or tell you a destination it just created still needs to be shared first.
 
-Only destinations you can access are returned, and destinations that aren't currently usable are omitted.
+Only destinations you can access are returned.

--- a/.changeset/6707-mcp-add-destination-tool.md
+++ b/.changeset/6707-mcp-add-destination-tool.md
@@ -1,0 +1,11 @@
+---
+"owox": minor
+---
+
+# Add an add_destination MCP tool
+
+AI assistants connected to OWOX over MCP can now create a new report-delivery destination on your behalf instead of only choosing from existing ones.
+
+For email-based destinations (email, Slack, Microsoft Teams, Google Chat) and Looker Studio, the destination is created directly and is ready to use right away. For Google Sheets, the assistant hands you a link to a simple in-app page where you sign in (if needed) and connect your Google account — the destination is created automatically once you approve access.
+
+Every destination created this way starts unshared, so a human reviews and shares it (Configure destination → Sharing) before it can be used in reports.

--- a/apps/backend/src/data-marts/controllers/data-destination.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-destination.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '@nestjs/common';
 import { OwnerFilter } from '../enums/owner-filter.enum';
 import { CreateDataDestinationApiDto } from '../dto/presentation/create-data-destination-api.dto';
+import { CreateConnectGoogleSheetsDestinationApiDto } from '../dto/presentation/create-connect-google-sheets-destination-api.dto';
 import { CreateDataDestinationService } from '../use-cases/create-data-destination.service';
 import { DataDestinationMapper } from '../mappers/data-destination.mapper';
 import { UpdateDataDestinationApiDto } from '../dto/presentation/update-data-destination-api.dto';
@@ -35,6 +36,7 @@ import { GoogleOAuthSettingsResponseDto } from '../dto/presentation/google-oauth
 
 import {
   CreateDataDestinationSpec,
+  CreateConnectGoogleSheetsDestinationSpec,
   DeleteDataDestinationSpec,
   GetDataDestinationImpactSpec,
   GetDataDestinationSpec,
@@ -121,6 +123,18 @@ export class DataDestinationController {
     @Body() dto: CreateDataDestinationApiDto
   ): Promise<DataDestinationResponseApiDto> {
     const command = this.mapper.toCreateCommand(context, dto);
+    const dataDestinationDto = await this.createService.run(command);
+    return await this.mapper.toApiResponse(dataDestinationDto);
+  }
+
+  @Auth(Role.viewer(Strategy.INTROSPECT))
+  @Post('connect/google-sheets')
+  @CreateConnectGoogleSheetsDestinationSpec()
+  async createConnectGoogleSheets(
+    @AuthContext() context: AuthorizationContext,
+    @Body() dto: CreateConnectGoogleSheetsDestinationApiDto
+  ): Promise<DataDestinationResponseApiDto> {
+    const command = this.mapper.toConnectGoogleSheetsCreateCommand(context, dto);
     const dataDestinationDto = await this.createService.run(command);
     return await this.mapper.toApiResponse(dataDestinationDto);
   }

--- a/apps/backend/src/data-marts/controllers/spec/data-destination.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-destination.api.ts
@@ -10,6 +10,7 @@ import {
   ApiQuery,
 } from '@nestjs/swagger';
 import { CreateDataDestinationApiDto } from '../../dto/presentation/create-data-destination-api.dto';
+import { CreateConnectGoogleSheetsDestinationApiDto } from '../../dto/presentation/create-connect-google-sheets-destination-api.dto';
 import { UpdateDataDestinationApiDto } from '../../dto/presentation/update-data-destination-api.dto';
 import { UpdateDestinationAvailabilityApiDto } from '../../dto/presentation/update-availability-api.dto';
 import { DataDestinationResponseApiDto } from '../../dto/presentation/data-destination-response-api.dto';
@@ -38,6 +39,17 @@ export function CreateDataDestinationSpec() {
   return applyDecorators(
     ApiOperation({ summary: 'Create a new Data Destination' }),
     ApiBody({ type: CreateDataDestinationApiDto }),
+    ApiCreatedResponse({ type: DataDestinationResponseApiDto })
+  );
+}
+
+export function CreateConnectGoogleSheetsDestinationSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary:
+        'Create a Google Sheets destination from the MCP connect flow (starts unshared internally)',
+    }),
+    ApiBody({ type: CreateConnectGoogleSheetsDestinationApiDto }),
     ApiCreatedResponse({ type: DataDestinationResponseApiDto })
   );
 }

--- a/apps/backend/src/data-marts/dto/domain/create-data-destination.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/create-data-destination.command.ts
@@ -2,19 +2,46 @@ import { DataDestinationType } from '../../data-destination-types/enums/data-des
 import { DataDestinationCredentials } from '../../data-destination-types/data-destination-credentials.type';
 import { DestinationConfig } from '../../entities/destination-config.type';
 
+export interface CreateDataDestinationCommandProps {
+  projectId: string;
+  title: string;
+  type: DataDestinationType;
+  userId: string;
+  credentials?: DataDestinationCredentials;
+  credentialId?: string;
+  sourceDestinationId?: string;
+  ownerIds?: string[];
+  roles?: string[];
+  config?: DestinationConfig | null;
+  availableForUse?: boolean;
+}
+
 export class CreateDataDestinationCommand {
-  constructor(
-    public readonly projectId: string,
-    public readonly title: string,
-    public readonly type: DataDestinationType,
-    public readonly userId: string,
-    public readonly credentials?: DataDestinationCredentials,
-    public readonly credentialId?: string,
-    public readonly sourceDestinationId?: string,
-    public readonly ownerIds?: string[],
-    public readonly roles: string[] = [],
-    public readonly config?: DestinationConfig | null
-  ) {}
+  public readonly projectId: string;
+  public readonly title: string;
+  public readonly type: DataDestinationType;
+  public readonly userId: string;
+  public readonly credentials?: DataDestinationCredentials;
+  public readonly credentialId?: string;
+  public readonly sourceDestinationId?: string;
+  public readonly ownerIds?: string[];
+  public readonly roles: string[];
+  public readonly config?: DestinationConfig | null;
+  public readonly availableForUse?: boolean;
+
+  constructor(props: CreateDataDestinationCommandProps) {
+    this.projectId = props.projectId;
+    this.title = props.title;
+    this.type = props.type;
+    this.userId = props.userId;
+    this.credentials = props.credentials;
+    this.credentialId = props.credentialId;
+    this.sourceDestinationId = props.sourceDestinationId;
+    this.ownerIds = props.ownerIds;
+    this.roles = props.roles ?? [];
+    this.config = props.config;
+    this.availableForUse = props.availableForUse;
+  }
 
   hasCredentials(): boolean {
     return this.credentials !== undefined;

--- a/apps/backend/src/data-marts/dto/presentation/create-connect-google-sheets-destination-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/create-connect-google-sheets-destination-api.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class CreateConnectGoogleSheetsDestinationApiDto {
+  @ApiProperty({ example: 'Google Sheets (user@example.com)' })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({ description: 'Pre-created Google OAuth credential ID from the connect flow' })
+  @IsUUID()
+  credentialId: string;
+}

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.spec.ts
@@ -2,11 +2,68 @@ jest.mock('../use-cases/list-data-destinations.service', () => ({
   ListDataDestinationsService: jest.fn(),
 }));
 
+import { BadRequestException } from '@nestjs/common';
 import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
 import { DataDestinationDto } from '../dto/domain/data-destination.dto';
 import { UserProjectionDto } from '../../idp/dto/domain/user-projection.dto';
-import type { ListDataDestinationsService } from '../use-cases/list-data-destinations.service';
+import { ListDataDestinationsService } from '../use-cases/list-data-destinations.service';
+import { CreateDataDestinationService } from '../use-cases/create-data-destination.service';
+import { DataDestinationCredentialService } from '../services/data-destination-credential.service';
+import { PublicOriginService } from '../../common/config/public-origin.service';
 import { McpDataDestinationsFacadeImpl } from './mcp-data-destinations.facade.impl';
+
+function createFacade(
+  listDataDestinationsService: Pick<ListDataDestinationsService, 'run'>
+): McpDataDestinationsFacadeImpl {
+  const dataDestinationCredentialService = {
+    getByIds: jest.fn().mockResolvedValue(new Map()),
+  };
+
+  return new McpDataDestinationsFacadeImpl(
+    listDataDestinationsService as unknown as ListDataDestinationsService,
+    {} as unknown as CreateDataDestinationService,
+    dataDestinationCredentialService as unknown as DataDestinationCredentialService,
+    {} as unknown as PublicOriginService
+  );
+}
+
+function createFacadeForCreate(
+  overrides: {
+    createDataDestinationService?: Pick<CreateDataDestinationService, 'run'>;
+    dataDestinationCredentialService?: Pick<DataDestinationCredentialService, 'getById'>;
+    publicOriginService?: Pick<PublicOriginService, 'getLookerStudioDeploymentUrl'>;
+  } = {}
+): {
+  facade: McpDataDestinationsFacadeImpl;
+  createDataDestinationService: any;
+  dataDestinationCredentialService: any;
+  publicOriginService: any;
+} {
+  const createDataDestinationService = {
+    run: jest.fn(),
+    ...overrides.createDataDestinationService,
+  };
+  const dataDestinationCredentialService = {
+    getById: jest.fn(),
+    ...overrides.dataDestinationCredentialService,
+  };
+  const publicOriginService = {
+    getLookerStudioDeploymentUrl: jest.fn(() => 'https://looker.example.com/deploy'),
+    ...overrides.publicOriginService,
+  };
+
+  return {
+    facade: new McpDataDestinationsFacadeImpl(
+      {} as unknown as ListDataDestinationsService,
+      createDataDestinationService as unknown as CreateDataDestinationService,
+      dataDestinationCredentialService as unknown as DataDestinationCredentialService,
+      publicOriginService as unknown as PublicOriginService
+    ),
+    createDataDestinationService,
+    dataDestinationCredentialService,
+    publicOriginService,
+  };
+}
 
 function buildDestination(overrides: {
   id: string;
@@ -49,7 +106,7 @@ describe('McpDataDestinationsFacadeImpl', () => {
       ]),
     } as unknown as jest.Mocked<ListDataDestinationsService>;
 
-    const facade = new McpDataDestinationsFacadeImpl(listDataDestinationsService);
+    const facade = createFacade(listDataDestinationsService);
 
     const result = await facade.listDestinations({
       projectId: 'project-1',
@@ -66,10 +123,181 @@ describe('McpDataDestinationsFacadeImpl', () => {
     );
     expect(result).toEqual({
       destinations: [
-        { id: 'dest_1', name: 'Marketing Sheet', type: 'google_sheets', owner: 'ann@owox.com' },
-        { id: 'dest_2', name: 'Ops Teams', type: 'teams', owner: null },
+        {
+          id: 'dest_1',
+          name: 'Marketing Sheet',
+          type: 'google_sheets',
+          owner: 'ann@owox.com',
+          connectedGoogleAccount: null,
+          createdAt: '2026-06-01T10:00:00.000Z',
+        },
+        {
+          id: 'dest_2',
+          name: 'Ops Teams',
+          type: 'teams',
+          owner: null,
+          connectedGoogleAccount: null,
+          createdAt: '2026-06-01T10:00:00.000Z',
+        },
       ],
     });
+  });
+
+  it("resolves the connected Google account for google_sheets destinations from the credential's identity", async () => {
+    const listDataDestinationsService = {
+      run: jest.fn().mockResolvedValue([
+        new DataDestinationDto(
+          'dest_1',
+          'Marketing Sheet',
+          DataDestinationType.GOOGLE_SHEETS,
+          'project-1',
+          new Date('2026-06-01T10:00:00.000Z'),
+          new Date('2026-06-02T10:00:00.000Z'),
+          'credential-1'
+        ),
+        buildDestination({
+          id: 'dest_2',
+          title: 'Ops Teams',
+          type: DataDestinationType.MS_TEAMS,
+        }),
+      ]),
+    } as unknown as jest.Mocked<ListDataDestinationsService>;
+    const dataDestinationCredentialService = {
+      getByIds: jest.fn().mockResolvedValue(
+        new Map([
+          [
+            'credential-1',
+            {
+              credentials: {},
+              identity: { email: 'attacker@gmail.com' },
+            },
+          ],
+        ])
+      ),
+    };
+
+    const facade = new McpDataDestinationsFacadeImpl(
+      listDataDestinationsService as unknown as ListDataDestinationsService,
+      {} as unknown as CreateDataDestinationService,
+      dataDestinationCredentialService as unknown as DataDestinationCredentialService,
+      {} as unknown as PublicOriginService
+    );
+
+    const result = await facade.listDestinations({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: [],
+    });
+
+    expect(dataDestinationCredentialService.getByIds).toHaveBeenCalledWith(
+      ['credential-1'],
+      'project-1'
+    );
+    expect(dataDestinationCredentialService.getByIds).toHaveBeenCalledTimes(1);
+    expect(result.destinations.map(d => [d.id, d.connectedGoogleAccount])).toEqual([
+      ['dest_1', 'attacker@gmail.com'],
+      ['dest_2', null],
+    ]);
+  });
+
+  it('returns null connectedGoogleAccount when credential batch-fetch fails', async () => {
+    const listDataDestinationsService = {
+      run: jest.fn().mockResolvedValue([
+        new DataDestinationDto(
+          'dest_1',
+          'Marketing Sheet',
+          DataDestinationType.GOOGLE_SHEETS,
+          'project-1',
+          new Date('2026-06-01T10:00:00.000Z'),
+          new Date('2026-06-02T10:00:00.000Z'),
+          'credential-1'
+        ),
+        buildDestination({
+          id: 'dest_2',
+          title: 'Ops Teams',
+          type: DataDestinationType.MS_TEAMS,
+        }),
+      ]),
+    } as unknown as jest.Mocked<ListDataDestinationsService>;
+    const dataDestinationCredentialService = {
+      getByIds: jest.fn().mockRejectedValue(new Error('database timeout')),
+    };
+
+    const facade = new McpDataDestinationsFacadeImpl(
+      listDataDestinationsService as unknown as ListDataDestinationsService,
+      {} as unknown as CreateDataDestinationService,
+      dataDestinationCredentialService as unknown as DataDestinationCredentialService,
+      {} as unknown as PublicOriginService
+    );
+
+    const result = await facade.listDestinations({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: [],
+    });
+
+    expect(result.destinations.map(d => [d.id, d.connectedGoogleAccount, d.name])).toEqual([
+      ['dest_1', null, 'Marketing Sheet'],
+      ['dest_2', null, 'Ops Teams'],
+    ]);
+  });
+
+  it('batch-fetches connected Google accounts for multiple google_sheets destinations', async () => {
+    const listDataDestinationsService = {
+      run: jest
+        .fn()
+        .mockResolvedValue([
+          new DataDestinationDto(
+            'dest_1',
+            'Sheet One',
+            DataDestinationType.GOOGLE_SHEETS,
+            'project-1',
+            new Date('2026-06-01T10:00:00.000Z'),
+            new Date('2026-06-02T10:00:00.000Z'),
+            'credential-1'
+          ),
+          new DataDestinationDto(
+            'dest_2',
+            'Sheet Two',
+            DataDestinationType.GOOGLE_SHEETS,
+            'project-1',
+            new Date('2026-06-01T10:00:00.000Z'),
+            new Date('2026-06-02T10:00:00.000Z'),
+            'credential-2'
+          ),
+        ]),
+    } as unknown as jest.Mocked<ListDataDestinationsService>;
+    const dataDestinationCredentialService = {
+      getByIds: jest.fn().mockResolvedValue(
+        new Map([
+          ['credential-1', { identity: { email: 'alice@gmail.com' } }],
+          ['credential-2', { identity: { email: 'bob@gmail.com' } }],
+        ])
+      ),
+    };
+
+    const facade = new McpDataDestinationsFacadeImpl(
+      listDataDestinationsService as unknown as ListDataDestinationsService,
+      {} as unknown as CreateDataDestinationService,
+      dataDestinationCredentialService as unknown as DataDestinationCredentialService,
+      {} as unknown as PublicOriginService
+    );
+
+    const result = await facade.listDestinations({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: [],
+    });
+
+    expect(dataDestinationCredentialService.getByIds).toHaveBeenCalledWith(
+      ['credential-1', 'credential-2'],
+      'project-1'
+    );
+    expect(dataDestinationCredentialService.getByIds).toHaveBeenCalledTimes(1);
+    expect(result.destinations.map(d => [d.id, d.connectedGoogleAccount])).toEqual([
+      ['dest_1', 'alice@gmail.com'],
+      ['dest_2', 'bob@gmail.com'],
+    ]);
   });
 
   it('maps every destination type to the lowercase MCP vocabulary', async () => {
@@ -86,7 +314,7 @@ describe('McpDataDestinationsFacadeImpl', () => {
         ]),
     } as unknown as jest.Mocked<ListDataDestinationsService>;
 
-    const facade = new McpDataDestinationsFacadeImpl(listDataDestinationsService);
+    const facade = createFacade(listDataDestinationsService);
 
     const result = await facade.listDestinations({
       projectId: 'project-1',
@@ -104,7 +332,7 @@ describe('McpDataDestinationsFacadeImpl', () => {
     ]);
   });
 
-  it('filters out destinations that are not available for use', async () => {
+  it('includes destinations that are not yet available for use, without exposing sharing status', async () => {
     const listDataDestinationsService = {
       run: jest.fn().mockResolvedValue([
         buildDestination({
@@ -114,15 +342,15 @@ describe('McpDataDestinationsFacadeImpl', () => {
           availableForUse: true,
         }),
         buildDestination({
-          id: 'broken',
-          title: 'Broken',
+          id: 'unshared',
+          title: 'Unshared',
           type: DataDestinationType.GOOGLE_SHEETS,
           availableForUse: false,
         }),
       ]),
     } as unknown as jest.Mocked<ListDataDestinationsService>;
 
-    const facade = new McpDataDestinationsFacadeImpl(listDataDestinationsService);
+    const facade = createFacade(listDataDestinationsService);
 
     const result = await facade.listDestinations({
       projectId: 'project-1',
@@ -130,7 +358,10 @@ describe('McpDataDestinationsFacadeImpl', () => {
       roles: [],
     });
 
-    expect(result.destinations.map(d => d.id)).toEqual(['usable']);
+    // Unshared destinations are still surfaced (not filtered out), but the MCP response
+    // never reports availableForUse — that's a UI/REST concern, not an MCP one.
+    expect(result.destinations.map(d => d.id)).toEqual(['usable', 'unshared']);
+    expect(result.destinations.every(d => !('availableForUse' in d))).toBe(true);
   });
 
   it('reports the creator as owner, ignoring the unordered owners relation', async () => {
@@ -153,7 +384,7 @@ describe('McpDataDestinationsFacadeImpl', () => {
       ]),
     } as unknown as jest.Mocked<ListDataDestinationsService>;
 
-    const facade = new McpDataDestinationsFacadeImpl(listDataDestinationsService);
+    const facade = createFacade(listDataDestinationsService);
 
     const result = await facade.listDestinations({
       projectId: 'project-1',
@@ -162,5 +393,169 @@ describe('McpDataDestinationsFacadeImpl', () => {
     });
 
     expect(result.destinations.map(d => d.owner)).toEqual(['creator@owox.com', null]);
+  });
+
+  describe('createDestination', () => {
+    const baseRequest = {
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+    };
+
+    // The MCP tool always resolves a display title before calling; this only covers the
+    // facade's own defensive backstop for a hypothetical caller that doesn't.
+    it('falls back to the raw destination type when no title is given at all', async () => {
+      const { facade, createDataDestinationService } = createFacadeForCreate({
+        createDataDestinationService: {
+          run: jest.fn().mockResolvedValue({ id: 'new-dest', title: 'slack' }),
+        },
+      });
+
+      await facade.createDestination({
+        ...baseRequest,
+        type: 'slack',
+        emails: ['user@example.com'],
+      });
+
+      expect(createDataDestinationService.run).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'slack' })
+      );
+    });
+
+    it('maps email-based types to email-credentials and starts them unshared', async () => {
+      const { facade, createDataDestinationService } = createFacadeForCreate({
+        createDataDestinationService: {
+          run: jest.fn().mockResolvedValue({ id: 'email-dest', title: 'Marketing Email' }),
+        },
+      });
+
+      const result = await facade.createDestination({
+        ...baseRequest,
+        type: 'email',
+        title: 'Marketing Email',
+        emails: ['ops@example.com', 'alerts@example.com'],
+      });
+
+      expect(createDataDestinationService.run).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: 'project-1',
+          userId: 'user-1',
+          roles: ['viewer'],
+          title: 'Marketing Email',
+          type: DataDestinationType.EMAIL,
+          credentials: {
+            type: 'email-credentials',
+            to: ['ops@example.com', 'alerts@example.com'],
+          },
+          availableForUse: false,
+        })
+      );
+      expect(result).toEqual({
+        id: 'email-dest',
+        name: 'Marketing Email',
+        lookerStudioCredentials: undefined,
+      });
+    });
+
+    it('rejects google_sheets with a clear error instead of falling into the email-credentials branch', async () => {
+      const { facade, createDataDestinationService } = createFacadeForCreate();
+
+      await expect(
+        facade.createDestination({
+          ...baseRequest,
+          type: 'google_sheets',
+        })
+      ).rejects.toThrow(
+        'google_sheets destinations cannot be created directly; use the OAuth connect flow instead'
+      );
+      expect(createDataDestinationService.run).not.toHaveBeenCalled();
+    });
+
+    it('rejects direct creation when emails are missing for non-looker types', async () => {
+      const { facade, createDataDestinationService } = createFacadeForCreate();
+
+      await expect(
+        facade.createDestination({
+          ...baseRequest,
+          type: 'slack',
+          title: 'Ops Slack',
+        })
+      ).rejects.toThrow(
+        new BadRequestException('Emails list is required for direct destination creation')
+      );
+
+      expect(createDataDestinationService.run).not.toHaveBeenCalled();
+    });
+
+    it('rejects looker_studio creation when the credential record cannot be resolved', async () => {
+      const { facade, createDataDestinationService, dataDestinationCredentialService } =
+        createFacadeForCreate({
+          createDataDestinationService: {
+            run: jest.fn().mockResolvedValue({
+              id: 'looker-dest',
+              title: 'Looker Studio MCP Destination',
+              credentialId: 'cred-looker-1',
+            }),
+          },
+          dataDestinationCredentialService: {
+            getById: jest.fn().mockResolvedValue(null),
+          },
+        });
+
+      await expect(
+        facade.createDestination({
+          ...baseRequest,
+          type: 'looker_studio',
+          title: 'Looker Studio MCP Destination',
+        })
+      ).rejects.toThrow(
+        'Looker Studio connector credentials could not be resolved after destination creation'
+      );
+
+      expect(createDataDestinationService.run).toHaveBeenCalled();
+      expect(dataDestinationCredentialService.getById).toHaveBeenCalledWith('cred-looker-1');
+    });
+
+    it('assembles Looker Studio connector credentials from the stored credential record', async () => {
+      const { facade, createDataDestinationService, dataDestinationCredentialService } =
+        createFacadeForCreate({
+          createDataDestinationService: {
+            run: jest.fn().mockResolvedValue({
+              id: 'looker-dest',
+              title: 'Looker Studio MCP Destination',
+              credentialId: 'cred-looker-1',
+            }),
+          },
+          dataDestinationCredentialService: {
+            getById: jest.fn().mockResolvedValue({
+              credentials: { destinationSecretKey: 'secret-key-123' },
+            }),
+          },
+        });
+
+      const result = await facade.createDestination({
+        ...baseRequest,
+        type: 'looker_studio',
+        title: 'Looker Studio MCP Destination',
+      });
+
+      expect(createDataDestinationService.run).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: DataDestinationType.LOOKER_STUDIO,
+          credentials: { type: 'looker-studio-credentials' },
+          availableForUse: false,
+        })
+      );
+      expect(dataDestinationCredentialService.getById).toHaveBeenCalledWith('cred-looker-1');
+      expect(result).toEqual({
+        id: 'looker-dest',
+        name: 'Looker Studio MCP Destination',
+        lookerStudioCredentials: {
+          destinationId: 'looker-dest',
+          destinationSecretKey: 'secret-key-123',
+          deploymentUrl: 'https://looker.example.com/deploy',
+        },
+      });
+    });
   });
 });

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.spec.ts
@@ -487,7 +487,7 @@ describe('McpDataDestinationsFacadeImpl', () => {
       expect(createDataDestinationService.run).not.toHaveBeenCalled();
     });
 
-    it('rejects looker_studio creation when the credential record cannot be resolved', async () => {
+    it('returns the created looker_studio destination when the credential record cannot be resolved', async () => {
       const { facade, createDataDestinationService, dataDestinationCredentialService } =
         createFacadeForCreate({
           createDataDestinationService: {
@@ -502,18 +502,19 @@ describe('McpDataDestinationsFacadeImpl', () => {
           },
         });
 
-      await expect(
-        facade.createDestination({
-          ...baseRequest,
-          type: 'looker_studio',
-          title: 'Looker Studio MCP Destination',
-        })
-      ).rejects.toThrow(
-        'Looker Studio connector credentials could not be resolved after destination creation'
-      );
+      const result = await facade.createDestination({
+        ...baseRequest,
+        type: 'looker_studio',
+        title: 'Looker Studio MCP Destination',
+      });
 
       expect(createDataDestinationService.run).toHaveBeenCalled();
       expect(dataDestinationCredentialService.getById).toHaveBeenCalledWith('cred-looker-1');
+      expect(result).toEqual({
+        id: 'looker-dest',
+        name: 'Looker Studio MCP Destination',
+        lookerStudioCredentials: undefined,
+      });
     });
 
     it('assembles Looker Studio connector credentials from the stored credential record', async () => {

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.spec.ts
@@ -9,7 +9,6 @@ import { UserProjectionDto } from '../../idp/dto/domain/user-projection.dto';
 import { ListDataDestinationsService } from '../use-cases/list-data-destinations.service';
 import { CreateDataDestinationService } from '../use-cases/create-data-destination.service';
 import { DataDestinationCredentialService } from '../services/data-destination-credential.service';
-import { PublicOriginService } from '../../common/config/public-origin.service';
 import { McpDataDestinationsFacadeImpl } from './mcp-data-destinations.facade.impl';
 
 function createFacade(
@@ -22,8 +21,7 @@ function createFacade(
   return new McpDataDestinationsFacadeImpl(
     listDataDestinationsService as unknown as ListDataDestinationsService,
     {} as unknown as CreateDataDestinationService,
-    dataDestinationCredentialService as unknown as DataDestinationCredentialService,
-    {} as unknown as PublicOriginService
+    dataDestinationCredentialService as unknown as DataDestinationCredentialService
   );
 }
 
@@ -31,13 +29,11 @@ function createFacadeForCreate(
   overrides: {
     createDataDestinationService?: Pick<CreateDataDestinationService, 'run'>;
     dataDestinationCredentialService?: Pick<DataDestinationCredentialService, 'getById'>;
-    publicOriginService?: Pick<PublicOriginService, 'getLookerStudioDeploymentUrl'>;
   } = {}
 ): {
   facade: McpDataDestinationsFacadeImpl;
   createDataDestinationService: any;
   dataDestinationCredentialService: any;
-  publicOriginService: any;
 } {
   const createDataDestinationService = {
     run: jest.fn(),
@@ -47,21 +43,14 @@ function createFacadeForCreate(
     getById: jest.fn(),
     ...overrides.dataDestinationCredentialService,
   };
-  const publicOriginService = {
-    getLookerStudioDeploymentUrl: jest.fn(() => 'https://looker.example.com/deploy'),
-    ...overrides.publicOriginService,
-  };
-
   return {
     facade: new McpDataDestinationsFacadeImpl(
       {} as unknown as ListDataDestinationsService,
       createDataDestinationService as unknown as CreateDataDestinationService,
-      dataDestinationCredentialService as unknown as DataDestinationCredentialService,
-      publicOriginService as unknown as PublicOriginService
+      dataDestinationCredentialService as unknown as DataDestinationCredentialService
     ),
     createDataDestinationService,
     dataDestinationCredentialService,
-    publicOriginService,
   };
 }
 
@@ -453,7 +442,6 @@ describe('McpDataDestinationsFacadeImpl', () => {
       expect(result).toEqual({
         id: 'email-dest',
         name: 'Marketing Email',
-        lookerStudioCredentials: undefined,
       });
     });
 
@@ -487,7 +475,7 @@ describe('McpDataDestinationsFacadeImpl', () => {
       expect(createDataDestinationService.run).not.toHaveBeenCalled();
     });
 
-    it('returns the created looker_studio destination when the credential record cannot be resolved', async () => {
+    it('returns the created looker_studio destination without reading connector credentials', async () => {
       const { facade, createDataDestinationService, dataDestinationCredentialService } =
         createFacadeForCreate({
           createDataDestinationService: {
@@ -498,7 +486,7 @@ describe('McpDataDestinationsFacadeImpl', () => {
             }),
           },
           dataDestinationCredentialService: {
-            getById: jest.fn().mockResolvedValue(null),
+            getById: jest.fn(),
           },
         });
 
@@ -509,53 +497,10 @@ describe('McpDataDestinationsFacadeImpl', () => {
       });
 
       expect(createDataDestinationService.run).toHaveBeenCalled();
-      expect(dataDestinationCredentialService.getById).toHaveBeenCalledWith('cred-looker-1');
+      expect(dataDestinationCredentialService.getById).not.toHaveBeenCalled();
       expect(result).toEqual({
         id: 'looker-dest',
         name: 'Looker Studio MCP Destination',
-        lookerStudioCredentials: undefined,
-      });
-    });
-
-    it('assembles Looker Studio connector credentials from the stored credential record', async () => {
-      const { facade, createDataDestinationService, dataDestinationCredentialService } =
-        createFacadeForCreate({
-          createDataDestinationService: {
-            run: jest.fn().mockResolvedValue({
-              id: 'looker-dest',
-              title: 'Looker Studio MCP Destination',
-              credentialId: 'cred-looker-1',
-            }),
-          },
-          dataDestinationCredentialService: {
-            getById: jest.fn().mockResolvedValue({
-              credentials: { destinationSecretKey: 'secret-key-123' },
-            }),
-          },
-        });
-
-      const result = await facade.createDestination({
-        ...baseRequest,
-        type: 'looker_studio',
-        title: 'Looker Studio MCP Destination',
-      });
-
-      expect(createDataDestinationService.run).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: DataDestinationType.LOOKER_STUDIO,
-          credentials: { type: 'looker-studio-credentials' },
-          availableForUse: false,
-        })
-      );
-      expect(dataDestinationCredentialService.getById).toHaveBeenCalledWith('cred-looker-1');
-      expect(result).toEqual({
-        id: 'looker-dest',
-        name: 'Looker Studio MCP Destination',
-        lookerStudioCredentials: {
-          destinationId: 'looker-dest',
-          destinationSecretKey: 'secret-key-123',
-          deploymentUrl: 'https://looker.example.com/deploy',
-        },
       });
     });
   });

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
@@ -1,16 +1,42 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
 import { ListDataDestinationsCommand } from '../dto/domain/list-data-destinations.command';
 import { ListDataDestinationsService } from '../use-cases/list-data-destinations.service';
-import { toMcpDestinationType } from './mcp-destination-type';
+import { CreateDataDestinationService } from '../use-cases/create-data-destination.service';
+import { CreateDataDestinationCommand } from '../dto/domain/create-data-destination.command';
+import { DataDestinationCredentialService } from '../services/data-destination-credential.service';
+import { PublicOriginService } from '../../common/config/public-origin.service';
+import { DataDestinationCredential } from '../entities/data-destination-credential.entity';
+import { DataDestinationCredentials } from '../data-destination-types/data-destination-credentials.type';
+import { LookerStudioConnectorCredentials } from '../data-destination-types/looker-studio-connector/schemas/looker-studio-connector-credentials.schema';
+import { toMcpDestinationType, type McpDestinationType } from './mcp-destination-type';
 import {
   McpDataDestinationsFacade,
   McpListDestinationsRequest,
   McpListDestinationsResponse,
+  McpCreateDestinationRequest,
+  McpCreateDestinationResponse,
 } from './mcp-data-destinations.facade';
+
+const REVERSE_DESTINATION_TYPE_MAP: Record<McpDestinationType, DataDestinationType> = {
+  google_sheets: DataDestinationType.GOOGLE_SHEETS,
+  looker_studio: DataDestinationType.LOOKER_STUDIO,
+  email: DataDestinationType.EMAIL,
+  slack: DataDestinationType.SLACK,
+  teams: DataDestinationType.MS_TEAMS,
+  google_chat: DataDestinationType.GOOGLE_CHAT,
+};
 
 @Injectable()
 export class McpDataDestinationsFacadeImpl implements McpDataDestinationsFacade {
-  constructor(private readonly listDataDestinationsService: ListDataDestinationsService) {}
+  private readonly logger = new Logger(McpDataDestinationsFacadeImpl.name);
+
+  constructor(
+    private readonly listDataDestinationsService: ListDataDestinationsService,
+    private readonly createDataDestinationService: CreateDataDestinationService,
+    private readonly dataDestinationCredentialService: DataDestinationCredentialService,
+    private readonly publicOriginService: PublicOriginService
+  ) {}
 
   async listDestinations(
     request: McpListDestinationsRequest
@@ -19,18 +45,148 @@ export class McpDataDestinationsFacadeImpl implements McpDataDestinationsFacade 
       new ListDataDestinationsCommand(request.projectId, request.userId, request.roles)
     );
 
+    const connectedGoogleAccountByDestinationId = await this.fetchConnectedGoogleAccounts(
+      items,
+      request.projectId
+    );
+
     return {
-      destinations: items
-        .filter(destination => destination.availableForUse)
-        .map(destination => ({
-          id: destination.id,
-          name: destination.title,
-          type: toMcpDestinationType(destination.type),
-          // Report the creator as the owner. The `owners` relation has no stable
-          // ordering, so picking one of potentially several owners would be
-          // non-deterministic; the creator is a single, stable value.
-          owner: destination.createdByUser?.email ?? null,
-        })),
+      destinations: items.map(destination => ({
+        id: destination.id,
+        name: destination.title,
+        type: toMcpDestinationType(destination.type),
+        // Report the creator as the owner. The `owners` relation has no stable
+        // ordering, so picking one of potentially several owners would be
+        // non-deterministic; the creator is a single, stable value.
+        owner: destination.createdByUser?.email ?? null,
+        connectedGoogleAccount: connectedGoogleAccountByDestinationId.get(destination.id) ?? null,
+        createdAt: destination.createdAt.toISOString(),
+      })),
+    };
+  }
+
+  /**
+   * For google_sheets destinations, resolves which Google account actually completed
+   * OAuth consent — distinct from the OWOX `owner`/creator, and the only way to notice
+   * a mismatch after the MCP-driven Connect Google Sheets page finishes setup.
+   */
+  private async fetchConnectedGoogleAccounts(
+    destinations: Array<{ id: string; type: DataDestinationType; credentialId?: string | null }>,
+    projectId: string
+  ): Promise<Map<string, string | null>> {
+    const googleSheetsDestinations = destinations.filter(
+      destination =>
+        destination.type === DataDestinationType.GOOGLE_SHEETS && destination.credentialId
+    );
+
+    const credentialIds = googleSheetsDestinations.map(
+      destination => destination.credentialId as string
+    );
+
+    let credentialsById: Map<string, DataDestinationCredential>;
+    try {
+      credentialsById = await this.dataDestinationCredentialService.getByIds(
+        credentialIds,
+        projectId
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Failed to batch-fetch Google OAuth identities for ${credentialIds.length} credential(s); ` +
+          'connectedGoogleAccount will be null for affected google_sheets destinations',
+        error instanceof Error ? error.stack : String(error)
+      );
+      return new Map(googleSheetsDestinations.map(destination => [destination.id, null] as const));
+    }
+
+    return new Map(
+      googleSheetsDestinations.map(destination => {
+        const credential = credentialsById.get(destination.credentialId as string);
+        return [destination.id, credential?.identity?.email ?? null] as const;
+      })
+    );
+  }
+
+  async createDestination(
+    request: McpCreateDestinationRequest
+  ): Promise<McpCreateDestinationResponse> {
+    const dataDestinationType = REVERSE_DESTINATION_TYPE_MAP[request.type];
+
+    // google_sheets never reaches this method — AddDestinationTool intercepts it earlier
+    // and routes through the OAuth connect flow instead. Guarded explicitly so a future
+    // caller gets a clear error instead of silently falling into the email-credentials
+    // branch below and seeing a confusing "Emails list is required" message.
+    if (request.type === 'google_sheets') {
+      throw new BadRequestException(
+        'google_sheets destinations cannot be created directly; use the OAuth connect flow instead'
+      );
+    }
+
+    let credentials: DataDestinationCredentials;
+    if (request.type === 'looker_studio') {
+      credentials = {
+        type: 'looker-studio-credentials',
+      };
+    } else {
+      if (!request.emails || request.emails.length === 0) {
+        throw new BadRequestException('Emails list is required for direct destination creation');
+      }
+      credentials = {
+        type: 'email-credentials',
+        to: request.emails as [string, ...string[]],
+      };
+    }
+
+    const command = new CreateDataDestinationCommand({
+      projectId: request.projectId,
+      // The MCP tool always resolves a title before calling — this is a defensive
+      // backstop only, not a formatting concern this facade should own.
+      title: request.title ?? request.type,
+      type: dataDestinationType,
+      userId: request.userId,
+      credentials,
+      roles: request.roles,
+      // MCP-created destinations start unshared — an agent-created destination shouldn't
+      // silently become available to the whole project's reports before a human reviews it.
+      availableForUse: false,
+    });
+
+    const result = await this.createDataDestinationService.run(command);
+
+    let lookerStudioCredentials:
+      | {
+          destinationId: string;
+          destinationSecretKey: string;
+          deploymentUrl: string;
+        }
+      | undefined = undefined;
+    if (request.type === 'looker_studio') {
+      if (!result.credentialId) {
+        throw new BadRequestException(
+          'Looker Studio destination was created but has no credential record'
+        );
+      }
+
+      const credential = await this.dataDestinationCredentialService.getById(result.credentialId);
+      const destinationSecretKey = credential?.credentials
+        ? ((credential.credentials as LookerStudioConnectorCredentials).destinationSecretKey ?? '')
+        : '';
+      if (!credential?.credentials || !destinationSecretKey) {
+        throw new BadRequestException(
+          'Looker Studio connector credentials could not be resolved after destination creation'
+        );
+      }
+
+      lookerStudioCredentials = {
+        destinationId: result.id,
+        destinationSecretKey,
+        deploymentUrl: this.publicOriginService.getLookerStudioDeploymentUrl(),
+      };
+    }
+
+    return {
+      id: result.id,
+      name: result.title,
+      lookerStudioCredentials,
     };
   }
 }

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
@@ -160,27 +160,27 @@ export class McpDataDestinationsFacadeImpl implements McpDataDestinationsFacade 
         }
       | undefined = undefined;
     if (request.type === 'looker_studio') {
-      if (!result.credentialId) {
-        throw new BadRequestException(
-          'Looker Studio destination was created but has no credential record'
+      try {
+        const credential = result.credentialId
+          ? await this.dataDestinationCredentialService.getById(result.credentialId)
+          : null;
+        const destinationSecretKey = credential?.credentials
+          ? ((credential.credentials as LookerStudioConnectorCredentials).destinationSecretKey ?? '')
+          : '';
+
+        if (destinationSecretKey) {
+          lookerStudioCredentials = {
+            destinationId: result.id,
+            destinationSecretKey,
+            deploymentUrl: this.publicOriginService.getLookerStudioDeploymentUrl(),
+          };
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Failed to resolve Looker Studio connector credentials for destination ${result.id}`,
+          error instanceof Error ? error.stack : String(error)
         );
       }
-
-      const credential = await this.dataDestinationCredentialService.getById(result.credentialId);
-      const destinationSecretKey = credential?.credentials
-        ? ((credential.credentials as LookerStudioConnectorCredentials).destinationSecretKey ?? '')
-        : '';
-      if (!credential?.credentials || !destinationSecretKey) {
-        throw new BadRequestException(
-          'Looker Studio connector credentials could not be resolved after destination creation'
-        );
-      }
-
-      lookerStudioCredentials = {
-        destinationId: result.id,
-        destinationSecretKey,
-        deploymentUrl: this.publicOriginService.getLookerStudioDeploymentUrl(),
-      };
     }
 
     return {

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.impl.ts
@@ -5,10 +5,8 @@ import { ListDataDestinationsService } from '../use-cases/list-data-destinations
 import { CreateDataDestinationService } from '../use-cases/create-data-destination.service';
 import { CreateDataDestinationCommand } from '../dto/domain/create-data-destination.command';
 import { DataDestinationCredentialService } from '../services/data-destination-credential.service';
-import { PublicOriginService } from '../../common/config/public-origin.service';
 import { DataDestinationCredential } from '../entities/data-destination-credential.entity';
 import { DataDestinationCredentials } from '../data-destination-types/data-destination-credentials.type';
-import { LookerStudioConnectorCredentials } from '../data-destination-types/looker-studio-connector/schemas/looker-studio-connector-credentials.schema';
 import { toMcpDestinationType, type McpDestinationType } from './mcp-destination-type';
 import {
   McpDataDestinationsFacade,
@@ -34,8 +32,7 @@ export class McpDataDestinationsFacadeImpl implements McpDataDestinationsFacade 
   constructor(
     private readonly listDataDestinationsService: ListDataDestinationsService,
     private readonly createDataDestinationService: CreateDataDestinationService,
-    private readonly dataDestinationCredentialService: DataDestinationCredentialService,
-    private readonly publicOriginService: PublicOriginService
+    private readonly dataDestinationCredentialService: DataDestinationCredentialService
   ) {}
 
   async listDestinations(
@@ -152,41 +149,9 @@ export class McpDataDestinationsFacadeImpl implements McpDataDestinationsFacade 
 
     const result = await this.createDataDestinationService.run(command);
 
-    let lookerStudioCredentials:
-      | {
-          destinationId: string;
-          destinationSecretKey: string;
-          deploymentUrl: string;
-        }
-      | undefined = undefined;
-    if (request.type === 'looker_studio') {
-      try {
-        const credential = result.credentialId
-          ? await this.dataDestinationCredentialService.getById(result.credentialId)
-          : null;
-        const destinationSecretKey = credential?.credentials
-          ? ((credential.credentials as LookerStudioConnectorCredentials).destinationSecretKey ?? '')
-          : '';
-
-        if (destinationSecretKey) {
-          lookerStudioCredentials = {
-            destinationId: result.id,
-            destinationSecretKey,
-            deploymentUrl: this.publicOriginService.getLookerStudioDeploymentUrl(),
-          };
-        }
-      } catch (error) {
-        this.logger.warn(
-          `Failed to resolve Looker Studio connector credentials for destination ${result.id}`,
-          error instanceof Error ? error.stack : String(error)
-        );
-      }
-    }
-
     return {
       id: result.id,
       name: result.title,
-      lookerStudioCredentials,
     };
   }
 }

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.ts
@@ -29,11 +29,6 @@ export interface McpCreateDestinationRequest {
 export interface McpCreateDestinationResponse {
   id: string;
   name: string;
-  lookerStudioCredentials?: {
-    destinationId: string;
-    destinationSecretKey: string;
-    deploymentUrl: string;
-  };
 }
 
 export interface McpListDestinationsResponse {

--- a/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-destinations.facade.ts
@@ -13,6 +13,27 @@ export interface McpDestinationListItem {
   name: string;
   type: McpDestinationType;
   owner: string | null;
+  connectedGoogleAccount?: string | null;
+  createdAt: string;
+}
+
+export interface McpCreateDestinationRequest {
+  projectId: string;
+  userId: string;
+  roles: string[];
+  type: McpDestinationType;
+  title?: string;
+  emails?: string[];
+}
+
+export interface McpCreateDestinationResponse {
+  id: string;
+  name: string;
+  lookerStudioCredentials?: {
+    destinationId: string;
+    destinationSecretKey: string;
+    deploymentUrl: string;
+  };
 }
 
 export interface McpListDestinationsResponse {
@@ -21,4 +42,5 @@ export interface McpListDestinationsResponse {
 
 export interface McpDataDestinationsFacade {
   listDestinations(request: McpListDestinationsRequest): Promise<McpListDestinationsResponse>;
+  createDestination(request: McpCreateDestinationRequest): Promise<McpCreateDestinationResponse>;
 }

--- a/apps/backend/src/data-marts/mappers/data-destination.mapper.spec.ts
+++ b/apps/backend/src/data-marts/mappers/data-destination.mapper.spec.ts
@@ -43,3 +43,33 @@ describe('DataDestinationMapper - destination config normalization', () => {
     expect(command.config).toBeUndefined();
   });
 });
+
+describe('DataDestinationMapper - MCP connect Google Sheets flow', () => {
+  const mapper = new DataDestinationMapper(null as never, null as never, null as never);
+  const context = {
+    projectId: 'proj-1',
+    userId: 'user-1',
+    roles: ['viewer'],
+  } as never;
+
+  it('builds a connect-flow command that starts unshared and links the OAuth credential', () => {
+    const command = mapper.toConnectGoogleSheetsCreateCommand(context, {
+      title: 'Google Sheets (user@example.com)',
+      credentialId: 'cred-oauth-1',
+    });
+
+    expect(command).toMatchObject({
+      projectId: 'proj-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      title: 'Google Sheets (user@example.com)',
+      type: DataDestinationType.GOOGLE_SHEETS,
+      credentials: undefined,
+      credentialId: 'cred-oauth-1',
+      sourceDestinationId: undefined,
+      ownerIds: undefined,
+      config: undefined,
+      availableForUse: false,
+    });
+  });
+});

--- a/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
@@ -1,11 +1,15 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { AuthorizationContext } from '../../idp';
 import { UserProjectionsListDto } from '../../idp/dto/domain/user-projections-list.dto';
-import { CreateDataDestinationCommand } from '../dto/domain/create-data-destination.command';
+import {
+  CreateDataDestinationCommand,
+  CreateDataDestinationCommandProps,
+} from '../dto/domain/create-data-destination.command';
 import { DataDestinationDto } from '../dto/domain/data-destination.dto';
 import { DeleteDataDestinationCommand } from '../dto/domain/delete-data-destination.command';
 import { GetDataDestinationCommand } from '../dto/domain/get-data-destination.command';
 import { ListDataDestinationsCommand } from '../dto/domain/list-data-destinations.command';
+import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
 import { DataDestinationCredentialsUtils } from '../data-destination-types/data-destination-credentials.utils';
 import { RotateSecretKeyCommand } from '../dto/domain/rotate-secret-key.command';
 import { GetDestinationOAuthStatusCommand } from '../dto/domain/google-oauth/get-destination-oauth-status.command';
@@ -16,6 +20,7 @@ import { ExchangeOAuthCodeCommand } from '../dto/domain/google-oauth/exchange-oa
 import { ExchangeAuthorizationCodeRequestDto } from '../dto/presentation/google-oauth/exchange-authorization-code-request.dto';
 import { GenerateAuthorizationUrlRequestDto } from '../dto/presentation/google-oauth/generate-authorization-url-request.dto';
 import { UpdateDataDestinationCommand } from '../dto/domain/update-data-destination.command';
+import { CreateConnectGoogleSheetsDestinationApiDto } from '../dto/presentation/create-connect-google-sheets-destination-api.dto';
 import { CreateDataDestinationApiDto } from '../dto/presentation/create-data-destination-api.dto';
 import { DataDestinationResponseApiDto } from '../dto/presentation/data-destination-response-api.dto';
 import { UpdateDataDestinationApiDto } from '../dto/presentation/update-data-destination-api.dto';
@@ -43,22 +48,45 @@ export class DataDestinationMapper {
     private readonly publicOriginService: PublicOriginService,
     private readonly dataDestinationCredentialService: DataDestinationCredentialService
   ) {}
+
+  private buildCreateCommand(
+    context: AuthorizationContext,
+    options: Omit<CreateDataDestinationCommandProps, 'projectId' | 'userId' | 'roles'>
+  ): CreateDataDestinationCommand {
+    return new CreateDataDestinationCommand({
+      ...options,
+      projectId: context.projectId,
+      userId: context.userId,
+      roles: context.roles ?? [],
+    });
+  }
+
   toCreateCommand(
     context: AuthorizationContext,
     dto: CreateDataDestinationApiDto
   ): CreateDataDestinationCommand {
-    return new CreateDataDestinationCommand(
-      context.projectId,
-      dto.title,
-      dto.type,
-      context.userId,
-      dto.credentials,
-      dto.credentialId,
-      dto.sourceDestinationId,
-      dto.ownerIds,
-      context.roles ?? [],
-      this.normalizeDestinationConfig(dto.config)
-    );
+    return this.buildCreateCommand(context, {
+      title: dto.title,
+      type: dto.type,
+      credentials: dto.credentials,
+      credentialId: dto.credentialId,
+      sourceDestinationId: dto.sourceDestinationId,
+      ownerIds: dto.ownerIds,
+      config: this.normalizeDestinationConfig(dto.config),
+    });
+  }
+
+  toConnectGoogleSheetsCreateCommand(
+    context: AuthorizationContext,
+    dto: CreateConnectGoogleSheetsDestinationApiDto
+  ): CreateDataDestinationCommand {
+    return this.buildCreateCommand(context, {
+      title: dto.title,
+      type: DataDestinationType.GOOGLE_SHEETS,
+      credentialId: dto.credentialId,
+      // MCP-driven connect flow — starts unshared; not client-controlled.
+      availableForUse: false,
+    });
   }
 
   toUpdateCommand(

--- a/apps/backend/src/data-marts/services/data-destination-credential.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-destination-credential.service.spec.ts
@@ -1,0 +1,91 @@
+import { In, IsNull, Repository } from 'typeorm';
+import { DataDestinationCredentialService } from './data-destination-credential.service';
+import { DataDestinationCredential } from '../entities/data-destination-credential.entity';
+import { DestinationCredentialType } from '../enums/destination-credential-type.enum';
+
+describe('DataDestinationCredentialService', () => {
+  const createService = () => {
+    const repository = {
+      create: jest.fn(),
+      save: jest.fn(),
+      findOne: jest.fn(),
+      find: jest.fn(),
+      softDelete: jest.fn(),
+    } as unknown as Repository<DataDestinationCredential>;
+
+    return {
+      service: new DataDestinationCredentialService(repository),
+      repository,
+    };
+  };
+
+  describe('getByIds', () => {
+    it('returns an empty Map without hitting the database when ids is empty', async () => {
+      const { service, repository } = createService();
+
+      const result = await service.getByIds([], 'proj-1');
+
+      expect(result).toEqual(new Map());
+      expect(repository.find).not.toHaveBeenCalled();
+    });
+
+    it('batch-fetches credentials scoped to the given project and indexes them by id', async () => {
+      const { service, repository } = createService();
+      const entities = [
+        {
+          id: 'cred-1',
+          projectId: 'proj-1',
+          type: DestinationCredentialType.GOOGLE_OAUTH,
+          identity: { email: 'alice@gmail.com' },
+        },
+        {
+          id: 'cred-2',
+          projectId: 'proj-1',
+          type: DestinationCredentialType.GOOGLE_OAUTH,
+          identity: { email: 'bob@gmail.com' },
+        },
+      ] as DataDestinationCredential[];
+      (repository.find as jest.Mock).mockResolvedValue(entities);
+
+      const result = await service.getByIds(['cred-1', 'cred-2'], 'proj-1');
+
+      expect(result).toEqual(
+        new Map([
+          ['cred-1', entities[0]],
+          ['cred-2', entities[1]],
+        ])
+      );
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { id: In(['cred-1', 'cred-2']), projectId: 'proj-1', deletedAt: IsNull() },
+      });
+    });
+
+    it('omits soft-deleted credentials because the query filters deletedAt IS NULL', async () => {
+      const { service, repository } = createService();
+      const activeCredential = {
+        id: 'cred-1',
+        projectId: 'proj-1',
+        type: DestinationCredentialType.GOOGLE_OAUTH,
+        deletedAt: null,
+      } as DataDestinationCredential;
+      (repository.find as jest.Mock).mockResolvedValue([activeCredential]);
+
+      const result = await service.getByIds(['cred-1', 'cred-deleted'], 'proj-1');
+
+      expect(result).toEqual(new Map([['cred-1', activeCredential]]));
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { id: In(['cred-1', 'cred-deleted']), projectId: 'proj-1', deletedAt: IsNull() },
+      });
+    });
+
+    it('rejects a batch larger than the configured cap without hitting the database', async () => {
+      const { service, repository } = createService();
+      const tooManyIds = Array.from({ length: 501 }, (_, i) => `cred-${i}`);
+
+      await expect(service.getByIds(tooManyIds, 'proj-1')).rejects.toThrow(
+        'Cannot fetch more than 500 credentials at once'
+      );
+      expect(repository.find).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/data-marts/services/data-destination-credential.service.ts
+++ b/apps/backend/src/data-marts/services/data-destination-credential.service.ts
@@ -1,10 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, IsNull, LessThan } from 'typeorm';
+import { Repository, IsNull, LessThan, In } from 'typeorm';
 import { DataDestinationCredential } from '../entities/data-destination-credential.entity';
 import { DestinationCredentialType } from '../enums/destination-credential-type.enum';
 import type { CredentialIdentity } from '../entities/credential-identity.type';
 import type { StoredDestinationCredentials } from '../entities/stored-destination-credentials.type';
+
+const MAX_BATCH_SIZE = 500;
 
 @Injectable()
 export class DataDestinationCredentialService {
@@ -34,6 +36,23 @@ export class DataDestinationCredentialService {
 
   async getById(id: string): Promise<DataDestinationCredential | null> {
     return this.repo.findOne({ where: { id, deletedAt: IsNull() } });
+  }
+
+  async getByIds(
+    ids: string[],
+    projectId: string
+  ): Promise<Map<string, DataDestinationCredential>> {
+    if (ids.length === 0) {
+      return new Map();
+    }
+    if (ids.length > MAX_BATCH_SIZE) {
+      throw new BadRequestException(`Cannot fetch more than ${MAX_BATCH_SIZE} credentials at once`);
+    }
+
+    const entities = await this.repo.find({
+      where: { id: In(ids), projectId, deletedAt: IsNull() },
+    });
+    return new Map(entities.map(entity => [entity.id, entity]));
   }
 
   async getByProjectId(projectId: string): Promise<DataDestinationCredential[]> {

--- a/apps/backend/src/data-marts/use-cases/create-data-destination.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-destination.service.spec.ts
@@ -133,13 +133,13 @@ describe('CreateDataDestinationService', () => {
 
   it('should call syncOwners with creator userId when ownerIds not provided', async () => {
     const { service } = createService();
-    const command = new CreateDataDestinationCommand(
-      'proj-1',
-      'Test Dest',
-      DataDestinationType.LOOKER_STUDIO,
-      'user-0',
-      { type: 'looker-studio-credentials' } as never
-    );
+    const command = new CreateDataDestinationCommand({
+      projectId: 'proj-1',
+      title: 'Test Dest',
+      type: DataDestinationType.LOOKER_STUDIO,
+      userId: 'user-0',
+      credentials: { type: 'looker-studio-credentials' } as never,
+    });
 
     await service.run(command);
 
@@ -156,13 +156,13 @@ describe('CreateDataDestinationService', () => {
 
   it('should make a new destination available for use but private for maintenance by default', async () => {
     const { service } = createService();
-    const command = new CreateDataDestinationCommand(
-      'proj-1',
-      'Test Dest',
-      DataDestinationType.LOOKER_STUDIO,
-      'user-0',
-      { type: 'looker-studio-credentials' } as never
-    );
+    const command = new CreateDataDestinationCommand({
+      projectId: 'proj-1',
+      title: 'Test Dest',
+      type: DataDestinationType.LOOKER_STUDIO,
+      userId: 'user-0',
+      credentials: { type: 'looker-studio-credentials' } as never,
+    });
 
     await service.run(command);
 
@@ -175,15 +175,37 @@ describe('CreateDataDestinationService', () => {
     );
   });
 
+  it('respects an explicit availableForUse override (e.g. MCP-created destinations start unshared)', async () => {
+    const { service } = createService();
+    const command = new CreateDataDestinationCommand({
+      projectId: 'proj-1',
+      title: 'Test Dest',
+      type: DataDestinationType.LOOKER_STUDIO,
+      userId: 'user-0',
+      credentials: { type: 'looker-studio-credentials' } as never,
+      availableForUse: false,
+    });
+
+    await service.run(command);
+
+    const repository = (service as unknown as { repository: { create: jest.Mock } }).repository;
+    expect(repository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        availableForUse: false,
+        availableForMaintenance: false,
+      })
+    );
+  });
+
   it('always validates the configured folder on create (a new folder is always "changed")', async () => {
     const { service, folderValidator } = createService();
-    const command = new CreateDataDestinationCommand(
-      'proj-1',
-      'Test Dest',
-      DataDestinationType.LOOKER_STUDIO,
-      'user-0',
-      { type: 'looker-studio-credentials' } as never
-    );
+    const command = new CreateDataDestinationCommand({
+      projectId: 'proj-1',
+      title: 'Test Dest',
+      type: DataDestinationType.LOOKER_STUDIO,
+      userId: 'user-0',
+      credentials: { type: 'looker-studio-credentials' } as never,
+    });
 
     await service.run(command);
 
@@ -193,16 +215,14 @@ describe('CreateDataDestinationService', () => {
 
   it('should call syncOwners with provided ownerIds', async () => {
     const { service } = createService();
-    const command = new CreateDataDestinationCommand(
-      'proj-1',
-      'Test Dest',
-      DataDestinationType.LOOKER_STUDIO,
-      'user-0',
-      { type: 'looker-studio-credentials' } as never,
-      undefined,
-      undefined,
-      ['user-1', 'user-2']
-    );
+    const command = new CreateDataDestinationCommand({
+      projectId: 'proj-1',
+      title: 'Test Dest',
+      type: DataDestinationType.LOOKER_STUDIO,
+      userId: 'user-0',
+      credentials: { type: 'looker-studio-credentials' } as never,
+      ownerIds: ['user-1', 'user-2'],
+    });
 
     await service.run(command);
 
@@ -225,14 +245,13 @@ describe('CreateDataDestinationService', () => {
         projectId: 'other-project',
       });
 
-      const command = new CreateDataDestinationCommand(
-        'proj-1',
-        'Test',
-        DataDestinationType.GOOGLE_SHEETS,
-        'user-0',
-        undefined,
-        'cred-1'
-      );
+      const command = new CreateDataDestinationCommand({
+        projectId: 'proj-1',
+        title: 'Test',
+        type: DataDestinationType.GOOGLE_SHEETS,
+        userId: 'user-0',
+        credentialId: 'cred-1',
+      });
 
       await expect(service.run(command)).rejects.toThrow(
         'Credential does not belong to this project'
@@ -243,14 +262,13 @@ describe('CreateDataDestinationService', () => {
       const { service, dataDestinationCredentialService } = createService();
       dataDestinationCredentialService.getById.mockResolvedValue(null);
 
-      const command = new CreateDataDestinationCommand(
-        'proj-1',
-        'Test',
-        DataDestinationType.GOOGLE_SHEETS,
-        'user-0',
-        undefined,
-        'cred-missing'
-      );
+      const command = new CreateDataDestinationCommand({
+        projectId: 'proj-1',
+        title: 'Test',
+        type: DataDestinationType.GOOGLE_SHEETS,
+        userId: 'user-0',
+        credentialId: 'cred-missing',
+      });
 
       await expect(service.run(command)).rejects.toThrow(
         'Credential does not belong to this project'
@@ -265,14 +283,13 @@ describe('CreateDataDestinationService', () => {
         projectId: 'proj-1',
       });
 
-      const command = new CreateDataDestinationCommand(
-        'proj-1',
-        'Test',
-        DataDestinationType.GOOGLE_SHEETS,
-        'user-0',
-        undefined,
-        'cred-1'
-      );
+      const command = new CreateDataDestinationCommand({
+        projectId: 'proj-1',
+        title: 'Test',
+        type: DataDestinationType.GOOGLE_SHEETS,
+        userId: 'user-0',
+        credentialId: 'cred-1',
+      });
 
       const result = await service.run(command);
 
@@ -280,6 +297,35 @@ describe('CreateDataDestinationService', () => {
         googleOAuthClientService.getDestinationOAuth2ClientByCredentialId
       ).toHaveBeenCalledWith('cred-1');
       expect(result).toEqual({ id: 'dest-1' });
+    });
+
+    it('persists availableForUse=false for the MCP connect Google Sheets command shape', async () => {
+      const { service, dataDestinationCredentialService, repository } = createService();
+      dataDestinationCredentialService.getById.mockResolvedValue({
+        id: 'cred-oauth-1',
+        projectId: 'proj-1',
+      });
+
+      const command = new CreateDataDestinationCommand({
+        projectId: 'proj-1',
+        title: 'Google Sheets (user@example.com)',
+        type: DataDestinationType.GOOGLE_SHEETS,
+        userId: 'user-0',
+        credentialId: 'cred-oauth-1',
+        roles: ['viewer'],
+        availableForUse: false,
+      });
+
+      await service.run(command);
+
+      expect(repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: DataDestinationType.GOOGLE_SHEETS,
+          credentialId: 'cred-oauth-1',
+          availableForUse: false,
+          availableForMaintenance: false,
+        })
+      );
     });
 
     it('rejects credential already linked to another destination when caller lacks COPY_CREDENTIALS', async () => {
@@ -292,14 +338,13 @@ describe('CreateDataDestinationService', () => {
       repository.findOne.mockResolvedValue({ id: 'existing-dest', credentialId: 'cred-1' });
       accessDecisionService.canAccess.mockResolvedValue(false);
 
-      const command = new CreateDataDestinationCommand(
-        'proj-1',
-        'Test',
-        DataDestinationType.GOOGLE_SHEETS,
-        'user-0',
-        undefined,
-        'cred-1'
-      );
+      const command = new CreateDataDestinationCommand({
+        projectId: 'proj-1',
+        title: 'Test',
+        type: DataDestinationType.GOOGLE_SHEETS,
+        userId: 'user-0',
+        credentialId: 'cred-1',
+      });
 
       await expect(service.run(command)).rejects.toThrow(
         'You do not have permission to copy credentials from this destination'
@@ -329,14 +374,13 @@ describe('CreateDataDestinationService', () => {
       repository.findOne.mockResolvedValue({ id: 'existing-dest', credentialId: 'cred-1' });
       accessDecisionService.canAccess.mockResolvedValue(true);
 
-      const command = new CreateDataDestinationCommand(
-        'proj-1',
-        'Test',
-        DataDestinationType.GOOGLE_SHEETS,
-        'user-0',
-        undefined,
-        'cred-1'
-      );
+      const command = new CreateDataDestinationCommand({
+        projectId: 'proj-1',
+        title: 'Test',
+        type: DataDestinationType.GOOGLE_SHEETS,
+        userId: 'user-0',
+        credentialId: 'cred-1',
+      });
 
       const result = await service.run(command);
 

--- a/apps/backend/src/data-marts/use-cases/create-data-destination.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-destination.service.spec.ts
@@ -281,6 +281,7 @@ describe('CreateDataDestinationService', () => {
       dataDestinationCredentialService.getById.mockResolvedValue({
         id: 'cred-1',
         projectId: 'proj-1',
+        createdById: 'user-0',
       });
 
       const command = new CreateDataDestinationCommand({
@@ -304,6 +305,7 @@ describe('CreateDataDestinationService', () => {
       dataDestinationCredentialService.getById.mockResolvedValue({
         id: 'cred-oauth-1',
         projectId: 'proj-1',
+        createdById: 'user-0',
       });
 
       const command = new CreateDataDestinationCommand({
@@ -326,6 +328,26 @@ describe('CreateDataDestinationService', () => {
           availableForMaintenance: false,
         })
       );
+    });
+
+    it('rejects an unlinked credential created by another same-project user', async () => {
+      const { service, dataDestinationCredentialService, repository } = createService();
+      dataDestinationCredentialService.getById.mockResolvedValue({
+        id: 'cred-1',
+        projectId: 'proj-1',
+        createdById: 'user-1',
+      });
+      repository.findOne.mockResolvedValue(null);
+
+      const command = new CreateDataDestinationCommand({
+        projectId: 'proj-1',
+        title: 'Test',
+        type: DataDestinationType.GOOGLE_SHEETS,
+        userId: 'user-0',
+        credentialId: 'cred-1',
+      });
+
+      await expect(service.run(command)).rejects.toThrow('Credential does not belong to this user');
     });
 
     it('rejects credential already linked to another destination when caller lacks COPY_CREDENTIALS', async () => {

--- a/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
@@ -58,6 +58,7 @@ export class CreateDataDestinationService {
   @Transactional()
   async run(command: CreateDataDestinationCommand): Promise<DataDestinationDto> {
     this.availableDestinationTypesService.verifyIsAllowed(command.type);
+    const availableForUse = command.availableForUse ?? true;
 
     // Mutual exclusion: sourceDestinationId vs credentials/credentialId
     if (command.sourceDestinationId && command.hasCredentials()) {
@@ -110,7 +111,7 @@ export class CreateDataDestinationService {
         projectId: command.projectId,
         credentialId: newCredId,
         createdById: command.userId,
-        availableForUse: true,
+        availableForUse,
         availableForMaintenance: false,
         config: command.config ?? null,
       });
@@ -160,7 +161,7 @@ export class CreateDataDestinationService {
         projectId: command.projectId,
         credentialId: command.credentialId,
         createdById: command.userId,
-        availableForUse: true,
+        availableForUse,
         availableForMaintenance: false,
         config: command.config ?? null,
       });
@@ -204,7 +205,7 @@ export class CreateDataDestinationService {
       projectId: command.projectId,
       credentialId: credentialRecord.id,
       createdById: command.userId,
-      availableForUse: true,
+      availableForUse,
       availableForMaintenance: false,
       config: command.config ?? null,
     });

--- a/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-destination.service.ts
@@ -147,6 +147,8 @@ export class CreateDataDestinationService {
             'You do not have permission to copy credentials from this destination'
           );
         }
+      } else if (credential.createdById !== command.userId) {
+        throw new ForbiddenException('Credential does not belong to this user');
       }
 
       const oauth2Client =

--- a/apps/backend/src/ee/mcp/tools/add-destination.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/add-destination.tool.spec.ts
@@ -1,0 +1,242 @@
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import type { McpDataDestinationsFacade } from '../../../data-marts/facades/mcp-data-destinations.facade';
+import type { PublicOriginService } from '../../../common/config/public-origin.service';
+import { AddDestinationTool } from './add-destination.tool';
+
+describe('AddDestinationTool', () => {
+  const context: McpAuthContext = {
+    clientId: 'mcp-client-1',
+    userId: 'user-1',
+    projectId: 'project-1',
+    roles: ['viewer'],
+    resource: 'https://mcp.owox.com/mcp',
+    scopes: ['mcp:write'],
+    authFlow: 'mcp',
+  };
+
+  let destinationsFacade: jest.Mocked<McpDataDestinationsFacade>;
+  let publicOriginService: jest.Mocked<PublicOriginService>;
+  let tool: AddDestinationTool;
+
+  beforeEach(() => {
+    destinationsFacade = {
+      listDestinations: jest.fn(),
+      createDestination: jest.fn(),
+    };
+    publicOriginService = {
+      getPublicOrigin: jest.fn(() => 'https://app.owox.com'),
+    } as unknown as jest.Mocked<PublicOriginService>;
+
+    tool = new AddDestinationTool(destinationsFacade, publicOriginService);
+  });
+
+  it('describes metadata properly', () => {
+    expect(tool).toMatchObject({
+      name: 'add_destination',
+      requiredScopes: ['mcp:write'],
+      annotations: {
+        title: 'Add Destination',
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    });
+    expect(tool.description).toContain('google_sheets');
+    expect(tool.description).toContain('email-based types');
+    expect(tool.description).toContain('looker_studio');
+  });
+
+  it('validates and parses valid input', () => {
+    const valid = {
+      destination_type: 'google_sheets',
+      title: 'My Google Sheets',
+    };
+    expect(tool.parseInput(valid)).toEqual(valid);
+  });
+
+  it.each(['', '   '])('rejects blank destination titles', title => {
+    expect(() => tool.parseInput({ destination_type: 'email', title })).toThrow();
+  });
+
+  it('rejects invalid destination types', () => {
+    const invalid = {
+      destination_type: 'invalid_type',
+    };
+    expect(() => tool.parseInput(invalid)).toThrow();
+  });
+
+  // No role gate here: creating a destination has no parent entity to check access
+  // against (unlike reports/schedules, which check access on the data mart/report they
+  // attach to), and the REST API allows any project member (viewer included) to create
+  // one via POST /data-destinations — this tool matches that, not a stricter policy.
+  it('allows creation for a caller with only the viewer role', async () => {
+    const result = await tool.handler({ destination_type: 'google_sheets' }, context);
+
+    const structured = result.structuredContent as any;
+    expect(structured.authorization_url).toContain('/ui/project-1/connect/google-sheets');
+  });
+
+  it('builds a Connect Google Sheets page link with defaults', async () => {
+    const result = await tool.handler({ destination_type: 'google_sheets' }, context);
+
+    const structured = result.structuredContent as any;
+    expect(structured.authorization_url).toBe(
+      'https://app.owox.com/ui/project-1/connect/google-sheets'
+    );
+    expect(structured.instructions).toContain('signed in to OWOX');
+    expect(structured.instructions).toContain('member of');
+    expect(structured.instructions).toContain('same account');
+    // No destination_id is returned for google_sheets — the entity doesn't exist yet —
+    // and the agent must be told explicitly how to find it afterward.
+    expect(structured.destination_id).toBeUndefined();
+    expect(structured.instructions).toContain('does NOT include a destination_id');
+    expect(structured.instructions).toContain('list_destinations');
+    expect(structured.instructions).toContain('never pick by createdAt');
+    expect(structured.instructions).toContain('cannot be predicted in advance');
+    expect(structured.instructions).toContain('connectedGoogleAccount');
+    expect(structured.instructions).toContain('ask the user which one they mean');
+
+    expect(result.content[0]).toEqual({
+      type: 'text',
+      text: JSON.stringify(structured, null, 2),
+    });
+  });
+
+  // The Connect Google Sheets page never pre-fills its Title field from a link — an
+  // unverified query param isn't proof of what the user wants — so `title` is ignored
+  // entirely for google_sheets, unlike the directly-created types below.
+  it('ignores the title parameter for google_sheets — no query param on the link at all', async () => {
+    const result = await tool.handler(
+      { destination_type: 'google_sheets', title: 'My Google Sheets' },
+      context
+    );
+
+    const structured = result.structuredContent as any;
+    const url = new URL(structured.authorization_url);
+    expect(url.pathname).toBe('/ui/project-1/connect/google-sheets');
+    expect(url.search).toBe('');
+  });
+
+  it('supports direct creation of email-based destination if emails are provided', async () => {
+    destinationsFacade.createDestination.mockResolvedValue({
+      id: 'new-dest-id',
+      name: 'Marketing Email List',
+    });
+
+    const result = await tool.handler(
+      {
+        destination_type: 'email',
+        title: 'Marketing Email List',
+        emails: ['test@example.com', 'user@example.com'],
+      },
+      context
+    );
+
+    expect(destinationsFacade.createDestination).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      type: 'email',
+      title: 'Marketing Email List',
+      emails: ['test@example.com', 'user@example.com'],
+    });
+
+    const structured = result.structuredContent as any;
+    expect(structured.destination_id).toBe('new-dest-id');
+    expect(structured.instructions).toContain('Successfully connected Email destination');
+  });
+
+  it('rejects looker_studio creation when connector credentials are missing from the facade response', async () => {
+    destinationsFacade.createDestination.mockResolvedValue({
+      id: 'looker-dest-id',
+      name: 'Looker Studio MCP Destination',
+    });
+
+    await expect(
+      tool.handler(
+        {
+          destination_type: 'looker_studio',
+          title: 'Looker Studio MCP Destination',
+        },
+        context
+      )
+    ).rejects.toThrow(
+      'Data Studio destination was created but connector credentials could not be resolved'
+    );
+  });
+
+  it('supports direct creation of looker_studio destination and returns credentials', async () => {
+    destinationsFacade.createDestination.mockResolvedValue({
+      id: 'looker-dest-id',
+      name: 'Looker Studio MCP Destination',
+      lookerStudioCredentials: {
+        destinationId: 'looker-dest-id',
+        destinationSecretKey: 'mock-secret-key-123',
+        deploymentUrl: 'https://looker.example.com',
+      },
+    });
+
+    const result = await tool.handler(
+      {
+        destination_type: 'looker_studio',
+        title: 'Looker Studio MCP Destination',
+      },
+      context
+    );
+
+    expect(destinationsFacade.createDestination).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      type: 'looker_studio',
+      title: 'Looker Studio MCP Destination',
+    });
+
+    const structured = result.structuredContent as any;
+    expect(structured.destination_id).toBe('looker-dest-id');
+    expect(structured.instructions).toContain(
+      'Data Studio Destination "Looker Studio MCP Destination" has been successfully enabled'
+    );
+    expect(structured.instructions).toContain('Data Destinations in OWOX Data Marts');
+    // The secret must never appear in the MCP response, even for a destination just created.
+    expect(structured.instructions).not.toContain('mock-secret-key-123');
+    expect(JSON.stringify(structured)).not.toContain('mock-secret-key-123');
+  });
+
+  it.each([
+    ['email', 'Email'],
+    ['slack', 'Slack'],
+    ['teams', 'Teams'],
+    ['google_chat', 'Google Chat'],
+  ] as const)(
+    'defaults the title to a plain label for %s, not an uppercase/MCP-suffixed one',
+    async (type, expectedTitle) => {
+      destinationsFacade.createDestination.mockResolvedValue({
+        id: 'new-dest-id',
+        name: expectedTitle,
+      });
+
+      await tool.handler({ destination_type: type, emails: ['user@example.com'] }, context);
+
+      expect(destinationsFacade.createDestination).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expectedTitle })
+      );
+    }
+  );
+
+  it('throws a validation error if emails are missing for email-based types', async () => {
+    await expect(
+      tool.handler(
+        {
+          destination_type: 'email',
+          title: 'Marketing Email List',
+        },
+        context
+      )
+    ).rejects.toThrow(
+      "The 'emails' parameter is required for creating email-based destination types"
+    );
+
+    expect(destinationsFacade.createDestination).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/ee/mcp/tools/add-destination.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/add-destination.tool.spec.ts
@@ -146,34 +146,10 @@ describe('AddDestinationTool', () => {
     expect(structured.instructions).toContain('Successfully connected Email destination');
   });
 
-  it('rejects looker_studio creation when connector credentials are missing from the facade response', async () => {
+  it('supports direct creation of looker_studio destination without returning credentials', async () => {
     destinationsFacade.createDestination.mockResolvedValue({
       id: 'looker-dest-id',
       name: 'Looker Studio MCP Destination',
-    });
-
-    await expect(
-      tool.handler(
-        {
-          destination_type: 'looker_studio',
-          title: 'Looker Studio MCP Destination',
-        },
-        context
-      )
-    ).rejects.toThrow(
-      'Data Studio destination was created but connector credentials could not be resolved'
-    );
-  });
-
-  it('supports direct creation of looker_studio destination and returns credentials', async () => {
-    destinationsFacade.createDestination.mockResolvedValue({
-      id: 'looker-dest-id',
-      name: 'Looker Studio MCP Destination',
-      lookerStudioCredentials: {
-        destinationId: 'looker-dest-id',
-        destinationSecretKey: 'mock-secret-key-123',
-        deploymentUrl: 'https://looker.example.com',
-      },
     });
 
     const result = await tool.handler(
@@ -198,9 +174,8 @@ describe('AddDestinationTool', () => {
       'Data Studio Destination "Looker Studio MCP Destination" has been successfully enabled'
     );
     expect(structured.instructions).toContain('Data Destinations in OWOX Data Marts');
-    // The secret must never appear in the MCP response, even for a destination just created.
-    expect(structured.instructions).not.toContain('mock-secret-key-123');
-    expect(JSON.stringify(structured)).not.toContain('mock-secret-key-123');
+    expect(JSON.stringify(structured)).not.toContain('destinationSecretKey');
+    expect(JSON.stringify(structured)).not.toContain('lookerStudioCredentials');
   });
 
   it.each([

--- a/apps/backend/src/ee/mcp/tools/add-destination.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/add-destination.tool.ts
@@ -161,13 +161,6 @@ export class AddDestinationTool implements McpToolDefinition<AddDestinationInput
         title,
       });
 
-      const creds = created.lookerStudioCredentials;
-      if (!creds?.deploymentUrl || !creds.destinationSecretKey) {
-        throw new BadRequestException(
-          'Data Studio destination was created but connector credentials could not be resolved'
-        );
-      }
-
       // The Destination Secret Key (Token) must never be sent through MCP/chat, even for a
       // destination just created in this same call — it's a live credential, not a display
       // value, so the user retrieves it themselves from the OWOX Data Marts UI.

--- a/apps/backend/src/ee/mcp/tools/add-destination.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/add-destination.tool.ts
@@ -1,0 +1,226 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import type { McpScope } from '@owox/idp-protocol';
+import { PublicOriginService } from '../../../common/config/public-origin.service';
+import {
+  MCP_DATA_DESTINATIONS_FACADE,
+  type McpDataDestinationsFacade,
+} from '../../../data-marts/facades/mcp-data-destinations.facade';
+import { MCP_DESTINATION_TYPES } from '../../../data-marts/facades/mcp-destination-type';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import { jsonToolResult, type McpToolDefinition, type McpToolResult } from './mcp-tool.definition';
+import { buildConnectGoogleSheetsUiPath } from './mcp-flow-ui-path';
+import { joinPublicOrigin } from './mcp-public-url.util';
+
+const EMAIL_BASED_TYPES = ['email', 'slack', 'teams', 'google_chat'];
+
+/**
+ * Plain, mechanical label for a destination type — used both in agent-facing messages and
+ * as the default destination name when the caller doesn't provide a title. No curated
+ * per-type mapping to maintain: "google_chat" -> "Google Chat", "teams" -> "Teams", etc. —
+ * just enough to avoid an all-caps or "_"-ridden name, nothing more.
+ */
+function toDisplayLabel(type: string): string {
+  return type
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+const inputSchema = z
+  .object({
+    destination_type: z
+      .enum(MCP_DESTINATION_TYPES)
+      .describe(
+        'The type of destination to connect/create (e.g. google_sheets, looker_studio, email, slack, teams, google_chat).'
+      ),
+    title: z
+      .string()
+      .trim()
+      .min(1)
+      .optional()
+      .describe(
+        'Optional custom name for the new destination itself (e.g. "Marketing Team Google ' +
+          'Sheet"), NOT the name of the report you may be creating this destination for. A ' +
+          'destination is a standalone, reusable connection target — once created, it can be ' +
+          'reused by any number of future reports, so name it after what it represents (the ' +
+          'team, tool, or channel it points to), not after the specific report that prompted ' +
+          'you to create it. Does NOT apply to google_sheets: that page never pre-fills its ' +
+          "name from this parameter — the user always sets it directly in the form, so it's " +
+          'ignored there. Applies to email, slack, teams, google_chat, and looker_studio only.'
+      ),
+    emails: z
+      .array(z.string().email())
+      .optional()
+      .describe(
+        'Mandatory list of target email addresses/delivery targets. This parameter is STRICTLY REQUIRED for email-based types (email, slack, teams, google_chat). Do NOT attempt to call this tool for email-based types without asking the user for these email addresses first.'
+      ),
+  })
+  .strict();
+
+type AddDestinationInput = z.infer<typeof inputSchema>;
+
+@Injectable()
+export class AddDestinationTool implements McpToolDefinition<AddDestinationInput> {
+  readonly name = 'add_destination';
+  readonly description =
+    'Adds a report-delivery destination. Behavior depends on destination_type: ' +
+    'for google_sheets, returns a link to a simple in-app "Connect Google Sheets" page — ' +
+    'the user must be signed in to OWOX (prompted if not) and a member of this project ' +
+    '(asked to request access if not); on the page they click to start Google OAuth, and ' +
+    'the destination is created automatically as soon as they approve access — no extra ' +
+    'save step; the person who completed it can use it in their own reports right away, ' +
+    'but it starts unshared for everyone else on the project — another project member ' +
+    'cannot use it until a human shares it — this call does NOT return a destination_id, ' +
+    'because the destination does not exist yet, and its name is not known in advance ' +
+    'either (the user sets it directly in the form, this tool never pre-fills it); ' +
+    'after the user confirms they completed it, ' +
+    'call list_destinations and filter to google_sheets entries whose ' +
+    'connectedGoogleAccount matches who the user expected — never pick by createdAt/recency, ' +
+    'another destination may be created concurrently by someone else; if more than one ' +
+    'entry still matches, ask the user which one they mean instead of guessing; ' +
+    'for email-based types (email, slack, teams, google_chat), creates the destination ' +
+    'directly and requires the emails parameter — no OAuth involved, destination_id is ' +
+    'returned immediately; ' +
+    'for looker_studio (pull-based connector), creates the destination directly and returns ' +
+    'destination_id immediately — no OAuth, no emails needed; the connector credentials ' +
+    '(including the Destination Secret Key/Token) are never sent through MCP/chat — the ' +
+    'user must open the destination in the OWOX Data Marts UI to copy them.';
+  readonly zodSchema = inputSchema.shape;
+  readonly outputSchema = {
+    authorization_url: z.string().optional(),
+    instructions: z.string(),
+    destination_id: z
+      .string()
+      .optional()
+      .describe(
+        'The new destination id. Present for every destination_type EXCEPT google_sheets ' +
+          '(returned immediately, before any external action is needed). For google_sheets, ' +
+          'this is absent — use list_destinations after the user confirms setup instead.'
+      ),
+  };
+  readonly annotations = {
+    title: 'Add Destination',
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: false,
+  };
+  readonly requiredScopes: McpScope[] = ['mcp:write'];
+
+  constructor(
+    @Inject(MCP_DATA_DESTINATIONS_FACADE)
+    private readonly destinations: McpDataDestinationsFacade,
+    private readonly publicOriginService: PublicOriginService
+  ) {}
+
+  parseInput(input: unknown): AddDestinationInput {
+    return inputSchema
+      .refine(
+        data =>
+          !EMAIL_BASED_TYPES.includes(data.destination_type) ||
+          (data.emails && data.emails.length > 0),
+        {
+          message:
+            "The 'emails' parameter is required for creating email-based destination types (email, slack, teams, google_chat). " +
+            'Please ask the user to specify one or more email addresses first before calling this tool.',
+          path: ['emails'],
+        }
+      )
+      .parse(input);
+  }
+
+  async handler(input: AddDestinationInput, context: McpAuthContext): Promise<McpToolResult> {
+    const parsed = this.parseInput(input);
+    const destinationType = parsed.destination_type;
+    const humanType = toDisplayLabel(destinationType);
+    const title = parsed.title ?? humanType;
+
+    if (EMAIL_BASED_TYPES.includes(destinationType)) {
+      const created = await this.destinations.createDestination({
+        projectId: context.projectId,
+        userId: context.userId,
+        roles: context.roles,
+        type: destinationType,
+        title,
+        emails: parsed.emails,
+      });
+
+      return jsonToolResult({
+        destination_id: created.id,
+        instructions: `Successfully connected ${humanType} destination "${created.name}" for report delivery.`,
+      });
+    }
+
+    // Direct creation for Looker Studio (no browser OAuth popup is needed)
+    if (destinationType === 'looker_studio') {
+      const created = await this.destinations.createDestination({
+        projectId: context.projectId,
+        userId: context.userId,
+        roles: context.roles,
+        type: destinationType,
+        title,
+      });
+
+      const creds = created.lookerStudioCredentials;
+      if (!creds?.deploymentUrl || !creds.destinationSecretKey) {
+        throw new BadRequestException(
+          'Data Studio destination was created but connector credentials could not be resolved'
+        );
+      }
+
+      // The Destination Secret Key (Token) must never be sent through MCP/chat, even for a
+      // destination just created in this same call — it's a live credential, not a display
+      // value, so the user retrieves it themselves from the OWOX Data Marts UI.
+      const instructions = `Data Studio Destination "${created.name}" has been successfully enabled!
+Open Data Destinations in OWOX Data Marts and edit "${created.name}" to copy its connector credentials (Deployment URL, Destination ID, and Destination Secret Key) into the OWOX Data Marts Data Studio connector interface.`;
+
+      return jsonToolResult({
+        destination_id: created.id,
+        instructions,
+      });
+    }
+
+    if (destinationType === 'google_sheets') {
+      // A link into a normal, authenticated, project-scoped in-app page (ConnectFlowLayout /
+      // ConnectGoogleSheetsPage) — no token minted, no unauthenticated backend route. The
+      // user must already be signed in to OWOX and a member of this project; the existing
+      // route guards (ProjectIdGuard/ProjectRoleGuard) handle sign-in prompts, project
+      // switching, and access requests. Deliberately no title/name is passed through the
+      // URL — the page never pre-fills its Title field from a query param (an unverified
+      // value from a link isn't proof of what the user actually wants), so the agent can
+      // never predict the final name in advance; the user always sets it in the form.
+      const setupUrl = joinPublicOrigin(
+        this.publicOriginService.getPublicOrigin(),
+        buildConnectGoogleSheetsUiPath(context.projectId)
+      );
+
+      return jsonToolResult({
+        authorization_url: setupUrl,
+        instructions:
+          'Open this link in your browser. You must be signed in to OWOX with the same account ' +
+          'that connected MCP and be a member of this project; otherwise MCP will not be ' +
+          'able to find the unshared destination afterward. If needed, you will be prompted ' +
+          'to sign in or request project access. It opens a simple "Connect Google Sheets" ' +
+          'page — click "Connect with ' +
+          'Google" there. Your Google Sheets destination is created automatically as soon ' +
+          'as you approve access, no extra save step. You can use it in your own reports ' +
+          'right away, but it starts unshared for everyone else on the project — other ' +
+          'project members cannot use it until a human shares it. This response does NOT ' +
+          "include a destination_id — it doesn't exist yet. Once the user says they're " +
+          'done: call list_destinations, filter to google_sheets entries, and match by ' +
+          'connectedGoogleAccount against who the user expected — never pick by createdAt ' +
+          'or recency, someone else could create a destination at the same time. Its name ' +
+          'is whatever the user set in the form and cannot be predicted in advance. If ' +
+          'exactly one entry matches connectedGoogleAccount, use it; if more than one ' +
+          'still matches, do not guess — ask the user which one they mean.',
+      });
+    }
+
+    // Unreachable for the current MCP_DESTINATION_TYPES (email-based, looker_studio, and
+    // google_sheets above already cover all of them exhaustively) — guards against a
+    // future destination type being added to the enum without a matching branch here.
+    throw new BadRequestException(
+      `No creation flow is implemented for destination type '${destinationType}'.`
+    );
+  }
+}

--- a/apps/backend/src/ee/mcp/tools/add-report.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/add-report.tool.ts
@@ -8,7 +8,8 @@ import {
 } from '../../../data-marts/facades/mcp-reports.facade';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import { jsonToolResult, type McpToolDefinition, type McpToolResult } from './mcp-tool.definition';
-import { buildReportsUiPath, joinPublicOrigin } from './data-mart-ui-path';
+import { buildReportsUiPath } from './data-mart-ui-path';
+import { joinPublicOrigin } from './mcp-public-url.util';
 
 const inputSchema = z
   .object({

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -120,6 +120,7 @@ describe('ListDataMartsTool', () => {
       'AddReportTool',
       'UpdateReportTool',
       'DeleteReportTool',
+      'AddDestinationTool',
     ]);
     expect(registry.getTool('list_data_marts')).toBeDefined();
     expect(registry.getTool('query_data_mart')).toBeUndefined();

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.ts
@@ -8,7 +8,8 @@ import {
 } from '../../../data-marts/facades/mcp-data-marts.facade';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import { jsonToolResult, type McpToolDefinition, type McpToolResult } from './mcp-tool.definition';
-import { buildDataMartUiPath, joinPublicOrigin } from './data-mart-ui-path';
+import { buildDataMartUiPath } from './data-mart-ui-path';
+import { joinPublicOrigin } from './mcp-public-url.util';
 
 type ListDataMartsInput = Record<string, never>;
 

--- a/apps/backend/src/ee/mcp/tools/data-mart-ui-path.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-ui-path.ts
@@ -5,7 +5,3 @@ export function buildDataMartUiPath(projectId: string, dataMartId: string): stri
 export function buildReportsUiPath(projectId: string, dataMartId: string): string {
   return `/ui/${encodeURIComponent(projectId)}/data-marts/${encodeURIComponent(dataMartId)}/reports`;
 }
-
-export function joinPublicOrigin(publicOrigin: string, path: string): string {
-  return new URL(path, `${publicOrigin.replace(/\/+$/, '')}/`).toString();
-}

--- a/apps/backend/src/ee/mcp/tools/list-destinations.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/list-destinations.tool.ts
@@ -17,7 +17,19 @@ type ListDestinationsInput = z.infer<typeof inputSchema>;
 export class ListDestinationsTool implements McpToolDefinition<ListDestinationsInput> {
   readonly name = 'list_destinations';
   readonly description =
-    'List destinations in the active OWOX project to target when creating a report.';
+    'List destinations in the active OWOX project to target when creating a report. ' +
+    'Also the only way to learn the destination_id and connected Google account for a ' +
+    'google_sheets destination just created via add_destination, since that call does ' +
+    'not return an id synchronously — see its description. When matching that destination, ' +
+    'never pick by createdAt/recency — someone else may create a destination at the same ' +
+    'time, so the newest entry is not reliably the right one. Filter by connectedGoogleAccount ' +
+    'matching who the user expected instead; if exactly one entry matches, use it, and if ' +
+    'more than one still matches, ask the user which one they mean rather than guessing. ' +
+    'Destinations created via add_destination start unshared: the creator can use them ' +
+    'in their own reports right away, but other project members cannot until a human ' +
+    'shares them (Configure destination → Sharing) — this tool does not report sharing ' +
+    "status, so if the report is for someone other than the destination's creator, " +
+    'confirm with the user that it has been shared rather than assuming it.';
   readonly zodSchema = inputSchema.shape;
   readonly outputSchema = {
     destinations: z.array(
@@ -26,6 +38,24 @@ export class ListDestinationsTool implements McpToolDefinition<ListDestinationsI
         name: z.string(),
         type: z.enum(MCP_DESTINATION_TYPES),
         owner: z.string().nullable(),
+        connectedGoogleAccount: z
+          .string()
+          .nullable()
+          .optional()
+          .describe(
+            'For google_sheets destinations: the Google account that completed OAuth ' +
+              'consent. This is the field to match on when identifying a destination just ' +
+              'created via add_destination. If more than one google_sheets entry matches ' +
+              'the expected account, ask the user which one they mean instead of guessing.'
+          ),
+        createdAt: z
+          .string()
+          .describe(
+            'ISO 8601 timestamp, informational only. Do not use it to pick between ' +
+              'candidate google_sheets destinations — someone else may create one at the ' +
+              'same time, so the newest entry is not reliably the right one. Its `name` ' +
+              'cannot be predicted in advance; the user sets it in the form.'
+          ),
       })
     ),
   };

--- a/apps/backend/src/ee/mcp/tools/mcp-flow-ui-path.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-flow-ui-path.ts
@@ -1,0 +1,15 @@
+/**
+ * Path for the minimal, chrome-free "Connect Google Sheets" page (ConnectFlowLayout in the
+ * web app) — an authenticated, project-scoped page: opening it relies entirely on the
+ * normal OWOX sign-in/project-membership guards, no token is embedded in the URL. The route
+ * itself isn't MCP-specific (it's a generic "connect" flow any external client can link to)
+ * — only this function, which the add_destination MCP tool uses to build the link, is.
+ *
+ * Deliberately takes no title/name option: the page never pre-fills its Title field from the
+ * URL — a query param isn't proof of what the caller actually intends, and displaying or
+ * pre-filling untrusted content from a link is exactly the kind of risk this flow avoids.
+ * The user always sets the name directly in the form instead.
+ */
+export function buildConnectGoogleSheetsUiPath(projectId: string): string {
+  return `/ui/${encodeURIComponent(projectId)}/connect/google-sheets`;
+}

--- a/apps/backend/src/ee/mcp/tools/mcp-public-url.util.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-public-url.util.spec.ts
@@ -1,0 +1,21 @@
+import { joinPublicOrigin } from './mcp-public-url.util';
+
+describe('joinPublicOrigin', () => {
+  it('joins a relative path onto the origin', () => {
+    expect(
+      joinPublicOrigin('https://app.owox.com', '/ui/project-1/data-marts/dm_1/data-setup')
+    ).toBe('https://app.owox.com/ui/project-1/data-marts/dm_1/data-setup');
+  });
+
+  it('handles a trailing slash on the origin', () => {
+    expect(joinPublicOrigin('https://app.owox.com/', '/ui/project-1/connect/google-sheets')).toBe(
+      'https://app.owox.com/ui/project-1/connect/google-sheets'
+    );
+  });
+
+  it('preserves a query string on the path', () => {
+    expect(joinPublicOrigin('https://app.owox.com', '/ui/project-1/connect/x?title=Foo')).toBe(
+      'https://app.owox.com/ui/project-1/connect/x?title=Foo'
+    );
+  });
+});

--- a/apps/backend/src/ee/mcp/tools/mcp-public-url.util.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-public-url.util.ts
@@ -1,0 +1,8 @@
+/**
+ * Joins a relative in-app path onto the configured public origin, producing an absolute
+ * URL a caller outside the app (e.g. an MCP client) can open directly. Shared across all
+ * MCP tools that link into the web app UI — not specific to any one flow/domain.
+ */
+export function joinPublicOrigin(publicOrigin: string, path: string): string {
+  return new URL(path, `${publicOrigin.replace(/\/+$/, '')}/`).toString();
+}

--- a/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
@@ -15,6 +15,7 @@ import { SearchDataMartsTool } from './search-data-marts.tool';
 import { SummarizeDataCatalogTool } from './summarize-data-catalog.tool';
 import { UpdateReportRunScheduleTool } from './update-report-run-schedule.tool';
 import { UpdateReportTool } from './update-report.tool';
+import { AddDestinationTool } from './add-destination.tool';
 
 export const MCP_TOOL_PROVIDER_CLASSES: Array<Type<McpToolDefinition>> = [
   SummarizeDataCatalogTool,
@@ -32,6 +33,7 @@ export const MCP_TOOL_PROVIDER_CLASSES: Array<Type<McpToolDefinition>> = [
   AddReportTool,
   UpdateReportTool,
   DeleteReportTool,
+  AddDestinationTool,
 ];
 
 export const MCP_TOOL_DEFINITIONS_PROVIDER: Provider = {

--- a/apps/backend/src/ee/mcp/tools/search-data-marts.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/search-data-marts.tool.ts
@@ -9,7 +9,8 @@ import {
 import { PublicOriginService } from '../../../common/config/public-origin.service';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import { jsonToolResult, type McpToolDefinition, type McpToolResult } from './mcp-tool.definition';
-import { buildDataMartUiPath, joinPublicOrigin } from './data-mart-ui-path';
+import { buildDataMartUiPath } from './data-mart-ui-path';
+import { joinPublicOrigin } from './mcp-public-url.util';
 
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 25;

--- a/apps/backend/src/ee/mcp/tools/summarize-data-catalog.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/summarize-data-catalog.tool.ts
@@ -8,7 +8,8 @@ import {
 } from '../../../data-marts/facades/mcp-data-marts.facade';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import type { McpToolDefinition, McpToolResult } from './mcp-tool.definition';
-import { buildDataMartUiPath, joinPublicOrigin } from './data-mart-ui-path';
+import { buildDataMartUiPath } from './data-mart-ui-path';
+import { joinPublicOrigin } from './mcp-public-url.util';
 
 const inputSchema = z.object({}).strict();
 type SummarizeDataCatalogInput = z.infer<typeof inputSchema>;

--- a/apps/web/src/features/data-destination/shared/services/data-destination.service.ts
+++ b/apps/web/src/features/data-destination/shared/services/data-destination.service.ts
@@ -65,6 +65,17 @@ export class DataDestinationService extends ApiService {
   }
 
   /**
+   * MCP connect-flow: creates a Google Sheets destination after OAuth.
+   * Sharing defaults are enforced server-side (not client-controlled).
+   */
+  async createConnectGoogleSheetsDestination(data: {
+    title: string;
+    credentialId: string;
+  }): Promise<DataDestinationResponseDto> {
+    return this.post<DataDestinationResponseDto>('/connect/google-sheets', data);
+  }
+
+  /**
    * Update an existing data destination
    * @param id Data destination ID
    * @param data Data to update

--- a/apps/web/src/features/google-oauth/components/GoogleOAuthConnectButton.tsx
+++ b/apps/web/src/features/google-oauth/components/GoogleOAuthConnectButton.tsx
@@ -170,6 +170,7 @@ export function GoogleOAuthConnectButton({
           onSuccess?.(credentialId);
           void fetchStatus();
         } else {
+          console.error('Google OAuth callback reported failure', event.data.error);
           setConnectError(
             event.data.error ?? 'Failed to connect your Google account. Please try again.'
           );
@@ -189,6 +190,7 @@ export function GoogleOAuthConnectButton({
         }
       }, 500);
     } catch (error) {
+      console.error('Failed to start Google OAuth connection', error);
       setConnecting(false);
       setConnectError(
         error instanceof Error

--- a/apps/web/src/features/google-oauth/pages/GoogleOAuthCallbackPage.tsx
+++ b/apps/web/src/features/google-oauth/pages/GoogleOAuthCallbackPage.tsx
@@ -54,6 +54,7 @@ export function GoogleOAuthCallbackPage() {
         // Client-side state check (tab-scoped via sessionStorage).
         // The real CSRF protection is the server-side JWT signature in the state token.
         const storedState = sessionStorage.getItem('oauth_state');
+
         if (state !== storedState) {
           clearOAuthSessionData();
           if (

--- a/apps/web/src/layouts/ConnectFlowLayout.test.tsx
+++ b/apps/web/src/layouts/ConnectFlowLayout.test.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { ConnectFlowLayout } from './ConnectFlowLayout';
+
+vi.mock('./ProjectAuthGuards', () => ({
+  ProjectAuthGuards: ({ children }: { children: ReactNode }) => (
+    <div data-testid='project-auth-guards'>{children}</div>
+  ),
+}));
+
+describe('ConnectFlowLayout', () => {
+  it('renders the routed page through the guard chain, with no sidebar chrome', () => {
+    render(
+      <MemoryRouter initialEntries={['/ui/project-1/connect/google-sheets']}>
+        <Routes>
+          <Route path='/ui/:projectId/connect' element={<ConnectFlowLayout />}>
+            <Route path='google-sheets' element={<div>Connect Google Sheets page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const guards = screen.getByTestId('project-auth-guards');
+    expect(guards).toContainElement(screen.getByText('Connect Google Sheets page'));
+    expect(screen.queryByTestId('full-app-sidebar')).not.toBeInTheDocument();
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/layouts/ConnectFlowLayout.tsx
+++ b/apps/web/src/layouts/ConnectFlowLayout.tsx
@@ -1,0 +1,24 @@
+import { Outlet } from 'react-router-dom';
+import { ThemeProvider } from '../app/providers/theme-provider.tsx';
+import { ProjectAuthGuards } from './ProjectAuthGuards';
+
+/**
+ * Minimal, chrome-free layout for quick single-purpose "connect X" flows opened directly
+ * from an external link — not tied to any one integration surface (the MCP add_destination
+ * tool links here today, but the same pattern fits an Excel add-in, a Google Sheets add-on,
+ * or any other client that needs a fast, focused setup page). Still fully authenticated and
+ * project-scoped — reuses the exact same guard chain as MainLayout via ProjectAuthGuards —
+ * just without the sidebar/nav chrome. Reuse this for future connect-flow pages rather than
+ * adding more one-off layouts.
+ */
+export function ConnectFlowLayout() {
+  return (
+    <ThemeProvider>
+      <ProjectAuthGuards>
+        <div className='bg-background flex min-h-screen items-center justify-center p-4'>
+          <Outlet />
+        </div>
+      </ProjectAuthGuards>
+    </ThemeProvider>
+  );
+}

--- a/apps/web/src/layouts/MainLayout.tsx
+++ b/apps/web/src/layouts/MainLayout.tsx
@@ -22,11 +22,8 @@ import { storageService } from '../services';
 import { GlobalLoader, LoadingProvider, useLoading } from '../shared/components/GlobalLoader';
 import { Toaster as SonnerToaster } from '@owox/ui/components/sonner';
 import { Toaster as HotToaster } from '../shared/components/Toaster';
-import { AuthGuard } from '../features/idp';
-import { ProjectIdGuard } from '../features/idp/components/ProjectIdGuard';
-import { ProjectRoleGuard } from '../features/idp/components/ProjectRoleGuard';
 import { useUser } from '../features/idp/hooks';
-import { ProjectsProvider } from '../features/idp/context/ProjectsContext';
+import { ProjectAuthGuards } from './ProjectAuthGuards';
 import { Separator } from '@owox/ui/components/separator';
 import { ArchiveRestore, Box, DatabaseIcon, LockKeyhole } from 'lucide-react';
 import { HelpMenu } from '../components/AppSidebar/HelpMenu';
@@ -115,31 +112,25 @@ function MainLayoutContent() {
       {/* Legacy react-hot-toast Toaster to keep previously configured toasts working */}
       <HotToaster />
       <GlobalLoader isLoading={isLoading} />
-      <AuthGuard>
-        <ProjectIdGuard>
-          <ProjectRoleGuard>
-            <ProjectsProvider>
-              {user && hasEmptyProjectRoles ? (
-                <>
-                  <RestrictedProjectSidebar />
-                  <SidebarInset className='min-w-0'>
-                    {showTrigger && <SidebarTrigger />}
-                    <Outlet />
-                  </SidebarInset>
-                </>
-              ) : (
-                <>
-                  <AppSidebar variant='inset' collapsible='icon' />
-                  <SidebarInset className='min-w-0'>
-                    {showTrigger && <SidebarTrigger />}
-                    <Outlet />
-                  </SidebarInset>
-                </>
-              )}
-            </ProjectsProvider>
-          </ProjectRoleGuard>
-        </ProjectIdGuard>
-      </AuthGuard>
+      <ProjectAuthGuards>
+        {user && hasEmptyProjectRoles ? (
+          <>
+            <RestrictedProjectSidebar />
+            <SidebarInset className='min-w-0'>
+              {showTrigger && <SidebarTrigger />}
+              <Outlet />
+            </SidebarInset>
+          </>
+        ) : (
+          <>
+            <AppSidebar variant='inset' collapsible='icon' />
+            <SidebarInset className='min-w-0'>
+              {showTrigger && <SidebarTrigger />}
+              <Outlet />
+            </SidebarInset>
+          </>
+        )}
+      </ProjectAuthGuards>
     </>
   );
 }

--- a/apps/web/src/layouts/ProjectAuthGuards.test.tsx
+++ b/apps/web/src/layouts/ProjectAuthGuards.test.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ProjectAuthGuards } from './ProjectAuthGuards';
+
+vi.mock('../features/idp', () => ({
+  AuthGuard: ({ children }: { children: ReactNode }) => (
+    <div data-testid='auth-guard'>{children}</div>
+  ),
+}));
+
+vi.mock('../features/idp/components/ProjectIdGuard', () => ({
+  ProjectIdGuard: ({ children }: { children: ReactNode }) => (
+    <div data-testid='project-id-guard'>{children}</div>
+  ),
+}));
+
+vi.mock('../features/idp/components/ProjectRoleGuard', () => ({
+  ProjectRoleGuard: ({ children }: { children: ReactNode }) => (
+    <div data-testid='project-role-guard'>{children}</div>
+  ),
+}));
+
+vi.mock('../features/idp/context/ProjectsContext', () => ({
+  ProjectsProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid='projects-provider'>{children}</div>
+  ),
+}));
+
+describe('ProjectAuthGuards', () => {
+  it('renders children through the full guard chain, in order', () => {
+    render(
+      <ProjectAuthGuards>
+        <div data-testid='content'>Protected content</div>
+      </ProjectAuthGuards>
+    );
+
+    const authGuard = screen.getByTestId('auth-guard');
+    const projectIdGuard = screen.getByTestId('project-id-guard');
+    const projectRoleGuard = screen.getByTestId('project-role-guard');
+    const projectsProvider = screen.getByTestId('projects-provider');
+    const content = screen.getByTestId('content');
+
+    expect(authGuard).toContainElement(projectIdGuard);
+    expect(projectIdGuard).toContainElement(projectRoleGuard);
+    expect(projectRoleGuard).toContainElement(projectsProvider);
+    expect(projectsProvider).toContainElement(content);
+  });
+});

--- a/apps/web/src/layouts/ProjectAuthGuards.tsx
+++ b/apps/web/src/layouts/ProjectAuthGuards.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+import { AuthGuard } from '../features/idp';
+import { ProjectIdGuard } from '../features/idp/components/ProjectIdGuard';
+import { ProjectRoleGuard } from '../features/idp/components/ProjectRoleGuard';
+import { ProjectsProvider } from '../features/idp/context/ProjectsContext';
+
+/**
+ * The auth/project guard chain shared by every authenticated `/ui/:projectId/...` layout:
+ * sign-in required, active project re-synced to the URL's :projectId (with a transparent
+ * re-auth if it doesn't match the current session), non-members routed to request-access.
+ * Extracted out of MainLayout so minimal, chrome-free layouts (e.g. ConnectFlowLayout) can
+ * reuse the same guarantees without pulling in the sidebar/nav chrome.
+ */
+export function ProjectAuthGuards({ children }: { children: ReactNode }) {
+  return (
+    <AuthGuard>
+      <ProjectIdGuard>
+        <ProjectRoleGuard>
+          <ProjectsProvider>{children}</ProjectsProvider>
+        </ProjectRoleGuard>
+      </ProjectIdGuard>
+    </AuthGuard>
+  );
+}

--- a/apps/web/src/pages/connect/ConnectGoogleSheetsDonePage.test.tsx
+++ b/apps/web/src/pages/connect/ConnectGoogleSheetsDonePage.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { ConnectGoogleSheetsDonePage } from './ConnectGoogleSheetsDonePage';
+
+function renderDonePage() {
+  return render(
+    <MemoryRouter initialEntries={['/ui/project-1/connect/google-sheets/done']}>
+      <Routes>
+        <Route
+          path='/ui/:projectId/connect/google-sheets/done'
+          element={<ConnectGoogleSheetsDonePage />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ConnectGoogleSheetsDonePage', () => {
+  it('shows a generic success message, with no data taken from the URL', () => {
+    renderDonePage();
+
+    expect(
+      screen.getByText(/your google sheets destination was created successfully/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/you can close this tab now/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/connect/ConnectGoogleSheetsDonePage.tsx
+++ b/apps/web/src/pages/connect/ConnectGoogleSheetsDonePage.tsx
@@ -1,0 +1,26 @@
+import { CheckCircle2 } from 'lucide-react';
+
+/**
+ * A dedicated, static route for the post-creation confirmation — not just a state inside
+ * ConnectGoogleSheetsPage. Navigated to (via `navigate(..., { replace: true })`) right after
+ * the destination is created, so a page refresh (or the browser restoring this tab later)
+ * lands back here instead of the connect form, which would otherwise risk creating a
+ * duplicate destination if "Connect with Google" were triggered again.
+ *
+ * Deliberately generic, with no destination title or other data taken from the URL: a query
+ * param can't be trusted to reflect what was actually created (or that anything was created
+ * at all), so nothing here should be treated as an authoritative confirmation of details.
+ */
+export function ConnectGoogleSheetsDonePage() {
+  return (
+    <div className='bg-card text-card-foreground w-full max-w-lg rounded-lg p-6 text-center shadow-lg'>
+      <div className='mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30'>
+        <CheckCircle2 className='h-7 w-7 text-green-600 dark:text-green-400' aria-hidden='true' />
+      </div>
+      <p className='text-sm'>Your Google Sheets destination was created successfully.</p>
+      <p className='text-muted-foreground mt-1 text-sm'>
+        You can close this tab now and return to your conversation to continue.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/pages/connect/ConnectGoogleSheetsPage.test.tsx
+++ b/apps/web/src/pages/connect/ConnectGoogleSheetsPage.test.tsx
@@ -1,0 +1,222 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectGoogleSheetsPage } from './ConnectGoogleSheetsPage';
+import { ConnectGoogleSheetsDonePage } from './ConnectGoogleSheetsDonePage';
+import { destinationOAuthApi } from '../../features/google-oauth';
+import { dataDestinationService } from '../../features/data-destination/shared';
+
+// Real react-router navigation (not just a recorder) so the assertions below can verify
+// the actual /done route renders after a successful save, matching this app's established
+// test pattern of mocking `useProjectRoute` rather than wrapping pages in a full AuthProvider.
+vi.mock('../../shared/hooks', () => ({
+  useProjectRoute: () => {
+    const navigate = useNavigate();
+    return {
+      navigate: (path: string, options?: { replace?: boolean }) =>
+        navigate(`/ui/project-1${path}`, options),
+      scope: (path: string) => `/ui/project-1${path}`,
+      projectId: 'project-1',
+    };
+  },
+}));
+
+vi.mock('../../features/google-oauth', () => ({
+  destinationOAuthApi: {
+    getSettings: vi.fn(),
+    getCredentialStatus: vi.fn(),
+  },
+  GoogleOAuthConnectButton: ({ onSuccess }: { onSuccess?: (credentialId: string) => void }) => (
+    <button
+      type='button'
+      onClick={() => {
+        onSuccess?.('credential-1');
+      }}
+    >
+      Connect with Google (mock)
+    </button>
+  ),
+}));
+
+vi.mock('../../features/data-destination/shared', async () => {
+  const actual = await vi.importActual<typeof import('../../features/data-destination/shared')>(
+    '../../features/data-destination/shared'
+  );
+  return {
+    ...actual,
+    dataDestinationService: { createConnectGoogleSheetsDestination: vi.fn() },
+  };
+});
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/ui/project-1/connect/google-sheets']}>
+      <Routes>
+        <Route path='/ui/:projectId/connect/google-sheets' element={<ConnectGoogleSheetsPage />} />
+        <Route
+          path='/ui/:projectId/connect/google-sheets/done'
+          element={<ConnectGoogleSheetsDonePage />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ConnectGoogleSheetsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('close', vi.fn());
+    vi.mocked(destinationOAuthApi.getSettings).mockResolvedValue({ available: true });
+    vi.mocked(destinationOAuthApi.getCredentialStatus).mockResolvedValue({
+      isValid: true,
+      credentialId: 'credential-1',
+      user: { email: 'user@example.com' },
+    });
+    vi.mocked(dataDestinationService.createConnectGoogleSheetsDestination).mockResolvedValue({
+      id: 'destination-1',
+    } as never);
+  });
+
+  it('starts the Title field with the plain default — never pre-filled from the URL', async () => {
+    renderPage();
+
+    expect(await screen.findByDisplayValue('Google Sheets')).toBeInTheDocument();
+  });
+
+  it('creates the destination automatically once Google access is granted, without a Save button', async () => {
+    renderPage();
+
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+
+    const titleInput = await screen.findByDisplayValue('Google Sheets');
+    fireEvent.change(titleInput, { target: { value: 'My Google Sheets' } });
+    await waitFor(() => {
+      expect(titleInput).toHaveValue('My Google Sheets');
+    });
+    (await screen.findByText('Connect with Google (mock)')).click();
+
+    await waitFor(() => {
+      expect(dataDestinationService.createConnectGoogleSheetsDestination).toHaveBeenCalledWith({
+        title: 'My Google Sheets',
+        credentialId: 'credential-1',
+      });
+    });
+  });
+
+  it('appends the connected Google account email to the untouched default title', async () => {
+    renderPage();
+
+    (await screen.findByText('Connect with Google (mock)')).click();
+
+    await waitFor(() => {
+      expect(dataDestinationService.createConnectGoogleSheetsDestination).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Google Sheets (user@example.com)' })
+      );
+    });
+  });
+
+  it('does not append an email to a title typed by hand', async () => {
+    renderPage();
+
+    const titleInput = await screen.findByDisplayValue('Google Sheets');
+    fireEvent.change(titleInput, { target: { value: 'My Google Sheets' } });
+    await waitFor(() => {
+      expect(titleInput).toHaveValue('My Google Sheets');
+    });
+    (await screen.findByText('Connect with Google (mock)')).click();
+
+    await waitFor(() => {
+      expect(dataDestinationService.createConnectGoogleSheetsDestination).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'My Google Sheets' })
+      );
+    });
+  });
+
+  it('tries to close the tab, then navigates to the dedicated confirmation route once created', async () => {
+    renderPage();
+
+    (await screen.findByText('Connect with Google (mock)')).click();
+
+    // The confirmation route shows a generic message — not the title, which came from an
+    // untrusted query param and can't be treated as proof of what was actually created.
+    expect(
+      await screen.findByText(/your google sheets destination was created successfully/i)
+    ).toBeInTheDocument();
+    expect(await screen.findByText(/you can close this tab now/i)).toBeInTheDocument();
+    expect(window.close).toHaveBeenCalledTimes(1);
+    // The form itself is gone — we're on the /done route now, not just showing local state,
+    // so a refresh here can never re-render the connect form and risk a duplicate create.
+    expect(screen.queryByText('Connect with Google (mock)')).not.toBeInTheDocument();
+  });
+
+  it('shows a blurred overlay with a loading message while the destination is being created', async () => {
+    let resolveCreate: (value: { id: string }) => void = () => undefined;
+    vi.mocked(dataDestinationService.createConnectGoogleSheetsDestination).mockReturnValue(
+      new Promise(resolve => {
+        resolveCreate = resolve;
+      }) as never
+    );
+
+    renderPage();
+
+    (await screen.findByText('Connect with Google (mock)')).click();
+
+    const overlay = await screen.findByTestId('saving-overlay');
+    expect(overlay).toBeInTheDocument();
+    expect(await screen.findByText(/Creating your Google Sheets destination/i)).toBeInTheDocument();
+
+    resolveCreate({ id: 'destination-1' });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('saving-overlay')).not.toBeInTheDocument();
+    });
+  });
+
+  it('ignores a second onSuccess firing while a save is already in flight', async () => {
+    let resolveCreate: (value: { id: string }) => void = () => undefined;
+    vi.mocked(dataDestinationService.createConnectGoogleSheetsDestination).mockReturnValue(
+      new Promise(resolve => {
+        resolveCreate = resolve;
+      }) as never
+    );
+
+    renderPage();
+
+    const connectButton = await screen.findByText('Connect with Google (mock)');
+    connectButton.click();
+    connectButton.click();
+    connectButton.click();
+
+    await screen.findByTestId('saving-overlay');
+    expect(dataDestinationService.createConnectGoogleSheetsDestination).toHaveBeenCalledTimes(1);
+
+    resolveCreate({ id: 'destination-1' });
+    await waitFor(() => {
+      expect(screen.queryByTestId('saving-overlay')).not.toBeInTheDocument();
+    });
+    expect(dataDestinationService.createConnectGoogleSheetsDestination).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error and allows retrying by reconnecting when creation fails', async () => {
+    vi.mocked(dataDestinationService.createConnectGoogleSheetsDestination).mockRejectedValueOnce(
+      new Error('Duplicate title')
+    );
+
+    renderPage();
+
+    const connectButton = await screen.findByText('Connect with Google (mock)');
+    connectButton.click();
+
+    expect(await screen.findByText('Duplicate title')).toBeInTheDocument();
+
+    vi.mocked(dataDestinationService.createConnectGoogleSheetsDestination).mockResolvedValue({
+      id: 'destination-1',
+    } as never);
+    connectButton.click();
+
+    await waitFor(() => {
+      expect(dataDestinationService.createConnectGoogleSheetsDestination).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText(/was created successfully/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/connect/ConnectGoogleSheetsPage.tsx
+++ b/apps/web/src/pages/connect/ConnectGoogleSheetsPage.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Loader2 } from 'lucide-react';
+import { Input } from '@owox/ui/components/input';
+import { CopyableField } from '@owox/ui/components/common/copyable-field';
+import { Form, FormControl, FormItem, FormLabel, FormLayout } from '@owox/ui/components/form';
+import { useProjectRoute } from '../../shared/hooks';
+import {
+  GoogleOAuthConnectButton,
+  destinationOAuthApi,
+  type OAuthSettings,
+  type OAuthStatus,
+} from '../../features/google-oauth';
+import { dataDestinationService } from '../../features/data-destination';
+
+const DEFAULT_TITLE = 'Google Sheets';
+
+interface ConnectGoogleSheetsFormValues {
+  title: string;
+}
+
+export function ConnectGoogleSheetsPage() {
+  const { navigate } = useProjectRoute();
+  // The Title field is never pre-filled from the URL — a query param isn't proof of what
+  // the user actually wants, so the user always sets the name directly in this form.
+  const form = useForm<ConnectGoogleSheetsFormValues>({
+    defaultValues: { title: DEFAULT_TITLE },
+  });
+
+  const [oauthSettings, setOauthSettings] = useState<OAuthSettings | null>(null);
+  const [credentialId, setCredentialId] = useState<string | null>(null);
+  const [oauthEmail, setOauthEmail] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  // Guards handleSave itself (not just the UI overlay) against a second onSuccess firing
+  // while a save is already in flight — the overlay's `pointer-events-none` blocks normal
+  // clicks, but this is the actual correctness guarantee against a duplicate create call.
+  const savingRef = useRef(false);
+  // Dedupes getCredentialStatus calls for the same credentialId: onSuccess fires the
+  // credentialId effect below AND handleSave in the same tick, both wanting the same
+  // status response — this cache lets them share a single in-flight request.
+  const credentialStatusRequests = useRef(new Map<string, Promise<OAuthStatus>>());
+
+  const fetchCredentialStatus = (id: string): Promise<OAuthStatus> => {
+    const cached = credentialStatusRequests.current.get(id);
+    if (cached) return cached;
+
+    const request = destinationOAuthApi.getCredentialStatus(id);
+    credentialStatusRequests.current.set(id, request);
+    request.catch(() => credentialStatusRequests.current.delete(id));
+    return request;
+  };
+
+  useEffect(() => {
+    destinationOAuthApi
+      .getSettings()
+      .then(setOauthSettings)
+      .catch((error: unknown) => {
+        console.error('Failed to load Google OAuth settings', error);
+        setOauthSettings({ available: false });
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!credentialId) {
+      setOauthEmail(null);
+      return;
+    }
+    let cancelled = false;
+    fetchCredentialStatus(credentialId)
+      .then(status => {
+        if (!cancelled) setOauthEmail(status.user?.email ?? null);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        console.error('Failed to load the connected Google account', error);
+        setOauthEmail(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [credentialId]);
+
+  // Fires once per completed OAuth grant (not tied to credentialId state, so reconnecting
+  // after a failed save retries it even if the same Google account is reconnected).
+  const handleSave = async (connectedCredentialId: string) => {
+    if (savingRef.current) return;
+
+    let currentTitle = form.getValues('title').trim();
+    if (!currentTitle) {
+      setSaveError('Title is required.');
+      return;
+    }
+    savingRef.current = true;
+    setIsSaving(true);
+    setSaveError(null);
+
+    // Only the untouched default name gets the connected account appended — a title the
+    // user typed by hand is used as-is.
+    const usedDefaultTitle = currentTitle === DEFAULT_TITLE;
+    if (usedDefaultTitle) {
+      try {
+        const status = await fetchCredentialStatus(connectedCredentialId);
+        if (status.user?.email) {
+          currentTitle = `${currentTitle} (${status.user.email})`;
+        }
+      } catch (error) {
+        console.error(
+          'Failed to resolve the connected Google account for the default title',
+          error
+        );
+      }
+    }
+
+    try {
+      await dataDestinationService.createConnectGoogleSheetsDestination({
+        title: currentTitle,
+        credentialId: connectedCredentialId,
+      });
+    } catch (error) {
+      console.error('Failed to create the Google Sheets destination', error);
+      setSaveError(
+        error instanceof Error
+          ? error.message
+          : 'Failed to create the destination. Please try again.'
+      );
+      setIsSaving(false);
+      savingRef.current = false;
+      return;
+    }
+
+    // The destination now exists — try to close the tab. Browsers silently no-op this for
+    // tabs not opened via script, so fall through by navigating to the dedicated confirmation
+    // route (not just a local state) — a refresh then lands back on that plain screen instead
+    // of this form, which would otherwise risk creating a duplicate destination. No details
+    // (like the title) are passed along — an untrusted query param isn't proof of what was
+    // actually created, so the confirmation stays deliberately generic.
+    window.close();
+    navigate('/connect/google-sheets/done', { replace: true });
+  };
+
+  if (oauthSettings && !oauthSettings.available) {
+    return (
+      <div className='bg-card text-card-foreground w-full max-w-lg space-y-4 rounded-lg p-4 shadow-lg'>
+        <h1 className='text-lg font-semibold'>Connect Google Sheets</h1>
+        <p className='text-muted-foreground text-sm'>
+          Google OAuth isn&apos;t configured for this OWOX instance, so this quick-connect page
+          can&apos;t be used. Ask your admin to configure Google OAuth, or create a Google Sheets
+          destination manually from the OWOX web app (Destinations → Add destination) using a
+          Service Account key instead.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='bg-card text-card-foreground relative w-full max-w-lg overflow-hidden rounded-lg shadow-lg'>
+      <Form {...form}>
+        <div className={isSaving ? 'pointer-events-none blur-sm' : undefined}>
+          <div className='px-4 pt-4'>
+            <h1 className='text-lg font-semibold'>Connect Google Sheets</h1>
+            <p className='text-muted-foreground mt-1 text-sm'>
+              Grant access to your Google account to create this destination.
+            </p>
+          </div>
+
+          <FormLayout variant='light' className='px-4 py-4'>
+            <FormItem>
+              <FormLabel tooltip='Name the destination to clarify its purpose'>Title</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder={DEFAULT_TITLE}
+                  disabled={isSaving}
+                  {...form.register('title')}
+                />
+              </FormControl>
+            </FormItem>
+
+            <FormItem>
+              <FormLabel tooltip='Authorize OWOX to access your Google Sheets'>
+                Connect with Google OAuth
+              </FormLabel>
+              <GoogleOAuthConnectButton
+                resourceType='destination'
+                onSuccess={connectedCredentialId => {
+                  setCredentialId(connectedCredentialId);
+                  void handleSave(connectedCredentialId);
+                }}
+                onStatusChange={(isConnected, connectedCredentialId) => {
+                  setCredentialId(isConnected ? (connectedCredentialId ?? null) : null);
+                }}
+              />
+              {oauthEmail && (
+                <div className='mt-2 flex flex-col gap-1'>
+                  <FormLabel>Authenticated email</FormLabel>
+                  <CopyableField value={oauthEmail}>{oauthEmail}</CopyableField>
+                </div>
+              )}
+            </FormItem>
+
+            {saveError && <p className='text-destructive text-sm'>{saveError}</p>}
+          </FormLayout>
+        </div>
+      </Form>
+
+      {isSaving && (
+        <div
+          data-testid='saving-overlay'
+          className='bg-card/60 absolute inset-0 flex items-center justify-center'
+        >
+          <p className='text-muted-foreground flex items-center gap-2 text-sm font-medium'>
+            <Loader2 className='h-4 w-4 animate-spin' />
+            Creating your Google Sheets destination…
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -22,6 +22,9 @@ import { oauthRoutes } from './oauth.routes';
 import { RootErrorBoundary, LayoutErrorBoundary } from '../components/errors';
 import { MyApiKeysPage } from '../features/api-keys/pages/MyApiKeysPage';
 import { SearchPage } from '../pages/search/SearchPage';
+import { ConnectFlowLayout } from '../layouts/ConnectFlowLayout';
+import { ConnectGoogleSheetsPage } from '../pages/connect/ConnectGoogleSheetsPage';
+import { ConnectGoogleSheetsDonePage } from '../pages/connect/ConnectGoogleSheetsDonePage';
 
 const routes: RouteObject[] = [
   {
@@ -133,6 +136,23 @@ const routes: RouteObject[] = [
       {
         path: '*',
         element: <NotFound />,
+      },
+    ],
+  },
+  {
+    path: '/ui/:projectId/connect',
+    element: <ConnectFlowLayout />,
+    errorElement: <RootErrorBoundary />,
+    children: [
+      {
+        path: 'google-sheets',
+        element: <ConnectGoogleSheetsPage />,
+        errorElement: <LayoutErrorBoundary />,
+      },
+      {
+        path: 'google-sheets/done',
+        element: <ConnectGoogleSheetsDonePage />,
+        errorElement: <LayoutErrorBoundary />,
       },
     ],
   },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -45,6 +45,41 @@ export default defineConfig(({ mode }) => ({
         target: 'http://localhost:3000',
         changeOrigin: true,
       },
+      // MCP transport (Streamable HTTP) — lets an external client (Claude Desktop/web,
+      // ChatGPT, ...) connect to this single dev-server origin instead of the bare
+      // backend port, so the same https://localhost:5173 (or its tunnel URL) works for
+      // both the /ui/* pages and the MCP endpoint.
+      '/mcp': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+      // OAuth discovery documents (MCP dynamic client registration, protected-resource
+      // metadata) — served at the origin root, no /api prefix (see
+      // PROTOCOL_ROUTE_EXCLUSIONS in the backend).
+      '/.well-known': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+      // The actual OAuth 2.0 protocol endpoints backing MCP dynamic client registration.
+      // Proxied by exact path, NOT a blanket '/oauth' prefix — this app's own frontend
+      // routes live under /oauth/* too (e.g. /oauth/google/callback, oauth.routes.tsx),
+      // and a blanket rule would wrongly send those to the backend instead of the SPA.
+      '/oauth/authorize': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+      '/oauth/register': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+      '/oauth/token': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+      '/oauth/jwks': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
     },
   },
 }));


### PR DESCRIPTION
## Summary

Adds an `add_destination` MCP tool (task #6707): an AI assistant connected to OWOX over MCP can now create a new report-delivery destination directly, instead of only picking from existing ones via `list_destinations`.

Write tool (`mcp:write` scope, `readOnlyHint: false`).

## What changed

- **New MCP tool** `AddDestinationTool` (`ee/mcp/tools/add-destination.tool.ts`) — input `{ destination_type, title?, emails? }`; behavior branches on `destination_type`:
  - **email-based** (`email`, `slack`, `teams`, `google_chat`) — created directly via `McpDataDestinationsFacade.createDestination`; requires `emails`; `destination_id` returned immediately.
  - **`looker_studio`** — created directly, no OAuth/emails needed; returns connector deployment URL + destination id/secret so the caller can wire up the connector right away.
  - **`google_sheets`** — no facade round-trip. Returns a link into a new, minimal, authenticated in-app "Connect Google Sheets" page (`ConnectGoogleSheetsPage`); the destination doesn't exist yet, so no `destination_id` is returned — the caller is told to poll `list_destinations` afterward once the user confirms they finished.
- **New frontend flow** for the `google_sheets` case:
  - `ConnectFlowLayout` + extracted `ProjectAuthGuards` (pulled out of `MainLayout`, no behavior change there) — a reusable, chrome-free, but still fully authenticated/project-scoped layout for future single-purpose "connect X" pages, not just this one.
  - `ConnectGoogleSheetsPage` — a simplified version of the existing "Configure destination" form: title input + `GoogleOAuthConnectButton`; creates the destination automatically as soon as Google access is granted, no separate save step.
  - `ConnectGoogleSheetsDonePage` — a dedicated confirmation route (not just local component state), so refreshing the tab after success can't accidentally re-show the connect form and risk a duplicate destination. Deliberately generic (no destination name from the URL — an unverified query param isn't proof of what was actually created).
- **`availableForUse` threaded through creation**: `CreateDataDestinationCommand`, the REST `CreateDataDestinationApiDto`, and the create use-case all gained an optional `availableForUse` (default `true`, preserving existing behavior). Every destination created via `add_destination` starts `availableForUse: false` — a human must review and share it (Configure destination → Sharing) before it can be used in reports.
- **`list_destinations` updated** to expose `availableForUse` and `connectedGoogleAccount` (for `google_sheets`, the Google account that completed OAuth) so an agent can find the destination it just created and confirm it's the right one before using it.
- **Cleanup while touching this area**: removed a duplicate `joinPublicOrigin` helper (was defined in both `data-mart-ui-path.ts` and the new `mcp-public-url.util.ts`), consolidated on one.

## Design notes

- **No parent-entity role gate.** Unlike report/schedule MCP tools (which check access against an existing data mart/report), destination creation has no parent entity to check access against — matching the REST `POST /data-destinations` endpoint, which already allows any project member (viewer included).
- **`google_sheets` never round-trips a title/name through the URL.** Earlier iterations passed `title` as a query param into the connect page and pre-filled it there; this was dropped entirely — an unverified value from a link isn't proof of what the user actually wants, so the user always sets the destination's name directly in the form.
- **The confirmation page carries no data from the URL either**, for the same reason — it's a static "success" screen, not a place to reflect back arbitrary content from a link.

## Testing

- Unit tests: `add-destination.tool.spec.ts` (all three destination-type branches, default-title generation, missing-emails rejection, metadata), `mcp-data-destinations.facade.impl.spec.ts`, `create-data-destination.service.spec.ts`, `ConnectGoogleSheetsPage.test.tsx`, `ConnectGoogleSheetsDonePage.test.tsx`, `ProjectAuthGuards.test.tsx`, `ConnectFlowLayout.test.tsx`.
- Full regression: backend `src/data-marts` + `src/ee/mcp` (336 suites / 4657 tests) and the touched frontend suites — all green. `tsc`, `eslint`, `prettier` clean on both apps.