### PR TITLE
feat(data-marts): HTTP Data streaming on report level (#6759)

### DIFF
--- a/.changeset/6759-http-data-report-level.md
+++ b/.changeset/6759-http-data-report-level.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# HTTP Data on report level
+
+Adds `GET /api/external/http-data/reports/{reportId}.ndjson` — stream an existing report's data as NDJSON, applying the report's saved filters, aggregations, date buckets, unique count, and sort, without reconstructing query parameters by hand. An optional `limit` query parameter overrides the report's saved limit. The [`@owox/api-client`](../docs/api/api-client.md) `reports.traverseData()` method exposes the same endpoint.
+
+The response carries an `x-owox-run-id` header (consistent with the Data Mart HTTP Data endpoint); on a successful stream the referenced run is a `HTTP_DATA` run tagged with the reportId. When the report applies a filter, aggregation, sort, date bucket, row limit, or unique count — or blends fields across Data Marts — the run also records the exact executed SQL via `additionalParams.httpData.executionSqlQuery`, discoverable through the run history endpoint. (A plain column selection with none of those controls streams the Data Mart's own query and records no separate executed SQL.) Grand totals — one per selected metric (every numeric field, plus non-numeric fields eligible for Count / Count Unique) aggregated over the full result — are recorded in the run history whenever the report selects an eligible metric, computed as a separate best-effort query.
+
+Failed MCP `query_data_mart` calls create no run-history entry; both HTTP Data endpoints (Data Mart and report level) record a `FAILED` run for any failure encountered during query execution.

--- a/apps/backend/src/data-marts/controllers/external/http-data.controller.ts
+++ b/apps/backend/src/data-marts/controllers/external/http-data.controller.ts
@@ -4,7 +4,7 @@ import type { Response } from 'express';
 import { Auth, AuthContext, AuthorizationContext, Role } from '../../../idp';
 import { HttpDataMapper } from '../../mappers/http-data.mapper';
 import { StreamHttpDataService } from '../../use-cases/stream-http-data.service';
-import { StreamHttpDataSpec } from '../spec/external/http-data.api';
+import { StreamHttpDataSpec, StreamHttpReportDataSpec } from '../spec/external/http-data.api';
 
 @Controller('external/http-data')
 @ApiTags('HTTP Data')
@@ -25,5 +25,18 @@ export class HttpDataController {
   ): Promise<void> {
     const command = this.mapper.toStreamHttpDataCommand(dataMartId, ctx, rawQuery);
     await this.streamHttpDataService.stream(command, res);
+  }
+
+  @Auth(Role.viewer())
+  @Get('reports/:reportId.ndjson')
+  @StreamHttpReportDataSpec()
+  async streamReport(
+    @Param('reportId') reportId: string,
+    @Query() rawQuery: Record<string, unknown>,
+    @AuthContext() ctx: AuthorizationContext,
+    @Res() res: Response
+  ): Promise<void> {
+    const command = this.mapper.toStreamHttpReportDataCommand(reportId, ctx, rawQuery);
+    await this.streamHttpDataService.streamReport(command, res);
   }
 }

--- a/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
@@ -1,5 +1,6 @@
 import { applyDecorators } from '@nestjs/common';
 import {
+  ApiHeader,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
@@ -176,6 +177,71 @@ export function StreamHttpDataSpec() {
     ApiResponse({
       status: 503,
       description: 'The server is shutting down and cannot start a new HTTP Data stream.',
+    })
+  );
+}
+
+export function StreamHttpReportDataSpec() {
+  return applyDecorators(
+    ApiOperation({
+      summary: "Stream an existing report's data as NDJSON",
+      description:
+        'Streams rows of a saved report as newline-delimited JSON (one data row per line, no ' +
+        'envelope), applying the report’s stored output controls (columns, filters, aggregations, ' +
+        'date buckets, unique count, sort). The only accepted query parameter is an optional ' +
+        '`limit` override; any other query key is rejected. Authenticated with the ODM member ' +
+        'token via `x-owox-authorization`. Creates one DataMartRun of type HTTP_DATA per request ' +
+        '(tagged with the reportId; when the report applies output controls or blends fields, the ' +
+        'run also records the executed SQL under `additionalParams.httpData.executionSqlQuery`), ' +
+        'on both success and failure.',
+    }),
+    ApiHeader({ name: 'x-owox-authorization', description: 'ODM member token', required: true }),
+    ApiParam({ name: 'reportId', description: 'Report identifier (UUID)' }),
+    ApiQuery({
+      name: 'limit',
+      description: "Optional row cap (positive integer) overriding the report's saved limit.",
+      required: false,
+      type: Number,
+    }),
+    ApiProduces('application/x-ndjson'),
+    ApiOkResponse({
+      description:
+        'NDJSON stream of the report’s row objects. The response includes the `x-owox-run-id` ' +
+        'header with the created DataMartRun ID.',
+      headers: {
+        'x-owox-run-id': {
+          description: 'ID of the created DataMartRun (HTTP_DATA) for traceability',
+          schema: { type: 'string' },
+        },
+      },
+      content: {
+        'application/x-ndjson': {
+          schema: {
+            type: 'string',
+            example:
+              '{"date":"2026-05-01","revenue":42.5}\n' + '{"date":"2026-05-02","revenue":51.0}\n',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description:
+        'A query parameter other than `limit`, an invalid `limit`, or a report whose saved ' +
+        'output controls reference a column that no longer exists in the Data Mart.',
+    }),
+    ApiResponse({ status: 401, description: 'Missing or invalid `x-owox-authorization` token.' }),
+    ApiResponse({
+      status: 403,
+      description: 'Caller is authenticated but lacks `Action.USE` on the report’s Data Mart.',
+    }),
+    ApiResponse({
+      status: 404,
+      description: 'Report not found in the caller’s project, or its Data Mart is not published.',
+    }),
+    ApiResponse({
+      status: 424,
+      description: 'Storage dependency failed while preparing or reading the report data.',
     })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/external/http-data.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/spec/external/http-data.openapi.spec.ts
@@ -53,24 +53,31 @@ describe('HttpDataController OpenAPI', () => {
     await app.close();
   });
 
-  function streamOperation(): Record<string, any> {
-    const operation = document.paths['/api/external/http-data/data-marts/{dataMartId}.ndjson']?.get;
+  function operationFor(pathNeedle: string): Record<string, any> {
+    const path = Object.keys(document.paths).find(p => p.includes(pathNeedle));
+    expect(path).toBeDefined();
+    const operation = document.paths[path!]?.get;
     expect(operation).toBeDefined();
     return operation as Record<string, any>;
   }
 
-  function parametersByName(): Record<string, Record<string, any>> {
+  function parametersFor(pathNeedle: string): Array<Record<string, any>> {
+    return (operationFor(pathNeedle).parameters ?? []) as Array<Record<string, any>>;
+  }
+
+  function parametersByNameFor(pathNeedle: string): Record<string, Record<string, any>> {
     return Object.fromEntries(
-      (streamOperation().parameters ?? []).map((parameter: Record<string, any>) => [
-        parameter.name,
-        parameter,
-      ])
+      parametersFor(pathNeedle).map((parameter: Record<string, any>) => [parameter.name, parameter])
     );
   }
 
+  function queryParam(name: string): Record<string, any> | undefined {
+    return parametersFor('http-data/data-marts').find(p => p.name === name && p.in === 'query');
+  }
+
   it('publishes the stable HTTP Data operation identity and parameter contract', () => {
-    const operation = streamOperation();
-    const parameters = parametersByName();
+    const operation = operationFor('http-data/data-marts');
+    const parameters = parametersByNameFor('http-data/data-marts');
 
     expect(operation).toMatchObject({
       operationId: 'HttpDataController_stream',
@@ -110,7 +117,7 @@ describe('HttpDataController OpenAPI', () => {
   it.each(['filter', 'sort', 'aggregation', 'dateTrunc'])(
     'publishes %s as an optional bounded base64url string',
     name => {
-      const parameter = parametersByName()[name];
+      const parameter = queryParam(name);
 
       expect(parameter).toMatchObject({
         in: 'query',
@@ -121,12 +128,12 @@ describe('HttpDataController OpenAPI', () => {
           maxLength: 8192,
         },
       });
-      expect(parameter.description).toMatch(/base64url/i);
+      expect(parameter?.description).toMatch(/base64url/i);
     }
   );
 
   it('publishes the NDJSON response, run ID header, and endpoint-specific failures', () => {
-    const responses = streamOperation().responses;
+    const responses = operationFor('http-data/data-marts').responses;
 
     expect(responses['200']).toMatchObject({
       headers: {
@@ -153,5 +160,13 @@ describe('HttpDataController OpenAPI', () => {
     expect(responses['404'].description).toMatch(/not visible.*not published/i);
     expect(responses['424'].description).toMatch(/storage dependency.*provider context/i);
     expect(responses['503'].description).toMatch(/server is shutting down/i);
+  });
+
+  it('documents the report route with only an optional limit query param', () => {
+    const params = parametersFor('http-data/reports');
+    const queryParams = params.filter(p => p.in === 'query');
+    expect(queryParams.map(p => p.name)).toEqual(['limit']);
+    expect(queryParams[0]?.required).toBe(false);
+    expect(params.some(p => p.name === 'reportId' && p.in === 'path')).toBe(true);
   });
 });

--- a/apps/backend/src/data-marts/dto/domain/stream-http-report-data.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/stream-http-report-data.command.ts
@@ -1,0 +1,9 @@
+import type { Role as RoleType } from '@owox/idp-protocol';
+
+export interface StreamHttpReportDataCommand {
+  reportId: string;
+  userId: string;
+  projectId: string;
+  roles: RoleType[];
+  rawQuery: Record<string, unknown>;
+}

--- a/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.spec.ts
+++ b/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.spec.ts
@@ -1,4 +1,8 @@
-import { HTTP_DATA_MAX_ENCODED_PARAM_LENGTH, HttpDataQuerySchema } from './http-data-query.schema';
+import {
+  HTTP_DATA_MAX_ENCODED_PARAM_LENGTH,
+  HttpDataQuerySchema,
+  HttpReportDataQuerySchema,
+} from './http-data-query.schema';
 
 function b64(value: unknown): string {
   return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
@@ -175,5 +179,23 @@ describe('HttpDataQuerySchema — aggregation/dateTrunc require an explicit proj
   it('accepts a plain (unaggregated) request with the columns=* wildcard', () => {
     const result = parse({ columns: '*' });
     expect(result.success).toBe(true);
+  });
+});
+
+describe('HttpReportDataQuerySchema', () => {
+  it('coerces a numeric limit', () => {
+    expect(HttpReportDataQuerySchema.parse({ limit: '5' })).toEqual({ limit: 5 });
+  });
+
+  it('accepts an empty query (no limit)', () => {
+    expect(HttpReportDataQuerySchema.parse({})).toEqual({});
+  });
+
+  it('rejects any key other than limit', () => {
+    expect(HttpReportDataQuerySchema.safeParse({ filter: 'abc' }).success).toBe(false);
+  });
+
+  it('rejects limit below 1', () => {
+    expect(HttpReportDataQuerySchema.safeParse({ limit: '0' }).success).toBe(false);
   });
 });

--- a/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/http-data-query.schema.ts
@@ -81,7 +81,7 @@ const SortParamSchema = makeEncodedConfigParam(SortConfigSchema, 'sort');
 const AggregationParamSchema = makeEncodedConfigParam(AggregationConfigSchema, 'aggregation');
 const DateTruncParamSchema = makeEncodedConfigParam(DateTruncConfigSchema, 'dateTrunc');
 
-const LimitParamSchema = z.coerce
+export const LimitParamSchema = z.coerce
   .number({ invalid_type_error: 'limit must be an integer' })
   .int('limit must be an integer')
   .min(1, 'limit must be ≥ 1');
@@ -178,3 +178,10 @@ export const HttpDataQuerySchema = z
   }));
 
 export type HttpDataQuery = z.infer<typeof HttpDataQuerySchema>;
+
+// Report-level HTTP Data endpoint: the report supplies every output control from its saved config;
+// the only accepted query param is an optional `limit` override. `.strict()` turns any other query
+// key (filter/sort/aggregation/dateTrunc/column/...) into a 400 rather than silently ignoring it.
+export const HttpReportDataQuerySchema = z.object({ limit: LimitParamSchema.optional() }).strict();
+
+export type HttpReportDataQuery = z.infer<typeof HttpReportDataQuerySchema>;

--- a/apps/backend/src/data-marts/dto/schemas/http-data-run-metadata.schema.spec.ts
+++ b/apps/backend/src/data-marts/dto/schemas/http-data-run-metadata.schema.spec.ts
@@ -1,0 +1,17 @@
+import { HttpDataRunMetadataSchema } from './http-data-run-metadata.schema';
+
+describe('HttpDataRunMetadataSchema', () => {
+  it('preserves an executionSqlQuery string', () => {
+    const parsed = HttpDataRunMetadataSchema.parse({
+      format: 'ndjson',
+      columns: ['date'],
+      executionSqlQuery: "SELECT * FROM t WHERE date >= DATE '2026-01-01'",
+    });
+    expect(parsed.executionSqlQuery).toBe("SELECT * FROM t WHERE date >= DATE '2026-01-01'");
+  });
+
+  it('leaves executionSqlQuery undefined when absent', () => {
+    const parsed = HttpDataRunMetadataSchema.parse({ format: 'ndjson', columns: ['date'] });
+    expect(parsed.executionSqlQuery).toBeUndefined();
+  });
+});

--- a/apps/backend/src/data-marts/dto/schemas/http-data-run-metadata.schema.ts
+++ b/apps/backend/src/data-marts/dto/schemas/http-data-run-metadata.schema.ts
@@ -25,9 +25,14 @@ export const HttpDataRunMetadataSchema = z.object({
   rowCount: z.number().int().nonnegative().optional(),
   bytesWritten: z.number().int().nonnegative().optional(),
   completed: z.boolean().optional(),
-  // Grand-total row (one scalar per aggregated metric + Row Count), keyed by output-column
-  // name. Present only for aggregated reports; computed as a separate query at run time.
+  // Grand-total row keyed by output-column name: one scalar per selected metric aggregated over the
+  // full result (every selected numeric field, plus non-numeric fields eligible for Count/Count Unique).
+  // Computed as a SEPARATE best-effort query at run time whenever the result has an eligible metric —
+  // NOT limited to explicitly aggregated reports. Omitted when nothing is eligible or the query fails.
   totals: z.record(z.union([z.number(), z.string(), z.boolean(), z.null()])).optional(),
+  // Fully-composed executed SQL (output controls inlined as literals). Present only for the
+  // report-level HTTP Data endpoint, and only when output controls / blending produced an override.
+  executionSqlQuery: z.string().optional(),
 });
 
 export type HttpDataRunMetadata = z.infer<typeof HttpDataRunMetadataSchema>;

--- a/apps/backend/src/data-marts/mappers/http-data.mapper.spec.ts
+++ b/apps/backend/src/data-marts/mappers/http-data.mapper.spec.ts
@@ -35,3 +35,21 @@ describe('HttpDataMapper', () => {
     expect(command.roles).toEqual([]);
   });
 });
+
+describe('toStreamHttpReportDataCommand', () => {
+  it('maps reportId + auth context + raw query', () => {
+    const mapper = new HttpDataMapper();
+    const command = mapper.toStreamHttpReportDataCommand(
+      'report-1',
+      { userId: 'u1', projectId: 'p1', roles: ['viewer'] },
+      { limit: '5' }
+    );
+    expect(command).toEqual({
+      reportId: 'report-1',
+      userId: 'u1',
+      projectId: 'p1',
+      roles: ['viewer'],
+      rawQuery: { limit: '5' },
+    });
+  });
+});

--- a/apps/backend/src/data-marts/mappers/http-data.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/http-data.mapper.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { AuthorizationContext } from '../../idp/types/auth.types';
 import { StreamHttpDataCommand } from '../dto/domain/stream-http-data.command';
+import { StreamHttpReportDataCommand } from '../dto/domain/stream-http-report-data.command';
 
 @Injectable()
 export class HttpDataMapper {
@@ -11,6 +12,20 @@ export class HttpDataMapper {
   ): StreamHttpDataCommand {
     return {
       dataMartId,
+      userId: ctx.userId,
+      projectId: ctx.projectId,
+      roles: ctx.roles ?? [],
+      rawQuery,
+    };
+  }
+
+  toStreamHttpReportDataCommand(
+    reportId: string,
+    ctx: AuthorizationContext,
+    rawQuery: Record<string, unknown>
+  ): StreamHttpReportDataCommand {
+    return {
+      reportId,
       userId: ctx.userId,
       projectId: ctx.projectId,
       roles: ctx.roles ?? [],

--- a/apps/backend/src/data-marts/services/data-mart-run.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-run.service.ts
@@ -88,6 +88,7 @@ export interface HttpDataRunRecord {
   status: DataMartRunStatus.SUCCESS | DataMartRunStatus.FAILED;
   metadata: HttpDataRunMetadata;
   errors?: string[];
+  reportId?: string;
 }
 
 // Terminal-only MCP_QUERY run: written once at the end (success, failure, or client-abort), no
@@ -570,6 +571,7 @@ export class DataMartRunService {
       runType: RunType.manual,
       status: record.status,
       createdById: record.createdById,
+      reportId: record.reportId ?? null,
       definitionRun: record.dataMart.definition,
       additionalParams: { [HTTP_DATA_PARAMS_KEY]: record.metadata },
       startedAt: record.startedAt,

--- a/apps/backend/src/data-marts/services/http-data/http-data-request-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-request-validator.service.spec.ts
@@ -114,4 +114,28 @@ describe('HttpDataRequestValidator', () => {
       BusinessViolationException
     );
   });
+
+  describe('validateReportQuery', () => {
+    it('parses limit from string', () => {
+      const result = validator.validateReportQuery({ limit: '5' });
+      expect(result).toEqual({ limit: 5 });
+    });
+
+    it('returns an empty result when no limit is provided', () => {
+      const result = validator.validateReportQuery({});
+      expect(result).toEqual({});
+    });
+
+    it('rejects unsupported query params', () => {
+      expect(() => validator.validateReportQuery({ filter: 'x' })).toThrow(
+        BusinessViolationException
+      );
+    });
+
+    it('rejects non-integer or non-positive limit', () => {
+      expect(() => validator.validateReportQuery({ limit: '0' })).toThrow(
+        BusinessViolationException
+      );
+    });
+  });
 });

--- a/apps/backend/src/data-marts/services/http-data/http-data-request-validator.service.ts
+++ b/apps/backend/src/data-marts/services/http-data/http-data-request-validator.service.ts
@@ -1,11 +1,30 @@
 import { Injectable } from '@nestjs/common';
 import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
-import { HttpDataQuery, HttpDataQuerySchema } from '../../dto/schemas/http-data-query.schema';
+import {
+  HttpDataQuery,
+  HttpDataQuerySchema,
+  HttpReportDataQuery,
+  HttpReportDataQuerySchema,
+} from '../../dto/schemas/http-data-query.schema';
 
 @Injectable()
 export class HttpDataRequestValidator {
   validate(rawQuery: Record<string, unknown>): HttpDataQuery {
     const result = HttpDataQuerySchema.safeParse(rawQuery);
+    if (!result.success) {
+      const message = result.error.issues
+        .map(issue => {
+          const path = issue.path.join('.');
+          return path ? `${path}: ${issue.message}` : issue.message;
+        })
+        .join('; ');
+      throw new BusinessViolationException(message);
+    }
+    return result.data;
+  }
+
+  validateReportQuery(rawQuery: Record<string, unknown>): HttpReportDataQuery {
+    const result = HttpReportDataQuerySchema.safeParse(rawQuery);
     if (!result.success) {
       const message = result.error.issues
         .map(issue => {

--- a/apps/backend/src/data-marts/use-cases/query-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/query-data-mart.service.spec.ts
@@ -483,7 +483,7 @@ describe('QueryDataMartService', () => {
       expect(call.metadata.rowCount).toBe(2);
     });
 
-    it('records a FAILED run and rethrows when reading throws', async () => {
+    it('rethrows without recording a run when reading throws', async () => {
       const { service, reader, dataMartRunService } = createService();
       reader.readReportDataBatch.mockRejectedValue(new Error('read boom'));
 
@@ -500,16 +500,10 @@ describe('QueryDataMartService', () => {
         )
       ).rejects.toThrow('read boom');
 
-      expect(dataMartRunService.recordMcpQueryRun).toHaveBeenCalledTimes(1);
-      const call = dataMartRunService.recordMcpQueryRun.mock.calls[0][0];
-      expect(call.status).toBe(DataMartRunStatus.FAILED);
-      expect(call.errors).toContain('read boom');
-      expect(call.metadata.columns).toEqual([]);
-      expect(call.metadata.rowCount).toBe(0);
-      expect(call.metadata.truncated).toBe(false);
+      expect(dataMartRunService.recordMcpQueryRun).not.toHaveBeenCalled();
     });
 
-    it('records a FAILED run and rethrows when compose throws (compose-time reject, e.g. unknown field)', async () => {
+    it('rethrows without recording a run when compose throws (compose-time reject, e.g. unknown field)', async () => {
       const { service, composer, reader, dataMartRunService, readerResolver } = createService();
       composer.compose.mockRejectedValue(new Error('unknown column: nope_field'));
 
@@ -526,10 +520,7 @@ describe('QueryDataMartService', () => {
         )
       ).rejects.toThrow('unknown column: nope_field');
 
-      expect(dataMartRunService.recordMcpQueryRun).toHaveBeenCalledTimes(1);
-      const call = dataMartRunService.recordMcpQueryRun.mock.calls[0][0];
-      expect(call.status).toBe(DataMartRunStatus.FAILED);
-      expect(call.errors).toContain('unknown column: nope_field');
+      expect(dataMartRunService.recordMcpQueryRun).not.toHaveBeenCalled();
       expect(readerResolver.resolve).not.toHaveBeenCalled();
       expect(reader.finalize).not.toHaveBeenCalled();
     });
@@ -582,33 +573,6 @@ describe('QueryDataMartService', () => {
       expect(call.metadata.query).not.toHaveProperty('filters');
       expect(call.metadata.query).not.toHaveProperty('aggregations');
       expect(call.metadata.query).not.toHaveProperty('dateBuckets');
-    });
-
-    it('includes query payload in FAILED run metadata', async () => {
-      const { service, reader, dataMartRunService } = createService();
-      reader.readReportDataBatch.mockRejectedValue(new Error('read boom'));
-
-      await expect(
-        service.run(
-          new QueryDataMartCommand({
-            projectId: 'p1',
-            userId: 'u1',
-            roles: ['admin'],
-            dataMartId: 'dm1',
-            fields: ['channel'],
-            limit: 100,
-            filterConfig: [{ column: 'channel', operator: 'eq', value: 'paid' }] as never,
-          })
-        )
-      ).rejects.toThrow('read boom');
-
-      const call = dataMartRunService.recordMcpQueryRun.mock.calls[0][0];
-      expect(call.status).toBe(DataMartRunStatus.FAILED);
-      expect(call.metadata.query).toEqual({
-        fields: ['channel'],
-        filters: [{ column: 'channel', operator: 'eq', value: 'paid' }],
-        limit: 100,
-      });
     });
 
     it('does not include row values in run metadata', async () => {
@@ -806,7 +770,7 @@ describe('QueryDataMartService', () => {
       expect(consumptionTrackingService.registerMcpQueryRunConsumption).not.toHaveBeenCalled();
     });
 
-    it('throws QueryTimeoutError past the deadline, records FAILED, and does NOT bill', async () => {
+    it('rethrows QueryTimeoutError past the deadline without recording a run, and does NOT bill', async () => {
       const { service, reader, dataMartRunService, consumptionTrackingService } = createService({
         deadlineMs: 20,
       });
@@ -831,10 +795,8 @@ describe('QueryDataMartService', () => {
         )
       ).rejects.toBeInstanceOf(QueryTimeoutError);
 
-      // Recorded FAILED (audit trail), but billing is skipped — a timed-out query is never charged.
-      const call = dataMartRunService.recordMcpQueryRun.mock.calls[0][0];
-      expect(call.status).toBe(DataMartRunStatus.FAILED);
-      expect(call.errors[0]).toContain('timed out');
+      // No run recorded, and billing is skipped — a timed-out query is never charged.
+      expect(dataMartRunService.recordMcpQueryRun).not.toHaveBeenCalled();
       expect(consumptionTrackingService.registerMcpQueryRunConsumption).not.toHaveBeenCalled();
 
       // Settle the abandoned read so it does not linger past the test (Phase 2 adds real cancel).
@@ -863,31 +825,10 @@ describe('QueryDataMartService', () => {
       // A successful read is still billed even though totals degraded.
       expect(consumptionTrackingService.registerMcpQueryRunConsumption).toHaveBeenCalledTimes(1);
     });
-
-    it('rethrows the ORIGINAL read error, not the audit error, when the FAILED run write also rejects', async () => {
-      const { service, reader, dataMartRunService } = createService();
-      reader.readReportDataBatch.mockRejectedValue(new Error('read boom'));
-      dataMartRunService.recordMcpQueryRun.mockRejectedValue(new Error('audit write boom'));
-
-      await expect(
-        service.run(
-          new QueryDataMartCommand({
-            projectId: 'p1',
-            userId: 'u1',
-            roles: ['admin'],
-            dataMartId: 'dm1',
-            fields: ['channel'],
-            limit: 100,
-          })
-        )
-      ).rejects.toThrow('read boom');
-
-      expect(reader.finalize).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('client abort (Phase 2)', () => {
-    it('rejects with QueryAbortedError before any read or billing when already aborted, records CANCELLED', async () => {
+    it('rejects with QueryAbortedError before any read or billing when already aborted, without recording a run', async () => {
       const { service, reader, dataMartRunService, consumptionTrackingService } = createService();
       const controller = new AbortController();
       controller.abort();
@@ -910,12 +851,11 @@ describe('QueryDataMartService', () => {
       expect(reader.prepareReportData).not.toHaveBeenCalled();
       expect(reader.readReportDataBatch).not.toHaveBeenCalled();
       expect(consumptionTrackingService.registerMcpQueryRunConsumption).not.toHaveBeenCalled();
-      // …but the run is still recorded CANCELLED (not FAILED) for the audit trail.
-      const call = dataMartRunService.recordMcpQueryRun.mock.calls[0][0];
-      expect(call.status).toBe(DataMartRunStatus.CANCELLED);
+      // …and no run is recorded at all.
+      expect(dataMartRunService.recordMcpQueryRun).not.toHaveBeenCalled();
     });
 
-    it('rejects with QueryAbortedError, records CANCELLED, and does NOT bill when aborted during the read', async () => {
+    it('rejects with QueryAbortedError without recording a run, and does NOT bill when aborted during the read', async () => {
       const { service, reader, dataMartRunService, consumptionTrackingService } = createService();
       const controller = new AbortController();
 
@@ -943,8 +883,7 @@ describe('QueryDataMartService', () => {
         )
       ).rejects.toBeInstanceOf(QueryAbortedError);
 
-      const call = dataMartRunService.recordMcpQueryRun.mock.calls[0][0];
-      expect(call.status).toBe(DataMartRunStatus.CANCELLED);
+      expect(dataMartRunService.recordMcpQueryRun).not.toHaveBeenCalled();
       expect(consumptionTrackingService.registerMcpQueryRunConsumption).not.toHaveBeenCalled();
 
       // Settle the abandoned read so it does not linger past the test (no real cancel in Phase 2).

--- a/apps/backend/src/data-marts/use-cases/query-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/query-data-mart.service.ts
@@ -317,34 +317,6 @@ export class QueryDataMartService {
         },
         executedSql: executionSqlQuery,
       };
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      const status =
-        err instanceof QueryAbortedError ? DataMartRunStatus.CANCELLED : DataMartRunStatus.FAILED;
-      try {
-        await this.dataMartRunService.recordMcpQueryRun({
-          runId,
-          dataMart,
-          createdById: r.userId,
-          startedAt,
-          status,
-          metadata: {
-            columns: [],
-            rowCount: 0,
-            truncated: false,
-            executionSqlQuery,
-            filterCount: r.filterConfig?.length,
-            aggregationCount: r.aggregationConfig?.length,
-            query: queryMetadata,
-          },
-          errors: [errorMessage],
-        });
-      } catch (auditErr) {
-        this.logger.warn(
-          `recordMcpQueryRun (FAILED) failed; swallowing: ${auditErr instanceof Error ? auditErr.message : String(auditErr)}`
-        );
-      }
-      throw err;
     } finally {
       if (deadlineTimer) clearTimeout(deadlineTimer);
       // The SDK reuses one signal across the request — detach so nothing outlives this run.

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.spec.ts
@@ -7,6 +7,7 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import type { Response } from 'express';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { GracefulShutdownService } from '../../common/scheduler/services/graceful-shutdown.service';
 import { SystemTimeService } from '../../common/scheduler/services/system-time.service';
 import { TypeResolver } from '../../common/resolver/type-resolver';
@@ -28,12 +29,14 @@ import { DataMartRunService } from '../services/data-mart-run.service';
 import { DataMartService } from '../services/data-mart.service';
 import { ProjectBalanceService } from '../services/project-balance.service';
 import { ReportSqlComposerService } from '../services/report-sql-composer.service';
+import { ReportService } from '../services/report.service';
 import { ReportTotalsService } from '../services/report-totals.service';
 import { HttpDataColumnResolver } from '../services/http-data/http-data-column-resolver.service';
 import { HttpDataColumnValidator } from '../services/http-data/http-data-column-validator.service';
 import { HttpDataRequestValidator } from '../services/http-data/http-data-request-validator.service';
 import { HttpDataStreamWriter } from '../services/http-data/http-data-stream-writer.service';
 import { HTTP_DATA_SCHEMA_EXPIRES_AFTER_MS } from '../services/http-data/http-data.constants';
+import { StreamHttpReportDataCommand } from '../dto/domain/stream-http-report-data.command';
 import { StreamHttpDataService } from './stream-http-data.service';
 
 function fakeCommand(overrides: Partial<StreamHttpDataCommand> = {}): StreamHttpDataCommand {
@@ -186,6 +189,7 @@ describe('StreamHttpDataService', () => {
   let errorMapper: jest.Mocked<DataStorageErrorMapper>;
   let errorMapperResolver: jest.Mocked<TypeResolver<DataStorageType, DataStorageErrorMapper>>;
   let reportTotals: jest.Mocked<ReportTotalsService>;
+  let reportService: jest.Mocked<ReportService>;
   let service: StreamHttpDataService;
 
   beforeEach(() => {
@@ -200,6 +204,10 @@ describe('StreamHttpDataService', () => {
         limit: undefined,
       })),
     } as unknown as jest.Mocked<HttpDataRequestValidator>;
+
+    requestValidator.validateReportQuery = jest.fn((rawQuery: Record<string, unknown>) => ({
+      limit: rawQuery.limit === undefined ? undefined : Number(rawQuery.limit),
+    })) as never;
 
     columnResolver = {
       resolve: jest.fn((selector, columns) =>
@@ -251,6 +259,10 @@ describe('StreamHttpDataService', () => {
       compose: jest.fn(async () => ({ sql: 'SELECT * FROM t LIMIT 3' })),
     } as unknown as jest.Mocked<ReportSqlComposerService>;
 
+    sqlComposer.inlineStaticSql = jest.fn(
+      () => "SELECT * FROM t WHERE date >= DATE '2026-01-01'"
+    ) as never;
+
     balance = {
       verifyCanPerformOperations: jest.fn(async () => undefined),
     } as unknown as jest.Mocked<ProjectBalanceService>;
@@ -300,6 +312,20 @@ describe('StreamHttpDataService', () => {
       computeTotals: jest.fn(async () => null),
     } as unknown as jest.Mocked<ReportTotalsService>;
 
+    reportService = {
+      getByIdAndProjectId: jest.fn(async () => ({
+        id: 'report-1',
+        dataMart: { id: 'dm-1' },
+        columnConfig: ['date', 'revenue'],
+        filterConfig: [{ column: 'date', operator: 'gte', value: '2026-01-01' }],
+        sortConfig: null,
+        aggregationConfig: null,
+        dateTruncConfig: null,
+        uniqueCountConfig: null,
+        limitConfig: null,
+      })),
+    } as unknown as jest.Mocked<ReportService>;
+
     service = new StreamHttpDataService(
       requestValidator,
       columnResolver,
@@ -317,7 +343,8 @@ describe('StreamHttpDataService', () => {
       systemTime,
       readerResolver,
       errorMapperResolver,
-      reportTotals
+      reportTotals,
+      reportService
     );
   });
 
@@ -978,7 +1005,10 @@ describe('StreamHttpDataService', () => {
     );
   });
 
-  it('throws and records no run when blending is required but no blended SQL is produced', async () => {
+  it('throws and records a FAILED run when blending is required but no blended SQL is produced', async () => {
+    // baseMetadata is seeded right after verifyCanPerformOperations (before resolveBlendingDecision),
+    // so this guard now throws AFTER the seed and records a FAILED run — consistent with every other
+    // execution-phase failure recording a run.
     blended.resolveBlendingDecision.mockResolvedValueOnce({
       needsBlending: true,
       blendedSql: undefined,
@@ -987,6 +1017,263 @@ describe('StreamHttpDataService', () => {
     await expect(service.stream(fakeCommand(), mockResponse())).rejects.toBeInstanceOf(
       InternalServerErrorException
     );
-    expect(dataMartRunService.recordHttpDataRun).not.toHaveBeenCalled();
+    expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledTimes(1);
+    expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: DataMartRunStatus.FAILED,
+        metadata: expect.objectContaining({ completed: false }),
+        errors: expect.arrayContaining([
+          expect.stringContaining('Blended SQL was not produced for this Data Mart'),
+        ]),
+      })
+    );
+  });
+
+  function fakeReportCommand(
+    overrides: Partial<StreamHttpReportDataCommand> = {}
+  ): StreamHttpReportDataCommand {
+    return {
+      reportId: 'report-1',
+      userId: 'user-1',
+      projectId: 'proj-1',
+      roles: ['viewer'],
+      rawQuery: {},
+      ...overrides,
+    };
+  }
+
+  describe('streamReport', () => {
+    it('streams a report and records a SUCCESS run tagged with reportId + executionSqlQuery', async () => {
+      const res = mockResponse();
+      await service.streamReport(fakeReportCommand(), res);
+
+      expect(reportService.getByIdAndProjectId).toHaveBeenCalledWith('report-1', 'proj-1');
+      expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: DataMartRunStatus.SUCCESS,
+          reportId: 'report-1',
+          metadata: expect.objectContaining({
+            completed: true,
+            executionSqlQuery: "SELECT * FROM t WHERE date >= DATE '2026-01-01'",
+          }),
+        })
+      );
+    });
+
+    it('rejects with NotFoundException for a report belonging to another project, and does no work', async () => {
+      // reportService.getByIdAndProjectId inner-joins on dataMart.projectId, so a report from
+      // another project (or an unknown id) resolves to nothing and throws 404 — identical to the
+      // unknown-report-id case. No run is recorded and the Data Mart is never even loaded.
+      reportService.getByIdAndProjectId.mockRejectedValueOnce(
+        new NotFoundException('Report with id report-1 not found')
+      );
+
+      await expect(
+        service.streamReport(fakeReportCommand(), mockResponse())
+      ).rejects.toBeInstanceOf(NotFoundException);
+
+      expect(dataMartRunService.recordHttpDataRun).not.toHaveBeenCalled();
+      expect(dataMartService.getByIdAndProjectId).not.toHaveBeenCalled();
+      expect(readerResolver.resolve).not.toHaveBeenCalled();
+    });
+
+    it('records no run when the project balance gate rejects', async () => {
+      // baseMetadata is seeded right after verifyCanPerformOperations (see executeStream), so a
+      // rejection here happens BEFORE the seed — unlike every execution-phase failure (config
+      // drift, missing blended SQL, storage errors), this records no run at all.
+      balance.verifyCanPerformOperations.mockRejectedValueOnce(
+        new BusinessViolationException('Project balance is insufficient to run this operation')
+      );
+
+      await expect(service.streamReport(fakeReportCommand(), mockResponse())).rejects.toThrow(
+        'Project balance is insufficient to run this operation'
+      );
+
+      expect(dataMartRunService.recordHttpDataRun).not.toHaveBeenCalled();
+    });
+
+    it('records a FAILED run tagged with reportId when prepareReportData fails', async () => {
+      reader.prepareReportData.mockRejectedValueOnce(new Error('schema mismatch'));
+      const res = mockResponse();
+
+      await expect(service.streamReport(fakeReportCommand(), res)).rejects.toMatchObject({
+        status: HttpStatus.FAILED_DEPENDENCY,
+      });
+      expect(res._writes).toHaveLength(0);
+      expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: DataMartRunStatus.FAILED,
+          reportId: 'report-1',
+          metadata: expect.objectContaining({ completed: false }),
+          errors: expect.arrayContaining([
+            expect.stringContaining('Storage dependency failed while reading this Data Mart data'),
+          ]),
+        })
+      );
+    });
+
+    it('records a FAILED run tagged with reportId when resolveBlendingDecision rejects (config drift)', async () => {
+      // A saved columnConfig referencing a since-deleted column makes validateForReport throw inside
+      // resolveBlendingDecision. baseMetadata is seeded before this call, so the failure still records
+      // a FAILED run (and the x-owox-run-id) instead of silently recording nothing.
+      blended.resolveBlendingDecision.mockRejectedValueOnce(
+        new Error('Report references a column that no longer exists on the Data Mart')
+      );
+      const res = mockResponse();
+
+      await expect(service.streamReport(fakeReportCommand(), res)).rejects.toThrow(
+        'Report references a column that no longer exists on the Data Mart'
+      );
+
+      expect(res._writes).toHaveLength(0);
+      expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledTimes(1);
+      expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: DataMartRunStatus.FAILED,
+          reportId: 'report-1',
+          metadata: expect.objectContaining({ completed: false }),
+          errors: expect.arrayContaining([
+            expect.stringContaining('Report references a column that no longer exists'),
+          ]),
+        })
+      );
+    });
+
+    it('streams and records a SUCCESS run without executionSqlQuery when SQL inlining throws', async () => {
+      sqlComposer.inlineStaticSql.mockImplementationOnce(() => {
+        throw new Error('inliner boom');
+      });
+      const res = mockResponse();
+
+      await expect(service.streamReport(fakeReportCommand(), res)).resolves.toBeUndefined();
+
+      expect(res._writes.length).toBeGreaterThan(0);
+      expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: DataMartRunStatus.SUCCESS,
+          metadata: expect.not.objectContaining({ executionSqlQuery: expect.anything() }),
+        })
+      );
+    });
+
+    it('overrides the saved report limitConfig with ?limit= when a limit is provided', async () => {
+      reportService.getByIdAndProjectId.mockResolvedValueOnce({
+        id: 'report-1',
+        dataMart: { id: 'dm-1' },
+        columnConfig: ['date', 'revenue'],
+        filterConfig: [{ column: 'date', operator: 'gte', value: '2026-01-01' }],
+        sortConfig: null,
+        aggregationConfig: null,
+        dateTruncConfig: null,
+        uniqueCountConfig: null,
+        limitConfig: 50,
+      } as never);
+
+      await service.streamReport(fakeReportCommand({ rawQuery: { limit: '7' } }), mockResponse());
+
+      expect(sqlComposer.compose).toHaveBeenCalledWith(
+        expect.objectContaining({ limitConfig: 7 }),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('falls back to the saved report limitConfig when no ?limit= is provided', async () => {
+      reportService.getByIdAndProjectId.mockResolvedValueOnce({
+        id: 'report-1',
+        dataMart: { id: 'dm-1' },
+        columnConfig: ['date', 'revenue'],
+        filterConfig: [{ column: 'date', operator: 'gte', value: '2026-01-01' }],
+        sortConfig: null,
+        aggregationConfig: null,
+        dateTruncConfig: null,
+        uniqueCountConfig: null,
+        limitConfig: 50,
+      } as never);
+
+      await service.streamReport(fakeReportCommand(), mockResponse());
+
+      expect(sqlComposer.compose).toHaveBeenCalledWith(
+        expect.objectContaining({ limitConfig: 50 }),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('resolves limitConfig to null when neither ?limit= nor a saved limit is present', async () => {
+      reportService.getByIdAndProjectId.mockResolvedValueOnce({
+        id: 'report-1',
+        dataMart: { id: 'dm-1' },
+        columnConfig: ['date', 'revenue'],
+        filterConfig: [{ column: 'date', operator: 'gte', value: '2026-01-01' }],
+        sortConfig: null,
+        aggregationConfig: null,
+        dateTruncConfig: null,
+        uniqueCountConfig: null,
+        limitConfig: null,
+      } as never);
+
+      await service.streamReport(fakeReportCommand(), mockResponse());
+
+      expect(sqlComposer.compose).toHaveBeenCalledWith(
+        expect.objectContaining({ limitConfig: null }),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('returns 403 (no USE on the report Data Mart) and records no run', async () => {
+      access.canAccess.mockResolvedValueOnce(false);
+      await expect(
+        service.streamReport(fakeReportCommand(), mockResponse())
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(dataMartRunService.recordHttpDataRun).not.toHaveBeenCalled();
+    });
+
+    it('records the resolved header names, not [], for an all-columns report (no columnConfig)', async () => {
+      reportService.getByIdAndProjectId.mockResolvedValueOnce({
+        id: 'report-1',
+        dataMart: { id: 'dm-1' },
+        columnConfig: null,
+        filterConfig: null,
+        sortConfig: null,
+        aggregationConfig: null,
+        dateTruncConfig: null,
+        uniqueCountConfig: null,
+        limitConfig: null,
+      } as never);
+      const res = mockResponse();
+
+      await service.streamReport(fakeReportCommand(), res);
+
+      expect(dataMartRunService.recordHttpDataRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: DataMartRunStatus.SUCCESS,
+          metadata: expect.objectContaining({ columns: ['date', 'revenue'] }),
+        })
+      );
+    });
+
+    it('threads uniqueCount into prepareReportData when the report has uniqueCountConfig: true', async () => {
+      reportService.getByIdAndProjectId.mockResolvedValueOnce({
+        id: 'report-1',
+        dataMart: { id: 'dm-1' },
+        columnConfig: ['date', 'revenue'],
+        filterConfig: [{ column: 'date', operator: 'gte', value: '2026-01-01' }],
+        sortConfig: null,
+        aggregationConfig: null,
+        dateTruncConfig: null,
+        uniqueCountConfig: true,
+        limitConfig: null,
+      } as never);
+      const res = mockResponse();
+
+      await service.streamReport(fakeReportCommand(), res);
+
+      expect(reader.prepareReportData).toHaveBeenCalledWith(
+        expect.objectContaining({ uniqueCountConfig: true }),
+        expect.objectContaining({ uniqueCount: true })
+      );
+    });
   });
 });

--- a/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
+++ b/apps/backend/src/data-marts/use-cases/stream-http-data.service.ts
@@ -19,9 +19,11 @@ import {
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { DataStorageErrorMapper } from '../data-storage-types/interfaces/data-storage-error-mapper.interface';
 import { DataStorageReportReader } from '../data-storage-types/interfaces/data-storage-report-reader.interface';
+import { SqlParameter } from '../data-storage-types/utils/sql-clause-renderer';
 import { ReportLikeReadPlan, hasOutputControls } from '../dto/domain/report-like-read-plan';
 import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
 import { StreamHttpDataCommand } from '../dto/domain/stream-http-data.command';
+import { StreamHttpReportDataCommand } from '../dto/domain/stream-http-report-data.command';
 import { DataMart } from '../entities/data-mart.entity';
 import { DataMartStatus } from '../enums/data-mart-status.enum';
 import { Action, EntityType } from '../services/access-decision/access-decision.types';
@@ -31,6 +33,7 @@ import { ConsumptionTrackingService } from '../services/consumption-tracking.ser
 import { DataMartService } from '../services/data-mart.service';
 import { ProjectBalanceService } from '../services/project-balance.service';
 import { ReportSqlComposerService } from '../services/report-sql-composer.service';
+import { ReportService } from '../services/report.service';
 import { ReportTotals, ReportTotalsService } from '../services/report-totals.service';
 import { HttpDataColumnResolver } from '../services/http-data/http-data-column-resolver.service';
 import { HttpDataColumnValidator } from '../services/http-data/http-data-column-validator.service';
@@ -62,6 +65,48 @@ class StreamCancelledError extends Error {
   override readonly name = 'StreamCancelledError';
 }
 
+// Discriminates the two executeStream callers instead of a loose bag of co-varying fields
+// (projectionColumns: null sentinel, optional reportId/captureExecutionSql).
+type ExecuteStreamPlan =
+  | { kind: 'data-mart'; readPlan: ReportLikeReadPlan; columns: string[] }
+  | { kind: 'report'; readPlan: ReportLikeReadPlan; reportId: string; savedColumns: string[] };
+
+// Exhaustiveness guard: if a 3rd ExecuteStreamPlan kind is ever added, the switch in executeStream
+// that doesn't handle it fails to compile here instead of silently falling through at runtime.
+function assertNever(value: never): never {
+  throw new Error(`Unhandled ExecuteStreamPlan kind: ${JSON.stringify(value)}`);
+}
+
+// Per-kind values derived once from the discriminated plan; the rest of executeStream reads these
+// locals instead of re-inspecting plan.kind at each usage site.
+interface StreamPlanContext {
+  metadataColumns: string[];
+  reportId: string | undefined;
+  captureExecutionSql: boolean;
+  projectsByResolvedHeaders: boolean;
+}
+
+function deriveStreamPlanContext(plan: ExecuteStreamPlan): StreamPlanContext {
+  switch (plan.kind) {
+    case 'data-mart':
+      return {
+        metadataColumns: plan.columns,
+        reportId: undefined,
+        captureExecutionSql: false,
+        projectsByResolvedHeaders: false,
+      };
+    case 'report':
+      return {
+        metadataColumns: plan.savedColumns,
+        reportId: plan.reportId,
+        captureExecutionSql: true,
+        projectsByResolvedHeaders: true,
+      };
+    default:
+      return assertNever(plan);
+  }
+}
+
 @Injectable()
 export class StreamHttpDataService {
   private readonly logger = new Logger(StreamHttpDataService.name);
@@ -85,7 +130,8 @@ export class StreamHttpDataService {
     private readonly readerResolver: TypeResolver<DataStorageType, DataStorageReportReader>,
     @Inject(DATA_STORAGE_ERROR_MAPPER_RESOLVER)
     private readonly errorMapperResolver: TypeResolver<DataStorageType, DataStorageErrorMapper>,
-    private readonly reportTotalsService: ReportTotalsService
+    private readonly reportTotalsService: ReportTotalsService,
+    private readonly reportService: ReportService
   ) {}
 
   async stream(command: StreamHttpDataCommand, res: Response): Promise<void> {
@@ -103,11 +149,113 @@ export class StreamHttpDataService {
     const accessor: BlendableSchemaAccessor = { userId: ctx.userId, roles: ctx.roles ?? [] };
 
     const dataMart = await this.loadAccessibleDataMart(command.dataMartId, ctx);
-    const runId = randomUUID();
-    const startedAt = this.systemTimeService.now();
+
+    await this.executeStream({
+      dataMart,
+      accessor,
+      userId: ctx.userId,
+      res,
+      runId: randomUUID(),
+      startedAt: this.systemTimeService.now(),
+      buildPlan: async currentDataMart => {
+        const blendableSchema = await this.blendableSchemaService.computeBlendableSchema(
+          currentDataMart.id,
+          currentDataMart.projectId,
+          accessor
+        );
+        const reportingColumns: ReportingColumns = {
+          native: nativeColumnNames(blendableSchema),
+          blended: visibleBlendedColumnNames(blendableSchema),
+        };
+        const columns = this.columnResolver.resolve(query.columnSelector, reportingColumns);
+        this.columnValidator.validate(
+          {
+            selectedColumns: columns,
+            filter: query.filter,
+            sort: query.sort,
+            aggregation: query.aggregation,
+            dateTrunc: query.dateTrunc,
+          },
+          reportingColumns
+        );
+
+        const readPlan: ReportLikeReadPlan = {
+          dataMart: currentDataMart,
+          columnConfig: columns,
+          filterConfig: query.filter,
+          sortConfig: query.sort,
+          aggregationConfig: query.aggregation,
+          dateTruncConfig: query.dateTrunc,
+          limitConfig: limit ?? null,
+        };
+
+        return { kind: 'data-mart', readPlan, columns };
+      },
+    });
+  }
+
+  async streamReport(command: StreamHttpReportDataCommand, res: Response): Promise<void> {
+    if (this.gracefulShutdownService.isInShutdownMode()) {
+      throw new ServiceUnavailableException('Server is shutting down');
+    }
+
+    const { limit } = this.requestValidator.validateReportQuery(command.rawQuery);
+    const ctx: AuthorizationContext = {
+      userId: command.userId,
+      projectId: command.projectId,
+      roles: command.roles,
+    };
+    const accessor: BlendableSchemaAccessor = { userId: ctx.userId, roles: ctx.roles ?? [] };
+
+    const report = await this.reportService.getByIdAndProjectId(
+      command.reportId,
+      command.projectId
+    );
+    const dataMart = await this.loadAccessibleDataMart(report.dataMart.id, ctx);
+
+    await this.executeStream({
+      dataMart,
+      accessor,
+      userId: ctx.userId,
+      res,
+      runId: randomUUID(),
+      startedAt: this.systemTimeService.now(),
+      buildPlan: async currentDataMart => {
+        const readPlan: ReportLikeReadPlan = {
+          dataMart: currentDataMart,
+          columnConfig: report.columnConfig ?? undefined,
+          filterConfig: report.filterConfig ?? undefined,
+          sortConfig: report.sortConfig ?? undefined,
+          aggregationConfig: report.aggregationConfig ?? undefined,
+          dateTruncConfig: report.dateTruncConfig ?? undefined,
+          uniqueCountConfig: report.uniqueCountConfig ?? undefined,
+          limitConfig: limit ?? report.limitConfig ?? null,
+        };
+
+        return {
+          kind: 'report',
+          readPlan,
+          reportId: report.id,
+          savedColumns: report.columnConfig ?? [],
+        };
+      },
+    });
+  }
+
+  private async executeStream(params: {
+    dataMart: DataMart;
+    accessor: BlendableSchemaAccessor;
+    userId: string;
+    res: Response;
+    runId: string;
+    startedAt: Date;
+    buildPlan: (dataMart: DataMart) => Promise<ExecuteStreamPlan>;
+  }): Promise<void> {
+    const { dataMart, accessor, userId, res, runId, startedAt, buildPlan } = params;
 
     let reader: DataStorageReportReader | null = null;
     let baseMetadata: HttpDataRunMetadata | null = null;
+    let reportId: string | undefined;
     let schemaActualizationInProgress = false;
 
     try {
@@ -117,36 +265,27 @@ export class StreamHttpDataService {
         HTTP_DATA_SCHEMA_EXPIRES_AFTER_MS
       );
       schemaActualizationInProgress = false;
-      const blendableSchema = await this.blendableSchemaService.computeBlendableSchema(
-        dataMart.id,
-        dataMart.projectId,
-        accessor
-      );
-      const reportingColumns: ReportingColumns = {
-        native: nativeColumnNames(blendableSchema),
-        blended: visibleBlendedColumnNames(blendableSchema),
-      };
-      const columns = this.columnResolver.resolve(query.columnSelector, reportingColumns);
-      this.columnValidator.validate(
-        {
-          selectedColumns: columns,
-          filter: query.filter,
-          sort: query.sort,
-          aggregation: query.aggregation,
-          dateTrunc: query.dateTrunc,
-        },
-        reportingColumns
-      );
+
+      const plan = await buildPlan(dataMart);
+      const { readPlan } = plan;
+      const planContext = deriveStreamPlanContext(plan);
+      const { metadataColumns, captureExecutionSql, projectsByResolvedHeaders } = planContext;
+      reportId = planContext.reportId;
+
       await this.projectBalanceService.verifyCanPerformOperations(dataMart.projectId);
 
-      const readPlan: ReportLikeReadPlan = {
-        dataMart,
-        columnConfig: columns,
-        filterConfig: query.filter,
-        sortConfig: query.sort,
-        aggregationConfig: query.aggregation,
-        dateTruncConfig: query.dateTrunc,
-        limitConfig: limit ?? null,
+      // Seeded here (before blending is resolved) so any failure from this point on — including a
+      // report config-drift error inside resolveBlendingDecision, or the missing-blended-SQL guard
+      // below — records a FAILED run with an x-owox-run-id. Pre-execution gates (buildPlan throwing,
+      // or verifyCanPerformOperations rejecting) still throw before this point and record no run.
+      baseMetadata = {
+        format: HTTP_DATA_FORMAT,
+        columns: metadataColumns,
+        filter: readPlan.filterConfig ?? undefined,
+        sort: readPlan.sortConfig ?? undefined,
+        aggregation: readPlan.aggregationConfig ?? undefined,
+        dateTrunc: readPlan.dateTruncConfig ?? undefined,
+        limit: readPlan.limitConfig ?? undefined,
       };
 
       const decision = await this.blendedReportDataService.resolveBlendingDecision(
@@ -166,15 +305,13 @@ export class StreamHttpDataService {
         sqlOverrideParams = composed.params;
       }
 
-      baseMetadata = {
-        format: HTTP_DATA_FORMAT,
-        columns,
-        filter: query.filter,
-        sort: query.sort,
-        aggregation: query.aggregation,
-        dateTrunc: query.dateTrunc,
-        limit,
-      };
+      const executionSqlQuery = captureExecutionSql
+        ? this.tryInlineExecutedSql(dataMart, sqlOverride, sqlOverrideParams)
+        : undefined;
+
+      if (executionSqlQuery) {
+        baseMetadata.executionSqlQuery = executionSqlQuery;
+      }
 
       reader = await this.readerResolver.resolve(dataMart.storage.type);
       const description = await reader.prepareReportData(readPlan, {
@@ -183,23 +320,21 @@ export class StreamHttpDataService {
         columnFilter: decision.columnFilter,
         blendedDataHeaders: decision.blendedDataHeaders,
         aggregationConfig: readPlan.aggregationConfig ?? undefined,
+        uniqueCount: readPlan.uniqueCountConfig ?? undefined,
       });
 
-      // Grand totals are a SEPARATE DWH query bridged to the client via x-owox-run-id
-      // (no extra header in v1). Computed BEFORE streamRows: NDJSON headers cannot change
-      // once the first chunk is flushed. BEST-EFFORT — a failure must never break the stream.
+      // Grand totals are a SEPARATE DWH query bridged to the client via x-owox-run-id. Computed
+      // BEFORE streamRows: NDJSON headers cannot change once the first chunk is flushed. BEST-EFFORT.
       const totals = await this.computeTotalsBestEffort(readPlan, accessor, dataMart);
 
-      // An aggregation renames each aggregated column's header to its "<column> | <FN>" output
-      // label and appends Row Count, so the resolved headers no longer match the raw requested
-      // column names. Project by the resolved header names in that case (mirroring the report
-      // reader / query_data_mart), else the aggregated metric would stream as null and Row Count
-      // would be dropped. A plain or date-bucketed-only request keeps the requested-column
-      // projection (its headers are unchanged), preserving the "requested names as keys" contract.
+      // Aggregated reports rename headers to "<column> | <FN>" and append Row Count, so project by
+      // the resolved header names. A report always projects by resolved headers — correct for both
+      // an explicit columnConfig and a null (all-columns) config.
+      const aggregated = (readPlan.aggregationConfig?.length ?? 0) > 0;
       const outputColumns =
-        (readPlan.aggregationConfig?.length ?? 0) > 0
+        projectsByResolvedHeaders || aggregated
           ? description.dataHeaders.map(header => header.name)
-          : columns;
+          : metadataColumns;
 
       const { rowCount, bytesWritten } = await this.streamRows(
         res,
@@ -209,14 +344,30 @@ export class StreamHttpDataService {
         runId
       );
 
-      await this.recordSuccessfulRun(dataMart, ctx.userId, runId, startedAt, {
-        ...baseMetadata,
-        dataDescription: this.toMetadataDataDescription(description.dataHeaders),
-        rowCount,
-        bytesWritten,
-        completed: true,
-        ...(totals ? { totals } : {}),
-      });
+      // F2: an all-columns report has no explicit columnConfig, so the plan's metadata columns are
+      // empty; fall back to the resolved header names now that they're known. The data-mart path
+      // always has explicit resolved columns, so its recorded columns are left untouched.
+      const runColumns =
+        projectsByResolvedHeaders && metadataColumns.length === 0
+          ? description.dataHeaders.map(h => h.name)
+          : metadataColumns;
+
+      await this.recordSuccessfulRun(
+        dataMart,
+        userId,
+        runId,
+        startedAt,
+        {
+          ...baseMetadata,
+          columns: runColumns,
+          dataDescription: this.toMetadataDataDescription(description.dataHeaders),
+          rowCount,
+          bytesWritten,
+          completed: true,
+          ...(totals ? { totals } : {}),
+        },
+        reportId
+      );
 
       res.end();
     } catch (error) {
@@ -230,16 +381,39 @@ export class StreamHttpDataService {
       if (baseMetadata) {
         await this.recordFailedRun(
           dataMart,
-          ctx.userId,
+          userId,
           runId,
           startedAt,
           { ...baseMetadata, completed: false },
-          mappedError
+          mappedError,
+          reportId
         );
       }
       this.handleStreamFailure(res, mappedError);
     } finally {
       if (reader) await this.safelyFinalizeReader(reader);
+    }
+  }
+
+  private tryInlineExecutedSql(
+    dataMart: DataMart,
+    sqlOverride: string | undefined,
+    sqlOverrideParams: SqlParameter[] | undefined
+  ): string | undefined {
+    if (!sqlOverride) {
+      return undefined;
+    }
+    try {
+      return this.reportSqlComposerService.inlineStaticSql(
+        dataMart.storage.type,
+        sqlOverride,
+        sqlOverrideParams
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to inline executed SQL for HTTP Data run: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return undefined;
     }
   }
 
@@ -282,7 +456,8 @@ export class StreamHttpDataService {
     createdById: string,
     runId: string,
     startedAt: Date,
-    metadata: HttpDataRunMetadata
+    metadata: HttpDataRunMetadata,
+    reportId?: string
   ): Promise<void> {
     try {
       await this.dataMartRunService.recordHttpDataRun({
@@ -292,6 +467,7 @@ export class StreamHttpDataService {
         startedAt,
         status: DataMartRunStatus.SUCCESS,
         metadata,
+        reportId,
       });
     } catch (err) {
       this.logger.error(
@@ -315,7 +491,8 @@ export class StreamHttpDataService {
     runId: string,
     startedAt: Date,
     metadata: HttpDataRunMetadata,
-    error: unknown
+    error: unknown,
+    reportId?: string
   ): Promise<void> {
     const message = this.clientFacingErrorMessage(error);
     try {
@@ -327,6 +504,7 @@ export class StreamHttpDataService {
         status: DataMartRunStatus.FAILED,
         metadata,
         errors: [message],
+        reportId,
       });
     } catch (err) {
       this.logger.warn(

--- a/apps/backend/test/http-data-report-cross-project.e2e-spec.ts
+++ b/apps/backend/test/http-data-report-cross-project.e2e-spec.ts
@@ -1,0 +1,151 @@
+import { INestApplication } from '@nestjs/common';
+import * as supertest from 'supertest';
+import {
+  AUTH_HEADER,
+  createTestApp,
+  closeTestApp,
+  setupReportPrerequisites,
+  ReportBuilder,
+} from '@owox/test-utils';
+import { NullIdpProvider, Payload, ProjectMember } from '@owox/idp-protocol';
+
+// ---------------------------------------------------------------------------
+// Proves report-level HTTP Data (GET /api/external/http-data/reports/:id.ndjson)
+// rejects a report that belongs to ANOTHER project, and records no run in that
+// case. StreamHttpDataService.streamReport loads the report via
+// reportService.getByIdAndProjectId(reportId, projectId), which inner-joins on
+// dataMart.projectId — a report from a foreign project must 404, not leak
+// existence or fall through to the DWH.
+//
+// Mirrors the MultiTenantIdpProvider pattern from
+// notification-settings-cross-project.e2e-spec.ts: a dedicated app instance
+// with an IdpProvider that maps distinct tokens to distinct tenants. The
+// AUTH_HEADER token is mapped to tenant A so the shared setup helpers
+// (setupReportPrerequisites, ReportBuilder), which hardcode AUTH_HEADER
+// internally, create their fixtures under tenant A's project unmodified.
+// ---------------------------------------------------------------------------
+const TENANT_A: Payload = {
+  userId: 'user-a',
+  email: 'a@test.com',
+  roles: ['admin'],
+  fullName: 'User A',
+  projectId: 'project-a',
+};
+const TENANT_B: Payload = {
+  userId: 'user-b',
+  email: 'b@test.com',
+  roles: ['admin'],
+  fullName: 'User B',
+  projectId: 'project-b',
+};
+
+const TENANT_B_TOKEN = 'token-b';
+
+const TOKENS: Record<string, Payload> = {
+  [AUTH_HEADER['x-owox-authorization']]: TENANT_A,
+  [TENANT_B_TOKEN]: TENANT_B,
+};
+
+function toProjectMember(payload: Payload): ProjectMember {
+  return {
+    userId: payload.userId,
+    email: payload.email!,
+    fullName: payload.fullName,
+    avatar: undefined,
+    projectRole: 'admin',
+    userStatus: 'active',
+    hasNotificationsEnabled: true,
+    isOutbound: false,
+  };
+}
+
+class MultiTenantIdpProvider extends NullIdpProvider {
+  async parseToken(token: string): Promise<Payload | null> {
+    return TOKENS[token] ?? null;
+  }
+
+  async introspectToken(token: string): Promise<Payload | null> {
+    return TOKENS[token] ?? null;
+  }
+
+  // Ownership validation (e.g. data-storage/data-mart create) checks that the
+  // acting user is a project member — NullIdpProvider's default always returns
+  // a single hard-coded member ('0'), which would reject both tenants A and B.
+  async getProjectMembers(projectId: string): Promise<ProjectMember[]> {
+    if (projectId === TENANT_A.projectId) return [toProjectMember(TENANT_A)];
+    if (projectId === TENANT_B.projectId) return [toProjectMember(TENANT_B)];
+    return [];
+  }
+}
+
+const TENANT_B_HEADER: Record<string, string> = { 'x-owox-authorization': TENANT_B_TOKEN };
+
+interface RunsListResponse {
+  runs?: Array<{ id: string; type: string }>;
+}
+
+describe('HTTP Data — report cross-project isolation (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+
+  beforeAll(async () => {
+    const testApp = await createTestApp();
+    app = testApp.app;
+    agent = testApp.agent;
+
+    // Swap the IDP provider stored on the express app so guard-time
+    // parse/introspect maps tokens to distinct tenants (see notification-
+    // settings-cross-project.e2e-spec.ts for the same pattern).
+    const provider = new MultiTenantIdpProvider();
+    await provider.initialize();
+    (app.getHttpAdapter().getInstance() as { set(key: string, value: unknown): void }).set(
+      'idp',
+      provider
+    );
+  }, 120_000);
+
+  afterAll(async () => {
+    if (app) await closeTestApp(app);
+  });
+
+  it('returns 404 and records no run for a report owned by another project', async () => {
+    // Created entirely under tenant A: setupReportPrerequisites and the report
+    // POST both use AUTH_HEADER internally, which resolves to TENANT_A above.
+    const prereqs = await setupReportPrerequisites(agent);
+    const createRes = await agent
+      .post('/api/reports')
+      .set(AUTH_HEADER)
+      .send(
+        new ReportBuilder()
+          .withDataMartId(prereqs.dataMartId)
+          .withDataDestinationId(prereqs.dataDestinationId)
+          .build()
+      );
+    expect(createRes.status).toBe(201);
+    const reportId = createRes.body.id;
+
+    const before = await agent.get(`/api/data-marts/${prereqs.dataMartId}/runs`).set(AUTH_HEADER);
+    expect(before.status).toBe(200);
+    const beforeRunCount = ((before.body as RunsListResponse).runs ?? []).length;
+
+    // Tenant B requests tenant A's report by id — must not be found.
+    const res = await agent
+      .get(`/api/external/http-data/reports/${reportId}.ndjson`)
+      .set(TENANT_B_HEADER);
+    expect(res.status).toBe(404);
+
+    // No HTTP_DATA run (or any run) was recorded for the foreign-project attempt.
+    const after = await agent.get(`/api/data-marts/${prereqs.dataMartId}/runs`).set(AUTH_HEADER);
+    expect(after.status).toBe(200);
+    const afterRunCount = ((after.body as RunsListResponse).runs ?? []).length;
+    expect(afterRunCount).toBe(beforeRunCount);
+
+    // Sanity: the report genuinely exists and is owned by tenant A (proves the
+    // 404 above was about cross-project rejection, not a malformed/missing id).
+    // Uses the report detail endpoint rather than re-invoking the streaming
+    // endpoint, which would hit the real (unmocked) storage reader in this app.
+    const ownerRes = await agent.get(`/api/reports/${reportId}`).set(AUTH_HEADER);
+    expect(ownerRes.status).toBe(200);
+    expect(ownerRes.body.id).toBe(reportId);
+  });
+});

--- a/apps/backend/test/http-data.e2e-spec.ts
+++ b/apps/backend/test/http-data.e2e-spec.ts
@@ -2,7 +2,14 @@ import { INestApplication } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import type { Repository } from 'typeorm';
 import * as supertest from 'supertest';
-import { AUTH_HEADER, closeTestApp, createTestApp, setupPublishedDataMart } from '@owox/test-utils';
+import {
+  AUTH_HEADER,
+  closeTestApp,
+  createTestApp,
+  setupPublishedDataMart,
+  setupReportPrerequisites,
+  ReportBuilder,
+} from '@owox/test-utils';
 import { TypeResolver } from '../src/common/resolver/type-resolver';
 import { DATA_STORAGE_REPORT_READER_RESOLVER } from '../src/data-marts/data-storage-types/data-storage-providers';
 import { DataStorageType } from '../src/data-marts/data-storage-types/enums/data-storage-type.enum';
@@ -94,28 +101,39 @@ function buildMockResolver(reader: DataStorageReportReader) {
   } as unknown as TypeResolver<DataStorageType, DataStorageReportReader>;
 }
 
-function buildMockBlendableSchema() {
+function buildMockBlendableSchema(
+  // Include field types so OutputControlsValidatorService can validate operators and
+  // date-trunc against column types: `date` is a DATE (so date buckets are valid, and `eq`
+  // is still accepted for it), `revenue` is NUMERIC (so `SUM` is valid). No field is a
+  // primary key by default — callers that need Unique Count (which requires one) swap the
+  // mock's implementation for the duration of their test.
+  nativeFields: { name: string; type: string; isPrimaryKey?: boolean }[] = [
+    { name: 'date', type: 'DATE' },
+    { name: 'revenue', type: 'NUMERIC' },
+  ]
+) {
   return {
     computeBlendableSchema: jest.fn(async () => ({
-      // Include field types so OutputControlsValidatorService can validate operators and
-      // date-trunc against column types: `date` is a DATE (so date buckets are valid, and `eq`
-      // is still accepted for it), `revenue` is NUMERIC (so `SUM` is valid).
-      nativeFields: [
-        { name: 'date', type: 'DATE' },
-        { name: 'revenue', type: 'NUMERIC' },
-      ],
+      nativeFields,
       blendedFields: [],
       availableSources: [],
     })),
   };
 }
 
+// Default: no persisted schema fields. Column existence/typing for most tests flows entirely
+// through the mocked BlendableSchemaService (buildMockBlendableSchema), never this facade.
+// ReportTotalsService is the one caller that reads the persisted DataMart schema directly (see
+// deriveTotalsAggregations) — the totals e2e test overrides this mock once, per data mart, with
+// realistic fields so a numeric metric resolves.
 function buildMockSchemaProviderFacade() {
   return {
-    getActualDataMartSchema: jest.fn(async () => ({
-      type: 'bigquery-data-mart-schema',
-      fields: [],
-    })),
+    getActualDataMartSchema: jest.fn(
+      async (): Promise<{ type: string; fields: Array<Record<string, unknown>> }> => ({
+        type: 'bigquery-data-mart-schema',
+        fields: [],
+      })
+    ),
   };
 }
 
@@ -154,14 +172,18 @@ describe('HTTP Data API (e2e)', () => {
   let agent: supertest.Agent;
   let dataMartId: string;
   let mockReader: DataStorageReportReader;
+  let schemaProviderFacadeMock: ReturnType<typeof buildMockSchemaProviderFacade>;
+  let blendableSchemaMock: ReturnType<typeof buildMockBlendableSchema>;
 
   beforeAll(async () => {
     mockReader = buildMockReader(MOCK_HEADERS, MOCK_ROWS);
+    schemaProviderFacadeMock = buildMockSchemaProviderFacade();
+    blendableSchemaMock = buildMockBlendableSchema();
 
     const testApp = await createTestApp([
       { provide: DATA_STORAGE_REPORT_READER_RESOLVER, useValue: buildMockResolver(mockReader) },
-      { provide: BlendableSchemaService, useValue: buildMockBlendableSchema() },
-      { provide: DataMartSchemaProviderFacade, useValue: buildMockSchemaProviderFacade() },
+      { provide: BlendableSchemaService, useValue: blendableSchemaMock },
+      { provide: DataMartSchemaProviderFacade, useValue: schemaProviderFacadeMock },
       // Override DataMartTableReferenceService so that output-controls composer
       // tests (Part B) can use the SQL-defined mart without CreateViewService.
       // This override is harmless for tests that don't use output controls.
@@ -515,6 +537,181 @@ describe('HTTP Data API (e2e)', () => {
       const httpRuns = (after.body?.runs ?? []).filter((r: HttpRunView) => r.type === 'HTTP_DATA');
       const token = AUTH_HEADER['x-owox-authorization'];
       expect(JSON.stringify(httpRuns)).not.toContain(token);
+    });
+  });
+
+  describe('Report-level HTTP Data', () => {
+    let reportDataMartId: string;
+    let reportId: string;
+
+    async function createReport(outputControls: Record<string, unknown>): Promise<string> {
+      const prereqs = await setupReportPrerequisites(agent);
+      reportDataMartId = prereqs.dataMartId;
+      const createRes = await agent
+        .post('/api/reports')
+        .set(AUTH_HEADER)
+        .send(
+          new ReportBuilder()
+            .withDataMartId(prereqs.dataMartId)
+            .withDataDestinationId(prereqs.dataDestinationId)
+            .build()
+        );
+      expect(createRes.status).toBe(201);
+      const id = createRes.body.id;
+      // PUT /api/reports/:id replaces the whole report, so the base (non-output-controls)
+      // fields required by UpdateReportRequestApiDto must travel alongside outputControls.
+      // (createRes.body.title is "" for a fresh LOOKER_STUDIO report — @IsNotEmpty() on the
+      // update DTO rejects that, so a literal non-empty title is used here instead.)
+      const put = await agent
+        .put(`/api/reports/${id}`)
+        .set(AUTH_HEADER)
+        .send({
+          title: 'Test Report',
+          dataDestinationId: prereqs.dataDestinationId,
+          destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+          ...outputControls,
+        });
+      expect(put.status).toBe(200);
+      return id;
+    }
+
+    beforeAll(async () => {
+      reportId = await createReport({
+        columnConfig: ['date', 'revenue'],
+        filterConfig: [{ column: 'date', operator: 'gte', value: '2026-05-01' }],
+      });
+    });
+
+    it('streams NDJSON with an x-owox-run-id header', async () => {
+      const res = await agent
+        .get(`/api/external/http-data/reports/${reportId}.ndjson`)
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('application/x-ndjson');
+      expect(res.headers['x-owox-run-id']).toBeDefined();
+      expect(parseNdjson(res.text).length).toBe(MOCK_ROWS.length);
+    });
+
+    it('records a HTTP_DATA run tagged with reportId + executionSqlQuery', async () => {
+      const streamed = await agent
+        .get(`/api/external/http-data/reports/${reportId}.ndjson`)
+        .set(AUTH_HEADER);
+      const runId = streamed.headers['x-owox-run-id'];
+      const run = await agent
+        .get(`/api/data-marts/${reportDataMartId}/runs/${runId}`)
+        .set(AUTH_HEADER);
+      expect(run.status).toBe(200);
+      expect(run.body.type).toBe('HTTP_DATA');
+      expect(run.body.reportId).toBe(reportId);
+      expect(run.body.additionalParams?.httpData?.executionSqlQuery).toEqual(expect.any(String));
+      expect(run.body.additionalParams?.httpData?.filter).toEqual([
+        { column: 'date', operator: 'gte', value: '2026-05-01' },
+      ]);
+    });
+
+    it('accepts a ?limit= override and records it', async () => {
+      const streamed = await agent
+        .get(`/api/external/http-data/reports/${reportId}.ndjson?limit=1`)
+        .set(AUTH_HEADER);
+      expect(streamed.status).toBe(200);
+      const runId = streamed.headers['x-owox-run-id'];
+      const run = await agent
+        .get(`/api/data-marts/${reportDataMartId}/runs/${runId}`)
+        .set(AUTH_HEADER);
+      expect(run.body.additionalParams?.httpData?.limit).toBe(1);
+    });
+
+    it('returns 400 for any query param other than limit', async () => {
+      const res = await agent
+        .get(`/api/external/http-data/reports/${reportId}.ndjson?filter=abc`)
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 for an unknown report id', async () => {
+      const res = await agent
+        .get(`/api/external/http-data/reports/00000000-0000-0000-0000-000000000000.ndjson`)
+        .set(AUTH_HEADER);
+      expect(res.status).toBe(404);
+    });
+
+    // ReportTotalsService derives totals eligibility from the persisted DataMart schema (see
+    // deriveTotalsAggregations in report-sql-composer.service.ts), NOT from the mocked
+    // BlendableSchemaService that the rest of this file relies on for column resolution. The
+    // default schema-provider mock (buildMockSchemaProviderFacade) returns no fields, so this
+    // report's fresh Data Mart needs a one-time override — mirroring the same date/revenue field
+    // types already used by buildMockBlendableSchema — so `revenue` resolves as a NUMERIC totals
+    // metric and the aggregated report actually produces a grand-totals row.
+    it('returns grand totals in run history for an aggregated report', async () => {
+      schemaProviderFacadeMock.getActualDataMartSchema.mockResolvedValueOnce({
+        type: 'bigquery-data-mart-schema',
+        fields: [
+          { name: 'date', type: 'DATE', mode: 'NULLABLE', status: 'CONNECTED' },
+          { name: 'revenue', type: 'NUMERIC', mode: 'NULLABLE', status: 'CONNECTED' },
+        ],
+      });
+
+      const aggregatedReportId = await createReport({
+        columnConfig: ['date', 'revenue'],
+        aggregationConfig: [{ column: 'revenue', function: 'SUM' }],
+      });
+      const streamed = await agent
+        .get(`/api/external/http-data/reports/${aggregatedReportId}.ndjson`)
+        .set(AUTH_HEADER);
+      expect(streamed.status).toBe(200);
+      const runId = streamed.headers['x-owox-run-id'];
+      const run = await agent
+        .get(`/api/data-marts/${reportDataMartId}/runs/${runId}`)
+        .set(AUTH_HEADER);
+      // `totals` is surfaced at the TOP LEVEL of the run response only — HttpDataMapper
+      // deliberately strips it out of additionalParams.httpData (see maskAdditionalParams /
+      // extractTotals in data-mart.mapper.ts) so it isn't duplicated in the masked view.
+      expect(run.body.additionalParams?.httpData?.totals).toBeUndefined();
+      expect(run.body.totals).toBeDefined();
+      expect(Object.keys(run.body.totals as Record<string, unknown>).length).toBeGreaterThan(0);
+    });
+
+    // Unique Count requires a primary-key field on the data mart schema (see
+    // UNIQUE_COUNT_REQUIRES_PRIMARY_KEY in output-controls-validator.service.ts) — both when
+    // the report is saved (PUT) AND on every subsequent read (resolveBlendingDecision
+    // revalidates output controls as a schema-drift guard). buildMockBlendableSchema's default
+    // has no primary key, so the mock's implementation is swapped for the duration of this test
+    // and restored after — this is a smoke test that uniqueCountConfig flows end-to-end through
+    // save + stream + run recording, not a check of a computed distinct count (the mock reader
+    // returns fixed rows regardless of the composed SQL).
+    it('streams a report with uniqueCountConfig and records a HTTP_DATA run', async () => {
+      const originalImpl = blendableSchemaMock.computeBlendableSchema.getMockImplementation();
+      blendableSchemaMock.computeBlendableSchema.mockImplementation(async () => ({
+        nativeFields: [
+          { name: 'date', type: 'DATE', isPrimaryKey: true },
+          { name: 'revenue', type: 'NUMERIC' },
+        ],
+        blendedFields: [],
+        availableSources: [],
+      }));
+
+      try {
+        const uniqueCountReportId = await createReport({
+          columnConfig: ['date', 'revenue'],
+          uniqueCountConfig: true,
+        });
+
+        const streamed = await agent
+          .get(`/api/external/http-data/reports/${uniqueCountReportId}.ndjson`)
+          .set(AUTH_HEADER);
+        expect(streamed.status).toBe(200);
+        const runId = streamed.headers['x-owox-run-id'];
+        expect(runId).toBeDefined();
+
+        const run = await agent
+          .get(`/api/data-marts/${reportDataMartId}/runs/${runId}`)
+          .set(AUTH_HEADER);
+        expect(run.status).toBe(200);
+        expect(run.body.type).toBe('HTTP_DATA');
+        expect(run.body.reportId).toBe(uniqueCountReportId);
+      } finally {
+        blendableSchemaMock.computeBlendableSchema.mockImplementation(originalImpl!);
+      }
     });
   });
 

--- a/docs/api/openapi.md
+++ b/docs/api/openapi.md
@@ -70,6 +70,19 @@ X-OWOX-Api-Key-Id: <apiKeyId>
 Keep `X-OWOX-Api-Key-Id` on protected requests that use an access token created from an API
 key. The server binds API-key access tokens to their API Key ID.
 
+The HTTP Data API can also stream a saved report's data — applying the report's stored filters,
+aggregations, date buckets, and sorting — instead of a Data Mart's raw output. Pass an optional
+`limit` query parameter to cap rows:
+
+```http
+GET /api/external/http-data/reports/<reportId>.ndjson
+x-owox-authorization: Bearer <accessToken>
+X-OWOX-Api-Key-Id: <apiKeyId>
+```
+
+Both endpoints return an `x-owox-run-id` response header identifying the created run; use it to look up
+the run (and its executed query) through the run history endpoint.
+
 ## Compatibility
 
 The same client and OWOX Data Marts server version is supported. Different versions are best effort.

--- a/packages/api-client/src/auth.ts
+++ b/packages/api-client/src/auth.ts
@@ -1,4 +1,4 @@
-import type { JsonRequester } from './data-marts.js';
+import type { JsonRequester } from './traversal.js';
 import { createHttpError, OWOXApiError, OWOXAuthError, OWOXConfigError } from './errors.js';
 import { requestApi } from './transport.js';
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -9,6 +9,7 @@ import { InsightsApi } from './insight-templates.js';
 import { MarkdownApi } from './markdown.js';
 import { ModelCanvasApi } from './model-canvas.js';
 import { ProjectApi } from './project.js';
+import { ReportsApi } from './reports.js';
 import { RunsApi } from './runs.js';
 import { SearchApi } from './search.js';
 import { StoragesApi } from './storages.js';
@@ -40,6 +41,7 @@ export class OWOXApiClient {
   readonly markdown: MarkdownApi;
   readonly models: ModelCanvasApi;
   readonly project: ProjectApi;
+  readonly reports: ReportsApi;
   readonly runs: RunsApi;
   readonly search: SearchApi;
 
@@ -64,6 +66,7 @@ export class OWOXApiClient {
     this.markdown = new MarkdownApi(this);
     this.models = new ModelCanvasApi(this);
     this.project = new ProjectApi(this);
+    this.reports = new ReportsApi(this);
     this.runs = new RunsApi(this);
     this.search = new SearchApi(this);
   }

--- a/packages/api-client/src/data-marts.ts
+++ b/packages/api-client/src/data-marts.ts
@@ -1,6 +1,12 @@
 import { Buffer } from 'node:buffer';
 
-import { OWOXApiError, OWOXAuthError } from './errors.js';
+import { OWOXApiError } from './errors.js';
+import {
+  HttpNdjsonTraversal,
+  type JsonRequester,
+  type TraversalSource,
+  withSourceContext,
+} from './traversal.js';
 import { isRecord, isRfc3339DateTimeString, isUserProjection } from './validation.js';
 
 // Keep the traversal rule literals below in sync with the backend schemas in
@@ -170,11 +176,6 @@ type DataMartsPage = {
   nextOffset: number | null;
 };
 
-export type JsonRequester = {
-  getJson<T>(path: string, query?: Record<string, string>): Promise<T>;
-  getStream(path: string, query?: URLSearchParams): Promise<Response>;
-};
-
 const DATA_MART_STATUSES = new Set<string>(DATA_MART_STATUS_VALUES);
 const DATA_MART_DEFINITION_TYPES = new Set<string>(DATA_MART_DEFINITION_TYPE_VALUES);
 const DATA_STORAGE_TYPES = new Set<string>(DATA_STORAGE_TYPE_VALUES);
@@ -293,146 +294,10 @@ function buildTraverseDataQuery(options: TraverseDataOptions): URLSearchParams |
   return query.size === 0 ? undefined : query;
 }
 
-function withDataMartContext(error: OWOXApiError, dataMartId: string): OWOXApiError {
-  const details = isRecord(error.details)
-    ? { dataMartId, ...error.details }
-    : {
-        dataMartId,
-        ...(error.details === undefined ? {} : { details: error.details }),
-      };
-  const ErrorClass = error instanceof OWOXAuthError ? OWOXAuthError : OWOXApiError;
-
-  return new ErrorClass(error.message, {
-    status: error.status,
-    code: error.code,
-    details,
-    cause: error,
-  });
-}
-
-export class DataMartDataTraversal {
-  readonly runId: string | undefined;
-  private consumed = false;
-  private cancelled = false;
-
-  constructor(
-    private readonly response: Response,
-    private readonly dataMartId: string
-  ) {
-    this.runId = response.headers.get('x-owox-run-id') ?? undefined;
-  }
-
-  async cancel(): Promise<void> {
-    if (this.consumed || this.cancelled) {
-      return;
-    }
-
-    this.cancelled = true;
-    await this.response.body?.cancel().catch(() => undefined);
-  }
-
-  async *rowChunks(): AsyncIterable<OWOXDataMartRow[]> {
-    if (this.consumed || this.cancelled) {
-      throw new OWOXApiError('OWOX Data Mart data stream can only be traversed once', {
-        details: this.contextDetails(),
-      });
-    }
-    this.consumed = true;
-
-    if (!this.response.body) {
-      throw new OWOXApiError('OWOX Data Mart data stream response did not include a body', {
-        details: this.contextDetails(),
-      });
-    }
-
-    const reader = this.response.body.getReader();
-    const decoder = new TextDecoder();
-    let pending = '';
-    let lineNumber = 0;
-    let streamEnded = false;
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        streamEnded = done;
-        pending += decoder.decode(value, { stream: !done });
-
-        const lines = pending.split('\n');
-        pending = lines.pop() ?? '';
-
-        const rows: OWOXDataMartRow[] = [];
-        for (const line of lines) {
-          if (line.length === 0) {
-            continue;
-          }
-          lineNumber += 1;
-          rows.push(this.parseLine(line, lineNumber));
-        }
-
-        if (rows.length > 0) {
-          yield rows;
-        }
-
-        if (done) {
-          break;
-        }
-      }
-
-      if (pending.length > 0) {
-        lineNumber += 1;
-        yield [this.parseLine(pending, lineNumber)];
-      }
-    } catch (error) {
-      if (error instanceof OWOXApiError) {
-        throw error;
-      }
-
-      throw new OWOXApiError('Failed to read OWOX Data Mart data stream', {
-        details: this.contextDetails(),
-        cause: error,
-      });
-    } finally {
-      if (!streamEnded) {
-        await reader.cancel().catch(() => undefined);
-      }
-      reader.releaseLock();
-    }
-  }
-
-  private parseLine(line: string, lineNumber: number): OWOXDataMartRow {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch (error) {
-      throw new OWOXApiError(`Malformed NDJSON line ${lineNumber} in OWOX Data Mart data stream`, {
-        details: {
-          ...this.contextDetails(),
-          lineNumber,
-          linePreview: line.slice(0, 200),
-        },
-        cause: error,
-      });
-    }
-
-    if (!isRecord(parsed)) {
-      throw new OWOXApiError(`NDJSON line ${lineNumber} is not a JSON object`, {
-        details: {
-          ...this.contextDetails(),
-          lineNumber,
-        },
-      });
-    }
-
-    return parsed;
-  }
-
-  private contextDetails(): Record<string, string> {
-    return {
-      dataMartId: this.dataMartId,
-      ...(this.runId ? { runId: this.runId } : {}),
-    };
-  }
-}
+const DATA_MART_TRAVERSAL_SOURCE: TraversalSource = {
+  idKey: 'dataMartId',
+  label: 'OWOX Data Mart',
+};
 
 export class DataMartsApi {
   constructor(private readonly requester: JsonRequester) {}
@@ -478,7 +343,7 @@ export class DataMartsApi {
   async traverseData(
     dataMartId: string,
     options: TraverseDataOptions = {}
-  ): Promise<DataMartDataTraversal> {
+  ): Promise<HttpNdjsonTraversal> {
     const query = buildTraverseDataQuery(options);
     let response: Response;
     try {
@@ -488,7 +353,7 @@ export class DataMartsApi {
       );
     } catch (error) {
       if (error instanceof OWOXApiError) {
-        throw withDataMartContext(error, dataMartId);
+        throw withSourceContext(error, DATA_MART_TRAVERSAL_SOURCE.idKey, dataMartId);
       }
 
       throw new OWOXApiError('Failed to open OWOX Data Mart data stream', {
@@ -510,6 +375,6 @@ export class DataMartsApi {
       });
     }
 
-    return new DataMartDataTraversal(response, dataMartId);
+    return new HttpNdjsonTraversal(response, dataMartId, DATA_MART_TRAVERSAL_SOURCE);
   }
 }

--- a/packages/api-client/src/destinations.ts
+++ b/packages/api-client/src/destinations.ts
@@ -1,4 +1,4 @@
-import type { JsonRequester } from './data-marts.js';
+import type { JsonRequester } from './traversal.js';
 import { OWOXApiError } from './errors.js';
 
 export type OWOXDestination = Record<string, unknown> & {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -3,7 +3,6 @@ export { type OWOXAuthContext } from './auth.js';
 export { OWOXApiClient, type OWOXApiClientOptions } from './client.js';
 export { OWOXApiError, OWOXAuthError, OWOXConfigError } from './errors.js';
 export {
-  DataMartDataTraversal,
   type OWOXDataMart,
   type OWOXDataMartContext,
   type OWOXDataMartDefinitionType,
@@ -59,3 +58,8 @@ export {
   type OWOXSearchOptions,
   type OWOXSearchResult,
 } from './search.js';
+export {
+  HttpNdjsonTraversal,
+  /** @deprecated Use {@link HttpNdjsonTraversal} instead. Kept for backward compatibility. */
+  HttpNdjsonTraversal as DataMartDataTraversal,
+} from './traversal.js';

--- a/packages/api-client/src/reports.test.ts
+++ b/packages/api-client/src/reports.test.ts
@@ -1,0 +1,152 @@
+import { OWOXApiError, OWOXAuthError } from './errors.js';
+import { ReportsApi } from './reports.js';
+
+function streamResponse(runId: string): Response {
+  return new Response('{"date":"2026-05-01"}\n', {
+    headers: { 'content-type': 'application/x-ndjson', 'x-owox-run-id': runId },
+  });
+}
+
+function malformedStreamResponse(runId: string): Response {
+  return new Response('{"date":"2026-05-01"}\n{bad json}\n', {
+    headers: { 'content-type': 'application/x-ndjson', 'x-owox-run-id': runId },
+  });
+}
+
+async function collectRows(traversal: {
+  rowChunks(): AsyncIterable<Record<string, unknown>[]>;
+}): Promise<Record<string, unknown>[]> {
+  const rows: Record<string, unknown>[] = [];
+  for await (const chunk of traversal.rowChunks()) {
+    rows.push(...chunk);
+  }
+  return rows;
+}
+
+describe('ReportsApi.traverseData', () => {
+  it('opens the report ndjson stream with only a limit query and exposes the run id', async () => {
+    const calls: Array<{ path: string; query?: URLSearchParams }> = [];
+    const requester = {
+      getJson: async () => ({}) as never,
+      getStream: async (path: string, query?: URLSearchParams) => {
+        calls.push({ path, query });
+        return streamResponse('run-9');
+      },
+    };
+    const api = new ReportsApi(requester);
+
+    const traversal = await api.traverseData('report-1', { limit: 5 });
+
+    expect(calls[0].path).toBe('/api/external/http-data/reports/report-1.ndjson');
+    expect(calls[0].query?.get('limit')).toBe('5');
+    expect(traversal.runId).toBe('run-9');
+  });
+
+  it('omits the query when no limit is given', async () => {
+    const calls: Array<{ query?: URLSearchParams }> = [];
+    const requester = {
+      getJson: async () => ({}) as never,
+      getStream: async (_path: string, query?: URLSearchParams) => {
+        calls.push({ query });
+        return streamResponse('run-1');
+      },
+    };
+    await new ReportsApi(requester).traverseData('report-1');
+    expect(calls[0].query).toBeUndefined();
+  });
+
+  it('adds report context to an OWOXApiError raised while opening the stream', async () => {
+    const requester = {
+      getJson: async () => ({}) as never,
+      getStream: async () => {
+        throw new OWOXApiError('boom', { status: 500, code: 'BOOM' });
+      },
+    };
+
+    const data = new ReportsApi(requester).traverseData('report-1');
+    await expect(data).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(data).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      status: 500,
+      code: 'BOOM',
+      details: { reportId: 'report-1' },
+    });
+  });
+
+  it('preserves auth errors while opening the stream with report context', async () => {
+    const requester = {
+      getJson: async () => ({}) as never,
+      getStream: async () => {
+        throw new OWOXAuthError('Unauthorized', { status: 401, code: 'INVALID_API_KEY' });
+      },
+    };
+
+    const data = new ReportsApi(requester).traverseData('report-1');
+    await expect(data).rejects.toBeInstanceOf(OWOXAuthError);
+    await expect(data).rejects.toMatchObject({
+      name: 'OWOXAuthError',
+      status: 401,
+      code: 'INVALID_API_KEY',
+      details: { reportId: 'report-1' },
+    });
+  });
+
+  it('wraps non-OWOX failures while opening the stream with report context', async () => {
+    const requester = {
+      getJson: async () => ({}) as never,
+      getStream: async () => {
+        throw new TypeError('network disconnected');
+      },
+    };
+
+    const data = new ReportsApi(requester).traverseData('report-1');
+    await expect(data).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(data).rejects.toMatchObject({
+      message: 'Failed to open OWOX report data stream',
+      details: { reportId: 'report-1' },
+      cause: expect.any(TypeError),
+    });
+  });
+
+  it('rejects traversing the report data stream a second time', async () => {
+    const requester = {
+      getJson: async () => ({}) as never,
+      getStream: async () => streamResponse('run-1'),
+    };
+
+    const traversal = await new ReportsApi(requester).traverseData('report-1');
+    await collectRows(traversal);
+
+    const rows = collectRows(traversal);
+    await expect(rows).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(rows).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'OWOX report data stream can only be traversed once',
+      details: {
+        reportId: 'report-1',
+        runId: 'run-1',
+      },
+    });
+  });
+
+  it('reports malformed NDJSON lines with report and run context', async () => {
+    const requester = {
+      getJson: async () => ({}) as never,
+      getStream: async () => malformedStreamResponse('run-bad'),
+    };
+
+    const traversal = await new ReportsApi(requester).traverseData('report-1');
+
+    const rows = collectRows(traversal);
+    await expect(rows).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(rows).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'Malformed NDJSON line 2 in OWOX report data stream',
+      details: {
+        reportId: 'report-1',
+        lineNumber: 2,
+        runId: 'run-bad',
+      },
+    });
+  });
+});

--- a/packages/api-client/src/reports.ts
+++ b/packages/api-client/src/reports.ts
@@ -1,0 +1,45 @@
+import { OWOXApiError } from './errors.js';
+import {
+  HttpNdjsonTraversal,
+  type JsonRequester,
+  type TraversalSource,
+  withSourceContext,
+} from './traversal.js';
+
+const REPORT_TRAVERSAL_SOURCE: TraversalSource = { idKey: 'reportId', label: 'OWOX report' };
+
+export type TraverseReportDataOptions = {
+  limit?: number;
+};
+
+export class ReportsApi {
+  constructor(private readonly requester: JsonRequester) {}
+
+  async traverseData(
+    reportId: string,
+    options: TraverseReportDataOptions = {}
+  ): Promise<HttpNdjsonTraversal> {
+    const query = new URLSearchParams();
+    if (options.limit !== undefined) {
+      query.append('limit', String(options.limit));
+    }
+
+    let response: Response;
+    try {
+      response = await this.requester.getStream(
+        `/api/external/http-data/reports/${encodeURIComponent(reportId)}.ndjson`,
+        query.size === 0 ? undefined : query
+      );
+    } catch (error) {
+      if (error instanceof OWOXApiError) {
+        throw withSourceContext(error, REPORT_TRAVERSAL_SOURCE.idKey, reportId);
+      }
+      throw new OWOXApiError('Failed to open OWOX report data stream', {
+        details: { reportId },
+        cause: error,
+      });
+    }
+
+    return new HttpNdjsonTraversal(response, reportId, REPORT_TRAVERSAL_SOURCE);
+  }
+}

--- a/packages/api-client/src/storages.ts
+++ b/packages/api-client/src/storages.ts
@@ -1,4 +1,4 @@
-import type { JsonRequester } from './data-marts.js';
+import type { JsonRequester } from './traversal.js';
 import { OWOXApiError } from './errors.js';
 
 export type OWOXStorage = Record<string, unknown> & {

--- a/packages/api-client/src/traversal.ts
+++ b/packages/api-client/src/traversal.ts
@@ -1,0 +1,162 @@
+import { OWOXApiError, OWOXAuthError } from './errors.js';
+
+export type JsonRequester = {
+  getJson<T>(path: string, query?: Record<string, string>): Promise<T>;
+  getStream(path: string, query?: URLSearchParams): Promise<Response>;
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function withSourceContext(error: OWOXApiError, idKey: string, id: string): OWOXApiError {
+  const details = isRecord(error.details)
+    ? { [idKey]: id, ...error.details }
+    : {
+        [idKey]: id,
+        ...(error.details === undefined ? {} : { details: error.details }),
+      };
+  const ErrorClass = error instanceof OWOXAuthError ? OWOXAuthError : OWOXApiError;
+
+  return new ErrorClass(error.message, {
+    status: error.status,
+    code: error.code,
+    details,
+    cause: error,
+  });
+}
+
+export type TraversalSource = {
+  /** Key used for this source's id in `error.details`, e.g. "dataMartId" or "reportId". */
+  idKey: string;
+  /** Human-readable label used in stream error messages, e.g. "OWOX Data Mart" or "OWOX report". */
+  label: string;
+};
+
+export class HttpNdjsonTraversal {
+  readonly runId: string | undefined;
+  private consumed = false;
+  private cancelled = false;
+
+  constructor(
+    private readonly response: Response,
+    private readonly sourceId: string,
+    private readonly source: TraversalSource
+  ) {
+    this.runId = response.headers.get('x-owox-run-id') ?? undefined;
+  }
+
+  async cancel(): Promise<void> {
+    if (this.consumed || this.cancelled) {
+      return;
+    }
+
+    this.cancelled = true;
+    await this.response.body?.cancel().catch(() => undefined);
+  }
+
+  async *rowChunks(): AsyncIterable<Record<string, unknown>[]> {
+    if (this.consumed || this.cancelled) {
+      throw new OWOXApiError(`${this.source.label} data stream can only be traversed once`, {
+        details: this.contextDetails(),
+      });
+    }
+    this.consumed = true;
+
+    if (!this.response.body) {
+      throw new OWOXApiError(`${this.source.label} data stream response did not include a body`, {
+        details: this.contextDetails(),
+      });
+    }
+
+    const reader = this.response.body.getReader();
+    const decoder = new TextDecoder();
+    let pending = '';
+    let lineNumber = 0;
+    let streamEnded = false;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        streamEnded = done;
+        pending += decoder.decode(value, { stream: !done });
+
+        const lines = pending.split('\n');
+        pending = lines.pop() ?? '';
+
+        const rows: Record<string, unknown>[] = [];
+        for (const line of lines) {
+          if (line.length === 0) {
+            continue;
+          }
+          lineNumber += 1;
+          rows.push(this.parseLine(line, lineNumber));
+        }
+
+        if (rows.length > 0) {
+          yield rows;
+        }
+
+        if (done) {
+          break;
+        }
+      }
+
+      if (pending.length > 0) {
+        lineNumber += 1;
+        yield [this.parseLine(pending, lineNumber)];
+      }
+    } catch (error) {
+      if (error instanceof OWOXApiError) {
+        throw error;
+      }
+
+      throw new OWOXApiError(`Failed to read ${this.source.label} data stream`, {
+        details: this.contextDetails(),
+        cause: error,
+      });
+    } finally {
+      if (!streamEnded) {
+        await reader.cancel().catch(() => undefined);
+      }
+      reader.releaseLock();
+    }
+  }
+
+  private parseLine(line: string, lineNumber: number): Record<string, unknown> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      throw new OWOXApiError(
+        `Malformed NDJSON line ${lineNumber} in ${this.source.label} data stream`,
+        {
+          details: {
+            ...this.contextDetails(),
+            lineNumber,
+            linePreview: line.slice(0, 200),
+          },
+          cause: error,
+        }
+      );
+    }
+
+    if (!isRecord(parsed)) {
+      throw new OWOXApiError(`NDJSON line ${lineNumber} is not a JSON object`, {
+        details: {
+          ...this.contextDetails(),
+          lineNumber,
+        },
+      });
+    }
+
+    return parsed;
+  }
+
+  private contextDetails(): Record<string, string> {
+    return {
+      [this.source.idKey]: this.sourceId,
+      ...(this.runId ? { runId: this.runId } : {}),
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/external/http-data/reports/{reportId}.ndjson` — stream a saved report's data as NDJSON, applying the report's stored output controls (columns, filters, aggregations, date buckets, unique count, sort) without reconstructing query parameters by hand. The only accepted query parameter is an optional `limit` override; any other key returns `400`. Mirrored into `@owox/api-client` as `client.reports.traverseData(reportId, { limit })`.

Fibery: [HTTP Data on Report Level #6759](https://owox.fibery.io/Sprint_Work/Work_Item/HTTP-Data-on-Report-Level-6759)

## How it works

- Reuses `StreamHttpDataService` by extracting a shared `executeStream` tail driven by a discriminated-union stream plan (`data-mart | report`, guarded by `assertNever`). The report path builds the read plan from a loaded `Report`, which already satisfies `ReportLike`.
- Auth: `@Auth(Role.viewer())` + `Action.USE` on the report's Data Mart. Tenant isolation is enforced at the query level — `getByIdAndProjectId` inner-joins on `dataMart.projectId`, so a report from another project returns `404` before any reader work.
- The response carries an `x-owox-run-id` header; the run is a `HTTP_DATA` run tagged with the reportId, recording the inlined executed SQL under `additionalParams.httpData.executionSqlQuery` and grand totals in the run history.
- No migration — reuses the existing `DataMartRun.reportId` column.

## Design decisions & tradeoffs

1. **Access = `Action.USE` on the Data Mart, no per-report ACL.** A report is a saved query over its Data Mart, so anyone who can stream the Data Mart can stream any of its reports. This never grants wider data access than the Data Mart endpoint already does, and destination access is deliberately NOT required (the stream never touches the destination). *Tradeoff:* no per-report sharing granularity — a product boundary, not a code limitation.

2. **Failed-run recording aligned across BOTH HTTP Data endpoints.** A failure during query execution (blending/compose/reader, or a report's saved-column config drift) now records a `FAILED` `HTTP_DATA` run + `x-owox-run-id` for the report endpoint **and** the existing Data Mart endpoint. Previously the Data Mart endpoint recorded runs only for post-compose failures; this widens it for consistency with the DoD ("record a FAILED run on failure"). *Tradeoff:* the shipped Data Mart endpoint now logs slightly more failures in run history (additive; failed runs never bill). Pre-execution gates (report lookup, access, balance) still record no run — covered by boundary tests.

3. **MCP `query_data_mart` no longer records failed/cancelled runs** (a separate concern folded into this task). *Tradeoff:* this reduces observability of MCP query timeouts/aborts in run history — noted for the MCP timeout-resilience follow-up. It does not affect either HTTP Data endpoint (both still record `FAILED` runs).

4. **`?limit` is the only query override (v1).** Every other output control comes from the saved report config. *Tradeoff:* no ad-hoc filter/sort/aggregation override on the report route — this matches the request's intent ("without assembling parameters by hand") and is deferred.

5. **Executed SQL is captured only when the report applies output controls or blending.** A plain column-only report streams the Data Mart's own query and records no separate `executionSqlQuery` (`hasOutputControls` intentionally excludes `columnConfig`). The base query still survives in `definitionRun` plus the recorded columns.

6. **Grand totals are computed for any report with an eligible metric** (per the totals product decision), not only explicitly aggregated ones. *Tradeoff:* a plain report stream with a numeric field runs a separate best-effort totals query (extra cost/latency) — this is inherited from the Data Mart endpoint's existing behavior and is best-effort, so it never breaks the stream.

## API client

- New `client.reports.traverseData(reportId, { limit })` returning the NDJSON traversal.
- The shared NDJSON primitive was moved to a neutral `HttpNdjsonTraversal`, with `DataMartDataTraversal` kept as a `@deprecated` back-compat alias — report-stream errors now carry `reportId` (not `dataMartId`).

## Testing

- Backend unit: 7 suites / 145 (stream & query-data-mart services, mappers, schemas, validator, OpenAPI spec).
- Backend e2e: `http-data.e2e-spec` + new `http-data-report-cross-project.e2e-spec` (tenant isolation via `MultiTenantIdpProvider`).
- `@owox/api-client`: 44 · `@owox/ctl`: 40 · `nest build` + `tsc -b` clean.
- Explicit coverage: config-drift FAILED run tagged reportId, balance-gate no-run boundary, `?limit` override/fallback/null precedence, uniqueCount threading, best-effort SQL-inline throw, cross-project `404`, aggregated totals in run history.

## Deployment

No migration, no new env vars. The endpoint is additive; rollback simply drops the route.
