### PR TITLE
feat(tiktok-ads): let Data Level choose insights reporting grain

### DIFF
--- a/.changeset/6617-tiktok-ads-data-level.md
+++ b/.changeset/6617-tiktok-ads-data-level.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Data Level selection for TikTok Ads performance reports
+
+TikTok Ads `ad_insights` and `ad_insights_by_country` now honor the selected **Data Level** (advertiser, campaign, ad group, or ad). Data Level is a dropdown in the main connector settings, and the field selector pins only the unique-key fields that level requires. Advertiser-level reports no longer force you to include `ad_id` and can group by date alone. Choose Data Level before selecting fields; when you change it on a connector that already has data, use a new Data Mart so rows merge correctly.

--- a/apps/backend/src/data-marts/connector-types/connector-fields-schema.ts
+++ b/apps/backend/src/data-marts/connector-types/connector-fields-schema.ts
@@ -7,6 +7,7 @@ export const ConnectorFieldsSchema = z.array(
     description: z.string().optional(),
     documentation: z.string().optional(),
     uniqueKeys: z.array(z.string()).optional(),
+    uniqueKeysByDataLevel: z.record(z.string(), z.array(z.string())).optional(),
     defaultFields: z.array(z.string()).optional(),
     destinationName: z.string().optional(),
     fields: z

--- a/apps/backend/src/data-marts/mappers/connector.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/connector.mapper.ts
@@ -53,6 +53,7 @@ export class ConnectorMapper {
       description: field.description,
       documentation: field.documentation,
       uniqueKeys: field.uniqueKeys,
+      uniqueKeysByDataLevel: field.uniqueKeysByDataLevel,
       defaultFields: field.defaultFields,
       destinationName: field.destinationName,
       fields: field.fields?.map(field => ({

--- a/apps/backend/src/data-marts/services/connector/connector.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector.service.ts
@@ -48,6 +48,7 @@ interface SourceFieldsGroup {
   description: string;
   documentation: string;
   uniqueKeys: string[];
+  uniqueKeysByDataLevel?: Record<string, string[]>;
   defaultFields?: string[];
   destinationName: string;
   fields: Record<string, SourceFieldDefinition>;
@@ -508,6 +509,7 @@ export class ConnectorService {
       description: sourceFieldsSchema[key].description,
       documentation: sourceFieldsSchema[key].documentation,
       uniqueKeys: sourceFieldsSchema[key].uniqueKeys,
+      uniqueKeysByDataLevel: sourceFieldsSchema[key].uniqueKeysByDataLevel,
       defaultFields: sourceFieldsSchema[key].defaultFields,
       destinationName: sourceFieldsSchema[key].destinationName,
       fields: Object.keys(sourceFieldsSchema[key].fields).map(fieldKey => ({

--- a/apps/web/src/features/connectors/edit/components/ConnectorDefinitionField/AddConfigurationButton.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorDefinitionField/AddConfigurationButton.tsx
@@ -6,7 +6,7 @@ import type { ConnectorConfig } from '../../../../data-marts/edit';
 
 interface AddConfigurationButtonProps {
   storageType: DataStorageType;
-  onAddConfiguration: (newConfig: Record<string, unknown>) => void;
+  onAddConfiguration: (connector: ConnectorConfig) => void;
   existingConnector?: ConnectorConfig;
 }
 
@@ -20,8 +20,9 @@ export function AddConfigurationButton({
       <DataMartConnectorView
         dataStorageType={storageType}
         onSubmit={(connector: ConnectorConfig) => {
-          const newConfig = connector.source.configuration[0] || {};
-          onAddConfiguration(newConfig);
+          // Pass the whole connector (not just configuration[0]) so the Data Level-derived
+          // fields computed in ConnectorEditForm reach addConfiguration and get merged in.
+          onAddConfiguration(connector);
         }}
         configurationOnly={true}
         existingConnector={

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
@@ -341,6 +341,7 @@ export function ConnectorEditForm({
               connectorFields={connectorFields}
               selectedField={selectedNode}
               selectedFields={selectedFields}
+              configuration={connectorConfiguration}
               onFieldToggle={handleFieldToggle}
               onSelectAllFields={handleSelectAllFields}
             />
@@ -394,6 +395,7 @@ export function ConnectorEditForm({
             connectorFields={connectorFields}
             selectedField={selectedNode}
             selectedFields={selectedFields}
+            configuration={connectorConfiguration}
             onFieldToggle={handleFieldToggle}
             onSelectAllFields={handleSelectAllFields}
           />

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
@@ -14,7 +14,7 @@ import type { ConnectorConfig } from '../../../../data-marts/edit';
 import type { ConnectorFieldsResponseApiDto } from '../../../shared/api';
 import { AppWizard, AppWizardLayout, AppWizardActions } from '@owox/ui/components/common/wizard';
 import { trackEvent } from '../../../../../utils';
-import { DATA_LEVEL_CONFIG_KEY } from '../../../shared/constants/connector-config';
+import { resolveEffectiveDataLevel } from '../../../shared/constants/connector-config';
 
 interface ConnectorEditFormProps {
   onSubmit: (connector: ConnectorConfig) => void;
@@ -178,7 +178,12 @@ export function ConnectorEditForm({
     selectedConnector,
   ]);
 
-  // Union the persisted fields with whatever the chosen DataLevel requires (e.g. TikTok
+  const effectiveDataLevel = useMemo(
+    () => resolveEffectiveDataLevel(connectorConfiguration, connectorSpecification),
+    [connectorConfiguration, connectorSpecification]
+  );
+
+  // Union the persisted fields with whatever the effective DataLevel requires (e.g. TikTok
   // ad_insights needs ad_id at AUCTION_AD). No-op for nodes without uniqueKeysByDataLevel.
   // Falls back to the unchanged fields if connectorFields hasn't loaded yet, but that
   // window isn't user-reachable: loadFieldsSafely is always triggered for an existing
@@ -186,15 +191,14 @@ export function ConnectorEditForm({
   // the <StepNavigation> call site below until that fetch settles.
   const fieldsForSave = useMemo(() => {
     const fields = existingConnector?.source.fields ?? selectedFields;
-    const dataLevel = connectorConfiguration[DATA_LEVEL_CONFIG_KEY];
-    if (typeof dataLevel !== 'string') return fields;
+    if (!effectiveDataLevel) return fields;
 
     const node = existingConnector?.source.node ?? selectedNode;
     const required = connectorFields?.find(f => f.name === node)?.uniqueKeysByDataLevel?.[
-      dataLevel
+      effectiveDataLevel
     ];
     return required?.length ? Array.from(new Set([...fields, ...required])) : fields;
-  }, [existingConnector, selectedFields, selectedNode, connectorConfiguration, connectorFields]);
+  }, [existingConnector, selectedFields, selectedNode, effectiveDataLevel, connectorFields]);
 
   const handleConnectorSelect = (connector: ConnectorListItem) => {
     setSelectedConnector(connector);

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
@@ -14,6 +14,7 @@ import type { ConnectorConfig } from '../../../../data-marts/edit';
 import type { ConnectorFieldsResponseApiDto } from '../../../shared/api';
 import { AppWizard, AppWizardLayout, AppWizardActions } from '@owox/ui/components/common/wizard';
 import { trackEvent } from '../../../../../utils';
+import { DATA_LEVEL_CONFIG_KEY } from '../../../shared/constants/connector-config';
 
 interface ConnectorEditFormProps {
   onSubmit: (connector: ConnectorConfig) => void;
@@ -179,12 +180,13 @@ export function ConnectorEditForm({
 
   // Union the persisted fields with whatever the chosen DataLevel requires (e.g. TikTok
   // ad_insights needs ad_id at AUCTION_AD). No-op for nodes without uniqueKeysByDataLevel.
-  // ponytail: best-effort — if fields haven't loaded yet the run fails loudly with
-  // "Missing required unique fields"; acceptable since changing DataLevel on existing data
-  // is already discouraged in the field's description.
+  // Falls back to the unchanged fields if connectorFields hasn't loaded yet, but that
+  // window isn't user-reachable: loadFieldsSafely is always triggered for an existing
+  // connector, and the Save button is disabled via isLoading={... || loadingFields} at
+  // the <StepNavigation> call site below until that fetch settles.
   const fieldsForSave = useMemo(() => {
     const fields = existingConnector?.source.fields ?? selectedFields;
-    const dataLevel = connectorConfiguration.DataLevel;
+    const dataLevel = connectorConfiguration[DATA_LEVEL_CONFIG_KEY];
     if (typeof dataLevel !== 'string') return fields;
 
     const node = existingConnector?.source.node ?? selectedNode;

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
@@ -2,7 +2,6 @@ import { useConnector } from '../../../shared/model/hooks/useConnector';
 import type { ConnectorListItem } from '../../../shared/model/types/connector';
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { DataStorageType } from '../../../../data-storage';
-import { Alert, AlertDescription } from '@owox/ui/components/alert';
 import {
   ConnectorSelectionStep,
   ConfigurationStep,
@@ -15,9 +14,6 @@ import type { ConnectorConfig } from '../../../../data-marts/edit';
 import type { ConnectorFieldsResponseApiDto } from '../../../shared/api';
 import { AppWizard, AppWizardLayout, AppWizardActions } from '@owox/ui/components/common/wizard';
 import { trackEvent } from '../../../../../utils';
-
-const DATA_LEVEL_DEFAULT = 'AUCTION_AD';
-const DATA_LEVEL_DEPENDENT_TIKTOK_NODES = new Set(['ad_insights', 'ad_insights_by_country']);
 
 interface ConnectorEditFormProps {
   onSubmit: (connector: ConnectorConfig) => void;
@@ -87,19 +83,6 @@ export function ConnectorEditForm({
   );
 
   const totalSteps = steps.length;
-
-  const getDataLevel = (configuration?: Record<string, unknown>) => {
-    return typeof configuration?.DataLevel === 'string'
-      ? configuration.DataLevel
-      : DATA_LEVEL_DEFAULT;
-  };
-
-  const isDataLevelDependentTikTokNode = (connectorName?: string, nodeName?: string) => {
-    return (
-      connectorName === 'TikTokAds' &&
-      Boolean(nodeName && DATA_LEVEL_DEPENDENT_TIKTOK_NODES.has(nodeName))
-    );
-  };
 
   const loadSpecificationSafely = useCallback(
     async (connectorName: string) => {
@@ -171,19 +154,8 @@ export function ConnectorEditForm({
         setSelectedConnector(existingConnectorDef);
 
         void loadSpecificationSafely(existingConnectorDef.name);
-        if (!configurationOnly && mode !== 'fields-only') {
-          void loadFieldsSafely(existingConnectorDef.name);
-        }
-        if (mode === 'fields-only') {
-          void loadFieldsSafely(existingConnectorDef.name);
-        }
-        if (
-          configurationOnly &&
-          source.configuration.length > 0 &&
-          isDataLevelDependentTikTokNode(existingConnectorDef.name, source.node)
-        ) {
-          void loadFieldsSafely(existingConnectorDef.name);
-        }
+        // Fields power both the Fields step and the data-level reconciliation at save.
+        void loadFieldsSafely(existingConnectorDef.name);
       }
     }
 
@@ -205,42 +177,22 @@ export function ConnectorEditForm({
     selectedConnector,
   ]);
 
-  const selectedNodeForConfiguration = existingConnector?.source.node ?? selectedNode;
-  const currentDataLevel = getDataLevel(connectorConfiguration);
-  const originalDataLevel = getDataLevel(existingConnector?.source.configuration[0]);
-  const isDataLevelReconciliationRelevant =
-    configurationOnly &&
-    Boolean(existingConnector?.source.configuration.length) &&
-    isDataLevelDependentTikTokNode(existingConnector?.source.name, selectedNodeForConfiguration);
-  const hasDataLevelChanged =
-    isDataLevelReconciliationRelevant && currentDataLevel !== originalDataLevel;
-  const requiredFieldsForCurrentDataLevel = useMemo(() => {
-    if (!hasDataLevelChanged) return [];
-
-    const selectedNodeSchema = connectorFields?.find(
-      field => field.name === selectedNodeForConfiguration
-    );
-
-    return selectedNodeSchema?.uniqueKeysByDataLevel?.[currentDataLevel] ?? [];
-  }, [connectorFields, currentDataLevel, hasDataLevelChanged, selectedNodeForConfiguration]);
-  const fieldsAfterDataLevelReconciliation = useMemo(() => {
+  // Union the persisted fields with whatever the chosen DataLevel requires (e.g. TikTok
+  // ad_insights needs ad_id at AUCTION_AD). No-op for nodes without uniqueKeysByDataLevel.
+  // ponytail: best-effort — if fields haven't loaded yet the run fails loudly with
+  // "Missing required unique fields"; acceptable since changing DataLevel on existing data
+  // is already discouraged in the field's description.
+  const fieldsForSave = useMemo(() => {
     const fields = existingConnector?.source.fields ?? selectedFields;
-    if (!hasDataLevelChanged || requiredFieldsForCurrentDataLevel.length === 0) {
-      return fields;
-    }
+    const dataLevel = connectorConfiguration.DataLevel;
+    if (typeof dataLevel !== 'string') return fields;
 
-    return Array.from(new Set([...fields, ...requiredFieldsForCurrentDataLevel]));
-  }, [
-    existingConnector?.source.fields,
-    hasDataLevelChanged,
-    requiredFieldsForCurrentDataLevel,
-    selectedFields,
-  ]);
-  const fieldsAddedForDataLevel = useMemo(() => {
-    const existingFields = new Set(existingConnector?.source.fields ?? selectedFields);
-    return requiredFieldsForCurrentDataLevel.filter(fieldName => !existingFields.has(fieldName));
-  }, [existingConnector?.source.fields, requiredFieldsForCurrentDataLevel, selectedFields]);
-  const isDataLevelReconciliationPending = hasDataLevelChanged && connectorFields === null;
+    const node = existingConnector?.source.node ?? selectedNode;
+    const required = connectorFields?.find(f => f.name === node)?.uniqueKeysByDataLevel?.[
+      dataLevel
+    ];
+    return required?.length ? Array.from(new Set([...fields, ...required])) : fields;
+  }, [existingConnector, selectedFields, selectedNode, connectorConfiguration, connectorFields]);
 
   const handleConnectorSelect = (connector: ConnectorListItem) => {
     setSelectedConnector(connector);
@@ -336,9 +288,7 @@ export function ConnectorEditForm({
 
   const canGoNext = () => {
     if (configurationOnly) {
-      return (
-        selectedConnector !== null && configurationIsValid && !isDataLevelReconciliationPending
-      );
+      return selectedConnector !== null && configurationIsValid;
     }
 
     if (mode === 'fields-only') {
@@ -480,23 +430,7 @@ export function ConnectorEditForm({
 
   return (
     <AppWizard>
-      <AppWizardLayout>
-        {renderCurrentStep()}
-
-        {hasDataLevelChanged && (
-          <Alert className='bg-background'>
-            <AlertDescription>
-              Data Level changed from <span className='font-medium'>{originalDataLevel}</span> to{' '}
-              <span className='font-medium'>{currentDataLevel}</span>.
-              {isDataLevelReconciliationPending
-                ? ' Loading field requirements before saving.'
-                : fieldsAddedForDataLevel.length > 0
-                  ? ` OWOX will also keep ${fieldsAddedForDataLevel.join(', ')} selected so this configuration can run with the new Data Level.`
-                  : ' The selected fields already include the required fields for the new Data Level.'}
-            </AlertDescription>
-          </Alert>
-        )}
-      </AppWizardLayout>
+      <AppWizardLayout>{renderCurrentStep()}</AppWizardLayout>
 
       <AppWizardActions variant='horizontal'>
         <StepNavigation
@@ -514,7 +448,7 @@ export function ConnectorEditForm({
                   name: selectedConnector.name,
                   configuration: [connectorConfiguration],
                   node: existingConnector?.source.node ?? selectedNode,
-                  fields: fieldsAfterDataLevelReconciliation,
+                  fields: fieldsForSave,
                 },
                 storage: existingConnector?.storage ?? {
                   fullyQualifiedName: existingConnector?.storage.fullyQualifiedName ?? '',

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
@@ -2,6 +2,7 @@ import { useConnector } from '../../../shared/model/hooks/useConnector';
 import type { ConnectorListItem } from '../../../shared/model/types/connector';
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { DataStorageType } from '../../../../data-storage';
+import { Alert, AlertDescription } from '@owox/ui/components/alert';
 import {
   ConnectorSelectionStep,
   ConfigurationStep,
@@ -14,6 +15,9 @@ import type { ConnectorConfig } from '../../../../data-marts/edit';
 import type { ConnectorFieldsResponseApiDto } from '../../../shared/api';
 import { AppWizard, AppWizardLayout, AppWizardActions } from '@owox/ui/components/common/wizard';
 import { trackEvent } from '../../../../../utils';
+
+const DATA_LEVEL_DEFAULT = 'AUCTION_AD';
+const DATA_LEVEL_DEPENDENT_TIKTOK_NODES = new Set(['ad_insights', 'ad_insights_by_country']);
 
 interface ConnectorEditFormProps {
   onSubmit: (connector: ConnectorConfig) => void;
@@ -83,6 +87,19 @@ export function ConnectorEditForm({
   );
 
   const totalSteps = steps.length;
+
+  const getDataLevel = (configuration?: Record<string, unknown>) => {
+    return typeof configuration?.DataLevel === 'string'
+      ? configuration.DataLevel
+      : DATA_LEVEL_DEFAULT;
+  };
+
+  const isDataLevelDependentTikTokNode = (connectorName?: string, nodeName?: string) => {
+    return (
+      connectorName === 'TikTokAds' &&
+      Boolean(nodeName && DATA_LEVEL_DEPENDENT_TIKTOK_NODES.has(nodeName))
+    );
+  };
 
   const loadSpecificationSafely = useCallback(
     async (connectorName: string) => {
@@ -160,6 +177,13 @@ export function ConnectorEditForm({
         if (mode === 'fields-only') {
           void loadFieldsSafely(existingConnectorDef.name);
         }
+        if (
+          configurationOnly &&
+          source.configuration.length > 0 &&
+          isDataLevelDependentTikTokNode(existingConnectorDef.name, source.node)
+        ) {
+          void loadFieldsSafely(existingConnectorDef.name);
+        }
       }
     }
 
@@ -180,6 +204,43 @@ export function ConnectorEditForm({
     loadFieldsSafely,
     selectedConnector,
   ]);
+
+  const selectedNodeForConfiguration = existingConnector?.source.node ?? selectedNode;
+  const currentDataLevel = getDataLevel(connectorConfiguration);
+  const originalDataLevel = getDataLevel(existingConnector?.source.configuration[0]);
+  const isDataLevelReconciliationRelevant =
+    configurationOnly &&
+    Boolean(existingConnector?.source.configuration.length) &&
+    isDataLevelDependentTikTokNode(existingConnector?.source.name, selectedNodeForConfiguration);
+  const hasDataLevelChanged =
+    isDataLevelReconciliationRelevant && currentDataLevel !== originalDataLevel;
+  const requiredFieldsForCurrentDataLevel = useMemo(() => {
+    if (!hasDataLevelChanged) return [];
+
+    const selectedNodeSchema = connectorFields?.find(
+      field => field.name === selectedNodeForConfiguration
+    );
+
+    return selectedNodeSchema?.uniqueKeysByDataLevel?.[currentDataLevel] ?? [];
+  }, [connectorFields, currentDataLevel, hasDataLevelChanged, selectedNodeForConfiguration]);
+  const fieldsAfterDataLevelReconciliation = useMemo(() => {
+    const fields = existingConnector?.source.fields ?? selectedFields;
+    if (!hasDataLevelChanged || requiredFieldsForCurrentDataLevel.length === 0) {
+      return fields;
+    }
+
+    return Array.from(new Set([...fields, ...requiredFieldsForCurrentDataLevel]));
+  }, [
+    existingConnector?.source.fields,
+    hasDataLevelChanged,
+    requiredFieldsForCurrentDataLevel,
+    selectedFields,
+  ]);
+  const fieldsAddedForDataLevel = useMemo(() => {
+    const existingFields = new Set(existingConnector?.source.fields ?? selectedFields);
+    return requiredFieldsForCurrentDataLevel.filter(fieldName => !existingFields.has(fieldName));
+  }, [existingConnector?.source.fields, requiredFieldsForCurrentDataLevel, selectedFields]);
+  const isDataLevelReconciliationPending = hasDataLevelChanged && connectorFields === null;
 
   const handleConnectorSelect = (connector: ConnectorListItem) => {
     setSelectedConnector(connector);
@@ -275,7 +336,9 @@ export function ConnectorEditForm({
 
   const canGoNext = () => {
     if (configurationOnly) {
-      return selectedConnector !== null && configurationIsValid;
+      return (
+        selectedConnector !== null && configurationIsValid && !isDataLevelReconciliationPending
+      );
     }
 
     if (mode === 'fields-only') {
@@ -417,7 +480,23 @@ export function ConnectorEditForm({
 
   return (
     <AppWizard>
-      <AppWizardLayout>{renderCurrentStep()}</AppWizardLayout>
+      <AppWizardLayout>
+        {renderCurrentStep()}
+
+        {hasDataLevelChanged && (
+          <Alert className='bg-background'>
+            <AlertDescription>
+              Data Level changed from <span className='font-medium'>{originalDataLevel}</span> to{' '}
+              <span className='font-medium'>{currentDataLevel}</span>.
+              {isDataLevelReconciliationPending
+                ? ' Loading field requirements before saving.'
+                : fieldsAddedForDataLevel.length > 0
+                  ? ` OWOX will also keep ${fieldsAddedForDataLevel.join(', ')} selected so this configuration can run with the new Data Level.`
+                  : ' The selected fields already include the required fields for the new Data Level.'}
+            </AlertDescription>
+          </Alert>
+        )}
+      </AppWizardLayout>
 
       <AppWizardActions variant='horizontal'>
         <StepNavigation
@@ -435,7 +514,7 @@ export function ConnectorEditForm({
                   name: selectedConnector.name,
                   configuration: [connectorConfiguration],
                   node: existingConnector?.source.node ?? selectedNode,
-                  fields: existingConnector?.source.fields ?? selectedFields,
+                  fields: fieldsAfterDataLevelReconciliation,
                 },
                 storage: existingConnector?.storage ?? {
                   fullyQualifiedName: existingConnector?.storage.fullyQualifiedName ?? '',

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.test.tsx
@@ -1,0 +1,159 @@
+import { FieldsSelectionStep } from './FieldsSelectionStep.tsx';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ComponentProps } from 'react';
+import type { ConnectorFieldsResponseApiDto } from '../../../../shared/api/types/response';
+import type { ConnectorListItem } from '../../../../shared/model/types/connector';
+
+// FieldsSelectionStep renders OpenIssueLink, which needs a router context.
+function renderStep(props: ComponentProps<typeof FieldsSelectionStep>) {
+  return render(
+    <MemoryRouter>
+      <FieldsSelectionStep {...props} />
+    </MemoryRouter>
+  );
+}
+
+const connector: ConnectorListItem = {
+  name: 'TikTokAds',
+  displayName: 'TikTok Ads',
+  description: '',
+  logoBase64: null,
+  docUrl: null,
+};
+
+const connectorFields: ConnectorFieldsResponseApiDto[] = [
+  {
+    name: 'ad_insights',
+    uniqueKeys: ['ad_id', 'stat_time_day'],
+    uniqueKeysByDataLevel: {
+      AUCTION_ADVERTISER: ['stat_time_day'],
+      AUCTION_CAMPAIGN: ['campaign_id', 'stat_time_day'],
+      AUCTION_ADGROUP: ['adgroup_id', 'stat_time_day'],
+      AUCTION_AD: ['ad_id', 'stat_time_day'],
+    },
+    fields: [
+      { name: 'ad_id' },
+      { name: 'campaign_id' },
+      { name: 'adgroup_id' },
+      { name: 'stat_time_day' },
+      { name: 'impressions' },
+    ],
+  },
+];
+
+const noop = () => {
+  /* not under test */
+};
+
+describe('FieldsSelectionStep — Data Level unique key pinning', () => {
+  it('pins only stat_time_day and leaves ad_id toggleable at AUCTION_ADVERTISER', () => {
+    renderStep({
+      connector,
+      connectorFields,
+      selectedField: 'ad_insights',
+      selectedFields: ['stat_time_day', 'impressions'],
+      configuration: { DataLevel: 'AUCTION_ADVERTISER' },
+      onFieldToggle: noop,
+      onSelectAllFields: noop,
+    });
+
+    expect(screen.getByRole('checkbox', { name: 'stat_time_day' })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'ad_id' })).not.toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'campaign_id' })).not.toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'adgroup_id' })).not.toBeDisabled();
+  });
+
+  it('pins ad_id at AUCTION_AD', () => {
+    renderStep({
+      connector,
+      connectorFields,
+      selectedField: 'ad_insights',
+      selectedFields: ['ad_id', 'stat_time_day', 'impressions'],
+      configuration: { DataLevel: 'AUCTION_AD' },
+      onFieldToggle: noop,
+      onSelectAllFields: noop,
+    });
+
+    expect(screen.getByRole('checkbox', { name: 'ad_id' })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'stat_time_day' })).toBeDisabled();
+  });
+
+  it('pins campaign_id at AUCTION_CAMPAIGN and leaves ad_id toggleable', () => {
+    renderStep({
+      connector,
+      connectorFields,
+      selectedField: 'ad_insights',
+      selectedFields: ['campaign_id', 'stat_time_day', 'impressions'],
+      configuration: { DataLevel: 'AUCTION_CAMPAIGN' },
+      onFieldToggle: noop,
+      onSelectAllFields: noop,
+    });
+
+    expect(screen.getByRole('checkbox', { name: 'campaign_id' })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'stat_time_day' })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'ad_id' })).not.toBeDisabled();
+  });
+
+  it('falls back to the static uniqueKeys when no Data Level is configured', () => {
+    renderStep({
+      connector,
+      connectorFields,
+      selectedField: 'ad_insights',
+      selectedFields: ['ad_id', 'stat_time_day', 'impressions'],
+      configuration: {},
+      onFieldToggle: noop,
+      onSelectAllFields: noop,
+    });
+
+    expect(screen.getByRole('checkbox', { name: 'ad_id' })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'stat_time_day' })).toBeDisabled();
+  });
+});
+
+describe('FieldsSelectionStep — Data Level tip is node-name agnostic', () => {
+  // Gating on uniqueKeysByDataLevel presence (not a hardcoded node name list) means any
+  // connector/node exposing it gets the same pinning + tip behavior for free.
+  const genericNodeFields: ConnectorFieldsResponseApiDto[] = [
+    {
+      name: 'some_other_node',
+      uniqueKeys: ['id', 'date'],
+      uniqueKeysByDataLevel: { DAILY: ['date'], CAMPAIGN: ['campaign_id', 'date'] },
+      fields: [{ name: 'id' }, { name: 'campaign_id' }, { name: 'date' }],
+    },
+  ];
+
+  it('shows the tip and pins fields for a non-TikTok node name that has uniqueKeysByDataLevel', () => {
+    renderStep({
+      connector,
+      connectorFields: genericNodeFields,
+      selectedField: 'some_other_node',
+      selectedFields: ['date'],
+      configuration: { DataLevel: 'DAILY' },
+      onFieldToggle: noop,
+      onSelectAllFields: noop,
+    });
+
+    expect(screen.getByText(/Required fields depend on Data Level/)).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'date' })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'campaign_id' })).not.toBeDisabled();
+  });
+
+  it('hides the tip for a node without uniqueKeysByDataLevel, even with a Data Level set', () => {
+    const nodeWithoutDataLevelKeys: ConnectorFieldsResponseApiDto[] = [
+      { name: 'catalog_node', uniqueKeys: ['id'], fields: [{ name: 'id' }] },
+    ];
+
+    renderStep({
+      connector,
+      connectorFields: nodeWithoutDataLevelKeys,
+      selectedField: 'catalog_node',
+      selectedFields: ['id'],
+      configuration: { DataLevel: 'DAILY' },
+      onFieldToggle: noop,
+      onSelectAllFields: noop,
+    });
+
+    expect(screen.queryByText(/Required fields depend on Data Level/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
@@ -59,7 +59,7 @@ export function FieldsSelectionStep({
       return selectedFieldData.uniqueKeysByDataLevel[selectedDataLevel];
     }
     return selectedFieldData?.uniqueKeys ?? [];
-  }, [selectedFieldData, selectedDataLevel]);
+  }, [selectedFieldData?.uniqueKeys, selectedFieldData?.uniqueKeysByDataLevel, selectedDataLevel]);
   const showDataLevelFieldsTip = Boolean(
     selectedDataLevel && selectedFieldData?.uniqueKeysByDataLevel?.[selectedDataLevel]
   );

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
@@ -290,7 +290,7 @@ export function FieldsSelectionStep({
                   <span className='text-foreground font-medium'>{uniqueKeys.join(', ')}</span>{' '}
                   selected so rows merge correctly.
                 </p>
-                <p>Change Data Level in connector settings before selecting fields.</p>
+                <p>If needed, change Data Level in connector settings before selecting fields.</p>
               </div>
             </div>
           )}

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
@@ -19,6 +19,7 @@ import { ConnectorFieldSortOrder } from '../../../../shared/types';
 import { OpenIssueLink, StepperHeroBlock } from '../components';
 import type { ConnectorListItem } from '../../../../shared/model/types/connector';
 import { Unplug } from 'lucide-react';
+import { DATA_LEVEL_CONFIG_KEY } from '../../../../shared/constants/connector-config';
 
 interface FieldsSelectionStepProps {
   connector: ConnectorListItem;
@@ -51,7 +52,7 @@ export function FieldsSelectionStep({
     () => selectedFieldData?.fields ?? [],
     [selectedFieldData?.fields]
   );
-  const dataLevel = configuration?.DataLevel;
+  const dataLevel = configuration?.[DATA_LEVEL_CONFIG_KEY];
   const selectedDataLevel = typeof dataLevel === 'string' ? dataLevel : null;
   const uniqueKeys = useMemo(() => {
     if (selectedDataLevel && selectedFieldData?.uniqueKeysByDataLevel?.[selectedDataLevel]) {
@@ -59,10 +60,9 @@ export function FieldsSelectionStep({
     }
     return selectedFieldData?.uniqueKeys ?? [];
   }, [selectedFieldData, selectedDataLevel]);
-  const showDataLevelFieldsTip =
-    selectedDataLevel &&
-    (selectedField === 'ad_insights' || selectedField === 'ad_insights_by_country') &&
-    Boolean(selectedFieldData?.uniqueKeysByDataLevel?.[selectedDataLevel]);
+  const showDataLevelFieldsTip = Boolean(
+    selectedDataLevel && selectedFieldData?.uniqueKeysByDataLevel?.[selectedDataLevel]
+  );
 
   const originalIndexByName = useMemo(() => {
     const indexMap = new Map<string, number>();

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
@@ -1,5 +1,5 @@
 import type { ConnectorFieldsResponseApiDto } from '../../../../shared/api/types/response';
-import { Search, KeyRound, ArrowDownZA, ArrowUpAZ, ArrowUpDown, X } from 'lucide-react';
+import { Search, KeyRound, ArrowDownZA, ArrowUpAZ, ArrowUpDown, Info, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   AppWizardStepSection,
@@ -52,12 +52,17 @@ export function FieldsSelectionStep({
     [selectedFieldData?.fields]
   );
   const dataLevel = configuration?.DataLevel;
+  const selectedDataLevel = typeof dataLevel === 'string' ? dataLevel : null;
   const uniqueKeys = useMemo(() => {
-    if (typeof dataLevel === 'string' && selectedFieldData?.uniqueKeysByDataLevel?.[dataLevel]) {
-      return selectedFieldData.uniqueKeysByDataLevel[dataLevel];
+    if (selectedDataLevel && selectedFieldData?.uniqueKeysByDataLevel?.[selectedDataLevel]) {
+      return selectedFieldData.uniqueKeysByDataLevel[selectedDataLevel];
     }
     return selectedFieldData?.uniqueKeys ?? [];
-  }, [selectedFieldData, dataLevel]);
+  }, [selectedFieldData, selectedDataLevel]);
+  const showDataLevelFieldsTip =
+    selectedDataLevel &&
+    (selectedField === 'ad_insights' || selectedField === 'ad_insights_by_country') &&
+    Boolean(selectedFieldData?.uniqueKeysByDataLevel?.[selectedDataLevel]);
 
   const originalIndexByName = useMemo(() => {
     const indexMap = new Map<string, number>();
@@ -272,6 +277,24 @@ export function FieldsSelectionStep({
         <AppWizardStepSection
           title={`Selected ${String(selectedTotalCount)} of ${String(availableFieldNames.length)} fields for "${selectedField}" data`}
         >
+          {showDataLevelFieldsTip && (
+            <div className='border-border bg-muted/30 text-muted-foreground flex gap-3 rounded-md border px-3 py-2 text-sm'>
+              <Info className='mt-0.5 h-4 w-4 shrink-0' aria-hidden='true' />
+              <div className='space-y-1'>
+                <p>
+                  Required fields depend on Data Level. Current Data Level:{' '}
+                  <span className='text-foreground font-medium'>{selectedDataLevel}</span>.
+                </p>
+                <p>
+                  OWOX keeps{' '}
+                  <span className='text-foreground font-medium'>{uniqueKeys.join(', ')}</span>{' '}
+                  selected so rows merge correctly.
+                </p>
+                <p>Change Data Level in connector settings before selecting fields.</p>
+              </div>
+            </div>
+          )}
+
           <AppWizardStepCards>
             {filteredFields.map(field => {
               const isUniqueKey = uniqueKeys.includes(field.name);

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/FieldsSelectionStep.tsx
@@ -25,6 +25,7 @@ interface FieldsSelectionStepProps {
   connectorFields: ConnectorFieldsResponseApiDto[] | null;
   selectedField: string;
   selectedFields: string[];
+  configuration?: Record<string, unknown>;
   onFieldToggle: (fieldName: string, isChecked: boolean) => void;
   onSelectAllFields: (fieldNames: string[], isSelected: boolean) => void;
 }
@@ -34,6 +35,7 @@ export function FieldsSelectionStep({
   connectorFields,
   selectedField,
   selectedFields,
+  configuration,
   onFieldToggle,
   onSelectAllFields,
 }: FieldsSelectionStepProps) {
@@ -49,10 +51,13 @@ export function FieldsSelectionStep({
     () => selectedFieldData?.fields ?? [],
     [selectedFieldData?.fields]
   );
-  const uniqueKeys = useMemo(
-    () => selectedFieldData?.uniqueKeys ?? [],
-    [selectedFieldData?.uniqueKeys]
-  );
+  const dataLevel = configuration?.DataLevel;
+  const uniqueKeys = useMemo(() => {
+    if (typeof dataLevel === 'string' && selectedFieldData?.uniqueKeysByDataLevel?.[dataLevel]) {
+      return selectedFieldData.uniqueKeysByDataLevel[dataLevel];
+    }
+    return selectedFieldData?.uniqueKeys ?? [];
+  }, [selectedFieldData, dataLevel]);
 
   const originalIndexByName = useMemo(() => {
     const indexMap = new Map<string, number>();

--- a/apps/web/src/features/connectors/shared/api/types/response/connector.response.dto.ts
+++ b/apps/web/src/features/connectors/shared/api/types/response/connector.response.dto.ts
@@ -47,6 +47,7 @@ export interface ConnectorFieldsResponseApiDto {
   description?: string;
   documentation?: string;
   uniqueKeys?: string[];
+  uniqueKeysByDataLevel?: Record<string, string[]>;
   defaultFields?: string[];
   destinationName?: string;
   fields?: ConnectorFieldResponseApiDto[];

--- a/apps/web/src/features/connectors/shared/constants/connector-config.test.ts
+++ b/apps/web/src/features/connectors/shared/constants/connector-config.test.ts
@@ -1,0 +1,28 @@
+import { DATA_LEVEL_CONFIG_KEY, resolveEffectiveDataLevel } from './connector-config.ts';
+
+const spec = [{ name: DATA_LEVEL_CONFIG_KEY, default: 'AUCTION_AD' }];
+
+describe('resolveEffectiveDataLevel', () => {
+  it('prefers the value set in the configuration', () => {
+    expect(resolveEffectiveDataLevel({ DataLevel: 'AUCTION_ADVERTISER' }, spec)).toBe(
+      'AUCTION_ADVERTISER'
+    );
+  });
+
+  it('falls back to the spec default when the config omits Data Level', () => {
+    // The regression this guards: config form does not push an unchanged spec default into
+    // configuration, so leaving Data Level at its default leaves it absent here. Without the
+    // fallback, reconciliation would skip and a run defaulting to AUCTION_AD fails on ad_id.
+    expect(resolveEffectiveDataLevel({}, spec)).toBe('AUCTION_AD');
+  });
+
+  it('ignores a non-string configured value and uses the spec default', () => {
+    expect(resolveEffectiveDataLevel({ DataLevel: 123 }, spec)).toBe('AUCTION_AD');
+  });
+
+  it('returns undefined when neither config nor spec provides a string data level', () => {
+    expect(resolveEffectiveDataLevel({}, [])).toBeUndefined();
+    expect(resolveEffectiveDataLevel({}, null)).toBeUndefined();
+    expect(resolveEffectiveDataLevel({}, [{ name: DATA_LEVEL_CONFIG_KEY }])).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/connectors/shared/constants/connector-config.ts
+++ b/apps/web/src/features/connectors/shared/constants/connector-config.ts
@@ -5,3 +5,21 @@
  * following this convention gets the same field-pinning behavior for free.
  */
 export const DATA_LEVEL_CONFIG_KEY = 'DataLevel' as const;
+
+/**
+ * Resolve the Data Level the connector will actually run with. The config form does not
+ * push an unchanged spec default into the configuration object, so when the user leaves
+ * Data Level at its default it is absent from `configuration` — yet the connector still
+ * defaults to it at runtime. Fall back to the spec default so field reconciliation targets
+ * the same level the run will use. Returns undefined when no string data level applies.
+ */
+export function resolveEffectiveDataLevel(
+  configuration: Record<string, unknown>,
+  specification: readonly { name: string; default?: unknown }[] | null | undefined
+): string | undefined {
+  const configured = configuration[DATA_LEVEL_CONFIG_KEY];
+  if (typeof configured === 'string') return configured;
+
+  const specDefault = specification?.find(spec => spec.name === DATA_LEVEL_CONFIG_KEY)?.default;
+  return typeof specDefault === 'string' ? specDefault : undefined;
+}

--- a/apps/web/src/features/connectors/shared/constants/connector-config.ts
+++ b/apps/web/src/features/connectors/shared/constants/connector-config.ts
@@ -1,0 +1,7 @@
+/**
+ * Config field name a connector uses to select its reporting grain, when its
+ * unique-key fields vary by that value (see `uniqueKeysByDataLevel` in
+ * `ConnectorFieldsResponseApiDto`). Not tied to a specific connector — any connector
+ * following this convention gets the same field-pinning behavior for free.
+ */
+export const DATA_LEVEL_CONFIG_KEY = 'DataLevel' as const;

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
@@ -101,13 +101,21 @@ export function ConnectorDefinitionField({
         const updatedConfigurations = [...currentDefinition.connector.source.configuration];
         updatedConfigurations[configIndex] = connector.source.configuration[0] || {};
 
+        // connector.source.fields may add fields required by a changed config parameter
+        // (e.g. TikTok Ads Data Level). Union rather than overwrite so editing
+        // configuration can never drop previously selected fields, regardless of what
+        // triggered the update.
+        const updatedFields = Array.from(
+          new Set([...currentDefinition.connector.source.fields, ...connector.source.fields])
+        );
+
         const updatedDefinition: ConnectorDefinitionConfig = {
           connector: {
             ...currentDefinition.connector,
             source: {
               ...currentDefinition.connector.source,
               configuration: updatedConfigurations,
-              fields: connector.source.fields,
+              fields: updatedFields,
             },
           },
         };

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
@@ -213,14 +213,24 @@ export function ConnectorDefinitionField({
     }
   };
 
-  const addConfiguration = async (newConfig: Record<string, unknown>) => {
+  const addConfiguration = async (connector: ConnectorConfig) => {
     const currentValues = getValues();
     const currentDefinition = currentValues.definition as ConnectorDefinitionConfig;
 
     if (isConnectorDefinition(currentDefinition)) {
+      const newConfig = connector.source.configuration[0] || {};
+
+      // A new configuration can require fields the existing ones don't (e.g. a different
+      // TikTok Data Level). Union so all configurations sharing this destination have
+      // every required unique key; never drop previously selected fields.
+      const updatedFields = Array.from(
+        new Set([...currentDefinition.connector.source.fields, ...connector.source.fields])
+      );
+
       const updatedSource: ConnectorSourceConfig = {
         ...currentDefinition.connector.source,
         configuration: [...currentDefinition.connector.source.configuration, newConfig],
+        fields: updatedFields,
       };
 
       const updatedDefinition: ConnectorDefinitionConfig = {
@@ -274,7 +284,7 @@ export function ConnectorDefinitionField({
                       <div className='flex items-center gap-2'>
                         <AddConfigurationButton
                           storageType={storageType}
-                          onAddConfiguration={newConfig => void addConfiguration(newConfig)}
+                          onAddConfiguration={connector => void addConfiguration(connector)}
                           existingConnector={
                             isConnectorConfigured(field.value as ConnectorDefinitionConfig)
                               ? {

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/ConnectorDefinitionField.tsx
@@ -107,6 +107,7 @@ export function ConnectorDefinitionField({
             source: {
               ...currentDefinition.connector.source,
               configuration: updatedConfigurations,
+              fields: connector.source.fields,
             },
           },
         };

--- a/docs/getting-started/setup-guide/connector-data-mart.md
+++ b/docs/getting-started/setup-guide/connector-data-mart.md
@@ -39,6 +39,8 @@ Each connector has a set of required parameters. The most common ones include:
 
 📌 Some connectors may have additional parameters — see their setup guides.
 
+Some parameters use a fixed list of values. Choose these before moving to field selection, especially when the parameter changes the reporting grain. For example, TikTok Ads **Data Level** changes which fields are required for performance endpoints.
+
 ![Create Data Mart 4](../../res/screens/Connector-Based-DataMart-Connector-Config.png)
 
 ## Step 3: Add Access Credentials
@@ -69,7 +71,7 @@ Each connector includes one or more data nodes. For example, Facebook Ads has no
 
 👉 **Create a separate Data Mart for each node** you want to pull data from.
 
-Next, click **Select all** or select just the fields you want to store in your data warehouse.
+Next, click **Select all** or select just the fields you want to store in your data warehouse. Required unique-key fields stay selected because the connector needs them to merge data correctly. Some connectors adjust these required fields based on the parameters selected in the previous step.
 
 ![Create Data Mart 5](../../res/screens/Connector-Based-DataMart-Schema-Setup.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10282,7 +10282,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10299,7 +10298,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10316,7 +10314,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10333,7 +10330,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10350,7 +10346,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10367,7 +10362,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10384,7 +10378,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10401,7 +10394,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10418,7 +10410,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10435,7 +10426,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10452,7 +10442,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10469,7 +10458,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -37746,7 +37734,8 @@
         "fs-extra": "^11",
         "glob": "^13",
         "globals": "^16",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^4.1.8"
       }
     },
     "packages/connectors/node_modules/fs-extra": {

--- a/packages/connectors/CREATING_CONNECTOR.md
+++ b/packages/connectors/CREATING_CONNECTOR.md
@@ -152,6 +152,7 @@ Configuration parameters are defined in the Source constructor using `config.mer
 - `default` — default value if not provided
 - `label` — human-readable label for UI
 - `description` — detailed description for documentation
+- `options` — allowed values for a fixed-choice parameter; used by the UI to render a selector
 
 **Special Attributes:**
 
@@ -312,11 +313,37 @@ constructor(config) {
           type: 'numeric string'
         }
       },
+      uniqueKeys: ['field1'],
+      defaultFields: ['field2'],
+      destinationName: 'example_endpoint',
       limit: 100 // optional: pagination limit
     }
   };
 }
 ```
+
+`uniqueKeys` defines the fields used to merge rows into the destination. The field selector keeps these fields selected so users cannot create an invalid import schema.
+
+If a node's unique keys depend on the connector `DataLevel` configuration value, add `uniqueKeysByDataLevel` to the node schema returned by `getFieldsSchema()`:
+
+```javascript
+getFieldsSchema() {
+  const schema = super.getFieldsSchema();
+
+  schema['endpoint-name'] = {
+    ...schema['endpoint-name'],
+    uniqueKeysByDataLevel: {
+      DAILY: ['date'],
+      CAMPAIGN: ['campaign_id', 'date'],
+      AD: ['ad_id', 'date']
+    }
+  };
+
+  return schema;
+}
+```
+
+Keep runtime merge keys aligned with the schema. If you expose `uniqueKeysByDataLevel` for the UI, the connector should also choose the same keys when creating storage and validating requested fields.
 
 ## 6. Testing Your Connector
 

--- a/packages/connectors/CREATING_CONNECTOR.md
+++ b/packages/connectors/CREATING_CONNECTOR.md
@@ -152,7 +152,6 @@ Configuration parameters are defined in the Source constructor using `config.mer
 - `default` — default value if not provided
 - `label` — human-readable label for UI
 - `description` — detailed description for documentation
-- `options` — allowed values for a fixed-choice parameter; used by the UI to render a selector
 
 **Special Attributes:**
 
@@ -313,37 +312,11 @@ constructor(config) {
           type: 'numeric string'
         }
       },
-      uniqueKeys: ['field1'],
-      defaultFields: ['field2'],
-      destinationName: 'example_endpoint',
       limit: 100 // optional: pagination limit
     }
   };
 }
 ```
-
-`uniqueKeys` defines the fields used to merge rows into the destination. The field selector keeps these fields selected so users cannot create an invalid import schema.
-
-If a node's unique keys depend on the connector `DataLevel` configuration value, add `uniqueKeysByDataLevel` to the node schema returned by `getFieldsSchema()`:
-
-```javascript
-getFieldsSchema() {
-  const schema = super.getFieldsSchema();
-
-  schema['endpoint-name'] = {
-    ...schema['endpoint-name'],
-    uniqueKeysByDataLevel: {
-      DAILY: ['date'],
-      CAMPAIGN: ['campaign_id', 'date'],
-      AD: ['ad_id', 'date']
-    }
-  };
-
-  return schema;
-}
-```
-
-Keep runtime merge keys aligned with the schema. If you expose `uniqueKeysByDataLevel` for the UI, the connector should also choose the same keys when creating storage and validating requested fields.
 
 ## 6. Testing Your Connector
 

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -21,7 +21,8 @@
     "lint:md": "markdownlint-cli2 --config ../../.markdownlint-cli2.mjs",
     "lint:md:fix": "markdownlint-cli2 --config ../../.markdownlint-cli2.mjs --fix",
     "format": "prettier --write \"**/*.{js,mjs,json}\"",
-    "format:check": "prettier --check \"**/*.{js,mjs,json}\""
+    "format:check": "prettier --check \"**/*.{js,mjs,json}\"",
+    "test": "vitest run"
   },
   "files": [
     "dist/**/*.js",
@@ -57,6 +58,7 @@
     "fs-extra": "^11",
     "glob": "^13",
     "globals": "^16",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/connectors/src/Sources/TikTokAds/Connector.js
+++ b/packages/connectors/src/Sources/TikTokAds/Connector.js
@@ -227,7 +227,10 @@ var TikTokAdsConnector = class TikTokAdsConnector extends AbstractConnector {
         throw new Error(`Unique keys for '${nodeName}' are not defined in fields schema`);
       }
 
-      let uniqueFields = this.source.fieldsSchema[nodeName]["uniqueKeys"];
+      const dataLevel = (nodeName === 'ad_insights' || nodeName === 'ad_insights_by_country')
+        ? this.source.getValidatedDataLevel()
+        : null;
+      let uniqueFields = this.source.getUniqueKeysForNode(nodeName, dataLevel);
 
       // Create storage instance (Google Sheets is the default storage)
       this.storages[nodeName] = new globalThis[ this.storageName ](

--- a/packages/connectors/src/Sources/TikTokAds/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/TikTokAds/GETTING_STARTED.md
@@ -65,7 +65,7 @@ You can add any supported metrics to the required fields, but do not remove the 
 3. Specify the **dataset** where the data will be stored (or leave the default).  
 4. Click **Finish**, then **Publish Data Mart**.
 
-See [Data Level for Performance Nodes](README.md#data-level-for-performance-nodes) in the README for the full required-fields table per level.
+For the full required-fields table per level, see the **Data Level for Performance Nodes** section in [README](README.md).
 
 ![TikTok Ads Publish Data Mart](res/tiktok_ads_publish.png)
 

--- a/packages/connectors/src/Sources/TikTokAds/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/TikTokAds/GETTING_STARTED.md
@@ -23,7 +23,7 @@ Before proceeding, please make sure that:
    - **Access Token** – paste the token you generated earlier.  
    - **App ID** and **App Secret** – available in the **Basic Information** section of your TikTok app.  
    - **Advertiser ID** – paste the ID you received together with the access token, or retrieve it directly from [TikTok Ads Manager](https://ads.tiktok.com/).  
-4. Open **Advanced** settings if you need a performance reporting grain other than the default. **Data Level** applies to `ad_insights` and `ad_insights_by_country` and supports:
+4. Set **Data Level** if you need a performance reporting grain other than the default. It applies to `ad_insights` and `ad_insights_by_country` and supports:
    - `AUCTION_ADVERTISER`
    - `AUCTION_CAMPAIGN`
    - `AUCTION_ADGROUP`

--- a/packages/connectors/src/Sources/TikTokAds/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/TikTokAds/GETTING_STARTED.md
@@ -46,15 +46,17 @@ Before proceeding, please make sure that:
 
 Choose **Data Level** before selecting fields. For `ad_insights` and `ad_insights_by_country`, TikTok returns rows at the selected reporting grain, and OWOX pins the matching unique-key fields so rows can be merged correctly.
 
-Use `AUCTION_AD` when you need daily metrics per ad. Keep `ad_id` and `stat_time_day` selected.
+Use `AUCTION_AD` when you need daily metrics per ad. Keep `ad_id`, `stat_time_day`, and `advertiser_id` selected.
 
-Use `AUCTION_ADGROUP` when you need daily metrics per ad group. Keep `adgroup_id` and `stat_time_day` selected.
+Use `AUCTION_ADGROUP` when you need daily metrics per ad group. Keep `adgroup_id`, `stat_time_day`, and `advertiser_id` selected.
 
-Use `AUCTION_CAMPAIGN` when you need daily metrics per campaign. Keep `campaign_id` and `stat_time_day` selected.
+Use `AUCTION_CAMPAIGN` when you need daily metrics per campaign. Keep `campaign_id`, `stat_time_day`, and `advertiser_id` selected.
 
-Use `AUCTION_ADVERTISER` when you need advertiser-level daily totals. Keep `stat_time_day` selected.
+Use `AUCTION_ADVERTISER` when you need advertiser-level daily totals. Keep `stat_time_day` and `advertiser_id` selected.
 
 Use `ad_insights_by_country` when you also need a geographic breakdown. It follows the same **Data Level** grain and adds `country_code` to the required fields.
+
+`advertiser_id` is always required: if **Advertiser IDs** lists more than one advertiser, they write into the same destination table, and `advertiser_id` is what keeps their rows from merging into each other.
 
 You can add any supported metrics to the required fields, but do not remove the required fields from the schema. If you change **Data Level** after data has already been loaded, use a new Data Mart or destination table.
 
@@ -63,12 +65,7 @@ You can add any supported metrics to the required fields, but do not remove the 
 3. Specify the **dataset** where the data will be stored (or leave the default).  
 4. Click **Finish**, then **Publish Data Mart**.
 
-| Data Level | Required fields for `ad_insights` | Required fields for `ad_insights_by_country` |
-| --- | --- | --- |
-| `AUCTION_ADVERTISER` | `stat_time_day` | `stat_time_day`, `country_code` |
-| `AUCTION_CAMPAIGN` | `campaign_id`, `stat_time_day` | `campaign_id`, `stat_time_day`, `country_code` |
-| `AUCTION_ADGROUP` | `adgroup_id`, `stat_time_day` | `adgroup_id`, `stat_time_day`, `country_code` |
-| `AUCTION_AD` | `ad_id`, `stat_time_day` | `ad_id`, `stat_time_day`, `country_code` |
+See [Data Level for Performance Nodes](README.md#data-level-for-performance-nodes) in the README for the full required-fields table per level.
 
 ![TikTok Ads Publish Data Mart](res/tiktok_ads_publish.png)
 

--- a/packages/connectors/src/Sources/TikTokAds/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/TikTokAds/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 Before proceeding, please make sure that:
 
-- You have already created an **access token**, as described in [GETTING_STARTED.md](GETTING_STARTED.md).  
+- You have already created an **access token**, as described in [CREDENTIALS.md](CREDENTIALS.md).
 - You [have run **OWOX Data Marts**](https://docs.owox.com/docs/getting-started/quick-start/) and created at least one storage in the **Storages** section.  
 
 ![TikTok Storage](res/tiktok_storage.png)
@@ -23,7 +23,14 @@ Before proceeding, please make sure that:
    - **Access Token** – paste the token you generated earlier.  
    - **App ID** and **App Secret** – available in the **Basic Information** section of your TikTok app.  
    - **Advertiser ID** – paste the ID you received together with the access token, or retrieve it directly from [TikTok Ads Manager](https://ads.tiktok.com/).  
-4. Leave all other fields as default and proceed to the next step.  
+4. Open **Advanced** settings if you need a performance reporting grain other than the default. **Data Level** applies to `ad_insights` and `ad_insights_by_country` and supports:
+   - `AUCTION_ADVERTISER`
+   - `AUCTION_CAMPAIGN`
+   - `AUCTION_ADGROUP`
+   - `AUCTION_AD` (default)
+5. Leave the remaining fields as default and proceed to the next step.
+
+> If this connector has already loaded data, do not change **Data Level** for the same destination table. Create a new Data Mart or use a new destination table so records are merged with the correct unique keys.
 
 ![TikTok Input Source](res/tiktok_ads_connector.png)
 
@@ -35,10 +42,33 @@ Before proceeding, please make sure that:
 
 ## Configure Data Import
 
-1. Choose one of the available **endpoints**.  
-2. Select the required **fields**.  
+### Pair Data Level with Fields
+
+Choose **Data Level** before selecting fields. For `ad_insights` and `ad_insights_by_country`, TikTok returns rows at the selected reporting grain, and OWOX pins the matching unique-key fields so rows can be merged correctly.
+
+Use `AUCTION_AD` when you need daily metrics per ad. Keep `ad_id` and `stat_time_day` selected.
+
+Use `AUCTION_ADGROUP` when you need daily metrics per ad group. Keep `adgroup_id` and `stat_time_day` selected.
+
+Use `AUCTION_CAMPAIGN` when you need daily metrics per campaign. Keep `campaign_id` and `stat_time_day` selected.
+
+Use `AUCTION_ADVERTISER` when you need advertiser-level daily totals. Keep `stat_time_day` selected.
+
+Use `ad_insights_by_country` when you also need a geographic breakdown. It follows the same **Data Level** grain and adds `country_code` to the required fields.
+
+You can add any supported metrics to the required fields, but do not remove the required fields from the schema. If you change **Data Level** after data has already been loaded, use a new Data Mart or destination table.
+
+1. Choose one of the available **endpoints**. For performance reporting, use `ad_insights`; use `ad_insights_by_country` when you also need the `country_code` breakdown.
+2. Select the required **fields**. For performance endpoints, the required unique-key fields are pinned based on the **Data Level** value you selected during connector setup.
 3. Specify the **dataset** where the data will be stored (or leave the default).  
 4. Click **Finish**, then **Publish Data Mart**.
+
+| Data Level | Required fields for `ad_insights` | Required fields for `ad_insights_by_country` |
+| --- | --- | --- |
+| `AUCTION_ADVERTISER` | `stat_time_day` | `stat_time_day`, `country_code` |
+| `AUCTION_CAMPAIGN` | `campaign_id`, `stat_time_day` | `campaign_id`, `stat_time_day`, `country_code` |
+| `AUCTION_ADGROUP` | `adgroup_id`, `stat_time_day` | `adgroup_id`, `stat_time_day`, `country_code` |
+| `AUCTION_AD` | `ad_id`, `stat_time_day` | `ad_id`, `stat_time_day`, `country_code` |
 
 ![TikTok Ads Publish Data Mart](res/tiktok_ads_publish.png)
 

--- a/packages/connectors/src/Sources/TikTokAds/README.md
+++ b/packages/connectors/src/Sources/TikTokAds/README.md
@@ -6,6 +6,31 @@ The **TikTok Ads Source** allows you to transfer raw data from TikTok advertisin
 
 To begin, check out [**GETTING STARTED.md**](GETTING_STARTED.md) for step-by-step instructions.
 
+## Available Data
+
+| Node | Description | Destination table |
+| --- | --- | --- |
+| `advertiser` | Advertiser account details, including name, company, and currency. | `tiktok_ads_advertiser` |
+| `campaigns` | Campaign settings, status, budget, and schedule. | `tiktok_ads_campaigns` |
+| `ad_groups` | Ad group settings, bid strategy, optimization goal, placement, and targeting schedule. | `tiktok_ads_ad_groups` |
+| `ads` | Individual ad creatives, statuses, and campaign/ad group links. | `tiktok_ads_ads` |
+| `ad_insights` | Daily performance metrics at the selected TikTok Ads data level. | `tiktok_ads_ad_insights` |
+| `ad_insights_by_country` | Daily performance metrics at the selected TikTok Ads data level, broken down by country. | `tiktok_ads_ad_insights_by_country` |
+| `audiences` | Custom audiences, including type, size, validity status, and expiration. | `tiktok_ads_audiences` |
+
+## Data Level for Performance Nodes
+
+`Data Level` controls the reporting grain for `ad_insights` and `ad_insights_by_country`. The default is `AUCTION_AD`.
+
+| Data Level | `ad_insights` unique key fields | `ad_insights_by_country` unique key fields |
+| --- | --- | --- |
+| `AUCTION_ADVERTISER` | `stat_time_day` | `stat_time_day`, `country_code` |
+| `AUCTION_CAMPAIGN` | `campaign_id`, `stat_time_day` | `campaign_id`, `stat_time_day`, `country_code` |
+| `AUCTION_ADGROUP` | `adgroup_id`, `stat_time_day` | `adgroup_id`, `stat_time_day`, `country_code` |
+| `AUCTION_AD` | `ad_id`, `stat_time_day` | `ad_id`, `stat_time_day`, `country_code` |
+
+The field selector keeps the required unique-key fields selected for the chosen data level, so choose the data level before customizing fields. If a connector has already loaded data, changing `Data Level` can make new rows merge against a different key structure in the same destination table. Use a new Data Mart or destination table when changing the reporting grain.
+
 ## Table of Contents
 
 - [**GETTING STARTED**](GETTING_STARTED.md) – quick and easy setup guide.

--- a/packages/connectors/src/Sources/TikTokAds/README.md
+++ b/packages/connectors/src/Sources/TikTokAds/README.md
@@ -24,10 +24,12 @@ To begin, check out [**GETTING STARTED.md**](GETTING_STARTED.md) for step-by-ste
 
 | Data Level | `ad_insights` unique key fields | `ad_insights_by_country` unique key fields |
 | --- | --- | --- |
-| `AUCTION_ADVERTISER` | `stat_time_day` | `stat_time_day`, `country_code` |
-| `AUCTION_CAMPAIGN` | `campaign_id`, `stat_time_day` | `campaign_id`, `stat_time_day`, `country_code` |
-| `AUCTION_ADGROUP` | `adgroup_id`, `stat_time_day` | `adgroup_id`, `stat_time_day`, `country_code` |
-| `AUCTION_AD` | `ad_id`, `stat_time_day` | `ad_id`, `stat_time_day`, `country_code` |
+| `AUCTION_ADVERTISER` | `stat_time_day`, `advertiser_id` | `stat_time_day`, `country_code`, `advertiser_id` |
+| `AUCTION_CAMPAIGN` | `campaign_id`, `stat_time_day`, `advertiser_id` | `campaign_id`, `stat_time_day`, `country_code`, `advertiser_id` |
+| `AUCTION_ADGROUP` | `adgroup_id`, `stat_time_day`, `advertiser_id` | `adgroup_id`, `stat_time_day`, `country_code`, `advertiser_id` |
+| `AUCTION_AD` | `ad_id`, `stat_time_day`, `advertiser_id` | `ad_id`, `stat_time_day`, `country_code`, `advertiser_id` |
+
+`advertiser_id` is always a unique key: `AdvertiserIDs` can list several advertisers writing into the same destination table, and only `advertiser_id` tells their rows apart at `AUCTION_ADVERTISER`, which has no other per-advertiser dimension.
 
 The field selector keeps the required unique-key fields selected for the chosen data level, so choose the data level before customizing fields. If a connector has already loaded data, changing `Data Level` can make new rows merge against a different key structure in the same destination table. Use a new Data Mart or destination table when changing the reporting grain.
 

--- a/packages/connectors/src/Sources/TikTokAds/Source.js
+++ b/packages/connectors/src/Sources/TikTokAds/Source.js
@@ -362,7 +362,14 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
   }
 
   /**
-   * Get unique key fields for a node, accounting for data-level dependent dimensions
+   * Get unique key fields for a node, accounting for data-level dependent dimensions.
+   *
+   * advertiser_id is always included for the insights nodes: AdvertiserIDs can list
+   * several advertisers that all write into the same destination table (one storage
+   * instance is cached per node in Connector.js), and at AUCTION_ADVERTISER there is no
+   * other dimension to tell two advertisers' same-day rows apart, so the MERGE key would
+   * collide across advertisers without it. campaign_id/adgroup_id/ad_id are unique
+   * platform-wide, so this is a no-op (redundant-but-harmless) at the other data levels.
    *
    * @param {string} nodeName - The node name (e.g. ad_insights, ad_insights_by_country)
    * @param {string} dataLevel - The reporting data level (only relevant for insights nodes)
@@ -370,10 +377,11 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
    */
   getUniqueKeysForNode(nodeName, dataLevel) {
     if (nodeName === 'ad_insights') {
-      return this.getDimensionsForDataLevel(dataLevel);
+      return this.populateDimensions(this.getDimensionsForDataLevel(dataLevel), 'advertiser_id');
     }
     if (nodeName === 'ad_insights_by_country') {
-      return this.populateDimensions(this.getDimensionsForDataLevel(dataLevel), 'country_code');
+      const dimensions = this.populateDimensions(this.getDimensionsForDataLevel(dataLevel), 'country_code');
+      return this.populateDimensions(dimensions, 'advertiser_id');
     }
     return this.fieldsSchema[nodeName].uniqueKeys;
   }
@@ -381,28 +389,22 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
   /**
    * Get fields schema, adding a uniqueKeysByDataLevel map to insights nodes so the
    * config UI can pin the correct fields for whichever DataLevel the user picks
-   * (e.g. AUCTION_ADVERTISER doesn't require ad_id, only AUCTION_AD does).
+   * (e.g. AUCTION_ADVERTISER doesn't require ad_id, only AUCTION_AD does). Reuses
+   * getUniqueKeysForNode so the UI can never drift from the actual merge/validation keys.
    *
    * @return {object} - Fields schema, keyed by node name
    */
   getFieldsSchema() {
     const schema = super.getFieldsSchema();
 
-    const uniqueKeysByDataLevel = {};
-    for (const level of TIKTOK_ADS_DATA_LEVELS) {
-      uniqueKeysByDataLevel[level] = this.getDimensionsForDataLevel(level);
-    }
+    for (const nodeName of ['ad_insights', 'ad_insights_by_country']) {
+      if (!schema[nodeName]) continue;
 
-    if (schema.ad_insights) {
-      schema.ad_insights = { ...schema.ad_insights, uniqueKeysByDataLevel };
-    }
-
-    if (schema.ad_insights_by_country) {
-      const byCountryUniqueKeysByDataLevel = {};
+      const uniqueKeysByDataLevel = {};
       for (const level of TIKTOK_ADS_DATA_LEVELS) {
-        byCountryUniqueKeysByDataLevel[level] = this.populateDimensions(uniqueKeysByDataLevel[level], 'country_code');
+        uniqueKeysByDataLevel[level] = this.getUniqueKeysForNode(nodeName, level);
       }
-      schema.ad_insights_by_country = { ...schema.ad_insights_by_country, uniqueKeysByDataLevel: byCountryUniqueKeysByDataLevel };
+      schema[nodeName] = { ...schema[nodeName], uniqueKeysByDataLevel };
     }
 
     return schema;
@@ -442,11 +444,12 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
 
     // Validate that required unique fields are included
     if (this.fieldsSchema[nodeName].uniqueKeys) {
-      const nodeDataLevel = (nodeName === 'ad_insights' || nodeName === 'ad_insights_by_country')
-        ? this.getValidatedDataLevel()
-        : null;
+      const isInsightsNode = nodeName === 'ad_insights' || nodeName === 'ad_insights_by_country';
+      const nodeDataLevel = isInsightsNode ? this.getValidatedDataLevel() : null;
       const uniqueKeys = this.getUniqueKeysForNode(nodeName, nodeDataLevel);
-      const missingKeys = uniqueKeys.filter(key => !fields.includes(key));
+      const missingKeys = uniqueKeys.filter(
+        key => !(isInsightsNode && key === 'advertiser_id') && !fields.includes(key)
+      );
 
       if (missingKeys.length > 0) {
         throw new Error(`Missing required unique fields for endpoint '${nodeName}'. Missing fields: ${missingKeys.join(', ')}`);
@@ -657,19 +660,10 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
     // Filter out any extremely large fields or fields not in schema
     const processedRecord = {};
 
-    // First ensure uniqueKey fields are always included
-    if (schema[nodeName].uniqueKeys) {
-      for (const keyField of schema[nodeName].uniqueKeys) {
-        if (keyField in record) {
-          processedRecord[keyField] = record[keyField];
-        }
-        else if (keyField === 'advertiser_id' && nodeName === 'ad_insights') {
-          processedRecord['advertiser_id'] = this.currentAdvertiserId || '';
-        }
-      }
-    }
-
-    // Next add all other fields defined in the schema
+    // Add all fields defined in the schema. Every node's uniqueKeys are themselves schema
+    // fields (verified across advertiser/campaigns/ad_groups/ads/ad_insights*/audiences),
+    // and advertiser_id is force-set onto the record above for ad_insights/
+    // ad_insights_by_country/audiences, so no separate "ensure uniqueKeys" pass is needed.
     for (let field in schema[nodeName].fields) {
       if (field in record && !processedRecord[field]) {
         processedRecord[field] = record[field];

--- a/packages/connectors/src/Sources/TikTokAds/Source.js
+++ b/packages/connectors/src/Sources/TikTokAds/Source.js
@@ -105,7 +105,7 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
         requiredType: "string",
         default: "AUCTION_AD",
         label: "Data Level",
-        description: "Data level for ad_insights reports",
+        description: "Data level for ad_insights reports. Changing this on a connector that already has data can produce incorrect merges into the existing destination table — use a new destination if you change it.",
         options: TIKTOK_ADS_DATA_LEVELS,
         attributes: [CONFIG_ATTRIBUTES.ADVANCED]
       },

--- a/packages/connectors/src/Sources/TikTokAds/Source.js
+++ b/packages/connectors/src/Sources/TikTokAds/Source.js
@@ -105,9 +105,8 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
         requiredType: "string",
         default: "AUCTION_AD",
         label: "Data Level",
-        description: "Data level for ad_insights reports. Changing this on a connector that already has data can produce incorrect merges into the existing destination table — use a new destination if you change it.",
-        options: TIKTOK_ADS_DATA_LEVELS,
-        attributes: [CONFIG_ATTRIBUTES.ADVANCED]
+        description: "Data level for ad_insights reports. Switching levels after data exists can corrupt merges — use a new table in another Data Mart instead.",
+        options: TIKTOK_ADS_DATA_LEVELS
       },
       StartDate: {
         requiredType: "date",

--- a/packages/connectors/src/Sources/TikTokAds/Source.js
+++ b/packages/connectors/src/Sources/TikTokAds/Source.js
@@ -383,7 +383,7 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
       const dimensions = this.populateDimensions(this.getDimensionsForDataLevel(dataLevel), 'country_code');
       return this.populateDimensions(dimensions, 'advertiser_id');
     }
-    return this.fieldsSchema[nodeName].uniqueKeys;
+    return this.fieldsSchema[nodeName]?.uniqueKeys ?? [];
   }
 
   /**

--- a/packages/connectors/src/Sources/TikTokAds/Source.js
+++ b/packages/connectors/src/Sources/TikTokAds/Source.js
@@ -5,6 +5,8 @@
  * file that was distributed with this source code.
  */
 
+var TIKTOK_ADS_DATA_LEVELS = ["AUCTION_ADVERTISER", "AUCTION_CAMPAIGN", "AUCTION_ADGROUP", "AUCTION_AD"];
+
 var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
 
   constructor(config) {
@@ -103,7 +105,8 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
         requiredType: "string",
         default: "AUCTION_AD",
         label: "Data Level",
-        description: "Data level for ad_insights reports (AUCTION_ADVERTISER, AUCTION_CAMPAIGN, AUCTION_ADGROUP, AUCTION_AD)",
+        description: "Data level for ad_insights reports",
+        options: TIKTOK_ADS_DATA_LEVELS,
         attributes: [CONFIG_ATTRIBUTES.ADVANCED]
       },
       StartDate: {
@@ -311,8 +314,7 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
     let dataLevel = this.config.DataLevel && this.config.DataLevel.value ?
       this.config.DataLevel.value : "AUCTION_AD";
 
-    const validDataLevels = ["AUCTION_ADVERTISER", "AUCTION_CAMPAIGN", "AUCTION_ADGROUP", "AUCTION_AD"];
-    if (!validDataLevels.includes(dataLevel)) {
+    if (!TIKTOK_ADS_DATA_LEVELS.includes(dataLevel)) {
       this.config.logMessage(`Invalid data_level: ${dataLevel}. Using default AUCTION_AD.`);
       dataLevel = "AUCTION_AD";
     }
@@ -361,8 +363,55 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
   }
 
   /**
+   * Get unique key fields for a node, accounting for data-level dependent dimensions
+   *
+   * @param {string} nodeName - The node name (e.g. ad_insights, ad_insights_by_country)
+   * @param {string} dataLevel - The reporting data level (only relevant for insights nodes)
+   * @return {array} - Array of unique key fields
+   */
+  getUniqueKeysForNode(nodeName, dataLevel) {
+    if (nodeName === 'ad_insights') {
+      return this.getDimensionsForDataLevel(dataLevel);
+    }
+    if (nodeName === 'ad_insights_by_country') {
+      return this.populateDimensions(this.getDimensionsForDataLevel(dataLevel), 'country_code');
+    }
+    return this.fieldsSchema[nodeName].uniqueKeys;
+  }
+
+  /**
+   * Get fields schema, adding a uniqueKeysByDataLevel map to insights nodes so the
+   * config UI can pin the correct fields for whichever DataLevel the user picks
+   * (e.g. AUCTION_ADVERTISER doesn't require ad_id, only AUCTION_AD does).
+   *
+   * @return {object} - Fields schema, keyed by node name
+   */
+  getFieldsSchema() {
+    const schema = super.getFieldsSchema();
+
+    const uniqueKeysByDataLevel = {};
+    for (const level of TIKTOK_ADS_DATA_LEVELS) {
+      uniqueKeysByDataLevel[level] = this.getDimensionsForDataLevel(level);
+    }
+
+    if (schema.ad_insights) {
+      schema.ad_insights = { ...schema.ad_insights, uniqueKeysByDataLevel };
+    }
+
+    if (schema.ad_insights_by_country) {
+      const byCountryUniqueKeysByDataLevel = {};
+      for (const level of TIKTOK_ADS_DATA_LEVELS) {
+        byCountryUniqueKeysByDataLevel[level] = this.populateDimensions(uniqueKeysByDataLevel[level], 'country_code');
+      }
+      schema.ad_insights_by_country = { ...schema.ad_insights_by_country, uniqueKeysByDataLevel: byCountryUniqueKeysByDataLevel };
+    }
+
+    return schema;
+  }
+
+  /**
    * Filter and validate metrics for API request
-   * 
+   *
    * @param {array} filteredFields - All requested fields
    * @param {array} dimensions - Dimension fields to exclude
    * @param {array} validMetricsList - List of valid metrics
@@ -394,7 +443,10 @@ var TikTokAdsSource = class TikTokAdsSource extends AbstractSource {
 
     // Validate that required unique fields are included
     if (this.fieldsSchema[nodeName].uniqueKeys) {
-      const uniqueKeys = this.fieldsSchema[nodeName].uniqueKeys;
+      const nodeDataLevel = (nodeName === 'ad_insights' || nodeName === 'ad_insights_by_country')
+        ? this.getValidatedDataLevel()
+        : null;
+      const uniqueKeys = this.getUniqueKeysForNode(nodeName, nodeDataLevel);
       const missingKeys = uniqueKeys.filter(key => !fields.includes(key));
 
       if (missingKeys.length > 0) {

--- a/packages/connectors/src/Sources/TikTokAds/TikTokAdsAPIReference/TikTokAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/TikTokAds/TikTokAdsAPIReference/TikTokAdsFieldsSchema.js
@@ -47,7 +47,7 @@ var TikTokAdsFieldsSchema = {
     "description": "Daily ad performance — impressions, clicks, spend, conversions, video views, and engagement.",
     "documentation": "https://ads.tiktok.com/marketing_api/docs?id=1738864915188737",
     "fields": adInsightsFields,
-    "uniqueKeys": ["ad_id", "stat_time_day"],
+    "uniqueKeys": ["ad_id", "stat_time_day", "advertiser_id"],
     "defaultFields": ["advertiser_id", "date_start", "date_end", "impressions", "clicks", "spend"],
     "destinationName": "tiktok_ads_ad_insights",
     "isTimeSeries": true
@@ -57,7 +57,7 @@ var TikTokAdsFieldsSchema = {
     "description": "Daily ad performance broken down by country — impressions, clicks, spend, conversions, and video views.",
     "documentation": "https://ads.tiktok.com/marketing_api/docs?id=1738864915188737",
     "fields": adInsightsByCountryFields,
-    "uniqueKeys": ["ad_id", "stat_time_day", "country_code"],
+    "uniqueKeys": ["ad_id", "stat_time_day", "country_code", "advertiser_id"],
     "defaultFields": ["advertiser_id", "date_start", "date_end", "impressions", "clicks", "spend"],
     "destinationName": "tiktok_ads_ad_insights_by_country",
     "isTimeSeries": true

--- a/packages/connectors/test/Sources/TikTokAds/Source.test.js
+++ b/packages/connectors/test/Sources/TikTokAds/Source.test.js
@@ -145,6 +145,9 @@ describe('fetchData unique-key validation', () => {
           advertiser_id: {},
         },
       },
+      // Non-insights node so getUniqueKeysForNode's static fallback path stays exercisable
+      // if a future test targets a catalog node.
+      ads: { uniqueKeys: ['ad_id'], fields: { ad_id: {} } },
     },
     config: {},
     getValidatedDataLevel: () => 'AUCTION_AD',

--- a/packages/connectors/test/Sources/TikTokAds/Source.test.js
+++ b/packages/connectors/test/Sources/TikTokAds/Source.test.js
@@ -1,0 +1,195 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const coreSourcePath = path.join(__dirname, '../../../src/Core/AbstractSource.js');
+const sourcePath = path.join(__dirname, '../../../src/Sources/TikTokAds/Source.js');
+
+// Both files are GAS-style code (`var X = class X {...}`, no imports/exports).
+// Load the real AbstractSource first so TikTokAdsSource's `extends AbstractSource`
+// and `super.getFieldsSchema()` resolve against the actual implementation, not a
+// hand-copied stub that could drift from it. We never instantiate either class, so
+// constructor-only globals (CONFIG_ATTRIBUTES, etc.) never need to be real. Loaded at
+// module scope (not in beforeAll) so describe-body code below can use `proto` too —
+// describe callbacks run during collection, before any beforeAll hook fires.
+loadGasClass(coreSourcePath);
+loadGasClass(sourcePath);
+const proto = globalThis.TikTokAdsSource.prototype;
+
+describe('getDimensionsForDataLevel', () => {
+  it.each([
+    ['AUCTION_ADVERTISER', ['stat_time_day']],
+    ['AUCTION_CAMPAIGN', ['campaign_id', 'stat_time_day']],
+    ['AUCTION_ADGROUP', ['adgroup_id', 'stat_time_day']],
+    ['AUCTION_AD', ['ad_id', 'stat_time_day']],
+  ])('%s -> %j', (dataLevel, expected) => {
+    expect(proto.getDimensionsForDataLevel.call(null, dataLevel)).toEqual(expected);
+  });
+
+  it('falls back to AUCTION_AD dimensions for an unknown level', () => {
+    expect(proto.getDimensionsForDataLevel.call(null, 'NOT_A_LEVEL')).toEqual([
+      'ad_id',
+      'stat_time_day',
+    ]);
+  });
+});
+
+describe('getUniqueKeysForNode', () => {
+  const fakeSource = {
+    getDimensionsForDataLevel: proto.getDimensionsForDataLevel,
+    populateDimensions: proto.populateDimensions,
+    fieldsSchema: { ads: { uniqueKeys: ['ad_id'] } },
+  };
+  const uniqueKeysFor = (nodeName, dataLevel) =>
+    proto.getUniqueKeysForNode.call(fakeSource, nodeName, dataLevel);
+
+  // advertiser_id is always included: AdvertiserIDs can list several advertisers writing
+  // into the same destination table, and AUCTION_ADVERTISER has no other dimension to
+  // separate them, so the BigQuery MERGE key would collide across advertisers without it.
+  it('ad_insights drops ad_id but keeps advertiser_id at AUCTION_ADVERTISER', () => {
+    expect(uniqueKeysFor('ad_insights', 'AUCTION_ADVERTISER')).toEqual([
+      'stat_time_day',
+      'advertiser_id',
+    ]);
+  });
+
+  it('ad_insights keeps ad_id and advertiser_id at AUCTION_AD', () => {
+    expect(uniqueKeysFor('ad_insights', 'AUCTION_AD')).toEqual([
+      'ad_id',
+      'stat_time_day',
+      'advertiser_id',
+    ]);
+  });
+
+  it('ad_insights_by_country adds country_code and advertiser_id on top of the data-level dimensions', () => {
+    expect(uniqueKeysFor('ad_insights_by_country', 'AUCTION_ADVERTISER')).toEqual([
+      'stat_time_day',
+      'country_code',
+      'advertiser_id',
+    ]);
+    expect(uniqueKeysFor('ad_insights_by_country', 'AUCTION_CAMPAIGN')).toEqual([
+      'campaign_id',
+      'stat_time_day',
+      'country_code',
+      'advertiser_id',
+    ]);
+  });
+
+  it('falls back to the static schema uniqueKeys for non-insights nodes', () => {
+    expect(uniqueKeysFor('ads', null)).toEqual(['ad_id']);
+  });
+});
+
+describe('getFieldsSchema', () => {
+  const fakeSource = {
+    getDimensionsForDataLevel: proto.getDimensionsForDataLevel,
+    populateDimensions: proto.populateDimensions,
+    getUniqueKeysForNode: proto.getUniqueKeysForNode,
+    fieldsSchema: {
+      ads: { uniqueKeys: ['ad_id'], fields: { ad_id: {} } },
+      ad_insights: {
+        uniqueKeys: ['ad_id', 'stat_time_day', 'advertiser_id'],
+        fields: { ad_id: {}, stat_time_day: {}, advertiser_id: {} },
+      },
+      ad_insights_by_country: {
+        uniqueKeys: ['ad_id', 'stat_time_day', 'country_code', 'advertiser_id'],
+        fields: { ad_id: {}, stat_time_day: {}, country_code: {}, advertiser_id: {} },
+      },
+      catalog_only: {}, // no `fields` -> excluded by the base getFieldsSchema filter
+    },
+  };
+  const schema = () => proto.getFieldsSchema.call(fakeSource);
+
+  it('excludes nodes without a fields map, like the base implementation', () => {
+    expect(schema().catalog_only).toBeUndefined();
+  });
+
+  it('leaves non-insights nodes untouched', () => {
+    expect(schema().ads).toEqual({ uniqueKeys: ['ad_id'], fields: { ad_id: {} } });
+  });
+
+  it('attaches uniqueKeysByDataLevel for every data level on ad_insights, always including advertiser_id', () => {
+    expect(schema().ad_insights.uniqueKeysByDataLevel).toEqual({
+      AUCTION_ADVERTISER: ['stat_time_day', 'advertiser_id'],
+      AUCTION_CAMPAIGN: ['campaign_id', 'stat_time_day', 'advertiser_id'],
+      AUCTION_ADGROUP: ['adgroup_id', 'stat_time_day', 'advertiser_id'],
+      AUCTION_AD: ['ad_id', 'stat_time_day', 'advertiser_id'],
+    });
+  });
+
+  it('attaches country_code- and advertiser_id-inclusive uniqueKeysByDataLevel for ad_insights_by_country', () => {
+    expect(schema().ad_insights_by_country.uniqueKeysByDataLevel).toEqual({
+      AUCTION_ADVERTISER: ['stat_time_day', 'country_code', 'advertiser_id'],
+      AUCTION_CAMPAIGN: ['campaign_id', 'stat_time_day', 'country_code', 'advertiser_id'],
+      AUCTION_ADGROUP: ['adgroup_id', 'stat_time_day', 'country_code', 'advertiser_id'],
+      AUCTION_AD: ['ad_id', 'stat_time_day', 'country_code', 'advertiser_id'],
+    });
+  });
+
+  it('does not mutate the source fieldsSchema it read from', () => {
+    schema();
+    expect(fakeSource.fieldsSchema.ad_insights.uniqueKeysByDataLevel).toBeUndefined();
+  });
+});
+
+describe('fetchData unique-key validation', () => {
+  const createSource = () => ({
+    fieldsSchema: {
+      ad_insights: {
+        uniqueKeys: ['ad_id', 'stat_time_day', 'advertiser_id'],
+        fields: {
+          ad_id: {},
+          stat_time_day: {},
+          advertiser_id: {},
+        },
+      },
+    },
+    config: {},
+    getValidatedDataLevel: () => 'AUCTION_AD',
+    getUniqueKeysForNode: proto.getUniqueKeysForNode,
+    getDimensionsForDataLevel: proto.getDimensionsForDataLevel,
+    populateDimensions: proto.populateDimensions,
+    getFilteredMetrics: proto.getFilteredMetrics,
+    castFields: record => record,
+    _getAppId: () => '',
+    _getAccessToken: () => '',
+    _getAppSecret: () => '',
+  });
+
+  it('allows advertiser_id to be omitted because castFields injects it', async () => {
+    const originalProvider = globalThis.TiktokMarketingApiProvider;
+    globalThis.TiktokMarketingApiProvider = class {
+      getValidAdInsightsMetrics() {
+        return [];
+      }
+
+      async getAdInsights() {
+        return [];
+      }
+    };
+
+    try {
+      await expect(
+        proto.fetchData.call(createSource(), 'ad_insights', 'advertiser-1', [
+          'ad_id',
+          'stat_time_day',
+        ])
+      ).resolves.toHaveLength(0);
+    } finally {
+      globalThis.TiktokMarketingApiProvider = originalProvider;
+    }
+  });
+
+  it('still rejects unique keys that must be returned by the API', async () => {
+    await expect(
+      proto.fetchData.call(createSource(), 'ad_insights', 'advertiser-1', [
+        'stat_time_day',
+        'advertiser_id',
+      ])
+    ).rejects.toThrow(
+      "Missing required unique fields for endpoint 'ad_insights'. Missing fields: ad_id"
+    );
+  });
+});

--- a/packages/connectors/test/support/loadGasClass.js
+++ b/packages/connectors/test/support/loadGasClass.js
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import vm from 'vm';
+
+/**
+ * Loads a GAS-style source file (a `var X = class X extends Y {...}` script with
+ * no imports/exports) into the current realm so its class can be inspected in tests.
+ *
+ * Runs in `vm.runInThisContext` (not `vm.createContext`) so returned objects (arrays,
+ * etc.) share the real Array/Object prototypes — a separate vm context would produce
+ * cross-realm values that fail `toEqual`/`deepStrictEqual` even when structurally equal.
+ *
+ * @param {string} filePath - absolute path to the source file
+ * @param {Record<string, unknown>} globalsStub - globals the file's top-level code needs
+ *   (e.g. a minimal `AbstractSource` base class). Only values referenced before/without
+ *   instantiation need to be real; constructor-only globals (CONFIG_ATTRIBUTES, etc.) can
+ *   be omitted as long as tests don't call `new`.
+ * @return {unknown} whatever global the file's `var <Name> = class ...` declares — caller
+ *   must know the expected export name and read it off `globalThis` after calling this.
+ */
+export function loadGasClass(filePath, globalsStub = {}) {
+  for (const [key, value] of Object.entries(globalsStub)) {
+    globalThis[key] = value;
+  }
+  vm.runInThisContext(fs.readFileSync(filePath, 'utf8'), { filename: filePath });
+}

--- a/packages/connectors/vitest.config.js
+++ b/packages/connectors/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.js'],
+  },
+});


### PR DESCRIPTION
# Problem

TikTok Ads `ad_insights` and `ad_insights_by_country` always required `ad_id` + `stat_time_day` as unique keys, no matter which **Data Level** was selected. The field selector pinned `ad_id` and disabled its checkbox, so advertiser-, campaign-, and ad-group-level (date-only) reporting was impossible — even though the connector already sent the correct dimensions to TikTok for those levels. Any run at a non-ad level failed with `Missing required unique fields for endpoint 'ad_insights'. Missing fields: ad_id`. The root cause: the connector, the backend field-schema DTO, and the web field selector all read a single static `uniqueKeys` from the schema instead of one that varies by Data Level. Data Level also sat under Advanced settings, making the coupling easy to miss.

# Solution

The unique-key set for the insights nodes is now derived from the selected Data Level everywhere it matters, and that mapping is surfaced to the UI so it can pin the right fields.

- **Connector (`Source.js`, `Connector.js`)**: added `getUniqueKeysForNode(node, dataLevel)` as the single source of truth (advertiser→`stat_time_day`, campaign→`campaign_id,stat_time_day`, etc.), and overrode `getFieldsSchema()` to expose a `uniqueKeysByDataLevel` map. Storage creation and the fetch-time "missing required fields" guard now use these derived keys, so the destination key structure and the validation match the actual grain.
- **Backend**: threaded `uniqueKeysByDataLevel` through the zod field schema, the service mapper, the connector mapper, and the response DTO so the value survives every hop to the client.
- **Web**: the field selector pins the correct keys for the chosen Data Level (falling back to static keys for other connectors), shows an inline tip explaining the dependency, and unions the required keys into the saved field list on configuration-only edits. Data Level moved out of Advanced into the main settings as a dropdown, with a warning about changing grain on data that already exists.
- **Docs**: updated the TikTok README/GETTING_STARTED, the setup guide, and the connector-authoring guide.

Known trade-offs (documented, not enforced): changing Data Level on a destination that already has data can misalign merges because the table's primary key is fixed at creation while the merge key now varies — the field description and docs steer users to a new Data Mart instead. Config-only save is best-effort if the field schema has not finished loading.

# Changes

- Added `getUniqueKeysForNode` and a `getFieldsSchema` override exposing `uniqueKeysByDataLevel` in TikTok Ads `Source.js`
- Switched TikTok `Connector.js` storage creation and `Source.js` fetch validation to data-level-derived unique keys
- Made `DataLevel` a dropdown (via `options`), moved it out of Advanced settings, and rewrote its description to warn about changing grain on existing data
- Threaded `uniqueKeysByDataLevel` through the backend zod schema, `ConnectorService` mapper, `ConnectorMapper`, and web response DTO
- Updated `FieldsSelectionStep` to pin fields by selected Data Level and show an inline explanatory tip
- Unioned required fields into the saved field list on configuration-only edits in `ConnectorEditForm` and `ConnectorDefinitionField`
- Updated TikTok Ads `README.md` / `GETTING_STARTED.md`, the connector setup guide, and `CREATING_CONNECTOR.md`; fixed a broken self-link to point to `CREDENTIALS.md`

![Drop down list](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/6ae238ff-65a3-4a15-62a5-dd3c08444500/public)

![Note with current Data Level](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/442bde02-3677-4e06-056f-736aa2160d00/public)
