### PR TITLE
feat(mcp): make query_data_mart timeout-resilient

### DIFF
--- a/apps/backend/src/data-marts/config/mcp-operation-timeout-exclusions.spec.ts
+++ b/apps/backend/src/data-marts/config/mcp-operation-timeout-exclusions.spec.ts
@@ -1,0 +1,35 @@
+import { pathToRegexp } from 'path-to-regexp';
+import { addLeadingSlash } from '@nestjs/common/utils/shared.utils';
+import { isRouteExcluded } from '@nestjs/core/router/utils';
+import { RequestMethod } from '@nestjs/common';
+import { MCP_OPERATION_TIMEOUT_EXCLUSIONS } from './mcp-operation-timeout-exclusions';
+
+/**
+ * Regression guard for the /mcp operation-timeout preemption. NestJS binds the module's global
+ * `{*path}` middleware to the global-prefix-excluded /mcp route, so without an explicit exclusion the
+ * 30s operation-timeout middleware 408s a long query_data_mart run (and bills a SUCCESS the client
+ * already saw fail). This asserts our exclusion entries actually match a real /mcp request, using
+ * NestJS's own `isRouteExcluded` + `pathToRegexp` — the same matching the middleware uses at runtime.
+ */
+describe('MCP operation-timeout exclusions', () => {
+  // Mirror NestJS's mapToExcludeRoute: each entry compiles to a pathRegex over its leading-slashed path.
+  const compiled = MCP_OPERATION_TIMEOUT_EXCLUSIONS.map(route => ({
+    path: route.path,
+    requestMethod: route.method,
+    pathRegex: pathToRegexp(addLeadingSlash(route.path)).regexp,
+  }));
+
+  const isExcluded = (url: string) =>
+    isRouteExcluded(compiled, url, RequestMethod[RequestMethod.POST]);
+
+  it('excludes the /mcp transport route and its subpaths', () => {
+    expect(isExcluded('/mcp')).toBe(true);
+    expect(isExcluded('/mcp/')).toBe(true);
+    expect(isExcluded('/mcp/sse')).toBe(true);
+  });
+
+  it('does not over-exclude unrelated routes', () => {
+    expect(isExcluded('/api/data-marts/abc')).toBe(false);
+    expect(isExcluded('/api/mcp-lookalike')).toBe(false);
+  });
+});

--- a/apps/backend/src/data-marts/config/mcp-operation-timeout-exclusions.spec.ts
+++ b/apps/backend/src/data-marts/config/mcp-operation-timeout-exclusions.spec.ts
@@ -19,8 +19,7 @@ describe('MCP operation-timeout exclusions', () => {
     pathRegex: pathToRegexp(addLeadingSlash(route.path)).regexp,
   }));
 
-  const isExcluded = (url: string) =>
-    isRouteExcluded(compiled, url, RequestMethod[RequestMethod.POST]);
+  const isExcluded = (url: string) => isRouteExcluded(compiled, url, RequestMethod.POST);
 
   it('excludes the /mcp transport route and its subpaths', () => {
     expect(isExcluded('/mcp')).toBe(true);

--- a/apps/backend/src/data-marts/config/mcp-operation-timeout-exclusions.ts
+++ b/apps/backend/src/data-marts/config/mcp-operation-timeout-exclusions.ts
@@ -1,0 +1,8 @@
+import { RequestMethod } from '@nestjs/common';
+
+// NestJS still binds the global `{*path}` operation-timeout middleware to the prefix-excluded /mcp
+// route, so without this a 30s 408 preempts query_data_mart's own 3-min deadline (and bills a SUCCESS).
+export const MCP_OPERATION_TIMEOUT_EXCLUSIONS = [
+  { path: 'mcp', method: RequestMethod.ALL },
+  { path: 'mcp/{*path}', method: RequestMethod.ALL },
+];

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -183,6 +183,7 @@ import { ConnectorState } from './entities/connector-state.entity';
 import { ReportDataCache } from './entities/report-data-cache.entity';
 import { IdpModule } from '../idp/idp.module';
 import { createOperationTimeoutMiddleware } from '../common/middleware/operation-timeout.middleware';
+import { MCP_OPERATION_TIMEOUT_EXCLUSIONS } from './config/mcp-operation-timeout-exclusions';
 import { CommonModule } from '../common/common.module';
 import { ConnectorSecretService } from './services/connector/connector-secret.service';
 import { DataMartRunService } from './services/data-mart-run.service';
@@ -850,7 +851,8 @@ export class DataMartsModule {
       .exclude(
         { path: 'data-marts/:id/definition', method: RequestMethod.PUT },
         { path: 'data-marts/:id/publish', method: RequestMethod.PUT },
-        { path: 'external/{*path}', method: RequestMethod.ALL }
+        { path: 'external/{*path}', method: RequestMethod.ALL },
+        ...MCP_OPERATION_TIMEOUT_EXCLUSIONS
       )
       .forRoutes({ path: '{*path}', method: RequestMethod.ALL });
   }

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.spec.ts
@@ -98,4 +98,28 @@ describe('BigQueryApiAdapter jobTimeoutMs (Phase 3)', () => {
     ).rejects.toThrow('Job stopped by cancel');
     expect(job.cancel).toHaveBeenCalledTimes(1);
   });
+
+  it('does not busy-poll getMetadata after abort — one immediate re-poll, then a bounded interval', async () => {
+    jest.useFakeTimers();
+    try {
+      const { adapter, job } = createAdapter();
+      const controller = new AbortController();
+      controller.abort();
+      job.getMetadata.mockResolvedValue([{ status: { state: 'RUNNING' } }]);
+
+      const p = adapter.executeQuery('SELECT 1', undefined, undefined, controller.signal);
+      // Flush microtasks WITHOUT advancing time: initial poll + exactly one immediate re-poll, then
+      // the loop parks on the bounded sleep. A busy-poll would call getMetadata many more times here.
+      await jest.advanceTimersByTimeAsync(0);
+      expect(job.getMetadata).toHaveBeenCalledTimes(2);
+
+      // The bounded interval must elapse before the next poll; finish the job so the promise settles.
+      job.getMetadata.mockResolvedValue([{ status: { state: 'DONE' } }]);
+      await jest.advanceTimersByTimeAsync(2000);
+      await p;
+      expect(job.getMetadata).toHaveBeenCalledTimes(3);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.spec.ts
@@ -1,0 +1,101 @@
+import { BigQuery } from '@google-cloud/bigquery';
+import { BigQueryApiAdapter } from './bigquery-api.adapter';
+import { BIGQUERY_AUTODETECT_LOCATION } from '../schemas/bigquery-config.schema';
+import { BIGQUERY_OAUTH_TYPE } from '../schemas/bigquery-credentials.schema';
+
+// Mock only the BigQuery constructor — the adapter uses it as the single value import;
+// everything else it imports from the SDK is type-only and erased at compile time.
+jest.mock('@google-cloud/bigquery', () => ({
+  BigQuery: jest.fn(),
+}));
+
+describe('BigQueryApiAdapter jobTimeoutMs (Phase 3)', () => {
+  const createQueryJob = jest.fn();
+
+  const createAdapter = () => {
+    const job = {
+      id: 'job-1',
+      metadata: {},
+      getMetadata: jest.fn().mockResolvedValue([{ status: { state: 'DONE' } }]),
+      cancel: jest.fn().mockResolvedValue(undefined),
+    };
+    createQueryJob.mockResolvedValue([job]);
+    (BigQuery as unknown as jest.Mock).mockImplementation(() => ({ createQueryJob }));
+
+    // OAuth-type credentials keep the JWT branch (google-auth-library) out of the constructor.
+    const credentials = { type: BIGQUERY_OAUTH_TYPE, oauth2Client: {} } as never;
+    const config = { projectId: 'my-project', location: BIGQUERY_AUTODETECT_LOCATION } as never;
+    return { adapter: new BigQueryApiAdapter(credentials, config), job };
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('adds jobTimeoutMs (ms, verbatim) to the query config when a timeout is passed', async () => {
+    const { adapter } = createAdapter();
+
+    await adapter.executeQuery('SELECT 1', undefined, 30000);
+
+    expect(createQueryJob).toHaveBeenCalledTimes(1);
+    expect(createQueryJob.mock.calls[0][0]).toMatchObject({
+      query: 'SELECT 1',
+      jobTimeoutMs: 30000,
+    });
+  });
+
+  it('omits jobTimeoutMs entirely when no timeout is passed (regression)', async () => {
+    const { adapter } = createAdapter();
+
+    await adapter.executeQuery('SELECT 1');
+
+    expect(createQueryJob.mock.calls[0][0]).not.toHaveProperty('jobTimeoutMs');
+  });
+
+  it('adds jobTimeoutMs alongside named params when both are provided', async () => {
+    const { adapter } = createAdapter();
+
+    await adapter.executeQuery('SELECT @a', [{ name: 'a', value: 1 }] as never, 45000);
+
+    expect(createQueryJob.mock.calls[0][0]).toMatchObject({
+      parameterMode: 'NAMED',
+      jobTimeoutMs: 45000,
+    });
+  });
+
+  it('cancels the running job when the abort signal fires', async () => {
+    const { adapter, job } = createAdapter();
+    const controller = new AbortController();
+    controller.abort();
+
+    await adapter.executeQuery('SELECT 1', undefined, undefined, controller.signal);
+
+    expect(job.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cancel the job when no signal is passed (regression)', async () => {
+    const { adapter, job } = createAdapter();
+
+    await adapter.executeQuery('SELECT 1');
+
+    expect(job.cancel).not.toHaveBeenCalled();
+  });
+
+  it('cancels and surfaces the cancelled job as an error when aborted mid-run', async () => {
+    const { adapter, job } = createAdapter();
+    const controller = new AbortController();
+    // First poll: still running (and triggers the abort); the interruptible sleep then wakes early
+    // and the next poll sees the job DONE with a cancellation error.
+    job.getMetadata
+      .mockImplementationOnce(() => {
+        controller.abort();
+        return Promise.resolve([{ status: { state: 'RUNNING' } }]);
+      })
+      .mockResolvedValue([
+        { status: { state: 'DONE', errorResult: { message: 'Job stopped by cancel' } } },
+      ]);
+
+    await expect(
+      adapter.executeQuery('SELECT 1', undefined, undefined, controller.signal)
+    ).rejects.toThrow('Job stopped by cancel');
+    expect(job.cancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.ts
@@ -87,20 +87,15 @@ export class BigQueryApiAdapter {
     jobTimeoutMs?: number,
     signal?: AbortSignal
   ): Promise<{ jobId: string }> {
-    const queryConfig: Query =
-      params && params.length > 0
-        ? {
-            query,
-            params: Object.fromEntries(params.map(p => [p.name, p.value])),
-            parameterMode: 'NAMED',
-            ...this.getLocationOption(),
-            ...(jobTimeoutMs !== undefined ? { jobTimeoutMs } : {}),
-          }
-        : {
-            query,
-            ...this.getLocationOption(),
-            ...(jobTimeoutMs !== undefined ? { jobTimeoutMs } : {}),
-          };
+    const queryConfig: Query = {
+      query,
+      ...this.getLocationOption(),
+      ...(jobTimeoutMs !== undefined ? { jobTimeoutMs } : {}),
+    };
+    if (params && params.length > 0) {
+      queryConfig.params = Object.fromEntries(params.map(p => [p.name, p.value]));
+      queryConfig.parameterMode = 'NAMED';
+    }
 
     const [job] = await this.bigQuery.createQueryJob(queryConfig);
 

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.ts
@@ -136,6 +136,7 @@ export class BigQueryApiAdapter {
    * {@link executeQuery}, matching the previous `bigQuery.query()` behaviour.
    */
   private async waitForJobToComplete(job: Job, signal?: AbortSignal): Promise<void> {
+    let repolledAfterAbort = false;
     while (true) {
       const [metadata] = await job.getMetadata();
       if (metadata?.status?.state === 'DONE') {
@@ -147,18 +148,17 @@ export class BigQueryApiAdapter {
         }
         return;
       }
-      // Interruptible: an abort wakes the sleep so we re-poll immediately after job.cancel() (fired
-      // by executeQuery's abort handler) instead of waiting out the full poll interval.
-      await this.interruptibleSleep(BigQueryApiAdapter.JOB_POLL_INTERVAL_MS, signal);
+      // One immediate re-poll after job.cancel(), then a bounded interval — never busy-poll jobs.get.
+      if (signal?.aborted && !repolledAfterAbort) {
+        repolledAfterAbort = true;
+        continue;
+      }
+      await this.edgeInterruptibleSleep(BigQueryApiAdapter.JOB_POLL_INTERVAL_MS, signal);
     }
   }
 
-  private interruptibleSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  private edgeInterruptibleSleep(ms: number, signal?: AbortSignal): Promise<void> {
     return new Promise(resolve => {
-      if (signal?.aborted) {
-        resolve();
-        return;
-      }
       const onAbort = () => {
         clearTimeout(timer);
         resolve();
@@ -167,6 +167,7 @@ export class BigQueryApiAdapter {
         signal?.removeEventListener('abort', onAbort);
         resolve();
       }, ms);
+      // Fires only on the abort edge; if already aborted it never fires, so the full interval elapses.
       signal?.addEventListener('abort', onAbort, { once: true });
     });
   }

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/adapters/bigquery-api.adapter.ts
@@ -76,8 +76,17 @@ export class BigQueryApiAdapter {
    * When params are provided, BigQuery named parameter mode is used
    * (@paramName placeholders). The SDK infers types from JS values
    * (string, number, boolean, Date).
+   *
+   * `jobTimeoutMs` (already in ms) caps warehouse cost by aborting the job server-side; unset = no change.
+   * `signal` (client disconnect/cancel) cancels the running job immediately — the poll loop then
+   * surfaces the cancellation as a thrown error. Unset = no cancellation hook.
    */
-  public async executeQuery(query: string, params?: SqlParameter[]): Promise<{ jobId: string }> {
+  public async executeQuery(
+    query: string,
+    params?: SqlParameter[],
+    jobTimeoutMs?: number,
+    signal?: AbortSignal
+  ): Promise<{ jobId: string }> {
     const queryConfig: Query =
       params && params.length > 0
         ? {
@@ -85,14 +94,31 @@ export class BigQueryApiAdapter {
             params: Object.fromEntries(params.map(p => [p.name, p.value])),
             parameterMode: 'NAMED',
             ...this.getLocationOption(),
+            ...(jobTimeoutMs !== undefined ? { jobTimeoutMs } : {}),
           }
         : {
             query,
             ...this.getLocationOption(),
+            ...(jobTimeoutMs !== undefined ? { jobTimeoutMs } : {}),
           };
 
     const [job] = await this.bigQuery.createQueryJob(queryConfig);
-    await this.waitForJobToComplete(job);
+
+    // Best-effort warehouse cancel: on abort, ask BigQuery to cancel the job. The poll loop below
+    // then sees the job finish (cancelled) and throws, so we stop billing compute for a gone client.
+    const onAbort = () => {
+      job.cancel().catch(() => undefined);
+    };
+    if (signal) {
+      if (signal.aborted) onAbort();
+      else signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    try {
+      await this.waitForJobToComplete(job, signal);
+    } finally {
+      signal?.removeEventListener('abort', onAbort);
+    }
     this.setLocationFromJob(job);
 
     const jobId = job.id;
@@ -109,7 +135,7 @@ export class BigQueryApiAdapter {
    * (e.g. invalid SQL) so a bad query still surfaces as a thrown error from
    * {@link executeQuery}, matching the previous `bigQuery.query()` behaviour.
    */
-  private async waitForJobToComplete(job: Job): Promise<void> {
+  private async waitForJobToComplete(job: Job, signal?: AbortSignal): Promise<void> {
     while (true) {
       const [metadata] = await job.getMetadata();
       if (metadata?.status?.state === 'DONE') {
@@ -121,8 +147,28 @@ export class BigQueryApiAdapter {
         }
         return;
       }
-      await new Promise(resolve => setTimeout(resolve, BigQueryApiAdapter.JOB_POLL_INTERVAL_MS));
+      // Interruptible: an abort wakes the sleep so we re-poll immediately after job.cancel() (fired
+      // by executeQuery's abort handler) instead of waiting out the full poll interval.
+      await this.interruptibleSleep(BigQueryApiAdapter.JOB_POLL_INTERVAL_MS, signal);
     }
+  }
+
+  private interruptibleSleep(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise(resolve => {
+      if (signal?.aborted) {
+        resolve();
+        return;
+      }
+      const onAbort = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
   }
 
   /**

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-reader.service.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-reader.service.spec.ts
@@ -1,0 +1,65 @@
+import { BigQueryReportReader } from './bigquery-report-reader.service';
+import { DataMartDefinitionType } from '../../../enums/data-mart-definition-type.enum';
+
+describe('BigQueryReportReader queryTimeoutMs threading (Phase 3)', () => {
+  const buildReport = () =>
+    ({
+      dataMart: {
+        storage: { id: 's1', config: { projectId: 'my-project' } },
+        definitionType: DataMartDefinitionType.SQL,
+        definition: { sqlQuery: 'SELECT 1' },
+        schema: { type: 'bigquery-data-mart-schema', fields: [] },
+      },
+    }) as never;
+
+  const createReader = () => {
+    const adapter = {
+      executeQuery: jest.fn().mockResolvedValue({ jobId: 'job-1' }),
+      getJob: jest.fn().mockResolvedValue({
+        metadata: {
+          configuration: {
+            query: { destinationTable: { projectId: 'p', datasetId: 'd', tableId: 't' } },
+          },
+        },
+      }),
+      createTableReference: jest.fn().mockReturnValue({
+        getRows: jest.fn().mockResolvedValue([[], undefined]),
+      }),
+    };
+    const adapterFactory = { createFromStorage: jest.fn().mockResolvedValue(adapter) };
+    const queryBuilder = { buildQuery: jest.fn() };
+    const headersGenerator = { generateHeaders: jest.fn().mockReturnValue([]) };
+    const credentialsResolver = {};
+    const reader = new BigQueryReportReader(
+      adapterFactory as never,
+      queryBuilder as never,
+      headersGenerator as never,
+      credentialsResolver as never
+    );
+    return { reader, adapter };
+  };
+
+  it('threads queryTimeoutMs and signal into adapter.executeQuery', async () => {
+    const { reader, adapter } = createReader();
+    const signal = new AbortController().signal;
+
+    await reader.prepareReportData(buildReport(), {
+      sqlOverride: 'SELECT 1',
+      queryTimeoutMs: 30000,
+      signal,
+    });
+    // executeQuery is lazy — the first batch read materializes the destination table.
+    await reader.readReportDataBatch();
+
+    expect(adapter.executeQuery).toHaveBeenCalledWith('SELECT 1', undefined, 30000, signal);
+  });
+
+  it('passes an undefined timeout and signal when the options are absent (regression)', async () => {
+    const { reader, adapter } = createReader();
+
+    await reader.prepareReportData(buildReport(), { sqlOverride: 'SELECT 1' });
+    await reader.readReportDataBatch();
+
+    expect(adapter.executeQuery).toHaveBeenCalledWith('SELECT 1', undefined, undefined, undefined);
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-reader.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-report-reader.service.ts
@@ -37,6 +37,7 @@ import type { SqlParameter } from '../../utils/sql-clause-renderer';
 export class BigQueryReportReader implements DataStorageReportReader {
   protected readonly logger = new Logger(BigQueryReportReader.name);
   readonly type: DataStorageType = DataStorageType.GOOGLE_BIGQUERY;
+  readonly honorsQueryTimeout = true;
 
   private adapter: BigQueryApiAdapter;
   private reportResultTable: Table;
@@ -52,6 +53,8 @@ export class BigQueryReportReader implements DataStorageReportReader {
   private sqlOverride?: string;
   private sqlOverrideParams?: SqlParameter[];
   private columnFilter?: string[];
+  private queryTimeoutMs?: number;
+  private signal?: AbortSignal;
 
   constructor(
     protected readonly adapterFactory: BigQueryApiAdapterFactory,
@@ -90,6 +93,8 @@ export class BigQueryReportReader implements DataStorageReportReader {
     this.sqlOverride = options?.sqlOverride;
     this.sqlOverrideParams = options?.sqlOverrideParams;
     this.columnFilter = options?.columnFilter;
+    this.queryTimeoutMs = options?.queryTimeoutMs;
+    this.signal = options?.signal;
 
     this.reportDataHeaders = resolveReportDataHeaders(
       this.headersGenerator.generateHeaders(schema),
@@ -181,7 +186,12 @@ export class BigQueryReportReader implements DataStorageReportReader {
   }
 
   private async prepareQueryData(query: string, params?: SqlParameter[]): Promise<void> {
-    const { jobId } = await this.adapter.executeQuery(query, params);
+    const { jobId } = await this.adapter.executeQuery(
+      query,
+      params,
+      this.queryTimeoutMs,
+      this.signal
+    );
     const jobResult = await this.adapter.getJob(jobId);
     const destinationTable = jobResult.metadata.configuration.query.destinationTable;
     this.defineReportResultTable(

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-report-reader.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/data-storage-report-reader.interface.ts
@@ -55,12 +55,30 @@ export interface PrepareReportDataOptions {
    * row carries only the metric aggregates (Row Count is a per-group column, not a total).
    */
   rowCount?: boolean;
+
+  /**
+   * Server-side per-query timeout (ms). BigQuery/Snowflake abort the job/statement at the
+   * warehouse when exceeded, capping cost. Other storages currently ignore it.
+   */
+  queryTimeoutMs?: number;
+
+  /**
+   * When it fires (client disconnect/cancel), BigQuery/Snowflake cancel the in-flight warehouse
+   * job/statement so an abandoned query stops billing compute immediately. Other storages ignore it.
+   */
+  signal?: AbortSignal;
 }
 
 /**
  * Interface for reading report data from a data storage
  */
 export interface DataStorageReportReader extends TypedComponent<DataStorageType> {
+  /**
+   * Whether this reader enforces `PrepareReportDataOptions.queryTimeoutMs` at the warehouse. Readers
+   * that leave it unset silently drop the cap — callers relying on a cost bound should observe that.
+   */
+  readonly honorsQueryTimeout?: boolean;
+
   /**
    * Prepares report data for reading
    */

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/adapters/snowflake-api.adapter.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/adapters/snowflake-api.adapter.spec.ts
@@ -1,0 +1,108 @@
+import { SnowflakeApiAdapter } from './snowflake-api.adapter';
+import { SnowflakeAuthMethod } from '../enums/snowflake-auth-method.enum';
+
+const mockConnection = {
+  isUp: jest.fn().mockReturnValue(true),
+  connect: jest.fn((cb: (e: Error | null) => void) => cb(null)),
+  execute: jest.fn(),
+  destroy: jest.fn((cb: (e: Error | null) => void) => cb(null)),
+};
+
+jest.mock('snowflake-sdk', () => ({
+  configure: jest.fn(),
+  createConnection: jest.fn(() => mockConnection),
+}));
+
+describe('SnowflakeApiAdapter STATEMENT_TIMEOUT_IN_SECONDS (Phase 3)', () => {
+  const stmt = {
+    getColumns: () => [],
+    getQueryId: () => 'q1',
+  };
+
+  const createAdapter = () => {
+    mockConnection.execute.mockImplementation((opts: { complete: (...a: unknown[]) => void }) =>
+      opts.complete(null, stmt, [])
+    );
+    return new SnowflakeApiAdapter(
+      { authMethod: SnowflakeAuthMethod.PASSWORD, username: 'u', password: 'p' } as never,
+      { account: 'a', warehouse: 'w' } as never
+    );
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('adds parameters.STATEMENT_TIMEOUT_IN_SECONDS (ms→s) when a timeout is passed', async () => {
+    const adapter = createAdapter();
+
+    await adapter.executeQuery('SELECT 1', false, 30000);
+
+    expect(mockConnection.execute.mock.calls[0][0]).toMatchObject({
+      parameters: { STATEMENT_TIMEOUT_IN_SECONDS: 30 },
+    });
+  });
+
+  it('rounds a sub-second remainder up (1500ms → 2s)', async () => {
+    const adapter = createAdapter();
+
+    await adapter.executeQuery('SELECT 1', false, 1500);
+
+    expect(mockConnection.execute.mock.calls[0][0].parameters).toEqual({
+      STATEMENT_TIMEOUT_IN_SECONDS: 2,
+    });
+  });
+
+  it('omits parameters entirely when no timeout is passed (regression)', async () => {
+    const adapter = createAdapter();
+
+    await adapter.executeQuery('SELECT 1');
+
+    expect(mockConnection.execute.mock.calls[0][0]).not.toHaveProperty('parameters');
+  });
+
+  it('cancels the running statement when the abort signal fires', async () => {
+    // execute stays pending until cancel fires the complete callback (like a real cancelled query).
+    let complete!: (e: Error | null, s: unknown, r: unknown[]) => void;
+    const statement = {
+      cancel: jest.fn((cb: () => void) => {
+        complete(new Error('SQL execution canceled'), stmt, []);
+        cb();
+      }),
+    };
+    mockConnection.execute.mockImplementation((opts: { complete: (...a: unknown[]) => void }) => {
+      complete = opts.complete as never;
+      return statement;
+    });
+    const adapter = new SnowflakeApiAdapter(
+      { authMethod: SnowflakeAuthMethod.PASSWORD, username: 'u', password: 'p' } as never,
+      { account: 'a', warehouse: 'w' } as never
+    );
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      adapter.executeQuery('SELECT 1', false, undefined, controller.signal)
+    ).rejects.toThrow();
+    expect(statement.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attach a lingering abort listener when the query completes synchronously', async () => {
+    const cancel = jest.fn((cb: () => void) => cb());
+    const syncStmt = { getColumns: () => [], getQueryId: () => 'q1', cancel };
+    // execute completes synchronously, before the adapter can register the abort handler.
+    mockConnection.execute.mockImplementation((opts: { complete: (...a: unknown[]) => void }) => {
+      opts.complete(null, syncStmt, []);
+      return syncStmt;
+    });
+    const adapter = new SnowflakeApiAdapter(
+      { authMethod: SnowflakeAuthMethod.PASSWORD, username: 'u', password: 'p' } as never,
+      { account: 'a', warehouse: 'w' } as never
+    );
+    const controller = new AbortController();
+
+    await adapter.executeQuery('SELECT 1', false, undefined, controller.signal);
+    // The query already finished; a later abort on the (reused) signal must not reach the statement.
+    controller.abort();
+
+    expect(cancel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/adapters/snowflake-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/adapters/snowflake-api.adapter.ts
@@ -93,11 +93,16 @@ export class SnowflakeApiAdapter {
   }
 
   /**
-   * Executes a SQL query
+   * Executes a SQL query. `queryTimeoutMs` caps warehouse cost via STATEMENT_TIMEOUT_IN_SECONDS
+   * (Snowflake's unit is SECONDS, so the ms budget is rounded up to ≥1s); unset = no change.
+   * `signal` (client disconnect/cancel) cancels the running statement immediately so an abandoned
+   * query stops billing compute; the cancel surfaces as a rejected promise. Unset = no cancel hook.
    */
   public async executeQuery(
     query: string,
-    dryRun: boolean = false
+    dryRun: boolean = false,
+    queryTimeoutMs?: number,
+    signal?: AbortSignal
   ): Promise<{
     queryId: string;
     rows?: Record<string, unknown>[];
@@ -108,10 +113,24 @@ export class SnowflakeApiAdapter {
     }
 
     return new Promise((resolve, reject) => {
-      this.connection.execute({
+      let settled = false;
+      let onAbort: (() => void) | undefined;
+      const cleanup = () => {
+        settled = true;
+        if (signal && onAbort) signal.removeEventListener('abort', onAbort);
+      };
+      const statement = this.connection.execute({
         sqlText: query,
         describeOnly: dryRun,
+        ...(queryTimeoutMs !== undefined
+          ? {
+              parameters: {
+                STATEMENT_TIMEOUT_IN_SECONDS: Math.max(1, Math.ceil(queryTimeoutMs / 1000)),
+              },
+            }
+          : {}),
         complete: (err, stmt, rows) => {
+          cleanup();
           if (err) {
             reject(
               new Error(
@@ -138,6 +157,15 @@ export class SnowflakeApiAdapter {
           }
         },
       });
+
+      // Best-effort warehouse cancel: on abort, cancel the running statement so a gone client stops
+      // billing compute. The cancel triggers the complete callback with an error → the promise rejects.
+      // `!settled` guards a synchronous complete (would leave a listener attached past resolve).
+      if (signal && !settled) {
+        onAbort = () => statement.cancel(() => undefined);
+        if (signal.aborted) onAbort();
+        else signal.addEventListener('abort', onAbort, { once: true });
+      }
     });
   }
 

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/adapters/snowflake-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/adapters/snowflake-api.adapter.ts
@@ -162,7 +162,14 @@ export class SnowflakeApiAdapter {
       // billing compute. The cancel triggers the complete callback with an error → the promise rejects.
       // `!settled` guards a synchronous complete (would leave a listener attached past resolve).
       if (signal && !settled) {
-        onAbort = () => statement.cancel(() => undefined);
+        onAbort = () => {
+          // Guard a driver that throws synchronously on an already-gone statement/connection.
+          try {
+            statement.cancel(() => undefined);
+          } catch {
+            /* best-effort cancel */
+          }
+        };
         if (signal.aborted) onAbort();
         else signal.addEventListener('abort', onAbort, { once: true });
       }

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-report-reader.service.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-report-reader.service.spec.ts
@@ -1,0 +1,52 @@
+import { SnowflakeReportReader } from './snowflake-report-reader.service';
+
+describe('SnowflakeReportReader queryTimeoutMs threading (Phase 3)', () => {
+  const buildReport = () =>
+    ({
+      dataMart: {
+        storage: { id: 's1' },
+        definition: { sqlQuery: 'SELECT 1' },
+        schema: { type: 'snowflake-data-mart-schema', fields: [] },
+      },
+    }) as never;
+
+  const createReader = () => {
+    const adapter = {
+      executeQuery: jest
+        .fn()
+        .mockResolvedValue({ queryId: 'q1', rows: [], metadata: { columns: [] } }),
+      fetchResultsByQueryId: jest.fn().mockResolvedValue([]),
+      destroy: jest.fn().mockResolvedValue(undefined),
+    };
+    const adapterFactory = { createFromStorage: jest.fn().mockResolvedValue(adapter) };
+    const queryBuilder = { buildQuery: jest.fn().mockReturnValue('SELECT built') };
+    const headersGenerator = { generateHeaders: jest.fn().mockReturnValue([]) };
+    const reader = new SnowflakeReportReader(
+      adapterFactory as never,
+      queryBuilder as never,
+      headersGenerator as never
+    );
+    return { reader, adapter };
+  };
+
+  it('threads options.queryTimeoutMs and signal into adapter.executeQuery', async () => {
+    const { reader, adapter } = createReader();
+    const signal = new AbortController().signal;
+
+    await reader.prepareReportData(buildReport(), {
+      sqlOverride: 'SELECT 1',
+      queryTimeoutMs: 30000,
+      signal,
+    });
+
+    expect(adapter.executeQuery).toHaveBeenCalledWith('SELECT 1', false, 30000, signal);
+  });
+
+  it('passes an undefined timeout and signal when the options are absent (regression)', async () => {
+    const { reader, adapter } = createReader();
+
+    await reader.prepareReportData(buildReport(), { sqlOverride: 'SELECT 1' });
+
+    expect(adapter.executeQuery).toHaveBeenCalledWith('SELECT 1', false, undefined, undefined);
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-report-reader.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-report-reader.service.ts
@@ -25,6 +25,7 @@ import { resolveReportDataHeaders } from '../../utils/report-data-headers.utils'
 export class SnowflakeReportReader implements DataStorageReportReader {
   private readonly logger = new Logger(SnowflakeReportReader.name);
   readonly type = DataStorageType.SNOWFLAKE;
+  readonly honorsQueryTimeout = true;
 
   private adapter: SnowflakeApiAdapter;
   private reportDataHeaders: ReportDataHeader[];
@@ -73,7 +74,12 @@ export class SnowflakeReportReader implements DataStorageReportReader {
       this.queryBuilder.buildQuery(definition, { columns: options?.columnFilter });
     this.logger.debug(`Executing query: ${query}`);
 
-    const result = await this.adapter.executeQuery(query);
+    const result = await this.adapter.executeQuery(
+      query,
+      false,
+      options?.queryTimeoutMs,
+      options?.signal
+    );
     this.queryId = result.queryId;
     this.currentRowIndex = 0;
 

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.spec.ts
@@ -481,6 +481,69 @@ describe('McpDataMartsFacadeImpl', () => {
     expect(blendableSchemaService.computeBlendableSchema).not.toHaveBeenCalled();
   });
 
+  it('forwards the request and abort signal to QueryDataMartService.run', async () => {
+    const response = {
+      columns: ['country'],
+      rows: 'country\nUA',
+      truncated: false,
+      totals: null,
+    };
+    const queryDataMartService = {
+      run: jest.fn().mockResolvedValue(response),
+    } as unknown as jest.Mocked<QueryDataMartService>;
+    const facade = new McpDataMartsFacadeImpl(
+      createListDataMartsService([]),
+      createGetDataMartService(),
+      createDataMartService(),
+      queryDataMartService,
+      createBlendableSchemaService(),
+      createRelationshipService()
+    );
+    const request = {
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      dataMartId: 'dm_1',
+      fields: ['country'],
+      limit: 100,
+    };
+    const signal = new AbortController().signal;
+
+    await expect(facade.queryDataMart(request, signal)).resolves.toBe(response);
+    expect(queryDataMartService.run).toHaveBeenCalledWith(
+      expect.objectContaining({ request }),
+      signal
+    );
+  });
+
+  it('forwards an undefined signal when none is provided to queryDataMart', async () => {
+    const queryDataMartService = {
+      run: jest.fn().mockResolvedValue({ columns: [], rows: '', truncated: false, totals: null }),
+    } as unknown as jest.Mocked<QueryDataMartService>;
+    const facade = new McpDataMartsFacadeImpl(
+      createListDataMartsService([]),
+      createGetDataMartService(),
+      createDataMartService(),
+      queryDataMartService,
+      createBlendableSchemaService(),
+      createRelationshipService()
+    );
+    const request = {
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      dataMartId: 'dm_1',
+      fields: ['country'],
+      limit: 100,
+    };
+
+    await facade.queryDataMart(request);
+    expect(queryDataMartService.run).toHaveBeenCalledWith(
+      expect.objectContaining({ request }),
+      undefined
+    );
+  });
+
   it('degrades to no joined fields when blended-schema computation fails', async () => {
     const listDataMartsService = createListDataMartsService([]);
     const dataMartService = createDataMartService({

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.ts
@@ -137,8 +137,11 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
     }
   }
 
-  async queryDataMart(request: McpQueryDataMartRequest): Promise<McpQueryDataMartResponse> {
-    return this.queryDataMartService.run(new QueryDataMartCommand(request));
+  async queryDataMart(
+    request: McpQueryDataMartRequest,
+    signal?: AbortSignal
+  ): Promise<McpQueryDataMartResponse> {
+    return this.queryDataMartService.run(new QueryDataMartCommand(request), signal);
   }
 
   async summarizeDataCatalog(

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.ts
@@ -86,8 +86,33 @@ export interface McpDataCatalogSummaryResponse {
 export interface McpDataMartsFacade {
   listDataMarts(request: McpListDataMartsRequest): Promise<McpListDataMartsResponse>;
   getDataMartDetails(request: McpGetDataMartDetailsRequest): Promise<McpDataMartDetailsResponse>;
-  queryDataMart(request: McpQueryDataMartRequest): Promise<McpQueryDataMartResponse>;
+  queryDataMart(
+    request: McpQueryDataMartRequest,
+    signal?: AbortSignal
+  ): Promise<McpQueryDataMartResponse>;
   summarizeDataCatalog(
     request: McpSummarizeDataCatalogRequest
   ): Promise<McpDataCatalogSummaryResponse>;
+}
+
+// Part of the queryDataMart contract: the tool catches these to emit query_timeout / query_cancelled.
+// They live on the facade surface (not in the use-case) so consumers don't reach into internals.
+
+// Recorded FAILED and never billed (billing is success-path only).
+export class QueryTimeoutError extends Error {
+  readonly deadlineMs: number;
+  constructor(deadlineMs: number) {
+    super(`query_data_mart timed out after ${deadlineMs} ms`);
+    this.name = 'QueryTimeoutError';
+    this.deadlineMs = deadlineMs;
+  }
+}
+
+// Client aborted (disconnect / cancel). Recorded CANCELLED, never billed. Stops the server waiting;
+// does not cancel the warehouse job.
+export class QueryAbortedError extends Error {
+  constructor() {
+    super('query_data_mart was cancelled by the client');
+    this.name = 'QueryAbortedError';
+  }
 }

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.ts
@@ -108,8 +108,8 @@ export class QueryTimeoutError extends Error {
   }
 }
 
-// Client aborted (disconnect / cancel). Recorded CANCELLED, never billed. Stops the server waiting;
-// does not cancel the warehouse job.
+// Client aborted (disconnect / cancel). Recorded CANCELLED, never billed. Stops the server waiting
+// and asks the warehouse to cancel the in-flight job/statement (for storages that honor it).
 export class QueryAbortedError extends Error {
   constructor() {
     super('query_data_mart was cancelled by the client');

--- a/apps/backend/src/data-marts/services/data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.ts
@@ -90,13 +90,14 @@ export interface HttpDataRunRecord {
   errors?: string[];
 }
 
-// Terminal-only MCP_QUERY run: written once at the end (success or failure), no RUNNING phase.
+// Terminal-only MCP_QUERY run: written once at the end (success, failure, or client-abort), no
+// RUNNING phase. CANCELLED is recorded when the request's AbortSignal fires mid-query.
 export interface McpQueryRunRecord {
   runId: string;
   dataMart: DataMart;
   createdById: string;
   startedAt: Date;
-  status: DataMartRunStatus.SUCCESS | DataMartRunStatus.FAILED;
+  status: DataMartRunStatus.SUCCESS | DataMartRunStatus.FAILED | DataMartRunStatus.CANCELLED;
   metadata: McpQueryRunMetadata;
   errors?: string[];
 }

--- a/apps/backend/src/data-marts/services/report-totals.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-totals.service.spec.ts
@@ -142,6 +142,25 @@ describe('ReportTotalsService', () => {
     expect(readerResolver.resolve).toHaveBeenCalledWith(DataStorageType.GOOGLE_BIGQUERY);
   });
 
+  it('forwards queryTimeoutMs into the reader prepareReportData options (Phase 3)', async () => {
+    const { service, reader } = createService();
+
+    await service.computeTotals(buildReport(), {} as never, DataStorageType.GOOGLE_BIGQUERY, 30000);
+
+    expect(reader.prepareReportData).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ queryTimeoutMs: 30000 })
+    );
+  });
+
+  it('omits queryTimeoutMs from the reader options when none is passed (regression)', async () => {
+    const { service, reader } = createService();
+
+    await service.computeTotals(buildReport(), {} as never, DataStorageType.GOOGLE_BIGQUERY);
+
+    expect(reader.prepareReportData.mock.calls[0][1]).not.toHaveProperty('queryTimeoutMs');
+  });
+
   it('empty totals dataset (no rows) returns null', async () => {
     const reader = createReader([new ReportDataHeader('revenue | SUM')], undefined);
     const { service } = createService({ reader });

--- a/apps/backend/src/data-marts/services/report-totals.service.ts
+++ b/apps/backend/src/data-marts/services/report-totals.service.ts
@@ -36,7 +36,9 @@ export class ReportTotalsService {
   async computeTotals(
     report: ReportLike,
     accessor: BlendableSchemaAccessor,
-    storageType: DataStorageType
+    storageType: DataStorageType,
+    queryTimeoutMs?: number,
+    signal?: AbortSignal
   ): Promise<ReportTotals | null> {
     const totals = await this.reportSqlComposerService.composeTotals(report, accessor);
     if (!totals) {
@@ -58,6 +60,9 @@ export class ReportTotalsService {
         blendedDataHeaders: totals.blendedDataHeaders,
         // Row Count / Unique Count are not part of the totals summary.
         rowCount: false,
+        // Only when supplied, so non-MCP callers stay unchanged.
+        ...(queryTimeoutMs !== undefined ? { queryTimeoutMs } : {}),
+        ...(signal !== undefined ? { signal } : {}),
       });
 
       const batch = await reader.readReportDataBatch(undefined, 1);

--- a/apps/backend/src/data-marts/use-cases/query-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/query-data-mart.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { QueryDataMartCommand, QueryDataMartService } from './query-data-mart.service';
+import { QueryAbortedError, QueryTimeoutError } from '../facades/mcp-data-marts.facade';
 import { ProjectOperationBlockedException } from '../../common/exceptions/project-operation-blocked.exception';
 import { ProjectBlockedReason } from '../enums/project-blocked-reason.enum';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
@@ -23,6 +24,7 @@ describe('QueryDataMartService', () => {
       batches?: ReportDataBatch[];
       accessAllowed?: boolean;
       balanceAllowed?: boolean;
+      deadlineMs?: number;
     } = {}
   ) => {
     const dataHeaders = overrides.dataHeaders ?? [
@@ -84,7 +86,6 @@ describe('QueryDataMartService', () => {
     const consumptionTrackingService = {
       registerMcpQueryRunConsumption: jest.fn().mockResolvedValue(undefined),
     };
-
     const service = new QueryDataMartService(
       dataMartService as never,
       composer as never,
@@ -93,7 +94,10 @@ describe('QueryDataMartService', () => {
       dataMartRunService as never,
       accessDecisionService as never,
       projectBalanceService as never,
-      consumptionTrackingService as never
+      consumptionTrackingService as never,
+      // Default deadline is large (constructor default) so normal tests never time out; pass a tiny
+      // value to exercise the timeout path.
+      overrides.deadlineMs ?? 3_600_000
     );
 
     return {
@@ -758,6 +762,64 @@ describe('QueryDataMartService', () => {
       expect(consumptionTrackingService.registerMcpQueryRunConsumption).not.toHaveBeenCalled();
     });
 
+    it('throws QueryTimeoutError past the deadline, records FAILED, and does NOT bill', async () => {
+      const { service, reader, dataMartRunService, consumptionTrackingService } = createService({
+        deadlineMs: 20,
+      });
+      // Hold the DWH read pending (controllable deferred) so the server-side deadline fires first.
+      let rejectRead!: (e: Error) => void;
+      reader.prepareReportData.mockReturnValue(
+        new Promise((_resolve, reject) => {
+          rejectRead = reject;
+        })
+      );
+
+      await expect(
+        service.run(
+          new QueryDataMartCommand({
+            projectId: 'p1',
+            userId: 'u1',
+            roles: ['admin'],
+            dataMartId: 'dm1',
+            fields: ['channel'],
+            limit: 100,
+          })
+        )
+      ).rejects.toBeInstanceOf(QueryTimeoutError);
+
+      // Recorded FAILED (audit trail), but billing is skipped — a timed-out query is never charged.
+      const call = dataMartRunService.recordMcpQueryRun.mock.calls[0][0];
+      expect(call.status).toBe(DataMartRunStatus.FAILED);
+      expect(call.errors[0]).toContain('timed out');
+      expect(consumptionTrackingService.registerMcpQueryRunConsumption).not.toHaveBeenCalled();
+
+      // Settle the abandoned read so it does not linger past the test (Phase 2 adds real cancel).
+      rejectRead(new Error('read abandoned after timeout'));
+    });
+
+    it('runs totals in parallel and still degrades to null (rows + billing) when totals rejects', async () => {
+      const { service, reportTotalsService, consumptionTrackingService } = createService();
+      reportTotalsService.computeTotals.mockRejectedValue(new Error('totals boom'));
+
+      const result = await service.run(
+        new QueryDataMartCommand({
+          projectId: 'p1',
+          userId: 'u1',
+          roles: ['admin'],
+          dataMartId: 'dm1',
+          fields: ['channel', 'revenue'],
+          limit: 100,
+        })
+      );
+
+      // Totals started in parallel with the read; its failure must not fail the rows read.
+      expect(result.rows).toHaveLength(2);
+      expect(result.totals).toBeNull();
+      expect(reportTotalsService.computeTotals).toHaveBeenCalledTimes(1);
+      // A successful read is still billed even though totals degraded.
+      expect(consumptionTrackingService.registerMcpQueryRunConsumption).toHaveBeenCalledTimes(1);
+    });
+
     it('rethrows the ORIGINAL read error, not the audit error, when the FAILED run write also rejects', async () => {
       const { service, reader, dataMartRunService } = createService();
       reader.readReportDataBatch.mockRejectedValue(new Error('read boom'));
@@ -777,6 +839,213 @@ describe('QueryDataMartService', () => {
       ).rejects.toThrow('read boom');
 
       expect(reader.finalize).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('client abort (Phase 2)', () => {
+    it('rejects with QueryAbortedError before any read or billing when already aborted, records CANCELLED', async () => {
+      const { service, reader, dataMartRunService, consumptionTrackingService } = createService();
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        service.run(
+          new QueryDataMartCommand({
+            projectId: 'p1',
+            userId: 'u1',
+            roles: ['admin'],
+            dataMartId: 'dm1',
+            fields: ['channel'],
+            limit: 100,
+          }),
+          controller.signal
+        )
+      ).rejects.toBeInstanceOf(QueryAbortedError);
+
+      // An already-abandoned request never touches the warehouse and is never billed…
+      expect(reader.prepareReportData).not.toHaveBeenCalled();
+      expect(reader.readReportDataBatch).not.toHaveBeenCalled();
+      expect(consumptionTrackingService.registerMcpQueryRunConsumption).not.toHaveBeenCalled();
+      // …but the run is still recorded CANCELLED (not FAILED) for the audit trail.
+      const call = dataMartRunService.recordMcpQueryRun.mock.calls[0][0];
+      expect(call.status).toBe(DataMartRunStatus.CANCELLED);
+    });
+
+    it('rejects with QueryAbortedError, records CANCELLED, and does NOT bill when aborted during the read', async () => {
+      const { service, reader, dataMartRunService, consumptionTrackingService } = createService();
+      const controller = new AbortController();
+
+      // Hold the DWH read pending and fire the client abort exactly when the read starts, so the
+      // abort wins the race (Phase 2 only stops waiting — the read is never truly cancelled).
+      let rejectRead!: (e: Error) => void;
+      reader.prepareReportData.mockImplementation(() => {
+        controller.abort();
+        return new Promise((_resolve, reject) => {
+          rejectRead = reject;
+        });
+      });
+
+      await expect(
+        service.run(
+          new QueryDataMartCommand({
+            projectId: 'p1',
+            userId: 'u1',
+            roles: ['admin'],
+            dataMartId: 'dm1',
+            fields: ['channel'],
+            limit: 100,
+          }),
+          controller.signal
+        )
+      ).rejects.toBeInstanceOf(QueryAbortedError);
+
+      const call = dataMartRunService.recordMcpQueryRun.mock.calls[0][0];
+      expect(call.status).toBe(DataMartRunStatus.CANCELLED);
+      expect(consumptionTrackingService.registerMcpQueryRunConsumption).not.toHaveBeenCalled();
+
+      // Settle the abandoned read so it does not linger past the test (no real cancel in Phase 2).
+      rejectRead(new Error('read abandoned after abort'));
+    });
+
+    it('behaves exactly as before when no signal is passed (regression)', async () => {
+      const { service, dataMartRunService, consumptionTrackingService } = createService();
+
+      const result = await service.run(
+        new QueryDataMartCommand({
+          projectId: 'p1',
+          userId: 'u1',
+          roles: ['admin'],
+          dataMartId: 'dm1',
+          fields: ['channel', 'revenue'],
+          limit: 100,
+        })
+      );
+
+      expect(result.columns).toEqual(['channel', 'revenue']);
+      expect(result.rows).toHaveLength(2);
+      const call = dataMartRunService.recordMcpQueryRun.mock.calls[0][0];
+      expect(call.status).toBe(DataMartRunStatus.SUCCESS);
+      expect(consumptionTrackingService.registerMcpQueryRunConsumption).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('resource lifecycle & parallelism (review follow-up)', () => {
+    const cmd = (limit: number) =>
+      new QueryDataMartCommand({
+        projectId: 'p1',
+        userId: 'u1',
+        roles: ['admin'],
+        dataMartId: 'dm1',
+        fields: ['channel'],
+        limit,
+      });
+    const flush = () => new Promise(resolve => setImmediate(resolve));
+
+    it('over-reads limit+1 rows to detect truncation without a separate COUNT query', async () => {
+      const { service, reader } = createService();
+      await service.run(cmd(50));
+      // A 51st row is the truncation signal; the first page must therefore request limit+1.
+      expect(reader.readReportDataBatch).toHaveBeenCalledWith(undefined, 51);
+    });
+
+    it('does not mark truncated when exactly limit rows are returned (boundary)', async () => {
+      const { service } = createService({
+        batches: [
+          new ReportDataBatch(
+            [
+              ['fb', 10],
+              ['org', 8],
+            ],
+            null
+          ),
+        ],
+      });
+      const result = await service.run(cmd(2));
+      expect(result.rows).toHaveLength(2);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('reads rows in parallel with totals — the read proceeds while totals is still pending', async () => {
+      const { service, reader, reportTotalsService } = createService();
+      let resolveTotals!: (v: null) => void;
+      reportTotalsService.computeTotals.mockReturnValue(
+        new Promise(resolve => {
+          resolveTotals = resolve;
+        })
+      );
+
+      const run = service.run(cmd(100));
+      await flush();
+
+      // Totals is still pending, yet the rows read has already run — a totals-first sequential
+      // implementation would have blocked the read here.
+      expect(reportTotalsService.computeTotals).toHaveBeenCalledTimes(1);
+      expect(reader.prepareReportData).toHaveBeenCalledTimes(1);
+      expect(reader.readReportDataBatch).toHaveBeenCalled();
+
+      resolveTotals(null);
+      const result = await run;
+      expect(result.totals).toBeNull();
+    });
+
+    it('clears the deadline timer and detaches the abort listener on a successful run', async () => {
+      const { service } = createService();
+      const controller = new AbortController();
+      const removeSpy = jest.spyOn(controller.signal, 'removeEventListener');
+      const clearSpy = jest.spyOn(global, 'clearTimeout');
+
+      await service.run(cmd(100), controller.signal);
+
+      expect(clearSpy).toHaveBeenCalled();
+      expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+      clearSpy.mockRestore();
+    });
+
+    it('finalizes the reader even when the deadline is lost before the reader is resolved (no leak)', async () => {
+      const { service, reader, composer } = createService({ deadlineMs: 20 });
+      // Hold compose pending so the deadline fires BEFORE the reader is ever resolved — the exact
+      // window where the old outer-finally cleanup would skip a reader produce assigns later.
+      let resolveCompose!: (v: { sql: string; params: never[] }) => void;
+      composer.compose.mockReturnValue(
+        new Promise(resolve => {
+          resolveCompose = resolve;
+        })
+      );
+
+      await expect(service.run(cmd(100))).rejects.toBeInstanceOf(QueryTimeoutError);
+
+      // The race is already lost; let produce continue past compose so it resolves the reader.
+      resolveCompose({ sql: 'SELECT 1', params: [] });
+      await flush();
+
+      // produce owns the reader now, so its finally finalizes it even though it lost the race.
+      expect(reader.finalize).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops paging once the client aborts mid-read (cooperative cancellation)', async () => {
+      const { service, reader } = createService({
+        batches: [
+          new ReportDataBatch([['fb', 1]], 'next-1'),
+          new ReportDataBatch([['org', 2]], 'next-2'),
+        ],
+      });
+      const controller = new AbortController();
+      // Abort after the first page so the loop's pre-read guard trips before the second fetch.
+      let page = 0;
+      reader.readReportDataBatch.mockImplementation(() => {
+        const batch =
+          page === 0 ? new ReportDataBatch([['fb', 1]], 'next-1') : new ReportDataBatch([], null);
+        page += 1;
+        controller.abort();
+        return Promise.resolve(batch);
+      });
+
+      await expect(service.run(cmd(100), controller.signal)).rejects.toBeInstanceOf(
+        QueryAbortedError
+      );
+
+      // Only the first page was fetched; the abort guard stopped the loop before a second read.
+      expect(reader.readReportDataBatch).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -931,6 +1200,39 @@ describe('QueryDataMartService', () => {
       expect(composer.compose).toHaveBeenCalledWith(
         expect.objectContaining({ dateTruncConfig: null }),
         expect.anything()
+      );
+    });
+  });
+
+  describe('per-query DWH timeout (Phase 3)', () => {
+    it('passes queryTimeoutMs (= the configured deadline) into the rows prepareReportData options and computeTotals', async () => {
+      const { service, reader, reportTotalsService } = createService({ deadlineMs: 12_345 });
+
+      await service.run(
+        new QueryDataMartCommand({
+          projectId: 'p1',
+          userId: 'u1',
+          roles: ['admin'],
+          dataMartId: 'dm1',
+          fields: ['channel', 'revenue'],
+          limit: 100,
+        })
+      );
+
+      // The rows read carries the same nominal deadline as the app-side timer — the DWH aborts
+      // the job server-side at that bound, capping cost even if the JS deadline never fires.
+      expect(reader.prepareReportData).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ queryTimeoutMs: 12_345 })
+      );
+      // Totals is a separate DWH query; it gets the same timeout (4th arg) and the request signal
+      // (5th arg, undefined here since none was passed) so an abort cancels both warehouse queries.
+      expect(reportTotalsService.computeTotals).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        DataStorageType.GOOGLE_BIGQUERY,
+        12_345,
+        undefined
       );
     });
   });

--- a/apps/backend/src/data-marts/use-cases/query-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/query-data-mart.service.spec.ts
@@ -1047,6 +1047,44 @@ describe('QueryDataMartService', () => {
       // Only the first page was fetched; the abort guard stopped the loop before a second read.
       expect(reader.readReportDataBatch).toHaveBeenCalledTimes(1);
     });
+
+    it('aborts the DWH work signal on the deadline so the warehouse job is cancelled', async () => {
+      const { service, reader } = createService({ deadlineMs: 20 });
+      let capturedSignal: AbortSignal | undefined;
+      let rejectRead!: (e: Error) => void;
+      reader.prepareReportData.mockImplementation(
+        (_plan: unknown, opts: { signal?: AbortSignal }) => {
+          capturedSignal = opts?.signal;
+          return new Promise((_res, reject) => {
+            rejectRead = reject;
+          });
+        }
+      );
+
+      await expect(service.run(cmd(100))).rejects.toBeInstanceOf(QueryTimeoutError);
+
+      // The reader got a live signal that the deadline aborted — the adapter cancels the job on it.
+      expect(capturedSignal).toBeDefined();
+      expect(capturedSignal!.aborted).toBe(true);
+      rejectRead(new Error('read abandoned after timeout'));
+    });
+
+    it('aborts the totals work signal when the rows read fails (no orphaned totals query)', async () => {
+      const { service, reader, reportTotalsService } = createService();
+      let totalsSignal: AbortSignal | undefined;
+      reportTotalsService.computeTotals.mockImplementation(
+        (_p: unknown, _a: unknown, _s: unknown, _t: unknown, signal?: AbortSignal) => {
+          totalsSignal = signal;
+          return Promise.resolve(null);
+        }
+      );
+      reader.readReportDataBatch.mockRejectedValue(new Error('read boom'));
+
+      await expect(service.run(cmd(100))).rejects.toThrow('read boom');
+
+      expect(totalsSignal).toBeDefined();
+      expect(totalsSignal!.aborted).toBe(true);
+    });
   });
 
   it('happy-path: fields + one slice + one aggregation → columns, rows, and totals block', async () => {
@@ -1225,14 +1263,14 @@ describe('QueryDataMartService', () => {
         expect.anything(),
         expect.objectContaining({ queryTimeoutMs: 12_345 })
       );
-      // Totals is a separate DWH query; it gets the same timeout (4th arg) and the request signal
-      // (5th arg, undefined here since none was passed) so an abort cancels both warehouse queries.
+      // Totals is a separate DWH query; it gets the same timeout (4th arg) and the internal work
+      // signal (5th arg) so the deadline / a client abort / a rows failure cancels both queries.
       expect(reportTotalsService.computeTotals).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
         DataStorageType.GOOGLE_BIGQUERY,
         12_345,
-        undefined
+        expect.any(AbortSignal)
       );
     });
   });

--- a/apps/backend/src/data-marts/use-cases/query-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/query-data-mart.service.ts
@@ -132,6 +132,8 @@ export class QueryDataMartService {
     let executionSqlQuery: string | undefined;
     let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
     let abortListener: (() => void) | undefined;
+    // Cancels the DWH work on any early exit (client abort / deadline / rows failure), not just abort.
+    const workController = new AbortController();
     try {
       // Inside the try so `dataMart` is resolved for the CANCELLED audit row.
       if (signal?.aborted) {
@@ -141,10 +143,10 @@ export class QueryDataMartService {
       // Only the app-side timer and abort actually stop the server waiting; both throw, so billing
       // (success-path only) is skipped. Audit + billing stay OUTSIDE the race — fast local writes.
       const deadline = new Promise<never>((_, reject) => {
-        deadlineTimer = setTimeout(
-          () => reject(new QueryTimeoutError(this.queryDeadlineMs)),
-          this.queryDeadlineMs
-        );
+        deadlineTimer = setTimeout(() => {
+          workController.abort();
+          reject(new QueryTimeoutError(this.queryDeadlineMs));
+        }, this.queryDeadlineMs);
       });
 
       // Intentionally the SAME budget as the app-side timer, NOT lower: the warehouse clock starts
@@ -155,7 +157,10 @@ export class QueryDataMartService {
 
       const aborted = new Promise<never>((_, reject) => {
         if (signal) {
-          abortListener = () => reject(new QueryAbortedError());
+          abortListener = () => {
+            workController.abort();
+            reject(new QueryAbortedError());
+          };
           signal.addEventListener('abort', abortListener, { once: true });
         }
       });
@@ -180,7 +185,13 @@ export class QueryDataMartService {
           // Run totals in PARALLEL with the rows read (wall-clock ≈ max, not sum); failure degrades to null.
           const totalsPromise: Promise<McpQueryDataMartResponse['totals']> =
             this.reportTotalsService
-              .computeTotals(readPlan, accessor, dataMart.storage.type, queryTimeoutMs, signal)
+              .computeTotals(
+                readPlan,
+                accessor,
+                dataMart.storage.type,
+                queryTimeoutMs,
+                workController.signal
+              )
               .catch(totalsErr => {
                 this.logger.warn(
                   `computeTotals failed; degrading to null: ${totalsErr instanceof Error ? totalsErr.message : String(totalsErr)}`
@@ -203,7 +214,7 @@ export class QueryDataMartService {
             columnFilter: r.fields,
             aggregationConfig: readPlan.aggregationConfig ?? undefined,
             queryTimeoutMs,
-            signal,
+            signal: workController.signal,
           });
           const columns = description.dataHeaders.map(header => header.name);
 
@@ -227,6 +238,7 @@ export class QueryDataMartService {
           const totals = await totalsPromise;
           return { columns, trimmed, truncated, totals };
         } finally {
+          workController.abort();
           try {
             await reader?.finalize();
           } catch (finalizeErr) {

--- a/apps/backend/src/data-marts/use-cases/query-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/query-data-mart.service.ts
@@ -1,4 +1,11 @@
-import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+  Optional,
+} from '@nestjs/common';
 import { randomUUID } from 'node:crypto';
 import { TypeResolver } from '../../common/resolver/type-resolver';
 import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../data-storage-types/data-storage-providers';
@@ -18,6 +25,8 @@ import { ConsumptionTrackingService } from '../services/consumption-tracking.ser
 import {
   McpQueryDataMartRequest,
   McpQueryDataMartResponse,
+  QueryAbortedError,
+  QueryTimeoutError,
 } from '../facades/mcp-data-marts.facade';
 import { AccessDecisionService, EntityType, Action } from '../services/access-decision';
 
@@ -25,17 +34,17 @@ export class QueryDataMartCommand {
   constructor(public readonly request: McpQueryDataMartRequest) {}
 }
 
-// Upper bound on rows read per query, independent of the MCP tool's own clamp (query-data-mart.
-// input.ts MAX_LIMIT) — this guards direct service/facade callers that bypass the tool schema.
+// Guards direct facade callers that bypass the tool schema's own clamp.
 const MAX_QUERY_LIMIT = 1000;
 
+// Server-side deadline for one run; on expiry the run fails query_timeout and is not billed. Matches
+// SERVER_TIMEOUT_MS (3 min), so the /mcp controller raises its socket timeout above this or the idle
+// timer would blunt-reset a computing request first. Overridable via constructor for tests.
+export const DEFAULT_QUERY_DEADLINE_MS = 3 * 60_000;
+
 /**
- * Reads rows for a single Data Mart on behalf of the `query_data_mart` MCP tool.
- *
- * The SQL is composed from the read plan and handed to the reader as `sqlOverride`, with
- * `columnFilter` restricting the emitted headers to the selected fields in their requested
- * order. Without these the reader falls back to `SELECT *` and ignores the field selection,
- * filters, and limit.
+ * Reads rows for a single Data Mart on behalf of the `query_data_mart` MCP tool. The composed SQL is
+ * passed to the reader as `sqlOverride` + `columnFilter`; without them it falls back to `SELECT *`.
  */
 @Injectable()
 export class QueryDataMartService {
@@ -50,17 +59,17 @@ export class QueryDataMartService {
     private readonly dataMartRunService: DataMartRunService,
     private readonly accessDecisionService: AccessDecisionService,
     private readonly projectBalanceService: ProjectBalanceService,
-    private readonly consumptionTrackingService: ConsumptionTrackingService
+    private readonly consumptionTrackingService: ConsumptionTrackingService,
+    @Optional() private readonly queryDeadlineMs: number = DEFAULT_QUERY_DEADLINE_MS
   ) {}
 
-  async run(command: QueryDataMartCommand): Promise<McpQueryDataMartResponse> {
+  async run(
+    command: QueryDataMartCommand,
+    signal?: AbortSignal
+  ): Promise<McpQueryDataMartResponse> {
     const r = command.request;
 
-    // Defense-in-depth for direct facade callers: the MCP tool clamps limit to 1–MAX_QUERY_LIMIT,
-    // but the facade contract types it as a bare number. A limit < 1 would still read and then fail
-    // to persist the run (McpQueryRunMetadataSchema requires limit.positive()), silently dropping
-    // the audit row inside the best-effort catch; an unbounded upper limit invites a memory/DWH
-    // overload. Bound both ends up front, before any read or billing.
+    // Bound before any read/billing — the facade types limit as a bare number, bypassing the tool clamp.
     if (!Number.isInteger(r.limit) || r.limit < 1 || r.limit > MAX_QUERY_LIMIT) {
       throw new BadRequestException(
         `query_data_mart: limit must be an integer between 1 and ${MAX_QUERY_LIMIT}`
@@ -71,23 +80,17 @@ export class QueryDataMartService {
     try {
       dataMart = await this.dataMartService.getByIdAndProjectId(r.dataMartId, r.projectId);
     } catch (err) {
-      // Normalize the missing-DM message to the exact constant the hidden-DM path throws below —
-      // getByIdAndProjectId's message embeds the id + projectId, which would let a caller tell
-      // "doesn't exist" apart from "exists but you can't see it". Both must be indistinguishable.
+      // Missing / unpublished / hidden must all be indistinguishable — same not-found, no id leak.
       if (err instanceof NotFoundException) {
         throw new NotFoundException(`Data Mart not found`);
       }
       throw err;
     }
 
-    // Only PUBLISHED data marts are queryable — mirror StreamHttpDataService's boundary so a visible
-    // DRAFT cannot be executed by ID. Reuse the same not-found message so an unpublished DM is
-    // indistinguishable from a missing/hidden one.
     if (dataMart.status !== DataMartStatus.PUBLISHED) {
       throw new NotFoundException(`Data Mart not found`);
     }
 
-    // Throw not-found (not forbidden) on a hidden DM so the caller cannot tell it apart from a missing one.
     const canSee = await this.accessDecisionService.canAccess(
       r.userId,
       r.roles,
@@ -126,59 +129,119 @@ export class QueryDataMartService {
       limit: r.limit,
     };
 
-    let reader: DataStorageReportReader | undefined;
     let executionSqlQuery: string | undefined;
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    let abortListener: (() => void) | undefined;
     try {
-      const composed = await this.composer.compose(readPlan, accessor);
-      // Persist a self-contained SQL string for Run History (parameters inlined, like report
-      // runs) so the recorded "Executed SQL" is runnable, not @p/? placeholders. Best-effort:
-      // fall back to the parameterized SQL if inlining is unsupported for this storage.
-      try {
-        executionSqlQuery = this.composer.inlineStaticSql(
-          dataMart.storage.type,
-          composed.sql,
-          composed.params
-        );
-      } catch {
-        executionSqlQuery = composed.sql;
+      // Inside the try so `dataMart` is resolved for the CANCELLED audit row.
+      if (signal?.aborted) {
+        throw new QueryAbortedError();
       }
-      reader = await this.readerResolver.resolve(dataMart.storage.type);
-      const description = await reader.prepareReportData(readPlan, {
-        sqlOverride: composed.sql,
-        sqlOverrideParams: composed.params,
-        columnFilter: r.fields,
-        aggregationConfig: readPlan.aggregationConfig ?? undefined,
+
+      // Only the app-side timer and abort actually stop the server waiting; both throw, so billing
+      // (success-path only) is skipped. Audit + billing stay OUTSIDE the race — fast local writes.
+      const deadline = new Promise<never>((_, reject) => {
+        deadlineTimer = setTimeout(
+          () => reject(new QueryTimeoutError(this.queryDeadlineMs)),
+          this.queryDeadlineMs
+        );
       });
-      const columns = description.dataHeaders.map(header => header.name);
 
-      const rows: unknown[][] = [];
-      let batchId: string | undefined;
-      do {
-        const batch = await reader.readReportDataBatch(batchId, overReadLimit - rows.length);
-        rows.push(...batch.dataRows);
-        batchId = batch.nextDataBatchId ?? undefined;
-        // A reader may return an empty page with a non-null next token (Redshift/Athena forward the
-        // warehouse NextToken verbatim and ignore the row cap). Without this break the loop would
-        // spin forever, since rows.length never advances past an empty page.
-        if (batch.dataRows.length === 0) break;
-      } while (batchId && rows.length < overReadLimit);
+      // Intentionally the SAME budget as the app-side timer, NOT lower: the warehouse clock starts
+      // later (after compose/resolve/prepare above), so the JS timer reliably wins under normal load
+      // and returns a clean query_timeout. The equal DWH cap is a cost backstop for a wedged event
+      // loop where the JS timer can't fire. Only BigQuery/Snowflake honor it; others ignore it.
+      const queryTimeoutMs = this.queryDeadlineMs;
 
-      const truncated = rows.length > r.limit;
-      const trimmed = truncated ? rows.slice(0, r.limit) : rows;
+      const aborted = new Promise<never>((_, reject) => {
+        if (signal) {
+          abortListener = () => reject(new QueryAbortedError());
+          signal.addEventListener('abort', abortListener, { once: true });
+        }
+      });
 
-      // computeTotals is a secondary DWH query — degrade gracefully on failure.
-      let totals: McpQueryDataMartResponse['totals'] = null;
-      try {
-        totals = await this.reportTotalsService.computeTotals(
-          readPlan,
-          accessor,
-          dataMart.storage.type
-        );
-      } catch (totalsErr) {
-        this.logger.warn(
-          `computeTotals failed; degrading to null: ${totalsErr instanceof Error ? totalsErr.message : String(totalsErr)}`
-        );
-      }
+      const produce = (async () => {
+        // produce owns its reader and finalizes it here — the outer finally fires when the race
+        // settles and would skip a reader assigned after a lost race (leak) or destroy one mid-read.
+        let reader: DataStorageReportReader | undefined;
+        try {
+          const composed = await this.composer.compose(readPlan, accessor);
+          // Inline params so Run History's "Executed SQL" is runnable; fall back if unsupported.
+          try {
+            executionSqlQuery = this.composer.inlineStaticSql(
+              dataMart.storage.type,
+              composed.sql,
+              composed.params
+            );
+          } catch {
+            executionSqlQuery = composed.sql;
+          }
+
+          // Run totals in PARALLEL with the rows read (wall-clock ≈ max, not sum); failure degrades to null.
+          const totalsPromise: Promise<McpQueryDataMartResponse['totals']> =
+            this.reportTotalsService
+              .computeTotals(readPlan, accessor, dataMart.storage.type, queryTimeoutMs, signal)
+              .catch(totalsErr => {
+                this.logger.warn(
+                  `computeTotals failed; degrading to null: ${totalsErr instanceof Error ? totalsErr.message : String(totalsErr)}`
+                );
+                return null;
+              });
+
+          reader = await this.readerResolver.resolve(dataMart.storage.type);
+          // Make the silent gap observable: a cap was requested but this storage drops it, so the
+          // query has no warehouse-side cost cap — only the app-side deadline. Adding a new storage
+          // without honorsQueryTimeout will surface here.
+          if (queryTimeoutMs !== undefined && !reader.honorsQueryTimeout) {
+            this.logger.debug(
+              `Storage ${dataMart.storage.type} does not honor queryTimeoutMs; no warehouse-side cost cap for this query.`
+            );
+          }
+          const description = await reader.prepareReportData(readPlan, {
+            sqlOverride: composed.sql,
+            sqlOverrideParams: composed.params,
+            columnFilter: r.fields,
+            aggregationConfig: readPlan.aggregationConfig ?? undefined,
+            queryTimeoutMs,
+            signal,
+          });
+          const columns = description.dataHeaders.map(header => header.name);
+
+          const rows: unknown[][] = [];
+          let batchId: string | undefined;
+          do {
+            // Cooperative cancellation: once the client aborted, stop paging — the DWH job is capped
+            // by queryTimeoutMs, but there is no point buffering more rows nobody will receive.
+            if (signal?.aborted) {
+              throw new QueryAbortedError();
+            }
+            const batch = await reader.readReportDataBatch(batchId, overReadLimit - rows.length);
+            rows.push(...batch.dataRows);
+            batchId = batch.nextDataBatchId ?? undefined;
+            // Empty page + non-null token (Redshift/Athena) would spin forever — stop.
+            if (batch.dataRows.length === 0) break;
+          } while (batchId && rows.length < overReadLimit);
+
+          const truncated = rows.length > r.limit;
+          const trimmed = truncated ? rows.slice(0, r.limit) : rows;
+          const totals = await totalsPromise;
+          return { columns, trimmed, truncated, totals };
+        } finally {
+          try {
+            await reader?.finalize();
+          } catch (finalizeErr) {
+            this.logger.warn(
+              `reader.finalize() failed; ignoring: ${finalizeErr instanceof Error ? finalizeErr.message : String(finalizeErr)}`
+            );
+          }
+        }
+      })();
+
+      const { columns, trimmed, truncated, totals } = await Promise.race([
+        produce,
+        deadline,
+        aborted,
+      ]);
 
       // Audit save is best-effort — a successful read must not become FAILED.
       let runRecorded = false;
@@ -191,9 +254,7 @@ export class QueryDataMartService {
           status: DataMartRunStatus.SUCCESS,
           metadata: {
             columns,
-            // Rows read from the warehouse (audit). The client's `returned_rows` may be lower
-            // if the tool's byte-cap trims the payload — an intentional divergence: metadata
-            // records the query result size, the response reflects the transported payload.
+            // Rows read (audit); the tool's byte-cap may trim the transported payload below this.
             rowCount: trimmed.length,
             truncated,
             executionSqlQuery,
@@ -209,11 +270,7 @@ export class QueryDataMartService {
         );
       }
 
-      // Consumption is best-effort AND gated on the audit write: never bill a run that has no
-      // Run History record. That would over-charge the user with a consumption `reportRunId` that
-      // resolves to nothing — an untraceable charge. If the audit write failed we suppress billing
-      // (favor a revenue miss over an untraceable charge). A tracking failure still must not fail
-      // an already-successful read.
+      // Never bill a run with no audit record — that charge would resolve to nothing (untraceable).
       if (runRecorded) {
         try {
           await this.consumptionTrackingService.registerMcpQueryRunConsumption(dataMart, runId);
@@ -236,14 +293,15 @@ export class QueryDataMartService {
       };
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
-      // Best-effort — a failing audit write must not replace the original error.
+      const status =
+        err instanceof QueryAbortedError ? DataMartRunStatus.CANCELLED : DataMartRunStatus.FAILED;
       try {
         await this.dataMartRunService.recordMcpQueryRun({
           runId,
           dataMart,
           createdById: r.userId,
           startedAt,
-          status: DataMartRunStatus.FAILED,
+          status,
           metadata: {
             columns: [],
             rowCount: 0,
@@ -262,16 +320,9 @@ export class QueryDataMartService {
       }
       throw err;
     } finally {
-      // Best-effort, like every other secondary op here: a finalize() rejection (e.g. Snowflake
-      // adapter.destroy / Databricks cursor close on a network blip) must not convert an
-      // already-returned, already-billed success into a tool error, nor mask the original error.
-      try {
-        await reader?.finalize();
-      } catch (finalizeErr) {
-        this.logger.warn(
-          `reader.finalize() failed; ignoring: ${finalizeErr instanceof Error ? finalizeErr.message : String(finalizeErr)}`
-        );
-      }
+      if (deadlineTimer) clearTimeout(deadlineTimer);
+      // The SDK reuses one signal across the request — detach so nothing outlives this run.
+      if (signal && abortListener) signal.removeEventListener('abort', abortListener);
     }
   }
 }

--- a/apps/backend/src/data-marts/use-cases/query-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/query-data-mart.service.ts
@@ -204,7 +204,7 @@ export class QueryDataMartService {
           // query has no warehouse-side cost cap — only the app-side deadline. Adding a new storage
           // without honorsQueryTimeout will surface here.
           if (queryTimeoutMs !== undefined && !reader.honorsQueryTimeout) {
-            this.logger.debug(
+            this.logger.warn(
               `Storage ${dataMart.storage.type} does not honor queryTimeoutMs; no warehouse-side cost cap for this query.`
             );
           }

--- a/apps/backend/src/ee/mcp/controllers/mcp-transport.controller.spec.ts
+++ b/apps/backend/src/ee/mcp/controllers/mcp-transport.controller.spec.ts
@@ -1,24 +1,29 @@
 import type { McpAuthenticatedRequest } from '../auth/mcp-auth-context';
 import type { McpStreamableHttpTransportHandler } from '../sdk/mcp-streamable-http-transport.handler';
-import { McpTransportController } from './mcp-transport.controller';
+import { McpTransportController, MCP_REQUEST_SOCKET_TIMEOUT_MS } from './mcp-transport.controller';
+import { DEFAULT_QUERY_DEADLINE_MS } from '../../../data-marts/use-cases/query-data-mart.service';
+
+const mcpContext = {
+  clientId: 'mcp-client-1',
+  userId: 'user-1',
+  projectId: 'project-1',
+  roles: ['admin'],
+  resource: 'https://mcp.owox.com/mcp',
+  scopes: ['mcp:read'],
+  authFlow: 'mcp',
+};
 
 describe('McpTransportController', () => {
-  it('delegates authenticated HTTP requests to SDK transport handler', async () => {
+  const createController = () => {
     const transportHandler = {
       handleRequest: jest.fn().mockResolvedValue(undefined),
     } as unknown as McpStreamableHttpTransportHandler;
-    const controller = new McpTransportController(transportHandler);
-    const request = {
-      mcpContext: {
-        clientId: 'mcp-client-1',
-        userId: 'user-1',
-        projectId: 'project-1',
-        roles: ['admin'],
-        resource: 'https://mcp.owox.com/mcp',
-        scopes: ['mcp:read'],
-        authFlow: 'mcp',
-      },
-    } as McpAuthenticatedRequest;
+    return { controller: new McpTransportController(transportHandler), transportHandler };
+  };
+
+  it('delegates authenticated HTTP requests to SDK transport handler', async () => {
+    const { controller, transportHandler } = createController();
+    const request = { mcpContext } as McpAuthenticatedRequest;
     const response = {};
     const body = { method: 'tools/list' };
 
@@ -30,5 +35,27 @@ describe('McpTransportController', () => {
       body,
       request.mcpContext
     );
+  });
+
+  it('raises the per-request socket timeout so a computing MCP call is not idle-reset', async () => {
+    const { controller } = createController();
+    const setTimeout = jest.fn();
+    const request = { mcpContext, setTimeout } as unknown as McpAuthenticatedRequest;
+
+    await controller.handleMcp(request, {} as never, { method: 'tools/call' });
+
+    expect(setTimeout).toHaveBeenCalledWith(MCP_REQUEST_SOCKET_TIMEOUT_MS);
+  });
+
+  it('does not throw when the request has no setTimeout (guard)', async () => {
+    const { controller, transportHandler } = createController();
+    const request = { mcpContext } as McpAuthenticatedRequest;
+
+    await expect(controller.handleMcp(request, {} as never, {})).resolves.toBeUndefined();
+    expect(transportHandler.handleRequest).toHaveBeenCalled();
+  });
+
+  it('keeps the socket timeout above the query deadline so the app timeout wins', () => {
+    expect(MCP_REQUEST_SOCKET_TIMEOUT_MS).toBeGreaterThan(DEFAULT_QUERY_DEADLINE_MS);
   });
 });

--- a/apps/backend/src/ee/mcp/controllers/mcp-transport.controller.ts
+++ b/apps/backend/src/ee/mcp/controllers/mcp-transport.controller.ts
@@ -5,6 +5,10 @@ import { McpAuthExceptionFilter } from '../auth/mcp-auth.exception-filter';
 import { McpAuthGuard } from '../auth/mcp-auth.guard';
 import { McpStreamableHttpTransportHandler } from '../sdk/mcp-streamable-http-transport.handler';
 
+// Above query_data_mart's 3-min deadline so the global socket-idle timeout (SERVER_TIMEOUT_MS)
+// doesn't blunt-reset a computing MCP call before it can return a clean query_timeout. LB (1h) caps.
+export const MCP_REQUEST_SOCKET_TIMEOUT_MS = 4 * 60_000;
+
 @Controller()
 @UseGuards(McpAuthGuard)
 @UseFilters(McpAuthExceptionFilter)
@@ -19,6 +23,10 @@ export class McpTransportController {
     @Res() response: Response,
     @Body() body: unknown
   ): Promise<void> {
+    if (typeof request.setTimeout === 'function') {
+      request.setTimeout(MCP_REQUEST_SOCKET_TIMEOUT_MS);
+    }
+
     const startedAt = Date.now();
     const requestSessionId = this.getRequestedSessionId(request);
     const rpc = this.getJsonRpcSummary(body);

--- a/apps/backend/src/ee/mcp/sdk/mcp-sdk-server.factory.spec.ts
+++ b/apps/backend/src/ee/mcp/sdk/mcp-sdk-server.factory.spec.ts
@@ -79,10 +79,36 @@ describe('McpSdkServerFactory', () => {
     );
 
     const sdkHandler = mockRegisterTool.mock.calls[0][2];
+    const signal = new AbortController().signal;
+    await expect(sdkHandler({ query: 'orders' }, { signal })).resolves.toEqual({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+    // The SDK's per-request abort signal (client disconnect/cancel) must reach the tool handler.
+    expect(handler).toHaveBeenCalledWith({ query: 'orders' }, context, signal);
+  });
+
+  it('forwards an undefined signal when the SDK provides no extra', async () => {
+    const handler = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    const tool = {
+      name: 'list_data_marts',
+      description: 'List data marts',
+      zodSchema: { query: z.string().optional() },
+      requiredScopes: ['mcp:read'],
+      handler,
+    } as McpToolDefinition<{ query?: string }>;
+    const McpSdkServerFactory = await loadFactory();
+    const factory = new McpSdkServerFactory(
+      new McpConfigService({ get: jest.fn() } as never),
+      new McpToolRegistry([tool])
+    );
+
+    factory.create(context);
+    const sdkHandler = mockRegisterTool.mock.calls[0][2];
+
     await expect(sdkHandler({ query: 'orders' })).resolves.toEqual({
       content: [{ type: 'text', text: 'ok' }],
     });
-    expect(handler).toHaveBeenCalledWith({ query: 'orders' }, context);
+    expect(handler).toHaveBeenCalledWith({ query: 'orders' }, context, undefined);
   });
 
   it('rejects tool calls when token context lacks required scope', async () => {

--- a/apps/backend/src/ee/mcp/sdk/mcp-sdk-server.factory.ts
+++ b/apps/backend/src/ee/mcp/sdk/mcp-sdk-server.factory.ts
@@ -17,7 +17,7 @@ type McpSdkToolRegistrar = {
       outputSchema?: ZodRawShape;
       annotations?: ToolAnnotations;
     },
-    callback: (input: unknown) => Promise<McpToolResult>
+    callback: (input: unknown, extra: { signal?: AbortSignal }) => Promise<McpToolResult>
   ): unknown;
 };
 
@@ -45,9 +45,11 @@ export class McpSdkServerFactory {
           ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
           ...(tool.annotations ? { annotations: tool.annotations } : {}),
         },
-        async input => {
+        async (input, extra) => {
           this.assertScopes(mcpContext, tool.requiredScopes);
-          return tool.handler(input, mcpContext);
+          // extra.signal fires on client disconnect/cancel — thread it so an abandoned query stops
+          // waiting and is recorded CANCELLED (not billed) instead of running to completion.
+          return tool.handler(input, mcpContext, extra?.signal);
         }
       );
     }

--- a/apps/backend/src/ee/mcp/tools/mcp-tool.definition.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-tool.definition.ts
@@ -21,5 +21,5 @@ export interface McpToolDefinition<TInput = unknown> {
   readonly outputSchema?: ZodRawShape;
   readonly annotations?: ToolAnnotations;
   readonly requiredScopes: McpScope[];
-  handler(input: TInput, context: McpAuthContext): Promise<McpToolResult>;
+  handler(input: TInput, context: McpAuthContext, signal?: AbortSignal): Promise<McpToolResult>;
 }

--- a/apps/backend/src/ee/mcp/tools/query-data-mart.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/query-data-mart.tool.spec.ts
@@ -8,6 +8,10 @@ import {
 import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
 import { ProjectOperationBlockedException } from '../../../common/exceptions/project-operation-blocked.exception';
 import { ProjectBlockedReason } from '../../../data-marts/enums/project-blocked-reason.enum';
+import {
+  QueryAbortedError,
+  QueryTimeoutError,
+} from '../../../data-marts/facades/mcp-data-marts.facade';
 
 const AUTH_CTX = {
   projectId: 'p1',
@@ -77,10 +81,50 @@ describe('QueryDataMartTool', () => {
       const sc = result.structuredContent as { truncated: boolean };
       expect(sc.truncated).toBe(true);
     });
+
+    it('forwards the request AbortSignal to the facade', async () => {
+      facade.queryDataMart.mockResolvedValue({
+        columns: ['id'],
+        rows: [['1']],
+        truncated: false,
+        totals: null,
+      });
+      const controller = new AbortController();
+
+      await tool.handler(
+        { data_mart_id: 'dm1', fields: ['id'] },
+        AUTH_CTX as never,
+        controller.signal
+      );
+
+      expect(facade.queryDataMart).toHaveBeenCalledTimes(1);
+      expect(facade.queryDataMart.mock.calls[0][1]).toBe(controller.signal);
+    });
   });
 
   describe('error mapping', () => {
-    it('maps NotFoundException → permission_denied', async () => {
+    it('maps QueryTimeoutError → query_timeout (actionable, mentions not billed)', async () => {
+      facade.queryDataMart.mockRejectedValue(new QueryTimeoutError(30000));
+
+      const result = await tool.handler({ data_mart_id: 'dm1', fields: ['f1'] }, AUTH_CTX as never);
+
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent).toMatchObject({ error_code: 'query_timeout' });
+      const msg = (result.structuredContent as { message?: string }).message ?? '';
+      expect(msg).toMatch(/not billed/i);
+      expect(msg).toMatch(/fewer fields|limit|aggregate|filter/i);
+    });
+
+    it('maps QueryAbortedError → query_cancelled', async () => {
+      facade.queryDataMart.mockRejectedValue(new QueryAbortedError());
+
+      const result = await tool.handler({ data_mart_id: 'dm1', fields: ['f1'] }, AUTH_CTX as never);
+
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent).toMatchObject({ error_code: 'query_cancelled' });
+    });
+
+    it('maps NotFoundException → permission_denied without leaking the exception message', async () => {
       facade.queryDataMart.mockRejectedValue(
         new NotFoundException('Data Mart with id dm1 and projectId p1 not found')
       );
@@ -93,6 +137,8 @@ describe('QueryDataMartTool', () => {
         type: 'text',
         text: expect.stringContaining('permission_denied'),
       });
+      // The raw exception embeds the id/projectId — the tool must return a static message, not forward it.
+      expect(JSON.stringify(result)).not.toContain('projectId p1');
     });
 
     it('maps UnsupportedOperatorError → unsupported_operator', async () => {

--- a/apps/backend/src/ee/mcp/tools/query-data-mart.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/query-data-mart.tool.ts
@@ -4,6 +4,8 @@ import type { McpScope } from '@owox/idp-protocol';
 import {
   MCP_DATA_MARTS_FACADE,
   type McpDataMartsFacade,
+  QueryAbortedError,
+  QueryTimeoutError,
 } from '../../../data-marts/facades/mcp-data-marts.facade';
 import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
 import { ProjectOperationBlockedException } from '../../../common/exceptions/project-operation-blocked.exception';
@@ -74,34 +76,37 @@ If truncated is true, not all matching rows were returned: narrow the query (few
     private readonly dataMarts: McpDataMartsFacade
   ) {}
 
-  // The MCP SDK validates arguments against `zodSchema` (the schema shape, non-strict) BEFORE
-  // calling handler(): it strips unknown keys and rejects bad enums/missing fields with its own
-  // generic error. So through a real MCP client this re-parse rarely fires — `.strict()`,
-  // `invalid_input`, and the unsupported_aggregation/unsupported_date_bucket branches in mapError
-  // are effectively defense-in-depth for direct/facade callers (only `unsupported_operator` is
-  // reachable via a client, since those operators are intentionally in the enum).
+  // The SDK already validates against zodSchema before handler(); this strict re-parse guards
+  // direct/facade callers that bypass it.
   private parseInput(input: unknown): QueryDataMartInput {
     return queryDataMartInputSchema.parse(input);
   }
 
-  async handler(input: QueryDataMartInput, context: McpAuthContext): Promise<McpToolResult> {
+  async handler(
+    input: QueryDataMartInput,
+    context: McpAuthContext,
+    signal?: AbortSignal
+  ): Promise<McpToolResult> {
     try {
       const parsed = this.parseInput(input);
       const filterConfig = mapMcpFiltersToRules(parsed.slices, parsed.filters);
       const aggregationConfig = mapMcpAggregations(parsed.aggregations);
       const dateTruncConfig = mapMcpDateBuckets(parsed.date_buckets);
 
-      const res = await this.dataMarts.queryDataMart({
-        projectId: context.projectId,
-        userId: context.userId,
-        roles: context.roles,
-        dataMartId: parsed.data_mart_id,
-        fields: parsed.fields,
-        filterConfig,
-        aggregationConfig,
-        dateTruncConfig,
-        limit: parsed.limit ?? DEFAULT_LIMIT,
-      });
+      const res = await this.dataMarts.queryDataMart(
+        {
+          projectId: context.projectId,
+          userId: context.userId,
+          roles: context.roles,
+          dataMartId: parsed.data_mart_id,
+          fields: parsed.fields,
+          filterConfig,
+          aggregationConfig,
+          dateTruncConfig,
+          limit: parsed.limit ?? DEFAULT_LIMIT,
+        },
+        signal
+      );
 
       const { tsv, rowCount, capped } = serializeTsvWithByteCap(
         res.columns,
@@ -138,6 +143,21 @@ If truncated is true, not all matching rows were returned: narrow the query (few
       return toStructuredToolError('invalid_input', `Invalid query input — ${detail}`);
     }
 
+    if (err instanceof QueryTimeoutError) {
+      return toStructuredToolError(
+        'query_timeout',
+        'The query took too long and was stopped (it was not billed). Make it lighter: request fewer fields, add tighter filters/slices, aggregate instead of returning raw rows, or lower the limit — then retry.'
+      );
+    }
+
+    // Rarely delivered (the client already disconnected); kept for direct callers.
+    if (err instanceof QueryAbortedError) {
+      return toStructuredToolError(
+        'query_cancelled',
+        'The query was cancelled before it finished (it was not billed).'
+      );
+    }
+
     if (err instanceof UnsupportedOperatorError) {
       const supported = SUPPORTED_MCP_OPERATORS.join(', ');
       return toStructuredToolError(
@@ -155,7 +175,8 @@ If truncated is true, not all matching rows were returned: narrow the query (few
     }
 
     if (err instanceof NotFoundException) {
-      return toStructuredToolError('permission_denied', err.message);
+      // Static string — a deeper resolver's NotFoundException could embed an id/title we must not leak.
+      return toStructuredToolError('permission_denied', 'Data mart not found or not accessible.');
     }
 
     if (err instanceof ProjectOperationBlockedException) {
@@ -182,9 +203,7 @@ If truncated is true, not all matching rows were returned: narrow the query (few
       );
     }
 
-    // Source-access / exclusion violations. Their message embeds the caller's name/email AND the
-    // restricted data-mart titles (which discovery deliberately hides) — never forward that to the
-    // AI provider. Return a generic denial with no titles or identity.
+    // Generic denial — the raw message leaks the caller's identity and hidden data-mart titles.
     if (
       err instanceof BusinessViolationException &&
       (err.errorDetails?.['deniedDataMartIds'] || err.errorDetails?.['excludedDataMartIds'])
@@ -201,7 +220,7 @@ If truncated is true, not all matching rows were returned: narrow the query (few
         | Array<{ code?: string; column?: string; function?: string }>
         | undefined;
 
-      // A genuinely unknown column (hallucinated / disconnected) — the field name is wrong.
+      // Wrong field name — point at the schema.
       if (errors?.some(e => e.code === 'FILTER_COLUMN_UNKNOWN')) {
         return toStructuredToolError(
           'field_not_found',
@@ -209,9 +228,7 @@ If truncated is true, not all matching rows were returned: narrow the query (few
         );
       }
 
-      // `slices` were used on a data mart with no joined/blended sources. slices are pre-join
-      // filters — they only make sense when the data mart blends another one in. Point the model
-      // at the real fix instead of the generic "re-check the schema" fallback.
+      // slices are pre-join filters; on a non-blended data mart they don't apply.
       if (errors?.some(e => e.code === 'PRE_JOIN_FILTERS_REQUIRE_JOINED_DATA_MART')) {
         return toStructuredToolError(
           'slices_not_applicable',
@@ -219,9 +236,7 @@ If truncated is true, not all matching rows were returned: narrow the query (few
         );
       }
 
-      // The column exists but was left out of `fields`. This is structural — the field name is
-      // correct, so the field_not_found "re-check the schema" guidance would send the model in
-      // circles. Point it at the real fix: add the referenced field to `fields`.
+      // Field name is correct but missing from `fields` — a re-fetch would loop the model; fix is to add it.
       const notSelected = new Set([
         'AGGREGATION_COLUMN_NOT_SELECTED',
         'DATE_TRUNC_COLUMN_NOT_SELECTED',
@@ -236,10 +251,7 @@ If truncated is true, not all matching rows were returned: narrow the query (few
         );
       }
 
-      // The field exists and is selected, but the data mart's output controls don't permit this
-      // aggregate function on it (admin-restricted / type-incompatible), or the (column, function)
-      // pair is duplicated. Name field+function so the model can pick an allowed aggregation
-      // instead of getting the bare "Output controls validation failed" string it can't act on.
+      // Output controls reject this aggregate on this field (or it's a duplicate) — name field+function.
       const aggNotAllowed = new Set([
         'AGGREGATION_FUNCTION_NOT_ALLOWED_FOR_FIELD',
         'AGGREGATION_FUNCTION_NOT_ALLOWED_FOR_TYPE',
@@ -261,9 +273,7 @@ If truncated is true, not all matching rows were returned: narrow the query (few
       }
     }
 
-    // Unclassified error (raw DWH/driver text, unexpected exception). Do NOT forward err.message to
-    // the AI provider — it can carry SQL fragments, identifiers, or PII. The full error is still
-    // recorded in Run History for operators.
+    // Never forward the raw message — it can carry SQL/identifiers/PII. Full error stays in Run History.
     return toStructuredToolError(
       'query_failed',
       'The query could not be completed. Verify the field names, filters, and aggregations against get_data_mart_details_by_id, then retry.'


### PR DESCRIPTION
## What

Makes the synchronous MCP tool `query_data_mart` resilient to slow/abandoned queries so a long or cancelled run ends cleanly and is **never billed**, instead of running to completion and charging for a result nobody receives.

## Design — three layers of defense

1. **App-side deadline** (`DEFAULT_QUERY_DEADLINE_MS = 3 min`). `QueryDataMartService.run` bounds the DWH work (compose + read + totals) with `Promise.race([produce, deadline, aborted])`. On expiry it throws `QueryTimeoutError` → the run is recorded `FAILED` and billing (success-path only) is skipped.
2. **Client abort** via the MCP request's `AbortSignal`, threaded `tool → sdk factory → facade → service`. On abort it throws `QueryAbortedError` → recorded `CANCELLED`, not billed. The read loop also bails cooperatively once the signal fires.
3. **Native warehouse cancellation** as a cost backstop. `signal` + `queryTimeoutMs` are threaded (optional) into the BigQuery/Snowflake adapters: BigQuery sets `jobTimeoutMs` and calls `job.cancel()` on abort; Snowflake sets `STATEMENT_TIMEOUT_IN_SECONDS` and calls `statement.cancel()` on abort. Both the rows read and the totals query are cancelled. Storages that don't honor it (`honorsQueryTimeout` unset) are logged so the gap is observable.

The `/mcp` controller raises the per-request socket timeout to 4 min so the global 3-min socket-idle timeout (`SERVER_TIMEOUT_MS`) doesn't blunt-reset a computing request before the app deadline returns a clean `query_timeout`.

**Billing invariant:** consumption is success-path only and additionally gated on the Run History (audit) write succeeding — no timeout/abort/failed run is ever billed, and no success is billed without an audit row.

## Backward compatibility

`signal` and `queryTimeoutMs` are **optional** params on the shared adapters/readers. Every other `executeQuery` caller (create-view, sql-run, schema-provider, report runs) passes neither → identical behavior. No migrations, no entity changes, no new env vars (the timeout is a code constant, deliberately not env-driven).

## Testing

- New/changed facade impl (`queryDataMart(signal)`) has unit tests (CI-blocking rule).
- Adversarial cases covered: reader-finalize leak on a lost race, true totals parallelism, `limit+1` over-read + `=== limit` boundary, resource cleanup (timer + abort listener), cooperative loop-bail, BigQuery/Snowflake native-cancel paths, and Snowflake sync-complete listener safety.
- Verified: `tsc -p tsconfig.build.json` clean, ESLint clean, full touched-area suite green.