### PR TITLE
feat(auth): rename KYA Storage option labels for MQO

### DIFF
--- a/packages/idp-owox-better-auth/src/core/onboarding-constants.ts
+++ b/packages/idp-owox-better-auth/src/core/onboarding-constants.ts
@@ -93,6 +93,6 @@ export const PRIMARY_STORAGE_OPTIONS: OnboardingOption[] = [
   { value: PRIMARY_STORAGE_ANSWER.AZURE_SYNAPSE, label: 'Azure Synapse' },
   { value: PRIMARY_STORAGE_ANSWER.OWOX_CLOUD_EU, label: 'OWOX Cloud (EU)' },
   { value: PRIMARY_STORAGE_ANSWER.OWOX_CLOUD_US, label: 'OWOX Cloud (US)' },
-  { value: PRIMARY_STORAGE_ANSWER.DONT_KNOW, label: "Don't know" },
-  { value: PRIMARY_STORAGE_ANSWER.OTHER, label: 'Other' },
+  { value: PRIMARY_STORAGE_ANSWER.DONT_KNOW, label: "Don't have it yet" },
+  { value: PRIMARY_STORAGE_ANSWER.OTHER, label: 'Other data warehouse' },
 ];

--- a/packages/idp-owox-better-auth/src/resources/templates/pages/onboarding.ejs
+++ b/packages/idp-owox-better-auth/src/resources/templates/pages/onboarding.ejs
@@ -151,7 +151,7 @@ const storageIcons = {
                 type="text"
                 id="storage-other-text"
                 maxlength="500"
-                placeholder="Tell us which storage..."
+                placeholder="Tell us which data warehouse..."
                 class="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
               />
             </div>
@@ -779,7 +779,7 @@ const storageIcons = {
     }
   }
 
-  // Shuffle primary storage: randomize DWH options only; fix OWOX (EU→US), "Don't know", then Other.
+  // Shuffle primary storage: randomize DWH options only; fix OWOX (EU→US), "Don't have it yet", then Other data warehouse.
   function shufflePrimaryStorageOptions() {
     const container = document.getElementById('q-primary-storage');
     if (!container) return;


### PR DESCRIPTION
## Summary

- Rename KYA onboarding Storage option labels to match updated MQO / `DWHisFound` wording:
  - **Don't know** → **Don't have it yet**
  - **Other** → **Other data warehouse**
- Keep stored answer values (`dont_know`, `other`) unchanged for backward compatibility with existing answers and MQO pipeline
- Align free-text placeholder and shuffle comment with the new labels

## Test plan

- [x] Open KYA onboarding questionnaire (first admin of a new project)
- [x] On Storage step, confirm labels: **Don't have it yet**, **Other data warehouse**
- [x] Select **Other data warehouse** and confirm free-text placeholder mentions data warehouse
- [x] Submit answers and verify stored values remain `dont_know` / `other` (not renamed values)
- [x] Confirm OWOX Cloud EU/US labels are unchanged