### PR TITLE
fix(backend): stamp Google Sheets A1 import note at finish time

### DIFF
--- a/.changeset/6665-gs-a1-import-finish-time.md
+++ b/.changeset/6665-gs-a1-import-finish-time.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Google Sheets A1 note shows import finish time
+
+The A1 cell note for a Google Sheets export now records **when the import finished**, not when the first data batch started writing. While rows are still streaming, only the short ODM marker is present; the full provenance block (`Imported at …`, data mart title, and link) is written in the finalize step after all data is on the sheet.

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -1,4 +1,5 @@
 import { sheets_v4 } from 'googleapis';
+import { DateTime } from 'luxon';
 import { ColumnPlan, PreviousImportedColumn } from '../../../dto/domain/column-plan.dto';
 import { ReportDataBatch } from '../../../dto/domain/report-data-batch.dto';
 import { ReportDataDescription } from '../../../dto/domain/report-data-description.dto';
@@ -683,35 +684,30 @@ describe('GoogleSheetsReportWriter — preserves user column formats across refr
 });
 
 describe('GoogleSheetsReportWriter — per-column header notes', () => {
-  it('writes the full ODM note only on the first column and the description + short marker on the rest', async () => {
+  it('writes short markers on every column during header write, then the full A1 note only in finalize', async () => {
     const { writer, report, finalImportedNames, metadataFormatter } = buildWriter({
       availableRowsCount: 11,
     });
 
     // Give every column its own description so we can assert it flows through
-    // to both the first-column note and the non-first markers.
+    // to both the first-column full note and the short markers.
     const headers = finalImportedNames.map(
       name => new ReportDataHeader(name, undefined, `${name} description`)
     );
 
     await writer.prepareToWriteReport(report as never, new ReportDataDescription(headers, 1));
     await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
-    await writer.finalize();
 
-    // Three imported columns → exactly one full note (A1) + two short markers.
-    expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledTimes(1);
+    // After the first batch, headers are written with short markers only —
+    // the full A1 provenance note must wait until finalize (finish time).
+    expect(metadataFormatter.buildImportedColumnNote).not.toHaveBeenCalled();
     expect(metadataFormatter.buildImportedColumnMarker).toHaveBeenCalledTimes(
-      finalImportedNames.length - 1
+      finalImportedNames.length
     );
-    // The full note carries the first column's description ('country').
-    expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledWith(
+    expect(metadataFormatter.buildImportedColumnMarker).toHaveBeenCalledWith(
       'country description',
-      'DM',
-      expect.any(String),
-      expect.any(String),
       expect.any(Boolean)
     );
-    // The non-first columns carry their own description ahead of the marker.
     expect(metadataFormatter.buildImportedColumnMarker).toHaveBeenCalledWith(
       'clicks description',
       expect.any(Boolean)
@@ -720,6 +716,120 @@ describe('GoogleSheetsReportWriter — per-column header notes', () => {
       'cost description',
       expect.any(Boolean)
     );
+
+    await writer.finalize();
+
+    // Finalize upgrades A1 to the full ODM provenance block once.
+    expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledTimes(1);
+    expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledWith(
+      'country description',
+      'DM',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Boolean)
+    );
+    // Markers were not rewritten in finalize — still only the header-write calls.
+    expect(metadataFormatter.buildImportedColumnMarker).toHaveBeenCalledTimes(
+      finalImportedNames.length
+    );
+    // A1 full note is applied via createNoteRequest(row 0, col 0) in finalize.
+    expect(metadataFormatter.createNoteRequest).toHaveBeenCalledWith(SHEET_ID, 'note', 0, 0);
+  });
+
+  it('stamps the A1 note with finish time, not header-write (start) time', async () => {
+    const { writer, report, finalImportedNames, metadataFormatter } = buildWriter({
+      availableRowsCount: 11,
+    });
+
+    const headers = finalImportedNames.map(
+      name => new ReportDataHeader(name, undefined, `${name} description`)
+    );
+
+    // Valid DateTime so the mock matches DateTime.now()'s branded return type.
+    const finish = DateTime.utc(2026, 6, 16, 10, 5, 0);
+    const nowSpy = jest
+      .spyOn(DateTime, 'now')
+      .mockImplementation(() => finish as ReturnType<typeof DateTime.now>);
+
+    try {
+      await writer.prepareToWriteReport(report as never, new ReportDataDescription(headers, 1));
+      await writer.writeReportDataBatch(new ReportDataBatch([['A', '10', '2']]));
+      // Header write no longer calls DateTime.now; only finalize does.
+      await writer.finalize();
+
+      expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledTimes(1);
+      const dateArg = metadataFormatter.buildImportedColumnNote.mock.calls[0][3] as string;
+      // Spreadsheet timezone in the harness is UTC — finish minute must appear.
+      expect(dateArg).toContain('10:05:00');
+      expect(dateArg).toContain('UTC');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('uses the A1 (final layout) column description when sheet order differs from SQL order', async () => {
+    // Sheet layout: clicks is in A1; SQL still emits country first.
+    const { writer, report, metadataFormatter } = buildWriter({
+      availableRowsCount: 11,
+      finalImportedNames: ['clicks', 'country', 'cost'],
+    });
+
+    const headers = [
+      new ReportDataHeader('country', undefined, 'country description'),
+      new ReportDataHeader('clicks', undefined, 'clicks description'),
+      new ReportDataHeader('cost', undefined, 'cost description'),
+    ];
+
+    await writer.prepareToWriteReport(report as never, new ReportDataDescription(headers, 1));
+    await writer.writeReportDataBatch(new ReportDataBatch([['10', 'A', '2']]));
+    await writer.finalize();
+
+    // Full note must describe the first *final* column (clicks), not SQL[0] (country).
+    expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledTimes(1);
+    expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledWith(
+      'clicks description',
+      'DM',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Boolean)
+    );
+  });
+
+  it('writes the full A1 note on the zero-batch success path', async () => {
+    const { writer, report, finalImportedNames, metadataFormatter } = buildWriter({
+      availableRowsCount: 11,
+    });
+
+    const headers = finalImportedNames.map(
+      name => new ReportDataHeader(name, undefined, `${name} description`)
+    );
+
+    await writer.prepareToWriteReport(report as never, new ReportDataDescription(headers, 0));
+    // No data batches — finalize applies deferred mutations then finishes.
+    await writer.finalize();
+
+    expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledTimes(1);
+    expect(metadataFormatter.buildImportedColumnNote).toHaveBeenCalledWith(
+      'country description',
+      'DM',
+      expect.any(String),
+      expect.any(String),
+      expect.any(Boolean)
+    );
+  });
+
+  it('does not write the full A1 note when the reader fails before any batch', async () => {
+    const { writer, report, finalImportedNames, metadataFormatter } = buildWriter({
+      availableRowsCount: 11,
+    });
+
+    await writer.prepareToWriteReport(
+      report as never,
+      new ReportDataDescription(makeHeaders(...finalImportedNames), 1)
+    );
+    await writer.finalize(new Error('reader failed before any batch'));
+
+    expect(metadataFormatter.buildImportedColumnNote).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -379,7 +379,9 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
    *   - sets tab color and freezes the header row;
    *   - persists `OWOX_REPORT_META` (one per sheet) and `OWOX_COLUMNS`
    *     (the imported-range column list for next refresh);
-   *   - replays user fill-down formulas across all freshly written data rows.
+   *   - replays user fill-down formulas across all freshly written data rows;
+   *   - writes the full A1 provenance note with finish-time `Imported at …`
+   *     (header write only places short markers so the stamp is not early).
    *
    * When `processingError` is set we **skip** the deferred-mutation
    * fallback: the upstream pipeline failed before producing meaningful
@@ -544,6 +546,37 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
         if (restoreFormatRequests.length > 0) {
           requests.push(...restoreFormatRequests);
         }
+
+        // A1 full provenance note with finish-time "Imported at …". Written
+        // here (not in writeHeaders) so the timestamp is the end of the
+        // import, not the start of the first data batch. Header-write time
+        // only places short markers on every imported column.
+        //
+        // `dataMart` is always the main/home data mart — columns pulled in from
+        // joinable data marts only change the column alias, never this note — so
+        // A1 references the original data mart even for blended marts.
+        const firstColumnName = this.columnPlan.finalImportedNames[0];
+        const firstColumnHeader = this.headersByName.get(firstColumnName);
+        const dateFinished = DateTime.now().setZone(this.spreadsheetTimeZone);
+        const dateFinishedFormatted = `${dateFinished.toFormat('yyyy LLL d, HH:mm:ss')} ${dateFinished.zoneName}`;
+        const isCommunityEdition = !this.appEditionConfig.isEnterpriseEdition();
+        const publicOrigin = this.publicOriginService.getPublicOrigin();
+        const dataMartUrl = buildDataMartUrl(
+          publicOrigin,
+          dataMart.projectId,
+          dataMart.id,
+          '/data-setup'
+        );
+        const a1Note = this.metadataFormatter.buildImportedColumnNote(
+          firstColumnHeader?.description,
+          this.dataMartTitle,
+          dataMartUrl,
+          dateFinishedFormatted,
+          isCommunityEdition
+        );
+        requests.push(
+          this.metadataFormatter.createNoteRequest(this.destination.sheetId, a1Note, 0, 0)
+        );
 
         await this.adapter.batchUpdate(this.destination.spreadsheetId, requests);
 
@@ -938,10 +971,16 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
   }
 
   /**
-   * Writes header values + per-cell notes inside the imported rectangle, and
-   * resets/applies header formatting bounded to the same width. Format reset
-   * is **not** propagated to columns past the imported range so user content
-   * outside it keeps its styling.
+   * Writes header values + short per-cell notes inside the imported rectangle,
+   * and resets/applies header formatting bounded to the same width. Format
+   * reset is **not** propagated to columns past the imported range so user
+   * content outside it keeps its styling.
+   *
+   * Notes written here are short markers only (column description +
+   * `--- Imported via OWOX Data Marts ---`). The full A1 provenance block
+   * (including finish-time `Imported at …`) is deferred to {@link finalize}
+   * so the timestamp reflects when the import actually completed, not when
+   * the first data batch started writing.
    */
   private async writeHeaders(): Promise<void> {
     return this.executeWithErrorHandling(async () => {
@@ -965,45 +1004,16 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
         headerRow,
       ]);
 
-      // Per-column note: every imported column carries its own description.
-      // Only the FIRST column of the range (index 0, i.e. A1) additionally
-      // carries the full provenance block — the ODM metadata (import time,
-      // data mart title, link). Every other imported column gets its
-      // description followed by just a short `--- Imported via OWOX Data
-      // Marts ---` marker, so the per-column description is preserved without
-      // repeating the same provenance metadata across every header.
-      //
-      // `dataMart` is always the main/home data mart — columns pulled in from
-      // joinable data marts only change the column alias, never this note — so
-      // A1 already references the right (original) data mart for blended marts.
-      const dateNow = DateTime.now().setZone(this.spreadsheetTimeZone);
-      const dateNowFormatted = `${dateNow.toFormat('yyyy LLL d, HH:mm:ss')} ${dateNow.zoneName}`;
-      const dataMart = this.report.dataMart;
+      // Per-column short marker only at header-write time. Full A1 provenance
+      // (import finish time, data mart title, link) is applied in finalize.
       const isCommunityEdition = !this.appEditionConfig.isEnterpriseEdition();
-      const publicOrigin = this.publicOriginService.getPublicOrigin();
-      const dataMartUrl = buildDataMartUrl(
-        publicOrigin,
-        dataMart.projectId,
-        dataMart.id,
-        '/data-setup'
-      );
 
       const noteRequests = this.reportDataHeaders.map(header => {
         const idx = this.columnPlan.nameToFinalIndex.get(header.name)!;
-        // The range always starts at column A, so index 0 is the first column.
-        const note =
-          idx === 0
-            ? this.metadataFormatter.buildImportedColumnNote(
-                header.description,
-                this.dataMartTitle,
-                dataMartUrl,
-                dateNowFormatted,
-                isCommunityEdition
-              )
-            : this.metadataFormatter.buildImportedColumnMarker(
-                header.description,
-                isCommunityEdition
-              );
+        const note = this.metadataFormatter.buildImportedColumnMarker(
+          header.description,
+          isCommunityEdition
+        );
         return this.metadataFormatter.createNoteRequest(sheetId, note, 0, idx);
       });
 


### PR DESCRIPTION
## Summary

- The A1 cell note for Google Sheets exports used the **start** of the first data batch as `Imported at …`, so users could open the note while rows were still streaming and see a misleading “already imported” timestamp.
- The full A1 provenance note (import time, data mart title, link) is now written only in **finalize**, using finish time in the spreadsheet timezone.
- During the write, headers still get short ODM markers only (no `Imported at` stamp).

## Test plan

- [x] Unit: short markers on every column after first batch; full A1 note only after `finalize`
- [x] Unit: A1 note uses finish-time stamp (`DateTime.now` mocked)
- [x] Unit: A1 description follows **final sheet order**, not SQL order
- [x] Unit: zero-batch success still writes full A1 note
- [x] Unit: reader failure before any batch leaves full A1 note unwritten
- [x] Full `google-sheets-report-writer.spec.ts` suite green (32 tests)
- [x] Optional manual: run a multi-batch Sheets export, confirm note during run has no finish `Imported at`, and after success shows finish time