### PR TITLE
feat(api): add project setup progress client

### DIFF
--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -14,3 +14,12 @@ same authenticated retry and error behavior as existing client requests.
 
 `@owox/api-client` now exposes paginated Models canvas data marts through
 `models.getDataMarts()` and their visible relationship edges through `models.getEdges()`.
+
+## Add project setup progress API contract and client support
+
+`GET /api/project-setup-progress` now publishes an explicit OpenAPI response contract.
+`@owox/api-client` adds `project.getSetupProgress()` and exports
+`OWOXProjectSetupProgress`, `OWOXProjectSetupProgressSteps`, and
+`OWOXProjectSetupStepState` for inspecting versioned, member-aware setup state. Existing
+authenticated viewer access is unchanged, and consumers can adopt the client method without a
+migration.

--- a/apps/backend/src/data-marts/controllers/project-setup-progress.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/project-setup-progress.controller.openapi.spec.ts
@@ -1,0 +1,112 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
+
+jest.mock('../../idp', () => ({
+  __esModule: true,
+  Auth: () => () => undefined,
+  AuthContext: () => () => undefined,
+  Role: {
+    viewer: jest.fn(),
+  },
+  Strategy: {
+    PARSE: 'parse',
+  },
+}));
+
+import { ProjectSetupProgressMapper } from '../mappers/project-setup-progress.mapper';
+import { GetProjectSetupProgressService } from '../use-cases/get-project-setup-progress.service';
+import { ProjectSetupProgressController } from './project-setup-progress.controller';
+
+describe('ProjectSetupProgressController OpenAPI', () => {
+  let app: INestApplication;
+  let document: OpenAPIObject;
+
+  beforeAll(async () => {
+    const providers = [GetProjectSetupProgressService, ProjectSetupProgressMapper].map(provide => ({
+      provide,
+      useValue: {},
+    }));
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ProjectSetupProgressController],
+      providers,
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    document = SwaggerModule.createDocument(
+      app,
+      new DocumentBuilder().setTitle('Test API').setVersion('1.0').build()
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  function resolveRef(ref: string): Record<string, any> {
+    const schemaName = ref.split('/').at(-1)!;
+    return document.components?.schemas?.[schemaName] as Record<string, any>;
+  }
+
+  it('documents the project setup progress operation and response schema', () => {
+    const operation = document.paths['/api/project-setup-progress']?.get;
+
+    expect(operation?.summary).toBe('Get project setup progress');
+    expect(operation?.responses['200']).toMatchObject({
+      description: 'The merged setup progress for the current project member.',
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/ProjectSetupProgressResponseApiDto' },
+        },
+      },
+    });
+
+    const responseSchema = document.components?.schemas
+      ?.ProjectSetupProgressResponseApiDto as Record<string, any>;
+    expect(responseSchema).toMatchObject({
+      required: ['version', 'stepsSchemaVersion', 'progress', 'steps'],
+      properties: {
+        version: { type: 'integer', minimum: 1 },
+        stepsSchemaVersion: { type: 'integer', minimum: 1 },
+        progress: { type: 'integer', minimum: 0, maximum: 100 },
+        steps: {
+          description: 'Per-step state (project-scoped + user-scoped, merged)',
+          allOf: [{ $ref: '#/components/schemas/ProjectSetupStepsApiDto' }],
+        },
+      },
+    });
+
+    const stepsSchema = resolveRef(responseSchema.properties.steps.allOf[0].$ref);
+    expect(stepsSchema.required).toEqual([
+      'hasStorage',
+      'hasDraftDataMart',
+      'hasPublishedDataMart',
+      'hasDestination',
+      'hasReport',
+      'hasReportRun',
+      'hasTeammatesInvited',
+      'hasGoogleSheetsDestination',
+      'hasGoogleSheetsExtension',
+      'hasGoogleSheetsReportRun',
+    ]);
+    expect(Object.values(stepsSchema.properties)).toEqual(
+      Array(10).fill({ $ref: '#/components/schemas/ProjectSetupStepStateApiDto' })
+    );
+
+    expect(resolveRef('#/components/schemas/ProjectSetupStepStateApiDto')).toMatchObject({
+      required: ['done', 'completedAt'],
+      properties: {
+        done: { type: 'boolean' },
+        completedAt: {
+          type: 'string',
+          format: 'date-time',
+          nullable: true,
+        },
+      },
+    });
+  });
+});

--- a/apps/backend/src/data-marts/controllers/project-setup-progress.controller.ts
+++ b/apps/backend/src/data-marts/controllers/project-setup-progress.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AuthContext, AuthorizationContext, Auth } from '../../idp';
 import { Role, Strategy } from '../../idp/types/role-config.types';
 import { ProjectSetupProgressResponseApiDto } from '../dto/presentation/project-setup-progress-response-api.dto';
@@ -16,6 +16,11 @@ export class ProjectSetupProgressController {
 
   @Auth(Role.viewer(Strategy.PARSE))
   @Get()
+  @ApiOperation({ summary: 'Get project setup progress' })
+  @ApiOkResponse({
+    description: 'The merged setup progress for the current project member.',
+    type: ProjectSetupProgressResponseApiDto,
+  })
   async getProgress(
     @AuthContext() context: AuthorizationContext
   ): Promise<ProjectSetupProgressResponseApiDto> {

--- a/apps/backend/src/data-marts/dto/presentation/project-setup-progress-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/project-setup-progress-response-api.dto.ts
@@ -1,20 +1,74 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { ProjectSetupSteps } from '../domain/project-setup-steps.interface';
+
+export class ProjectSetupStepStateApiDto {
+  @ApiProperty({ description: 'Whether the setup step is complete' })
+  done: boolean;
+
+  @ApiProperty({
+    type: String,
+    format: 'date-time',
+    nullable: true,
+    description: 'When the setup step was completed, or null while incomplete',
+  })
+  completedAt: string | null;
+}
+
+export class ProjectSetupStepsApiDto {
+  @ApiProperty({ type: ProjectSetupStepStateApiDto })
+  hasStorage: ProjectSetupStepStateApiDto;
+
+  @ApiProperty({ type: ProjectSetupStepStateApiDto })
+  hasDraftDataMart: ProjectSetupStepStateApiDto;
+
+  @ApiProperty({ type: ProjectSetupStepStateApiDto })
+  hasPublishedDataMart: ProjectSetupStepStateApiDto;
+
+  @ApiProperty({ type: ProjectSetupStepStateApiDto })
+  hasDestination: ProjectSetupStepStateApiDto;
+
+  @ApiProperty({ type: ProjectSetupStepStateApiDto })
+  hasReport: ProjectSetupStepStateApiDto;
+
+  @ApiProperty({ type: ProjectSetupStepStateApiDto })
+  hasReportRun: ProjectSetupStepStateApiDto;
+
+  @ApiProperty({ type: ProjectSetupStepStateApiDto })
+  hasTeammatesInvited: ProjectSetupStepStateApiDto;
+
+  @ApiProperty({ type: ProjectSetupStepStateApiDto })
+  hasGoogleSheetsDestination: ProjectSetupStepStateApiDto;
+
+  @ApiProperty({ type: ProjectSetupStepStateApiDto })
+  hasGoogleSheetsExtension: ProjectSetupStepStateApiDto;
+
+  @ApiProperty({ type: ProjectSetupStepStateApiDto })
+  hasGoogleSheetsReportRun: ProjectSetupStepStateApiDto;
+}
 
 export class ProjectSetupProgressResponseApiDto {
-  @ApiProperty({ example: 1, description: 'API contract version' })
+  @ApiProperty({ type: 'integer', minimum: 1, example: 1, description: 'API contract version' })
   version: number;
 
-  @ApiProperty({ example: 1, description: 'Schema version of the persisted steps JSON' })
+  @ApiProperty({
+    type: 'integer',
+    minimum: 1,
+    example: 1,
+    description: 'Schema version of the persisted steps JSON',
+  })
   stepsSchemaVersion: number;
 
-  @ApiProperty({ example: 42, description: 'Percentage of completed steps (0..100)' })
+  @ApiProperty({
+    type: 'integer',
+    minimum: 0,
+    maximum: 100,
+    example: 42,
+    description: 'Percentage of completed steps (0..100)',
+  })
   progress: number;
 
   @ApiProperty({
-    type: 'object',
-    additionalProperties: true,
+    type: ProjectSetupStepsApiDto,
     description: 'Per-step state (project-scoped + user-scoped, merged)',
   })
-  steps: ProjectSetupSteps;
+  steps: ProjectSetupStepsApiDto;
 }

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -71,6 +71,22 @@ await client.project.updateDescription(
 await client.project.updateDescription(null);
 ```
 
+## Check project setup progress
+
+Use `project.getSetupProgress()` to inspect the current project member's merged project- and
+user-scoped onboarding state. The response includes the API contract version, persisted steps
+schema version, completion percentage, and per-step completion details.
+
+```ts
+const setupProgress = await client.project.getSetupProgress();
+
+console.log(setupProgress.progress);
+
+for (const [step, state] of Object.entries(setupProgress.steps)) {
+  console.log(step, state.done, state.completedAt);
+}
+```
+
 ## List data marts
 
 ```ts

--- a/docs/api/coverage.md
+++ b/docs/api/coverage.md
@@ -21,6 +21,21 @@ npm test -w @owox/backend -- --runInBand --runTestsByPath src/project-settings/c
 npm test -w @owox/api-client -- --runInBand --runTestsByPath src/client.test.ts
 ```
 
+## Project setup progress
+
+Coverage updated: 2026-07-21
+
+| Method and path                   | Exposure                                                  | OpenAPI status                               | API client status                     | Verification evidence                                                                                                            | Exemption approval |
+| --------------------------------- | --------------------------------------------------------- | -------------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `GET /api/project-setup-progress` | Authenticated public; Project Member (`viewer` or higher) | Covered: operation and `200` response schema | Covered: `project.getSetupProgress()` | Backend `project-setup-progress.controller.openapi.spec.ts`; client `project-setup-progress.test.ts` (auth, response validation) | Not applicable     |
+
+Focused verification:
+
+```sh
+npm test -w @owox/backend -- --runInBand --runTestsByPath src/data-marts/controllers/project-setup-progress.controller.openapi.spec.ts
+npm test -w @owox/api-client -- --runInBand --runTestsByPath src/project-setup-progress.test.ts
+```
+
 ## Models canvas
 
 Coverage updated: 2026-07-21

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -16,4 +16,9 @@ export {
   type OWOXModelCanvasJoinCondition,
   type OWOXModelCanvasNode,
 } from './model-canvas.js';
-export { type OWOXProjectSettings } from './project.js';
+export {
+  type OWOXProjectSettings,
+  type OWOXProjectSetupProgress,
+  type OWOXProjectSetupProgressSteps,
+  type OWOXProjectSetupStepState,
+} from './project.js';

--- a/packages/api-client/src/project-setup-progress.test.ts
+++ b/packages/api-client/src/project-setup-progress.test.ts
@@ -1,0 +1,110 @@
+import { OWOXApiClient, OWOXApiError } from './index.js';
+
+type RecordedRequest = {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+};
+
+const apiOrigin = 'https://example.test';
+const apiKeyId = 'pmk_AbCdEfGhIjKlMnOpQrStUv';
+const apiKey = `owox_key_${Buffer.from(
+  JSON.stringify({
+    apiOrigin,
+    apiKeyId,
+    apiKeySecret: 'secret-value-that-must-not-leak',
+  }),
+  'utf8'
+).toString('base64url')}`;
+
+function createJsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function createFetchMock(handler: (request: RecordedRequest) => Response): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const headers: Record<string, string> = {};
+    request.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    const parsedUrl = new URL(request.url);
+    return handler({
+      method: request.method,
+      url: `${parsedUrl.pathname}${parsedUrl.search}`,
+      headers,
+    });
+  }) as typeof fetch;
+}
+
+const setupProgress = {
+  version: 1,
+  stepsSchemaVersion: 1,
+  progress: 40,
+  steps: {
+    hasStorage: { done: true, completedAt: '2026-07-21T12:00:00.000Z' },
+    hasDraftDataMart: { done: true, completedAt: '2026-07-21T12:01:00.000Z' },
+    hasPublishedDataMart: { done: true, completedAt: '2026-07-21T12:02:00.000Z' },
+    hasDestination: { done: true, completedAt: '2026-07-21T12:03:00.000Z' },
+    hasReport: { done: false, completedAt: null },
+    hasReportRun: { done: false, completedAt: null },
+    hasTeammatesInvited: { done: false, completedAt: null },
+    hasGoogleSheetsDestination: { done: false, completedAt: null },
+    hasGoogleSheetsExtension: { done: false, completedAt: null },
+    hasGoogleSheetsReportRun: { done: false, completedAt: null },
+  },
+};
+
+describe('Project setup progress API', () => {
+  it('gets merged setup progress through an authenticated request', async () => {
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      if (request.method === 'GET' && request.url === '/api/project-setup-progress') {
+        expect(request.headers['x-owox-authorization']).toBe('Bearer access-token-1');
+        expect(request.headers['x-owox-api-key-id']).toBe(apiKeyId);
+        return createJsonResponse(200, setupProgress);
+      }
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.project.getSetupProgress()).resolves.toEqual(setupProgress);
+  });
+
+  it.each([
+    [
+      'an invalid nested step',
+      {
+        ...setupProgress,
+        steps: {
+          ...setupProgress.steps,
+          hasStorage: { done: 'yes', completedAt: null },
+        },
+      },
+    ],
+    ['an out-of-range progress percentage', { ...setupProgress, progress: 101 }],
+    ['a fractional API contract version', { ...setupProgress, version: 1.5 }],
+    ['a non-positive steps schema version', { ...setupProgress, stepsSchemaVersion: 0 }],
+  ])('rejects a response with %s', async (_label, response) => {
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      return createJsonResponse(200, response);
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    const result = client.project.getSetupProgress();
+    await expect(result).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'OWOX Project Setup Progress API returned an unexpected response shape',
+      details: response,
+    });
+    await expect(result).rejects.toBeInstanceOf(OWOXApiError);
+  });
+});

--- a/packages/api-client/src/project.ts
+++ b/packages/api-client/src/project.ts
@@ -4,15 +4,64 @@ export type OWOXProjectSettings = {
   description: string | null;
 };
 
+export type OWOXProjectSetupStepState = {
+  done: boolean;
+  completedAt: string | null;
+};
+
+export type OWOXProjectSetupProgressSteps = {
+  hasStorage: OWOXProjectSetupStepState;
+  hasDraftDataMart: OWOXProjectSetupStepState;
+  hasPublishedDataMart: OWOXProjectSetupStepState;
+  hasDestination: OWOXProjectSetupStepState;
+  hasReport: OWOXProjectSetupStepState;
+  hasReportRun: OWOXProjectSetupStepState;
+  hasTeammatesInvited: OWOXProjectSetupStepState;
+  hasGoogleSheetsDestination: OWOXProjectSetupStepState;
+  hasGoogleSheetsExtension: OWOXProjectSetupStepState;
+  hasGoogleSheetsReportRun: OWOXProjectSetupStepState;
+};
+
+export type OWOXProjectSetupProgress = {
+  version: number;
+  stepsSchemaVersion: number;
+  progress: number;
+  steps: OWOXProjectSetupProgressSteps;
+};
+
 type ProjectRequester = {
   getJson<T>(path: string): Promise<T>;
   putJson<T>(path: string, jsonBody: unknown): Promise<T>;
 };
 
+const PROJECT_SETUP_STEP_KEYS = [
+  'hasStorage',
+  'hasDraftDataMart',
+  'hasPublishedDataMart',
+  'hasDestination',
+  'hasReport',
+  'hasReportRun',
+  'hasTeammatesInvited',
+  'hasGoogleSheetsDestination',
+  'hasGoogleSheetsExtension',
+  'hasGoogleSheetsReportRun',
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isProjectSetupStepState(value: unknown): value is OWOXProjectSetupStepState {
+  return (
+    isRecord(value) &&
+    typeof value.done === 'boolean' &&
+    (typeof value.completedAt === 'string' || value.completedAt === null)
+  );
+}
+
 function parseProjectSettings(response: unknown): OWOXProjectSettings {
   if (
-    typeof response !== 'object' ||
-    response === null ||
+    !isRecord(response) ||
     !('description' in response) ||
     (typeof response.description !== 'string' && response.description !== null)
   ) {
@@ -24,11 +73,52 @@ function parseProjectSettings(response: unknown): OWOXProjectSettings {
   return { description: response.description };
 }
 
+function parseProjectSetupProgress(response: unknown): OWOXProjectSetupProgress {
+  if (
+    !isRecord(response) ||
+    typeof response.version !== 'number' ||
+    !Number.isInteger(response.version) ||
+    response.version < 1 ||
+    typeof response.stepsSchemaVersion !== 'number' ||
+    !Number.isInteger(response.stepsSchemaVersion) ||
+    response.stepsSchemaVersion < 1 ||
+    typeof response.progress !== 'number' ||
+    !Number.isInteger(response.progress) ||
+    response.progress < 0 ||
+    response.progress > 100 ||
+    !isRecord(response.steps)
+  ) {
+    throw new OWOXApiError(
+      'OWOX Project Setup Progress API returned an unexpected response shape',
+      { details: response }
+    );
+  }
+
+  const steps = response.steps;
+  if (
+    !PROJECT_SETUP_STEP_KEYS.every(key => isProjectSetupStepState(steps[key])) ||
+    !Object.values(steps).every(isProjectSetupStepState)
+  ) {
+    throw new OWOXApiError(
+      'OWOX Project Setup Progress API returned an unexpected response shape',
+      { details: response }
+    );
+  }
+
+  return response as OWOXProjectSetupProgress;
+}
+
 export class ProjectApi {
   constructor(private readonly requester: ProjectRequester) {}
 
   async getSettings(): Promise<OWOXProjectSettings> {
     return parseProjectSettings(await this.requester.getJson<unknown>('/api/projects/settings'));
+  }
+
+  async getSetupProgress(): Promise<OWOXProjectSetupProgress> {
+    return parseProjectSetupProgress(
+      await this.requester.getJson<unknown>('/api/project-setup-progress')
+    );
   }
 
   async updateDescription(description: string | null): Promise<OWOXProjectSettings> {


### PR DESCRIPTION
<!-- owox-factory:api-surface-maintenance case=owox-data-marts/project-setup-progress -->

## Scope

- Publish an explicit OpenAPI operation and nested response schema for `GET /api/project-setup-progress` without changing authenticated viewer access.
- Add `project.getSetupProgress()` and exported setup-progress response/step types to `@owox/api-client`, including runtime response validation.
- Add consumer usage, API coverage, focused executable evidence, and a distinct section in the canonical API-surface changeset.
- Keep `docs/api/openapi.md` unchanged.

## Coverage matrix

| Surface | Before | After |
| --- | --- | --- |
| Backend/OpenAPI | Authenticated viewer route existed without an explicit operation or `200` response contract | Explicit operation, version/range constraints, ten named setup steps, and nested step-state schema |
| API client | No setup-progress method or exported response types | `project.getSetupProgress()` plus `OWOXProjectSetupProgress`, `OWOXProjectSetupProgressSteps`, and `OWOXProjectSetupStepState` |
| Executable evidence | Service-internal tests only | Focused Swagger contract test plus authenticated client and malformed-response tests |
| Consumer docs/coverage | No setup-progress usage or capability row | Usage example, capability row, verification commands, and `Coverage updated: 2026-07-21` |
| Release metadata | Canonical changeset contained Project settings and Models canvas sections | Those sections are preserved and a distinct consumer-facing Project setup progress section is appended |

Audited base commit: `72f3d47fbb842a8b8b1ed69cd41052b9383ff6b1`

## Verification

- `npm test -w @owox/backend -- --runInBand --runTestsByPath src/data-marts/controllers/project-setup-progress.controller.openapi.spec.ts` — 1/1 passed
- `npm test -w @owox/api-client -- --runInBand --runTestsByPath src/project-setup-progress.test.ts` — 5/5 passed
- `npm run typecheck -w @owox/api-client` — passed
- Affected backend and API-client ESLint checks — passed
- Affected-file Prettier check — passed
- Markdownlint for consumer docs, coverage, and changeset — passed
- `npm exec changeset -- status --since main` — passed and includes `@owox/api-client`
- Independent full-diff and post-fix delta reviews — no remaining findings

The backend workspace-wide TypeScript baseline reports existing errors in unrelated tests; focused test compilation and linting cover the changed backend files, which do not appear in that baseline error set.

## Exemptions

None.

## Blocker register

- `Audit all`: baseline blocker. The same workflow fails on current `main` (`3a5abb3520cf19e1e97575c52e4381fee9af1cbf`) because `npm audit --omit=dev` reports five existing production dependency advisories (one high `adm-zip`, four moderate Astro-chain advisories). This PR changes no dependency manifest or lockfile; available fixes require breaking upgrades outside this slice.
- All other GitHub checks: passed.
- Code/review blockers: none known.

🤖 Codex (GPT-5.6 Sol High)
