### PR TITLE
fix(api): reject API keys for OAuth-only routes

### DIFF
--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -62,11 +62,8 @@ consumers can adopt the client method without a migration.
 
 ## Require interactive authentication for OAuth flows
 
-OAuth-flow-only connector, Data Destination, and Data Storage operations now reject
-API-key-derived authentication. This includes connector OAuth settings, exchange, and status;
-Data Destination OAuth settings, credential status, authorization, exchange, status, and
-revocation; Google Sheets connection completion at
-`POST /api/data-destinations/connect/google-sheets`; and Data Storage OAuth settings, exchange,
-authorization, status, and revocation. Consumers using API keys for these routes must migrate the
-flow to an interactively authenticated user session; API keys remain available for independently
-useful non-OAuth resource operations.
+OAuth routes under `/api/connectors/{connectorName}/oauth`, `/api/data-destinations/oauth`,
+`/api/data-destinations/{id}/oauth`, `/api/data-storages/oauth`, and
+`/api/data-storages/{id}/oauth`, plus `POST /api/data-destinations/connect/google-sheets`, now
+reject API-key authentication and require an interactive user session. API-key access to non-OAuth
+resource operations is unchanged.

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -59,3 +59,14 @@ API-key-derived project and member context. `@owox/api-client` exposes `auth.get
 `OWOXAuthContext` for validating a configured API key and reading that context without exposing
 the API key secret. Existing authentication and authorization behavior are unchanged, and
 consumers can adopt the client method without a migration.
+
+## Require interactive authentication for OAuth flows
+
+OAuth-flow-only connector, Data Destination, and Data Storage operations now reject
+API-key-derived authentication. This includes connector OAuth settings, exchange, and status;
+Data Destination OAuth settings, credential status, authorization, exchange, status, and
+revocation; Google Sheets connection completion at
+`POST /api/data-destinations/connect/google-sheets`; and Data Storage OAuth settings, exchange,
+authorization, status, and revocation. Consumers using API keys for these routes must migrate the
+flow to an interactively authenticated user session; API keys remain available for independently
+useful non-OAuth resource operations.

--- a/apps/backend/src/data-marts/controllers/connector.controller.ts
+++ b/apps/backend/src/data-marts/controllers/connector.controller.ts
@@ -15,7 +15,7 @@ import { ConnectorFieldsResponseApiDto } from '../dto/presentation/connector-fie
 import { SpecificationConnectorService } from '../use-cases/connector/specification-connector.service';
 import { FieldsConnectorService } from '../use-cases/connector/fields-connector.service';
 import { ConnectorMapper } from '../mappers/connector.mapper';
-import { Auth, AuthorizationContext, AuthContext } from '../../idp';
+import { Auth, AuthorizationContext, AuthContext, RejectApiKeyAuth } from '../../idp';
 import { Role } from '../../idp/types/role-config.types';
 import { ExchangeOAuthCredentialsDto } from '../dto/presentation/exchange-oauth-credentials.dto';
 import { ConnectorOAuthCredentialsResponseApiDto } from '../dto/presentation/connector-oauth-credentials-response-api.dto';
@@ -63,6 +63,7 @@ export class ConnectorController {
   }
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Get(':connectorName/oauth/settings')
   @GetConnectorOAuthSettingsSpec()
   async getConnectorOAuthSettings(
@@ -74,6 +75,7 @@ export class ConnectorController {
   }
 
   @Auth(Role.editor())
+  @RejectApiKeyAuth()
   @Post(':connectorName/oauth/exchange')
   @ExchangeOAuthCredentialsSpec()
   async handleOAuthCallback(
@@ -93,6 +95,7 @@ export class ConnectorController {
   }
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Get(':connectorName/oauth/status/:credentialId')
   @GetConnectorOAuthStatusSpec()
   async getConnectorOAuthStatus(

--- a/apps/backend/src/data-marts/controllers/data-destination.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-destination.controller.ts
@@ -25,7 +25,7 @@ import { ListDataDestinationsByTypeService } from '../use-cases/list-data-destin
 import { DataDestinationByTypeResponseApiDto } from '../dto/presentation/data-destination-by-type-response-api.dto';
 import { ListDataDestinationsByTypeCommand } from '../dto/domain/list-data-destinations-by-type.command';
 import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
-import { Auth, AuthContext, AuthorizationContext } from '../../idp';
+import { Auth, AuthContext, AuthorizationContext, RejectApiKeyAuth } from '../../idp';
 import { Role, Strategy } from '../../idp/types/role-config.types';
 import { GenerateAuthorizationUrlRequestDto } from '../dto/presentation/google-oauth/generate-authorization-url-request.dto';
 import { GenerateAuthorizationUrlResponseDto } from '../dto/presentation/google-oauth/generate-authorization-url-response.dto';
@@ -128,6 +128,7 @@ export class DataDestinationController {
   }
 
   @Auth(Role.viewer(Strategy.INTROSPECT))
+  @RejectApiKeyAuth()
   @Post('connect/google-sheets')
   @CreateConnectGoogleSheetsDestinationSpec()
   async createConnectGoogleSheets(
@@ -180,6 +181,7 @@ export class DataDestinationController {
   // --- OAuth endpoints (must be declared before parameterized :id routes) ---
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Get('oauth/settings')
   @OAuthSettingsSpec()
   async getOAuthSettings(): Promise<GoogleOAuthSettingsResponseDto> {
@@ -187,6 +189,7 @@ export class DataDestinationController {
   }
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Get('oauth/credential-status/:credentialId')
   @OAuthCredentialStatusSpec()
   async getOAuthCredentialStatus(
@@ -198,6 +201,7 @@ export class DataDestinationController {
   }
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Post('oauth/authorize')
   @HttpCode(200)
   @OAuthAuthorizeSpec()
@@ -210,6 +214,7 @@ export class DataDestinationController {
   }
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Post('oauth/exchange')
   @HttpCode(200)
   @OAuthExchangeSpec()
@@ -279,6 +284,7 @@ export class DataDestinationController {
   }
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Post(':id/oauth/authorize')
   @HttpCode(200)
   @OAuthAuthorizeSpec(true)
@@ -293,6 +299,7 @@ export class DataDestinationController {
   }
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Get(':id/oauth/status')
   @OAuthStatusSpec()
   async getOAuthStatus(
@@ -305,6 +312,7 @@ export class DataDestinationController {
   }
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Delete(':id/oauth')
   @HttpCode(204)
   @OAuthRevokeSpec()

--- a/apps/backend/src/data-marts/controllers/data-storage.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-storage.controller.ts
@@ -12,7 +12,7 @@ import {
   Query,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Auth, AuthContext, AuthorizationContext } from '../../idp';
+import { Auth, AuthContext, AuthorizationContext, RejectApiKeyAuth } from '../../idp';
 import { Role, Strategy } from '../../idp/types/role-config.types';
 import { CreateDataStorageApiDto } from '../dto/presentation/create-data-storage-api.dto';
 import { DataStorageAccessValidationResponseApiDto } from '../dto/presentation/data-storage-access-validation-response-api.dto';
@@ -159,6 +159,7 @@ export class DataStorageController {
   // --- OAuth endpoints (must be declared before parameterized :id routes) ---
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Get('oauth/settings')
   @OAuthSettingsSpec()
   async getOAuthSettings(): Promise<GoogleOAuthSettingsResponseDto> {
@@ -166,6 +167,7 @@ export class DataStorageController {
   }
 
   @Auth(Role.editor())
+  @RejectApiKeyAuth()
   @Post('oauth/exchange')
   @HttpCode(200)
   @OAuthExchangeSpec()
@@ -228,6 +230,7 @@ export class DataStorageController {
   }
 
   @Auth(Role.editor())
+  @RejectApiKeyAuth()
   @Post(':id/oauth/authorize')
   @HttpCode(200)
   @OAuthAuthorizeSpec()
@@ -242,6 +245,7 @@ export class DataStorageController {
   }
 
   @Auth(Role.viewer())
+  @RejectApiKeyAuth()
   @Get(':id/oauth/status')
   @OAuthStatusSpec()
   async getOAuthStatus(
@@ -254,6 +258,7 @@ export class DataStorageController {
   }
 
   @Auth(Role.editor())
+  @RejectApiKeyAuth()
   @Delete(':id/oauth')
   @HttpCode(204)
   @OAuthRevokeSpec()

--- a/apps/backend/src/data-marts/controllers/oauth-flow-only.controller.spec.ts
+++ b/apps/backend/src/data-marts/controllers/oauth-flow-only.controller.spec.ts
@@ -83,6 +83,8 @@ type ControllerWithHandler = Type;
 
 const SWAGGER_OPERATION_METADATA = 'swagger/apiOperation';
 
+// Keep this behavior inventory semantically aligned with the independently maintained
+// Support Matrix exclusion inventory in apps/docs/scripts/api-coverage-matrix.test.mjs.
 const oauthFlowOnlyRoutes: Array<{
   controller: ControllerWithHandler;
   handlerName: string;
@@ -190,4 +192,33 @@ describe('OAuth-flow-only controller routes', () => {
       expect(Reflect.getMetadata(REJECT_API_KEY_AUTH_METADATA, handler)).toBe(true);
     }
   );
+
+  it('does not reject API keys at controller level or on other handlers', () => {
+    const controllers = [...new Set(oauthFlowOnlyRoutes.map(({ controller }) => controller))];
+    const expectedRejectedHandlers = oauthFlowOnlyRoutes
+      .map(({ controller, handlerName }) => `${controller.name}.${handlerName}`)
+      .sort();
+    const rejectedControllers = controllers
+      .filter(controller => Reflect.getMetadata(REJECT_API_KEY_AUTH_METADATA, controller) === true)
+      .map(controller => controller.name);
+    const rejectedHandlers = controllers
+      .flatMap(controller =>
+        Object.getOwnPropertyNames(controller.prototype)
+          .filter(handlerName => handlerName !== 'constructor')
+          .filter(handlerName => {
+            const handler = (
+              controller.prototype as unknown as Record<string, (...args: never[]) => unknown>
+            )[handlerName];
+            return (
+              typeof handler === 'function' &&
+              Reflect.getMetadata(REJECT_API_KEY_AUTH_METADATA, handler) === true
+            );
+          })
+          .map(handlerName => `${controller.name}.${handlerName}`)
+      )
+      .sort();
+
+    expect(rejectedControllers).toEqual([]);
+    expect(rejectedHandlers).toEqual(expectedRejectedHandlers);
+  });
 });

--- a/apps/backend/src/data-marts/controllers/oauth-flow-only.controller.spec.ts
+++ b/apps/backend/src/data-marts/controllers/oauth-flow-only.controller.spec.ts
@@ -1,0 +1,193 @@
+jest.mock('../../idp', () => {
+  const noopDecorator = () => () => undefined;
+  const rejectApiKeyAuth = jest.requireActual('../../idp/decorators/reject-api-key-auth.decorator');
+
+  return {
+    Auth: noopDecorator,
+    AuthContext: noopDecorator,
+    ...rejectApiKeyAuth,
+  };
+});
+
+jest.mock(
+  '@owox/connectors',
+  () => ({
+    AvailableConnectors: {},
+    Connectors: {},
+    Core: {},
+  }),
+  { virtual: true }
+);
+
+jest.mock(
+  '@owox/internal-helpers',
+  () => ({
+    BaseEvent: class {
+      toJSON() {
+        return {};
+      }
+    },
+  }),
+  { virtual: true }
+);
+
+jest.mock('@owox/idp-protocol', () => ({}), { virtual: true });
+
+jest.mock('../use-cases/connector/available-connector.service', () => ({}));
+jest.mock('../use-cases/connector/specification-connector.service', () => ({}));
+jest.mock('../use-cases/connector/fields-connector.service', () => ({}));
+jest.mock('../mappers/connector.mapper', () => ({}));
+jest.mock('../services/connector/connector-oauth.service', () => ({}));
+jest.mock('../use-cases/create-data-destination.service', () => ({}));
+jest.mock('../use-cases/update-data-destination.service', () => ({}));
+jest.mock('../use-cases/get-data-destination.service', () => ({}));
+jest.mock('../use-cases/list-data-destinations.service', () => ({}));
+jest.mock('../use-cases/list-data-destinations-by-type.service', () => ({}));
+jest.mock('../use-cases/delete-data-destination.service', () => ({}));
+jest.mock('../use-cases/get-data-destination-impact.service', () => ({}));
+jest.mock('../use-cases/rotate-secret-key.service', () => ({}));
+jest.mock('../mappers/data-destination.mapper', () => ({}));
+jest.mock('../services/google-oauth/google-oauth-flow.service', () => ({}));
+jest.mock('../use-cases/google-oauth/get-destination-oauth-status.service', () => ({}));
+jest.mock('../use-cases/google-oauth/get-destination-oauth-credential-status.service', () => ({}));
+jest.mock('../use-cases/google-oauth/generate-destination-oauth-url.service', () => ({}));
+jest.mock('../use-cases/google-oauth/revoke-destination-oauth.service', () => ({}));
+jest.mock('../use-cases/google-oauth/exchange-oauth-code.service', () => ({}));
+jest.mock('../use-cases/update-availability.service', () => ({}));
+jest.mock('../services/access-decision', () => ({
+  Action: {},
+  EntityType: {},
+}));
+jest.mock('../use-cases/google-sheets/create-google-sheet-document.service', () => ({}));
+jest.mock('../use-cases/create-data-storage.service', () => ({}));
+jest.mock('../use-cases/delete-data-storage.service', () => ({}));
+jest.mock('../use-cases/get-data-storage.service', () => ({}));
+jest.mock('../use-cases/list-data-storages.service', () => ({}));
+jest.mock('../use-cases/update-data-storage.service', () => ({}));
+jest.mock('../use-cases/validate-data-storage-access.service', () => ({}));
+jest.mock('../use-cases/google-oauth/get-storage-oauth-status.service', () => ({}));
+jest.mock('../use-cases/google-oauth/generate-storage-oauth-url.service', () => ({}));
+jest.mock('../use-cases/google-oauth/revoke-storage-oauth.service', () => ({}));
+jest.mock('../use-cases/list-data-storages-by-type.service', () => ({}));
+jest.mock('../use-cases/list-storage-resources.service', () => ({}));
+jest.mock('../mappers/data-storage.mapper', () => ({}));
+
+import { RequestMethod, Type } from '@nestjs/common';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import { REJECT_API_KEY_AUTH_METADATA } from '../../idp/decorators/reject-api-key-auth.decorator';
+import { ConnectorController } from './connector.controller';
+import { DataDestinationController } from './data-destination.controller';
+import { DataStorageController } from './data-storage.controller';
+
+type ControllerWithHandler = Type;
+
+const SWAGGER_OPERATION_METADATA = 'swagger/apiOperation';
+
+const oauthFlowOnlyRoutes: Array<{
+  controller: ControllerWithHandler;
+  handlerName: string;
+  endpoint: string;
+}> = [
+  {
+    controller: ConnectorController,
+    handlerName: 'getConnectorOAuthSettings',
+    endpoint: 'GET /api/connectors/{connectorName}/oauth/settings',
+  },
+  {
+    controller: ConnectorController,
+    handlerName: 'handleOAuthCallback',
+    endpoint: 'POST /api/connectors/{connectorName}/oauth/exchange',
+  },
+  {
+    controller: ConnectorController,
+    handlerName: 'getConnectorOAuthStatus',
+    endpoint: 'GET /api/connectors/{connectorName}/oauth/status/{credentialId}',
+  },
+  {
+    controller: DataDestinationController,
+    handlerName: 'createConnectGoogleSheets',
+    endpoint: 'POST /api/data-destinations/connect/google-sheets',
+  },
+  {
+    controller: DataDestinationController,
+    handlerName: 'getOAuthSettings',
+    endpoint: 'GET /api/data-destinations/oauth/settings',
+  },
+  {
+    controller: DataDestinationController,
+    handlerName: 'getOAuthCredentialStatus',
+    endpoint: 'GET /api/data-destinations/oauth/credential-status/{credentialId}',
+  },
+  {
+    controller: DataDestinationController,
+    handlerName: 'generateOAuthAuthorizationUrlStandalone',
+    endpoint: 'POST /api/data-destinations/oauth/authorize',
+  },
+  {
+    controller: DataDestinationController,
+    handlerName: 'exchangeOAuthCode',
+    endpoint: 'POST /api/data-destinations/oauth/exchange',
+  },
+  {
+    controller: DataDestinationController,
+    handlerName: 'generateOAuthAuthorizationUrl',
+    endpoint: 'POST /api/data-destinations/{id}/oauth/authorize',
+  },
+  {
+    controller: DataDestinationController,
+    handlerName: 'getOAuthStatus',
+    endpoint: 'GET /api/data-destinations/{id}/oauth/status',
+  },
+  {
+    controller: DataDestinationController,
+    handlerName: 'revokeOAuth',
+    endpoint: 'DELETE /api/data-destinations/{id}/oauth',
+  },
+  {
+    controller: DataStorageController,
+    handlerName: 'getOAuthSettings',
+    endpoint: 'GET /api/data-storages/oauth/settings',
+  },
+  {
+    controller: DataStorageController,
+    handlerName: 'exchangeOAuthCode',
+    endpoint: 'POST /api/data-storages/oauth/exchange',
+  },
+  {
+    controller: DataStorageController,
+    handlerName: 'generateOAuthAuthorizationUrl',
+    endpoint: 'POST /api/data-storages/{id}/oauth/authorize',
+  },
+  {
+    controller: DataStorageController,
+    handlerName: 'getOAuthStatus',
+    endpoint: 'GET /api/data-storages/{id}/oauth/status',
+  },
+  {
+    controller: DataStorageController,
+    handlerName: 'revokeOAuth',
+    endpoint: 'DELETE /api/data-storages/{id}/oauth',
+  },
+];
+
+describe('OAuth-flow-only controller routes', () => {
+  it.each(oauthFlowOnlyRoutes)(
+    'marks $endpoint as unavailable to API-key-derived authentication',
+    ({ controller, handlerName, endpoint }) => {
+      const handler = (
+        controller.prototype as unknown as Record<string, (...args: never[]) => unknown>
+      )[handlerName];
+      const controllerPath = Reflect.getMetadata(PATH_METADATA, controller) as string;
+      const handlerPath = Reflect.getMetadata(PATH_METADATA, handler) as string;
+      const requestMethod = Reflect.getMetadata(METHOD_METADATA, handler) as RequestMethod;
+      const route = `/api/${controllerPath}/${handlerPath}`.replace(/:([^/]+)/g, '{$1}');
+      const swaggerOperation = Reflect.getMetadata(SWAGGER_OPERATION_METADATA, handler) as
+        | { summary?: string }
+        | undefined;
+
+      expect(`${RequestMethod[requestMethod]} ${route}`).toBe(endpoint);
+      expect(swaggerOperation?.summary).toEqual(expect.any(String));
+      expect(Reflect.getMetadata(REJECT_API_KEY_AUTH_METADATA, handler)).toBe(true);
+    }
+  );
+});

--- a/apps/docs/scripts/api-coverage-matrix.test.mjs
+++ b/apps/docs/scripts/api-coverage-matrix.test.mjs
@@ -260,6 +260,8 @@ test('checked-in matrix uses the public Support Matrix title', () => {
 });
 
 test('checked-in matrix excludes OAuth-flow-only business routes', () => {
+  // Keep this scope inventory semantically aligned with the independently maintained
+  // controller behavior inventory in oauth-flow-only.controller.spec.ts.
   const oauthFlowOnlyEndpoints = [
     'GET /api/connectors/{connectorName}/oauth/settings',
     'POST /api/connectors/{connectorName}/oauth/exchange',

--- a/apps/docs/scripts/api-coverage-matrix.test.mjs
+++ b/apps/docs/scripts/api-coverage-matrix.test.mjs
@@ -258,3 +258,32 @@ test('includes the API-key-compatible markdown parser endpoint', () => {
 test('checked-in matrix uses the public Support Matrix title', () => {
   assert.equal(checkedInMatrix.split('\n', 1)[0], '# Support Matrix');
 });
+
+test('checked-in matrix excludes OAuth-flow-only business routes', () => {
+  const oauthFlowOnlyEndpoints = [
+    'GET /api/connectors/{connectorName}/oauth/settings',
+    'POST /api/connectors/{connectorName}/oauth/exchange',
+    'GET /api/connectors/{connectorName}/oauth/status/{credentialId}',
+    'POST /api/data-destinations/connect/google-sheets',
+    'GET /api/data-destinations/oauth/settings',
+    'GET /api/data-destinations/oauth/credential-status/{credentialId}',
+    'POST /api/data-destinations/oauth/authorize',
+    'POST /api/data-destinations/oauth/exchange',
+    'POST /api/data-destinations/{id}/oauth/authorize',
+    'GET /api/data-destinations/{id}/oauth/status',
+    'DELETE /api/data-destinations/{id}/oauth',
+    'GET /api/data-storages/oauth/settings',
+    'POST /api/data-storages/oauth/exchange',
+    'POST /api/data-storages/{id}/oauth/authorize',
+    'GET /api/data-storages/{id}/oauth/status',
+    'DELETE /api/data-storages/{id}/oauth',
+  ];
+  const checkedInEndpoints = new Set(
+    parseCoverageMatrix(checkedInMatrix).rows.map(row => row.endpoint)
+  );
+
+  assert.deepEqual(
+    oauthFlowOnlyEndpoints.filter(endpoint => checkedInEndpoints.has(endpoint)),
+    []
+  );
+});

--- a/docs/api/coverage.md
+++ b/docs/api/coverage.md
@@ -18,7 +18,7 @@ means the dimension has not been evaluated and does not imply a gap.
 
 | API-key endpoints | Fully covered | OpenAPI covered | API client covered | Unassessed |
 | ----------------: | ------------: | ---------------: | -----------------: | ---------: |
-|               155 |     9/155 (6%) |       9/155 (6%) |         9/155 (6%) |        146 |
+|               139 |     9/139 (6%) |       9/139 (6%) |         9/139 (6%) |        130 |
 
 Fully covered means both OpenAPI and API client coverage are complete. All
 percentages use the complete endpoint inventory below as their denominator.
@@ -35,9 +35,6 @@ percentages use the complete endpoint inventory below as their denominator.
 | --- | --- | --- |
 | `GET /api/connectors` | Unassessed | Unassessed |
 | `GET /api/connectors/{connectorName}/fields` | Unassessed | Unassessed |
-| `POST /api/connectors/{connectorName}/oauth/exchange` | Unassessed | Unassessed |
-| `GET /api/connectors/{connectorName}/oauth/settings` | Unassessed | Unassessed |
-| `GET /api/connectors/{connectorName}/oauth/status/{credentialId}` | Unassessed | Unassessed |
 | `GET /api/connectors/{connectorName}/specification` | Unassessed | Unassessed |
 
 ## Contexts
@@ -73,20 +70,12 @@ percentages use the complete endpoint inventory below as their denominator.
 | `GET /api/data-destinations` | Unassessed | Unassessed |
 | `POST /api/data-destinations` | Unassessed | Unassessed |
 | `GET /api/data-destinations/by-type/{type}` | Unassessed | Unassessed |
-| `POST /api/data-destinations/connect/google-sheets` | Unassessed | Unassessed |
-| `POST /api/data-destinations/oauth/authorize` | Unassessed | Unassessed |
-| `GET /api/data-destinations/oauth/credential-status/{credentialId}` | Unassessed | Unassessed |
-| `POST /api/data-destinations/oauth/exchange` | Unassessed | Unassessed |
-| `GET /api/data-destinations/oauth/settings` | Unassessed | Unassessed |
 | `DELETE /api/data-destinations/{id}` | Unassessed | Unassessed |
 | `GET /api/data-destinations/{id}` | Unassessed | Unassessed |
 | `PUT /api/data-destinations/{id}` | Unassessed | Unassessed |
 | `PUT /api/data-destinations/{id}/availability` | Unassessed | Unassessed |
 | `POST /api/data-destinations/{id}/google-sheets/documents` | Unassessed | Unassessed |
 | `GET /api/data-destinations/{id}/impact` | Unassessed | Unassessed |
-| `DELETE /api/data-destinations/{id}/oauth` | Unassessed | Unassessed |
-| `POST /api/data-destinations/{id}/oauth/authorize` | Unassessed | Unassessed |
-| `GET /api/data-destinations/{id}/oauth/status` | Unassessed | Unassessed |
 | `POST /api/data-destinations/{id}/rotate-secret-key` | Unassessed | Unassessed |
 
 ## Data Marts
@@ -136,8 +125,6 @@ percentages use the complete endpoint inventory below as their denominator.
 | `GET /api/data-storages` | Unassessed | Unassessed |
 | `POST /api/data-storages` | Unassessed | Unassessed |
 | `GET /api/data-storages/by-type/{type}` | Unassessed | Unassessed |
-| `POST /api/data-storages/oauth/exchange` | Unassessed | Unassessed |
-| `GET /api/data-storages/oauth/settings` | Unassessed | Unassessed |
 | `POST /api/data-storages/{dataStorageId}/publish-drafts-triggers` | Unassessed | Unassessed |
 | `DELETE /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}` | Unassessed | Unassessed |
 | `GET /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}` | Unassessed | Unassessed |
@@ -146,9 +133,6 @@ percentages use the complete endpoint inventory below as their denominator.
 | `GET /api/data-storages/{id}` | Unassessed | Unassessed |
 | `PUT /api/data-storages/{id}` | Unassessed | Unassessed |
 | `PUT /api/data-storages/{id}/availability` | Unassessed | Unassessed |
-| `DELETE /api/data-storages/{id}/oauth` | Unassessed | Unassessed |
-| `POST /api/data-storages/{id}/oauth/authorize` | Unassessed | Unassessed |
-| `GET /api/data-storages/{id}/oauth/status` | Unassessed | Unassessed |
 | `GET /api/data-storages/{id}/resources` | Unassessed | Unassessed |
 | `POST /api/data-storages/{id}/validate-access` | Unassessed | Unassessed |
 


### PR DESCRIPTION
<!-- owox-factory:api-surface-maintenance case=owox-data-marts/oauth-flow-only-api-scope -->

## Scope

- Reject API-key-derived authentication on all 16 business routes whose sole purpose is to initiate, complete, exchange, inspect, or revoke OAuth authorization or credentials.
- Cover the connector OAuth settings/exchange/status routes, destination OAuth settings/credential-status/authorize/exchange/status/revoke routes, storage OAuth settings/exchange/authorize/status/revoke routes, and Google Sheets OAuth connection completion.
- Preserve API-key access for generic destination/storage operations and other routes with independent non-OAuth utility.
- Remove the flow-only routes from the API-key Support Matrix as scope classifications and update its derived totals.

## Coverage matrix

| Surface | Before | After |
| --- | ---: | ---: |
| In-scope API-key endpoints | 155 | 139 |
| Fully covered | 9/155 | 9/139 |
| OpenAPI covered | 9/155 | 9/139 |
| API client covered | 9/155 | 9/139 |
| Unassessed | 146 | 130 |

The 16 removed rows are OAuth-flow-only exclusions, not coverage gaps or exemptions.

## Audited base

`a64abfd6fc4a4d8803280d95b0e442b82605a659` (`origin/main` at publication). Current
`main` at `deb379295c054182d07a7577d7d1815c4941f768` is integrated, including the shared
API-key authentication OpenAPI primitive and canonical workflow changeset update from PR #1452.

## Verification

- Initial focused backend route/Swagger/rejection-metadata and `IdpGuard` suites: 27/27 tests.
- Review follow-up controller scope invariant: 17/17 tests.
- After integrating current `main`, focused route, shared auth OpenAPI, and `IdpGuard` suites:
  34/34 tests; Support Matrix tests and validator: 18/18 tests, 139 endpoints, and 9 fully covered.
- Affected backend and docs ESLint, workspace-aware Prettier, Markdownlint, Changesets status, and `git diff --check` pass.
- Independent initial, whole-branch, follow-up, and post-merge delta reviews found no remaining issues.
- `docs/api/openapi.md` is unchanged; the managed worktree is clean at head `6710913b0`.
- All final-head required checks except the classified `Audit all` baseline are green.

## Exemptions

None.

## Blocker register

- Review blockers: none.
- Merge blocker: `Audit all` reports the 12 dependency findings already present in the unchanged
  lockfile; this branch does not modify dependency manifests or the lockfile.
- Merge blocker: engineer approval applies to prior head `5b7ca0895`; final-head approval is pending.
- Baseline: the repository-wide backend TypeScript check reports existing unbuilt-workspace and unrelated-test diagnostics; no diagnostic references a changed TypeScript file.

🤖 Codex (GPT-5.6 Sol High)
