### PR TITLE
fix(bigquery): alias output-control queries as main when table name matches column

### DIFF
--- a/.changeset/6685-bq-table-column-name-collision.md
+++ b/.changeset/6685-bq-table-column-name-collision.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Fix BigQuery report runs when table name matches a filter column
+
+BigQuery treats an unaliased table’s short name as a row `STRUCT` alias. When a Table Data Mart pointed at a table such as `…country` and a report filtered on a column also named `country`, the generated SQL compared a `STRUCT` to a string and failed (for example on Google Sheets export).
+
+Output-controls queries now alias the source as `main` and qualify filter/sort references (`main.\`country\``) in `WHERE`, `ORDER BY`, and `HAVING`. SELECT projections stay unqualified so nested RECORD paths keep their previous shape. Existing reports need no reconfiguration; only the generated SQL shape changes.

--- a/.changeset/6685-bq-table-column-name-collision.md
+++ b/.changeset/6685-bq-table-column-name-collision.md
@@ -6,4 +6,4 @@
 
 BigQuery treats an unaliased table’s short name as a row `STRUCT` alias. When a Table Data Mart pointed at a table such as `…country` and a report filtered on a column also named `country`, the generated SQL compared a `STRUCT` to a string and failed (for example on Google Sheets export).
 
-Output-controls queries now alias the source as `main` and qualify filter/sort references (`main.\`country\``) in `WHERE`, `ORDER BY`, and `HAVING`. SELECT projections stay unqualified so nested RECORD paths keep their previous shape. Existing reports need no reconfiguration; only the generated SQL shape changes.
+Output-controls and explicit-projection queries now alias the source as `src` and qualify filter/sort references (`src.\`country\``) in `WHERE`, `ORDER BY`, and `HAVING`. SELECT and GROUP BY stay unqualified so nested RECORD paths keep their previous shape. Existing reports need no reconfiguration; only the generated SQL shape changes.

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder-edge-cases.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder-edge-cases.spec.ts
@@ -112,14 +112,14 @@ describe('BigQueryQueryBuilder — simple-path edge cases', () => {
     const sql = result.sql;
 
     // FROM must reference the view (dot-separated FQN → backtick-quoted parts) with alias
-    expect(sql).toContain('FROM `proj`.`ds`.`my_analytics_view` AS main');
+    expect(sql).toContain('FROM `proj`.`ds`.`my_analytics_view` AS src');
 
     // WHERE must appear before ORDER BY
-    expect(sql).toContain('WHERE main.`revenue` >= @p0');
+    expect(sql).toContain('WHERE src.`revenue` >= @p0');
     expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('ORDER BY'));
 
     // ORDER BY must appear before LIMIT
-    expect(sql).toContain('ORDER BY\n  main.`revenue` DESC');
+    expect(sql).toContain('ORDER BY\n  src.`revenue` DESC');
     expect(sql.indexOf('ORDER BY')).toBeLessThan(sql.indexOf('LIMIT'));
 
     // LIMIT at the end

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder-edge-cases.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder-edge-cases.spec.ts
@@ -111,15 +111,15 @@ describe('BigQueryQueryBuilder — simple-path edge cases', () => {
 
     const sql = result.sql;
 
-    // FROM must reference the view (dot-separated FQN → backtick-quoted parts)
-    expect(sql).toContain('FROM `proj`.`ds`.`my_analytics_view`');
+    // FROM must reference the view (dot-separated FQN → backtick-quoted parts) with alias
+    expect(sql).toContain('FROM `proj`.`ds`.`my_analytics_view` AS main');
 
     // WHERE must appear before ORDER BY
-    expect(sql).toContain('WHERE `revenue` >= @p0');
+    expect(sql).toContain('WHERE main.`revenue` >= @p0');
     expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('ORDER BY'));
 
     // ORDER BY must appear before LIMIT
-    expect(sql).toContain('ORDER BY\n  `revenue` DESC');
+    expect(sql).toContain('ORDER BY\n  main.`revenue` DESC');
     expect(sql.indexOf('ORDER BY')).toBeLessThan(sql.indexOf('LIMIT'));
 
     // LIMIT at the end

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.aggregation.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.aggregation.spec.ts
@@ -34,7 +34,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  `channel`,\n' +
         '  SUM(`revenue`) AS `revenue | SUM`\n' +
-        'FROM `proj`.`dataset`.`tbl`\n' +
+        'FROM `proj`.`dataset`.`tbl` AS main\n' +
         'GROUP BY\n' +
         '  `channel`'
     );
@@ -51,7 +51,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  `day`,\n' +
         '  COUNT(DISTINCT `sessionId`) AS `sessionId | COUNTUNIQUE`\n' +
-        'FROM `p`.`d`.`t`\n' +
+        'FROM `p`.`d`.`t` AS main\n' +
         'GROUP BY\n' +
         '  `day`\n' +
         'ORDER BY\n' +
@@ -70,7 +70,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  `channel`,\n' +
         '  SUM(`revenue`) AS `revenue | SUM`\n' +
-        'FROM `p`.`d`.`t`\n' +
+        'FROM `p`.`d`.`t` AS main\n' +
         'GROUP BY\n' +
         '  `channel`\n' +
         'ORDER BY\n' +
@@ -89,8 +89,8 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  `channel`,\n' +
         '  SUM(`revenue`) AS `revenue | SUM`\n' +
-        'FROM `p`.`d`.`t`\n' +
-        'WHERE `channel` = @p0\n' +
+        'FROM `p`.`d`.`t` AS main\n' +
+        'WHERE main.`channel` = @p0\n' +
         'GROUP BY\n' +
         '  `channel`'
     );
@@ -106,7 +106,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  DATE_TRUNC(DATE(`date`), MONTH) AS `date`,\n' +
         '  SUM(`revenue`) AS `revenue | SUM`\n' +
-        'FROM `p`.`d`.`t`\n' +
+        'FROM `p`.`d`.`t` AS main\n' +
         'GROUP BY\n' +
         '  DATE_TRUNC(DATE(`date`), MONTH)'
     );
@@ -120,7 +120,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
     expect(await sqlOf(result)).toBe(
       'SELECT\n' +
         '  DATE_TRUNC(DATE(`date`), YEAR) AS `date`\n' +
-        'FROM `p`.`d`.`t`\n' +
+        'FROM `p`.`d`.`t` AS main\n' +
         'GROUP BY\n' +
         '  DATE_TRUNC(DATE(`date`), YEAR)'
     );
@@ -135,7 +135,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  `channel`,\n' +
         '  COUNT(*) AS `Row Count`\n' +
-        'FROM `p`.`d`.`t`\n' +
+        'FROM `p`.`d`.`t` AS main\n' +
         'GROUP BY\n' +
         '  `channel`'
     );
@@ -152,7 +152,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
         '  `channel`,\n' +
         '  SUM(`revenue`) AS `revenue | SUM`,\n' +
         '  COUNT(*) AS `Row Count`\n' +
-        'FROM `p`.`d`.`t`\n' +
+        'FROM `p`.`d`.`t` AS main\n' +
         'GROUP BY\n' +
         '  `channel`'
     );
@@ -166,7 +166,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
     });
     const sql = await sqlOf(result);
     expect(sql).toContain('GROUP BY\n  `channel`');
-    expect(sql).toContain('HAVING SUM(`revenue`) > @h0');
+    expect(sql).toContain('HAVING SUM(main.`revenue`) > @h0');
     // The only filter is post-aggregation → no WHERE; HAVING follows GROUP BY.
     expect(sql).not.toContain('WHERE');
     expect(sql.indexOf('GROUP BY')).toBeLessThan(sql.indexOf('HAVING'));
@@ -183,8 +183,8 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       ],
     });
     const sql = await sqlOf(result);
-    expect(sql).toContain('WHERE `channel` = @p0');
-    expect(sql).toContain('HAVING SUM(`revenue`) > @h0');
+    expect(sql).toContain('WHERE main.`channel` = @p0');
+    expect(sql).toContain('HAVING SUM(main.`revenue`) > @h0');
     // SQL clause order: WHERE < GROUP BY < HAVING.
     expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('GROUP BY'));
     expect(sql.indexOf('GROUP BY')).toBeLessThan(sql.indexOf('HAVING'));
@@ -205,7 +205,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       columnTypes: new Map([['order_date', 'DATE']]),
     });
     const sql = await sqlOf(result);
-    expect(sql).toContain('HAVING COUNT(DISTINCT `order_date`) >= @h0');
+    expect(sql).toContain('HAVING COUNT(DISTINCT main.`order_date`) >= @h0');
     expect(sql).not.toContain('CAST(@h0 AS DATE)');
   });
 
@@ -217,6 +217,6 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       columnTypes: new Map([['order_date', 'DATE']]),
     });
     const sql = await sqlOf(result);
-    expect(sql).toContain('HAVING MIN(`order_date`) >= CAST(@h0 AS DATE)');
+    expect(sql).toContain('HAVING MIN(main.`order_date`) >= CAST(@h0 AS DATE)');
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.aggregation.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.aggregation.spec.ts
@@ -34,7 +34,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  `channel`,\n' +
         '  SUM(`revenue`) AS `revenue | SUM`\n' +
-        'FROM `proj`.`dataset`.`tbl` AS main\n' +
+        'FROM `proj`.`dataset`.`tbl` AS src\n' +
         'GROUP BY\n' +
         '  `channel`'
     );
@@ -51,7 +51,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  `day`,\n' +
         '  COUNT(DISTINCT `sessionId`) AS `sessionId | COUNTUNIQUE`\n' +
-        'FROM `p`.`d`.`t` AS main\n' +
+        'FROM `p`.`d`.`t` AS src\n' +
         'GROUP BY\n' +
         '  `day`\n' +
         'ORDER BY\n' +
@@ -70,7 +70,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  `channel`,\n' +
         '  SUM(`revenue`) AS `revenue | SUM`\n' +
-        'FROM `p`.`d`.`t` AS main\n' +
+        'FROM `p`.`d`.`t` AS src\n' +
         'GROUP BY\n' +
         '  `channel`\n' +
         'ORDER BY\n' +
@@ -89,8 +89,8 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  `channel`,\n' +
         '  SUM(`revenue`) AS `revenue | SUM`\n' +
-        'FROM `p`.`d`.`t` AS main\n' +
-        'WHERE main.`channel` = @p0\n' +
+        'FROM `p`.`d`.`t` AS src\n' +
+        'WHERE src.`channel` = @p0\n' +
         'GROUP BY\n' +
         '  `channel`'
     );
@@ -106,7 +106,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  DATE_TRUNC(DATE(`date`), MONTH) AS `date`,\n' +
         '  SUM(`revenue`) AS `revenue | SUM`\n' +
-        'FROM `p`.`d`.`t` AS main\n' +
+        'FROM `p`.`d`.`t` AS src\n' +
         'GROUP BY\n' +
         '  DATE_TRUNC(DATE(`date`), MONTH)'
     );
@@ -120,7 +120,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
     expect(await sqlOf(result)).toBe(
       'SELECT\n' +
         '  DATE_TRUNC(DATE(`date`), YEAR) AS `date`\n' +
-        'FROM `p`.`d`.`t` AS main\n' +
+        'FROM `p`.`d`.`t` AS src\n' +
         'GROUP BY\n' +
         '  DATE_TRUNC(DATE(`date`), YEAR)'
     );
@@ -135,7 +135,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       'SELECT\n' +
         '  `channel`,\n' +
         '  COUNT(*) AS `Row Count`\n' +
-        'FROM `p`.`d`.`t` AS main\n' +
+        'FROM `p`.`d`.`t` AS src\n' +
         'GROUP BY\n' +
         '  `channel`'
     );
@@ -152,7 +152,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
         '  `channel`,\n' +
         '  SUM(`revenue`) AS `revenue | SUM`,\n' +
         '  COUNT(*) AS `Row Count`\n' +
-        'FROM `p`.`d`.`t` AS main\n' +
+        'FROM `p`.`d`.`t` AS src\n' +
         'GROUP BY\n' +
         '  `channel`'
     );
@@ -166,7 +166,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
     });
     const sql = await sqlOf(result);
     expect(sql).toContain('GROUP BY\n  `channel`');
-    expect(sql).toContain('HAVING SUM(main.`revenue`) > @h0');
+    expect(sql).toContain('HAVING SUM(src.`revenue`) > @h0');
     // The only filter is post-aggregation → no WHERE; HAVING follows GROUP BY.
     expect(sql).not.toContain('WHERE');
     expect(sql.indexOf('GROUP BY')).toBeLessThan(sql.indexOf('HAVING'));
@@ -183,8 +183,8 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       ],
     });
     const sql = await sqlOf(result);
-    expect(sql).toContain('WHERE main.`channel` = @p0');
-    expect(sql).toContain('HAVING SUM(main.`revenue`) > @h0');
+    expect(sql).toContain('WHERE src.`channel` = @p0');
+    expect(sql).toContain('HAVING SUM(src.`revenue`) > @h0');
     // SQL clause order: WHERE < GROUP BY < HAVING.
     expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('GROUP BY'));
     expect(sql.indexOf('GROUP BY')).toBeLessThan(sql.indexOf('HAVING'));
@@ -205,7 +205,7 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       columnTypes: new Map([['order_date', 'DATE']]),
     });
     const sql = await sqlOf(result);
-    expect(sql).toContain('HAVING COUNT(DISTINCT main.`order_date`) >= @h0');
+    expect(sql).toContain('HAVING COUNT(DISTINCT src.`order_date`) >= @h0');
     expect(sql).not.toContain('CAST(@h0 AS DATE)');
   });
 
@@ -217,6 +217,6 @@ describe('BigQueryQueryBuilder — aggregations', () => {
       columnTypes: new Map([['order_date', 'DATE']]),
     });
     const sql = await sqlOf(result);
-    expect(sql).toContain('HAVING MIN(main.`order_date`) >= CAST(@h0 AS DATE)');
+    expect(sql).toContain('HAVING MIN(src.`order_date`) >= CAST(@h0 AS DATE)');
   });
 });

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.spec.ts
@@ -101,8 +101,8 @@ describe('BigQueryQueryBuilder', () => {
       expect(isQueryBuildResult(result)).toBe(true);
       if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
       expect(result.sql).toContain('`a`,\n  `b`');
-      expect(result.sql).toContain('FROM `proj`.`dataset`.`tbl`');
-      expect(result.sql).toContain('WHERE `a` = @p0');
+      expect(result.sql).toContain('FROM `proj`.`dataset`.`tbl` AS main');
+      expect(result.sql).toContain('WHERE main.`a` = @p0');
       expect(result.params).toEqual([{ name: 'p0', value: 1 }]);
     });
 
@@ -117,8 +117,25 @@ describe('BigQueryQueryBuilder', () => {
       const sql = result.sql;
       expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('ORDER BY'));
       expect(sql.indexOf('ORDER BY')).toBeLessThan(sql.indexOf('LIMIT'));
-      expect(sql).toContain('ORDER BY\n  `a` ASC');
+      expect(sql).toContain('ORDER BY\n  main.`a` ASC');
       expect(sql).toContain('LIMIT 10');
+    });
+
+    it('aliases FROM and qualifies filter when column matches table short name (STRUCT collision)', async () => {
+      // Fibery 6685: unaliased FROM …`country` makes bare `country` a row STRUCT in WHERE.
+      const result = await builder.buildQuery(tableDefinition('proj.shop_data.country'), {
+        columns: ['order_id', 'country'],
+        filters: [{ column: 'country', operator: 'eq', value: 'Canada' }],
+      });
+      if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
+      expect(result.sql).toBe(
+        'SELECT\n' +
+          '  `order_id`,\n' +
+          '  `country`\n' +
+          'FROM `proj`.`shop_data`.`country` AS main\n' +
+          'WHERE main.`country` = @p0'
+      );
+      expect(result.params).toEqual([{ name: 'p0', value: 'Canada' }]);
     });
 
     it('returns plain string when there are no output controls (sort only undefined)', async () => {
@@ -136,9 +153,9 @@ describe('BigQueryQueryBuilder', () => {
         mainTableReference: '`proj`.`dataset`.`view_abc`',
       });
       if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
-      expect(result.sql).toContain('FROM `proj`.`dataset`.`view_abc`');
+      expect(result.sql).toContain('FROM `proj`.`dataset`.`view_abc` AS main');
       expect(result.sql).not.toContain('SELECT 1');
-      expect(result.sql).toContain("(`x` IS NULL OR `x` = '')");
+      expect(result.sql).toContain("(main.`x` IS NULL OR main.`x` = '')");
     });
 
     it('throws when SQL-def has output controls but no mainTableReference', async () => {
@@ -160,7 +177,7 @@ describe('BigQueryQueryBuilder', () => {
       });
       expect(isQueryBuildResult(result)).toBe(true);
       if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
-      expect(result.sql).toContain('FROM `proj`.`ds`.`my_view`');
+      expect(result.sql).toContain('FROM `proj`.`ds`.`my_view` AS main');
     });
 
     it('returns QueryBuildResult with correct FROM for connector definition', async () => {
@@ -169,7 +186,7 @@ describe('BigQueryQueryBuilder', () => {
       });
       expect(isQueryBuildResult(result)).toBe(true);
       if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
-      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl`');
+      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl` AS main');
     });
 
     it('returns QueryBuildResult with correct FROM for table-pattern definition', async () => {
@@ -178,7 +195,7 @@ describe('BigQueryQueryBuilder', () => {
       });
       expect(isQueryBuildResult(result)).toBe(true);
       if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
-      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl_*`');
+      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl_*` AS main');
     });
 
     it('handles limit 0 as "no limit" (limit !== null only when explicit positive)', async () => {

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.spec.ts
@@ -68,7 +68,7 @@ describe('BigQueryQueryBuilder', () => {
         columns: ['campaign_name', 'date_column'],
       });
       expect(sql).toBe(
-        'SELECT\n  `campaign_name`,\n  `date_column`\nFROM `proj`.`dataset`.`tbl` AS main'
+        'SELECT\n  `campaign_name`,\n  `date_column`\nFROM `proj`.`dataset`.`tbl` AS src'
       );
     });
 
@@ -77,7 +77,7 @@ describe('BigQueryQueryBuilder', () => {
         columns: ['address.city', 'user_id'],
       });
       expect(sql).toBe(
-        'SELECT\n  `address`.`city`,\n  `user_id`\nFROM `proj`.`dataset`.`tbl` AS main'
+        'SELECT\n  `address`.`city`,\n  `user_id`\nFROM `proj`.`dataset`.`tbl` AS src'
       );
     });
 
@@ -85,14 +85,24 @@ describe('BigQueryQueryBuilder', () => {
       const sql = await builder.buildQuery(tableDefinition('proj.shop_data.country'), {
         columns: ['country'],
       });
-      expect(sql).toBe('SELECT\n  `country`\nFROM `proj`.`shop_data`.`country` AS main');
+      expect(sql).toBe('SELECT\n  `country`\nFROM `proj`.`shop_data`.`country` AS src');
+    });
+
+    it('does not use AS main so a projected column named main stays a column, not row STRUCT', async () => {
+      const sql = await builder.buildQuery(tableDefinition('proj.dataset.sales'), {
+        columns: ['main', 'revenue'],
+      });
+      expect(sql).toBe(
+        'SELECT\n  `main`,\n  `revenue`\nFROM `proj`.`dataset`.`sales` AS src'
+      );
+      expect(sql).not.toMatch(/AS main(?:\s|$)/);
     });
 
     it('wraps SQL definition queries when columns are provided', async () => {
       const sql = await builder.buildQuery(sqlDefinition('SELECT a, b, c FROM t;'), {
         columns: ['a', 'c'],
       });
-      expect(sql).toBe('SELECT\n  `a`,\n  `c`\nFROM (SELECT a, b, c FROM t) AS main');
+      expect(sql).toBe('SELECT\n  `a`,\n  `c`\nFROM (SELECT a, b, c FROM t) AS src');
     });
 
     it('ignores empty columns list and falls back to SELECT *', async () => {
@@ -112,8 +122,8 @@ describe('BigQueryQueryBuilder', () => {
       expect(isQueryBuildResult(result)).toBe(true);
       if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
       expect(result.sql).toContain('`a`,\n  `b`');
-      expect(result.sql).toContain('FROM `proj`.`dataset`.`tbl` AS main');
-      expect(result.sql).toContain('WHERE main.`a` = @p0');
+      expect(result.sql).toContain('FROM `proj`.`dataset`.`tbl` AS src');
+      expect(result.sql).toContain('WHERE src.`a` = @p0');
       expect(result.params).toEqual([{ name: 'p0', value: 1 }]);
     });
 
@@ -128,7 +138,7 @@ describe('BigQueryQueryBuilder', () => {
       const sql = result.sql;
       expect(sql.indexOf('WHERE')).toBeLessThan(sql.indexOf('ORDER BY'));
       expect(sql.indexOf('ORDER BY')).toBeLessThan(sql.indexOf('LIMIT'));
-      expect(sql).toContain('ORDER BY\n  main.`a` ASC');
+      expect(sql).toContain('ORDER BY\n  src.`a` ASC');
       expect(sql).toContain('LIMIT 10');
     });
 
@@ -143,8 +153,8 @@ describe('BigQueryQueryBuilder', () => {
         'SELECT\n' +
           '  `order_id`,\n' +
           '  `country`\n' +
-          'FROM `proj`.`shop_data`.`country` AS main\n' +
-          'WHERE main.`country` = @p0'
+          'FROM `proj`.`shop_data`.`country` AS src\n' +
+          'WHERE src.`country` = @p0'
       );
       expect(result.params).toEqual([{ name: 'p0', value: 'Canada' }]);
     });
@@ -154,7 +164,7 @@ describe('BigQueryQueryBuilder', () => {
         columns: ['a'],
       });
       expect(typeof result).toBe('string');
-      expect(result).toBe('SELECT\n  `a`\nFROM `proj`.`dataset`.`tbl` AS main');
+      expect(result).toBe('SELECT\n  `a`\nFROM `proj`.`dataset`.`tbl` AS src');
     });
 
     it('uses mainTableReference for SQL-def with output controls', async () => {
@@ -164,9 +174,9 @@ describe('BigQueryQueryBuilder', () => {
         mainTableReference: '`proj`.`dataset`.`view_abc`',
       });
       if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
-      expect(result.sql).toContain('FROM `proj`.`dataset`.`view_abc` AS main');
+      expect(result.sql).toContain('FROM `proj`.`dataset`.`view_abc` AS src');
       expect(result.sql).not.toContain('SELECT 1');
-      expect(result.sql).toContain("(main.`x` IS NULL OR main.`x` = '')");
+      expect(result.sql).toContain("(src.`x` IS NULL OR src.`x` = '')");
     });
 
     it('throws when SQL-def has output controls but no mainTableReference', async () => {
@@ -188,7 +198,7 @@ describe('BigQueryQueryBuilder', () => {
       });
       expect(isQueryBuildResult(result)).toBe(true);
       if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
-      expect(result.sql).toContain('FROM `proj`.`ds`.`my_view` AS main');
+      expect(result.sql).toContain('FROM `proj`.`ds`.`my_view` AS src');
     });
 
     it('returns QueryBuildResult with correct FROM for connector definition', async () => {
@@ -197,7 +207,7 @@ describe('BigQueryQueryBuilder', () => {
       });
       expect(isQueryBuildResult(result)).toBe(true);
       if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
-      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl` AS main');
+      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl` AS src');
     });
 
     it('returns QueryBuildResult with correct FROM for table-pattern definition', async () => {
@@ -206,7 +216,7 @@ describe('BigQueryQueryBuilder', () => {
       });
       expect(isQueryBuildResult(result)).toBe(true);
       if (!isQueryBuildResult(result)) throw new Error('expected QueryBuildResult');
-      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl_*` AS main');
+      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl_*` AS src');
     });
 
     it('handles limit 0 as "no limit" (limit !== null only when explicit positive)', async () => {

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.spec.ts
@@ -67,21 +67,32 @@ describe('BigQueryQueryBuilder', () => {
       const sql = await builder.buildQuery(tableDefinition('proj.dataset.tbl'), {
         columns: ['campaign_name', 'date_column'],
       });
-      expect(sql).toBe('SELECT\n  `campaign_name`,\n  `date_column`\nFROM `proj`.`dataset`.`tbl`');
+      expect(sql).toBe(
+        'SELECT\n  `campaign_name`,\n  `date_column`\nFROM `proj`.`dataset`.`tbl` AS main'
+      );
     });
 
     it('escapes nested RECORD paths as backtick-separated parts', async () => {
       const sql = await builder.buildQuery(tableDefinition('proj.dataset.tbl'), {
         columns: ['address.city', 'user_id'],
       });
-      expect(sql).toBe('SELECT\n  `address`.`city`,\n  `user_id`\nFROM `proj`.`dataset`.`tbl`');
+      expect(sql).toBe(
+        'SELECT\n  `address`.`city`,\n  `user_id`\nFROM `proj`.`dataset`.`tbl` AS main'
+      );
+    });
+
+    it('aliases FROM when a projected column matches the table short name', async () => {
+      const sql = await builder.buildQuery(tableDefinition('proj.shop_data.country'), {
+        columns: ['country'],
+      });
+      expect(sql).toBe('SELECT\n  `country`\nFROM `proj`.`shop_data`.`country` AS main');
     });
 
     it('wraps SQL definition queries when columns are provided', async () => {
       const sql = await builder.buildQuery(sqlDefinition('SELECT a, b, c FROM t;'), {
         columns: ['a', 'c'],
       });
-      expect(sql).toBe('SELECT\n  `a`,\n  `c`\nFROM (SELECT a, b, c FROM t)');
+      expect(sql).toBe('SELECT\n  `a`,\n  `c`\nFROM (SELECT a, b, c FROM t) AS main');
     });
 
     it('ignores empty columns list and falls back to SELECT *', async () => {
@@ -138,12 +149,12 @@ describe('BigQueryQueryBuilder', () => {
       expect(result.params).toEqual([{ name: 'p0', value: 'Canada' }]);
     });
 
-    it('returns plain string when there are no output controls (sort only undefined)', async () => {
+    it('returns plain string with aliased FROM for explicit projection only', async () => {
       const result = await builder.buildQuery(tableDefinition('proj.dataset.tbl'), {
         columns: ['a'],
       });
       expect(typeof result).toBe('string');
-      expect(result).toBe('SELECT\n  `a`\nFROM `proj`.`dataset`.`tbl`');
+      expect(result).toBe('SELECT\n  `a`\nFROM `proj`.`dataset`.`tbl` AS main');
     });
 
     it('uses mainTableReference for SQL-def with output controls', async () => {

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.spec.ts
@@ -92,9 +92,7 @@ describe('BigQueryQueryBuilder', () => {
       const sql = await builder.buildQuery(tableDefinition('proj.dataset.sales'), {
         columns: ['main', 'revenue'],
       });
-      expect(sql).toBe(
-        'SELECT\n  `main`,\n  `revenue`\nFROM `proj`.`dataset`.`sales` AS src'
-      );
+      expect(sql).toBe('SELECT\n  `main`,\n  `revenue`\nFROM `proj`.`dataset`.`sales` AS src');
       expect(sql).not.toMatch(/AS main(?:\s|$)/);
     });
 

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.ts
@@ -24,6 +24,16 @@ import { effectiveComparisonType } from '../../field-aggregation';
 export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
   readonly type: DataStorageType = DataStorageType.GOOGLE_BIGQUERY;
 
+  /**
+   * Correlation name for output-controls queries. Matches the blended CTE name (`main`).
+   *
+   * BigQuery treats an unaliased table's short name as the row STRUCT alias, so
+   * `FROM …country WHERE country = 'x'` compares STRUCT vs STRING. Aliasing the
+   * source removes that collision; WHERE/ORDER BY/HAVING are then qualified for
+   * an explicit column reference.
+   */
+  private static readonly FROM_ALIAS = 'main';
+
   constructor(private readonly clauseRenderer: BigQueryClauseRenderer) {}
 
   async buildQuery(
@@ -56,7 +66,10 @@ export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
       );
     }
 
-    const fromClause = this.resolveFromClauseWithOutputControls(definition, queryOptions);
+    // Alias the source so the table short name is no longer a row STRUCT range variable.
+    const fromClause = `${this.resolveFromClauseWithOutputControls(definition, queryOptions)} AS ${BigQueryQueryBuilder.FROM_ALIAS}`;
+    const qualifyColumn = (column: string) =>
+      `${BigQueryQueryBuilder.FROM_ALIAS}.${escapeBigQueryIdentifier(column)}`;
     // Field types let the renderer compare the date part of TIMESTAMP/DATETIME
     // columns against CURRENT_DATE() for relative_date filters (a bare TIMESTAMP =
     // DATE comparison is a type error in BigQuery).
@@ -66,15 +79,17 @@ export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
       : undefined;
     const where = this.clauseRenderer.renderWhere(
       queryOptions?.filters ?? [],
-      undefined,
+      qualifyColumn,
       'p',
       resolveColumnType
     );
-    const orderBy = this.clauseRenderer.renderOrderBy(queryOptions?.sort ?? []);
+    const orderBy = this.clauseRenderer.renderOrderBy(queryOptions?.sort ?? [], qualifyColumn);
     const limit = this.clauseRenderer.renderLimit(queryOptions?.limit ?? null);
 
     // Aggregations (or a date-trunc bucket / Row Count / Unique Count) replace the plain
     // SELECT list with `<dims>, FN(<metric>) AS …` and inject GROUP BY.
+    // SELECT/GROUP BY stay unqualified: after FROM … AS main, bare column names resolve
+    // to columns of main (no need to qualify projections — that path forces nested AS work).
     if (aggregations.length > 0 || dateTruncs.length > 0 || rowCount || uniqueCount) {
       const agg = this.clauseRenderer.renderAggregatedSelect(
         queryOptions?.columns ?? [],
@@ -95,7 +110,7 @@ export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
       );
       const having = this.clauseRenderer.renderHaving(
         queryOptions?.filters ?? [],
-        undefined,
+        qualifyColumn,
         'h',
         resolveColumnType
       );

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.ts
@@ -44,6 +44,7 @@ export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
     const dateTruncs = queryOptions?.dateTruncs ?? [];
     const rowCount = queryOptions?.rowCount === true;
     const uniqueCount = queryOptions?.uniqueCount === true;
+    const hasExplicitProjection = (queryOptions?.columns?.length ?? 0) > 0;
     const hasOutputControls =
       (queryOptions?.filters?.length ?? 0) > 0 ||
       (queryOptions?.sort?.length ?? 0) > 0 ||
@@ -55,7 +56,7 @@ export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
 
     const selectList = this.buildSelectList(queryOptions?.columns);
 
-    if (!hasOutputControls) {
+    if (!hasOutputControls && !hasExplicitProjection) {
       // Backward-compatible path.
       if (isSqlDefinition(definition) && !queryOptions?.columns?.length) {
         return definition.sqlQuery;
@@ -67,7 +68,10 @@ export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
     }
 
     // Alias the source so the table short name is no longer a row STRUCT range variable.
-    const fromClause = `${this.resolveFromClauseWithOutputControls(definition, queryOptions)} AS ${BigQueryQueryBuilder.FROM_ALIAS}`;
+    const sourceFromClause = hasOutputControls
+      ? this.resolveFromClauseWithOutputControls(definition, queryOptions)
+      : this.resolveFromClauseWithoutOutputControls(definition);
+    const fromClause = `${sourceFromClause} AS ${BigQueryQueryBuilder.FROM_ALIAS}`;
     const qualifyColumn = (column: string) =>
       `${BigQueryQueryBuilder.FROM_ALIAS}.${escapeBigQueryIdentifier(column)}`;
     // Field types let the renderer compare the date part of TIMESTAMP/DATETIME
@@ -120,10 +124,10 @@ export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
       };
     }
 
-    return {
-      sql: `${composeSelectFromClause(selectList, fromClause)}${where.sql}${orderBy.sql}${limit.sql}`,
-      params: [...where.params, ...orderBy.params, ...limit.params],
-    };
+    const sql = `${composeSelectFromClause(selectList, fromClause)}${where.sql}${orderBy.sql}${limit.sql}`;
+    return hasOutputControls
+      ? { sql, params: [...where.params, ...orderBy.params, ...limit.params] }
+      : sql;
   }
 
   private resolveFromClauseWithoutOutputControls(definition: DataMartDefinition): string {

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-query.builder.ts
@@ -25,14 +25,14 @@ export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
   readonly type: DataStorageType = DataStorageType.GOOGLE_BIGQUERY;
 
   /**
-   * Correlation name for output-controls queries. Matches the blended CTE name (`main`).
+   * Correlation name for flat output-controls / explicit-projection queries.
    *
    * BigQuery treats an unaliased table's short name as the row STRUCT alias, so
    * `FROM …country WHERE country = 'x'` compares STRUCT vs STRING. Aliasing the
    * source removes that collision; WHERE/ORDER BY/HAVING are then qualified for
    * an explicit column reference.
    */
-  private static readonly FROM_ALIAS = 'main';
+  private static readonly FROM_ALIAS = 'src';
 
   constructor(private readonly clauseRenderer: BigQueryClauseRenderer) {}
 
@@ -92,8 +92,8 @@ export class BigQueryQueryBuilder implements DataMartQueryBuilderAsync {
 
     // Aggregations (or a date-trunc bucket / Row Count / Unique Count) replace the plain
     // SELECT list with `<dims>, FN(<metric>) AS …` and inject GROUP BY.
-    // SELECT/GROUP BY stay unqualified: after FROM … AS main, bare column names resolve
-    // to columns of main (no need to qualify projections — that path forces nested AS work).
+    // SELECT/GROUP BY stay unqualified: after FROM … AS src, bare column names resolve
+    // to columns of src (qualifying projections would force nested-RECORD AS work).
     if (aggregations.length > 0 || dateTruncs.length > 0 || rowCount || uniqueCount) {
       const agg = this.clauseRenderer.renderAggregatedSelect(
         queryOptions?.columns ?? [],

--- a/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
@@ -315,7 +315,7 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
       ]);
       expect(result!.sql).toContain('SUM(`revenue`) AS `revenue | SUM`');
       expect(result!.sql).toContain('MAX(`quantity`) AS `quantity | MAX`');
-      expect(result!.sql).toContain('WHERE `channel` = @p0');
+      expect(result!.sql).toContain('WHERE main.`channel` = @p0');
       expect(result!.sql).not.toMatch(/GROUP BY/);
       expect(result!.sql).not.toMatch(/ORDER BY/);
       expect(result!.sql).not.toMatch(/LIMIT/);
@@ -381,7 +381,7 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
 
       const result = await service.composeTotals(report, {} as never);
 
-      expect(result!.sql).toContain('WHERE `channel` = @p0');
+      expect(result!.sql).toContain('WHERE main.`channel` = @p0');
       expect(result!.sql).not.toMatch(/HAVING/);
       expect(result!.sql).not.toMatch(/GROUP BY/);
     });

--- a/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
@@ -315,7 +315,7 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
       ]);
       expect(result!.sql).toContain('SUM(`revenue`) AS `revenue | SUM`');
       expect(result!.sql).toContain('MAX(`quantity`) AS `quantity | MAX`');
-      expect(result!.sql).toContain('WHERE main.`channel` = @p0');
+      expect(result!.sql).toContain('WHERE src.`channel` = @p0');
       expect(result!.sql).not.toMatch(/GROUP BY/);
       expect(result!.sql).not.toMatch(/ORDER BY/);
       expect(result!.sql).not.toMatch(/LIMIT/);
@@ -381,7 +381,7 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
 
       const result = await service.composeTotals(report, {} as never);
 
-      expect(result!.sql).toContain('WHERE main.`channel` = @p0');
+      expect(result!.sql).toContain('WHERE src.`channel` = @p0');
       expect(result!.sql).not.toMatch(/HAVING/);
       expect(result!.sql).not.toMatch(/GROUP BY/);
     });

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
@@ -482,10 +482,10 @@ describe('ReportSqlComposerService', () => {
       const result = await composer.compose(report, { userId: 'user-1', roles: ['admin'] });
 
       expect(result.sql).toContain('SELECT\n  `name`,\n  `amount`');
-      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl` AS main');
-      expect(result.sql).toContain('WHERE main.`name` = @p0');
-      expect(result.sql).toContain('AND main.`amount` BETWEEN @p1 AND @p2');
-      expect(result.sql).toContain('ORDER BY\n  main.`amount` DESC');
+      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl` AS src');
+      expect(result.sql).toContain('WHERE src.`name` = @p0');
+      expect(result.sql).toContain('AND src.`amount` BETWEEN @p1 AND @p2');
+      expect(result.sql).toContain('ORDER BY\n  src.`amount` DESC');
       expect(result.sql).toContain('LIMIT 50');
 
       // The full param array — proves no string interpolation of user values.
@@ -517,7 +517,7 @@ describe('ReportSqlComposerService', () => {
 
       const result = await composer.compose(report, { userId: 'user-1', roles: ['admin'] });
 
-      expect(result.sql).toContain('STRPOS(main.`name`, @p0) > 0');
+      expect(result.sql).toContain('STRPOS(src.`name`, @p0) > 0');
       expect(result.sql).not.toMatch(/LIKE/);
       expect(result.params).toEqual([{ name: 'p0', value: '100%' }]);
     });
@@ -542,7 +542,7 @@ describe('ReportSqlComposerService', () => {
       // QueryBuildResult shape so the executor handles it uniformly.
       expect(isQueryBuildResult({ sql: result.sql, params: result.params ?? [] })).toBe(true);
       expect(result.params).toEqual([]);
-      expect(result.sql).toContain("(main.`name` IS NULL OR main.`name` = '')");
+      expect(result.sql).toContain("(src.`name` IS NULL OR src.`name` = '')");
     });
   });
 

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.spec.ts
@@ -482,10 +482,10 @@ describe('ReportSqlComposerService', () => {
       const result = await composer.compose(report, { userId: 'user-1', roles: ['admin'] });
 
       expect(result.sql).toContain('SELECT\n  `name`,\n  `amount`');
-      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl`');
-      expect(result.sql).toContain('WHERE `name` = @p0');
-      expect(result.sql).toContain('AND `amount` BETWEEN @p1 AND @p2');
-      expect(result.sql).toContain('ORDER BY\n  `amount` DESC');
+      expect(result.sql).toContain('FROM `proj`.`ds`.`tbl` AS main');
+      expect(result.sql).toContain('WHERE main.`name` = @p0');
+      expect(result.sql).toContain('AND main.`amount` BETWEEN @p1 AND @p2');
+      expect(result.sql).toContain('ORDER BY\n  main.`amount` DESC');
       expect(result.sql).toContain('LIMIT 50');
 
       // The full param array — proves no string interpolation of user values.
@@ -517,7 +517,7 @@ describe('ReportSqlComposerService', () => {
 
       const result = await composer.compose(report, { userId: 'user-1', roles: ['admin'] });
 
-      expect(result.sql).toContain('STRPOS(`name`, @p0) > 0');
+      expect(result.sql).toContain('STRPOS(main.`name`, @p0) > 0');
       expect(result.sql).not.toMatch(/LIKE/);
       expect(result.params).toEqual([{ name: 'p0', value: '100%' }]);
     });
@@ -542,7 +542,7 @@ describe('ReportSqlComposerService', () => {
       // QueryBuildResult shape so the executor handles it uniformly.
       expect(isQueryBuildResult({ sql: result.sql, params: result.params ?? [] })).toBe(true);
       expect(result.params).toEqual([]);
-      expect(result.sql).toContain("(`name` IS NULL OR `name` = '')");
+      expect(result.sql).toContain("(main.`name` IS NULL OR main.`name` = '')");
     });
   });
 


### PR DESCRIPTION
## Summary

* Fixes BigQuery report runs (including Google Sheets export) when a table short name matches a filtered or sorted column (e.g. table `…country` and filter `country = 'Canada'`).
* BigQuery treats an unaliased table short name as a row `STRUCT` range variable, so generated SQL like `FROM proj.ds.country WHERE country = @p0` compared STRUCT vs STRING.
* Output-controls and explicit-projection queries now use `FROM … AS src` and qualify WHERE, ORDER BY, and HAVING. SELECT and GROUP BY stay **unqualified** so nested RECORD paths keep their previous shape.
* Alias is `src` (not `main`) so a real data-mart column named `main` cannot reintroduce the same STRUCT collision. Blended `main` CTE path is unchanged.
* Existing reports need no reconfiguration; result headers and bound params stay stable. Changeset: `owox` minor.

## Test plan

* [x] Unit: `bigquery-query.builder*` + `report-sql-composer*` (STRUCT-collision regression, column named `main`)
* [x] Local repro with matching table/column names and a report filter
* [x] CI green
