### PR TITLE
fix(backend): report totals cover all selected metrics, not just numeric fields

### DIFF
--- a/.changeset/report-totals-non-numeric-metrics.md
+++ b/.changeset/report-totals-non-numeric-metrics.md
@@ -1,0 +1,13 @@
+---
+'owox': minor
+---
+
+# Report totals cover every selected metric, not just numeric fields
+
+Totals — returned by the `query_data_mart` MCP tool and retrievable for a Data Mart run via its
+`x-owox-run-id` — now summarize every metric a report aggregates, including `Count` and
+`Count Unique` on text, date, or boolean columns, across both native and joined Data Mart fields.
+Previously totals covered numeric fields only, so a scorecard that aggregates a text column (for
+example the number of distinct countries) came back empty even though the run succeeded. `Sample`
+(`ANY_VALUE`) and `Combined` (`STRING_AGG`) are no longer included in totals, since neither reduces
+to a meaningful grand total.

--- a/apps/backend/src/data-marts/dto/presentation/data-mart-run-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-mart-run-response-api.dto.ts
@@ -150,12 +150,14 @@ export class DataMartRunResponseApiDto {
     example: {
       'revenue | SUM': 1575.93,
       'revenue | AVG': 157.593,
-      'revenue | MIN': 12.5,
-      'revenue | MAX': 450,
+      'country | COUNTUNIQUE': 18,
     },
     description:
-      'Grand-totals summary: every selected numeric field aggregated by its allowed functions ' +
-      'over the full filtered dataset (no grouping). Null when the run produced no totals.',
+      'Grand-totals summary over the full filtered dataset (no grouping): every selected numeric ' +
+      'field, plus any non-numeric field the report aggregates as a metric (e.g. COUNT_DISTINCT ' +
+      'over a text column), each by its allowed aggregation functions. Covers native and joined ' +
+      'fields. ANY_VALUE and STRING_AGG are excluded (not meaningful as a grand total). Null when ' +
+      'the run produced no totals.',
     required: false,
     nullable: true,
   })

--- a/apps/backend/src/data-marts/dto/schemas/field-aggregation-governance.ts
+++ b/apps/backend/src/data-marts/dto/schemas/field-aggregation-governance.ts
@@ -8,6 +8,17 @@ export interface FieldGovernance {
   allowedAggregations: ReportAggregateFunction[];
 }
 
+/**
+ * Aggregation functions that do NOT reduce to a meaningful single grand total: `ANY_VALUE`
+ * returns one arbitrary row's value and `STRING_AGG` concatenates the whole column. Totals
+ * summaries omit them. The same pair is mapped to a DIMENSION by the Looker Studio aggregation
+ * mapper for the same reason — keep the two lists aligned when adding a new non-summarizable fn.
+ */
+export const NON_SUMMARIZABLE_AGGREGATIONS: ReadonlySet<ReportAggregateFunction> = new Set([
+  'ANY_VALUE',
+  'STRING_AGG',
+]);
+
 interface CategoryDefault {
   role: AggregationRole;
   allowedAggregations: ReportAggregateFunction[];

--- a/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
@@ -488,7 +488,10 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
     const blendedField = (
       name: string,
       type: string,
-      postJoinAggregations?: ReportAggregateFunction[]
+      postJoinAggregations?: ReportAggregateFunction[],
+      // The PRE-join roll-up run inside the bottom-up CTE. Must be valid for the field type —
+      // e.g. a STRING joined field cannot roll up with SUM, so pass ANY_VALUE there.
+      preJoinAggregation: ReportAggregateFunction = 'SUM'
     ): BlendedFieldDto => {
       const f = new BlendedFieldDto();
       f.name = name;
@@ -501,7 +504,7 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
       f.alias = '';
       f.description = '';
       f.isHidden = false;
-      f.aggregateFunction = 'SUM';
+      f.aggregateFunction = preJoinAggregation;
       f.postJoinAggregations = postJoinAggregations;
       f.transitiveDepth = 1;
       f.aliasPath = 'partner';
@@ -600,14 +603,15 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
     // metric (e.g. COUNT_DISTINCT over a joined text column) must appear in totals too, by its
     // post-join allowed functions — minus ANY_VALUE / STRING_AGG.
     it('includes a JOINED non-numeric field in totals when the report aggregates it', async () => {
+      // A STRING joined field must roll up pre-join with a STRING-valid function (ANY_VALUE),
+      // not SUM — so the generated CTE + outer SQL is executable BigQuery.
       const fields = [
-        blendedField('partner__country', 'STRING', [
-          'MIN',
-          'MAX',
-          'COUNT',
-          'COUNT_DISTINCT',
-          'STRING_AGG',
-        ]),
+        blendedField(
+          'partner__country',
+          'STRING',
+          ['MIN', 'MAX', 'COUNT', 'COUNT_DISTINCT', 'STRING_AGG'],
+          'ANY_VALUE'
+        ),
       ];
       const { service } = makeBlendedTotalsComposer(fields);
       const report = buildTotalsReport({
@@ -625,6 +629,24 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
       expect(fns).toEqual(expect.arrayContaining(['COUNT', 'COUNT_DISTINCT', 'MIN', 'MAX']));
       // STRING_AGG (and ANY_VALUE) are excluded from totals on the joined path too.
       expect(fns).not.toContain('STRING_AGG');
+
+      // The generated SQL must be executable: the bottom-up CTE rolls the STRING column up with
+      // ANY_VALUE (never SUM over text), and the ungrouped outer SELECT applies the post-join
+      // totals functions — COUNT / COUNT_DISTINCT / MIN / MAX — over the joined column.
+      const splitAt = result!.sql.lastIndexOf('\n\nSELECT');
+      const cte = result!.sql.slice(0, splitAt);
+      const finalSelect = result!.sql.slice(splitAt);
+      expect(cte).toContain('ANY_VALUE(country) AS partner__country');
+      expect(result!.sql).not.toMatch(/SUM\(/); // no SUM over a text column anywhere
+      expect(finalSelect).toContain('MIN(partner.partner__country)');
+      expect(finalSelect).toContain('MAX(partner.partner__country)');
+      expect(finalSelect).toContain('COUNT(partner.partner__country)');
+      expect(finalSelect).toContain('COUNT(DISTINCT partner.partner__country)');
+      // Excluded functions never reach the totals SELECT.
+      expect(finalSelect).not.toContain('ANY_VALUE');
+      expect(finalSelect).not.toMatch(/STRING_?AGG/i);
+      // Single grand-total row — no outer GROUP BY.
+      expect(finalSelect).not.toMatch(/GROUP BY/);
     });
 
     // A JOINED non-numeric field the report does NOT aggregate stays a plain dimension — not in
@@ -632,7 +654,7 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
     it('excludes a JOINED non-numeric field from totals when the report does not aggregate it', async () => {
       const fields = [
         blendedField('partner__cost', 'FLOAT', ['SUM']),
-        blendedField('partner__country', 'STRING', ['COUNT', 'COUNT_DISTINCT']),
+        blendedField('partner__country', 'STRING', ['COUNT', 'COUNT_DISTINCT'], 'ANY_VALUE'),
       ];
       const { service } = makeBlendedTotalsComposer(fields);
       const report = buildTotalsReport({

--- a/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
@@ -9,7 +9,10 @@ import {
   countPositionalPlaceholders,
 } from '../data-storage-types/athena/services/athena-clause-renderer';
 import { BlendedFieldDto } from '../dto/domain/blendable-schema.dto';
-import { ReportAggregateFunction } from '../dto/schemas/aggregate-function.schema';
+import {
+  AggregateFunction,
+  ReportAggregateFunction,
+} from '../dto/schemas/aggregate-function.schema';
 
 describe('ReportSqlComposerService — aggregations wiring', () => {
   const buildReport = (overrides: Partial<Report> = {}): Report =>
@@ -369,16 +372,9 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
       expect(blendedReportDataService.resolveBlendingDecision).not.toHaveBeenCalled();
     });
 
-    // REPRODUCTION — Vlad's dashboard scorecard (chat thread YjeZ1yvBxSg / repro-totals.mjs):
-    // a COUNT_DISTINCT metric over a STRING field, NO grouping. Per WI #6680 §D totals are "по
-    // обраних метриках" (over the SELECTED metrics), and §C: "Unique-by-PK — звичайна метрика з
-    // COUNT_DISTINCT". Governance already permits COUNT/COUNT_DISTINCT on STRING fields
-    // (field-aggregation-governance.ts: string → ['COUNT','COUNT_DISTINCT']). But
-    // resolveTotalsAllowedForColumn hard-gates on `categorizeFieldType(type) !== 'number'` and
-    // returns [] BEFORE consulting governance — so the COUNT_DISTINCT metric is dropped,
-    // composeTotals returns null, and getRunById.totals is null even though the run SUCCEEDED and
-    // the aggregate streamed ({"country | COUNTUNIQUE":18}). Totals must follow governance, not a
-    // numeric-type gate. RED today.
+    // Requirement (WI #6680 §D): a COUNT_DISTINCT metric over a STRING field with no grouping
+    // must appear in totals — totals follow the field's governance-allowed functions, not a
+    // numeric-type gate (governance permits COUNT/COUNT_DISTINCT on STRING).
     it('scorecard: COUNT_DISTINCT over a STRING metric (NO grouping) is included in totals (WI #6680 §D)', async () => {
       const { service } = makeBqTotalsComposer(['country']);
       const report = buildTotalsReport(
@@ -490,8 +486,9 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
       type: string,
       postJoinAggregations?: ReportAggregateFunction[],
       // The PRE-join roll-up run inside the bottom-up CTE. Must be valid for the field type —
-      // e.g. a STRING joined field cannot roll up with SUM, so pass ANY_VALUE there.
-      preJoinAggregation: ReportAggregateFunction = 'SUM'
+      // e.g. a STRING joined field cannot roll up with SUM, so pass ANY_VALUE there. Pre-join
+      // aggregates are the base function set (no percentiles).
+      preJoinAggregation: AggregateFunction = 'SUM'
     ): BlendedFieldDto => {
       const f = new BlendedFieldDto();
       f.name = name;
@@ -666,6 +663,39 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
       expect(result).not.toBeNull();
       expect(result!.columns).toContain('partner__cost');
       expect(result!.columns).not.toContain('partner__country');
+    });
+
+    // A stale post-join override can name functions the current type can't run (e.g. SUM saved
+    // before a field became STRING). collectBlendedAllowedSets clamps the override to the type's
+    // supported set — as the native path does — so the totals plan never carries SUM(string),
+    // which would make the validator throw and silently null the whole totals block.
+    it('clamps a stale numeric override on a joined STRING field to type-supported functions', async () => {
+      const fields = [
+        blendedField(
+          'partner__country',
+          'STRING',
+          ['SUM', 'AVG', 'COUNT', 'COUNT_DISTINCT'],
+          'ANY_VALUE'
+        ),
+      ];
+      const { service } = makeBlendedTotalsComposer(fields);
+      const report = buildTotalsReport({
+        columnConfig: ['partner__country'],
+        aggregationConfig: [{ column: 'partner__country', function: 'COUNT_DISTINCT' }],
+      } as Partial<Report>);
+
+      const result = await service.composeTotals(report, {} as never);
+
+      expect(result).not.toBeNull();
+      const fns = result!.aggregations
+        .filter(a => a.column === 'partner__country')
+        .map(a => a.function);
+      // SUM / AVG are not supported for STRING → clamped away; the valid ones survive.
+      expect(fns).not.toContain('SUM');
+      expect(fns).not.toContain('AVG');
+      expect(fns).toEqual(expect.arrayContaining(['COUNT', 'COUNT_DISTINCT']));
+      expect(result!.sql).not.toMatch(/SUM\(/);
+      expect(result!.sql).not.toMatch(/AVG\(/);
     });
 
     it('resolves the blendable schema once and reuses it for the blended decision (no recompute)', async () => {

--- a/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
@@ -369,6 +369,71 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
       expect(blendedReportDataService.resolveBlendingDecision).not.toHaveBeenCalled();
     });
 
+    // REPRODUCTION — Vlad's dashboard scorecard (chat thread YjeZ1yvBxSg / repro-totals.mjs):
+    // a COUNT_DISTINCT metric over a STRING field, NO grouping. Per WI #6680 §D totals are "по
+    // обраних метриках" (over the SELECTED metrics), and §C: "Unique-by-PK — звичайна метрика з
+    // COUNT_DISTINCT". Governance already permits COUNT/COUNT_DISTINCT on STRING fields
+    // (field-aggregation-governance.ts: string → ['COUNT','COUNT_DISTINCT']). But
+    // resolveTotalsAllowedForColumn hard-gates on `categorizeFieldType(type) !== 'number'` and
+    // returns [] BEFORE consulting governance — so the COUNT_DISTINCT metric is dropped,
+    // composeTotals returns null, and getRunById.totals is null even though the run SUCCEEDED and
+    // the aggregate streamed ({"country | COUNTUNIQUE":18}). Totals must follow governance, not a
+    // numeric-type gate. RED today.
+    it('scorecard: COUNT_DISTINCT over a STRING metric (NO grouping) is included in totals (WI #6680 §D)', async () => {
+      const { service } = makeBqTotalsComposer(['country']);
+      const report = buildTotalsReport(
+        {
+          columnConfig: ['country'],
+          aggregationConfig: [{ column: 'country', function: 'COUNT_DISTINCT' }],
+        } as Partial<Report>,
+        // No schema-level metric/dimension role in practice — STRING defaults to 'dimension'.
+        // The ONLY signal that `country` is a metric here is that the report aggregates it.
+        [field('country', 'STRING')]
+      );
+
+      const result = await service.composeTotals(report, {} as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.columns).toContain('country');
+      expect(result!.aggregations).toEqual(
+        expect.arrayContaining([{ column: 'country', function: 'COUNT_DISTINCT' }])
+      );
+    });
+
+    // ANY_VALUE (an arbitrary row's value) and STRING_AGG (whole-column concat) are meaningless
+    // as a single grand-total number, so they are excluded from the totals summary for EVERY
+    // field even when the field's allowed set (per-field override or type-default) permits them.
+    it('excludes ANY_VALUE and STRING_AGG from totals even when the field allows them', async () => {
+      const { service } = makeBqTotalsComposer(['country']);
+      const report = buildTotalsReport(
+        {
+          columnConfig: ['country'],
+          aggregationConfig: [{ column: 'country', function: 'COUNT_DISTINCT' }],
+        } as Partial<Report>,
+        [
+          field('country', 'STRING', {
+            allowedAggregations: [
+              'MIN',
+              'MAX',
+              'ANY_VALUE',
+              'COUNT',
+              'COUNT_DISTINCT',
+              'STRING_AGG',
+            ],
+          }),
+        ]
+      );
+
+      const result = await service.composeTotals(report, {} as never);
+
+      expect(result).not.toBeNull();
+      const fns = result!.aggregations.map(a => a.function);
+      expect(fns).not.toContain('ANY_VALUE');
+      expect(fns).not.toContain('STRING_AGG');
+      // The meaningful ones survive.
+      expect(fns).toEqual(expect.arrayContaining(['COUNT', 'COUNT_DISTINCT', 'MIN', 'MAX']));
+    });
+
     it('strips HAVING (function-carrying) filters from the totals query, keeping WHERE filters', async () => {
       const { service } = makeBqTotalsComposer(['revenue']);
       const report = buildTotalsReport({
@@ -529,6 +594,56 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
       const finalSelect = result!.sql.slice(result!.sql.lastIndexOf('\n\nSELECT'));
       expect(finalSelect).toContain('SUM(partner.partner__cost)');
       expect(finalSelect).not.toMatch(/GROUP BY/);
+    });
+
+    // Symmetry with the main-mart rule: a JOINED non-numeric field the report aggregates as a
+    // metric (e.g. COUNT_DISTINCT over a joined text column) must appear in totals too, by its
+    // post-join allowed functions — minus ANY_VALUE / STRING_AGG.
+    it('includes a JOINED non-numeric field in totals when the report aggregates it', async () => {
+      const fields = [
+        blendedField('partner__country', 'STRING', [
+          'MIN',
+          'MAX',
+          'COUNT',
+          'COUNT_DISTINCT',
+          'STRING_AGG',
+        ]),
+      ];
+      const { service } = makeBlendedTotalsComposer(fields);
+      const report = buildTotalsReport({
+        columnConfig: ['partner__country'],
+        aggregationConfig: [{ column: 'partner__country', function: 'COUNT_DISTINCT' }],
+      } as Partial<Report>);
+
+      const result = await service.composeTotals(report, {} as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.columns).toContain('partner__country');
+      const fns = result!.aggregations
+        .filter(a => a.column === 'partner__country')
+        .map(a => a.function);
+      expect(fns).toEqual(expect.arrayContaining(['COUNT', 'COUNT_DISTINCT', 'MIN', 'MAX']));
+      // STRING_AGG (and ANY_VALUE) are excluded from totals on the joined path too.
+      expect(fns).not.toContain('STRING_AGG');
+    });
+
+    // A JOINED non-numeric field the report does NOT aggregate stays a plain dimension — not in
+    // totals (only the numeric joined field is auto-summarized).
+    it('excludes a JOINED non-numeric field from totals when the report does not aggregate it', async () => {
+      const fields = [
+        blendedField('partner__cost', 'FLOAT', ['SUM']),
+        blendedField('partner__country', 'STRING', ['COUNT', 'COUNT_DISTINCT']),
+      ];
+      const { service } = makeBlendedTotalsComposer(fields);
+      const report = buildTotalsReport({
+        columnConfig: ['partner__cost', 'partner__country'],
+      } as Partial<Report>);
+
+      const result = await service.composeTotals(report, {} as never);
+
+      expect(result).not.toBeNull();
+      expect(result!.columns).toContain('partner__cost');
+      expect(result!.columns).not.toContain('partner__country');
     });
 
     it('resolves the blendable schema once and reuses it for the blended decision (no recompute)', async () => {

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -24,6 +24,7 @@ import {
 } from '../data-storage-types/data-mart-schema.utils';
 import {
   resolveFieldGovernance,
+  NON_SUMMARIZABLE_AGGREGATIONS,
   type AggregationRole,
 } from '../dto/schemas/field-aggregation-governance';
 import { categorizeFieldType } from '../dto/schemas/field-type-category';
@@ -152,23 +153,30 @@ export class ReportSqlComposerService {
 
   /**
    * Composes the report's "Totals" query: a per-column summary computed as a SEPARATE
-   * query with NO grouping. For every NUMERIC field among the report's selected columns,
-   * totals compute ALL of that field's allowed aggregations (the per-field governance
-   * override, else the numeric type-default SUM/AVG/MIN/MAX). e.g. a `costs` column whose
-   * allowed set is SUM+AVG yields SUM(costs) and AVG(costs); and so on for every numeric
-   * column × every allowed function. Selected JOINED (blended) numeric fields are included
-   * too, governed by their post-join allowed set; any such field drives this onto the
-   * blended SQL path (still NO GROUP BY — every column is an aggregated metric). Returns
-   * `null` (totals skipped) when no selected numeric field has an allowed aggregation.
+   * query with NO grouping. A selected column is a totals metric when it is NUMERIC (an auto
+   * per-column summary, computed even if the report does not aggregate it) OR the report
+   * aggregates it as a metric (the only non-numeric metric signal). Each metric contributes
+   * ALL of its governance-allowed aggregations (per-field override, else the type-default) —
+   * so a numeric `costs` yields SUM/AVG/MIN/MAX and a text `country` the report aggregates
+   * yields COUNT/COUNT_DISTINCT. `ANY_VALUE` and `STRING_AGG` are always excluded (see
+   * {@link NON_SUMMARIZABLE_AGGREGATIONS}), so a value can be a number OR a string (MIN/MAX of
+   * a text metric). Selected JOINED (blended) fields follow the same rule; a blended metric
+   * drives `compose` onto the blended path (still NO GROUP BY). Returns `null` (totals skipped)
+   * when no selected column is a totals metric with a summarizable function.
    *
-   * Totals are INDEPENDENT of the report's own display aggregations — computed even for a
-   * non-aggregated report. Row Count and Unique Count are NOT part of totals. WHERE filters
-   * are respected; HAVING (function-carrying) filters are dropped (a single grand-total
-   * group). The blending decision is resolved FRESH from this metrics-only plan — never
-   * inherited from the full report (which carries dimension columns / the grouped main SQL
-   * and would emit GROUP BY, collapsing the grand total to the first group's row). The
-   * returned `aggregations`/`columns` let the totals reader resolve headers that match the
-   * SQL output columns. The input `report` is never mutated.
+   * ⚠️ Joined NON-numeric totals are dedup-function-dependent: a joined column is first rolled
+   * up per join key by its pre-join aggregate (default STRING_AGG for text), so a post-join
+   * COUNT_DISTINCT counts distinct rolled-up values, NOT distinct raw rows. Treat such a total
+   * as approximate — same accepted-limitation class as the unweighted blended AVG.
+   *
+   * Totals are otherwise INDEPENDENT of the report's own display aggregation functions — the
+   * numeric auto-summary is computed even for a non-aggregated report. Row Count and Unique
+   * Count are NOT part of totals. WHERE filters are respected; HAVING (function-carrying)
+   * filters are dropped (a single grand-total group). The blending decision is resolved FRESH
+   * from this metrics-only plan — never inherited from the full report (which carries dimension
+   * columns / the grouped main SQL and would emit GROUP BY, collapsing the grand total to the
+   * first group's row). The returned `aggregations`/`columns` let the totals reader resolve
+   * headers that match the SQL output columns. The input `report` is never mutated.
    */
   async composeTotals(
     report: ReportLike,
@@ -180,7 +188,7 @@ export class ReportSqlComposerService {
     columns: string[];
     blendedDataHeaders?: ReportDataHeader[];
   } | null> {
-    const { columns, aggregations, blendableSchema } = await this.deriveNumericTotalsAggregations(
+    const { columns, aggregations, blendableSchema } = await this.deriveTotalsAggregations(
       report,
       accessor
     );
@@ -202,7 +210,7 @@ export class ReportSqlComposerService {
       sortConfig: null,
       dateTruncConfig: null,
       limitConfig: null,
-      // Totals are a numeric-field summary only — no Unique Count, no Row Count.
+      // Totals are a metrics-only summary — no Unique Count, no Row Count.
       uniqueCountConfig: null,
       rowCount: false,
     };
@@ -244,23 +252,18 @@ export class ReportSqlComposerService {
   }
 
   /**
-   * For each TOTALS-ELIGIBLE field among the report's selected columns, emit one aggregation
-   * rule per allowed function. Field order follows the selection; function order follows the
-   * field's allowed set. A field is totals-eligible when it is either:
-   *   - NUMERIC (type-default 'metric') — an auto per-column numeric summary, computed even
-   *     when the report itself does not aggregate it; or
-   *   - explicitly AGGREGATED by the report (its name appears in `aggregationConfig`) — this
-   *     is the only signal that a NON-numeric field (e.g. a STRING with COUNT_DISTINCT) is a
-   *     metric, because there is no schema-level dimension/metric designation today.
-   * Either way the function set comes from the field's governance (per-field allowed set else
-   * the type-default), so a STRING metric contributes COUNT/COUNT_DISTINCT and a numeric one
-   * SUM/AVG/MIN/MAX — never a function the type cannot run. Non-numeric fields the report does
-   * NOT aggregate (plain dimensions) and unresolved columns are skipped. Selected JOINED
-   * (blended) numeric fields are included too, governed by their DM-level `postJoinAggregations`
-   * (else the type-default); any blended numeric column drives `compose` onto the blended path,
+   * For each TOTALS-METRIC field among the report's selected columns, emit one aggregation rule
+   * per governance-allowed function (see {@link isTotalsEligible} for the metric rule). Field
+   * order follows the selection; function order follows the field's allowed set. The function
+   * set comes from the field's governance (per-field allowed set else the type-default) with
+   * {@link NON_SUMMARIZABLE_AGGREGATIONS} removed, so a STRING metric contributes
+   * COUNT/COUNT_DISTINCT and a numeric one SUM/AVG/MIN/MAX — never a function the type cannot
+   * run. Plain non-numeric dimensions (not aggregated by the report) and unresolved columns are
+   * skipped. Selected JOINED (blended) fields follow the same rule via
+   * {@link collectBlendedAllowedSets}; a blended metric drives `compose` onto the blended path,
    * whose metrics-only SELECT carries no GROUP BY (every column is an aggregated metric).
    */
-  private async deriveNumericTotalsAggregations(
+  private async deriveTotalsAggregations(
     report: ReportLike,
     accessor: BlendableSchemaAccessor
   ): Promise<{
@@ -271,9 +274,10 @@ export class ReportSqlComposerService {
   }> {
     const descriptors = collectSchemaFieldPathDescriptors(report.dataMart.schema?.fields ?? []);
     const byName = new Map(descriptors.map(d => [d.name, d]));
-    // The fields the report explicitly aggregates — the only marker that a non-numeric column
-    // is a metric (WI #6680 §D: totals are over the SELECTED metrics; §C: Unique-by-PK is a
-    // normal COUNT_DISTINCT metric). No schema-level dimension/metric role exists yet.
+    // The columns the report aggregates — the metric signal for non-numeric fields (WI #6680
+    // §D: totals are over the SELECTED metrics; §C: Unique-by-PK is a normal COUNT_DISTINCT
+    // metric). A per-field dimension/metric role IS persisted (`aggregationRole`), but it is
+    // type-derived in practice, so totals key off type + report aggregation rather than role.
     const aggregatedColumns = new Set((report.aggregationConfig ?? []).map(rule => rule.column));
 
     // Only consult the blendable schema when the selection references columns the main
@@ -315,6 +319,19 @@ export class ReportSqlComposerService {
     return { columns, aggregations, blendableSchema };
   }
 
+  // The load-bearing totals metric rule, shared by the native and joined paths so they cannot
+  // silently diverge (the symmetry the totals tests guard): a field is a totals metric when it
+  // is NUMERIC (an auto per-column summary) OR the report aggregates it (`aggregationConfig`) —
+  // the only non-numeric metric signal, since the persisted `aggregationRole` is type-derived
+  // in practice.
+  private isTotalsEligible(
+    type: string,
+    name: string,
+    aggregatedColumns: ReadonlySet<string>
+  ): boolean {
+    return categorizeFieldType(type) === 'number' || aggregatedColumns.has(name);
+  }
+
   private resolveTotalsAllowedForColumn(
     name: string,
     mainByName: ReadonlyMap<string, SchemaFieldDescriptor>,
@@ -324,14 +341,11 @@ export class ReportSqlComposerService {
     const descriptor = mainByName.get(name);
     let allowed: ReportAggregateFunction[];
     if (descriptor) {
-      // Numerics get an auto summary (type-default 'metric'); non-numerics only count as
-      // metrics when the report itself aggregates them — the sole metric signal without a
-      // schema-level role. Either way governance decides which functions are valid for the
-      // type, so a STRING metric yields COUNT/COUNT_DISTINCT rather than SUM/AVG it can't run.
-      const isNumeric = categorizeFieldType(descriptor.type) === 'number';
-      if (!isNumeric && !aggregatedColumns.has(name)) {
+      if (!this.isTotalsEligible(descriptor.type, name, aggregatedColumns)) {
         return [];
       }
+      // Governance decides which functions are valid for the type, so a STRING metric yields
+      // COUNT/COUNT_DISTINCT rather than a SUM/AVG it can't run.
       allowed = resolveFieldGovernance(descriptor.type, {
         aggregationRole: descriptor.field.aggregationRole as AggregationRole | undefined,
         allowedAggregations: descriptor.field.allowedAggregations as
@@ -339,23 +353,24 @@ export class ReportSqlComposerService {
           | undefined,
       }).allowedAggregations;
     } else {
-      // Joined (blended) field: eligibility already applied in collectBlendedAllowedSets
-      // (numeric → auto summary; non-numeric → only when the report aggregates it).
+      // Joined (blended) field: eligibility + clamping already applied in collectBlendedAllowedSets.
       allowed = blendedByName.get(name) ?? [];
     }
-    // ANY_VALUE (an arbitrary row's value) and STRING_AGG (whole-column concat) do not summarize
-    // to a meaningful grand total, so the totals summary omits them for every field/type.
-    return allowed.filter(fn => fn !== 'ANY_VALUE' && fn !== 'STRING_AGG');
+    return allowed.filter(fn => !NON_SUMMARIZABLE_AGGREGATIONS.has(fn));
   }
 
-  // Joined fields eligible for totals, mapped to their post-join allowed set. Mirrors the
-  // main-mart rule so totals are symmetric across native and joined fields: a joined NUMERIC
-  // field gets an auto summary, while a joined NON-numeric field qualifies only when the report
-  // aggregates it as a metric (no schema-level dimension/metric role exists). Functions come
-  // from the field's `postJoinAggregations` (DM-level override) else the type-default; ANY_VALUE
-  // / STRING_AGG are stripped later in resolveTotalsAllowedForColumn.
-  // Accepted limitation: blended AVG (and percentiles) over a joined field is unweighted —
-  // an avg-of-avgs from the per-join rollup — see TODO(#6680) in abstract-blended-query-builder.ts.
+  // Joined fields that are totals metrics (same rule as the native path — see isTotalsEligible),
+  // mapped to their post-join allowed set. The per-field `postJoinAggregations` override (else
+  // the type-default) is CLAMPED through resolveFieldGovernance to the functions the type
+  // actually supports — mirroring the native path — so a stale override (e.g. a SUM saved before
+  // the field became STRING) cannot inject SQL the warehouse rejects and silently null the whole
+  // totals block. ANY_VALUE / STRING_AGG are stripped later in resolveTotalsAllowedForColumn.
+  //
+  // Accepted limitations for JOINED metrics — the grand total is re-aggregated over per-join-key
+  // roll-ups, not raw rows: blended AVG/percentiles are unweighted (avg-of-avgs — see TODO(#6680)
+  // in abstract-blended-query-builder.ts); a joined NON-numeric COUNT_DISTINCT counts distinct
+  // pre-join-rolled-up values (the default text roll-up is STRING_AGG concatenations), NOT
+  // distinct raw rows. Treat such totals as approximate.
   private collectBlendedAllowedSets(
     blendableSchema: BlendableSchemaDto,
     aggregatedColumns: ReadonlySet<string>
@@ -365,13 +380,12 @@ export class ReportSqlComposerService {
       if (blendedField.isHidden) {
         continue;
       }
-      const isNumeric = categorizeFieldType(blendedField.type) === 'number';
-      if (!isNumeric && !aggregatedColumns.has(blendedField.name)) {
+      if (!this.isTotalsEligible(blendedField.type, blendedField.name, aggregatedColumns)) {
         continue;
       }
-      const allowed =
-        blendedField.postJoinAggregations ??
-        resolveFieldGovernance(blendedField.type).allowedAggregations;
+      const allowed = resolveFieldGovernance(blendedField.type, {
+        allowedAggregations: blendedField.postJoinAggregations,
+      }).allowedAggregations;
       result.set(blendedField.name, allowed);
     }
     return result;

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -244,15 +244,21 @@ export class ReportSqlComposerService {
   }
 
   /**
-   * For each NUMERIC field among the report's selected columns (every numeric schema field
-   * when the report projects all columns), emit one aggregation rule per allowed function.
-   * Field order follows the selection; function order follows the field's allowed set.
-   * Main-mart numerics are governed by their per-field allowed set (else the numeric
-   * type-default). Selected columns that are JOINED (blended) numeric fields are included
-   * too, governed by their DM-level `postJoinAggregations` (else the type-default). Any
-   * blended numeric column drives `compose` onto the blended path, whose metrics-only
-   * SELECT carries no GROUP BY (every column is an aggregated metric). Non-numeric columns
-   * and unresolved columns are skipped.
+   * For each TOTALS-ELIGIBLE field among the report's selected columns, emit one aggregation
+   * rule per allowed function. Field order follows the selection; function order follows the
+   * field's allowed set. A field is totals-eligible when it is either:
+   *   - NUMERIC (type-default 'metric') — an auto per-column numeric summary, computed even
+   *     when the report itself does not aggregate it; or
+   *   - explicitly AGGREGATED by the report (its name appears in `aggregationConfig`) — this
+   *     is the only signal that a NON-numeric field (e.g. a STRING with COUNT_DISTINCT) is a
+   *     metric, because there is no schema-level dimension/metric designation today.
+   * Either way the function set comes from the field's governance (per-field allowed set else
+   * the type-default), so a STRING metric contributes COUNT/COUNT_DISTINCT and a numeric one
+   * SUM/AVG/MIN/MAX — never a function the type cannot run. Non-numeric fields the report does
+   * NOT aggregate (plain dimensions) and unresolved columns are skipped. Selected JOINED
+   * (blended) numeric fields are included too, governed by their DM-level `postJoinAggregations`
+   * (else the type-default); any blended numeric column drives `compose` onto the blended path,
+   * whose metrics-only SELECT carries no GROUP BY (every column is an aggregated metric).
    */
   private async deriveNumericTotalsAggregations(
     report: ReportLike,
@@ -265,6 +271,10 @@ export class ReportSqlComposerService {
   }> {
     const descriptors = collectSchemaFieldPathDescriptors(report.dataMart.schema?.fields ?? []);
     const byName = new Map(descriptors.map(d => [d.name, d]));
+    // The fields the report explicitly aggregates — the only marker that a non-numeric column
+    // is a metric (WI #6680 §D: totals are over the SELECTED metrics; §C: Unique-by-PK is a
+    // normal COUNT_DISTINCT metric). No schema-level dimension/metric role exists yet.
+    const aggregatedColumns = new Set((report.aggregationConfig ?? []).map(rule => rule.column));
 
     // Only consult the blendable schema when the selection references columns the main
     // schema doesn't own — otherwise a non-blended report pays no schema-resolution cost
@@ -279,8 +289,8 @@ export class ReportSqlComposerService {
           accessor
         )
       : undefined;
-    const blendedNumericByName = blendableSchema
-      ? this.collectBlendedNumericAllowedSets(blendableSchema)
+    const blendedByName = blendableSchema
+      ? this.collectBlendedAllowedSets(blendableSchema, aggregatedColumns)
       : new Map<string, ReportAggregateFunction[]>();
 
     const projected = projectedExplicit ? report.columnConfig! : descriptors.map(d => d.name);
@@ -288,7 +298,12 @@ export class ReportSqlComposerService {
     const columns: string[] = [];
     const aggregations: AggregationRule[] = [];
     for (const name of projected) {
-      const allowed = this.resolveTotalsAllowedForColumn(name, byName, blendedNumericByName);
+      const allowed = this.resolveTotalsAllowedForColumn(
+        name,
+        byName,
+        blendedByName,
+        aggregatedColumns
+      );
       if (allowed.length === 0) {
         continue;
       }
@@ -303,34 +318,55 @@ export class ReportSqlComposerService {
   private resolveTotalsAllowedForColumn(
     name: string,
     mainByName: ReadonlyMap<string, SchemaFieldDescriptor>,
-    blendedNumericByName: ReadonlyMap<string, ReportAggregateFunction[]>
+    blendedByName: ReadonlyMap<string, ReportAggregateFunction[]>,
+    aggregatedColumns: ReadonlySet<string>
   ): ReportAggregateFunction[] {
     const descriptor = mainByName.get(name);
+    let allowed: ReportAggregateFunction[];
     if (descriptor) {
-      if (categorizeFieldType(descriptor.type) !== 'number') {
+      // Numerics get an auto summary (type-default 'metric'); non-numerics only count as
+      // metrics when the report itself aggregates them — the sole metric signal without a
+      // schema-level role. Either way governance decides which functions are valid for the
+      // type, so a STRING metric yields COUNT/COUNT_DISTINCT rather than SUM/AVG it can't run.
+      const isNumeric = categorizeFieldType(descriptor.type) === 'number';
+      if (!isNumeric && !aggregatedColumns.has(name)) {
         return [];
       }
-      return resolveFieldGovernance(descriptor.type, {
+      allowed = resolveFieldGovernance(descriptor.type, {
         aggregationRole: descriptor.field.aggregationRole as AggregationRole | undefined,
         allowedAggregations: descriptor.field.allowedAggregations as
           | ReportAggregateFunction[]
           | undefined,
       }).allowedAggregations;
+    } else {
+      // Joined (blended) field: eligibility already applied in collectBlendedAllowedSets
+      // (numeric → auto summary; non-numeric → only when the report aggregates it).
+      allowed = blendedByName.get(name) ?? [];
     }
-    return blendedNumericByName.get(name) ?? [];
+    // ANY_VALUE (an arbitrary row's value) and STRING_AGG (whole-column concat) do not summarize
+    // to a meaningful grand total, so the totals summary omits them for every field/type.
+    return allowed.filter(fn => fn !== 'ANY_VALUE' && fn !== 'STRING_AGG');
   }
 
-  // Joined numeric fields the report selects, mapped to their post-join allowed set. The
-  // blendable schema already resolved `postJoinAggregations` (DM-level override, else the
-  // numeric type-default); we just filter to numerics that the selection references.
+  // Joined fields eligible for totals, mapped to their post-join allowed set. Mirrors the
+  // main-mart rule so totals are symmetric across native and joined fields: a joined NUMERIC
+  // field gets an auto summary, while a joined NON-numeric field qualifies only when the report
+  // aggregates it as a metric (no schema-level dimension/metric role exists). Functions come
+  // from the field's `postJoinAggregations` (DM-level override) else the type-default; ANY_VALUE
+  // / STRING_AGG are stripped later in resolveTotalsAllowedForColumn.
   // Accepted limitation: blended AVG (and percentiles) over a joined field is unweighted —
   // an avg-of-avgs from the per-join rollup — see TODO(#6680) in abstract-blended-query-builder.ts.
-  private collectBlendedNumericAllowedSets(
-    blendableSchema: BlendableSchemaDto
+  private collectBlendedAllowedSets(
+    blendableSchema: BlendableSchemaDto,
+    aggregatedColumns: ReadonlySet<string>
   ): Map<string, ReportAggregateFunction[]> {
     const result = new Map<string, ReportAggregateFunction[]>();
     for (const blendedField of blendableSchema.blendedFields) {
-      if (blendedField.isHidden || categorizeFieldType(blendedField.type) !== 'number') {
+      if (blendedField.isHidden) {
+        continue;
+      }
+      const isNumeric = categorizeFieldType(blendedField.type) === 'number';
+      if (!isNumeric && !aggregatedColumns.has(blendedField.name)) {
         continue;
       }
       const allowed =

--- a/apps/backend/src/data-marts/services/report-totals.service.ts
+++ b/apps/backend/src/data-marts/services/report-totals.service.ts
@@ -12,16 +12,17 @@ export type ReportTotals = Record<string, number | string | boolean | null>;
 /**
  * Computes the report's "Totals" summary row as a SEPARATE DWH query at run time.
  *
- * The totals SQL — every selected numeric field aggregated by all of its allowed functions,
- * over the full filtered dataset with NO grouping (see
- * {@link ReportSqlComposerService.composeTotals}) — produces a single row. This service runs
- * that SQL through a FRESH per-storage reader as an `sqlOverride`, resolves headers from the
- * SAME derived aggregation plan (so header names match the SQL output aliases), reads exactly
- * one row, and zips it into a flat `{ "<header.name>": value }` object.
+ * The totals SQL — each selected totals metric (numeric fields, plus non-numeric fields the
+ * report aggregates) summarized by all of its allowed functions, over the full filtered dataset
+ * with NO grouping (see {@link ReportSqlComposerService.composeTotals}) — produces a single row.
+ * This service runs that SQL through a FRESH per-storage reader as an `sqlOverride`, resolves
+ * headers from the SAME derived aggregation plan (so header names match the SQL output aliases),
+ * reads exactly one row, and zips it into a flat `{ "<header.name>": value }` object. A value can
+ * be a number OR a string (e.g. MIN/MAX of a text metric).
  *
- * Returns `null` when no selected numeric field has an allowed aggregation (composeTotals
- * returns null) or when the dataset is empty (the DWH produced no row). Callers treat totals
- * as BEST-EFFORT: this service never participates in the primary run/stream success path.
+ * Returns `null` when the report has no totals metric with a summarizable function (composeTotals
+ * returns null) or when the dataset is empty (the DWH produced no row). Callers treat totals as
+ * BEST-EFFORT: this service never participates in the primary run/stream success path.
  */
 @Injectable()
 export class ReportTotalsService {
@@ -51,8 +52,8 @@ export class ReportTotalsService {
       const description = await reader.prepareReportData(report, {
         sqlOverride: totals.sql,
         sqlOverrideParams: totals.params,
-        // Headers must derive from the SAME numeric-field aggregation plan composeTotals
-        // built, so each header name equals its SQL output alias.
+        // Headers must derive from the SAME metrics aggregation plan composeTotals built,
+        // so each header name equals its SQL output alias.
         columnFilter: totals.columns,
         aggregationConfig: totals.aggregations,
         // Joined-numeric totals are not native columns; their base type travels here so the

--- a/apps/web/src/features/data-marts/edit/model/types/data-mart-run.ts
+++ b/apps/web/src/features/data-marts/edit/model/types/data-mart-run.ts
@@ -27,7 +27,9 @@ export interface DataMartRunItem {
   aiAssistantDefinition: DataMartRunAiAssistantDefinition | null;
   createdByUser: UserProjection | null;
   additionalParams: Record<string, unknown> | null;
-  /** Grand-totals summary (numeric fields × allowed aggregations); null when none. */
+  /** Grand-totals summary (numeric fields plus report-aggregated metrics × allowed
+   * aggregations, excluding ANY_VALUE/STRING_AGG); values may be numbers or strings; null when
+   * none. */
   totals: Record<string, number | string | boolean | null> | null;
 }
 

--- a/apps/web/src/features/data-marts/shared/types/api/response/data-mart-run.response.dto.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/response/data-mart-run.response.dto.ts
@@ -30,7 +30,9 @@ export interface DataMartRunResponseDto {
   aiSourceDefinition: DataMartRunAiSourceDefinitionDto | null;
   createdByUser: UserProjectionDto | null;
   additionalParams: Record<string, unknown> | null;
-  /** Grand-totals summary (numeric fields × allowed aggregations); null/absent when none. */
+  /** Grand-totals summary (numeric fields plus report-aggregated metrics × allowed
+   * aggregations, excluding ANY_VALUE/STRING_AGG); values may be numbers or strings;
+   * null/absent when none. */
   totals?: Record<string, number | string | boolean | null> | null;
 }
 

--- a/docs/getting-started/setup-guide/report-aggregations.md
+++ b/docs/getting-started/setup-guide/report-aggregations.md
@@ -130,6 +130,7 @@ The SQL OWOX builds for an aggregated report is fully transparent — preview it
 - A date bucket's time zone affects only the bucketing. Date **filters** on the same field are evaluated in the warehouse's session time zone, so rows near midnight can land on different sides of a bucket boundary than of a filter boundary. Keep this in mind when combining a non-session time-zone bucket with a date filter on the same field.
 - Percentiles (`P25`/`P50`/`P75`/`P95`) are **approximate** on BigQuery and Athena and **exact** (continuous-interpolated) on Redshift, Snowflake, and Databricks, so the same percentile can differ slightly between storages.
 - For joined Data Marts, report-level aggregation is applied **on top of** the join roll-up; see [Joinable Data Marts](./joinable-data-marts.md).
+- **Totals over joined fields are approximate**, because they re-aggregate the per-join roll-up rather than raw rows: `AVG`/percentiles are unweighted (an average of per-join averages), and a `Count Unique` over a joined **text** field counts distinct rolled-up values (by default a concatenation of the joined rows), not distinct raw values. Totals over the Data Mart's own (native) fields are exact.
 
 ## Related Links
 

--- a/docs/getting-started/setup-guide/report-aggregations.md
+++ b/docs/getting-started/setup-guide/report-aggregations.md
@@ -11,7 +11,7 @@ Summarize Data Mart data directly in a report — group by dimensions, apply agg
 - **Group by** the remaining columns automatically (every non-aggregated selected column becomes a grouping key).
 - **Bucket a date/timestamp** by day, week, month, quarter, or year (with an optional time zone).
 - Add a **Unique count** metric (`COUNT(DISTINCT primary key)`).
-- Get **Totals** for every numeric field — each by all of its allowed functions — returned as a separate block.
+- Get **Totals** for numeric fields and any aggregated metric — each by its allowed functions — returned as a separate block.
 - Govern, at the Data Mart level, which functions each field may use.
 
 Works across all supported storages: **BigQuery, Athena, Snowflake, Redshift, and Databricks**.
@@ -109,9 +109,9 @@ Whenever a report is aggregated, OWOX automatically adds a **`Row Count`** colum
 
 ## Totals
 
-**Totals** are a per-column summary over the full filtered dataset, with no grouping. Every selected **numeric** field is aggregated by **all of its allowed functions** — for example `Sum`, `Average`, `Min`, and `Max` of `revenue`. Totals are computed **in the warehouse** by a separate query and returned as a **separate block**, so they stay accurate and are never recomputed from the displayed rows.
+**Totals** are a per-column summary over the full filtered dataset, with no grouping. Totals cover every selected **numeric** field — aggregated by **all of its allowed functions** (for example `Sum`, `Average`, `Min`, and `Max` of `revenue`) — plus any **non-numeric field the report aggregates as a metric** (for example `Count Unique` on a text `country` column, giving its distinct count). `Sample` (`ANY_VALUE`) and `Combined` (`STRING_AGG`) are **never** part of Totals: a single representative value or a full-column concatenation is not a meaningful grand total. Totals are computed **in the warehouse** by a separate query and returned as a **separate block**, so they stay accurate and are never recomputed from the displayed rows.
 
-Totals are produced even when the report itself is not grouped, and they cover numeric fields from joined Data Marts as well. `Row Count` and `Unique count` are not part of Totals.
+Totals are produced even when the report itself is not grouped, and fields from joined Data Marts are included on the same basis (numeric fields automatically; non-numeric ones when the report aggregates them). `Row Count` and `Unique count` are not part of Totals.
 
 > ⚠️ Totals are returned in the report **data API** (used by the MCP server and HTTP destinations), not written into Google Sheets or Looker Studio report output.
 


### PR DESCRIPTION
## Problem

Report totals — returned by `query_data_mart` and retrievable for a Data Mart run via its `x-owox-run-id` → run details — were computed only for **numeric** fields. A scorecard that aggregates a non-numeric column (e.g. `COUNT_DISTINCT` over a text field) returned `totals: null` from `getRunById` / `query_data_mart` even after the run succeeded and the aggregate was present in the streamed rows.

## Fix

Totals are now driven by field governance instead of a hard numeric-type gate. A field contributes to totals when it is either:

- **numeric** — an auto per-column summary (unchanged), or
- **aggregated by the report as a metric** — the only metric signal, since there is no schema-level dimension/metric role.

Each field is summarized by its governance-allowed functions, so a text metric yields `COUNT` / `COUNT_DISTINCT` rather than a `SUM`/`AVG` it can't run. This is **symmetric across native and joined** Data Mart fields. `ANY_VALUE` and `STRING_AGG` are excluded from totals — neither reduces to a meaningful grand total.

`query_data_mart` (MCP) and the HTTP Data run / `getRunById` path share the same `ReportTotalsService.computeTotals`, so they behave identically.

## Testing

- **Unit:** new coverage for a `COUNT_DISTINCT`-over-text scorecard, `ANY_VALUE`/`STRING_AGG` exclusion, and joined-field symmetry (positive + negative), alongside the existing totals suites.
- **End-to-end on BigQuery:** verified totals for a text `COUNT_DISTINCT`, numeric `SUM/AVG/MIN/MAX` + percentiles, exclusion of `ANY_VALUE`/`STRING_AGG`, and a joined text `COUNT` — against the previous `null` behavior.
- **Docs:** `report-aggregations.md` Totals section updated.
