### PR TITLE
fix(data-marts): name the real cause when a Sheets destination folder is unreachable

### DIFF
--- a/.changeset/gsheets-drive-api-disabled-diagnostics.md
+++ b/.changeset/gsheets-drive-api-disabled-diagnostics.md
@@ -1,0 +1,17 @@
+---
+'owox': minor
+---
+
+# Explain why a Google Sheets destination folder is unreachable
+
+Saving a Google Sheets destination with a Drive folder validates that the service account can write there. Every failure reported the same cause — "the folder was not found or the service account is not a member" — even when the service account was a Content Manager on the Shared Drive and sharing was never the problem. The most common real cause is the Google Drive API being disabled in the service account's Cloud project, which Drive returns as a 403 that is indistinguishable from a permission error by status alone.
+
+Folder-access failures are now classified from the error body and reported individually:
+
+- **Drive API disabled** — names the Cloud project, links the exact page to enable the API (using the activation URL Google provides), and states that the Sheets API alone does not cover folder placement.
+- **Folder not found** — asks the user to check the folder URL as well as Shared Drive membership.
+- **Access denied** — points at membership and at organization-level Drive sharing policies.
+
+The document auto-creation path reports a disabled Drive API the same way, instead of suggesting a sharing change that cannot help. The underlying Google error is also logged as part of the log message rather than as a Nest logger context, so it is visible when diagnosing.
+
+Documentation now includes a step for enabling the Google Drive API and a troubleshooting section covering each folder-access message.

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.spec.ts
@@ -381,4 +381,63 @@ describe('GoogleSheetsApiAdapter (pure helpers)', () => {
       expect(adapter.findOwoxColumnsMetadataForSheet([], 1)).toEqual([]);
     });
   });
+
+  describe('driveApiDisabled', () => {
+    /** The 403 Google returns when the Drive API is off in the caller's project. */
+    const serviceDisabledError = () =>
+      Object.assign(
+        new Error('Google Drive API has not been used in project 42 before or it is disabled.'),
+        {
+          response: {
+            status: 403,
+            data: {
+              error: {
+                status: 'PERMISSION_DENIED',
+                errors: [{ reason: 'accessNotConfigured' }],
+                details: [
+                  {
+                    reason: 'SERVICE_DISABLED',
+                    metadata: {
+                      activationUrl:
+                        'https://console.developers.google.com/apis/api/drive.googleapis.com/overview?project=42',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        }
+      );
+
+    it('recognizes a disabled Drive API and returns the activation URL', () => {
+      expect(GoogleSheetsApiAdapter.driveApiDisabled(serviceDisabledError())).toEqual({
+        activationUrl:
+          'https://console.developers.google.com/apis/api/drive.googleapis.com/overview?project=42',
+      });
+    });
+
+    it('recognizes it from the message alone when the body carries no reason codes', () => {
+      const error = new Error(
+        'Google Drive API has not been used in project 42 before or it is disabled.'
+      );
+      expect(GoogleSheetsApiAdapter.driveApiDisabled(error)).toEqual({ activationUrl: undefined });
+    });
+
+    it('ignores a genuine permission error', () => {
+      const error = Object.assign(new Error('The caller does not have permission'), {
+        response: {
+          status: 403,
+          data: { error: { status: 'PERMISSION_DENIED', errors: [{ reason: 'forbidden' }] } },
+        },
+      });
+      expect(GoogleSheetsApiAdapter.driveApiDisabled(error)).toBeUndefined();
+    });
+
+    it('ignores a missing-folder error', () => {
+      const error = Object.assign(new Error('File not found: abc'), {
+        response: { status: 404, data: { error: { errors: [{ reason: 'notFound' }] } } },
+      });
+      expect(GoogleSheetsApiAdapter.driveApiDisabled(error)).toBeUndefined();
+    });
+  });
 });

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/adapters/google-sheets-api.adapter.ts
@@ -6,6 +6,31 @@ import { GOOGLE_SHEETS_METADATA_KEYS } from '../constants/google-sheets-metadata
 import { GoogleSheetsCredentials } from '../schemas/google-sheets-credentials.schema';
 
 /**
+ * Why a Drive folder lookup failed. These fail for entirely different reasons and
+ * need entirely different remediation, so they are kept apart rather than
+ * collapsed into a single "no access" flag:
+ *
+ * - `drive_api_disabled` — the Drive API is off in the key's Cloud project. No
+ *   amount of sharing fixes it; `activationUrl` (when Google supplies one) points
+ *   at the exact enable page.
+ * - `not_found` — Drive returned 404: wrong ID, or the caller is not a member.
+ * - `forbidden` — Drive returned 403: the caller is known but not permitted.
+ */
+export type FolderAccessFailure =
+  | { reason: 'drive_api_disabled'; activationUrl?: string }
+  | { reason: 'not_found' }
+  | { reason: 'forbidden' };
+
+export interface FolderAccess {
+  accessible: boolean;
+  isFolder: boolean;
+  isSharedDrive: boolean;
+  canAddChildren: boolean;
+  /** Set only when `accessible` is false. */
+  failure?: FolderAccessFailure;
+}
+
+/**
  * Adapter for Google Sheets API operations
  */
 export class GoogleSheetsApiAdapter {
@@ -268,12 +293,7 @@ export class GoogleSheetsApiAdapter {
    *
    * @param folderId - Drive folder ID to inspect
    */
-  public async getFolderAccess(folderId: string): Promise<{
-    accessible: boolean;
-    isFolder: boolean;
-    isSharedDrive: boolean;
-    canAddChildren: boolean;
-  }> {
+  public async getFolderAccess(folderId: string): Promise<FolderAccess> {
     const drive = this.getDriveService();
     // Bound the round-trip: folder validation runs inside the destination-save
     // transaction, so a hung Drive call must not hold the DB connection/locks
@@ -304,11 +324,19 @@ export class GoogleSheetsApiAdapter {
       // or service account is not a member", blocking an otherwise-valid save.
       const status = GoogleSheetsApiAdapter.httpStatusOf(error);
       if (status === 403 || status === 404) {
+        const failure = GoogleSheetsApiAdapter.classifyFolderAccessFailure(error, status);
         GoogleSheetsApiAdapter.LOGGER.warn(
-          `getFolderAccess: cannot access folder ${folderId}`,
-          error instanceof Error ? error.message : String(error)
+          `getFolderAccess: cannot access folder ${folderId} (${status}, ${failure.reason}): ${
+            error instanceof Error ? error.message : String(error)
+          }`
         );
-        return { accessible: false, isFolder: false, isSharedDrive: false, canAddChildren: false };
+        return {
+          accessible: false,
+          isFolder: false,
+          isSharedDrive: false,
+          canAddChildren: false,
+          failure,
+        };
       }
       GoogleSheetsApiAdapter.LOGGER.error(
         `getFolderAccess: transient/unexpected error inspecting folder ${folderId}`,
@@ -316,6 +344,75 @@ export class GoogleSheetsApiAdapter {
       );
       throw error;
     }
+  }
+
+  /**
+   * Classifies a 403/404 Drive failure into an actionable reason.
+   *
+   * The "Drive API disabled in the project" 403 is singled out because it is
+   * indistinguishable from a permission problem by status alone, yet it is the
+   * one case where sharing the folder can never help — the Sheets API being
+   * enabled does not enable Drive.
+   */
+  private static classifyFolderAccessFailure(error: unknown, status: number): FolderAccessFailure {
+    const disabled = GoogleSheetsApiAdapter.driveApiDisabled(error);
+    if (disabled) {
+      return { reason: 'drive_api_disabled', activationUrl: disabled.activationUrl };
+    }
+    return status === 404 ? { reason: 'not_found' } : { reason: 'forbidden' };
+  }
+
+  /**
+   * Recognizes Google's "this API is not enabled in your project" 403, returning
+   * the activation URL it carries (when present). Undefined for every other error.
+   *
+   * Callers use this to avoid blaming folder sharing for a project-config problem.
+   */
+  public static driveApiDisabled(error: unknown): { activationUrl?: string } | undefined {
+    const reasons = GoogleSheetsApiAdapter.googleErrorReasons(error);
+    const disabled =
+      reasons.includes('accessNotConfigured') ||
+      reasons.includes('SERVICE_DISABLED') ||
+      // Fallback for error shapes that carry no machine-readable reason.
+      /has not been used in project|is disabled/i.test(
+        error instanceof Error ? error.message : String(error)
+      );
+    if (!disabled) return undefined;
+    return { activationUrl: GoogleSheetsApiAdapter.activationUrlOf(error) };
+  }
+
+  /** Machine-readable reason codes carried by a Google API error body. */
+  private static googleErrorReasons(error: unknown): string[] {
+    const body = (error as { response?: { data?: unknown } })?.response?.data as
+      | {
+          error?: {
+            status?: string;
+            errors?: Array<{ reason?: string }>;
+            details?: Array<{ reason?: string }>;
+          };
+        }
+      | undefined;
+    const inner = body?.error;
+    const reasons: string[] = [];
+    for (const e of inner?.errors ?? []) {
+      if (e?.reason) reasons.push(e.reason);
+    }
+    for (const d of inner?.details ?? []) {
+      if (d?.reason) reasons.push(d.reason);
+    }
+    return reasons;
+  }
+
+  /** The exact "enable this API" console URL Google attaches to a SERVICE_DISABLED error. */
+  private static activationUrlOf(error: unknown): string | undefined {
+    const body = (error as { response?: { data?: unknown } })?.response?.data as
+      | { error?: { details?: Array<{ metadata?: { activationUrl?: string } }> } }
+      | undefined;
+    for (const d of body?.error?.details ?? []) {
+      const url = d?.metadata?.activationUrl;
+      if (typeof url === 'string' && url.startsWith('https://')) return url;
+    }
+    return undefined;
   }
 
   /** Best-effort extraction of the HTTP status from a Google/Gaxios error. */

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-folder-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-folder-validator.service.spec.ts
@@ -41,6 +41,16 @@ describe('GoogleSheetsFolderValidator', () => {
     credentialId: string | null = 'cred-1'
   ) => ({ id: 'dest-1', credentialId, config }) as never;
 
+  /** Runs the validator and hands back the error it threw, so its message can be asserted on. */
+  const captureFailure = async (validator: GoogleSheetsFolderValidator): Promise<Error> => {
+    try {
+      await validator.validateConfiguredFolder(destination({ folderId: 'f1' }));
+    } catch (error) {
+      return error as Error;
+    }
+    throw new Error('expected validateConfiguredFolder to reject, but it resolved');
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetFolderAccess.mockResolvedValue({
@@ -83,10 +93,62 @@ describe('GoogleSheetsFolderValidator', () => {
       isFolder: false,
       isSharedDrive: false,
       canAddChildren: false,
+      failure: { reason: 'not_found' },
     });
     await expect(
       validator.validateConfiguredFolder(destination({ folderId: 'f1' }))
-    ).rejects.toThrow(DestinationFolderAccessException);
+    ).rejects.toThrow(/was not found, or the service account .* is not a member/);
+  });
+
+  it('blames the disabled Drive API — not folder sharing — and links the activation page', async () => {
+    const { validator } = createValidator(SA_CREDENTIAL);
+    mockGetFolderAccess.mockResolvedValue({
+      accessible: false,
+      isFolder: false,
+      isSharedDrive: false,
+      canAddChildren: false,
+      failure: {
+        reason: 'drive_api_disabled',
+        activationUrl: 'https://console.developers.google.com/apis/api/drive.googleapis.com/x',
+      },
+    });
+    const error = await captureFailure(validator);
+    expect(error).toBeInstanceOf(DestinationFolderAccessException);
+    expect(error.message).toContain('Google Drive API is not enabled');
+    expect(error.message).toContain('(proj)');
+    expect(error.message).toContain(
+      'https://console.developers.google.com/apis/api/drive.googleapis.com/x'
+    );
+    expect(error.message).not.toContain('Content Manager');
+  });
+
+  it('falls back to a console link built from the key project when Google sends no activation URL', async () => {
+    const { validator } = createValidator(SA_CREDENTIAL);
+    mockGetFolderAccess.mockResolvedValue({
+      accessible: false,
+      isFolder: false,
+      isSharedDrive: false,
+      canAddChildren: false,
+      failure: { reason: 'drive_api_disabled' },
+    });
+    const error = await captureFailure(validator);
+    expect(error.message).toContain(
+      'https://console.cloud.google.com/apis/library/drive.googleapis.com?project=proj'
+    );
+  });
+
+  it('reports a 403 as a denial rather than a missing folder', async () => {
+    const { validator } = createValidator(SA_CREDENTIAL);
+    mockGetFolderAccess.mockResolvedValue({
+      accessible: false,
+      isFolder: false,
+      isSharedDrive: false,
+      canAddChildren: false,
+      failure: { reason: 'forbidden' },
+    });
+    const error = await captureFailure(validator);
+    expect(error.message).toContain('denied the service account');
+    expect(error.message).toContain('sa@proj.iam.gserviceaccount.com');
   });
 
   it('throws when the folder is not in a Shared Drive', async () => {

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-folder-validator.service.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-folder-validator.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { DataDestination } from '../../../entities/data-destination.entity';
 import { DataDestinationCredentialService } from '../../../services/data-destination-credential.service';
 import { DestinationCredentialType } from '../../../enums/destination-credential-type.enum';
-import { GoogleSheetsApiAdapter } from '../adapters/google-sheets-api.adapter';
+import { FolderAccessFailure, GoogleSheetsApiAdapter } from '../adapters/google-sheets-api.adapter';
 import { GoogleSheetsCredentialsSchema } from '../schemas/google-sheets-credentials.schema';
 import { DestinationFolderAccessException } from '../../../exceptions/google-oauth.exceptions';
 
@@ -47,8 +47,12 @@ export class GoogleSheetsFolderValidator {
 
     if (!access.accessible) {
       throw new DestinationFolderAccessException(
-        `The Drive folder was not found or the service account (${saEmail}) is not a member of it. Add this account as a member of the Shared Drive with the Content Manager role (a sharing link alone is not enough).`,
-        { folderId }
+        GoogleSheetsFolderValidator.describeFailure(
+          access.failure,
+          saEmail,
+          serviceAccountKey.project_id
+        ),
+        { folderId, reason: access.failure?.reason }
       );
     }
     if (!access.isFolder) {
@@ -69,5 +73,39 @@ export class GoogleSheetsFolderValidator {
         { folderId }
       );
     }
+  }
+
+  /**
+   * Turns a lookup failure into remediation the user can act on. Each reason gets
+   * its own message: the three causes look identical from the outside (Drive just
+   * says "no"), so a single message would send users to re-check sharing even
+   * when sharing was never the problem.
+   */
+  private static describeFailure(
+    failure: FolderAccessFailure | undefined,
+    saEmail: string,
+    projectId: string
+  ): string {
+    if (failure?.reason === 'drive_api_disabled') {
+      const url =
+        failure.activationUrl ??
+        `https://console.cloud.google.com/apis/library/drive.googleapis.com?project=${projectId}`;
+      return (
+        `The Google Drive API is not enabled in the service account's Google Cloud project (${projectId}), ` +
+        `so OWOX cannot place documents in a Drive folder. Enable it at ${url}, wait a minute for it to take effect, then save again. ` +
+        `Note that having the Google Sheets API enabled is not enough — folder placement needs the Drive API as well.`
+      );
+    }
+    if (failure?.reason === 'forbidden') {
+      return (
+        `Google Drive denied the service account (${saEmail}) access to this folder. ` +
+        `Add it as a member of the Shared Drive with the Content Manager role (a sharing link alone is not enough), ` +
+        `and check that no Drive sharing policy in your organization blocks this account.`
+      );
+    }
+    return (
+      `The Drive folder was not found, or the service account (${saEmail}) is not a member of it. ` +
+      `Check that the folder URL is correct, and add this account as a member of the Shared Drive with the Content Manager role (a sharing link alone is not enough).`
+    );
   }
 }

--- a/apps/backend/src/data-marts/use-cases/google-sheets/create-google-sheet-document.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/google-sheets/create-google-sheet-document.service.spec.ts
@@ -26,6 +26,13 @@ jest.mock('../../data-destination-types/google-sheets/adapters/google-sheets-api
     }
     return undefined;
   };
+  // Delegate to the real classifier rather than re-implementing it: the whole
+  // point of these tests is that the service reacts to what Google actually sends.
+  const actual = jest.requireActual(
+    '../../data-destination-types/google-sheets/adapters/google-sheets-api.adapter'
+  );
+  (ctor as unknown as Record<string, unknown>).driveApiDisabled =
+    actual.GoogleSheetsApiAdapter.driveApiDisabled.bind(actual.GoogleSheetsApiAdapter);
   return { GoogleSheetsApiAdapter: ctor };
 });
 
@@ -322,6 +329,45 @@ describe('CreateGoogleSheetDocumentService', () => {
     await expect(
       service.run(new CreateGoogleSheetDocumentCommand('dest-1', 'proj-1', 'X'))
     ).rejects.toThrow(SheetFolderCreateFailedException);
+  });
+
+  it('tells the user to enable the Drive API instead of blaming folder sharing', async () => {
+    const { service } = createService(
+      buildDestination(DestinationCredentialType.GOOGLE_SERVICE_ACCOUNT, { folderId: 'folder-1' }),
+      { type: 'google-sheets-credentials', serviceAccountKey: VALID_SA_KEY }
+    );
+    // A disabled Drive API arrives as a 403 — same status as a real permission
+    // problem, so the remediation must come from the error body, not the status.
+    mockCreateSpreadsheetInFolder.mockRejectedValue(
+      Object.assign(new Error('Google Drive API has not been used in project proj before'), {
+        response: {
+          status: 403,
+          data: {
+            error: {
+              errors: [{ reason: 'accessNotConfigured' }],
+              details: [
+                {
+                  reason: 'SERVICE_DISABLED',
+                  metadata: { activationUrl: 'https://console.developers.google.com/enable-drive' },
+                },
+              ],
+            },
+          },
+        },
+      })
+    );
+
+    const error = await service
+      .run(new CreateGoogleSheetDocumentCommand('dest-1', 'proj-1', 'X'))
+      .then(
+        () => undefined,
+        (e: unknown) => e as Error
+      );
+
+    expect(error).toBeInstanceOf(SheetFolderCreateFailedException);
+    expect(error?.message).toContain('Google Drive API is not enabled');
+    expect(error?.message).toContain('https://console.developers.google.com/enable-drive');
+    expect(error?.message).not.toContain('Content Manager');
   });
 
   it('surfaces a transient Drive error as GoogleApiException, not a folder error', async () => {

--- a/apps/backend/src/data-marts/use-cases/google-sheets/create-google-sheet-document.service.ts
+++ b/apps/backend/src/data-marts/use-cases/google-sheets/create-google-sheet-document.service.ts
@@ -276,6 +276,18 @@ export class CreateGoogleSheetDocumentService {
         error
       );
     }
+    // A disabled Drive API also surfaces as 403, but no sharing change can fix it —
+    // replace the path's sharing hint with the one instruction that will.
+    const disabled = GoogleSheetsApiAdapter.driveApiDisabled(error);
+    if (disabled) {
+      throw new SheetFolderCreateFailedException(
+        destinationId,
+        error,
+        `The Google Drive API is not enabled in the Google Cloud project behind this destination's credentials. Enable it${
+          disabled.activationUrl ? ` at ${disabled.activationUrl}` : ''
+        } and try again — the Google Sheets API alone does not cover folder placement.`
+      );
+    }
     throw new SheetFolderCreateFailedException(destinationId, error, hint);
   }
 }

--- a/docs/destinations/supported-destinations/google-sheets.md
+++ b/docs/destinations/supported-destinations/google-sheets.md
@@ -17,7 +17,15 @@ To allow OWOX Data Marts to interact with Google Sheets, enable the Google Sheet
 2. Click **Enable** to activate the API for your project.
 3. If it's already enabled, you'll see the API dashboard — that's fine.
 
-#### 2. Create a Service Account and JSON Key
+#### 2. Enable the Google Drive API
+
+Enable the [Google Drive API](https://console.cloud.google.com/apis/library/drive.googleapis.com/) in the **same** project if you want OWOX to create new spreadsheets for you inside a Drive folder.
+
+The Sheets API can read and write spreadsheets, but it cannot place a file into a folder — that is a Drive operation. If this API is off, saving a destination with a folder fails with a message telling you the Drive API is not enabled, and pointing at the page to enable it.
+
+> **Note:** After enabling, allow up to a minute for the change to propagate before retrying.
+
+#### 3. Create a Service Account and JSON Key
 
 A service account is required to authenticate OWOX Data Marts with Google Sheets.
 
@@ -61,6 +69,20 @@ Click **Connect Google Account** to authenticate using your personal Google acco
 #### 5. Finalize Setup
 
 Review your entries and click **Save** to integrate the **Destination**, or **Cancel** to discard changes.
+
+---
+
+## Troubleshooting Folder Access
+
+When a **Destination** has a Drive folder configured, OWOX checks that it can actually write there before saving, so problems surface at setup time instead of during a refresh. If the save fails, match the message below:
+
+- **"The Google Drive API is not enabled..."** — enable the [Google Drive API](https://console.cloud.google.com/apis/library/drive.googleapis.com/) in the Cloud project named in the message (the one your service account key belongs to), wait a minute, then save again. The Google Sheets API being enabled does not cover folder placement.
+- **"The Drive folder was not found, or the service account is not a member..."** — check the folder URL you pasted, then open the folder's Shared Drive, click **Manage members**, and add the service account's email as a member.
+- **"Google Drive denied the service account access..."** — the account is known to Drive but not allowed in. Confirm its membership on the Shared Drive and check whether an organization-level Drive sharing policy blocks accounts outside your domain.
+- **"The service account cannot create files in this folder"** — it is a member, but with too weak a role. Change its role to **Content Manager**; **Viewer** and **Commenter** cannot create files.
+- **"The folder must be located in a Shared Drive"** — a service account has no My Drive storage of its own, so a file it creates in a My Drive folder would be owned by nobody and invisible to your team. Move the folder to a Shared Drive, or use OAuth instead.
+
+> **Note:** Adding the service account through a **sharing link** is not enough — it must be an explicit member of the Shared Drive, with its full `...iam.gserviceaccount.com` address.
 
 ---
 


### PR DESCRIPTION
## Problem

Saving a Google Sheets destination with a Drive folder validates that the service account can actually write there. Every failure produced the same message:

> The Drive folder was not found or the service account (…) is not a member of it. Add this account as a member of the Shared Drive with the Content Manager role (a sharing link alone is not enough).

That message is a guess. `getFolderAccess` treated any 403 **or** 404 from Drive as "no access", so at least four different causes shared one text. The most common real cause is the **Google Drive API being disabled** in the service account's Cloud project — Drive returns that as a 403, indistinguishable from a permission error by status alone. Users who had already added the service account as a Content Manager were sent to re-check sharing that was never the problem, with nothing in the message hinting at the Cloud Console.

This is not hypothetical: it is what prompted this PR. A destination whose service account was a Content Manager on both the Shared Drive and the folder failed to save, and the message pointed away from the actual fix.

The Sheets API being enabled does not cover folder placement: putting a file into a folder is a Drive operation. Nothing in the docs said so.

## Changes

**Classify the failure instead of collapsing it** (`google-sheets-api.adapter.ts`)

`getFolderAccess` now returns a `failure` reason alongside `accessible: false`:

- `drive_api_disabled` — detected from `accessNotConfigured` / `SERVICE_DISABLED` in the error body, with a message-text fallback for shapes that carry no reason codes. Captures the `activationUrl` Google attaches, so the user gets the exact enable page.
- `not_found` — 404.
- `forbidden` — any other 403.

Transient errors (429/5xx) still propagate untouched, so an outage is never reported as a misconfigured folder.

**Report each cause with the remediation that applies** (`google-sheets-folder-validator.service.ts`)

The disabled-API case now names the Cloud project, links the activation page (falling back to a console URL built from the key's `project_id`), and states outright that the Sheets API is not enough. The 403 case points at membership *and* at organization-level Drive sharing policies. The 404 case asks the user to check the folder URL, not just sharing.

**Same treatment on the auto-creation path** (`create-google-sheet-document.service.ts`)

A disabled Drive API during `createSpreadsheetInFolder` also arrived as a 403 and got the path's sharing hint appended — advice that cannot help. It now gets the enable-the-API instruction instead.

**Logging**

The underlying Google error was passed as the second positional argument to `Logger.warn`, which NestJS renders as the log *context* (a bracketed prefix) rather than the body. That is a large part of why the real cause was easy to miss while diagnosing. It is now part of the message, along with the status and classified reason.

**Docs** (`docs/destinations/supported-destinations/google-sheets.md`)

Added an "Enable the Google Drive API" setup step explaining why the Sheets API alone is insufficient, and a "Troubleshooting Folder Access" section mapping each of the five folder messages to the action that fixes it.

## Testing

`npx jest src/data-marts/use-cases/google-sheets src/data-marts/data-destination-types/google-sheets` — 159 passed, 9 suites. ESLint clean on both directories.

New coverage: each failure reason produces its own message; the disabled-API message carries Google's activation URL and does **not** mention Content Manager; the console-link fallback when Google sends no activation URL; the classifier ignores genuine permission and not-found errors; and the auto-creation path reports the disabled API rather than blaming sharing.

The classifier is exercised against fixtures shaped like Google's `SERVICE_DISABLED` 403 response, not against a live Drive API. The reason codes and `activationUrl` it keys on come from the real error body observed in the reported case; a reviewer with a project where the Drive API is off can confirm the end-to-end message.

Note for reviewers: `create-google-sheet-document.service.spec.ts` mocks the adapter class wholesale, so the new static needed to be reachable from the mock. It delegates to the real classifier via `jest.requireActual` rather than re-implementing it, so the mock cannot drift from what Google actually sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)