### PR TITLE
fix(web): preserve typed input and focus in connector settings

### DIFF
--- a/.changeset/6765-connector-config-input-glitch.md
+++ b/.changeset/6765-connector-config-input-glitch.md
@@ -11,3 +11,7 @@ character, forcing users to click back into the field.
 
 Both problems are fixed. Fields now keep focus and accept every character,
 whether typed quickly or pasted.
+
+Nested credential fields now also show their readable labels everywhere. Some
+tabs previously showed the raw field name, such as "ServiceAccountKey" instead
+of "Service Account Key (JSON)".

--- a/.changeset/6765-connector-config-input-glitch.md
+++ b/.changeset/6765-connector-config-input-glitch.md
@@ -1,0 +1,13 @@
+---
+'owox': minor
+---
+
+# Fix dropped characters and lost focus in connector settings
+
+Previously, typing into a field on the "Configure Settings" step dropped
+characters, so text seemed to appear only on the second try. Pasted values
+could revert as well. Credential fields also lost focus after the first
+character, forcing users to click back into the field.
+
+Both problems are fixed. Fields now keep focus and accept every character,
+whether typed quickly or pasted.

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { ConnectorEditForm } from './ConnectorEditForm';
+import { DataStorageType } from '../../../../data-storage';
+
+interface RecordedProps {
+  initialConfiguration?: Record<string, unknown>;
+  onConfigurationChange?: (configuration: Record<string, unknown>) => void;
+}
+
+const { recorded } = vi.hoisted(() => ({ recorded: [] as RecordedProps[] }));
+
+vi.mock('./steps', () => ({
+  ConnectorSelectionStep: () => null,
+  NodesSelectionStep: () => null,
+  FieldsSelectionStep: () => null,
+  TargetSetupStep: () => null,
+  ConfigurationStep: (props: RecordedProps) => {
+    recorded.push(props);
+    return null;
+  },
+}));
+
+vi.mock('./components', () => ({
+  Stepper: () => null,
+  StepNavigation: () => null,
+  StepperHeroBlock: () => null,
+  OpenIssueLink: () => null,
+}));
+
+vi.mock('../../../shared/model/hooks/useConnector', () => ({
+  useConnector: () => ({
+    connectors: [
+      {
+        name: 'GoogleAds',
+        displayName: 'Google Ads',
+        description: '',
+        logoBase64: null,
+        docUrl: null,
+      },
+    ],
+    connectorSpecification: [{ name: 'CustomerId', requiredType: 'string', required: true }],
+    connectorFields: null,
+    loading: false,
+    loadingSpecification: false,
+    loadingFields: false,
+    error: null,
+    fetchAvailableConnectors: vi.fn(),
+    fetchConnectorSpecification: vi.fn(),
+    fetchConnectorFields: vi.fn(),
+  }),
+}));
+
+function renderForm() {
+  return render(
+    <ConnectorEditForm
+      onSubmit={vi.fn()}
+      dataStorageType={DataStorageType.GOOGLE_BIGQUERY}
+      configurationOnly
+    />
+  );
+}
+
+const lastProps = () => recorded[recorded.length - 1];
+
+describe('ConnectorEditForm configuration echo', () => {
+  beforeEach(() => {
+    recorded.length = 0;
+  });
+
+  // ConfigurationStep tells its own echo apart from a genuine outside change by
+  // comparing references (its `lastEchoedConfigRef`). Cloning the configuration here
+  // would silently reintroduce the dropped-character bug, so pin the contract.
+  it('passes the reported configuration object back by reference', () => {
+    renderForm();
+
+    const onConfigurationChange = lastProps().onConfigurationChange;
+    expect(onConfigurationChange).toBeTypeOf('function');
+
+    const reported = { CustomerId: 'ABC' };
+    act(() => {
+      onConfigurationChange?.(reported);
+    });
+
+    expect(
+      lastProps().initialConfiguration,
+      'initialConfiguration must be the very object reported by ConfigurationStep. A clone ' +
+        "here (equal contents, new reference) breaks that step's echo guard and drops " +
+        'typed characters.'
+    ).toBe(reported);
+  });
+
+  it('keeps passing the same reference across repeated reports', () => {
+    renderForm();
+
+    const first = { CustomerId: 'A' };
+    act(() => {
+      lastProps().onConfigurationChange?.(first);
+    });
+    expect(lastProps().initialConfiguration).toBe(first);
+
+    const second = { CustomerId: 'AB' };
+    act(() => {
+      lastProps().onConfigurationChange?.(second);
+    });
+    expect(lastProps().initialConfiguration).toBe(second);
+  });
+});

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/ConnectorEditForm.tsx
@@ -248,6 +248,13 @@ export function ConnectorEditForm({
     setIsDirty(true);
   };
 
+  // Stores the object by reference on purpose, and `initialConfiguration` hands that
+  // same reference back to ConfigurationStep. That step compares it against the last
+  // value it reported (see its `lastEchoedConfigRef`) to tell its own echo apart from
+  // a genuine outside change, and skips re-seeding the form on an echo.
+  // Do not clone or normalise here (`{ ...configuration }`, structuredClone, etc.):
+  // every echo would become a new reference, the step would re-seed on each keystroke,
+  // and typed characters would be dropped again.
   const handleConfigurationChange = useCallback((configuration: Record<string, unknown>) => {
     setConnectorConfiguration(configuration);
     setIsDirty(true);

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.test.tsx
@@ -81,7 +81,7 @@ describe('ConfigurationStep', () => {
   // is pinned by reference in ConnectorEditForm.test.tsx instead.
   it('keeps every typed character in a top-level field', () => {
     render(<Harness />);
-    const input = screen.getByLabelText(/Customer ID/i);
+    const input = screen.getByLabelText<HTMLInputElement>(/Customer ID/i);
 
     for (const char of 'ABCDEFGH') {
       typeChar(input, char);
@@ -92,7 +92,7 @@ describe('ConfigurationStep', () => {
 
   it('keeps every typed character in a nested oneOf secret field', () => {
     render(<Harness />);
-    const input = screen.getByLabelText(/Service Account Key/i);
+    const input = screen.getByLabelText<HTMLInputElement>(/Service Account Key/i);
 
     for (const char of 'ABCDEFGH') {
       typeChar(input, char);
@@ -107,7 +107,7 @@ describe('ConfigurationStep', () => {
   // ConfigurationSecretField, remounted the input and dropped focus.
   it('renders a nested secret field as the same element across the first keystroke', () => {
     render(<Harness />);
-    const before = screen.getByLabelText(/Service Account Key/i);
+    const before = screen.getByLabelText<HTMLInputElement>(/Service Account Key/i);
     before.focus();
     expect(document.activeElement).toBe(before);
 

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.test.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ConfigurationStep } from './ConfigurationStep';
+import type { ConnectorSpecificationResponseApiDto } from '../../../../shared/api';
+import { RequiredType } from '../../../../shared/api';
+
+vi.mock(
+  '../../../../../data-marts/edit/components/DataMartDefinitionSettings/form/CopyConfigurationButton',
+  () => ({ CopyConfigurationButton: () => null })
+);
+
+vi.mock('../../../../../../utils', () => ({ trackEvent: vi.fn() }));
+
+const connector = {
+  name: 'GoogleAds',
+  displayName: 'Google Ads',
+  description: '',
+  logoBase64: null,
+  docUrl: null,
+};
+
+const spec: ConnectorSpecificationResponseApiDto[] = [
+  {
+    name: 'CustomerId',
+    title: 'Customer ID',
+    requiredType: RequiredType.STRING,
+    required: true,
+  },
+  {
+    name: 'AuthType',
+    title: 'Auth Type',
+    requiredType: RequiredType.OBJECT,
+    required: true,
+    oneOf: [
+      {
+        label: 'Service Account',
+        value: 'service_account',
+        requiredType: RequiredType.OBJECT,
+        items: {
+          ServiceAccountKey: {
+            name: 'ServiceAccountKey',
+            title: 'Service Account Key',
+            requiredType: RequiredType.STRING,
+            required: true,
+            attributes: ['SECRET'],
+          },
+        },
+      },
+    ],
+  },
+];
+
+/**
+ * Mimics ConnectorEditForm: stores the reported configuration by reference and
+ * hands that same object straight back as `initialConfiguration`.
+ */
+function Harness() {
+  const [configuration, setConfiguration] = useState<Record<string, unknown>>({});
+  return (
+    <ConfigurationStep
+      connector={connector}
+      connectorSpecification={spec}
+      initialConfiguration={configuration}
+      onConfigurationChange={setConfiguration}
+    />
+  );
+}
+
+/** Types one character the way a browser does: append to the current DOM value. */
+function typeChar(input: HTMLInputElement, char: string) {
+  fireEvent.change(input, { target: { value: input.value + char } });
+}
+
+describe('ConfigurationStep', () => {
+  // The two typing tests below are smoke coverage for controlled-input wiring, not
+  // regression cover for the parent/child echo race. Verified by reverting the echo
+  // guard in ConfigurationStep: they still pass. `fireEvent` wraps every event in
+  // `act()`, which flushes effects to completion between keystrokes, so the prop can
+  // never be staler than local state and the race cannot occur here. The echo contract
+  // is pinned by reference in ConnectorEditForm.test.tsx instead.
+  it('keeps every typed character in a top-level field', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText(/Customer ID/i);
+
+    for (const char of 'ABCDEFGH') {
+      typeChar(input, char);
+    }
+
+    expect(input.value).toBe('ABCDEFGH');
+  });
+
+  it('keeps every typed character in a nested oneOf secret field', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText(/Service Account Key/i);
+
+    for (const char of 'ABCDEFGH') {
+      typeChar(input, char);
+    }
+
+    expect(input.value).toBe('ABCDEFGH');
+  });
+
+  // Real regression cover: verified to fail when `isSecret` is made value-derived again.
+  // `isSecret` must come from the spec alone. Deriving it from the value flipped it on
+  // the first keystroke, which swapped ConfigurationStringField for
+  // ConfigurationSecretField, remounted the input and dropped focus.
+  it('renders a nested secret field as the same element across the first keystroke', () => {
+    render(<Harness />);
+    const before = screen.getByLabelText(/Service Account Key/i);
+    before.focus();
+    expect(document.activeElement).toBe(before);
+
+    typeChar(before, 'A');
+
+    const after = screen.getByLabelText(/Service Account Key/i);
+    expect(after).toBe(before);
+    expect(document.activeElement).toBe(before);
+  });
+});

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.tsx
@@ -82,6 +82,10 @@ export function ConfigurationStep({
   const [configuration, setConfiguration] = useState<Record<string, unknown>>({});
   const initializedRef = useRef(false);
   const updatingFromParentRef = useRef(false);
+  // The exact object last reported upwards. The wizard stores it as-is and hands it
+  // straight back as `initialConfiguration`, so reference equality identifies our
+  // own echo and distinguishes it from a genuine outside change.
+  const lastEchoedConfigRef = useRef<Record<string, unknown> | null>(null);
   const [secretEditing, setSecretEditing] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
@@ -94,7 +98,10 @@ export function ConfigurationStep({
   }, [connector]);
 
   useEffect(() => {
-    if (connectorSpecification) {
+    // `initialConfiguration` is a dependency so a genuinely new configuration seeds
+    // the form, but our own echo must not: re-seeding from it discarded characters
+    // as they were typed, which is why input appeared to lag a keystroke behind.
+    if (connectorSpecification && initialConfiguration !== lastEchoedConfigRef.current) {
       updatingFromParentRef.current = true;
 
       const config = migrateNestedConfigValuesToTopLevel(
@@ -129,7 +136,10 @@ export function ConfigurationStep({
       initializedRef.current &&
       initialConfiguration &&
       Object.keys(initialConfiguration).length > 0 &&
-      connectorSpecification
+      connectorSpecification &&
+      // Ignore our own echo. It is always at least one keystroke behind local
+      // state, so re-applying it here overwrote characters as they were typed.
+      initialConfiguration !== lastEchoedConfigRef.current
     ) {
       updatingFromParentRef.current = true;
       setConfiguration(
@@ -147,6 +157,7 @@ export function ConfigurationStep({
       !updatingFromParentRef.current &&
       Object.keys(configuration).length > 0
     ) {
+      lastEchoedConfigRef.current = configuration;
       onConfigurationChange?.(configuration);
     }
   }, [configuration, onConfigurationChange]);

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationListRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationListRender.tsx
@@ -41,8 +41,6 @@ function renderItems(
           configuration={configuration}
           onValueChange={onValueChange}
           isEditingExisting={isEditingExisting}
-          isSecretEditing={isSecretEditing}
-          onSecretEditToggle={onSecretEditToggle}
           connectorName={connectorName}
         />
       );

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationOneOfRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationOneOfRender.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect, useMemo } from 'react';
 import { type ConnectorSpecificationResponseApiDto } from '../../../../../shared/api/types';
-import { AppWizardStepItemOneOf, AppWizardStepLabel } from '@owox/ui/components/common/wizard';
-import { configurationFieldRender } from './ConfigurationFieldRender';
+import { AppWizardStepItemOneOf } from '@owox/ui/components/common/wizard';
 import { TabsContent } from '@owox/ui/components/tabs';
-import { Button } from '@owox/ui/components/button';
 import { OauthRenderFactory } from './Oauth/OauthRenderFactory';
+import { NestedConfigurationField } from './NestedConfigurationField';
 import { SECRET_MASK } from '../../../../../../../shared/constants/secrets';
 
 interface ConfigurationOneOfRenderProps {
@@ -112,7 +111,6 @@ export function ConfigurationOneOfRender({
               />
             ) : (
               Object.entries(option.items).map(([itemName, itemSpec]) => {
-                const isFieldSecretEditing = fieldSecretEditing[itemName] ?? false;
                 const optionConfiguration =
                   typeof configuration[specification.name] === 'object' &&
                   configuration[specification.name] !== null
@@ -123,55 +121,22 @@ export function ConfigurationOneOfRender({
                   optionConfiguration[option.value] !== null
                     ? (optionConfiguration[option.value] as Record<string, unknown>)
                     : {};
-                // Spec-derived only: keying this off the config made it flip on the
-                // first keystroke, remounting the input and dropping focus.
-                const isSecret = itemSpec.attributes?.includes('SECRET') ?? false;
-                const hasStoredSecret =
-                  isSecret && isEditingExisting && nestedConfiguration[itemName] === SECRET_MASK;
                 return (
-                  <div key={itemName} className='mb-4'>
-                    <div className='flex items-center justify-between'>
-                      <AppWizardStepLabel
-                        htmlFor={itemName}
-                        required={itemSpec.required}
-                        tooltip={itemSpec.description}
-                        className='mb-2 justify-start'
-                      >
-                        {itemName}
-                      </AppWizardStepLabel>
-                      {/* Editing clears the mask, so `hasStoredSecret` alone would
-                          drop the button and leave no way to cancel. */}
-                      {(hasStoredSecret || isFieldSecretEditing) && (
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          type='button'
-                          onClick={() => {
-                            handleFieldSecretEditToggle(
-                              option.value,
-                              itemName,
-                              !isFieldSecretEditing
-                            );
-                          }}
-                        >
-                          {isFieldSecretEditing ? 'Cancel' : 'Edit'}
-                        </Button>
-                      )}
-                    </div>
-                    {configurationFieldRender({
-                      specification: { ...itemSpec, name: itemName },
-                      configuration: nestedConfiguration,
-                      onValueChange: (name, value) => {
-                        handleNestedValueChange(option.value, name, value);
-                      },
-                      flags: {
-                        isEditingExisting: hasStoredSecret,
-                        isSecret: isSecret,
-                        isSecretEditing: isFieldSecretEditing,
-                      },
-                      connectorName: connectorName,
-                    })}
-                  </div>
+                  <NestedConfigurationField
+                    key={itemName}
+                    itemName={itemName}
+                    itemSpec={itemSpec}
+                    nestedConfiguration={nestedConfiguration}
+                    isEditingExisting={isEditingExisting}
+                    isSecretEditing={fieldSecretEditing[itemName] ?? false}
+                    onSecretEditToggle={(name, enable) => {
+                      handleFieldSecretEditToggle(option.value, name, enable);
+                    }}
+                    onValueChange={(name, value) => {
+                      handleNestedValueChange(option.value, name, value);
+                    }}
+                    connectorName={connectorName}
+                  />
                 );
               })
             )}

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationOneOfRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationOneOfRender.tsx
@@ -118,16 +118,6 @@ export function ConfigurationOneOfRender({
               />
             ) : (
               Object.entries(option.items).map(([itemName, itemSpec]) => {
-                const currentObjectValue = (
-                  configuration[specification.name] &&
-                  typeof configuration[specification.name] === 'object'
-                    ? configuration[specification.name]
-                    : {}
-                ) as Record<string, unknown>;
-                const isSecret =
-                  Array.isArray(itemSpec.attributes) &&
-                  itemSpec.attributes.includes('SECRET') &&
-                  Object.keys(currentObjectValue)[0] === option.value;
                 const isFieldSecretEditing = fieldSecretEditing[itemName] ?? false;
                 const optionConfiguration =
                   typeof configuration[specification.name] === 'object' &&
@@ -139,6 +129,11 @@ export function ConfigurationOneOfRender({
                   optionConfiguration[option.value] !== null
                     ? (optionConfiguration[option.value] as Record<string, unknown>)
                     : {};
+                // Spec-derived only: keying this off the config made it flip on the
+                // first keystroke, remounting the input and dropping focus.
+                const isSecret = itemSpec.attributes?.includes('SECRET') ?? false;
+                const hasStoredSecret =
+                  isSecret && isEditingExisting && nestedConfiguration[itemName] === SECRET_MASK;
                 return (
                   <div key={itemName} className='mb-4'>
                     <div className='flex items-center justify-between'>
@@ -150,7 +145,7 @@ export function ConfigurationOneOfRender({
                       >
                         {itemName}
                       </AppWizardStepLabel>
-                      {isSecret && isEditingExisting && (
+                      {hasStoredSecret && (
                         <Button
                           variant='ghost'
                           size='sm'
@@ -174,7 +169,7 @@ export function ConfigurationOneOfRender({
                         handleNestedValueChange(option.value, name, value);
                       },
                       flags: {
-                        isEditingExisting: isEditingExisting,
+                        isEditingExisting: hasStoredSecret,
                         isSecret: isSecret,
                         isSecretEditing: isFieldSecretEditing,
                       },

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationOneOfRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationOneOfRender.tsx
@@ -12,8 +12,6 @@ interface ConfigurationOneOfRenderProps {
   configuration: Record<string, unknown>;
   onValueChange: (name: string, value: unknown) => void;
   isEditingExisting: boolean;
-  isSecretEditing: boolean;
-  onSecretEditToggle: (name: string, enable: boolean) => void;
   connectorName: string;
 }
 
@@ -22,8 +20,6 @@ export function ConfigurationOneOfRender({
   configuration,
   onValueChange,
   isEditingExisting,
-  isSecretEditing,
-  onSecretEditToggle,
   connectorName,
 }: ConfigurationOneOfRenderProps) {
   const detectSelectedOption = useMemo(() => {
@@ -112,8 +108,6 @@ export function ConfigurationOneOfRender({
                 configuration={configuration}
                 onValueChange={onValueChange}
                 connectorName={connectorName}
-                onSecretEditToggle={onSecretEditToggle}
-                secretEditing={{ [specification.name]: isSecretEditing }}
                 isEditingExisting={isEditingExisting}
               />
             ) : (
@@ -145,7 +139,9 @@ export function ConfigurationOneOfRender({
                       >
                         {itemName}
                       </AppWizardStepLabel>
-                      {hasStoredSecret && (
+                      {/* Editing clears the mask, so `hasStoredSecret` alone would
+                          drop the button and leave no way to cancel. */}
+                      {(hasStoredSecret || isFieldSecretEditing) && (
                         <Button
                           variant='ghost'
                           size='sm'

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/NestedConfigurationField.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/NestedConfigurationField.tsx
@@ -1,0 +1,89 @@
+import type { ConnectorSpecificationItemResponseApiDto } from '../../../../../shared/api/types';
+import { AppWizardStepLabel } from '@owox/ui/components/common/wizard';
+import { Button } from '@owox/ui/components/button';
+import { configurationFieldRender } from './ConfigurationFieldRender';
+import { SECRET_MASK } from '../../../../../../../shared/constants/secrets';
+
+interface NestedConfigurationFieldProps {
+  itemName: string;
+  itemSpec: ConnectorSpecificationItemResponseApiDto;
+  /** Values of the selected `oneOf` option, keyed by item name. */
+  nestedConfiguration: Record<string, unknown>;
+  isEditingExisting: boolean;
+  isSecretEditing: boolean;
+  onSecretEditToggle: (itemName: string, enable: boolean) => void;
+  onValueChange: (itemName: string, value: unknown) => void;
+  connectorName: string;
+}
+
+/**
+ * One field of a `oneOf` option, with its label and secret edit affordance.
+ *
+ * Shared by the OAuth manual-entry branch and the plain `oneOf` tabs so the two
+ * paths cannot drift apart on how secrets are masked, revealed and restored.
+ */
+export function NestedConfigurationField({
+  itemName,
+  itemSpec,
+  nestedConfiguration,
+  isEditingExisting,
+  isSecretEditing,
+  onSecretEditToggle,
+  onValueChange,
+  connectorName,
+}: NestedConfigurationFieldProps) {
+  // Spec-derived only: keying this off the value made it flip on the first keystroke,
+  // swapping the rendered field component and remounting the input, which dropped focus.
+  const isSecret = itemSpec.attributes?.includes('SECRET') ?? false;
+  // A secret is masked and readonly only once stored; the backend sends those back
+  // as SECRET_MASK.
+  const hasStoredSecret =
+    isSecret && isEditingExisting && nestedConfiguration[itemName] === SECRET_MASK;
+
+  return (
+    <div className='mb-4'>
+      <div className='flex items-center justify-between'>
+        <AppWizardStepLabel
+          htmlFor={itemName}
+          required={itemSpec.required}
+          tooltip={itemSpec.description}
+          className='mb-2 justify-start'
+        >
+          {itemSpec.title ?? itemName}
+        </AppWizardStepLabel>
+        {/* Editing clears the mask, so `hasStoredSecret` alone would drop the button
+            and leave no way to cancel. */}
+        {(hasStoredSecret || isSecretEditing) && (
+          <Button
+            variant='ghost'
+            size='sm'
+            type='button'
+            onClick={() => {
+              onSecretEditToggle(itemName, !isSecretEditing);
+            }}
+          >
+            {isSecretEditing ? 'Cancel' : 'Edit'}
+          </Button>
+        )}
+      </div>
+      {configurationFieldRender({
+        specification: { ...itemSpec, name: itemName },
+        configuration: nestedConfiguration,
+        onValueChange,
+        flags: {
+          // Intentionally `hasStoredSecret`, not `isEditingExisting` as the top-level
+          // ConfigurationItemRender passes. This flag only drives
+          // `isReadonly = isEditingExisting && !isSecretEditing` in ConfigurationSecretField,
+          // and ConfigurationStep's masking loop walks top-level specs only, so nested
+          // secrets are never pre-filled with SECRET_MASK on mount. Passing the raw prop
+          // here would render a never-set nested secret readonly and disabled behind a
+          // fake mask, with no way to enter it.
+          isEditingExisting: hasStoredSecret,
+          isSecret,
+          isSecretEditing,
+        },
+        connectorName,
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
@@ -26,8 +26,6 @@ interface OauthRenderFactoryProps {
   configuration: Record<string, unknown>;
   onValueChange: (name: string, value: unknown) => void;
   connectorName: string;
-  onSecretEditToggle?: (name: string, enable: boolean) => void;
-  secretEditing?: Record<string, boolean>;
   isEditingExisting?: boolean;
 }
 
@@ -49,11 +47,10 @@ export function OauthRenderFactory({
   configuration,
   onValueChange,
   connectorName,
-  onSecretEditToggle,
-  secretEditing = {},
   isEditingExisting = false,
 }: OauthRenderFactoryProps) {
   const [isLoading, setIsLoading] = useState(false);
+  const [fieldSecretEditing, setFieldSecretEditing] = useState<Record<string, boolean>>({});
   const [status, setStatus] = useState<OAuthStatusResponseDto | null>(null);
   const [settings, setSettings] = useState<OAuthSettingsResponseDto | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -151,6 +148,14 @@ export function OauthRenderFactory({
     });
   };
 
+  // Must go through handleNestedValueChange: the parent's onSecretEditToggle keys
+  // off the oneOf container name, so it would overwrite the entire credentials
+  // object with a scalar instead of clearing the one field being edited.
+  const handleFieldSecretEditToggle = (itemName: string, enable: boolean) => {
+    setFieldSecretEditing(prev => ({ ...prev, [itemName]: enable }));
+    handleNestedValueChange(itemName, enable ? '' : SECRET_MASK);
+  };
+
   const { checkStatus, getSettings, exchangeCredentials } = useOAuth();
 
   const handleOAuthSuccess = async (credentials: Record<string, unknown>) => {
@@ -239,7 +244,7 @@ export function OauthRenderFactory({
           // Spec-derived only: keying this off the value made it flip on the first
           // keystroke, swapping the rendered field component and remounting the input.
           const isSecret = itemSpec.attributes?.includes('SECRET') ?? false;
-          const isSecretEditing = secretEditing[specification.name] ?? false;
+          const isSecretEditing = fieldSecretEditing[itemName] ?? false;
           // A secret is masked and readonly only once stored; the backend sends
           // those back as SECRET_MASK.
           const hasStoredSecret =
@@ -256,13 +261,15 @@ export function OauthRenderFactory({
                 >
                   {itemSpec.title ?? itemName}
                 </AppWizardStepLabel>
-                {hasStoredSecret && onSecretEditToggle && (
+                {/* Editing clears the mask, so `hasStoredSecret` alone would drop
+                    the button and leave no way to cancel. */}
+                {(hasStoredSecret || isSecretEditing) && (
                   <Button
                     variant='ghost'
                     size='sm'
                     type='button'
                     onClick={() => {
-                      onSecretEditToggle(specification.name, !isSecretEditing);
+                      handleFieldSecretEditToggle(itemName, !isSecretEditing);
                     }}
                   >
                     {isSecretEditing ? 'Cancel' : 'Edit'}

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
@@ -14,8 +14,7 @@ import type {
   OAuthSettingsResponseDto,
 } from '../../../../../../shared/api/types/response/oauth.response.dto';
 import { Button } from '@owox/ui/components/button';
-import { configurationFieldRender } from '../ConfigurationFieldRender';
-import { AppWizardStepLabel } from '@owox/ui/components/common/wizard';
+import { NestedConfigurationField } from '../NestedConfigurationField';
 import { SECRET_MASK } from '../../../../../../../../shared/constants/secrets';
 
 const SOURCE_CREDENTIAL_KEY = '_source_credential_id';
@@ -240,58 +239,19 @@ export function OauthRenderFactory({
   if ((isManualMode || !isOAuthEnabled) && option?.items) {
     return (
       <div className='space-y-4'>
-        {Object.entries(option.items).map(([itemName, itemSpec]) => {
-          // Spec-derived only: keying this off the value made it flip on the first
-          // keystroke, swapping the rendered field component and remounting the input.
-          const isSecret = itemSpec.attributes?.includes('SECRET') ?? false;
-          const isSecretEditing = fieldSecretEditing[itemName] ?? false;
-          // A secret is masked and readonly only once stored; the backend sends
-          // those back as SECRET_MASK.
-          const hasStoredSecret =
-            isSecret && isEditingExisting && nestedConfiguration[itemName] === SECRET_MASK;
-
-          return (
-            <div key={itemName} className='mb-4'>
-              <div className='flex items-center justify-between'>
-                <AppWizardStepLabel
-                  htmlFor={itemName}
-                  required={itemSpec.required}
-                  tooltip={itemSpec.description}
-                  className='mb-2 justify-start'
-                >
-                  {itemSpec.title ?? itemName}
-                </AppWizardStepLabel>
-                {/* Editing clears the mask, so `hasStoredSecret` alone would drop
-                    the button and leave no way to cancel. */}
-                {(hasStoredSecret || isSecretEditing) && (
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    type='button'
-                    onClick={() => {
-                      handleFieldSecretEditToggle(itemName, !isSecretEditing);
-                    }}
-                  >
-                    {isSecretEditing ? 'Cancel' : 'Edit'}
-                  </Button>
-                )}
-              </div>
-              {configurationFieldRender({
-                specification: { ...itemSpec, name: itemName },
-                configuration: nestedConfiguration,
-                onValueChange: (name, value) => {
-                  handleNestedValueChange(name, value);
-                },
-                flags: {
-                  isEditingExisting: hasStoredSecret,
-                  isSecret: isSecret,
-                  isSecretEditing: isSecretEditing,
-                },
-                connectorName: connectorName,
-              })}
-            </div>
-          );
-        })}
+        {Object.entries(option.items).map(([itemName, itemSpec]) => (
+          <NestedConfigurationField
+            key={itemName}
+            itemName={itemName}
+            itemSpec={itemSpec}
+            nestedConfiguration={nestedConfiguration}
+            isEditingExisting={isEditingExisting}
+            isSecretEditing={fieldSecretEditing[itemName] ?? false}
+            onSecretEditToggle={handleFieldSecretEditToggle}
+            onValueChange={handleNestedValueChange}
+            connectorName={connectorName}
+          />
+        ))}
         {isOAuthEnabled && (
           <Button
             variant='link'

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
@@ -16,6 +16,7 @@ import type {
 import { Button } from '@owox/ui/components/button';
 import { configurationFieldRender } from '../ConfigurationFieldRender';
 import { AppWizardStepLabel } from '@owox/ui/components/common/wizard';
+import { SECRET_MASK } from '../../../../../../../../shared/constants/secrets';
 
 const SOURCE_CREDENTIAL_KEY = '_source_credential_id';
 
@@ -235,10 +236,14 @@ export function OauthRenderFactory({
     return (
       <div className='space-y-4'>
         {Object.entries(option.items).map(([itemName, itemSpec]) => {
-          const isSecret = Array.isArray(itemSpec.attributes)
-            ? itemSpec.attributes.includes('SECRET') && nestedConfiguration[itemName] !== undefined
-            : false;
+          // Spec-derived only: keying this off the value made it flip on the first
+          // keystroke, swapping the rendered field component and remounting the input.
+          const isSecret = itemSpec.attributes?.includes('SECRET') ?? false;
           const isSecretEditing = secretEditing[specification.name] ?? false;
+          // A secret is masked and readonly only once stored; the backend sends
+          // those back as SECRET_MASK.
+          const hasStoredSecret =
+            isSecret && isEditingExisting && nestedConfiguration[itemName] === SECRET_MASK;
 
           return (
             <div key={itemName} className='mb-4'>
@@ -251,7 +256,7 @@ export function OauthRenderFactory({
                 >
                   {itemSpec.title ?? itemName}
                 </AppWizardStepLabel>
-                {isSecret && isEditingExisting && onSecretEditToggle && (
+                {hasStoredSecret && onSecretEditToggle && (
                   <Button
                     variant='ghost'
                     size='sm'
@@ -271,7 +276,7 @@ export function OauthRenderFactory({
                   handleNestedValueChange(name, value);
                 },
                 flags: {
-                  isEditingExisting: isEditingExisting,
+                  isEditingExisting: hasStoredSecret,
                   isSecret: isSecret,
                   isSecretEditing: isSecretEditing,
                 },


### PR DESCRIPTION
# Problem

Typing into a field on the connector "Configure Settings" step silently dropped characters, so text often appeared only on the second attempt, and pasted values could revert to their previous contents. Credential fields had a second, separate defect: they lost focus after the very first character, forcing the user to click back into the field to continue.

The dropped characters came from a state echo loop. `ConfigurationStep` keeps the configuration in local state and reports every change up to `ConnectorEditForm`, which stores that object as-is and passes it straight back down as the `initialConfiguration` prop. Both hydration effects list that prop as a dependency and react by calling `setConfiguration` with a full replacement built from it — but that copy is always at least one keystroke behind local state, so each keystroke raced and overwrote the one before it.

The lost focus was unrelated: in both `oneOf` renderers, `isSecret` was derived partly from the field's current value. The first keystroke flipped it from `false` to `true`, which swapped `ConfigurationStringField` for `ConfigurationSecretField` at the same position in the tree. React unmounts the input on a component-type change, so focus jumped to the surrounding tabs panel.

# Solution

For the echo loop, `ConfigurationStep` now records the exact object it last reported upward in `lastEchoedConfigRef`, and both hydration effects skip when `initialConfiguration` is that same reference. Reference equality is reliable here because the wizard stores the object without copying it, so identity cleanly separates "my own echo" from a genuine external change. Configurations arriving from outside still seed the form as before.

Deleting the second hydration effect was tried first and rejected. That effect is load-bearing: it restores the nested OAuth configuration at mount, and removing it wiped stored credentials when opening an existing connector and marked the form dirty on mount, producing a false unsaved-changes prompt. Guarding the effect keeps that behaviour intact while closing the race.

For the focus loss, `isSecret` is now derived from the specification alone, so the rendered component type is stable while typing. A new `hasStoredSecret` check (value equals `SECRET_MASK`, which is how the backend returns saved secrets) takes over the masked/readonly decision and the "Edit" button condition, so existing connectors still show stored secrets masked and unchanged.

Verified in the browser against the running app: typing the full alphabet at both 40ms and 0ms per character, and pasting, now yield the exact string in top-level and nested fields — previously these returned truncated values such as `ACEGKLPSTVXZ1348`. Regression checks confirm stored secrets remain masked and readonly, no unsaved-changes prompt appears on open, and focus survives the first keystroke.

# Changes

- Added `lastEchoedConfigRef` to `ConfigurationStep` to track the configuration object last reported to the wizard
- Guarded both hydration effects in `ConfigurationStep` against re-seeding from the component's own echo, fixing dropped characters and reverted pastes
- Changed `isSecret` in `ConfigurationOneOfRender` and `OauthRenderFactory` to be derived from the field specification only, so the rendered field component no longer changes identity mid-typing
- Added a `hasStoredSecret` check in both renderers to drive the masked/readonly state and the "Edit" button, preserving existing-connector behaviour
- Removed the now-unused `currentObjectValue` computation from `ConfigurationOneOfRender`