### PR TITLE
chore: add changeset for Google Sheets refresh error details and selection

### DIFF
--- a/.changeset/6741-refresh-all-error-details-and-selection.md
+++ b/.changeset/6741-refresh-all-error-details-and-selection.md
@@ -1,0 +1,14 @@
+---
+'owox': minor
+---
+
+# Clearer failed-report errors and selective refresh in Google Sheets
+
+Refreshing reports from the Google Sheets extension is easier to control and troubleshoot:
+
+- On **Refresh all reports**, see each report’s title, sheet, and last-run status, including a clear error message when the last run failed.
+- Choose which reports to refresh with checkboxes, select all, or quickly target only failed, successful, or never-run reports, then start refresh when you’re ready.
+- On the single-report refresh screen, failed runs show the actual error details and an **Open report** action so you can jump straight into fixing the setup.
+- The same last-run error details are available from the **All reports** list.
+
+This helps you understand what went wrong and refresh only the reports that need it, without re-running everything in the document.


### PR DESCRIPTION
## Summary
- Adds a changeset for the Google Sheets extension improvements around failed-report error details and selective refresh.
- Covers clearer last-run error messages, checkbox-based report selection (including failed/successful/never-run filters), and an **Open report** action from the single-report refresh screen and All reports list.
- Marks `owox` as a **minor** release.

## Test plan
- [x] Confirm the changeset file is valid and picked up by the release workflow
- [x] Verify the release notes wording matches the shipped Google Sheets refresh UX