### PR TITLE
refactor(web): extract UnsavedChangesConfirmationDialog and add e2e regression guard

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,8 @@ dist
 dist-cjs
 build
 coverage
+playwright-report
+test-results
 
 # Dependencies
 package-lock.json

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -28,6 +28,7 @@ e2e/
     ├── run-history.spec.ts          # Run history: empty state, manual run, status badge, timestamps, log views
     ├── notifications.spec.ts        # Notification settings: page render, toggle, edit sheet
     ├── lifecycle.spec.ts            # Full lifecycle: storage -> datamart -> definition -> publish
+    ├── sheet-confirmation-dialogs.spec.ts  # Sheet-hosted confirmation dialogs (unsaved changes + membership decline)
     └── oauth-skeletons.spec.ts      # OAuth connector skeletons (all skipped, credential-gated)
 ```
 
@@ -177,7 +178,11 @@ Located in `helpers/radix.ts`. Handles Radix UI component interactions that invo
 | `selectComboboxOption(trigger, optionText, searchText?)` | Click a cmdk Combobox trigger, optionally search, click option |
 | `dismissSheet(sheetContent)` | Press Escape to close a Sheet, wait for animation |
 | `dismissDialog(dialogContent)` | Press Escape to close a Dialog, wait for animation |
+| `confirmationDialog()` | Locator for the topmost open Dialog content layer (`[data-slot="dialog-content"].last()`) |
 | `confirmDialog(confirmLabel?)` | Click confirm button in a ConfirmationDialog (default label: "Confirm") |
+| `stayOnDirtySheet(hostSheet)` | Cancel the unsaved-changes dialog (`No, stay here`) and assert the host sheet stays open |
+| `leaveDirtySheet(hostSheet)` | Confirm leave on the unsaved-changes dialog (`Yes, leave now`) and assert the host sheet closes |
+| `cancelSheetHostedDialog(hostSheet, cancelLabel)` | Click cancel on a sheet-hosted dialog and assert the host sheet stays open |
 
 ```typescript
 test('example with radix', async ({ page, radix }) => {

--- a/apps/web/e2e/helpers/radix.ts
+++ b/apps/web/e2e/helpers/radix.ts
@@ -56,14 +56,59 @@ export class RadixHelpers {
   }
 
   /**
+   * Returns the topmost ConfirmationDialog content layer.
+   */
+  confirmationDialog(): Locator {
+    return this.page.locator('[data-slot="dialog-content"]').last();
+  }
+
+  /**
    * Click the confirm button in a ConfirmationDialog.
    * ConfirmationDialog has a confirm button with the label passed as confirmLabel (default "Confirm").
    */
   async confirmDialog(confirmLabel = 'Confirm'): Promise<void> {
-    const dialog = this.page.locator('[data-slot="dialog-content"]');
+    const dialog = this.confirmationDialog();
     await expect(dialog).toBeVisible();
     await dialog.getByRole('button', { name: confirmLabel }).click();
     await expect(dialog).not.toBeVisible();
+  }
+
+  /**
+   * Click the cancel button in the standard unsaved-changes sheet guard dialog.
+   * Asserts the host sheet stays open — the regression guard for the nested
+   * dismissable-layer fix from PR #1355.
+   */
+  async stayOnDirtySheet(hostSheet: Locator): Promise<void> {
+    const dialog = this.confirmationDialog();
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Unsaved Changes' })).toBeVisible();
+    await dialog.getByRole('button', { name: 'No, stay here' }).click();
+    await expect(dialog).not.toBeVisible();
+    await expect(hostSheet).toBeVisible();
+  }
+
+  /**
+   * Confirm leaving a dirty sheet via the standard unsaved-changes dialog.
+   */
+  async leaveDirtySheet(hostSheet: Locator): Promise<void> {
+    const dialog = this.confirmationDialog();
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Unsaved Changes' })).toBeVisible();
+    await dialog.getByRole('button', { name: 'Yes, leave now' }).click();
+    await expect(dialog).not.toBeVisible();
+    await expect(hostSheet).not.toBeVisible();
+  }
+
+  /**
+   * Dismiss a sheet-hosted confirmation dialog via its cancel button and
+   * assert the host sheet remains open.
+   */
+  async cancelSheetHostedDialog(hostSheet: Locator, cancelLabel: string | RegExp): Promise<void> {
+    const dialog = this.confirmationDialog();
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole('button', { name: cancelLabel }).click();
+    await expect(dialog).not.toBeVisible();
+    await expect(hostSheet).toBeVisible();
   }
 
   /**

--- a/apps/web/e2e/helpers/radix.ts
+++ b/apps/web/e2e/helpers/radix.ts
@@ -56,7 +56,7 @@ export class RadixHelpers {
   }
 
   /**
-   * Returns the topmost ConfirmationDialog content layer.
+   * Returns the topmost open Dialog content layer.
    */
   confirmationDialog(): Locator {
     return this.page.locator('[data-slot="dialog-content"]').last();

--- a/apps/web/e2e/specs/sheet-confirmation-dialogs.spec.ts
+++ b/apps/web/e2e/specs/sheet-confirmation-dialogs.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from '../fixtures/base';
+import { TESTIDS } from '../selectors/testids';
+
+/**
+ * Regression guard for sheet-hosted confirmation dialogs.
+ *
+ * PR #1355 fixed a dismissal loop by rendering ConfirmationDialog inside
+ * SheetContent. These tests exercise the real Radix dismissable-layer stack
+ * (outside happy-dom) and fail if the dialog is moved back outside the sheet.
+ */
+
+const MEMBERS_URL = '/ui/0/project-settings/members';
+
+const MOCK_MEMBERSHIP_REQUESTS = [
+  {
+    requestId: 'mock-req-bob',
+    email: 'bob@example.com',
+    fullName: 'Bob Example',
+    avatar: null,
+    userId: 'user-bob',
+    requestedRole: 'editor',
+    createdAt: new Date().toISOString(),
+  },
+];
+
+async function mockMembershipRequestRoutes(page: import('@playwright/test').Page): Promise<void> {
+  await page.route('**/api/members/requests', route => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_MEMBERSHIP_REQUESTS),
+      });
+    }
+    return route.continue();
+  });
+
+  await page.route('**/api/members/requests/*/decline', route => {
+    return route.fulfill({ status: 204, body: '' });
+  });
+}
+
+test.describe('Sheet-hosted confirmation dialogs', () => {
+  test.describe('Storage config sheet — unsaved changes guard', () => {
+    test.beforeEach(async ({ apiHelpers }) => {
+      await apiHelpers.createStorage('GOOGLE_BIGQUERY');
+    });
+
+    test('keeps the sheet open when the user cancels leaving dirty form', async ({
+      page,
+      radix,
+    }) => {
+      await page.goto('/ui/0/data-storages');
+      await expect(page.getByTestId(TESTIDS.storageListPage)).toBeVisible();
+
+      await page.getByRole('button', { name: 'Open menu' }).first().click();
+      await page.getByRole('menuitem', { name: 'Edit' }).click();
+
+      const sheet = page.getByTestId(TESTIDS.storageConfigSheet);
+      const form = page.getByTestId(TESTIDS.storageEditForm);
+      await expect(sheet).toBeVisible();
+      await expect(form).toBeVisible();
+
+      const titleInput = form.getByLabel('Title');
+      await titleInput.click();
+      await titleInput.fill('Dirty storage title');
+
+      await page.getByRole('button', { name: 'Cancel' }).click();
+      await radix.stayOnDirtySheet(sheet);
+
+      // Guard against the original re-open loop: dialog must not immediately return.
+      await expect(radix.confirmationDialog()).not.toBeVisible();
+      await expect(sheet).toBeVisible();
+      await expect(titleInput).toHaveValue('Dirty storage title');
+    });
+
+    test('closes the sheet when the user confirms leaving dirty form', async ({
+      page,
+      radix,
+    }) => {
+      await page.goto('/ui/0/data-storages');
+      await expect(page.getByTestId(TESTIDS.storageListPage)).toBeVisible();
+
+      await page.getByRole('button', { name: 'Open menu' }).first().click();
+      await page.getByRole('menuitem', { name: 'Edit' }).click();
+
+      const sheet = page.getByTestId(TESTIDS.storageConfigSheet);
+      const form = page.getByTestId(TESTIDS.storageEditForm);
+      await expect(sheet).toBeVisible();
+
+      const titleInput = form.getByLabel('Title');
+      await titleInput.click();
+      await titleInput.fill('Dirty storage title');
+
+      await page.keyboard.press('Escape');
+      await radix.leaveDirtySheet(sheet);
+    });
+  });
+
+  test.describe('Membership request sheet — decline confirmation', () => {
+    test.beforeEach(async ({ page }) => {
+      await mockMembershipRequestRoutes(page);
+      await page.goto(MEMBERS_URL);
+      await expect(page.getByTestId(TESTIDS.pendingRequestsSection)).toBeVisible({
+        timeout: 25_000,
+      });
+    });
+
+    test('keeps the sheet open when decline confirmation is cancelled', async ({ page, radix }) => {
+      await page.getByText('bob@example.com').click();
+
+      const sheet = page.getByTestId(TESTIDS.membershipRequestSheet);
+      await expect(sheet).toBeVisible();
+      await expect(sheet.getByText('bob@example.com')).toBeVisible();
+
+      await sheet.getByRole('button', { name: /Decline request/i }).click();
+      await expect(
+        page.getByRole('heading', { name: /Decline membership request/i })
+      ).toBeVisible();
+
+      await radix.cancelSheetHostedDialog(sheet, 'Cancel');
+
+      await expect(radix.confirmationDialog()).not.toBeVisible();
+      await expect(sheet).toBeVisible();
+      await expect(sheet.getByText('bob@example.com')).toBeVisible();
+    });
+
+    test('closes the sheet when decline is confirmed', async ({ page, radix }) => {
+      await page.getByText('bob@example.com').click();
+
+      const sheet = page.getByTestId(TESTIDS.membershipRequestSheet);
+      await expect(sheet).toBeVisible();
+
+      await sheet.getByRole('button', { name: /Decline request/i }).click();
+      await expect(
+        page.getByRole('heading', { name: /Decline membership request/i })
+      ).toBeVisible();
+
+      await radix.confirmDialog('Decline');
+      await expect(sheet).not.toBeVisible();
+      await expect(page.getByText('bob@example.com')).toBeHidden();
+    });
+  });
+});

--- a/apps/web/e2e/specs/sheet-confirmation-dialogs.spec.ts
+++ b/apps/web/e2e/specs/sheet-confirmation-dialogs.spec.ts
@@ -74,10 +74,7 @@ test.describe('Sheet-hosted confirmation dialogs', () => {
       await expect(titleInput).toHaveValue('Dirty storage title');
     });
 
-    test('closes the sheet when the user confirms leaving dirty form', async ({
-      page,
-      radix,
-    }) => {
+    test('closes the sheet when the user confirms leaving dirty form', async ({ page, radix }) => {
       await page.goto('/ui/0/data-storages');
       await expect(page.getByTestId(TESTIDS.storageListPage)).toBeVisible();
 

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -4,7 +4,11 @@ import { config } from '@owox/eslint-config/vite-react';
 export default tseslint.config(
   ...config,
   {
-    ignores: ['src/features/data-marts/insights-prev/**'],
+    ignores: [
+      'src/features/data-marts/insights-prev/**',
+      'playwright-report/**',
+      'test-results/**',
+    ],
   },
   // Allow numbers in template literals (e.g. field array index paths like `items.${index}.name`)
   {

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditSheet/ConnectorEditSheet.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditSheet/ConnectorEditSheet.tsx
@@ -8,7 +8,7 @@ import {
 import type { DataStorageType } from '../../../../data-storage';
 import { ConnectorEditForm } from '../ConnectorEditForm/ConnectorEditForm';
 import type { ConnectorConfig } from '../../../../data-marts/edit';
-import { ConfirmationDialog } from '../../../../../shared/components/ConfirmationDialog';
+import { UnsavedChangesConfirmationDialog } from '../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import { useUnsavedGuard } from '../../../../../hooks/useUnsavedGuard';
 import { useIntercomLauncher } from '../../../../../shared/hooks/useIntercomLauncher';
 
@@ -85,17 +85,10 @@ export function ConnectorEditSheet({
           preselectedConnector={preselectedConnector}
           onDirtyChange={handleFormDirtyChange}
         />
-        {/* Rendered inside SheetContent so Radix treats it as a nested dismissable layer;
-              interacting with it then doesn't dismiss the sheet (which caused a re-open loop). */}
-        <ConfirmationDialog
+        <UnsavedChangesConfirmationDialog
           open={showUnsavedDialog}
           onOpenChange={setShowUnsavedDialog}
-          title='Unsaved Changes'
-          description='You have unsaved changes. Exit without saving?'
-          confirmLabel='Yes, leave now'
-          cancelLabel='No, stay here'
           onConfirm={confirmClose}
-          variant='destructive'
         />
       </SheetContent>
     </Sheet>

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditSheet/DataDestinationConfigSheet.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditSheet/DataDestinationConfigSheet.tsx
@@ -2,7 +2,7 @@ import { type DataDestination, DataDestinationType } from '../../../shared';
 import { DataDestinationForm } from '../DataDestinationEditForm';
 import type { DataDestinationFormData } from '../../../shared';
 import { useEffect, useRef } from 'react';
-import { ConfirmationDialog } from '../../../../../shared/components/ConfirmationDialog';
+import { UnsavedChangesConfirmationDialog } from '../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import {
   Sheet,
   SheetContent,
@@ -196,17 +196,10 @@ export function DataDestinationConfigSheet({
           allowedDestinationTypes={allowedDestinationTypes}
           destinationId={dataDestination?.id}
         />
-        {/* Rendered inside SheetContent so Radix treats it as a nested dismissable layer;
-              interacting with it then doesn't dismiss the sheet (which caused a re-open loop). */}
-        <ConfirmationDialog
+        <UnsavedChangesConfirmationDialog
           open={showUnsavedDialog}
           onOpenChange={setShowUnsavedDialog}
-          title='Unsaved Changes'
-          description='You have unsaved changes. Exit without saving?'
-          confirmLabel='Yes, leave now'
-          cancelLabel='No, stay here'
           onConfirm={confirmClose}
-          variant='destructive'
         />
       </SheetContent>
     </Sheet>

--- a/apps/web/src/features/data-marts/insights/components/InsightSourcesPanel.tsx
+++ b/apps/web/src/features/data-marts/insights/components/InsightSourcesPanel.tsx
@@ -58,6 +58,7 @@ import {
   FormActions,
 } from '@owox/ui/components/form';
 import { ConfirmationDialog } from '../../../../shared/components/ConfirmationDialog';
+import { UnsavedChangesConfirmationDialog } from '../../../../shared/components/UnsavedChangesConfirmationDialog';
 import { useUnsavedGuard } from '../../../../hooks/useUnsavedGuard';
 import { useSqlDryRunTrigger } from '../../shared/hooks/useSqlDryRunTrigger';
 import { formatBytes } from '../../../../utils';
@@ -902,17 +903,10 @@ function SourceEditSheet({
             </FormActions>
           </AppForm>
         </Form>
-        {/* Rendered inside SheetContent so Radix treats it as a nested dismissable layer;
-              interacting with it then doesn't dismiss the sheet (which caused a re-open loop). */}
-        <ConfirmationDialog
+        <UnsavedChangesConfirmationDialog
           open={showUnsavedDialog}
           onOpenChange={setShowUnsavedDialog}
-          title='Unsaved Changes'
-          description='You have unsaved changes. Exit without saving?'
-          confirmLabel='Yes, leave now'
-          cancelLabel='No, stay here'
           onConfirm={confirmClose}
-          variant='destructive'
         />
       </SheetContent>
     </Sheet>

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditSheet/EmailReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditSheet/EmailReportEditSheet.tsx
@@ -6,7 +6,7 @@ import {
   SheetTitle,
 } from '@owox/ui/components/sheet';
 import { useCallback } from 'react';
-import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
+import { UnsavedChangesConfirmationDialog } from '../../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import { DataDestinationProvider } from '../../../../../data-destination';
 import type { DataDestination } from '../../../../../data-destination';
 import { ReportFormMode, TemplateSourceTypeEnum } from '../../../shared';
@@ -120,17 +120,10 @@ export function EmailReportEditSheet({
             isReadOnly={isReadOnly}
           />
         </DataDestinationProvider>
-        {/* Rendered inside SheetContent so Radix treats it as a nested dismissable layer;
-              interacting with it then doesn't dismiss the sheet (which caused a re-open loop). */}
-        <ConfirmationDialog
+        <UnsavedChangesConfirmationDialog
           open={showUnsavedDialog}
           onOpenChange={setShowUnsavedDialog}
-          title='Unsaved Changes'
-          description='You have unsaved changes. Exit without saving?'
-          confirmLabel='Yes, leave now'
-          cancelLabel='No, stay here'
           onConfirm={confirmClose}
-          variant='destructive'
         />
       </SheetContent>
     </Sheet>

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
@@ -5,7 +5,7 @@ import {
   SheetTitle,
   SheetDescription,
 } from '@owox/ui/components/sheet';
-import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
+import { UnsavedChangesConfirmationDialog } from '../../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report.ts';
 import { GoogleSheetsReportEditForm } from '../GoogleSheetsReportEditForm';
 import { DataDestinationProvider } from '../../../../../data-destination';
@@ -76,17 +76,10 @@ export function GoogleSheetsReportEditSheet({
             preSelectedDestination={preSelectedDestination}
           />
         </DataDestinationProvider>
-        {/* Rendered inside SheetContent so Radix treats it as a nested dismissable layer;
-              interacting with it then doesn't dismiss the sheet (which caused a re-open loop). */}
-        <ConfirmationDialog
+        <UnsavedChangesConfirmationDialog
           open={showUnsavedDialog}
           onOpenChange={setShowUnsavedDialog}
-          title='Unsaved Changes'
-          description='You have unsaved changes. Exit without saving?'
-          confirmLabel='Yes, leave now'
-          cancelLabel='No, stay here'
           onConfirm={confirmClose}
-          variant='destructive'
         />
       </SheetContent>
     </Sheet>

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
@@ -5,7 +5,7 @@ import {
   SheetTitle,
   SheetDescription,
 } from '@owox/ui/components/sheet';
-import { ConfirmationDialog } from '../../../../../../shared/components/ConfirmationDialog';
+import { UnsavedChangesConfirmationDialog } from '../../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report.ts';
 import { LookerStudioReportEditForm } from '../LookerStudioReportEditForm';
 import { DataDestinationProvider } from '../../../../../data-destination';
@@ -74,17 +74,10 @@ export function LookerStudioReportEditSheet({
             preSelectedDestination={preSelectedDestination}
           />
         </DataDestinationProvider>
-        {/* Rendered inside SheetContent so Radix treats it as a nested dismissable layer;
-              interacting with it then doesn't dismiss the sheet (which caused a re-open loop). */}
-        <ConfirmationDialog
+        <UnsavedChangesConfirmationDialog
           open={showUnsavedDialog}
           onOpenChange={setShowUnsavedDialog}
-          title='Unsaved Changes'
-          description='You have unsaved changes. Exit without saving?'
-          confirmLabel='Yes, leave now'
-          cancelLabel='No, stay here'
           onConfirm={confirmClose}
-          variant='destructive'
         />
       </SheetContent>
     </Sheet>

--- a/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerFormSheet/ScheduledTriggerFormSheet.tsx
+++ b/apps/web/src/features/data-marts/scheduled-triggers/components/ScheduledTriggerFormSheet/ScheduledTriggerFormSheet.tsx
@@ -14,7 +14,7 @@ import type {
   ScheduledTriggerConfig,
 } from '../../model/trigger-config.types';
 import { useMemo, useEffect, useRef } from 'react';
-import { ConfirmationDialog } from '../../../../../shared/components/ConfirmationDialog';
+import { UnsavedChangesConfirmationDialog } from '../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import { trackEvent } from '../../../../../utils';
 import { useUnsavedGuard } from '../../../../../hooks/useUnsavedGuard';
 import { useIntercomLauncher } from '../../../../../shared/hooks/useIntercomLauncher';
@@ -144,17 +144,10 @@ export function ScheduledTriggerFormSheet({
           onCancel={handleClose}
           onDirtyChange={handleFormDirtyChange}
         />
-        {/* Rendered inside SheetContent so Radix treats it as a nested dismissable layer;
-              interacting with it then doesn't dismiss the sheet (which caused a re-open loop). */}
-        <ConfirmationDialog
+        <UnsavedChangesConfirmationDialog
           open={showUnsavedDialog}
           onOpenChange={setShowUnsavedDialog}
-          title='Unsaved Changes'
-          description='You have unsaved changes. Exit without saving?'
-          confirmLabel='Yes, leave now'
-          cancelLabel='No, stay here'
           onConfirm={confirmClose}
-          variant='destructive'
         />
       </SheetContent>
     </Sheet>

--- a/apps/web/src/features/data-storage/edit/components/DataStorageEditSheet/DataStorageConfigSheet.tsx
+++ b/apps/web/src/features/data-storage/edit/components/DataStorageEditSheet/DataStorageConfigSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { ConfirmationDialog } from '../../../../../shared/components/ConfirmationDialog';
+import { UnsavedChangesConfirmationDialog } from '../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import {
   Sheet,
   SheetContent,
@@ -96,17 +96,10 @@ export function DataStorageConfigSheet({
           onCancel={handleClose}
           onDirtyChange={handleFormDirtyChange}
         />
-        {/* Rendered inside SheetContent so Radix treats it as a nested dismissable layer;
-              interacting with it then doesn't dismiss the sheet (which caused a re-open loop). */}
-        <ConfirmationDialog
+        <UnsavedChangesConfirmationDialog
           open={showUnsavedDialog}
           onOpenChange={setShowUnsavedDialog}
-          title='Unsaved Changes'
-          description='You have unsaved changes. Exit without saving?'
-          confirmLabel='Yes, leave now'
-          cancelLabel='No, stay here'
           onConfirm={confirmClose}
-          variant='destructive'
         />
       </SheetContent>
     </Sheet>

--- a/apps/web/src/hooks/useUnsavedGuard.ts
+++ b/apps/web/src/hooks/useUnsavedGuard.ts
@@ -8,7 +8,7 @@ import { useCallback, useState } from 'react';
  * - confirm close and reset state
  * - handle successful submit (reset + close)
  *
- * Note: render the unsaved-changes `ConfirmationDialog` *inside* the sheet's `SheetContent`
+ * Note: render `UnsavedChangesConfirmationDialog` *inside* the sheet's `SheetContent`
  * (not as a sibling of `Sheet`). That makes Radix treat it as a nested dismissable layer, so
  * interacting with the dialog does not dismiss the host sheet — which previously re-opened the
  * dialog and trapped the user in a loop.

--- a/apps/web/src/pages/data-marts/schedules/ProjectScheduledTriggerEditSheet.tsx
+++ b/apps/web/src/pages/data-marts/schedules/ProjectScheduledTriggerEditSheet.tsx
@@ -6,7 +6,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@owox/ui/components/sheet';
-import { ConfirmationDialog } from '../../../shared/components/ConfirmationDialog';
+import { UnsavedChangesConfirmationDialog } from '../../../shared/components/UnsavedChangesConfirmationDialog';
 import { useUnsavedGuard } from '../../../hooks/useUnsavedGuard';
 import { useIntercomLauncher } from '../../../shared/hooks/useIntercomLauncher';
 import { DataMartContext } from '../../../features/data-marts/edit/model/context/context';
@@ -117,17 +117,10 @@ export function ProjectScheduledTriggerEditSheet({
             onDirtyChange={handleFormDirtyChange}
           />
         </DataMartContext.Provider>
-        {/* Rendered inside SheetContent so Radix treats it as a nested dismissable layer;
-              interacting with it then doesn't dismiss the sheet (which caused a re-open loop). */}
-        <ConfirmationDialog
+        <UnsavedChangesConfirmationDialog
           open={showUnsavedDialog}
           onOpenChange={setShowUnsavedDialog}
-          title='Unsaved Changes'
-          description='You have unsaved changes. Exit without saving?'
-          confirmLabel='Yes, leave now'
-          cancelLabel='No, stay here'
           onConfirm={confirmClose}
-          variant='destructive'
         />
       </SheetContent>
     </Sheet>

--- a/apps/web/src/shared/components/UnsavedChangesConfirmationDialog/UnsavedChangesConfirmationDialog.test.tsx
+++ b/apps/web/src/shared/components/UnsavedChangesConfirmationDialog/UnsavedChangesConfirmationDialog.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { UnsavedChangesConfirmationDialog } from './UnsavedChangesConfirmationDialog';
+
+describe('UnsavedChangesConfirmationDialog', () => {
+  it('renders the standard unsaved-changes copy and buttons', () => {
+    render(<UnsavedChangesConfirmationDialog open onOpenChange={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByText('Unsaved Changes')).toBeInTheDocument();
+    expect(screen.getByText('You have unsaved changes. Exit without saving?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Yes, leave now' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'No, stay here' })).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when the user confirms leaving', () => {
+    const onConfirm = vi.fn();
+    render(<UnsavedChangesConfirmationDialog open onOpenChange={vi.fn()} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, leave now' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/shared/components/UnsavedChangesConfirmationDialog/UnsavedChangesConfirmationDialog.tsx
+++ b/apps/web/src/shared/components/UnsavedChangesConfirmationDialog/UnsavedChangesConfirmationDialog.tsx
@@ -1,0 +1,35 @@
+import { ConfirmationDialog } from '../ConfirmationDialog';
+
+/**
+ * Standard "exit without saving?" confirmation for sheet forms with unsaved changes.
+ *
+ * Render *inside* the sheet's `SheetContent` (not as a sibling of `Sheet`) so Radix treats
+ * it as a nested dismissable layer — interacting with the dialog then does not dismiss
+ * the host sheet (which previously re-opened the dialog and trapped the user in a loop).
+ */
+interface UnsavedChangesConfirmationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+export function UnsavedChangesConfirmationDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: UnsavedChangesConfirmationDialogProps) {
+  return (
+    <ConfirmationDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title='Unsaved Changes'
+      description='You have unsaved changes. Exit without saving?'
+      confirmLabel='Yes, leave now'
+      cancelLabel='No, stay here'
+      onConfirm={onConfirm}
+      variant='destructive'
+    />
+  );
+}
+
+export type { UnsavedChangesConfirmationDialogProps };

--- a/apps/web/src/shared/components/UnsavedChangesConfirmationDialog/index.ts
+++ b/apps/web/src/shared/components/UnsavedChangesConfirmationDialog/index.ts
@@ -1,0 +1,1 @@
+export * from './UnsavedChangesConfirmationDialog';


### PR DESCRIPTION
## Summary

Extracts the duplicated unsaved-changes `ConfirmationDialog` block from nine sheet components into a shared `UnsavedChangesConfirmationDialog`, and adds Playwright e2e coverage to guard the nested-dismissable-layer behaviour introduced in PR #1355.

## Problem

After PR #1355, the unsaved-changes confirmation dialog was rendered inside `SheetContent` in multiple sheet components to prevent a Radix dismissal loop. The dialog markup, copy, and explanatory comment were duplicated identically in every consumer, making future copy or behaviour changes error-prone.

There was also no automated regression guard for the fix: unit tests run on happy-dom with mocked Radix primitives and cannot exercise the real `DismissableLayer` stack.

## Solution

### Shared component

Added `UnsavedChangesConfirmationDialog` in `apps/web/src/shared/components/UnsavedChangesConfirmationDialog/`:
- Encapsulates fixed title, description, button labels, and `variant`
- Documents the requirement to render inside `SheetContent`
- Covered by unit tests

### Migration

Replaced the duplicated dialog block in 9 `useUnsavedGuard` consumers:
- `ConnectorEditSheet`
- `DataStorageConfigSheet`
- `DataDestinationConfigSheet`
- `EmailReportEditSheet`
- `GoogleSheetsReportEditSheet`
- `LookerStudioReportEditSheet`
- `ScheduledTriggerFormSheet`
- `ProjectScheduledTriggerEditSheet`
- `InsightSourcesPanel` (delete dialog still uses `ConfirmationDialog`)

Updated `useUnsavedGuard` JSDoc to reference the new component.

`SchemaUnsavedChangesDialog` is intentionally unchanged — it is a separate, schema-specific dialog with Save/Discard/Continue actions.

### E2E regression guard

Added `apps/web/e2e/specs/sheet-confirmation-dialogs.spec.ts` with 4 tests:
- **Storage config sheet** — dirty form → cancel (`No, stay here`) keeps sheet open; confirm (`Yes, leave now`) closes sheet
- **Membership request sheet** — decline confirmation → `Cancel` keeps sheet open; `Decline` closes sheet

Extended `RadixHelpers` with `stayOnDirtySheet`, `leaveDirtySheet`, and `cancelSheetHostedDialog`.

These tests fail if `ConfirmationDialog` is moved back outside `SheetContent`.

## Testing

- [x] `cd apps/web && npx playwright test e2e/specs/sheet-confirmation-dialogs.spec.ts` — 4/4 passed

## Notes

- Behaviour and copy are unchanged — this is a refactor plus regression coverage.
- E2E tests one representative `useUnsavedGuard` consumer (Storage) rather than all nine sheets, since they now share the same component with identical props.