### PR TITLE
feat(backend): introduce buildBlendedFieldUnifiedName for stable field aliasing

### DIFF
--- a/.changeset/6724-column-picker-nested-field-name-collision.md
+++ b/.changeset/6724-column-picker-nested-field-name-collision.md
@@ -1,0 +1,12 @@
+---
+'owox': patch
+---
+
+# Fix nested blended field name collisions in joinable data marts
+
+Nested (struct) fields in joined sources no longer share report column names with flat siblings after dots are replaced with underscores. For example, flat `campaign_id` and nested `campaign.id` under the same join alias now produce distinct unified names (`ads__campaign_id` vs `ads__campaign_id__a8702665`).
+
+- **Flat blended names** stay byte-for-byte unchanged; existing reports that only use flat joined columns need no config changes.
+- **Nested blended names** always include a stable 8-character hash of `(aliasPath, originalFieldName)`. New saves and reloads use the hashed form end-to-end.
+- **Legacy nested names** in already-saved `columnConfig` / filter / sort (pre-hash form such as `customers__campaign_id` for `campaign.id`) are intentionally not migrated in this release and will not resolve after deploy. That population was empty when this shipped; a follow-up migration can re-key them if needed. The pre-join filter migration (`MigratePreJoinFilterToUnifiedColumn`) still emits the pre-hash form for historical rules only.
+- **Rolling deploy:** during a mixed old/new backend fleet, nested-field reports saved or run mid-rollout can briefly orphan until every pod serves the hashed names. Self-heals once the fleet is fully on the new version; prefer rolling through before bulk-editing nested-column reports.

--- a/apps/backend/src/data-marts/controllers/spec/report-openapi.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report-openapi.ts
@@ -132,7 +132,7 @@ export class ReportFilterRuleApiDto {
   @ApiProperty({
     minLength: 1,
     description:
-      'Output column name. For slice filters (placement=pre-join), use the fully qualified blended column identifier, e.g. category_details__item_event_count.',
+      'Output column name. For slice filters (placement=pre-join), use the fully qualified blended column identifier from the blendable schema (flat: category_details__item_count; nested fields include a hash suffix).',
   })
   column: string;
 

--- a/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
@@ -128,9 +128,8 @@ describe('ReportController OpenAPI', () => {
     expect(filterRule.properties.value.oneOf).toHaveLength(3);
     expect(filterRule.properties.placement.enum).toEqual(['pre-join', 'post-join']);
     expect(filterRule.properties.aliasPath).toBeUndefined();
-    expect(filterRule.properties.column.description).toContain(
-      'category_details__item_event_count'
-    );
+    expect(filterRule.properties.column.description).toContain('category_details__item_count');
+    expect(filterRule.properties.column.description).toContain('hash suffix');
 
     expect(updateProperties.sortConfig).toMatchObject({
       type: 'array',

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/blended-query-builder.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/blended-query-builder.interface.ts
@@ -34,9 +34,12 @@ export interface BlendedColumnTypes {
 }
 
 /**
- * Flat resolution entry for one blended field, keyed by its unified name
- * (`<aliasPath with dots→_>__<originalFieldName with dots→_>`). Single source of
- * truth for resolving a unified column identifier back to the data it encodes.
+ * Flat resolution entry for one blended field, keyed by its unified name from
+ * `buildBlendedFieldUnifiedName`:
+ * - flat:   `<sqlPrefix>__<originalFieldName>`
+ * - nested: `<sqlPrefix>__<originalFieldName with dots→_>__<sha1(aliasPath|originalFieldName)[0:8]>`
+ * where `sqlPrefix` is `aliasPath` with dots→underscores. Single source of truth
+ * for resolving a unified column identifier back to the data it encodes.
  */
 export interface BlendedFieldEntry {
   aliasPath: string; // 'category.details'

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/blended-query-builder.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/blended-query-builder.interface.ts
@@ -35,11 +35,10 @@ export interface BlendedColumnTypes {
 
 /**
  * Flat resolution entry for one blended field, keyed by its unified name from
- * `buildBlendedFieldUnifiedName`:
- * - flat:   `<sqlPrefix>__<originalFieldName>`
- * - nested: `<sqlPrefix>__<originalFieldName with dots→_>__<sha1(aliasPath|originalFieldName)[0:8]>`
- * where `sqlPrefix` is `aliasPath` with dots→underscores. Single source of truth
- * for resolving a unified column identifier back to the data it encodes.
+ * `buildBlendedFieldUnifiedName` (identity = aliasPath + originalFieldName):
+ * - flat:   `<aliasPath dots→_>`__`<originalFieldName>`
+ * - nested: `<aliasPath dots→_>`__`<originalFieldName dots→_>`__`<sha1(aliasPath|originalFieldName)[0:8]>`
+ * Single source of truth for resolving a unified column identifier back to the data it encodes.
  */
 export interface BlendedFieldEntry {
   aliasPath: string; // 'category.details'

--- a/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
@@ -13,6 +13,7 @@ import { BlendedFieldsConfig } from '../dto/schemas/blended-fields-config.schema
 import { DataMartStatus } from '../enums/data-mart-status.enum';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
+import { buildBlendedFieldUnifiedName } from './blended-field-name';
 
 const defaultAccessor: BlendableSchemaAccessor = { userId: 'user-1', roles: ['admin'] };
 
@@ -247,6 +248,50 @@ describe('BlendableSchemaService', () => {
       expect(ageField.type).toBe('INTEGER');
       // Numeric default: SUM, not STRING_AGG
       expect(ageField.aggregateFunction).toBe('SUM');
+    });
+
+    it('should hash nested struct field names so they do not collide with flat fields', async () => {
+      dataMartService.getByIdAndProjectId.mockResolvedValue(
+        makeDataMart({ id: 'dm-1', blendedFieldsConfig: undefined })
+      );
+
+      const relationship = makeRelationship({
+        id: 'rel-1',
+        targetAlias: 'customers',
+        targetDataMart: makeDataMart({
+          id: 'dm-2',
+          title: 'Customers DM',
+          schema: {
+            type: 'bigquery-data-mart-schema',
+            fields: [
+              { name: 'campaign_id', type: 'STRING' },
+              {
+                name: 'campaign',
+                type: 'RECORD',
+                fields: [{ name: 'id', type: 'STRING' }],
+              },
+            ],
+          } as unknown as DataMart['schema'],
+        }),
+      });
+
+      relationshipService.findByStorageId.mockResolvedValue([relationship]);
+
+      const result = await service.computeBlendableSchema('dm-1', 'project-1', defaultAccessor);
+
+      const flat = result.blendedFields.find(f => f.originalFieldName === 'campaign_id');
+      const nested = result.blendedFields.find(f => f.originalFieldName === 'campaign.id');
+
+      expect(flat).toBeDefined();
+      expect(nested).toBeDefined();
+      expect(flat!.name).toBe('customers__campaign_id');
+      expect(nested!.name).toBe(
+        buildBlendedFieldUnifiedName('customers', 'customers', 'campaign.id')
+      );
+      expect(nested!.name).toBe('customers__campaign_id__b996a659');
+      expect(nested!.name).not.toBe(flat!.name);
+      expect(nested!.originalFieldName).toBe('campaign.id');
+      expect(nested!.aliasPath).toBe('customers');
     });
 
     it.each([

--- a/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
@@ -285,9 +285,7 @@ describe('BlendableSchemaService', () => {
       expect(flat).toBeDefined();
       expect(nested).toBeDefined();
       expect(flat!.name).toBe('customers__campaign_id');
-      expect(nested!.name).toBe(
-        buildBlendedFieldUnifiedName('customers', 'customers', 'campaign.id')
-      );
+      expect(nested!.name).toBe(buildBlendedFieldUnifiedName('customers', 'campaign.id'));
       expect(nested!.name).toBe('customers__campaign_id__b996a659');
       expect(nested!.name).not.toBe(flat!.name);
       expect(nested!.originalFieldName).toBe('campaign.id');

--- a/apps/backend/src/data-marts/services/blendable-schema.service.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.ts
@@ -223,11 +223,10 @@ export class BlendableSchemaService {
       );
       const flatTargetFields = flattenSchemaFields(targetSchemaFields);
 
-      // `sqlPrefix` is SQL‑safe because each `targetAlias` segment in
-      // `currentPath` is validated against `^[a-z0-9_]+$` in the Join
-      // Settings form. `displayPrefix` is free‑form and must never flow
-      // into SQL identifiers.
-      const sqlPrefix = currentPath.replace(/\./g, '_');
+      // Each `targetAlias` segment in `currentPath` is validated against
+      // `^[a-z0-9_]+$` in the Join Settings form, so the SQL-safe prefix
+      // derived inside `buildBlendedFieldUnifiedName` is safe. `displayPrefix`
+      // is free-form and must never flow into SQL identifiers.
       const displayPrefix = sourceConfig?.alias ?? rel.targetDataMart.title;
 
       const availableSource = new AvailableSourceDto();
@@ -246,7 +245,7 @@ export class BlendableSchemaService {
         const fieldOverride = sourceConfig?.fields?.[field.name];
 
         const dto = new BlendedFieldDto();
-        dto.name = buildBlendedFieldUnifiedName(currentPath, sqlPrefix, field.name);
+        dto.name = buildBlendedFieldUnifiedName(currentPath, field.name);
         dto.aliasPath = currentPath;
         dto.outputPrefix = displayPrefix;
         dto.sourceRelationshipId = rel.id;

--- a/apps/backend/src/data-marts/services/blendable-schema.service.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.ts
@@ -20,6 +20,7 @@ import { BusinessViolationException } from '../../common/exceptions/business-vio
 import { DataMartRelationship } from '../entities/data-mart-relationship.entity';
 import { DataMartStatus } from '../enums/data-mart-status.enum';
 import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
+import { buildBlendedFieldUnifiedName } from './blended-field-name';
 
 export interface BlendableSchemaAccessor {
   userId: string;
@@ -245,9 +246,7 @@ export class BlendableSchemaService {
         const fieldOverride = sourceConfig?.fields?.[field.name];
 
         const dto = new BlendedFieldDto();
-        // Replace dots in nested struct field paths (e.g. `struct.field`) with
-        // underscores so the resulting alias is a valid SQL identifier.
-        dto.name = `${sqlPrefix}__${field.name.replace(/\./g, '_')}`;
+        dto.name = buildBlendedFieldUnifiedName(currentPath, sqlPrefix, field.name);
         dto.aliasPath = currentPath;
         dto.outputPrefix = displayPrefix;
         dto.sourceRelationshipId = rel.id;

--- a/apps/backend/src/data-marts/services/blended-field-name.spec.ts
+++ b/apps/backend/src/data-marts/services/blended-field-name.spec.ts
@@ -2,37 +2,45 @@ import { buildBlendedFieldUnifiedName } from './blended-field-name';
 
 describe('buildBlendedFieldUnifiedName', () => {
   it('keeps a flat field name unchanged (no hash)', () => {
-    expect(buildBlendedFieldUnifiedName('ads', 'ads', 'campaign_id')).toBe('ads__campaign_id');
+    expect(buildBlendedFieldUnifiedName('ads', 'campaign_id')).toBe('ads__campaign_id');
   });
 
   it('always hashes a nested field, even with zero collision risk present', () => {
     // sha1('ads|campaign.id').slice(0, 8), computed independently of the implementation.
-    expect(buildBlendedFieldUnifiedName('ads', 'ads', 'campaign.id')).toBe(
-      'ads__campaign_id__a8702665'
-    );
+    expect(buildBlendedFieldUnifiedName('ads', 'campaign.id')).toBe('ads__campaign_id__a8702665');
   });
 
   it('gives the flat campaign_id and nested campaign.id case from the bug report distinct names', () => {
-    const flat = buildBlendedFieldUnifiedName('ads', 'ads', 'campaign_id');
-    const nested = buildBlendedFieldUnifiedName('ads', 'ads', 'campaign.id');
+    const flat = buildBlendedFieldUnifiedName('ads', 'campaign_id');
+    const nested = buildBlendedFieldUnifiedName('ads', 'campaign.id');
     expect(flat).not.toBe(nested);
   });
 
   it('hashes a 3-level struct path correctly, distinct from a 2-level path sharing the same leaf', () => {
-    const threeLevel = buildBlendedFieldUnifiedName('ads', 'ads', 'catalog.category.id');
-    const twoLevel = buildBlendedFieldUnifiedName('ads', 'ads', 'category.id');
+    const threeLevel = buildBlendedFieldUnifiedName('ads', 'catalog.category.id');
+    const twoLevel = buildBlendedFieldUnifiedName('ads', 'category.id');
     expect(threeLevel).toBe('ads__catalog_category_id__d614205f');
     expect(twoLevel).toBe('ads__category_id__3ec1e389');
     expect(threeLevel).not.toBe(twoLevel);
   });
 
+  it('derives sqlPrefix from aliasPath (nested join paths)', () => {
+    expect(buildBlendedFieldUnifiedName('category.details', 'item_count')).toBe(
+      'category_details__item_count'
+    );
+    // sha1('category.details|item.event_count').slice(0, 8)
+    expect(buildBlendedFieldUnifiedName('category.details', 'item.event_count')).toBe(
+      'category_details__item_event_count__d9cd4740'
+    );
+  });
+
   it('is stable regardless of any other field, proving there is no reactive/relational behavior', () => {
-    const first = buildBlendedFieldUnifiedName('ads', 'ads', 'campaign.id');
+    const first = buildBlendedFieldUnifiedName('ads', 'campaign.id');
     // Interleave calls for other, unrelated field identities in between - the
     // result for the same (aliasPath, originalFieldName) must never change.
-    buildBlendedFieldUnifiedName('orders', 'orders', 'customer.id');
-    buildBlendedFieldUnifiedName('ads', 'ads', 'campaign_id');
-    const second = buildBlendedFieldUnifiedName('ads', 'ads', 'campaign.id');
+    buildBlendedFieldUnifiedName('orders', 'customer.id');
+    buildBlendedFieldUnifiedName('ads', 'campaign_id');
+    const second = buildBlendedFieldUnifiedName('ads', 'campaign.id');
     expect(second).toBe(first);
   });
 });

--- a/apps/backend/src/data-marts/services/blended-field-name.spec.ts
+++ b/apps/backend/src/data-marts/services/blended-field-name.spec.ts
@@ -1,0 +1,38 @@
+import { buildBlendedFieldUnifiedName } from './blended-field-name';
+
+describe('buildBlendedFieldUnifiedName', () => {
+  it('keeps a flat field name unchanged (no hash)', () => {
+    expect(buildBlendedFieldUnifiedName('ads', 'ads', 'campaign_id')).toBe('ads__campaign_id');
+  });
+
+  it('always hashes a nested field, even with zero collision risk present', () => {
+    // sha1('ads|campaign.id').slice(0, 8), computed independently of the implementation.
+    expect(buildBlendedFieldUnifiedName('ads', 'ads', 'campaign.id')).toBe(
+      'ads__campaign_id__a8702665'
+    );
+  });
+
+  it('gives the flat campaign_id and nested campaign.id case from the bug report distinct names', () => {
+    const flat = buildBlendedFieldUnifiedName('ads', 'ads', 'campaign_id');
+    const nested = buildBlendedFieldUnifiedName('ads', 'ads', 'campaign.id');
+    expect(flat).not.toBe(nested);
+  });
+
+  it('hashes a 3-level struct path correctly, distinct from a 2-level path sharing the same leaf', () => {
+    const threeLevel = buildBlendedFieldUnifiedName('ads', 'ads', 'catalog.category.id');
+    const twoLevel = buildBlendedFieldUnifiedName('ads', 'ads', 'category.id');
+    expect(threeLevel).toBe('ads__catalog_category_id__d614205f');
+    expect(twoLevel).toBe('ads__category_id__3ec1e389');
+    expect(threeLevel).not.toBe(twoLevel);
+  });
+
+  it('is stable regardless of any other field, proving there is no reactive/relational behavior', () => {
+    const first = buildBlendedFieldUnifiedName('ads', 'ads', 'campaign.id');
+    // Interleave calls for other, unrelated field identities in between - the
+    // result for the same (aliasPath, originalFieldName) must never change.
+    buildBlendedFieldUnifiedName('orders', 'orders', 'customer.id');
+    buildBlendedFieldUnifiedName('ads', 'ads', 'campaign_id');
+    const second = buildBlendedFieldUnifiedName('ads', 'ads', 'campaign.id');
+    expect(second).toBe(first);
+  });
+});

--- a/apps/backend/src/data-marts/services/blended-field-name.ts
+++ b/apps/backend/src/data-marts/services/blended-field-name.ts
@@ -1,0 +1,20 @@
+import { createHash } from 'node:crypto';
+
+/** First 8 hex chars of sha1(aliasPath + '|' + originalFieldName) — a stable
+ * per-field identity, independent of any other field that does or doesn't exist. */
+function shortHash(aliasPath: string, originalFieldName: string): string {
+  return createHash('sha1').update(`${aliasPath}|${originalFieldName}`).digest('hex').slice(0, 8);
+}
+
+/** Unified name used in blendable-schema payloads and report saves. */
+export function buildBlendedFieldUnifiedName(
+  aliasPath: string,
+  sqlPrefix: string,
+  originalFieldName: string
+): string {
+  if (!originalFieldName.includes('.')) {
+    return `${sqlPrefix}__${originalFieldName}`; // flat — byte-identical to today, always
+  }
+  const readable = originalFieldName.replace(/\./g, '_');
+  return `${sqlPrefix}__${readable}__${shortHash(aliasPath, originalFieldName)}`; // nested — always hashed
+}

--- a/apps/backend/src/data-marts/services/blended-field-name.ts
+++ b/apps/backend/src/data-marts/services/blended-field-name.ts
@@ -6,14 +6,16 @@ function shortHash(aliasPath: string, originalFieldName: string): string {
   return createHash('sha1').update(`${aliasPath}|${originalFieldName}`).digest('hex').slice(0, 8);
 }
 
-/** Unified name used in blendable-schema payloads and report saves. */
-export function buildBlendedFieldUnifiedName(
-  aliasPath: string,
-  sqlPrefix: string,
-  originalFieldName: string
-): string {
+/**
+ * Unified name used in blendable-schema payloads and report saves.
+ * Identity depends only on `(aliasPath, originalFieldName)`:
+ * - flat:   `<aliasPath dots→_>`__`<originalFieldName>`
+ * - nested: `<aliasPath dots→_>`__`<originalFieldName dots→_>`__`<sha1[0:8]>`
+ */
+export function buildBlendedFieldUnifiedName(aliasPath: string, originalFieldName: string): string {
+  const sqlPrefix = aliasPath.replace(/\./g, '_');
   if (!originalFieldName.includes('.')) {
-    return `${sqlPrefix}__${originalFieldName}`; // flat — byte-identical to today, always
+    return `${sqlPrefix}__${originalFieldName}`; // flat — byte-identical to pre-hash naming
   }
   const readable = originalFieldName.replace(/\./g, '_');
   return `${sqlPrefix}__${readable}__${shortHash(aliasPath, originalFieldName)}`; // nested — always hashed

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -371,9 +371,10 @@ export class BlendedReportDataService {
     return chains;
   }
 
-  // Blended column refs are flat `<aliasPath>__<field>` strings; an alias rename or
-  // relationship removal orphans them, and unmatched names would otherwise be projected
-  // as native main columns — producing a cryptic storage error instead of this one.
+  // Blended column refs are unified names from `buildBlendedFieldUnifiedName`
+  // (flat: `<aliasPath>__<field>`; nested: same with a stable hash suffix). An alias
+  // rename or relationship removal orphans them, and unmatched names would otherwise
+  // be projected as native main columns — producing a cryptic storage error instead of this one.
   // Hidden fields are equally unavailable: schema-hidden ones are excluded from
   // reporting by definition, and blend-hidden ones are dropped from the final SELECT
   // while their data headers are still emitted — selecting either must fail here.

--- a/apps/backend/src/migrations/1779200000000-migrate-prejoin-filter-to-unified-column.ts
+++ b/apps/backend/src/migrations/1779200000000-migrate-prejoin-filter-to-unified-column.ts
@@ -19,12 +19,19 @@ export class MigratePreJoinFilterToUnifiedColumn1779200000000 implements Migrati
   // Folds a pre-join (slice) rule's aliasPath + raw column into the unified column
   // identifier (`<aliasPath dots->_>__<column dots->_>`) and drops aliasPath. Returns
   // true if anything changed. Inlined (not shared) so the migration stays self-contained.
+  //
+  // Deliberately emits the pre-hash nested format (e.g. `customers__campaign_id` for
+  // `campaign.id`), NOT the post-hash name from `buildBlendedFieldUnifiedName`. This
+  // migration only reshapes already-persisted pre-join rules; nested blended refs in
+  // saved configs were an empty population when hash suffixes were introduced. A
+  // follow-up data migration can re-key any remaining legacy nested names if needed.
   private migrateRules(rules: Rule[]): boolean {
     let changed = false;
     for (const rule of rules) {
       if (rule.placement === 'pre-join' && typeof rule.aliasPath === 'string') {
         const aliasPath = rule.aliasPath;
         const column = String(rule.column);
+        // Pre-hash unified form — do not track buildBlendedFieldUnifiedName.
         rule.column = `${aliasPath.replace(/\./g, '_')}__${column.replace(/\./g, '_')}`;
         delete rule.aliasPath;
         changed = true;

--- a/apps/web/src/features/data-marts/shared/types/output-config.ts
+++ b/apps/web/src/features/data-marts/shared/types/output-config.ts
@@ -104,7 +104,11 @@ export type DateTruncRule = z.infer<typeof DateTruncRuleSchema>;
 export type RelativeDatePreset = z.infer<typeof RelativeDatePresetSchema>;
 
 export interface JoinedSourceColumn {
-  /** Unified blended-field name stored on the rule, e.g. `category_details__item_event_count`. */
+  /**
+   * Unified blended-field name stored on the rule.
+   * Flat: `category_details__item_count`. Nested (struct path): includes a hash suffix,
+   * e.g. `category_details__item_event_count__a1b2c3d4`.
+   */
   id: string;
   /** Raw original field name, for friendly display in the slice picker. */
   name: string;


### PR DESCRIPTION
## Summary

- Fixes blended field unified-name collisions for nested (struct) fields in joinable data marts.
- Flat fields keep their existing names byte-for-byte (`{sqlPrefix}__{field}`); nested fields always get a stable hash suffix so paths like `campaign_id` and `campaign.id` no longer collapse to the same alias.
- Centralizes naming in `buildBlendedFieldUnifiedName` so the identity depends only on `(aliasPath, originalFieldName)`, not on sibling fields or reactive collision detection.

## Problem

`BlendableSchemaService` used to build report column names as:

```
${sqlPrefix}__${field.name.replace(/\./g, '_')}
```

That made a flat `campaign_id` and a nested `campaign.id` both become `…__campaign_id`. The column picker, filters, and field index then treated two different fields as one.

## Solution

| Field type | Unified name |
|---|---|
| Flat | `{sqlPrefix}__{name}` (unchanged) |
| Nested | `{sqlPrefix}__{dots→_}__{sha1(aliasPath\|originalFieldName)[0:8]}` |

Example: `ads__campaign_id` vs `ads__campaign_id__a8702665`.

## Scope

- **In scope:** nested blended fields from joined data marts (names used in blendable schema / reports).
- **Out of scope in this PR:** data migration for already-saved report `columnConfig` / `filterConfig` / `sortConfig` that still store legacy nested names (can be a follow-up if needed).

## Test plan

- [x] Unit tests for `buildBlendedFieldUnifiedName` pass (flat unchanged, nested hashed, collision case distinct, multi-level paths distinct, stability independent of other fields).
- [x] Open a data mart with a join where both `campaign_id` and `campaign.id` exist — both appear as separate selectable columns.
- [x] Selecting one does not toggle the other in the report column picker.
- [x] Existing reports that only use **flat** blended fields still resolve and run without config changes.
- [x] Nested field names in a newly saved report include the hash suffix and round-trip correctly on reload/run.
