### PR TITLE
docs(bigquery): clarify required storage roles

### DIFF
--- a/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/FormDescriptions/GoogleBigQueryAuthMethodDescription.tsx
+++ b/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/FormDescriptions/GoogleBigQueryAuthMethodDescription.tsx
@@ -32,6 +32,12 @@ export default function GoogleBigQueryAuthMethodDescription() {
               </p>
             </div>
           </div>
+          <p className='mt-3 text-sm'>
+            Whichever method you choose, the account (personal or service account) needs the{' '}
+            <strong>BigQuery Data Editor</strong> (<code>roles/bigquery.dataEditor</code>) and{' '}
+            <strong>BigQuery Job User</strong> (<code>roles/bigquery.jobUser</code>) roles on the
+            target Google Cloud project.
+          </p>
         </AccordionContent>
       </AccordionItem>
     </Accordion>

--- a/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/FormDescriptions/GoogleBigQueryOAuthDescription.tsx
+++ b/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/FormDescriptions/GoogleBigQueryOAuthDescription.tsx
@@ -40,6 +40,30 @@ export default function GoogleBigQueryOAuthDescription() {
             </a>
             .
           </p>
+          <p className='mt-2 text-sm'>
+            The connected Google account must have the <strong>BigQuery Data Editor</strong> (
+            <code>roles/bigquery.dataEditor</code>) and <strong>BigQuery Job User</strong> (
+            <code>roles/bigquery.jobUser</code>) roles on the target Google Cloud project. You can
+            check or assign them in{' '}
+            <a
+              href='https://console.cloud.google.com/iam-admin/iam'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='underline'
+            >
+              IAM & Admin → IAM
+            </a>
+            . See the{' '}
+            <a
+              href='https://docs.owox.com/docs/storages/supported-storages/google-bigquery/#option-b-google-oauth'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='underline'
+            >
+              documentation
+            </a>{' '}
+            for details.
+          </p>
         </AccordionContent>
       </AccordionItem>
     </Accordion>

--- a/docs/storages/supported-storages/google-bigquery.md
+++ b/docs/storages/supported-storages/google-bigquery.md
@@ -59,7 +59,7 @@ To get the JSON key, you'll need to create or use an existing service account in
 
 Click **Connect Google Account** to authenticate using your personal Google account via OAuth. You will be redirected to Google's consent screen to grant BigQuery access. Once authorized, your account will be linked to this Storage.
 
-> **Note:** The authenticated Google account must have `BigQuery Data Editor` and `BigQuery Job User` roles in the target project. OAuth tokens are automatically refreshed. If your session expires or access is revoked, you can reconnect at any time.
+> **Note:** The authenticated Google account must have `BigQuery Data Editor` (`roles/bigquery.dataEditor`) and `BigQuery Job User` (`roles/bigquery.jobUser`) roles in the target project. Check or assign these roles in [IAM & Admin → IAM](https://console.cloud.google.com/iam-admin/iam). OAuth tokens are automatically refreshed. If your session expires or access is revoked, you can reconnect at any time.
 
 ### Enable BigQuery API
 


### PR DESCRIPTION
# Problem

BigQuery storage setup did not clearly explain which Google Cloud IAM roles are required for OAuth and service account authentication. The UI omitted the exact role identifiers and did not provide a direct path for checking or assigning them. This made permission-related setup failures harder to diagnose and resolve.

# Solution

Updated the BigQuery authentication guidance in the storage form to identify the required roles for both authentication methods. Added direct links to Google Cloud IAM and the relevant OWOX documentation. Expanded the BigQuery setup guide with the exact IAM role identifiers and assignment location.

# Changes

- Added required BigQuery IAM roles to the authentication method guidance.
- Added role identifiers and IAM documentation links to the OAuth permission details.
- Updated the BigQuery setup guide with exact role identifiers and IAM assignment instructions.