### PR TITLE
fix(api): centralize OpenAPI auth contract

### DIFF
--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -59,3 +59,12 @@ API-key-derived project and member context. `@owox/api-client` exposes `auth.get
 `OWOXAuthContext` for validating a configured API key and reading that context without exposing
 the API key secret. Existing authentication and authorization behavior are unchanged, and
 consumers can adopt the client method without a migration.
+
+## Publish canonical API-key authentication headers
+
+Protected OpenAPI operations now declare `X-OWOX-Authorization` and, only when API-key-derived
+tokens are accepted, the optional `X-OWOX-Api-Key-Id` header that must match the token's API key
+ID. Routes that reject API-key authentication omit that conditional header, while
+`POST /api/auth/api-keys/exchange` retains its required API key ID input. Runtime authentication
+behavior is unchanged; generated clients and API tooling can use the shared header contract
+without endpoint-specific metadata.

--- a/apps/backend/src/config/swagger.config.ts
+++ b/apps/backend/src/config/swagger.config.ts
@@ -1,18 +1,99 @@
 import { INestApplication } from '@nestjs/common';
-import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
+import type {
+  OperationObject,
+  ParameterObject,
+  ReferenceObject,
+} from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
+import {
+  OWOX_API_KEY_AUTH_EXTENSION,
+  OWOX_API_KEY_ID_DESCRIPTION,
+  OWOX_API_KEY_ID_HEADER,
+  OWOX_AUTHORIZATION_DESCRIPTION,
+  OWOX_AUTHORIZATION_HEADER,
+  OWOX_AUTHORIZATION_SECURITY_SCHEME,
+} from '../idp/openapi/authentication.openapi';
 
-export function setupSwagger(app: INestApplication, path: string): void {
-  const config = new DocumentBuilder()
+const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
+
+export function buildSwaggerConfig() {
+  return new DocumentBuilder()
     .setTitle('OWOX Data Marts API')
     .setDescription('REST API used by frontend clients and service integrations.')
     .setVersion('1.0')
+    .addApiKey(
+      {
+        type: 'apiKey',
+        in: 'header',
+        name: OWOX_AUTHORIZATION_HEADER,
+        description: OWOX_AUTHORIZATION_DESCRIPTION,
+      },
+      OWOX_AUTHORIZATION_SECURITY_SCHEME
+    )
     .build();
+}
 
-  const document = SwaggerModule.createDocument(app, config);
+export function setupSwagger(app: INestApplication, path: string): void {
+  const document = createSwaggerDocument(app);
   SwaggerModule.setup(path, app, document, {
     useGlobalPrefix: true,
     jsonDocumentUrl: 'openapi.json',
     raw: ['json', 'yaml'],
     yamlDocumentUrl: 'openapi.yaml',
   });
+}
+
+export function createSwaggerDocument(app: INestApplication): OpenAPIObject {
+  const document = SwaggerModule.createDocument(app, buildSwaggerConfig());
+
+  for (const path of Object.values(document.paths)) {
+    for (const method of HTTP_METHODS) {
+      const operation = path[method];
+      if (operation && usesOwoxAuthorization(operation)) {
+        applyOwoxAuthenticationContract(operation);
+      }
+    }
+  }
+
+  return document;
+}
+
+function usesOwoxAuthorization(operation: OperationObject): boolean {
+  return Boolean(
+    operation.security?.some(requirement => OWOX_AUTHORIZATION_SECURITY_SCHEME in requirement)
+  );
+}
+
+function applyOwoxAuthenticationContract(operation: OperationObject): void {
+  const extensionOperation = operation as OperationObject & Record<string, unknown>;
+  const rejectsApiKeyAuth = extensionOperation[OWOX_API_KEY_AUTH_EXTENSION] === false;
+  const parameters = (operation.parameters ?? []).filter(
+    parameter =>
+      !isHeaderParameter(parameter, OWOX_AUTHORIZATION_HEADER) &&
+      !isHeaderParameter(parameter, OWOX_API_KEY_ID_HEADER)
+  );
+
+  if (!rejectsApiKeyAuth) {
+    parameters.push({
+      name: OWOX_API_KEY_ID_HEADER,
+      in: 'header',
+      required: false,
+      description: OWOX_API_KEY_ID_DESCRIPTION,
+      schema: { type: 'string' },
+    });
+  }
+
+  operation.parameters = parameters.length > 0 ? parameters : undefined;
+  delete extensionOperation[OWOX_API_KEY_AUTH_EXTENSION];
+}
+
+function isHeaderParameter(
+  parameter: ParameterObject | ReferenceObject,
+  headerName: string
+): parameter is ParameterObject {
+  return (
+    'in' in parameter &&
+    parameter.in === 'header' &&
+    parameter.name.toLowerCase() === headerName.toLowerCase()
+  );
 }

--- a/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/external/http-data.api.ts
@@ -1,6 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
 import {
-  ApiHeader,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
@@ -29,11 +28,6 @@ export function StreamHttpDataSpec() {
         'would group by every column). Authenticated ' +
         'with the ODM member token via `x-owox-authorization`. Creates one DataMartRun ' +
         'of type HTTP_DATA per request, available through the run history endpoint.',
-    }),
-    ApiHeader({
-      name: 'x-owox-authorization',
-      description: 'ODM member token',
-      required: true,
     }),
     ApiParam({
       name: 'dataMartId',

--- a/apps/backend/src/idp/controllers/auth-context.controller.openapi.spec.ts
+++ b/apps/backend/src/idp/controllers/auth-context.controller.openapi.spec.ts
@@ -33,54 +33,21 @@ describe('AuthContextController OpenAPI', () => {
     await app.close();
   });
 
-  it('documents the auth context operation, headers, and response schema', () => {
+  it('keeps the operation identity used by the Support Matrix', () => {
     const operation = document.paths['/api/auth/context']?.get;
 
-    expect(operation).toMatchObject({
-      operationId: 'AuthContextController_getContext',
-      tags: ['Authentication'],
-      summary: 'Get the current auth context',
+    expect(operation?.operationId).toBe('AuthContextController_getContext');
+  });
+
+  it('wires the response to the named auth-context presentation component', () => {
+    const operation = document.paths['/api/auth/context']?.get;
+    const response = operation?.responses['200'];
+
+    expect(
+      response && 'content' in response ? response.content?.['application/json']?.schema : null
+    ).toEqual({
+      $ref: '#/components/schemas/AuthContextResponseApiDto',
     });
-    expect(operation?.parameters).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'X-OWOX-Authorization',
-          in: 'header',
-          required: true,
-        }),
-        expect.objectContaining({
-          name: 'X-OWOX-Api-Key-Id',
-          in: 'header',
-          required: false,
-          description:
-            'Required when X-OWOX-Authorization contains an API-key access token; must match the token API key ID.',
-        }),
-      ])
-    );
-    expect(operation?.responses['200']).toMatchObject({
-      description: 'Auth context resolved by the backend auth guard.',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'object',
-            required: ['userId', 'projectId'],
-            properties: {
-              userId: { type: 'string' },
-              projectId: { type: 'string' },
-              email: { type: 'string', nullable: true },
-              fullName: { type: 'string', nullable: true },
-              avatar: { type: 'string', nullable: true },
-              roles: {
-                type: 'array',
-                items: { type: 'string', enum: ['admin', 'editor', 'viewer'] },
-              },
-              projectTitle: { type: 'string', nullable: true },
-              authFlow: { type: 'string', nullable: true },
-              apiKeyId: { type: 'string', nullable: true },
-            },
-          },
-        },
-      },
-    });
+    expect(document.components?.schemas?.AuthContextResponseApiDto).toBeDefined();
   });
 });

--- a/apps/backend/src/idp/controllers/auth-context.controller.ts
+++ b/apps/backend/src/idp/controllers/auth-context.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiHeader, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Auth, AuthContext } from '../decorators';
+import { AuthContextResponseApiDto } from '../dto/presentation/auth-context-response-api.dto';
 import { AuthorizationContext, Role, Strategy } from '../types';
 
 @Controller('auth/context')
@@ -9,32 +10,11 @@ export class AuthContextController {
   @Auth(Role.viewer(Strategy.INTROSPECT))
   @Get()
   @ApiOperation({ summary: 'Get the current auth context' })
-  @ApiHeader({ name: 'X-OWOX-Authorization', required: true })
-  @ApiHeader({
-    name: 'X-OWOX-Api-Key-Id',
-    required: false,
-    description:
-      'Required when X-OWOX-Authorization contains an API-key access token; must match the token API key ID.',
-  })
   @ApiOkResponse({
     description: 'Auth context resolved by the backend auth guard.',
-    schema: {
-      type: 'object',
-      required: ['userId', 'projectId'],
-      properties: {
-        userId: { type: 'string' },
-        projectId: { type: 'string' },
-        email: { type: 'string', nullable: true },
-        fullName: { type: 'string', nullable: true },
-        avatar: { type: 'string', nullable: true },
-        roles: { type: 'array', items: { type: 'string', enum: ['admin', 'editor', 'viewer'] } },
-        projectTitle: { type: 'string', nullable: true },
-        authFlow: { type: 'string', nullable: true },
-        apiKeyId: { type: 'string', nullable: true },
-      },
-    },
+    type: AuthContextResponseApiDto,
   })
-  getContext(@AuthContext() context: AuthorizationContext): AuthorizationContext {
+  getContext(@AuthContext() context: AuthorizationContext): AuthContextResponseApiDto {
     return {
       userId: context.userId,
       projectId: context.projectId,

--- a/apps/backend/src/idp/decorators/auth.decorator.openapi.spec.ts
+++ b/apps/backend/src/idp/decorators/auth.decorator.openapi.spec.ts
@@ -1,0 +1,156 @@
+import { Controller, Get, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ApiHeader, OpenAPIObject } from '@nestjs/swagger';
+import { createSwaggerDocument } from '../../config/swagger.config';
+import { ApiKeyExchangeController } from '../../project-member-api-keys/controllers/api-key-exchange.controller';
+import { ExchangeProjectMemberApiKeyService } from '../../project-member-api-keys/use-cases/exchange-project-member-api-key.service';
+import { IdpGuard } from '../guards/idp.guard';
+import { Role } from '../types';
+import { Auth } from './auth.decorator';
+import { RejectApiKeyAuth } from './reject-api-key-auth.decorator';
+
+@Controller('eligible')
+class EligibleController {
+  @Get()
+  @Auth(Role.viewer())
+  get(): void {}
+}
+
+@Controller('api-key-rejected')
+@RejectApiKeyAuth()
+class ApiKeyRejectedController {
+  @Get()
+  @Auth(Role.viewer())
+  get(): void {}
+}
+
+@Controller('local-auth-copy')
+class LocalAuthCopyController {
+  @Get()
+  @Auth(Role.viewer())
+  @ApiHeader({ name: 'x-owox-authorization', required: true })
+  get(): void {}
+}
+
+@Controller('public')
+class PublicController {
+  @Get()
+  @Auth(Role.none())
+  get(): void {}
+}
+
+describe('Auth OpenAPI contract', () => {
+  let app: INestApplication;
+  let document: OpenAPIObject;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [
+        EligibleController,
+        ApiKeyRejectedController,
+        LocalAuthCopyController,
+        PublicController,
+        ApiKeyExchangeController,
+      ],
+      providers: [{ provide: ExchangeProjectMemberApiKeyService, useValue: {} }],
+    })
+      .overrideGuard(IdpGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    document = createSwaggerDocument(app);
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it('documents the canonical OWOX authentication headers for eligible operations', () => {
+    const operation = document.paths['/eligible']?.get;
+    const parameters = operation?.parameters;
+
+    expect(operation?.security).toEqual([{ 'X-OWOX-Authorization': [] }]);
+    expect(parameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'X-OWOX-Api-Key-Id',
+          in: 'header',
+          required: false,
+          description: expect.stringMatching(/required.*match.*API key ID/i),
+        }),
+      ])
+    );
+  });
+
+  it('omits API-key metadata from authenticated operations that reject API keys', () => {
+    const operation = document.paths['/api-key-rejected']?.get;
+    const parameters = operation?.parameters;
+
+    expect(operation?.security).toEqual([{ 'X-OWOX-Authorization': [] }]);
+    expect(parameters).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'X-OWOX-Api-Key-Id',
+          in: 'header',
+        }),
+      ])
+    );
+  });
+
+  it('omits authentication metadata from public operations', () => {
+    const operation = document.paths['/public']?.get;
+    const parameters = operation?.parameters;
+
+    expect(operation?.security).toBeUndefined();
+    expect(parameters ?? []).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.stringMatching(/^X-OWOX-/),
+          in: 'header',
+        }),
+      ])
+    );
+  });
+
+  it('defines the X-OWOX authorization security scheme used by protected operations', () => {
+    expect(document.components?.securitySchemes).toMatchObject({
+      'X-OWOX-Authorization': {
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-OWOX-Authorization',
+        description: expect.stringContaining('Bearer'),
+      },
+    });
+  });
+
+  it('removes endpoint-local copies of the shared authorization input', () => {
+    const parameters = document.paths['/local-auth-copy']?.get?.parameters ?? [];
+
+    expect(parameters).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.stringMatching(/^x-owox-authorization$/i),
+          in: 'header',
+        }),
+      ])
+    );
+  });
+
+  it('keeps the API-key exchange header required without bearer-token security metadata', () => {
+    const operation = document.paths['/auth/api-keys/exchange']?.post;
+
+    expect(operation?.security).toBeUndefined();
+    expect(operation?.parameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'X-OWOX-Api-Key-Id',
+          in: 'header',
+          required: true,
+        }),
+      ])
+    );
+  });
+});

--- a/apps/backend/src/idp/decorators/auth.decorator.ts
+++ b/apps/backend/src/idp/decorators/auth.decorator.ts
@@ -1,7 +1,8 @@
 import { SetMetadata, applyDecorators, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiUnauthorizedResponse, ApiForbiddenResponse } from '@nestjs/swagger';
+import { ApiForbiddenResponse, ApiSecurity, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import type { RoleConfig } from '../types/role-config.types';
 import { IdpGuard } from '../guards/idp.guard';
+import { OWOX_AUTHORIZATION_SECURITY_SCHEME } from '../openapi/authentication.openapi';
 
 const ROLE_DISPLAY_NAMES: Record<string, string> = {
   admin: 'Project Admin',
@@ -38,9 +39,11 @@ const ROLE_DISPLAY_NAMES: Record<string, string> = {
  * ```
  */
 export const Auth = (roleConfig: RoleConfig) => {
-  const decorators = [SetMetadata('roleConfig', roleConfig), UseGuards(IdpGuard), ApiBearerAuth()];
+  const decorators = [SetMetadata('roleConfig', roleConfig), UseGuards(IdpGuard)];
 
   if (!roleConfig.optional) {
+    decorators.push(ApiSecurity(OWOX_AUTHORIZATION_SECURITY_SCHEME));
+
     decorators.push(ApiUnauthorizedResponse({ description: 'Authentication required' }));
   }
 

--- a/apps/backend/src/idp/decorators/reject-api-key-auth.decorator.ts
+++ b/apps/backend/src/idp/decorators/reject-api-key-auth.decorator.ts
@@ -1,5 +1,11 @@
-import { SetMetadata } from '@nestjs/common';
+import { SetMetadata, applyDecorators } from '@nestjs/common';
+import { ApiExtension } from '@nestjs/swagger';
+import { OWOX_API_KEY_AUTH_EXTENSION } from '../openapi/authentication.openapi';
 
 export const REJECT_API_KEY_AUTH_METADATA = 'rejectApiKeyAuth';
 
-export const RejectApiKeyAuth = () => SetMetadata(REJECT_API_KEY_AUTH_METADATA, true);
+export const RejectApiKeyAuth = () =>
+  applyDecorators(
+    SetMetadata(REJECT_API_KEY_AUTH_METADATA, true),
+    ApiExtension(OWOX_API_KEY_AUTH_EXTENSION, false)
+  );

--- a/apps/backend/src/idp/dto/presentation/auth-context-response-api.dto.ts
+++ b/apps/backend/src/idp/dto/presentation/auth-context-response-api.dto.ts
@@ -1,4 +1,4 @@
-import type { Role } from '@owox/idp-protocol';
+import { RoleEnum, type Role } from '@owox/idp-protocol';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class AuthContextResponseApiDto {
@@ -17,7 +17,7 @@ export class AuthContextResponseApiDto {
   @ApiPropertyOptional({ nullable: true })
   avatar?: string;
 
-  @ApiPropertyOptional({ enum: ['admin', 'editor', 'viewer'], isArray: true })
+  @ApiPropertyOptional({ enum: RoleEnum.options, isArray: true })
   roles?: Role[];
 
   @ApiPropertyOptional({ nullable: true })

--- a/apps/backend/src/idp/dto/presentation/auth-context-response-api.dto.ts
+++ b/apps/backend/src/idp/dto/presentation/auth-context-response-api.dto.ts
@@ -1,0 +1,31 @@
+import type { Role } from '@owox/idp-protocol';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AuthContextResponseApiDto {
+  @ApiProperty()
+  userId: string;
+
+  @ApiProperty()
+  projectId: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  email?: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  fullName?: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  avatar?: string;
+
+  @ApiPropertyOptional({ enum: ['admin', 'editor', 'viewer'], isArray: true })
+  roles?: Role[];
+
+  @ApiPropertyOptional({ nullable: true })
+  projectTitle?: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  authFlow?: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  apiKeyId?: string;
+}

--- a/apps/backend/src/idp/openapi/authentication.openapi.ts
+++ b/apps/backend/src/idp/openapi/authentication.openapi.ts
@@ -1,0 +1,9 @@
+export const OWOX_AUTHORIZATION_HEADER = 'X-OWOX-Authorization';
+export const OWOX_API_KEY_ID_HEADER = 'X-OWOX-Api-Key-Id';
+export const OWOX_AUTHORIZATION_SECURITY_SCHEME = OWOX_AUTHORIZATION_HEADER;
+export const OWOX_API_KEY_AUTH_EXTENSION = 'x-owox-api-key-auth';
+
+export const OWOX_AUTHORIZATION_DESCRIPTION = 'OWOX access token using the Bearer scheme.';
+
+export const OWOX_API_KEY_ID_DESCRIPTION =
+  'Required when X-OWOX-Authorization contains an API-key access token; must match the token API key ID.';

--- a/apps/backend/src/project-member-api-keys/controllers/api-key-exchange.controller.ts
+++ b/apps/backend/src/project-member-api-keys/controllers/api-key-exchange.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Headers, HttpCode, Post } from '@nestjs/common';
 import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { OWOX_API_KEY_ID_HEADER } from '../../idp/openapi/authentication.openapi';
 import { ExchangeProjectMemberApiKeyRequestApiDto } from '../dto/presentation/exchange-project-member-api-key-request-api.dto';
 import { ExchangeProjectMemberApiKeyResponseApiDto } from '../dto/presentation/exchange-project-member-api-key-response-api.dto';
 import { ExchangeProjectMemberApiKeyService } from '../use-cases/exchange-project-member-api-key.service';
@@ -14,7 +15,7 @@ export class ApiKeyExchangeController {
   @Post('exchange')
   @HttpCode(200)
   @ApiOperation({ summary: 'Exchange a project member API key for an ODM access token' })
-  @ApiHeader({ name: 'X-OWOX-Api-Key-Id', required: true })
+  @ApiHeader({ name: OWOX_API_KEY_ID_HEADER, required: true })
   @ApiResponse({ status: 200, type: ExchangeProjectMemberApiKeyResponseApiDto })
   async exchange(
     @Headers('x-owox-api-key-id') apiKeyId: string | undefined,


### PR DESCRIPTION
<!-- owox-factory:api-surface-maintenance case=owox-data-marts/openapi-contract-ownership -->

## Scope

- Model `X-OWOX-Authorization` as the shared OpenAPI security scheme for protected backend operations.
- Derive conditional `X-OWOX-Api-Key-Id` metadata from the existing `@RejectApiKeyAuth()` eligibility boundary, while preserving the required unauthenticated exchange header.
- Replace the inline `GET /api/auth/context` response schema with `AuthContextResponseApiDto` and a generated component reference.
- Keep the Support Matrix operation identity and coverage dates unchanged; `docs/api/openapi.md` remains byte-for-byte identical to `main`.

## Coverage matrix

| Surface | Before | After |
| --- | --- | --- |
| Protected authentication metadata | Standard bearer metadata plus endpoint-local X-OWOX header copies | One X-OWOX security scheme with generated conditional key-ID metadata |
| API-key-rejected operations | Runtime rejection could diverge from generated metadata | Existing rejection decorator owns runtime and OpenAPI eligibility |
| `GET /api/auth/context` response | Complete inline object schema | Named `AuthContextResponseApiDto` component reference |
| Support Matrix | Covered since 2026-07-22 | Unchanged operation link and covered-since date |

## Audited base

`a64abfd6fc4a4d8803280d95b0e442b82605a659`, the merge commit of PR #1451.

## Verification

- 9 focused backend suites, 33 tests, sequential with `--runInBand`
- changed-file TypeScript check using the case-local runtime configuration
- affected-file ESLint and Prettier checks
- Support Matrix validator: 17 tests; 155 endpoints and 9 fully covered
- canonical Changesets validation and Markdown lint
- independent full-diff review plus delta review: no remaining findings
- `docs/api/openapi.md` equality check against current `origin/main`
- review follow-up: 2 focused suites, 8 tests, changed-file typecheck, affected-file lint and formatting
- final-head CI: 17 successful checks; the known `Audit all` baseline failure is recorded below

## Exemptions

None.

## Blocker register

- Review blockers: none.
- Merge blocker: engineer reapproval remains pending for final head `18d762d06`.
- Merge blocker: `Audit all` reports the 12 dependency findings already present in the audited `package-lock.json`; this change does not modify dependency manifests or lockfiles.
- Merge blocker: repository-wide backend `tsc --noEmit` currently reports pre-existing errors in unrelated test files; the changed-file typecheck is clean.

🤖 Codex (GPT-5.6 Sol High)
