### PR TITLE
fix(mcp): keep inline log payloads sink-schema-stable

### DIFF
--- a/apps/backend/src/ee/mcp/observability/mcp-tool-call-event.spec.ts
+++ b/apps/backend/src/ee/mcp/observability/mcp-tool-call-event.spec.ts
@@ -324,8 +324,18 @@ describe('buildMcpToolCallEvent', () => {
     const ev = buildMcpToolCallEvent(baseParams({ context: { userId: 'u1' }, meta }));
     const p = ev.payload as Record<string, unknown>;
     expect(p['meta_truncated']).toBe(true);
-    expect(p['meta_k0']).toBe(0);
+    // Numeric meta is coerced to string (stable fixed-schema sink column); meta_truncated stays boolean.
+    expect(p['meta_k0']).toBe('0');
     expect(p['meta_k99']).toBeUndefined();
+  });
+
+  it('coerces numeric/boolean meta values to strings (fixed-schema sink safety)', () => {
+    const ev = buildMcpToolCallEvent(
+      baseParams({ context: { userId: 'u1' }, meta: { retries: 5, verbose: true } })
+    );
+    const p = ev.payload as Record<string, unknown>;
+    expect(p['meta_retries']).toBe('5');
+    expect(p['meta_verbose']).toBe('true');
   });
 
   it('a falsy thrown value (e.g. empty string) still counts as an error', () => {

--- a/apps/backend/src/ee/mcp/observability/mcp-tool-call-event.ts
+++ b/apps/backend/src/ee/mcp/observability/mcp-tool-call-event.ts
@@ -82,8 +82,8 @@ function computePseudoConversationId(
   return createHash('sha256').update(seed).digest('hex').slice(0, 32);
 }
 
-function flattenMeta(meta?: Record<string, unknown>): Record<string, string | number | boolean> {
-  const out: Record<string, string | number | boolean> = {};
+function flattenMeta(meta?: Record<string, unknown>): Record<string, string | boolean> {
+  const out: Record<string, string | boolean> = {};
   if (!meta) return out;
   const entries = Object.entries(meta);
   for (const [k, v] of entries.slice(0, MAX_META_KEYS)) {
@@ -93,10 +93,7 @@ function flattenMeta(meta?: Record<string, unknown>): Record<string, string | nu
       out[key] = REDACTED;
       continue;
     }
-    if (typeof v === 'number' || typeof v === 'boolean') {
-      out[key] = v;
-      continue;
-    }
+    // Coerce to string: a meta value numeric in one event and a string in another would split a fixed-schema sink column.
     const str = typeof v === 'string' ? v : JSON.stringify(redact(v));
     out[key] =
       str.length > MAX_META_VALUE_LEN ? `${str.slice(0, MAX_META_VALUE_LEN)}…[truncated]` : str;

--- a/packages/internal-helpers/src/integrations/blob-store/payload-offloader.test.ts
+++ b/packages/internal-helpers/src/integrations/blob-store/payload-offloader.test.ts
@@ -17,7 +17,25 @@ describe('PayloadOffloader', () => {
     };
     await offloader.apply(payload);
     expect(payload[OFFLOAD_KEY]).toBeUndefined();
-    expect(payload['result']).toEqual({ rows: 2 });
+    // Object values are JSON-stringified so a fixed-schema sink sees a stable STRING column.
+    expect(payload['result']).toBe('{"rows":2}');
+  });
+
+  it('inline: object/array значення стрінгіфаяться, скаляри — як є', async () => {
+    const offloader = new PayloadOffloader({ sink: 'inline', inlineMaxBytes: 4096 });
+    const payload: Record<string, unknown> = {
+      [OFFLOAD_KEY]: {
+        owox_request_id: 'r1', // scalar string
+        returned_rows: 5, // scalar number
+        arguments: { filters: [{ value: 'churned' }] }, // polymorphic object → JSON string
+        result: [{ a: 1 }], // array → JSON string
+      },
+    };
+    await offloader.apply(payload);
+    expect(payload['owox_request_id']).toBe('r1');
+    expect(payload['returned_rows']).toBe(5);
+    expect(payload['arguments']).toBe('{"filters":[{"value":"churned"}]}');
+    expect(payload['result']).toBe('[{"a":1}]');
   });
 
   it('inline: завеликий bulky не інлайниться, лишає маркери', async () => {

--- a/packages/internal-helpers/src/integrations/blob-store/payload-offloader.ts
+++ b/packages/internal-helpers/src/integrations/blob-store/payload-offloader.ts
@@ -17,6 +17,18 @@ export interface PayloadOffloaderConfig {
 }
 
 /**
+ * Inline a blob's fields into the record, JSON-stringifying object/array values. A fixed-schema
+ * sink (e.g. Cloud Logging → BigQuery auto-schema) would otherwise infer per-payload nested
+ * columns whose types collide across events (a filter value seen as FLOAT, then "churned") and
+ * drop the whole stream. Stringified fields land as a stable STRING column instead.
+ */
+function inlineBlob(payload: Record<string, unknown>, blob: Record<string, unknown>): void {
+  for (const [k, v] of Object.entries(blob)) {
+    payload[k] = v !== null && typeof v === 'object' ? JSON.stringify(v) : v;
+  }
+}
+
+/**
  * Moves a payload's bulky fields (under {@link OFFLOAD_KEY}) out of the inline record.
  * Generic — knows nothing about MCP. Mutates the passed payload in place and never throws:
  * offload failure degrades to a marker, the record is still emitted.
@@ -42,7 +54,7 @@ export class PayloadOffloader {
 
       if (this.config.sink === 'inline' || !this.config.blobStore || !this.config.pathBuilder) {
         if (bytes <= this.config.inlineMaxBytes) {
-          Object.assign(payload, blob as Record<string, unknown>);
+          inlineBlob(payload, blob as Record<string, unknown>);
         } else {
           payload['owox_payload_truncated'] = true;
           payload['owox_payload_bytes'] = bytes;
@@ -53,7 +65,7 @@ export class PayloadOffloader {
       // gcs sink: small payloads stay inline (queryable in logs/traces); only oversized ones
       // are offloaded to keep the log line and span attributes bounded.
       if (bytes <= this.config.inlineMaxBytes) {
-        Object.assign(payload, blob as Record<string, unknown>);
+        inlineBlob(payload, blob as Record<string, unknown>);
         return;
       }
 

--- a/packages/internal-helpers/src/integrations/event-bus/message-format.ts
+++ b/packages/internal-helpers/src/integrations/event-bus/message-format.ts
@@ -6,12 +6,12 @@ import { z } from 'zod';
  *   "version": "1.0",
  *   "body": { ... },
  *   "order": 123456, // timestamp with millis
- *   "producer": { "name": "owox-data-mats" }
+ *   "producer": { "name": "owox-data-marts" }
  * }
  */
 
 const MESSAGE_VERSION = '1.0' as const;
-const DEFAULT_PRODUCER_NAME = 'owox-data-mats' as const;
+const DEFAULT_PRODUCER_NAME = 'owox-data-marts' as const;
 
 export interface ProducerInfo {
   name: string;


### PR DESCRIPTION
## Problem

Production incident: the Cloud Logging sink `McpEventsToBigQuery` (→ dataset `owox_data_marts_mcp_events`) failed with `table_invalid_schema` (`Cannot convert value to floating point (bad value): churned`) and **stopped routing McpEventBus logs to BigQuery** (data loss).

Root cause: with `MCP_LOG_INLINE_PAYLOADS=true`, tool `arguments`/`result` were inlined into the log record as nested objects. The Cloud Logging→BigQuery auto-schema then inferred per-payload nested columns; the culprit is `jsonPayload.event.body.payload.arguments.filters.value` (a `query_data_mart` filter value). A numeric filter locked the column as `FLOAT`, after which a date string (`2026-01-01`), a boolean (`true`), a plain string (`Product`), or an object (`{from,to}`) all collided with it → schema error → the sink drops the whole stream.

## Fix

- `PayloadOffloader.inlineBlob` — object/array values are JSON-stringified on inline (stable STRING column); scalars pass through. Arbitrary JSON no longer produces nested RECORD columns that collide across events.
- `flattenMeta` — every `meta_*` value is coerced to a string (same class: a meta value numeric in one event and a string in another, e.g. `progressToken`, splits a column). `meta_truncated` stays boolean; `duration_ms` stays numeric (a separate typed field, not meta).
- GCS offload blobs are unchanged — still structured JSON for `LOAD ... JSON`-typed columns.
- Also fixes a typo in the event envelope's `producer.name` (`owox-data-mats` → `owox-data-marts`).

## Target stable schema

Typed scalars (tool/method/status, `duration_ms`, identity, `trace_id`, `error_*`, `owox_payload_ref`, `owox_payload_bytes`, `owox_payload_truncated`) + JSON strings (`arguments`, `result`, `sql`, all `meta_*`).

## Testing

- Updated 2 existing tests + added 2 targeted (the churned stringify scenario; numeric/boolean meta coercion).
- internal-helpers 75/75 + build; backend `nest build` clean. Validated against the real production sink errors — all six distinct failure signatures are resolved.

## Ops (after merge + deploy)

The already-polluted `stdout_*` tables have `arguments`/`result` as RECORD columns, so new STRING values will still conflict until the table is recreated. **Order matters:** deploy first, confirm the new pod writes `"arguments":"{...}"` as a string, then drop the polluted `stdout_*` / `export_errors_*` tables so the sink recreates a clean schema. Without the drop the sink stays broken until the next daily table (00:00 UTC).