### PR TITLE
fix(consumption): rename MCP query-run payload field reportRunId to runId

### DIFF
--- a/apps/backend/src/data-marts/services/consumption-tracking.service.ts
+++ b/apps/backend/src/data-marts/services/consumption-tracking.service.ts
@@ -220,7 +220,7 @@ export class ConsumptionTrackingService {
     }
     await this.sendConsumptionCommand(this.mcpQueryRunConsumptionTopic, {
       ...this.baseDataMartConsumptionPayload(dataMart),
-      reportRunId: runId,
+      runId,
     });
   }
 


### PR DESCRIPTION
## What

Renames the MCP `query_data_mart` consumption event's run-id field from `reportRunId` to `runId` in the published Pub/Sub payload (`registerMcpQueryRunConsumption`). An MCP query has no report, so `runId` is the accurate name.

## Scope

- **Only** the MCP consumption payload changes. HTTP Data (`registerHttpDataRunConsumption`) and report-run payloads keep `reportRunId` — untouched.

## Compatibility

Wire-compatible: the downstream integrated-backend consumer accepts both `runId` and `reportRunId` via `@JsonAlias`, so producer and consumer can roll out independently.