### PR TITLE
feat(http-data): stream aggregations and date buckets

### DIFF
--- a/.changeset/http-data-aggregations.md
+++ b/.changeset/http-data-aggregations.md
@@ -1,0 +1,13 @@
+---
+'owox': minor
+---
+
+# HTTP Data streaming supports aggregations and date buckets
+
+The HTTP Data streaming API, the [`@owox/api-client`](../docs/api/api-client.md) `traverseData()`
+method, and the [`owox-ctl data-marts stream`](../docs/api/owox-ctl.md) command now accept
+`aggregation` and `dateTrunc` parameters (`--aggregation` / `--date-bucket` on the CLI), matching
+the aggregation and date-bucket grouping already available for Reports. Any selected column without
+an aggregation rule becomes a grouping key, so you can stream pre-aggregated rows — for example
+monthly revenue totals — directly from a published Data Mart without building a Report. Grand
+totals and the applied aggregation are recorded in the HTTP_DATA run history.

--- a/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
@@ -19,7 +19,14 @@ export function StreamHttpDataSpec() {
         '`columns=**`; exact column names use repeated `column` parameters. Row objects ' +
         'use resolved column names as keys in the requested order. Omit both `columns` ' +
         'and `column`, or pass `columns=*`, for all native columns. Pass `columns=**` ' +
-        'for all native plus all reporting-visible blended columns. Authenticated ' +
+        'for all native plus all reporting-visible blended columns. When `aggregation` or ' +
+        '`dateTrunc` is used the row keys are the RESOLVED output labels — an aggregated ' +
+        'column becomes `"<column> | <TOKEN>"`, where `<TOKEN>` is an uppercase ' +
+        'spreadsheet-style token for the function (most match the function name, but ' +
+        '`COUNT_DISTINCT` becomes `COUNTUNIQUE`, `P50` becomes `MEDIAN`, `STRING_AGG` becomes ' +
+        '`STRINGAGG`, `ANY_VALUE` becomes `ANYVALUE`), and a synthetic `"Row Count"` column is ' +
+        'appended — and an explicit `column` projection is required (a wildcard selector ' +
+        'would group by every column). Authenticated ' +
         'with the ODM member token via `x-owox-authorization`. Creates one DataMartRun ' +
         'of type HTTP_DATA per request, available through the run history endpoint.',
     }),
@@ -83,6 +90,32 @@ export function StreamHttpDataSpec() {
       example: 'W3siY29sdW1uIjoiZGF0ZSIsImRpcmVjdGlvbiI6ImRlc2MifV0',
     }),
     ApiQuery({
+      name: 'aggregation',
+      description:
+        'Optional base64url-encoded JSON matching the `AggregationConfig` schema (same rule shape ' +
+        'as Reports: an array of `{ column, function }`). Any selected column without an ' +
+        'aggregation rule becomes a grouping key. Encode the JSON array with base64url ' +
+        '(URL-safe base64: `-`/`_` instead of `+`/`/`, no `=` padding). ' +
+        'Example JSON: `[{"column":"revenue","function":"SUM"}]` → ' +
+        'base64url `W3siY29sdW1uIjoicmV2ZW51ZSIsImZ1bmN0aW9uIjoiU1VNIn1d`.',
+      required: false,
+      type: String,
+      example: 'W3siY29sdW1uIjoicmV2ZW51ZSIsImZ1bmN0aW9uIjoiU1VNIn1d',
+    }),
+    ApiQuery({
+      name: 'dateTrunc',
+      description:
+        'Optional base64url-encoded JSON matching the `DateTruncConfig` schema (same rule shape ' +
+        'as Reports: an array of `{ column, unit, timeZone? }`), bucketing a date/timestamp ' +
+        'dimension by a calendar unit (DAY/WEEK/MONTH/QUARTER/YEAR). Encode the JSON array with ' +
+        'base64url (URL-safe base64: `-`/`_` instead of `+`/`/`, no `=` padding). ' +
+        'Example JSON: `[{"column":"date","unit":"MONTH"}]` → ' +
+        'base64url `W3siY29sdW1uIjoiZGF0ZSIsInVuaXQiOiJNT05USCJ9XQ`.',
+      required: false,
+      type: String,
+      example: 'W3siY29sdW1uIjoiZGF0ZSIsInVuaXQiOiJNT05USCJ9XQ',
+    }),
+    ApiQuery({
       name: 'limit',
       description: 'Optional row cap (positive integer).',
       required: false,
@@ -113,8 +146,10 @@ export function StreamHttpDataSpec() {
     ApiResponse({
       status: 400,
       description:
-        'Invalid request: unknown column, forbidden pagination parameter ' +
-        '(`pageToken`/`offset`), malformed filter/sort/limit, or unsupported storage type.',
+        'Invalid request: unknown column (including in an aggregation or dateTrunc rule), ' +
+        'forbidden pagination parameter (`pageToken`/`offset`), malformed ' +
+        'filter/sort/aggregation/dateTrunc/limit, aggregation or dateTrunc without an explicit ' +
+        '`column` projection, or unsupported storage type.',
     }),
     ApiResponse({ status: 401, description: 'Missing or invalid `x-owox-authorization` token.' }),
     ApiResponse({

--- a/apps/backend/src/data-marts/controllers/spec/external/http-data.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/spec/external/http-data.openapi.spec.ts
@@ -1,0 +1,77 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
+
+jest.mock('../../../../idp', () => ({
+  __esModule: true,
+  Auth: () => () => undefined,
+  AuthContext: () => () => undefined,
+  Role: {
+    viewer: jest.fn(),
+  },
+}));
+
+import { HttpDataController } from '../../external/http-data.controller';
+import { HttpDataMapper } from '../../../mappers/http-data.mapper';
+import { StreamHttpDataService } from '../../../use-cases/stream-http-data.service';
+
+describe('HttpDataController OpenAPI', () => {
+  let app: INestApplication;
+  let document: OpenAPIObject;
+
+  beforeAll(async () => {
+    const providers = [HttpDataMapper, StreamHttpDataService].map(provide => ({
+      provide,
+      useValue: {},
+    }));
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [HttpDataController],
+      providers,
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    document = SwaggerModule.createDocument(
+      app,
+      new DocumentBuilder().setTitle('Test API').setVersion('1.0').build()
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  function streamParameters(): Array<Record<string, any>> {
+    const path = Object.keys(document.paths).find(p => p.includes('http-data'));
+    expect(path).toBeDefined();
+    return (document.paths[path!]?.get?.parameters ?? []) as Array<Record<string, any>>;
+  }
+
+  function queryParam(name: string): Record<string, any> | undefined {
+    return streamParameters().find(p => p.name === name && p.in === 'query');
+  }
+
+  it('documents the aggregation query parameter as an optional base64url string', () => {
+    const aggregation = queryParam('aggregation');
+    expect(aggregation).toBeDefined();
+    expect(aggregation?.required).toBe(false);
+    expect(aggregation?.schema?.type).toBe('string');
+    expect(aggregation?.description).toMatch(/base64url/i);
+  });
+
+  it('documents the dateTrunc query parameter as an optional base64url string', () => {
+    const dateTrunc = queryParam('dateTrunc');
+    expect(dateTrunc).toBeDefined();
+    expect(dateTrunc?.required).toBe(false);
+    expect(dateTrunc?.schema?.type).toBe('string');
+    expect(dateTrunc?.description).toMatch(/base64url/i);
+  });
+
+  it('still documents the pre-existing filter and sort query parameters', () => {
+    expect(queryParam('filter')).toBeDefined();
+    expect(queryParam('sort')).toBeDefined();
+  });
+});

--- a/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.spec.ts
+++ b/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.spec.ts
@@ -1,0 +1,179 @@
+import { HTTP_DATA_MAX_ENCODED_PARAM_LENGTH, HttpDataQuerySchema } from './http-data-query.schema';
+
+function b64(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+function parse(rawQuery: Record<string, unknown>) {
+  const result = HttpDataQuerySchema.safeParse(rawQuery);
+  return result;
+}
+
+describe('HttpDataQuerySchema — aggregation', () => {
+  it('decodes a base64url-encoded aggregation config into the query', () => {
+    const aggregation = [
+      { column: 'revenue', function: 'SUM' },
+      { column: 'orders', function: 'COUNT_DISTINCT' },
+    ];
+    const result = parse({ column: 'revenue', aggregation: b64(aggregation) });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.aggregation).toEqual(aggregation);
+    }
+  });
+
+  it('leaves aggregation undefined when the parameter is absent', () => {
+    const result = parse({ column: 'date' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.aggregation).toBeUndefined();
+    }
+  });
+
+  it('rejects an aggregation parameter that is not valid base64url JSON', () => {
+    const result = parse({ column: 'revenue', aggregation: 'not-base64url-json' });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/^Invalid aggregation:/);
+    }
+  });
+
+  it('rejects an aggregation with an unknown function', () => {
+    const result = parse({
+      column: 'revenue',
+      aggregation: b64([{ column: 'revenue', function: 'NONSENSE' }]),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/^Invalid aggregation:/);
+    }
+  });
+});
+
+describe('HttpDataQuerySchema — dateTrunc', () => {
+  it('decodes a base64url-encoded date-trunc config into the query', () => {
+    const dateTrunc = [
+      { column: 'date', unit: 'MONTH' },
+      { column: 'created_at', unit: 'DAY', timeZone: 'America/New_York' },
+    ];
+    const result = parse({ column: 'date', dateTrunc: b64(dateTrunc) });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.dateTrunc).toEqual(dateTrunc);
+    }
+  });
+
+  it('leaves dateTrunc undefined when the parameter is absent', () => {
+    const result = parse({ column: 'date' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.dateTrunc).toBeUndefined();
+    }
+  });
+
+  it('rejects a date-trunc parameter that is not valid base64url JSON', () => {
+    const result = parse({ column: 'date', dateTrunc: 'not-base64url-json' });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/^Invalid dateTrunc:/);
+    }
+  });
+
+  it('rejects a date-trunc rule with an unknown unit', () => {
+    const result = parse({
+      column: 'date',
+      dateTrunc: b64([{ column: 'date', unit: 'FORTNIGHT' }]),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/^Invalid dateTrunc:/);
+    }
+  });
+
+  it('rejects a date-trunc rule with a malformed IANA time zone', () => {
+    const result = parse({
+      column: 'date',
+      dateTrunc: b64([{ column: 'date', unit: 'DAY', timeZone: "utc'; DROP TABLE" }]),
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/^Invalid dateTrunc:/);
+    }
+  });
+});
+
+describe('HttpDataQuerySchema — encoded parameter length cap', () => {
+  it('rejects an aggregation parameter longer than the max encoded length', () => {
+    const tooLong = 'A'.repeat(HTTP_DATA_MAX_ENCODED_PARAM_LENGTH + 1);
+    const result = parse({ column: 'revenue', aggregation: tooLong });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a dateTrunc parameter longer than the max encoded length', () => {
+    const tooLong = 'A'.repeat(HTTP_DATA_MAX_ENCODED_PARAM_LENGTH + 1);
+    const result = parse({ column: 'date', dateTrunc: tooLong });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a parameter exactly at the max encoded length (rejected only for content, not size)', () => {
+    // A cap-length string is NOT rejected by the size guard; it fails later only because it is not
+    // valid encoded JSON — proving the boundary is inclusive.
+    const atCap = 'A'.repeat(HTTP_DATA_MAX_ENCODED_PARAM_LENGTH);
+    const result = parse({ column: 'revenue', aggregation: atCap });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/^Invalid aggregation:/);
+    }
+  });
+});
+
+describe('HttpDataQuerySchema — aggregation/dateTrunc require an explicit projection', () => {
+  it('rejects an aggregation with no column selection (would group by every column)', () => {
+    const result = parse({ aggregation: b64([{ column: 'revenue', function: 'SUM' }]) });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const guard = result.error.issues.find(i => /explicit "column"/.test(i.message));
+      expect(guard?.path).toEqual(['aggregation']);
+    }
+  });
+
+  it('rejects an aggregation combined with the columns=* wildcard', () => {
+    const result = parse({
+      columns: '*',
+      column: 'revenue',
+      aggregation: b64([{ column: 'revenue', function: 'SUM' }]),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a date-trunc combined with columns=** and points the issue at dateTrunc', () => {
+    const result = parse({ columns: '**', dateTrunc: b64([{ column: 'date', unit: 'MONTH' }]) });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const guard = result.error.issues.find(i => /explicit "column"/.test(i.message));
+      expect(guard?.path).toEqual(['dateTrunc']);
+    }
+  });
+
+  it('accepts an aggregation with explicit column values', () => {
+    const result = parse({
+      column: ['date', 'revenue'],
+      aggregation: b64([{ column: 'revenue', function: 'SUM' }]),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a plain (unaggregated) request with the columns=* wildcard', () => {
+    const result = parse({ columns: '*' });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { FilterConfigSchema } from './filter-config.schema';
 import { SortConfigSchema } from './sort-config.schema';
+import { AggregationConfigSchema } from './aggregation-config.schema';
+import { DateTruncConfigSchema } from './date-trunc-config.schema';
 
 export const HTTP_DATA_MAX_ENCODED_PARAM_LENGTH = 8192;
 
@@ -43,57 +45,41 @@ function decodeBase64UrlJson(raw: string): unknown {
   }
 }
 
-const FilterParamSchema = z
-  .string()
-  .min(1)
-  .max(HTTP_DATA_MAX_ENCODED_PARAM_LENGTH)
-  .transform((raw, ctx) => {
-    let parsed: unknown;
-    try {
-      parsed = decodeBase64UrlJson(raw);
-    } catch (err) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Invalid filter: ${(err as Error).message}`,
-      });
-      return z.NEVER;
-    }
-    const result = FilterConfigSchema.safeParse(parsed);
-    if (!result.success) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Invalid filter: ${result.error.issues.map(i => i.message).join('; ')}`,
-      });
-      return z.NEVER;
-    }
-    return result.data;
-  });
+// Each output-control param carries a base64url-encoded JSON config (same rule shapes as
+// Reports). One factory keeps the decode → validate → issue flow — and the `Invalid <label>:`
+// error prefix — identical across filter/sort/aggregation/dateTrunc so they cannot drift.
+function makeEncodedConfigParam<T extends z.ZodTypeAny>(configSchema: T, label: string) {
+  return z
+    .string()
+    .min(1)
+    .max(HTTP_DATA_MAX_ENCODED_PARAM_LENGTH)
+    .transform((raw, ctx) => {
+      let parsed: unknown;
+      try {
+        parsed = decodeBase64UrlJson(raw);
+      } catch (err) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Invalid ${label}: ${(err as Error).message}`,
+        });
+        return z.NEVER;
+      }
+      const result = configSchema.safeParse(parsed);
+      if (!result.success) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Invalid ${label}: ${result.error.issues.map(i => i.message).join('; ')}`,
+        });
+        return z.NEVER;
+      }
+      return result.data;
+    });
+}
 
-const SortParamSchema = z
-  .string()
-  .min(1)
-  .max(HTTP_DATA_MAX_ENCODED_PARAM_LENGTH)
-  .transform((raw, ctx) => {
-    let parsed: unknown;
-    try {
-      parsed = decodeBase64UrlJson(raw);
-    } catch (err) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Invalid sort: ${(err as Error).message}`,
-      });
-      return z.NEVER;
-    }
-    const result = SortConfigSchema.safeParse(parsed);
-    if (!result.success) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Invalid sort: ${result.error.issues.map(i => i.message).join('; ')}`,
-      });
-      return z.NEVER;
-    }
-    return result.data;
-  });
+const FilterParamSchema = makeEncodedConfigParam(FilterConfigSchema, 'filter');
+const SortParamSchema = makeEncodedConfigParam(SortConfigSchema, 'sort');
+const AggregationParamSchema = makeEncodedConfigParam(AggregationConfigSchema, 'aggregation');
+const DateTruncParamSchema = makeEncodedConfigParam(DateTruncConfigSchema, 'dateTrunc');
 
 const LimitParamSchema = z.coerce
   .number({ invalid_type_error: 'limit must be an integer' })
@@ -141,6 +127,8 @@ export const HttpDataQuerySchema = z
     column: ExactColumnParamSchema,
     filter: FilterParamSchema.optional(),
     sort: SortParamSchema.optional(),
+    aggregation: AggregationParamSchema.optional(),
+    dateTrunc: DateTruncParamSchema.optional(),
     limit: LimitParamSchema.optional(),
   })
   .passthrough()
@@ -161,11 +149,31 @@ export const HttpDataQuerySchema = z
         message: `"${ALL_BLENDABLE_COLUMNS}" cannot be combined with exact column values`,
       });
     }
+    // Grouping (aggregation or date bucket) demands an explicit column projection, mirroring the
+    // Report rule AGGREGATION_REQUIRES_COLUMN_CONFIG. A wildcard/all-columns selection makes every
+    // unaggregated column a grouping key, so `SUM` over a wide mart degenerates to per-row groups
+    // (Row Count 1) and can blow up query cost — a footgun unique to the HTTP path. A grand total
+    // is still reachable by selecting ONLY the aggregated column (no grouping keys → one row).
+    const hasAggregation = (value.aggregation?.length ?? 0) > 0;
+    const hasGrouping = hasAggregation || (value.dateTrunc?.length ?? 0) > 0;
+    const hasExplicitColumns = value.columns === undefined && value.column.length > 0;
+    if (hasGrouping && !hasExplicitColumns) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [hasAggregation ? 'aggregation' : 'dateTrunc'],
+        message:
+          '"aggregation" and "dateTrunc" require an explicit "column" projection and cannot ' +
+          `combine with "${ALL_NATIVE_COLUMNS}"/"${ALL_BLENDABLE_COLUMNS}" or an empty column ` +
+          'selection (which would group by every column)',
+      });
+    }
   })
   .transform(value => ({
     columnSelector: toColumnSelector(value.columns, value.column),
     filter: value.filter,
     sort: value.sort,
+    aggregation: value.aggregation,
+    dateTrunc: value.dateTrunc,
     limit: value.limit,
   }));
 

--- a/apps/backend/src/data-marts/dto/schemas/http-data-run-metadata.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/http-data-run-metadata.schema.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { FilterConfigSchema } from './filter-config.schema';
 import { SortConfigSchema } from './sort-config.schema';
+import { AggregationConfigSchema } from './aggregation-config.schema';
+import { DateTruncConfigSchema } from './date-trunc-config.schema';
 
 export const HTTP_DATA_FORMAT = 'ndjson' as const;
 
@@ -16,6 +18,8 @@ export const HttpDataRunMetadataSchema = z.object({
   columns: z.array(z.string()),
   filter: FilterConfigSchema.optional(),
   sort: SortConfigSchema.optional(),
+  aggregation: AggregationConfigSchema.optional(),
+  dateTrunc: DateTruncConfigSchema.optional(),
   limit: z.number().int().positive().optional(),
   dataDescription: z.object({ dataHeaders: z.array(DataHeaderSchema) }).optional(),
   rowCount: z.number().int().nonnegative().optional(),

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-validator.service.spec.ts
@@ -43,6 +43,41 @@ describe('HttpDataColumnValidator', () => {
     ).toThrow(BusinessViolationException);
   });
 
+  it('validates aggregation columns for existence', () => {
+    expect(() =>
+      validator.validate(
+        {
+          selectedColumns: ['date', 'revenue'],
+          aggregation: [{ column: 'revenue', function: 'SUM' }],
+        },
+        columns
+      )
+    ).not.toThrow();
+
+    expect(() =>
+      validator.validate(
+        { selectedColumns: ['date'], aggregation: [{ column: 'ghost', function: 'SUM' }] },
+        columns
+      )
+    ).toThrow(BusinessViolationException);
+  });
+
+  it('validates date-trunc columns for existence', () => {
+    expect(() =>
+      validator.validate(
+        { selectedColumns: ['date'], dateTrunc: [{ column: 'date', unit: 'MONTH' }] },
+        columns
+      )
+    ).not.toThrow();
+
+    expect(() =>
+      validator.validate(
+        { selectedColumns: ['date'], dateTrunc: [{ column: 'ghost', unit: 'MONTH' }] },
+        columns
+      )
+    ).toThrow(BusinessViolationException);
+  });
+
   it('ignores pre-join filter columns (resolved by aliasPath downstream, not by name here)', () => {
     expect(() =>
       validator.validate(

--- a/apps/backend/src/data-marts/services/http-data/http-data-column-validator.service.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-column-validator.service.ts
@@ -2,12 +2,16 @@ import { Injectable } from '@nestjs/common';
 import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
 import { FilterConfig } from '../../dto/schemas/filter-config.schema';
 import { SortConfig } from '../../dto/schemas/sort-config.schema';
+import { AggregationConfig } from '../../dto/schemas/aggregation-config.schema';
+import { DateTruncConfig } from '../../dto/schemas/date-trunc-config.schema';
 import { ReportingColumns } from './http-data-column-sets.util';
 
 export interface HttpDataColumnValidationInput {
   selectedColumns: string[];
   filter?: FilterConfig;
   sort?: SortConfig;
+  aggregation?: AggregationConfig;
+  dateTrunc?: DateTruncConfig;
 }
 
 @Injectable()
@@ -35,6 +39,12 @@ export class HttpDataColumnValidator {
       }
     }
     for (const rule of input.sort ?? []) {
+      referenced.add(rule.column);
+    }
+    for (const rule of input.aggregation ?? []) {
+      referenced.add(rule.column);
+    }
+    for (const rule of input.dateTrunc ?? []) {
       referenced.add(rule.column);
     }
     return referenced;

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.spec.ts
@@ -653,6 +653,8 @@ describe('StreamHttpDataService', () => {
       columnSelector: { mode: 'explicit' as const, explicit: ['date', 'revenue'] },
       filter: undefined,
       sort: undefined,
+      aggregation: undefined,
+      dateTrunc: undefined,
       limit: 5,
     });
     await service.stream(fakeCommand(), mockResponse());
@@ -695,6 +697,171 @@ describe('StreamHttpDataService', () => {
     );
   });
 
+  it('composes SQL when only an aggregation is requested (no filter/sort/limit)', async () => {
+    const aggregation = [{ column: 'revenue', function: 'SUM' }];
+    requestValidator.validate.mockReturnValueOnce({
+      columnSelector: { mode: 'explicit', explicit: ['date', 'revenue'] },
+      filter: undefined,
+      sort: undefined,
+      aggregation,
+      dateTrunc: undefined,
+      limit: undefined,
+    } as never);
+
+    await service.stream(fakeCommand(), mockResponse());
+
+    expect(sqlComposer.compose).toHaveBeenCalledWith(
+      expect.objectContaining({ aggregationConfig: aggregation }),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('composes SQL when only a date bucket is requested (no filter/sort/limit)', async () => {
+    const dateTrunc = [{ column: 'date', unit: 'MONTH' }];
+    requestValidator.validate.mockReturnValueOnce({
+      columnSelector: { mode: 'explicit', explicit: ['date', 'revenue'] },
+      filter: undefined,
+      sort: undefined,
+      aggregation: undefined,
+      dateTrunc,
+      limit: undefined,
+    } as never);
+
+    await service.stream(fakeCommand(), mockResponse());
+
+    expect(sqlComposer.compose).toHaveBeenCalledWith(
+      expect.objectContaining({ dateTruncConfig: dateTrunc }),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('passes aggregation and date-trunc columns to the column validator', async () => {
+    const aggregation = [{ column: 'revenue', function: 'SUM' }];
+    const dateTrunc = [{ column: 'date', unit: 'MONTH' }];
+    requestValidator.validate.mockReturnValueOnce({
+      columnSelector: { mode: 'explicit', explicit: ['date', 'revenue'] },
+      filter: undefined,
+      sort: undefined,
+      aggregation,
+      dateTrunc,
+      limit: undefined,
+    } as never);
+
+    await service.stream(fakeCommand(), mockResponse());
+
+    expect(columnValidator.validate).toHaveBeenCalledWith(
+      expect.objectContaining({ aggregation, dateTrunc }),
+      expect.anything()
+    );
+  });
+
+  it('records decoded aggregation/dateTrunc in the run metadata', async () => {
+    const aggregation = [{ column: 'revenue', function: 'SUM' }];
+    const dateTrunc = [{ column: 'date', unit: 'MONTH' }];
+    requestValidator.validate.mockReturnValueOnce({
+      columnSelector: { mode: 'explicit', explicit: ['date'] },
+      filter: undefined,
+      sort: undefined,
+      aggregation,
+      dateTrunc,
+      limit: undefined,
+    } as never);
+
+    await service.stream(fakeCommand(), mockResponse());
+
+    expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: DataMartRunStatus.SUCCESS,
+        metadata: expect.objectContaining({ aggregation, dateTrunc }),
+      })
+    );
+  });
+
+  it('streams the aggregated (renamed) headers and Row Count, not the raw requested columns', async () => {
+    // The reader renames an aggregated column's header to its "<column> | <FN>" output label and
+    // appends Row Count (see resolveReportDataHeaders). The stream must project rows by those
+    // resolved header names, else the aggregated metric is emitted as null and Row Count is dropped.
+    const aggregation = [{ column: 'revenue', function: 'SUM' }];
+    requestValidator.validate.mockReturnValueOnce({
+      columnSelector: { mode: 'explicit', explicit: ['date', 'revenue'] },
+      filter: undefined,
+      sort: undefined,
+      aggregation,
+      dateTrunc: undefined,
+      limit: undefined,
+    } as never);
+    reader.prepareReportData.mockResolvedValueOnce(
+      new ReportDataDescription([
+        new ReportDataHeader('date'),
+        new ReportDataHeader('revenue | SUM'),
+        new ReportDataHeader('Row Count'),
+      ])
+    );
+    reader.readReportDataBatch.mockResolvedValueOnce(
+      new ReportDataBatch([['2026-05-01', 93, 2]], null)
+    );
+    const res = mockResponse();
+
+    await service.stream(fakeCommand(), res);
+
+    expect(res._writes).toEqual(['{"date":"2026-05-01","revenue | SUM":93,"Row Count":2}\n']);
+  });
+
+  it('streams a date-bucket-only request by the requested column names (headers are not renamed)', async () => {
+    // date-trunc keeps its output alias equal to the column name (DATE_TRUNC(...) AS date), so the
+    // resolved headers still match the requested columns → requested-column projection is correct.
+    const dateTrunc = [{ column: 'date', unit: 'MONTH' }];
+    requestValidator.validate.mockReturnValueOnce({
+      columnSelector: { mode: 'explicit', explicit: ['date', 'revenue'] },
+      filter: undefined,
+      sort: undefined,
+      aggregation: undefined,
+      dateTrunc,
+      limit: undefined,
+    } as never);
+    reader.prepareReportData.mockResolvedValueOnce(
+      new ReportDataDescription([new ReportDataHeader('date'), new ReportDataHeader('revenue')])
+    );
+    reader.readReportDataBatch.mockResolvedValueOnce(
+      new ReportDataBatch([['2026-05-01', 42]], null)
+    );
+    const res = mockResponse();
+
+    await service.stream(fakeCommand(), res);
+
+    expect(res._writes).toEqual(['{"date":"2026-05-01","revenue":42}\n']);
+  });
+
+  it('streams aggregation + date-bucket by the resolved (renamed) header names', async () => {
+    const aggregation = [{ column: 'revenue', function: 'SUM' }];
+    const dateTrunc = [{ column: 'date', unit: 'MONTH' }];
+    requestValidator.validate.mockReturnValueOnce({
+      columnSelector: { mode: 'explicit', explicit: ['date', 'revenue'] },
+      filter: undefined,
+      sort: undefined,
+      aggregation,
+      dateTrunc,
+      limit: undefined,
+    } as never);
+    reader.prepareReportData.mockResolvedValueOnce(
+      new ReportDataDescription([
+        new ReportDataHeader('date'),
+        new ReportDataHeader('revenue | SUM'),
+        new ReportDataHeader('Row Count'),
+      ])
+    );
+    reader.readReportDataBatch.mockResolvedValueOnce(
+      new ReportDataBatch([['2026-01-01', 300, 3]], null)
+    );
+    const res = mockResponse();
+
+    await service.stream(fakeCommand(), res);
+
+    expect(res._writes).toEqual(['{"date":"2026-01-01","revenue | SUM":300,"Row Count":3}\n']);
+  });
+
   it('rejects via the read/abort race when the client disconnects during a pending first batch read', async () => {
     reader.readReportDataBatch.mockImplementationOnce(() => new Promise<never>(() => {}));
     const res = mockResponse();
@@ -718,6 +885,8 @@ describe('StreamHttpDataService', () => {
       columnSelector: { mode: 'allBlendable' as const },
       filter: undefined,
       sort: undefined,
+      aggregation: undefined,
+      dateTrunc: undefined,
       limit: undefined,
     });
     columnResolver.resolve.mockReturnValueOnce(['date', 'revenue', 'orders__cost']);
@@ -749,6 +918,8 @@ describe('StreamHttpDataService', () => {
       columnSelector: { mode: 'allBlendable' as const },
       filter: undefined,
       sort: undefined,
+      aggregation: undefined,
+      dateTrunc: undefined,
       limit: undefined,
     });
     blendableSchema.computeBlendableSchema.mockResolvedValueOnce({

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
@@ -19,7 +19,7 @@ import {
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { DataStorageErrorMapper } from '../data-storage-types/interfaces/data-storage-error-mapper.interface';
 import { DataStorageReportReader } from '../data-storage-types/interfaces/data-storage-report-reader.interface';
-import { ReportLikeReadPlan } from '../dto/domain/report-like-read-plan';
+import { ReportLikeReadPlan, hasOutputControls } from '../dto/domain/report-like-read-plan';
 import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
 import { StreamHttpDataCommand } from '../dto/domain/stream-http-data.command';
 import { DataMart } from '../entities/data-mart.entity';
@@ -128,7 +128,13 @@ export class StreamHttpDataService {
       };
       const columns = this.columnResolver.resolve(query.columnSelector, reportingColumns);
       this.columnValidator.validate(
-        { selectedColumns: columns, filter: query.filter, sort: query.sort },
+        {
+          selectedColumns: columns,
+          filter: query.filter,
+          sort: query.sort,
+          aggregation: query.aggregation,
+          dateTrunc: query.dateTrunc,
+        },
         reportingColumns
       );
       await this.projectBalanceService.verifyCanPerformOperations(dataMart.projectId);
@@ -138,6 +144,8 @@ export class StreamHttpDataService {
         columnConfig: columns,
         filterConfig: query.filter,
         sortConfig: query.sort,
+        aggregationConfig: query.aggregation,
+        dateTruncConfig: query.dateTrunc,
         limitConfig: limit ?? null,
       };
 
@@ -152,9 +160,7 @@ export class StreamHttpDataService {
 
       let sqlOverride: string | undefined = decision.blendedSql;
       let sqlOverrideParams = decision.params;
-      const hasOutputControls =
-        (query.filter?.length ?? 0) > 0 || (query.sort?.length ?? 0) > 0 || limit != null;
-      if (!decision.needsBlending && hasOutputControls) {
+      if (!decision.needsBlending && hasOutputControls(readPlan)) {
         const composed = await this.reportSqlComposerService.compose(readPlan, accessor, decision);
         sqlOverride = composed.sql;
         sqlOverrideParams = composed.params;
@@ -165,6 +171,8 @@ export class StreamHttpDataService {
         columns,
         filter: query.filter,
         sort: query.sort,
+        aggregation: query.aggregation,
+        dateTrunc: query.dateTrunc,
         limit,
       };
 
@@ -182,11 +190,22 @@ export class StreamHttpDataService {
       // once the first chunk is flushed. BEST-EFFORT — a failure must never break the stream.
       const totals = await this.computeTotalsBestEffort(readPlan, accessor, dataMart);
 
+      // An aggregation renames each aggregated column's header to its "<column> | <FN>" output
+      // label and appends Row Count, so the resolved headers no longer match the raw requested
+      // column names. Project by the resolved header names in that case (mirroring the report
+      // reader / query_data_mart), else the aggregated metric would stream as null and Row Count
+      // would be dropped. A plain or date-bucketed-only request keeps the requested-column
+      // projection (its headers are unchanged), preserving the "requested names as keys" contract.
+      const outputColumns =
+        (readPlan.aggregationConfig?.length ?? 0) > 0
+          ? description.dataHeaders.map(header => header.name)
+          : columns;
+
       const { rowCount, bytesWritten } = await this.streamRows(
         res,
         reader,
         description.dataHeaders,
-        columns,
+        outputColumns,
         runId
       );
 

--- a/apps/backend/test/http-data.e2e-spec.ts
+++ b/apps/backend/test/http-data.e2e-spec.ts
@@ -26,6 +26,8 @@ interface HttpRunView {
       columns?: string[];
       filter?: Array<{ column: string; operator: string; value: string }>;
       sort?: Array<{ column: string; direction: string }>;
+      aggregation?: Array<{ column: string; function: string }>;
+      dateTrunc?: Array<{ column: string; unit: string; timeZone?: string }>;
       limit?: number;
       completed?: boolean;
       rowCount?: number;
@@ -50,14 +52,36 @@ const MOCK_ROWS: unknown[][] = [
 // Reset to null before each output-controls happy-path test.
 let capturedPrepareOptions: Record<string, unknown> | null = null;
 
+// Aggregated result the mock reader returns when a request carries an aggregation: [dimension,
+// metric, Row Count] positional row, matching the [date, "revenue | SUM", "Row Count"] header set.
+const MOCK_AGGREGATED_ROWS: unknown[][] = [['2026-05-01', 999, MOCK_ROWS.length]];
+
 function buildMockReader(headers: ReportDataHeader[], rows: unknown[][]): DataStorageReportReader {
+  // Simulate the real reader's aggregated-header resolution: an aggregation renames each aggregated
+  // column to "<column> | <FN>" and appends Row Count (see resolveReportDataHeaders), so the stream
+  // must project rows by those resolved names, not the raw requested columns.
+  let aggregated = false;
   return {
     type: DataStorageType.GOOGLE_BIGQUERY,
     prepareReportData: jest.fn(async (_plan: unknown, options: unknown) => {
       capturedPrepareOptions = options as Record<string, unknown>;
-      return new ReportDataDescription(headers, rows.length);
+      const aggregations =
+        (options as { aggregationConfig?: Array<{ column: string; function: string }> })
+          ?.aggregationConfig ?? [];
+      aggregated = aggregations.length > 0;
+      if (!aggregated) return new ReportDataDescription(headers, rows.length);
+      const renamed = headers.map(header => {
+        const fn = aggregations.find(a => a.column === header.name)?.function;
+        return fn ? new ReportDataHeader(`${header.name} | ${fn}`) : header;
+      });
+      return new ReportDataDescription(
+        [...renamed, new ReportDataHeader('Row Count')],
+        MOCK_AGGREGATED_ROWS.length
+      );
     }),
-    readReportDataBatch: jest.fn(async () => new ReportDataBatch(rows, null)),
+    readReportDataBatch: jest.fn(
+      async () => new ReportDataBatch(aggregated ? MOCK_AGGREGATED_ROWS : rows, null)
+    ),
     finalize: jest.fn(async () => undefined),
     getState: jest.fn(() => null),
     initFromState: jest.fn(async () => undefined),
@@ -73,10 +97,11 @@ function buildMockResolver(reader: DataStorageReportReader) {
 function buildMockBlendableSchema() {
   return {
     computeBlendableSchema: jest.fn(async () => ({
-      // Include field types so OutputControlsValidatorService can validate
-      // filter operators against column types (e.g. 'eq' is valid for STRING).
+      // Include field types so OutputControlsValidatorService can validate operators and
+      // date-trunc against column types: `date` is a DATE (so date buckets are valid, and `eq`
+      // is still accepted for it), `revenue` is NUMERIC (so `SUM` is valid).
       nativeFields: [
-        { name: 'date', type: 'STRING' },
+        { name: 'date', type: 'DATE' },
         { name: 'revenue', type: 'NUMERIC' },
       ],
       blendedFields: [],
@@ -190,6 +215,39 @@ describe('HTTP Data API (e2e)', () => {
     it('returns 400 for unknown column', async () => {
       const res = await agent
         .get(`/api/external/http-data/data-marts/${dataMartId}.ndjson?column=ghost`)
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for an unknown column in an aggregation rule', async () => {
+      const b64 = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url');
+      const aggregation = b64([{ column: 'ghost', function: 'SUM' }]);
+      const res = await agent
+        .get(
+          `/api/external/http-data/data-marts/${dataMartId}.ndjson?column=date&column=revenue&aggregation=${aggregation}`
+        )
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for an unknown column in a date-trunc rule', async () => {
+      const b64 = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url');
+      const dateTrunc = b64([{ column: 'ghost', unit: 'MONTH' }]);
+      const res = await agent
+        .get(
+          `/api/external/http-data/data-marts/${dataMartId}.ndjson?column=date&dateTrunc=${dateTrunc}`
+        )
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when an aggregation is combined with a wildcard column selector', async () => {
+      const b64 = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url');
+      const aggregation = b64([{ column: 'revenue', function: 'SUM' }]);
+      const res = await agent
+        .get(
+          `/api/external/http-data/data-marts/${dataMartId}.ndjson?columns=*&aggregation=${aggregation}`
+        )
         .set(AUTH_HEADER);
       expect(res.status).toBe(400);
     });
@@ -381,6 +439,70 @@ describe('HTTP Data API (e2e)', () => {
       expect(httpData?.filter).toEqual(filter);
       expect(httpData?.sort).toEqual(sort);
       expect(httpData?.limit).toBe(5);
+      expect(httpData?.completed).toBe(true);
+    });
+
+    it('groups by an aggregation and records it in the persisted HTTP_DATA run metadata', async () => {
+      const b64 = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url');
+      const aggregation = [{ column: 'revenue', function: 'SUM' }];
+      const aggregationParam = b64(aggregation);
+
+      const before = await agent.get(`/api/data-marts/${dataMartId}/runs`).set(AUTH_HEADER);
+      const beforeHttpRuns = ((before.body?.runs ?? []) as Array<{ type: string }>).filter(
+        r => r.type === 'HTTP_DATA'
+      ).length;
+
+      const res = await agent
+        .get(
+          `/api/external/http-data/data-marts/${dataMartId}.ndjson?column=date&column=revenue&aggregation=${aggregationParam}`
+        )
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(200);
+      // The streamed rows carry the resolved aggregated header name and Row Count — the requested
+      // `revenue` column is NOT emitted as a bare (null) key.
+      expect(parseNdjson(res.text)).toEqual([
+        { date: '2026-05-01', 'revenue | SUM': 999, 'Row Count': MOCK_ROWS.length },
+      ]);
+
+      const after = await agent.get(`/api/data-marts/${dataMartId}/runs`).set(AUTH_HEADER);
+      const httpRuns: HttpRunView[] = (after.body?.runs ?? []).filter(
+        (r: HttpRunView) => r.type === 'HTTP_DATA'
+      );
+      expect(httpRuns.length).toBe(beforeHttpRuns + 1);
+
+      const newest = httpRuns[0];
+      const httpData = newest.additionalParams?.httpData;
+      expect(httpData?.aggregation).toEqual(aggregation);
+      expect(httpData?.completed).toBe(true);
+    });
+
+    it('records aggregation + date bucket in the persisted HTTP_DATA run metadata', async () => {
+      const b64 = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url');
+      const aggregation = [{ column: 'revenue', function: 'SUM' }];
+      const dateTrunc = [{ column: 'date', unit: 'MONTH' }];
+
+      const before = await agent.get(`/api/data-marts/${dataMartId}/runs`).set(AUTH_HEADER);
+      const beforeHttpRuns = ((before.body?.runs ?? []) as Array<{ type: string }>).filter(
+        r => r.type === 'HTTP_DATA'
+      ).length;
+
+      const res = await agent
+        .get(
+          `/api/external/http-data/data-marts/${dataMartId}.ndjson?column=date&column=revenue` +
+            `&aggregation=${b64(aggregation)}&dateTrunc=${b64(dateTrunc)}`
+        )
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(200);
+
+      const after = await agent.get(`/api/data-marts/${dataMartId}/runs`).set(AUTH_HEADER);
+      const httpRuns: HttpRunView[] = (after.body?.runs ?? []).filter(
+        (r: HttpRunView) => r.type === 'HTTP_DATA'
+      );
+      expect(httpRuns.length).toBe(beforeHttpRuns + 1);
+
+      const httpData = httpRuns[0].additionalParams?.httpData;
+      expect(httpData?.aggregation).toEqual(aggregation);
+      expect(httpData?.dateTrunc).toEqual(dateTrunc);
       expect(httpData?.completed).toBe(true);
     });
 

--- a/apps/ctl/src/commands/data-marts/stream.test.ts
+++ b/apps/ctl/src/commands/data-marts/stream.test.ts
@@ -82,4 +82,33 @@ describe('data-marts stream', () => {
       '--sort must be valid JSON'
     );
   });
+
+  it('parses aggregation and date-bucket flags as JSON arrays for traversal options', () => {
+    expect(
+      buildTraverseDataOptions({
+        columns: '*',
+        column: ['revenue'],
+        aggregation: '[{"column":"revenue","function":"SUM"}]',
+        'date-bucket': '[{"column":"date","unit":"MONTH"}]',
+        limit: 1000,
+      })
+    ).toEqual({
+      columns: '*',
+      column: ['revenue'],
+      filter: undefined,
+      sort: undefined,
+      aggregation: [{ column: 'revenue', function: 'SUM' }],
+      dateTrunc: [{ column: 'date', unit: 'MONTH' }],
+      limit: 1000,
+    });
+  });
+
+  it('rejects malformed aggregation and date-bucket JSON flags before opening the stream', () => {
+    expect(() => buildTraverseDataOptions({ aggregation: '{"column":"revenue"}' })).toThrow(
+      '--aggregation must be a JSON array'
+    );
+    expect(() => buildTraverseDataOptions({ 'date-bucket': 'not-json' })).toThrow(
+      '--date-bucket must be valid JSON'
+    );
+  });
 });

--- a/apps/ctl/src/commands/data-marts/stream.ts
+++ b/apps/ctl/src/commands/data-marts/stream.ts
@@ -20,12 +20,14 @@ type DataMartsStreamFlags = {
   column?: string[];
   filter?: string;
   sort?: string;
+  aggregation?: string;
+  'date-bucket'?: string;
   limit?: number;
 };
 
 function parseJsonArrayFlag(
   value: string | undefined,
-  flagName: '--filter' | '--sort'
+  flagName: '--filter' | '--sort' | '--aggregation' | '--date-bucket'
 ): unknown[] | undefined {
   if (value === undefined) {
     return undefined;
@@ -51,6 +53,8 @@ export function buildTraverseDataOptions(flags: DataMartsStreamFlags): TraverseD
     column: flags.column,
     filter: parseJsonArrayFlag(flags.filter, '--filter'),
     sort: parseJsonArrayFlag(flags.sort, '--sort'),
+    aggregation: parseJsonArrayFlag(flags.aggregation, '--aggregation'),
+    dateTrunc: parseJsonArrayFlag(flags['date-bucket'], '--date-bucket'),
     limit: flags.limit,
   };
 }
@@ -104,6 +108,14 @@ export default class DataMartsStream extends BaseCommand {
     }),
     sort: Flags.string({
       description: 'Sort config as a JSON array',
+    }),
+    aggregation: Flags.string({
+      description:
+        'Aggregation config as a JSON array of {column, function}. Any selected column without a rule becomes a grouping key.',
+    }),
+    'date-bucket': Flags.string({
+      description:
+        'Date-bucket config as a JSON array of {column, unit, timeZone?}, truncating a date/timestamp dimension by DAY/WEEK/MONTH/QUARTER/YEAR.',
     }),
   };
 

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -66,6 +66,8 @@ const data = await client.dataMarts.traverseData('dm_123', {
   column: ['Revenue: net = USD'],
   filter: [{ column: 'Event Date (local)', operator: 'gte', value: '2026-01-01' }],
   sort: [{ column: 'Event Date (local)', direction: 'asc' }],
+  aggregation: [{ column: 'Revenue: net = USD', function: 'SUM' }],
+  dateTrunc: [{ column: 'Event Date (local)', unit: 'MONTH' }],
   limit: 1000,
 });
 
@@ -88,6 +90,8 @@ Column selection uses two separate fields:
 Do not pass comma-separated column lists. Column names are opaque strings and may contain commas, equals signs, spaces, quotes, or other symbols.
 
 Use `filter` and `sort` arrays with the same rule shapes as report output controls. For normal filters on the streamed output, omit `placement` or use `placement: 'post-join'`. Use `placement: 'pre-join'` with `aliasPath` only when filtering a joined source before it is joined into the result.
+
+Use `aggregation` and `dateTrunc` arrays to group the streamed rows, with the same rule shapes as report output controls. `aggregation` takes `{ column, function }` rules; `function` is any report aggregate function — `SUM`, `AVG`, `MIN`, `MAX`, `COUNT`, `COUNT_DISTINCT`, `STRING_AGG`, `ANY_VALUE`, or a percentile (`P25`, `P50`, `P75`, `P95`). `dateTrunc` takes `{ column, unit, timeZone? }` rules that bucket a date/timestamp dimension by `DAY`, `WEEK`, `MONTH`, `QUARTER`, or `YEAR`. Any selected column without an aggregation rule becomes a grouping key. Aggregation and `dateTrunc` require an explicit `column` list — they cannot combine with `columns: '*'` or `columns: '**'` (a wildcard would group by every column). The streamed row keys are the resolved labels: an aggregated column becomes `"<column> | <TOKEN>"` (plus a `"Row Count"` column), where `<TOKEN>` is an uppercase spreadsheet-style token — most match the function name, but `COUNT_DISTINCT` becomes `COUNTUNIQUE`, `P50` becomes `MEDIAN`, `STRING_AGG` becomes `STRINGAGG`, and `ANY_VALUE` becomes `ANYVALUE`.
 
 ## List storages
 

--- a/docs/api/owox-ctl.md
+++ b/docs/api/owox-ctl.md
@@ -145,6 +145,11 @@ owox-ctl data-marts stream dm_123 \
   --columns '**' \
   --filter '[{"placement":"pre-join","aliasPath":"users","column":"country","operator":"eq","value":"US"}]' \
   --limit 1000
+owox-ctl data-marts stream dm_123 \
+  --column 'date' \
+  --column 'revenue' \
+  --date-bucket '[{"column":"date","unit":"MONTH"}]' \
+  --aggregation '[{"column":"revenue","function":"SUM"}]'
 ```
 
 Use `--columns '*'` or `--columns '**'` for column-set selectors. Quote `*` and `**` so your shell does not expand them.
@@ -158,6 +163,10 @@ Use `--filter` and `--sort` with JSON arrays. Column names inside filter and sor
 For normal filters on the streamed output, omit `placement` or use `"placement":"post-join"`.
 
 Use `"placement":"pre-join"` only when you need to filter a joined source before it is joined into the result. In that case `aliasPath` identifies which joined source path the filter applies to, for example `"users"` or `"users.profiles"`. Pre-join filters are advanced joined-field filters; they require `aliasPath`, and `aliasPath` is not valid for normal post-join filters.
+
+Use `--aggregation` and `--date-bucket` with JSON arrays to group the streamed rows, with the same rule shapes as report output controls. `--aggregation` takes `{ "column", "function" }` rules; `function` is any report aggregate function — `SUM`, `AVG`, `MIN`, `MAX`, `COUNT`, `COUNT_DISTINCT`, `STRING_AGG`, `ANY_VALUE`, or a percentile (`P25`, `P50`, `P75`, `P95`). `--date-bucket` takes `{ "column", "unit", "timeZone"? }` rules that truncate a date/timestamp dimension to `DAY`, `WEEK`, `MONTH`, `QUARTER`, or `YEAR`. Any selected column that has no aggregation rule becomes a grouping key, so aggregating over `revenue` while selecting `date` groups the totals by `date`.
+
+Aggregation and date buckets require an explicit `--column` projection; they cannot combine with `--columns '*'` or `--columns '**'`, because a wildcard selection would turn every column into a grouping key. For a single grand total, select only the aggregated column (no grouping keys → one row). When you aggregate, the streamed row keys are the resolved output labels — an aggregated column becomes `"<column> | <TOKEN>"` and a `"Row Count"` column is appended. `<TOKEN>` is an uppercase spreadsheet-style token for the function: most match the function name, but `COUNT_DISTINCT` becomes `COUNTUNIQUE`, `P50` becomes `MEDIAN`, `STRING_AGG` becomes `STRINGAGG`, and `ANY_VALUE` becomes `ANYVALUE`.
 
 ## Use owox-ctl with AI agents
 

--- a/packages/api-client/src/data-marts.test.ts
+++ b/packages/api-client/src/data-marts.test.ts
@@ -180,6 +180,39 @@ describe('DataMartsApi.traverseData', () => {
     ).toEqual(sort);
   });
 
+  it('encodes aggregation and dateTrunc as base64url query params', async () => {
+    const aggregation = [{ column: 'revenue', function: 'SUM' }];
+    const dateTrunc = [{ column: 'date', unit: 'MONTH' }];
+    const fetchMock = createFetchMock(request => {
+      if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+
+      if (
+        request.method === 'GET' &&
+        request.url.startsWith('/api/external/http-data/data-marts/dm-1.ndjson')
+      ) {
+        return createNdjsonResponse(['{"date":"2026-05-01"}\n'], { 'x-owox-run-id': 'run-1' });
+      }
+
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+
+    const client = new OWOXApiClient({ apiKey, fetchImpl: fetchMock.fetchImpl });
+
+    await client.dataMarts.traverseData('dm-1', { aggregation, dateTrunc });
+
+    const request = fetchMock.requests.find(({ method }) => method === 'GET');
+    expect(request).toBeDefined();
+    const url = new URL(`${apiOrigin}${request?.url}`);
+    expect(
+      JSON.parse(Buffer.from(url.searchParams.get('aggregation')!, 'base64url').toString('utf8'))
+    ).toEqual(aggregation);
+    expect(
+      JSON.parse(Buffer.from(url.searchParams.get('dateTrunc')!, 'base64url').toString('utf8'))
+    ).toEqual(dateTrunc);
+  });
+
   it('reports malformed NDJSON lines with line and run context', async () => {
     const fetchMock = createFetchMock(request => {
       if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {

--- a/packages/api-client/src/data-marts.ts
+++ b/packages/api-client/src/data-marts.ts
@@ -14,6 +14,8 @@ export type TraverseDataOptions = {
   column?: string[];
   filter?: unknown[] | null;
   sort?: unknown[] | null;
+  aggregation?: unknown[] | null;
+  dateTrunc?: unknown[] | null;
   limit?: number;
 };
 
@@ -68,6 +70,12 @@ function buildTraverseDataQuery(options: TraverseDataOptions): URLSearchParams |
   }
   if (options.sort != null) {
     query.append('sort', encodeBase64UrlJson(options.sort));
+  }
+  if (options.aggregation != null) {
+    query.append('aggregation', encodeBase64UrlJson(options.aggregation));
+  }
+  if (options.dateTrunc != null) {
+    query.append('dateTrunc', encodeBase64UrlJson(options.dateTrunc));
   }
   if (options.limit !== undefined) {
     query.append('limit', String(options.limit));


### PR DESCRIPTION
## Summary

Extends the HTTP Data streaming contract end-to-end so a published Data Mart can be streamed **pre-aggregated**, matching the aggregation + date-bucket grouping already available for Reports. The report engine (compose / GROUP BY / aggregates / date-trunc / totals) already exists and is reused via the shared `ReportLikeReadPlan` helpers — this PR threads two new query parameters through every layer rather than forking the logic.

Two new base64url-encoded JSON parameters, mirroring the existing `filter` / `sort` encoding:

- `aggregation` → `AggregationConfig` (`[{ column, function }]`)
- `dateTrunc` → `DateTruncConfig` (`[{ column, unit, timeZone? }]`)

## Layers

- **Backend Zod schema** (`HttpDataQuerySchema`): decodes both params via a DRY `makeEncodedConfigParam` factory (also folding the existing filter/sort decoders into it); requires an explicit `column` projection when grouping, mirroring the Report rule `AGGREGATION_REQUIRES_COLUMN_CONFIG` (a wildcard selection would otherwise group by every column).
- **Service** (`stream-http-data.service`): threads both configs into the read plan; the output-controls gate now uses the shared `hasOutputControls(readPlan)` so an aggregation-only / date-bucket-only request triggers SQL composition; the column validator checks aggregation/dateTrunc columns; the HTTP_DATA run metadata records both.
- **`@owox/api-client`**: `TraverseDataOptions` + `buildTraverseDataQuery` encode both.
- **`owox-ctl data-marts stream`**: new `--aggregation` / `--date-bucket` flags.
- **OpenAPI + docs**: `ApiQuery` entries, a `HttpDataController` OpenAPI spec test, and updated `owox-ctl` / `api-client` docs.

## Row keys

When aggregating, streamed row keys are the resolved output labels — an aggregated column becomes `"<column> | <TOKEN>"` (an uppercase spreadsheet token; e.g. `COUNT_DISTINCT` → `COUNTUNIQUE`, `P50` → `MEDIAN`) and a `"Row Count"` column is appended. A plain or date-bucket-only request keeps the requested-column keys.

## Testing

- Backend: 64 unit tests (schema / column-validator / service / OpenAPI) + 31 e2e (400 paths + run-metadata round-trip); `nest build` and `tsc` clean.
- `@owox/api-client`: 33 tests. `@owox/ctl`: 40 tests.

Includes a changeset (`owox: minor`).