### PR TITLE
fix(web): stop schema output edits from being silently reverted

### DIFF
--- a/.changeset/6725-schema-column-visibility-reset.md
+++ b/.changeset/6725-schema-column-visibility-reset.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Output schema edits no longer get silently reverted
+
+Previously, unchecking a column (like Alias or Description) in the Output Schema table would revert to visible again after a few seconds, or reset whenever you switched tabs and came back. Toggling "Hidden from reports" on a field while an AI-generated alias or description was still loading would also get undone once the generation finished. Now, column visibility choices persist per data mart across tab switches and page reloads, and any field edits made while AI generation is running are preserved instead of being overwritten. Generating metadata that fills in nothing new also no longer marks the schema as unsaved.

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.test.tsx
@@ -1,0 +1,323 @@
+import type { ReactNode } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DataStorageType } from '../../../../data-storage/shared/model/types/data-storage-type.enum';
+import {
+  BigQueryFieldMode,
+  BigQueryFieldType,
+  DataMartSchemaFieldStatus,
+  type BigQueryDataMartSchema,
+  type DataMartSchema,
+} from '../../../shared/types/data-mart-schema.types';
+import { DataMartDefinitionType } from '../../../shared';
+import type { DataMartContextType } from '../../model/context/types';
+import { DataMartSchemaSettings } from './DataMartSchemaSettings';
+
+const testState = vi.hoisted(() => ({
+  outletContext: null as unknown,
+  toast: vi.fn(),
+  generateAllFieldDescriptions: vi.fn(),
+  generateAllFieldAliases: vi.fn(),
+  generateAllFieldMetadata: vi.fn(),
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: testState.toast,
+}));
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useOutletContext: () => testState.outletContext,
+  };
+});
+
+vi.mock('../../model/hooks', () => ({
+  useAiHelperAvailability: () => ({ enabled: true }),
+  useAiHelper: () => ({
+    pendingScope: null,
+    generateFieldAlias: vi.fn(),
+    generateFieldDescription: vi.fn(),
+    generateAllFieldDescriptions: testState.generateAllFieldDescriptions,
+    generateAllFieldAliases: testState.generateAllFieldAliases,
+    generateAllFieldMetadata: testState.generateAllFieldMetadata,
+  }),
+}));
+
+vi.mock('@owox/ui/components/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button type='button' disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@owox/ui/components/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./SchemaContent', () => ({
+  SchemaContent: ({
+    schema,
+    onFieldsChange,
+  }: {
+    schema: DataMartSchema | null | undefined;
+    onFieldsChange: (fields: BigQueryDataMartSchema['fields']) => void;
+  }) => {
+    const field = schema?.fields[0];
+    return (
+      <>
+        <div data-testid='schema-field'>
+          {field
+            ? `${field.isHiddenForReporting ? 'hidden' : 'visible'}:${field.alias ?? ''}:${field.description ?? ''}`
+            : ''}
+        </div>
+        {schema && field && (
+          <button
+            type='button'
+            onClick={() => {
+              onFieldsChange([
+                { ...field, alias: '' } as BigQueryDataMartSchema['fields'][number],
+                ...schema.fields.slice(1),
+              ] as BigQueryDataMartSchema['fields']);
+            }}
+          >
+            Set alias empty
+          </button>
+        )}
+      </>
+    );
+  },
+}));
+
+function createSchema(
+  isHiddenForReporting: boolean,
+  alias?: string,
+  description?: string
+): BigQueryDataMartSchema {
+  return {
+    type: 'bigquery-data-mart-schema',
+    fields: [
+      {
+        name: 'id',
+        type: BigQueryFieldType.INTEGER,
+        mode: BigQueryFieldMode.NULLABLE,
+        isPrimaryKey: false,
+        isHiddenForReporting,
+        status: DataMartSchemaFieldStatus.CONNECTED,
+        alias,
+        description,
+      },
+    ],
+  };
+}
+
+function createContext(id: string, schema: BigQueryDataMartSchema): DataMartContextType {
+  const context = {
+    dataMart: {
+      id,
+      schema,
+      storage: { type: DataStorageType.GOOGLE_BIGQUERY },
+    },
+    isLoading: false,
+    error: null,
+    isSchemaActualizationLoading: false,
+    updateDataMartSchema: vi.fn().mockResolvedValue(undefined),
+    registerSchemaGuard: vi.fn(),
+    runGuarded: vi.fn((action: (resolved: DataMartSchema) => void) => {
+      action(schema);
+    }),
+  };
+  return context as unknown as DataMartContextType;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(res => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('DataMartSchemaSettings bulk AI generation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      buttonName: 'Generate field descriptions',
+      generate: testState.generateAllFieldDescriptions,
+      response: [{ name: 'id', description: 'Description generated for A' }],
+    },
+    {
+      buttonName: 'Generate field aliases',
+      generate: testState.generateAllFieldAliases,
+      response: [{ name: 'id', alias: 'Alias generated for A' }],
+    },
+    {
+      buttonName: 'Generate field aliases & descriptions',
+      generate: testState.generateAllFieldMetadata,
+      response: [
+        {
+          name: 'id',
+          alias: 'Alias generated for A',
+          description: 'Description generated for A',
+        },
+      ],
+    },
+  ])('ignores $buttonName results after the active data mart changes', async testCase => {
+    const generation = deferred<{ name: string; alias?: string; description?: string }[]>();
+    testCase.generate.mockReturnValueOnce(generation.promise);
+
+    testState.outletContext = createContext('data-mart-a', createSchema(false));
+    const { rerender } = render(
+      <DataMartSchemaSettings definitionType={DataMartDefinitionType.SQL} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: testCase.buttonName }));
+    expect(testCase.generate).toHaveBeenCalledWith('data-mart-a');
+
+    testState.outletContext = createContext('data-mart-b', createSchema(true));
+    rerender(<DataMartSchemaSettings definitionType={DataMartDefinitionType.SQL} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('schema-field')).toHaveTextContent('hidden::');
+    });
+
+    await act(async () => {
+      generation.resolve(testCase.response);
+      await generation.promise;
+    });
+
+    expect(screen.getByTestId('schema-field')).toHaveTextContent('hidden::');
+    expect(screen.getByTestId('schema-field')).not.toHaveTextContent(/generated for A/i);
+  });
+
+  it('applies a generated alias when an empty value changes from undefined to an empty string', async () => {
+    const generation = deferred<{ name: string; alias: string }[]>();
+    testState.generateAllFieldAliases.mockReturnValueOnce(generation.promise);
+    testState.outletContext = createContext('data-mart-a', createSchema(false));
+
+    render(<DataMartSchemaSettings definitionType={DataMartDefinitionType.SQL} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate field aliases' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Set alias empty' }));
+
+    await act(async () => {
+      generation.resolve([{ name: 'id', alias: 'Generated alias' }]);
+      await generation.promise;
+    });
+
+    expect(screen.getByTestId('schema-field')).toHaveTextContent('visible:Generated alias:');
+  });
+
+  it('does not overwrite an existing alias cleared while generation is pending', async () => {
+    const generation = deferred<{ name: string; alias: string }[]>();
+    testState.generateAllFieldAliases.mockReturnValueOnce(generation.promise);
+    testState.outletContext = createContext('data-mart-a', createSchema(false, 'Existing alias'));
+
+    render(<DataMartSchemaSettings definitionType={DataMartDefinitionType.SQL} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Generate field aliases' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Set alias empty' }));
+
+    await act(async () => {
+      generation.resolve([{ name: 'id', alias: 'Generated alias' }]);
+      await generation.promise;
+    });
+
+    expect(screen.getByTestId('schema-field')).toHaveTextContent('visible::');
+    expect(screen.getByTestId('schema-field')).not.toHaveTextContent('Generated alias');
+  });
+
+  it.each([
+    {
+      buttonName: 'Generate field descriptions',
+      generate: testState.generateAllFieldDescriptions,
+      schema: createSchema(false, undefined, 'Existing description'),
+      response: [{ name: 'id', description: 'Generated description' }],
+      message:
+        'No field descriptions were applied. Values may already be filled or fields may have changed during generation.',
+    },
+    {
+      buttonName: 'Generate field aliases',
+      generate: testState.generateAllFieldAliases,
+      schema: createSchema(false, 'Existing alias'),
+      response: [{ name: 'id', alias: 'Generated alias' }],
+      message:
+        'No field aliases were applied. Values may already be filled or fields may have changed during generation.',
+    },
+    {
+      buttonName: 'Generate field aliases & descriptions',
+      generate: testState.generateAllFieldMetadata,
+      schema: createSchema(false, 'Existing alias', 'Existing description'),
+      response: [{ name: 'id', alias: 'Generated alias', description: 'Generated description' }],
+      message:
+        'No field aliases or descriptions were applied. Values may already be filled or fields may have changed during generation.',
+    },
+  ])('reports when $buttonName produces no applicable changes', async testCase => {
+    testCase.generate.mockResolvedValueOnce(testCase.response);
+    testState.outletContext = createContext('data-mart-a', testCase.schema);
+
+    render(<DataMartSchemaSettings definitionType={DataMartDefinitionType.SQL} />);
+    fireEvent.click(screen.getByRole('button', { name: testCase.buttonName }));
+
+    await waitFor(() => {
+      expect(testState.toast).toHaveBeenCalledWith(testCase.message);
+    });
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('reports when duplicate field names prevent all generated updates', async () => {
+    const schema = createSchema(false);
+    schema.fields.push({ ...schema.fields[0] });
+    testState.generateAllFieldAliases.mockResolvedValueOnce([
+      { name: 'id', alias: 'Generated alias' },
+    ]);
+    testState.outletContext = createContext('data-mart-a', schema);
+
+    render(<DataMartSchemaSettings definitionType={DataMartDefinitionType.SQL} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Generate field aliases' }));
+
+    await waitFor(() => {
+      expect(testState.toast).toHaveBeenCalledWith(
+        'No generated field metadata was applied because duplicate field names cannot be matched reliably.'
+      );
+    });
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('reports duplicate field names when other generated updates are applied', async () => {
+    const schema = createSchema(false);
+    schema.fields.push({ ...schema.fields[0] }, { ...schema.fields[0], name: 'date' });
+    testState.generateAllFieldAliases.mockResolvedValueOnce([
+      { name: 'id', alias: 'Generated ID alias' },
+      { name: 'date', alias: 'Generated date alias' },
+    ]);
+    testState.outletContext = createContext('data-mart-a', schema);
+
+    render(<DataMartSchemaSettings definitionType={DataMartDefinitionType.SQL} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Generate field aliases' }));
+
+    await waitFor(() => {
+      expect(testState.toast).toHaveBeenCalledWith(
+        'Some fields were skipped because duplicate field names cannot be matched reliably.'
+      );
+    });
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
@@ -33,6 +33,67 @@ type BulkAiScope =
   | DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS
   | DataMartMetadataScope.ALL_FIELD_ALIASES;
 
+const isFilled = (value: string | undefined): boolean => !!value && value.trim() !== '';
+
+interface EditableMetadataField {
+  name: string;
+  alias?: string;
+  description?: string;
+}
+
+type GeneratedMetadata = Pick<EditableMetadataField, 'alias' | 'description'>;
+
+function countByName(fields: readonly EditableMetadataField[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const field of fields) {
+    counts.set(field.name, (counts.get(field.name) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * Merges AI-generated alias/description values onto the live schema fields. A value
+ * is applied only when the field's property is empty AND unchanged since the request
+ * started (compared against `originalFields`), so edits or deliberate clears made
+ * while the slow generation call was in flight are never overwritten. Unchanged
+ * fields keep their original reference and `changed` reports whether anything was
+ * applied, letting callers skip a no-op schema update.
+ */
+function mergeGeneratedMetadata(
+  currentFields: readonly EditableMetadataField[],
+  originalFields: readonly EditableMetadataField[],
+  generatedByName: ReadonlyMap<string, GeneratedMetadata>,
+  props: readonly ('alias' | 'description')[]
+): { fields: EditableMetadataField[]; changed: boolean } {
+  const originalByName = new Map(originalFields.map(field => [field.name, field]));
+  // Fields, generated results, and the pre-generation snapshot are all matched by
+  // name (there is no stable field id). Names are user-editable and can briefly
+  // collide, so a duplicated name can't be attributed to a specific row - skip
+  // those to avoid applying AI output to the wrong field.
+  const currentNameCounts = countByName(currentFields);
+  const originalNameCounts = countByName(originalFields);
+  let changed = false;
+  const fields = currentFields.map(field => {
+    const gen = generatedByName.get(field.name);
+    if (!gen) return field;
+    if (currentNameCounts.get(field.name) !== 1 || originalNameCounts.get(field.name) !== 1) {
+      return field;
+    }
+    const original = originalByName.get(field.name);
+    let next = field;
+    for (const prop of props) {
+      const value = gen[prop];
+      const unchanged = !original || field[prop] === original[prop];
+      if (value && !isFilled(field[prop]) && unchanged) {
+        next = { ...next, [prop]: value };
+        changed = true;
+      }
+    }
+    return next;
+  });
+  return { fields, changed };
+}
+
 /**
  * Main component for editing data mart schema settings
  * Uses custom hooks for state management and the SchemaContent component for rendering
@@ -166,20 +227,23 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
     [dataMartId, generateFieldDescription]
   );
 
-  const isFilled = (value: string | undefined): boolean => !!value && value.trim() !== '';
-
+  // The three bulk handlers all merge generated metadata onto the current live
+  // schema (schemaRef), preserving edits made during the slow generation call, and
+  // skip the schema update entirely when nothing was applied. See mergeGeneratedMetadata.
   const handleGenerateAllFieldDescriptions = useCallback(
     async (targetSchema: ResolvedSchema) => {
       if (!dataMartId || !targetSchema) return;
       const generated = await generateAllFieldDescriptions(dataMartId);
       if (!generated) return;
-      const byName = new Map(generated.map(field => [field.name, field.description]));
-      const updated = targetSchema.fields.map(field => {
-        if (isFilled(field.description)) return field;
-        const description = byName.get(field.name);
-        return description ? { ...field, description } : field;
-      });
-      updateSchema(updated as typeof targetSchema.fields);
+      const byName = new Map(generated.map(f => [f.name, { description: f.description }]));
+      const currentFields = schemaRef.current?.fields ?? targetSchema.fields;
+      const { fields, changed } = mergeGeneratedMetadata(
+        currentFields,
+        targetSchema.fields,
+        byName,
+        ['description']
+      );
+      if (changed) updateSchema(fields as typeof targetSchema.fields);
     },
     [dataMartId, generateAllFieldDescriptions, updateSchema]
   );
@@ -189,13 +253,15 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
       if (!dataMartId || !targetSchema) return;
       const generated = await generateAllFieldAliases(dataMartId);
       if (!generated) return;
-      const byName = new Map(generated.map(field => [field.name, field.alias]));
-      const updated = targetSchema.fields.map(field => {
-        if (isFilled(field.alias)) return field;
-        const alias = byName.get(field.name);
-        return alias ? { ...field, alias } : field;
-      });
-      updateSchema(updated as typeof targetSchema.fields);
+      const byName = new Map(generated.map(f => [f.name, { alias: f.alias }]));
+      const currentFields = schemaRef.current?.fields ?? targetSchema.fields;
+      const { fields, changed } = mergeGeneratedMetadata(
+        currentFields,
+        targetSchema.fields,
+        byName,
+        ['alias']
+      );
+      if (changed) updateSchema(fields as typeof targetSchema.fields);
     },
     [dataMartId, generateAllFieldAliases, updateSchema]
   );
@@ -205,16 +271,17 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
       if (!dataMartId || !targetSchema) return;
       const generated = await generateAllFieldMetadata(dataMartId);
       if (!generated) return;
-      const byName = new Map(generated.map(field => [field.name, field]));
-      const updated = targetSchema.fields.map(field => {
-        const gen = byName.get(field.name);
-        if (!gen) return field;
-        const next = { ...field };
-        if (!isFilled(field.alias) && gen.alias) next.alias = gen.alias;
-        if (!isFilled(field.description) && gen.description) next.description = gen.description;
-        return next;
-      });
-      updateSchema(updated as typeof targetSchema.fields);
+      const byName = new Map(
+        generated.map(f => [f.name, { alias: f.alias, description: f.description }])
+      );
+      const currentFields = schemaRef.current?.fields ?? targetSchema.fields;
+      const { fields, changed } = mergeGeneratedMetadata(
+        currentFields,
+        targetSchema.fields,
+        byName,
+        ['alias', 'description']
+      );
+      if (changed) updateSchema(fields as typeof targetSchema.fields);
     },
     [dataMartId, generateAllFieldMetadata, updateSchema]
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/DataMartSchemaSettings.tsx
@@ -8,6 +8,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { Loader2, Sparkles } from 'lucide-react';
 import { useCallback, useEffect, useRef } from 'react';
+import toast from 'react-hot-toast';
 import { useOutletContext } from 'react-router-dom';
 import type {
   AthenaSchemaField,
@@ -33,7 +34,9 @@ type BulkAiScope =
   | DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS
   | DataMartMetadataScope.ALL_FIELD_ALIASES;
 
-const isFilled = (value: string | undefined): boolean => !!value && value.trim() !== '';
+const normalizeMetadataValue = (value: string | undefined): string => value?.trim() ?? '';
+
+const isFilled = (value: string | undefined): boolean => normalizeMetadataValue(value) !== '';
 
 interface EditableMetadataField {
   name: string;
@@ -42,6 +45,9 @@ interface EditableMetadataField {
 }
 
 type GeneratedMetadata = Pick<EditableMetadataField, 'alias' | 'description'>;
+
+type MutableFieldArray<T extends readonly EditableMetadataField[]> =
+  T extends readonly (infer TField extends EditableMetadataField)[] ? TField[] : never;
 
 function countByName(fields: readonly EditableMetadataField[]): Map<string, number> {
   const counts = new Map<string, number>();
@@ -59,12 +65,18 @@ function countByName(fields: readonly EditableMetadataField[]): Map<string, numb
  * fields keep their original reference and `changed` reports whether anything was
  * applied, letting callers skip a no-op schema update.
  */
+function mergeGeneratedMetadata<TFields extends readonly EditableMetadataField[]>(
+  currentFields: TFields,
+  originalFields: readonly EditableMetadataField[],
+  generatedByName: ReadonlyMap<string, GeneratedMetadata>,
+  props: readonly ('alias' | 'description')[]
+): { fields: MutableFieldArray<TFields>; changed: boolean; duplicateNamesSkipped: boolean };
 function mergeGeneratedMetadata(
   currentFields: readonly EditableMetadataField[],
   originalFields: readonly EditableMetadataField[],
   generatedByName: ReadonlyMap<string, GeneratedMetadata>,
   props: readonly ('alias' | 'description')[]
-): { fields: EditableMetadataField[]; changed: boolean } {
+): { fields: EditableMetadataField[]; changed: boolean; duplicateNamesSkipped: boolean } {
   const originalByName = new Map(originalFields.map(field => [field.name, field]));
   // Fields, generated results, and the pre-generation snapshot are all matched by
   // name (there is no stable field id). Names are user-editable and can briefly
@@ -73,17 +85,20 @@ function mergeGeneratedMetadata(
   const currentNameCounts = countByName(currentFields);
   const originalNameCounts = countByName(originalFields);
   let changed = false;
+  let duplicateNamesSkipped = false;
   const fields = currentFields.map(field => {
     const gen = generatedByName.get(field.name);
     if (!gen) return field;
     if (currentNameCounts.get(field.name) !== 1 || originalNameCounts.get(field.name) !== 1) {
+      duplicateNamesSkipped = true;
       return field;
     }
     const original = originalByName.get(field.name);
     let next = field;
     for (const prop of props) {
       const value = gen[prop];
-      const unchanged = !original || field[prop] === original[prop];
+      const unchanged =
+        !original || normalizeMetadataValue(field[prop]) === normalizeMetadataValue(original[prop]);
       if (value && !isFilled(field[prop]) && unchanged) {
         next = { ...next, [prop]: value };
         changed = true;
@@ -91,7 +106,41 @@ function mergeGeneratedMetadata(
     }
     return next;
   });
-  return { fields, changed };
+  return { fields, changed, duplicateNamesSkipped };
+}
+
+function showBulkMergeFeedback(
+  scope: BulkAiScope,
+  changed: boolean,
+  duplicateNamesSkipped: boolean
+): void {
+  if (duplicateNamesSkipped) {
+    toast(
+      changed
+        ? 'Some fields were skipped because duplicate field names cannot be matched reliably.'
+        : 'No generated field metadata was applied because duplicate field names cannot be matched reliably.'
+    );
+    return;
+  }
+  if (changed) return;
+
+  switch (scope) {
+    case DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS:
+      toast(
+        'No field descriptions were applied. Values may already be filled or fields may have changed during generation.'
+      );
+      break;
+    case DataMartMetadataScope.ALL_FIELD_ALIASES:
+      toast(
+        'No field aliases were applied. Values may already be filled or fields may have changed during generation.'
+      );
+      break;
+    case DataMartMetadataScope.ALL_FIELD_METADATA:
+      toast(
+        'No field aliases or descriptions were applied. Values may already be filled or fields may have changed during generation.'
+      );
+      break;
+  }
 }
 
 /**
@@ -118,6 +167,8 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
 
   const schemaRef = useRef(schema);
   schemaRef.current = schema;
+  const activeDataMartIdRef = useRef(dataMartId);
+  activeDataMartIdRef.current = dataMartId;
 
   const { enabled: isAiHelperEnabled } = useAiHelperAvailability();
   const {
@@ -234,16 +285,21 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
     async (targetSchema: ResolvedSchema) => {
       if (!dataMartId || !targetSchema) return;
       const generated = await generateAllFieldDescriptions(dataMartId);
-      if (!generated) return;
+      if (!generated || activeDataMartIdRef.current !== dataMartId) return;
       const byName = new Map(generated.map(f => [f.name, { description: f.description }]));
       const currentFields = schemaRef.current?.fields ?? targetSchema.fields;
-      const { fields, changed } = mergeGeneratedMetadata(
+      const { fields, changed, duplicateNamesSkipped } = mergeGeneratedMetadata(
         currentFields,
         targetSchema.fields,
         byName,
         ['description']
       );
-      if (changed) updateSchema(fields as typeof targetSchema.fields);
+      if (changed) updateSchema(fields);
+      showBulkMergeFeedback(
+        DataMartMetadataScope.ALL_FIELD_DESCRIPTIONS,
+        changed,
+        duplicateNamesSkipped
+      );
     },
     [dataMartId, generateAllFieldDescriptions, updateSchema]
   );
@@ -252,16 +308,21 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
     async (targetSchema: ResolvedSchema) => {
       if (!dataMartId || !targetSchema) return;
       const generated = await generateAllFieldAliases(dataMartId);
-      if (!generated) return;
+      if (!generated || activeDataMartIdRef.current !== dataMartId) return;
       const byName = new Map(generated.map(f => [f.name, { alias: f.alias }]));
       const currentFields = schemaRef.current?.fields ?? targetSchema.fields;
-      const { fields, changed } = mergeGeneratedMetadata(
+      const { fields, changed, duplicateNamesSkipped } = mergeGeneratedMetadata(
         currentFields,
         targetSchema.fields,
         byName,
         ['alias']
       );
-      if (changed) updateSchema(fields as typeof targetSchema.fields);
+      if (changed) updateSchema(fields);
+      showBulkMergeFeedback(
+        DataMartMetadataScope.ALL_FIELD_ALIASES,
+        changed,
+        duplicateNamesSkipped
+      );
     },
     [dataMartId, generateAllFieldAliases, updateSchema]
   );
@@ -270,18 +331,23 @@ export function DataMartSchemaSettings({ definitionType }: DataMartSchemaSetting
     async (targetSchema: ResolvedSchema) => {
       if (!dataMartId || !targetSchema) return;
       const generated = await generateAllFieldMetadata(dataMartId);
-      if (!generated) return;
+      if (!generated || activeDataMartIdRef.current !== dataMartId) return;
       const byName = new Map(
         generated.map(f => [f.name, { alias: f.alias, description: f.description }])
       );
       const currentFields = schemaRef.current?.fields ?? targetSchema.fields;
-      const { fields, changed } = mergeGeneratedMetadata(
+      const { fields, changed, duplicateNamesSkipped } = mergeGeneratedMetadata(
         currentFields,
         targetSchema.fields,
         byName,
         ['alias', 'description']
       );
-      if (changed) updateSchema(fields as typeof targetSchema.fields);
+      if (changed) updateSchema(fields);
+      showBulkMergeFeedback(
+        DataMartMetadataScope.ALL_FIELD_METADATA,
+        changed,
+        duplicateNamesSkipped
+      );
     },
     [dataMartId, generateAllFieldMetadata, updateSchema]
   );

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useColumnVisibility.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useColumnVisibility.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ColumnDef } from '@tanstack/react-table';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useColumnVisibility } from './useColumnVisibility';
+
+interface TestRow {
+  name: string;
+  description?: string;
+  status?: string;
+}
+
+const columns = [
+  { accessorKey: 'name', enableHiding: false },
+  { accessorKey: 'description', meta: { hidden: true } },
+  { accessorKey: 'status' },
+] as ColumnDef<TestRow>[];
+
+describe('useColumnVisibility', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('rejects an array stored as column visibility and restores defaults', async () => {
+    const storageKey = 'schema-column-visibility';
+    localStorage.setItem(storageKey, JSON.stringify(['name']));
+
+    const { result } = renderHook(() => useColumnVisibility(columns, storageKey));
+
+    expect(result.current.columnVisibility).toEqual({ description: false });
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem(storageKey) ?? 'null')).toEqual({
+        description: false,
+      });
+    });
+  });
+
+  it('keeps only boolean visibility values for current columns', async () => {
+    const storageKey = 'schema-column-visibility';
+    localStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        description: true,
+        status: false,
+        removedColumn: false,
+      })
+    );
+
+    const { result } = renderHook(() => useColumnVisibility(columns, storageKey));
+
+    expect(result.current.columnVisibility).toEqual({
+      description: true,
+      status: false,
+    });
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem(storageKey) ?? 'null')).toEqual({
+        description: true,
+        status: false,
+      });
+    });
+  });
+
+  it('discards saved visibility for columns that cannot be hidden', async () => {
+    const storageKey = 'schema-column-visibility';
+    localStorage.setItem(storageKey, JSON.stringify({ name: false }));
+
+    const { result } = renderHook(() => useColumnVisibility(columns, storageKey));
+
+    expect(result.current.columnVisibility).toEqual({ description: false });
+    await waitFor(() => {
+      expect(JSON.parse(localStorage.getItem(storageKey) ?? 'null')).toEqual({
+        description: false,
+      });
+    });
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useColumnVisibility.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useColumnVisibility.ts
@@ -8,18 +8,35 @@ interface ExtendedColumnMeta<TData> extends ColumnMeta<TData, unknown> {
   title?: string;
 }
 
+function getColumnId<TData>(column: ColumnDef<TData>): string | undefined {
+  if (column.id) return column.id;
+  if ('accessorKey' in column && typeof column.accessorKey === 'string') {
+    return column.accessorKey;
+  }
+  return undefined;
+}
+
 /**
  * Loads the initial visibility for a storage key, layering any saved value over the
  * default-hidden set so unsaved columns fall back to their default state.
  */
 function loadColumnVisibility(
   storageKey: string | undefined,
-  defaultHiddenColumns: Record<string, boolean>
+  defaultHiddenColumns: Record<string, boolean>,
+  columnIds: readonly string[]
 ): Record<string, boolean> {
-  const saved = storageKey
-    ? (storageService.get(storageKey, 'json') as Record<string, boolean> | null)
-    : null;
-  return saved ? { ...defaultHiddenColumns, ...saved } : defaultHiddenColumns;
+  const savedRaw = storageKey ? storageService.get(storageKey, 'json') : null;
+  if (!savedRaw || typeof savedRaw !== 'object' || Array.isArray(savedRaw)) {
+    return defaultHiddenColumns;
+  }
+
+  const saved: Record<string, boolean> = {};
+  for (const id of columnIds) {
+    if (typeof savedRaw[id] === 'boolean') {
+      saved[id] = savedRaw[id];
+    }
+  }
+  return { ...defaultHiddenColumns, ...saved };
 }
 
 /**
@@ -29,6 +46,15 @@ function loadColumnVisibility(
  * @returns Object containing column visibility state and setter
  */
 export function useColumnVisibility<TData>(columns: ColumnDef<TData>[], storageKey?: string) {
+  const hideableColumnIds = useMemo(
+    () =>
+      columns
+        .filter(column => column.enableHiding !== false)
+        .map(getColumnId)
+        .filter((id): id is string => id !== undefined),
+    [columns]
+  );
+
   /**
    * Generates default hidden columns configuration
    */
@@ -38,14 +64,7 @@ export function useColumnVisibility<TData>(columns: ColumnDef<TData>[], storageK
         ? (Object.fromEntries(
             columns
               .filter(col => col.meta && (col.meta as ExtendedColumnMeta<TData>).hidden)
-              .map(col => [
-                'id' in col && col.id
-                  ? col.id
-                  : 'accessorKey' in col && typeof col.accessorKey === 'string'
-                    ? col.accessorKey
-                    : undefined,
-                false,
-              ])
+              .map(col => [getColumnId(col), false])
               .filter(([key]) => key !== undefined)
           ) as Record<string, boolean>)
         : {},
@@ -53,7 +72,7 @@ export function useColumnVisibility<TData>(columns: ColumnDef<TData>[], storageK
   );
 
   const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>(() =>
-    loadColumnVisibility(storageKey, defaultHiddenColumns)
+    loadColumnVisibility(storageKey, defaultHiddenColumns, hideableColumnIds)
   );
 
   // When storageKey changes for an already-mounted table (e.g. navigating between
@@ -63,7 +82,7 @@ export function useColumnVisibility<TData>(columns: ColumnDef<TData>[], storageK
   const [prevStorageKey, setPrevStorageKey] = useState(storageKey);
   if (storageKey !== prevStorageKey) {
     setPrevStorageKey(storageKey);
-    setColumnVisibility(loadColumnVisibility(storageKey, defaultHiddenColumns));
+    setColumnVisibility(loadColumnVisibility(storageKey, defaultHiddenColumns, hideableColumnIds));
   }
 
   // `columns` is rebuilt on every render (new array/object identities), so

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useColumnVisibility.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useColumnVisibility.ts
@@ -36,14 +36,20 @@ export function useColumnVisibility<TData>(columns: ColumnDef<TData>[]) {
     [columns]
   );
 
-  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>({});
+  const [columnVisibility, setColumnVisibility] =
+    useState<Record<string, boolean>>(defaultHiddenColumns);
 
-  /**
-   * Initialize column visibility with default hidden columns
-   */
+  // `columns` is rebuilt on every render (new array/object identities), so
+  // `defaultHiddenColumns` never stays referentially equal even when its content
+  // doesn't change. Key off the actual set of hidden column ids instead, so this
+  // effect only re-applies defaults when that set genuinely changes - otherwise it
+  // would keep clobbering the user's manual show/hide toggles on every re-render.
+  const defaultHiddenColumnsKey = Object.keys(defaultHiddenColumns).sort().join(',');
+
   useEffect(() => {
     setColumnVisibility(defaultHiddenColumns);
-  }, [defaultHiddenColumns]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultHiddenColumnsKey]);
 
   return {
     columnVisibility,

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useColumnVisibility.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/hooks/useColumnVisibility.ts
@@ -1,5 +1,6 @@
 import type { ColumnDef, ColumnMeta } from '@tanstack/react-table';
 import { useEffect, useMemo, useState } from 'react';
+import { storageService } from '../../../../../../services/localstorage.service';
 
 // Define proper type for column meta with hidden and title properties
 interface ExtendedColumnMeta<TData> extends ColumnMeta<TData, unknown> {
@@ -8,11 +9,26 @@ interface ExtendedColumnMeta<TData> extends ColumnMeta<TData, unknown> {
 }
 
 /**
+ * Loads the initial visibility for a storage key, layering any saved value over the
+ * default-hidden set so unsaved columns fall back to their default state.
+ */
+function loadColumnVisibility(
+  storageKey: string | undefined,
+  defaultHiddenColumns: Record<string, boolean>
+): Record<string, boolean> {
+  const saved = storageKey
+    ? (storageService.get(storageKey, 'json') as Record<string, boolean> | null)
+    : null;
+  return saved ? { ...defaultHiddenColumns, ...saved } : defaultHiddenColumns;
+}
+
+/**
  * Custom hook for managing column visibility functionality
  * @param columns - Table columns configuration
+ * @param storageKey - Optional localStorage key; when provided, visibility is persisted per browser
  * @returns Object containing column visibility state and setter
  */
-export function useColumnVisibility<TData>(columns: ColumnDef<TData>[]) {
+export function useColumnVisibility<TData>(columns: ColumnDef<TData>[], storageKey?: string) {
   /**
    * Generates default hidden columns configuration
    */
@@ -36,8 +52,19 @@ export function useColumnVisibility<TData>(columns: ColumnDef<TData>[]) {
     [columns]
   );
 
-  const [columnVisibility, setColumnVisibility] =
-    useState<Record<string, boolean>>(defaultHiddenColumns);
+  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>(() =>
+    loadColumnVisibility(storageKey, defaultHiddenColumns)
+  );
+
+  // When storageKey changes for an already-mounted table (e.g. navigating between
+  // data marts without a remount), re-read the new key's saved value during render.
+  // Doing it here rather than in an effect keeps the persist effect below from first
+  // writing the previous key's visibility to the new key.
+  const [prevStorageKey, setPrevStorageKey] = useState(storageKey);
+  if (storageKey !== prevStorageKey) {
+    setPrevStorageKey(storageKey);
+    setColumnVisibility(loadColumnVisibility(storageKey, defaultHiddenColumns));
+  }
 
   // `columns` is rebuilt on every render (new array/object identities), so
   // `defaultHiddenColumns` never stays referentially equal even when its content
@@ -47,9 +74,17 @@ export function useColumnVisibility<TData>(columns: ColumnDef<TData>[]) {
   const defaultHiddenColumnsKey = Object.keys(defaultHiddenColumns).sort().join(',');
 
   useEffect(() => {
-    setColumnVisibility(defaultHiddenColumns);
+    // Merge rather than overwrite, so a real change in the default-hidden set (e.g. a
+    // new column) doesn't discard visibility choices already made for other columns.
+    setColumnVisibility(prev => ({ ...defaultHiddenColumns, ...prev }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultHiddenColumnsKey]);
+
+  // Persist to localStorage so the choice survives tab switches/unmounts and reloads.
+  useEffect(() => {
+    if (!storageKey) return;
+    storageService.set(storageKey, columnVisibility);
+  }, [columnVisibility, storageKey]);
 
   return {
     columnVisibility,

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/SchemaTable.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/SchemaTable.tsx
@@ -81,8 +81,8 @@ export function SchemaTable<T extends BaseSchemaField>({
   rowComponent = TableRow as ComponentType<RowComponentProps<Row<T>>>,
   getRowId,
 }: SchemaTableProps<T>) {
-  // Get schema actualization loading state from context
-  const { isSchemaActualizationLoading } = useOutletContext<DataMartContextType>();
+  // Get schema actualization loading state and current data mart from context
+  const { isSchemaActualizationLoading, dataMart } = useOutletContext<DataMartContextType>();
 
   // Use the columns provided by the parent component
   const columns = initialColumns;
@@ -91,8 +91,14 @@ export function SchemaTable<T extends BaseSchemaField>({
   const DragContext = dragContext;
   const RowComponent = rowComponent;
 
-  // Column visibility state
-  const { columnVisibility, setColumnVisibility } = useColumnVisibility(columns);
+  // Column visibility state, persisted per data mart so it survives tab switches and reloads
+  const columnVisibilityStorageKey = dataMart?.id
+    ? `data-mart-schema-column-visibility-${dataMart.id}`
+    : undefined;
+  const { columnVisibility, setColumnVisibility } = useColumnVisibility(
+    columns,
+    columnVisibilityStorageKey
+  );
 
   // Create table instance
   const table = useReactTable<T>({


### PR DESCRIPTION
# Problem

In the Output Schema table, several kinds of edits could get silently undone:

1. Unchecking a column (e.g. Alias, Description) in the column visibility menu would revert to visible again a few seconds later, or whenever the user switched tabs and came back. `useColumnVisibility` re-applied the default visibility set inside a `useEffect` keyed on a freshly-computed `defaultHiddenColumns` object, which got a new object identity on almost every re-render, overwriting the manual toggle each time. Since the schema settings page also lives at a real route, switching tabs unmounted and remounted the component with no persistence layer to restore the choice.
2. Toggling "Hidden from reports" on a field — or clearing an alias/description — while a bulk AI generation was still running would get reverted once generation finished. The AI handlers captured a schema snapshot at click time and, after the slow (polling) generation call resolved, rebuilt the field list from that stale snapshot, discarding any edits made in the meantime.
3. Running a bulk AI generation that filled in nothing new still marked the schema as unsaved, needlessly enabling Save and arming the unsaved-changes guard.

# Solution

- Fixed `useColumnVisibility`'s reset effect to key off a stable, content-derived signature of the hidden-column set instead of the unstable object reference, and to merge rather than overwrite visibility state.
- Added optional `localStorage` persistence to `useColumnVisibility`, scoped per data mart id, so the choice survives route unmounts/remounts and page reloads. Handled the case where the storage key changes on an already-mounted table (navigating between data marts without an unmount) by re-reading the new key's saved value during render, before the persist effect can write stale data into it.
- Extracted a single `mergeGeneratedMetadata` helper used by all three bulk AI handlers. It merges generated values onto the live schema (`schemaRef.current`) instead of the pre-generation snapshot, applies a generated value only when the field's property is both empty and unchanged since the request started (so mid-flight edits and deliberate clears are preserved), and reports whether anything changed so the handlers can skip a no-op schema update.

# Changes

- Reworked `useColumnVisibility` to key its reset effect on a stable hidden-columns signature instead of an unstable object reference, and to merge rather than overwrite visibility state.
- Added optional `storageKey` param to `useColumnVisibility` with `localStorage` read/write for persisting column visibility per data mart.
- Added a render-time re-read of saved visibility when `storageKey` changes without a remount, preventing cross-data-mart state leakage.
- Updated `SchemaTable` to pass a data-mart-scoped storage key (`data-mart-schema-column-visibility-{id}`) into `useColumnVisibility`.
- Extracted `mergeGeneratedMetadata` (plus module-scope `isFilled`) and routed all three bulk AI handlers through it, so generated metadata is applied onto the live schema, mid-generation edits and clears are preserved, and no-op generations no longer mark the schema dirty.

# Rationale

- `SchemaTable` uses a visibility-only hook because `useTableStorage` also owns sorting, pagination, and sizing and assumes a stable storage prefix. The schema table remains mounted when the data mart ID changes, so its hook explicitly rehydrates visibility when the storage key changes.
- Column visibility is intentionally scoped per data mart so changing one schema’s layout does not affect other data marts. The small per-mart localStorage entries are an accepted tradeoff.