### PR TITLE
feat(auth): enforce view-only session restrictions

### DIFF
--- a/.changeset/view-only-session-restrictions.md
+++ b/.changeset/view-only-session-restrictions.md
@@ -1,0 +1,13 @@
+---
+'owox': minor
+---
+
+# View-only session restrictions
+
+Authenticated sessions in view-only mode are read-only and do not emit client analytics.
+
+- State-changing HTTP methods (`POST`, `PUT`, `PATCH`, `DELETE`) return **403** with code `ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE`.
+- Safe methods (`GET`, `HEAD`, `OPTIONS`) continue to work as usual.
+- Auth context and the current-user payload expose an optional `viewOnly` flag.
+- MCP OAuth authorization (`/oauth/authorize`) is rejected for view-only sessions so they cannot mint MCP tokens that would bypass REST restrictions.
+- Web client skips GTM bootstrap and dataLayer events (including identify/logout) for these sessions.

--- a/.changeset/view-only-session-restrictions.md
+++ b/.changeset/view-only-session-restrictions.md
@@ -6,7 +6,7 @@
 
 Authenticated sessions in view-only mode are read-only and do not emit client analytics.
 
-- State-changing HTTP methods (`POST`, `PUT`, `PATCH`, `DELETE`) return **403** with code `ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE`.
+- State-changing HTTP methods (`POST`, `PUT`, `PATCH`, `DELETE`) return **403** with code `ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE`; explicitly annotated read-semantics `POST` endpoints remain available.
 - Safe methods (`GET`, `HEAD`, `OPTIONS`) continue to work as usual.
 - Auth context and the current-user payload expose an optional `viewOnly` flag.
 - MCP OAuth authorization (`/oauth/authorize`) is rejected for view-only sessions so they cannot mint MCP tokens that would bypass REST restrictions.

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
@@ -14,6 +14,7 @@ jest.mock('../../idp', () => ({
   __esModule: true,
   Auth: () => () => undefined,
   AuthContext: () => () => undefined,
+  ViewOnlySafe: () => () => undefined,
   Role: {
     admin: jest.fn(),
     editor: jest.fn(),

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Auth, AuthContext, AuthorizationContext, Role, Strategy } from '../../idp';
+import { Auth, AuthContext, AuthorizationContext, Role, Strategy, ViewOnlySafe } from '../../idp';
 import { BlendableSchemaDto } from '../dto/domain/blendable-schema.dto';
 import { BatchDataMartHealthStatusRequestApiDto } from '../dto/presentation/batch-data-mart-health-status-request-api.dto';
 import { BatchDataMartHealthStatusResponseApiDto } from '../dto/presentation/batch-data-mart-health-status-response-api.dto';
@@ -348,6 +348,7 @@ export class DataMartController {
   }
 
   @Auth(Role.viewer(Strategy.PARSE))
+  @ViewOnlySafe()
   @Post('health-status')
   @HttpCode(200)
   @BatchDataMartHealthStatusSpec()

--- a/apps/backend/src/data-marts/controllers/data-storage.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-storage.controller.ts
@@ -12,7 +12,7 @@ import {
   Query,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Auth, AuthContext, AuthorizationContext, RejectApiKeyAuth } from '../../idp';
+import { Auth, AuthContext, AuthorizationContext, RejectApiKeyAuth, ViewOnlySafe } from '../../idp';
 import { Role, Strategy } from '../../idp/types/role-config.types';
 import { CreateDataStorageApiDto } from '../dto/presentation/create-data-storage-api.dto';
 import { DataStorageAccessValidationResponseApiDto } from '../dto/presentation/data-storage-access-validation-response-api.dto';
@@ -217,6 +217,7 @@ export class DataStorageController {
   }
 
   @Auth(Role.viewer(Strategy.INTROSPECT))
+  @ViewOnlySafe()
   @Post(':id/validate-access')
   @HttpCode(200)
   @ValidateDataStorageAccessSpec()

--- a/apps/backend/src/data-marts/controllers/guard-regression.spec.ts
+++ b/apps/backend/src/data-marts/controllers/guard-regression.spec.ts
@@ -33,6 +33,27 @@ function extractAuthDecorators(source: string): Array<{ method: string; role: st
   return results;
 }
 
+function extractViewOnlySafeMethods(source: string): string[] {
+  const results: string[] = [];
+  const lines = source.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!lines[i].includes('@ViewOnlySafe()')) {
+      continue;
+    }
+
+    for (let j = i + 1; j < Math.min(i + 8, lines.length); j++) {
+      const methodMatch = lines[j].match(/async\s+(\w+)\s*\(/);
+      if (methodMatch) {
+        results.push(methodMatch[1]);
+        break;
+      }
+    }
+  }
+
+  return results;
+}
+
 describe('DataMart controller — editor guards unchanged', () => {
   const source = readController('data-mart.controller.ts');
   const decorators = extractAuthDecorators(source);
@@ -143,6 +164,34 @@ describe('DataMart utility triggers — viewer guards (lowered)', () => {
     const entry = decorators.find(d => d.method === 'createTrigger');
     expect(entry).toBeDefined();
     expect(entry!.role).toBe('viewer');
+  });
+});
+
+describe('View-only safe POST routes', () => {
+  it('allows only the read-semantics Data Mart health endpoint', () => {
+    expect(extractViewOnlySafeMethods(readController('data-mart.controller.ts'))).toEqual([
+      'getBatchHealthStatus',
+    ]);
+  });
+
+  it('allows only Storage access validation', () => {
+    expect(extractViewOnlySafeMethods(readController('data-storage.controller.ts'))).toEqual([
+      'validate',
+    ]);
+  });
+
+  it('allows Markdown rendering', () => {
+    expect(extractViewOnlySafeMethods(readController('markdown-parser.controller.ts'))).toEqual([
+      'parseToHtml',
+    ]);
+  });
+
+  it('keeps SQL preview blocked because it can execute SQL and update validation state', () => {
+    expect(
+      extractViewOnlySafeMethods(
+        readController('insight-artifact-sql-preview-trigger.controller.ts')
+      )
+    ).toEqual([]);
   });
 });
 

--- a/apps/backend/src/data-marts/controllers/markdown-parser.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/markdown-parser.controller.openapi.spec.ts
@@ -10,6 +10,7 @@ jest.mock('../../common/markdown/markdown-parser.service', () => ({
 jest.mock('../../idp', () => ({
   __esModule: true,
   Auth: () => () => undefined,
+  ViewOnlySafe: () => () => undefined,
   Role: {
     viewer: jest.fn(),
   },

--- a/apps/backend/src/data-marts/controllers/markdown-parser.controller.ts
+++ b/apps/backend/src/data-marts/controllers/markdown-parser.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { MarkdownParser } from '../../common/markdown/markdown-parser.service';
-import { Auth, Role, Strategy } from '../../idp';
+import { Auth, Role, Strategy, ViewOnlySafe } from '../../idp';
 import { MarkdownParseRequestApiDto } from '../dto/presentation/markdown-parse-request-api.dto';
 import { ParseMarkdownToHtmlSpec } from './spec/markdown-parser.api';
 
@@ -11,6 +11,7 @@ export class MarkdownParserController {
   constructor(private readonly markdownParser: MarkdownParser) {}
 
   @Auth(Role.viewer(Strategy.INTROSPECT))
+  @ViewOnlySafe()
   @Post('/parse-to-html')
   @ParseMarkdownToHtmlSpec()
   async parseToHtml(@Body() request: MarkdownParseRequestApiDto): Promise<string> {

--- a/apps/backend/src/data-marts/controllers/oauth-flow-only.controller.spec.ts
+++ b/apps/backend/src/data-marts/controllers/oauth-flow-only.controller.spec.ts
@@ -5,6 +5,7 @@ jest.mock('../../idp', () => {
   return {
     Auth: noopDecorator,
     AuthContext: noopDecorator,
+    ViewOnlySafe: noopDecorator,
     ...rejectApiKeyAuth,
   };
 });

--- a/apps/backend/src/idp/controllers/auth-context.controller.spec.ts
+++ b/apps/backend/src/idp/controllers/auth-context.controller.spec.ts
@@ -44,6 +44,7 @@ describe('AuthContextController', () => {
       projectTitle: 'Demo Project',
       authFlow: 'api_key',
       apiKeyId: 'pmk_AbCdEfGhIjKlMnOpQrStUv',
+      viewOnly: undefined,
     });
   });
 
@@ -66,7 +67,27 @@ describe('AuthContextController', () => {
       projectTitle: undefined,
       authFlow: undefined,
       apiKeyId: undefined,
+      viewOnly: undefined,
     });
+  });
+
+  it('propagates viewOnly for view-only sessions', () => {
+    expect(
+      controller.getContext({
+        userId: 'user-1',
+        projectId: 'project-1',
+        email: 'user@example.com',
+        fullName: 'User Example',
+        roles: ['admin'],
+        viewOnly: true,
+      })
+    ).toEqual(
+      expect.objectContaining({
+        userId: 'user-1',
+        projectId: 'project-1',
+        viewOnly: true,
+      })
+    );
   });
 
   it('does not expose MCP server URL from generic auth context', () => {
@@ -90,6 +111,7 @@ describe('AuthContextController', () => {
       projectTitle: undefined,
       authFlow: undefined,
       apiKeyId: undefined,
+      viewOnly: undefined,
     });
   });
 });

--- a/apps/backend/src/idp/controllers/auth-context.controller.ts
+++ b/apps/backend/src/idp/controllers/auth-context.controller.ts
@@ -25,6 +25,7 @@ export class AuthContextController {
       projectTitle: context.projectTitle,
       authFlow: context.authFlow,
       apiKeyId: context.apiKeyId,
+      viewOnly: context.viewOnly,
     };
   }
 }

--- a/apps/backend/src/idp/controllers/intercom.controller.spec.ts
+++ b/apps/backend/src/idp/controllers/intercom.controller.spec.ts
@@ -5,6 +5,7 @@ import { IssueIntercomJwtService } from '../use-cases/issue-intercom-jwt.service
 import { IntercomMapper } from '../mappers/intercom.mapper';
 import { IssueIntercomJwtCommand } from '../dto/domain/issue-intercom-jwt.command';
 import { REJECT_API_KEY_AUTH_METADATA } from '../decorators/reject-api-key-auth.decorator';
+import { VIEW_ONLY_SAFE_METADATA } from '../decorators/view-only-safe.decorator';
 
 jest.mock('../decorators/auth.decorator', () => ({
   __esModule: true,
@@ -51,6 +52,12 @@ describe('IntercomController', () => {
 
   it('rejects API-key authentication at the controller level', () => {
     expect(Reflect.getMetadata(REJECT_API_KEY_AUTH_METADATA, IntercomController)).toBe(true);
+  });
+
+  it('allows Intercom JWT issuance in view-only sessions', () => {
+    expect(
+      Reflect.getMetadata(VIEW_ONLY_SAFE_METADATA, IntercomController.prototype.issueJwt)
+    ).toBe(true);
   });
 
   it('should propagate BadRequestException from use-case', async () => {

--- a/apps/backend/src/idp/controllers/intercom.controller.ts
+++ b/apps/backend/src/idp/controllers/intercom.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Post, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Auth, AuthContext, RejectApiKeyAuth } from '../decorators';
+import { Auth, AuthContext, RejectApiKeyAuth, ViewOnlySafe } from '../decorators';
 import type { AuthorizationContext } from '../types';
 import { Role, Strategy } from '../types';
 import { IssueIntercomJwtService } from '../use-cases/issue-intercom-jwt.service';
@@ -18,6 +18,7 @@ export class IntercomController {
   ) {}
 
   @Auth(Role.viewer(Strategy.PARSE))
+  @ViewOnlySafe()
   @Post('jwt')
   @HttpCode(HttpStatus.OK)
   @IssueIntercomJwtSpec()

--- a/apps/backend/src/idp/decorators/auth-context.decorator.spec.ts
+++ b/apps/backend/src/idp/decorators/auth-context.decorator.spec.ts
@@ -28,7 +28,21 @@ describe('getAuthorizationContext', () => {
       projectTitle: 'Project One',
       authFlow: 'api_key',
       apiKeyId: 'pmk_AbCdEfGhIjKlMnOpQrStUv',
+      viewOnly: undefined,
     });
+  });
+
+  it('propagates viewOnly flag from the authenticated request', () => {
+    const request = {
+      idpContext: {
+        projectId: 'project-1',
+        userId: 'user-1',
+        roles: ['admin'],
+        viewOnly: true,
+      },
+    } as AuthenticatedRequest;
+
+    expect(getAuthorizationContext(request).viewOnly).toBe(true);
   });
 
   it('throws when the request has no IDP context', () => {

--- a/apps/backend/src/idp/decorators/auth-context.decorator.ts
+++ b/apps/backend/src/idp/decorators/auth-context.decorator.ts
@@ -34,6 +34,7 @@ export function getAuthorizationContext(request: AuthenticatedRequest): Authoriz
       projectTitle: request.idpContext.projectTitle,
       authFlow: request.idpContext.authFlow,
       apiKeyId: request.idpContext.apiKeyId,
+      viewOnly: request.idpContext.viewOnly,
     };
   }
 

--- a/apps/backend/src/idp/decorators/index.ts
+++ b/apps/backend/src/idp/decorators/index.ts
@@ -1,3 +1,4 @@
 export { AuthContext } from './auth-context.decorator';
 export { Auth } from './auth.decorator';
 export { RejectApiKeyAuth, REJECT_API_KEY_AUTH_METADATA } from './reject-api-key-auth.decorator';
+export { ViewOnlySafe, VIEW_ONLY_SAFE_METADATA } from './view-only-safe.decorator';

--- a/apps/backend/src/idp/decorators/view-only-safe.decorator.ts
+++ b/apps/backend/src/idp/decorators/view-only-safe.decorator.ts
@@ -1,0 +1,12 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const VIEW_ONLY_SAFE_METADATA = 'viewOnlySafe';
+
+/**
+ * Marks a read-semantics POST endpoint as safe for view-only sessions.
+ *
+ * The IDP guard intentionally reads this metadata only from route handlers and
+ * honors it only for POST requests. Mutating PUT/PATCH/DELETE endpoints remain
+ * blocked even if annotated.
+ */
+export const ViewOnlySafe = () => SetMetadata(VIEW_ONLY_SAFE_METADATA, true);

--- a/apps/backend/src/idp/dto/presentation/auth-context-response-api.dto.ts
+++ b/apps/backend/src/idp/dto/presentation/auth-context-response-api.dto.ts
@@ -32,7 +32,7 @@ export class AuthContextResponseApiDto {
   @ApiPropertyOptional({
     nullable: true,
     description:
-      'True when the session is in view-only mode. Clients should disable analytics and mutating UI actions.',
+      'True when the session is in view-only mode. Mutating API requests are rejected server-side; clients may also suppress analytics.',
   })
   viewOnly?: boolean;
 }

--- a/apps/backend/src/idp/dto/presentation/auth-context-response-api.dto.ts
+++ b/apps/backend/src/idp/dto/presentation/auth-context-response-api.dto.ts
@@ -28,4 +28,11 @@ export class AuthContextResponseApiDto {
 
   @ApiPropertyOptional({ nullable: true })
   apiKeyId?: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'True when the session is in view-only mode. Clients should disable analytics and mutating UI actions.',
+  })
+  viewOnly?: boolean;
 }

--- a/apps/backend/src/idp/filters/idp-exception.filter.spec.ts
+++ b/apps/backend/src/idp/filters/idp-exception.filter.spec.ts
@@ -1,0 +1,53 @@
+import { ArgumentsHost } from '@nestjs/common';
+import {
+  ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE,
+  AuthorizationError,
+  ViewOnlyModeError,
+} from '@owox/idp-protocol';
+import { IdpExceptionFilter } from './idp-exception.filter';
+
+describe('IdpExceptionFilter', () => {
+  it('returns 403 with ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE for ViewOnlyModeError', () => {
+    const filter = new IdpExceptionFilter();
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => ({ status }),
+      }),
+    } as unknown as ArgumentsHost;
+
+    filter.catch(new ViewOnlyModeError(), host);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 403,
+        code: ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE,
+        message: 'Action not allowed in view-only mode',
+      })
+    );
+  });
+
+  it('keeps generic AuthorizationError code for non-view-only denials', () => {
+    const filter = new IdpExceptionFilter();
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const host = {
+      switchToHttp: () => ({
+        getResponse: () => ({ status }),
+      }),
+    } as unknown as ArgumentsHost;
+
+    filter.catch(new AuthorizationError('Access denied by api key'), host);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 403,
+        code: 'AUTHORIZATION_ERROR',
+        message: 'Access denied by api key',
+      })
+    );
+  });
+});

--- a/apps/backend/src/idp/guards/idp.guard.spec.ts
+++ b/apps/backend/src/idp/guards/idp.guard.spec.ts
@@ -1,6 +1,12 @@
 import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { AuthenticationError, AuthorizationError, type Payload } from '@owox/idp-protocol';
+import {
+  ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE,
+  AuthenticationError,
+  AuthorizationError,
+  type Payload,
+  ViewOnlyModeError,
+} from '@owox/idp-protocol';
 import { ClsService } from 'nestjs-cls';
 import { IdpProviderService } from '../services/idp-provider.service';
 import { IdpProjectionsService } from '../services/idp-projections.service';
@@ -75,6 +81,7 @@ describe('IdpGuard', () => {
       roles: [],
       authFlow: undefined,
       apiKeyId: undefined,
+      viewOnly: undefined,
     });
   });
 
@@ -85,8 +92,15 @@ describe('IdpGuard', () => {
     await expect(guard.canActivate(context())).rejects.toThrow(AuthorizationError);
   });
 
-  it('keeps Role.none optional and does not authenticate', async () => {
+  it('keeps Role.none optional and does not authenticate or apply view-only checks', async () => {
+    // Optional routes skip IDP entirely — even if a user access token is present
+    // and would be view-only. Real auth for those endpoints is external (service
+    // account / connector JWT), so view-only is not applied here by design.
     roleConfig = Role.none();
+    request.method = 'POST';
+    request.headers = { 'x-owox-authorization': 'Bearer access-token' };
+    idpProvider.parseToken.mockResolvedValue(payload(['admin'], { viewOnly: true }));
+    idpProvider.introspectToken.mockResolvedValue(payload(['admin'], { viewOnly: true }));
 
     await expect(guard.canActivate(context())).resolves.toBe(true);
 
@@ -225,6 +239,84 @@ describe('IdpGuard', () => {
     );
 
     await expect(guard.canActivate(context())).resolves.toBe(true);
+  });
+
+  describe('view-only restrictions', () => {
+    it.each(['GET', 'HEAD', 'OPTIONS'] as const)(
+      'allows view-only sessions for safe method %s',
+      async method => {
+        roleConfig = Role.viewer(Strategy.PARSE);
+        request.method = method;
+        idpProvider.parseToken.mockResolvedValue(payload(['admin'], { viewOnly: true }));
+
+        await expect(guard.canActivate(context())).resolves.toBe(true);
+
+        expect(request.idpContext.viewOnly).toBe(true);
+        expect(clsService.set).toHaveBeenCalledWith(
+          AUTH_CONTEXT,
+          expect.objectContaining({ viewOnly: true })
+        );
+      }
+    );
+
+    it.each(['POST', 'PUT', 'PATCH', 'DELETE'] as const)(
+      'rejects view-only sessions for state-changing method %s with ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE',
+      async method => {
+        roleConfig = Role.viewer(Strategy.PARSE);
+        request.method = method;
+        idpProvider.parseToken.mockResolvedValue(payload(['admin'], { viewOnly: true }));
+
+        let error: unknown;
+        try {
+          await guard.canActivate(context());
+        } catch (caughtError) {
+          error = caughtError;
+        }
+
+        expect(error).toBeInstanceOf(ViewOnlyModeError);
+        expect(error).toBeInstanceOf(AuthorizationError);
+        expect((error as ViewOnlyModeError).code).toBe(ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE);
+        expect((error as ViewOnlyModeError).getStatus()).toBe(403);
+        expect(idpProjectionsService.updateProjectionsFromIdpPayload).not.toHaveBeenCalled();
+      }
+    );
+
+    it('does not treat roles or unrelated claims as view-only', async () => {
+      roleConfig = Role.viewer(Strategy.PARSE);
+      request.method = 'POST';
+      // Unrelated claim noise — only Payload.viewOnly enables restrictions.
+      idpProvider.parseToken.mockResolvedValue(
+        payload(['viewer'], { readOnly: true } as Partial<Payload>)
+      );
+
+      await expect(guard.canActivate(context())).resolves.toBe(true);
+    });
+
+    it('allows state-changing methods when viewOnly is false or absent', async () => {
+      roleConfig = Role.viewer(Strategy.PARSE);
+      request.method = 'POST';
+      idpProvider.parseToken.mockResolvedValue(payload(['editor'], { viewOnly: false }));
+
+      await expect(guard.canActivate(context())).resolves.toBe(true);
+    });
+
+    it('enforces view-only before updating IDP projections on mutations', async () => {
+      roleConfig = Role.viewer(Strategy.PARSE);
+      request.method = 'PUT';
+      idpProvider.parseToken.mockResolvedValue(payload(['admin'], { viewOnly: true }));
+
+      await expect(guard.canActivate(context())).rejects.toBeInstanceOf(ViewOnlyModeError);
+      expect(idpProjectionsService.updateProjectionsFromIdpPayload).not.toHaveBeenCalled();
+    });
+
+    it('also enforces view-only when token is resolved via INTROSPECT strategy', async () => {
+      roleConfig = Role.viewer(Strategy.INTROSPECT);
+      request.method = 'PATCH';
+      idpProvider.introspectToken.mockResolvedValue(payload(['admin'], { viewOnly: true }));
+
+      await expect(guard.canActivate(context())).rejects.toBeInstanceOf(ViewOnlyModeError);
+      expect(idpProvider.parseToken).not.toHaveBeenCalled();
+    });
   });
 
   function context(): ExecutionContext {

--- a/apps/backend/src/idp/guards/idp.guard.spec.ts
+++ b/apps/backend/src/idp/guards/idp.guard.spec.ts
@@ -12,11 +12,13 @@ import { IdpProviderService } from '../services/idp-provider.service';
 import { IdpProjectionsService } from '../services/idp-projections.service';
 import { Role, Strategy, type RoleConfig } from '../types';
 import { REJECT_API_KEY_AUTH_METADATA } from '../decorators/reject-api-key-auth.decorator';
+import { VIEW_ONLY_SAFE_METADATA } from '../decorators/view-only-safe.decorator';
 import { AuthenticatedRequest, AUTH_CONTEXT, IdpGuard } from './idp.guard';
 
 describe('IdpGuard', () => {
   let roleConfig: RoleConfig;
   let rejectApiKeyAuth: boolean;
+  let viewOnlySafe: boolean;
   let request: AuthenticatedRequest;
   let idpProvider: {
     parseToken: jest.Mock<Promise<Payload | null>, [string]>;
@@ -31,6 +33,7 @@ describe('IdpGuard', () => {
   beforeEach(() => {
     roleConfig = Role.authenticated(Strategy.PARSE);
     rejectApiKeyAuth = false;
+    viewOnlySafe = false;
     request = {
       headers: {
         'x-owox-authorization': 'Bearer access-token',
@@ -59,6 +62,9 @@ describe('IdpGuard', () => {
           }
           if (metadataKey === REJECT_API_KEY_AUTH_METADATA) {
             return rejectApiKeyAuth;
+          }
+          if (metadataKey === VIEW_ONLY_SAFE_METADATA) {
+            return viewOnlySafe;
           }
           return undefined;
         }),
@@ -299,6 +305,29 @@ describe('IdpGuard', () => {
 
       await expect(guard.canActivate(context())).resolves.toBe(true);
     });
+
+    it('allows a read-semantics POST explicitly marked as view-only safe', async () => {
+      roleConfig = Role.viewer(Strategy.PARSE);
+      viewOnlySafe = true;
+      request.method = 'POST';
+      idpProvider.parseToken.mockResolvedValue(payload(['viewer'], { viewOnly: true }));
+
+      await expect(guard.canActivate(context())).resolves.toBe(true);
+
+      expect(request.idpContext.viewOnly).toBe(true);
+    });
+
+    it.each(['PUT', 'PATCH', 'DELETE'] as const)(
+      'does not apply the view-only safe escape hatch to %s',
+      async method => {
+        roleConfig = Role.viewer(Strategy.PARSE);
+        viewOnlySafe = true;
+        request.method = method;
+        idpProvider.parseToken.mockResolvedValue(payload(['admin'], { viewOnly: true }));
+
+        await expect(guard.canActivate(context())).rejects.toBeInstanceOf(ViewOnlyModeError);
+      }
+    );
 
     it('enforces view-only before updating IDP projections on mutations', async () => {
       roleConfig = Role.viewer(Strategy.PARSE);

--- a/apps/backend/src/idp/guards/idp.guard.ts
+++ b/apps/backend/src/idp/guards/idp.guard.ts
@@ -3,8 +3,11 @@ import { Request } from 'express';
 import {
   AuthenticationError,
   AuthorizationError,
+  isSafeHttpMethodForViewOnly,
+  isViewOnlyPayload,
   Payload,
   Role as RoleType,
+  ViewOnlyModeError,
 } from '@owox/idp-protocol';
 import { IdpProjectionsService } from '../services/idp-projections.service';
 import { Strategy } from '../types';
@@ -28,6 +31,8 @@ export interface AuthenticatedRequest extends Request {
     projectTitle?: string;
     authFlow?: string;
     apiKeyId?: string;
+    /** True when the session is in view-only mode. */
+    viewOnly?: boolean;
   };
 }
 
@@ -60,6 +65,10 @@ export class IdpGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
 
+    // Role.none() / optional auth: IdpGuard does not parse user tokens and does not
+    // apply view-only restrictions. Callers of these routes authenticate outside IDP
+    // (e.g. InternalApiGuard service-account tokens, GoogleJwtBody connector JWTs).
+    // A user view-only access token is not accepted as credentials on those paths.
     if (roleConfig.optional) {
       return true;
     }
@@ -68,6 +77,10 @@ export class IdpGuard implements CanActivate {
       const tokenPayload = await this.authenticateUser(request, roleConfig.strategy);
       this.checkApiKeyUsageRestrictions(tokenPayload, Boolean(rejectApiKeyAuth));
       this.checkApiKeyHeaderBinding(request, tokenPayload);
+      this.checkViewOnlyRestrictions(request, tokenPayload);
+
+      // Propagate only when true so normal sessions stay free of the flag.
+      const viewOnly = isViewOnlyPayload(tokenPayload) || undefined;
 
       request.idpContext = {
         userId: tokenPayload.userId,
@@ -79,6 +92,7 @@ export class IdpGuard implements CanActivate {
         projectTitle: tokenPayload.projectTitle,
         authFlow: tokenPayload.authFlow,
         apiKeyId: tokenPayload.apiKeyId,
+        viewOnly,
       };
 
       this.cls.set(AUTH_CONTEXT, {
@@ -87,6 +101,7 @@ export class IdpGuard implements CanActivate {
         roles: tokenPayload.roles,
         authFlow: tokenPayload.authFlow,
         apiKeyId: tokenPayload.apiKeyId,
+        viewOnly,
       });
 
       if (request && STATE_CHANGING_METHODS.includes(request.method)) {
@@ -94,6 +109,7 @@ export class IdpGuard implements CanActivate {
         void this.idpProjectionsService.updateProjectionsFromIdpPayload(tokenPayload);
       }
     } catch (error) {
+      // AuthorizationError covers ViewOnlyModeError (subclass) and role/API-key denials.
       if (error instanceof UnauthorizedException || error instanceof AuthorizationError) {
         throw error;
       }
@@ -124,6 +140,33 @@ export class IdpGuard implements CanActivate {
     }
 
     return tokenPayload;
+  }
+
+  /**
+   * Blocks state-changing requests when the session is in view-only mode.
+   * Safe methods (GET/HEAD/OPTIONS) remain allowed.
+   *
+   * Scope: only routes that go through authenticateUser (required @Auth roles).
+   * Intentionally NOT applied to Role.none() / optional routes (service or
+   * connector auth, not user IDP).
+   *
+   * MCP is a separate auth path; view-only sessions are blocked from minting
+   * MCP tokens in OAuthAuthorizationController so write tools cannot bypass
+   * this guard.
+   *
+   * View-only detection is delegated to idp-protocol so claim resolution can
+   * evolve independently of this guard.
+   */
+  private checkViewOnlyRestrictions(request: AuthenticatedRequest, tokenPayload: Payload): void {
+    if (!isViewOnlyPayload(tokenPayload)) {
+      return;
+    }
+
+    if (isSafeHttpMethodForViewOnly(request.method)) {
+      return;
+    }
+
+    throw new ViewOnlyModeError();
   }
 
   private checkApiKeyHeaderBinding(request: AuthenticatedRequest, tokenPayload: Payload): void {

--- a/apps/backend/src/idp/guards/idp.guard.ts
+++ b/apps/backend/src/idp/guards/idp.guard.ts
@@ -15,6 +15,7 @@ import { Reflector } from '@nestjs/core';
 import { IdpProviderService } from '../services/idp-provider.service';
 import { ClsService } from 'nestjs-cls';
 import { REJECT_API_KEY_AUTH_METADATA } from '../decorators/reject-api-key-auth.decorator';
+import { VIEW_ONLY_SAFE_METADATA } from '../decorators/view-only-safe.decorator';
 
 export interface AuthenticatedRequest extends Request {
   idpContext: {
@@ -57,6 +58,9 @@ export class IdpGuard implements CanActivate {
       REJECT_API_KEY_AUTH_METADATA,
       [context.getHandler(), context.getClass()]
     );
+    const viewOnlySafe = this.reflector.getAllAndOverride<boolean>(VIEW_ONLY_SAFE_METADATA, [
+      context.getHandler(),
+    ]);
 
     if (!roleConfig) {
       throw new AuthenticationError('No role configuration found');
@@ -76,7 +80,7 @@ export class IdpGuard implements CanActivate {
       const tokenPayload = await this.authenticateUser(request, roleConfig.strategy);
       this.checkApiKeyUsageRestrictions(tokenPayload, Boolean(rejectApiKeyAuth));
       this.checkApiKeyHeaderBinding(request, tokenPayload);
-      this.checkViewOnlyRestrictions(request, tokenPayload);
+      this.checkViewOnlyRestrictions(request, tokenPayload, Boolean(viewOnlySafe));
 
       // Propagate only when true so normal sessions stay free of the flag.
       const viewOnly = isViewOnlyPayload(tokenPayload) || undefined;
@@ -146,8 +150,9 @@ export class IdpGuard implements CanActivate {
 
   /**
    * Blocks POST/PUT/PATCH/DELETE when the session is in view-only mode.
-   * GET/HEAD/OPTIONS remain allowed. Some POSTs are read-semantics in practice;
-   * that trade-off is accepted for a simple method-based policy.
+   * GET/HEAD/OPTIONS remain allowed. A POST endpoint may opt in with
+   * @ViewOnlySafe only when it has read semantics and does not mutate project
+   * or external data. The escape hatch never applies to PUT/PATCH/DELETE.
    *
    * Scope: only routes that go through authenticateUser (required @Auth roles).
    * Intentionally NOT applied to Role.none() / optional routes (service or
@@ -159,12 +164,20 @@ export class IdpGuard implements CanActivate {
    * are not re-checked against live session viewOnly here — that is Identity /
    * MCP token lifecycle responsibility.
    */
-  private checkViewOnlyRestrictions(request: AuthenticatedRequest, tokenPayload: Payload): void {
+  private checkViewOnlyRestrictions(
+    request: AuthenticatedRequest,
+    tokenPayload: Payload,
+    viewOnlySafe: boolean
+  ): void {
     if (!isViewOnlyPayload(tokenPayload)) {
       return;
     }
 
     if (!STATE_CHANGING_METHODS.includes(request.method)) {
+      return;
+    }
+
+    if (request.method === 'POST' && viewOnlySafe) {
       return;
     }
 

--- a/apps/backend/src/idp/guards/idp.guard.ts
+++ b/apps/backend/src/idp/guards/idp.guard.ts
@@ -3,7 +3,6 @@ import { Request } from 'express';
 import {
   AuthenticationError,
   AuthorizationError,
-  isSafeHttpMethodForViewOnly,
   isViewOnlyPayload,
   Payload,
   Role as RoleType,
@@ -104,6 +103,9 @@ export class IdpGuard implements CanActivate {
         viewOnly,
       });
 
+      // Strategy.PARSE reads viewOnly only from the locally verified JWT. If
+      // Identity flips a session to view-only without revoking/re-issuing access
+      // tokens, write access remains until the token expires.
       if (request && STATE_CHANGING_METHODS.includes(request.method)) {
         // Update IDP projections in the background
         void this.idpProjectionsService.updateProjectionsFromIdpPayload(tokenPayload);
@@ -143,8 +145,9 @@ export class IdpGuard implements CanActivate {
   }
 
   /**
-   * Blocks state-changing requests when the session is in view-only mode.
-   * Safe methods (GET/HEAD/OPTIONS) remain allowed.
+   * Blocks POST/PUT/PATCH/DELETE when the session is in view-only mode.
+   * GET/HEAD/OPTIONS remain allowed. Some POSTs are read-semantics in practice;
+   * that trade-off is accepted for a simple method-based policy.
    *
    * Scope: only routes that go through authenticateUser (required @Auth roles).
    * Intentionally NOT applied to Role.none() / optional routes (service or
@@ -152,17 +155,16 @@ export class IdpGuard implements CanActivate {
    *
    * MCP is a separate auth path; view-only sessions are blocked from minting
    * MCP tokens in OAuthAuthorizationController so write tools cannot bypass
-   * this guard.
-   *
-   * View-only detection is delegated to idp-protocol so claim resolution can
-   * evolve independently of this guard.
+   * this guard. Tokens already issued (and refresh grants for those tokens)
+   * are not re-checked against live session viewOnly here — that is Identity /
+   * MCP token lifecycle responsibility.
    */
   private checkViewOnlyRestrictions(request: AuthenticatedRequest, tokenPayload: Payload): void {
     if (!isViewOnlyPayload(tokenPayload)) {
       return;
     }
 
-    if (isSafeHttpMethodForViewOnly(request.method)) {
+    if (!STATE_CHANGING_METHODS.includes(request.method)) {
       return;
     }
 

--- a/apps/backend/src/idp/oauth/controllers/oauth-authorization.controller.spec.ts
+++ b/apps/backend/src/idp/oauth/controllers/oauth-authorization.controller.spec.ts
@@ -2,6 +2,7 @@ import { Logger } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import {
   AuthorizationError,
+  ViewOnlyModeError,
   type McpOAuthProjectMemberContext,
   type Payload,
 } from '@owox/idp-protocol';
@@ -264,6 +265,40 @@ describe('OAuthAuthorizationController', () => {
     await expect(
       controller.authorize({}, request, response as unknown as Response)
     ).rejects.toThrow(AuthorizationError);
+    expect(oauthIdp.createAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it('rejects view-only sessions from obtaining MCP authorization codes', async () => {
+    const { controller, provider, oauthIdp, clientRegistry } = createController();
+    provider.parseToken.mockResolvedValueOnce({
+      ...payload,
+      viewOnly: true,
+    });
+    const response = createResponse();
+    const request = createRequest({
+      headers: { 'x-owox-authorization': 'Bearer view-only-access-token' },
+    });
+
+    await expect(
+      controller.authorize({}, request, response as unknown as Response)
+    ).rejects.toThrow(ViewOnlyModeError);
+    expect(oauthIdp.createAuthorizationCode).not.toHaveBeenCalled();
+    expect(clientRegistry.attachUserIfMissing).not.toHaveBeenCalled();
+  });
+
+  it('rejects view-only sessions resolved via refresh cookie', async () => {
+    const { controller, provider, oauthIdp } = createController();
+    provider.parseToken.mockResolvedValueOnce({
+      ...payload,
+      viewOnly: true,
+    });
+    const response = createResponse();
+    const request = createRequest({ cookies: { refreshToken: 'refresh-token-1' } });
+
+    await expect(
+      controller.authorize({}, request, response as unknown as Response)
+    ).rejects.toThrow(ViewOnlyModeError);
+    expect(provider.refreshToken).toHaveBeenCalledWith('refresh-token-1');
     expect(oauthIdp.createAuthorizationCode).not.toHaveBeenCalled();
   });
 

--- a/apps/backend/src/idp/oauth/controllers/oauth-authorization.controller.ts
+++ b/apps/backend/src/idp/oauth/controllers/oauth-authorization.controller.ts
@@ -11,6 +11,8 @@ import {
 import type { Request, Response } from 'express';
 import {
   AuthorizationError,
+  isViewOnlyPayload,
+  ViewOnlyModeError,
   type AuthResult,
   type McpOAuthProjectMemberContext,
   type Payload,
@@ -49,6 +51,12 @@ export class OAuthAuthorizationController {
     const authorization = await this.resolveAuthorizationContext(provider, request, response);
     if (!authorization) {
       return;
+    }
+
+    // View-only sessions must not mint MCP tokens: write tools would otherwise
+    // bypass IdpGuard and mutate project state under the impersonated user.
+    if (authorization.context.viewOnly === true) {
+      throw new ViewOnlyModeError('MCP authorization is not allowed in view-only mode');
     }
 
     await this.clientRegistry.attachUserIfMissing(
@@ -266,6 +274,8 @@ export class OAuthAuthorizationController {
       projectTitle: payload.projectTitle,
       authFlow: payload.authFlow,
       apiKeyId: payload.apiKeyId,
+      // Propagate only when true so normal sessions stay free of the flag.
+      viewOnly: isViewOnlyPayload(payload) || undefined,
     };
   }
 }

--- a/apps/backend/src/idp/types/auth.types.ts
+++ b/apps/backend/src/idp/types/auth.types.ts
@@ -13,4 +13,9 @@ export interface AuthorizationContext {
   projectTitle?: string;
   authFlow?: string;
   apiKeyId?: string;
+  /**
+   * True when the session is in view-only mode.
+   * Used by web/analytics and other clients that need session restrictions.
+   */
+  viewOnly?: boolean;
 }

--- a/apps/web/src/app/api/apiClient.ts
+++ b/apps/web/src/app/api/apiClient.ts
@@ -111,7 +111,12 @@ apiClient.interceptors.response.use(
     }
 
     if (error.response?.status === 403 && !skipErrorToast) {
-      showApiErrorToast(error, 'Access forbidden - insufficient permissions', { persistent: true });
+      const errorCode = (error.response.data as { code?: string } | undefined)?.code;
+      const message =
+        errorCode === 'ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE'
+          ? 'This action is not available in view-only mode'
+          : 'Access forbidden - insufficient permissions';
+      showApiErrorToast(error, message, { persistent: true });
     }
 
     if (error.response?.status === 400 && !skipErrorToast) {

--- a/apps/web/src/app/gtm/GoogleTagManager.test.tsx
+++ b/apps/web/src/app/gtm/GoogleTagManager.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequestStatus } from '../../shared/types/request-status';
+import { GoogleTagManager } from './GoogleTagManager';
+
+vi.mock('../store/hooks', () => ({
+  useFlags: vi.fn(),
+}));
+
+vi.mock('../../features/idp', () => ({
+  useAuth: vi.fn(),
+  isViewOnlySession: (user: { viewOnly?: boolean } | null | undefined) => user?.viewOnly === true,
+}));
+
+const { useFlags } = await import('../store/hooks');
+const { useAuth } = await import('../../features/idp');
+
+describe('GoogleTagManager', () => {
+  beforeEach(() => {
+    cleanup();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does nothing when flags are not loaded', () => {
+    vi.mocked(useFlags).mockReturnValue({ flags: null, callState: RequestStatus.LOADING } as never);
+    vi.mocked(useAuth).mockReturnValue({ user: { id: 'u', projectId: 'p' } } as never);
+
+    render(<GoogleTagManager />);
+
+    expect(document.getElementById('gtm-script')).toBeNull();
+    expect(document.getElementById('gtm-noscript')).toBeNull();
+  });
+
+  it('does not install GTM for view-only sessions', () => {
+    vi.mocked(useFlags).mockReturnValue({
+      flags: { GOOGLE_TAG_MANAGER_CONTAINER_ID: 'GTM-TEST123' },
+      callState: RequestStatus.LOADED,
+    } as never);
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 'u', projectId: 'p', viewOnly: true },
+    } as never);
+
+    render(<GoogleTagManager />);
+
+    expect(document.getElementById('gtm-script')).toBeNull();
+    expect(document.getElementById('gtm-noscript')).toBeNull();
+  });
+
+  it('installs GTM when container id is set and session is not view-only', () => {
+    vi.mocked(useFlags).mockReturnValue({
+      flags: { GOOGLE_TAG_MANAGER_CONTAINER_ID: 'GTM-TEST123' },
+      callState: RequestStatus.LOADED,
+    } as never);
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 'u', projectId: 'p' },
+    } as never);
+
+    render(<GoogleTagManager />);
+
+    expect(document.getElementById('gtm-script')).not.toBeNull();
+    expect(document.getElementById('gtm-noscript')).not.toBeNull();
+    expect(document.getElementById('gtm-script')?.innerHTML).toContain('GTM-TEST123');
+  });
+
+  it('does nothing when container id flag is empty', () => {
+    vi.mocked(useFlags).mockReturnValue({
+      flags: { GOOGLE_TAG_MANAGER_CONTAINER_ID: '  ' },
+      callState: RequestStatus.LOADED,
+    } as never);
+    vi.mocked(useAuth).mockReturnValue({
+      user: { id: 'u', projectId: 'p' },
+    } as never);
+
+    render(<GoogleTagManager />);
+
+    expect(document.getElementById('gtm-script')).toBeNull();
+  });
+});

--- a/apps/web/src/app/gtm/GoogleTagManager.test.tsx
+++ b/apps/web/src/app/gtm/GoogleTagManager.test.tsx
@@ -53,6 +53,18 @@ describe('GoogleTagManager', () => {
     expect(document.getElementById('gtm-noscript')).toBeNull();
   });
 
+  it('does not install GTM when user is still null', () => {
+    vi.mocked(useFlags).mockReturnValue({
+      flags: { GOOGLE_TAG_MANAGER_CONTAINER_ID: 'GTM-TEST123' },
+      callState: RequestStatus.LOADED,
+    } as never);
+    vi.mocked(useAuth).mockReturnValue({ user: null } as never);
+
+    render(<GoogleTagManager />);
+
+    expect(document.getElementById('gtm-script')).toBeNull();
+  });
+
   it('installs GTM when container id is set and session is not view-only', () => {
     vi.mocked(useFlags).mockReturnValue({
       flags: { GOOGLE_TAG_MANAGER_CONTAINER_ID: 'GTM-TEST123' },

--- a/apps/web/src/app/gtm/GoogleTagManager.tsx
+++ b/apps/web/src/app/gtm/GoogleTagManager.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useFlags } from '../store/hooks';
 import { RequestStatus } from '../../shared/types/request-status.ts';
+import { isViewOnlySession, useAuth } from '../../features/idp';
 
 const GTM_SCRIPT_ID = 'gtm-script';
 const GTM_NOSCRIPT_ID = 'gtm-noscript';
@@ -68,17 +69,24 @@ function extractContainerId(flags: Record<string, unknown>): string {
   return (containerId ?? '').trim();
 }
 
+/**
+ * Loads GTM when configured via app flags.
+ * Skipped entirely in view-only sessions so PostHog / GA4 tags and
+ * session recordings never start for these read-only sessions.
+ */
 export function GoogleTagManager(): null {
   const { flags, callState } = useFlags();
+  const { user } = useAuth();
 
   useEffect(() => {
     if (callState !== RequestStatus.LOADED || !flags) return;
+    if (isViewOnlySession(user)) return;
 
     const containerId = extractContainerId(flags);
     if (!containerId) return;
 
     initializeGTM(containerId);
-  }, [flags, callState]);
+  }, [flags, callState, user]);
 
   return null;
 }

--- a/apps/web/src/app/gtm/GoogleTagManager.tsx
+++ b/apps/web/src/app/gtm/GoogleTagManager.tsx
@@ -73,13 +73,19 @@ function extractContainerId(flags: Record<string, unknown>): string {
  * Loads GTM when configured via app flags.
  * Skipped entirely in view-only sessions so PostHog / GA4 tags and
  * session recordings never start for these read-only sessions.
+ *
+ * Limitation: if the session flips normal → view-only mid-SPA after GTM was
+ * already bootstrapped, we only stop new dataLayer pushes (see
+ * suppressClientAnalytics). Tags already running inside the container are not
+ * torn down without a full page reload.
  */
 export function GoogleTagManager(): null {
   const { flags, callState } = useFlags();
   const { user } = useAuth();
 
   useEffect(() => {
-    if (callState !== RequestStatus.LOADED || !flags) return;
+    // Fail closed until auth resolves: do not load GTM without a known user.
+    if (callState !== RequestStatus.LOADED || !flags || !user) return;
     if (isViewOnlySession(user)) return;
 
     const containerId = extractContainerId(flags);

--- a/apps/web/src/features/idp/context/AuthContext.tsx
+++ b/apps/web/src/features/idp/context/AuthContext.tsx
@@ -8,6 +8,7 @@ import {
   getUserApi,
   RedirectStorageService,
   isBlockedUserError,
+  isViewOnlySession,
 } from '../services';
 import { getProjectIdFromPath } from '../utils/project-id';
 import {
@@ -15,7 +16,13 @@ import {
   clearTokenProvider,
   DefaultTokenProvider,
 } from '../../../app/api/token-provider';
-import { pushToDataLayer, trackUserIdentified, trackLogout } from '../../../utils';
+import {
+  pushToDataLayer,
+  trackUserIdentified,
+  trackLogout,
+  suppressClientAnalytics,
+  setAnalyticsDisabled,
+} from '../../../utils';
 import { buildProjectPath } from '../../../utils/path';
 import {
   buildProjectRequestAccessPath,
@@ -280,14 +287,23 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [initializeAuth]);
 
   useEffect(() => {
-    if (state.user) {
-      pushToDataLayer({ projectId: state.user.projectId });
-      trackUserIdentified({
-        userId: state.user.id,
-        userEmail: state.user.email,
-        userFullName: state.user.fullName,
-      });
+    if (!state.user) {
+      return;
     }
+
+    // View-only: do not identify the user or emit analytics events.
+    if (isViewOnlySession(state.user)) {
+      suppressClientAnalytics();
+      return;
+    }
+
+    setAnalyticsDisabled(false);
+    pushToDataLayer({ projectId: state.user.projectId });
+    trackUserIdentified({
+      userId: state.user.id,
+      userEmail: state.user.email,
+      userFullName: state.user.fullName,
+    });
   }, [state.user]);
 
   useEffect(() => {

--- a/apps/web/src/features/idp/services/auth.service.test.ts
+++ b/apps/web/src/features/idp/services/auth.service.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { currentUserResponseToUser, isViewOnlySession } from './auth.service';
+import type { CurrentUserResponse, User } from '../types';
+
+describe('currentUserResponseToUser', () => {
+  it('maps standard user fields without viewOnly', () => {
+    const actual = currentUserResponseToUser(baseResponse());
+
+    expect(actual).toEqual({
+      id: 'user-1',
+      email: 'user@example.com',
+      fullName: 'User Example',
+      roles: ['viewer'],
+      projectId: 'project-1',
+      projectTitle: 'Demo Project',
+      mcpServerUrl: undefined,
+      avatar: 'https://img.test/a.png',
+      onboarding: undefined,
+      viewOnly: undefined,
+    });
+  });
+
+  it('surfaces viewOnly only when the API returns true', () => {
+    expect(currentUserResponseToUser(baseResponse({ viewOnly: true })).viewOnly).toBe(true);
+    expect(currentUserResponseToUser(baseResponse({ viewOnly: false })).viewOnly).toBeUndefined();
+    expect(currentUserResponseToUser(baseResponse()).viewOnly).toBeUndefined();
+  });
+});
+
+describe('isViewOnlySession', () => {
+  it('returns true only for users with viewOnly:true', () => {
+    expect(isViewOnlySession({ id: 'u', projectId: 'p', viewOnly: true } satisfies User)).toBe(
+      true
+    );
+    expect(isViewOnlySession({ id: 'u', projectId: 'p', viewOnly: false } satisfies User)).toBe(
+      false
+    );
+    expect(isViewOnlySession({ id: 'u', projectId: 'p' } satisfies User)).toBe(false);
+    expect(isViewOnlySession(null)).toBe(false);
+    expect(isViewOnlySession(undefined)).toBe(false);
+  });
+});
+
+function baseResponse(overrides: Partial<CurrentUserResponse> = {}): CurrentUserResponse {
+  return {
+    userId: 'user-1',
+    projectId: 'project-1',
+    email: 'user@example.com',
+    fullName: 'User Example',
+    avatar: 'https://img.test/a.png',
+    roles: ['viewer'],
+    projectTitle: 'Demo Project',
+    ...overrides,
+  };
+}

--- a/apps/web/src/features/idp/services/auth.service.ts
+++ b/apps/web/src/features/idp/services/auth.service.ts
@@ -14,7 +14,17 @@ export function currentUserResponseToUser(payload: CurrentUserResponse): User {
     mcpServerUrl: payload.mcpServerUrl,
     avatar: payload.avatar,
     onboarding: payload.onboarding,
+    // Only surface when true so normal sessions stay free of the flag.
+    viewOnly: payload.viewOnly === true ? true : undefined,
   };
+}
+
+/**
+ * Whether the current session is in view-only mode.
+ * Prefer this helper over raw field checks so analytics/UI gates stay consistent.
+ */
+export function isViewOnlySession(user: User | null | undefined): boolean {
+  return user?.viewOnly === true;
 }
 
 /**
@@ -43,6 +53,7 @@ export function hasAllRoles(user: User | null, roles: Role[]): boolean {
 
 export const AuthService = {
   currentUserResponseToUser,
+  isViewOnlySession,
   hasRole,
   hasAnyRole,
   hasAllRoles,

--- a/apps/web/src/features/idp/types/auth-api.types.ts
+++ b/apps/web/src/features/idp/types/auth-api.types.ts
@@ -23,6 +23,8 @@ export interface CurrentUserResponse {
   projectTitle?: string;
   onboarding?: OnboardingAnswer[];
   mcpServerUrl?: string;
+  /** True when the session is in view-only mode. */
+  viewOnly?: boolean;
 }
 
 /**

--- a/apps/web/src/features/idp/types/user.types.ts
+++ b/apps/web/src/features/idp/types/user.types.ts
@@ -21,6 +21,11 @@ export interface User {
   projectTitle?: string;
   mcpServerUrl?: string;
   onboarding?: OnboardingAnswer[];
+  /**
+   * True when the session is in view-only mode.
+   * Use this to disable analytics/session recordings and mutating UI.
+   */
+  viewOnly?: boolean;
 }
 
 /**

--- a/apps/web/src/features/idp/types/user.types.ts
+++ b/apps/web/src/features/idp/types/user.types.ts
@@ -23,7 +23,8 @@ export interface User {
   onboarding?: OnboardingAnswer[];
   /**
    * True when the session is in view-only mode.
-   * Use this to disable analytics/session recordings and mutating UI.
+   * Server rejects mutating API methods; client uses this to suppress analytics.
+   * UI controls may stay enabled — blocked actions fail after the request.
    */
   viewOnly?: boolean;
 }

--- a/apps/web/src/utils/data-layer.test.ts
+++ b/apps/web/src/utils/data-layer.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  isAnalyticsDisabled,
+  pushToDataLayer,
+  setAnalyticsDisabled,
+  suppressClientAnalytics,
+  trackEvent,
+  trackLogout,
+  trackUserIdentified,
+} from './data-layer';
+
+describe('data-layer analytics gate', () => {
+  beforeEach(() => {
+    setAnalyticsDisabled(false);
+    window.dataLayer = { push: vi.fn() } as unknown as typeof window.dataLayer;
+  });
+
+  afterEach(() => {
+    setAnalyticsDisabled(false);
+    vi.restoreAllMocks();
+  });
+
+  it('pushes events when analytics are enabled', () => {
+    trackEvent({ event: 'test_event', category: 'Test', action: 'Click' });
+
+    expect(window.dataLayer?.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'test_event',
+        category: 'Test',
+        action: 'Click',
+        eventType: 'app',
+      })
+    );
+  });
+
+  it('does not push trackEvent / identify / logout when analytics are disabled', () => {
+    setAnalyticsDisabled(true);
+
+    trackEvent({ event: 'should_not_fire' });
+    trackUserIdentified({ userId: 'u1', userEmail: 'a@b.c' });
+    trackLogout();
+    pushToDataLayer({ projectId: 'p1' });
+
+    expect(window.dataLayer?.push).not.toHaveBeenCalled();
+    expect(isAnalyticsDisabled()).toBe(true);
+  });
+
+  it('suppressClientAnalytics disables dataLayer pushes', () => {
+    suppressClientAnalytics();
+    trackEvent({ event: 'blocked' });
+
+    expect(isAnalyticsDisabled()).toBe(true);
+    expect(window.dataLayer?.push).not.toHaveBeenCalled();
+  });
+
+  it('re-enables pushes after setAnalyticsDisabled(false)', () => {
+    setAnalyticsDisabled(true);
+    trackEvent({ event: 'blocked' });
+    expect(window.dataLayer?.push).not.toHaveBeenCalled();
+
+    setAnalyticsDisabled(false);
+    trackEvent({ event: 'allowed' });
+    expect(window.dataLayer?.push).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'allowed' })
+    );
+  });
+});

--- a/apps/web/src/utils/data-layer.ts
+++ b/apps/web/src/utils/data-layer.ts
@@ -31,12 +31,41 @@ declare global {
   }
 }
 
+/**
+ * When true, no events are pushed to dataLayer (GTM / GA4 / PostHog tags).
+ * Used for view-only sessions so product analytics stay off for these users.
+ */
+let analyticsDisabled = false;
+
+/**
+ * Enable or disable client analytics emission (dataLayer pushes).
+ */
+export function setAnalyticsDisabled(disabled: boolean): void {
+  analyticsDisabled = disabled;
+}
+
+export function isAnalyticsDisabled(): boolean {
+  return analyticsDisabled;
+}
+
+/**
+ * Suppress client analytics for view-only sessions by no-op'ing dataLayer pushes.
+ * GTM is not bootstrapped for these sessions separately in GoogleTagManager.
+ */
+export function suppressClientAnalytics(): void {
+  setAnalyticsDisabled(true);
+}
+
 const initializeDataLayer = (): void => {
   if (typeof window !== 'undefined' && !window.dataLayer) {
     window.dataLayer = [] as unknown as DataLayer;
   }
 };
+
 export const trackEvent = (eventData: AnalyticsEvent): void => {
+  if (analyticsDisabled) {
+    return;
+  }
   eventData.timestamp = eventData.timestamp ?? Date.now();
   eventData.eventType = eventData.eventType ?? 'app';
   pushToDataLayer(eventData);
@@ -62,6 +91,9 @@ export const trackLogout = (): void => {
 };
 
 export const pushToDataLayer = (data: Record<string, unknown>): void => {
+  if (analyticsDisabled) {
+    return;
+  }
   if (typeof window !== 'undefined') {
     initializeDataLayer();
     try {

--- a/packages/idp-owox-better-auth/src/client/dto/idpOwoxPayloadDto.test.ts
+++ b/packages/idp-owox-better-auth/src/client/dto/idpOwoxPayloadDto.test.ts
@@ -18,7 +18,16 @@ describe('IdpOwoxPayloadSchema', () => {
     expect(() => IdpOwoxPayloadSchema.parse(payload({ roles: undefined }))).toThrow();
   });
 
-  function payload(overrides: { roles?: unknown }) {
+  it('accepts the optional viewOnly claim', () => {
+    expect(IdpOwoxPayloadSchema.parse(payload({ viewOnly: true })).viewOnly).toBe(true);
+    expect(IdpOwoxPayloadSchema.parse(payload({})).viewOnly).toBeUndefined();
+  });
+
+  it('rejects a non-boolean viewOnly claim', () => {
+    expect(() => IdpOwoxPayloadSchema.parse(payload({ viewOnly: 'true' }))).toThrow();
+  });
+
+  function payload(overrides: { roles?: unknown; viewOnly?: unknown }) {
     const base: Record<string, unknown> = {
       userId: 'user-1',
       projectId: 'project-1',
@@ -36,6 +45,9 @@ describe('IdpOwoxPayloadSchema', () => {
       } else {
         base.roles = overrides.roles;
       }
+    }
+    if (Object.prototype.hasOwnProperty.call(overrides, 'viewOnly')) {
+      base.viewOnly = overrides.viewOnly;
     }
 
     return base;

--- a/packages/idp-owox-better-auth/src/client/dto/idpOwoxPayloadDto.ts
+++ b/packages/idp-owox-better-auth/src/client/dto/idpOwoxPayloadDto.ts
@@ -28,6 +28,7 @@ export const IdpOwoxPayloadSchema = z
     signinProvider: z.string().optional().nullable(),
     authFlow: z.string().optional().nullable(),
     apiKeyId: z.string().optional().nullable(),
+    viewOnly: z.boolean().optional(),
   })
   .passthrough();
 

--- a/packages/idp-owox-better-auth/src/client/dto/introspectionDto.test.ts
+++ b/packages/idp-owox-better-auth/src/client/dto/introspectionDto.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from '@jest/globals';
+import { IntrospectionResponseSchema } from './introspectionDto.js';
+
+describe('IntrospectionResponseSchema', () => {
+  it('accepts active responses with and without viewOnly', () => {
+    expect(IntrospectionResponseSchema.parse(activeResponse()).viewOnly).toBeUndefined();
+    expect(IntrospectionResponseSchema.parse(activeResponse({ viewOnly: true })).viewOnly).toBe(
+      true
+    );
+  });
+
+  it('accepts inactive responses from IB with and without viewOnly', () => {
+    expect(IntrospectionResponseSchema.parse(inactiveResponse()).viewOnly).toBeUndefined();
+    expect(IntrospectionResponseSchema.parse(inactiveResponse({ viewOnly: false })).viewOnly).toBe(
+      false
+    );
+  });
+
+  it('accepts the minimal inactive response contract', () => {
+    expect(IntrospectionResponseSchema.parse({ isActive: false })).toEqual({ isActive: false });
+  });
+
+  it('rejects a non-boolean viewOnly claim in inactive responses', () => {
+    expect(() =>
+      IntrospectionResponseSchema.parse(inactiveResponse({ viewOnly: 'false' }))
+    ).toThrow();
+  });
+
+  function activeResponse(overrides: Record<string, unknown> = {}) {
+    return {
+      isActive: true,
+      userId: 'user-1',
+      projectId: 'project-1',
+      userEmail: 'user@example.com',
+      userFullName: 'User Example',
+      userAvatar: 'https://img.test/a.png',
+      roles: ['viewer'],
+      projectTitle: 'Demo Project',
+      signinProvider: 'google',
+      authFlow: 'app_owox',
+      apiKeyId: null,
+      ...overrides,
+    };
+  }
+
+  function inactiveResponse(overrides: Record<string, unknown> = {}) {
+    return {
+      isActive: false,
+      userId: null,
+      projectId: null,
+      userEmail: null,
+      userFullName: null,
+      userAvatar: null,
+      roles: null,
+      projectTitle: null,
+      authFlow: null,
+      apiKeyId: null,
+      ...overrides,
+    };
+  }
+});

--- a/packages/idp-owox-better-auth/src/client/dto/introspectionDto.ts
+++ b/packages/idp-owox-better-auth/src/client/dto/introspectionDto.ts
@@ -11,14 +11,23 @@ const ActiveSchema = IdpOwoxPayloadSchema.extend({
 });
 
 type PayloadShape = typeof IdpOwoxPayloadSchema extends z.ZodObject<infer S> ? S : never;
+// Inactive introspection responses carry no usable identity. IB versions differ
+// in which null payload fields they serialize, so keep those fields optional
+// while validating any field that is present.
 const inactiveShape = Object.fromEntries(
-  Object.keys((IdpOwoxPayloadSchema as z.ZodObject<PayloadShape>).shape).map(k => [k, z.null()])
-) as { [K in keyof IdpOwoxPayload]: z.ZodNull };
+  Object.keys((IdpOwoxPayloadSchema as z.ZodObject<PayloadShape>).shape).map(k => [
+    k,
+    z.null().optional(),
+  ])
+) as { [K in keyof IdpOwoxPayload]: z.ZodOptional<z.ZodNull> };
 
 const InactiveSchema = z
   .object(inactiveShape)
   .strict()
-  .extend({ isActive: z.literal(false) });
+  .extend({
+    isActive: z.literal(false),
+    viewOnly: z.boolean().nullable().optional(),
+  });
 
 /** Token introspection response schema. */
 export const IntrospectionResponseSchema = z.discriminatedUnion('isActive', [

--- a/packages/idp-owox-better-auth/src/controllers/onboarding-controller.test.ts
+++ b/packages/idp-owox-better-auth/src/controllers/onboarding-controller.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE } from '@owox/idp-protocol';
+import type { Request, Response } from 'express';
+import { CORE_REFRESH_TOKEN_COOKIE } from '../core/constants.js';
+import type { OwoxTokenFacade } from '../facades/owox-token-facade.js';
+import type { OnboardingService } from '../services/onboarding/onboarding-service.js';
+import { OnboardingController } from './onboarding-controller.js';
+
+function createResponseMock(): Response & { body?: unknown; statusCode?: number } {
+  const res = {} as Response & { body?: unknown; statusCode?: number };
+  res.statusCode = 200;
+  res.status = jest.fn((code: number) => {
+    res.statusCode = code;
+    return res;
+  }) as unknown as Response['status'];
+  res.json = jest.fn((body: unknown) => {
+    res.body = body;
+    return res;
+  }) as unknown as Response['json'];
+  res.redirect = jest.fn((url: string) => {
+    res.body = { redirect: url };
+    return res;
+  }) as unknown as Response['redirect'];
+  return res;
+}
+
+function createController(viewOnly: boolean) {
+  const onboardingService = {
+    shouldShowQuestionnaire: jest.fn(async () => true),
+    saveAnswers: jest.fn(async () => undefined),
+  } as unknown as OnboardingService;
+
+  const tokenFacade = {
+    refreshToken: jest.fn(async () => ({
+      accessToken: 'access',
+      refreshToken: 'refresh-rotated',
+      refreshTokenExpiresIn: 3600,
+    })),
+    parseToken: jest.fn(async () => ({
+      userId: 'user-1',
+      projectId: 'project-1',
+      roles: ['admin'],
+      ...(viewOnly ? { viewOnly: true } : {}),
+    })),
+    setTokenToCookie: jest.fn(),
+  } as unknown as OwoxTokenFacade;
+
+  return {
+    controller: new OnboardingController(onboardingService, tokenFacade),
+    onboardingService,
+    tokenFacade,
+  };
+}
+
+describe('OnboardingController view-only', () => {
+  const req = {
+    cookies: { [CORE_REFRESH_TOKEN_COOKIE]: 'refresh' },
+    body: {
+      answers: [{ questionId: 'q1', answerValue: 'a1' }],
+      redirect: '/',
+    },
+  } as unknown as Request;
+
+  it('rejects POST /auth/onboarding for view-only sessions', async () => {
+    const { controller, onboardingService } = createController(true);
+    const res = createResponseMock();
+
+    await controller.submitAnswers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        code: ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE,
+      })
+    );
+    expect(onboardingService.saveAnswers).not.toHaveBeenCalled();
+  });
+
+  it('redirects GET /auth/onboarding for view-only sessions', async () => {
+    const { controller, onboardingService } = createController(true);
+    const res = createResponseMock();
+
+    await controller.onboardingPage(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith('/');
+    expect(onboardingService.shouldShowQuestionnaire).not.toHaveBeenCalled();
+  });
+
+  it('allows POST /auth/onboarding for normal sessions', async () => {
+    const { controller, onboardingService } = createController(false);
+    const res = createResponseMock();
+
+    await controller.submitAnswers(req, res);
+
+    expect(onboardingService.saveAnswers).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ redirect: '/' });
+  });
+});

--- a/packages/idp-owox-better-auth/src/controllers/onboarding-controller.ts
+++ b/packages/idp-owox-better-auth/src/controllers/onboarding-controller.ts
@@ -1,7 +1,4 @@
-import {
-  ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE,
-  isViewOnlyPayload,
-} from '@owox/idp-protocol';
+import { ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE, isViewOnlyPayload } from '@owox/idp-protocol';
 import { sendSecureHtml } from '@owox/internal-helpers';
 import type { Express, Request, Response } from 'express';
 import { AUTH_BASE_PATH, CORE_REFRESH_TOKEN_COOKIE } from '../core/constants.js';

--- a/packages/idp-owox-better-auth/src/controllers/onboarding-controller.ts
+++ b/packages/idp-owox-better-auth/src/controllers/onboarding-controller.ts
@@ -1,3 +1,7 @@
+import {
+  ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE,
+  isViewOnlyPayload,
+} from '@owox/idp-protocol';
 import { sendSecureHtml } from '@owox/internal-helpers';
 import type { Express, Request, Response } from 'express';
 import { AUTH_BASE_PATH, CORE_REFRESH_TOKEN_COOKIE } from '../core/constants.js';
@@ -22,11 +26,16 @@ export class OnboardingController {
   /**
    * GET /auth/onboarding — renders the questionnaire page.
    * Requires a valid refreshToken cookie and the user must meet onboarding criteria.
+   * View-only sessions are redirected home (they cannot submit answers).
    */
   async onboardingPage(req: Request, res: Response): Promise<void> {
     const ctx = await this.resolveUserContext(req, res);
     if (!ctx.userId) {
       return res.redirect(`${AUTH_BASE_PATH}/sign-in`);
+    }
+
+    if (ctx.viewOnly) {
+      return res.redirect('/');
     }
 
     const eligible = await this.isEligible(ctx.userId, ctx.projectId);
@@ -47,12 +56,26 @@ export class OnboardingController {
 
   /**
    * POST /auth/onboarding — saves answers and returns redirect URL.
+   * Express route (outside Nest IdpGuard) — enforces view-only here.
    */
   async submitAnswers(req: Request, res: Response): Promise<void> {
     try {
-      const { userId, projectId, biUserId, userRole } = await this.resolveUserContext(req, res);
+      const { userId, projectId, biUserId, userRole, viewOnly } = await this.resolveUserContext(
+        req,
+        res
+      );
       if (!userId) {
         res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      if (viewOnly) {
+        res.status(403).json({
+          statusCode: 403,
+          code: ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE,
+          message: 'Action not allowed in view-only mode',
+          error: 'Action not allowed in view-only mode',
+        });
         return;
       }
 
@@ -102,16 +125,22 @@ export class OnboardingController {
   }
 
   /**
-   * Resolves userId, projectId, biUserId, and role from the refresh token cookie.
+   * Resolves userId, projectId, biUserId, role, and viewOnly from the refresh token cookie.
    * Refreshes the token and updates the cookie following the standard auth pattern.
    */
   private async resolveUserContext(
     req: Request,
     res: Response
-  ): Promise<{ userId: string; projectId: string; biUserId: string; userRole: string }> {
+  ): Promise<{
+    userId: string;
+    projectId: string;
+    biUserId: string;
+    userRole: string;
+    viewOnly: boolean;
+  }> {
     const refreshToken = req.cookies?.[CORE_REFRESH_TOKEN_COOKIE];
     if (!refreshToken) {
-      return { userId: '', projectId: '', biUserId: '', userRole: 'viewer' };
+      return { userId: '', projectId: '', biUserId: '', userRole: 'viewer', viewOnly: false };
     }
 
     try {
@@ -128,6 +157,7 @@ export class OnboardingController {
           // biUserId is the same as userId in the refresh token payload
           biUserId: payload.userId,
           userRole: role,
+          viewOnly: isViewOnlyPayload(payload),
         };
       }
     } catch (error) {
@@ -137,9 +167,8 @@ export class OnboardingController {
         error instanceof Error ? error : undefined
       );
     }
-    return { userId: '', projectId: '', biUserId: '', userRole: 'viewer' };
+    return { userId: '', projectId: '', biUserId: '', userRole: 'viewer', viewOnly: false };
   }
-
   /**
    * Validates redirect is a safe relative path. Returns '/' for any suspicious value.
    */

--- a/packages/idp-owox-better-auth/src/mappers/client-payload-mapper.test.ts
+++ b/packages/idp-owox-better-auth/src/mappers/client-payload-mapper.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from '@jest/globals';
+import { toPayload } from './client-payload-mapper.js';
+
+describe('toPayload', () => {
+  it('maps a standard Identity OWOX payload without viewOnly', () => {
+    const actual = toPayload(basePayload());
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        userId: 'user-1',
+        projectId: 'project-1',
+        email: 'user@example.com',
+        fullName: 'User Example',
+        roles: ['viewer'],
+        projectTitle: 'Demo Project',
+      })
+    );
+    expect(actual.viewOnly).toBeUndefined();
+  });
+
+  it('normalizes canonical viewOnly claim to Payload.viewOnly', () => {
+    const actual = toPayload(basePayload({ viewOnly: true }));
+
+    expect(actual.viewOnly).toBe(true);
+  });
+
+  it('does not map readOnly into viewOnly', () => {
+    expect(toPayload(basePayload({ readOnly: true })).viewOnly).toBeUndefined();
+  });
+
+  it('does not set viewOnly when the claim is false', () => {
+    const actual = toPayload(basePayload({ viewOnly: false }));
+
+    expect(actual.viewOnly).toBeUndefined();
+  });
+
+  it('keeps roles independent from viewOnly', () => {
+    const actual = toPayload(basePayload({ roles: ['admin'], viewOnly: true }));
+
+    expect(actual.roles).toEqual(['admin']);
+    expect(actual.viewOnly).toBe(true);
+  });
+
+  function basePayload(overrides: Record<string, unknown> = {}) {
+    return {
+      userId: 'user-1',
+      projectId: 'project-1',
+      userEmail: 'user@example.com',
+      userFullName: 'User Example',
+      userAvatar: 'https://img.test/a.png',
+      roles: ['viewer'],
+      projectTitle: 'Demo Project',
+      signinProvider: 'google',
+      ...overrides,
+    };
+  }
+});

--- a/packages/idp-owox-better-auth/src/mappers/client-payload-mapper.ts
+++ b/packages/idp-owox-better-auth/src/mappers/client-payload-mapper.ts
@@ -1,18 +1,25 @@
 import { IdpOwoxPayloadSchema, type IdpOwoxPayload } from '../client/index.js';
-import { Payload, PayloadSchema } from '@owox/idp-protocol';
+import { Payload, PayloadSchema, resolveViewOnlyFromClaims } from '@owox/idp-protocol';
 
-const IdpOwoxToPayloadSchema = IdpOwoxPayloadSchema.transform((src: IdpOwoxPayload) => ({
-  userId: src.userId,
-  projectId: src.projectId,
-  email: src.userEmail,
-  signinProvider: src.signinProvider ?? undefined,
-  fullName: src.userFullName,
-  avatar: src.userAvatar ?? undefined,
-  roles: src.roles,
-  projectTitle: src.projectTitle,
-  authFlow: src.authFlow ?? undefined,
-  apiKeyId: src.apiKeyId ?? undefined,
-})).pipe(PayloadSchema);
+const IdpOwoxToPayloadSchema = IdpOwoxPayloadSchema.transform((src: IdpOwoxPayload) => {
+  // Only the protocol contract field viewOnly is mapped — no readOnly/roles mixing.
+  const viewOnly = resolveViewOnlyFromClaims(src as Record<string, unknown>);
+
+  return {
+    userId: src.userId,
+    projectId: src.projectId,
+    email: src.userEmail,
+    signinProvider: src.signinProvider ?? undefined,
+    fullName: src.userFullName,
+    avatar: src.userAvatar ?? undefined,
+    roles: src.roles,
+    projectTitle: src.projectTitle,
+    authFlow: src.authFlow ?? undefined,
+    apiKeyId: src.apiKeyId ?? undefined,
+    // Only set when true so normal sessions stay free of the flag.
+    ...(viewOnly ? { viewOnly: true } : {}),
+  };
+}).pipe(PayloadSchema);
 
 /**
  * Maps Identity OWOX payloads into idp-protocol payloads.

--- a/packages/idp-owox-better-auth/src/mappers/client-payload-mapper.ts
+++ b/packages/idp-owox-better-auth/src/mappers/client-payload-mapper.ts
@@ -3,7 +3,7 @@ import { Payload, PayloadSchema, resolveViewOnlyFromClaims } from '@owox/idp-pro
 
 const IdpOwoxToPayloadSchema = IdpOwoxPayloadSchema.transform((src: IdpOwoxPayload) => {
   // Only the protocol contract field viewOnly is mapped — no readOnly/roles mixing.
-  const viewOnly = resolveViewOnlyFromClaims(src as Record<string, unknown>);
+  const viewOnly = resolveViewOnlyFromClaims(src);
 
   return {
     userId: src.userId,

--- a/packages/idp-protocol/src/index.ts
+++ b/packages/idp-protocol/src/index.ts
@@ -6,3 +6,6 @@ export * from './providers/index.js';
 
 // Middleware
 export * from './middleware/index.js';
+
+// Shared utilities (view-only claim resolution, etc.)
+export * from './utils/view-only.js';

--- a/packages/idp-protocol/src/types/errors.ts
+++ b/packages/idp-protocol/src/types/errors.ts
@@ -33,8 +33,24 @@ export class AuthenticationError extends IdpError {
  * Authorization error
  */
 export class AuthorizationError extends IdpError {
-  constructor(message: string = 'Insufficient permissions') {
-    super(message, 'AUTHORIZATION_ERROR', 403);
+  constructor(message: string = 'Insufficient permissions', code: string = 'AUTHORIZATION_ERROR') {
+    super(message, code, 403);
+  }
+}
+
+/**
+ * Error code returned when a view-only session attempts a state-changing
+ * HTTP method.
+ */
+export const ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE = 'ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE';
+
+/**
+ * View-only session attempted a mutating request.
+ */
+export class ViewOnlyModeError extends AuthorizationError {
+  constructor(message: string = 'Action not allowed in view-only mode') {
+    super(message, ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE);
+    this.name = 'ViewOnlyModeError';
   }
 }
 

--- a/packages/idp-protocol/src/types/models.ts
+++ b/packages/idp-protocol/src/types/models.ts
@@ -33,6 +33,11 @@ export const PayloadSchema = z
     signinProvider: z.string().optional(),
     authFlow: z.string().optional(),
     apiKeyId: z.string().optional(),
+    /**
+     * When true, the session is in view-only mode.
+     * Providers should normalize provider-specific claims into this field.
+     */
+    viewOnly: z.boolean().optional(),
   })
   .passthrough();
 

--- a/packages/idp-protocol/src/utils/index.ts
+++ b/packages/idp-protocol/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './view-only.js';

--- a/packages/idp-protocol/src/utils/view-only.test.ts
+++ b/packages/idp-protocol/src/utils/view-only.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from '@jest/globals';
+import type { Payload } from '../types/models.js';
+import {
+  isSafeHttpMethodForViewOnly,
+  isViewOnlyPayload,
+  resolveViewOnlyFromClaims,
+  VIEW_ONLY_SAFE_HTTP_METHODS,
+} from './view-only.js';
+
+describe('resolveViewOnlyFromClaims', () => {
+  it('returns false for nullish claims', () => {
+    expect(resolveViewOnlyFromClaims(null)).toBe(false);
+    expect(resolveViewOnlyFromClaims(undefined)).toBe(false);
+  });
+
+  it('returns true only when viewOnly is boolean true', () => {
+    expect(resolveViewOnlyFromClaims({ viewOnly: true })).toBe(true);
+    expect(resolveViewOnlyFromClaims({ viewOnly: false })).toBe(false);
+  });
+
+  it('ignores non-contract fields such as readOnly and roles', () => {
+    expect(resolveViewOnlyFromClaims({ readOnly: true })).toBe(false);
+    expect(resolveViewOnlyFromClaims({ roles: ['viewer'] })).toBe(false);
+  });
+
+  it('ignores non-boolean viewOnly values', () => {
+    expect(resolveViewOnlyFromClaims({ viewOnly: 'true' })).toBe(false);
+  });
+
+  it('returns false when no view-only signal is present', () => {
+    expect(resolveViewOnlyFromClaims({ userId: 'u1', roles: ['admin'] })).toBe(false);
+  });
+});
+
+describe('isViewOnlyPayload', () => {
+  it('returns false for nullish payload', () => {
+    expect(isViewOnlyPayload(null)).toBe(false);
+    expect(isViewOnlyPayload(undefined)).toBe(false);
+  });
+
+  it('reads only Payload.viewOnly', () => {
+    const payload: Payload = {
+      userId: 'user-1',
+      projectId: 'project-1',
+      viewOnly: true,
+    };
+
+    expect(isViewOnlyPayload(payload)).toBe(true);
+    expect(
+      isViewOnlyPayload({
+        userId: 'user-1',
+        projectId: 'project-1',
+        viewOnly: false,
+      })
+    ).toBe(false);
+    expect(
+      isViewOnlyPayload({
+        userId: 'user-1',
+        projectId: 'project-1',
+      })
+    ).toBe(false);
+  });
+
+  it('does not treat unrelated passthrough claims as view-only', () => {
+    const payload = {
+      userId: 'user-1',
+      projectId: 'project-1',
+      readOnly: true,
+      roles: ['viewer'],
+    } as Payload;
+
+    expect(isViewOnlyPayload(payload)).toBe(false);
+  });
+});
+
+describe('isSafeHttpMethodForViewOnly', () => {
+  it.each([...VIEW_ONLY_SAFE_HTTP_METHODS])('allows safe method %s', method => {
+    expect(isSafeHttpMethodForViewOnly(method)).toBe(true);
+    expect(isSafeHttpMethodForViewOnly(method.toLowerCase())).toBe(true);
+  });
+
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE', 'post', 'Put'])(
+    'rejects state-changing method %s',
+    method => {
+      expect(isSafeHttpMethodForViewOnly(method)).toBe(false);
+    }
+  );
+
+  it('rejects empty method values', () => {
+    expect(isSafeHttpMethodForViewOnly(undefined)).toBe(false);
+    expect(isSafeHttpMethodForViewOnly(null)).toBe(false);
+    expect(isSafeHttpMethodForViewOnly('')).toBe(false);
+  });
+});

--- a/packages/idp-protocol/src/utils/view-only.test.ts
+++ b/packages/idp-protocol/src/utils/view-only.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import type { Payload } from '../types/models.js';
-import {
-  isSafeHttpMethodForViewOnly,
-  isViewOnlyPayload,
-  resolveViewOnlyFromClaims,
-  VIEW_ONLY_SAFE_HTTP_METHODS,
-} from './view-only.js';
+import { isViewOnlyPayload, resolveViewOnlyFromClaims } from './view-only.js';
 
 describe('resolveViewOnlyFromClaims', () => {
   it('returns false for nullish claims', () => {
@@ -70,25 +65,5 @@ describe('isViewOnlyPayload', () => {
     } as Payload;
 
     expect(isViewOnlyPayload(payload)).toBe(false);
-  });
-});
-
-describe('isSafeHttpMethodForViewOnly', () => {
-  it.each([...VIEW_ONLY_SAFE_HTTP_METHODS])('allows safe method %s', method => {
-    expect(isSafeHttpMethodForViewOnly(method)).toBe(true);
-    expect(isSafeHttpMethodForViewOnly(method.toLowerCase())).toBe(true);
-  });
-
-  it.each(['POST', 'PUT', 'PATCH', 'DELETE', 'post', 'Put'])(
-    'rejects state-changing method %s',
-    method => {
-      expect(isSafeHttpMethodForViewOnly(method)).toBe(false);
-    }
-  );
-
-  it('rejects empty method values', () => {
-    expect(isSafeHttpMethodForViewOnly(undefined)).toBe(false);
-    expect(isSafeHttpMethodForViewOnly(null)).toBe(false);
-    expect(isSafeHttpMethodForViewOnly('')).toBe(false);
   });
 });

--- a/packages/idp-protocol/src/utils/view-only.ts
+++ b/packages/idp-protocol/src/utils/view-only.ts
@@ -1,0 +1,46 @@
+import type { Payload } from '../types/models.js';
+
+/**
+ * HTTP methods that are safe to allow in view-only sessions.
+ * Matches RFC 9110 safe methods used by the ODM API surface.
+ */
+export const VIEW_ONLY_SAFE_HTTP_METHODS = ['GET', 'HEAD', 'OPTIONS'] as const;
+
+/**
+ * Resolves whether token claims represent a view-only session.
+ *
+ * Only the protocol contract field `viewOnly` is considered. Provider-specific
+ * flags (for example API-key `readOnly`) must be normalized into `viewOnly` by
+ * the identity provider / token issuer — they are not interpreted here.
+ */
+export function resolveViewOnlyFromClaims(
+  claims: Record<string, unknown> | null | undefined
+): boolean {
+  if (!claims) {
+    return false;
+  }
+
+  return claims.viewOnly === true;
+}
+
+/**
+ * Whether the authenticated payload is a view-only session.
+ */
+export function isViewOnlyPayload(payload: Payload | null | undefined): boolean {
+  if (!payload) {
+    return false;
+  }
+
+  return payload.viewOnly === true;
+}
+
+/**
+ * Whether the HTTP method is allowed for view-only sessions.
+ */
+export function isSafeHttpMethodForViewOnly(method: string | undefined | null): boolean {
+  if (!method) {
+    return false;
+  }
+
+  return (VIEW_ONLY_SAFE_HTTP_METHODS as readonly string[]).includes(method.toUpperCase());
+}

--- a/packages/idp-protocol/src/utils/view-only.ts
+++ b/packages/idp-protocol/src/utils/view-only.ts
@@ -7,13 +7,17 @@ import type { Payload } from '../types/models.js';
  * flags (for example API-key `readOnly`) must be normalized into `viewOnly` by
  * the identity provider / token issuer — they are not interpreted here.
  *
- * Single source of truth for claim detection; `isViewOnlyPayload` delegates here
- * so issuer mapping and guard enforcement cannot drift.
+ * Accepts any object (including Zod passthrough issuer payloads) so callers do
+ * not need casts when `viewOnly` is not in the declared schema shape.
+ * `isViewOnlyPayload` delegates here so issuer mapping and guard enforcement
+ * cannot drift.
  */
-export function resolveViewOnlyFromClaims(
-  claims: { viewOnly?: unknown } | null | undefined
-): boolean {
-  return claims?.viewOnly === true;
+export function resolveViewOnlyFromClaims(claims: object | null | undefined): boolean {
+  if (claims == null) {
+    return false;
+  }
+
+  return (claims as { viewOnly?: unknown }).viewOnly === true;
 }
 
 /**

--- a/packages/idp-protocol/src/utils/view-only.ts
+++ b/packages/idp-protocol/src/utils/view-only.ts
@@ -1,46 +1,24 @@
 import type { Payload } from '../types/models.js';
 
 /**
- * HTTP methods that are safe to allow in view-only sessions.
- * Matches RFC 9110 safe methods used by the ODM API surface.
- */
-export const VIEW_ONLY_SAFE_HTTP_METHODS = ['GET', 'HEAD', 'OPTIONS'] as const;
-
-/**
  * Resolves whether token claims represent a view-only session.
  *
  * Only the protocol contract field `viewOnly` is considered. Provider-specific
  * flags (for example API-key `readOnly`) must be normalized into `viewOnly` by
  * the identity provider / token issuer — they are not interpreted here.
+ *
+ * Single source of truth for claim detection; `isViewOnlyPayload` delegates here
+ * so issuer mapping and guard enforcement cannot drift.
  */
 export function resolveViewOnlyFromClaims(
-  claims: Record<string, unknown> | null | undefined
+  claims: { viewOnly?: unknown } | null | undefined
 ): boolean {
-  if (!claims) {
-    return false;
-  }
-
-  return claims.viewOnly === true;
+  return claims?.viewOnly === true;
 }
 
 /**
  * Whether the authenticated payload is a view-only session.
  */
 export function isViewOnlyPayload(payload: Payload | null | undefined): boolean {
-  if (!payload) {
-    return false;
-  }
-
-  return payload.viewOnly === true;
-}
-
-/**
- * Whether the HTTP method is allowed for view-only sessions.
- */
-export function isSafeHttpMethodForViewOnly(method: string | undefined | null): boolean {
-  if (!method) {
-    return false;
-  }
-
-  return (VIEW_ONLY_SAFE_HTTP_METHODS as readonly string[]).includes(method.toUpperCase());
+  return resolveViewOnlyFromClaims(payload);
 }


### PR DESCRIPTION
## Summary

- Treat view-only sessions as read-only at the API layer: allow `GET` / `HEAD` / `OPTIONS`, reject `POST` / `PUT` / `PATCH` / `DELETE` with **403** and code `ACTION_NOT_ALLOWED_IN_VIEW_ONLY_MODE`.
- Add optional `Payload.viewOnly` to the IDP protocol, claim resolution via `resolveViewOnlyFromClaims` (canonical `viewOnly` only — no aliases such as `readOnly`), and normalization in `idp-owox-better-auth` `toPayload`.
- Surface `viewOnly` on auth context (`GET /api/auth/context`), request/CLS context, and the web user model (`User.viewOnly` + `isViewOnlySession`).
- Reject MCP OAuth authorization (`GET /oauth/authorize`) for view-only sessions so they cannot mint MCP tokens that would bypass REST restrictions via write tools.
- Suppress client analytics for view-only sessions: skip GTM bootstrap and no-op dataLayer events (including identify/logout).

## Behavior notes

- API enforcement lives in `IdpGuard` for **required** authenticated Nest REST routes. IDP session endpoints such as `/auth/access-token` stay outside this guard so clients can still refresh tokens.
- **`Role.none()` / optional routes intentionally skip IDP auth and view-only checks.** Those endpoints authenticate outside the user IDP token path (for example `InternalApiGuard` service-account tokens on legacy data-marts sync, and `GoogleJwtBody` connector JWTs on Looker Studio). A user view-only access token is not accepted as credentials there.
- **MCP:** view-only sessions cannot complete OAuth authorize, so they cannot obtain new MCP tokens. MCP write tools remain gated by `mcp:write` scopes on tokens that were already issued outside view-only mode.
- Until identity tokens actually include a view-only signal, normal sessions are unchanged (dormant until the claim is present).
- Analytics suppression is driven by `user.viewOnly` on the web client; GTM is not loaded for those sessions, so tags that would load PostHog / session recording do not start.

## Test plan

- [x] Unit: `@owox/idp-protocol` claim resolution + safe methods
- [x] Unit: `idp-owox-better-auth` payload mapper
- [x] Unit: `IdpGuard` method matrix, error code/status, projections skip
- [x] Unit: `IdpGuard` documents Role.none() skip of view-only (no token parse)
- [x] Unit: OAuth authorize rejects view-only sessions (header token + refresh cookie)
- [x] Unit: auth context controller/decorator + exception filter body
- [x] Unit: web `currentUserResponseToUser` / `isViewOnlySession`
- [x] Unit: web dataLayer analytics gate
- [x] Unit: web GTM skipped for view-only sessions
- [ ] Manual: token with `viewOnly` → mutating API returns 403
- [ ] Manual: same session → GET endpoints and `/auth/access-token` still succeed
- [ ] Manual: view-only session cannot complete MCP OAuth authorize
- [ ] Manual: `/api/auth/context` and `/auth/api/user` expose `viewOnly: true` when applicable
- [ ] Manual: view-only session does not load GTM / does not emit dataLayer events