### PR TITLE
fix(reports): report column picker UX fixes (#6733)

### DIFF
--- a/.changeset/aggregation-picker-open-and-unique-count-font.md
+++ b/.changeset/aggregation-picker-open-and-unique-count-font.md
@@ -6,7 +6,9 @@
 
 Adding a column in the report column picker's Aggregations panel now opens the
 aggregation editor immediately, instead of showing only an icon that required a
-second click. The auto-generated "Unique count" row now uses the same font as the
+second click, and its Apply button stays disabled until you pick a function or
+bucket so a new column can no longer be discarded by an empty Apply. The
+auto-generated "Unique count" row now uses the same font as the
 other fields in the column list, so it no longer stands out as visually inconsistent.
 The relative-date "Last N days/months" filter input can now be cleared with
 Backspace instead of snapping back to 0. When editing a single filter or slice, a

--- a/.changeset/aggregation-picker-open-and-unique-count-font.md
+++ b/.changeset/aggregation-picker-open-and-unique-count-font.md
@@ -2,11 +2,13 @@
 'owox': minor
 ---
 
-# Report column picker fixes: aggregation editor, Unique count font, Last-N filter input
+# Report column picker fixes: aggregation editor, Unique count font, filter input & delete
 
 Adding a column in the report column picker's Aggregations panel now opens the
 aggregation editor immediately, instead of showing only an icon that required a
 second click. The auto-generated "Unique count" row now uses the same font as the
 other fields in the column list, so it no longer stands out as visually inconsistent.
 The relative-date "Last N days/months" filter input can now be cleared with
-Backspace instead of snapping back to 0.
+Backspace instead of snapping back to 0. When editing a single filter or slice, a
+trash button in the editor header now lets you delete it directly, instead of only
+being able to remove it from the top Filters section.

--- a/.changeset/aggregation-picker-open-and-unique-count-font.md
+++ b/.changeset/aggregation-picker-open-and-unique-count-font.md
@@ -1,0 +1,10 @@
+---
+'owox': minor
+---
+
+# Report column picker: aggregation editor opens on the first click, Unique count row font
+
+Adding a column in the report column picker's Aggregations panel now opens the
+aggregation editor immediately, instead of showing only an icon that required a
+second click. The auto-generated "Unique count" row now uses the same font as the
+other fields in the column list, so it no longer stands out as visually inconsistent.

--- a/.changeset/aggregation-picker-open-and-unique-count-font.md
+++ b/.changeset/aggregation-picker-open-and-unique-count-font.md
@@ -2,9 +2,11 @@
 'owox': minor
 ---
 
-# Report column picker: aggregation editor opens on the first click, Unique count row font
+# Report column picker fixes: aggregation editor, Unique count font, Last-N filter input
 
 Adding a column in the report column picker's Aggregations panel now opens the
 aggregation editor immediately, instead of showing only an icon that required a
 second click. The auto-generated "Unique count" row now uses the same font as the
 other fields in the column list, so it no longer stands out as visually inconsistent.
+The relative-date "Last N days/months" filter input can now be cleared with
+Backspace instead of snapping back to 0.

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/AggregationEditorPopover.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/AggregationEditorPopover.test.tsx
@@ -252,3 +252,68 @@ describe('AggregationEditorPopover — date bucket time zone', () => {
     expect(screen.getByLabelText('Time zone')).toBeInTheDocument();
   });
 });
+
+describe('AggregationEditorPopover — Apply gating', () => {
+  it('disables Apply for a brand-new column until a function is chosen (no silent discard)', () => {
+    render(
+      <AggregationEditorPopover
+        open
+        onOpenChange={() => undefined}
+        trigger={<button>open</button>}
+        column='orders.revenue'
+        fieldType='INTEGER'
+        allowedAggregations={NUMERIC_ALLOWED}
+        onApply={vi.fn()}
+      />
+    );
+
+    const apply = screen.getByRole('button', { name: 'Apply' });
+    expect(apply).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText('SUM'));
+    expect(apply).not.toBeDisabled();
+  });
+
+  it('disables Apply for a brand-new date column until a bucket or function is chosen', () => {
+    render(
+      <AggregationEditorPopover
+        open
+        onOpenChange={() => undefined}
+        trigger={<button>open</button>}
+        column='orders.ordered_at'
+        fieldType='TIMESTAMP'
+        allowedAggregations={DATE_ALLOWED}
+        onApply={vi.fn()}
+      />
+    );
+
+    const apply = screen.getByRole('button', { name: 'Apply' });
+    expect(apply).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Group by bucket'), { target: { value: 'WEEK' } });
+    expect(apply).not.toBeDisabled();
+  });
+
+  it('keeps Apply enabled when editing an existing selection so clearing it removes the rule', () => {
+    render(
+      <AggregationEditorPopover
+        open
+        onOpenChange={() => undefined}
+        trigger={<button>open</button>}
+        column='orders.revenue'
+        fieldType='INTEGER'
+        allowedAggregations={NUMERIC_ALLOWED}
+        initialFunctions={['SUM']}
+        onApply={vi.fn()}
+      />
+    );
+
+    const apply = screen.getByRole('button', { name: 'Apply' });
+    expect(apply).not.toBeDisabled();
+
+    // Unchecking the only function leaves Apply enabled — applying the empty draft
+    // is the intended "remove" path for an existing rule.
+    fireEvent.click(screen.getByLabelText('SUM'));
+    expect(apply).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/AggregationEditorPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/AggregationEditorPopover.tsx
@@ -136,6 +136,15 @@ export function AggregationEditorPopover(props: AggregationEditorPopoverProps) {
   }
 
   const bucketActive = isDate && bucket !== null;
+  // A brand-new column (nothing pre-selected) must choose a function or bucket — an
+  // empty Apply would silently discard it. Editing an existing selection keeps Apply
+  // enabled so clearing it and applying removes the rule.
+  const hadInitialSelection =
+    (props.initialFunctions?.length ?? 0) > 0 || (props.initialBucket ?? null) !== null;
+  const canApply =
+    props.allowedAggregations.some(fn => functions.includes(fn)) ||
+    bucketActive ||
+    hadInitialSelection;
 
   return (
     <Popover open={props.open} onOpenChange={props.onOpenChange}>
@@ -235,7 +244,7 @@ export function AggregationEditorPopover(props: AggregationEditorPopoverProps) {
           <Button variant='outline' size='sm' onClick={handleCancel}>
             Cancel
           </Button>
-          <Button size='sm' onClick={handleApply}>
+          <Button size='sm' onClick={handleApply} disabled={!canApply}>
             Apply
           </Button>
         </div>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/AggregationSettingsDropdown.autoOpen.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/AggregationSettingsDropdown.autoOpen.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  AggregationSettingsDropdown,
+  type AggregationDropdownColumn,
+} from './AggregationSettingsDropdown';
+import type { OutputConfig } from '../../../shared/types/output-config';
+
+// Integration coverage for #6733.3: selecting a column from the "Add aggregation"
+// picker must open the editor IMMEDIATELY (no second click). The leaf FieldSearchPicker
+// (Radix Popover + cmdk) is exercised by its own tests; here we stub it down to a plain
+// onSelect trigger so we can drive the container's pending → auto-open wiring, and expose
+// the popover `open` state so the auto-open is observable.
+vi.mock('./FieldSearchPicker', () => ({
+  FieldSearchPicker: ({
+    items,
+    onSelect,
+  }: {
+    items: { value: string; label: string }[];
+    onSelect: (value: string) => void;
+  }) => (
+    <div>
+      {items.map(item => (
+        <button
+          key={item.value}
+          onClick={() => {
+            onSelect(item.value);
+          }}
+        >
+          add:{item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@owox/ui/components/popover', () => ({
+  Popover: ({ open, children }: { open?: boolean; children: React.ReactNode }) => (
+    <div data-testid='agg-popover' data-open={String(Boolean(open))}>
+      {children}
+    </div>
+  ),
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@owox/ui/components/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <select>{children}</select>,
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+const EMPTY_CONFIG: OutputConfig = {
+  filterConfig: [],
+  sortConfig: [],
+  limitConfig: null,
+  aggregationConfig: [],
+  dateTruncConfig: [],
+  uniqueCountConfig: false,
+};
+
+const revenue: AggregationDropdownColumn = {
+  name: 'orders.revenue',
+  type: 'INTEGER',
+  label: 'Revenue',
+};
+const margin: AggregationDropdownColumn = {
+  name: 'orders.margin',
+  type: 'INTEGER',
+  label: 'Margin',
+};
+
+describe('AggregationSettingsDropdown — pending column auto-opens the editor (#6733.3)', () => {
+  it('opens the aggregation editor immediately after picking a column (no second click)', () => {
+    render(
+      <AggregationSettingsDropdown
+        value={EMPTY_CONFIG}
+        onChange={() => undefined}
+        selectedColumns={[revenue]}
+      />
+    );
+
+    // No editor popover is mounted until a column is picked.
+    expect(screen.queryByTestId('agg-popover')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'add:Revenue' }));
+
+    // The pending column now renders the editor already open — the whole point of the fix.
+    expect(screen.getByTestId('agg-popover')).toHaveAttribute('data-open', 'true');
+    expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+  });
+
+  it('resets the pending column (back to the picker) when the editor is dismissed via Cancel', () => {
+    render(
+      <AggregationSettingsDropdown
+        value={EMPTY_CONFIG}
+        onChange={() => undefined}
+        selectedColumns={[revenue, margin]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'add:Margin' }));
+    expect(screen.getByTestId('agg-popover')).toHaveAttribute('data-open', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    // onClose → setPendingColumn(null) → the picker comes back (both columns addable again).
+    expect(screen.queryByTestId('agg-popover')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'add:Revenue' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'add:Margin' })).toBeInTheDocument();
+  });
+
+  it('applies the picked column and returns to the picker', () => {
+    const onChange = vi.fn();
+    render(
+      <AggregationSettingsDropdown
+        value={EMPTY_CONFIG}
+        onChange={onChange}
+        selectedColumns={[revenue]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'add:Revenue' }));
+    fireEvent.click(screen.getByLabelText('SUM'));
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    const cfg = onChange.mock.lastCall?.[0] as OutputConfig | undefined;
+    expect(cfg?.aggregationConfig).toEqual([{ column: 'orders.revenue', function: 'SUM' }]);
+    // Editor closed; picker restored.
+    expect(screen.queryByTestId('agg-popover')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/AggregationSettingsDropdown.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/AggregationSettingsDropdown.tsx
@@ -201,6 +201,7 @@ function AggregationSection({
       <div className='mt-2'>
         {pendingColumn ? (
           <RowAggregationIcon
+            key={pendingColumn.name}
             column={pendingColumn.name}
             fieldType={pendingColumn.type}
             displayLabel={pendingColumn.label}
@@ -209,6 +210,10 @@ function AggregationSection({
             activeFunctions={functionsForColumn(pendingColumn.name, aggregations)}
             activeBucket={bucketForColumn(pendingColumn.name, dateTrunc)}
             alwaysVisible
+            autoOpen
+            onClose={() => {
+              setPendingColumn(null);
+            }}
             onApplyDraft={draft => {
               const next = applyAggregationDraft(
                 pendingColumn.name,

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterEditorPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterEditorPopover.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@owox/ui/components/popover';
 import { Button } from '@owox/ui/components/button';
 import { Label } from '@owox/ui/components/label';
-import { X } from 'lucide-react';
+import { X, Trash2 } from 'lucide-react';
 import type { FilterRule } from '../../../shared/types/output-config';
 import { operatorLabelFor } from './output-controls-operators';
 import { summarizeFilterRule } from './filter-rule-summary';
@@ -23,6 +23,8 @@ export interface FilterEditorPopoverProps {
   onCancel?: () => void;
   existingRules?: readonly FilterRule[];
   onRemoveExistingAt?: (index: number) => void;
+  /** Delete the single filter being edited; shown as a header trash action (edit mode only). */
+  onDelete?: () => void;
 }
 
 export function FilterEditorPopover(props: FilterEditorPopoverProps) {
@@ -72,10 +74,26 @@ export function FilterEditorPopover(props: FilterEditorPopoverProps) {
     <Popover open={props.open} onOpenChange={props.onOpenChange}>
       <PopoverTrigger asChild>{props.trigger}</PopoverTrigger>
       <PopoverContent className='w-72 space-y-3'>
-        <div>
-          <div className='text-sm font-medium'>{props.displayLabel ?? props.column}</div>
-          {props.dataMartName && (
-            <div className='text-muted-foreground text-[11px]'>{props.dataMartName}</div>
+        <div className='flex items-start justify-between gap-2'>
+          <div className='min-w-0'>
+            <div className='text-sm font-medium'>{props.displayLabel ?? props.column}</div>
+            {props.dataMartName && (
+              <div className='text-muted-foreground text-[11px]'>{props.dataMartName}</div>
+            )}
+          </div>
+          {props.onDelete && (
+            <Button
+              variant='ghost'
+              size='sm'
+              className='text-muted-foreground hover:text-destructive -mt-1 -mr-1 h-6 w-6 shrink-0 p-0'
+              onClick={() => {
+                props.onDelete?.();
+                props.onOpenChange(false);
+              }}
+              aria-label='Delete filter'
+            >
+              <Trash2 className='h-4 w-4' />
+            </Button>
           )}
         </div>
 

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterOrSliceEditorPopover.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 import { Popover, PopoverContent, PopoverTrigger } from '@owox/ui/components/popover';
 import { Button } from '@owox/ui/components/button';
 import { Label } from '@owox/ui/components/label';
-import { X, Layers } from 'lucide-react';
+import { X, Layers, Trash2 } from 'lucide-react';
 import type { FilterRule } from '../../../shared/types/output-config';
 import { operatorLabelFor } from './output-controls-operators';
 import { summarizeFilterRule } from './filter-rule-summary';
@@ -20,6 +20,8 @@ interface SliceOnlyProps {
   existingSlicesForColumn?: readonly FilterRule[];
   onRemoveExistingAt?: (index: number) => void;
   initialRule?: FilterRule;
+  /** Delete the single slice being edited; shown as a header trash action (edit mode only). */
+  onDelete?: () => void;
 }
 
 export interface FilterOrSliceEditorPopoverProps {
@@ -133,17 +135,34 @@ function TabbedPopover(props: TabbedPopoverProps) {
   const hasExistingFilters = !!props.filterProps.existingRules?.length;
   const hasExistingSlices = !!props.sliceProps.existingSlicesForColumn?.length;
   const applyLabel = (tab === 'filter' ? hasExistingFilters : hasExistingSlices) ? 'Add' : 'Apply';
+  const activeDelete = tab === 'filter' ? props.filterProps.onDelete : props.sliceProps.onDelete;
 
   return (
     <Popover open={props.open} onOpenChange={props.onOpenChange}>
       <PopoverTrigger asChild>{props.trigger}</PopoverTrigger>
       <PopoverContent className='w-72 space-y-3'>
-        <div>
-          <div className='text-sm font-medium'>
-            {props.displayLabel ?? (tab === 'slice' ? props.sliceColumn : props.column)}
+        <div className='flex items-start justify-between gap-2'>
+          <div className='min-w-0'>
+            <div className='text-sm font-medium'>
+              {props.displayLabel ?? (tab === 'slice' ? props.sliceColumn : props.column)}
+            </div>
+            {props.dataMartName && (
+              <div className='text-muted-foreground text-[11px]'>{props.dataMartName}</div>
+            )}
           </div>
-          {props.dataMartName && (
-            <div className='text-muted-foreground text-[11px]'>{props.dataMartName}</div>
+          {activeDelete && (
+            <Button
+              variant='ghost'
+              size='sm'
+              className='text-muted-foreground hover:text-destructive -mt-1 -mr-1 h-6 w-6 shrink-0 p-0'
+              onClick={() => {
+                activeDelete();
+                props.onOpenChange(false);
+              }}
+              aria-label={tab === 'filter' ? 'Delete filter' : 'Delete slice'}
+            >
+              <Trash2 className='h-4 w-4' />
+            </Button>
           )}
         </div>
 

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.test.tsx
@@ -452,6 +452,26 @@ describe('FilterValueEditor — relative_date operator', () => {
 
     expect(lastCall(onChange)).toBeNull();
   });
+
+  it('clearing the Last-N input leaves it empty instead of snapping back to 0 (Backspace bug)', () => {
+    // Regression: the field coerced '' → 0 and re-rendered "0", so Backspace could
+    // never empty it. It must stay empty so the user can type a fresh value.
+    const { onChange } = renderEditor({
+      fieldType: DATE_TYPE,
+      initialRule: {
+        column: COL,
+        operator: 'relative_date',
+        value: { kind: 'last_n_days', n: 30 },
+      },
+    });
+
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect((input as HTMLInputElement).value).toBe('');
+    // An empty N is invalid → no rule emitted.
+    expect(lastCall(onChange)).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
@@ -111,8 +111,9 @@ function buildRule(args: { column: string; fieldType: string; state: EditorState
 
   if (op === 'relative_date') {
     if (state.relativeKind === 'last_n_days' || state.relativeKind === 'last_n_months') {
-      const n = Number(state.relativeN);
-      if (state.relativeN === '' || !Number.isInteger(n) || n <= 0 || n > 3650) {
+      const trimmed = state.relativeN.trim();
+      const n = Number(trimmed);
+      if (trimmed === '' || !Number.isInteger(n) || n <= 0 || n > 3650) {
         throw new Error('N must be between 1 and 3650');
       }
       return {

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterValueEditor.tsx
@@ -31,7 +31,8 @@ interface EditorState {
   betweenFrom: string;
   betweenTo: string;
   relativeKind: RelativeDatePreset['kind'];
-  relativeN: number;
+  /** Raw text so the field can be emptied while editing; parsed/validated in buildRule. */
+  relativeN: string;
 }
 
 const RELATIVE_KINDS: { value: RelativeDatePreset['kind']; label: string }[] = [
@@ -60,7 +61,7 @@ function getInitialState(rule: FilterRule | undefined, fallbackOp: FilterOperato
     betweenFrom: '',
     betweenTo: '',
     relativeKind: 'today',
-    relativeN: 7,
+    relativeN: '7',
   };
   if (!rule) return state;
   state.op = rule.operator as FilterOperator;
@@ -69,7 +70,7 @@ function getInitialState(rule: FilterRule | undefined, fallbackOp: FilterOperato
     state.betweenTo = String(rule.value.to);
   } else if (rule.operator === 'relative_date') {
     state.relativeKind = rule.value.kind;
-    if ('n' in rule.value) state.relativeN = rule.value.n;
+    if ('n' in rule.value) state.relativeN = String(rule.value.n);
   } else if (!NO_VALUE_OPS.has(rule.operator as FilterOperator)) {
     const value = (rule as { value: string | number | boolean }).value;
     state.scalar = String(value);
@@ -110,13 +111,14 @@ function buildRule(args: { column: string; fieldType: string; state: EditorState
 
   if (op === 'relative_date') {
     if (state.relativeKind === 'last_n_days' || state.relativeKind === 'last_n_months') {
-      if (!Number.isInteger(state.relativeN) || state.relativeN <= 0 || state.relativeN > 3650) {
+      const n = Number(state.relativeN);
+      if (state.relativeN === '' || !Number.isInteger(n) || n <= 0 || n > 3650) {
         throw new Error('N must be between 1 and 3650');
       }
       return {
         column,
         operator: 'relative_date',
-        value: { kind: state.relativeKind, n: state.relativeN },
+        value: { kind: state.relativeKind, n },
       };
     }
     return { column, operator: 'relative_date', value: { kind: state.relativeKind } };
@@ -263,7 +265,7 @@ export function FilterValueEditor({
               max={3650}
               value={state.relativeN}
               onChange={e => {
-                setState(s => ({ ...s, relativeN: Number(e.target.value) || 0 }));
+                setState(s => ({ ...s, relativeN: e.target.value }));
               }}
             />
           )}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
@@ -881,6 +881,18 @@ describe('ReportColumnPicker Unique count virtual row', () => {
     expect(screen.getByText('Unique count')).toBeInTheDocument();
   });
 
+  it('renders the Unique count label in the same monospace font as the native field rows', () => {
+    // The native field rows (e.g. `field.name`) render in font-mono; the virtual
+    // Unique count row must not visually diverge from them (#6733.4 font fix).
+    renderPicker(pkSchema(), ['id', 'name'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: { ...baseOutputConfig },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    expect(screen.getByText('Unique count').className).toMatch(/font-mono/);
+  });
+
   it('does NOT render the Unique count row when the schema has no PK field', () => {
     renderPicker(noPkSchema(), ['col_a', 'col_b'], {
       storageType: DataStorageType.GOOGLE_BIGQUERY,

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -1298,7 +1298,7 @@ export function ReportColumnPicker({
                 });
               }}
             />
-            <span className='min-w-0 truncate text-xs'>Unique count</span>
+            <span className='min-w-0 truncate font-mono text-xs'>Unique count</span>
             {effectiveOutputConfig.uniqueCountConfig && (
               <span className='ml-auto flex items-center'>
                 <Tooltip>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowAggregationIcon.autoOpen.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowAggregationIcon.autoOpen.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RowAggregationIcon } from './RowAggregationIcon';
+import type { ReportAggregateFunction } from '../../../shared/types/relationship.types';
+
+// Unlike the sibling spec, this mock EXPOSES the controlled `open` prop (as data-open)
+// so we can assert the auto-open behaviour of the dropdown's pending "add" entry —
+// the whole point of item #6733.3 ("the Aggregation block does not show on first invoke").
+vi.mock('@owox/ui/components/popover', () => ({
+  Popover: ({ open, children }: { open?: boolean; children: React.ReactNode }) => (
+    <div data-testid='agg-popover' data-open={String(Boolean(open))}>
+      {children}
+    </div>
+  ),
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@owox/ui/components/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <select>{children}</select>,
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+const NUMERIC_ALLOWED: ReportAggregateFunction[] = ['SUM', 'AVG'];
+
+describe('RowAggregationIcon — autoOpen / onClose (pending add entry)', () => {
+  it('mounts the editor already open when autoOpen is set', () => {
+    render(
+      <RowAggregationIcon
+        column='orders.revenue'
+        fieldType='INTEGER'
+        allowedAggregations={NUMERIC_ALLOWED}
+        activeFunctions={[]}
+        activeBucket={null}
+        alwaysVisible
+        autoOpen
+        onApplyDraft={() => undefined}
+      />
+    );
+
+    expect(screen.getByTestId('agg-popover')).toHaveAttribute('data-open', 'true');
+  });
+
+  it('mounts closed when autoOpen is not set (default)', () => {
+    render(
+      <RowAggregationIcon
+        column='orders.revenue'
+        fieldType='INTEGER'
+        allowedAggregations={NUMERIC_ALLOWED}
+        activeFunctions={[]}
+        activeBucket={null}
+        onApplyDraft={() => undefined}
+      />
+    );
+
+    expect(screen.getByTestId('agg-popover')).toHaveAttribute('data-open', 'false');
+  });
+
+  it('fires onClose when the editor is dismissed via Cancel (so the pending column can reset)', () => {
+    const onClose = vi.fn();
+    render(
+      <RowAggregationIcon
+        column='orders.revenue'
+        fieldType='INTEGER'
+        allowedAggregations={NUMERIC_ALLOWED}
+        activeFunctions={[]}
+        activeBucket={null}
+        alwaysVisible
+        autoOpen
+        onClose={onClose}
+        onApplyDraft={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('agg-popover')).toHaveAttribute('data-open', 'false');
+  });
+
+  it('fires onClose after applying a draft (Apply also closes the editor)', () => {
+    const onClose = vi.fn();
+    const onApplyDraft = vi.fn();
+    render(
+      <RowAggregationIcon
+        column='orders.revenue'
+        fieldType='INTEGER'
+        allowedAggregations={NUMERIC_ALLOWED}
+        activeFunctions={[]}
+        activeBucket={null}
+        alwaysVisible
+        autoOpen
+        onClose={onClose}
+        onApplyDraft={onApplyDraft}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText('SUM'));
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(onApplyDraft).toHaveBeenCalledWith({ functions: ['SUM'], bucket: null, timeZone: null });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowAggregationIcon.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowAggregationIcon.tsx
@@ -26,6 +26,10 @@ interface RowAggregationIconProps {
    * default hover-gating would leave nothing to reveal the icon.
    */
   alwaysVisible?: boolean;
+  /** Open the editor immediately on mount (the dropdown's pending "add" entry). */
+  autoOpen?: boolean;
+  /** Fired whenever the editor closes, so a pending selection can be reset. */
+  onClose?: () => void;
   onApplyDraft: (draft: AggregationDraft) => void;
 }
 
@@ -39,11 +43,18 @@ export function RowAggregationIcon({
   activeBucket,
   activeTimeZone,
   alwaysVisible = false,
+  autoOpen = false,
+  onClose,
   onApplyDraft,
 }: RowAggregationIconProps) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(autoOpen);
   const count = activeFunctions.length + (activeBucket !== null ? 1 : 0);
   const isActive = count > 0;
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) onClose?.();
+  };
 
   const trigger = (
     <button
@@ -65,7 +76,7 @@ export function RowAggregationIcon({
   return (
     <AggregationEditorPopover
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={handleOpenChange}
       trigger={trigger}
       column={column}
       fieldType={fieldType}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.test.tsx
@@ -179,4 +179,65 @@ describe('RowFilterIcon — remove-only popup', () => {
     expect(screen.getByRole('button', { name: /^(Apply|Add)$/ })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
   });
+
+  it('editing a single existing filter exposes a Delete filter button that removes it', () => {
+    const onRemoveAt = vi.fn();
+    render(
+      <RowFilterIcon
+        column='native_one'
+        fieldType='STRING'
+        activeRules={[filterRule]}
+        onAdd={() => undefined}
+        onReplaceAt={() => undefined}
+        onRemoveAt={onRemoveAt}
+      />
+    );
+
+    // Single-filter edit mode renders the editor (no "Active filters" list), so the
+    // delete affordance must live in the editor header.
+    expect(screen.queryByText('Active filters')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete filter' }));
+    expect(onRemoveAt).toHaveBeenCalledWith(0);
+  });
+
+  it('does not show a Delete filter button when adding a new filter (nothing to delete)', () => {
+    render(
+      <RowFilterIcon
+        column='native_one'
+        fieldType='STRING'
+        activeRules={[]}
+        onAdd={() => undefined}
+        onReplaceAt={() => undefined}
+        onRemoveAt={() => undefined}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Delete filter' })).not.toBeInTheDocument();
+  });
+
+  it('editing a single existing slice exposes a Delete slice button that removes it', () => {
+    const onRemoveSliceAt = vi.fn();
+    render(
+      <RowFilterIcon
+        column='b__hidden_field'
+        fieldType='STRING'
+        activeRules={[]}
+        onAdd={() => undefined}
+        onRemoveAt={() => undefined}
+        sliceIconProps={{
+          unifiedFieldName: 'b__hidden_field',
+          existingSlices: [sliceRule],
+          existingSliceIndices: [3],
+          onAddSlice: () => undefined,
+          onRemoveSliceAt,
+          onReplaceSliceAt: () => undefined,
+        }}
+      />
+    );
+
+    // Slice tab is the default here (no filters, one slice) and opens in edit mode.
+    expect(screen.queryByText('Active slices')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete slice' }));
+    expect(onRemoveSliceAt).toHaveBeenCalledWith(3);
+  });
 });

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.test.tsx
@@ -240,4 +240,54 @@ describe('RowFilterIcon — remove-only popup', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete slice' }));
     expect(onRemoveSliceAt).toHaveBeenCalledWith(3);
   });
+
+  it('does not show the header Delete button with 2+ filters (list mode owns removal via per-row X)', () => {
+    const filterRule2 = { column: 'ghost__col', operator: 'contains', value: 'z' } as FilterRule;
+    render(
+      <RowFilterIcon
+        column='native_one'
+        fieldType='STRING'
+        activeRules={[filterRule, filterRule2]}
+        onAdd={() => undefined}
+        onReplaceAt={() => undefined}
+        onRemoveAt={() => undefined}
+      />
+    );
+
+    // Multi-item mode shows the "Active filters" list (each row its own X) — the
+    // single-item header trash must NOT also appear.
+    expect(screen.getByText('Active filters')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Remove filter' })).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: 'Delete filter' })).not.toBeInTheDocument();
+  });
+
+  it('does not show the header Delete button with 2+ slices (list mode owns removal via per-row X)', () => {
+    const sliceRule2 = {
+      column: 'b__hidden_field',
+      operator: 'contains',
+      value: 'z',
+      placement: 'pre-join',
+    } as FilterRule;
+    render(
+      <RowFilterIcon
+        column='b__hidden_field'
+        fieldType='STRING'
+        activeRules={[]}
+        onAdd={() => undefined}
+        onRemoveAt={() => undefined}
+        sliceIconProps={{
+          unifiedFieldName: 'b__hidden_field',
+          existingSlices: [sliceRule, sliceRule2],
+          existingSliceIndices: [3, 5],
+          onAddSlice: () => undefined,
+          onRemoveSliceAt: () => undefined,
+          onReplaceSliceAt: () => undefined,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Active slices')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Remove slice' })).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: 'Delete slice' })).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
@@ -100,6 +100,21 @@ export function RowFilterIcon({
       }
     : undefined;
 
+  // Delete affordances for single-item edit mode (no "Active …" list is shown there).
+  const deleteEditedFilter = editFilter
+    ? () => {
+        const idx = activeRules.indexOf(editFilter);
+        if (idx >= 0) onRemoveAt(idx);
+      }
+    : undefined;
+  const deleteEditedSlice =
+    editSlice && sliceIconProps
+      ? () => {
+          const idx = sliceIconProps.existingSlices.indexOf(editSlice);
+          if (idx >= 0) sliceIconProps.onRemoveSliceAt(sliceIconProps.existingSliceIndices[idx]);
+        }
+      : undefined;
+
   const trigger = (
     <button
       type='button'
@@ -161,6 +176,7 @@ export function RowFilterIcon({
           initialRule: editFilter,
           existingRules: editFilter ? [] : activeRules,
           onRemoveExistingAt: onRemoveAt,
+          onDelete: deleteEditedFilter,
         }}
         sliceProps={{
           onApply: handleSliceApply,
@@ -169,6 +185,7 @@ export function RowFilterIcon({
           onRemoveExistingAt: localIdx => {
             sliceIconProps.onRemoveSliceAt(sliceIconProps.existingSliceIndices[localIdx]);
           },
+          onDelete: deleteEditedSlice,
         }}
         trigger={trigger}
       />
@@ -187,6 +204,7 @@ export function RowFilterIcon({
       initialRule={editFilter}
       existingRules={editFilter ? [] : activeRules}
       onRemoveExistingAt={onRemoveAt}
+      onDelete={deleteEditedFilter}
       trigger={trigger}
     />
   );

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/RowFilterIcon.tsx
@@ -101,6 +101,8 @@ export function RowFilterIcon({
     : undefined;
 
   // Delete affordances for single-item edit mode (no "Active …" list is shown there).
+  // Unlike apply, delete reads the live index: editFilter/editSlice is the original rule
+  // (still a member of the array), not a post-edit draft, so indexOf stays valid — no snapshot ref needed.
   const deleteEditedFilter = editFilter
     ? () => {
         const idx = activeRules.indexOf(editFilter);


### PR DESCRIPTION
## What & why

A set of small UX fixes for the report column picker (Fibery #6733). All front-end, scoped to
`apps/web/src/features/data-marts/edit/components/ReportColumnPicker/`.

- **Aggregations editor opens on the first invoke.** Picking a column from the "Add aggregation"
  picker set the pending column but left the editor popover closed, so it looked like nothing
  happened until a second click. The editor now opens immediately, and its **Apply button stays
  disabled until a function or bucket is chosen** — a brand-new column can no longer be silently
  discarded by an empty Apply (editing an existing selection keeps Apply enabled so clearing it
  removes the rule).
- **"Unique count" row font.** The auto-generated "Unique count" virtual row rendered in the
  default font while every native field row uses `font-mono`, so it was the lone sans-serif entry.
  It now matches the surrounding rows.
- **Clear the relative-date "Last N days/months" filter input with Backspace.** The value was stored
  as a number and empty input coerced to `0`, so Backspace could never empty the field. It now
  stores the raw text and validates on apply; an empty value is treated as invalid.
- **Delete a filter/slice from the editor popover.** Editing a single existing filter (or slice)
  offered only Cancel/Apply, so the only way to remove it was from the top Filters section. A trash
  button in the editor header (edit mode only) now deletes it directly.

## Testing

- `apps/web` ReportColumnPicker suite: 192/192 (Vitest), `tsc -b` clean.
- New tests: pending-column auto-open flow, Apply-gating, filter/slice delete wiring + list-mode
  absence guards, Last-N clear-to-empty.

## Notes

- The Google Sheets extension mirrors these changes in a separate PR (`OWOX/google-sheets-extension`).
- Known non-blocking follow-up (pre-existing, shared with `OutputSettingsDropdown`): keyboard focus
  is not restored when the auto-opened aggregation editor is dismissed — to be addressed together
  with that sibling.
