### PR TITLE
docs(facebook): improve list and paragraph formatting in connector guides

### DIFF
--- a/packages/connectors/src/Sources/FacebookMarketing/CREDENTIALS.md
+++ b/packages/connectors/src/Sources/FacebookMarketing/CREDENTIALS.md
@@ -7,35 +7,17 @@ You can connect in two ways:
 1. [**OAuth**](#oauth): use this method when **Continue with Facebook** appears.
 2. [**Access Token**](#access-token): use this method for manual setup.
 
-OAuth gives most users the shortest path.
-
-OWOX renews supported OAuth credentials while Meta keeps the grant valid.
-
-Manual setup requires a Meta app, an access token, an App ID, and an App Secret.
+OAuth gives most users the shortest path. OWOX renews supported OAuth credentials while Meta keeps the grant valid. Manual setup requires a Meta app, an access token, an App ID, and an App Secret.
 
 > **Self-hosted deployments:** If the **Continue with Facebook** button is not available, use the **Access Token** method.
 
-**Before you start:** Use a Facebook account with access to the target ad account.
-
-Accepted ad account roles: Admin, Advertiser, or Analyst.
-
-Without access, Meta returns empty results or a permission error.
+**Before you start:** Use a Facebook account with access to the target ad account. Accepted ad account roles: Admin, Advertiser, or Analyst. Without access, Meta returns empty results or a permission error.
 
 ## OAuth
 
-Click **Continue with Facebook** in the connector settings.
-
-Log in with a Facebook account that can access the ad account.
-
-Then confirm access.
-
-The button shows **Authenticated as...** after a successful login.
-
-Enter the numeric Account ID.
-
-Do not include the `act_` prefix.
-
-To import from multiple accounts, separate IDs with commas or semicolons.
+1. Click **Continue with Facebook** in the connector settings.
+2. Log in with a Facebook account that can access the ad account, then confirm access. The button shows **Authenticated as...** after a successful login.
+3. Enter the numeric Account ID. Do not include the `act_` prefix. To import from multiple accounts, separate IDs with commas or semicolons.
 
 See [where to find Account IDs](GETTING_STARTED.md#set-up-the-connector).
 
@@ -49,21 +31,11 @@ Reconnect with Facebook in these cases:
 
 ![OWOX Facebook connector settings showing the Continue with Facebook button and the Account ID field](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/6e96957f-29cf-4e21-b45d-a05c746d4e00/public)
 
-Next, open **Configure Data Import**.
-
-Then choose the data you want to fetch.
-
-See [Configure Data Import](GETTING_STARTED.md#configure-data-import).
+Next, open **Configure Data Import** and choose the data you want to fetch. See [Configure Data Import](GETTING_STARTED.md#configure-data-import).
 
 ## Access Token
 
-Use this method when you need manual credentials.
-
-You will create a Meta app and get an access token.
-
-If you already used **OAuth**, skip this section.
-
-OAuth users do not need a manual access token.
+Use this method when you need manual credentials. You will create a Meta app and get an access token. If you already used **OAuth**, skip this section — OAuth users do not need a manual access token.
 
 > **Before you start:** Step 3 sends your **App Secret** and authorization **code**, then receives your **Access Token**.
 > Use [Postman Desktop](https://www.postman.com/downloads/) or `curl` for better security.
@@ -73,33 +45,22 @@ OAuth users do not need a manual access token.
 
 ## Step 1: Sign In to the Meta for Developers Portal
 
-Visit [Meta for Developers](https://developers.facebook.com/).
-
-Log in with your Facebook account.
-
-Go to **My Apps**.
-
-Click **Create App**.
-
-Enter an **App Name**.
-
-Example: `OWOX Data Marts App`.
+1. Visit [Meta for Developers](https://developers.facebook.com/).
+2. Log in with your Facebook account.
+3. Go to **My Apps**.
+4. Click **Create App**.
+5. Enter an **App Name**, for example `OWOX Data Marts App`.
 
 ![Meta for Developers My Apps page with the Create App button](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/007cab5d-de72-4e9c-c444-f7064be3e800/public)
 
 ![Create App form with the App Name field filled in](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/03a9f215-3cdf-4f8f-54e8-69d3c26c8700/public)
 
-In **Use Cases**, open the **Filter by** panel.
-
-Select **All** to list every use case.
-
-Choose **Measure ad performance data with Marketing API**.
-
-Connect your Business Portfolio.
-
-Leave the other fields as default.
-
-Click **Create app** on the final step.
+1. In **Use Cases**, open the **Filter by** panel.
+2. Select **All** to list every use case.
+3. Choose **Measure ad performance data with Marketing API**.
+4. Connect your Business Portfolio.
+5. Leave the other fields as default.
+6. Click **Create app** on the final step.
 
 > No Business Portfolio yet?
 > Pick **Create a business portfolio** here.
@@ -110,27 +71,21 @@ Click **Create app** on the final step.
 
 ## Step 2: Get the App Credentials and Authorization Code
 
-- Open your new app.
-- Go to **App Settings → Basic**.
-- Copy your **App ID**.
-- Copy your **App Secret**.
+1. Open your new app.
+2. Go to **App Settings → Basic**.
+3. Copy your **App ID**.
+4. Copy your **App Secret**.
 
 ![App Settings Basic page showing the App ID and App Secret fields](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/a488338c-60e6-423c-6ea0-0d8c6824aa00/public)
 
-Build the authorization URL from the template below.
-
-Replace only `YOUR_APP_ID` with your **App ID**.
+Build the authorization URL from the template below. Replace only `YOUR_APP_ID` with your **App ID**.
 
 OWOX requests both permissions because endpoints read different API areas:
 
 - `ads_read` covers reporting endpoints: **Ad Account Insights**, its breakdown variants by **Age and Gender**, **Country**, **Device Platform**, **Link URL Asset**, **Product ID**, **Publisher Platform and Position**, and **Region**, plus **Ad Insights by Ad Set** and **Ad Insights by Campaign**.
 - `ads_management` covers ad account and ad object endpoints: **Ad Account**, **Ad Account User**, **Ad Account Ads**, **Ad Account Ad Creatives**, and **Ad Object (formerly Ad Group)**.
 
-OWOX only reads data from these endpoints.
-
-The connector does not create or change ads.
-
-OWOX includes `ads_management` so the same token can read supported ad account and ad object data.
+OWOX only reads data from these endpoints. The connector does not create or change ads. OWOX includes `ads_management` so the same token can read supported ad account and ad object data.
 
 The URL requests both permissions in the `scope` parameter:
 
@@ -138,36 +93,20 @@ The URL requests both permissions in the `scope` parameter:
 https://www.facebook.com/v25.0/dialog/oauth?client_id=YOUR_APP_ID&redirect_uri=http://localhost:8080/&response_type=code&scope=ads_read,ads_management&state=owox_fb_auth
 ```
 
-The `state` value helps check this authorization request.
+The `state` value helps check this authorization request. You can keep `owox_fb_auth` or replace it with random text.
 
-You can keep `owox_fb_auth`.
-
-You can also replace it with random text.
-
-- Replace `YOUR_APP_ID` in the authorization URL.
-- Open the URL in your browser.
-- Confirm that you use the right Facebook account.
-- Click **Continue as...** or **Connect**.
-- Click **Save**.
-- Click **Got it**.
+1. Replace `YOUR_APP_ID` in the authorization URL.
+2. Open the URL in your browser.
+3. Confirm that you use the right Facebook account.
+4. Click **Continue as...** or **Connect**.
+5. Click **Save**.
+6. Click **Got it**.
 
 ![Facebook authorization dialog in the browser with the Continue and Save buttons](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/ee11eeca-966e-460d-dd8d-857fdcc25500/public)
 
 If Meta shows a `redirect_uri` error, see [Troubleshooting Credential Setup](#troubleshooting-credential-setup).
 
-After you authorize, the browser redirects to a URL.
-
-The URL includes long `code` and `state` parameters.
-
-Check that the returned `state` value matches your authorization URL.
-
-If it does not match, stop and repeat **Step 2**.
-
-Then copy the **code** value.
-
-Copy everything after `code=` and before `&state=...`.
-
-You need this code in the next step.
+After you authorize, the browser redirects to a URL that includes long `code` and `state` parameters. Check that the returned `state` value matches your authorization URL; if it does not match, stop and repeat **Step 2**. Then copy the **code** value — everything after `code=` and before `&state=...`. You need this code in the next step.
 
 > **Note:** You may see `This site can't be reached`.
 > This is expected.
@@ -178,9 +117,7 @@ You need this code in the next step.
 
 ## Step 3: Generate and Save the Access Token
 
-Exchange the authorization code for an **Access Token**.
-
-Use [Postman Desktop](https://www.postman.com/downloads/), `curl`, or [ReqBin](https://reqbin.com/).
+Exchange the authorization code for an **Access Token** using [Postman Desktop](https://www.postman.com/downloads/), `curl`, or [ReqBin](https://reqbin.com/).
 
 Send a `POST` request to:
 
@@ -188,29 +125,17 @@ Send a `POST` request to:
 https://graph.facebook.com/v25.0/oauth/access_token
 ```
 
-Open the **Body** tab.
+Open the **Body** tab and set the body type to **x-www-form-urlencoded**.
 
-Set the body type to **x-www-form-urlencoded**.
-
-In ReqBin, choose **Form**.
-
-In ReqBin, paste this body as one line.
-
-Replace the placeholder values first:
+**ReqBin:** choose **Form**, then paste this body as one line. Replace the placeholder values first:
 
 ```text
 client_id=YOUR_APP_ID&client_secret=YOUR_APP_SECRET&redirect_uri=http://localhost:8080/&code=CODE_FROM_THE_PREVIOUS_STEP
 ```
 
-The `&` characters separate parameters in ReqBin.
+The `&` characters separate parameters. Do not add an extra `&` after the `code` value.
 
-Do not add an extra `&` after the `code` value.
-
-If you use Postman Desktop, use separate key/value rows.
-
-Open **Body → x-www-form-urlencoded**.
-
-Add `client_id`, `client_secret`, `redirect_uri`, and `code`.
+**Postman Desktop:** open **Body → x-www-form-urlencoded** and add separate rows for `client_id`, `client_secret`, `redirect_uri`, and `code`.
 
 ![API client POST request to the Facebook oauth/access_token endpoint](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/0ac09525-a564-437d-9356-01b66aeb4500/public)
 ![API client Body tab set to form-encoded with client_id, client_secret, redirect_uri, and code parameters](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/a0fd3462-03ff-495a-cfbf-e220a5fe3500/public)
@@ -220,13 +145,7 @@ Click **Send**. The response contains your **Access Token**.
 
 ![API client response panel showing the returned access_token value](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/79df572a-9f78-4b0f-dad9-fa7626908d00/public)
 
-Copy the **Access Token**.
-
-Store it securely.
-
-OWOX needs the **Access Token**, **App ID**, and **App Secret**.
-
-OWOX uses them to create a long-lived token.
+Copy the **Access Token** and store it securely. OWOX needs the **Access Token**, **App ID**, and **App Secret** to create a long-lived token.
 
 > **Facebook access tokens can expire in about 60 days.**
 > OWOX uses the **App ID** and **App Secret** to exchange and refresh the token.
@@ -234,13 +153,7 @@ OWOX uses them to create a long-lived token.
 
 ## Step 4: Use the Credentials
 
-You now have the **App ID**, **App Secret**, and **Access Token**.
-
-OWOX needs all three credentials.
-
-Use them in the Data Mart setup.
-
-Follow [Getting Started](GETTING_STARTED.md) to fill in the connector fields.
+You now have the **App ID**, **App Secret**, and **Access Token**. OWOX needs all three credentials. Use them in the Data Mart setup, and follow [Getting Started](GETTING_STARTED.md) to fill in the connector fields.
 
 ## Troubleshooting Credential Setup
 
@@ -248,23 +161,15 @@ Use this section for access token and authorization code errors.
 
 ### Error: `This authorization code has been used`
 
-**Cause:**
-You already exchanged this authorization code for an access token.
+**Cause:** You already exchanged this authorization code for an access token. Each code works only once.
 
-Each code works only once.
-
-**Solution:**
-Repeat **Step 2** to generate a new temporary authorization code and try again.
+**Solution:** Repeat **Step 2** to generate a new temporary authorization code and try again.
 
 ### Error: `redirect_uri isn't an absolute URI. Check RFC 3986`
 
-**Cause:**
-Your `redirect_uri` has the wrong format.
+**Cause:** Your `redirect_uri` has the wrong format. Meta requires a valid absolute URI.
 
-Meta requires a valid absolute URI.
-
-**Solution:**
-Check that your `redirect_uri` matches this format:
+**Solution:** Check that your `redirect_uri` matches this format:
 
 ![API client request highlighting the correctly formatted redirect_uri value http://localhost:8080/](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/f0989ba4-5d72-433b-09d6-bf15136b5d00/public)
 
@@ -276,27 +181,15 @@ http://localhost:8080/
 
 ### Error: `This authorization code has expired`
 
-**Cause:**
-The temporary authorization code expired.
+**Cause:** The temporary authorization code expired. Facebook issues short-lived codes.
 
-Facebook issues short-lived codes.
-
-**Solution:**
-Repeat **Step 2** to obtain a new temporary code and retry the request.
+**Solution:** Repeat **Step 2** to obtain a new temporary code and retry the request.
 
 ### Error: `redirect_uri` mismatch or invalid redirect URI
 
-**Cause:**
-Meta rejected the redirect URL used in the authorization request.
+**Cause:** Meta rejected the redirect URL used in the authorization request.
 
-**Solution:**
-If your app has no **Facebook Login** product, add it from the app dashboard sidebar.
-
-Open **Facebook Login → Settings**.
-
-Add `http://localhost:8080/` as a **Valid OAuth Redirect URI**.
-
-Then repeat **Step 2**.
+**Solution:** If your app has no **Facebook Login** product, add it from the app dashboard sidebar. Open **Facebook Login → Settings**, add `http://localhost:8080/` as a **Valid OAuth Redirect URI**, then repeat **Step 2**.
 
 > **Tip:** Generate the authorization code and use it right away.
 

--- a/packages/connectors/src/Sources/FacebookMarketing/ENDPOINTS_AND_FIELDS.md
+++ b/packages/connectors/src/Sources/FacebookMarketing/ENDPOINTS_AND_FIELDS.md
@@ -1,12 +1,6 @@
 # Facebook Marketing Supported Endpoints and Fields
 
-This page lists the Facebook Marketing endpoints and fields in the Facebook Ads connector.
-
-Use it to choose an endpoint and fields.
-
-Each endpoint lists its destination table, unique keys, and Meta reference.
-
-OWOX requests Meta Graph API version `v25.0`.
+This page lists the Facebook Marketing endpoints and fields in the Facebook Ads connector. Use it to choose an endpoint and fields. Each endpoint lists its destination table, unique keys, and Meta reference. OWOX requests Meta Graph API version `v25.0`.
 
 ## Which Endpoint Should I Choose?
 
@@ -40,16 +34,11 @@ OWOX requests Meta Graph API version `v25.0`.
 
 ## Field Table Notes
 
-- **Connector field** shows the field name in OWOX.
-- OWOX writes the connector field to the destination table.
-- **Meta API field** shows the field expression that OWOX requests from Meta.
-- Nested fields use expressions such as `creative.id`.
-- **Data type** shows the type that OWOX uses in the destination schema.
-- OWOX uses **Unique keys** to match rows during loading.
-- OWOX adds these unique keys to every request automatically.
-- You do not need to select them as fields.
-- Insights endpoints return daily rows at the ad, ad set, or campaign level.
-- Breakdown endpoints add the listed breakdown fields.
+- **Connector field**: the field name in OWOX. OWOX writes it to the destination table.
+- **Meta API field**: the field expression that OWOX requests from Meta. Nested fields use expressions such as `creative.id`.
+- **Data type**: the type that OWOX uses in the destination schema.
+- **Unique keys**: OWOX uses them to match rows during loading and adds them to every request automatically, so you do not need to select them as fields.
+- Insights endpoints return daily rows at the ad, ad set, or campaign level. Breakdown endpoints add the listed breakdown fields.
 
 ## Account and Ad Object Fields
 

--- a/packages/connectors/src/Sources/FacebookMarketing/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/FacebookMarketing/GETTING_STARTED.md
@@ -23,9 +23,7 @@ For a general connector walkthrough, see [Connector-based Data Mart](https://doc
 3. Select a storage.
 4. Click **Create Data Mart**.
 
-If you have no storage yet, click **New Storage**.
-
-You can create the storage now and configure it later.
+If you have no storage yet, click **New Storage**. You can create the storage now and configure it later.
 
 ![OWOX Data Mart creation screen with title and storage fields](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/2e1163df-bd1c-4825-4ce9-c6f66f11b500/public)
 
@@ -35,11 +33,7 @@ You can create the storage now and configure it later.
 2. Choose **Facebook Ads**.
 3. Choose your authentication method.
 
-For OAuth, click **Continue with Facebook**.
-
-Then sign in with a Facebook user who can access the ad account.
-
-If the button does not appear, use the **Access Token** method.
+For OAuth, click **Continue with Facebook**, then sign in with a Facebook user who can access the ad account. If the button does not appear, use the **Access Token** method.
 
 For manual authentication, fill in these fields:
 
@@ -47,17 +41,7 @@ For manual authentication, fill in these fields:
 - **App ID**: enter your Meta App ID.
 - **App Secret**: enter your Meta App Secret.
 
-Then fill in **Account IDs**.
-
-Use numeric ad account IDs only.
-
-Do not include the `act_` prefix.
-
-You can find the ID in [Meta Ads Manager](https://adsmanager.facebook.com/adsmanager/manage/accounts) under **Account Overview**.
-
-To import from multiple accounts, separate IDs with commas or semicolons.
-
-The authorized Facebook user must access every listed account.
+Then fill in **Account IDs**. Use numeric ad account IDs only, without the `act_` prefix. You can find the ID in [Meta Ads Manager](https://adsmanager.facebook.com/adsmanager/manage/accounts) under **Account Overview**. To import from multiple accounts, separate IDs with commas or semicolons. The authorized Facebook user must access every listed account.
 
 ![Facebook Ads connector setup screen with OAuth and manual authentication options](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/9336bfac-506a-4590-f0fa-4a3ca7d16300/public)
 
@@ -79,31 +63,19 @@ For spend, clicks, impressions, conversions, and ROAS, choose **Ad Account Insig
 
 For endpoint details, see [Endpoints and Fields](ENDPOINTS_AND_FIELDS.md).
 
-If OWOX disables **Publish & Run Data Mart**, check the storage.
-
-OWOX cannot publish a Data Mart until the selected storage has valid settings.
-
-See [Storage Management](https://docs.owox.com/docs/storages/manage-storages/#adding-a-new-storage).
+If OWOX disables **Publish & Run Data Mart**, check the storage. OWOX cannot publish a Data Mart until the selected storage has valid settings. See [Storage Management](https://docs.owox.com/docs/storages/manage-storages/#adding-a-new-storage).
 
 ![Configure Data Import screen with Facebook Ads endpoint, fields, and dataset settings](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/5975a655-aeea-4ec6-d5f6-f74cb5db4500/public)
 
 ## Run the Data Mart
 
-You can run the Data Mart manually after setup.
-
-You can also [schedule connector runs](https://docs.owox.com/docs/getting-started/setup-guide/connector-triggers/).
+You can run the Data Mart manually after setup. You can also [schedule connector runs](https://docs.owox.com/docs/getting-started/setup-guide/connector-triggers/).
 
 ### Incremental Load
 
 Choose **Manual run → Incremental load**.
 
-On the first incremental run, OWOX imports data from the first day of the previous month through today.
-
-After a successful incremental run, OWOX stores the last requested date.
-
-On later incremental runs, OWOX starts from that date minus **Reimport Lookback Window**.
-
-This lookback helps refresh recently changed Facebook Ads metrics.
+On the first incremental run, OWOX imports data from the first day of the previous month through today. After a successful incremental run, OWOX stores the last requested date. On later incremental runs, OWOX starts from that date minus **Reimport Lookback Window**. This lookback helps refresh recently changed Facebook Ads metrics.
 
 ![Manual run menu showing the Incremental load option](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/e7e0db3e-5088-4372-515c-ae22e961a200/public)
 
@@ -119,31 +91,21 @@ Choose **Backfill (custom period)** to import a specific date range.
 2. Select **End Date**.
 3. Click **Run**.
 
-OWOX imports both the start date and the end date.
-
-If you leave **End Date** empty, OWOX uses today.
+OWOX imports both the start date and the end date. If you leave **End Date** empty, OWOX uses today.
 
 ![Backfill dialog with Start Date, End Date, and Run button](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/b8a71ff2-60a1-4b8e-135b-4bf8b30d4600/public)
 
 ## Check the Result
 
-Open **Run history**.
-
-The run has finished when the status shows **Success**.
+Open **Run history**. The run has finished when the status shows **Success**.
 
 ![Run history tab showing a successful Facebook Ads import](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/da9ea591-9924-4465-091b-90a65c827800/public)
 
-You can query the imported tables in the dataset you selected.
-
-You can also send the data to a destination.
-
-See [Destination Management](https://docs.owox.com/docs/destinations/manage-destinations/) and [Google Sheets](https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/).
+You can query the imported tables in the dataset you selected. You can also send the data to a destination. See [Destination Management](https://docs.owox.com/docs/destinations/manage-destinations/) and [Google Sheets](https://docs.owox.com/docs/destinations/supported-destinations/google-sheets/).
 
 ## Troubleshooting
 
-If a run fails, open **Run history**.
-
-Then match the Meta error with [Troubleshooting](TROUBLESHOOTING.md).
+If a run fails, open **Run history**. Then match the Meta error with [Troubleshooting](TROUBLESHOOTING.md).
 
 For credential setup errors, see [Credentials](CREDENTIALS.md#troubleshooting-credential-setup).
 

--- a/packages/connectors/src/Sources/FacebookMarketing/TROUBLESHOOTING.md
+++ b/packages/connectors/src/Sources/FacebookMarketing/TROUBLESHOOTING.md
@@ -1,8 +1,6 @@
 # Troubleshooting Facebook Ads Imports
 
-Use this guide after you save credentials.
-
-It covers setup, manual runs, scheduled runs, and backfills.
+Use this guide after you save credentials. It covers setup, manual runs, scheduled runs, and backfills.
 
 For access token or authorization code errors, see [Credentials](CREDENTIALS.md#troubleshooting-credential-setup).
 
@@ -11,19 +9,11 @@ For access token or authorization code errors, see [Credentials](CREDENTIALS.md#
 Before changing credentials or app settings, check these items:
 
 - Check **Run history** for the exact Meta error.
-- Check **Account IDs**.
-- Use numeric IDs only.
-- Do not include the `act_` prefix.
-- Separate multiple Account IDs with commas or semicolons.
-- Check **Facebook access**.
-- The authorized Facebook user must access every selected ad account.
-- Check **Permissions**.
-- The token must include `ads_read` and `ads_management`.
+- Check **Account IDs**: use numeric IDs only, without the `act_` prefix, and separate multiple IDs with commas or semicolons.
+- Check **Facebook access**: the authorized Facebook user must access every selected ad account.
+- Check **Permissions**: the token must include `ads_read` and `ads_management`.
 - For large backfills, reduce the date range, selected fields, or breakdowns.
-- If the error continues, open the Data Mart settings.
-- Expand **Advanced settings**.
-- Lower **API Page Limit**, for example to `25`.
-- Save the Data Mart and rerun it.
+- If the error continues, open the Data Mart settings, expand **Advanced settings**, lower **API Page Limit** (for example to `25`), then save and rerun.
 
 If these checks look correct, match the **Run history** error with the cases below.
 


### PR DESCRIPTION
# Problem

The Facebook Ads connector guides, overhauled in #1380, were written with one short sentence per line. Wherever a run of those lines was actually a step sequence, it read as a stack of disconnected fragments instead of a numbered list, and check/definition lists flattened their sub-details into sibling bullets at the same level. Explanatory prose also broke every sentence onto its own paragraph, making continuous text hard to read. The content was correct, but the formatting hurt scannability and made steps easy to lose track of.

# Solution

Reformatted the connector docs so structure matches intent, without changing any instructions or facts:
- Converted genuine step sequences to numbered ordered lists (OAuth flow, Meta app sign-in, use-case setup, Step 2 credential/authorization actions).
- Collapsed flattened lists into grouped bullets that fold each item's sub-details into its own entry (TROUBLESHOOTING "Quick Checks", ENDPOINTS_AND_FIELDS "Field Table Notes").
- Merged sentence-per-line prose into flowing paragraphs across all four files, while leaving lists, code blocks, `>` callouts, images, and standalone cross-reference lines untouched.
- Grouped the Step 3 access-token instructions by tool (ReqBin vs Postman) instead of interleaving them.

README.md needed no changes and was left as-is.

# Changes

- Reformatted OAuth and Step 1/Step 2 action sequences in `CREDENTIALS.md` into numbered lists and merged its prose into paragraphs.
- Reorganized Step 3 in `CREDENTIALS.md` to separate the ReqBin and Postman Desktop paths.
- Inlined the `**Cause:**` / `**Solution:**` troubleshooting blocks onto single lines in `CREDENTIALS.md`.
- Merged sentence-per-line prose into paragraphs in `GETTING_STARTED.md` (connector setup, incremental load, backfill, result, and troubleshooting sections).
- Merged the intro prose in `TROUBLESHOOTING.md` and collapsed the flat "Quick Checks" list into grouped bullets.
- Merged the intro prose in `ENDPOINTS_AND_FIELDS.md` and collapsed the flat "Field Table Notes" list into grouped bullets.