### PR TITLE
refactor(web): move refresh and AI buttons to TableToolbar

### DIFF
--- a/.changeset/6550-output-schema-buttons-improve.md
+++ b/.changeset/6550-output-schema-buttons-improve.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Improve Output Schema AI actions
+
+This PR improves the discoverability and organization of Output Schema actions. The **Refresh schema** and global **Generate field aliases & descriptions** actions are now located in the table toolbar, keeping all primary actions in one place. The global AI action has also been simplified by removing the dropdown menu, allowing users to generate both field aliases and descriptions with a single click.
+
+To make AI features easier to discover, AI action buttons have been added to the **Alias** and **Description** column headers, allowing users to generate values for an entire column directly where the action applies.
+
+To support these changes, all business logic remains in `DataMartSchemaSettings`, while `TableToolbar` stays a presentational component. A new `SchemaToolbar` interface is used to pass toolbar state and callbacks through the component hierarchy.

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.test.tsx
@@ -12,6 +12,7 @@ import {
 import { DataMartDefinitionType } from '../../../shared';
 import type { DataMartContextType } from '../../model/context/types';
 import { DataMartSchemaSettings } from './DataMartSchemaSettings';
+import type { SchemaToolbar } from './types/schema-toolbar';
 
 const testState = vi.hoisted(() => ({
   outletContext: null as unknown,
@@ -74,9 +75,11 @@ vi.mock('./SchemaContent', () => ({
   SchemaContent: ({
     schema,
     onFieldsChange,
+    schemaToolbar,
   }: {
     schema: DataMartSchema | null | undefined;
     onFieldsChange: (fields: BigQueryDataMartSchema['fields']) => void;
+    schemaToolbar: SchemaToolbar;
   }) => {
     const field = schema?.fields[0];
     return (
@@ -86,6 +89,22 @@ vi.mock('./SchemaContent', () => ({
             ? `${field.isHiddenForReporting ? 'hidden' : 'visible'}:${field.alias ?? ''}:${field.description ?? ''}`
             : ''}
         </div>
+        {/* Expose AI toolbar actions for DataMartSchemaSettings tests. */}
+        {schemaToolbar.showAiHelper && (
+          <>
+            <button type='button' onClick={schemaToolbar.ai.onGenerateDescriptions}>
+              Generate field descriptions
+            </button>
+
+            <button type='button' onClick={schemaToolbar.ai.onGenerateAliases}>
+              Generate field aliases
+            </button>
+
+            <button type='button' onClick={schemaToolbar.ai.onGenerateMetadata}>
+              Generate field aliases & descriptions
+            </button>
+          </>
+        )}
         {schema && field && (
           <button
             type='button'

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
@@ -1,12 +1,4 @@
 import { Button } from '@owox/ui/components/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@owox/ui/components/dropdown-menu';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
-import { Loader2, Sparkles } from 'lucide-react';
 import { useCallback, useEffect, useRef } from 'react';
 import toast from 'react-hot-toast';
 import { useOutletContext } from 'react-router-dom';
@@ -23,6 +15,7 @@ import { SchemaContent } from './SchemaContent';
 import { DataMartDefinitionType, DataMartMetadataScope } from '../../../shared/index.ts';
 import { useAiHelper, useAiHelperAvailability } from '../../model/hooks';
 import type { ResolvedSchema } from '../../model/hooks';
+import type { SchemaToolbar } from './types/schema-toolbar';
 
 interface DataMartSchemaSettingsProps {
   definitionType: DataMartDefinitionType | null;
@@ -182,7 +175,7 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
   // Backend rejects metadata generation for CONNECTOR data marts; hide the buttons
   // so the user is never offered an action that's guaranteed to 422.
   const isConnector = definitionType === DataMartDefinitionType.CONNECTOR;
-  const showAiHelper = isAiHelperEnabled && !isConnector;
+  const showAiHelper = Boolean(isAiHelperEnabled) && !isConnector;
 
   // Reset schema when operation is successful
   useEffect(() => {
@@ -377,13 +370,50 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
   );
 
   // Disable buttons during schema operations (save or actualization)
-  const isSchemaOperationInProgress = isLoading || isSchemaActualizationLoading;
+  const isSchemaOperationInProgress = isLoading || Boolean(isSchemaActualizationLoading);
   const isAiBusy = aiPendingScope !== null;
-  const isBulkAiBusy =
-    aiPendingScope?.scope === DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS ||
-    aiPendingScope?.scope === DataMartMetadataScope.ALL_FIELD_ALIASES ||
-    aiPendingScope?.scope === DataMartMetadataScope.ALL_FIELD_METADATA;
   const hasFields = !!schema && schema.fields.length > 0;
+
+  const schemaToolbar: SchemaToolbar = {
+    showAiHelper,
+
+    refresh: {
+      disabled: !definitionType || isSchemaOperationInProgress,
+      onClick: handleActualize,
+    },
+
+    ai: {
+      disabled: !hasFields || isSchemaOperationInProgress || isAiBusy,
+      loading: {
+        metadata: aiPendingScope?.scope === DataMartMetadataScope.ALL_FIELD_METADATA,
+
+        aliases: aiPendingScope?.scope === DataMartMetadataScope.ALL_FIELD_ALIASES,
+
+        descriptions: aiPendingScope?.scope === DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS,
+      },
+
+      onGenerateMetadata: () => {
+        runGuarded?.(resolved => runBulkAi(DataMartMetadataScope.ALL_FIELD_METADATA, resolved), {
+          intent: 'ai',
+        });
+      },
+
+      onGenerateDescriptions: () => {
+        runGuarded?.(
+          resolved => runBulkAi(DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS, resolved),
+          {
+            intent: 'ai',
+          }
+        );
+      },
+
+      onGenerateAliases: () => {
+        runGuarded?.(resolved => runBulkAi(DataMartMetadataScope.ALL_FIELD_ALIASES, resolved), {
+          intent: 'ai',
+        });
+      },
+    },
+  };
 
   if (!dataMart) {
     return <div>Error: Data mart not found</div>;
@@ -404,6 +434,7 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
               }
             : undefined
         }
+        schemaToolbar={schemaToolbar}
       />
       <div className='align-items-center mt-4 flex justify-between'>
         <div className='flex items-center gap-2'>
@@ -424,88 +455,7 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
           </Button>
         </div>
 
-        <div className='flex items-center gap-2'>
-          {showAiHelper && (
-            <DropdownMenu>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type='button'
-                      variant='outline'
-                      size='icon'
-                      disabled={!hasFields || Boolean(isSchemaOperationInProgress) || isAiBusy}
-                      aria-label='Generate field metadata with AI'
-                    >
-                      {isBulkAiBusy ? (
-                        <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
-                      ) : (
-                        <Sparkles className='h-4 w-4' aria-hidden='true' />
-                      )}
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side='bottom'>Generate field metadata with AI</TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent align='end'>
-                <DropdownMenuItem
-                  className='cursor-pointer'
-                  disabled={!hasFields || isAiBusy}
-                  onClick={() => {
-                    runGuarded?.(
-                      resolved => runBulkAi(DataMartMetadataScope.ALL_FIELD_METADATA, resolved),
-                      {
-                        intent: 'ai',
-                      }
-                    );
-                  }}
-                >
-                  <Sparkles className='mr-2 h-4 w-4' />
-                  Generate field aliases & descriptions
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  className='cursor-pointer'
-                  disabled={!hasFields || isAiBusy}
-                  onClick={() => {
-                    runGuarded?.(
-                      resolved => runBulkAi(DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS, resolved),
-                      {
-                        intent: 'ai',
-                      }
-                    );
-                  }}
-                >
-                  <Sparkles className='mr-2 h-4 w-4' />
-                  Generate field descriptions
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  className='cursor-pointer'
-                  disabled={!hasFields || isAiBusy}
-                  onClick={() => {
-                    runGuarded?.(
-                      resolved => runBulkAi(DataMartMetadataScope.ALL_FIELD_ALIASES, resolved),
-                      {
-                        intent: 'ai',
-                      }
-                    );
-                  }}
-                >
-                  <Sparkles className='mr-2 h-4 w-4' />
-                  Generate field aliases
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-
-          <Button
-            type='button'
-            variant='outline'
-            onClick={handleActualize}
-            disabled={!definitionType || isSchemaOperationInProgress}
-          >
-            Refresh schema
-          </Button>
-        </div>
+        <div className='flex items-center gap-2'></div>
       </div>
     </div>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SchemaContent.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SchemaContent.tsx
@@ -24,6 +24,7 @@ import {
   isSnowflakeSchema,
 } from './utils';
 import type { SchemaAiHelper } from './types/ai-helper';
+import type { SchemaToolbar } from './types/schema-toolbar';
 
 /**
  * Props for the SchemaContent component
@@ -44,6 +45,7 @@ interface SchemaContentProps {
   ) => void;
   /** AI helper handlers; omit to hide AI buttons on this deployment. */
   aiHelper?: SchemaAiHelper;
+  schemaToolbar: SchemaToolbar;
 }
 
 /**
@@ -55,6 +57,7 @@ export function SchemaContent({
   storageType,
   onFieldsChange,
   aiHelper,
+  schemaToolbar,
 }: SchemaContentProps) {
   // If schema doesn't exist, create an initial schema based on storage type
   const initialSchema = useMemo(() => {
@@ -74,6 +77,7 @@ export function SchemaContent({
         fields={initialSchema.fields}
         onFieldsChange={onFieldsChange}
         aiHelper={aiHelper}
+        schemaToolbar={schemaToolbar}
       />
     );
   } else if (isAthenaSchema(initialSchema)) {
@@ -82,6 +86,7 @@ export function SchemaContent({
         fields={initialSchema.fields}
         onFieldsChange={onFieldsChange}
         aiHelper={aiHelper}
+        schemaToolbar={schemaToolbar}
       />
     );
   } else if (isSnowflakeSchema(initialSchema)) {
@@ -90,6 +95,7 @@ export function SchemaContent({
         fields={initialSchema.fields}
         onFieldsChange={onFieldsChange}
         aiHelper={aiHelper}
+        schemaToolbar={schemaToolbar}
       />
     );
   } else if (isRedshiftSchema(initialSchema)) {
@@ -98,6 +104,7 @@ export function SchemaContent({
         fields={initialSchema.fields}
         onFieldsChange={onFieldsChange}
         aiHelper={aiHelper}
+        schemaToolbar={schemaToolbar}
       />
     );
   } else if (isDatabricksSchema(initialSchema)) {
@@ -106,6 +113,7 @@ export function SchemaContent({
         fields={initialSchema.fields}
         onFieldsChange={onFieldsChange}
         aiHelper={aiHelper}
+        schemaToolbar={schemaToolbar}
       />
     );
   }

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/fields/SchemaFieldStatusIcon.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/fields/SchemaFieldStatusIcon.tsx
@@ -67,7 +67,7 @@ export function SchemaFieldStatusIcon({ status }: SchemaFieldStatusIconProps) {
             tabIndex={0}
           />
         </TooltipTrigger>
-        <TooltipContent id={tooltipId} side='bottom' role='tooltip'>
+        <TooltipContent id={tooltipId} role='tooltip'>
           <div className='text-xs font-medium'>{label}</div>
           <div className='mt-1 max-w-xs text-xs break-words whitespace-normal'>{description}</div>
         </TooltipContent>

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/table/SchemaHeaderAiButton.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/table/SchemaHeaderAiButton.tsx
@@ -1,0 +1,42 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { Loader2, Sparkles } from 'lucide-react';
+import { Button } from '@owox/ui/components/button';
+
+interface SchemaHeaderAiButtonProps {
+  tooltip: string;
+  ariaLabel: string;
+  disabled: boolean;
+  isLoading: boolean;
+  onClick: () => void;
+}
+
+export function SchemaHeaderAiButton({
+  tooltip,
+  ariaLabel,
+  disabled,
+  isLoading,
+  onClick,
+}: SchemaHeaderAiButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type='button'
+          variant='ghost'
+          size='icon-sm'
+          disabled={disabled}
+          onClick={onClick}
+          aria-label={ariaLabel}
+        >
+          {isLoading ? (
+            <Loader2 className='h-3.5 w-3.5 animate-spin' />
+          ) : (
+            <Sparkles className='h-3.5 w-3.5' />
+          )}
+        </Button>
+      </TooltipTrigger>
+
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/table/TableToolbar.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/table/TableToolbar.tsx
@@ -1,3 +1,5 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { Loader2, RefreshCw, Sparkles } from 'lucide-react';
 import { Button } from '@owox/ui/components/button';
 import { SearchInput } from '@owox/ui/components/common/search-input';
 import type { Table } from '@tanstack/react-table';
@@ -5,6 +7,7 @@ import { Plus } from 'lucide-react';
 import type { BaseSchemaField } from '../../../../../shared/types/data-mart-schema.types';
 import { DataMartSchemaFieldStatus } from '../../../../../shared/types/data-mart-schema.types';
 import { SchemaFieldStatusIcon } from '../fields';
+import type { SchemaToolbar } from '../../types/schema-toolbar';
 
 /**
  * Props for the TableToolbar component
@@ -24,6 +27,8 @@ interface TableToolbarProps<TData extends BaseSchemaField> {
   statusCounts?: Record<DataMartSchemaFieldStatus, number>;
   /** Whether the add field button should be disabled */
   disabled?: boolean;
+  /** Additional schema toolbar actions. */
+  schemaToolbar: SchemaToolbar;
 }
 
 /**
@@ -37,22 +42,23 @@ export function TableToolbar<TData extends BaseSchemaField>({
   onFilterChange,
   statusCounts,
   disabled = false,
+  schemaToolbar,
 }: TableToolbarProps<TData>) {
   return (
     <div className='mb-4 flex items-center justify-between gap-2 last:mb-0'>
-      <div className='flex items-center gap-2'>
+      <div className='flex grow items-center gap-2'>
         <SearchInput
           id={searchInputId}
           placeholder='Search fields'
           value={filterValue}
           onChange={onFilterChange}
-          className='border-muted dark:border-muted/50 rounded-md border bg-white pl-8 text-sm dark:bg-white/4 dark:hover:bg-white/8'
+          className='border-muted dark:border-muted/50 w-full min-w-0 rounded-md border bg-white pl-8 text-sm dark:bg-white/4 dark:hover:bg-white/8'
           aria-label='Search fields'
         />
       </div>
-      <div className='flex items-center gap-2'>
+      <div className='flex flex-shrink-0 items-center gap-2'>
         {statusCounts && (
-          <div className='mr-3 flex items-center gap-3'>
+          <div className='mr-3 flex items-center gap-4 border-r pr-4'>
             {Object.entries(statusCounts).map(([status, count]) => {
               if (count === 0) return null;
               return (
@@ -64,15 +70,56 @@ export function TableToolbar<TData extends BaseSchemaField>({
             })}
           </div>
         )}
-        <Button
-          variant='outline'
-          onClick={onAddField}
-          disabled={disabled}
-          aria-label='Add new field'
-        >
-          <Plus className='h-4 w-4' aria-hidden='true' />
-          Add Field
-        </Button>
+        {schemaToolbar.showAiHelper && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type='button'
+                variant='outline'
+                disabled={schemaToolbar.ai.disabled}
+                onClick={schemaToolbar.ai.onGenerateMetadata}
+                aria-label='Generate field aliases &amp; descriptions'
+              >
+                {schemaToolbar.ai.loading.metadata ? (
+                  <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
+                ) : (
+                  <Sparkles className='h-4 w-4' aria-hidden='true' />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Generate aliases &amp; descriptions for all fields</TooltipContent>
+          </Tooltip>
+        )}
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={schemaToolbar.refresh.onClick}
+              disabled={schemaToolbar.refresh.disabled}
+            >
+              <RefreshCw className='h-4 w-4' aria-hidden='true' />
+              <span className='hidden 2xl:inline'>Refresh schema</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Refresh schema</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant='outline'
+              onClick={onAddField}
+              disabled={disabled}
+              aria-label='Add new field'
+            >
+              <Plus className='h-4 w-4' aria-hidden='true' />
+              <span className='hidden 2xl:inline'>Add Field</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Add new field</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/table/index.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/components/table/index.ts
@@ -5,3 +5,4 @@
 
 export * from './TableActionsButton';
 export * from './TableToolbar';
+export * from './SchemaHeaderAiButton';

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/AthenaSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/AthenaSchemaTable.tsx
@@ -13,6 +13,7 @@ import { SchemaFieldTypeSelect } from '../components';
 import { useDragAndDrop } from '../hooks';
 import { BaseSchemaTable } from './BaseSchemaTable';
 import type { SchemaAiHelper } from '../types/ai-helper';
+import type { SchemaToolbar } from '../types/schema-toolbar';
 
 /**
  * Props for the AthenaSchemaTable component
@@ -24,12 +25,18 @@ interface AthenaSchemaTableProps {
   onFieldsChange?: (fields: AthenaSchemaField[]) => void;
   /** AI helper handlers; omit to hide AI buttons. */
   aiHelper?: SchemaAiHelper;
+  schemaToolbar: SchemaToolbar;
 }
 
 /**
  * Component for displaying and editing Athena schema fields
  */
-export function AthenaSchemaTable({ fields, onFieldsChange, aiHelper }: AthenaSchemaTableProps) {
+export function AthenaSchemaTable({
+  fields,
+  onFieldsChange,
+  aiHelper,
+  schemaToolbar,
+}: AthenaSchemaTableProps) {
   // Function to create a new Athena field
   const createNewField = useCallback(() => {
     return {
@@ -86,6 +93,7 @@ export function AthenaSchemaTable({ fields, onFieldsChange, aiHelper }: AthenaSc
         }}
         rowComponent={SortableTableRow}
         aiHelper={aiHelper}
+        schemaToolbar={schemaToolbar}
       />
     </DndContext>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.test.tsx
@@ -6,6 +6,7 @@ import {
   DataMartSchemaFieldStatus,
 } from '../../../../shared/types/data-mart-schema.types';
 import { AthenaSchemaTable } from './AthenaSchemaTable';
+import type { SchemaToolbar } from '../types/schema-toolbar';
 
 // SchemaTable uses useOutletContext for schema-actualization loading state
 vi.mock('react-router-dom', async importOriginal => {
@@ -15,6 +16,27 @@ vi.mock('react-router-dom', async importOriginal => {
     useOutletContext: vi.fn(() => ({ isSchemaActualizationLoading: false })),
   };
 });
+
+const mockSchemaToolbar: SchemaToolbar = {
+  showAiHelper: false,
+
+  refresh: {
+    disabled: false,
+    onClick: vi.fn(),
+  },
+
+  ai: {
+    disabled: false,
+    loading: {
+      metadata: false,
+      aliases: false,
+      descriptions: false,
+    },
+    onGenerateMetadata: vi.fn(),
+    onGenerateDescriptions: vi.fn(),
+    onGenerateAliases: vi.fn(),
+  },
+};
 
 function buildAthenaField(overrides: Partial<AthenaSchemaField> = {}): AthenaSchemaField {
   return {
@@ -33,14 +55,26 @@ describe('BaseSchemaTable — Aggregations column', () => {
 
   it('renders the "Available aggregations" column header (Σ icon with aria-label)', () => {
     const fields = [buildAthenaField()];
-    render(<AthenaSchemaTable fields={fields} onFieldsChange={() => {}} />);
+    render(
+      <AthenaSchemaTable
+        fields={fields}
+        onFieldsChange={() => {}}
+        schemaToolbar={mockSchemaToolbar}
+      />
+    );
 
     expect(screen.getByLabelText('Available aggregations')).toBeInTheDocument();
   });
 
   it('shows the STRING default (COUNT, COUNT_DISTINCT) as joined names for a STRING field with no allowedAggregations', () => {
     const fields = [buildAthenaField({ name: 'my_string', type: AthenaFieldType.STRING })];
-    render(<AthenaSchemaTable fields={fields} onFieldsChange={() => {}} />);
+    render(
+      <AthenaSchemaTable
+        fields={fields}
+        onFieldsChange={() => {}}
+        schemaToolbar={mockSchemaToolbar}
+      />
+    );
 
     // STRING default is [COUNT, COUNT_DISTINCT] — 2 items → joined names.
     expect(screen.getByText('COUNT, COUNT_DISTINCT')).toBeInTheDocument();
@@ -48,7 +82,13 @@ describe('BaseSchemaTable — Aggregations column', () => {
 
   it('shows "4 selected" for a numeric field with no allowedAggregations (type-derived default: SUM, AVG, MIN, MAX)', () => {
     const fields = [buildAthenaField({ name: 'revenue', type: AthenaFieldType.DOUBLE })];
-    render(<AthenaSchemaTable fields={fields} onFieldsChange={() => {}} />);
+    render(
+      <AthenaSchemaTable
+        fields={fields}
+        onFieldsChange={() => {}}
+        schemaToolbar={mockSchemaToolbar}
+      />
+    );
 
     // DOUBLE numeric default is [SUM, AVG, MIN, MAX] — 4 items → "4 selected".
     expect(screen.getByText('4 selected')).toBeInTheDocument();
@@ -56,14 +96,26 @@ describe('BaseSchemaTable — Aggregations column', () => {
 
   it('shows "COUNT" when field has explicit allowedAggregations: [COUNT]', () => {
     const fields = [buildAthenaField({ name: 'field_a', allowedAggregations: ['COUNT'] })];
-    render(<AthenaSchemaTable fields={fields} onFieldsChange={() => {}} />);
+    render(
+      <AthenaSchemaTable
+        fields={fields}
+        onFieldsChange={() => {}}
+        schemaToolbar={mockSchemaToolbar}
+      />
+    );
 
     expect(screen.getByText('COUNT')).toBeInTheDocument();
   });
 
   it('shows "None" when field has explicit allowedAggregations: []', () => {
     const fields = [buildAthenaField({ name: 'field_a', allowedAggregations: [] })];
-    render(<AthenaSchemaTable fields={fields} onFieldsChange={() => {}} />);
+    render(
+      <AthenaSchemaTable
+        fields={fields}
+        onFieldsChange={() => {}}
+        schemaToolbar={mockSchemaToolbar}
+      />
+    );
 
     expect(screen.getByText('None')).toBeInTheDocument();
   });
@@ -72,7 +124,13 @@ describe('BaseSchemaTable — Aggregations column', () => {
     const onFieldsChange = vi.fn();
     // STRING default is [COUNT, COUNT_DISTINCT] — both checked by default.
     const fields = [buildAthenaField({ name: 'my_string', type: AthenaFieldType.STRING })];
-    render(<AthenaSchemaTable fields={fields} onFieldsChange={onFieldsChange} />);
+    render(
+      <AthenaSchemaTable
+        fields={fields}
+        onFieldsChange={onFieldsChange}
+        schemaToolbar={mockSchemaToolbar}
+      />
+    );
 
     // Open the aggregations dropdown for the field
     const trigger = screen.getByRole('button', { name: 'Aggregations for my_string' });
@@ -95,7 +153,13 @@ describe('BaseSchemaTable — Aggregations column', () => {
   it('clearing all aggregations writes an explicit empty array [] (not dropped)', async () => {
     const onFieldsChange = vi.fn();
     const fields = [buildAthenaField({ name: 'field_a', allowedAggregations: ['COUNT'] })];
-    render(<AthenaSchemaTable fields={fields} onFieldsChange={onFieldsChange} />);
+    render(
+      <AthenaSchemaTable
+        fields={fields}
+        onFieldsChange={onFieldsChange}
+        schemaToolbar={mockSchemaToolbar}
+      />
+    );
 
     const trigger = screen.getByRole('button', { name: 'Aggregations for field_a' });
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
@@ -117,7 +181,13 @@ describe('BaseSchemaTable — Aggregations column', () => {
   it('turning a function ON calls onFieldsChange with that function added', async () => {
     const onFieldsChange = vi.fn();
     const fields = [buildAthenaField({ name: 'field_a', allowedAggregations: ['COUNT'] })];
-    render(<AthenaSchemaTable fields={fields} onFieldsChange={onFieldsChange} />);
+    render(
+      <AthenaSchemaTable
+        fields={fields}
+        onFieldsChange={onFieldsChange}
+        schemaToolbar={mockSchemaToolbar}
+      />
+    );
 
     const trigger = screen.getByRole('button', { name: 'Aggregations for field_a' });
     fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
@@ -134,4 +204,73 @@ describe('BaseSchemaTable — Aggregations column', () => {
     expect(updatedFields[0].allowedAggregations).toContain('MIN');
     expect(updatedFields[0].allowedAggregations).toContain('COUNT');
   });
+});
+
+it('renders AI header buttons when AI helper is enabled', () => {
+  const fields = [buildAthenaField()];
+
+  render(
+    <AthenaSchemaTable
+      fields={fields}
+      onFieldsChange={() => {}}
+      schemaToolbar={{
+        ...mockSchemaToolbar,
+        showAiHelper: true,
+      }}
+    />
+  );
+
+  expect(screen.getByLabelText('Generate field aliases')).toBeInTheDocument();
+
+  expect(screen.getByLabelText('Generate field descriptions')).toBeInTheDocument();
+});
+
+it('hides AI header buttons when AI helper is disabled', () => {
+  const fields = [buildAthenaField()];
+
+  render(
+    <AthenaSchemaTable
+      fields={fields}
+      onFieldsChange={() => {}}
+      schemaToolbar={{
+        ...mockSchemaToolbar,
+        showAiHelper: false,
+      }}
+    />
+  );
+
+  expect(screen.queryByLabelText('Generate field aliases')).not.toBeInTheDocument();
+
+  expect(screen.queryByLabelText('Generate field descriptions')).not.toBeInTheDocument();
+});
+
+it('calls AI callbacks when header buttons are clicked', () => {
+  const onGenerateAliases = vi.fn();
+  const onGenerateDescriptions = vi.fn();
+
+  const fields = [buildAthenaField()];
+
+  render(
+    <AthenaSchemaTable
+      fields={fields}
+      onFieldsChange={() => {}}
+      schemaToolbar={{
+        ...mockSchemaToolbar,
+        showAiHelper: true,
+        ai: {
+          ...mockSchemaToolbar.ai,
+          onGenerateAliases,
+          onGenerateDescriptions,
+        },
+      }}
+    />
+  );
+
+  fireEvent.click(screen.getByLabelText('Generate field aliases'));
+
+  expect(onGenerateAliases).toHaveBeenCalledTimes(1);
+
+  fireEvent.click(screen.getByLabelText('Generate field descriptions'));
+
+  expect(onGenerateDescriptions).toHaveBeenCalledTimes(1);
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@owox/ui/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import type { ColumnDef, Row, Table } from '@tanstack/react-table';
 import { EyeOff, Sigma } from 'lucide-react';
@@ -10,6 +11,7 @@ import {
   SchemaFieldActionsButton,
   SchemaFieldPrimaryKeyCheckbox,
   SchemaFieldStatusIcon,
+  SchemaHeaderAiButton,
   TableActionsButton,
 } from '../components';
 import { asString } from '../utils';
@@ -18,6 +20,7 @@ import type { SchemaAiHelper } from '../types/ai-helper';
 import { renderFieldAliasAi, renderFieldDescriptionAi } from '../utils/render-field-ai';
 import { AllowedAggregationsSelect } from '../AllowedAggregationsSelect';
 import { resolveFieldGovernance } from '../../../../shared/utils/aggregation-governance';
+import type { SchemaToolbar } from '../types/schema-toolbar';
 
 // Extended column definition with optional columnIndex property
 export type ExtendedColumnDef<T extends BaseSchemaField> = ColumnDef<T> & {
@@ -101,6 +104,8 @@ export interface BaseSchemaTableProps<T extends BaseSchemaField> {
   getRowId?: (row: Row<T>) => string | number;
   /** AI helper handlers passed to per-field actions menu. Omit to hide AI options. */
   aiHelper?: SchemaAiHelper;
+  /** Schema toolbar component */
+  schemaToolbar: SchemaToolbar;
 }
 
 /**
@@ -127,6 +132,7 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
   rowComponent,
   getRowId,
   aiHelper,
+  schemaToolbar,
 }: BaseSchemaTableProps<T>) {
   // Handler to update a field
   const updateField = useCallback(
@@ -276,10 +282,29 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
       {
         accessorKey: 'alias',
         header: () => (
-          <Tooltip>
-            <TooltipTrigger className='cursor-default'>Alias</TooltipTrigger>
-            <TooltipContent>Alternative name for the field</TooltipContent>
-          </Tooltip>
+          <div className='group flex items-center gap-1'>
+            <Tooltip>
+              <TooltipTrigger className='cursor-default'>Alias</TooltipTrigger>
+
+              <TooltipContent>Alternative name for the field</TooltipContent>
+            </Tooltip>
+            {schemaToolbar.showAiHelper && (
+              <div
+                className={cn(
+                  'opacity-0 transition-opacity group-hover:opacity-100',
+                  schemaToolbar.ai.loading.aliases && 'opacity-100'
+                )}
+              >
+                <SchemaHeaderAiButton
+                  tooltip='Generate aliases for all fields'
+                  ariaLabel='Generate field aliases'
+                  disabled={schemaToolbar.ai.disabled}
+                  isLoading={schemaToolbar.ai.loading.aliases}
+                  onClick={schemaToolbar.ai.onGenerateAliases}
+                />
+              </div>
+            )}
+          </div>
         ),
         size: 80,
         cell: ({ row }) => {
@@ -302,10 +327,29 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
       {
         accessorKey: 'description',
         header: () => (
-          <Tooltip>
-            <TooltipTrigger className='cursor-default'>Description</TooltipTrigger>
-            <TooltipContent>Detailed information about the field</TooltipContent>
-          </Tooltip>
+          <div className='group flex items-center gap-1'>
+            <Tooltip>
+              <TooltipTrigger className='cursor-default'>Description</TooltipTrigger>
+
+              <TooltipContent>Detailed information about the field</TooltipContent>
+            </Tooltip>
+            {schemaToolbar.showAiHelper && (
+              <div
+                className={cn(
+                  'opacity-0 transition-opacity group-hover:opacity-100',
+                  schemaToolbar.ai.loading.descriptions && 'opacity-100'
+                )}
+              >
+                <SchemaHeaderAiButton
+                  tooltip='Generate descriptions for all fields'
+                  ariaLabel='Generate field descriptions'
+                  disabled={schemaToolbar.ai.disabled}
+                  isLoading={schemaToolbar.ai.loading.descriptions}
+                  onClick={schemaToolbar.ai.onGenerateDescriptions}
+                />
+              </div>
+            )}
+          </div>
         ),
         cell: ({ row }) => {
           if (descriptionColumnCell) {
@@ -366,6 +410,12 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
       descriptionColumnCell,
       actionsColumnCell,
       aiHelper,
+      schemaToolbar.showAiHelper,
+      schemaToolbar.ai.disabled,
+      schemaToolbar.ai.loading.aliases,
+      schemaToolbar.ai.loading.descriptions,
+      schemaToolbar.ai.onGenerateAliases,
+      schemaToolbar.ai.onGenerateDescriptions,
     ]
   );
 
@@ -422,6 +472,7 @@ export function BaseSchemaTable<T extends BaseSchemaField>({
       dragContextProps={dragContextProps}
       rowComponent={rowComponent}
       getRowId={getRowId}
+      schemaToolbar={schemaToolbar}
     />
   );
 }

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BigQuerySchemaTable.tsx
@@ -26,6 +26,7 @@ import type { ExtendedColumnDef } from './BaseSchemaTable';
 import { BaseSchemaTable } from './BaseSchemaTable';
 import { renderFieldAliasAi, renderFieldDescriptionAi } from '../utils/render-field-ai';
 import type { SchemaAiHelper } from '../types/ai-helper';
+import type { SchemaToolbar } from '../types/schema-toolbar';
 
 /**
  * Props for the BigQuerySchemaTable component
@@ -37,6 +38,7 @@ interface BigQuerySchemaTableProps {
   onFieldsChange?: (fields: BigQuerySchemaField[]) => void;
   /** AI helper handlers; omit to hide AI buttons. */
   aiHelper?: SchemaAiHelper;
+  schemaToolbar: SchemaToolbar;
 }
 
 /**
@@ -47,6 +49,7 @@ export function BigQuerySchemaTable({
   fields,
   onFieldsChange,
   aiHelper,
+  schemaToolbar,
 }: BigQuerySchemaTableProps) {
   // Use the record expansion hook to manage expanded/collapsed state
   const {
@@ -361,6 +364,7 @@ export function BigQuerySchemaTable({
         descriptionColumnCell={descriptionColumnCell}
         actionsColumnCell={actionsColumnCell}
         aiHelper={aiHelper}
+        schemaToolbar={schemaToolbar}
         dragContext={SortableContext}
         dragContextProps={{
           items: flattenedFields.map(f => f.path ?? String(flattenedFields.indexOf(f))),

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/DatabricksSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/DatabricksSchemaTable.tsx
@@ -13,6 +13,7 @@ import { SchemaFieldTypeSelect } from '../components';
 import { useDragAndDrop } from '../hooks';
 import { BaseSchemaTable } from './BaseSchemaTable';
 import type { SchemaAiHelper } from '../types/ai-helper';
+import type { SchemaToolbar } from '../types/schema-toolbar';
 
 /**
  * Props for the DatabricksSchemaTable component
@@ -24,6 +25,7 @@ interface DatabricksSchemaTableProps {
   onFieldsChange?: (fields: DatabricksSchemaField[]) => void;
   /** AI helper handlers; omit to hide AI buttons. */
   aiHelper?: SchemaAiHelper;
+  schemaToolbar: SchemaToolbar;
 }
 
 /**
@@ -33,6 +35,7 @@ export function DatabricksSchemaTable({
   fields,
   onFieldsChange,
   aiHelper,
+  schemaToolbar,
 }: DatabricksSchemaTableProps) {
   // Function to create a new Databricks field
   const createNewField = useCallback(() => {
@@ -90,6 +93,7 @@ export function DatabricksSchemaTable({
         }}
         rowComponent={SortableTableRow}
         aiHelper={aiHelper}
+        schemaToolbar={schemaToolbar}
       />
     </DndContext>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/RedshiftSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/RedshiftSchemaTable.tsx
@@ -13,6 +13,7 @@ import { SchemaFieldTypeSelect } from '../components';
 import { useDragAndDrop } from '../hooks';
 import { BaseSchemaTable } from './BaseSchemaTable';
 import type { SchemaAiHelper } from '../types/ai-helper';
+import type { SchemaToolbar } from '../types/schema-toolbar';
 
 /**
  * Props for the RedshiftSchemaTable component
@@ -24,6 +25,7 @@ interface RedshiftSchemaTableProps {
   onFieldsChange?: (fields: RedshiftSchemaField[]) => void;
   /** AI helper handlers; omit to hide AI buttons. */
   aiHelper?: SchemaAiHelper;
+  schemaToolbar: SchemaToolbar;
 }
 
 /**
@@ -33,6 +35,7 @@ export function RedshiftSchemaTable({
   fields,
   onFieldsChange,
   aiHelper,
+  schemaToolbar,
 }: RedshiftSchemaTableProps) {
   // Function to create a new Redshift field
   const createNewField = useCallback(() => {
@@ -90,6 +93,7 @@ export function RedshiftSchemaTable({
         }}
         rowComponent={SortableTableRow}
         aiHelper={aiHelper}
+        schemaToolbar={schemaToolbar}
       />
     </DndContext>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/SchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/SchemaTable.tsx
@@ -25,6 +25,7 @@ import { schemaFieldFilter, useColumnVisibility, useTableFilter } from '../hooks
 import type { DragContextProps, RowComponentProps } from './BaseSchemaTable';
 import type { Props as SortableContextProps } from '@dnd-kit/sortable/dist/components/SortableContext';
 import type { DataMartContextType } from '../../../model/context/types';
+import type { SchemaToolbar } from '../types/schema-toolbar';
 
 // Sticky columns configuration
 interface StickyColumnConfig {
@@ -68,6 +69,7 @@ interface SchemaTableProps<T extends BaseSchemaField> {
   dragContextProps: DragContextProps; // Props for the drag-and-drop context
   rowComponent?: ComponentType<RowComponentProps<Row<T>>>; // Custom row component for drag-and-drop
   getRowId?: (row: Row<T>) => string | number; // Function to get the ID for a row
+  schemaToolbar: SchemaToolbar; // Schema toolbar component
 }
 
 export function SchemaTable<T extends BaseSchemaField>({
@@ -80,6 +82,7 @@ export function SchemaTable<T extends BaseSchemaField>({
   dragContextProps,
   rowComponent = TableRow as ComponentType<RowComponentProps<Row<T>>>,
   getRowId,
+  schemaToolbar,
 }: SchemaTableProps<T>) {
   // Get schema actualization loading state and current data mart from context
   const { isSchemaActualizationLoading, dataMart } = useOutletContext<DataMartContextType>();
@@ -171,6 +174,7 @@ export function SchemaTable<T extends BaseSchemaField>({
           onFilterChange={handleFilterChange}
           statusCounts={statusCounts}
           disabled={isSchemaActualizationLoading}
+          schemaToolbar={schemaToolbar}
         />
       )}
       <div className='mb-0 w-full'>

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/SnowflakeSchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/SnowflakeSchemaTable.tsx
@@ -13,6 +13,7 @@ import { SchemaFieldTypeSelect } from '../components';
 import { useDragAndDrop } from '../hooks';
 import { BaseSchemaTable } from './BaseSchemaTable';
 import type { SchemaAiHelper } from '../types/ai-helper';
+import type { SchemaToolbar } from '../types/schema-toolbar';
 
 /**
  * Props for the SnowflakeSchemaTable component
@@ -24,6 +25,7 @@ interface SnowflakeSchemaTableProps {
   onFieldsChange?: (fields: SnowflakeSchemaField[]) => void;
   /** AI helper handlers; omit to hide AI buttons. */
   aiHelper?: SchemaAiHelper;
+  schemaToolbar: SchemaToolbar;
 }
 
 /**
@@ -33,6 +35,7 @@ export function SnowflakeSchemaTable({
   fields,
   onFieldsChange,
   aiHelper,
+  schemaToolbar,
 }: SnowflakeSchemaTableProps) {
   // Function to create a new Snowflake field
   const createNewField = useCallback(() => {
@@ -90,6 +93,7 @@ export function SnowflakeSchemaTable({
         }}
         rowComponent={SortableTableRow}
         aiHelper={aiHelper}
+        schemaToolbar={schemaToolbar}
       />
     </DndContext>
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/types/schema-toolbar.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/types/schema-toolbar.ts
@@ -1,0 +1,25 @@
+/**
+ * Configuration for the schema table toolbar.
+ * Keeps business logic in DataMartSchemaSettings while allowing
+ * presentation components to render toolbar actions.
+ */
+export interface SchemaToolbar {
+  showAiHelper: boolean;
+
+  refresh: {
+    disabled: boolean;
+    onClick: () => void;
+  };
+
+  ai: {
+    disabled: boolean;
+    loading: {
+      metadata: boolean;
+      aliases: boolean;
+      descriptions: boolean;
+    };
+    onGenerateMetadata: () => void;
+    onGenerateDescriptions: () => void;
+    onGenerateAliases: () => void;
+  };
+}


### PR DESCRIPTION
# Refactor Output Schema toolbar actions

<img width="1791" height="1069" alt="Frame 23137619" src="https://github.com/user-attachments/assets/131713df-cc07-4d75-ab64-ae99a3ba6383" />

<img width="1791" height="1069" alt="Frame 23137620" src="https://github.com/user-attachments/assets/1a1e217c-1041-4b94-bd36-9abfef3d028a" />

<img width="1791" height="1069" alt="Frame 23137621" src="https://github.com/user-attachments/assets/7e2a2911-a98f-4a62-8de7-6dd21d7e2320" />

This PR improves the discoverability and organization of Output Schema actions. The **Refresh schema** and global **Generate field aliases & descriptions** actions are now located in the table toolbar, keeping all primary actions in one place. The global AI action has also been simplified by removing the dropdown menu, allowing users to generate both field aliases and descriptions with a single click.

To make AI features easier to discover, AI action buttons have been added to the **Alias** and **Description** column headers, allowing users to generate values for an entire column directly where the action applies.



To support these changes, all business logic remains in `DataMartSchemaSettings`, while `TableToolbar` stays a presentational component. A new `SchemaToolbar` interface is used to pass toolbar state and callbacks through the component hierarchy.