### PR TITLE
feat(api-client): add project run history

### DIFF
--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -23,3 +23,12 @@ same authenticated retry and error behavior as existing client requests.
 `OWOXProjectSetupStepState` for inspecting versioned, member-aware setup state. Existing
 authenticated viewer access is unchanged, and consumers can adopt the client method without a
 migration.
+
+## Add project run history API client support
+
+`@owox/api-client` adds `project.getRunHistory({ limit, offset })` for authenticated,
+project-wide Data Mart execution monitoring. It exports `OWOXProjectDataMartRunsResponse`,
+`OWOXProjectDataMartRun`, `OWOXProjectDataMartRunRef`, `OWOXProjectDataMartRunUser`,
+`OWOXProjectDataMartRunStatus`, `OWOXProjectDataMartRunType`,
+`OWOXProjectDataMartRunTriggerType`, and `OWOXProjectRunHistoryOptions`. Existing viewer access
+and HTTP behavior are unchanged, and consumers can adopt the client method without a migration.

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -26,7 +26,7 @@ migration.
 
 ## Add project run history API client support
 
-`@owox/api-client` adds `project.getRunHistory({ limit, offset })` for authenticated,
+`@owox/api-client` adds `runs.getHistory({ limit, offset })` for authenticated,
 project-wide Data Mart execution monitoring. It exports `OWOXProjectDataMartRunsResponse`,
 `OWOXProjectDataMartRun`, `OWOXProjectDataMartRunRef`, `OWOXProjectDataMartRunUser`,
 `OWOXProjectDataMartRunStatus`, `OWOXProjectDataMartRunType`,

--- a/apps/backend/src/data-marts/controllers/project-data-mart-runs.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/project-data-mart-runs.controller.openapi.spec.ts
@@ -1,0 +1,139 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
+
+jest.mock('../../idp', () => ({
+  __esModule: true,
+  Auth: () => () => undefined,
+  AuthContext: () => () => undefined,
+  Role: {
+    viewer: jest.fn(),
+  },
+  Strategy: {
+    PARSE: 'parse',
+  },
+}));
+
+jest.mock('../mappers/data-mart.mapper', () => ({
+  DataMartMapper: jest.fn(),
+}));
+
+jest.mock('../use-cases/list-project-data-mart-runs.service', () => ({
+  ListProjectDataMartRunsService: jest.fn(),
+}));
+
+import { DataMartMapper } from '../mappers/data-mart.mapper';
+import { ListProjectDataMartRunsService } from '../use-cases/list-project-data-mart-runs.service';
+import { ProjectDataMartRunsController } from './project-data-mart-runs.controller';
+
+describe('ProjectDataMartRunsController OpenAPI', () => {
+  let app: INestApplication;
+  let document: OpenAPIObject;
+
+  beforeAll(async () => {
+    const providers = [ListProjectDataMartRunsService, DataMartMapper].map(provide => ({
+      provide,
+      useValue: {},
+    }));
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ProjectDataMartRunsController],
+      providers,
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+
+    document = SwaggerModule.createDocument(
+      app,
+      new DocumentBuilder().setTitle('Test API').setVersion('1.0').build()
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  function resolveRef(ref: string): Record<string, any> {
+    const schemaName = ref.split('/').at(-1)!;
+    return document.components?.schemas?.[schemaName] as Record<string, any>;
+  }
+
+  it('documents project run history pagination and the typed response', () => {
+    const operation = document.paths['/api/data-marts/runs']?.get;
+
+    expect(operation?.summary).toBe('Get project DataMart run history');
+    expect(operation?.parameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'limit',
+          in: 'query',
+          required: false,
+          schema: expect.objectContaining({ type: 'number' }),
+        }),
+        expect.objectContaining({
+          name: 'offset',
+          in: 'query',
+          required: false,
+          schema: expect.objectContaining({ type: 'number' }),
+        }),
+      ])
+    );
+    expect(operation?.responses['200']).toMatchObject({
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/ProjectDataMartRunsResponseApiDto' },
+        },
+      },
+    });
+
+    const responseSchema = resolveRef('#/components/schemas/ProjectDataMartRunsResponseApiDto');
+    expect(responseSchema).toMatchObject({
+      required: ['runs'],
+      properties: {
+        runs: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/ProjectDataMartRunResponseApiDto' },
+        },
+      },
+    });
+
+    const runSchema = resolveRef('#/components/schemas/ProjectDataMartRunResponseApiDto');
+    expect(runSchema).toMatchObject({
+      required: [
+        'id',
+        'status',
+        'type',
+        'runType',
+        'dataMartId',
+        'createdAt',
+        'dataMart',
+        'createdByUser',
+      ],
+      properties: {
+        dataMart: { $ref: '#/components/schemas/ProjectDataMartRunRefResponseApiDto' },
+        createdByUser: {
+          nullable: true,
+          allOf: [{ $ref: '#/components/schemas/ProjectDataMartRunUserResponseApiDto' }],
+        },
+      },
+    });
+    expect(resolveRef('#/components/schemas/ProjectDataMartRunRefResponseApiDto')).toMatchObject({
+      required: ['id', 'title'],
+      properties: {
+        id: { type: 'string' },
+        title: { type: 'string' },
+      },
+    });
+    expect(resolveRef('#/components/schemas/ProjectDataMartRunUserResponseApiDto')).toMatchObject({
+      required: ['userId'],
+      properties: {
+        userId: { type: 'string' },
+        fullName: { type: 'string', nullable: true },
+        email: { type: 'string', nullable: true },
+        avatar: { type: 'string', nullable: true },
+      },
+    });
+  });
+});

--- a/apps/backend/src/data-marts/dto/presentation/project-data-mart-runs-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/project-data-mart-runs-response-api.dto.ts
@@ -9,9 +9,31 @@ export class ProjectDataMartRunRefResponseApiDto {
   title: string;
 }
 
+export class ProjectDataMartRunUserResponseApiDto {
+  @ApiProperty({ example: '44c7b3e4-5d6f-7a8b-9c0d-112233445566' })
+  userId: string;
+
+  @ApiProperty({ type: String, example: 'Ada Lovelace', required: false, nullable: true })
+  fullName?: string | null;
+
+  @ApiProperty({ type: String, example: 'ada@example.com', required: false, nullable: true })
+  email?: string | null;
+
+  @ApiProperty({
+    type: String,
+    example: 'https://example.com/avatar.png',
+    required: false,
+    nullable: true,
+  })
+  avatar?: string | null;
+}
+
 export class ProjectDataMartRunResponseApiDto extends DataMartRunResponseApiDto {
   @ApiProperty({ type: ProjectDataMartRunRefResponseApiDto })
   dataMart: ProjectDataMartRunRefResponseApiDto;
+
+  @ApiProperty({ type: ProjectDataMartRunUserResponseApiDto, nullable: true })
+  createdByUser: ProjectDataMartRunUserResponseApiDto | null;
 }
 
 export class ProjectDataMartRunsResponseApiDto {

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -87,6 +87,24 @@ for (const [step, state] of Object.entries(setupProgress.steps)) {
 }
 ```
 
+## Read project run history
+
+Use `project.getRunHistory()` to inspect historical Data Mart executions visible to the current
+project member. Pass optional `limit` and `offset` values to page through the project-wide history;
+the API defaults to at most 100 runs.
+
+```ts
+const history = await client.project.getRunHistory({ limit: 50, offset: 0 });
+
+for (const run of history.runs) {
+  console.log(run.dataMart.title, run.type, run.status, run.finishedAt);
+}
+```
+
+Each run includes its Data Mart ID and title, creator metadata when available, execution and trigger
+types, status, timestamps, and available logs, errors, metadata, and totals. This makes the method
+suitable for monitoring and automation without calling the HTTP endpoint directly.
+
 ## List data marts
 
 ```ts

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -89,12 +89,12 @@ for (const [step, state] of Object.entries(setupProgress.steps)) {
 
 ## Read project run history
 
-Use `project.getRunHistory()` to inspect historical Data Mart executions visible to the current
+Use `runs.getHistory()` to inspect historical Data Mart executions visible to the current
 project member. Pass optional `limit` and `offset` values to page through the project-wide history;
 the API defaults to at most 100 runs.
 
 ```ts
-const history = await client.project.getRunHistory({ limit: 50, offset: 0 });
+const history = await client.runs.getHistory({ limit: 50, offset: 0 });
 
 for (const run of history.runs) {
   console.log(run.dataMart.title, run.type, run.status, run.finishedAt);

--- a/docs/api/coverage.md
+++ b/docs/api/coverage.md
@@ -36,6 +36,21 @@ npm test -w @owox/backend -- --runInBand --runTestsByPath src/data-marts/control
 npm test -w @owox/api-client -- --runInBand --runTestsByPath src/project-setup-progress.test.ts
 ```
 
+## Project run history
+
+Coverage updated: 2026-07-21
+
+| Method and path            | Exposure                                                  | OpenAPI status                                                     | API client status                  | Verification evidence                                                                                                                     | Exemption approval |
+| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `GET /api/data-marts/runs` | Authenticated public; Project Member (`viewer` or higher) | Covered: operation, optional pagination, and `200` response schema | Covered: `project.getRunHistory()` | Backend `project-data-mart-runs.controller.openapi.spec.ts`; client `project-run-history.test.ts` (pagination, auth, response validation) | Not applicable     |
+
+Focused verification:
+
+```sh
+npm test -w @owox/backend -- --runInBand --runTestsByPath src/data-marts/controllers/project-data-mart-runs.controller.openapi.spec.ts
+npm test -w @owox/api-client -- --runInBand --runTestsByPath src/project-run-history.test.ts
+```
+
 ## Models canvas
 
 Coverage updated: 2026-07-21

--- a/docs/api/coverage.md
+++ b/docs/api/coverage.md
@@ -40,9 +40,9 @@ npm test -w @owox/api-client -- --runInBand --runTestsByPath src/project-setup-p
 
 Coverage updated: 2026-07-21
 
-| Method and path            | Exposure                                                  | OpenAPI status                                                     | API client status                  | Verification evidence                                                                                                                     | Exemption approval |
-| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
-| `GET /api/data-marts/runs` | Authenticated public; Project Member (`viewer` or higher) | Covered: operation, optional pagination, and `200` response schema | Covered: `project.getRunHistory()` | Backend `project-data-mart-runs.controller.openapi.spec.ts`; client `project-run-history.test.ts` (pagination, auth, response validation) | Not applicable     |
+| Method and path            | Exposure                                                  | OpenAPI status                                                     | API client status            | Verification evidence                                                                                                                     | Exemption approval |
+| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `GET /api/data-marts/runs` | Authenticated public; Project Member (`viewer` or higher) | Covered: operation, optional pagination, and `200` response schema | Covered: `runs.getHistory()` | Backend `project-data-mart-runs.controller.openapi.spec.ts`; client `project-run-history.test.ts` (pagination, auth, response validation) | Not applicable     |
 
 Focused verification:
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -7,6 +7,7 @@ import { DestinationsApi } from './destinations.js';
 import { createHttpError } from './errors.js';
 import { ModelCanvasApi } from './model-canvas.js';
 import { ProjectApi } from './project.js';
+import { RunsApi } from './runs.js';
 import { StoragesApi } from './storages.js';
 import { requestApi } from './transport.js';
 
@@ -34,6 +35,7 @@ export class OWOXApiClient {
   readonly destinations: DestinationsApi;
   readonly models: ModelCanvasApi;
   readonly project: ProjectApi;
+  readonly runs: RunsApi;
 
   private readonly apiOrigin: string;
   private readonly apiKeyId: string;
@@ -54,6 +56,7 @@ export class OWOXApiClient {
     this.destinations = new DestinationsApi(this);
     this.models = new ModelCanvasApi(this);
     this.project = new ProjectApi(this);
+    this.runs = new RunsApi(this);
   }
 
   async authenticate(): Promise<void> {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -17,6 +17,14 @@ export {
   type OWOXModelCanvasNode,
 } from './model-canvas.js';
 export {
+  type OWOXProjectDataMartRun,
+  type OWOXProjectDataMartRunRef,
+  type OWOXProjectDataMartRunsResponse,
+  type OWOXProjectDataMartRunStatus,
+  type OWOXProjectDataMartRunTriggerType,
+  type OWOXProjectDataMartRunType,
+  type OWOXProjectDataMartRunUser,
+  type OWOXProjectRunHistoryOptions,
   type OWOXProjectSettings,
   type OWOXProjectSetupProgress,
   type OWOXProjectSetupProgressSteps,

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -25,6 +25,8 @@ export {
   type OWOXProjectDataMartRunType,
   type OWOXProjectDataMartRunUser,
   type OWOXProjectRunHistoryOptions,
+} from './runs.js';
+export {
   type OWOXProjectSettings,
   type OWOXProjectSetupProgress,
   type OWOXProjectSetupProgressSteps,

--- a/packages/api-client/src/project-run-history.test.ts
+++ b/packages/api-client/src/project-run-history.test.ts
@@ -65,7 +65,7 @@ const runHistory: OWOXProjectDataMartRunsResponse = {
   ],
 };
 
-describe('Project run history API', () => {
+describe('Runs API', () => {
   it('gets project run history with optional pagination through an authenticated request', async () => {
     const fetchImpl = createFetchMock(request => {
       if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
@@ -80,9 +80,7 @@ describe('Project run history API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.project.getRunHistory({ limit: 25, offset: 50 })).resolves.toEqual(
-      runHistory
-    );
+    await expect(client.runs.getHistory({ limit: 25, offset: 50 })).resolves.toEqual(runHistory);
   });
 
   it('omits pagination query parameters when options are not provided', async () => {
@@ -97,7 +95,7 @@ describe('Project run history API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.project.getRunHistory()).resolves.toEqual({ runs: [] });
+    await expect(client.runs.getHistory()).resolves.toEqual({ runs: [] });
   });
 
   it('rejects an unexpected run-history response shape', async () => {
@@ -117,7 +115,7 @@ describe('Project run history API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    const result = client.project.getRunHistory();
+    const result = client.runs.getHistory();
     await expect(result).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Project Run History API returned an unexpected response shape',
@@ -143,7 +141,7 @@ describe('Project run history API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.project.getRunHistory()).rejects.toMatchObject({
+    await expect(client.runs.getHistory()).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Project Run History API returned an unexpected response shape',
       details: response,
@@ -161,7 +159,7 @@ describe('Project run history API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.project.getRunHistory()).rejects.toMatchObject({
+    await expect(client.runs.getHistory()).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Project Run History API returned an unexpected response shape',
       details: response,

--- a/packages/api-client/src/project-run-history.test.ts
+++ b/packages/api-client/src/project-run-history.test.ts
@@ -1,0 +1,170 @@
+import { OWOXApiClient, OWOXApiError, type OWOXProjectDataMartRunsResponse } from './index.js';
+
+type RecordedRequest = {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+};
+
+const apiOrigin = 'https://example.test';
+const apiKeyId = 'pmk_AbCdEfGhIjKlMnOpQrStUv';
+const apiKey = `owox_key_${Buffer.from(
+  JSON.stringify({
+    apiOrigin,
+    apiKeyId,
+    apiKeySecret: 'secret-value-that-must-not-leak',
+  }),
+  'utf8'
+).toString('base64url')}`;
+
+function createJsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function createFetchMock(handler: (request: RecordedRequest) => Response): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const headers: Record<string, string> = {};
+    request.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    const parsedUrl = new URL(request.url);
+    return handler({
+      method: request.method,
+      url: `${parsedUrl.pathname}${parsedUrl.search}`,
+      headers,
+    });
+  }) as typeof fetch;
+}
+
+const runHistory: OWOXProjectDataMartRunsResponse = {
+  runs: [
+    {
+      id: 'run-1',
+      status: 'SUCCESS',
+      type: 'CONNECTOR',
+      runType: 'scheduled',
+      dataMartId: 'data-mart-1',
+      dataMart: { id: 'data-mart-1', title: 'Marketing performance' },
+      createdAt: '2026-07-21T12:00:00.000Z',
+      startedAt: '2026-07-21T12:00:01.000Z',
+      finishedAt: '2026-07-21T12:05:00.000Z',
+      logs: [],
+      errors: null,
+      totals: null,
+      createdByUser: {
+        userId: 'user-1',
+        fullName: 'Ada Lovelace',
+        email: 'ada@example.test',
+        avatar: null,
+      },
+    },
+  ],
+};
+
+describe('Project run history API', () => {
+  it('gets project run history with optional pagination through an authenticated request', async () => {
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      if (request.method === 'GET' && request.url === '/api/data-marts/runs?limit=25&offset=50') {
+        expect(request.headers['x-owox-authorization']).toBe('Bearer access-token-1');
+        expect(request.headers['x-owox-api-key-id']).toBe(apiKeyId);
+        return createJsonResponse(200, runHistory);
+      }
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.project.getRunHistory({ limit: 25, offset: 50 })).resolves.toEqual(
+      runHistory
+    );
+  });
+
+  it('omits pagination query parameters when options are not provided', async () => {
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      if (request.method === 'GET' && request.url === '/api/data-marts/runs') {
+        return createJsonResponse(200, { runs: [] });
+      }
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.project.getRunHistory()).resolves.toEqual({ runs: [] });
+  });
+
+  it('rejects an unexpected run-history response shape', async () => {
+    const response = {
+      runs: [
+        {
+          ...runHistory.runs[0],
+          dataMart: { id: 'data-mart-1' },
+        },
+      ],
+    };
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      return createJsonResponse(200, response);
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    const result = client.project.getRunHistory();
+    await expect(result).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'OWOX Project Run History API returned an unexpected response shape',
+      details: response,
+    });
+    await expect(result).rejects.toBeInstanceOf(OWOXApiError);
+  });
+
+  it('rejects malformed run creator metadata', async () => {
+    const response = {
+      runs: [
+        {
+          ...runHistory.runs[0],
+          createdByUser: { userId: 42 },
+        },
+      ],
+    };
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      return createJsonResponse(200, response);
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.project.getRunHistory()).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'OWOX Project Run History API returned an unexpected response shape',
+      details: response,
+    });
+  });
+
+  it('rejects a run without creator metadata', async () => {
+    const { createdByUser: _createdByUser, ...runWithoutCreator } = runHistory.runs[0];
+    const response = { runs: [runWithoutCreator] };
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      return createJsonResponse(200, response);
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.project.getRunHistory()).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'OWOX Project Run History API returned an unexpected response shape',
+      details: response,
+    });
+  });
+});

--- a/packages/api-client/src/project.ts
+++ b/packages/api-client/src/project.ts
@@ -29,79 +29,8 @@ export type OWOXProjectSetupProgress = {
   steps: OWOXProjectSetupProgressSteps;
 };
 
-export type OWOXProjectDataMartRunStatus =
-  | 'PENDING'
-  | 'RUNNING'
-  | 'SUCCESS'
-  | 'FAILED'
-  | 'CANCELLED'
-  | 'INTERRUPTED'
-  | 'RESTRICTED';
-
-export type OWOXProjectDataMartRunType =
-  | 'CONNECTOR'
-  | 'GOOGLE_SHEETS_EXPORT'
-  | 'LOOKER_STUDIO'
-  | 'EMAIL'
-  | 'SLACK'
-  | 'MS_TEAMS'
-  | 'GOOGLE_CHAT'
-  | 'INSIGHT'
-  | 'INSIGHT_TEMPLATE'
-  | 'AI_ASSISTANT'
-  | 'HTTP_DATA'
-  | 'MCP_QUERY';
-
-export type OWOXProjectDataMartRunTriggerType = 'manual' | 'scheduled';
-
-export type OWOXProjectDataMartRunRef = {
-  id: string;
-  title: string;
-};
-
-export type OWOXProjectDataMartRunUser = {
-  userId: string;
-  fullName?: string | null;
-  email?: string | null;
-  avatar?: string | null;
-};
-
-export type OWOXProjectDataMartRun = {
-  id: string;
-  status: OWOXProjectDataMartRunStatus;
-  type: OWOXProjectDataMartRunType;
-  runType: OWOXProjectDataMartRunTriggerType;
-  dataMartId: string;
-  dataMart: OWOXProjectDataMartRunRef;
-  createdByUser: OWOXProjectDataMartRunUser | null;
-  definitionRun?: Record<string, unknown> | null;
-  reportId?: string | null;
-  reportDefinition?: Record<string, unknown> | null;
-  insightId?: string | null;
-  insightDefinition?: Record<string, unknown> | null;
-  insightTemplateId?: string | null;
-  insightTemplateDefinition?: Record<string, unknown> | null;
-  aiSourceDefinition?: Record<string, unknown> | null;
-  logs?: string[] | null;
-  errors?: string[] | null;
-  createdAt: string;
-  startedAt?: string | null;
-  finishedAt?: string | null;
-  additionalParams?: Record<string, unknown> | null;
-  totals?: Record<string, number | string | boolean | null> | null;
-};
-
-export type OWOXProjectDataMartRunsResponse = {
-  runs: OWOXProjectDataMartRun[];
-};
-
-export type OWOXProjectRunHistoryOptions = {
-  limit?: number;
-  offset?: number;
-};
-
 type ProjectRequester = {
-  getJson<T>(path: string, query?: Record<string, string>): Promise<T>;
+  getJson<T>(path: string): Promise<T>;
   putJson<T>(path: string, jsonBody: unknown): Promise<T>;
 };
 
@@ -118,31 +47,6 @@ const PROJECT_SETUP_STEP_KEYS = [
   'hasGoogleSheetsReportRun',
 ] as const;
 
-const PROJECT_DATA_MART_RUN_STATUSES = new Set<OWOXProjectDataMartRunStatus>([
-  'PENDING',
-  'RUNNING',
-  'SUCCESS',
-  'FAILED',
-  'CANCELLED',
-  'INTERRUPTED',
-  'RESTRICTED',
-]);
-
-const PROJECT_DATA_MART_RUN_TYPES = new Set<OWOXProjectDataMartRunType>([
-  'CONNECTOR',
-  'GOOGLE_SHEETS_EXPORT',
-  'LOOKER_STUDIO',
-  'EMAIL',
-  'SLACK',
-  'MS_TEAMS',
-  'GOOGLE_CHAT',
-  'INSIGHT',
-  'INSIGHT_TEMPLATE',
-  'AI_ASSISTANT',
-  'HTTP_DATA',
-  'MCP_QUERY',
-]);
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -152,82 +56,6 @@ function isProjectSetupStepState(value: unknown): value is OWOXProjectSetupStepS
     isRecord(value) &&
     typeof value.done === 'boolean' &&
     (typeof value.completedAt === 'string' || value.completedAt === null)
-  );
-}
-
-function isOptionalNullableRecord(value: unknown): boolean {
-  return value === undefined || value === null || isRecord(value);
-}
-
-function isOptionalNullableString(value: unknown): boolean {
-  return value === undefined || value === null || typeof value === 'string';
-}
-
-function isOptionalNullableStringArray(value: unknown): boolean {
-  return (
-    value === undefined ||
-    value === null ||
-    (Array.isArray(value) && value.every(item => typeof item === 'string'))
-  );
-}
-
-function isNullableProjectDataMartRunUser(value: unknown): boolean {
-  return (
-    value === null ||
-    (isRecord(value) &&
-      typeof value.userId === 'string' &&
-      isOptionalNullableString(value.fullName) &&
-      isOptionalNullableString(value.email) &&
-      isOptionalNullableString(value.avatar))
-  );
-}
-
-function isOptionalTotals(value: unknown): boolean {
-  return (
-    value === undefined ||
-    value === null ||
-    (isRecord(value) &&
-      Object.values(value).every(
-        item =>
-          item === null ||
-          typeof item === 'number' ||
-          typeof item === 'string' ||
-          typeof item === 'boolean'
-      ))
-  );
-}
-
-function isProjectDataMartRun(value: unknown): value is OWOXProjectDataMartRun {
-  if (!isRecord(value) || !isRecord(value.dataMart)) {
-    return false;
-  }
-
-  return (
-    typeof value.id === 'string' &&
-    typeof value.status === 'string' &&
-    PROJECT_DATA_MART_RUN_STATUSES.has(value.status as OWOXProjectDataMartRunStatus) &&
-    typeof value.type === 'string' &&
-    PROJECT_DATA_MART_RUN_TYPES.has(value.type as OWOXProjectDataMartRunType) &&
-    (value.runType === 'manual' || value.runType === 'scheduled') &&
-    typeof value.dataMartId === 'string' &&
-    typeof value.dataMart.id === 'string' &&
-    typeof value.dataMart.title === 'string' &&
-    isNullableProjectDataMartRunUser(value.createdByUser) &&
-    isOptionalNullableRecord(value.definitionRun) &&
-    isOptionalNullableString(value.reportId) &&
-    isOptionalNullableRecord(value.reportDefinition) &&
-    isOptionalNullableString(value.insightId) &&
-    isOptionalNullableRecord(value.insightDefinition) &&
-    isOptionalNullableString(value.insightTemplateId) &&
-    isOptionalNullableRecord(value.insightTemplateDefinition) &&
-    isOptionalNullableRecord(value.aiSourceDefinition) &&
-    isOptionalNullableStringArray(value.logs) &&
-    isOptionalNullableStringArray(value.errors) &&
-    typeof value.createdAt === 'string' &&
-    isOptionalNullableString(value.startedAt) &&
-    isOptionalNullableString(value.finishedAt) &&
-    isOptionalNullableRecord(value.additionalParams) &&
-    isOptionalTotals(value.totals)
   );
 }
 
@@ -280,20 +108,6 @@ function parseProjectSetupProgress(response: unknown): OWOXProjectSetupProgress 
   return response as OWOXProjectSetupProgress;
 }
 
-function parseProjectRunHistory(response: unknown): OWOXProjectDataMartRunsResponse {
-  if (
-    !isRecord(response) ||
-    !Array.isArray(response.runs) ||
-    !response.runs.every(isProjectDataMartRun)
-  ) {
-    throw new OWOXApiError('OWOX Project Run History API returned an unexpected response shape', {
-      details: response,
-    });
-  }
-
-  return response as OWOXProjectDataMartRunsResponse;
-}
-
 export class ProjectApi {
   constructor(private readonly requester: ProjectRequester) {}
 
@@ -304,22 +118,6 @@ export class ProjectApi {
   async getSetupProgress(): Promise<OWOXProjectSetupProgress> {
     return parseProjectSetupProgress(
       await this.requester.getJson<unknown>('/api/project-setup-progress')
-    );
-  }
-
-  async getRunHistory(
-    options: OWOXProjectRunHistoryOptions = {}
-  ): Promise<OWOXProjectDataMartRunsResponse> {
-    const query = {
-      ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
-      ...(options.offset === undefined ? {} : { offset: String(options.offset) }),
-    };
-
-    return parseProjectRunHistory(
-      await this.requester.getJson<unknown>(
-        '/api/data-marts/runs',
-        Object.keys(query).length === 0 ? undefined : query
-      )
     );
   }
 

--- a/packages/api-client/src/project.ts
+++ b/packages/api-client/src/project.ts
@@ -29,8 +29,79 @@ export type OWOXProjectSetupProgress = {
   steps: OWOXProjectSetupProgressSteps;
 };
 
+export type OWOXProjectDataMartRunStatus =
+  | 'PENDING'
+  | 'RUNNING'
+  | 'SUCCESS'
+  | 'FAILED'
+  | 'CANCELLED'
+  | 'INTERRUPTED'
+  | 'RESTRICTED';
+
+export type OWOXProjectDataMartRunType =
+  | 'CONNECTOR'
+  | 'GOOGLE_SHEETS_EXPORT'
+  | 'LOOKER_STUDIO'
+  | 'EMAIL'
+  | 'SLACK'
+  | 'MS_TEAMS'
+  | 'GOOGLE_CHAT'
+  | 'INSIGHT'
+  | 'INSIGHT_TEMPLATE'
+  | 'AI_ASSISTANT'
+  | 'HTTP_DATA'
+  | 'MCP_QUERY';
+
+export type OWOXProjectDataMartRunTriggerType = 'manual' | 'scheduled';
+
+export type OWOXProjectDataMartRunRef = {
+  id: string;
+  title: string;
+};
+
+export type OWOXProjectDataMartRunUser = {
+  userId: string;
+  fullName?: string | null;
+  email?: string | null;
+  avatar?: string | null;
+};
+
+export type OWOXProjectDataMartRun = {
+  id: string;
+  status: OWOXProjectDataMartRunStatus;
+  type: OWOXProjectDataMartRunType;
+  runType: OWOXProjectDataMartRunTriggerType;
+  dataMartId: string;
+  dataMart: OWOXProjectDataMartRunRef;
+  createdByUser: OWOXProjectDataMartRunUser | null;
+  definitionRun?: Record<string, unknown> | null;
+  reportId?: string | null;
+  reportDefinition?: Record<string, unknown> | null;
+  insightId?: string | null;
+  insightDefinition?: Record<string, unknown> | null;
+  insightTemplateId?: string | null;
+  insightTemplateDefinition?: Record<string, unknown> | null;
+  aiSourceDefinition?: Record<string, unknown> | null;
+  logs?: string[] | null;
+  errors?: string[] | null;
+  createdAt: string;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+  additionalParams?: Record<string, unknown> | null;
+  totals?: Record<string, number | string | boolean | null> | null;
+};
+
+export type OWOXProjectDataMartRunsResponse = {
+  runs: OWOXProjectDataMartRun[];
+};
+
+export type OWOXProjectRunHistoryOptions = {
+  limit?: number;
+  offset?: number;
+};
+
 type ProjectRequester = {
-  getJson<T>(path: string): Promise<T>;
+  getJson<T>(path: string, query?: Record<string, string>): Promise<T>;
   putJson<T>(path: string, jsonBody: unknown): Promise<T>;
 };
 
@@ -47,6 +118,31 @@ const PROJECT_SETUP_STEP_KEYS = [
   'hasGoogleSheetsReportRun',
 ] as const;
 
+const PROJECT_DATA_MART_RUN_STATUSES = new Set<OWOXProjectDataMartRunStatus>([
+  'PENDING',
+  'RUNNING',
+  'SUCCESS',
+  'FAILED',
+  'CANCELLED',
+  'INTERRUPTED',
+  'RESTRICTED',
+]);
+
+const PROJECT_DATA_MART_RUN_TYPES = new Set<OWOXProjectDataMartRunType>([
+  'CONNECTOR',
+  'GOOGLE_SHEETS_EXPORT',
+  'LOOKER_STUDIO',
+  'EMAIL',
+  'SLACK',
+  'MS_TEAMS',
+  'GOOGLE_CHAT',
+  'INSIGHT',
+  'INSIGHT_TEMPLATE',
+  'AI_ASSISTANT',
+  'HTTP_DATA',
+  'MCP_QUERY',
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -56,6 +152,82 @@ function isProjectSetupStepState(value: unknown): value is OWOXProjectSetupStepS
     isRecord(value) &&
     typeof value.done === 'boolean' &&
     (typeof value.completedAt === 'string' || value.completedAt === null)
+  );
+}
+
+function isOptionalNullableRecord(value: unknown): boolean {
+  return value === undefined || value === null || isRecord(value);
+}
+
+function isOptionalNullableString(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === 'string';
+}
+
+function isOptionalNullableStringArray(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (Array.isArray(value) && value.every(item => typeof item === 'string'))
+  );
+}
+
+function isNullableProjectDataMartRunUser(value: unknown): boolean {
+  return (
+    value === null ||
+    (isRecord(value) &&
+      typeof value.userId === 'string' &&
+      isOptionalNullableString(value.fullName) &&
+      isOptionalNullableString(value.email) &&
+      isOptionalNullableString(value.avatar))
+  );
+}
+
+function isOptionalTotals(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (isRecord(value) &&
+      Object.values(value).every(
+        item =>
+          item === null ||
+          typeof item === 'number' ||
+          typeof item === 'string' ||
+          typeof item === 'boolean'
+      ))
+  );
+}
+
+function isProjectDataMartRun(value: unknown): value is OWOXProjectDataMartRun {
+  if (!isRecord(value) || !isRecord(value.dataMart)) {
+    return false;
+  }
+
+  return (
+    typeof value.id === 'string' &&
+    typeof value.status === 'string' &&
+    PROJECT_DATA_MART_RUN_STATUSES.has(value.status as OWOXProjectDataMartRunStatus) &&
+    typeof value.type === 'string' &&
+    PROJECT_DATA_MART_RUN_TYPES.has(value.type as OWOXProjectDataMartRunType) &&
+    (value.runType === 'manual' || value.runType === 'scheduled') &&
+    typeof value.dataMartId === 'string' &&
+    typeof value.dataMart.id === 'string' &&
+    typeof value.dataMart.title === 'string' &&
+    isNullableProjectDataMartRunUser(value.createdByUser) &&
+    isOptionalNullableRecord(value.definitionRun) &&
+    isOptionalNullableString(value.reportId) &&
+    isOptionalNullableRecord(value.reportDefinition) &&
+    isOptionalNullableString(value.insightId) &&
+    isOptionalNullableRecord(value.insightDefinition) &&
+    isOptionalNullableString(value.insightTemplateId) &&
+    isOptionalNullableRecord(value.insightTemplateDefinition) &&
+    isOptionalNullableRecord(value.aiSourceDefinition) &&
+    isOptionalNullableStringArray(value.logs) &&
+    isOptionalNullableStringArray(value.errors) &&
+    typeof value.createdAt === 'string' &&
+    isOptionalNullableString(value.startedAt) &&
+    isOptionalNullableString(value.finishedAt) &&
+    isOptionalNullableRecord(value.additionalParams) &&
+    isOptionalTotals(value.totals)
   );
 }
 
@@ -108,6 +280,20 @@ function parseProjectSetupProgress(response: unknown): OWOXProjectSetupProgress 
   return response as OWOXProjectSetupProgress;
 }
 
+function parseProjectRunHistory(response: unknown): OWOXProjectDataMartRunsResponse {
+  if (
+    !isRecord(response) ||
+    !Array.isArray(response.runs) ||
+    !response.runs.every(isProjectDataMartRun)
+  ) {
+    throw new OWOXApiError('OWOX Project Run History API returned an unexpected response shape', {
+      details: response,
+    });
+  }
+
+  return response as OWOXProjectDataMartRunsResponse;
+}
+
 export class ProjectApi {
   constructor(private readonly requester: ProjectRequester) {}
 
@@ -118,6 +304,22 @@ export class ProjectApi {
   async getSetupProgress(): Promise<OWOXProjectSetupProgress> {
     return parseProjectSetupProgress(
       await this.requester.getJson<unknown>('/api/project-setup-progress')
+    );
+  }
+
+  async getRunHistory(
+    options: OWOXProjectRunHistoryOptions = {}
+  ): Promise<OWOXProjectDataMartRunsResponse> {
+    const query = {
+      ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
+      ...(options.offset === undefined ? {} : { offset: String(options.offset) }),
+    };
+
+    return parseProjectRunHistory(
+      await this.requester.getJson<unknown>(
+        '/api/data-marts/runs',
+        Object.keys(query).length === 0 ? undefined : query
+      )
     );
   }
 

--- a/packages/api-client/src/runs.ts
+++ b/packages/api-client/src/runs.ts
@@ -1,0 +1,215 @@
+import { OWOXApiError } from './errors.js';
+
+export type OWOXProjectDataMartRunStatus =
+  | 'PENDING'
+  | 'RUNNING'
+  | 'SUCCESS'
+  | 'FAILED'
+  | 'CANCELLED'
+  | 'INTERRUPTED'
+  | 'RESTRICTED';
+
+export type OWOXProjectDataMartRunType =
+  | 'CONNECTOR'
+  | 'GOOGLE_SHEETS_EXPORT'
+  | 'LOOKER_STUDIO'
+  | 'EMAIL'
+  | 'SLACK'
+  | 'MS_TEAMS'
+  | 'GOOGLE_CHAT'
+  | 'INSIGHT'
+  | 'INSIGHT_TEMPLATE'
+  | 'AI_ASSISTANT'
+  | 'HTTP_DATA'
+  | 'MCP_QUERY';
+
+export type OWOXProjectDataMartRunTriggerType = 'manual' | 'scheduled';
+
+export type OWOXProjectDataMartRunRef = {
+  id: string;
+  title: string;
+};
+
+export type OWOXProjectDataMartRunUser = {
+  userId: string;
+  fullName?: string | null;
+  email?: string | null;
+  avatar?: string | null;
+};
+
+export type OWOXProjectDataMartRun = {
+  id: string;
+  status: OWOXProjectDataMartRunStatus;
+  type: OWOXProjectDataMartRunType;
+  runType: OWOXProjectDataMartRunTriggerType;
+  dataMartId: string;
+  dataMart: OWOXProjectDataMartRunRef;
+  createdByUser: OWOXProjectDataMartRunUser | null;
+  definitionRun?: Record<string, unknown> | null;
+  reportId?: string | null;
+  reportDefinition?: Record<string, unknown> | null;
+  insightId?: string | null;
+  insightDefinition?: Record<string, unknown> | null;
+  insightTemplateId?: string | null;
+  insightTemplateDefinition?: Record<string, unknown> | null;
+  aiSourceDefinition?: Record<string, unknown> | null;
+  logs?: string[] | null;
+  errors?: string[] | null;
+  createdAt: string;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+  additionalParams?: Record<string, unknown> | null;
+  totals?: Record<string, number | string | boolean | null> | null;
+};
+
+export type OWOXProjectDataMartRunsResponse = {
+  runs: OWOXProjectDataMartRun[];
+};
+
+export type OWOXProjectRunHistoryOptions = {
+  limit?: number;
+  offset?: number;
+};
+
+type RunsRequester = {
+  getJson<T>(path: string, query?: Record<string, string>): Promise<T>;
+};
+
+const PROJECT_DATA_MART_RUN_STATUSES = new Set<OWOXProjectDataMartRunStatus>([
+  'PENDING',
+  'RUNNING',
+  'SUCCESS',
+  'FAILED',
+  'CANCELLED',
+  'INTERRUPTED',
+  'RESTRICTED',
+]);
+
+const PROJECT_DATA_MART_RUN_TYPES = new Set<OWOXProjectDataMartRunType>([
+  'CONNECTOR',
+  'GOOGLE_SHEETS_EXPORT',
+  'LOOKER_STUDIO',
+  'EMAIL',
+  'SLACK',
+  'MS_TEAMS',
+  'GOOGLE_CHAT',
+  'INSIGHT',
+  'INSIGHT_TEMPLATE',
+  'AI_ASSISTANT',
+  'HTTP_DATA',
+  'MCP_QUERY',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isOptionalNullableRecord(value: unknown): boolean {
+  return value === undefined || value === null || isRecord(value);
+}
+
+function isOptionalNullableString(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === 'string';
+}
+
+function isOptionalNullableStringArray(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (Array.isArray(value) && value.every(item => typeof item === 'string'))
+  );
+}
+
+function isNullableProjectDataMartRunUser(value: unknown): boolean {
+  return (
+    value === null ||
+    (isRecord(value) &&
+      typeof value.userId === 'string' &&
+      isOptionalNullableString(value.fullName) &&
+      isOptionalNullableString(value.email) &&
+      isOptionalNullableString(value.avatar))
+  );
+}
+
+function isOptionalTotals(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (isRecord(value) &&
+      Object.values(value).every(
+        item =>
+          item === null ||
+          typeof item === 'number' ||
+          typeof item === 'string' ||
+          typeof item === 'boolean'
+      ))
+  );
+}
+
+function isProjectDataMartRun(value: unknown): value is OWOXProjectDataMartRun {
+  if (!isRecord(value) || !isRecord(value.dataMart)) {
+    return false;
+  }
+
+  return (
+    typeof value.id === 'string' &&
+    typeof value.status === 'string' &&
+    PROJECT_DATA_MART_RUN_STATUSES.has(value.status as OWOXProjectDataMartRunStatus) &&
+    typeof value.type === 'string' &&
+    PROJECT_DATA_MART_RUN_TYPES.has(value.type as OWOXProjectDataMartRunType) &&
+    (value.runType === 'manual' || value.runType === 'scheduled') &&
+    typeof value.dataMartId === 'string' &&
+    typeof value.dataMart.id === 'string' &&
+    typeof value.dataMart.title === 'string' &&
+    isNullableProjectDataMartRunUser(value.createdByUser) &&
+    isOptionalNullableRecord(value.definitionRun) &&
+    isOptionalNullableString(value.reportId) &&
+    isOptionalNullableRecord(value.reportDefinition) &&
+    isOptionalNullableString(value.insightId) &&
+    isOptionalNullableRecord(value.insightDefinition) &&
+    isOptionalNullableString(value.insightTemplateId) &&
+    isOptionalNullableRecord(value.insightTemplateDefinition) &&
+    isOptionalNullableRecord(value.aiSourceDefinition) &&
+    isOptionalNullableStringArray(value.logs) &&
+    isOptionalNullableStringArray(value.errors) &&
+    typeof value.createdAt === 'string' &&
+    isOptionalNullableString(value.startedAt) &&
+    isOptionalNullableString(value.finishedAt) &&
+    isOptionalNullableRecord(value.additionalParams) &&
+    isOptionalTotals(value.totals)
+  );
+}
+
+function parseProjectRunHistory(response: unknown): OWOXProjectDataMartRunsResponse {
+  if (
+    !isRecord(response) ||
+    !Array.isArray(response.runs) ||
+    !response.runs.every(isProjectDataMartRun)
+  ) {
+    throw new OWOXApiError('OWOX Project Run History API returned an unexpected response shape', {
+      details: response,
+    });
+  }
+
+  return response as OWOXProjectDataMartRunsResponse;
+}
+
+export class RunsApi {
+  constructor(private readonly requester: RunsRequester) {}
+
+  async getHistory(
+    options: OWOXProjectRunHistoryOptions = {}
+  ): Promise<OWOXProjectDataMartRunsResponse> {
+    const query = {
+      ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
+      ...(options.offset === undefined ? {} : { offset: String(options.offset) }),
+    };
+
+    return parseProjectRunHistory(
+      await this.requester.getJson<unknown>(
+        '/api/data-marts/runs',
+        Object.keys(query).length === 0 ? undefined : query
+      )
+    );
+  }
+}


### PR DESCRIPTION
<!-- owox-factory:api-surface-maintenance case=owox-data-marts/project-run-history -->

## Summary

- add `runs.getHistory({ limit, offset })` to `@owox/api-client`
- export and validate typed project run-history responses, including Data Mart and creator references
- add focused OpenAPI contract evidence for `GET /api/data-marts/runs`
- document client usage and record the Project run history capability in API coverage
- append consumer-facing release notes to the existing canonical API-maintenance changeset

## Scope

- `apps/backend`: complete the project run-history response contract and add a focused Swagger test
- `packages/api-client`: add the runs namespace, exported types, validation, and focused tests
- `docs/api/api-client.md` and `docs/api/coverage.md`: add usage and coverage evidence
- `.changeset/api-surface-maintenance.md`: preserve prior sections and append Project run history
- `docs/api/openapi.md`: unchanged from current `main`

## Coverage matrix

| Surface | Before | After |
| --- | --- | --- |
| Backend/OpenAPI | Operation, optional `limit`/`offset`, and response DTO existed; no focused controller contract test and creator metadata was absent from the schema | Focused path/query/response test; required nullable creator metadata is described in the response schema |
| `@owox/api-client` | No project run-history method or exported response types | `runs.getHistory({ limit, offset })` with exported response/run/reference/user/status/type/trigger/options types and runtime shape validation |
| Documentation | No run-history client usage | Project-wide monitoring and pagination example added |
| Coverage | No Project run history capability | Capability records OpenAPI/client status and executable evidence, updated 2026-07-21 |
| Changeset | Canonical file contained Project settings, Models canvas, and Project setup progress | Prior sections preserved; distinct consumer-focused Project run history section appended |

## Audited base

`68813d781d1e9b0bbbd1d75cc0d8cc2a37f6b71b`

## Verification

- `npm test -w @owox/backend -- --runInBand --runTestsByPath src/data-marts/controllers/project-data-mart-runs.controller.openapi.spec.ts` — 1/1 passed
- `npm test -w @owox/api-client -- --runInBand --runTestsByPath src/project-run-history.test.ts` — 5/5 passed
- `npm run typecheck -w @owox/api-client`
- affected backend ESLint and `npm run lint -w @owox/api-client`
- affected-file Prettier and Markdown lint
- `npx changeset status --since=origin/main` — includes `@owox/api-client` in the fixed minor release group
- independent full-diff and delta reviews — no remaining Critical or Important findings
- excluded `docs/api/openapi.md` and unrelated `.changeset/6665-gs-a1-import-finish-time.md` match current `main`
- `Audit all` reports the same five `adm-zip`/Astro dependency advisories on audited base `68813d7`; this branch changes no dependency manifest or lockfile

## Exemptions

None.

## Blocker register

- `Audit all` is failing on five pre-existing dependency advisories. GitHub reports no required
  checks for this branch, the same workflow fails on audited `main` commit `68813d7`, and resolving
  it requires unrelated potentially breaking dependency upgrades. This API-maintenance case leaves
  that upstream CI issue intact while the heartbeat monitors subsequent runs.

🤖 Codex (GPT-5.6 Sol High)
