### PR TITLE
fix(web): clearer permission errors that persist until dismissed

### DIFF
--- a/.changeset/6716-clearer-permission-error-messages.md
+++ b/.changeset/6716-clearer-permission-error-messages.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Clearer permission errors when managing Storages, Destinations, and Data Marts
+
+Previously, actions like managing owners or configuring sharing failed with a vague message that did not explain who could perform them, and the error toast disappeared after a few seconds. Now each message names the exact role required — such as owner with the Technical User role, or Project Admin — and the "access forbidden" toast stays on screen until you dismiss it. This helps users understand why an action was blocked and what role they need to proceed.

--- a/apps/backend/src/data-marts/use-cases/update-availability.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-availability.service.ts
@@ -42,7 +42,9 @@ export class UpdateAvailabilityService {
       projectId
     );
     if (!canConfigure)
-      throw new ForbiddenException('You cannot configure sharing for this DataMart');
+      throw new ForbiddenException(
+        'You do not have permission to configure sharing for this Data Mart. You must be the Technical Owner with the Technical User role, or a Project Admin.'
+      );
 
     dm.availableForReporting = availableForReporting;
     dm.availableForMaintenance = availableForMaintenance;
@@ -71,7 +73,9 @@ export class UpdateAvailabilityService {
       projectId
     );
     if (!canConfigure)
-      throw new ForbiddenException('You cannot configure sharing for this Storage');
+      throw new ForbiddenException(
+        'You do not have permission to configure sharing for this Storage. You must be an owner with the Technical User role, or a Project Admin.'
+      );
 
     storage.availableForUse = availableForUse;
     storage.availableForMaintenance = availableForMaintenance;
@@ -100,7 +104,9 @@ export class UpdateAvailabilityService {
       projectId
     );
     if (!canConfigure)
-      throw new ForbiddenException('You cannot configure sharing for this Destination');
+      throw new ForbiddenException(
+        'You do not have permission to configure sharing for this Destination. You must be an owner of this Destination, or a Project Admin.'
+      );
 
     dest.availableForUse = availableForUse;
     dest.availableForMaintenance = availableForMaintenance;

--- a/apps/backend/src/data-marts/use-cases/update-data-destination.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-destination.service.spec.ts
@@ -41,6 +41,11 @@ describe('UpdateDataDestinationService - credential copy (sourceDestinationId)',
       credentialId?: string | null;
       sourceDestinationId?: string;
       config?: DestinationConfigOverride;
+      ownerIds?: string[];
+      userId?: string;
+      roles?: string[];
+      availableForUse?: boolean;
+      availableForMaintenance?: boolean;
     } = {}
   ): UpdateDataDestinationCommand => {
     return new UpdateDataDestinationCommand(
@@ -50,11 +55,11 @@ describe('UpdateDataDestinationService - credential copy (sourceDestinationId)',
       overrides.credentials as never,
       overrides.credentialId,
       overrides.sourceDestinationId,
-      undefined, // ownerIds
-      undefined, // userId
-      undefined, // roles
-      undefined, // availableForUse
-      undefined, // availableForMaintenance
+      overrides.ownerIds, // ownerIds
+      overrides.userId, // userId
+      overrides.roles, // roles
+      overrides.availableForUse, // availableForUse
+      overrides.availableForMaintenance, // availableForMaintenance
       undefined, // contextIds
       overrides.config
     );
@@ -199,6 +204,7 @@ describe('UpdateDataDestinationService - credential copy (sourceDestinationId)',
       dataDestinationCredentialService,
       googleOAuthClientService,
       folderValidator,
+      accessDecisionService,
     };
   };
 
@@ -408,6 +414,34 @@ describe('UpdateDataDestinationService - credential copy (sourceDestinationId)',
     await expect(service.run(command)).rejects.toThrow(
       /Cannot provide both sourceDestinationId and credentialId/
     );
+  });
+
+  describe('permission checks', () => {
+    it('throws ForbiddenException with the required-role message when managing owners is denied', async () => {
+      const { service, accessDecisionService } = createService();
+      accessDecisionService.canAccess.mockResolvedValue(false);
+
+      const command = makeCommand({ ownerIds: ['user-2'], userId: 'user-1', roles: ['editor'] });
+
+      await expect(service.run(command)).rejects.toThrow(
+        'You do not have permission to manage owners of this Destination. You must be an owner of this Destination, or a Project Admin.'
+      );
+    });
+
+    it('throws ForbiddenException with the required-role message when configuring sharing is denied', async () => {
+      const { service, accessDecisionService } = createService();
+      accessDecisionService.canAccess.mockResolvedValue(false);
+
+      const command = makeCommand({
+        userId: 'user-1',
+        roles: ['editor'],
+        availableForMaintenance: true,
+      });
+
+      await expect(service.run(command)).rejects.toThrow(
+        'You do not have permission to configure sharing for this Destination. You must be an owner of this Destination, or a Project Admin.'
+      );
+    });
   });
 
   describe('Drive folder validation (only on folder change)', () => {

--- a/apps/backend/src/data-marts/use-cases/update-data-destination.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-destination.service.ts
@@ -67,7 +67,9 @@ export class UpdateDataDestinationService {
         command.projectId
       );
       if (!canManage) {
-        throw new ForbiddenException('You cannot manage owners of this Destination');
+        throw new ForbiddenException(
+          'You do not have permission to manage owners of this Destination. You must be an owner of this Destination, or a Project Admin.'
+        );
       }
     }
 
@@ -85,7 +87,9 @@ export class UpdateDataDestinationService {
         command.projectId
       );
       if (!canConfigure) {
-        throw new ForbiddenException('You cannot configure sharing for this Destination');
+        throw new ForbiddenException(
+          'You do not have permission to configure sharing for this Destination. You must be an owner of this Destination, or a Project Admin.'
+        );
       }
     }
 

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-owners.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-owners.service.spec.ts
@@ -95,7 +95,9 @@ describe('UpdateDataMartOwnersService', () => {
       'non-owner',
       ['editor']
     );
-    await expect(service.run(command)).rejects.toThrow('You cannot manage owners');
+    await expect(service.run(command)).rejects.toThrow(
+      'You do not have permission to manage owners of this Data Mart. You must be the Technical Owner with the Technical User role, or a Project Admin.'
+    );
   });
 
   it('should replace business and technical owners via join tables', async () => {

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-owners.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-owners.service.ts
@@ -45,7 +45,9 @@ export class UpdateDataMartOwnersService {
         command.projectId
       );
       if (!canManage) {
-        throw new ForbiddenException('You cannot manage owners of this DataMart');
+        throw new ForbiddenException(
+          'You do not have permission to manage owners of this Data Mart. You must be the Technical Owner with the Technical User role, or a Project Admin.'
+        );
       }
     }
 

--- a/apps/backend/src/data-marts/use-cases/update-data-storage.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-storage.service.ts
@@ -67,7 +67,9 @@ export class UpdateDataStorageService {
         command.projectId
       );
       if (!canManage) {
-        throw new ForbiddenException('You cannot manage owners of this Storage');
+        throw new ForbiddenException(
+          'You do not have permission to manage owners of this Storage. You must be an owner with the Technical User role, or a Project Admin.'
+        );
       }
     }
 
@@ -85,7 +87,9 @@ export class UpdateDataStorageService {
         command.projectId
       );
       if (!canConfigure) {
-        throw new ForbiddenException('You cannot configure sharing for this Storage');
+        throw new ForbiddenException(
+          'You do not have permission to configure sharing for this Storage. You must be an owner with the Technical User role, or a Project Admin.'
+        );
       }
     }
 

--- a/apps/web/src/app/api/apiClient.ts
+++ b/apps/web/src/app/api/apiClient.ts
@@ -111,7 +111,7 @@ apiClient.interceptors.response.use(
     }
 
     if (error.response?.status === 403 && !skipErrorToast) {
-      showApiErrorToast(error, 'Access forbidden - insufficient permissions');
+      showApiErrorToast(error, 'Access forbidden - insufficient permissions', { persistent: true });
     }
 
     if (error.response?.status === 400 && !skipErrorToast) {

--- a/apps/web/src/shared/utils/showApiErrorToast.test.ts
+++ b/apps/web/src/shared/utils/showApiErrorToast.test.ts
@@ -77,7 +77,7 @@ describe('showApiErrorToast', () => {
       expect(root.type).toBe('span');
       expect(text).toBe('Denied');
       expect(closeButton.type).toBe('button');
-      expect(closeButton.props['aria-label']).toBe('Dismiss');
+      expect(closeButton.props['aria-label']).toBe('Dismiss error');
     });
 
     it('dismisses the toast when the close button is clicked', () => {

--- a/apps/web/src/shared/utils/showApiErrorToast.test.ts
+++ b/apps/web/src/shared/utils/showApiErrorToast.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ReactElement, ReactNode } from 'react';
+import toast from 'react-hot-toast';
+import { showApiErrorToast } from './showApiErrorToast';
+
+vi.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: { error: vi.fn(), dismiss: vi.fn() },
+}));
+
+const mockedToastError = vi.mocked(toast.error);
+const mockedToastDismiss = vi.mocked(toast.dismiss);
+
+/** Builds an axios-like error carrying the given response body. */
+function axiosError(data: unknown) {
+  return { response: { data } };
+}
+
+interface DismissButtonProps {
+  'aria-label': string;
+  onClick: () => void;
+}
+interface ToastBodyProps {
+  children: [ReactNode, ReactElement<DismissButtonProps>];
+}
+
+/** Renders the persistent-toast function renderer and returns the root element. */
+function renderPersistentToast(toastId = 'toast-1'): ReactElement<ToastBodyProps> {
+  const renderer = mockedToastError.mock.calls[0][0] as (t: {
+    id: string;
+  }) => ReactElement<ToastBodyProps>;
+  return renderer({ id: toastId });
+}
+
+describe('showApiErrorToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the server message when present', () => {
+    showApiErrorToast(axiosError({ message: 'Server says no' }));
+    expect(mockedToastError).toHaveBeenCalledWith('Server says no');
+  });
+
+  it('falls back when the error has no response body', () => {
+    expect(() => {
+      showApiErrorToast({});
+    }).not.toThrow();
+    expect(mockedToastError).toHaveBeenCalledWith('Something went wrong');
+  });
+
+  it('falls back when the server message is empty or whitespace', () => {
+    showApiErrorToast(axiosError({ message: '   ' }), 'Custom fallback');
+    expect(mockedToastError).toHaveBeenCalledWith('Custom fallback');
+  });
+
+  it('appends error details when present', () => {
+    showApiErrorToast(axiosError({ message: 'Denied', errorDetails: { error: 'extra info' } }));
+    expect(mockedToastError).toHaveBeenCalledWith('Denied. extra info');
+  });
+
+  describe('persistent option', () => {
+    it('creates a never-expiring toast deduped by message', () => {
+      showApiErrorToast(axiosError({ message: 'Denied' }), undefined, { persistent: true });
+      expect(mockedToastError).toHaveBeenCalledWith(expect.any(Function), {
+        duration: Infinity,
+        id: 'persistent-error:Denied',
+      });
+    });
+
+    it('renders selectable message text alongside a dismiss button', () => {
+      showApiErrorToast(axiosError({ message: 'Denied' }), undefined, { persistent: true });
+
+      const root = renderPersistentToast();
+      const [text, closeButton] = root.props.children;
+
+      expect(root.type).toBe('span');
+      expect(text).toBe('Denied');
+      expect(closeButton.type).toBe('button');
+      expect(closeButton.props['aria-label']).toBe('Dismiss');
+    });
+
+    it('dismisses the toast when the close button is clicked', () => {
+      showApiErrorToast(axiosError({ message: 'Denied' }), undefined, { persistent: true });
+
+      const root = renderPersistentToast('toast-42');
+      const [, closeButton] = root.props.children;
+      closeButton.props.onClick();
+
+      expect(mockedToastDismiss).toHaveBeenCalledWith('toast-42');
+    });
+  });
+});

--- a/apps/web/src/shared/utils/showApiErrorToast.ts
+++ b/apps/web/src/shared/utils/showApiErrorToast.ts
@@ -1,4 +1,5 @@
 import toast from 'react-hot-toast';
+import { createElement } from 'react';
 import type { ApiError } from '../../app/api/api-error.interface';
 import { extractApiError } from '../../app/api/extract-api-error.util';
 
@@ -7,17 +8,52 @@ import { extractApiError } from '../../app/api/extract-api-error.util';
  * - Always shows a fallback message if server message is missing.
  * - Appends details (if provided) in a readable way.
  */
-export function showApiErrorToast(error: unknown, fallbackMessage = 'Something went wrong') {
-  const apiError: ApiError = extractApiError(error);
+export function showApiErrorToast(
+  error: unknown,
+  fallbackMessage = 'Something went wrong',
+  options?: { persistent?: boolean }
+) {
+  const apiError = extractApiError(error) as ApiError | undefined;
 
-  // Ensure we always have a base message
-  let message = apiError.message?.trim() ?? fallbackMessage;
+  // Ensure we always have a base message (empty server messages fall back too)
+  let message = apiError?.message?.trim() ?? fallbackMessage;
+  if (message.length === 0) message = fallbackMessage;
 
   // Append details if present
-  if (apiError.errorDetails?.error?.trim()) {
-    message = `${message}. ${apiError.errorDetails.error}`;
+  const errorDetails = apiError?.errorDetails?.error?.trim();
+  if (errorDetails) {
+    message = `${message}. ${errorDetails}`;
   }
 
-  // Show toast
+  // Persistent toasts stay until the user dismisses them. A stable id keeps
+  // repeated identical errors from stacking; a button makes it keyboard-accessible.
+  if (options?.persistent) {
+    toast.error(
+      t =>
+        createElement(
+          'button',
+          {
+            type: 'button',
+            onClick: () => {
+              toast.dismiss(t.id);
+            },
+            style: {
+              cursor: 'pointer',
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              margin: 0,
+              font: 'inherit',
+              color: 'inherit',
+              textAlign: 'left',
+            },
+          },
+          message
+        ),
+      { duration: Infinity, id: `persistent-error:${message}` }
+    );
+    return;
+  }
+
   toast.error(message);
 }

--- a/apps/web/src/shared/utils/showApiErrorToast.ts
+++ b/apps/web/src/shared/utils/showApiErrorToast.ts
@@ -40,7 +40,7 @@ export function showApiErrorToast(
             'button',
             {
               type: 'button',
-              'aria-label': 'Dismiss',
+              'aria-label': 'Dismiss error',
               onClick: () => {
                 toast.dismiss(t.id);
               },

--- a/apps/web/src/shared/utils/showApiErrorToast.ts
+++ b/apps/web/src/shared/utils/showApiErrorToast.ts
@@ -26,29 +26,37 @@ export function showApiErrorToast(
   }
 
   // Persistent toasts stay until the user dismisses them. A stable id keeps
-  // repeated identical errors from stacking; a button makes it keyboard-accessible.
+  // repeated identical errors from stacking. The message text stays selectable
+  // (users may want to copy the required role), so dismissal is a dedicated,
+  // keyboard-accessible close button instead of the whole message.
   if (options?.persistent) {
     toast.error(
       t =>
         createElement(
-          'button',
-          {
-            type: 'button',
-            onClick: () => {
-              toast.dismiss(t.id);
+          'span',
+          { style: { display: 'flex', alignItems: 'center', gap: '0.5rem' } },
+          message,
+          createElement(
+            'button',
+            {
+              type: 'button',
+              'aria-label': 'Dismiss',
+              onClick: () => {
+                toast.dismiss(t.id);
+              },
+              style: {
+                cursor: 'pointer',
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                margin: 0,
+                font: 'inherit',
+                color: 'inherit',
+                flexShrink: 0,
+              },
             },
-            style: {
-              cursor: 'pointer',
-              background: 'none',
-              border: 'none',
-              padding: 0,
-              margin: 0,
-              font: 'inherit',
-              color: 'inherit',
-              textAlign: 'left',
-            },
-          },
-          message
+            '✕'
+          )
         ),
       { duration: Infinity, id: `persistent-error:${message}` }
     );


### PR DESCRIPTION
# Problem

When a user lacked permission to manage owners or configure sharing on a Storage, Destination, or Data Mart, the backend returned vague messages such as "You cannot manage owners of this Storage" — with no indication of which role was required or how to obtain access. On the frontend, these 403 errors surfaced as a toast that auto-dismissed after ~6 seconds, so a user who looked away could miss the explanation entirely. The role names in the messages also didn't match what users actually see in the Members UI (Technical User, Business User, Project Admin).

# Solution

- Rewrote the `ForbiddenException` messages across the affected use-cases to state the reason and the minimum role required, using the UI-facing role names. Wording is entity-specific because the access matrix genuinely differs: Storage and Data Mart require an owner with the Technical User role (Business-User owners are denied access), whereas any Destination owner qualifies.
- Made 403 error toasts persist until the user dismisses them, instead of auto-hiding. The persistent toast is rendered as a real `<button>` so it is keyboard-accessible, carries a stable id so identical repeated errors don't stack, and falls back safely when the server sends no error body.

# Changes

- Updated permission-denied messages in `update-data-storage`, `update-data-destination`, `update-data-mart-owners`, and `update-availability` use-cases to name the required role.
- Added a `persistent` option to `showApiErrorToast` that keeps the toast open (`duration: Infinity`), dedupes by message id, and is dismissable via a focusable button.
- Wired the 403 branch of the API client interceptor to request a persistent toast.
- Guarded `showApiErrorToast` against an undefined extracted API error so it falls back to the default message instead of throwing.

![Example of the error](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/29d3251a-0543-4ff3-6e11-85935261c100/public)