### PR TITLE
feat(web): enhance Document Link field UX in Google Sheets Report form

### DIFF
--- a/.changeset/6728-improve-gs-report-form-with-new-creatre-doc-btn.md
+++ b/.changeset/6728-improve-gs-report-form-with-new-creatre-doc-btn.md
@@ -1,0 +1,16 @@
+---
+'owox': minor
+---
+
+# Improve Document Link field UX
+
+Improve the UX of the Document Link section in the Google Sheets Report form by simplifying the available actions and making the primary workflow more obvious.
+
+- Show Open document only when a valid Google Sheets URL is provided.
+- Replace the disabled external link icon with a contextual action.
+- Present New Sheet as an alternative to pasting a URL by adding an "or" separator.
+- Update the input placeholder to "Paste a Google Sheets URL".
+- Replace the custom icon button with a standard ghost button for better UI consistency.
+- Refine the external link icon size and stroke for improved visual balance.
+
+Previously, the field displayed three actions at the same time (URL input, Open, and Create document), making the workflow harder to understand.

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -455,13 +455,16 @@ export const GoogleSheetsReportEditForm = forwardRef<
                                 type='button'
                                 variant='ghost'
                                 size='sm'
-                                className='size-8 p-0'
                                 onClick={() => {
                                   window.open(documentUrl.trim(), '_blank', 'noopener,noreferrer');
                                 }}
                                 aria-label='Open document in new tab'
                               >
-                                <ExternalLink className='h-3.5 w-3.5' strokeWidth={1.5} />
+                                <ExternalLink
+                                  className='h-3.5 w-3.5'
+                                  strokeWidth={1.5}
+                                  aria-hidden='true'
+                                />
                               </Button>
                             </TooltipTrigger>
                             <TooltipContent side='top' align='center' role='tooltip'>
@@ -471,7 +474,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
                         )}
                         {!isValidDocumentUrl && (
                           <>
-                            <span className='text-muted-foreground/75 text-sm'>or</span>
+                            <span className='text-muted-foreground text-sm'>or</span>
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <Button
@@ -484,7 +487,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
                                   {isCreatingSheet ? (
                                     <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
                                   ) : (
-                                    <Plus className='h-4 w-4' />
+                                    <Plus className='h-4 w-4' aria-hidden='true' />
                                   )}
                                   New Sheet
                                 </Button>

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -41,7 +41,7 @@ import { useProjectRoute } from '../../../../../../shared/hooks';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { Alert, AlertDescription, AlertTitle } from '@owox/ui/components/alert';
 import { Button } from '@owox/ui/components/button';
-import { AlertCircle, ExternalLink, Loader2 } from 'lucide-react';
+import { AlertCircle, ExternalLink, Loader2, Plus } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { showApiErrorToast } from '../../../../../../shared/utils/showApiErrorToast';
 import {
@@ -444,61 +444,59 @@ export const GoogleSheetsReportEditForm = forwardRef<
                       <div className='flex items-center gap-2'>
                         <Input
                           id={documentUrlInputId}
-                          placeholder='Document URL'
+                          placeholder='Paste a Google Sheets URL'
                           className='flex-1'
                           {...field}
                         />
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type='button'
-                              className={`flex-shrink-0 rounded-md p-2 transition-all duration-200 ${
-                                isValidDocumentUrl
-                                  ? 'text-blue-600 hover:bg-blue-50 hover:text-blue-700 dark:text-blue-400 dark:hover:bg-blue-950/20 dark:hover:text-blue-300'
-                                  : 'text-muted-foreground/30 cursor-not-allowed'
-                              }`}
-                              onClick={() => {
-                                if (isValidDocumentUrl) {
+                        {isValidDocumentUrl && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                type='button'
+                                variant='ghost'
+                                size='sm'
+                                className='size-8 p-0'
+                                onClick={() => {
                                   window.open(documentUrl.trim(), '_blank', 'noopener,noreferrer');
-                                }
-                              }}
-                              disabled={!isValidDocumentUrl}
-                              aria-label={
-                                isValidDocumentUrl
-                                  ? 'Open document in new tab'
-                                  : 'Document link is not valid'
-                              }
-                            >
-                              <ExternalLink className='h-4 w-4' aria-hidden='true' />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent side='top' align='center' role='tooltip'>
-                            {isValidDocumentUrl
-                              ? 'Open document in new tab'
-                              : 'Enter a valid URL to enable link'}
-                          </TooltipContent>
-                        </Tooltip>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              type='button'
-                              variant='outline'
-                              className='flex-shrink-0'
-                              disabled={!selectedDestinationId || isCreatingSheet}
-                              onClick={() => void handleCreateGoogleSheet()}
-                            >
-                              {isCreatingSheet ? (
-                                <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
-                              ) : null}
-                              Create document
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side='top' align='center' role='tooltip'>
-                            {selectedDestinationId
-                              ? 'Create a new Google Sheet in the selected destination and fill the link above'
-                              : 'Select a destination first'}
-                          </TooltipContent>
-                        </Tooltip>
+                                }}
+                                aria-label='Open document in new tab'
+                              >
+                                <ExternalLink className='h-3.5 w-3.5' strokeWidth={1.5} />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side='top' align='center' role='tooltip'>
+                              Open document
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
+                        {!isValidDocumentUrl && (
+                          <>
+                            <span className='text-muted-foreground/75 text-sm'>or</span>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  type='button'
+                                  variant='outline'
+                                  className='flex-shrink-0'
+                                  disabled={!selectedDestinationId || isCreatingSheet}
+                                  onClick={() => void handleCreateGoogleSheet()}
+                                >
+                                  {isCreatingSheet ? (
+                                    <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
+                                  ) : (
+                                    <Plus className='h-4 w-4' />
+                                  )}
+                                  New Sheet
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent side='top' align='center' role='tooltip'>
+                                {selectedDestinationId
+                                  ? 'Create a new Google Sheet in the selected destination and fill the link above'
+                                  : 'Select a destination first'}
+                              </TooltipContent>
+                            </Tooltip>
+                          </>
+                        )}
                       </div>
                     </FormControl>
                     <FormDescription>


### PR DESCRIPTION
Improve the UX of the Document Link section in the Google Sheets Report form by simplifying the available actions and making the primary workflow more obvious.

### What changed

<img width="575" height="143" alt="Screenshot 2026-07-08 220352" src="https://github.com/user-attachments/assets/dc04f8bc-0744-4f50-a98f-6284ebb98a91" />

- Show Open document only when a valid Google Sheets URL is provided.
- Replace the disabled external link icon with a contextual action.
- Present New Sheet as an alternative to pasting a URL by adding an "or" separator.
- Update the input placeholder to "Paste a Google Sheets URL".
- Replace the custom icon button with a standard ghost button for better UI consistency.
- Refine the external link icon size and stroke for improved visual balance.

<img width="569" height="137" alt="Screenshot 2026-07-08 220417" src="https://github.com/user-attachments/assets/f8c215f6-a987-4e31-ace4-03f24c60a9e8" />

### Why

Previously, the field displayed three actions at the same time (URL input, Open, and Create document), making the workflow harder to understand.

The updated design presents only the actions relevant to the current state:

- No document selected: paste a URL or create a new Sheet.
- Valid document selected: open the document directly.

This reduces visual clutter and makes the intended workflow easier to understand.