### PR TITLE
test(backend): anchor relative_date integration seed to the calendar year

### DIFF
--- a/apps/backend/src/data-marts/data-storage-types/utils/relative-date-seed-invariants.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/utils/relative-date-seed-invariants.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Calendar-bucket invariants for the relative_date integration-test seed.
+ *
+ * The real-DB integration suites (bigquery/athena/snowflake/redshift/databricks
+ * `.integration.ts`) seed a fixed set of rows whose dates are expressed relative
+ * to the DB clock, then assert which rows each `relative_date` preset returns.
+ * Because a preset compares against the *live* DB date, any seed row whose date
+ * is a sliding day-offset can drift across a calendar boundary and silently
+ * change which bucket it lands in — turning a green suite red on a specific day
+ * of the year. (Concretely: a "-200 days" row enters `this_year` once the run
+ * date passes day 201 of the year, which is exactly what broke the scheduled
+ * BigQuery + Athena suites on 2026-07-20.)
+ *
+ * This spec pins the seed *design* — not the DB — by mirroring the preset
+ * boundaries as pure date arithmetic and asserting each seed role lands in its
+ * intended calendar bucket for EVERY day of several representative years. It is
+ * the date-independent guard the integration suites themselves cannot be (they
+ * only ever run on a single day).
+ *
+ * The `anchoring` block ties the mirrored semantics back to production, so this
+ * spec fails loudly if `renderRelativeDate` ever moves the bucket boundaries and
+ * the mirror below (and the integration seed) must be revisited.
+ */
+import { BigQueryClauseRenderer } from '../bigquery/services/bigquery-clause-renderer';
+
+// --- UTC date arithmetic mirroring the SQL the renderer emits ----------------
+
+const DAY_MS = 86_400_000;
+
+/** DATE_ADD/DATE_SUB(..., INTERVAL n DAY) — exact day shift. */
+const shiftDays = (d: Date, n: number): Date => new Date(d.getTime() + n * DAY_MS);
+
+/** DATE_ADD/DATE_SUB(..., INTERVAL n MONTH) — month shift with end-of-month clamp. */
+function shiftMonths(d: Date, n: number): Date {
+  const total = d.getUTCFullYear() * 12 + d.getUTCMonth() + n;
+  const year = Math.floor(total / 12);
+  const month = ((total % 12) + 12) % 12;
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  return new Date(Date.UTC(year, month, Math.min(d.getUTCDate(), lastDay)));
+}
+
+/** DATE_TRUNC(..., YEAR) — first day of the row's calendar year. */
+const truncYear = (d: Date): Date => new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+
+const iso = (d: Date): string => d.toISOString().slice(0, 10);
+
+// --- preset predicates, mirroring renderRelativeDate -------------------------
+
+const isToday = (row: Date, today: Date): boolean => row.getTime() === today.getTime();
+
+const inLastNDays = (row: Date, today: Date, n: number): boolean =>
+  row.getTime() >= shiftDays(today, -n).getTime() && row.getTime() <= today.getTime();
+
+const inLastNMonths = (row: Date, today: Date, n: number): boolean =>
+  row.getTime() >= shiftMonths(today, -n).getTime() && row.getTime() <= today.getTime();
+
+const inThisYear = (row: Date, today: Date): boolean =>
+  row.getTime() >= truncYear(today).getTime() &&
+  row.getTime() < Date.UTC(today.getUTCFullYear() + 1, 0, 1);
+
+// --- seed roles from the bigquery/athena matrix table ------------------------
+// The date each role holds, as a function of the DB "today".
+
+const seed = {
+  today: (t: Date): Date => t, // rows 1 & 5
+  recent5d: (t: Date): Date => shiftDays(t, -5), // row 4
+  mid40d: (t: Date): Date => shiftDays(t, -40), // row 2
+  oldLastYear400d: (t: Date): Date => shiftDays(t, -400), // row 3
+  // row 6 — the "last year" bucket, anchored to the calendar year (mid last year)
+  // so it never drifts into this_year or the sliding windows regardless of run date.
+  // SQL: DATE_SUB(DATE_TRUNC(CURRENT_DATE(), YEAR), INTERVAL 6 MONTH) → Jul 1 of last year.
+  lastYearBucket: (t: Date): Date => shiftMonths(truncYear(t), -6),
+  future13m: (t: Date): Date => shiftMonths(t, 13), // row 7
+};
+
+// --- every day of a spread of representative years ---------------------------
+
+function eachDayUTC(years: number[]): Date[] {
+  const out: Date[] = [];
+  for (const y of years) {
+    for (let m = 0; m < 12; m++) {
+      const daysInMonth = new Date(Date.UTC(y, m + 1, 0)).getUTCDate();
+      for (let day = 1; day <= daysInMonth; day++) out.push(new Date(Date.UTC(y, m, day)));
+    }
+  }
+  return out;
+}
+
+// 2028 is a leap year; 2100 is a non-leap century year — both stress boundaries.
+const YEARS = [2025, 2026, 2027, 2028, 2100];
+const DAYS = eachDayUTC(YEARS);
+
+describe('relative_date seed calendar-bucket invariants', () => {
+  describe('anchoring: production preset boundaries the mirror depends on', () => {
+    const bq = new BigQueryClauseRenderer();
+
+    it('this_year spans the whole calendar year (start of year .. start of next year)', () => {
+      const sql = bq.renderWhere([
+        { column: 'd', operator: 'relative_date', value: { kind: 'this_year' } },
+      ]).sql;
+      expect(sql).toContain('DATE_TRUNC(CURRENT_DATE(), YEAR)');
+      expect(sql).toContain('INTERVAL 1 YEAR');
+    });
+
+    it('last_n_days / last_n_months are bounded above by today', () => {
+      const days = bq.renderWhere([
+        { column: 'd', operator: 'relative_date', value: { kind: 'last_n_days', n: 7 } },
+      ]).sql;
+      const months = bq.renderWhere([
+        { column: 'd', operator: 'relative_date', value: { kind: 'last_n_months', n: 3 } },
+      ]).sql;
+      expect(days).toContain('<= CURRENT_DATE()');
+      expect(months).toContain('<= CURRENT_DATE()');
+    });
+  });
+
+  describe('for every day of every representative year', () => {
+    it('today rows land in today / this_year / last_n_days(7) / last_n_months(3)', () => {
+      const bad = DAYS.filter(t => {
+        const row = seed.today(t);
+        return !(
+          isToday(row, t) &&
+          inThisYear(row, t) &&
+          inLastNDays(row, t, 7) &&
+          inLastNMonths(row, t, 3)
+        );
+      });
+      expect(bad.map(iso)).toEqual([]);
+    });
+
+    it('recent row (-5d) is in last_n_days(7) but is never "today"', () => {
+      const bad = DAYS.filter(t => {
+        const row = seed.recent5d(t);
+        return !inLastNDays(row, t, 7) || isToday(row, t);
+      });
+      expect(bad.map(iso)).toEqual([]);
+    });
+
+    it('mid row (-40d) is in last_n_months(3) but not in last_n_days(7)', () => {
+      const bad = DAYS.filter(t => {
+        const row = seed.mid40d(t);
+        return !inLastNMonths(row, t, 3) || inLastNDays(row, t, 7);
+      });
+      expect(bad.map(iso)).toEqual([]);
+    });
+
+    it('old row (-400d) is never in this_year / last_n_days(7) / last_n_months(3)', () => {
+      const bad = DAYS.filter(t => {
+        const row = seed.oldLastYear400d(t);
+        return inThisYear(row, t) || inLastNDays(row, t, 7) || inLastNMonths(row, t, 3);
+      });
+      expect(bad.map(iso)).toEqual([]);
+    });
+
+    it('future row (+13m) is never in this_year / last_n_days(7) / last_n_months(3)', () => {
+      const bad = DAYS.filter(t => {
+        const row = seed.future13m(t);
+        return inThisYear(row, t) || inLastNDays(row, t, 7) || inLastNMonths(row, t, 3);
+      });
+      expect(bad.map(iso)).toEqual([]);
+    });
+
+    // The invariant the -200d bug violates: the "last year" bucket must stay out
+    // of this_year (and the sliding windows) regardless of the run date.
+    it('last-year bucket row is never in this_year / last_n_days(7) / last_n_months(3)', () => {
+      const bad = DAYS.filter(t => {
+        const row = seed.lastYearBucket(t);
+        return inThisYear(row, t) || inLastNDays(row, t, 7) || inLastNMonths(row, t, 3);
+      });
+      expect(bad.map(iso)).toEqual([]);
+    });
+  });
+
+  // Documents WHY the integration this_year assertion must be membership-based
+  // (toContain / not.toContain) rather than an exact toEqual over recent rows:
+  // recent rows legitimately fall out of this_year near the start of the year.
+  it('recent (-5d) and mid (-40d) rows are NOT stably inside this_year', () => {
+    const recentUnstable = DAYS.some(t => !inThisYear(seed.recent5d(t), t));
+    const midUnstable = DAYS.some(t => !inThisYear(seed.mid40d(t), t));
+    expect(recentUnstable).toBe(true);
+    expect(midUnstable).toBe(true);
+  });
+});

--- a/apps/backend/test/integration/athena.integration.ts
+++ b/apps/backend/test/integration/athena.integration.ts
@@ -693,11 +693,14 @@ describeIfCredentials('Output controls — operator matrix & dates (real Athena)
     //   3  gamma    c      30  true   ~400 days ago (last year)
     //   4  alphabet a%b    40  true   5 days ago
     //   5  ALPHA    a_b    50  false  today
-    //   6  (empty)  x       0  true   200 days ago (last year)
+    //   6  (empty)  x       0  true   mid last year (anchored: Jul 1 of last year)
     //   7  future   f      70  true   ~13 months from now (next calendar year)
     //
-    // Date expressions use date_add so the relative_date assertions hold
-    // regardless of when the suite runs.
+    // Date expressions are anchored to the calendar year (not sliding day offsets
+    // near a boundary) so the relative_date assertions hold regardless of when the
+    // suite runs. Row 6 uses date_trunc('year', ...) - 6 months so it stays firmly
+    // in last year all year round; a plain "-200 days" drifts into this_year past
+    // ~Jul 20.
     // `created_ts` mirrors `created_at` but as a TIMESTAMP at 13:00 (NOT midnight)
     // for the "today" rows, so the relative_date half-open range is exercised on a
     // sub-day value — the case the old `= current_date` equality silently missed.
@@ -710,7 +713,7 @@ AS SELECT * FROM (VALUES
   (3, 'gamma',    'c',    30,  true,  date_add('day', -400, current_date),   cast(date_add('day', -400, current_date) AS timestamp)),
   (4, 'alphabet', 'a%b',  40,  true,  date_add('day', -5, current_date),     cast(date_add('day', -5, current_date) AS timestamp)),
   (5, 'ALPHA',    'a_b',  50,  false, current_date,                          date_add('hour', 13, cast(current_date AS timestamp))),
-  (6, '',         'x',     0,  true,  date_add('day', -200, current_date),   cast(date_add('day', -200, current_date) AS timestamp)),
+  (6, '',         'x',     0,  true,  date_add('month', -6, date_trunc('year', current_date)),  cast(date_add('month', -6, date_trunc('year', current_date)) AS timestamp)),
   (7, 'future',   'f',    70,  true,  date_add('month', 13, current_date),   cast(date_add('month', 13, current_date) AS timestamp))
 ) AS t (id, name, tag, score, active, created_at, created_ts)`;
 
@@ -899,18 +902,17 @@ AS SELECT * FROM (VALUES
 
   // --- relative_date on created_at (DATE column) ---
   // Row dates (relative to test run date):
-  //   1 → today        5 → today
-  //   4 → -5 days      2 → -40 days
-  //   6 → -200 days    3 → -400 days
+  //   1 → today            5 → today
+  //   4 → -5 days          2 → -40 days
+  //   6 → mid last year    3 → -400 days
   //
   // today    → rows dated current_date → [1, 5]
   // last_n_days(7) → >= current_date - 7 days → [1, 4, 5]
-  // this_year → >= date_trunc('year', current_date) → depends on how many days
-  //             ago fall in the current calendar year.
-  //             -5 days (row 4) and -40 days (row 2) are always in current year
-  //             as long as the test runs after Feb 10 of any year.
-  //             -200 days (row 6) and -400 days (row 3) are last year.
-  //             → [1, 2, 4, 5]
+  // last_n_months(3) → -40 days (~1.3 months) included → [1, 2, 4, 5]
+  // this_year → whole calendar year: today rows (1,5) in, other-year rows
+  //   (3 & 6 last year, 7 next year) out. Recent rows 2 & 4 are NOT asserted for
+  //   this_year — they legitimately leave it in early January (see the calendar
+  //   invariants in relative-date-seed-invariants.spec.ts).
 
   it('relative_date today on created_at → rows 1,5', async () => {
     const rows = await runMatrix({
@@ -954,13 +956,21 @@ AS SELECT * FROM (VALUES
     expect(ids(rows)).toEqual(['1', '4', '5']);
   }, 60000);
 
-  it('relative_date this_year on created_at → rows 1,2,4,5 (excludes future row 7)', async () => {
+  it('relative_date this_year on created_at → current-year rows in, other-year rows out', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'created_at', operator: 'relative_date', value: { kind: 'this_year' } }],
     });
-    // Row 7 is ~13 months in the future (next calendar year) and must NOT appear.
-    expect(ids(rows)).not.toContain('7');
-    expect(ids(rows)).toEqual(['1', '2', '4', '5']);
+    const got = ids(rows);
+    // today rows are always in the current calendar year
+    expect(got).toContain('1');
+    expect(got).toContain('5');
+    // other-year rows must never appear: rows 3 (-400d) & 6 (mid last year) are last
+    // year; row 7 (+13m) is next year — the this_year UPPER BOUND excludes it.
+    // Recent rows 2 (-40d) & 4 (-5d) are intentionally not asserted here — they
+    // legitimately leave this_year in early January (covered by last_n_days/months).
+    expect(got).not.toContain('3');
+    expect(got).not.toContain('6');
+    expect(got).not.toContain('7');
   }, 60000);
 
   it('relative_date last_n_months(3) on created_at → rows 1,2,4,5 (upper bound excludes future row 7)', async () => {

--- a/apps/backend/test/integration/bigquery.integration.ts
+++ b/apps/backend/test/integration/bigquery.integration.ts
@@ -780,10 +780,13 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
     //   3  gamma    c      30  true   ~400 days ago (last year)
     //   4  alphabet a%b    40  true   5 days ago
     //   5  ALPHA    a_b    50  false  today
-    //   6  (empty)  x       0  true   200 days ago (last year)
+    //   6  (empty)  x       0  true   mid last year (anchored: Jul 1 of last year)
     //   7  future   f      70  true   ~13 months from now (next calendar year)
     //
-    // DATE_SUB expressions ensure relative_date assertions hold whenever the suite runs.
+    // Row-date expressions are anchored to the calendar year (not sliding day
+    // offsets near a boundary) so relative_date assertions hold whenever the suite
+    // runs. Row 6 uses DATE_TRUNC(...,YEAR) - 6 months so it stays firmly in last
+    // year all year round; a plain "-200 days" drifts into this_year past ~Jul 20.
     // created_ts mirrors created_at as a TIMESTAMP at 13:00 (NOT midnight) for the
     // "today" rows, so relative_date exercises the DATE(col) wrapper on a sub-day
     // value — without it BigQuery raises "No matching signature for =" (TIMESTAMP vs DATE).
@@ -795,7 +798,7 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
         (3, 'gamma',    'c',    30,  true,  DATE_SUB(CURRENT_DATE(), INTERVAL 400 DAY),    TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 400 DAY))),
         (4, 'alphabet', 'a%b',  40,  true,  DATE_SUB(CURRENT_DATE(), INTERVAL 5 DAY),      TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 5 DAY))),
         (5, 'ALPHA',    'a_b',  50,  false, CURRENT_DATE(),                                TIMESTAMP_ADD(TIMESTAMP(CURRENT_DATE()), INTERVAL 13 HOUR)),
-        (6, '',         'x',     0,  true,  DATE_SUB(CURRENT_DATE(), INTERVAL 200 DAY),    TIMESTAMP(DATE_SUB(CURRENT_DATE(), INTERVAL 200 DAY))),
+        (6, '',         'x',     0,  true,  DATE_SUB(DATE_TRUNC(CURRENT_DATE(), YEAR), INTERVAL 6 MONTH),  TIMESTAMP(DATE_SUB(DATE_TRUNC(CURRENT_DATE(), YEAR), INTERVAL 6 MONTH))),
         (7, 'future',   'f',    70,  true,  DATE_ADD(CURRENT_DATE(), INTERVAL 13 MONTH),   TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL 13 MONTH)))`
     );
   }, 120000);
@@ -964,14 +967,17 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
 
   // --- relative_date on created_at (DATE column) ---
   // Row dates (relative to test run date):
-  //   1 → today        5 → today
-  //   4 → -5 days      2 → -40 days
-  //   6 → -200 days    3 → -400 days
+  //   1 → today            5 → today
+  //   4 → -5 days          2 → -40 days
+  //   6 → mid last year    3 → -400 days
   //
   // today    → rows dated CURRENT_DATE() → [1, 5]
   // last_n_days(7) → >= CURRENT_DATE - 7 days → [1, 4, 5]
-  // this_year → >= DATE_TRUNC(CURRENT_DATE, YEAR) → [1, 2, 4, 5]
   // last_n_months(3) → -40 days (~1.3 months) included → [1, 2, 4, 5]
+  // this_year → whole calendar year: today rows (1,5) in, other-year rows
+  //   (3 & 6 last year, 7 next year) out. Recent rows 2 & 4 are NOT asserted for
+  //   this_year — they legitimately leave it in early January (see the calendar
+  //   invariants in relative-date-seed-invariants.spec.ts).
 
   it('relative_date today on created_at → rows 1,5', async () => {
     const rows = await runMatrix({
@@ -1013,13 +1019,19 @@ describeIfCredentials('Output controls — operator matrix & dates (real BigQuer
     expect(ids(rows)).toEqual([1, 4, 5]);
   }, 60000);
 
-  it('relative_date this_year on created_at → rows 1,2,4,5 (excludes future row 7)', async () => {
+  it('relative_date this_year on created_at → current-year rows in, other-year rows out', async () => {
     const rows = await runMatrix({
       filters: [{ column: 'created_at', operator: 'relative_date', value: { kind: 'this_year' } }],
     });
-    // Row 7 is ~13 months in the future (next calendar year) and must NOT appear.
-    expect(ids(rows)).not.toContain(7);
-    expect(ids(rows)).toEqual([1, 2, 4, 5]);
+    const got = ids(rows);
+    // today rows are always in the current calendar year
+    expect(got).toContain(1);
+    expect(got).toContain(5);
+    // other-year rows must never appear: rows 3 (-400d) & 6 (mid last year) are last
+    // year; row 7 (+13m) is next year — the this_year UPPER BOUND excludes it.
+    expect(got).not.toContain(3);
+    expect(got).not.toContain(6);
+    expect(got).not.toContain(7);
   }, 60000);
 
   it('relative_date last_n_months(3) on created_at → rows 1,2,4,5 (upper bound excludes future row 7)', async () => {


### PR DESCRIPTION
## Problem

The scheduled **Integration Tests (Real DB)** workflow started failing deterministically for **BigQuery** and **Athena** from **2026-07-20** onward (green through Jul 19, red every run since). Snowflake / Redshift / Databricks stayed green.

Both failures were the same test on both engines:

> `Output controls — operator matrix & dates › relative_date this_year on created_at → rows 1,2,4,5 (excludes future row 7)`

It is **not flaky** — it is a calendar time-bomb. The matrix table seeded its "last year" row (row 6) as `CURRENT_DATE − 200 days`. `this_year` renders as the whole calendar year (`>= DATE_TRUNC(CURRENT_DATE, YEAR) AND < …+1 YEAR`). In a non-leap year day 200 is Jul 19, so once the run date passes day 201 (Jul 20), `CURRENT_DATE − 200 days` lands back in the current calendar year and row 6 unexpectedly enters `this_year`, breaking `toEqual([1,2,4,5])`.

The over-specified `toEqual` also hid a second, mirror-image window: recent rows 2 (`−40d`) and 4 (`−5d`) legitimately fall *out* of `this_year` in early January, so the same test would also fail for the first weeks of the year.

## Fix

Bring BigQuery and Athena in line with the robust pattern already used by the Snowflake / Redshift / Databricks suites:

- **Anchor row 6 to the calendar year** — `DATE_TRUNC(YEAR) − 6 months` (mid last year) instead of a sliding `−200 days`, so it stays firmly in last year all year round.
- **Relax the `this_year` assertion to membership checks** — today rows in (`toContain`), other-year rows out (`not.toContain` for rows 3/6/7). Recent rows 2/4 are no longer asserted for `this_year`; their bucket membership is covered by the `last_n_days` / `last_n_months` tests.

## Regression guard (TDD)

Added `relative-date-seed-invariants.spec.ts` — a **date-independent** unit test that mirrors the `renderRelativeDate` boundaries and asserts each seed role lands in its intended calendar bucket for **every day of several representative years** (incl. leap 2028 and non-leap century 2100). It fails with the old `−200 days` formula (from day 201) and passes with the anchored one — proving the fix holds regardless of run date, not just today. An `anchoring` block ties the mirrored semantics back to the real renderer, so the guard fails loudly if the preset boundaries ever change.

## Verification

Ran the full matrix suites locally against the real databases:

| Suite | Before | After |
|---|---|---|
| BigQuery | 67 ✅ / 1 ❌ | **68 / 68 ✅** |
| Athena | 57 ✅ / 1 ❌ | **58 / 58 ✅** |

Unit guard: 9/9 across all sampled days/years.

> Note: these integration jobs run on a schedule (not on PRs), so they won't run automatically here — the results above are from local runs against the real BigQuery/Athena.

## Notes

- Test-only change; the production `relative_date` renderer is unchanged. No changeset (per repo convention, test-only changes don't get one).
