### PR TITLE
refactor(mcp): require only mcp:write scope on MCP write tools

### DIFF
--- a/apps/backend/src/ee/mcp/tools/create-report-run-schedule.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/create-report-run-schedule.tool.spec.ts
@@ -88,7 +88,7 @@ describe('CreateReportRunScheduleTool', () => {
 
     expect(tool).toMatchObject({
       name: 'create_report_run_schedule',
-      requiredScopes: ['mcp:read', 'mcp:write'],
+      requiredScopes: ['mcp:write'],
       annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
     });
     expect(tool.description).toContain('Creates a new');

--- a/apps/backend/src/ee/mcp/tools/create-report-run-schedule.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/create-report-run-schedule.tool.ts
@@ -41,7 +41,7 @@ export class CreateReportRunScheduleTool implements McpToolDefinition<CreateRepo
     destructiveHint: false,
     openWorldHint: false,
   };
-  readonly requiredScopes: McpScope[] = ['mcp:read', 'mcp:write'];
+  readonly requiredScopes: McpScope[] = ['mcp:write'];
 
   constructor(
     @Inject(MCP_SCHEDULED_TRIGGERS_FACADE)

--- a/apps/backend/src/ee/mcp/tools/delete-report-run-schedule.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/delete-report-run-schedule.tool.spec.ts
@@ -68,11 +68,10 @@ describe('DeleteReportRunScheduleTool', () => {
 
     expect(tool).toMatchObject({
       name: 'delete_report_run_schedule',
-      requiredScopes: ['mcp:read', 'mcp:write'],
+      requiredScopes: ['mcp:write'],
       annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: false },
     });
     expect(tool.description).toContain('trigger_id');
     expect(tool.description).toContain('left intact');
-    expect(context.scopes).toEqual(tool.requiredScopes);
   });
 });

--- a/apps/backend/src/ee/mcp/tools/delete-report-run-schedule.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/delete-report-run-schedule.tool.ts
@@ -33,7 +33,7 @@ export class DeleteReportRunScheduleTool implements McpToolDefinition<DeleteRepo
     destructiveHint: true,
     openWorldHint: false,
   };
-  readonly requiredScopes: McpScope[] = ['mcp:read', 'mcp:write'];
+  readonly requiredScopes: McpScope[] = ['mcp:write'];
 
   constructor(
     @Inject(MCP_SCHEDULED_TRIGGERS_FACADE)

--- a/apps/backend/src/ee/mcp/tools/update-report-run-schedule.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/update-report-run-schedule.tool.spec.ts
@@ -93,7 +93,7 @@ describe('UpdateReportRunScheduleTool', () => {
 
     expect(tool).toMatchObject({
       name: 'update_report_run_schedule',
-      requiredScopes: ['mcp:read', 'mcp:write'],
+      requiredScopes: ['mcp:write'],
       annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
     });
     expect(tool.description).toContain('Updates one existing');

--- a/apps/backend/src/ee/mcp/tools/update-report-run-schedule.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/update-report-run-schedule.tool.ts
@@ -39,7 +39,7 @@ export class UpdateReportRunScheduleTool implements McpToolDefinition<UpdateRepo
     destructiveHint: false,
     openWorldHint: false,
   };
-  readonly requiredScopes: McpScope[] = ['mcp:read', 'mcp:write'];
+  readonly requiredScopes: McpScope[] = ['mcp:write'];
 
   constructor(
     @Inject(MCP_SCHEDULED_TRIGGERS_FACADE)


### PR DESCRIPTION
## What

Aligns all MCP write tools to a single `requiredScopes` convention: `['mcp:write']` only.

The report write tools (`add_report`, `update_report`) already declare `['mcp:write']`, while the schedule write tools (`create_report_run_schedule`, `update_report_run_schedule`, `delete_report_run_schedule`) declared `['mcp:read', 'mcp:write']`. This PR changes the three schedule tools (and their specs) to match.

## Why

`McpSdkServerFactory.assertScopes` requires **every** listed scope to be present on the token, so also listing `mcp:read` would reject a hypothetical write-only token for no functional reason. Least-required-scope wins: a write tool needs `mcp:write`, nothing else.

There is no behavioral difference today — clients request both scopes and tokens carry both — this is convention cleanup only.

Raised by @romandubovyi in the delete_report scope thread on #1383.

## Notes

- Dropped the `expect(context.scopes).toEqual(tool.requiredScopes)` assertion in `delete-report-run-schedule.tool.spec.ts` — it compared the test token's scopes to the tool's required scopes, an equality that only held by coincidence and is meaningless once the tool requires a subset of what the token carries.
- Docs ([mcp.md](https://github.com/OWOX/owox-data-marts/blob/main/docs/getting-started/setup-guide/mcp.md)) already describe `mcp:write` as the scope for write tools without claiming schedule tools need `mcp:read`, so no doc change needed.

## Verification

From `apps/backend`:
- `npx jest src/ee/mcp` — 24 suites, 135 tests passed
- `npx nest build` — clean
- `npx eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)