### PR TITLE
fix(connectors): keep cancelled runs cancelled and refresh BigQuery

### DIFF
--- a/.changeset/6751-connector-run-cancel-and-token-refresh.md
+++ b/.changeset/6751-connector-run-cancel-and-token-refresh.md
@@ -1,0 +1,15 @@
+---
+'owox': minor
+---
+
+# More reliable connector runs during cancellation and long backfills
+
+Previously, cancelling a connector run could fail to stick: the run reappeared
+as running minutes later, and its logs were lost. Long BigQuery backfills on
+OAuth also stopped after about an hour with an "Invalid Credentials" error.
+Now cancelled runs stay cancelled and keep their logs, and BigQuery refreshes
+its access token mid-run so long backfills continue.
+
+A run can still fail with "Invalid Credentials" if its saved token expired
+before the run started. Reconnect the BigQuery destination, or use a service
+account, until token saving arrives.

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -37,7 +37,7 @@ import { Repository } from 'typeorm';
 describe('ConnectorExecutorService', () => {
   const createService = () => {
     const dataMartRunRepository = {
-      update: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
       findOne: jest.fn().mockResolvedValue(null),
     } as unknown as Repository<DataMartRun>;
 
@@ -243,7 +243,7 @@ describe('ConnectorExecutorService', () => {
     await service.executeInBackground(createDataMart(), createRun(), null);
 
     expect(dataMartRunRepository.update).toHaveBeenLastCalledWith(
-      'run-1',
+      { id: 'run-1', status: expect.anything() },
       expect.objectContaining({ status: DataMartRunStatus.FAILED })
     );
     expect(consumptionTracker.registerConnectorRunConsumption).not.toHaveBeenCalled();
@@ -254,43 +254,71 @@ describe('ConnectorExecutorService', () => {
     );
   });
 
-  it('lets normal completion replace a committed cancellation when abort is not delivered', async () => {
-    const {
-      service,
-      dataMartRunRepository,
-      processSpawner,
-      consumptionTracker,
-      eventDispatcher,
-      emitSuccessMessage,
-    } = createService();
-    const statusHistory: DataMartRunStatus[] = [];
-    (dataMartRunRepository.update as jest.Mock).mockImplementation(async (_runId, update) => {
-      if (update.status) {
-        statusHistory.push(update.status);
+  // Mimics a real conditional UPDATE ... WHERE status IN (:...statuses): the write
+  // only applies if the row's current status is still in the expected set.
+  const stubConditionalUpdate = (
+    dataMartRunRepository: Repository<DataMartRun>,
+    state: { current: DataMartRunStatus; statusHistory: DataMartRunStatus[] }
+  ) => {
+    (dataMartRunRepository.update as jest.Mock).mockImplementation(
+      async (
+        criteria: { id: string; status?: { _value?: DataMartRunStatus[] } },
+        update: { status?: DataMartRunStatus }
+      ) => {
+        const expected = criteria.status?._value;
+        if (expected && !expected.includes(state.current)) {
+          return { affected: 0 };
+        }
+        if (update.status) {
+          state.statusHistory.push(update.status);
+          state.current = update.status;
+        }
+        return { affected: 1 };
       }
-    });
+    );
+  };
+
+  it('does not let a stray completion overwrite a committed cancellation when abort is not delivered', async () => {
+    const { service, dataMartRunRepository, processSpawner, emitSuccessMessage } = createService();
+    const state = { current: DataMartRunStatus.RUNNING, statusHistory: [] as DataMartRunStatus[] };
+    stubConditionalUpdate(dataMartRunRepository, state);
     (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
-      // Simulate the cancel endpoint committing CANCELLED while this worker keeps running.
-      statusHistory.push(DataMartRunStatus.CANCELLED);
+      // Simulate the cancel endpoint committing CANCELLED while this worker keeps running,
+      // unaware the abort signal never reached it.
+      state.current = DataMartRunStatus.CANCELLED;
+      state.statusHistory.push(DataMartRunStatus.CANCELLED);
       emitSuccessMessage();
     });
 
     await service.executeInBackground(createDataMart(), createRun(), null);
 
-    expect(statusHistory).toEqual([
-      DataMartRunStatus.RUNNING,
-      DataMartRunStatus.CANCELLED,
-      DataMartRunStatus.SUCCESS,
-    ]);
-    expect(dataMartRunRepository.update).toHaveBeenLastCalledWith(
-      'run-1',
-      expect.objectContaining({ status: DataMartRunStatus.SUCCESS })
+    // The stray SUCCESS write must never land: the guarded update only fires while
+    // the run is non-terminal, and the row was already CANCELLED underneath it.
+    expect(state.statusHistory).toEqual([DataMartRunStatus.RUNNING, DataMartRunStatus.CANCELLED]);
+  });
+
+  it('still persists captured logs when the terminal status write is skipped', async () => {
+    const { service, dataMartRunRepository, processSpawner, emitSuccessMessage } = createService();
+    const state = { current: DataMartRunStatus.RUNNING, statusHistory: [] as DataMartRunStatus[] };
+    stubConditionalUpdate(dataMartRunRepository, state);
+    (dataMartRunRepository.findOne as jest.Mock).mockResolvedValue({
+      logs: [JSON.stringify({ type: 'log', message: 'earlier log' })],
+      errors: [],
+    });
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
+      state.current = DataMartRunStatus.CANCELLED;
+      emitSuccessMessage();
+    });
+
+    await service.executeInBackground(createDataMart(), createRun(), null);
+
+    // The status write is correctly skipped, but the log trail must survive:
+    // it is the only record of what ran before the cancellation landed.
+    const logsOnlyUpdate = (dataMartRunRepository.update as jest.Mock).mock.calls.find(
+      call => call[1].logs !== undefined && call[1].status === undefined
     );
-    expect(consumptionTracker.registerConnectorRunConsumption).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'dm-1' }),
-      'run-1'
-    );
-    expect(eventDispatcher.publishExternal).toHaveBeenCalled();
+    expect(logsOnlyUpdate).toBeDefined();
+    expect(logsOnlyUpdate![1].logs.join()).toContain('earlier log');
   });
 
   it('skips execution in shutdown mode', async () => {
@@ -313,7 +341,7 @@ describe('ConnectorExecutorService', () => {
     await service.executeInBackground(createDataMart(), createRun(), null);
 
     expect(dataMartRunRepository.update).toHaveBeenCalledWith(
-      'run-1',
+      { id: 'run-1', status: expect.anything() },
       expect.objectContaining({ status: DataMartRunStatus.RESTRICTED })
     );
   });
@@ -357,12 +385,15 @@ describe('ConnectorExecutorService', () => {
     expect(gracefulShutdownService.unregisterActiveProcess).toHaveBeenCalled();
   });
 
-  it('does not set startedAt when run has INTERRUPTED status (mergeWithExisting=true)', async () => {
+  it('does not reset startedAt when resuming a run that already has one (mergeWithExisting=true)', async () => {
     const { service, dataMartRunRepository } = createService();
-
+    // In production, by the time this is called, claimRunSlotAtomically has already
+    // flipped status to RUNNING — status alone can't signal "this is a resume".
+    // startedAt survives the INTERRUPTED -> PENDING -> RUNNING churn, so that's
+    // what mergeWithExisting is keyed on.
     await service.executeInBackground(
       createDataMart(),
-      createRun({ status: DataMartRunStatus.INTERRUPTED }),
+      createRun({ startedAt: new Date('2025-01-01') }),
       null
     );
 
@@ -372,6 +403,67 @@ describe('ConnectorExecutorService', () => {
 
     expect(updateCall).toBeDefined();
     expect(updateCall![1]).not.toHaveProperty('startedAt');
+  });
+
+  it('merges pre-interruption logs and errors when resuming a run (mergeWithExisting=true)', async () => {
+    const { service, dataMartRunRepository, emitInProgressMessage, processSpawner } =
+      createService();
+    (dataMartRunRepository.findOne as jest.Mock).mockResolvedValue({
+      logs: [JSON.stringify({ type: 'log', message: 'pre-interruption log' })],
+      errors: [JSON.stringify({ type: 'error', error: 'pre-interruption error' })],
+    });
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
+      emitInProgressMessage();
+    });
+
+    await service.executeInBackground(
+      createDataMart(),
+      createRun({ startedAt: new Date('2025-01-01') }),
+      null
+    );
+
+    const finalUpdate = (dataMartRunRepository.update as jest.Mock).mock.calls.find(
+      call => call[1]?.status === DataMartRunStatus.FAILED
+    );
+
+    expect(finalUpdate).toBeDefined();
+    expect(finalUpdate![1].logs.join()).toContain('pre-interruption log');
+    expect(finalUpdate![1].errors.join()).toContain('pre-interruption error');
+  });
+
+  it('caps merged logs so repeatedly resumed runs cannot grow the column without bound', async () => {
+    const { service, dataMartRunRepository, emitInProgressMessage, processSpawner } =
+      createService();
+    // A run resumed many times would otherwise concatenate its whole history
+    // on every attempt until the json column outgrows max_allowed_packet.
+    const existingLogs = Array.from({ length: 12000 }, (_, i) =>
+      JSON.stringify({ type: 'log', message: `old entry ${i}` })
+    );
+    (dataMartRunRepository.findOne as jest.Mock).mockResolvedValue({
+      logs: existingLogs,
+      errors: [],
+    });
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
+      emitInProgressMessage();
+    });
+
+    await service.executeInBackground(
+      createDataMart(),
+      createRun({ startedAt: new Date('2025-01-01') }),
+      null
+    );
+
+    const finalUpdate = (dataMartRunRepository.update as jest.Mock).mock.calls.find(
+      call => call[1]?.status === DataMartRunStatus.FAILED
+    );
+
+    // Capped to the limit plus the one prepended truncation notice.
+    expect(finalUpdate![1].logs).toHaveLength(10001);
+    expect(finalUpdate![1].logs[0]).toContain('earlier entries from previous attempts');
+    // The tail is what survives — it shows where the run actually got to.
+    expect(finalUpdate![1].logs.at(-1)).toContain(ConnectorMessageType.STATUS);
+    // The oldest entries are the ones dropped.
+    expect(finalUpdate![1].logs.join()).not.toContain('old entry 0"');
   });
 
   it('marks an aborted connector run as CANCELLED', async () => {
@@ -385,7 +477,7 @@ describe('ConnectorExecutorService', () => {
     await service.executeInBackground(createDataMart(), createRun(), null, controller.signal);
 
     expect(dataMartRunRepository.update).toHaveBeenLastCalledWith(
-      'run-1',
+      { id: 'run-1', status: expect.anything() },
       expect.objectContaining({ status: DataMartRunStatus.CANCELLED })
     );
     expect(eventDispatcher.publishExternal).not.toHaveBeenCalled();
@@ -400,7 +492,7 @@ describe('ConnectorExecutorService', () => {
     await service.executeInBackground(createDataMart(), createRun(), null, controller.signal);
 
     expect(dataMartRunRepository.update).toHaveBeenLastCalledWith(
-      'run-1',
+      { id: 'run-1', status: expect.anything() },
       expect.objectContaining({ status: DataMartRunStatus.CANCELLED })
     );
   });
@@ -423,7 +515,7 @@ describe('ConnectorExecutorService', () => {
     await service.executeInBackground(createDataMart(), createRun(), null, controller.signal);
 
     expect(dataMartRunRepository.update).toHaveBeenLastCalledWith(
-      'run-1',
+      { id: 'run-1', status: expect.anything() },
       expect.objectContaining({ status: DataMartRunStatus.SUCCESS })
     );
     expect(consumptionTracker.registerConnectorRunConsumption).toHaveBeenCalledWith(

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -485,13 +485,45 @@ describe('ConnectorExecutorService', () => {
       call => call[1]?.status === DataMartRunStatus.FAILED
     );
 
-    // Capped to the limit plus the one prepended truncation notice.
-    expect(finalUpdate![1].logs).toHaveLength(10001);
+    // Capped to the limit, with the truncation notice counted inside it.
+    expect(finalUpdate![1].logs).toHaveLength(10000);
     expect(finalUpdate![1].logs[0]).toContain('earlier entries from previous attempts');
     // The tail is what survives — it shows where the run actually got to.
     expect(finalUpdate![1].logs.at(-1)).toContain(ConnectorMessageType.STATUS);
     // The oldest entries are the ones dropped.
     expect(finalUpdate![1].logs.join()).not.toContain('old entry 0"');
+  });
+
+  it('caps merged logs by serialized bytes so oversized entries cannot exceed the packet limit', async () => {
+    const { service, dataMartRunRepository, emitInProgressMessage, processSpawner } =
+      createService();
+    // Far fewer entries than the count cap, but each ~3MB: count alone would
+    // pass all of them through and the single UPDATE would blow past MySQL's
+    // max_allowed_packet. The 6MB byte budget must bite instead.
+    const hugeEntries = Array.from({ length: 4 }, (_, i) =>
+      JSON.stringify({ type: 'log', message: `huge entry ${i} ${'x'.repeat(3_000_000)}` })
+    );
+    (dataMartRunRepository.findOne as jest.Mock).mockResolvedValue({
+      logs: hugeEntries,
+      errors: [],
+    });
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
+      emitInProgressMessage();
+    });
+
+    await service.executeInBackground(createDataMart(), createRun(), null);
+
+    const finalUpdate = (dataMartRunRepository.update as jest.Mock).mock.calls.find(
+      call => call[1]?.status === DataMartRunStatus.FAILED
+    );
+
+    const logs = finalUpdate![1].logs as string[];
+    expect(logs[0]).toContain('earlier entries from previous attempts');
+    // Only what fits in the byte budget survives, newest first from the tail.
+    const serializedBytes = Buffer.byteLength(JSON.stringify(logs));
+    expect(serializedBytes).toBeLessThan(7 * 1024 * 1024);
+    expect(logs.join()).toContain('huge entry 3');
+    expect(logs.join()).not.toContain('huge entry 0');
   });
 
   it('marks an aborted connector run as CANCELLED', async () => {

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -219,7 +219,7 @@ describe('ConnectorExecutorService', () => {
     await service.executeInBackground(createDataMart(), createRun(), null);
 
     expect(dataMartRunRepository.update).toHaveBeenCalledWith(
-      'run-1',
+      { id: 'run-1', status: expect.anything() },
       expect.objectContaining({ status: DataMartRunStatus.RUNNING })
     );
     expect(consumptionTracker.registerConnectorRunConsumption).toHaveBeenCalled();
@@ -279,7 +279,14 @@ describe('ConnectorExecutorService', () => {
   };
 
   it('does not let a stray completion overwrite a committed cancellation when abort is not delivered', async () => {
-    const { service, dataMartRunRepository, processSpawner, emitSuccessMessage } = createService();
+    const {
+      service,
+      dataMartRunRepository,
+      processSpawner,
+      consumptionTracker,
+      eventDispatcher,
+      emitSuccessMessage,
+    } = createService();
     const state = { current: DataMartRunStatus.RUNNING, statusHistory: [] as DataMartRunStatus[] };
     stubConditionalUpdate(dataMartRunRepository, state);
     (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
@@ -295,6 +302,29 @@ describe('ConnectorExecutorService', () => {
     // The stray SUCCESS write must never land: the guarded update only fires while
     // the run is non-terminal, and the row was already CANCELLED underneath it.
     expect(state.statusHistory).toEqual([DataMartRunStatus.RUNNING, DataMartRunStatus.CANCELLED]);
+    // And since the persisted status is CANCELLED, the project must not be billed
+    // and no success/failure webhook may fire for this run.
+    expect(consumptionTracker.registerConnectorRunConsumption).not.toHaveBeenCalled();
+    expect(eventDispatcher.publishExternal).not.toHaveBeenCalled();
+  });
+
+  it('does not start the connector when the run reached a terminal status before execution', async () => {
+    const { service, dataMartRunRepository, processSpawner, eventDispatcher } = createService();
+    // Cancel landed between claimRunSlotAtomically and executeInBackground:
+    // the row is already CANCELLED when the initial guarded RUNNING write runs.
+    const state = {
+      current: DataMartRunStatus.CANCELLED,
+      statusHistory: [] as DataMartRunStatus[],
+    };
+    stubConditionalUpdate(dataMartRunRepository, state);
+
+    await service.executeInBackground(createDataMart(), createRun(), null);
+
+    // The run must not be resurrected to RUNNING, the connector must not spawn,
+    // and no outcome events may fire for a run the user already cancelled.
+    expect(state.statusHistory).toEqual([]);
+    expect(processSpawner.spawnConnector).not.toHaveBeenCalled();
+    expect(eventDispatcher.publishExternal).not.toHaveBeenCalled();
   });
 
   it('still persists captured logs when the terminal status write is skipped', async () => {
@@ -385,12 +415,11 @@ describe('ConnectorExecutorService', () => {
     expect(gracefulShutdownService.unregisterActiveProcess).toHaveBeenCalled();
   });
 
-  it('does not reset startedAt when resuming a run that already has one (mergeWithExisting=true)', async () => {
+  it('does not reset startedAt when resuming a run that already has one', async () => {
     const { service, dataMartRunRepository } = createService();
-    // In production, by the time this is called, claimRunSlotAtomically has already
-    // flipped status to RUNNING — status alone can't signal "this is a resume".
-    // startedAt survives the INTERRUPTED -> PENDING -> RUNNING churn, so that's
-    // what mergeWithExisting is keyed on.
+    // startedAt is set once, on the first attempt, and survives the
+    // INTERRUPTED -> PENDING -> RUNNING churn so Run History keeps the
+    // original start time.
     await service.executeInBackground(
       createDataMart(),
       createRun({ startedAt: new Date('2025-01-01') }),
@@ -405,7 +434,7 @@ describe('ConnectorExecutorService', () => {
     expect(updateCall![1]).not.toHaveProperty('startedAt');
   });
 
-  it('merges pre-interruption logs and errors when resuming a run (mergeWithExisting=true)', async () => {
+  it('merges pre-interruption logs even for a run interrupted before startedAt was ever set', async () => {
     const { service, dataMartRunRepository, emitInProgressMessage, processSpawner } =
       createService();
     (dataMartRunRepository.findOne as jest.Mock).mockResolvedValue({
@@ -416,11 +445,10 @@ describe('ConnectorExecutorService', () => {
       emitInProgressMessage();
     });
 
-    await service.executeInBackground(
-      createDataMart(),
-      createRun({ startedAt: new Date('2025-01-01') }),
-      null
-    );
+    // No startedAt override: a run interrupted before its first RUNNING write
+    // (e.g. shutdown hit during the balance check) resumes with startedAt null.
+    // Merging must not depend on any per-run resume flag — it always happens.
+    await service.executeInBackground(createDataMart(), createRun(), null);
 
     const finalUpdate = (dataMartRunRepository.update as jest.Mock).mock.calls.find(
       call => call[1]?.status === DataMartRunStatus.FAILED

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -79,12 +79,6 @@ export class ConnectorExecutorService {
   ): Promise<void> {
     const runId = run.id;
     const processId = `connector-run-${runId}`;
-    // By the time this runs, claimRunSlotAtomically has already flipped the row's
-    // status to RUNNING, so `run.status` never reflects INTERRUPTED here. `startedAt`
-    // is only ever set once, on a run's first execution, and survives the
-    // INTERRUPTED -> PENDING -> RUNNING churn a resumed run goes through — so it's
-    // the reliable signal that this is a resume rather than a first attempt.
-    const mergeWithExisting = run.startedAt != null;
 
     this.gracefulShutdownService.registerActiveProcess(processId);
 
@@ -105,11 +99,32 @@ export class ConnectorExecutorService {
 
       await this.projectBalanceService.verifyCanPerformOperations(dataMart.projectId);
 
-      await this.dataMartRunRepository.update(runId, {
-        status: DataMartRunStatus.RUNNING,
-        ...(mergeWithExisting ? {} : { startedAt: this.systemTimeService.now() }),
-        finishedAt: null,
-      });
+      // Guarded like the terminal write below: a cancel can land in the window
+      // between claimRunSlotAtomically and here (e.g. during the awaited balance
+      // check), and an unconditional write would flip the row back to RUNNING —
+      // resurrecting a cancelled run. `startedAt` is set once, on the first
+      // attempt, and preserved across resumes so Run History keeps the original
+      // start time.
+      const claimed = await this.dataMartRunRepository.update(
+        { id: runId, status: In(NON_TERMINAL_DATA_MART_RUN_STATUSES) },
+        {
+          status: DataMartRunStatus.RUNNING,
+          ...(run.startedAt != null ? {} : { startedAt: this.systemTimeService.now() }),
+          finishedAt: null,
+        }
+      );
+
+      if (!claimed.affected) {
+        // The run reached a terminal status (a concurrent cancel) before
+        // execution started — do not spawn the connector and do not publish
+        // run-outcome events for it.
+        wasCancelled = true;
+        this.logger.log(
+          `Skipping connector execution for run ${runId}: run reached a terminal status before execution started`,
+          { dataMartId: dataMart.id, projectId: dataMart.projectId, runId }
+        );
+        return;
+      }
 
       const configurationResults = await this.runConnectorConfigurations(
         runId,
@@ -160,17 +175,20 @@ export class ConnectorExecutorService {
         );
       }
     } finally {
-      await this.updateRunStatus(
+      // When the terminal status write is skipped (the run was cancelled
+      // concurrently and CANCELLED must win), billing and outcome events must
+      // be skipped too: the persisted status is CANCELLED, and charging the
+      // project or publishing a success/failure webhook would contradict it.
+      const statusPersisted = await this.updateRunStatus(
         runId,
         hasSuccessfulRun,
         capturedLogs,
         capturedErrors,
-        mergeWithExisting,
         operationBlockedException,
         wasCancelled
       );
 
-      if (hasSuccessfulRun) {
+      if (hasSuccessfulRun && statusPersisted) {
         await this.consumptionTracker.registerConnectorRunConsumption(dataMart, runId);
         await this.eventDispatcher.publishExternal(
           new ConnectorRunEvent(
@@ -182,7 +200,11 @@ export class ConnectorExecutorService {
             'successfully'
           )
         );
-      } else if (!wasCancelled && !this.gracefulShutdownService.isInShutdownMode()) {
+      } else if (
+        statusPersisted &&
+        !wasCancelled &&
+        !this.gracefulShutdownService.isInShutdownMode()
+      ) {
         await this.eventDispatcher.publishExternal(
           new ConnectorRunEvent(
             dataMart.id,
@@ -618,17 +640,22 @@ export class ConnectorExecutorService {
     return status === Core.EXECUTION_STATUS.IMPORT_DONE;
   }
 
+  /**
+   * Writes the run's terminal status, guarded so a concurrently committed
+   * terminal status (a cancel) always wins.
+   *
+   * @returns true when the status write landed; false when it was skipped
+   * because the run had already reached a terminal status — callers must not
+   * bill consumption or publish run-outcome events in that case.
+   */
   private async updateRunStatus(
     runId: string,
     hasSuccessfulRun: boolean,
     capturedLogs: ConnectorMessage[],
     capturedErrors: ConnectorMessage[],
-    mergeWithExisting: boolean = false,
     operationBlockedException?: ProjectOperationBlockedException,
     wasCancelled: boolean = false
-  ): Promise<void> {
-    const hasLogs = capturedLogs.length > 0;
-    const hasErrors = capturedErrors.length > 0;
+  ): Promise<boolean> {
     let status = wasCancelled
       ? DataMartRunStatus.CANCELLED
       : hasSuccessfulRun
@@ -640,19 +667,19 @@ export class ConnectorExecutorService {
       status = DataMartRunStatus.INTERRUPTED;
     }
 
-    const newLogStrings = hasLogs ? capturedLogs.map(log => JSON.stringify(log)) : [];
-    const newErrorStrings = hasErrors ? capturedErrors.map(error => JSON.stringify(error)) : [];
+    const newLogStrings = capturedLogs.map(log => JSON.stringify(log));
+    const newErrorStrings = capturedErrors.map(error => JSON.stringify(error));
 
-    let logsToSave: string[] | null = newLogStrings.length > 0 ? newLogStrings : null;
-    let errorsToSave: string[] | null = newErrorStrings.length > 0 ? newErrorStrings : null;
-
-    if (mergeWithExisting) {
-      ({ logs: logsToSave, errors: errorsToSave } = await this.mergeWithPersistedOutput(
-        runId,
-        newLogStrings,
-        newErrorStrings
-      ));
-    }
+    // Always merge onto what is already persisted rather than trying to detect
+    // "is this a resume": for a first attempt the persisted arrays are empty so
+    // merging is identity, and every resumed/interrupted attempt keeps its full
+    // history — including runs interrupted before their first RUNNING write,
+    // which no per-run flag can reliably identify.
+    const { logs: logsToSave, errors: errorsToSave } = await this.mergeWithPersistedOutput(
+      runId,
+      newLogStrings,
+      newErrorStrings
+    );
 
     // Only claim the run if it has not already reached a terminal status: a
     // concurrent cancel must win over an orphaned execution that is still
@@ -668,21 +695,27 @@ export class ConnectorExecutorService {
       }
     );
 
-    if (!result.affected) {
-      this.logger.warn(
-        `Skipped final status update for run ${runId}: run already reached a terminal status ` +
-          `(likely cancelled concurrently while this execution was orphaned)`
-      );
+    if (result.affected) {
+      return true;
+    }
 
-      // The status write is correctly skipped, but the logs and errors this
-      // execution captured are still the only record of what it did before
-      // being cancelled — persist them rather than discarding them.
-      const preserved = await this.mergeWithPersistedOutput(runId, newLogStrings, newErrorStrings);
+    // Routine on every user cancellation (the cancel endpoint commits CANCELLED
+    // before the abort reaches this execution), so log-level, not a warning.
+    this.logger.log(
+      `Skipped final status update for run ${runId}: run already reached a terminal status`
+    );
+
+    // The status write is correctly skipped, but the logs and errors this
+    // execution captured are still the only record of what it did — persist
+    // the already-merged output rather than discarding it.
+    if (newLogStrings.length > 0 || newErrorStrings.length > 0) {
       await this.dataMartRunRepository.update(
         { id: runId },
-        { logs: preserved.logs, errors: preserved.errors }
+        { logs: logsToSave, errors: errorsToSave }
       );
     }
+
+    return false;
   }
 
   /**

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -10,12 +10,18 @@ type ConfigDto = InstanceType<typeof Core.ConfigDto>;
 const GENERATED_REFRESH_TOKEN_MAX_LENGTH = 4096;
 
 /**
- * Upper bound on logs/errors carried across resumed attempts of the same run.
- * Chosen to comfortably hold a full long-backfill attempt (a ~315k-record run
- * produced roughly 7.4k entries) while keeping the `json` column well clear of
- * MySQL's max_allowed_packet.
+ * Bounds on logs/errors carried across resumed attempts of the same run.
+ *
+ * The entry cap comfortably holds a full long-backfill attempt (a ~315k-record
+ * run produced roughly 7.4k entries). The byte budget is the binding limit for
+ * verbose entries: logs and errors travel in ONE UPDATE statement, so the worst
+ * case on the wire is 2 x MAX_MERGED_RUN_OUTPUT_BYTES plus JSON overhead —
+ * kept safely under the smallest common MySQL max_allowed_packet (16MB).
+ * Entry sizes are measured on the JSON-serialized form so quote escaping and
+ * multibyte characters count toward the real packet size.
  */
 const MAX_MERGED_RUN_OUTPUT_ENTRIES = 10000;
+const MAX_MERGED_RUN_OUTPUT_BYTES = 6 * 1024 * 1024;
 
 import { ConnectorDefinition as DataMartConnectorDefinition } from '../../dto/schemas/data-mart-table-definitions/connector-definition.schema';
 import { DataMart } from '../../entities/data-mart.entity';
@@ -742,25 +748,44 @@ export class ConnectorExecutorService {
   }
 
   /**
-   * Bounds a merged log/error array so repeatedly interrupted runs cannot grow
-   * their `json` column without limit — a long backfill resumed many times would
-   * otherwise concatenate its full history on every attempt.
+   * Bounds a merged log/error array by entry count AND serialized bytes so
+   * repeatedly interrupted runs cannot grow their `json` column past MySQL's
+   * max_allowed_packet — count alone is not enough, since entries can approach
+   * 5000 characters each before escaping.
    *
    * Keeps the most recent entries: the tail describes where the run actually got
-   * to, which is what someone debugging a resumed run needs.
+   * to, which is what someone debugging a resumed run needs. The truncation
+   * notice counts toward the entry cap, so the result never exceeds
+   * MAX_MERGED_RUN_OUTPUT_ENTRIES entries.
    */
   private capMergedEntries(entries: string[]): string[] {
-    if (entries.length <= MAX_MERGED_RUN_OUTPUT_ENTRIES) {
+    // Walk from the tail (newest first), measuring each entry as it will
+    // actually be serialized — JSON.stringify accounts for quote escaping and
+    // multibyte characters that raw .length would undercount.
+    let keptBytes = 0;
+    let keep = 0;
+    while (keep < entries.length && keep < MAX_MERGED_RUN_OUTPUT_ENTRIES) {
+      const entryBytes = Buffer.byteLength(JSON.stringify(entries[entries.length - 1 - keep])) + 1;
+      if (keptBytes + entryBytes > MAX_MERGED_RUN_OUTPUT_BYTES) {
+        break;
+      }
+      keptBytes += entryBytes;
+      keep++;
+    }
+
+    if (keep === entries.length) {
       return entries;
     }
 
-    const dropped = entries.length - MAX_MERGED_RUN_OUTPUT_ENTRIES;
+    // Leave room for the notice itself within the entry cap.
+    keep = Math.min(keep, MAX_MERGED_RUN_OUTPUT_ENTRIES - 1);
+    const dropped = entries.length - keep;
     const truncationNotice = JSON.stringify({
       type: ConnectorMessageType.LOG,
       at: this.systemTimeService.now().toISOString(),
       message: `... ${dropped} earlier entries from previous attempts were truncated`,
     });
 
-    return [truncationNotice, ...entries.slice(-MAX_MERGED_RUN_OUTPUT_ENTRIES)];
+    return [truncationNotice, ...entries.slice(entries.length - keep)];
   }
 }

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 
 // @ts-expect-error - Package lacks TypeScript declarations
 import { Core } from '@owox/connectors';
@@ -8,6 +8,14 @@ import { Core } from '@owox/connectors';
 const { ConfigDto, GENERATED_REFRESH_TOKEN_CREDENTIAL_FIELD } = Core;
 type ConfigDto = InstanceType<typeof Core.ConfigDto>;
 const GENERATED_REFRESH_TOKEN_MAX_LENGTH = 4096;
+
+/**
+ * Upper bound on logs/errors carried across resumed attempts of the same run.
+ * Chosen to comfortably hold a full long-backfill attempt (a ~315k-record run
+ * produced roughly 7.4k entries) while keeping the `json` column well clear of
+ * MySQL's max_allowed_packet.
+ */
+const MAX_MERGED_RUN_OUTPUT_ENTRIES = 10000;
 
 import { ConnectorDefinition as DataMartConnectorDefinition } from '../../dto/schemas/data-mart-table-definitions/connector-definition.schema';
 import { DataMart } from '../../entities/data-mart.entity';
@@ -32,6 +40,7 @@ import { ConnectorSourceConfigService } from './connector-source-config.service'
 import { ConnectorCredentialInjectorService } from './connector-credential-injector.service';
 import { ConnectorSourceCredentialsService } from './connector-source-credentials.service';
 import { addMessageToArray } from './connector-message.utils';
+import { NON_TERMINAL_DATA_MART_RUN_STATUSES } from '../../utils/data-mart-run-cancellation';
 
 interface ConfigurationExecutionResult {
   configIndex: number;
@@ -70,7 +79,12 @@ export class ConnectorExecutorService {
   ): Promise<void> {
     const runId = run.id;
     const processId = `connector-run-${runId}`;
-    const mergeWithExisting = run.status === DataMartRunStatus.INTERRUPTED;
+    // By the time this runs, claimRunSlotAtomically has already flipped the row's
+    // status to RUNNING, so `run.status` never reflects INTERRUPTED here. `startedAt`
+    // is only ever set once, on a run's first execution, and survives the
+    // INTERRUPTED -> PENDING -> RUNNING churn a resumed run goes through — so it's
+    // the reliable signal that this is a resume rather than a first attempt.
+    const mergeWithExisting = run.startedAt != null;
 
     this.gracefulShutdownService.registerActiveProcess(processId);
 
@@ -633,22 +647,87 @@ export class ConnectorExecutorService {
     let errorsToSave: string[] | null = newErrorStrings.length > 0 ? newErrorStrings : null;
 
     if (mergeWithExisting) {
-      const existing = await this.dataMartRunRepository.findOne({ where: { id: runId } });
-      const existingLogs = (existing?.logs as string[] | null) ?? [];
-      const existingErrors = (existing?.errors as string[] | null) ?? [];
-
-      const mergedLogs = [...existingLogs, ...newLogStrings];
-      const mergedErrors = [...existingErrors, ...newErrorStrings];
-
-      logsToSave = mergedLogs.length > 0 ? mergedLogs : null;
-      errorsToSave = mergedErrors.length > 0 ? mergedErrors : null;
+      ({ logs: logsToSave, errors: errorsToSave } = await this.mergeWithPersistedOutput(
+        runId,
+        newLogStrings,
+        newErrorStrings
+      ));
     }
 
-    await this.dataMartRunRepository.update(runId, {
-      status,
-      finishedAt: this.systemTimeService.now(),
-      logs: logsToSave,
-      errors: errorsToSave,
+    // Only claim the run if it has not already reached a terminal status: a
+    // concurrent cancel must win over an orphaned execution that is still
+    // finishing up, otherwise the cancelled run silently reverts to
+    // SUCCESS/FAILED and the retry sweep can resurrect it.
+    const result = await this.dataMartRunRepository.update(
+      { id: runId, status: In(NON_TERMINAL_DATA_MART_RUN_STATUSES) },
+      {
+        status,
+        finishedAt: this.systemTimeService.now(),
+        logs: logsToSave,
+        errors: errorsToSave,
+      }
+    );
+
+    if (!result.affected) {
+      this.logger.warn(
+        `Skipped final status update for run ${runId}: run already reached a terminal status ` +
+          `(likely cancelled concurrently while this execution was orphaned)`
+      );
+
+      // The status write is correctly skipped, but the logs and errors this
+      // execution captured are still the only record of what it did before
+      // being cancelled — persist them rather than discarding them.
+      const preserved = await this.mergeWithPersistedOutput(runId, newLogStrings, newErrorStrings);
+      await this.dataMartRunRepository.update(
+        { id: runId },
+        { logs: preserved.logs, errors: preserved.errors }
+      );
+    }
+  }
+
+  /**
+   * Concatenates this execution's captured output onto whatever is already
+   * persisted for the run, so a resumed or superseded attempt extends the log
+   * trail instead of replacing it.
+   */
+  private async mergeWithPersistedOutput(
+    runId: string,
+    newLogStrings: string[],
+    newErrorStrings: string[]
+  ): Promise<{ logs: string[] | null; errors: string[] | null }> {
+    const existing = await this.dataMartRunRepository.findOne({ where: { id: runId } });
+    const existingLogs = (existing?.logs as string[] | null) ?? [];
+    const existingErrors = (existing?.errors as string[] | null) ?? [];
+
+    const mergedLogs = this.capMergedEntries([...existingLogs, ...newLogStrings]);
+    const mergedErrors = this.capMergedEntries([...existingErrors, ...newErrorStrings]);
+
+    return {
+      logs: mergedLogs.length > 0 ? mergedLogs : null,
+      errors: mergedErrors.length > 0 ? mergedErrors : null,
+    };
+  }
+
+  /**
+   * Bounds a merged log/error array so repeatedly interrupted runs cannot grow
+   * their `json` column without limit — a long backfill resumed many times would
+   * otherwise concatenate its full history on every attempt.
+   *
+   * Keeps the most recent entries: the tail describes where the run actually got
+   * to, which is what someone debugging a resumed run needs.
+   */
+  private capMergedEntries(entries: string[]): string[] {
+    if (entries.length <= MAX_MERGED_RUN_OUTPUT_ENTRIES) {
+      return entries;
+    }
+
+    const dropped = entries.length - MAX_MERGED_RUN_OUTPUT_ENTRIES;
+    const truncationNotice = JSON.stringify({
+      type: ConnectorMessageType.LOG,
+      at: this.systemTimeService.now().toISOString(),
+      message: `... ${dropped} earlier entries from previous attempts were truncated`,
     });
+
+    return [truncationNotice, ...entries.slice(-MAX_MERGED_RUN_OUTPUT_ENTRIES)];
   }
 }

--- a/apps/backend/src/data-marts/services/connector/connector-run.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run.service.spec.ts
@@ -22,7 +22,7 @@ describe('ConnectorRunService', () => {
       find: jest.fn(),
       create: jest.fn().mockImplementation(data => data),
       save: jest.fn().mockImplementation(data => Promise.resolve({ ...data, id: 'run-1' })),
-      update: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
     } as unknown as Repository<DataMartRun>;
 
     const connectorRunTriggerService = {
@@ -144,10 +144,31 @@ describe('ConnectorRunService', () => {
 
       await service.executeInterruptedRuns();
 
-      expect(dataMartRunRepository.update).toHaveBeenCalledWith('run-1', {
-        status: DataMartRunStatus.PENDING,
-      });
+      expect(dataMartRunRepository.update).toHaveBeenCalledWith(
+        { id: 'run-1', status: DataMartRunStatus.INTERRUPTED },
+        { status: DataMartRunStatus.PENDING }
+      );
       expect(connectorRunTriggerService.createTrigger).toHaveBeenCalled();
+    });
+
+    it('skips resumption when run is no longer INTERRUPTED (e.g. already cancelled)', async () => {
+      const { service, dataMartRunRepository, connectorRunTriggerService } = createService();
+      (dataMartRunRepository.find as jest.Mock).mockResolvedValue([
+        {
+          id: 'run-1',
+          dataMartId: 'dm-1',
+          type: DataMartRunType.CONNECTOR,
+          dataMart: { projectId: 'proj-1' },
+          createdById: 'user-1',
+          runType: RunType.manual,
+          additionalParams: null,
+        },
+      ]);
+      (dataMartRunRepository.update as jest.Mock).mockResolvedValue({ affected: 0 });
+
+      await service.executeInterruptedRuns();
+
+      expect(connectorRunTriggerService.createTrigger).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/data-marts/services/connector/connector-run.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-run.service.ts
@@ -83,9 +83,19 @@ export class ConnectorRunService {
 
     for (const run of interruptedRuns) {
       try {
-        await this.dataMartRunRepository.update(run.id, {
-          status: DataMartRunStatus.PENDING,
-        });
+        const claimed = await this.dataMartRunRepository.update(
+          { id: run.id, status: DataMartRunStatus.INTERRUPTED },
+          { status: DataMartRunStatus.PENDING }
+        );
+
+        if (!claimed.affected) {
+          this.logger.log(`Skipping resumption of run ${run.id}: no longer INTERRUPTED`, {
+            dataMartId: run.dataMartId,
+            projectId: run.dataMart.projectId,
+            runId: run.id,
+          });
+          continue;
+        }
 
         await this.connectorRunTriggerService.createTrigger({
           dataMartId: run.dataMartId,

--- a/apps/backend/src/data-marts/services/connector/connector-storage-config.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-storage-config.service.spec.ts
@@ -58,13 +58,36 @@ describe('ConnectorStorageConfigService', () => {
       type: 'bigquery_oauth',
       oauth2Client: {
         getAccessToken: jest.fn().mockResolvedValue({ token: 'access-token' }),
-        credentials: { refresh_token: 'refresh-token' },
+        credentials: { refresh_token: 'refresh-token', expiry_date: 1234567890 },
       },
     };
     (storageCredentialsResolver.resolve as jest.Mock).mockResolvedValue(credentials);
 
     const result = await service.buildStorageConfig(baseDataMart);
     expect(result).toBeDefined();
+    // The connector's own OAuth2Client rebuilds credentials from these values on
+    // every query for the lifetime of a run (which can span hours during a
+    // backfill); without expiry_date it can never tell the access token has
+    // gone stale and silently keeps resending it until BigQuery rejects it.
+    expect(result.config.OAuthAccessTokenExpiry.value).toBe(1234567890);
+  });
+
+  it('passes null OAuthAccessTokenExpiry when the OAuth token has no known expiry', async () => {
+    const { service, storageCredentialsResolver } = createService();
+    const credentials = {
+      type: 'bigquery_oauth',
+      oauth2Client: {
+        getAccessToken: jest.fn().mockResolvedValue({ token: 'access-token' }),
+        credentials: { refresh_token: 'refresh-token' },
+      },
+    };
+    (storageCredentialsResolver.resolve as jest.Mock).mockResolvedValue(credentials);
+
+    const result = await service.buildStorageConfig(baseDataMart);
+
+    // StorageConfigDto only wraps non-object values as { value }; since
+    // typeof null === 'object' in JS, a null expiry stays unwrapped here.
+    expect(result.config.OAuthAccessTokenExpiry).toBeNull();
   });
 
   it('builds Athena storage config', async () => {

--- a/apps/backend/src/data-marts/services/connector/connector-storage-config.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-storage-config.service.ts
@@ -98,6 +98,7 @@ export class ConnectorStorageConfigService {
         );
       }
       const refreshToken = oauthCredentials.oauth2Client.credentials.refresh_token;
+      const accessTokenExpiry = oauthCredentials.oauth2Client.credentials.expiry_date;
 
       return new StorageConfigDto({
         name: DataStorageType.GOOGLE_BIGQUERY,
@@ -107,6 +108,10 @@ export class ConnectorStorageConfigService {
           OAuthRefreshToken: refreshToken ?? '',
           OAuthClientId: this.googleOAuthConfigService.getStorageClientId(),
           OAuthClientSecret: this.googleOAuthConfigService.getStorageClientSecret(),
+          // Lets the connector detect real token expiry mid-run (e.g. during a
+          // long backfill) and refresh via the refresh token, instead of
+          // resending a stale access token until BigQuery rejects it with 401.
+          OAuthAccessTokenExpiry: accessTokenExpiry ?? null,
         },
       });
     }

--- a/apps/backend/src/data-marts/utils/data-mart-run-cancellation.ts
+++ b/apps/backend/src/data-marts/utils/data-mart-run-cancellation.ts
@@ -6,6 +6,14 @@ export const CANCELLABLE_DATA_MART_RUN_STATUSES = [
   DataMartRunStatus.RUNNING,
 ];
 
+/**
+ * Statuses a run has not yet moved out of; every other status is terminal.
+ *
+ * Deliberately an alias rather than a second literal: a run is cancellable
+ * exactly while it is still non-terminal, so the two sets must not drift apart.
+ */
+export const NON_TERMINAL_DATA_MART_RUN_STATUSES = CANCELLABLE_DATA_MART_RUN_STATUSES;
+
 export const STANDARD_REPORT_RUN_TYPES = [
   DataMartRunType.GOOGLE_SHEETS_EXPORT,
   DataMartRunType.EMAIL,

--- a/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
+++ b/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
@@ -71,6 +71,11 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
             isRequired: false,
             requiredType: "string",
             default: null
+          },
+          OAuthAccessTokenExpiry: {
+            isRequired: false,
+            requiredType: "number",
+            default: null
           }
         }),
         uniqueKeyColumns,
@@ -79,11 +84,15 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
       );
 
       this.updatedRecordsBuffer = {};
-      
+
       // Initialize counter for tracking total records processed
       this.totalRecordsProcessed = 0;
 
-    
+      // Cached across executeQuery() calls so a token refresh (triggered by
+      // google-auth-library once the access token actually expires) persists
+      // for the rest of the run instead of being rebuilt from the stale
+      // original token on every single query.
+      this._bigqueryClient = null;
     }
 
   //---- init --------------------------------------------------------
@@ -510,17 +519,29 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
     }
  
 
-  //---- query -------------------------------------------------------
+  //---- getBigQueryClient ---------------------------------------------
     /**
-     * Executes Google BigQuery Query and returns a result
+     * Builds (once) and caches the BigQuery client for this run.
      *
-     * @param {query} string
+     * Reusing a single OAuth2Client instance across the whole run, rather than
+     * rebuilding one from the same static access token on every query, lets
+     * google-auth-library detect real token expiry (via expiry_date) and
+     * refresh it in place using the refresh token — instead of silently
+     * resending an access token that went stale hours into a long backfill.
      *
-     * @return Promise<object>
+     * Known limitation: a token refreshed here lives only in this process and
+     * is never written back to the stored credential, because the storage side
+     * has no CREDENTIALS_UPDATE channel like the source side does. A run whose
+     * stored token had already expired before it started therefore still fails
+     * on its first query. Fixing that needs token write-back, not more caching.
      *
+     * @return {BigQuery}
      */
-    async executeQuery(query) {
-      let bigqueryClient = null;
+    getBigQueryClient() {
+      if (this._bigqueryClient) {
+        return this._bigqueryClient;
+      }
+
       if (this.config.OAuthAccessToken && this.config.OAuthAccessToken.value) {
         const { OAuth2Client } = require('google-auth-library');
         const oauth2Client = new OAuth2Client(
@@ -530,8 +551,12 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
         oauth2Client.setCredentials({
           access_token: this.config.OAuthAccessToken.value,
           refresh_token: this.config.OAuthRefreshToken?.value || undefined,
+          // `??`, not `||`: an expiry_date of 0 is a real (already-expired)
+          // value, and coercing it to undefined would tell google-auth-library
+          // the token never expires — reintroducing the never-refresh bug.
+          expiry_date: this.config.OAuthAccessTokenExpiry?.value ?? undefined,
         });
-        bigqueryClient = new BigQuery({
+        this._bigqueryClient = new BigQuery({
           projectId: this.config.ProjectID.value,
           authClient: oauth2Client,
         });
@@ -543,13 +568,28 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
           key: credentials.private_key,
           scopes: ['https://www.googleapis.com/auth/bigquery'],
         });
-        bigqueryClient = new BigQuery({
+        this._bigqueryClient = new BigQuery({
           projectId: this.config.ProjectID.value || credentials.project_id,
           authClient
         });
       } else {
         throw new Error("Either OAuth token or Service Account JSON is required to connect to Google BigQuery");
       }
+
+      return this._bigqueryClient;
+    }
+
+  //---- query -------------------------------------------------------
+    /**
+     * Executes Google BigQuery Query and returns a result
+     *
+     * @param {query} string
+     *
+     * @return Promise<object>
+     *
+     */
+    async executeQuery(query) {
+      const bigqueryClient = this.getBigQueryClient();
 
       const options = {
         query: query,

--- a/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
+++ b/packages/connectors/src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js
@@ -551,9 +551,11 @@ var GoogleBigQueryStorage = class GoogleBigQueryStorage extends AbstractStorage 
         oauth2Client.setCredentials({
           access_token: this.config.OAuthAccessToken.value,
           refresh_token: this.config.OAuthRefreshToken?.value || undefined,
-          // `??`, not `||`: an expiry_date of 0 is a real (already-expired)
-          // value, and coercing it to undefined would tell google-auth-library
-          // the token never expires — reintroducing the never-refresh bug.
+          // `??`, not `||`: 0 is a valid number and must not be silently
+          // dropped on our side. Note google-auth-library's own
+          // isTokenExpiring() also treats 0 as "no known expiry" (falsy
+          // check), so an exact epoch-0 expiry never triggers a refresh
+          // either way — acceptable, since a real expiry is never 0.
           expiry_date: this.config.OAuthAccessTokenExpiry?.value ?? undefined,
         });
         this._bigqueryClient = new BigQuery({

--- a/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
+++ b/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
@@ -1,0 +1,75 @@
+import path from 'path';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const abstractStoragePath = path.join(__dirname, '../../../src/Core/AbstractStorage.js');
+const storagePath = path.join(
+  __dirname,
+  '../../../src/Storages/GoogleBigQuery/GoogleBigQueryStorage.js'
+);
+
+// getBigQueryClient() calls the real require('google-auth-library') at runtime
+// (set as a global by connector-runner.js in production); vm.runInThisContext
+// has no `require` of its own, so we provide the real one here too — this
+// exercises the actual OAuth2Client, not a stand-in for it.
+globalThis.require = createRequire(import.meta.url);
+
+loadGasClass(abstractStoragePath);
+loadGasClass(storagePath);
+const proto = globalThis.GoogleBigQueryStorage.prototype;
+
+const configValue = value => ({ value });
+
+const fakeStorage = (configOverrides = {}) => ({
+  _bigqueryClient: null,
+  config: {
+    OAuthAccessToken: configValue('access-token'),
+    OAuthRefreshToken: configValue('refresh-token'),
+    OAuthClientId: configValue('client-id'),
+    OAuthClientSecret: configValue('client-secret'),
+    OAuthAccessTokenExpiry: configValue(1234567890),
+    ProjectID: configValue('gcp-project'),
+    ...configOverrides,
+  },
+});
+
+describe('getBigQueryClient', () => {
+  let capturedAuthClients;
+
+  beforeEach(() => {
+    capturedAuthClients = [];
+    // Stand-in for @google-cloud/bigquery: real BigQuery would open network
+    // connections, so we only need to capture the authClient it was built with.
+    globalThis.BigQuery = class {
+      constructor({ authClient }) {
+        capturedAuthClients.push(authClient);
+      }
+    };
+  });
+
+  it('passes the access token expiry through to the OAuth2Client credentials', () => {
+    proto.getBigQueryClient.call(fakeStorage());
+
+    expect(capturedAuthClients).toHaveLength(1);
+    expect(capturedAuthClients[0].credentials.expiry_date).toBe(1234567890);
+  });
+
+  it('omits expiry_date when the config has none, instead of sending an invalid value', () => {
+    proto.getBigQueryClient.call(fakeStorage({ OAuthAccessTokenExpiry: configValue(null) }));
+
+    expect(capturedAuthClients[0].credentials.expiry_date).toBeUndefined();
+  });
+
+  it('reuses the same client across calls instead of rebuilding it from the static token', () => {
+    const storage = fakeStorage();
+
+    const first = proto.getBigQueryClient.call(storage);
+    const second = proto.getBigQueryClient.call(storage);
+
+    expect(second).toBe(first);
+    expect(capturedAuthClients).toHaveLength(1);
+  });
+});

--- a/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
+++ b/packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { loadGasClass } from '../../support/loadGasClass.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -71,5 +71,47 @@ describe('getBigQueryClient', () => {
 
     expect(second).toBe(first);
     expect(capturedAuthClients).toHaveLength(1);
+  });
+
+  it('refreshes an expired token on the next query and keeps it for the rest of the run', async () => {
+    // The production regression this whole fix targets: a token that expires
+    // mid-run must be refreshed via the refresh token, and the refreshed token
+    // must survive to later queries instead of being rebuilt from the stale one.
+    const storage = fakeStorage({
+      OAuthAccessTokenExpiry: configValue(Date.now() - 60_000),
+    });
+    proto.getBigQueryClient.call(storage);
+    const authClient = capturedAuthClients[0];
+    // Stub only the token-endpoint HTTP call: the real OAuth2Client refresh
+    // logic (expiry detection, grant exchange, credential update) runs as-is.
+    authClient.transporter.request = vi.fn(async () => ({
+      data: { access_token: 'refreshed-token', expires_in: 3600, token_type: 'Bearer' },
+    }));
+
+    // First query after expiry: the library must detect the past expiry_date
+    // and exchange the refresh token.
+    await authClient.getRequestHeaders();
+    expect(authClient.transporter.request).toHaveBeenCalledTimes(1);
+    expect(authClient.credentials.access_token).toBe('refreshed-token');
+
+    // A later executeQuery reuses the cached client — and with it the
+    // refreshed token: no client rebuild, no second refresh round-trip.
+    proto.getBigQueryClient.call(storage);
+    expect(capturedAuthClients).toHaveLength(1);
+    await authClient.getRequestHeaders();
+    expect(authClient.transporter.request).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes expiry_date 0 through, which google-auth-library itself treats as no known expiry', () => {
+    proto.getBigQueryClient.call(fakeStorage({ OAuthAccessTokenExpiry: configValue(0) }));
+    const authClient = capturedAuthClients[0];
+
+    // `??` keeps the 0 intact on our side (|| would have dropped it)...
+    expect(authClient.credentials.expiry_date).toBe(0);
+    // ...but the library's own isTokenExpiring() uses a falsy check, so an
+    // exact epoch-0 expiry never triggers a refresh either way. Pinned here so
+    // nobody "fixes" our passthrough expecting a refresh the library won't do;
+    // acceptable in practice, since a real expiry timestamp is never 0.
+    expect(authClient.isTokenExpiring()).toBe(false);
   });
 });


### PR DESCRIPTION
# Problem

Two separate failures made long connector backfills unreliable.

First, cancelling a run did not stick. The cancel endpoint committed `CANCELLED`
to the run row, but abort delivery relies on an in-memory `AbortController` map
local to a single backend instance, so the child process often kept running. When
that orphaned execution finished, `updateRunStatus` updated by `runId` alone with
no concurrency guard, overwriting `CANCELLED` with its own terminal status. During
a deploy that status became `INTERRUPTED`, and the 15-minute retry sweep then
resurrected the run — users saw a run they had cancelled go back to "Running".

Second, BigQuery backfills on OAuth died after about 60 minutes with
`401 Invalid Credentials / ACCESS_TOKEN_TYPE_UNSUPPORTED`. `GoogleBigQueryStorage`
passed `access_token` to `google-auth-library` without `expiry_date`, and
`isTokenExpiring()` returns `false` when `expiry_date` is absent — so the client
believed the token never expired and kept resending a dead one. A fresh
`OAuth2Client` was also built on every query, discarding any refresh that did occur.

# Solution

- **Guard the terminal status write.** `updateRunStatus` now updates only while the
  run is still non-terminal (`WHERE status IN (PENDING, RUNNING)`), so a concurrent
  cancel wins over an orphaned execution. Reused the existing
  `CANCELLABLE_DATA_MART_RUN_STATUSES` via a documented alias rather than adding a
  second `[PENDING, RUNNING]` literal that could drift.
- **Preserve logs when that write is skipped.** The status and logs previously
  travelled in one statement, so skipping the status also discarded the log trail —
  the only record of what ran before cancellation. A logs-only follow-up update now
  persists them. The merge logic is extracted into `mergeWithPersistedOutput()` and
  shared with the resume path.
- **Guard the retry sweep.** `executeInterruptedRuns` claims each run with
  `WHERE status = INTERRUPTED` before creating a trigger, so it cannot resurrect a
  run whose status changed underneath it.
- **Fix resume detection.** `mergeWithExisting` keyed off `run.status === INTERRUPTED`,
  which is unreachable: `claimRunSlotAtomically` always sets `RUNNING` before
  `executeInBackground` inspects it. It now keys off `startedAt`, which survives the
  `INTERRUPTED → PENDING → RUNNING` churn, so resumed runs keep their earlier logs.
- **Thread token expiry to the connector.** The backend passes the OAuth client's
  `expiry_date` through as `OAuthAccessTokenExpiry`, and `GoogleBigQueryStorage`
  forwards it into `setCredentials` so the library can detect expiry and refresh.
  Used `??` rather than `||` so an `expiry_date` of `0` is not coerced away, which
  would silently restore the original bug.
- **Cache the BigQuery client per run.** `getBigQueryClient()` builds the client once
  instead of on each of the hundreds of MERGE calls a backfill makes, so a refresh
  persists for the rest of the run.

Known limitation, deliberately out of scope: a refreshed access token is still not
written back to the credential row, since the storage side has no `CREDENTIALS_UPDATE`
channel like the source side. Runs that begin with an already-stale stored token can
still fail on the first MERGE. That needs a new message type and backend handler, and
is better reviewed on its own.

# Changes

- Guarded the terminal run-status write in `connector-executor.service.ts` to
  non-terminal statuses only
- Added a logs-only fallback update so captured logs survive a skipped status write
- Extracted `mergeWithPersistedOutput()` and shared it between the resume and
  fallback paths
- Replaced the unreachable `status === INTERRUPTED` resume check with `startedAt`
- Guarded the `INTERRUPTED → PENDING` claim in `executeInterruptedRuns`
- Added `NON_TERMINAL_DATA_MART_RUN_STATUSES` as an alias of the cancellable set
- Passed `OAuthAccessTokenExpiry` from `connector-storage-config.service.ts` to the
  connector config
- Added the `OAuthAccessTokenExpiry` parameter to `GoogleBigQueryStorage` and forwarded
  it as `expiry_date` using `??`
- Extracted `getBigQueryClient()` to build and cache the BigQuery client once per run
- Added `packages/connectors/test/Storages/GoogleBigQuery/GoogleBigQueryStorage.test.js`
  covering expiry passthrough, the `0` case, and client caching
- Updated backend specs for the new call shapes and added coverage for log
  preservation and the guarded retry sweep