### PR TITLE
fix(mcp): query_data_mart schema inlining + require mcp:write

### DIFF
--- a/apps/backend/src/ee/mcp/tools/query-data-mart.input.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/query-data-mart.input.spec.ts
@@ -1,3 +1,4 @@
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import {
   mapMcpFiltersToRules,
   mapMcpAggregations,
@@ -200,5 +201,67 @@ describe('queryDataMartInputSchema enum validation', () => {
       date_buckets: [{ field: 'd', unit: 'MONTH' }],
     });
     expect(result.date_buckets?.[0]?.unit).toBe('MONTH');
+  });
+});
+
+describe('queryDataMartInputSchema filter value typing', () => {
+  it('accepts a between filter with an object {from, to} value', () => {
+    const parsed = queryDataMartInputSchema.parse({
+      data_mart_id: 'dm1',
+      fields: ['amount'],
+      filters: [{ field: 'amount', operator: 'between', value: { from: 10, to: 20 } }],
+    });
+    expect(parsed.filters?.[0]?.value).toEqual({ from: 10, to: 20 });
+  });
+
+  it('accepts scalar and array filter values', () => {
+    const parsed = queryDataMartInputSchema.parse({
+      data_mart_id: 'dm1',
+      fields: ['channel'],
+      slices: [{ field: 'channel', operator: 'eq', value: 'fb' }],
+      filters: [{ field: 'ids', operator: 'in', value: [1, 2, 3] }],
+    });
+    expect(parsed.slices?.[0]?.value).toBe('fb');
+    expect(parsed.filters?.[0]?.value).toEqual([1, 2, 3]);
+  });
+});
+
+// Guards the OpenAI tool-verification contract. The MCP SDK's v3 path
+// (server/zod-json-schema-compat.js) converts with zodToJsonSchema at strictUnions + input pipe and
+// the default $refStrategy 'root'; if slices/filters ever share a schema instance again, a $ref
+// reappears and OpenAI collapses `filters` to any[] ("Unclear Arguments").
+describe('query_data_mart tool JSON Schema (OpenAI verification)', () => {
+  const json = zodToJsonSchema(queryDataMartInputSchema, {
+    strictUnions: true,
+    pipeStrategy: 'input',
+  }) as {
+    properties: Record<string, { items: { type?: string; properties: Record<string, unknown> } }>;
+  };
+
+  const collectRefs = (node: unknown, path = ''): string[] => {
+    if (!node || typeof node !== 'object') return [];
+    const out: string[] = [];
+    const record = node as Record<string, unknown>;
+    if (typeof record.$ref === 'string') out.push(`${path} -> ${record.$ref}`);
+    for (const [k, v] of Object.entries(record)) out.push(...collectRefs(v, `${path}/${k}`));
+    return out;
+  };
+
+  it('emits no $ref anywhere (OpenAI does not resolve internal $ref)', () => {
+    expect(collectRefs(json)).toEqual([]);
+  });
+
+  it('inlines filters.items as a concrete object with field/operator/value', () => {
+    const items = json.properties.filters.items;
+    expect(items.type).toBe('object');
+    expect(Object.keys(items.properties)).toEqual(['field', 'operator', 'value']);
+  });
+
+  it('advertises a typed value union for slices and filters, not an empty {}', () => {
+    for (const key of ['slices', 'filters']) {
+      const value = json.properties[key].items.properties.value as { anyOf?: unknown[] };
+      expect(value).not.toEqual({});
+      expect(Array.isArray(value.anyOf)).toBe(true);
+    }
   });
 });

--- a/apps/backend/src/ee/mcp/tools/query-data-mart.input.ts
+++ b/apps/backend/src/ee/mcp/tools/query-data-mart.input.ts
@@ -16,7 +16,7 @@ const DEFAULT_LIMIT = 20;
 
 // Operators unsupported by the internal FilterRule are accepted here and rejected
 // at mapping time with a precise error, rather than silently dropped.
-export const McpOperatorEnum = z.enum([
+const MCP_OPERATORS = [
   'eq',
   'neq',
   'contains',
@@ -39,13 +39,26 @@ export const McpOperatorEnum = z.enum([
   'this_week',
   'this_month',
   'this_year',
-]);
+] as const;
 
-const McpFilterSchema = z.object({
-  field: z.string().min(1),
-  operator: McpOperatorEnum,
-  value: z.unknown().optional(),
-});
+export const McpOperatorEnum = z.enum(MCP_OPERATORS);
+
+// Fresh instance per use — a shared one becomes a JSON-Schema $ref that OpenAI can't resolve (filters → any[]).
+const makeMcpFilterSchema = () =>
+  z.object({
+    field: z.string().min(1),
+    operator: z.enum(MCP_OPERATORS),
+    value: z
+      .union([
+        z.string(),
+        z.number(),
+        z.boolean(),
+        z.array(z.unknown()),
+        z.record(z.unknown()),
+        z.null(),
+      ])
+      .optional(),
+  });
 
 // The MCP tool advertises only these functions (tool description + docs/mcp.md). A strict subset of
 // REPORT_AGGREGATE_FUNCTIONS — STRING_AGG and ANY_VALUE are intentionally NOT exposed, so the input
@@ -90,13 +103,13 @@ export const queryDataMartInputSchema = z
         'Exact field names to return, copied verbatim from get_data_mart_details_by_id. MUST include every field named in aggregations and date_buckets — a field you aggregate or bucket but omit here is rejected. Fields here that are neither aggregated nor bucketed become group-by dimensions.'
       ),
     slices: z
-      .array(McpFilterSchema)
+      .array(makeMcpFilterSchema())
       .optional()
       .describe(
         "Pre-join filters: narrow a JOINED data mart before it is blended in. Criteria on a joined data mart's own fields only — never the main data mart."
       ),
     filters: z
-      .array(McpFilterSchema)
+      .array(makeMcpFilterSchema())
       .optional()
       .describe(
         'Post-join filters on the blended result. May reference a field that is NOT in "fields" (e.g. filter on a column you do not display).'

--- a/apps/backend/src/ee/mcp/tools/query-data-mart.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/query-data-mart.tool.spec.ts
@@ -23,7 +23,7 @@ describe('QueryDataMartTool', () => {
 
   it('exposes the MCP contract', () => {
     expect(tool.name).toBe('query_data_mart');
-    expect(tool.requiredScopes).toEqual(['mcp:read']);
+    expect(tool.requiredScopes).toEqual(['mcp:read', 'mcp:write']);
     expect(tool.annotations).toMatchObject({ title: 'Query Data Mart', openWorldHint: false });
   });
 

--- a/apps/backend/src/ee/mcp/tools/query-data-mart.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/query-data-mart.tool.ts
@@ -67,7 +67,7 @@ If truncated is true, not all matching rows were returned: narrow the query (few
     idempotentHint: false, // each call is a new billable Run
     openWorldHint: false,
   };
-  readonly requiredScopes: McpScope[] = ['mcp:read'];
+  readonly requiredScopes: McpScope[] = ['mcp:read', 'mcp:write'];
 
   constructor(
     @Inject(MCP_DATA_MARTS_FACADE)


### PR DESCRIPTION
Two related `query_data_mart` fixes.

## 1. Inline the filter schema so OpenAI tool verification passes
`filters` and `slices` shared one Zod schema instance, so the Zod→JSON-Schema converter (MCP SDK v3 path → `zodToJsonSchema`, default `$refStrategy: 'root'`) emitted `filters.items` as a `$ref` to `slices.items`. OpenAI's tool verifier does not resolve internal `$ref` and flagged `filters` as `any[]` ("Unclear Arguments"). Separately, `value` was `z.unknown()`, rendered as an untyped `{}`.

**Fix:** build each filter/slice schema from a fresh factory (no shared instance → no `$ref`) and type `value` as a concrete union (`object` covers `between`'s `{from,to}`, `array` covers `in`/`not_in`). **Runtime filter behavior is unchanged** — only the advertised JSON Schema. Adds a regression test asserting the generated schema has zero `$ref` and a typed `value`.

## 2. Require `mcp:write` for query_data_mart
The tool returns rows but also records a billable Run and consumes credits (`readOnlyHint: false`), so it is not a pure read. MCP scopes are flat — `mcp:write` does not imply `mcp:read` — so a tool needing both must list both explicitly. Changes `requiredScopes` from `['mcp:read']` to `['mcp:read', 'mcp:write']` (consistent with the report-run-schedule tools).

## Verification
- `ee/mcp` suite green (30 suites / 187 tests, incl. new schema regression + parse tests)
- `tsc -p tsconfig.build.json` clean, ESLint clean

No changeset — MCP-internal tool schema/scope, no data-facing runtime change.