### PR TITLE
feat(data-marts): add Models canvas with storage-scoped relationship graph

### DIFF
--- a/.changeset/6659-model-canvas.md
+++ b/.changeset/6659-model-canvas.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Model canvas
+
+Add Models canvas: a project-level read-only visualization of the data marts visible to the user in a storage and their relationships, available from the new "Models" sidebar item under Data Marts. Includes filters by storage, status and relationships, search with highlighting, join-field labels on edges, node-avoiding edge routing, selectable layout directions, and directional (including bidirectional) join edges. Both the new canvas and the existing Joinable Data Marts graph are now rendered with React Flow (replacing Rete.js) while preserving their established graph styling and interactions.

--- a/apps/backend/src/data-marts/controllers/model-canvas.controller.ts
+++ b/apps/backend/src/data-marts/controllers/model-canvas.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Auth, AuthContext, AuthorizationContext, Role, Strategy } from '../../idp';
+import { GetModelCanvasDataMartsQueryApiDto } from '../dto/presentation/get-model-canvas-data-marts-query-api.dto';
+import { GetModelCanvasEdgesQueryApiDto } from '../dto/presentation/get-model-canvas-edges-query-api.dto';
+import {
+  ModelCanvasDataMartsResponseApiDto,
+  ModelCanvasEdgesResponseApiDto,
+} from '../dto/presentation/model-canvas-response-api.dto';
+import { ModelCanvasMapper } from '../mappers/model-canvas.mapper';
+import { GetModelCanvasDataMartsService } from '../use-cases/get-model-canvas-data-marts.service';
+import { GetModelCanvasEdgesService } from '../use-cases/get-model-canvas-edges.service';
+import { GetModelCanvasDataMartsSpec, GetModelCanvasEdgesSpec } from './spec/model-canvas.api';
+
+@Controller('model-canvas')
+@ApiTags('Model Canvas')
+export class ModelCanvasController {
+  constructor(
+    private readonly getModelCanvasDataMartsService: GetModelCanvasDataMartsService,
+    private readonly getModelCanvasEdgesService: GetModelCanvasEdgesService,
+    private readonly mapper: ModelCanvasMapper
+  ) {}
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get('data-marts')
+  @GetModelCanvasDataMartsSpec()
+  async getDataMarts(
+    @AuthContext() context: AuthorizationContext,
+    @Query() query: GetModelCanvasDataMartsQueryApiDto
+  ): Promise<ModelCanvasDataMartsResponseApiDto> {
+    const command = this.mapper.toDataMartsCommand(context, query);
+    const result = await this.getModelCanvasDataMartsService.run(command);
+    return this.mapper.toDataMartsResponse(result);
+  }
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get('edges')
+  @GetModelCanvasEdgesSpec()
+  async getEdges(
+    @AuthContext() context: AuthorizationContext,
+    @Query() query: GetModelCanvasEdgesQueryApiDto
+  ): Promise<ModelCanvasEdgesResponseApiDto> {
+    const command = this.mapper.toEdgesCommand(context, query.storageId);
+    return this.getModelCanvasEdgesService.run(command);
+  }
+}

--- a/apps/backend/src/data-marts/controllers/spec/model-canvas.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/model-canvas.api.ts
@@ -1,0 +1,30 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import {
+  ModelCanvasDataMartsResponseApiDto,
+  ModelCanvasEdgesResponseApiDto,
+} from '../../dto/presentation/model-canvas-response-api.dto';
+
+export function GetModelCanvasDataMartsSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Get a page of data marts of a storage for the project data model canvas',
+    }),
+    ApiOkResponse({
+      description: 'Data marts are access-filtered like the data mart list',
+      type: ModelCanvasDataMartsResponseApiDto,
+    })
+  );
+}
+
+export function GetModelCanvasEdgesSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Get the relationships between visible data marts of a storage for the model canvas',
+    }),
+    ApiOkResponse({
+      description: 'Edges reference only data marts visible to the current user',
+      type: ModelCanvasEdgesResponseApiDto,
+    })
+  );
+}

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -407,6 +407,10 @@ import { UpdateProjectMemberApiKeyService } from './use-cases/project-member-api
 import { RevokeProjectMemberApiKeyService } from './use-cases/project-member-api-keys/revoke-project-member-api-key.service';
 import { ProjectMemberApiKeysMapper } from './mappers/project-member-api-keys.mapper';
 import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-member-api-keys.module';
+import { ModelCanvasController } from './controllers/model-canvas.controller';
+import { ModelCanvasMapper } from './mappers/model-canvas.mapper';
+import { GetModelCanvasDataMartsService } from './use-cases/get-model-canvas-data-marts.service';
+import { GetModelCanvasEdgesService } from './use-cases/get-model-canvas-edges.service';
 
 @Module({
   imports: [
@@ -495,6 +499,7 @@ import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-m
     LegacyDataMartsSyncController,
     ProjectSetupProgressController,
     DataMartRelationshipController,
+    ModelCanvasController,
     DataStorageRelationshipController,
     ContextController,
     ProjectMembersController,
@@ -514,6 +519,8 @@ import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-m
     McpDataCatalogSummaryService,
     CreateDataMartService,
     ListDataMartsService,
+    GetModelCanvasDataMartsService,
+    GetModelCanvasEdgesService,
     QueryDataMartService,
     SummarizeMcpDataCatalogService,
     {
@@ -789,6 +796,7 @@ import { ProjectMemberApiKeysModule } from '../project-member-api-keys/project-m
     ReportSqlComposerService,
     ReportTotalsService,
     RelationshipMapper,
+    ModelCanvasMapper,
     McpDataCatalogSummaryMapper,
     CreateDataMartRelationshipService,
     UpdateDataMartRelationshipService,

--- a/apps/backend/src/data-marts/dto/domain/get-model-canvas-data-marts.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/get-model-canvas-data-marts.command.ts
@@ -1,0 +1,9 @@
+export class GetModelCanvasDataMartsCommand {
+  constructor(
+    public readonly projectId: string,
+    public readonly userId: string,
+    public readonly roles: string[],
+    public readonly storageId: string,
+    public readonly offset?: number
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/get-model-canvas-edges.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/get-model-canvas-edges.command.ts
@@ -1,0 +1,8 @@
+export class GetModelCanvasEdgesCommand {
+  constructor(
+    public readonly projectId: string,
+    public readonly userId: string,
+    public readonly roles: string[],
+    public readonly storageId: string
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/model-canvas.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/model-canvas.dto.ts
@@ -1,0 +1,20 @@
+import { DataMartStatus } from '../../enums/data-mart-status.enum';
+import { DataMartRelationshipGraphEdgeDto } from './data-mart-relationship-graph-edge.dto';
+
+export interface ModelCanvasNodeDto {
+  id: string;
+  title: string;
+  status: DataMartStatus;
+  description: string | null;
+  fieldCount: number;
+}
+
+export interface ModelCanvasDataMartsDto {
+  items: ModelCanvasNodeDto[];
+  total: number;
+  offset: number;
+}
+
+export interface ModelCanvasEdgesDto {
+  edges: DataMartRelationshipGraphEdgeDto[];
+}

--- a/apps/backend/src/data-marts/dto/presentation/get-model-canvas-data-marts-query-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/get-model-canvas-data-marts-query-api.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsUUID, Min } from 'class-validator';
+
+export class GetModelCanvasDataMartsQueryApiDto {
+  @ApiProperty({ description: 'Data storage ID scoping the canvas' })
+  @IsUUID()
+  storageId: string;
+
+  @ApiPropertyOptional({
+    description: 'Number of data marts to skip before returning results',
+    default: 0,
+    minimum: 0,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  offset?: number;
+}

--- a/apps/backend/src/data-marts/dto/presentation/get-model-canvas-edges-query-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/get-model-canvas-edges-query-api.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class GetModelCanvasEdgesQueryApiDto {
+  @ApiProperty({ description: 'Data storage ID scoping the canvas' })
+  @IsUUID()
+  storageId: string;
+}

--- a/apps/backend/src/data-marts/dto/presentation/model-canvas-response-api.dto.spec.ts
+++ b/apps/backend/src/data-marts/dto/presentation/model-canvas-response-api.dto.spec.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Module } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ApiOkResponse, DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { ModelCanvasDataMartsResponseApiDto } from './model-canvas-response-api.dto';
+
+@Controller('model-canvas-schema-test')
+class ModelCanvasSchemaTestController {
+  @Get()
+  @ApiOkResponse({ type: ModelCanvasDataMartsResponseApiDto })
+  getResponse(): ModelCanvasDataMartsResponseApiDto {
+    throw new Error('Schema-only test controller');
+  }
+}
+
+@Module({ controllers: [ModelCanvasSchemaTestController] })
+class ModelCanvasSchemaTestModule {}
+
+describe('Model Canvas OpenAPI response schema', () => {
+  it('describes nullable scalar fields as their scalar OpenAPI types', async () => {
+    const testingModule = await Test.createTestingModule({
+      imports: [ModelCanvasSchemaTestModule],
+    }).compile();
+    const app = testingModule.createNestApplication();
+    const document = SwaggerModule.createDocument(app, new DocumentBuilder().build());
+    await app.close();
+
+    expect(document.components?.schemas).toMatchObject({
+      ModelCanvasNodeApiDto: {
+        properties: {
+          description: { type: 'string', nullable: true },
+        },
+      },
+      ModelCanvasDataMartsResponseApiDto: {
+        properties: {
+          nextOffset: { type: 'number', nullable: true },
+        },
+      },
+    });
+  });
+});

--- a/apps/backend/src/data-marts/dto/presentation/model-canvas-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/model-canvas-response-api.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { DataMartStatus } from '../../enums/data-mart-status.enum';
+
+export class ModelCanvasNodeApiDto {
+  @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
+  id: string;
+
+  @ApiProperty({ example: 'Orders' })
+  title: string;
+
+  @ApiProperty({ enum: DataMartStatus, example: DataMartStatus.PUBLISHED })
+  status: DataMartStatus;
+
+  @ApiProperty({ type: String, example: 'All orders enriched with customer data', nullable: true })
+  description: string | null;
+
+  @ApiProperty({ example: 12, description: 'Number of fields in the output schema' })
+  fieldCount: number;
+}
+
+export class ModelCanvasJoinConditionApiDto {
+  @ApiProperty({ example: 'customer_id' })
+  sourceFieldName: string;
+
+  @ApiProperty({ example: 'id' })
+  targetFieldName: string;
+}
+
+export class ModelCanvasEdgeApiDto {
+  @ApiProperty({ example: '2f6c1f88-0000-4a5a-8b12-abcdef123456' })
+  id: string;
+
+  @ApiProperty({ example: '9cabc24e-1234-4a5a-8b12-abcdef123456' })
+  sourceDataMartId: string;
+
+  @ApiProperty({ example: '7b1de930-5678-4c3b-9d34-fedcba654321' })
+  targetDataMartId: string;
+
+  @ApiProperty({ type: [ModelCanvasJoinConditionApiDto] })
+  joinConditions: ModelCanvasJoinConditionApiDto[];
+}
+
+export class ModelCanvasDataMartsResponseApiDto {
+  @ApiProperty({ type: [ModelCanvasNodeApiDto] })
+  items: ModelCanvasNodeApiDto[];
+
+  @ApiProperty({ example: 120 })
+  total: number;
+
+  @ApiProperty({
+    type: Number,
+    example: 50,
+    nullable: true,
+    description: 'Next offset to fetch, null if no more data',
+  })
+  nextOffset: number | null;
+}
+
+export class ModelCanvasEdgesResponseApiDto {
+  @ApiProperty({ type: [ModelCanvasEdgeApiDto] })
+  edges: ModelCanvasEdgeApiDto[];
+}

--- a/apps/backend/src/data-marts/mappers/model-canvas.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/model-canvas.mapper.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { AuthorizationContext } from '../../idp';
+import { GetModelCanvasDataMartsCommand } from '../dto/domain/get-model-canvas-data-marts.command';
+import { GetModelCanvasEdgesCommand } from '../dto/domain/get-model-canvas-edges.command';
+import { ModelCanvasDataMartsDto, ModelCanvasNodeDto } from '../dto/domain/model-canvas.dto';
+import { GetModelCanvasDataMartsQueryApiDto } from '../dto/presentation/get-model-canvas-data-marts-query-api.dto';
+import { ModelCanvasDataMartsResponseApiDto } from '../dto/presentation/model-canvas-response-api.dto';
+import { DataMart } from '../entities/data-mart.entity';
+
+@Injectable()
+export class ModelCanvasMapper {
+  toDataMartsCommand(
+    context: AuthorizationContext,
+    query: GetModelCanvasDataMartsQueryApiDto
+  ): GetModelCanvasDataMartsCommand {
+    return new GetModelCanvasDataMartsCommand(
+      context.projectId,
+      context.userId,
+      context.roles ?? [],
+      query.storageId,
+      query.offset
+    );
+  }
+
+  toEdgesCommand(context: AuthorizationContext, storageId: string): GetModelCanvasEdgesCommand {
+    return new GetModelCanvasEdgesCommand(
+      context.projectId,
+      context.userId,
+      context.roles ?? [],
+      storageId
+    );
+  }
+
+  toNodeDto(dataMart: DataMart): ModelCanvasNodeDto {
+    return {
+      id: dataMart.id,
+      title: dataMart.title,
+      status: dataMart.status,
+      description: dataMart.description ?? null,
+      fieldCount: dataMart.schema?.fields?.length ?? 0,
+    };
+  }
+
+  toDataMartsDto(dataMarts: DataMart[], total: number, offset: number): ModelCanvasDataMartsDto {
+    return {
+      items: dataMarts.map(dataMart => this.toNodeDto(dataMart)),
+      total,
+      offset,
+    };
+  }
+
+  toDataMartsResponse(dto: ModelCanvasDataMartsDto): ModelCanvasDataMartsResponseApiDto {
+    const nextOffset = dto.offset + dto.items.length;
+    return {
+      items: dto.items,
+      total: dto.total,
+      nextOffset: nextOffset < dto.total ? nextOffset : null,
+    };
+  }
+}

--- a/apps/backend/src/data-marts/repositories/data-mart-relationship.repository.spec.ts
+++ b/apps/backend/src/data-marts/repositories/data-mart-relationship.repository.spec.ts
@@ -68,4 +68,23 @@ describe('DataMartRelationshipRepository', () => {
 
     expect(repository.createQueryBuilder).not.toHaveBeenCalled();
   });
+
+  it('scopes storage graph rows by project and storage', async () => {
+    const qb = createQueryBuilder();
+    const repository = {
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    } as unknown as jest.Mocked<Repository<DataMartRelationship>>;
+    const graphRepository = new DataMartRelationshipRepository(repository);
+
+    await graphRepository.listGraphEdgeRowsByProjectIdAndStorageId('project-1', 'storage-1');
+
+    expect(qb.where).toHaveBeenCalledWith('relationship.projectId = :projectId', {
+      projectId: 'project-1',
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith('relationship.dataStorage = :storageId', {
+      storageId: 'storage-1',
+    });
+    expect(qb.orderBy).toHaveBeenCalledWith('relationship.createdAt', 'ASC');
+    expect(qb.getRawMany).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/backend/src/data-marts/repositories/data-mart-relationship.repository.ts
+++ b/apps/backend/src/data-marts/repositories/data-mart-relationship.repository.ts
@@ -23,6 +23,21 @@ export class DataMartRelationshipRepository {
   ): Promise<DataMartRelationshipGraphEdgeRow[]> {
     if (sourceDataMartIds.length === 0) return [];
 
+    return this.buildGraphEdgeRowsQuery(projectId)
+      .andWhere('source.id IN (:...sourceDataMartIds)', { sourceDataMartIds })
+      .getRawMany<DataMartRelationshipGraphEdgeRow>();
+  }
+
+  async listGraphEdgeRowsByProjectIdAndStorageId(
+    projectId: string,
+    storageId: string
+  ): Promise<DataMartRelationshipGraphEdgeRow[]> {
+    return this.buildGraphEdgeRowsQuery(projectId)
+      .andWhere('relationship.dataStorage = :storageId', { storageId })
+      .getRawMany<DataMartRelationshipGraphEdgeRow>();
+  }
+
+  private buildGraphEdgeRowsQuery(projectId: string) {
     return this.repository
       .createQueryBuilder('relationship')
       .select('relationship.id', 'id')
@@ -32,8 +47,6 @@ export class DataMartRelationshipRepository {
       .innerJoin('relationship.sourceDataMart', 'source')
       .innerJoin('relationship.targetDataMart', 'target')
       .where('relationship.projectId = :projectId', { projectId })
-      .andWhere('source.id IN (:...sourceDataMartIds)', { sourceDataMartIds })
-      .orderBy('relationship.createdAt', 'ASC')
-      .getRawMany<DataMartRelationshipGraphEdgeRow>();
+      .orderBy('relationship.createdAt', 'ASC');
   }
 }

--- a/apps/backend/src/data-marts/services/data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-relationship.service.ts
@@ -66,6 +66,18 @@ export class DataMartRelationshipService {
     return rows.map(row => this.mapper.toGraphEdgeDto(row));
   }
 
+  async findGraphEdgesByStorageId(
+    storageId: string,
+    projectId: string
+  ): Promise<DataMartRelationshipGraphEdgeDto[]> {
+    const rows = await this.relationshipRepository.listGraphEdgeRowsByProjectIdAndStorageId(
+      projectId,
+      storageId
+    );
+
+    return rows.map(row => this.mapper.toGraphEdgeDto(row));
+  }
+
   async findSourceDataMartIdsByTargetDataMartId(
     targetDataMartId: string,
     projectId: string

--- a/apps/backend/src/data-marts/services/data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart.service.spec.ts
@@ -1,6 +1,9 @@
 import { DataMartService } from './data-mart.service';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import type { DataMart } from '../entities/data-mart.entity';
+import { DataSource, EntitySchema, type Repository } from 'typeorm';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
+import { RoleScope } from '../enums/role-scope.enum';
 
 function makeDataMart(overrides: Partial<DataMart> = {}): DataMart {
   return {
@@ -84,3 +87,161 @@ describe('DataMartService schema actualization', () => {
     warnSpy.mockRestore();
   });
 });
+
+const canvasDataMartSchema = new EntitySchema<DataMart>({
+  name: 'CanvasDataMart',
+  tableName: 'data_mart',
+  columns: {
+    id: { type: String, primary: true },
+    title: { type: String },
+    projectId: { type: String },
+    storage: { name: 'storageId', type: String },
+    schema: { type: 'simple-json', nullable: true },
+    status: { type: String },
+    description: { type: String, nullable: true },
+    availableForReporting: { type: Boolean, default: false },
+    availableForMaintenance: { type: Boolean, default: false },
+    deletedAt: { type: Date, nullable: true, deleteDate: true },
+  },
+});
+
+describe('DataMartService canvas visibility queries', () => {
+  let dataSource: DataSource;
+  let repository: Repository<DataMart>;
+  let service: DataMartService;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'better-sqlite3',
+      database: ':memory:',
+      entities: [canvasDataMartSchema],
+      synchronize: true,
+      logging: false,
+    });
+    await dataSource.initialize();
+    repository = dataSource.getRepository<DataMart>('CanvasDataMart');
+    service = new DataMartService(repository, null as never, null as never, null as never);
+
+    await createCanvasVisibilityTables(dataSource);
+    await seedCanvasDataMarts(repository, dataSource);
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('applies project, storage, soft-delete, ownership, sharing, context, count, and ordering', async () => {
+    const result = await service.findByProjectIdAndStorageIdForCanvas('project-1', 'storage-1', {
+      userId: 'viewer-1',
+      roles: ['viewer'],
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+      limit: 1,
+      offset: 1,
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.items.map(item => item.id)).toEqual(['shared-context']);
+  });
+
+  it('gives editors maintenance visibility while admins bypass the ownership/share gate', async () => {
+    const editor = await service.findByProjectIdAndStorageIdForCanvas('project-1', 'storage-1', {
+      userId: 'editor-1',
+      roles: ['editor'],
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+    });
+    const admin = await service.findByProjectIdAndStorageIdForCanvas('project-1', 'storage-1', {
+      userId: 'admin-1',
+      roles: ['admin'],
+      roleScope: RoleScope.ENTIRE_PROJECT,
+    });
+
+    expect(editor.items.map(item => item.id)).toEqual([
+      'owned',
+      'shared-context',
+      'maintenance-context',
+    ]);
+    expect(admin.items.map(item => item.id)).toEqual([
+      'owned',
+      'shared-context',
+      'maintenance-context',
+      'shared-other-context',
+    ]);
+  });
+
+  it('uses the same scoped visibility gate when selecting edge endpoint IDs', async () => {
+    const ids = await service.findVisibleIdsByProjectIdAndStorageId('project-1', 'storage-1', {
+      userId: 'viewer-1',
+      roles: ['viewer'],
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+    });
+
+    expect(new Set(ids)).toEqual(new Set(['owned', 'shared-context']));
+  });
+});
+
+async function createCanvasVisibilityTables(dataSource: DataSource): Promise<void> {
+  await dataSource.query(
+    'CREATE TABLE data_mart_technical_owners (data_mart_id varchar, user_id varchar)'
+  );
+  await dataSource.query(
+    'CREATE TABLE data_mart_business_owners (data_mart_id varchar, user_id varchar)'
+  );
+  await dataSource.query(
+    'CREATE TABLE data_mart_contexts (data_mart_id varchar, context_id varchar)'
+  );
+  await dataSource.query(
+    'CREATE TABLE member_role_contexts (user_id varchar, project_id varchar, context_id varchar)'
+  );
+  await dataSource.query('CREATE TABLE context (id varchar PRIMARY KEY, deletedAt datetime)');
+}
+
+async function seedCanvasDataMarts(
+  repository: Repository<DataMart>,
+  dataSource: DataSource
+): Promise<void> {
+  const rows = [
+    canvasRow('owned', 'Alpha'),
+    canvasRow('shared-context', 'Beta', { availableForReporting: true }),
+    canvasRow('maintenance-context', 'Delta', { availableForMaintenance: true }),
+    canvasRow('shared-other-context', 'Gamma', { availableForReporting: true }),
+    canvasRow('deleted', 'Deleted', { availableForReporting: true, deletedAt: new Date() }),
+    canvasRow('other-storage', 'Other storage', {
+      storage: 'storage-2' as unknown as DataMart['storage'],
+      availableForReporting: true,
+    }),
+    canvasRow('other-project', 'Other project', {
+      projectId: 'project-2',
+      availableForReporting: true,
+    }),
+  ];
+  await repository.insert(rows);
+
+  await dataSource.query(
+    "INSERT INTO data_mart_technical_owners (data_mart_id, user_id) VALUES ('owned', 'viewer-1'), ('owned', 'editor-1')"
+  );
+  await dataSource.query(
+    "INSERT INTO context (id, deletedAt) VALUES ('context-1', NULL), ('context-2', NULL)"
+  );
+  await dataSource.query(
+    "INSERT INTO member_role_contexts (user_id, project_id, context_id) VALUES ('viewer-1', 'project-1', 'context-1'), ('editor-1', 'project-1', 'context-1')"
+  );
+  await dataSource.query(
+    "INSERT INTO data_mart_contexts (data_mart_id, context_id) VALUES ('shared-context', 'context-1'), ('maintenance-context', 'context-1'), ('shared-other-context', 'context-2')"
+  );
+}
+
+function canvasRow(id: string, title: string, overrides: Partial<DataMart> = {}): DataMart {
+  return {
+    id,
+    title,
+    projectId: 'project-1',
+    storage: 'storage-1' as unknown as DataMart['storage'],
+    schema: { fields: [{ name: `${id}-field` }] },
+    status: DataMartStatus.PUBLISHED,
+    description: null,
+    availableForReporting: false,
+    availableForMaintenance: false,
+    deletedAt: null,
+    ...overrides,
+  } as unknown as DataMart;
+}

--- a/apps/backend/src/data-marts/services/data-mart.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import { DataMartSchemaMergerFacade } from '../data-storage-types/facades/data-mart-schema-merger.facade';
 import { DataMartSchemaProviderFacade } from '../data-storage-types/facades/data-mart-schema-provider.facade';
 import { DataMartDefinitionSchema } from '../dto/schemas/data-mart-table-definitions/data-mart-definition.schema';
@@ -10,7 +10,7 @@ import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum'
 import { DataMartStatus } from '../enums/data-mart-status.enum';
 import { OwnerFilter } from '../enums/owner-filter.enum';
 import { RoleScope } from '../enums/role-scope.enum';
-import { buildContextGateSql } from '../utils/build-context-gate-sql';
+import { applyDataMartVisibilityFilter } from '../utils/apply-data-mart-visibility-filter';
 import { DataMartSearchIndexInvalidationService } from './data-mart-search-index-invalidation.service';
 
 @Injectable()
@@ -105,37 +105,7 @@ export class DataMartService {
       .where('dm.projectId = :projectId', { projectId })
       .andWhere('dm.deletedAt IS NULL');
 
-    // Access filtering: non-admin sees only owned + shared
-    const isAdmin = options?.roles?.includes('admin');
-    if (!isAdmin && options?.userId) {
-      const isTu = options.roles?.includes('editor');
-      const roleScope: RoleScope = options?.roleScope ?? RoleScope.ENTIRE_PROJECT;
-      const contextGate = buildContextGateSql({
-        joinTable: 'data_mart_contexts',
-        entityIdColumn: 'data_mart_id',
-        entityAlias: 'dm',
-      });
-      const sharedClause = isTu
-        ? `(dm.availableForReporting = :isTrue OR dm.availableForMaintenance = :isTrue)`
-        : `dm.availableForReporting = :isTrue`;
-      qb.andWhere(
-        `(
-          EXISTS (SELECT 1 FROM data_mart_technical_owners t WHERE t.data_mart_id = dm.id AND t.user_id = :userId)
-          OR EXISTS (SELECT 1 FROM data_mart_business_owners b WHERE b.data_mart_id = dm.id AND b.user_id = :userId)
-          OR (
-            ${sharedClause}
-            AND ${contextGate}
-          )
-        )`,
-        {
-          userId: options.userId,
-          isTrue: true,
-          roleScope,
-          entireProjectScope: RoleScope.ENTIRE_PROJECT,
-          projectId,
-        }
-      );
-    }
+    this.applyNonAdminVisibilityGate(qb, projectId, options);
 
     if (options?.ownerFilter === OwnerFilter.HAS_OWNERS) {
       qb.andWhere(
@@ -191,6 +161,72 @@ export class DataMartService {
       return item;
     });
     return { items, total };
+  }
+
+  private applyNonAdminVisibilityGate(
+    qb: SelectQueryBuilder<DataMart>,
+    projectId: string,
+    options?: { userId?: string; roles?: string[]; roleScope?: RoleScope }
+  ): void {
+    applyDataMartVisibilityFilter(qb, {
+      dataMartAlias: 'dm',
+      projectId,
+      userId: options?.userId,
+      roles: options?.roles,
+      roleScope: options?.roleScope,
+    });
+  }
+
+  private buildCanvasVisibleDataMartsQuery(
+    projectId: string,
+    storageId: string,
+    options?: { userId?: string; roles?: string[]; roleScope?: RoleScope }
+  ): SelectQueryBuilder<DataMart> {
+    const qb = this.dataMartRepository
+      .createQueryBuilder('dm')
+      .where('dm.projectId = :projectId', { projectId })
+      .andWhere('dm.storage = :storageId', { storageId })
+      .andWhere('dm.deletedAt IS NULL');
+
+    this.applyNonAdminVisibilityGate(qb, projectId, options);
+
+    return qb;
+  }
+
+  async findByProjectIdAndStorageIdForCanvas(
+    projectId: string,
+    storageId: string,
+    options?: {
+      userId?: string;
+      roles?: string[];
+      roleScope?: RoleScope;
+      limit?: number;
+      offset?: number;
+    }
+  ): Promise<{ items: DataMart[]; total: number }> {
+    const qb = this.buildCanvasVisibleDataMartsQuery(projectId, storageId, options)
+      .select(['dm.id', 'dm.title', 'dm.status', 'dm.description', 'dm.schema'])
+      .orderBy('dm.title', 'ASC')
+      .addOrderBy('dm.id', 'ASC')
+      .take(options?.limit)
+      .skip(options?.offset);
+
+    const countQb = qb.clone().take(undefined).skip(undefined);
+    const [total, items] = await Promise.all([countQb.getCount(), qb.getMany()]);
+
+    return { items, total };
+  }
+
+  async findVisibleIdsByProjectIdAndStorageId(
+    projectId: string,
+    storageId: string,
+    options?: { userId?: string; roles?: string[]; roleScope?: RoleScope }
+  ): Promise<string[]> {
+    const rows = await this.buildCanvasVisibleDataMartsQuery(projectId, storageId, options)
+      .select('dm.id', 'id')
+      .getRawMany<{ id: string }>();
+
+    return rows.map(row => row.id);
   }
 
   async findByProjectIdAndDefinitionType(

--- a/apps/backend/src/data-marts/use-cases/get-model-canvas-data-marts.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-model-canvas-data-marts.service.spec.ts
@@ -1,0 +1,208 @@
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { GetModelCanvasDataMartsCommand } from '../dto/domain/get-model-canvas-data-marts.command';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
+import { RoleScope } from '../enums/role-scope.enum';
+import { ModelCanvasMapper } from '../mappers/model-canvas.mapper';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+import { ContextAccessService } from '../services/context/context-access.service';
+import { DataMartService } from '../services/data-mart.service';
+import { DataStorageService } from '../services/data-storage.service';
+import { DataMart } from '../entities/data-mart.entity';
+import { GetModelCanvasDataMartsService } from './get-model-canvas-data-marts.service';
+
+describe('GetModelCanvasDataMartsService', () => {
+  const dataMartService = { findByProjectIdAndStorageIdForCanvas: jest.fn() };
+  const dataStorageService = { getByProjectIdAndId: jest.fn() };
+  const contextAccessService = { getRoleScope: jest.fn() };
+  const accessDecisionService = {
+    canAccess: jest.fn(),
+    canAccessMany: jest.fn(),
+  };
+
+  const service = new GetModelCanvasDataMartsService(
+    dataMartService as unknown as DataMartService,
+    dataStorageService as unknown as DataStorageService,
+    contextAccessService as unknown as ContextAccessService,
+    new ModelCanvasMapper(),
+    accessDecisionService as unknown as AccessDecisionService
+  );
+
+  const command = new GetModelCanvasDataMartsCommand(
+    'project-1',
+    'user-1',
+    ['editor'],
+    'storage-1',
+    10
+  );
+
+  const dm = (id: string, overrides: Partial<DataMart> = {}): DataMart =>
+    ({
+      id,
+      title: `DM ${id}`,
+      status: DataMartStatus.PUBLISHED,
+      description: null,
+      schema: undefined,
+      ...overrides,
+    }) as DataMart;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    dataStorageService.getByProjectIdAndId.mockResolvedValue({ id: 'storage-1' });
+    contextAccessService.getRoleScope.mockResolvedValue(RoleScope.ENTIRE_PROJECT);
+    accessDecisionService.canAccess.mockResolvedValue(true);
+    accessDecisionService.canAccessMany.mockResolvedValue(new Map());
+    dataMartService.findByProjectIdAndStorageIdForCanvas.mockResolvedValue({
+      items: [],
+      total: 0,
+    });
+  });
+
+  it('throws when userId is missing', async () => {
+    const anonymous = new GetModelCanvasDataMartsCommand('project-1', '', ['editor'], 'storage-1');
+    await expect(service.run(anonymous)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('validates that the storage belongs to the project', async () => {
+    dataStorageService.getByProjectIdAndId.mockRejectedValue(new Error('not found'));
+    await expect(service.run(command)).rejects.toThrow('not found');
+    expect(dataStorageService.getByProjectIdAndId).toHaveBeenCalledWith('project-1', 'storage-1');
+    expect(accessDecisionService.canAccess).not.toHaveBeenCalled();
+  });
+
+  it('rejects storage access before querying role scope or data marts', async () => {
+    accessDecisionService.canAccess.mockResolvedValue(false);
+
+    await expect(service.run(command)).rejects.toThrow(
+      new ForbiddenException('You do not have access to this Storage')
+    );
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.STORAGE,
+      'storage-1',
+      Action.SEE,
+      'project-1'
+    );
+    expect(contextAccessService.getRoleScope).not.toHaveBeenCalled();
+    expect(dataMartService.findByProjectIdAndStorageIdForCanvas).not.toHaveBeenCalled();
+  });
+
+  it('maps data marts to nodes with fieldCount from schema', async () => {
+    dataMartService.findByProjectIdAndStorageIdForCanvas.mockResolvedValue({
+      items: [
+        dm('a', { schema: { fields: [{}, {}, {}] } as never, description: 'desc' }),
+        dm('b', { status: DataMartStatus.DRAFT }),
+      ],
+      total: 2,
+    });
+
+    const result = await service.run(command);
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.STORAGE,
+      'storage-1',
+      Action.SEE,
+      'project-1'
+    );
+    expect(result.items).toEqual([
+      {
+        id: 'a',
+        title: 'DM a',
+        status: DataMartStatus.PUBLISHED,
+        description: 'desc',
+        fieldCount: 3,
+      },
+      { id: 'b', title: 'DM b', status: DataMartStatus.DRAFT, description: null, fieldCount: 0 },
+    ]);
+  });
+
+  it('forwards pagination and returns total/offset from the domain query', async () => {
+    dataMartService.findByProjectIdAndStorageIdForCanvas.mockResolvedValue({
+      items: [dm('a')],
+      total: 42,
+    });
+
+    const result = await service.run(command);
+
+    expect(dataMartService.findByProjectIdAndStorageIdForCanvas).toHaveBeenCalledWith(
+      'project-1',
+      'storage-1',
+      {
+        userId: 'user-1',
+        roles: ['editor'],
+        roleScope: RoleScope.ENTIRE_PROJECT,
+        limit: 1000,
+        offset: 10,
+      }
+    );
+    expect(result.total).toBe(42);
+    expect(result.offset).toBe(10);
+  });
+
+  it('defaults offset to 0 when not provided', async () => {
+    const noOffset = new GetModelCanvasDataMartsCommand(
+      'project-1',
+      'user-1',
+      ['editor'],
+      'storage-1'
+    );
+
+    const result = await service.run(noOffset);
+
+    expect(dataMartService.findByProjectIdAndStorageIdForCanvas).toHaveBeenCalledWith(
+      'project-1',
+      'storage-1',
+      expect.objectContaining({ offset: 0 })
+    );
+    expect(result.offset).toBe(0);
+  });
+
+  it('resolves role scope for non-admins and skips the lookup for admins', async () => {
+    contextAccessService.getRoleScope.mockResolvedValue(RoleScope.SELECTED_CONTEXTS);
+    await service.run(command);
+    expect(contextAccessService.getRoleScope).toHaveBeenCalledWith('user-1', 'project-1');
+    expect(dataMartService.findByProjectIdAndStorageIdForCanvas).toHaveBeenCalledWith(
+      'project-1',
+      'storage-1',
+      {
+        userId: 'user-1',
+        roles: ['editor'],
+        roleScope: RoleScope.SELECTED_CONTEXTS,
+        limit: 1000,
+        offset: 10,
+      }
+    );
+
+    jest.resetAllMocks();
+    dataStorageService.getByProjectIdAndId.mockResolvedValue({ id: 'storage-1' });
+    accessDecisionService.canAccess.mockResolvedValue(true);
+    dataMartService.findByProjectIdAndStorageIdForCanvas.mockResolvedValue({
+      items: [],
+      total: 0,
+    });
+
+    const admin = new GetModelCanvasDataMartsCommand(
+      'project-1',
+      'user-1',
+      ['admin'],
+      'storage-1',
+      10
+    );
+    await service.run(admin);
+    expect(contextAccessService.getRoleScope).not.toHaveBeenCalled();
+    expect(dataMartService.findByProjectIdAndStorageIdForCanvas).toHaveBeenCalledWith(
+      'project-1',
+      'storage-1',
+      {
+        userId: 'user-1',
+        roles: ['admin'],
+        roleScope: RoleScope.ENTIRE_PROJECT,
+        limit: 1000,
+        offset: 10,
+      }
+    );
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/get-model-canvas-data-marts.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-model-canvas-data-marts.service.ts
@@ -1,0 +1,62 @@
+import { ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { GetModelCanvasDataMartsCommand } from '../dto/domain/get-model-canvas-data-marts.command';
+import { ModelCanvasDataMartsDto } from '../dto/domain/model-canvas.dto';
+import { RoleScope } from '../enums/role-scope.enum';
+import { ModelCanvasMapper } from '../mappers/model-canvas.mapper';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+import { ContextAccessService } from '../services/context/context-access.service';
+import { DataMartService } from '../services/data-mart.service';
+import { DataStorageService } from '../services/data-storage.service';
+
+const CANVAS_DATA_MARTS_PAGE_SIZE = 1000;
+
+@Injectable()
+export class GetModelCanvasDataMartsService {
+  constructor(
+    private readonly dataMartService: DataMartService,
+    private readonly dataStorageService: DataStorageService,
+    private readonly contextAccessService: ContextAccessService,
+    private readonly mapper: ModelCanvasMapper,
+    private readonly accessDecisionService: AccessDecisionService
+  ) {}
+
+  async run(command: GetModelCanvasDataMartsCommand): Promise<ModelCanvasDataMartsDto> {
+    if (!command.userId) {
+      throw new UnauthorizedException('Authenticated user is required');
+    }
+
+    await this.dataStorageService.getByProjectIdAndId(command.projectId, command.storageId);
+
+    const canSee = await this.accessDecisionService.canAccess(
+      command.userId,
+      command.roles,
+      EntityType.STORAGE,
+      command.storageId,
+      Action.SEE,
+      command.projectId
+    );
+    if (!canSee) {
+      throw new ForbiddenException('You do not have access to this Storage');
+    }
+
+    const isAdmin = command.roles.includes('admin');
+    const roleScope: RoleScope = isAdmin
+      ? RoleScope.ENTIRE_PROJECT
+      : await this.contextAccessService.getRoleScope(command.userId, command.projectId);
+
+    const offset = command.offset ?? 0;
+    const { items, total } = await this.dataMartService.findByProjectIdAndStorageIdForCanvas(
+      command.projectId,
+      command.storageId,
+      {
+        userId: command.userId,
+        roles: command.roles,
+        roleScope,
+        limit: CANVAS_DATA_MARTS_PAGE_SIZE,
+        offset,
+      }
+    );
+
+    return this.mapper.toDataMartsDto(items, total, offset);
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/get-model-canvas-edges.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-model-canvas-edges.service.spec.ts
@@ -1,0 +1,151 @@
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { DataMartRelationshipGraphEdgeDto } from '../dto/domain/data-mart-relationship-graph-edge.dto';
+import { GetModelCanvasEdgesCommand } from '../dto/domain/get-model-canvas-edges.command';
+import { RoleScope } from '../enums/role-scope.enum';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+import { ContextAccessService } from '../services/context/context-access.service';
+import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
+import { DataMartService } from '../services/data-mart.service';
+import { DataStorageService } from '../services/data-storage.service';
+import { GetModelCanvasEdgesService } from './get-model-canvas-edges.service';
+
+describe('GetModelCanvasEdgesService', () => {
+  const dataMartService = { findVisibleIdsByProjectIdAndStorageId: jest.fn() };
+  const dataStorageService = { getByProjectIdAndId: jest.fn() };
+  const relationshipService = { findGraphEdgesByStorageId: jest.fn() };
+  const contextAccessService = { getRoleScope: jest.fn() };
+  const accessDecisionService = {
+    canAccess: jest.fn(),
+    canAccessMany: jest.fn(),
+  };
+
+  const service = new GetModelCanvasEdgesService(
+    dataMartService as unknown as DataMartService,
+    dataStorageService as unknown as DataStorageService,
+    relationshipService as unknown as DataMartRelationshipService,
+    contextAccessService as unknown as ContextAccessService,
+    accessDecisionService as unknown as AccessDecisionService
+  );
+
+  const command = new GetModelCanvasEdgesCommand('project-1', 'user-1', ['editor'], 'storage-1');
+
+  const edge = (id: string, sourceId: string, targetId: string) =>
+    new DataMartRelationshipGraphEdgeDto(id, sourceId, targetId, [
+      { sourceFieldName: 'a', targetFieldName: 'b' },
+    ]);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    dataStorageService.getByProjectIdAndId.mockResolvedValue({ id: 'storage-1' });
+    contextAccessService.getRoleScope.mockResolvedValue(RoleScope.ENTIRE_PROJECT);
+    accessDecisionService.canAccess.mockResolvedValue(true);
+    accessDecisionService.canAccessMany.mockResolvedValue(new Map());
+    dataMartService.findVisibleIdsByProjectIdAndStorageId.mockResolvedValue([]);
+    relationshipService.findGraphEdgesByStorageId.mockResolvedValue([]);
+  });
+
+  it('throws when userId is missing', async () => {
+    const anonymous = new GetModelCanvasEdgesCommand('project-1', '', ['editor'], 'storage-1');
+    await expect(service.run(anonymous)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('validates that the storage belongs to the project', async () => {
+    dataStorageService.getByProjectIdAndId.mockRejectedValue(new Error('not found'));
+    await expect(service.run(command)).rejects.toThrow('not found');
+    expect(dataStorageService.getByProjectIdAndId).toHaveBeenCalledWith('project-1', 'storage-1');
+    expect(accessDecisionService.canAccess).not.toHaveBeenCalled();
+  });
+
+  it('rejects storage access before querying role scope or graph data', async () => {
+    accessDecisionService.canAccess.mockResolvedValue(false);
+
+    await expect(service.run(command)).rejects.toThrow(
+      new ForbiddenException('You do not have access to this Storage')
+    );
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.STORAGE,
+      'storage-1',
+      Action.SEE,
+      'project-1'
+    );
+    expect(contextAccessService.getRoleScope).not.toHaveBeenCalled();
+    expect(dataMartService.findVisibleIdsByProjectIdAndStorageId).not.toHaveBeenCalled();
+    expect(relationshipService.findGraphEdgesByStorageId).not.toHaveBeenCalled();
+  });
+
+  it('keeps an edge when both ends are visible', async () => {
+    dataMartService.findVisibleIdsByProjectIdAndStorageId.mockResolvedValue(['a', 'b']);
+    relationshipService.findGraphEdgesByStorageId.mockResolvedValue([edge('e1', 'a', 'b')]);
+
+    const result = await service.run(command);
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.STORAGE,
+      'storage-1',
+      Action.SEE,
+      'project-1'
+    );
+    expect(result.edges.map(e => e.id)).toEqual(['e1']);
+    expect(relationshipService.findGraphEdgesByStorageId).toHaveBeenCalledWith(
+      'storage-1',
+      'project-1'
+    );
+  });
+
+  it('drops an edge when the target data mart is not visible', async () => {
+    dataMartService.findVisibleIdsByProjectIdAndStorageId.mockResolvedValue(['a']);
+    relationshipService.findGraphEdgesByStorageId.mockResolvedValue([edge('e1', 'a', 'hidden')]);
+
+    const result = await service.run(command);
+
+    expect(result.edges).toEqual([]);
+  });
+
+  it('drops an edge when the source data mart is not visible', async () => {
+    dataMartService.findVisibleIdsByProjectIdAndStorageId.mockResolvedValue(['b']);
+    relationshipService.findGraphEdgesByStorageId.mockResolvedValue([edge('e1', 'hidden', 'b')]);
+
+    const result = await service.run(command);
+
+    expect(result.edges).toEqual([]);
+  });
+
+  it('resolves role scope for non-admins and skips the lookup for admins', async () => {
+    contextAccessService.getRoleScope.mockResolvedValue(RoleScope.SELECTED_CONTEXTS);
+    await service.run(command);
+    expect(contextAccessService.getRoleScope).toHaveBeenCalledWith('user-1', 'project-1');
+    expect(dataMartService.findVisibleIdsByProjectIdAndStorageId).toHaveBeenCalledWith(
+      'project-1',
+      'storage-1',
+      {
+        userId: 'user-1',
+        roles: ['editor'],
+        roleScope: RoleScope.SELECTED_CONTEXTS,
+      }
+    );
+
+    jest.resetAllMocks();
+    dataStorageService.getByProjectIdAndId.mockResolvedValue({ id: 'storage-1' });
+    accessDecisionService.canAccess.mockResolvedValue(true);
+    dataMartService.findVisibleIdsByProjectIdAndStorageId.mockResolvedValue([]);
+    relationshipService.findGraphEdgesByStorageId.mockResolvedValue([]);
+
+    const admin = new GetModelCanvasEdgesCommand('project-1', 'user-1', ['admin'], 'storage-1');
+    await service.run(admin);
+    expect(contextAccessService.getRoleScope).not.toHaveBeenCalled();
+    expect(dataMartService.findVisibleIdsByProjectIdAndStorageId).toHaveBeenCalledWith(
+      'project-1',
+      'storage-1',
+      {
+        userId: 'user-1',
+        roles: ['admin'],
+        roleScope: RoleScope.ENTIRE_PROJECT,
+      }
+    );
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/get-model-canvas-edges.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-model-canvas-edges.service.ts
@@ -1,0 +1,61 @@
+import { ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { GetModelCanvasEdgesCommand } from '../dto/domain/get-model-canvas-edges.command';
+import { ModelCanvasEdgesDto } from '../dto/domain/model-canvas.dto';
+import { RoleScope } from '../enums/role-scope.enum';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+import { ContextAccessService } from '../services/context/context-access.service';
+import { DataMartRelationshipService } from '../services/data-mart-relationship.service';
+import { DataMartService } from '../services/data-mart.service';
+import { DataStorageService } from '../services/data-storage.service';
+
+@Injectable()
+export class GetModelCanvasEdgesService {
+  constructor(
+    private readonly dataMartService: DataMartService,
+    private readonly dataStorageService: DataStorageService,
+    private readonly relationshipService: DataMartRelationshipService,
+    private readonly contextAccessService: ContextAccessService,
+    private readonly accessDecisionService: AccessDecisionService
+  ) {}
+
+  async run(command: GetModelCanvasEdgesCommand): Promise<ModelCanvasEdgesDto> {
+    if (!command.userId) {
+      throw new UnauthorizedException('Authenticated user is required');
+    }
+
+    await this.dataStorageService.getByProjectIdAndId(command.projectId, command.storageId);
+
+    const canSee = await this.accessDecisionService.canAccess(
+      command.userId,
+      command.roles,
+      EntityType.STORAGE,
+      command.storageId,
+      Action.SEE,
+      command.projectId
+    );
+    if (!canSee) {
+      throw new ForbiddenException('You do not have access to this Storage');
+    }
+
+    const isAdmin = command.roles.includes('admin');
+    const roleScope: RoleScope = isAdmin
+      ? RoleScope.ENTIRE_PROJECT
+      : await this.contextAccessService.getRoleScope(command.userId, command.projectId);
+
+    const [visibleIds, allEdges] = await Promise.all([
+      this.dataMartService.findVisibleIdsByProjectIdAndStorageId(
+        command.projectId,
+        command.storageId,
+        { userId: command.userId, roles: command.roles, roleScope }
+      ),
+      this.relationshipService.findGraphEdgesByStorageId(command.storageId, command.projectId),
+    ]);
+
+    const visibleIdSet = new Set(visibleIds);
+    const edges = allEdges.filter(
+      edge => visibleIdSet.has(edge.sourceDataMartId) && visibleIdSet.has(edge.targetDataMartId)
+    );
+
+    return { edges };
+  }
+}

--- a/apps/backend/src/data-marts/utils/project-list-sql-dialects.spec.ts
+++ b/apps/backend/src/data-marts/utils/project-list-sql-dialects.spec.ts
@@ -5,8 +5,10 @@ import { Report } from '../entities/report.entity';
 import { DataMartRun } from '../entities/data-mart-run.entity';
 import { DataMartScheduledTrigger } from '../entities/data-mart-scheduled-trigger.entity';
 import { InsightTemplate } from '../entities/insight-template.entity';
+import { DataMart } from '../entities/data-mart.entity';
 import { RoleScope } from '../enums/role-scope.enum';
 import { OwnerFilter } from '../enums/owner-filter.enum';
+import { DataMartService } from '../services/data-mart.service';
 import { applyDataMartVisibilityFilter } from './apply-data-mart-visibility-filter';
 
 type Dialect = 'better-sqlite3' | 'mysql';
@@ -109,6 +111,34 @@ function buildProjectInsightTemplateQuery(dataSource: DataSource) {
   return applyViewerVisibility(qb);
 }
 
+function buildCanvasDataMartQuery(dataSource: DataSource) {
+  const service = new DataMartService(
+    dataSource.getRepository(DataMart),
+    null as never,
+    null as never,
+    null as never
+  );
+  const queryBuilderService = service as unknown as {
+    buildCanvasVisibleDataMartsQuery: (
+      projectId: string,
+      storageId: string,
+      options: { userId: string; roles: string[]; roleScope: RoleScope }
+    ) => SelectQueryBuilder<DataMart>;
+  };
+
+  return queryBuilderService
+    .buildCanvasVisibleDataMartsQuery('project-1', 'storage-1', {
+      userId: 'user-1',
+      roles: ['viewer'],
+      roleScope: RoleScope.SELECTED_CONTEXTS,
+    })
+    .select(['dm.id', 'dm.title', 'dm.status', 'dm.description', 'dm.schema'])
+    .orderBy('dm.title', 'ASC')
+    .addOrderBy('dm.id', 'ASC')
+    .take(1_000)
+    .skip(0);
+}
+
 describe('project Data Mart list SQL dialects', () => {
   const unsupportedDialectPatterns = [
     /\bILIKE\b/i,
@@ -128,6 +158,7 @@ describe('project Data Mart list SQL dialects', () => {
         buildProjectRunQuery(dataSource),
         buildProjectScheduledTriggerQuery(dataSource),
         buildProjectInsightTemplateQuery(dataSource),
+        buildCanvasDataMartQuery(dataSource),
       ];
 
       for (const qb of queries) {
@@ -139,6 +170,9 @@ describe('project Data Mart list SQL dialects', () => {
       }
 
       expect(buildProjectInsightTemplateQuery(dataSource).getSql()).not.toContain('sourceEntities');
+      const canvasSql = buildCanvasDataMartQuery(dataSource).getSql();
+      expect(canvasSql).toContain('storageId');
+      expect(canvasSql).toContain('data_mart_contexts');
     }
   );
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "type-check:watch": "tsc --noEmit --watch"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -48,18 +49,13 @@
     "@owox/ui": "../packages/ui",
     "@tailwindcss/vite": "^4.1.8",
     "@tanstack/react-query": "^5.66.0",
+    "@xyflow/react": "^12.11.2",
     "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.58.0",
     "react-hot-toast": "^2.5.2",
     "react-router-dom": "^7.6.2",
-    "rete": "^2.0.6",
-    "rete-area-plugin": "^2.1.5",
-    "rete-connection-plugin": "^2.0.5",
-    "rete-minimap-plugin": "^2.0.3",
-    "rete-react-plugin": "^2.1.0",
-    "styled-components": "^6.3.12",
     "tailwindcss": "^4.1.8"
   },
   "devDependencies": {

--- a/apps/web/src/components/AppSidebar/MainMenu/MainMenu.test.tsx
+++ b/apps/web/src/components/AppSidebar/MainMenu/MainMenu.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../../features/idp', () => ({
 
 describe('MainMenu', () => {
   it.each([
+    ['Models', '/ui/project-1/data-marts/models'],
     ['Reports', '/ui/project-1/data-marts/reports'],
     ['Insights', '/ui/project-1/data-marts/insights'],
     ['Triggers', '/ui/project-1/data-marts/schedules'],
@@ -35,6 +36,7 @@ describe('MainMenu', () => {
 
     expect(labels).toEqual([
       'Data Marts',
+      'Models',
       'Reports',
       'Insights',
       'Triggers',

--- a/apps/web/src/components/AppSidebar/MainMenu/MainMenu.tsx
+++ b/apps/web/src/components/AppSidebar/MainMenu/MainMenu.tsx
@@ -14,6 +14,7 @@ import { MainMenuItems } from './items';
 import type { MainMenuItem } from './types';
 
 const PROJECT_WIDE_DATA_MART_PATHS = [
+  '/data-marts/models',
   '/data-marts/runs',
   '/data-marts/schedules',
   '/data-marts/reports',

--- a/apps/web/src/components/AppSidebar/MainMenu/items.ts
+++ b/apps/web/src/components/AppSidebar/MainMenu/items.ts
@@ -5,6 +5,7 @@ import {
   DatabaseIcon,
   FileText,
   HistoryIcon,
+  Network,
   Sparkles,
 } from 'lucide-react';
 import type { MainMenuItem } from './types';
@@ -15,6 +16,11 @@ export const MainMenuItems: MainMenuItem[] = [
     url: '/data-marts',
     icon: Box,
     children: [
+      {
+        title: 'Models',
+        url: '/data-marts/models',
+        icon: Network,
+      },
       {
         title: 'Reports',
         url: '/data-marts/reports',

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/DataMartRelationshipsContent.tsx
@@ -42,9 +42,8 @@ import { RelationshipAccordionItem } from './RelationshipAccordionItem';
 import { TargetDataMartPicker } from './TargetDataMartPicker';
 import { useTransientRelationships } from './useTransientRelationships';
 
-// `RelationshipCanvas` pulls in Rete.js and its plugins (~50 kB gzipped).
-// Load it only when the user switches to graph view so the default table
-// path keeps the main bundle small.
+// Load React Flow and the graph renderer only when the user switches to graph
+// view so the default table path keeps the main bundle small.
 const RelationshipCanvas = lazy(() =>
   import('./RelationshipCanvas').then(module => ({ default: module.RelationshipCanvas }))
 );

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DataMartRelationship } from '../../../shared/types/relationship.types';
 import { RelationshipCanvas } from './RelationshipCanvas';
 
@@ -8,9 +8,14 @@ interface ReactFlowStubProps {
   children?: ReactNode;
   minZoom?: number;
   nodes?: {
+    id: string;
     position: { x: number; y: number };
     width?: number;
     height?: number;
+    data: {
+      isSource: boolean;
+      onOpenExternal: () => void;
+    };
   }[];
   onMove?: (event: unknown, viewport: ViewportStub) => void;
   onMoveStart?: (event: unknown) => void;
@@ -71,6 +76,30 @@ describe('RelationshipCanvas viewport', () => {
     reactFlowHarness.store.width = 800;
     reactFlowHarness.store.height = 600;
     reactFlowHarness.scope.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens relationship targets without exposing the opener or referrer', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    render(<RelationshipCanvas {...buildCanvasProps([buildRelationship('rel-1', 'target-1')])} />);
+
+    await waitFor(() => {
+      expect(reactFlowHarness.latestProps?.nodes).toHaveLength(2);
+    });
+    const targetNode = reactFlowHarness.latestProps?.nodes?.find(node => !node.data.isSource);
+    expect(targetNode).toBeDefined();
+
+    targetNode?.data.onOpenExternal();
+
+    expect(openSpy).toHaveBeenCalledWith(
+      '/data-marts/target-1/data-setup',
+      '_blank',
+      'noopener,noreferrer'
+    );
   });
 
   it('passes the low zoom floor to a full fit after the interactive floor was raised', async () => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.test.tsx
@@ -1,0 +1,298 @@
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DataMartRelationship } from '../../../shared/types/relationship.types';
+import { RelationshipCanvas } from './RelationshipCanvas';
+
+interface ReactFlowStubProps {
+  children?: ReactNode;
+  minZoom?: number;
+  nodes?: {
+    position: { x: number; y: number };
+    width?: number;
+    height?: number;
+  }[];
+  onMove?: (event: unknown, viewport: ViewportStub) => void;
+  onMoveStart?: (event: unknown) => void;
+}
+
+interface ViewportStub {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+const reactFlowHarness = vi.hoisted(() => {
+  const fitView = vi.fn<(options?: unknown) => Promise<boolean>>();
+  const getZoom = vi.fn<() => number>();
+  const setViewport = vi.fn<(viewport: ViewportStub) => Promise<boolean>>();
+  const zoomTo = vi.fn<(zoom: number, options?: unknown) => Promise<boolean>>();
+
+  return {
+    fitView,
+    getZoom,
+    setViewport,
+    zoomTo,
+    instance: { fitView, getZoom, setViewport, zoomTo },
+    latestProps: null as ReactFlowStubProps | null,
+    store: { width: 800, height: 600 },
+    scope: vi.fn((path: string) => path),
+  };
+});
+
+vi.mock('@xyflow/react', () => ({
+  Background: () => null,
+  BackgroundVariant: { Lines: 'lines' },
+  Handle: () => null,
+  MiniMap: () => null,
+  Position: { Left: 'left', Right: 'right' },
+  ReactFlow: (props: ReactFlowStubProps) => {
+    reactFlowHarness.latestProps = props;
+    return <div data-testid='react-flow'>{props.children}</div>;
+  },
+  ReactFlowProvider: ({ children }: { children: ReactNode }) => children,
+  getBezierPath: () => [''],
+  useReactFlow: () => reactFlowHarness.instance,
+  useStore: (selector: (state: { width: number; height: number }) => unknown) =>
+    selector(reactFlowHarness.store),
+}));
+
+vi.mock('../../../../../shared/hooks', () => ({
+  useProjectRoute: () => ({ scope: reactFlowHarness.scope }),
+}));
+
+describe('RelationshipCanvas viewport', () => {
+  beforeEach(() => {
+    reactFlowHarness.fitView.mockReset().mockResolvedValue(true);
+    reactFlowHarness.getZoom.mockReset().mockReturnValue(1.5);
+    reactFlowHarness.setViewport.mockReset().mockResolvedValue(true);
+    reactFlowHarness.zoomTo.mockReset().mockResolvedValue(true);
+    reactFlowHarness.latestProps = null;
+    reactFlowHarness.store.width = 800;
+    reactFlowHarness.store.height = 600;
+    reactFlowHarness.scope.mockClear();
+  });
+
+  it('passes the low zoom floor to a full fit after the interactive floor was raised', async () => {
+    render(<RelationshipCanvas {...buildCanvasProps([buildRelationship('rel-1', 'target-1')])} />);
+
+    await waitFor(() => {
+      expect(reactFlowHarness.fitView).toHaveBeenCalledTimes(1);
+      expect(reactFlowHarness.latestProps?.minZoom).toBe(1.5);
+    });
+    reactFlowHarness.fitView.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fit to view' }));
+
+    await waitFor(() => {
+      expect(reactFlowHarness.fitView).toHaveBeenCalledWith(
+        expect.objectContaining({
+          minZoom: 0.05,
+          maxZoom: 3,
+          padding: 1 / 0.85 - 1,
+        })
+      );
+    });
+  });
+
+  it('re-enables automatic fit when graph content changes after a user move', async () => {
+    const initialRelationship = buildRelationship('rel-1', 'target-1');
+    const { rerender } = render(
+      <RelationshipCanvas {...buildCanvasProps([initialRelationship])} />
+    );
+
+    await waitFor(() => {
+      expect(reactFlowHarness.fitView).toHaveBeenCalledTimes(1);
+      expect(reactFlowHarness.latestProps?.minZoom).toBe(1.5);
+    });
+    reactFlowHarness.latestProps?.onMoveStart?.({ type: 'pointerdown' });
+
+    const semanticallyUnchangedRelationship = {
+      ...initialRelationship,
+      sourceDataMart: { ...initialRelationship.sourceDataMart },
+      targetDataMart: { ...initialRelationship.targetDataMart },
+      joinConditions: initialRelationship.joinConditions.map(condition => ({ ...condition })),
+    };
+    rerender(<RelationshipCanvas {...buildCanvasProps([semanticallyUnchangedRelationship])} />);
+
+    expect(reactFlowHarness.fitView).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <RelationshipCanvas
+        {...buildCanvasProps([
+          semanticallyUnchangedRelationship,
+          buildRelationship('rel-2', 'target-2'),
+        ])}
+      />
+    );
+
+    await waitFor(() => {
+      expect(reactFlowHarness.fitView).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it.each([0.05, 1, 3])(
+    'clamps user panning to 150 screen pixels around the graph at zoom %s',
+    async zoom => {
+      render(
+        <RelationshipCanvas
+          {...buildCanvasProps([
+            buildRelationship('rel-1', 'target-1'),
+            buildRelationship('rel-2', 'target-2'),
+          ])}
+        />
+      );
+
+      await waitFor(() => {
+        expect(reactFlowHarness.latestProps?.nodes).toHaveLength(3);
+      });
+
+      const bounds = getRenderedGraphBounds();
+      const onMove = reactFlowHarness.latestProps?.onMove;
+      expect(onMove).toBeTypeOf('function');
+
+      onMove?.(new MouseEvent('mousemove'), {
+        x: Number.NEGATIVE_INFINITY,
+        y: Number.NEGATIVE_INFINITY,
+        zoom,
+      });
+      await waitFor(() => {
+        expect(reactFlowHarness.setViewport).toHaveBeenCalledTimes(1);
+      });
+      onMove?.(new MouseEvent('mousemove'), {
+        x: Number.POSITIVE_INFINITY,
+        y: Number.POSITIVE_INFINITY,
+        zoom,
+      });
+      await waitFor(() => {
+        expect(reactFlowHarness.setViewport).toHaveBeenCalledTimes(2);
+      });
+
+      const lowerViewport = {
+        x: 150 - bounds.maxX * zoom,
+        y: 150 - bounds.maxY * zoom,
+        zoom,
+      };
+      const upperViewport = {
+        x: reactFlowHarness.store.width - 150 - bounds.minX * zoom,
+        y: reactFlowHarness.store.height - 150 - bounds.minY * zoom,
+        zoom,
+      };
+      expect(reactFlowHarness.setViewport).toHaveBeenNthCalledWith(1, lowerViewport);
+      expect(reactFlowHarness.setViewport).toHaveBeenNthCalledWith(2, upperViewport);
+      expect(lowerViewport.x + bounds.maxX * zoom).toBeCloseTo(150);
+      expect(lowerViewport.y + bounds.maxY * zoom).toBeCloseTo(150);
+      expect(upperViewport.x + bounds.minX * zoom).toBeCloseTo(reactFlowHarness.store.width - 150);
+      expect(upperViewport.y + bounds.minY * zoom).toBeCloseTo(reactFlowHarness.store.height - 150);
+
+      if (zoom === 0.05) {
+        expect((bounds.maxX - bounds.minX) * zoom).toBeLessThan(reactFlowHarness.store.width - 300);
+        expect(lowerViewport.x).toBeLessThan(upperViewport.x);
+      }
+    }
+  );
+
+  it('clamps a programmatic-origin move without recursing on its correction', async () => {
+    render(
+      <RelationshipCanvas
+        {...buildCanvasProps([
+          buildRelationship('rel-1', 'target-1'),
+          buildRelationship('rel-2', 'target-2'),
+        ])}
+      />
+    );
+
+    await waitFor(() => {
+      expect(reactFlowHarness.latestProps?.nodes).toHaveLength(3);
+    });
+
+    const outOfBoundsViewport = { x: -10_000, y: 10_000, zoom: 1 };
+    reactFlowHarness.setViewport.mockImplementation(async correctedViewport => {
+      if (reactFlowHarness.setViewport.mock.calls.length === 1) {
+        reactFlowHarness.latestProps?.onMove?.(null, correctedViewport);
+      }
+      return true;
+    });
+
+    reactFlowHarness.latestProps?.onMove?.(null, outOfBoundsViewport);
+
+    expect(reactFlowHarness.setViewport).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      name: 'MiniMap pointer interaction',
+      interact: () => {
+        fireEvent.pointerDown(screen.getByTestId('react-flow'));
+      },
+    },
+    {
+      name: 'custom zoom control',
+      interact: () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
+      },
+    },
+  ])('preserves the viewport after a $name when the pane resizes', async ({ interact }) => {
+    const relationship = buildRelationship('rel-1', 'target-1');
+    const { rerender } = render(<RelationshipCanvas {...buildCanvasProps([relationship])} />);
+
+    await waitFor(() => {
+      expect(reactFlowHarness.fitView).toHaveBeenCalledTimes(1);
+    });
+    reactFlowHarness.fitView.mockClear();
+
+    interact();
+    reactFlowHarness.store.width = 900;
+    rerender(<RelationshipCanvas {...buildCanvasProps([relationship])} />);
+
+    await waitFor(() => {
+      expect(reactFlowHarness.latestProps).not.toBeNull();
+    });
+    expect(reactFlowHarness.fitView).not.toHaveBeenCalled();
+  });
+});
+
+function getRenderedGraphBounds() {
+  const nodes = reactFlowHarness.latestProps?.nodes ?? [];
+  return {
+    minX: Math.min(...nodes.map(node => node.position.x)),
+    minY: Math.min(...nodes.map(node => node.position.y)),
+    maxX: Math.max(...nodes.map(node => node.position.x + (node.width ?? 0))),
+    maxY: Math.max(...nodes.map(node => node.position.y + (node.height ?? 0))),
+  };
+}
+
+function buildCanvasProps(relationships: DataMartRelationship[]) {
+  return {
+    dataMartId: 'source-1',
+    dataMartTitle: 'Source',
+    dataMartStatus: 'PUBLISHED',
+    relationships,
+    relationshipGraph: null,
+    searchQuery: '',
+  };
+}
+
+function buildRelationship(id: string, targetId: string): DataMartRelationship {
+  return {
+    id,
+    dataStorageId: 'storage-1',
+    sourceDataMart: {
+      id: 'source-1',
+      title: 'Source',
+      status: 'PUBLISHED',
+      userHasAccess: true,
+    },
+    targetDataMart: {
+      id: targetId,
+      title: `Target ${targetId}`,
+      status: 'PUBLISHED',
+      userHasAccess: true,
+    },
+    targetAlias: targetId,
+    joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'source_id' }],
+    createdById: 'user-1',
+    createdAt: '2026-07-13T00:00:00.000Z',
+    modifiedAt: '2026-07-13T00:00:00.000Z',
+  };
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
@@ -827,7 +827,7 @@ export function RelationshipCanvas({
   const { scope } = useProjectRoute();
   const handleOpenExternal = useCallback(
     (targetId: string) => {
-      window.open(scope(`/data-marts/${targetId}/data-setup`), '_blank');
+      window.open(scope(`/data-marts/${targetId}/data-setup`), '_blank', 'noopener,noreferrer');
     },
     [scope]
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
@@ -1,14 +1,41 @@
 import { Badge } from '@owox/ui/components/badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { ExternalLink, Info, Locate, Maximize2, ZoomIn, ZoomOut } from 'lucide-react';
-import { useCallback, useEffect, useRef } from 'react';
-import { createRoot } from 'react-dom/client';
-import type { GetSchemes } from 'rete';
-import { ClassicPreset, NodeEditor } from 'rete';
-import { AreaExtensions, AreaPlugin } from 'rete-area-plugin';
-import { ConnectionPlugin, Presets as ConnectionPresets } from 'rete-connection-plugin';
-import { type MinimapExtra, MinimapPlugin } from 'rete-minimap-plugin';
-import { Presets as ReactPresets, type ReactArea2D, ReactPlugin } from 'rete-react-plugin';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Background,
+  BackgroundVariant,
+  Handle,
+  MiniMap,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  getBezierPath,
+  useReactFlow,
+  useStore,
+  type Edge,
+  type EdgeProps,
+  type Node,
+  type NodeProps,
+  type Viewport,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
 import { Button } from '../../../../../shared/components/Button';
+import { useProjectRoute } from '../../../../../shared/hooks';
+import {
+  DIMMED_OPACITY,
+  EDGE_COLOR,
+  EDGE_STROKE_WIDTH,
+  EDGE_WARNING_DASH,
+  HIGHLIGHT_COLOR,
+  NODE_BORDER_COLOR,
+  NODE_PULSE_KEYFRAMES,
+  SOCKET_STYLE,
+  STATIC_NODE_STYLE,
+  WARNING_COLOR,
+} from '../../../shared/canvas/constants';
+import { computeCanvasHighlight, NO_HIGHLIGHT } from '../../../shared/canvas/highlight';
+import { clampCanvasViewport, getCanvasGraphBounds } from '../../../shared/canvas/viewport';
 import type {
   DataMartRelationship,
   RelationshipGraph,
@@ -20,9 +47,10 @@ import {
   hasRelationshipWarning,
 } from './relationship-warning-state';
 import {
+  GRAPH_ZOOM_MAX,
   getGraphZoomRange,
   getNextGraphZoom,
-  isGraphZoomAllowed,
+  type GraphZoomRange,
 } from './relationship-canvas-zoom';
 
 interface RelationshipCanvasProps {
@@ -39,109 +67,78 @@ interface RelationshipCanvasProps {
   style?: React.CSSProperties;
 }
 
-const SOCKET = new ClassicPreset.Socket('rel');
 const NODE_W = 240;
 const SRC_H = 48;
 const TGT_H = 74;
 const H_GAP = 280;
 const V_GAP = 24;
-const NODE_BORDER = '#9ca3af'; // gray-400, visible in both themes
-const HIGHLIGHT_COLOR = '#3b82f6'; // blue-500
-const DRAFT_COLOR = '#f97316'; // orange-500
 const FIT_VIEW_SCALE = 0.85;
+const FIT_VIEW_PADDING = 1 / FIT_VIEW_SCALE - 1;
+const GRAPH_ZOOM_MIN = 0.05;
+const GRAPH_PAN_PADDING = 150;
 
-class DMNode extends ClassicPreset.Node {
-  width = NODE_W;
-  height = SRC_H;
+export interface RelationshipNodeData {
   isSource: boolean;
-  dmId: string;
-  depth: number;
+  label: string;
   targetAlias?: string;
   fieldCount?: number;
   description?: string | null;
-  onOpenExternal?: () => void;
   isDraft: boolean;
   isBlocked: boolean;
   isJoinNotConfigured: boolean;
   isCycleStub: boolean;
   userHasAccess: boolean;
-  highlighted = false;
-  dimmed = false;
-
-  constructor(
-    label: string,
-    dmId: string,
-    isSource: boolean,
-    depth: number,
-    opts: {
-      userHasAccess: boolean;
-      targetAlias?: string;
-      fieldCount?: number;
-      description?: string | null;
-      onOpenExternal?: () => void;
-      isDraft?: boolean;
-      isBlocked?: boolean;
-      isJoinNotConfigured?: boolean;
-      isCycleStub?: boolean;
-    }
-  ) {
-    super(label);
-    this.dmId = dmId;
-    this.isSource = isSource;
-    this.depth = depth;
-    this.targetAlias = opts.targetAlias;
-    this.fieldCount = opts.fieldCount;
-    this.description = opts.description;
-    this.onOpenExternal = opts.onOpenExternal;
-    this.isDraft = opts.isDraft ?? false;
-    this.isBlocked = opts.isBlocked ?? false;
-    this.isJoinNotConfigured = opts.isJoinNotConfigured ?? false;
-    this.isCycleStub = opts.isCycleStub ?? false;
-    this.userHasAccess = opts.userHasAccess;
-    if (!isSource) this.height = TGT_H;
-  }
+  hasOutgoing: boolean;
+  highlighted: boolean;
+  dimmed: boolean;
+  onOpenExternal: () => void;
 }
 
-type Schemes = GetSchemes<DMNode, ClassicPreset.Connection<ClassicPreset.Node, ClassicPreset.Node>>;
-type AreaExtra = ReactArea2D<Schemes> | MinimapExtra;
+export type RelationshipFlowNodeType = Node<
+  RelationshipNodeData & Record<string, unknown>,
+  'relationshipNode'
+>;
 
-const { RefSocket } = ReactPresets.classic;
+interface RelationshipEdgeData {
+  warning: boolean;
+  dimmed: boolean;
+}
 
-function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Schemes>) => void }) {
-  const n = props.data;
+type RelationshipFlowEdgeType = Edge<
+  RelationshipEdgeData & Record<string, unknown>,
+  'relationshipEdge'
+> & { data: RelationshipEdgeData };
 
+export function RelationshipFlowNode({ data }: NodeProps<RelationshipFlowNodeType>) {
   function handleExtClick(e: React.MouseEvent) {
     e.stopPropagation();
     e.preventDefault();
-    n.onOpenExternal?.();
+    data.onOpenExternal();
   }
 
-  const outputs = Object.entries(n.outputs);
-  const inputs = Object.entries(n.inputs);
-
-  if (n.isSource) {
+  if (data.isSource) {
     return (
       <div
         className='text-primary flex items-center'
         style={{
-          width: n.width,
-          height: n.height,
+          width: NODE_W,
+          height: SRC_H,
           borderRadius: 8,
-          border: `2px solid ${n.highlighted ? HIGHLIGHT_COLOR : n.isDraft ? DRAFT_COLOR : NODE_BORDER}`,
-          boxShadow: n.highlighted
+          border: `2px solid ${data.highlighted ? HIGHLIGHT_COLOR : data.isDraft ? WARNING_COLOR : NODE_BORDER_COLOR}`,
+          boxShadow: data.highlighted
             ? `0 0 0 3px ${HIGHLIGHT_COLOR}40, 0 0 12px ${HIGHLIGHT_COLOR}60`
             : '0 1px 4px 0 rgba(0,0,0,0.12)',
           background: '#eff6ff',
           fontSize: 13,
           fontWeight: 600,
           position: 'relative',
-          opacity: n.dimmed ? 0.15 : 1,
-          filter: n.dimmed ? 'grayscale(0.8)' : undefined,
-          animation: n.highlighted ? 'node-pulse 1.5s ease-in-out infinite' : undefined,
+          opacity: data.dimmed ? DIMMED_OPACITY : 1,
+          filter: data.dimmed ? 'grayscale(0.8)' : undefined,
+          animation: data.highlighted ? 'node-pulse 1.5s ease-in-out infinite' : undefined,
           transition: 'opacity 0.2s, filter 0.2s',
         }}
       >
-        {n.isDraft && (
+        {data.isDraft && (
           <span
             style={{
               position: 'absolute',
@@ -149,55 +146,49 @@ function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Sch
               right: 4,
               fontSize: 10,
               fontWeight: 600,
-              color: DRAFT_COLOR,
+              color: WARNING_COLOR,
               lineHeight: 1,
             }}
           >
             Draft
           </span>
         )}
-        <div className='truncate' style={{ flex: 1, padding: '0 14px' }} title={n.label}>
-          {n.label}
+        <div className='truncate' style={{ flex: 1, padding: '0 14px' }} title={data.label}>
+          {data.label}
         </div>
-        {outputs.map(
-          ([key, output]) =>
-            output && (
-              <div key={key} style={{ position: 'absolute', right: -5, top: '50%', marginTop: -5 }}>
-                <RefSocket
-                  name='output-socket'
-                  side='output'
-                  socketKey={key}
-                  nodeId={n.id}
-                  emit={props.emit}
-                  payload={output.socket}
-                />
-              </div>
-            )
+        {data.hasOutgoing && (
+          <Handle
+            type='source'
+            position={Position.Right}
+            isConnectable={false}
+            style={SOCKET_STYLE}
+          />
         )}
       </div>
     );
   }
 
-  const borderColor = hasRelationshipWarning(n) ? DRAFT_COLOR : NODE_BORDER;
-  const badgeLabel = getRelationshipWarningLabel(n);
+  const borderColor = hasRelationshipWarning(data) ? WARNING_COLOR : NODE_BORDER_COLOR;
+  const badgeLabel = getRelationshipWarningLabel(data);
+  const openExternalLabel = `Open ${data.label} in new tab`;
 
   return (
     <div
-      title={n.isCycleStub ? CYCLE_STUB_TOOLTIP : undefined}
+      title={data.isCycleStub ? CYCLE_STUB_TOOLTIP : undefined}
       style={{
-        width: n.width,
-        height: n.height,
+        width: NODE_W,
+        height: TGT_H,
         borderRadius: 8,
-        border: `2px solid ${n.highlighted ? HIGHLIGHT_COLOR : borderColor}`,
+        border: `2px solid ${data.highlighted ? HIGHLIGHT_COLOR : borderColor}`,
         background: 'var(--background)',
-        boxShadow: n.highlighted
+        boxShadow: data.highlighted
           ? `0 0 0 3px ${HIGHLIGHT_COLOR}40, 0 0 12px ${HIGHLIGHT_COLOR}60`
           : '0 1px 4px 0 rgba(0,0,0,0.12)',
         cursor: 'default',
         position: 'relative',
-        opacity: n.dimmed ? 0.15 : 1,
-        filter: n.dimmed ? 'grayscale(0.8)' : undefined,
-        animation: n.highlighted ? 'node-pulse 1.5s ease-in-out infinite' : undefined,
+        opacity: data.dimmed ? DIMMED_OPACITY : 1,
+        filter: data.dimmed ? 'grayscale(0.8)' : undefined,
+        animation: data.highlighted ? 'node-pulse 1.5s ease-in-out infinite' : undefined,
         transition: 'opacity 0.2s, filter 0.2s',
       }}
     >
@@ -209,7 +200,7 @@ function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Sch
             right: 4,
             fontSize: 10,
             fontWeight: 600,
-            color: DRAFT_COLOR,
+            color: WARNING_COLOR,
             lineHeight: 1,
             whiteSpace: 'nowrap',
           }}
@@ -217,24 +208,7 @@ function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Sch
           {badgeLabel}
         </span>
       )}
-      {inputs.map(
-        ([key, input]) =>
-          input && (
-            <div
-              key={key}
-              style={{ position: 'absolute', left: -5, top: '50%', marginTop: -5, zIndex: 1 }}
-            >
-              <RefSocket
-                name='input-socket'
-                side='input'
-                socketKey={key}
-                nodeId={n.id}
-                emit={props.emit}
-                payload={input.socket}
-              />
-            </div>
-          )
-      )}
+      <Handle type='target' position={Position.Left} isConnectable={false} style={SOCKET_STYLE} />
       <div
         className='bg-muted flex items-center justify-between'
         style={{
@@ -245,30 +219,42 @@ function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Sch
         }}
       >
         <span className='flex min-w-0 items-center gap-1.5'>
-          <span className='truncate' title={n.label}>
-            {n.label}
+          <span className='truncate' title={data.label}>
+            {data.label}
           </span>
-          {!n.userHasAccess && <NoAccessIndicatorNative />}
+          {!data.userHasAccess && <NoAccessIndicatorNative />}
         </span>
         <div className='ml-2 flex shrink-0 items-center gap-0.5'>
-          {n.description && (
-            <span
-              className='text-muted-foreground hover:text-foreground inline-flex cursor-default rounded p-0.5 transition-colors'
-              title={n.description}
-            >
-              <Info style={{ width: 14, height: 14 }} />
-            </span>
+          {data.description && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type='button'
+                  className='text-muted-foreground hover:text-foreground inline-flex cursor-default rounded p-0.5 transition-colors'
+                  aria-label={`Description for ${data.label}`}
+                  onPointerDown={event => {
+                    event.stopPropagation();
+                  }}
+                >
+                  <Info style={{ width: 14, height: 14 }} aria-hidden='true' />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side='top' align='center' role='tooltip'>
+                {data.description}
+              </TooltipContent>
+            </Tooltip>
           )}
           <button
+            type='button'
             className='text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded p-0.5 transition-colors'
             onPointerDown={e => {
               e.stopPropagation();
             }}
             onClick={handleExtClick}
-            title='Open in new tab'
-            aria-label='Open in new tab'
+            title={openExternalLabel}
+            aria-label={openExternalLabel}
           >
-            <ExternalLink style={{ width: 14, height: 14 }} />
+            <ExternalLink style={{ width: 14, height: 14 }} aria-hidden='true' />
           </button>
         </div>
       </div>
@@ -276,64 +262,116 @@ function NodeComponent(props: { data: Schemes['Node']; emit: (e: ReactArea2D<Sch
         className='text-muted-foreground flex items-center gap-2'
         style={{ padding: '6px 14px 8px', fontSize: 11, minWidth: 0 }}
       >
-        {n.targetAlias && (
+        {data.targetAlias && (
           <Badge
             variant='secondary'
             className='inline-block max-w-[120px] truncate px-1.5 py-0 text-[10px]'
-            title={n.targetAlias}
+            title={data.targetAlias}
           >
-            {n.targetAlias}
+            {data.targetAlias}
           </Badge>
         )}
         <span className='ml-auto shrink-0'>
-          {n.fieldCount ?? 0} field{n.fieldCount !== 1 ? 's' : ''}
+          {data.fieldCount ?? 0} field{data.fieldCount !== 1 ? 's' : ''}
         </span>
       </div>
-      {outputs.map(
-        ([key, output]) =>
-          output && (
-            <div
-              key={key}
-              style={{ position: 'absolute', right: -5, top: '50%', marginTop: -5, zIndex: 1 }}
-            >
-              <RefSocket
-                name='output-socket'
-                side='output'
-                socketKey={key}
-                nodeId={n.id}
-                emit={props.emit}
-                payload={output.socket}
-              />
-            </div>
-          )
+      {data.hasOutgoing && (
+        <Handle
+          type='source'
+          position={Position.Right}
+          isConnectable={false}
+          style={SOCKET_STYLE}
+        />
       )}
     </div>
   );
 }
 
-function SocketComponent() {
+function RelationshipFlowEdge({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+}: EdgeProps<RelationshipFlowEdgeType>) {
+  const [path] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+  const color = data.warning ? WARNING_COLOR : EDGE_COLOR;
+
   return (
-    <div
-      style={{
-        width: 10,
-        height: 10,
-        borderRadius: '50%',
-        background: NODE_BORDER,
-        border: '2px solid var(--background)',
-      }}
+    <path
+      d={path}
+      fill='none'
+      strokeWidth={EDGE_STROKE_WIDTH}
+      stroke={color}
+      strokeDasharray={data.warning ? EDGE_WARNING_DASH : undefined}
+      opacity={data.dimmed ? DIMMED_OPACITY : 1}
+      style={{ transition: 'opacity 0.2s' }}
     />
   );
 }
 
-interface EditorHandle {
-  destroy: () => void;
-  fitView: () => Promise<void>;
-  zoomBy: (delta: number) => Promise<void>;
-  highlightNodes: (query: string) => void;
+const nodeTypes = { relationshipNode: RelationshipFlowNode };
+const edgeTypes = { relationshipEdge: RelationshipFlowEdge };
+
+interface NodeInfo {
+  dmId: string;
+  title: string;
+  description?: string | null;
+  depth: number;
+  isSource: boolean;
+  userHasAccess: boolean;
+  targetAlias?: string;
+  fieldCount?: number;
+  isDraft?: boolean;
+  isBlocked?: boolean;
+  isJoinNotConfigured?: boolean;
+  isCycleStub?: boolean;
 }
 
-async function setupEditor(
-  container: HTMLElement,
+interface EdgeInfo {
+  sourceId: string;
+  targetId: string;
+}
+
+interface RelationshipFlowGraph {
+  nodes: RelationshipFlowNodeType[];
+  edges: RelationshipFlowEdgeType[];
+}
+
+function getRelationshipFlowGraphIdentity(graph: RelationshipFlowGraph): string {
+  return JSON.stringify([
+    graph.nodes.map(node => [
+      node.id,
+      node.position.x,
+      node.position.y,
+      node.width,
+      node.height,
+      node.data.isSource,
+      node.data.label,
+      node.data.targetAlias,
+      node.data.fieldCount,
+      node.data.description,
+      node.data.isDraft,
+      node.data.isBlocked,
+      node.data.isJoinNotConfigured,
+      node.data.isCycleStub,
+      node.data.userHasAccess,
+      node.data.hasOutgoing,
+    ]),
+    graph.edges.map(edge => [edge.id, edge.source, edge.target, edge.data.warning]),
+  ]);
+}
+
+function buildRelationshipFlow(
   dataMartId: string,
   dataMartTitle: string,
   dataMartDescription: string | null | undefined,
@@ -342,110 +380,14 @@ async function setupEditor(
   graph: RelationshipGraph | null,
   fieldCounts: Map<string, number> | undefined,
   onOpenExternal: (targetDmId: string) => void
-): Promise<EditorHandle> {
-  const editor = new NodeEditor<Schemes>();
-  const area = new AreaPlugin<Schemes, AreaExtra>(container);
-  const connPlugin = new ConnectionPlugin<Schemes, AreaExtra>();
-  const render = new ReactPlugin<Schemes, AreaExtra>({ createRoot });
-  const minimap = new MinimapPlugin<Schemes>();
-
-  const { useConnection } = ReactPresets.classic;
-
-  function DraftAwareConnection(props: {
-    data: Schemes['Connection'] & { isLoop?: boolean };
-    styles?: () => unknown;
-  }) {
-    const { path } = useConnection();
-    if (!path) return null;
-    const src = editor.getNode(props.data.source);
-    const tgt = editor.getNode(props.data.target);
-    const orange =
-      src?.isDraft === true ||
-      src?.isBlocked === true ||
-      src?.isJoinNotConfigured === true ||
-      src?.isCycleStub === true ||
-      tgt?.isDraft === true ||
-      tgt?.isBlocked === true ||
-      tgt?.isJoinNotConfigured === true ||
-      tgt?.isCycleStub === true;
-    const bothDimmed =
-      (src?.dimmed === true || src === undefined) && (tgt?.dimmed === true || tgt === undefined);
-
-    return (
-      <svg
-        data-testid='connection'
-        style={{
-          overflow: 'visible',
-          position: 'absolute',
-          pointerEvents: 'none',
-          width: 9999,
-          height: 9999,
-        }}
-      >
-        <path
-          d={path}
-          fill='none'
-          strokeWidth='5px'
-          stroke={orange ? DRAFT_COLOR : 'steelblue'}
-          strokeDasharray={orange ? '8 4' : undefined}
-          opacity={bothDimmed ? 0.15 : 1}
-          style={{ pointerEvents: 'auto', transition: 'opacity 0.2s' }}
-        />
-      </svg>
-    );
-  }
-
-  render.addPreset(
-    ReactPresets.classic.setup({
-      customize: {
-        node() {
-          return NodeComponent;
-        },
-        socket() {
-          return SocketComponent;
-        },
-        connection() {
-          return DraftAwareConnection;
-        },
-      },
-    })
-  );
-  render.addPreset(ReactPresets.minimap.setup());
-  connPlugin.addPreset(ConnectionPresets.classic.setup());
-
-  editor.use(area);
-  area.use(connPlugin);
-  area.use(render);
-  area.use(minimap);
-
-  interface NodeInfo {
-    id: string;
-    dmId: string;
-    title: string;
-    description?: string | null;
-    depth: number;
-    isSource: boolean;
-    userHasAccess: boolean;
-    targetAlias?: string;
-    fieldCount?: number;
-    isDraft?: boolean;
-    isBlocked?: boolean;
-    isJoinNotConfigured?: boolean;
-    isCycleStub?: boolean;
-  }
-  interface EdgeInfo {
-    sourceId: string;
-    targetId: string;
-  }
-
+): RelationshipFlowGraph {
   const nodeInfos = new Map<string, NodeInfo>();
-  const edges: EdgeInfo[] = [];
+  const edgeInfos: EdgeInfo[] = [];
   const hasOutgoing = new Set<string>();
 
   const rootIsDraft = dataMartStatus === 'DRAFT';
 
   nodeInfos.set(dataMartId, {
-    id: dataMartId,
     dmId: dataMartId,
     title: dataMartTitle,
     description: dataMartDescription,
@@ -462,15 +404,14 @@ async function setupEditor(
   function addEdgeAndNode(
     parentNodeKey: string,
     dmId: string,
-    info: Omit<NodeInfo, 'id' | 'dmId'>,
+    info: Omit<NodeInfo, 'dmId'>,
     aliasPath: string
-  ): string {
+  ): void {
     const nodeKey = `${dmId}-${nodeCounter++}`;
-    edges.push({ sourceId: parentNodeKey, targetId: nodeKey });
+    edgeInfos.push({ sourceId: parentNodeKey, targetId: nodeKey });
     hasOutgoing.add(parentNodeKey);
-    nodeInfos.set(nodeKey, { id: nodeKey, dmId, ...info });
+    nodeInfos.set(nodeKey, { dmId, ...info });
     aliasPathToNodeKey.set(aliasPath, nodeKey);
-    return nodeKey;
   }
 
   if (graph) {
@@ -521,179 +462,112 @@ async function setupEditor(
     }
   }
 
-  const nodeMap = new Map<string, DMNode>();
-  const columns = new Map<number, DMNode[]>();
-
+  const columns = new Map<number, string[]>();
+  const heights = new Map<string, number>();
   for (const [nodeKey, info] of nodeInfos) {
-    const node = new DMNode(info.title, info.dmId, info.isSource, info.depth, {
-      targetAlias: info.targetAlias,
-      fieldCount: info.fieldCount,
-      description: info.description,
-      isDraft: info.isDraft,
-      isBlocked: info.isBlocked,
-      isJoinNotConfigured: info.isJoinNotConfigured,
-      isCycleStub: info.isCycleStub,
-      userHasAccess: info.userHasAccess,
-      onOpenExternal: () => {
-        onOpenExternal(info.dmId);
-      },
-    });
-
-    if (hasOutgoing.has(nodeKey) && !info.isCycleStub) {
-      node.addOutput('out', new ClassicPreset.Output(SOCKET));
-    }
-    if (!info.isSource) {
-      node.addInput('in', new ClassicPreset.Input(SOCKET));
-    }
-
-    await editor.addNode(node);
-    nodeMap.set(nodeKey, node);
-
+    heights.set(nodeKey, info.isSource ? SRC_H : TGT_H);
     const col = columns.get(info.depth) ?? [];
     if (!columns.has(info.depth)) columns.set(info.depth, col);
-    col.push(node);
+    col.push(nodeKey);
   }
 
-  for (const edge of edges) {
-    const src = nodeMap.get(edge.sourceId);
-    const tgt = nodeMap.get(edge.targetId);
-    if (src && tgt) {
-      await editor.addConnection(
-        new ClassicPreset.Connection(
-          src as ClassicPreset.Node,
-          'out',
-          tgt as ClassicPreset.Node,
-          'in'
-        )
-      );
-    }
-  }
-
+  const positions = new Map<string, { x: number; y: number }>();
   const maxDepth = Math.max(...Array.from(columns.keys()));
 
   for (let d = 0; d <= maxDepth; d++) {
     const col = columns.get(d) ?? [];
     let y = 0;
 
-    for (const node of col) {
-      await area.translate(node.id, { x: d * (NODE_W + H_GAP), y });
-      y += node.height + V_GAP;
+    for (const nodeKey of col) {
+      positions.set(nodeKey, { x: d * (NODE_W + H_GAP), y });
+      y += (heights.get(nodeKey) ?? TGT_H) + V_GAP;
     }
 
     if (d === 0 && col.length === 1) {
+      const rootKey = col[0];
       const nextCol = columns.get(1) ?? [];
-      const nextH = nextCol.reduce((s, n) => s + n.height + V_GAP, -V_GAP);
-      await area.translate(col[0].id, {
-        x: 0,
-        y: Math.max(0, nextH / 2 - col[0].height / 2),
-      });
+      const nextH = nextCol.reduce((s, k) => s + (heights.get(k) ?? TGT_H) + V_GAP, -V_GAP);
+      const rootH = heights.get(rootKey) ?? SRC_H;
+      positions.set(rootKey, { x: 0, y: Math.max(0, nextH / 2 - rootH / 2) });
     }
   }
 
-  const BASE_GRID = 16;
-  const updateGrid = () => {
-    const { x, y, k } = area.area.transform;
-    const size = BASE_GRID * k;
-    container.style.backgroundSize = `${size}px ${size}px`;
-    container.style.backgroundPosition = `${x}px ${y}px`;
-  };
+  const nodes: RelationshipFlowNodeType[] = [];
+  for (const [nodeKey, info] of nodeInfos) {
+    nodes.push({
+      id: nodeKey,
+      type: 'relationshipNode',
+      position: positions.get(nodeKey) ?? { x: 0, y: 0 },
+      width: NODE_W,
+      height: heights.get(nodeKey) ?? TGT_H,
+      draggable: false,
+      selectable: false,
+      focusable: false,
+      style: STATIC_NODE_STYLE,
+      data: {
+        isSource: info.isSource,
+        label: info.title,
+        targetAlias: info.targetAlias,
+        fieldCount: info.fieldCount,
+        description: info.description,
+        isDraft: info.isDraft ?? false,
+        isBlocked: info.isBlocked ?? false,
+        isJoinNotConfigured: info.isJoinNotConfigured ?? false,
+        isCycleStub: info.isCycleStub ?? false,
+        userHasAccess: info.userHasAccess,
+        hasOutgoing: hasOutgoing.has(nodeKey) && !info.isCycleStub,
+        highlighted: false,
+        dimmed: false,
+        onOpenExternal: () => {
+          onOpenExternal(info.dmId);
+        },
+      },
+    });
+  }
 
-  let zoomRange = getGraphZoomRange(area.area.transform.k);
+  const edges: RelationshipFlowEdgeType[] = [];
+  for (const edge of edgeInfos) {
+    const src = nodeInfos.get(edge.sourceId);
+    const tgt = nodeInfos.get(edge.targetId);
+    if (!src || !tgt) continue;
+    const warning =
+      src.isDraft === true ||
+      src.isBlocked === true ||
+      src.isJoinNotConfigured === true ||
+      src.isCycleStub === true ||
+      tgt.isDraft === true ||
+      tgt.isBlocked === true ||
+      tgt.isJoinNotConfigured === true ||
+      tgt.isCycleStub === true;
 
-  const updateZoomRangeFromCurrentTransform = () => {
-    zoomRange = getGraphZoomRange(area.area.transform.k);
-  };
+    edges.push({
+      id: `${edge.sourceId}->${edge.targetId}`,
+      type: 'relationshipEdge',
+      source: edge.sourceId,
+      target: edge.targetId,
+      focusable: false,
+      selectable: false,
+      data: { warning, dimmed: false },
+    });
+  }
 
-  let isFittingView = false;
-
-  const fitView = async () => {
-    isFittingView = true;
-    try {
-      await AreaExtensions.zoomAt(area, editor.getNodes(), { scale: FIT_VIEW_SCALE });
-    } finally {
-      isFittingView = false;
-    }
-    updateZoomRangeFromCurrentTransform();
-    updateGrid();
-  };
-  await fitView();
-
-  const zoomBy = async (delta: number) => {
-    const cx = container.clientWidth / 2;
-    const cy = container.clientHeight / 2;
-    const { k } = area.area.transform;
-    const next = getNextGraphZoom(k, delta, zoomRange);
-    if (!next) return;
-    await area.area.zoom(next.zoom, -cx * next.delta, -cy * next.delta);
-    updateGrid();
-  };
-
-  AreaExtensions.restrictor(area, {
-    translation: () => {
-      const { k } = area.area.transform;
-      const bb = AreaExtensions.getBoundingBox(area, editor.getNodes());
-      const rect = container.getBoundingClientRect();
-      const pad = 150;
-      return {
-        left: pad - bb.right * k,
-        right: rect.width - pad - bb.left * k,
-        top: pad - bb.bottom * k,
-        bottom: rect.height - pad - bb.top * k,
-      };
-    },
-  });
-
-  area.addPipe(ctx => {
-    if (ctx.type === 'zoom') {
-      if (ctx.data.source === 'dblclick') return undefined;
-      const nextK = ctx.data.zoom;
-      if (!isGraphZoomAllowed(nextK, zoomRange, { allowBelowMin: isFittingView })) {
-        return undefined;
-      }
-    }
-    if (ctx.type === 'nodetranslate') return undefined;
-    if (ctx.type === 'translated' || ctx.type === 'zoomed') {
-      updateGrid();
-    }
-    return ctx;
-  });
-
-  const highlightNodes = (query: string) => {
-    const q = query.toLowerCase();
-    const matching: DMNode[] = [];
-
-    for (const node of editor.getNodes()) {
-      const prev = { h: node.highlighted, d: node.dimmed };
-      node.highlighted = q !== '' && node.label.toLowerCase().includes(q);
-      node.dimmed = q !== '' && !node.highlighted;
-      if (node.highlighted) matching.push(node);
-      if (prev.h !== node.highlighted || prev.d !== node.dimmed) {
-        void area.update('node', node.id);
-      }
-    }
-
-    // Also update connections so they dim when both endpoints are dimmed
-    for (const conn of editor.getConnections()) {
-      void area.update('connection', conn.id);
-    }
-
-    if (matching.length > 0) {
-      // Keep the full-graph fit as the zoom-out floor; search only focuses matching nodes.
-      void AreaExtensions.zoomAt(area, matching, { scale: FIT_VIEW_SCALE });
-    }
-  };
-
-  return {
-    destroy: () => {
-      area.destroy();
-    },
-    fitView,
-    zoomBy,
-    highlightNodes,
-  };
+  return { nodes, edges };
 }
 
-export function RelationshipCanvas({
+interface RelationshipCanvasInnerProps {
+  dataMartId: string;
+  dataMartTitle: string;
+  dataMartDescription?: string | null;
+  dataMartStatus: string;
+  relationships: DataMartRelationship[];
+  relationshipGraph: RelationshipGraph | null;
+  connectedFieldCounts?: Map<string, number>;
+  searchQuery: string;
+  onRequestFullscreen?: () => void;
+  onOpenExternal: (targetId: string) => void;
+}
+
+function RelationshipCanvasInner({
   dataMartId,
   dataMartTitle,
   dataMartDescription,
@@ -703,26 +577,31 @@ export function RelationshipCanvas({
   connectedFieldCounts,
   searchQuery,
   onRequestFullscreen,
-  className,
-  style,
-}: RelationshipCanvasProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const editorRef = useRef<EditorHandle | null>(null);
-  const searchQueryRef = useRef(searchQuery);
-  searchQueryRef.current = searchQuery;
+  onOpenExternal,
+}: RelationshipCanvasInnerProps) {
+  const reactFlow = useReactFlow<RelationshipFlowNodeType, RelationshipFlowEdgeType>();
+  const paneWidth = useStore(s => s.width);
+  const paneHeight = useStore(s => s.height);
+  const hasFitRef = useRef(false);
+  const userInteractedRef = useRef(false);
+  const [zoomRange, setZoomRange] = useState<GraphZoomRange>({
+    min: GRAPH_ZOOM_MIN,
+    max: GRAPH_ZOOM_MAX,
+  });
 
-  const handleOpenExternal = useCallback((targetId: string) => {
-    const basePath = window.location.pathname.replace(/\/data-marts\/.*/, '');
-    window.open(`${basePath}/data-marts/${targetId}/data-setup`, '_blank');
-  }, []);
-
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || relationships.length === 0) return;
-
-    let cancelled = false;
-    void setupEditor(
-      el,
+  const graphResult = useMemo(
+    () =>
+      buildRelationshipFlow(
+        dataMartId,
+        dataMartTitle,
+        dataMartDescription,
+        dataMartStatus,
+        relationships,
+        relationshipGraph,
+        connectedFieldCounts,
+        onOpenExternal
+      ),
+    [
       dataMartId,
       dataMartTitle,
       dataMartDescription,
@@ -730,54 +609,128 @@ export function RelationshipCanvas({
       relationships,
       relationshipGraph,
       connectedFieldCounts,
-      handleOpenExternal
-    ).then(h => {
-      if (cancelled) {
-        h.destroy();
-        return;
-      }
-      editorRef.current = h;
-      if (searchQueryRef.current) {
-        h.highlightNodes(searchQueryRef.current);
-      }
-    });
+      onOpenExternal,
+    ]
+  );
 
-    return () => {
-      cancelled = true;
-      editorRef.current?.destroy();
-      editorRef.current = null;
-      el.replaceChildren();
-    };
-  }, [
-    dataMartId,
-    dataMartTitle,
-    dataMartDescription,
-    dataMartStatus,
-    relationships,
-    relationshipGraph,
-    connectedFieldCounts,
-    handleOpenExternal,
-  ]);
+  const graphIdentity = useMemo(() => getRelationshipFlowGraphIdentity(graphResult), [graphResult]);
+  const graphBounds = useMemo(() => getCanvasGraphBounds(graphResult.nodes), [graphResult.nodes]);
+  const previousGraphIdentityRef = useRef(graphIdentity);
 
   useEffect(() => {
-    editorRef.current?.highlightNodes(searchQuery);
-  }, [searchQuery]);
+    if (previousGraphIdentityRef.current === graphIdentity) return;
+    previousGraphIdentityRef.current = graphIdentity;
+    userInteractedRef.current = false;
+  }, [graphIdentity]);
 
-  if (relationships.length === 0) return null;
+  const highlightState = useMemo(
+    () =>
+      computeCanvasHighlight(
+        graphResult.nodes,
+        searchQuery,
+        node => node.id,
+        node => node.data.label
+      ),
+    [graphResult.nodes, searchQuery]
+  );
+
+  const flowNodes = useMemo(
+    () =>
+      graphResult.nodes.map(node => {
+        const state = highlightState.get(node.id) ?? NO_HIGHLIGHT;
+        return node.data.highlighted === state.highlighted && node.data.dimmed === state.dimmed
+          ? node
+          : { ...node, data: { ...node.data, ...state } };
+      }),
+    [graphResult.nodes, highlightState]
+  );
+
+  const flowEdges = useMemo(
+    () =>
+      graphResult.edges.map(edge => {
+        const dimmed =
+          (highlightState.get(edge.source)?.dimmed ?? false) &&
+          (highlightState.get(edge.target)?.dimmed ?? false);
+        return edge.data.dimmed === dimmed ? edge : { ...edge, data: { ...edge.data, dimmed } };
+      }),
+    [graphResult.edges, highlightState]
+  );
+
+  const highlightStateRef = useRef(highlightState);
+  highlightStateRef.current = highlightState;
+
+  const zoomToMatches = useCallback(() => {
+    const matchingIds = [...highlightStateRef.current.entries()]
+      .filter(([, s]) => s.highlighted)
+      .map(([id]) => id);
+    if (matchingIds.length === 0) return;
+    void reactFlow.fitView({
+      nodes: matchingIds.map(id => ({ id })),
+      duration: 300,
+      padding: FIT_VIEW_PADDING,
+    });
+  }, [reactFlow]);
+
+  const fitFull = useCallback(() => {
+    return reactFlow
+      .fitView({
+        minZoom: GRAPH_ZOOM_MIN,
+        maxZoom: GRAPH_ZOOM_MAX,
+        padding: FIT_VIEW_PADDING,
+      })
+      .then(() => {
+        setZoomRange(getGraphZoomRange(reactFlow.getZoom()));
+      });
+  }, [reactFlow]);
+
+  const markUserInteracted = useCallback(() => {
+    userInteractedRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (paneWidth === 0 || paneHeight === 0) return;
+    if (userInteractedRef.current) return;
+    void fitFull().then(() => {
+      hasFitRef.current = true;
+      zoomToMatches();
+    });
+  }, [paneWidth, paneHeight, graphResult, fitFull, zoomToMatches]);
+
+  useEffect(() => {
+    if (!hasFitRef.current) return;
+    zoomToMatches();
+  }, [highlightState, zoomToMatches]);
+
+  const handleZoom = useCallback(
+    (delta: number) => {
+      markUserInteracted();
+      const next = getNextGraphZoom(reactFlow.getZoom(), delta, zoomRange);
+      if (!next) return;
+      void reactFlow.zoomTo(next.zoom, { duration: 150 });
+    },
+    [markUserInteracted, reactFlow, zoomRange]
+  );
+
+  const handleMove = useCallback(
+    (_event: MouseEvent | TouchEvent | null, viewport: Viewport) => {
+      if (paneWidth === 0 || paneHeight === 0) return;
+
+      const clampedViewport = clampCanvasViewport(
+        viewport,
+        graphBounds,
+        paneWidth,
+        paneHeight,
+        GRAPH_PAN_PADDING
+      );
+      if (clampedViewport.x === viewport.x && clampedViewport.y === viewport.y) return;
+
+      void reactFlow.setViewport(clampedViewport);
+    },
+    [graphBounds, paneHeight, paneWidth, reactFlow]
+  );
 
   return (
-    <div
-      className={`rel-canvas relative overflow-hidden rounded-lg border ${className ?? ''}`}
-      style={style ?? { height: 480 }}
-    >
-      <style>{`
-        .rel-canvas svg path { stroke-width: 1.5px !important; }
-        .rel-canvas [data-testid="minimap"] { transform: scale(0.5); transform-origin: bottom right; }
-        @keyframes node-pulse {
-          0%, 100% { box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25), 0 0 12px rgba(59, 130, 246, 0.4); }
-          50% { box-shadow: 0 0 0 6px rgba(59, 130, 246, 0.15), 0 0 20px rgba(59, 130, 246, 0.5); }
-        }
-      `}</style>
+    <>
       <div className='absolute top-3 right-3 z-10 flex items-start gap-2'>
         <div className='flex flex-col gap-1.5'>
           <Button
@@ -785,7 +738,8 @@ export function RelationshipCanvas({
             size='icon'
             className='h-12 w-12'
             onClick={() => {
-              void editorRef.current?.fitView();
+              markUserInteracted();
+              void fitFull();
             }}
             aria-label='Fit to view'
           >
@@ -796,7 +750,7 @@ export function RelationshipCanvas({
             size='icon'
             className='h-12 w-12'
             onClick={() => {
-              void editorRef.current?.zoomBy(0.25);
+              handleZoom(0.25);
             }}
             aria-label='Zoom in'
           >
@@ -807,7 +761,7 @@ export function RelationshipCanvas({
             size='icon'
             className='h-12 w-12'
             onClick={() => {
-              void editorRef.current?.zoomBy(-0.25);
+              handleZoom(-0.25);
             }}
             aria-label='Zoom out'
           >
@@ -827,15 +781,79 @@ export function RelationshipCanvas({
         </div>
       </div>
       <div
-        ref={containerRef}
-        style={{
-          width: '100%',
-          height: '100%',
-          backgroundImage:
-            'linear-gradient(rgba(0,0,0,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(0,0,0,0.06) 1px, transparent 1px)',
-          backgroundSize: '16px 16px',
-        }}
-      />
+        className='h-full w-full'
+        onPointerDownCapture={markUserInteracted}
+        onWheelCapture={markUserInteracted}
+      >
+        <ReactFlow
+          nodes={flowNodes}
+          edges={flowEdges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          edgesFocusable={false}
+          zoomOnDoubleClick={false}
+          minZoom={zoomRange.min}
+          maxZoom={zoomRange.max}
+          onMove={handleMove}
+          onMoveStart={(event: unknown) => {
+            if (event) markUserInteracted();
+          }}
+          style={{ width: '100%', height: '100%' }}
+        >
+          <Background variant={BackgroundVariant.Lines} gap={16} color='rgba(0,0,0,0.06)' />
+          <MiniMap pannable zoomable style={{ width: 140, height: 100 }} />
+        </ReactFlow>
+      </div>
+    </>
+  );
+}
+
+export function RelationshipCanvas({
+  dataMartId,
+  dataMartTitle,
+  dataMartDescription,
+  dataMartStatus,
+  relationships,
+  relationshipGraph,
+  connectedFieldCounts,
+  searchQuery,
+  onRequestFullscreen,
+  className,
+  style,
+}: RelationshipCanvasProps) {
+  const { scope } = useProjectRoute();
+  const handleOpenExternal = useCallback(
+    (targetId: string) => {
+      window.open(scope(`/data-marts/${targetId}/data-setup`), '_blank');
+    },
+    [scope]
+  );
+
+  if (relationships.length === 0) return null;
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-lg border ${className ?? ''}`}
+      style={style ?? { height: 480 }}
+    >
+      <style>{NODE_PULSE_KEYFRAMES}</style>
+      <ReactFlowProvider>
+        <RelationshipCanvasInner
+          dataMartId={dataMartId}
+          dataMartTitle={dataMartTitle}
+          dataMartDescription={dataMartDescription}
+          dataMartStatus={dataMartStatus}
+          relationships={relationships}
+          relationshipGraph={relationshipGraph}
+          connectedFieldCounts={connectedFieldCounts}
+          searchQuery={searchQuery}
+          onRequestFullscreen={onRequestFullscreen}
+          onOpenExternal={handleOpenExternal}
+        />
+      </ReactFlowProvider>
     </div>
   );
 }

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipFlowNode.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipFlowNode.test.tsx
@@ -1,0 +1,74 @@
+import type { NodeProps } from '@xyflow/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { RelationshipFlowNode, type RelationshipFlowNodeType } from './RelationshipCanvas';
+
+vi.mock('@xyflow/react', async importOriginal => {
+  const actual = await importOriginal<typeof import('@xyflow/react')>();
+  return {
+    ...actual,
+    Handle: () => null,
+    Position: { Left: 'left', Right: 'right' },
+  };
+});
+
+function renderNode(onOpenExternal = vi.fn()) {
+  const props = {
+    id: 'customers',
+    type: 'relationshipNode',
+    data: {
+      isSource: false,
+      label: 'Customers',
+      targetAlias: 'customers',
+      fieldCount: 3,
+      description: 'Customer dimension',
+      isDraft: false,
+      isBlocked: false,
+      isJoinNotConfigured: false,
+      isCycleStub: false,
+      userHasAccess: true,
+      hasOutgoing: false,
+      highlighted: false,
+      dimmed: false,
+      onOpenExternal,
+    },
+    dragging: false,
+    zIndex: 0,
+    selectable: false,
+    deletable: false,
+    selected: false,
+    draggable: false,
+    isConnectable: false,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
+  } as NodeProps<RelationshipFlowNodeType>;
+
+  return render(<RelationshipFlowNode {...props} />);
+}
+
+describe('RelationshipFlowNode', () => {
+  it('shows the description tooltip from a keyboard-focusable trigger', async () => {
+    renderNode();
+
+    const descriptionHelp = screen.getByRole('button', { name: 'Description for Customers' });
+    act(() => {
+      descriptionHelp.focus();
+    });
+
+    expect(descriptionHelp).toHaveFocus();
+    await waitFor(() => {
+      expect(descriptionHelp).toHaveAttribute('aria-describedby');
+    });
+    const descriptionId = descriptionHelp.getAttribute('aria-describedby');
+    expect(document.getElementById(descriptionId ?? '')).toHaveTextContent('Customer dimension');
+  });
+
+  it('includes the data mart title in the external action name', () => {
+    const onOpenExternal = vi.fn();
+    renderNode(onOpenExternal);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Customers in new tab' }));
+
+    expect(onOpenExternal).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  GRAPH_ZOOM_MAX,
-  getGraphZoomRange,
-  getNextGraphZoom,
-  isGraphZoomAllowed,
-} from './relationship-canvas-zoom';
+import { GRAPH_ZOOM_MAX, getGraphZoomRange, getNextGraphZoom } from './relationship-canvas-zoom';
 
 describe('relationship canvas zoom', () => {
   it('uses the fitted graph zoom as the minimum zoom', () => {
@@ -48,20 +43,5 @@ describe('relationship canvas zoom', () => {
   it('falls back to a valid minimum for invalid fitted zoom values', () => {
     expect(getGraphZoomRange(Number.NaN).min).toBe(1);
     expect(getGraphZoomRange(0).min).toBe(1);
-  });
-
-  it('checks whether a zoom value is inside the graph zoom range', () => {
-    const range = getGraphZoomRange(0.5);
-
-    expect(isGraphZoomAllowed(0.5, range)).toBe(true);
-    expect(isGraphZoomAllowed(0.49, range)).toBe(false);
-    expect(isGraphZoomAllowed(GRAPH_ZOOM_MAX + 0.01, range)).toBe(false);
-  });
-
-  it('allows programmatic fit zoom below the current range minimum', () => {
-    const range = getGraphZoomRange(1);
-
-    expect(isGraphZoomAllowed(0.25, range, { allowBelowMin: true })).toBe(true);
-    expect(isGraphZoomAllowed(GRAPH_ZOOM_MAX + 0.01, range, { allowBelowMin: true })).toBe(false);
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.ts
@@ -7,10 +7,6 @@ export interface GraphZoomRange {
   max: number;
 }
 
-interface GraphZoomAllowedOptions {
-  allowBelowMin?: boolean;
-}
-
 export function getGraphZoomRange(fittedZoom: number): GraphZoomRange {
   const safeFittedZoom =
     Number.isFinite(fittedZoom) && fittedZoom > 0
@@ -39,14 +35,4 @@ export function getNextGraphZoom(
     zoom,
     delta: zoom / currentZoom - 1,
   };
-}
-
-export function isGraphZoomAllowed(
-  zoom: number,
-  range: GraphZoomRange,
-  options: GraphZoomAllowedOptions = {}
-): boolean {
-  const min = options.allowBelowMin ? 0 : range.min - GRAPH_ZOOM_EPSILON;
-
-  return zoom >= min && zoom <= range.max + GRAPH_ZOOM_EPSILON;
 }

--- a/apps/web/src/features/data-marts/model-canvas/api/model-canvas.service.ts
+++ b/apps/web/src/features/data-marts/model-canvas/api/model-canvas.service.ts
@@ -1,0 +1,44 @@
+import type { AxiosRequestConfig } from '../../../../app/api/apiClient';
+import { ApiService } from '../../../../services';
+import type { ModelCanvasEdge, ModelCanvasNode } from '../model/types';
+
+interface ModelCanvasDataMartsResponseDto {
+  items: ModelCanvasNode[];
+  total: number;
+  nextOffset: number | null;
+}
+
+interface ModelCanvasEdgesResponseDto {
+  edges: ModelCanvasEdge[];
+}
+
+class ModelCanvasService extends ApiService {
+  constructor() {
+    super('/model-canvas');
+  }
+
+  async getDataMarts(storageId: string, config?: AxiosRequestConfig): Promise<ModelCanvasNode[]> {
+    const allItems: ModelCanvasNode[] = [];
+    let nextOffset: number | null = 0;
+
+    while (nextOffset !== null) {
+      const page: ModelCanvasDataMartsResponseDto = await this.get<ModelCanvasDataMartsResponseDto>(
+        '/data-marts',
+        { storageId, offset: nextOffset },
+        config
+      );
+
+      allItems.push(...page.items);
+      nextOffset = page.nextOffset;
+    }
+
+    return allItems;
+  }
+
+  async getEdges(storageId: string, config?: AxiosRequestConfig): Promise<ModelCanvasEdge[]> {
+    const response = await this.get<ModelCanvasEdgesResponseDto>('/edges', { storageId }, config);
+    return response.edges;
+  }
+}
+
+export const modelCanvasService = new ModelCanvasService();

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.test.tsx
@@ -1,0 +1,150 @@
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DataMartStatus } from '../../shared/enums/data-mart-status.enum';
+import ModelCanvas from './ModelCanvas';
+
+interface ViewportStub {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
+interface ReactFlowStubProps {
+  children?: ReactNode;
+  nodes?: {
+    position: { x: number; y: number };
+    width?: number;
+    height?: number;
+  }[];
+  onMove?: (event: unknown, viewport: ViewportStub) => void;
+}
+
+const reactFlow = vi.hoisted(() => ({
+  fitView: vi.fn().mockResolvedValue(undefined),
+  zoomIn: vi.fn().mockResolvedValue(undefined),
+  zoomOut: vi.fn().mockResolvedValue(undefined),
+  setViewport: vi.fn().mockResolvedValue(undefined),
+  latestProps: null as ReactFlowStubProps | null,
+  store: { width: 800, height: 600 },
+}));
+
+vi.mock('@xyflow/react', () => ({
+  Background: () => null,
+  BackgroundVariant: { Lines: 'lines' },
+  Handle: () => null,
+  MarkerType: { ArrowClosed: 'arrowclosed' },
+  MiniMap: () => null,
+  Position: { Bottom: 'bottom', Left: 'left', Right: 'right', Top: 'top' },
+  ReactFlow: (props: ReactFlowStubProps) => {
+    reactFlow.latestProps = props;
+    return <div>{props.children}</div>;
+  },
+  ReactFlowProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useReactFlow: () => reactFlow,
+  useStore: (selector: (state: { width: number; height: number }) => unknown) =>
+    selector(reactFlow.store),
+}));
+
+describe('ModelCanvas', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    reactFlow.latestProps = null;
+    reactFlow.store.width = 800;
+    reactFlow.store.height = 600;
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps active search matches fitted after changing layout direction', async () => {
+    render(
+      <ModelCanvas
+        nodes={[
+          {
+            id: 'orders',
+            title: 'Orders',
+            status: DataMartStatus.PUBLISHED,
+            description: null,
+            fieldCount: 3,
+          },
+          {
+            id: 'customers',
+            title: 'Customers',
+            status: DataMartStatus.PUBLISHED,
+            description: null,
+            fieldCount: 2,
+          },
+        ]}
+        edges={[]}
+        searchQuery='orders'
+        onOpenDataMart={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(reactFlow.fitView).toHaveBeenCalled();
+    });
+    reactFlow.fitView.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Canvas settings' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Vertical' }));
+
+    await waitFor(() => {
+      expect(reactFlow.fitView).toHaveBeenCalled();
+    });
+    expect(reactFlow.fitView).toHaveBeenLastCalledWith({
+      nodes: [{ id: 'orders' }],
+      duration: 300,
+      padding: 0.2,
+    });
+  });
+
+  it('clamps MiniMap and programmatic panning to the rendered graph bounds', async () => {
+    render(
+      <ModelCanvas
+        nodes={[
+          {
+            id: 'orders',
+            title: 'Orders',
+            status: DataMartStatus.PUBLISHED,
+            description: null,
+            fieldCount: 3,
+          },
+          {
+            id: 'customers',
+            title: 'Customers',
+            status: DataMartStatus.PUBLISHED,
+            description: null,
+            fieldCount: 2,
+          },
+        ]}
+        edges={[]}
+        searchQuery=''
+        onOpenDataMart={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(reactFlow.latestProps?.nodes).toHaveLength(2);
+    });
+    const nodes = reactFlow.latestProps?.nodes ?? [];
+    const minY = Math.min(...nodes.map(node => node.position.y));
+    const maxX = Math.max(...nodes.map(node => node.position.x + (node.width ?? 0)));
+
+    reactFlow.latestProps?.onMove?.(null, { x: -10_000, y: 10_000, zoom: 1 });
+
+    expect(reactFlow.setViewport).toHaveBeenCalledWith({
+      x: 150 - maxX,
+      y: reactFlow.store.height - 150 - minY,
+      zoom: 1,
+    });
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.tsx
@@ -1,0 +1,477 @@
+import { Check, Locate, Settings, ZoomIn, ZoomOut } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Background,
+  BackgroundVariant,
+  MarkerType,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+  useStore,
+  type Viewport,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { Popover, PopoverContent, PopoverTitle, PopoverTrigger } from '@owox/ui/components/popover';
+import { Switch } from '@owox/ui/components/switch';
+import { Button } from '../../../../shared/components/Button';
+import { storageService } from '../../../../services/localstorage.service';
+import {
+  EDGE_COLOR,
+  NODE_PULSE_KEYFRAMES,
+  STATIC_NODE_STYLE,
+  WARNING_COLOR,
+} from '../../shared/canvas/constants';
+import {
+  computeCanvasHighlight,
+  NO_HIGHLIGHT,
+  type CanvasHighlightState,
+} from '../../shared/canvas/highlight';
+import { clampCanvasViewport, getCanvasGraphBounds } from '../../shared/canvas/viewport';
+import { DataMartStatus } from '../../shared/enums/data-mart-status.enum';
+import {
+  CANVAS_DIRECTION_OPTIONS,
+  parseCanvasDirection,
+  type CanvasDirection,
+} from '../model/graph/canvas-direction';
+import {
+  runDagreLayout,
+  type DagreLayoutEdge,
+  type DagreLayoutNode,
+} from '../model/graph/dagre-layout';
+import type { CanvasRenderEdge } from '../model/graph/merge-bidirectional-edges';
+import { computeParallelEdgeOffsets } from '../model/graph/parallel-edge-offsets';
+import type { PathPoint } from '../model/graph/rounded-path';
+import type { ModelCanvasNode } from '../model/types';
+import ModelCanvasFlowEdge, { type ModelCanvasFlowEdgeType } from './ModelCanvasFlowEdge';
+import ModelCanvasFlowNode, {
+  NODE_HEIGHT,
+  NODE_WIDTH,
+  type ModelCanvasFlowNodeType,
+} from './ModelCanvasFlowNode';
+
+interface ModelCanvasProps {
+  nodes: ModelCanvasNode[];
+  edges: CanvasRenderEdge[];
+  searchQuery: string;
+  onOpenDataMart: (dataMartId: string) => void;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const LAYOUT_LS_KEY = 'model-canvas-layout';
+const JOIN_LABELS_LS_KEY = 'model-canvas-show-join-fields';
+const FIT_VIEW_PADDING = 0.2;
+const MARKER_SIZE = 12;
+const LABEL_CHAR_WIDTH = 6.6;
+const LABEL_HORIZONTAL_PADDING = 18;
+const LABEL_LINE_HEIGHT = 16.5;
+const LABEL_VERTICAL_PADDING = 8;
+const CANVAS_PAN_PADDING = 150;
+
+function estimateEdgeLabelDimensions(
+  joinLabel: string[]
+): { width: number; height: number } | undefined {
+  if (joinLabel.length === 0) return undefined;
+  const maxLineChars = Math.max(...joinLabel.map(line => line.length));
+  return {
+    width: maxLineChars * LABEL_CHAR_WIDTH + LABEL_HORIZONTAL_PADDING,
+    height: joinLabel.length * LABEL_LINE_HEIGHT + LABEL_VERTICAL_PADDING,
+  };
+}
+
+const nodeTypes = { modelCanvasNode: ModelCanvasFlowNode };
+const edgeTypes = { modelCanvasEdge: ModelCanvasFlowEdge };
+
+interface FlowNodeParams {
+  node: ModelCanvasNode;
+  position: PathPoint;
+  hasIncoming: boolean;
+  hasOutgoing: boolean;
+  highlight: CanvasHighlightState;
+  direction: CanvasDirection;
+  onOpenExternal: () => void;
+}
+
+function buildFlowNode(params: FlowNodeParams): ModelCanvasFlowNodeType {
+  const { node, highlight } = params;
+  return {
+    id: node.id,
+    type: 'modelCanvasNode',
+    position: params.position,
+    width: NODE_WIDTH,
+    height: NODE_HEIGHT,
+    draggable: false,
+    selectable: false,
+    focusable: false,
+    style: STATIC_NODE_STYLE,
+    data: {
+      title: node.title,
+      isDraft: node.status === DataMartStatus.DRAFT,
+      fieldCount: node.fieldCount,
+      description: node.description,
+      hasIncoming: params.hasIncoming,
+      hasOutgoing: params.hasOutgoing,
+      highlighted: highlight.highlighted,
+      dimmed: highlight.dimmed,
+      direction: params.direction,
+      onOpenExternal: params.onOpenExternal,
+    },
+  };
+}
+
+function buildJoinLabel(edge: CanvasRenderEdge): string[] {
+  return edge.joinConditions.map(c => `${c.sourceFieldName} = ${c.targetFieldName}`);
+}
+
+interface FlowEdgeParams {
+  edge: CanvasRenderEdge;
+  joinLabel: string[];
+  route: PathPoint[];
+  bowOffset: number;
+  warning: boolean;
+  dimmed: boolean;
+  labelPosition: PathPoint | undefined;
+  direction: CanvasDirection;
+}
+
+function buildFlowEdge(params: FlowEdgeParams): ModelCanvasFlowEdgeType {
+  const { edge, warning } = params;
+  const color = warning ? WARNING_COLOR : EDGE_COLOR;
+  const marker = { type: MarkerType.ArrowClosed, color, width: MARKER_SIZE, height: MARKER_SIZE };
+
+  return {
+    id: edge.id,
+    type: 'modelCanvasEdge',
+    source: edge.sourceId,
+    target: edge.targetId,
+    focusable: false,
+    selectable: false,
+    markerEnd: marker,
+    markerStart: edge.bidirectional ? marker : undefined,
+    data: {
+      route: params.route,
+      bowOffset: params.bowOffset,
+      warning,
+      joinLabel: params.joinLabel,
+      dimmed: params.dimmed,
+      labelPosition: params.labelPosition,
+      direction: params.direction,
+    },
+  };
+}
+
+interface ModelCanvasInnerProps {
+  nodes: ModelCanvasNode[];
+  edges: CanvasRenderEdge[];
+  searchQuery: string;
+  onOpenDataMart: (dataMartId: string) => void;
+}
+
+function ModelCanvasInner({ nodes, edges, searchQuery, onOpenDataMart }: ModelCanvasInnerProps) {
+  const reactFlow = useReactFlow<ModelCanvasFlowNodeType, ModelCanvasFlowEdgeType>();
+  const paneWidth = useStore(state => state.width);
+  const paneHeight = useStore(state => state.height);
+
+  const onOpenDataMartRef = useRef(onOpenDataMart);
+  onOpenDataMartRef.current = onOpenDataMart;
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+  const searchQueryRef = useRef(searchQuery);
+  searchQueryRef.current = searchQuery;
+
+  const [direction, setDirection] = useState<CanvasDirection>(() =>
+    parseCanvasDirection(storageService.get(LAYOUT_LS_KEY))
+  );
+  const [showJoinLabels, setShowJoinLabels] = useState(
+    () => storageService.get(JOIN_LABELS_LS_KEY, 'boolean') ?? false
+  );
+  const [ready, setReady] = useState(false);
+  const [flowNodes, setFlowNodes] = useState<ModelCanvasFlowNodeType[]>([]);
+  const [flowEdges, setFlowEdges] = useState<ModelCanvasFlowEdgeType[]>([]);
+  const graphBounds = useMemo(() => getCanvasGraphBounds(flowNodes), [flowNodes]);
+
+  useEffect(() => {
+    const hasIncoming = new Set(edges.map(e => e.targetId));
+    const hasOutgoing = new Set(edges.map(e => e.sourceId));
+    const isDraft = new Map(nodes.map(n => [n.id, n.status === DataMartStatus.DRAFT]));
+    const highlightState = computeCanvasHighlight(
+      nodes,
+      searchQueryRef.current,
+      n => n.id,
+      n => n.title
+    );
+
+    const dagreNodes: DagreLayoutNode[] = nodes.map(n => ({
+      id: n.id,
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+    }));
+    const joinLabels = showJoinLabels
+      ? new Map(edges.map(e => [e.id, buildJoinLabel(e)]))
+      : new Map<string, string[]>();
+    const dagreEdges: DagreLayoutEdge[] = edges.map(e => ({
+      id: e.id,
+      sourceId: e.sourceId,
+      targetId: e.targetId,
+      label: estimateEdgeLabelDimensions(joinLabels.get(e.id) ?? []),
+    }));
+
+    const { positions, routes, labelPositions } = runDagreLayout(dagreNodes, dagreEdges, direction);
+    const offsets = computeParallelEdgeOffsets(edges);
+
+    setFlowNodes(
+      nodes.map(node =>
+        buildFlowNode({
+          node,
+          position: positions.get(node.id) ?? { x: 0, y: 0 },
+          hasIncoming: hasIncoming.has(node.id),
+          hasOutgoing: hasOutgoing.has(node.id),
+          highlight: highlightState.get(node.id) ?? NO_HIGHLIGHT,
+          direction,
+          onOpenExternal: () => {
+            onOpenDataMartRef.current(node.id);
+          },
+        })
+      )
+    );
+
+    setFlowEdges(
+      edges.map(edge => {
+        const dagreRoute = routes.get(edge.id) ?? [];
+        const bowOffset = dagreRoute.length === 0 ? (offsets.get(edge.id) ?? 0) : 0;
+        const sourceDimmed = highlightState.get(edge.sourceId)?.dimmed ?? false;
+        const targetDimmed = highlightState.get(edge.targetId)?.dimmed ?? false;
+        return buildFlowEdge({
+          edge,
+          joinLabel: joinLabels.get(edge.id) ?? [],
+          route: dagreRoute,
+          bowOffset,
+          warning:
+            edge.joinNotConfigured ||
+            (isDraft.get(edge.sourceId) ?? false) ||
+            (isDraft.get(edge.targetId) ?? false),
+          dimmed: sourceDimmed && targetDimmed,
+          labelPosition: bowOffset === 0 ? labelPositions.get(edge.id) : undefined,
+          direction,
+        });
+      })
+    );
+
+    setReady(true);
+
+    const matchingIds = [...highlightState.entries()]
+      .filter(([, state]) => state.highlighted)
+      .map(([id]) => id);
+    const rafId = requestAnimationFrame(() => {
+      void reactFlow.fitView(
+        matchingIds.length > 0
+          ? {
+              nodes: matchingIds.map(id => ({ id })),
+              duration: 300,
+              padding: FIT_VIEW_PADDING,
+            }
+          : { padding: FIT_VIEW_PADDING, duration: 300 }
+      );
+    });
+
+    return () => {
+      cancelAnimationFrame(rafId);
+    };
+  }, [nodes, edges, direction, showJoinLabels, reactFlow]);
+
+  useEffect(() => {
+    const state = computeCanvasHighlight(
+      nodesRef.current,
+      searchQuery,
+      n => n.id,
+      n => n.title
+    );
+
+    setFlowNodes(prev =>
+      prev.map(node => {
+        const next = state.get(node.id) ?? NO_HIGHLIGHT;
+        return node.data.highlighted === next.highlighted && node.data.dimmed === next.dimmed
+          ? node
+          : { ...node, data: { ...node.data, ...next } };
+      })
+    );
+
+    setFlowEdges(prev =>
+      prev.map(edge => {
+        const sourceDimmed = state.get(edge.source)?.dimmed ?? false;
+        const targetDimmed = state.get(edge.target)?.dimmed ?? false;
+        const dimmed = sourceDimmed && targetDimmed;
+        return edge.data.dimmed === dimmed ? edge : { ...edge, data: { ...edge.data, dimmed } };
+      })
+    );
+
+    const matchingIds = [...state.entries()].filter(([, s]) => s.highlighted).map(([id]) => id);
+    if (matchingIds.length > 0) {
+      void reactFlow.fitView({
+        nodes: matchingIds.map(id => ({ id })),
+        duration: 300,
+        padding: FIT_VIEW_PADDING,
+      });
+    }
+  }, [searchQuery, reactFlow]);
+
+  const handleDirectionChange = useCallback((next: CanvasDirection) => {
+    setDirection(next);
+    storageService.set(LAYOUT_LS_KEY, next);
+  }, []);
+
+  const handleJoinLabelsChange = useCallback((checked: boolean) => {
+    setShowJoinLabels(checked);
+    storageService.set(JOIN_LABELS_LS_KEY, checked);
+  }, []);
+
+  const handleMove = useCallback(
+    (_event: MouseEvent | TouchEvent | null, viewport: Viewport) => {
+      if (paneWidth === 0 || paneHeight === 0) return;
+
+      const clampedViewport = clampCanvasViewport(
+        viewport,
+        graphBounds,
+        paneWidth,
+        paneHeight,
+        CANVAS_PAN_PADDING
+      );
+      if (clampedViewport.x === viewport.x && clampedViewport.y === viewport.y) return;
+
+      void reactFlow.setViewport(clampedViewport);
+    },
+    [graphBounds, paneHeight, paneWidth, reactFlow]
+  );
+
+  return (
+    <>
+      <div className='absolute top-3 right-3 z-10 flex flex-col gap-1.5'>
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-12 w-12'
+          onClick={() => {
+            void reactFlow.fitView({ padding: FIT_VIEW_PADDING, duration: 300 });
+          }}
+          aria-label='Fit to view'
+        >
+          <Locate className='h-6 w-6' />
+        </Button>
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-12 w-12'
+          onClick={() => {
+            void reactFlow.zoomIn({ duration: 150 });
+          }}
+          aria-label='Zoom in'
+        >
+          <ZoomIn className='h-6 w-6' />
+        </Button>
+        <Button
+          variant='outline'
+          size='icon'
+          className='h-12 w-12'
+          onClick={() => {
+            void reactFlow.zoomOut({ duration: 150 });
+          }}
+          aria-label='Zoom out'
+        >
+          <ZoomOut className='h-6 w-6' />
+        </Button>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant='outline'
+              size='icon'
+              className='h-12 w-12'
+              aria-label='Canvas settings'
+            >
+              <Settings className='h-6 w-6' />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align='end' side='left' className='w-56'>
+            <PopoverTitle>Layout algorithm</PopoverTitle>
+            <div role='radiogroup' aria-label='Layout algorithm' className='mt-2 space-y-0.5'>
+              {CANVAS_DIRECTION_OPTIONS.map(option => (
+                <button
+                  key={option.value}
+                  type='button'
+                  role='radio'
+                  aria-checked={direction === option.value}
+                  className='hover:bg-muted flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-sm'
+                  onClick={() => {
+                    handleDirectionChange(option.value);
+                  }}
+                >
+                  <span>{option.label}</span>
+                  {direction === option.value && <Check className='h-4 w-4' />}
+                </button>
+              ))}
+            </div>
+            <div className='mt-3 flex items-center justify-between gap-2 border-t pt-3'>
+              <label htmlFor='model-canvas-show-join-fields' className='text-sm'>
+                Show join fields
+              </label>
+              <Switch
+                id='model-canvas-show-join-fields'
+                checked={showJoinLabels}
+                onCheckedChange={handleJoinLabelsChange}
+              />
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+      {ready && (
+        <ReactFlow
+          nodes={flowNodes}
+          edges={flowEdges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+          edgesFocusable={false}
+          minZoom={0.05}
+          maxZoom={2}
+          onMove={handleMove}
+          fitView
+          fitViewOptions={{ padding: FIT_VIEW_PADDING }}
+          style={{ width: '100%', height: '100%' }}
+        >
+          <Background variant={BackgroundVariant.Lines} gap={16} color='rgba(0,0,0,0.06)' />
+          <MiniMap pannable zoomable style={{ width: 140, height: 100 }} />
+        </ReactFlow>
+      )}
+    </>
+  );
+}
+
+export default function ModelCanvas({
+  nodes,
+  edges,
+  searchQuery,
+  onOpenDataMart,
+  className,
+  style,
+}: ModelCanvasProps) {
+  if (nodes.length === 0) return null;
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-lg border ${className ?? ''}`}
+      style={style ?? { height: 480 }}
+    >
+      <style>{NODE_PULSE_KEYFRAMES}</style>
+      <ReactFlowProvider>
+        <ModelCanvasInner
+          nodes={nodes}
+          edges={edges}
+          searchQuery={searchQuery}
+          onOpenDataMart={onOpenDataMart}
+        />
+      </ReactFlowProvider>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowEdge.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowEdge.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef, useState } from 'react';
+import { getBezierPath, type Edge, type EdgeProps } from '@xyflow/react';
+import {
+  DIMMED_OPACITY,
+  EDGE_COLOR,
+  EDGE_STROKE_WIDTH,
+  EDGE_WARNING_DASH,
+  WARNING_COLOR,
+} from '../../shared/canvas/constants';
+import type { CanvasDirection } from '../model/graph/canvas-direction';
+import { PARALLEL_EDGE_SPACING } from '../model/graph/parallel-edge-offsets';
+import { buildRoundedPath, type PathPoint } from '../model/graph/rounded-path';
+
+const EDGE_CORNER_RADIUS = 10;
+
+export interface ModelCanvasFlowEdgeData {
+  route: PathPoint[];
+  bowOffset: number;
+  warning: boolean;
+  joinLabel: string[];
+  dimmed: boolean;
+  labelPosition?: PathPoint;
+  direction: CanvasDirection;
+}
+
+export type ModelCanvasFlowEdgeType = Edge<
+  ModelCanvasFlowEdgeData & Record<string, unknown>,
+  'modelCanvasEdge'
+> & {
+  data: ModelCanvasFlowEdgeData;
+};
+
+export default function ModelCanvasFlowEdge({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  markerStart,
+  markerEnd,
+  data,
+}: EdgeProps<ModelCanvasFlowEdgeType>) {
+  const pathRef = useRef<SVGPathElement>(null);
+  const [midpoint, setMidpoint] = useState<{ x: number; y: number } | null>(null);
+
+  const { route, bowOffset, warning, joinLabel, dimmed, labelPosition, direction } = data;
+
+  let path: string;
+  if (route.length > 0) {
+    path = buildRoundedPath(
+      [{ x: sourceX, y: sourceY }, ...route, { x: targetX, y: targetY }],
+      EDGE_CORNER_RADIUS
+    );
+  } else if (bowOffset !== 0) {
+    if (direction === 'vertical') {
+      const c = Math.max(40, Math.abs(targetY - sourceY) * 0.3);
+      path = `M ${sourceX} ${sourceY} C ${sourceX + bowOffset} ${sourceY + c}, ${targetX + bowOffset} ${targetY - c}, ${targetX} ${targetY}`;
+    } else {
+      const c = Math.max(40, Math.abs(targetX - sourceX) * 0.3);
+      path = `M ${sourceX} ${sourceY} C ${sourceX + c} ${sourceY + bowOffset}, ${targetX - c} ${targetY + bowOffset}, ${targetX} ${targetY}`;
+    }
+  } else {
+    [path] = getBezierPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition });
+  }
+
+  const t = 0.5 + Math.max(-0.18, Math.min(0.18, (bowOffset / PARALLEL_EDGE_SPACING) * 0.24));
+  const color = warning ? WARNING_COLOR : EDGE_COLOR;
+
+  useEffect(() => {
+    if (labelPosition || joinLabel.length === 0) return;
+    const el = pathRef.current;
+    if (!el) {
+      setMidpoint(null);
+      return;
+    }
+    const len = el.getTotalLength();
+    const pt = el.getPointAtLength(len * t);
+    setMidpoint({ x: pt.x, y: pt.y });
+  }, [path, t, labelPosition, joinLabel]);
+
+  const labelPoint = labelPosition ?? midpoint;
+
+  return (
+    <>
+      <path
+        ref={pathRef}
+        d={path}
+        fill='none'
+        strokeWidth={EDGE_STROKE_WIDTH}
+        stroke={color}
+        strokeDasharray={warning ? EDGE_WARNING_DASH : undefined}
+        opacity={dimmed ? DIMMED_OPACITY : 1}
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+        style={{ pointerEvents: 'auto', transition: 'opacity 0.2s' }}
+      />
+      {joinLabel.length > 0 && labelPoint && (
+        <foreignObject
+          x={labelPoint.x}
+          y={labelPoint.y}
+          width={1}
+          height={1}
+          style={{ overflow: 'visible' }}
+        >
+          <div
+            style={{
+              transform: 'translate(-50%, -50%)',
+              width: 'max-content',
+              background: 'var(--background)',
+              border: '1px solid var(--border)',
+              borderRadius: 8,
+              padding: '3px 8px',
+              fontSize: 11,
+              fontWeight: 600,
+              lineHeight: 1.5,
+              color: 'var(--foreground)',
+              pointerEvents: 'none',
+              opacity: dimmed ? DIMMED_OPACITY : 1,
+              transition: 'opacity 0.2s',
+              boxShadow: '0 1px 3px 0 rgba(0,0,0,0.08)',
+            }}
+          >
+            {joinLabel.map(line => (
+              <div key={line}>{line}</div>
+            ))}
+          </div>
+        </foreignObject>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.test.tsx
@@ -1,0 +1,69 @@
+import type { NodeProps } from '@xyflow/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ModelCanvasFlowNode, { type ModelCanvasFlowNodeType } from './ModelCanvasFlowNode';
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => null,
+  Position: { Bottom: 'bottom', Left: 'left', Right: 'right', Top: 'top' },
+}));
+
+function renderNode(onOpenExternal = vi.fn()) {
+  const props = {
+    id: 'orders',
+    type: 'modelCanvasNode',
+    data: {
+      title: 'Orders',
+      isDraft: false,
+      fieldCount: 3,
+      description: 'Customer order facts',
+      hasIncoming: true,
+      hasOutgoing: true,
+      highlighted: false,
+      dimmed: false,
+      direction: 'horizontal',
+      onOpenExternal,
+    },
+    dragging: false,
+    zIndex: 0,
+    selectable: false,
+    deletable: false,
+    selected: false,
+    draggable: false,
+    isConnectable: false,
+    positionAbsoluteX: 0,
+    positionAbsoluteY: 0,
+  } as NodeProps<ModelCanvasFlowNodeType>;
+
+  return render(<ModelCanvasFlowNode {...props} />);
+}
+
+describe('ModelCanvasFlowNode', () => {
+  it('shows the description tooltip when its accessible trigger receives focus', async () => {
+    renderNode();
+
+    const descriptionHelp = screen.getByRole('button', { name: 'Description for Orders' });
+    act(() => {
+      descriptionHelp.focus();
+    });
+
+    expect(descriptionHelp).toHaveFocus();
+    await waitFor(() => {
+      expect(descriptionHelp).toHaveAttribute('aria-describedby');
+    });
+    const descriptionId = descriptionHelp.getAttribute('aria-describedby');
+    expect(document.getElementById(descriptionId ?? '')).toHaveTextContent('Customer order facts');
+    expect(document.querySelector('[data-slot="tooltip-content"]')).toHaveTextContent(
+      'Customer order facts'
+    );
+  });
+
+  it('includes the data mart title in the external action name', () => {
+    const onOpenExternal = vi.fn();
+    renderNode(onOpenExternal);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Orders in new tab' }));
+
+    expect(onOpenExternal).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.test.tsx
@@ -66,4 +66,21 @@ describe('ModelCanvasFlowNode', () => {
 
     expect(onOpenExternal).toHaveBeenCalledOnce();
   });
+
+  it('uses a non-submit external action button', () => {
+    renderNode();
+
+    expect(screen.getByRole('button', { name: 'Open Orders in new tab' })).toHaveAttribute(
+      'type',
+      'button'
+    );
+  });
+
+  it('hides the decorative external-link icon from assistive technology', () => {
+    renderNode();
+
+    const externalAction = screen.getByRole('button', { name: 'Open Orders in new tab' });
+
+    expect(externalAction.querySelector('svg')).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.tsx
@@ -123,6 +123,7 @@ export default function ModelCanvasFlowNode({ data }: NodeProps<ModelCanvasFlowN
             </Tooltip>
           )}
           <button
+            type='button'
             className='text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded p-0.5 transition-colors'
             onPointerDown={e => {
               e.stopPropagation();
@@ -131,7 +132,7 @@ export default function ModelCanvasFlowNode({ data }: NodeProps<ModelCanvasFlowN
             title={openExternalLabel}
             aria-label={openExternalLabel}
           >
-            <ExternalLink style={{ width: 14, height: 14 }} />
+            <ExternalLink style={{ width: 14, height: 14 }} aria-hidden='true' />
           </button>
         </div>
       </div>

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.tsx
@@ -1,0 +1,156 @@
+import { ExternalLink, Info } from 'lucide-react';
+import { Handle, Position, type Node, type NodeProps } from '@xyflow/react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import {
+  DIMMED_OPACITY,
+  HIGHLIGHT_COLOR,
+  NODE_BORDER_COLOR,
+  SOCKET_STYLE,
+  WARNING_COLOR,
+} from '../../shared/canvas/constants';
+import type { CanvasDirection } from '../model/graph/canvas-direction';
+
+export const NODE_WIDTH = 240;
+export const NODE_HEIGHT = 74;
+
+export interface ModelCanvasFlowNodeData {
+  title: string;
+  isDraft: boolean;
+  fieldCount: number;
+  description: string | null;
+  hasIncoming: boolean;
+  hasOutgoing: boolean;
+  highlighted: boolean;
+  dimmed: boolean;
+  direction: CanvasDirection;
+  onOpenExternal: () => void;
+}
+
+export type ModelCanvasFlowNodeType = Node<
+  ModelCanvasFlowNodeData & Record<string, unknown>,
+  'modelCanvasNode'
+>;
+
+export default function ModelCanvasFlowNode({ data }: NodeProps<ModelCanvasFlowNodeType>) {
+  const borderColor = data.highlighted
+    ? HIGHLIGHT_COLOR
+    : data.isDraft
+      ? WARNING_COLOR
+      : NODE_BORDER_COLOR;
+
+  function handleExtClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    e.preventDefault();
+    data.onOpenExternal();
+  }
+
+  const targetPosition = data.direction === 'vertical' ? Position.Top : Position.Left;
+  const sourcePosition = data.direction === 'vertical' ? Position.Bottom : Position.Right;
+  const openExternalLabel = `Open ${data.title} in new tab`;
+
+  return (
+    <div
+      style={{
+        width: NODE_WIDTH,
+        height: NODE_HEIGHT,
+        borderRadius: 8,
+        border: `2px solid ${borderColor}`,
+        background: 'var(--background)',
+        boxShadow: data.highlighted
+          ? `0 0 0 3px ${HIGHLIGHT_COLOR}40, 0 0 12px ${HIGHLIGHT_COLOR}60`
+          : '0 1px 4px 0 rgba(0,0,0,0.12)',
+        cursor: 'default',
+        position: 'relative',
+        opacity: data.dimmed ? DIMMED_OPACITY : 1,
+        filter: data.dimmed ? 'grayscale(0.8)' : undefined,
+        animation: data.highlighted ? 'node-pulse 1.5s ease-in-out infinite' : undefined,
+        transition: 'opacity 0.2s, filter 0.2s',
+      }}
+    >
+      {data.isDraft && (
+        <span
+          style={{
+            position: 'absolute',
+            top: -18,
+            right: 4,
+            fontSize: 10,
+            fontWeight: 600,
+            color: WARNING_COLOR,
+            lineHeight: 1,
+          }}
+        >
+          Draft
+        </span>
+      )}
+      {data.hasIncoming && (
+        <Handle
+          type='target'
+          position={targetPosition}
+          isConnectable={false}
+          style={SOCKET_STYLE}
+        />
+      )}
+      <div
+        className='bg-muted flex items-center justify-between'
+        style={{
+          padding: '8px 10px 8px 14px',
+          fontSize: 13,
+          fontWeight: 600,
+          borderRadius: '6px 6px 0 0',
+        }}
+      >
+        <span className='truncate' title={data.title}>
+          {data.title}
+        </span>
+        <div className='ml-2 flex shrink-0 items-center gap-0.5'>
+          {data.description && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type='button'
+                  className='text-muted-foreground hover:text-foreground inline-flex cursor-default rounded p-0.5 transition-colors'
+                  aria-label={`Description for ${data.title}`}
+                  onPointerDown={e => {
+                    e.stopPropagation();
+                  }}
+                >
+                  <Info style={{ width: 14, height: 14 }} aria-hidden='true' />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side='top' align='center' role='tooltip'>
+                {data.description}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <button
+            className='text-muted-foreground hover:text-foreground shrink-0 cursor-pointer rounded p-0.5 transition-colors'
+            onPointerDown={e => {
+              e.stopPropagation();
+            }}
+            onClick={handleExtClick}
+            title={openExternalLabel}
+            aria-label={openExternalLabel}
+          >
+            <ExternalLink style={{ width: 14, height: 14 }} />
+          </button>
+        </div>
+      </div>
+      <div
+        className='text-muted-foreground flex items-center'
+        style={{ padding: '6px 14px 8px', fontSize: 11, minWidth: 0 }}
+      >
+        <span className='ml-auto shrink-0'>
+          {data.fieldCount} field{data.fieldCount !== 1 ? 's' : ''}
+        </span>
+      </div>
+      {data.hasOutgoing && (
+        <Handle
+          type='source'
+          position={sourcePosition}
+          isConnectable={false}
+          style={SOCKET_STYLE}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasToolbar.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasToolbar.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DataStorageType } from '../../../data-storage/shared/model/types/data-storage-type.enum';
+import { ModelCanvasToolbar } from './ModelCanvasToolbar';
+
+function renderToolbar() {
+  return render(
+    <ModelCanvasToolbar
+      storages={[
+        {
+          id: 'storage-1',
+          type: DataStorageType.GOOGLE_BIGQUERY,
+          title: 'Warehouse',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          modifiedAt: new Date('2026-01-01T00:00:00.000Z'),
+          publishedDataMartsCount: 1,
+          draftDataMartsCount: 0,
+        },
+      ]}
+      storageId='storage-1'
+      onStorageChange={vi.fn()}
+      status='published'
+      onStatusChange={vi.fn()}
+      rel='connected'
+      onRelChange={vi.fn()}
+      searchQuery=''
+      onSearchChange={vi.fn()}
+    />
+  );
+}
+
+describe('ModelCanvasToolbar', () => {
+  it('labels its select filters and exposes the selected storage', () => {
+    renderToolbar();
+
+    expect(screen.getByRole('combobox', { name: 'Storage' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Status' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Relationships' })).toBeInTheDocument();
+  });
+
+  it('keeps the controls on one row and constrains the search width', () => {
+    const { container } = renderToolbar();
+
+    expect(container.firstElementChild).toHaveClass('flex-nowrap');
+    expect(container.firstElementChild).not.toHaveClass('flex-wrap');
+
+    const searchInput = screen.getByRole('textbox', { name: 'Search data marts' });
+    expect(searchInput.parentElement?.parentElement).toHaveClass(
+      'ml-auto',
+      'w-[240px]',
+      'min-w-[180px]',
+      'shrink',
+      '[&>div]:w-full'
+    );
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasToolbar.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasToolbar.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react';
+import { SearchInput } from '@owox/ui/components/common/search-input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@owox/ui/components/select';
+import { Combobox } from '../../../../shared/components/Combobox/combobox';
+import type { DataStorageListItem } from '../../../data-storage/shared/model/types/data-storage-list';
+import { DataStorageTypeModel } from '../../../data-storage/shared/types/data-storage-type.model';
+import type { CanvasRelFilter, CanvasStatusFilter } from '../model/graph/filter-canvas-data';
+
+interface ModelCanvasToolbarProps {
+  storages: DataStorageListItem[];
+  storageId: string | null;
+  onStorageChange: (id: string) => void;
+  status: CanvasStatusFilter;
+  onStatusChange: (status: CanvasStatusFilter) => void;
+  rel: CanvasRelFilter;
+  onRelChange: (rel: CanvasRelFilter) => void;
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+}
+
+export function ModelCanvasToolbar(props: ModelCanvasToolbarProps) {
+  const { storageOptions, storageIcons } = useMemo(() => {
+    const sorted = [...props.storages].sort((a, b) => a.title.localeCompare(b.title));
+    return {
+      storageOptions: sorted.map(storage => ({ value: storage.id, label: storage.title })),
+      storageIcons: new Map(
+        sorted.map(storage => [storage.id, DataStorageTypeModel.getInfo(storage.type).icon])
+      ),
+    };
+  }, [props.storages]);
+
+  return (
+    <div className='flex min-w-0 flex-nowrap items-center gap-2 pb-4'>
+      <label className='contents' aria-label='Storage'>
+        <Combobox
+          options={storageOptions}
+          value={props.storageId ?? ''}
+          onValueChange={props.onStorageChange}
+          placeholder='Select storage'
+          emptyMessage='No storages found'
+          className='w-[300px] min-w-[220px] shrink'
+          renderLabel={option => {
+            const Icon = storageIcons.get(option.value);
+            return (
+              <div className='flex min-w-0 flex-1 items-center gap-2'>
+                {Icon && <Icon size={16} className='shrink-0' />}
+                <span className='min-w-0 truncate'>{option.label}</span>
+              </div>
+            );
+          }}
+        />
+      </label>
+      <Select
+        value={props.status}
+        onValueChange={value => {
+          props.onStatusChange(value as CanvasStatusFilter);
+        }}
+      >
+        <SelectTrigger className='w-[180px] min-w-[150px]' aria-label='Status'>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value='published'>Published only</SelectItem>
+          <SelectItem value='draft'>Draft only</SelectItem>
+          <SelectItem value='all'>All statuses</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select
+        value={props.rel}
+        onValueChange={value => {
+          props.onRelChange(value as CanvasRelFilter);
+        }}
+      >
+        <SelectTrigger className='w-[220px] min-w-[180px]' aria-label='Relationships'>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value='connected'>With relationships only</SelectItem>
+          <SelectItem value='all'>All data marts</SelectItem>
+        </SelectContent>
+      </Select>
+      <div className='ml-auto w-[240px] min-w-[180px] shrink [&>div]:w-full'>
+        <SearchInput
+          id='model-canvas-search'
+          placeholder='Search data marts…'
+          value={props.searchQuery}
+          onChange={props.onSearchChange}
+          aria-label='Search data marts'
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.test.tsx
@@ -1,6 +1,8 @@
 import { StrictMode } from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DataMartStatus } from '../../shared/enums';
+import type { ModelCanvasData } from '../model/types';
 import { ModelCanvasView } from './ModelCanvasView';
 
 const viewState = vi.hoisted(() => ({
@@ -22,7 +24,7 @@ const viewState = vi.hoisted(() => ({
     error: null,
   },
   canvasHook: {
-    data: undefined as { nodes: []; edges: [] } | undefined,
+    data: undefined as ModelCanvasData | undefined,
     isLoading: false,
     error: null as unknown,
   },
@@ -65,6 +67,19 @@ vi.mock('./ModelCanvasToolbar', () => ({
   ModelCanvasToolbar: () => null,
 }));
 
+vi.mock('./ModelCanvas', () => ({
+  default: ({ onOpenDataMart }: { onOpenDataMart: (dataMartId: string) => void }) => (
+    <button
+      type='button'
+      onClick={() => {
+        onOpenDataMart('mart-1');
+      }}
+    >
+      Open Orders
+    </button>
+  ),
+}));
+
 vi.mock('@owox/ui/components/common/skeleton-list', () => ({
   SkeletonList: () => <div>Loading canvas</div>,
 }));
@@ -98,6 +113,49 @@ describe('ModelCanvasView', () => {
     viewState.canvasHook.data = undefined;
     viewState.canvasHook.isLoading = false;
     viewState.canvasHook.error = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens data marts in a tab without exposing the opener or referrer', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+    viewState.canvasHook.data = {
+      nodes: [
+        {
+          id: 'mart-1',
+          title: 'Orders',
+          status: DataMartStatus.PUBLISHED,
+          description: null,
+          fieldCount: 3,
+        },
+        {
+          id: 'mart-2',
+          title: 'Customers',
+          status: DataMartStatus.PUBLISHED,
+          description: null,
+          fieldCount: 2,
+        },
+      ],
+      edges: [
+        {
+          id: 'edge-1',
+          sourceDataMartId: 'mart-1',
+          targetDataMartId: 'mart-2',
+          joinConditions: [],
+        },
+      ],
+    };
+
+    render(<ModelCanvasView />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Open Orders' }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      '/data-marts/mart-1/data-setup',
+      '_blank',
+      'noopener,noreferrer'
+    );
   });
 
   it('shows a stable fallback when the canvas request fails without an Axios response', async () => {

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.test.tsx
@@ -1,0 +1,202 @@
+import { StrictMode } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ModelCanvasView } from './ModelCanvasView';
+
+const viewState = vi.hoisted(() => ({
+  fetchDataStorages: vi.fn(),
+  storageHook: {
+    dataStorages: [
+      {
+        id: 'storage-1',
+        type: 'GOOGLE_BIGQUERY',
+        title: 'Warehouse',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        modifiedAt: new Date('2026-01-01T00:00:00.000Z'),
+        publishedDataMartsCount: 1,
+        draftDataMartsCount: 0,
+      },
+    ],
+    currentDataStorage: null,
+    loading: false,
+    error: null,
+  },
+  canvasHook: {
+    data: undefined as { nodes: []; edges: [] } | undefined,
+    isLoading: false,
+    error: null as unknown,
+  },
+}));
+
+vi.mock('../../../data-storage/shared/model/hooks/useDataStorage', () => ({
+  useDataStorage: () => ({
+    ...viewState.storageHook,
+    fetchDataStorages: viewState.fetchDataStorages,
+    getDataStorageById: vi.fn(),
+    createDataStorage: vi.fn(),
+    updateDataStorage: vi.fn(),
+    deleteDataStorage: vi.fn(),
+    clearCurrentDataStorage: vi.fn(),
+  }),
+}));
+
+vi.mock('../model/use-model-canvas', () => ({
+  useModelCanvas: () => viewState.canvasHook,
+}));
+
+vi.mock('../model/use-model-canvas-filters', () => ({
+  useModelCanvasFilters: () => ({
+    storageId: 'storage-1',
+    setStorageId: vi.fn(),
+    status: 'published',
+    setStatus: vi.fn(),
+    rel: 'connected',
+    setRel: vi.fn(),
+    searchQuery: '',
+    setSearchQuery: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../../shared/hooks', () => ({
+  useProjectRoute: () => ({ scope: (path: string) => path }),
+}));
+
+vi.mock('./ModelCanvasToolbar', () => ({
+  ModelCanvasToolbar: () => null,
+}));
+
+vi.mock('@owox/ui/components/common/skeleton-list', () => ({
+  SkeletonList: () => <div>Loading canvas</div>,
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('ModelCanvasView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    viewState.fetchDataStorages.mockResolvedValue(undefined);
+    viewState.storageHook.dataStorages = [
+      {
+        id: 'storage-1',
+        type: 'GOOGLE_BIGQUERY',
+        title: 'Warehouse',
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        modifiedAt: new Date('2026-01-01T00:00:00.000Z'),
+        publishedDataMartsCount: 1,
+        draftDataMartsCount: 0,
+      },
+    ];
+    viewState.storageHook.loading = false;
+    viewState.canvasHook.data = undefined;
+    viewState.canvasHook.isLoading = false;
+    viewState.canvasHook.error = null;
+  });
+
+  it('shows a stable fallback when the canvas request fails without an Axios response', async () => {
+    viewState.canvasHook.error = new Error('Network Error');
+
+    render(<ModelCanvasView />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Failed to load the data model');
+  });
+
+  it('catches storage loading failures and offers a retry', async () => {
+    viewState.storageHook.dataStorages = [];
+    viewState.fetchDataStorages
+      .mockRejectedValueOnce(new Error('Network Error'))
+      .mockResolvedValueOnce(undefined);
+
+    render(<ModelCanvasView />);
+
+    expect(await screen.findByText('Failed to load storages')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry loading storages' }));
+
+    await waitFor(() => {
+      expect(viewState.fetchDataStorages).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('shows loading feedback while the initial storage request is pending', () => {
+    viewState.storageHook.dataStorages = [];
+    viewState.fetchDataStorages.mockReturnValue(new Promise(() => undefined));
+
+    render(<ModelCanvasView />);
+
+    expect(screen.getByText('Loading canvas')).toBeInTheDocument();
+    expect(screen.queryByText('Select a storage to view its data model')).not.toBeInTheDocument();
+  });
+
+  it('does not ask for a storage when none are available', async () => {
+    viewState.storageHook.dataStorages = [];
+
+    render(<ModelCanvasView />);
+
+    expect(await screen.findByRole('status')).toHaveTextContent('No storages available');
+    expect(screen.queryByText('Select a storage to view its data model')).not.toBeInTheDocument();
+  });
+
+  it('replaces a storage error with loading feedback during retry', async () => {
+    const retry = deferred<undefined>();
+    viewState.storageHook.dataStorages = [];
+    viewState.fetchDataStorages
+      .mockRejectedValueOnce(new Error('Network Error'))
+      .mockReturnValueOnce(retry.promise);
+
+    render(<ModelCanvasView />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry loading storages' }));
+
+    expect(screen.getByText('Loading canvas')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('announces informational empty states as status messages', async () => {
+    viewState.canvasHook.data = { nodes: [], edges: [] };
+
+    render(<ModelCanvasView />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('No data marts in this storage');
+    });
+  });
+
+  it('ignores an older storage failure after a newer StrictMode load succeeds', async () => {
+    const older = deferred<undefined>();
+    const newer = deferred<undefined>();
+    viewState.fetchDataStorages
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(newer.promise);
+
+    render(
+      <StrictMode>
+        <ModelCanvasView />
+      </StrictMode>
+    );
+
+    await waitFor(() => {
+      expect(viewState.fetchDataStorages).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      newer.resolve(undefined);
+      await newer.promise;
+    });
+    await act(async () => {
+      older.reject(new Error('Stale network failure'));
+      await older.promise.catch(() => undefined);
+    });
+
+    expect(screen.queryByText('Failed to load storages')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Retry loading storages' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
@@ -135,7 +135,11 @@ function ModelCanvasViewContent() {
             edges={renderEdges}
             searchQuery={filters.searchQuery}
             onOpenDataMart={dataMartId => {
-              window.open(scope(`/data-marts/${dataMartId}/data-setup`), '_blank');
+              window.open(
+                scope(`/data-marts/${dataMartId}/data-setup`),
+                '_blank',
+                'noopener,noreferrer'
+              );
             }}
             style={canvasStyle}
           />

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
@@ -1,0 +1,154 @@
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
+import { extractApiError } from '../../../../app/api';
+import { Button } from '../../../../shared/components/Button';
+import { DataStorageProvider } from '../../../data-storage/shared/model/context';
+import { useDataStorage } from '../../../data-storage/shared/model/hooks/useDataStorage';
+import { useProjectRoute } from '../../../../shared/hooks';
+import { filterCanvasData } from '../model/graph/filter-canvas-data';
+import { mergeBidirectionalEdges } from '../model/graph/merge-bidirectional-edges';
+import { useModelCanvas } from '../model/use-model-canvas';
+import { useModelCanvasFilters } from '../model/use-model-canvas-filters';
+import { ModelCanvasToolbar } from './ModelCanvasToolbar';
+
+const ModelCanvas = lazy(() => import('./ModelCanvas'));
+
+function CanvasMessage({
+  children,
+  role = 'status',
+}: {
+  children: React.ReactNode;
+  role?: 'alert' | 'status';
+}) {
+  return (
+    <div
+      role={role}
+      className='text-muted-foreground flex h-[480px] items-center justify-center rounded-lg border text-sm'
+    >
+      {children}
+    </div>
+  );
+}
+
+function extractErrorMessage(error: unknown): string | undefined {
+  const apiError = extractApiError(error) as ReturnType<typeof extractApiError> | undefined;
+  return apiError?.message;
+}
+
+function ModelCanvasViewContent() {
+  const { dataStorages, loading: loadingStorages, fetchDataStorages } = useDataStorage();
+  const [storageLoadError, setStorageLoadError] = useState<unknown>(null);
+  const [storageLoadPending, setStorageLoadPending] = useState(true);
+  const storageLoadGenerationRef = useRef(0);
+  const mountedRef = useRef(false);
+  const filters = useModelCanvasFilters();
+  const { scope } = useProjectRoute();
+  const storageKnown =
+    Boolean(filters.storageId) && dataStorages.some(s => s.id === filters.storageId);
+  const { data, isLoading, error } = useModelCanvas(storageKnown ? filters.storageId : null);
+
+  const loadDataStorages = useCallback(async () => {
+    const generation = ++storageLoadGenerationRef.current;
+    setStorageLoadError(null);
+    setStorageLoadPending(true);
+    try {
+      await fetchDataStorages();
+    } catch (error) {
+      if (mountedRef.current && generation === storageLoadGenerationRef.current) {
+        setStorageLoadError(error);
+      }
+    } finally {
+      if (mountedRef.current && generation === storageLoadGenerationRef.current) {
+        setStorageLoadPending(false);
+      }
+    }
+  }, [fetchDataStorages]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    void loadDataStorages();
+    return () => {
+      mountedRef.current = false;
+      storageLoadGenerationRef.current += 1;
+    };
+  }, [loadDataStorages]);
+
+  const filtered = useMemo(
+    () => (data ? filterCanvasData(data, filters.status, filters.rel) : null),
+    [data, filters.status, filters.rel]
+  );
+  const renderEdges = useMemo(
+    () => (filtered ? mergeBidirectionalEdges(filtered.edges) : []),
+    [filtered]
+  );
+
+  const canvasStyle = { height: 'calc(100vh - 220px)', minHeight: 480 };
+
+  return (
+    <div className='dm-card p-4'>
+      <ModelCanvasToolbar
+        storages={dataStorages}
+        storageId={filters.storageId}
+        onStorageChange={filters.setStorageId}
+        status={filters.status}
+        onStatusChange={filters.setStatus}
+        rel={filters.rel}
+        onRelChange={filters.setRel}
+        searchQuery={filters.searchQuery}
+        onSearchChange={filters.setSearchQuery}
+      />
+      {storageLoadError ? (
+        <CanvasMessage role='alert'>
+          <div className='flex flex-col items-center gap-3'>
+            <span>{extractErrorMessage(storageLoadError) ?? 'Failed to load storages'}</span>
+            <Button
+              type='button'
+              size='sm'
+              variant='outline'
+              aria-label='Retry loading storages'
+              onClick={() => {
+                void loadDataStorages();
+              }}
+            >
+              Retry
+            </Button>
+          </div>
+        </CanvasMessage>
+      ) : loadingStorages || storageLoadPending || isLoading ? (
+        <SkeletonList />
+      ) : dataStorages.length === 0 ? (
+        <CanvasMessage>No storages available</CanvasMessage>
+      ) : !filters.storageId || !storageKnown ? (
+        <CanvasMessage>Select a storage to view its data model</CanvasMessage>
+      ) : error ? (
+        <CanvasMessage role='alert'>
+          {extractErrorMessage(error) ?? 'Failed to load the data model'}
+        </CanvasMessage>
+      ) : !data || data.nodes.length === 0 ? (
+        <CanvasMessage>No data marts in this storage</CanvasMessage>
+      ) : !filtered || filtered.nodes.length === 0 ? (
+        <CanvasMessage>No data marts match the current filters</CanvasMessage>
+      ) : (
+        <Suspense fallback={<SkeletonList />}>
+          <ModelCanvas
+            nodes={filtered.nodes}
+            edges={renderEdges}
+            searchQuery={filters.searchQuery}
+            onOpenDataMart={dataMartId => {
+              window.open(scope(`/data-marts/${dataMartId}/data-setup`), '_blank');
+            }}
+            style={canvasStyle}
+          />
+        </Suspense>
+      )}
+    </div>
+  );
+}
+
+export function ModelCanvasView() {
+  return (
+    <DataStorageProvider>
+      <ModelCanvasViewContent />
+    </DataStorageProvider>
+  );
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/canvas-direction.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/canvas-direction.ts
@@ -1,0 +1,10 @@
+export type CanvasDirection = 'horizontal' | 'vertical';
+
+export const CANVAS_DIRECTION_OPTIONS: { value: CanvasDirection; label: string }[] = [
+  { value: 'horizontal', label: 'Horizontal' },
+  { value: 'vertical', label: 'Vertical' },
+];
+
+export function parseCanvasDirection(value: unknown): CanvasDirection {
+  return value === 'vertical' ? 'vertical' : 'horizontal';
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/dagre-layout.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/dagre-layout.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { type DagreLayoutEdge, type DagreLayoutNode, runDagreLayout } from './dagre-layout';
+
+const NODE_W = 240;
+const NODE_H = 74;
+
+function cycleFixture(): { nodes: DagreLayoutNode[]; edges: DagreLayoutEdge[] } {
+  const nodes: DagreLayoutNode[] = [
+    { id: 'a', width: NODE_W, height: NODE_H },
+    { id: 'b', width: NODE_W, height: NODE_H },
+    { id: 'c', width: NODE_W, height: NODE_H },
+    { id: 'isolated', width: NODE_W, height: NODE_H },
+  ];
+  const labelDims = { width: 250, height: 22 };
+  const edges: DagreLayoutEdge[] = [
+    { id: 'ab1', sourceId: 'a', targetId: 'b', label: labelDims },
+    { id: 'ab2', sourceId: 'a', targetId: 'b', label: labelDims },
+    { id: 'bc', sourceId: 'b', targetId: 'c' },
+    { id: 'ca', sourceId: 'c', targetId: 'a' },
+  ];
+  return { nodes, edges };
+}
+
+function uniquePositions(positions: Map<string, { x: number; y: number }>): boolean {
+  const seen = new Set<string>();
+  for (const { x, y } of positions.values()) {
+    const key = `${Math.round(x)}:${Math.round(y)}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+  }
+  return true;
+}
+
+function nodeRects(nodes: DagreLayoutNode[], positions: Map<string, { x: number; y: number }>) {
+  return nodes.map(node => {
+    const position = positions.get(node.id);
+    if (!position) throw new Error(`missing position for ${node.id}`);
+    return {
+      left: position.x,
+      right: position.x + node.width,
+      top: position.y,
+      bottom: position.y + node.height,
+    };
+  });
+}
+
+function rectsOverlap(
+  a: { left: number; right: number; top: number; bottom: number },
+  b: { left: number; right: number; top: number; bottom: number }
+): boolean {
+  return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+}
+
+describe.each([
+  { direction: 'horizontal' as const, rankdir: 'LR' },
+  { direction: 'vertical' as const, rankdir: 'TB' },
+])('runDagreLayout ($direction / $rankdir)', ({ direction }) => {
+  it('returns empty maps for empty input', () => {
+    const result = runDagreLayout([], [], direction);
+
+    expect(result.positions.size).toBe(0);
+    expect(result.routes.size).toBe(0);
+    expect(result.labelPositions.size).toBe(0);
+  });
+
+  it('produces unique, non-overlapping positions for every node', () => {
+    const { nodes, edges } = cycleFixture();
+
+    const result = runDagreLayout(nodes, edges, direction);
+
+    expect(result.positions.size).toBe(nodes.length);
+    for (const node of nodes) {
+      expect(result.positions.has(node.id)).toBe(true);
+    }
+    expect(uniquePositions(result.positions)).toBe(true);
+
+    const rects = nodeRects(nodes, result.positions);
+    for (let i = 0; i < rects.length; i++) {
+      for (let j = i + 1; j < rects.length; j++) {
+        expect(rectsOverlap(rects[i], rects[j])).toBe(false);
+      }
+    }
+  });
+
+  it('produces label positions for labeled edges that do not overlap node rects', () => {
+    const { nodes, edges } = cycleFixture();
+
+    const result = runDagreLayout(nodes, edges, direction);
+
+    const labeledEdges = edges.filter(edge => edge.label);
+    for (const edge of labeledEdges) {
+      expect(result.labelPositions.has(edge.id)).toBe(true);
+    }
+
+    const rects = nodeRects(nodes, result.positions);
+    for (const edge of labeledEdges) {
+      const center = result.labelPositions.get(edge.id);
+      if (!center) throw new Error(`missing label position for ${edge.id}`);
+      const label = edge.label;
+      if (!label) throw new Error('expected label dims');
+      const labelRect = {
+        left: center.x - label.width / 2,
+        right: center.x + label.width / 2,
+        top: center.y - label.height / 2,
+        bottom: center.y + label.height / 2,
+      };
+      for (const nodeRect of rects) {
+        expect(rectsOverlap(labelRect, nodeRect)).toBe(false);
+      }
+    }
+  });
+
+  it('gives parallel edges between the same nodes distinct route signatures', () => {
+    const { nodes, edges } = cycleFixture();
+
+    const result = runDagreLayout(nodes, edges, direction);
+
+    const ab1 = result.routes.get('ab1') ?? [];
+    const ab2 = result.routes.get('ab2') ?? [];
+    const labelAb1 = result.labelPositions.get('ab1');
+    const labelAb2 = result.labelPositions.get('ab2');
+
+    const routeSignature = (route: { x: number; y: number }[], label?: { x: number; y: number }) =>
+      JSON.stringify({ route: route.map(p => [Math.round(p.x), Math.round(p.y)]), label });
+
+    expect(routeSignature(ab1, labelAb1)).not.toBe(routeSignature(ab2, labelAb2));
+  });
+});
+
+it('keeps a deep graph renderable when Dagre exhausts the call stack', () => {
+  const nodes = Array.from({ length: 2_000 }, (_, index) => ({
+    id: `node-${index}`,
+    width: NODE_W,
+    height: NODE_H,
+  }));
+  const edges = nodes.slice(1).map((node, index) => ({
+    id: `edge-${index}`,
+    sourceId: nodes[index].id,
+    targetId: node.id,
+  }));
+
+  const result = runDagreLayout(nodes, edges, 'horizontal');
+
+  expect(result.positions.size).toBe(nodes.length);
+  expect(uniquePositions(result.positions)).toBe(true);
+  for (const position of result.positions.values()) {
+    expect(Number.isFinite(position.x)).toBe(true);
+    expect(Number.isFinite(position.y)).toBe(true);
+  }
+});

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/dagre-layout.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/dagre-layout.ts
@@ -1,0 +1,110 @@
+import dagre from '@dagrejs/dagre';
+import type { EdgeLabel, GraphLabel, NodeLabel } from '@dagrejs/dagre';
+import type { CanvasDirection } from './canvas-direction';
+import type { PathPoint } from './rounded-path';
+
+export interface DagreLayoutNode {
+  id: string;
+  width: number;
+  height: number;
+}
+
+export interface DagreLayoutEdge {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  label?: { width: number; height: number };
+}
+
+export interface DagreLayoutResult {
+  positions: Map<string, PathPoint>;
+  routes: Map<string, PathPoint[]>;
+  labelPositions: Map<string, PathPoint>;
+}
+
+const FALLBACK_NODE_GAP = 80;
+
+function buildFallbackPositions(
+  nodes: DagreLayoutNode[],
+  direction: CanvasDirection
+): Map<string, PathPoint> {
+  const positions = new Map<string, PathPoint>();
+  const columnCount = Math.ceil(Math.sqrt(nodes.length));
+  const { maxWidth, maxHeight } = nodes.reduce(
+    (size, node) => ({
+      maxWidth: Math.max(size.maxWidth, node.width),
+      maxHeight: Math.max(size.maxHeight, node.height),
+    }),
+    { maxWidth: 0, maxHeight: 0 }
+  );
+
+  nodes.forEach((node, index) => {
+    const column = index % columnCount;
+    const row = Math.floor(index / columnCount);
+    const xIndex = direction === 'horizontal' ? column : row;
+    const yIndex = direction === 'horizontal' ? row : column;
+    positions.set(node.id, {
+      x: xIndex * (maxWidth + FALLBACK_NODE_GAP),
+      y: yIndex * (maxHeight + FALLBACK_NODE_GAP),
+    });
+  });
+
+  return positions;
+}
+
+export function runDagreLayout(
+  nodes: DagreLayoutNode[],
+  edges: DagreLayoutEdge[],
+  direction: CanvasDirection
+): DagreLayoutResult {
+  const positions = new Map<string, PathPoint>();
+  const routes = new Map<string, PathPoint[]>();
+  const labelPositions = new Map<string, PathPoint>();
+
+  if (nodes.length === 0) return { positions, routes, labelPositions };
+
+  const g = new dagre.graphlib.Graph<GraphLabel, NodeLabel, EdgeLabel>({ multigraph: true });
+  g.setGraph({ rankdir: direction === 'horizontal' ? 'LR' : 'TB' });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const node of nodes) {
+    g.setNode(node.id, { width: node.width, height: node.height });
+  }
+
+  for (const edge of edges) {
+    const edgeLabel: EdgeLabel = edge.label
+      ? { width: edge.label.width, height: edge.label.height, labelpos: 'c' }
+      : {};
+    g.setEdge(edge.sourceId, edge.targetId, edgeLabel, edge.id);
+  }
+
+  try {
+    dagre.layout(g);
+  } catch (error) {
+    if (!(error instanceof RangeError)) throw error;
+    return {
+      positions: buildFallbackPositions(nodes, direction),
+      routes,
+      labelPositions,
+    };
+  }
+
+  for (const nodeId of g.nodes()) {
+    const n = g.node(nodeId);
+    if (n.x === undefined || n.y === undefined) continue;
+    positions.set(nodeId, { x: n.x - n.width / 2, y: n.y - n.height / 2 });
+  }
+
+  for (const edge of edges) {
+    const ed = g.edge({ v: edge.sourceId, w: edge.targetId, name: edge.id });
+
+    const interiorPoints = (ed.points ?? []).slice(1, -1);
+    if (interiorPoints.length > 0) routes.set(edge.id, interiorPoints);
+
+    if (ed.x !== undefined && ed.y !== undefined) {
+      labelPositions.set(edge.id, { x: ed.x, y: ed.y });
+    }
+  }
+
+  return { positions, routes, labelPositions };
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/filter-canvas-data.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/filter-canvas-data.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { DataMartStatus } from '../../../shared/enums/data-mart-status.enum';
+import type { ModelCanvasData } from '../types';
+import { filterCanvasData } from './filter-canvas-data';
+
+const node = (id: string, status: DataMartStatus = DataMartStatus.PUBLISHED) => ({
+  id,
+  title: id,
+  status,
+  description: null,
+  fieldCount: 0,
+});
+
+const edge = (id: string, sourceDataMartId: string, targetDataMartId: string) => ({
+  id,
+  sourceDataMartId,
+  targetDataMartId,
+  joinConditions: [],
+});
+
+const data: ModelCanvasData = {
+  nodes: [node('a'), node('b'), node('c', DataMartStatus.DRAFT), node('isolated')],
+  edges: [edge('e1', 'a', 'b'), edge('e2', 'b', 'c')],
+};
+
+describe('filterCanvasData', () => {
+  it('published keeps only published nodes and drops edges touching removed nodes', () => {
+    const result = filterCanvasData(data, 'published', 'all');
+    expect(result.nodes.map(n => n.id)).toEqual(['a', 'b', 'isolated']);
+    expect(result.edges.map(e => e.id)).toEqual(['e1']);
+  });
+
+  it('draft keeps only draft nodes', () => {
+    const result = filterCanvasData(data, 'draft', 'all');
+    expect(result.nodes.map(n => n.id)).toEqual(['c']);
+    expect(result.edges).toEqual([]);
+  });
+
+  it('all keeps everything', () => {
+    const result = filterCanvasData(data, 'all', 'all');
+    expect(result.nodes).toHaveLength(4);
+    expect(result.edges).toHaveLength(2);
+  });
+
+  it('connected drops nodes without remaining edges', () => {
+    const result = filterCanvasData(data, 'all', 'connected');
+    expect(result.nodes.map(n => n.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('connected is evaluated after the status filter', () => {
+    const result = filterCanvasData(data, 'published', 'connected');
+    expect(result.nodes.map(n => n.id)).toEqual(['a', 'b']);
+    expect(result.edges.map(e => e.id)).toEqual(['e1']);
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/filter-canvas-data.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/filter-canvas-data.ts
@@ -1,0 +1,32 @@
+import { DataMartStatus } from '../../../shared/enums/data-mart-status.enum';
+import type { ModelCanvasData } from '../types';
+
+export type CanvasStatusFilter = 'published' | 'draft' | 'all';
+export type CanvasRelFilter = 'connected' | 'all';
+
+export function filterCanvasData(
+  data: ModelCanvasData,
+  status: CanvasStatusFilter,
+  rel: CanvasRelFilter
+): ModelCanvasData {
+  const nodes = data.nodes.filter(node => {
+    if (status === 'all') return true;
+    return status === 'draft'
+      ? node.status === DataMartStatus.DRAFT
+      : node.status === DataMartStatus.PUBLISHED;
+  });
+
+  const visibleIds = new Set(nodes.map(node => node.id));
+  const edges = data.edges.filter(
+    edge => visibleIds.has(edge.sourceDataMartId) && visibleIds.has(edge.targetDataMartId)
+  );
+
+  if (rel === 'connected') {
+    const connectedIds = new Set(
+      edges.flatMap(edge => [edge.sourceDataMartId, edge.targetDataMartId])
+    );
+    return { nodes: nodes.filter(node => connectedIds.has(node.id)), edges };
+  }
+
+  return { nodes, edges };
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/merge-bidirectional-edges.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/merge-bidirectional-edges.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import type { ModelCanvasEdge } from '../types';
+import { mergeBidirectionalEdges } from './merge-bidirectional-edges';
+
+const edge = (
+  id: string,
+  source: string,
+  target: string,
+  joinConditions: { sourceFieldName: string; targetFieldName: string }[]
+): ModelCanvasEdge => ({ id, sourceDataMartId: source, targetDataMartId: target, joinConditions });
+
+describe('mergeBidirectionalEdges', () => {
+  it('merges a fully mirrored pair into one bidirectional edge', () => {
+    const result = mergeBidirectionalEdges([
+      edge('e1', 'a', 'b', [{ sourceFieldName: 'x', targetFieldName: 'y' }]),
+      edge('e2', 'b', 'a', [{ sourceFieldName: 'y', targetFieldName: 'x' }]),
+    ]);
+    expect(result).toEqual([
+      {
+        id: 'e1+e2',
+        sourceId: 'a',
+        targetId: 'b',
+        bidirectional: true,
+        joinNotConfigured: false,
+        joinConditions: [{ sourceFieldName: 'x', targetFieldName: 'y' }],
+      },
+    ]);
+    expect(result[0].joinConditions).toEqual([{ sourceFieldName: 'x', targetFieldName: 'y' }]);
+  });
+
+  it('keeps non-mirrored reverse edges separate', () => {
+    const result = mergeBidirectionalEdges([
+      edge('e1', 'a', 'b', [{ sourceFieldName: 'x', targetFieldName: 'y' }]),
+      edge('e2', 'b', 'a', [{ sourceFieldName: 'q', targetFieldName: 'x' }]),
+    ]);
+    expect(result.map(e => e.bidirectional)).toEqual([false, false]);
+  });
+
+  it('keeps parallel edges in the same direction separate', () => {
+    const result = mergeBidirectionalEdges([
+      edge('e1', 'a', 'b', [{ sourceFieldName: 'x', targetFieldName: 'y' }]),
+      edge('e2', 'a', 'b', [{ sourceFieldName: 'z', targetFieldName: 'w' }]),
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it('never merges edges with empty join conditions and flags them', () => {
+    const result = mergeBidirectionalEdges([edge('e1', 'a', 'b', []), edge('e2', 'b', 'a', [])]);
+    expect(result).toHaveLength(2);
+    expect(result.every(e => e.joinNotConfigured)).toBe(true);
+  });
+
+  it('never merges self-loops', () => {
+    const result = mergeBidirectionalEdges([
+      edge('e1', 'a', 'a', [{ sourceFieldName: 'x', targetFieldName: 'x' }]),
+    ]);
+    expect(result).toEqual([
+      {
+        id: 'e1',
+        sourceId: 'a',
+        targetId: 'a',
+        bidirectional: false,
+        joinNotConfigured: false,
+        joinConditions: [{ sourceFieldName: 'x', targetFieldName: 'x' }],
+      },
+    ]);
+  });
+
+  it('mirror match is order-insensitive across multiple conditions', () => {
+    const result = mergeBidirectionalEdges([
+      edge('e1', 'a', 'b', [
+        { sourceFieldName: 'x', targetFieldName: 'y' },
+        { sourceFieldName: 'm', targetFieldName: 'n' },
+      ]),
+      edge('e2', 'b', 'a', [
+        { sourceFieldName: 'n', targetFieldName: 'm' },
+        { sourceFieldName: 'y', targetFieldName: 'x' },
+      ]),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].bidirectional).toBe(true);
+  });
+
+  it('rejects duplicate-condition false mirrors (multiset check)', () => {
+    const result = mergeBidirectionalEdges([
+      edge('e1', 'a', 'b', [
+        { sourceFieldName: 'x', targetFieldName: 'y' },
+        { sourceFieldName: 'm', targetFieldName: 'n' },
+      ]),
+      edge('e2', 'b', 'a', [
+        { sourceFieldName: 'y', targetFieldName: 'x' },
+        { sourceFieldName: 'y', targetFieldName: 'x' },
+      ]),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result.every(e => !e.bidirectional)).toBe(true);
+  });
+
+  it('keeps reverse edges separate when distinct join fields share a delimited key', () => {
+    const result = mergeBidirectionalEdges([
+      edge('e1', 'left', 'right', [{ sourceFieldName: 'a b', targetFieldName: 'c' }]),
+      edge('e2', 'right', 'left', [{ sourceFieldName: 'b c', targetFieldName: 'a' }]),
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result.every(e => !e.bidirectional)).toBe(true);
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/merge-bidirectional-edges.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/merge-bidirectional-edges.ts
@@ -1,0 +1,78 @@
+import type { ModelCanvasEdge, ModelCanvasJoinCondition } from '../types';
+
+export interface CanvasRenderEdge {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  bidirectional: boolean;
+  joinNotConfigured: boolean;
+  joinConditions: ModelCanvasJoinCondition[];
+}
+
+const conditionKey = (source: string, target: string) => JSON.stringify([source, target]);
+
+function conditionsMirror(a: ModelCanvasEdge, b: ModelCanvasEdge): boolean {
+  if (a.joinConditions.length === 0 || a.joinConditions.length !== b.joinConditions.length) {
+    return false;
+  }
+  const remaining = new Map<string, number>();
+  for (const c of a.joinConditions) {
+    const key = conditionKey(c.sourceFieldName, c.targetFieldName);
+    remaining.set(key, (remaining.get(key) ?? 0) + 1);
+  }
+  for (const c of b.joinConditions) {
+    const key = conditionKey(c.targetFieldName, c.sourceFieldName);
+    const count = remaining.get(key);
+    if (!count) return false;
+    remaining.set(key, count - 1);
+  }
+  return true;
+}
+
+export function mergeBidirectionalEdges(edges: ModelCanvasEdge[]): CanvasRenderEdge[] {
+  const byPair = new Map<string, ModelCanvasEdge[]>();
+  for (const edge of edges) {
+    const key = conditionKey(edge.sourceDataMartId, edge.targetDataMartId);
+    const list = byPair.get(key);
+    if (list) list.push(edge);
+    else byPair.set(key, [edge]);
+  }
+
+  const consumed = new Set<string>();
+  const result: CanvasRenderEdge[] = [];
+
+  for (const edge of edges) {
+    if (consumed.has(edge.id)) continue;
+    consumed.add(edge.id);
+
+    const isSelfLoop = edge.sourceDataMartId === edge.targetDataMartId;
+    const mirror = isSelfLoop
+      ? undefined
+      : byPair
+          .get(conditionKey(edge.targetDataMartId, edge.sourceDataMartId))
+          ?.find(candidate => !consumed.has(candidate.id) && conditionsMirror(edge, candidate));
+
+    if (mirror) {
+      consumed.add(mirror.id);
+      result.push({
+        id: [edge.id, mirror.id].sort().join('+'),
+        sourceId: edge.sourceDataMartId,
+        targetId: edge.targetDataMartId,
+        bidirectional: true,
+        joinNotConfigured: false,
+        joinConditions: edge.joinConditions,
+      });
+    } else {
+      result.push({
+        id: edge.id,
+        sourceId: edge.sourceDataMartId,
+        targetId: edge.targetDataMartId,
+        bidirectional: false,
+        joinNotConfigured: edge.joinConditions.length === 0,
+        joinConditions: edge.joinConditions,
+      });
+    }
+  }
+
+  return result;
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/parallel-edge-offsets.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/parallel-edge-offsets.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { CanvasRenderEdge } from './merge-bidirectional-edges';
+import { computeParallelEdgeOffsets } from './parallel-edge-offsets';
+
+const edge = (
+  id: string,
+  sourceId: string,
+  targetId: string,
+  bidirectional = false
+): CanvasRenderEdge => ({
+  id,
+  sourceId,
+  targetId,
+  bidirectional,
+  joinNotConfigured: false,
+  joinConditions: [],
+});
+
+describe('computeParallelEdgeOffsets', () => {
+  it('assigns 0 to a single edge between two marts', () => {
+    const offsets = computeParallelEdgeOffsets([edge('e1', 'a', 'b')]);
+    expect(offsets.get('e1')).toBe(0);
+  });
+
+  it('assigns symmetric offsets to two parallel edges, ordered by id', () => {
+    const offsets = computeParallelEdgeOffsets([edge('e2', 'a', 'b'), edge('e1', 'a', 'b')], 28);
+    expect(offsets.get('e1')).toBe(-14);
+    expect(offsets.get('e2')).toBe(14);
+  });
+
+  it('assigns symmetric offsets to three parallel edges, ordered by id', () => {
+    const offsets = computeParallelEdgeOffsets(
+      [edge('e3', 'a', 'b'), edge('e1', 'a', 'b'), edge('e2', 'a', 'b')],
+      28
+    );
+    expect(offsets.get('e1')).toBe(-28);
+    expect(offsets.get('e2')).toBe(0);
+    expect(offsets.get('e3')).toBe(28);
+  });
+
+  it('groups non-mirrored anti-parallel A->B and B->A into the same corridor', () => {
+    const offsets = computeParallelEdgeOffsets([edge('e1', 'a', 'b'), edge('e2', 'b', 'a')], 28);
+    expect(offsets.get('e1')).toBe(-14);
+    expect(offsets.get('e2')).toBe(14);
+  });
+
+  it('applies the default spacing when none is provided', () => {
+    const offsets = computeParallelEdgeOffsets([edge('e2', 'a', 'b'), edge('e1', 'a', 'b')]);
+    expect(offsets.get('e1')).toBe(-28);
+    expect(offsets.get('e2')).toBe(28);
+  });
+
+  it('assigns 0 to self-loops regardless of other self-loops', () => {
+    const offsets = computeParallelEdgeOffsets([edge('e1', 'a', 'a'), edge('e2', 'a', 'a')]);
+    expect(offsets.get('e1')).toBe(0);
+    expect(offsets.get('e2')).toBe(0);
+  });
+
+  it('lets a merged bidirectional edge participate in its forward-direction group', () => {
+    const offsets = computeParallelEdgeOffsets(
+      [edge('e1+e2', 'a', 'b', true), edge('e3', 'a', 'b')],
+      28
+    );
+    expect(offsets.get('e1+e2')).toBe(-14);
+    expect(offsets.get('e3')).toBe(14);
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/parallel-edge-offsets.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/parallel-edge-offsets.ts
@@ -1,0 +1,38 @@
+import type { CanvasRenderEdge } from './merge-bidirectional-edges';
+
+const pairKey = (sourceId: string, targetId: string) => [sourceId, targetId].sort().join('->');
+
+export const PARALLEL_EDGE_SPACING = 56;
+
+export function computeParallelEdgeOffsets(
+  edges: CanvasRenderEdge[],
+  spacing = PARALLEL_EDGE_SPACING
+): Map<string, number> {
+  const byPair = new Map<string, CanvasRenderEdge[]>();
+
+  for (const edge of edges) {
+    if (edge.sourceId === edge.targetId) continue;
+    const key = pairKey(edge.sourceId, edge.targetId);
+    const list = byPair.get(key);
+    if (list) list.push(edge);
+    else byPair.set(key, [edge]);
+  }
+
+  const offsets = new Map<string, number>();
+
+  for (const edge of edges) {
+    if (edge.sourceId === edge.targetId) {
+      offsets.set(edge.id, 0);
+    }
+  }
+
+  for (const group of byPair.values()) {
+    const ordered = [...group].sort((a, b) => a.id.localeCompare(b.id));
+    const n = ordered.length;
+    ordered.forEach((edge, index) => {
+      offsets.set(edge.id, (index - (n - 1) / 2) * spacing);
+    });
+  }
+
+  return offsets;
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/rounded-path.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/rounded-path.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildRoundedPath } from './rounded-path';
+
+describe('buildRoundedPath', () => {
+  it('returns an empty string for fewer than 2 points', () => {
+    expect(buildRoundedPath([], 10)).toBe('');
+    expect(buildRoundedPath([{ x: 0, y: 0 }], 10)).toBe('');
+  });
+
+  it('builds a straight line for 2 points', () => {
+    const path = buildRoundedPath(
+      [
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+      ],
+      10
+    );
+    expect(path).toBe('M 0 0 L 100 0');
+  });
+
+  it('builds a single rounded corner for an L-shape', () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ];
+    const path = buildRoundedPath(points, 10);
+
+    expect(path.match(/Q/g)?.length).toBe(1);
+    expect(path.startsWith('M 0 0')).toBe(true);
+    expect(path.endsWith('L 100 100')).toBe(true);
+  });
+
+  it('clamps the radius on short segments', () => {
+    const points = [
+      { x: 0, y: 0 },
+      { x: 4, y: 0 },
+      { x: 4, y: 4 },
+    ];
+    const path = buildRoundedPath(points, 10);
+
+    expect(path).not.toMatch(/NaN/);
+    expect(path).toBe('M 0 0 L 2 0 Q 4 0, 4 2 L 4 4');
+  });
+
+  it('does not produce NaN for collinear or zero-length segments', () => {
+    const collinear = buildRoundedPath(
+      [
+        { x: 0, y: 0 },
+        { x: 50, y: 0 },
+        { x: 100, y: 0 },
+      ],
+      10
+    );
+    expect(collinear).not.toMatch(/NaN/);
+
+    const zeroLength = buildRoundedPath(
+      [
+        { x: 0, y: 0 },
+        { x: 0, y: 0 },
+        { x: 100, y: 0 },
+      ],
+      10
+    );
+    expect(zeroLength).not.toMatch(/NaN/);
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/model/graph/rounded-path.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/graph/rounded-path.ts
@@ -1,0 +1,50 @@
+export interface PathPoint {
+  x: number;
+  y: number;
+}
+
+function segmentLength(a: PathPoint, b: PathPoint): number {
+  return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+function pointAtDistance(from: PathPoint, to: PathPoint, distance: number): PathPoint {
+  const length = segmentLength(from, to);
+  if (length === 0) return from;
+  const t = distance / length;
+  return {
+    x: from.x + (to.x - from.x) * t,
+    y: from.y + (to.y - from.y) * t,
+  };
+}
+
+export function buildRoundedPath(points: PathPoint[], radius: number): string {
+  if (points.length < 2) return '';
+  if (points.length === 2) {
+    const [a, b] = points;
+    return `M ${a.x} ${a.y} L ${b.x} ${b.y}`;
+  }
+
+  const [first, ...rest] = points;
+  let path = `M ${first.x} ${first.y}`;
+  let cursor = first;
+
+  for (let i = 1; i < points.length - 1; i++) {
+    const corner = points[i];
+    const next = points[i + 1];
+    const prevLen = segmentLength(cursor, corner);
+    const nextLen = segmentLength(corner, next);
+    const r = Math.max(0, Math.min(radius, prevLen / 2, nextLen / 2));
+
+    const cornerStart = r === 0 ? corner : pointAtDistance(corner, cursor, r);
+    const cornerEnd = r === 0 ? corner : pointAtDistance(corner, next, r);
+
+    path += ` L ${cornerStart.x} ${cornerStart.y}`;
+    path += ` Q ${corner.x} ${corner.y}, ${cornerEnd.x} ${cornerEnd.y}`;
+    cursor = cornerEnd;
+  }
+
+  const last = rest[rest.length - 1];
+  path += ` L ${last.x} ${last.y}`;
+
+  return path;
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/types.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/types.ts
@@ -1,0 +1,26 @@
+import type { DataMartStatus } from '../../shared/enums';
+
+export interface ModelCanvasJoinCondition {
+  sourceFieldName: string;
+  targetFieldName: string;
+}
+
+export interface ModelCanvasNode {
+  id: string;
+  title: string;
+  status: DataMartStatus;
+  description: string | null;
+  fieldCount: number;
+}
+
+export interface ModelCanvasEdge {
+  id: string;
+  sourceDataMartId: string;
+  targetDataMartId: string;
+  joinConditions: ModelCanvasJoinCondition[];
+}
+
+export interface ModelCanvasData {
+  nodes: ModelCanvasNode[];
+  edges: ModelCanvasEdge[];
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas-filters.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas-filters.ts
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { storageService } from '../../../../services/localstorage.service';
+import { useUrlParam } from '../../../../shared/hooks/useUrlParam';
+import type { CanvasRelFilter, CanvasStatusFilter } from './graph/filter-canvas-data';
+
+const STORAGE_LS_KEY_PREFIX = 'model-canvas-storage';
+
+export function useModelCanvasFilters() {
+  const { projectId = '' } = useParams<{ projectId: string }>();
+  const storageLsKey = `${STORAGE_LS_KEY_PREFIX}:${projectId}`;
+
+  const storage = useUrlParam('storage');
+  const status = useUrlParam('status');
+  const rel = useUrlParam('rel');
+  const search = useUrlParam('search');
+
+  const { value: storageValue, setParam: setStorageParam } = storage;
+
+  useEffect(() => {
+    if (storageValue) return;
+    const saved = storageService.get(storageLsKey);
+    if (saved) setStorageParam(saved);
+  }, [storageValue, setStorageParam, storageLsKey]);
+
+  const statusFilter: CanvasStatusFilter =
+    status.value === 'draft' ? 'draft' : status.value === 'all' ? 'all' : 'published';
+  const relFilter: CanvasRelFilter = rel.value === 'all' ? 'all' : 'connected';
+
+  return {
+    storageId: storage.value,
+    setStorageId: (id: string) => {
+      storageService.set(storageLsKey, id);
+      setStorageParam(id);
+    },
+    status: statusFilter,
+    setStatus: (next: CanvasStatusFilter) => {
+      if (next === 'published') status.removeParam();
+      else status.setParam(next);
+    },
+    rel: relFilter,
+    setRel: (next: CanvasRelFilter) => {
+      if (next === 'connected') rel.removeParam();
+      else rel.setParam(next);
+    },
+    searchQuery: search.value ?? '',
+    setSearchQuery: (next: string) => {
+      if (next) search.setParam(next);
+      else search.removeParam();
+    },
+  };
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.test.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useModelCanvas } from './use-model-canvas';
+
+const serviceMocks = vi.hoisted(() => ({
+  getDataMarts: vi.fn(),
+  getEdges: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useParams: () => ({ projectId: 'project-1' }),
+}));
+
+vi.mock('../api/model-canvas.service', () => ({
+  modelCanvasService: serviceMocks,
+}));
+
+function createWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useModelCanvas', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serviceMocks.getEdges.mockResolvedValue([]);
+  });
+
+  it('passes the query abort signal through both requests', async () => {
+    serviceMocks.getDataMarts.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useModelCanvas('storage-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const nodeConfig = serviceMocks.getDataMarts.mock.calls[0]?.[1];
+    const edgeConfig = serviceMocks.getEdges.mock.calls[0]?.[1];
+    expect(nodeConfig?.signal).toBeInstanceOf(AbortSignal);
+    expect(edgeConfig?.signal).toBe(nodeConfig?.signal);
+  });
+
+  it('aborts the inactive request when the selected storage changes', async () => {
+    let firstSignal: AbortSignal | undefined;
+    serviceMocks.getDataMarts
+      .mockImplementationOnce((_storageId: string, config: { signal?: AbortSignal }) => {
+        firstSignal = config.signal;
+        return new Promise(() => undefined);
+      })
+      .mockResolvedValueOnce([]);
+
+    const { rerender } = renderHook(({ storageId }) => useModelCanvas(storageId), {
+      initialProps: { storageId: 'storage-1' },
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(serviceMocks.getDataMarts).toHaveBeenCalledTimes(1);
+    });
+    rerender({ storageId: 'storage-2' });
+
+    await waitFor(() => {
+      expect(serviceMocks.getDataMarts).toHaveBeenCalledTimes(2);
+    });
+    expect(firstSignal?.aborted).toBe(true);
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { modelCanvasService } from '../api/model-canvas.service';
+import type { ModelCanvasData } from './types';
+
+export function useModelCanvas(storageId: string | null) {
+  const { projectId = '' } = useParams<{ projectId: string }>();
+
+  return useQuery({
+    queryKey: ['model-canvas', projectId, storageId],
+    queryFn: async ({ signal }): Promise<ModelCanvasData> => {
+      const id = storageId ?? '';
+      const config = { signal };
+      const [nodes, edges] = await Promise.all([
+        modelCanvasService.getDataMarts(id, config),
+        modelCanvasService.getEdges(id, config),
+      ]);
+      return { nodes, edges };
+    },
+    enabled: Boolean(storageId),
+  });
+}

--- a/apps/web/src/features/data-marts/shared/canvas/constants.ts
+++ b/apps/web/src/features/data-marts/shared/canvas/constants.ts
@@ -1,0 +1,30 @@
+import type { CSSProperties } from 'react';
+
+export const NODE_BORDER_COLOR = '#9ca3af';
+export const HIGHLIGHT_COLOR = '#3b82f6';
+export const WARNING_COLOR = '#f97316';
+export const EDGE_COLOR = 'steelblue';
+export const EDGE_STROKE_WIDTH = 1.5;
+export const EDGE_WARNING_DASH = '8 4';
+export const DIMMED_OPACITY = 0.15;
+
+export const SOCKET_STYLE: CSSProperties = {
+  width: 10,
+  height: 10,
+  borderRadius: '50%',
+  background: NODE_BORDER_COLOR,
+  border: '2px solid var(--background)',
+};
+
+// React Flow sets inline pointer-events:none on nodes that are neither draggable nor selectable
+export const STATIC_NODE_STYLE: CSSProperties = {
+  pointerEvents: 'all',
+  cursor: 'default',
+};
+
+export const NODE_PULSE_KEYFRAMES = `
+  @keyframes node-pulse {
+    0%, 100% { box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25), 0 0 12px rgba(59, 130, 246, 0.4); }
+    50% { box-shadow: 0 0 0 6px rgba(59, 130, 246, 0.15), 0 0 20px rgba(59, 130, 246, 0.5); }
+  }
+`;

--- a/apps/web/src/features/data-marts/shared/canvas/highlight.ts
+++ b/apps/web/src/features/data-marts/shared/canvas/highlight.ts
@@ -1,0 +1,21 @@
+export interface CanvasHighlightState {
+  highlighted: boolean;
+  dimmed: boolean;
+}
+
+export const NO_HIGHLIGHT: CanvasHighlightState = { highlighted: false, dimmed: false };
+
+export function computeCanvasHighlight<T>(
+  items: T[],
+  query: string,
+  getId: (item: T) => string,
+  getLabel: (item: T) => string
+): Map<string, CanvasHighlightState> {
+  const q = query.trim().toLowerCase();
+  const state = new Map<string, CanvasHighlightState>();
+  for (const item of items) {
+    const highlighted = q !== '' && getLabel(item).toLowerCase().includes(q);
+    state.set(getId(item), { highlighted, dimmed: q !== '' && !highlighted });
+  }
+  return state;
+}

--- a/apps/web/src/features/data-marts/shared/canvas/viewport.ts
+++ b/apps/web/src/features/data-marts/shared/canvas/viewport.ts
@@ -1,0 +1,53 @@
+import type { Viewport } from '@xyflow/react';
+
+interface CanvasBoundsNode {
+  position: { x: number; y: number };
+  width?: number | null;
+  height?: number | null;
+}
+
+export interface CanvasGraphBounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+export function getCanvasGraphBounds(nodes: readonly CanvasBoundsNode[]): CanvasGraphBounds {
+  if (nodes.length === 0) {
+    return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+  }
+
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (const node of nodes) {
+    minX = Math.min(minX, node.position.x);
+    minY = Math.min(minY, node.position.y);
+    maxX = Math.max(maxX, node.position.x + (node.width ?? 0));
+    maxY = Math.max(maxY, node.position.y + (node.height ?? 0));
+  }
+
+  return { minX, minY, maxX, maxY };
+}
+
+export function clampCanvasViewport(
+  viewport: Viewport,
+  bounds: CanvasGraphBounds,
+  paneWidth: number,
+  paneHeight: number,
+  padding: number
+): Viewport {
+  const minX = padding - bounds.maxX * viewport.zoom;
+  const maxX = paneWidth - padding - bounds.minX * viewport.zoom;
+  const minY = padding - bounds.maxY * viewport.zoom;
+  const maxY = paneHeight - padding - bounds.minY * viewport.zoom;
+
+  return {
+    x: Math.min(Math.max(viewport.x, minX), maxX),
+    y: Math.min(Math.max(viewport.y, minY), maxY),
+    zoom: viewport.zoom,
+  };
+}

--- a/apps/web/src/pages/data-marts/model-canvas/ModelCanvasPage.tsx
+++ b/apps/web/src/pages/data-marts/model-canvas/ModelCanvasPage.tsx
@@ -1,0 +1,14 @@
+import { ModelCanvasView } from '../../../features/data-marts/model-canvas/components/ModelCanvasView';
+
+export default function ModelCanvasPage() {
+  return (
+    <div className='dm-page' data-testid='modelCanvasPage'>
+      <header className='dm-page-header'>
+        <h1 className='dm-page-header-title'>Models</h1>
+      </header>
+      <div className='dm-page-content'>
+        <ModelCanvasView />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -7,6 +7,7 @@ import DataMartInsightsPage from '../pages/data-marts/insights/DataMartInsightsP
 import DataMartReportsPage from '../pages/data-marts/reports/DataMartReportsPage.tsx';
 import DataMartRunsPage from '../pages/data-marts/runs/DataMartRunsPage.tsx';
 import DataMartSchedulesPage from '../pages/data-marts/schedules/DataMartSchedulesPage.tsx';
+import ModelCanvasPage from '../pages/data-marts/model-canvas/ModelCanvasPage.tsx';
 import { DataMartDetailsPage } from '../pages/data-marts/edit';
 import CreateDataMartPage from '../pages/data-marts/create/CreateDataMartPage.tsx';
 import { DataStorageListPage } from '../pages/data-storage';
@@ -81,6 +82,11 @@ const routes: RouteObject[] = [
       {
         path: 'data-marts/insights',
         element: <DataMartInsightsPage />,
+        errorElement: <LayoutErrorBoundary />,
+      },
+      {
+        path: 'data-marts/models',
+        element: <ModelCanvasPage />,
         errorElement: <LayoutErrorBoundary />,
       },
       {

--- a/apps/web/src/services/localstorage.service.ts
+++ b/apps/web/src/services/localstorage.service.ts
@@ -28,8 +28,9 @@ export class LocalStorageService {
    * @param type - Optional type hint for value conversion ('boolean' | 'json')
    * @returns The stored value converted to the specified type, or null if not found
    */
-  get(key: string, type?: 'boolean'): boolean | null;
-  get(key: string, type?: 'json'): Record<string, unknown> | null;
+  get(key: string): string | null;
+  get(key: string, type: 'boolean'): boolean | null;
+  get(key: string, type: 'json'): Record<string, unknown> | null;
   get(key: string, type?: 'boolean' | 'json'): StorageValueType {
     try {
       const value = localStorage.getItem(key);

--- a/package-lock.json
+++ b/package-lock.json
@@ -583,6 +583,7 @@
       "version": "0.29.0",
       "license": "ELv2",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -591,18 +592,13 @@
         "@owox/ui": "../packages/ui",
         "@tailwindcss/vite": "^4.1.8",
         "@tanstack/react-query": "^5.66.0",
+        "@xyflow/react": "^12.11.2",
         "axios": "^1.11.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.58.0",
         "react-hot-toast": "^2.5.2",
         "react-router-dom": "^7.6.2",
-        "rete": "^2.0.6",
-        "rete-area-plugin": "^2.1.5",
-        "rete-connection-plugin": "^2.0.5",
-        "rete-minimap-plugin": "^2.0.3",
-        "rete-react-plugin": "^2.1.0",
-        "styled-components": "^6.3.12",
         "tailwindcss": "^4.1.8"
       },
       "devDependencies": {
@@ -3026,6 +3022,21 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
+    },
     "node_modules/@databricks/databricks-sql-kernel-darwin-arm64": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-darwin-arm64/-/databricks-sql-kernel-darwin-arm64-0.2.0.tgz",
@@ -3270,21 +3281,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.50.2",
@@ -11641,6 +11637,55 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -13364,6 +13409,48 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
+      "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.79",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -15184,15 +15271,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001805",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
@@ -15534,6 +15612,12 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
     },
     "node_modules/clean-regexp": {
       "version": "1.0.0",
@@ -16297,15 +16381,6 @@
         "uncrypto": "^0.1.3"
       }
     },
-    "node_modules/css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -16337,17 +16412,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/css-to-react-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
-      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -16444,6 +16508,111 @@
       "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
@@ -25696,12 +25865,6 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "license": "MIT"
-    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -30436,12 +30599,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
-    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -32203,86 +32360,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rete": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/rete/-/rete-2.0.6.tgz",
-      "integrity": "sha512-kPmlKCGFES2VWtY7Y7SCB8ZeXRMsgX5deza9cu4OwmfM/ZUimd461kC3hRyccoyVxE4POlHUx0gg2jcGfusHFg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      }
-    },
-    "node_modules/rete-area-plugin": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/rete-area-plugin/-/rete-area-plugin-2.3.2.tgz",
-      "integrity": "sha512-s7OrCz6xNwVl8EaJ7tXnJVQD9nbd+JAnf82qx/UDweRV86Q1qj2+nT8XkD5m1gSnvSZQqTlMptSiWUrouTEO+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "peerDependencies": {
-        "rete": "^2.0.0"
-      }
-    },
-    "node_modules/rete-connection-plugin": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/rete-connection-plugin/-/rete-connection-plugin-2.0.5.tgz",
-      "integrity": "sha512-KFtlOyEJRc0y9STVgo2T+t+j9u5fxiTxbyzPbMCm0uqncb3b8d2ABDIzvWoNo5zQAh2Oz/OvlUovupbzrGzpSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "peerDependencies": {
-        "rete": "^2.0.1",
-        "rete-area-plugin": "^2.0.0"
-      }
-    },
-    "node_modules/rete-minimap-plugin": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/rete-minimap-plugin/-/rete-minimap-plugin-2.0.3.tgz",
-      "integrity": "sha512-4rLvN6ykTY4Q1k6GO6W80mUbs5BXmGNtSXDumCF+eKkCK2nX8CNZGppcOqjTiWxHmsQfbZaKFwvnWDNwou4HHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "peerDependencies": {
-        "rete": "^2.0.1",
-        "rete-area-plugin": "^2.0.0"
-      }
-    },
-    "node_modules/rete-react-plugin": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rete-react-plugin/-/rete-react-plugin-2.1.2.tgz",
-      "integrity": "sha512-1vXZTmmTDq+YxlN+y2OwYAFj1Ip0JARTYNLtH1QU/l4UOhJP/wETkf7Wu8tIl85fyp23/4UE88bSJJEqXYH2Bg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "usehooks-ts": "^3.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.6 || ^17 || ^18 || ^19 ",
-        "react-dom": "^16.8.6 || ^17 || ^18 || ^19",
-        "rete": "^2.0.1",
-        "rete-area-plugin": "^2.0.0",
-        "rete-render-utils": "^2.0.0",
-        "styled-components": "^5.3.6 || ^6"
-      }
-    },
-    "node_modules/rete-render-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/rete-render-utils/-/rete-render-utils-2.0.3.tgz",
-      "integrity": "sha512-Oz4W2PNayHocRvlzadb5BCNf+tDzJ8RhTwB3ucBPCdCLKZ974wWDiTSCRfA287L2hmHVzRfBdyAwC03K9eP+4g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "peerDependencies": {
-        "rete": "^2.0.0",
-        "rete-area-plugin": "^2.0.0"
       }
     },
     "node_modules/retext": {
@@ -34612,48 +34689,6 @@
       "dependencies": {
         "inline-style-parser": "0.2.7"
       }
-    },
-    "node_modules/styled-components": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.3.tgz",
-      "integrity": "sha512-wYXrhu+JmDjZ1Tv7O0OopGTfztbzun43Pjjhh2H+xc0h5A09dwpZ5FJbrifJDcL8g5TA9btpWOX2+iSRuJTExw==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/is-prop-valid": "1.4.0",
-        "css-to-react-native": "3.2.0",
-        "csstype": "3.2.3",
-        "stylis": "4.3.6"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "css-to-react-native": ">= 3.2.0",
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-native": ">= 0.68.0"
-      },
-      "peerDependenciesMeta": {
-        "css-to-react-native": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/stylis": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "10.3.0",
@@ -37048,21 +37083,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/usehooks-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
-      "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.debounce": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=16.15.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -38201,6 +38221,34 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

- Add a new Models canvas for exploring storage-scoped Data Mart relationships.
- Migrate the Joinable Data Marts graph from Rete.js to React Flow with Dagre-based layouts.
- Keep graph data aligned with storage access and Data Mart visibility rules.
- Improve graph navigation, request lifecycle handling, accessibility, and responsive toolbar behavior.

## What changed

### Backend

- Add paginated Models canvas nodes and storage-scoped relationship edge endpoints.
- Enforce storage `SEE` access before loading graph data.
- Apply the existing owner, sharing, and context visibility policy to canvas nodes.
- Return an edge only when both endpoint Data Marts are visible to the current user.
- Document nullable response fields correctly in the generated OpenAPI schema.

### Frontend

- Add the Models navigation item, route, filters, search, and interactive graph view.
- Support horizontal and vertical layouts, relationship highlighting, external Data Mart actions, and viewport controls.
- Keep node and edge requests cancellable and prevent stale storage loads from replacing current state.
- Preserve user viewport interactions while refitting after meaningful graph changes.
- Fall back to a deterministic grid if Dagre overflows on an exceptionally deep graph.
- Keep the toolbar on one row and constrain the search field so it does not wrap below the filters.
- Improve keyboard and screen-reader access for filters, descriptions, actions, errors, and empty states.

### Dependencies

- Add React Flow and Dagre for graph rendering and layout.
- Remove the unused Rete.js and styled-components dependency chain.

## Testing

- `npm test -w @owox/web -- --run` — 119 files / 790 tests passed.
- `AWS_EC2_METADATA_DISABLED=true npm test -w @owox/backend -- --runInBand` — 405 suites / 5,164 tests passed.
- Web and backend production builds passed.
- Web, backend, and UI lint and Prettier checks passed; backend reports one pre-existing unrelated warning.
- `git diff --check HEAD` passed.

## Screenshots

<img width="1174" height="747" alt="CleanShot 2026-07-14 at 13 19 56" src="https://github.com/user-attachments/assets/db110024-a3f0-40f8-997d-e2965d4fdc19" />

<img width="256" height="446" alt="CleanShot 2026-07-14 at 13 20 28" src="https://github.com/user-attachments/assets/486ac584-20a6-4b04-a930-af17b3dc4540" />

<img width="312" height="258" alt="CleanShot 2026-07-14 at 13 20 50" src="https://github.com/user-attachments/assets/fa10f91c-4a22-4ec6-b0dc-ab284eb965a9" />

<img width="195" height="184" alt="CleanShot 2026-07-14 at 13 21 09" src="https://github.com/user-attachments/assets/16366960-a9be-45e9-9085-2e3d5cd61302" />

<img width="236" height="134" alt="CleanShot 2026-07-14 at 13 21 24" src="https://github.com/user-attachments/assets/34353e25-e887-4104-bb0d-fd4fb80a0783" />

<img width="322" height="163" alt="CleanShot 2026-07-14 at 13 22 26" src="https://github.com/user-attachments/assets/66ddcdd2-0cda-43b6-9b6f-d861063dd7b3" />



