### PR TITLE
Google Chat Destination integration 

### DIFF
--- a/.changeset/google-chat-direct-webhook.md
+++ b/.changeset/google-chat-direct-webhook.md
@@ -1,0 +1,10 @@
+---
+'owox': minor
+---
+
+# Add direct Google Chat delivery while preserving channel email
+
+Google Chat Destinations now offer Google Chat API and Channel Email delivery methods. Existing
+email-based destinations keep their current method, while new destinations default to direct API
+delivery through a space-specific incoming webhook. API messages are formatted cards containing the
+subject, Data Mart, complete rendered Insight, and a link back to OWOX.

--- a/.changeset/google-chat-direct-webhook.md
+++ b/.changeset/google-chat-direct-webhook.md
@@ -4,7 +4,7 @@
 
 # Add direct Google Chat delivery while preserving channel email
 
-Google Chat Destinations now offer Google Chat API and Channel Email delivery methods. Existing
-email-based destinations keep their current method, while new destinations default to direct API
-delivery through a space-specific incoming webhook. API messages are formatted cards containing the
-subject, Data Mart, complete rendered Insight, and a link back to OWOX.
+Google Chat Destinations now offer Incoming Webhook and Channel Email delivery methods. Existing
+email-based destinations keep their current method, while new destinations default to direct
+delivery through a space-specific incoming webhook. Webhook messages are formatted cards containing
+the subject, Data Mart name, rendered report, and a link back to OWOX Data Marts.

--- a/apps/backend/src/data-marts/data-destination-types/data-destination-credentials.type.ts
+++ b/apps/backend/src/data-marts/data-destination-types/data-destination-credentials.type.ts
@@ -2,9 +2,11 @@ import { z } from 'zod';
 import { EmailCredentialsSchema } from './ee/email/schemas/email-credentials.schema';
 import { GoogleSheetsCredentialsSchema } from './google-sheets/schemas/google-sheets-credentials.schema';
 import { LookerStudioConnectorCredentialsSchema } from './looker-studio-connector/schemas/looker-studio-connector-credentials.schema';
+import { GoogleChatCredentialsSchema } from './ee/google-chat/schemas/google-chat-credentials.schema';
 
 export const DataDestinationCredentialsSchema = z.discriminatedUnion('type', [
   EmailCredentialsSchema,
+  GoogleChatCredentialsSchema,
   GoogleSheetsCredentialsSchema,
   LookerStudioConnectorCredentialsSchema,
 ]);

--- a/apps/backend/src/data-marts/data-destination-types/data-destination-providers.ts
+++ b/apps/backend/src/data-marts/data-destination-types/data-destination-providers.ts
@@ -3,10 +3,11 @@ import { TypeResolver } from '../../common/resolver/type-resolver';
 import { AvailableDestinationTypesService } from './available-destination-types.service';
 import {
   EmailReportWriter,
-  GoogleChatReportWriter,
   MsTeamsReportWriter,
   SlackReportWriter,
 } from './ee/email/services/email-report-writer';
+import { GoogleChatReportWriter } from './ee/google-chat/services/google-chat-report-writer';
+import { GoogleChatWebhookClient } from './ee/google-chat/services/google-chat-webhook.client';
 import { DataDestinationType } from './enums/data-destination-type.enum';
 import { GoogleSheetsApiAdapterFactory } from './google-sheets/adapters/google-sheets-api-adapter.factory';
 import { GoogleSheetsReportCreatedListener } from './google-sheets/listeners/google-sheets-report-created.listener';
@@ -38,16 +39,16 @@ import { LookerStudioAggregationMapperService } from './looker-studio-connector/
 import { LookerStudioTypeMapperService } from './looker-studio-connector/services/looker-studio-type-mapper.service';
 import {
   EmailAccessValidator,
-  GoogleChatAccessValidator,
   MsTeamsAccessValidator,
   SlackAccessValidator,
 } from './ee/email/services/email-access-validator';
+import { GoogleChatAccessValidator } from './ee/google-chat/services/google-chat-access-validator';
 import {
   EmailCredentialsValidator,
-  GoogleChatCredentialsValidator,
   MsTeamsCredentialsValidator,
   SlackCredentialsValidator,
 } from './ee/email/services/email-credentials-validator';
+import { GoogleChatCredentialsValidator } from './ee/google-chat/services/google-chat-credentials-validator';
 
 export const DATA_DESTINATION_ACCESS_VALIDATOR_RESOLVER = Symbol(
   'DATA_DESTINATION_ACCESS_VALIDATOR_RESOLVER'
@@ -113,6 +114,7 @@ export const dataDestinationResolverProviders = [
   ...reportWriterProviders,
   ...googleSheetsUtilityProviders,
   ...publicCredentialsProviders,
+  GoogleChatWebhookClient,
   GoogleSheetsApiAdapterFactory,
   LookerStudioConnectorApiConfigService,
   LookerStudioConnectorApiSchemaService,

--- a/apps/backend/src/data-marts/data-destination-types/ee/email/README.md
+++ b/apps/backend/src/data-marts/data-destination-types/ee/email/README.md
@@ -1,10 +1,12 @@
 # Email destination — transitional note
 
-- Currently, the Email destination uses the common logic that is shared by four destination types:
+- Currently, the Email destination uses the common logic that is shared by three destination types:
   - EMAIL
   - SLACK
   - MS_TEAMS
-  - GOOGLE_CHAT
-- In the future, all destination types except Email are expected to receive their own type‑specific implementations and be extracted from here.
+- Google Chat has a type-specific implementation that supports both incoming webhooks and the
+  existing channel-email delivery method. Channel email reuses the shared email writer.
+- In the future, Slack and Microsoft Teams are expected to receive their own type-specific
+  implementations and be extracted from here.
 
 This README clarifies the current transitional state until those extractions are completed.

--- a/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-access-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-access-validator.ts
@@ -81,12 +81,3 @@ export class MsTeamsAccessValidator extends BaseEmailAccessValidator {
     super();
   }
 }
-
-@Injectable()
-export class GoogleChatAccessValidator extends BaseEmailAccessValidator {
-  protected readonly logger = new Logger(GoogleChatAccessValidator.name);
-  readonly type = DataDestinationType.GOOGLE_CHAT;
-  constructor(protected readonly credentialsResolver: DataDestinationCredentialsResolver) {
-    super();
-  }
-}

--- a/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-credentials-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-credentials-validator.ts
@@ -49,9 +49,3 @@ export class MsTeamsCredentialsValidator extends BaseEmailCredentialsValidator {
   protected readonly logger = new Logger(MsTeamsCredentialsValidator.name);
   readonly type = DataDestinationType.MS_TEAMS;
 }
-
-@Injectable()
-export class GoogleChatCredentialsValidator extends BaseEmailCredentialsValidator {
-  protected readonly logger = new Logger(GoogleChatCredentialsValidator.name);
-  readonly type = DataDestinationType.GOOGLE_CHAT;
-}

--- a/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.spec.ts
@@ -13,7 +13,7 @@ import { InsightTemplateSourceUsageService } from '../../../../services/insight-
 import { DataDestinationCredentialsResolver } from '../../../data-destination-credentials-resolver.service';
 import { DataDestinationType } from '../../../enums/data-destination-type.enum';
 import { ReportCondition } from '../../../enums/report-condition.enum';
-import { EmailReportWriter } from './email-report-writer';
+import { EmailReportWriter, MsTeamsReportWriter, SlackReportWriter } from './email-report-writer';
 
 jest.mock('../../../../../common/markdown/markdown-parser.service', () => ({
   COLOR_THEME: { LIGHT: 'LIGHT' },
@@ -21,7 +21,12 @@ jest.mock('../../../../../common/markdown/markdown-parser.service', () => ({
 }));
 
 describe('EmailReportWriter', () => {
-  const createWriter = () => {
+  const createWriter = (
+    destinationType:
+      | DataDestinationType.EMAIL
+      | DataDestinationType.SLACK
+      | DataDestinationType.MS_TEAMS = DataDestinationType.EMAIL
+  ) => {
     const emailProvider = {
       sendEmail: jest.fn().mockResolvedValue(undefined),
     };
@@ -62,9 +67,15 @@ describe('EmailReportWriter', () => {
     const sourceUsageService = {
       getUsedSourceKeys: jest.fn().mockReturnValue(['main']),
     };
+    const Writer =
+      destinationType === DataDestinationType.SLACK
+        ? SlackReportWriter
+        : destinationType === DataDestinationType.MS_TEAMS
+          ? MsTeamsReportWriter
+          : EmailReportWriter;
 
     return {
-      writer: new EmailReportWriter(
+      writer: new Writer(
         emailProvider as never,
         markdownParser as never as MarkdownParser,
         publicOriginService as never,
@@ -86,7 +97,7 @@ describe('EmailReportWriter', () => {
     };
   };
 
-  const createReport = (): Report =>
+  const createReport = (destinationType: DataDestinationType = DataDestinationType.EMAIL): Report =>
     ({
       id: 'report-1',
       title: 'Report',
@@ -104,7 +115,7 @@ describe('EmailReportWriter', () => {
       },
       dataDestination: {
         id: 'destination-1',
-        type: DataDestinationType.EMAIL,
+        type: destinationType,
       },
       dataMart: {
         id: 'data-mart-1',
@@ -129,9 +140,13 @@ describe('EmailReportWriter', () => {
       },
     }) as Report;
 
-  it('finalizes delivery without returning consumption metadata', async () => {
-    const { writer, emailProvider, eventDispatcher } = createWriter();
-    const report = createReport();
+  it.each([
+    { type: DataDestinationType.EMAIL, eventName: 'email.report.run.successfully' },
+    { type: DataDestinationType.SLACK, eventName: 'slack.report.run.successfully' },
+    { type: DataDestinationType.MS_TEAMS, eventName: 'ms-teams.report.run.successfully' },
+  ])('$type finalizes email delivery and emits its success event', async ({ type, eventName }) => {
+    const { writer, emailProvider, eventDispatcher } = createWriter(type);
+    const report = createReport(type);
 
     await writer.prepareToWriteReport(report, new ReportDataDescription([]));
     const result = await writer.finalize();
@@ -143,7 +158,7 @@ describe('EmailReportWriter', () => {
       name: string;
       payload: unknown;
     };
-    expect(event.name).toBe('email.report.run.successfully');
+    expect(event.name).toBe(eventName);
     expect(event.payload).toEqual({
       dataMartId: 'data-mart-1',
       runId: 'report-1',

--- a/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/email/services/email-report-writer.ts
@@ -58,7 +58,7 @@ import { InsightTemplate } from '../../../../entities/insight-template.entity';
  *
  * Subclasses must define the abstract properties `type` and `logger`.
  */
-abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
+export abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
   abstract readonly type: DataDestinationType;
   protected abstract readonly logger: Logger;
 
@@ -70,13 +70,13 @@ abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
     ERROR_SENDING: 'Error sending Report data',
   } as const;
 
-  private emailConfig: EmailConfig;
-  private emailCredentials: EmailCredentials;
-  private reportDataDescription: ReportDataDescription;
-  private report: Report;
+  protected emailConfig!: EmailConfig;
+  private emailCredentials!: EmailCredentials;
+  private reportDataDescription!: ReportDataDescription;
+  protected report!: Report;
   private reportDataRows: unknown[][] = [];
   private mainRowsTruncationInfo: RowsTruncationInfo | null = null;
-  private executionLogger?: ReportRunLogger;
+  protected executionLogger?: ReportRunLogger;
 
   protected constructor(
     private readonly emailProvider: EmailProviderFacade,
@@ -84,7 +84,7 @@ abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
     private readonly publicOriginService: PublicOriginService,
     private readonly insightTemplateFacade: DataMartInsightTemplateFacadeImpl,
     private readonly eventDispatcher: OwoxEventDispatcher,
-    private readonly credentialsResolver: DataDestinationCredentialsResolver,
+    protected readonly credentialsResolver: DataDestinationCredentialsResolver,
     private readonly sourceDataService: InsightTemplateSourceDataService,
     protected readonly insightTemplateService: InsightTemplateService,
     private readonly sourceUsageService: InsightTemplateSourceUsageService
@@ -103,15 +103,19 @@ abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
     }
     this.emailConfig = report.destinationConfig;
 
+    await this.prepareDeliveryCredentials(report);
+
+    this.reportDataDescription = reportDataDescription;
+    this.report = report;
+  }
+
+  protected async prepareDeliveryCredentials(report: Report): Promise<void> {
     const resolvedCredentials = await this.credentialsResolver.resolve(report.dataDestination);
     const parsed = EmailCredentialsSchema.safeParse(resolvedCredentials);
     if (!parsed.success) {
       throw new Error('Invalid Email credentials provided');
     }
     this.emailCredentials = parsed.data;
-
-    this.reportDataDescription = reportDataDescription;
-    this.report = report;
   }
 
   public async writeReportDataBatch(reportDataBatch: ReportDataBatch): Promise<void> {
@@ -137,8 +141,7 @@ abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
       });
     } else {
       const rendered = await this.renderMessageTemplate();
-      const emailHtml = await this.prepareEmailHtml(rendered);
-      await this.sendEmail(emailHtml);
+      await this.sendRenderedMessage(rendered);
     }
 
     await this.produceRunEvent('successfully');
@@ -371,6 +374,11 @@ abstract class BaseEmailReportWriter implements DataDestinationReportWriter {
     });
   }
 
+  protected async sendRenderedMessage(markdownContent: string): Promise<void> {
+    const emailHtml = await this.prepareEmailHtml(markdownContent);
+    await this.sendEmail(emailHtml);
+  }
+
   private async sendEmail(emailHtml: string): Promise<void> {
     await this.emailProvider.sendEmail(
       this.emailCredentials.to,
@@ -475,36 +483,6 @@ export class SlackReportWriter extends BaseEmailReportWriter {
 export class MsTeamsReportWriter extends BaseEmailReportWriter {
   protected readonly logger = new Logger(MsTeamsReportWriter.name);
   readonly type = DataDestinationType.MS_TEAMS;
-
-  constructor(
-    @Inject(EMAIL_PROVIDER_FACADE) emailProvider: EmailProviderFacade,
-    markdownParser: MarkdownParser,
-    publicOriginService: PublicOriginService,
-    insightTemplateFacade: DataMartInsightTemplateFacadeImpl,
-    eventDispatcher: OwoxEventDispatcher,
-    credentialsResolver: DataDestinationCredentialsResolver,
-    sourceDataService: InsightTemplateSourceDataService,
-    insightTemplateService: InsightTemplateService,
-    sourceUsageService: InsightTemplateSourceUsageService
-  ) {
-    super(
-      emailProvider,
-      markdownParser,
-      publicOriginService,
-      insightTemplateFacade,
-      eventDispatcher,
-      credentialsResolver,
-      sourceDataService,
-      insightTemplateService,
-      sourceUsageService
-    );
-  }
-}
-
-@Injectable({ scope: Scope.TRANSIENT })
-export class GoogleChatReportWriter extends BaseEmailReportWriter {
-  protected readonly logger = new Logger(GoogleChatReportWriter.name);
-  readonly type = DataDestinationType.GOOGLE_CHAT;
 
   constructor(
     @Inject(EMAIL_PROVIDER_FACADE) emailProvider: EmailProviderFacade,

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/schemas/google-chat-credentials.schema.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/schemas/google-chat-credentials.schema.spec.ts
@@ -1,0 +1,31 @@
+import {
+  GoogleChatCredentialsSchema,
+  isGoogleChatWebhookUrl,
+} from './google-chat-credentials.schema';
+
+describe('GoogleChatCredentialsSchema', () => {
+  const validUrl = 'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key-1&token=token-1';
+
+  it('accepts a Google Chat incoming webhook URL', () => {
+    expect(
+      GoogleChatCredentialsSchema.parse({
+        type: 'google-chat-credentials',
+        webhookUrl: validUrl,
+      })
+    ).toEqual({
+      type: 'google-chat-credentials',
+      webhookUrl: validUrl,
+    });
+  });
+
+  it.each([
+    'http://chat.googleapis.com/v1/spaces/space-1/messages?key=key&token=token',
+    'https://example.com/v1/spaces/space-1/messages?key=key&token=token',
+    'https://chat.googleapis.com:444/v1/spaces/space-1/messages?key=key&token=token',
+    'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key',
+    'https://chat.googleapis.com/v1/users/user-1/messages?key=key&token=token',
+    'not-a-url',
+  ])('rejects an unsafe or malformed URL: %s', webhookUrl => {
+    expect(isGoogleChatWebhookUrl(webhookUrl)).toBe(false);
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/schemas/google-chat-credentials.schema.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/schemas/google-chat-credentials.schema.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const GoogleChatCredentialsType = 'google-chat-credentials';
+
+const GOOGLE_CHAT_WEBHOOK_PATH = /^\/v1\/spaces\/[^/]+\/messages$/;
+
+export function isGoogleChatWebhookUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === 'https:' &&
+      url.hostname === 'chat.googleapis.com' &&
+      !url.port &&
+      !url.username &&
+      !url.password &&
+      !url.hash &&
+      GOOGLE_CHAT_WEBHOOK_PATH.test(url.pathname) &&
+      Boolean(url.searchParams.get('key')) &&
+      Boolean(url.searchParams.get('token'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+export const GoogleChatCredentialsSchema = z.object({
+  type: z.literal(GoogleChatCredentialsType),
+  webhookUrl: z
+    .string()
+    .trim()
+    .refine(isGoogleChatWebhookUrl, 'A valid Google Chat incoming webhook URL is required'),
+});
+
+export type GoogleChatCredentials = z.infer<typeof GoogleChatCredentialsSchema>;

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-access-validator.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-access-validator.spec.ts
@@ -1,0 +1,31 @@
+import { TemplateSourceTypeEnum } from '../../../../enums/template-source-type.enum';
+import { ReportCondition } from '../../../enums/report-condition.enum';
+import { GoogleChatAccessValidator } from './google-chat-access-validator';
+
+describe('GoogleChatAccessValidator', () => {
+  const config = {
+    type: 'email-config' as const,
+    subject: 'Weekly report',
+    reportCondition: ReportCondition.ALWAYS,
+    templateSource: {
+      type: TemplateSourceTypeEnum.CUSTOM_MESSAGE,
+      config: { messageTemplate: 'Insight' },
+    },
+  };
+
+  it.each([
+    {
+      type: 'google-chat-credentials',
+      webhookUrl: 'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key-1&token=token-1',
+    },
+    { type: 'email-credentials', to: ['space@example.com'] },
+  ])('accepts $type', async credentials => {
+    const validator = new GoogleChatAccessValidator({
+      resolve: jest.fn().mockResolvedValue(credentials),
+    } as never);
+
+    const result = await validator.validate(config, {} as never);
+
+    expect(result.valid).toBe(true);
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-access-validator.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-access-validator.spec.ts
@@ -28,4 +28,16 @@ describe('GoogleChatAccessValidator', () => {
 
     expect(result.valid).toBe(true);
   });
+
+  it('returns channel-email validation errors for invalid email credentials', async () => {
+    const validator = new GoogleChatAccessValidator({
+      resolve: jest.fn().mockResolvedValue({ type: 'email-credentials', to: [] }),
+    } as never);
+
+    const result = await validator.validate(config, {} as never);
+    const errors = result.reason?.errors as Array<{ path: Array<string | number> }>;
+
+    expect(result.valid).toBe(false);
+    expect(errors[0].path).toEqual(['to']);
+  });
 });

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-access-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-access-validator.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DataDestination } from '../../../../entities/data-destination.entity';
+import { DataDestinationConfig } from '../../../data-destination-config.type';
+import { DataDestinationCredentialsResolver } from '../../../data-destination-credentials-resolver.service';
+import { DataDestinationType } from '../../../enums/data-destination-type.enum';
+import {
+  DataDestinationAccessValidator,
+  ValidationResult,
+} from '../../../interfaces/data-destination-access-validator.interface';
+import { EmailConfigInputSchema } from '../../email/schemas/email-config.schema';
+import { EmailCredentialsSchema } from '../../email/schemas/email-credentials.schema';
+import { GoogleChatCredentialsSchema } from '../schemas/google-chat-credentials.schema';
+
+@Injectable()
+export class GoogleChatAccessValidator implements DataDestinationAccessValidator {
+  private readonly logger = new Logger(GoogleChatAccessValidator.name);
+  readonly type = DataDestinationType.GOOGLE_CHAT;
+
+  constructor(private readonly credentialsResolver: DataDestinationCredentialsResolver) {}
+
+  async validate(
+    destinationConfig: DataDestinationConfig,
+    dataDestination: DataDestination
+  ): Promise<ValidationResult> {
+    let resolvedCredentials;
+    try {
+      resolvedCredentials = await this.credentialsResolver.resolve(dataDestination);
+    } catch {
+      return new ValidationResult(false, 'Credentials are not configured');
+    }
+
+    const webhookCredentials = GoogleChatCredentialsSchema.safeParse(resolvedCredentials);
+    const emailCredentials = EmailCredentialsSchema.safeParse(resolvedCredentials);
+    if (!webhookCredentials.success && !emailCredentials.success) {
+      this.logger.warn('Invalid Google Chat credentials format', webhookCredentials.error);
+      return new ValidationResult(false, 'Invalid Google Chat credentials', {
+        errors: webhookCredentials.error.errors,
+      });
+    }
+
+    const config = EmailConfigInputSchema.safeParse(destinationConfig);
+    if (!config.success) {
+      this.logger.warn('Invalid Google Chat report configuration', config.error);
+      return new ValidationResult(false, 'Invalid configuration', {
+        errors: config.error.errors,
+      });
+    }
+
+    return new ValidationResult(true);
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-access-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-access-validator.ts
@@ -8,7 +8,10 @@ import {
   ValidationResult,
 } from '../../../interfaces/data-destination-access-validator.interface';
 import { EmailConfigInputSchema } from '../../email/schemas/email-config.schema';
-import { EmailCredentialsSchema } from '../../email/schemas/email-credentials.schema';
+import {
+  EmailCredentialsSchema,
+  EmailCredentialsType,
+} from '../../email/schemas/email-credentials.schema';
 import { GoogleChatCredentialsSchema } from '../schemas/google-chat-credentials.schema';
 
 @Injectable()
@@ -29,12 +32,14 @@ export class GoogleChatAccessValidator implements DataDestinationAccessValidator
       return new ValidationResult(false, 'Credentials are not configured');
     }
 
-    const webhookCredentials = GoogleChatCredentialsSchema.safeParse(resolvedCredentials);
-    const emailCredentials = EmailCredentialsSchema.safeParse(resolvedCredentials);
-    if (!webhookCredentials.success && !emailCredentials.success) {
-      this.logger.warn('Invalid Google Chat credentials format', webhookCredentials.error);
+    const credentialsValidation =
+      resolvedCredentials.type === EmailCredentialsType
+        ? EmailCredentialsSchema.safeParse(resolvedCredentials)
+        : GoogleChatCredentialsSchema.safeParse(resolvedCredentials);
+    if (!credentialsValidation.success) {
+      this.logger.warn('Invalid Google Chat credentials format', credentialsValidation.error);
       return new ValidationResult(false, 'Invalid Google Chat credentials', {
-        errors: webhookCredentials.error.errors,
+        errors: credentialsValidation.error.errors,
       });
     }
 

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-credentials-validator.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-credentials-validator.spec.ts
@@ -1,0 +1,34 @@
+import { DataDestinationCredentials } from '../../../data-destination-credentials.type';
+import { GoogleChatCredentialsValidator } from './google-chat-credentials-validator';
+
+describe('GoogleChatCredentialsValidator', () => {
+  const validator = new GoogleChatCredentialsValidator();
+
+  it('accepts direct webhook credentials', async () => {
+    const result = await validator.validate({
+      type: 'google-chat-credentials',
+      webhookUrl: 'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key-1&token=token-1',
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts the existing channel email delivery method', async () => {
+    const result = await validator.validate({
+      type: 'email-credentials',
+      to: ['space@example.com'],
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects invalid credentials', async () => {
+    const invalidCredentials = {
+      type: 'email-credentials',
+      to: [],
+    } as unknown as DataDestinationCredentials;
+    const result = await validator.validate(invalidCredentials);
+
+    expect(result.valid).toBe(false);
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-credentials-validator.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-credentials-validator.spec.ts
@@ -28,7 +28,9 @@ describe('GoogleChatCredentialsValidator', () => {
       to: [],
     } as unknown as DataDestinationCredentials;
     const result = await validator.validate(invalidCredentials);
+    const errors = result.reason?.errors as Array<{ path: Array<string | number> }>;
 
     expect(result.valid).toBe(false);
+    expect(errors[0].path).toEqual(['to']);
   });
 });

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-credentials-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-credentials-validator.ts
@@ -1,0 +1,28 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DataDestinationCredentials } from '../../../data-destination-credentials.type';
+import { DataDestinationType } from '../../../enums/data-destination-type.enum';
+import {
+  DataDestinationCredentialsValidator,
+  ValidationResult,
+} from '../../../interfaces/data-destination-credentials-validator.interface';
+import { EmailCredentialsSchema } from '../../email/schemas/email-credentials.schema';
+import { GoogleChatCredentialsSchema } from '../schemas/google-chat-credentials.schema';
+
+@Injectable()
+export class GoogleChatCredentialsValidator implements DataDestinationCredentialsValidator {
+  private readonly logger = new Logger(GoogleChatCredentialsValidator.name);
+  readonly type = DataDestinationType.GOOGLE_CHAT;
+
+  async validate(credentials: DataDestinationCredentials): Promise<ValidationResult> {
+    const webhookCredentials = GoogleChatCredentialsSchema.safeParse(credentials);
+    const emailCredentials = EmailCredentialsSchema.safeParse(credentials);
+    if (!webhookCredentials.success && !emailCredentials.success) {
+      this.logger.warn('Invalid Google Chat credentials format', webhookCredentials.error);
+      return new ValidationResult(false, 'Invalid Google Chat credentials', {
+        errors: webhookCredentials.error.errors,
+      });
+    }
+
+    return new ValidationResult(true);
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-credentials-validator.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-credentials-validator.ts
@@ -5,7 +5,10 @@ import {
   DataDestinationCredentialsValidator,
   ValidationResult,
 } from '../../../interfaces/data-destination-credentials-validator.interface';
-import { EmailCredentialsSchema } from '../../email/schemas/email-credentials.schema';
+import {
+  EmailCredentialsSchema,
+  EmailCredentialsType,
+} from '../../email/schemas/email-credentials.schema';
 import { GoogleChatCredentialsSchema } from '../schemas/google-chat-credentials.schema';
 
 @Injectable()
@@ -14,12 +17,14 @@ export class GoogleChatCredentialsValidator implements DataDestinationCredential
   readonly type = DataDestinationType.GOOGLE_CHAT;
 
   async validate(credentials: DataDestinationCredentials): Promise<ValidationResult> {
-    const webhookCredentials = GoogleChatCredentialsSchema.safeParse(credentials);
-    const emailCredentials = EmailCredentialsSchema.safeParse(credentials);
-    if (!webhookCredentials.success && !emailCredentials.success) {
-      this.logger.warn('Invalid Google Chat credentials format', webhookCredentials.error);
+    const credentialsValidation =
+      credentials.type === EmailCredentialsType
+        ? EmailCredentialsSchema.safeParse(credentials)
+        : GoogleChatCredentialsSchema.safeParse(credentials);
+    if (!credentialsValidation.success) {
+      this.logger.warn('Invalid Google Chat credentials format', credentialsValidation.error);
       return new ValidationResult(false, 'Invalid Google Chat credentials', {
-        errors: webhookCredentials.error.errors,
+        errors: credentialsValidation.error.errors,
       });
     }
 

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.spec.ts
@@ -1,0 +1,181 @@
+import { DataMartInsightTemplateStatus } from '../../../../ai-insights/data-mart-insights.types';
+import { ReportDataDescription } from '../../../../dto/domain/report-data-description.dto';
+import type { Report } from '../../../../entities/report.entity';
+import { TemplateSourceTypeEnum } from '../../../../enums/template-source-type.enum';
+import { DataDestinationType } from '../../../enums/data-destination-type.enum';
+import { ReportCondition } from '../../../enums/report-condition.enum';
+import { buildGoogleChatMessages, GoogleChatReportWriter } from './google-chat-report-writer';
+
+jest.mock('../../../../../common/markdown/markdown-parser.service', () => ({
+  COLOR_THEME: { LIGHT: 'LIGHT' },
+  MarkdownParser: function MarkdownParser() {},
+}));
+
+describe('GoogleChatReportWriter', () => {
+  const webhookUrl =
+    'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key-1&token=token-1';
+
+  const createReport = (): Report =>
+    ({
+      id: 'report-1',
+      title: 'Report',
+      createdById: 'user-1',
+      destinationConfig: {
+        type: 'email-config',
+        subject: 'Weekly report',
+        reportCondition: ReportCondition.ALWAYS,
+        templateSource: {
+          type: TemplateSourceTypeEnum.CUSTOM_MESSAGE,
+          config: { messageTemplate: '# Revenue\n\n**Up 12%**' },
+        },
+      },
+      dataDestination: {
+        id: 'destination-1',
+        type: DataDestinationType.GOOGLE_CHAT,
+      },
+      dataMart: {
+        id: 'data-mart-1',
+        title: 'Sales',
+        projectId: 'project-1',
+      },
+    }) as Report;
+
+  const createWriter = (credentials: object = { type: 'google-chat-credentials', webhookUrl }) => {
+    const emailProvider = { sendEmail: jest.fn().mockResolvedValue(undefined) };
+    const webhookClient = { send: jest.fn().mockResolvedValue(undefined) };
+    const eventDispatcher = { publishExternal: jest.fn().mockResolvedValue(undefined) };
+    const writer = new GoogleChatReportWriter(
+      emailProvider as never,
+      { parseToHtml: jest.fn().mockResolvedValue('<p>Rendered</p>') } as never,
+      { getPublicOrigin: jest.fn().mockReturnValue('https://example.test') } as never,
+      {
+        render: jest.fn().mockResolvedValue({
+          rendered: '# Revenue\n\n**Up 12%**',
+          status: DataMartInsightTemplateStatus.OK,
+          prompts: [],
+        }),
+      } as never,
+      eventDispatcher as never,
+      { resolve: jest.fn().mockResolvedValue(credentials) } as never,
+      { buildRenderContext: jest.fn() } as never,
+      { getByIdAndDataMartIdWithSourceEntities: jest.fn() } as never,
+      { getUsedSourceKeys: jest.fn() } as never,
+      webhookClient as never
+    );
+
+    return { writer, emailProvider, webhookClient, eventDispatcher };
+  };
+
+  it('posts the complete rendered Insight directly to Google Chat', async () => {
+    const { writer, emailProvider, webhookClient, eventDispatcher } = createWriter();
+
+    await writer.prepareToWriteReport(createReport(), new ReportDataDescription([]));
+    await writer.finalize();
+
+    expect(emailProvider.sendEmail).not.toHaveBeenCalled();
+    expect(webhookClient.send).toHaveBeenCalledWith(
+      webhookUrl,
+      expect.objectContaining({ cardsV2: expect.any(Array) })
+    );
+    const payload = webhookClient.send.mock.calls[0][1];
+    expect(payload.cardsV2[0].card.header).toEqual({
+      title: 'Weekly report',
+      subtitle: 'Data Mart: Sales',
+    });
+    expect(payload.cardsV2[0].card.sections[0].widgets[0].textParagraph).toEqual({
+      text: '# Revenue\n\n**Up 12%**',
+      textSyntax: 'MARKDOWN',
+    });
+    expect(payload.fallbackText).toBe('Weekly report — Data Mart: Sales');
+    expect(JSON.stringify(payload)).toContain(
+      'https://example.test/ui/project-1/data-marts/data-mart-1/reports'
+    );
+    expect(eventDispatcher.publishExternal.mock.calls[0][0].name).toBe(
+      'google-chat.report.run.successfully'
+    );
+  });
+
+  it('delivers through the Google Chat channel email when configured', async () => {
+    const { writer, emailProvider, webhookClient } = createWriter({
+      type: 'email-credentials',
+      to: ['space@example.com'],
+    });
+
+    await writer.prepareToWriteReport(createReport(), new ReportDataDescription([]));
+    await writer.finalize();
+
+    expect(emailProvider.sendEmail).toHaveBeenCalledWith(
+      ['space@example.com'],
+      'Weekly report',
+      expect.any(String)
+    );
+    expect(webhookClient.send).not.toHaveBeenCalled();
+  });
+
+  it('splits oversized Insights without dropping multibyte content', () => {
+    const markdown = `# Large insight\n${'Д'.repeat(16_000)}`;
+    const messages = buildGoogleChatMessages({
+      subject: 'Large report',
+      markdown,
+      dataMartTitle: 'Sales',
+      reportUrl: 'https://example.test/report',
+    });
+
+    expect(messages).toHaveLength(2);
+    const combined = messages
+      .map(message => message.cardsV2[0].card.sections[0].widgets[0])
+      .map(widget => ('textParagraph' in widget ? widget.textParagraph.text : ''))
+      .join('');
+    expect(combined).toBe(markdown);
+    expect(messages[0].cardsV2[0].card.header.subtitle).toContain('Part 1 of 2');
+    expect(messages.every(message => Buffer.byteLength(JSON.stringify(message)) <= 30_000)).toBe(
+      true
+    );
+  });
+
+  it('sizes complete serialized payloads when Markdown contains JSON escape characters', () => {
+    const markdown = '"\n'.repeat(12_000);
+    const messages = buildGoogleChatMessages({
+      subject: 'Escaped content',
+      markdown,
+      dataMartTitle: 'Sales',
+      reportUrl: 'https://example.test/report',
+    });
+
+    expect(messages.length).toBeGreaterThan(1);
+    expect(messages.every(message => Buffer.byteLength(JSON.stringify(message)) <= 30_000)).toBe(
+      true
+    );
+    expect(
+      messages
+        .map(message => message.cardsV2[0].card.sections[0].widgets[0])
+        .map(widget => ('textParagraph' in widget ? widget.textParagraph.text : ''))
+        .join('')
+    ).toBe(markdown.trim());
+  });
+
+  it('truncates unusually large headers while keeping the payload valid', () => {
+    const messages = buildGoogleChatMessages({
+      subject: 'S'.repeat(40_000),
+      markdown: 'Insight',
+      dataMartTitle: 'D'.repeat(40_000),
+      reportUrl: 'https://example.test/report',
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].cardsV2[0].card.header.title).toMatch(/…$/);
+    expect(messages[0].cardsV2[0].card.header.subtitle).toContain('…');
+    expect(Buffer.byteLength(JSON.stringify(messages[0]))).toBeLessThanOrEqual(30_000);
+  });
+
+  it('rejects an excessive number of parts before delivery starts', () => {
+    expect(() =>
+      buildGoogleChatMessages({
+        subject: 'Too large',
+        markdown: '\u0000'.repeat(120_000),
+        dataMartTitle: 'Sales',
+        reportUrl: 'https://example.test/report',
+      })
+    ).toThrow('exceeds the 20-message delivery limit');
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.spec.ts
@@ -112,6 +112,16 @@ describe('GoogleChatReportWriter', () => {
     expect(webhookClient.send).not.toHaveBeenCalled();
   });
 
+  it('reports invalid Google Chat credentials without an email-specific error', async () => {
+    const { writer } = createWriter({ type: 'email-credentials', to: [] });
+
+    await expect(
+      writer.prepareToWriteReport(createReport(), new ReportDataDescription([]))
+    ).rejects.toThrow(
+      'Google Chat destination has neither valid webhook nor channel-email credentials'
+    );
+  });
+
   it('splits oversized Insights without dropping multibyte content', () => {
     const markdown = `# Large insight\n${'Д'.repeat(16_000)}`;
     const messages = buildGoogleChatMessages({

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.spec.ts
@@ -40,17 +40,25 @@ describe('GoogleChatReportWriter', () => {
       },
     }) as Report;
 
-  const createWriter = (credentials: object = { type: 'google-chat-credentials', webhookUrl }) => {
+  const createWriter = (
+    credentials: object = { type: 'google-chat-credentials', webhookUrl },
+    rendered = '# Revenue\n\n**Up 12%**'
+  ) => {
     const emailProvider = { sendEmail: jest.fn().mockResolvedValue(undefined) };
     const webhookClient = { send: jest.fn().mockResolvedValue(undefined) };
     const eventDispatcher = { publishExternal: jest.fn().mockResolvedValue(undefined) };
+    const executionLogger = {
+      log: jest.fn(),
+      error: jest.fn(),
+      asArrays: jest.fn().mockReturnValue({ logs: [], errors: [] }),
+    };
     const writer = new GoogleChatReportWriter(
       emailProvider as never,
       { parseToHtml: jest.fn().mockResolvedValue('<p>Rendered</p>') } as never,
       { getPublicOrigin: jest.fn().mockReturnValue('https://example.test') } as never,
       {
         render: jest.fn().mockResolvedValue({
-          rendered: '# Revenue\n\n**Up 12%**',
+          rendered,
           status: DataMartInsightTemplateStatus.OK,
           prompts: [],
         }),
@@ -62,12 +70,14 @@ describe('GoogleChatReportWriter', () => {
       { getUsedSourceKeys: jest.fn() } as never,
       webhookClient as never
     );
+    writer.setExecutionContext({ runId: 'run-1', logger: executionLogger });
 
-    return { writer, emailProvider, webhookClient, eventDispatcher };
+    return { writer, emailProvider, webhookClient, eventDispatcher, executionLogger };
   };
 
   it('posts the complete rendered Insight directly to Google Chat', async () => {
-    const { writer, emailProvider, webhookClient, eventDispatcher } = createWriter();
+    const { writer, emailProvider, webhookClient, eventDispatcher, executionLogger } =
+      createWriter();
 
     await writer.prepareToWriteReport(createReport(), new ReportDataDescription([]));
     await writer.finalize();
@@ -83,7 +93,7 @@ describe('GoogleChatReportWriter', () => {
       subtitle: 'Data Mart: Sales',
     });
     expect(payload.cardsV2[0].card.sections[0].widgets[0].textParagraph).toEqual({
-      text: '# Revenue\n\n**Up 12%**',
+      text: '**Revenue**\n\n**Up 12%**',
       textSyntax: 'MARKDOWN',
     });
     expect(payload.fallbackText).toBe('Weekly report — Data Mart: Sales');
@@ -92,6 +102,43 @@ describe('GoogleChatReportWriter', () => {
     );
     expect(eventDispatcher.publishExternal.mock.calls[0][0].name).toBe(
       'google-chat.report.run.successfully'
+    );
+    expect(executionLogger.log).toHaveBeenCalledWith({
+      type: 'google_chat_part_sent',
+      part: 1,
+      totalParts: 1,
+    });
+    expect(executionLogger.log).toHaveBeenCalledWith({
+      type: 'google_chat_sent',
+      messageCount: 1,
+    });
+  });
+
+  it('logs partial delivery before propagating a later part failure', async () => {
+    const { writer, webhookClient, executionLogger } = createWriter(
+      { type: 'google-chat-credentials', webhookUrl },
+      `# Large insight\n${'Д'.repeat(16_000)}`
+    );
+    webhookClient.send
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('Google Chat API request failed'));
+
+    await writer.prepareToWriteReport(createReport(), new ReportDataDescription([]));
+    await expect(writer.finalize()).rejects.toThrow('Google Chat API request failed');
+
+    expect(executionLogger.log).toHaveBeenCalledWith({
+      type: 'google_chat_part_sent',
+      part: 1,
+      totalParts: 2,
+    });
+    expect(executionLogger.log).toHaveBeenCalledWith({
+      type: 'google_chat_part_failed',
+      part: 2,
+      totalParts: 2,
+      deliveredParts: 1,
+    });
+    expect(executionLogger.log).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'google_chat_sent' })
     );
   });
 
@@ -123,7 +170,7 @@ describe('GoogleChatReportWriter', () => {
   });
 
   it('splits oversized Insights without dropping multibyte content', () => {
-    const markdown = `# Large insight\n${'Д'.repeat(16_000)}`;
+    const markdown = `Large insight\n${'Д'.repeat(16_000)}`;
     const messages = buildGoogleChatMessages({
       subject: 'Large report',
       markdown,
@@ -141,6 +188,37 @@ describe('GoogleChatReportWriter', () => {
     expect(messages.every(message => Buffer.byteLength(JSON.stringify(message)) <= 30_000)).toBe(
       true
     );
+  });
+
+  it('downlevels unsupported headings and tables while preserving supported Markdown', () => {
+    const messages = buildGoogleChatMessages({
+      subject: 'Representative insight',
+      markdown: '# Revenue\n\n**Up 12%**\n\n| Metric | Value |\n| --- | ---: |\n| Revenue | $10 |',
+      dataMartTitle: 'Sales',
+      reportUrl: 'https://example.test/report',
+    });
+
+    const widget = messages[0].cardsV2[0].card.sections[0].widgets[0];
+    expect(widget).toEqual({
+      textParagraph: {
+        text: '**Revenue**\n\n**Up 12%**\n\n```\n| Metric | Value |\n| --- | ---: |\n| Revenue | $10 |\n```',
+        textSyntax: 'MARKDOWN',
+      },
+    });
+  });
+
+  it('does not rewrite heading or table-like text inside fenced code blocks', () => {
+    const markdown = '```\n# Heading-like code\n| A | B |\n| --- | --- |\n```';
+    const messages = buildGoogleChatMessages({
+      subject: 'Code sample',
+      markdown,
+      dataMartTitle: 'Sales',
+      reportUrl: 'https://example.test/report',
+    });
+
+    expect(messages[0].cardsV2[0].card.sections[0].widgets[0]).toEqual({
+      textParagraph: { text: markdown, textSyntax: 'MARKDOWN' },
+    });
   });
 
   it('sizes complete serialized payloads when Markdown contains JSON escape characters', () => {

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
@@ -1,0 +1,278 @@
+import { Inject, Injectable, Logger, Scope } from '@nestjs/common';
+import { PublicOriginService } from '../../../../../common/config/public-origin.service';
+import {
+  EMAIL_PROVIDER_FACADE,
+  EmailProviderFacade,
+} from '../../../../../common/email/shared/email-provider.facade';
+import { OwoxEventDispatcher } from '../../../../../common/event-dispatcher/owox-event-dispatcher';
+import { MarkdownParser } from '../../../../../common/markdown/markdown-parser.service';
+import { buildDataMartUrl } from '../../../../../common/helpers/data-mart-url.helper';
+import { DataMartInsightTemplateFacadeImpl } from '../../../../ai-insights/data-mart-insight-template.facade';
+import { Report } from '../../../../entities/report.entity';
+import { InsightTemplateSourceDataService } from '../../../../services/insight-template-source-data.service';
+import { InsightTemplateService } from '../../../../services/insight-template.service';
+import { InsightTemplateSourceUsageService } from '../../../../services/insight-template-source-usage.service';
+import { DataDestinationCredentialsResolver } from '../../../data-destination-credentials-resolver.service';
+import { DataDestinationType } from '../../../enums/data-destination-type.enum';
+import { BaseEmailReportWriter } from '../../email/services/email-report-writer';
+import {
+  GoogleChatCredentials,
+  GoogleChatCredentialsSchema,
+} from '../schemas/google-chat-credentials.schema';
+import { GoogleChatMessagePayload, GoogleChatWebhookClient } from './google-chat-webhook.client';
+
+const MAX_GOOGLE_CHAT_PAYLOAD_BYTES = 30_000;
+const MAX_GOOGLE_CHAT_MESSAGE_PARTS = 20;
+const MAX_HEADER_FIELD_BYTES = 512;
+const GOOGLE_CHAT_WRITE_INTERVAL_MS = 1_100;
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value;
+
+  const suffix = '…';
+  const availableBytes = maxBytes - Buffer.byteLength(suffix, 'utf8');
+  let result = '';
+  let usedBytes = 0;
+
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character, 'utf8');
+    if (usedBytes + characterBytes > availableBytes) break;
+    result += character;
+    usedBytes += characterBytes;
+  }
+
+  return `${result}${suffix}`;
+}
+
+function buildGoogleChatMessage(input: {
+  subject: string;
+  dataMartTitle: string;
+  reportUrl: string;
+  chunk: string;
+  index: number;
+  total: number;
+}): GoogleChatMessagePayload {
+  const partLabel = input.total > 1 ? ` · Part ${input.index + 1} of ${input.total}` : '';
+  const subtitle = `Data Mart: ${input.dataMartTitle}${partLabel}`;
+
+  return {
+    fallbackText: `${input.subject} — ${subtitle}`,
+    cardsV2: [
+      {
+        cardId: `owox-insight-${input.index + 1}`,
+        card: {
+          header: {
+            title: input.subject,
+            subtitle,
+          },
+          sections: [
+            {
+              widgets: [
+                {
+                  textParagraph: {
+                    text: input.chunk,
+                    textSyntax: 'MARKDOWN',
+                  },
+                },
+                {
+                  buttonList: {
+                    buttons: [
+                      {
+                        text: 'Open report in OWOX',
+                        onClick: { openLink: { url: input.reportUrl } },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function serializedPayloadBytes(payload: GoogleChatMessagePayload): number {
+  return Buffer.byteLength(JSON.stringify(payload), 'utf8');
+}
+
+function splitMarkdownForGoogleChat(input: {
+  markdown: string;
+  subject: string;
+  dataMartTitle: string;
+  reportUrl: string;
+}): string[] {
+  const characters = Array.from(input.markdown);
+  const chunks: string[] = [];
+  let offset = 0;
+
+  const fits = (chunk: string): boolean =>
+    serializedPayloadBytes(
+      buildGoogleChatMessage({
+        ...input,
+        chunk,
+        index: MAX_GOOGLE_CHAT_MESSAGE_PARTS - 1,
+        total: MAX_GOOGLE_CHAT_MESSAGE_PARTS,
+      })
+    ) <= MAX_GOOGLE_CHAT_PAYLOAD_BYTES;
+
+  if (!fits('')) {
+    throw new Error('Google Chat message headers exceed the API size limit');
+  }
+
+  while (offset < characters.length) {
+    if (chunks.length >= MAX_GOOGLE_CHAT_MESSAGE_PARTS) {
+      throw new Error(
+        `Google Chat Insight exceeds the ${MAX_GOOGLE_CHAT_MESSAGE_PARTS}-message delivery limit`
+      );
+    }
+
+    let low = 1;
+    let high = characters.length - offset;
+    let bestLength = 0;
+
+    while (low <= high) {
+      const candidateLength = Math.floor((low + high) / 2);
+      const candidate = characters.slice(offset, offset + candidateLength).join('');
+      if (fits(candidate)) {
+        bestLength = candidateLength;
+        low = candidateLength + 1;
+      } else {
+        high = candidateLength - 1;
+      }
+    }
+
+    if (bestLength === 0) {
+      throw new Error('Unable to split Google Chat message within the API size limit');
+    }
+
+    const candidateCharacters = characters.slice(offset, offset + bestLength);
+    const lastNewlineIndex = candidateCharacters.lastIndexOf('\n');
+    const hasMoreContent = bestLength < characters.length - offset;
+    const splitLength =
+      hasMoreContent && lastNewlineIndex >= 0 && lastNewlineIndex + 1 >= Math.floor(bestLength / 2)
+        ? lastNewlineIndex + 1
+        : bestLength;
+
+    chunks.push(candidateCharacters.slice(0, splitLength).join(''));
+    offset += splitLength;
+  }
+
+  return chunks;
+}
+
+export function buildGoogleChatMessages(input: {
+  subject: string;
+  markdown: string;
+  dataMartTitle: string;
+  reportUrl: string;
+}): GoogleChatMessagePayload[] {
+  const messageInput = {
+    subject: truncateUtf8(input.subject, MAX_HEADER_FIELD_BYTES),
+    dataMartTitle: truncateUtf8(input.dataMartTitle, MAX_HEADER_FIELD_BYTES),
+    reportUrl: input.reportUrl,
+  };
+  const markdown = input.markdown.trim() || 'No content';
+  const chunks = splitMarkdownForGoogleChat({ ...messageInput, markdown });
+
+  const messages = chunks.map((chunk, index) =>
+    buildGoogleChatMessage({
+      ...messageInput,
+      chunk,
+      index,
+      total: chunks.length,
+    })
+  );
+
+  if (messages.some(message => serializedPayloadBytes(message) > MAX_GOOGLE_CHAT_PAYLOAD_BYTES)) {
+    throw new Error('Google Chat message exceeds the API size limit');
+  }
+
+  return messages;
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+export class GoogleChatReportWriter extends BaseEmailReportWriter {
+  protected readonly logger = new Logger(GoogleChatReportWriter.name);
+  readonly type = DataDestinationType.GOOGLE_CHAT;
+
+  private googleChatCredentials?: GoogleChatCredentials;
+  private usesEmailDelivery = false;
+
+  constructor(
+    @Inject(EMAIL_PROVIDER_FACADE) emailProvider: EmailProviderFacade,
+    markdownParser: MarkdownParser,
+    private readonly chatPublicOriginService: PublicOriginService,
+    insightTemplateFacade: DataMartInsightTemplateFacadeImpl,
+    eventDispatcher: OwoxEventDispatcher,
+    credentialsResolver: DataDestinationCredentialsResolver,
+    sourceDataService: InsightTemplateSourceDataService,
+    insightTemplateService: InsightTemplateService,
+    sourceUsageService: InsightTemplateSourceUsageService,
+    private readonly webhookClient: GoogleChatWebhookClient
+  ) {
+    super(
+      emailProvider,
+      markdownParser,
+      chatPublicOriginService,
+      insightTemplateFacade,
+      eventDispatcher,
+      credentialsResolver,
+      sourceDataService,
+      insightTemplateService,
+      sourceUsageService
+    );
+  }
+
+  protected override async prepareDeliveryCredentials(report: Report): Promise<void> {
+    const resolvedCredentials = await this.credentialsResolver.resolve(report.dataDestination);
+    const parsed = GoogleChatCredentialsSchema.safeParse(resolvedCredentials);
+
+    if (parsed.success) {
+      this.googleChatCredentials = parsed.data;
+      this.usesEmailDelivery = false;
+      return;
+    }
+
+    // Channel email remains a supported delivery method for existing and new destinations.
+    this.usesEmailDelivery = true;
+    await super.prepareDeliveryCredentials(report);
+  }
+
+  protected override async sendRenderedMessage(markdownContent: string): Promise<void> {
+    if (this.usesEmailDelivery) {
+      await super.sendRenderedMessage(markdownContent);
+      return;
+    }
+
+    if (!this.googleChatCredentials) {
+      throw new Error('Google Chat webhook credentials are not configured');
+    }
+
+    const reportUrl = buildDataMartUrl(
+      this.chatPublicOriginService.getPublicOrigin(),
+      this.report.dataMart.projectId,
+      this.report.dataMart.id,
+      '/reports'
+    );
+    const messages = buildGoogleChatMessages({
+      subject: this.emailConfig.subject,
+      markdown: markdownContent,
+      dataMartTitle: this.report.dataMart.title,
+      reportUrl,
+    });
+
+    for (let index = 0; index < messages.length; index += 1) {
+      if (index > 0) {
+        await new Promise(resolve => setTimeout(resolve, GOOGLE_CHAT_WRITE_INTERVAL_MS));
+      }
+      await this.webhookClient.send(this.googleChatCredentials.webhookUrl, messages[index]);
+    }
+
+    this.executionLogger?.log({
+      type: 'google_chat_sent',
+      messageCount: messages.length,
+    });
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
@@ -148,7 +148,7 @@ function buildGoogleChatMessage(input: {
                   buttonList: {
                     buttons: [
                       {
-                        text: 'Open report in OWOX',
+                        text: 'Open report in OWOX Data Marts',
                         onClick: { openLink: { url: input.reportUrl } },
                       },
                     ],

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
@@ -45,6 +45,75 @@ function truncateUtf8(value: string, maxBytes: number): string {
   return `${result}${suffix}`;
 }
 
+function isMarkdownTableDelimiter(line: string): boolean {
+  const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '');
+  const cells = trimmed.split('|').map(cell => cell.trim());
+  return cells.length >= 2 && cells.every(cell => /^:?-{3,}:?$/.test(cell));
+}
+
+function boldHeading(text: string): string {
+  const trimmed = text.trim();
+  const alreadyBold =
+    (trimmed.startsWith('**') && trimmed.endsWith('**')) ||
+    (trimmed.startsWith('__') && trimmed.endsWith('__'));
+  return alreadyBold ? trimmed : `**${trimmed}**`;
+}
+
+/**
+ * Google Chat card Markdown does not support headings or tables. Downlevel only those
+ * constructs while leaving the supported Markdown subset and fenced code blocks untouched.
+ */
+function prepareMarkdownForGoogleChat(markdown: string): string {
+  const lines = markdown.split('\n');
+  const output: string[] = [];
+  let activeFence: '`' | '~' | null = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0] as '`' | '~';
+      activeFence = activeFence === marker ? null : (activeFence ?? marker);
+      output.push(line);
+      continue;
+    }
+
+    if (activeFence) {
+      output.push(line);
+      continue;
+    }
+
+    if (line.includes('|') && isMarkdownTableDelimiter(lines[index + 1] ?? '')) {
+      const tableLines = [line, lines[index + 1]];
+      index += 2;
+      while (index < lines.length && lines[index].trim() && lines[index].includes('|')) {
+        tableLines.push(lines[index]);
+        index += 1;
+      }
+      index -= 1;
+      output.push('```', ...tableLines, '```');
+      continue;
+    }
+
+    const atxHeading = line.match(/^\s{0,3}#{1,6}[ \t]+(.+?)\s*$/);
+    if (atxHeading) {
+      const heading = atxHeading[1].replace(/[ \t]+#+[ \t]*$/, '');
+      output.push(boldHeading(heading));
+      continue;
+    }
+
+    if (line.trim() && /^\s{0,3}(?:=+|-+)\s*$/.test(lines[index + 1] ?? '')) {
+      output.push(boldHeading(line));
+      index += 1;
+      continue;
+    }
+
+    output.push(line);
+  }
+
+  return output.join('\n');
+}
+
 function buildGoogleChatMessage(input: {
   subject: string;
   dataMartTitle: string;
@@ -176,7 +245,7 @@ export function buildGoogleChatMessages(input: {
     dataMartTitle: truncateUtf8(input.dataMartTitle, MAX_HEADER_FIELD_BYTES),
     reportUrl: input.reportUrl,
   };
-  const markdown = input.markdown.trim() || 'No content';
+  const markdown = prepareMarkdownForGoogleChat(input.markdown.trim() || 'No content');
   const chunks = splitMarkdownForGoogleChat({ ...messageInput, markdown });
 
   const messages = chunks.map((chunk, index) =>
@@ -272,11 +341,29 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
       reportUrl,
     });
 
+    // Incoming webhooks do not support transactions or rollback. If a later part fails,
+    // earlier parts remain delivered, so record each outcome for troubleshooting.
     for (let index = 0; index < messages.length; index += 1) {
       if (index > 0) {
         await new Promise(resolve => setTimeout(resolve, GOOGLE_CHAT_WRITE_INTERVAL_MS));
       }
-      await this.webhookClient.send(this.googleChatCredentials.webhookUrl, messages[index]);
+
+      try {
+        await this.webhookClient.send(this.googleChatCredentials.webhookUrl, messages[index]);
+        this.executionLogger?.log({
+          type: 'google_chat_part_sent',
+          part: index + 1,
+          totalParts: messages.length,
+        });
+      } catch (error) {
+        this.executionLogger?.log({
+          type: 'google_chat_part_failed',
+          part: index + 1,
+          totalParts: messages.length,
+          deliveredParts: index,
+        });
+        throw error;
+      }
     }
 
     this.executionLogger?.log({

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
@@ -14,6 +14,7 @@ import { InsightTemplateService } from '../../../../services/insight-template.se
 import { InsightTemplateSourceUsageService } from '../../../../services/insight-template-source-usage.service';
 import { DataDestinationCredentialsResolver } from '../../../data-destination-credentials-resolver.service';
 import { DataDestinationType } from '../../../enums/data-destination-type.enum';
+import { EmailCredentialsSchema } from '../../email/schemas/email-credentials.schema';
 import { BaseEmailReportWriter } from '../../email/services/email-report-writer';
 import {
   GoogleChatCredentials,
@@ -150,6 +151,8 @@ function splitMarkdownForGoogleChat(input: {
     const candidateCharacters = characters.slice(offset, offset + bestLength);
     const lastNewlineIndex = candidateCharacters.lastIndexOf('\n');
     const hasMoreContent = bestLength < characters.length - offset;
+    // Prefer a nearby newline, but do not parse or rewrite Markdown blocks: exact content and
+    // strict API payload sizing take priority over destination-specific reformatting here.
     const splitLength =
       hasMoreContent && lastNewlineIndex >= 0 && lastNewlineIndex + 1 >= Math.floor(bestLength / 2)
         ? lastNewlineIndex + 1
@@ -233,6 +236,12 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
       this.googleChatCredentials = parsed.data;
       this.usesEmailDelivery = false;
       return;
+    }
+
+    if (!EmailCredentialsSchema.safeParse(resolvedCredentials).success) {
+      throw new Error(
+        'Google Chat destination has neither valid webhook nor channel-email credentials'
+      );
     }
 
     // Channel email remains a supported delivery method for existing and new destinations.

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-webhook.client.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-webhook.client.spec.ts
@@ -1,0 +1,125 @@
+import { GoogleChatMessagePayload, GoogleChatWebhookClient } from './google-chat-webhook.client';
+
+describe('GoogleChatWebhookClient', () => {
+  const webhookUrl =
+    'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key-1&token=token-1';
+  const payload: GoogleChatMessagePayload = {
+    fallbackText: 'Report — Data Mart: Sales',
+    cardsV2: [
+      {
+        cardId: 'owox-insight-1',
+        card: {
+          header: { title: 'Report', subtitle: 'Data Mart: Sales' },
+          sections: [
+            {
+              widgets: [{ textParagraph: { text: '**Insight**', textSyntax: 'MARKDOWN' } }],
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('posts a card payload without following redirects', async () => {
+    const cancel = jest.fn().mockResolvedValue(undefined);
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({ ok: true, body: { cancel } } as unknown as Response);
+
+    await new GoogleChatWebhookClient().send(webhookUrl, payload);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      webhookUrl,
+      expect.objectContaining({
+        method: 'POST',
+        redirect: 'error',
+        body: JSON.stringify(payload),
+      })
+    );
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries HTTP 429 responses up to the bounded attempt limit', async () => {
+    const retryHeaders = { get: jest.fn().mockReturnValue('0') };
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: retryHeaders,
+      } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    await new GoogleChatWebhookClient().send(webhookUrl, payload);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops after three HTTP 429 attempts', async () => {
+    const retryHeaders = { get: jest.fn().mockReturnValue('0') };
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({ ok: false, status: 429, headers: retryHeaders } as unknown as Response);
+
+    await expect(new GoogleChatWebhookClient().send(webhookUrl, payload)).rejects.toThrow(
+      'Google Chat API returned HTTP 429'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not include the secret webhook URL in API errors', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({ ok: false, status: 403 } as Response);
+
+    await expect(new GoogleChatWebhookClient().send(webhookUrl, payload)).rejects.toThrow(
+      'Google Chat API returned HTTP 403'
+    );
+    await expect(new GoogleChatWebhookClient().send(webhookUrl, payload)).rejects.not.toThrow(
+      webhookUrl
+    );
+  });
+
+  it('sanitizes low-level network errors that could contain the secret URL', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error(`request failed for ${webhookUrl}`));
+
+    await expect(new GoogleChatWebhookClient().send(webhookUrl, payload)).rejects.toThrow(
+      'Google Chat API request failed'
+    );
+    await expect(new GoogleChatWebhookClient().send(webhookUrl, payload)).rejects.not.toThrow(
+      webhookUrl
+    );
+  });
+
+  it('blocks non-Google request targets before calling fetch', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch');
+
+    await expect(
+      new GoogleChatWebhookClient().send('https://example.com/webhook', payload)
+    ).rejects.toThrow('Invalid Google Chat incoming webhook URL');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('aborts requests that exceed the timeout', async () => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'fetch').mockImplementation((_url, init) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      });
+    });
+
+    const request = expect(new GoogleChatWebhookClient().send(webhookUrl, payload)).rejects.toThrow(
+      'Google Chat API request timed out'
+    );
+    await jest.advanceTimersByTimeAsync(10_000);
+
+    await request;
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-webhook.client.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-webhook.client.spec.ts
@@ -72,6 +72,41 @@ describe('GoogleChatWebhookClient', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
+  it('retries transient server errors', async () => {
+    jest.useFakeTimers();
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({ ok: false, status: 503 } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const request = new GoogleChatWebhookClient().send(webhookUrl, payload);
+    await jest.runAllTimersAsync();
+    await request;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('caps Retry-After delays', async () => {
+    jest.useFakeTimers();
+    const retryHeaders = { get: jest.fn().mockReturnValue('3600') };
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: retryHeaders,
+      } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    const request = new GoogleChatWebhookClient().send(webhookUrl, payload);
+    await jest.advanceTimersByTimeAsync(29_999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await request;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('does not include the secret webhook URL in API errors', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue({ ok: false, status: 403 } as Response);
 
@@ -84,14 +119,18 @@ describe('GoogleChatWebhookClient', () => {
   });
 
   it('sanitizes low-level network errors that could contain the secret URL', async () => {
-    jest.spyOn(global, 'fetch').mockRejectedValue(new Error(`request failed for ${webhookUrl}`));
+    jest.useFakeTimers();
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockRejectedValue(new Error(`request failed for ${webhookUrl}`));
 
-    await expect(new GoogleChatWebhookClient().send(webhookUrl, payload)).rejects.toThrow(
-      'Google Chat API request failed'
-    );
-    await expect(new GoogleChatWebhookClient().send(webhookUrl, payload)).rejects.not.toThrow(
-      webhookUrl
-    );
+    const request = new GoogleChatWebhookClient().send(webhookUrl, payload).catch(error => error);
+    await jest.runAllTimersAsync();
+    const error = (await request) as Error;
+
+    expect(error.message).toBe('Google Chat API request failed');
+    expect(error.message).not.toContain(webhookUrl);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it('blocks non-Google request targets before calling fetch', async () => {
@@ -118,7 +157,7 @@ describe('GoogleChatWebhookClient', () => {
     const request = expect(new GoogleChatWebhookClient().send(webhookUrl, payload)).rejects.toThrow(
       'Google Chat API request timed out'
     );
-    await jest.advanceTimersByTimeAsync(10_000);
+    await jest.runAllTimersAsync();
 
     await request;
   });

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-webhook.client.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-webhook.client.ts
@@ -1,0 +1,109 @@
+import { Injectable } from '@nestjs/common';
+import { isGoogleChatWebhookUrl } from '../schemas/google-chat-credentials.schema';
+
+export interface GoogleChatMessagePayload {
+  fallbackText: string;
+  cardsV2: Array<{
+    cardId: string;
+    card: {
+      header: {
+        title: string;
+        subtitle: string;
+      };
+      sections: Array<{
+        widgets: Array<
+          | {
+              textParagraph: {
+                text: string;
+                textSyntax: 'MARKDOWN';
+              };
+            }
+          | {
+              buttonList: {
+                buttons: Array<{
+                  text: string;
+                  onClick: { openLink: { url: string } };
+                }>;
+              };
+            }
+        >;
+      }>;
+    };
+  }>;
+}
+
+@Injectable()
+export class GoogleChatWebhookClient {
+  private static readonly REQUEST_TIMEOUT_MS = 10_000;
+  private static readonly MAX_ATTEMPTS = 3;
+  private static readonly RETRY_BASE_DELAY_MS = 1_000;
+
+  async send(webhookUrl: string, payload: GoogleChatMessagePayload): Promise<void> {
+    // The URL contains a secret token and is also the outbound request target. Validate it
+    // again at the network boundary even though destination credentials are validated on save.
+    if (!isGoogleChatWebhookUrl(webhookUrl)) {
+      throw new Error('Invalid Google Chat incoming webhook URL');
+    }
+
+    for (let attempt = 1; attempt <= GoogleChatWebhookClient.MAX_ATTEMPTS; attempt += 1) {
+      const response = await this.post(webhookUrl, payload);
+      if (response.ok) return;
+
+      if (response.status === 429 && attempt < GoogleChatWebhookClient.MAX_ATTEMPTS) {
+        const retryDelayMs = this.getRetryDelayMs(response, attempt);
+        if (retryDelayMs > 0) {
+          await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+        }
+        continue;
+      }
+
+      throw new Error(`Google Chat API returned HTTP ${response.status}`);
+    }
+  }
+
+  private async post(webhookUrl: string, payload: GoogleChatMessagePayload): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      GoogleChatWebhookClient.REQUEST_TIMEOUT_MS
+    );
+
+    try {
+      const response = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json; charset=UTF-8',
+          'User-Agent': 'OWOX-DataMarts-Google-Chat/1.0',
+        },
+        body: JSON.stringify(payload),
+        redirect: 'error',
+        signal: controller.signal,
+      });
+      await response.body?.cancel().catch(() => undefined);
+      return response;
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error('Google Chat API request timed out');
+      }
+      // Fetch implementations can attach the request URL to low-level network errors. Do not
+      // propagate those details because Google Chat webhook URLs contain a secret token.
+      throw new Error('Google Chat API request failed');
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private getRetryDelayMs(response: Response, attempt: number): number {
+    const retryAfter = response.headers?.get('retry-after');
+    if (retryAfter) {
+      const seconds = Number(retryAfter);
+      if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+
+      const retryAt = Date.parse(retryAfter);
+      if (Number.isFinite(retryAt)) return Math.max(0, retryAt - Date.now());
+    }
+
+    const exponentialDelay = GoogleChatWebhookClient.RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+    return exponentialDelay + Math.floor(Math.random() * 250);
+  }
+}

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-webhook.client.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-webhook.client.ts
@@ -37,6 +37,7 @@ export class GoogleChatWebhookClient {
   private static readonly REQUEST_TIMEOUT_MS = 10_000;
   private static readonly MAX_ATTEMPTS = 3;
   private static readonly RETRY_BASE_DELAY_MS = 1_000;
+  private static readonly MAX_RETRY_DELAY_MS = 30_000;
 
   async send(webhookUrl: string, payload: GoogleChatMessagePayload): Promise<void> {
     // The URL contains a secret token and is also the outbound request target. Validate it
@@ -46,18 +47,37 @@ export class GoogleChatWebhookClient {
     }
 
     for (let attempt = 1; attempt <= GoogleChatWebhookClient.MAX_ATTEMPTS; attempt += 1) {
-      const response = await this.post(webhookUrl, payload);
+      let response: Response;
+      try {
+        response = await this.post(webhookUrl, payload);
+      } catch (error) {
+        if (attempt >= GoogleChatWebhookClient.MAX_ATTEMPTS) throw error;
+        await this.waitBeforeRetry(undefined, attempt);
+        continue;
+      }
+
       if (response.ok) return;
 
-      if (response.status === 429 && attempt < GoogleChatWebhookClient.MAX_ATTEMPTS) {
-        const retryDelayMs = this.getRetryDelayMs(response, attempt);
-        if (retryDelayMs > 0) {
-          await new Promise(resolve => setTimeout(resolve, retryDelayMs));
-        }
+      if (
+        this.isTransientStatus(response.status) &&
+        attempt < GoogleChatWebhookClient.MAX_ATTEMPTS
+      ) {
+        await this.waitBeforeRetry(response, attempt);
         continue;
       }
 
       throw new Error(`Google Chat API returned HTTP ${response.status}`);
+    }
+  }
+
+  private isTransientStatus(status: number): boolean {
+    return status === 408 || status === 429 || status >= 500;
+  }
+
+  private async waitBeforeRetry(response: Response | undefined, attempt: number): Promise<void> {
+    const retryDelayMs = this.getRetryDelayMs(response, attempt);
+    if (retryDelayMs > 0) {
+      await new Promise(resolve => setTimeout(resolve, retryDelayMs));
     }
   }
 
@@ -93,17 +113,27 @@ export class GoogleChatWebhookClient {
     }
   }
 
-  private getRetryDelayMs(response: Response, attempt: number): number {
-    const retryAfter = response.headers?.get('retry-after');
+  private getRetryDelayMs(response: Response | undefined, attempt: number): number {
+    const retryAfter = response?.headers?.get('retry-after');
     if (retryAfter) {
       const seconds = Number(retryAfter);
-      if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+      if (Number.isFinite(seconds) && seconds >= 0) {
+        return Math.min(seconds * 1_000, GoogleChatWebhookClient.MAX_RETRY_DELAY_MS);
+      }
 
       const retryAt = Date.parse(retryAfter);
-      if (Number.isFinite(retryAt)) return Math.max(0, retryAt - Date.now());
+      if (Number.isFinite(retryAt)) {
+        return Math.min(
+          Math.max(0, retryAt - Date.now()),
+          GoogleChatWebhookClient.MAX_RETRY_DELAY_MS
+        );
+      }
     }
 
     const exponentialDelay = GoogleChatWebhookClient.RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
-    return exponentialDelay + Math.floor(Math.random() * 250);
+    return Math.min(
+      exponentialDelay + Math.floor(Math.random() * 250),
+      GoogleChatWebhookClient.MAX_RETRY_DELAY_MS
+    );
   }
 }

--- a/apps/backend/src/data-marts/dto/presentation/data-destination-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-destination-response-api.dto.ts
@@ -21,34 +21,40 @@ export type GoogleSheetsOAuthCredentialsPublic = {
   identity: CredentialIdentity | null;
 };
 
+export type GoogleChatCredentialsPublic = {
+  type: 'google-chat-credentials';
+  configured: true;
+};
+
 export class DataDestinationResponseApiDto {
   @ApiProperty({ example: 'abc123e4-5678-90ab-cdef-1234567890ab' })
-  id: string;
+  id!: string;
 
   @ApiProperty({ example: 'My Google Sheets Destination' })
-  title: string;
+  title!: string;
 
   @ApiProperty({ enum: DataDestinationType, example: DataDestinationType.GOOGLE_SHEETS })
-  type: DataDestinationType;
+  type!: DataDestinationType;
 
   @ApiProperty({ example: 'my-project' })
-  projectId: string;
+  projectId!: string;
 
   @ApiProperty({
     type: 'object',
     additionalProperties: true,
     description: 'Credentials without sensitive fields',
   })
-  credentials:
+  credentials!:
     | DataDestinationCredentials
     | DataDestinationCredentialsPublic
-    | GoogleSheetsOAuthCredentialsPublic;
+    | GoogleSheetsOAuthCredentialsPublic
+    | GoogleChatCredentialsPublic;
 
   @ApiProperty({ example: '2024-01-01T12:00:00.000Z' })
-  createdAt: Date;
+  createdAt!: Date;
 
   @ApiProperty({ example: '2024-01-02T15:30:00.000Z' })
-  modifiedAt: Date;
+  modifiedAt!: Date;
 
   @ApiProperty({ example: 'abc123e4-5678-90ab-cdef-1234567890ab', nullable: true, required: false })
   credentialId?: string | null;
@@ -57,7 +63,7 @@ export class DataDestinationResponseApiDto {
   createdByUser?: UserProjectionDto | null;
 
   @ApiProperty({ type: [UserProjectionDto] })
-  ownerUsers: UserProjectionDto[];
+  ownerUsers!: UserProjectionDto[];
 
   @ApiProperty({ example: true })
   availableForUse?: boolean;
@@ -66,7 +72,7 @@ export class DataDestinationResponseApiDto {
   availableForMaintenance?: boolean;
 
   @ApiProperty({ type: [Object] })
-  contexts: ContextSummary[];
+  contexts!: ContextSummary[];
 
   @ApiPropertyOptional({
     type: 'object',

--- a/apps/backend/src/data-marts/dto/presentation/data-destination-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-destination-response-api.dto.ts
@@ -26,6 +26,11 @@ export type GoogleChatCredentialsPublic = {
   configured: true;
 };
 
+type DataDestinationCredentialsWithoutGoogleChat = Exclude<
+  DataDestinationCredentials,
+  { type: 'google-chat-credentials' }
+>;
+
 export class DataDestinationResponseApiDto {
   @ApiProperty({ example: 'abc123e4-5678-90ab-cdef-1234567890ab' })
   id!: string;
@@ -45,7 +50,7 @@ export class DataDestinationResponseApiDto {
     description: 'Credentials without sensitive fields',
   })
   credentials!:
-    | DataDestinationCredentials
+    | DataDestinationCredentialsWithoutGoogleChat
     | DataDestinationCredentialsPublic
     | GoogleSheetsOAuthCredentialsPublic
     | GoogleChatCredentialsPublic;

--- a/apps/backend/src/data-marts/enums/destination-credential-type.enum.ts
+++ b/apps/backend/src/data-marts/enums/destination-credential-type.enum.ts
@@ -3,4 +3,5 @@ export enum DestinationCredentialType {
   GOOGLE_OAUTH = 'google_oauth',
   LOOKER_STUDIO = 'looker_studio',
   EMAIL = 'email',
+  GOOGLE_CHAT_WEBHOOK = 'google_chat_webhook',
 }

--- a/apps/backend/src/data-marts/mappers/data-destination.mapper.spec.ts
+++ b/apps/backend/src/data-marts/mappers/data-destination.mapper.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { DataDestinationMapper } from './data-destination.mapper';
 import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
+import { DataDestinationDto } from '../dto/domain/data-destination.dto';
 import { DestinationCredentialType } from '../enums/destination-credential-type.enum';
 
 /**
@@ -155,5 +156,42 @@ describe('DataDestinationMapper - credentials withheld from a plugin runtime', (
     await expect(mapper.toApiResponse(destination)).resolves.toMatchObject({
       credentials: expect.objectContaining({ destinationSecretKey: 'sk_live_do_not_leak' }),
     });
+  });
+});
+
+describe('DataDestinationMapper - Google Chat credential redaction', () => {
+  it('never returns the secret incoming webhook URL', async () => {
+    const webhookUrl =
+      'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key-1&token=secret-token';
+    const credentialService = {
+      getById: jest.fn().mockResolvedValue({
+        type: DestinationCredentialType.GOOGLE_CHAT_WEBHOOK,
+        credentials: { type: 'google-chat-credentials', webhookUrl },
+      }),
+    };
+    const mapper = new DataDestinationMapper(
+      null as never,
+      null as never,
+      credentialService as never,
+      null as never
+    );
+    const dto = new DataDestinationDto(
+      'destination-1',
+      'Marketing Chat',
+      DataDestinationType.GOOGLE_CHAT,
+      'project-1',
+      new Date('2026-07-17T12:00:00Z'),
+      new Date('2026-07-17T12:00:00Z'),
+      'credential-1'
+    );
+
+    const response = await mapper.toApiResponse(dto);
+
+    expect(response.credentials).toEqual({
+      type: 'google-chat-credentials',
+      configured: true,
+    });
+    expect(JSON.stringify(response)).not.toContain(webhookUrl);
+    expect(JSON.stringify(response)).not.toContain('secret-token');
   });
 });

--- a/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
@@ -315,7 +315,7 @@ export class DataDestinationMapper {
 
     if (!dto.credentialId) {
       this.logger.warn(`Destination ${dto.id} has no credentialId`);
-      return {} as DataDestinationCredentials;
+      return {} as DataDestinationResponseApiDto['credentials'];
     }
 
     const credential = await this.dataDestinationCredentialService.getById(dto.credentialId);
@@ -323,7 +323,7 @@ export class DataDestinationMapper {
       this.logger.warn(
         `Credential ${dto.credentialId} not found for destination ${dto.id} (possibly orphaned after soft-delete)`
       );
-      return {} as DataDestinationCredentials;
+      return {} as DataDestinationResponseApiDto['credentials'];
     }
 
     switch (credential.type) {
@@ -357,7 +357,10 @@ export class DataDestinationMapper {
       }
 
       case DestinationCredentialType.EMAIL:
-        return credential.credentials as DataDestinationCredentials;
+        return credential.credentials as Extract<
+          DataDestinationCredentials,
+          { type: 'email-credentials' }
+        >;
 
       case DestinationCredentialType.GOOGLE_CHAT_WEBHOOK:
         // Incoming webhook URLs include a secret token. The UI only needs to know that a

--- a/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
@@ -334,7 +334,10 @@ export class DataDestinationMapper {
         };
 
       case DestinationCredentialType.LOOKER_STUDIO: {
-        const creds = credential.credentials as DataDestinationCredentials;
+        const creds = credential.credentials as Extract<
+          DataDestinationCredentials,
+          { type: 'looker-studio-credentials' }
+        >;
         return {
           ...creds,
           destinationId: dto.id,
@@ -355,6 +358,14 @@ export class DataDestinationMapper {
 
       case DestinationCredentialType.EMAIL:
         return credential.credentials as DataDestinationCredentials;
+
+      case DestinationCredentialType.GOOGLE_CHAT_WEBHOOK:
+        // Incoming webhook URLs include a secret token. The UI only needs to know that a
+        // webhook is configured; a replacement URL can be pasted without reading the old one.
+        return {
+          type: 'google-chat-credentials' as const,
+          configured: true as const,
+        };
 
       default:
         throw new Error(

--- a/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-destination.mapper.ts
@@ -310,7 +310,7 @@ export class DataDestinationMapper {
     // No stored credential of any type reaches a plugin. The same empty shape the
     // orphaned-credential paths below already return, so every consumer handles it.
     if (this.isPluginRuntimeCall()) {
-      return {} as DataDestinationCredentials;
+      return {} as DataDestinationResponseApiDto['credentials'];
     }
 
     if (!dto.credentialId) {

--- a/apps/backend/src/data-marts/services/credential-type-resolver.spec.ts
+++ b/apps/backend/src/data-marts/services/credential-type-resolver.spec.ts
@@ -1,0 +1,14 @@
+import { DestinationCredentialType } from '../enums/destination-credential-type.enum';
+import { resolveDestinationCredentialType } from './credential-type-resolver';
+
+describe('resolveDestinationCredentialType', () => {
+  it('stores Google Chat incoming webhooks as their own credential type', () => {
+    expect(
+      resolveDestinationCredentialType({
+        type: 'google-chat-credentials',
+        webhookUrl:
+          'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key-1&token=token-1',
+      })
+    ).toBe(DestinationCredentialType.GOOGLE_CHAT_WEBHOOK);
+  });
+});

--- a/apps/backend/src/data-marts/services/credential-type-resolver.ts
+++ b/apps/backend/src/data-marts/services/credential-type-resolver.ts
@@ -38,6 +38,8 @@ export function resolveDestinationCredentialType(
       return DestinationCredentialType.LOOKER_STUDIO;
     case 'email-credentials':
       return DestinationCredentialType.EMAIL;
+    case 'google-chat-credentials':
+      return DestinationCredentialType.GOOGLE_CHAT_WEBHOOK;
     default:
       throw new Error(`Unknown destination credential type: ${String(credType)}`);
   }

--- a/apps/backend/src/data-marts/use-cases/update-data-destination.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-destination.service.spec.ts
@@ -26,6 +26,7 @@ import { UpdateDataDestinationService } from './update-data-destination.service'
 import { DataDestinationType } from '../data-destination-types/enums/data-destination-type.enum';
 import { DestinationCredentialType } from '../enums/destination-credential-type.enum';
 import { CopyCredentialService } from '../services/copy-credential.service';
+import { DataDestinationCredentials } from '../data-destination-types/data-destination-credentials.type';
 
 describe('UpdateDataDestinationService - credential copy (sourceDestinationId)', () => {
   const projectId = 'proj-1';
@@ -37,7 +38,7 @@ describe('UpdateDataDestinationService - credential copy (sourceDestinationId)',
   const makeCommand = (
     overrides: {
       id?: string;
-      credentials?: Record<string, string>;
+      credentials?: DataDestinationCredentials | Record<string, unknown>;
       credentialId?: string | null;
       sourceDestinationId?: string;
       config?: DestinationConfigOverride;
@@ -414,6 +415,106 @@ describe('UpdateDataDestinationService - credential copy (sourceDestinationId)',
     await expect(service.run(command)).rejects.toThrow(
       /Cannot provide both sourceDestinationId and credentialId/
     );
+  });
+
+  describe('Google Chat delivery method switching', () => {
+    const webhookUrl =
+      'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key-1&token=token-1';
+
+    it('replaces channel-email credentials with webhook credentials in place', async () => {
+      const {
+        service,
+        dataDestinationRepository,
+        dataDestinationService,
+        credentialsProcessor,
+        dataDestinationCredentialService,
+      } = createService();
+      const targetDestination = makeTargetDestination({
+        type: DataDestinationType.GOOGLE_CHAT,
+        credentialId: 'cred-existing',
+        credential: {
+          id: 'cred-existing',
+          type: DestinationCredentialType.EMAIL,
+          credentials: { type: 'email-credentials', to: ['space@example.com'] },
+        },
+      });
+      const credentials = { type: 'google-chat-credentials' as const, webhookUrl };
+
+      dataDestinationService.getByIdAndProjectId.mockResolvedValue(targetDestination);
+      dataDestinationRepository.save.mockResolvedValue(targetDestination);
+      credentialsProcessor.processCredentials.mockResolvedValue(credentials);
+
+      await service.run(makeCommand({ credentials }));
+
+      expect(dataDestinationCredentialService.update).toHaveBeenCalledWith('cred-existing', {
+        type: DestinationCredentialType.GOOGLE_CHAT_WEBHOOK,
+        credentials,
+        identity: null,
+      });
+    });
+
+    it('replaces webhook credentials with channel-email credentials in place', async () => {
+      const {
+        service,
+        dataDestinationRepository,
+        dataDestinationService,
+        credentialsProcessor,
+        dataDestinationCredentialService,
+      } = createService();
+      const targetDestination = makeTargetDestination({
+        type: DataDestinationType.GOOGLE_CHAT,
+        credentialId: 'cred-existing',
+        credential: {
+          id: 'cred-existing',
+          type: DestinationCredentialType.GOOGLE_CHAT_WEBHOOK,
+          credentials: { type: 'google-chat-credentials', webhookUrl },
+        },
+      });
+      const credentials = {
+        type: 'email-credentials' as const,
+        to: ['space@example.com'] as [string, ...string[]],
+      };
+
+      dataDestinationService.getByIdAndProjectId.mockResolvedValue(targetDestination);
+      dataDestinationRepository.save.mockResolvedValue(targetDestination);
+      credentialsProcessor.processCredentials.mockResolvedValue(credentials);
+
+      await service.run(makeCommand({ credentials }));
+
+      expect(dataDestinationCredentialService.update).toHaveBeenCalledWith('cred-existing', {
+        type: DestinationCredentialType.EMAIL,
+        credentials,
+        identity: null,
+      });
+    });
+
+    it('preserves the saved webhook when an update omits credentials', async () => {
+      const {
+        service,
+        dataDestinationRepository,
+        dataDestinationService,
+        credentialsProcessor,
+        dataDestinationCredentialService,
+      } = createService();
+      const targetDestination = makeTargetDestination({
+        type: DataDestinationType.GOOGLE_CHAT,
+        credentialId: 'cred-existing',
+        credential: {
+          id: 'cred-existing',
+          type: DestinationCredentialType.GOOGLE_CHAT_WEBHOOK,
+          credentials: { type: 'google-chat-credentials', webhookUrl },
+        },
+      });
+
+      dataDestinationService.getByIdAndProjectId.mockResolvedValue(targetDestination);
+      dataDestinationRepository.save.mockResolvedValue(targetDestination);
+
+      await service.run(makeCommand());
+
+      expect(credentialsProcessor.processCredentials).not.toHaveBeenCalled();
+      expect(dataDestinationCredentialService.update).not.toHaveBeenCalled();
+      expect(dataDestinationCredentialService.softDelete).not.toHaveBeenCalled();
+    });
   });
 
   describe('permission checks', () => {

--- a/apps/backend/src/ee/mcp/tools/add-destination.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/add-destination.tool.spec.ts
@@ -42,7 +42,8 @@ describe('AddDestinationTool', () => {
       },
     });
     expect(tool.description).toContain('google_sheets');
-    expect(tool.description).toContain('email-based types');
+    expect(tool.description).toContain('channel-email delivery only');
+    expect(tool.description).toContain('secret URL');
     expect(tool.description).toContain('looker_studio');
   });
 
@@ -209,7 +210,7 @@ describe('AddDestinationTool', () => {
         context
       )
     ).rejects.toThrow(
-      "The 'emails' parameter is required for creating email-based destination types"
+      "The 'emails' parameter is required for email, slack, teams, and channel-email Google Chat"
     );
 
     expect(destinationsFacade.createDestination).not.toHaveBeenCalled();

--- a/apps/backend/src/ee/mcp/tools/add-destination.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/add-destination.tool.ts
@@ -14,7 +14,7 @@ import { buildConnectGoogleSheetsUiPath } from './mcp-flow-ui-path';
 import { LOOKER_STUDIO_DESTINATION_GUIDE_URL } from './mcp-docs-urls';
 import { joinPublicOrigin } from './mcp-public-url.util';
 
-const EMAIL_BASED_TYPES = ['email', 'slack', 'teams', 'google_chat'];
+const MCP_CHANNEL_EMAIL_TYPES = ['email', 'slack', 'teams', 'google_chat'];
 
 /**
  * Plain, mechanical label for a destination type — used both in agent-facing messages and
@@ -55,7 +55,7 @@ const inputSchema = z
       .array(z.string().email())
       .optional()
       .describe(
-        'Mandatory list of target email addresses/delivery targets. This parameter is STRICTLY REQUIRED for email-based types (email, slack, teams, google_chat). Do NOT attempt to call this tool for email-based types without asking the user for these email addresses first.'
+        'Mandatory list of target email addresses/delivery targets. This parameter is STRICTLY REQUIRED for email, slack, teams, and google_chat through MCP. MCP creates Google Chat destinations using channel-email delivery only; direct webhook delivery must be configured in the OWOX UI/API, and the secret webhook URL must not be sent through MCP/chat.'
       ),
   })
   .strict();
@@ -81,9 +81,11 @@ export class AddDestinationTool implements McpToolDefinition<AddDestinationInput
     'connectedGoogleAccount matches who the user expected — never pick by createdAt/recency, ' +
     'another destination may be created concurrently by someone else; if more than one ' +
     'entry still matches, ask the user which one they mean instead of guessing; ' +
-    'for email-based types (email, slack, teams, google_chat), creates the destination ' +
-    'directly and requires the emails parameter — no OAuth involved, destination_id is ' +
-    'returned immediately; ' +
+    'for email, slack, and teams, creates the destination directly and requires the emails ' +
+    'parameter; for google_chat, MCP supports channel-email delivery only and also requires ' +
+    'emails — direct webhook delivery is configured in the OWOX UI/API, and its secret URL ' +
+    'must not be sent through MCP/chat; no OAuth is involved and destination_id is returned ' +
+    'immediately; ' +
     'for looker_studio (pull-based connector), creates the destination directly and returns ' +
     'destination_id immediately — no OAuth, no emails needed; the connector credentials ' +
     '(including the Destination Secret Key/Token) are never sent through MCP/chat — the ' +
@@ -125,11 +127,11 @@ export class AddDestinationTool implements McpToolDefinition<AddDestinationInput
     return inputSchema
       .refine(
         data =>
-          !EMAIL_BASED_TYPES.includes(data.destination_type) ||
+          !MCP_CHANNEL_EMAIL_TYPES.includes(data.destination_type) ||
           (data.emails && data.emails.length > 0),
         {
           message:
-            "The 'emails' parameter is required for creating email-based destination types (email, slack, teams, google_chat). " +
+            "The 'emails' parameter is required for email, slack, teams, and channel-email Google Chat destinations created through MCP. " +
             'Please ask the user to specify one or more email addresses first before calling this tool.',
           path: ['emails'],
         }
@@ -143,7 +145,7 @@ export class AddDestinationTool implements McpToolDefinition<AddDestinationInput
     const humanType = toDisplayLabel(destinationType);
     const title = parsed.title ?? humanType;
 
-    if (EMAIL_BASED_TYPES.includes(destinationType)) {
+    if (MCP_CHANNEL_EMAIL_TYPES.includes(destinationType)) {
       const created = await this.destinations.createDestination({
         projectId: context.projectId,
         userId: context.userId,

--- a/apps/web/e2e/fixtures/api-helpers.ts
+++ b/apps/web/e2e/fixtures/api-helpers.ts
@@ -212,12 +212,16 @@ export class ApiHelpers {
     }
   }
 
-  async createDestination(type = 'LOOKER_STUDIO', title?: string): Promise<{ id: string }> {
+  async createDestination(
+    type = 'LOOKER_STUDIO',
+    title?: string,
+    credentials?: Record<string, unknown>
+  ): Promise<{ id: string }> {
     const res = await this.page.request.post('/api/data-destinations', {
       data: {
         title: title ?? `E2E Destination ${Date.now()}`,
         type,
-        credentials: this.getCredentialsForType(type),
+        credentials: credentials ?? this.getCredentialsForType(type),
       },
     });
     expect(res.ok()).toBeTruthy();

--- a/apps/web/e2e/fixtures/api-helpers.ts
+++ b/apps/web/e2e/fixtures/api-helpers.ts
@@ -188,9 +188,10 @@ export class ApiHelpers {
 
   /**
    * Returns the credential payload required by the backend for the given
-   * destination type. EMAIL, MS_TEAMS and GOOGLE_CHAT all use the
-   * email-credentials schema; LOOKER_STUDIO has its own; GOOGLE_SHEETS
-   * requires OAuth/service-account and is left undefined here.
+   * destination type. EMAIL and MS_TEAMS use email credentials;
+   * GOOGLE_CHAT uses a syntactically valid test webhook (creation does not
+   * call it); LOOKER_STUDIO has its own; GOOGLE_SHEETS requires
+   * OAuth/service-account and is left undefined here.
    */
   private getCredentialsForType(type: string): Record<string, unknown> | undefined {
     switch (type) {
@@ -201,7 +202,11 @@ export class ApiHelpers {
       case 'MS_TEAMS':
         return { type: 'email-credentials', to: ['test-teams@example.com'] };
       case 'GOOGLE_CHAT':
-        return { type: 'email-credentials', to: ['test-chat@example.com'] };
+        return {
+          type: 'google-chat-credentials',
+          webhookUrl:
+            'https://chat.googleapis.com/v1/spaces/e2e-space/messages?key=e2e-key&token=e2e-token',
+        };
       default:
         return undefined;
     }

--- a/apps/web/e2e/specs/destination.spec.ts
+++ b/apps/web/e2e/specs/destination.spec.ts
@@ -99,6 +99,35 @@ for (const { type, label, prefix } of DESTINATION_TYPES) {
       await expect(page.getByText(updatedTitle)).toBeVisible();
     });
 
+    if (type === 'GOOGLE_CHAT') {
+      test('preserves a legacy Google Chat channel email when editing the title', async ({
+        page,
+        apiHelpers,
+      }) => {
+        const legacyEmail = 'legacy-space@example.com';
+        const legacyTitle = `Legacy Google Chat ${Date.now()}`;
+        const destination = await apiHelpers.createDestination('GOOGLE_CHAT', legacyTitle, {
+          type: 'email-credentials',
+          to: [legacyEmail],
+        });
+
+        await page.goto('/ui/0/data-destinations');
+        await page.getByText(legacyTitle).click();
+
+        const sheet = page.getByTestId(TESTIDS.destEditSheet);
+        await sheet.getByLabel('Title').fill(`Updated ${legacyTitle}`);
+        await sheet.getByRole('button', { name: 'Save' }).click();
+        await expect(sheet).not.toBeVisible();
+
+        const response = await page.request.get(`/api/data-destinations/${destination.id}`);
+        expect(response.ok()).toBeTruthy();
+        expect((await response.json()).credentials).toEqual({
+          type: 'email-credentials',
+          to: [legacyEmail],
+        });
+      });
+    }
+
     test(`deletes ${label} destination`, async ({ page, radix }) => {
       await page.goto('/ui/0/data-destinations');
       await expect(page.getByTestId(TESTIDS.destTab)).toBeVisible();

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/DataDestinationForm.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/DataDestinationForm.tsx
@@ -50,6 +50,7 @@ import { DestinationTypeField } from './DestinationTypeField';
 import { EmailFields } from './EmailFields';
 import { GoogleSheetsFields } from './GoogleSheetsFields';
 import { LookerStudioFields } from './LookerStudioFields';
+import { GoogleChatFields } from './GoogleChatFields';
 
 interface DataDestinationFormProps {
   initialData:
@@ -271,9 +272,7 @@ export function DataDestinationForm({
             />
           )}
 
-          {destinationType === DataDestinationType.GOOGLE_CHAT && (
-            <EmailFields form={form} emailsFieldTitle={'Enter Google Chat channel emails list'} />
-          )}
+          {destinationType === DataDestinationType.GOOGLE_CHAT && <GoogleChatFields form={form} />}
 
           <FormSection title='Ownership' defaultOpen={false} name='destination-ownership'>
             <FormItem>

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/descriptions/GoogleChatDescription.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/descriptions/GoogleChatDescription.tsx
@@ -7,15 +7,14 @@ export default function GoogleChatDescription() {
       <AccordionTrigger>How do I start sending to Google Chat?</AccordionTrigger>
       <AccordionContent>
         <p className='mb-2'>
-          To send reports to Google Chat, first configure the <strong>Google Chat</strong>{' '}
-          destination in this form (add a title and specify recipient addresses). Then, go to your
-          Data Mart page, open the <strong>Destinations</strong> tab, and create a report in the
-          Google Chat block.
+          Choose <strong>Google Chat API</strong> to send complete, formatted messages through an
+          incoming webhook, or <strong>Channel Email</strong> to keep the previous email-based
+          delivery. For API delivery, open <strong>Apps &amp; integrations</strong> in the target
+          Chat space, add an incoming webhook, and paste its URL here. Treat the URL as a secret.
         </p>
         <p className='mb-2'>
-          In the report settings, add a subject and message, and set the delivery conditions. The
-          generated report will be delivered by OWOX Data Marts to the connected space as chat
-          messages.
+          Then create a report from your Data Mart's <strong>Destinations</strong> tab and configure
+          its subject, message, and delivery conditions.
         </p>
         <p className='mb-2'>
           For more details, read the{' '}

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/descriptions/GoogleChatDescription.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/descriptions/GoogleChatDescription.tsx
@@ -7,10 +7,11 @@ export default function GoogleChatDescription() {
       <AccordionTrigger>How do I start sending to Google Chat?</AccordionTrigger>
       <AccordionContent>
         <p className='mb-2'>
-          Choose <strong>Google Chat API</strong> to send complete, formatted messages through an
-          incoming webhook, or <strong>Channel Email</strong> to keep the previous email-based
-          delivery. For API delivery, open <strong>Apps &amp; integrations</strong> in the target
-          Chat space, add an incoming webhook, and paste its URL here. Treat the URL as a secret.
+          Choose <strong>Incoming Webhook</strong> to send the report directly to the space as
+          formatted Google Chat messages, or <strong>Channel Email</strong> to send it by email to
+          the Chat space address. For webhook delivery, open{' '}
+          <strong>Apps &amp; integrations</strong> in the target space, add an incoming webhook, and
+          paste its URL here. Treat the URL as a secret.
         </p>
         <p className='mb-2'>
           Then create a report from your Data Mart's <strong>Destinations</strong> tab and configure

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.test.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.test.tsx
@@ -1,0 +1,123 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Form } from '@owox/ui/components/form';
+import {
+  DataDestinationType,
+  dataDestinationSchema,
+  type DataDestinationFormData,
+} from '../../../shared';
+import { GoogleChatFields } from './GoogleChatFields';
+
+type GoogleChatFormData = Extract<
+  DataDestinationFormData,
+  { type: DataDestinationType.GOOGLE_CHAT }
+>;
+
+function TestForm({
+  credentials,
+  onValid,
+}: {
+  credentials: GoogleChatFormData['credentials'];
+  onValid: (data: DataDestinationFormData) => void;
+}) {
+  const form = useForm<DataDestinationFormData>({
+    resolver: zodResolver(dataDestinationSchema),
+    defaultValues: {
+      title: 'Google Chat',
+      type: DataDestinationType.GOOGLE_CHAT,
+      credentials,
+    },
+    mode: 'onTouched',
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={event => void form.handleSubmit(onValid)(event)}>
+        <GoogleChatFields form={form} />
+        <output data-testid='dirty'>{String(form.formState.isDirty)}</output>
+        <button type='submit'>Save</button>
+      </form>
+    </Form>
+  );
+}
+
+describe('GoogleChatFields', () => {
+  it('keeps an existing channel-email destination in email mode', async () => {
+    const onValid = vi.fn();
+    render(
+      <TestForm
+        credentials={{ deliveryMethod: 'email', to: ['space@example.com'] }}
+        onValid={onValid}
+      />
+    );
+
+    expect(screen.getByRole('tab', { name: 'Channel Email' })).toHaveAttribute(
+      'data-state',
+      'active'
+    );
+    expect(screen.getByRole('textbox')).toHaveValue('space@example.com');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(onValid).toHaveBeenCalledTimes(1);
+    });
+    expect(onValid.mock.calls[0][0].credentials).toEqual({
+      deliveryMethod: 'email',
+      to: ['space@example.com'],
+    });
+  });
+
+  it('defaults an empty Google Chat form to webhook mode without marking it dirty', async () => {
+    const onValid = vi.fn();
+    render(<TestForm credentials={{} as GoogleChatFormData['credentials']} onValid={onValid} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Google Chat API' })).toHaveAttribute(
+        'data-state',
+        'active'
+      );
+    });
+    expect(screen.getByTestId('dirty')).toHaveTextContent('false');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(
+      await screen.findByText('Enter a valid Google Chat incoming webhook URL')
+    ).toBeInTheDocument();
+    expect(onValid).not.toHaveBeenCalled();
+  });
+
+  it('marks method changes dirty and preserves a configured hidden webhook', async () => {
+    const onValid = vi.fn();
+    render(
+      <TestForm credentials={{ deliveryMethod: 'webhook', configured: true }} onValid={onValid} />
+    );
+
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Channel Email' }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    const emailField = await screen.findByRole('textbox');
+    fireEvent.change(emailField, { target: { value: 'space@example.com' } });
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Google Chat API' }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(screen.getByTestId('dirty')).toHaveTextContent('true');
+    expect(
+      screen.getByPlaceholderText('Webhook configured — paste a new URL to replace it')
+    ).toHaveValue('');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => {
+      expect(onValid).toHaveBeenCalledTimes(1);
+    });
+    expect(onValid.mock.calls[0][0].credentials).toEqual({
+      deliveryMethod: 'webhook',
+      configured: true,
+    });
+  });
+});

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.test.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.test.tsx
@@ -58,6 +58,9 @@ describe('GoogleChatFields', () => {
       'data-state',
       'active'
     );
+    expect(
+      screen.getByText('Sends the report by email to the Google Chat space address.')
+    ).toBeInTheDocument();
     expect(screen.getByRole('textbox')).toHaveValue('space@example.com');
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -75,11 +78,14 @@ describe('GoogleChatFields', () => {
     render(<TestForm credentials={{} as GoogleChatFormData['credentials']} onValid={onValid} />);
 
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: 'Google Chat API' })).toHaveAttribute(
+      expect(screen.getByRole('tab', { name: 'Incoming Webhook' })).toHaveAttribute(
         'data-state',
         'active'
       );
     });
+    expect(
+      screen.getByText('Sends the report directly to the space as formatted Google Chat messages.')
+    ).toBeInTheDocument();
     expect(screen.getByTestId('dirty')).toHaveTextContent('false');
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -101,7 +107,7 @@ describe('GoogleChatFields', () => {
     });
     const emailField = await screen.findByRole('textbox');
     fireEvent.change(emailField, { target: { value: 'space@example.com' } });
-    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Google Chat API' }), {
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Incoming Webhook' }), {
       button: 0,
       ctrlKey: false,
     });

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.tsx
@@ -43,7 +43,7 @@ export function GoogleChatFields({ form }: { form: UseFormReturn<DataDestination
         <div className='flex items-center justify-between'>
           <FormLabel>Delivery Method</FormLabel>
           <Tabs value={deliveryMethod} onValueChange={handleDeliveryMethodChange}>
-            <TabsList>
+            <TabsList aria-label='Delivery method'>
               <TabsTrigger value='webhook'>Google Chat API</TabsTrigger>
               <TabsTrigger value='email'>Channel Email</TabsTrigger>
             </TabsList>

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.tsx
@@ -1,0 +1,83 @@
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@owox/ui/components/form';
+import { Input } from '@owox/ui/components/input';
+import { Tabs, TabsList, TabsTrigger } from '@owox/ui/components/tabs';
+import { useEffect } from 'react';
+import { type FieldPathValue, type Path, type UseFormReturn } from 'react-hook-form';
+import { type DataDestinationFormData } from '../../../shared';
+import { EmailFields } from './EmailFields';
+
+const WEBHOOK_FIELD_PATH = 'credentials.webhookUrl' as Path<DataDestinationFormData>;
+const DELIVERY_METHOD_FIELD_PATH = 'credentials.deliveryMethod' as Path<DataDestinationFormData>;
+const WEBHOOK_HELP =
+  'Paste the incoming webhook URL copied from Apps & integrations in your Google Chat space.';
+
+export function GoogleChatFields({ form }: { form: UseFormReturn<DataDestinationFormData> }) {
+  const watchedDeliveryMethod = form.watch(DELIVERY_METHOD_FIELD_PATH) as string | undefined;
+  const deliveryMethod = watchedDeliveryMethod === 'email' ? 'email' : 'webhook';
+  const configured = form.watch('credentials.configured' as Path<DataDestinationFormData>) as
+    | boolean
+    | undefined;
+
+  useEffect(() => {
+    if (watchedDeliveryMethod !== 'email' && watchedDeliveryMethod !== 'webhook') {
+      form.setValue(
+        DELIVERY_METHOD_FIELD_PATH,
+        'webhook' as FieldPathValue<DataDestinationFormData, typeof DELIVERY_METHOD_FIELD_PATH>,
+        { shouldDirty: false, shouldValidate: false }
+      );
+    }
+  }, [form, watchedDeliveryMethod]);
+
+  const handleDeliveryMethodChange = (value: string) => {
+    if (value !== 'email' && value !== 'webhook') return;
+    form.setValue(
+      DELIVERY_METHOD_FIELD_PATH,
+      value as FieldPathValue<DataDestinationFormData, typeof DELIVERY_METHOD_FIELD_PATH>,
+      { shouldDirty: true, shouldTouch: true, shouldValidate: true }
+    );
+  };
+
+  return (
+    <div className='space-y-4'>
+      <FormItem>
+        <div className='flex items-center justify-between'>
+          <FormLabel>Delivery Method</FormLabel>
+          <Tabs value={deliveryMethod} onValueChange={handleDeliveryMethodChange}>
+            <TabsList>
+              <TabsTrigger value='webhook'>Google Chat API</TabsTrigger>
+              <TabsTrigger value='email'>Channel Email</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+      </FormItem>
+
+      {deliveryMethod === 'webhook' ? (
+        <FormField
+          control={form.control}
+          name={WEBHOOK_FIELD_PATH}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel tooltip={WEBHOOK_HELP}>Google Chat incoming webhook URL</FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  type='password'
+                  autoComplete='off'
+                  value={typeof field.value === 'string' ? field.value : ''}
+                  placeholder={
+                    configured
+                      ? 'Webhook configured — paste a new URL to replace it'
+                      : 'https://chat.googleapis.com/v1/spaces/.../messages?key=...&token=...'
+                  }
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      ) : (
+        <EmailFields form={form} emailsFieldTitle='Enter Google Chat channel emails list' />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.tsx
@@ -1,4 +1,11 @@
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@owox/ui/components/form';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@owox/ui/components/form';
 import { Input } from '@owox/ui/components/input';
 import { Tabs, TabsList, TabsTrigger } from '@owox/ui/components/tabs';
 import { useEffect } from 'react';
@@ -44,11 +51,16 @@ export function GoogleChatFields({ form }: { form: UseFormReturn<DataDestination
           <FormLabel>Delivery Method</FormLabel>
           <Tabs value={deliveryMethod} onValueChange={handleDeliveryMethodChange}>
             <TabsList aria-label='Delivery method'>
-              <TabsTrigger value='webhook'>Google Chat API</TabsTrigger>
+              <TabsTrigger value='webhook'>Incoming Webhook</TabsTrigger>
               <TabsTrigger value='email'>Channel Email</TabsTrigger>
             </TabsList>
           </Tabs>
         </div>
+        <FormDescription>
+          {deliveryMethod === 'webhook'
+            ? 'Sends the report directly to the space as formatted Google Chat messages.'
+            : 'Sends the report by email to the Google Chat space address.'}
+        </FormDescription>
       </FormItem>
 
       {deliveryMethod === 'webhook' ? (

--- a/apps/web/src/features/data-destination/shared/enums/data-destination-credentials-type.enum.ts
+++ b/apps/web/src/features/data-destination/shared/enums/data-destination-credentials-type.enum.ts
@@ -3,4 +3,5 @@ export enum DataDestinationCredentialsType {
   GOOGLE_SHEETS_OAUTH_CREDENTIALS = 'google-sheets-oauth-credentials',
   LOOKER_STUDIO_CREDENTIALS = 'looker-studio-credentials',
   EMAIL_CREDENTIALS = 'email-credentials',
+  GOOGLE_CHAT_CREDENTIALS = 'google-chat-credentials',
 }

--- a/apps/web/src/features/data-destination/shared/model/mappers/destination-mapper.factory.ts
+++ b/apps/web/src/features/data-destination/shared/model/mappers/destination-mapper.factory.ts
@@ -1,14 +1,10 @@
 import { DataDestinationType } from '../../enums';
-import type {
-  EmailDataDestination,
-  GoogleChatDataDestination,
-  MsTeamsDataDestination,
-  SlackDataDestination,
-} from '../types';
+import type { EmailDataDestination, MsTeamsDataDestination, SlackDataDestination } from '../types';
 import type { DestinationMapper } from './destination-mapper.interface.ts';
 import { EmailMapper } from './email.mapper.ts';
 import { GoogleSheetsMapper } from './google-sheets.mapper.ts';
 import { LookerStudioMapper } from './looker-studio.mapper.ts';
+import { GoogleChatMapper } from './google-chat.mapper.ts';
 
 export const DestinationMapperFactory = {
   getMapper(type: DataDestinationType): DestinationMapper {
@@ -24,7 +20,7 @@ export const DestinationMapperFactory = {
       case DataDestinationType.MS_TEAMS:
         return new EmailMapper<MsTeamsDataDestination>(DataDestinationType.MS_TEAMS);
       case DataDestinationType.GOOGLE_CHAT:
-        return new EmailMapper<GoogleChatDataDestination>(DataDestinationType.GOOGLE_CHAT);
+        return new GoogleChatMapper();
       default:
         throw new Error(`Unknown destination type: ${type}`);
     }

--- a/apps/web/src/features/data-destination/shared/model/mappers/email.mapper.ts
+++ b/apps/web/src/features/data-destination/shared/model/mappers/email.mapper.ts
@@ -15,7 +15,6 @@ export class EmailMapper<T extends DataDestination> implements DestinationMapper
       | DataDestinationType.EMAIL
       | DataDestinationType.SLACK
       | DataDestinationType.MS_TEAMS
-      | DataDestinationType.GOOGLE_CHAT
   ) {}
 
   mapFromDto(dto: DataDestinationResponseDto): T {

--- a/apps/web/src/features/data-destination/shared/model/mappers/google-chat.mapper.test.ts
+++ b/apps/web/src/features/data-destination/shared/model/mappers/google-chat.mapper.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { DataDestinationCredentialsType, DataDestinationType } from '../../enums';
+import type { DataDestinationResponseDto } from '../../services/types';
+import { GoogleChatMapper } from './google-chat.mapper';
+
+describe('GoogleChatMapper', () => {
+  const mapper = new GoogleChatMapper();
+
+  it('maps a redacted API credential to a configured form state', () => {
+    const destination = mapper.mapFromDto({
+      id: 'destination-1',
+      title: 'Marketing Chat',
+      type: DataDestinationType.GOOGLE_CHAT,
+      projectId: 'project-1',
+      credentials: {
+        type: DataDestinationCredentialsType.GOOGLE_CHAT_CREDENTIALS,
+        configured: true,
+      },
+      createdAt: new Date('2026-07-17T12:00:00Z'),
+      modifiedAt: new Date('2026-07-17T12:00:00Z'),
+    } satisfies DataDestinationResponseDto);
+
+    expect(destination.credentials).toEqual({ deliveryMethod: 'webhook', configured: true });
+  });
+
+  it('sends a pasted webhook when creating a destination', () => {
+    const webhookUrl =
+      'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key-1&token=token-1';
+
+    expect(
+      mapper.mapToCreateRequest({
+        title: 'Marketing Chat',
+        type: DataDestinationType.GOOGLE_CHAT,
+        credentials: { deliveryMethod: 'webhook', webhookUrl },
+      })
+    ).toEqual({
+      title: 'Marketing Chat',
+      type: DataDestinationType.GOOGLE_CHAT,
+      credentials: {
+        type: DataDestinationCredentialsType.GOOGLE_CHAT_CREDENTIALS,
+        webhookUrl,
+      },
+    });
+  });
+
+  it('preserves an existing email-based Google Chat destination', () => {
+    const destination = mapper.mapFromDto({
+      id: 'destination-1',
+      title: 'Legacy Chat',
+      type: DataDestinationType.GOOGLE_CHAT,
+      projectId: 'project-1',
+      credentials: {
+        type: DataDestinationCredentialsType.EMAIL_CREDENTIALS,
+        to: ['space@example.com'],
+      },
+      createdAt: new Date('2026-07-17T12:00:00Z'),
+      modifiedAt: new Date('2026-07-17T12:00:00Z'),
+    } satisfies DataDestinationResponseDto);
+
+    expect(destination.credentials).toEqual({
+      deliveryMethod: 'email',
+      to: ['space@example.com'],
+    });
+  });
+
+  it('creates an email-based Google Chat destination when that method is selected', () => {
+    expect(
+      mapper.mapToCreateRequest({
+        title: 'Legacy delivery',
+        type: DataDestinationType.GOOGLE_CHAT,
+        credentials: { deliveryMethod: 'email', to: ['space@example.com'] },
+      })
+    ).toEqual({
+      title: 'Legacy delivery',
+      type: DataDestinationType.GOOGLE_CHAT,
+      credentials: {
+        type: DataDestinationCredentialsType.EMAIL_CREDENTIALS,
+        to: ['space@example.com'],
+      },
+    });
+  });
+
+  it('does not overwrite a saved webhook when the hidden field remains blank', () => {
+    expect(
+      mapper.mapToUpdateRequest({
+        title: 'Renamed Chat',
+        type: DataDestinationType.GOOGLE_CHAT,
+        credentials: { deliveryMethod: 'webhook', configured: true },
+      })
+    ).toEqual({ title: 'Renamed Chat' });
+  });
+
+  it('defaults an existing empty email configuration to webhook delivery', () => {
+    const destination = mapper.mapFromDto({
+      id: 'destination-1',
+      title: 'Empty Legacy Chat',
+      type: DataDestinationType.GOOGLE_CHAT,
+      projectId: 'project-1',
+      credentials: {
+        type: DataDestinationCredentialsType.EMAIL_CREDENTIALS,
+        to: [],
+      },
+      createdAt: new Date('2026-07-17T12:00:00Z'),
+      modifiedAt: new Date('2026-07-17T12:00:00Z'),
+    } satisfies DataDestinationResponseDto);
+
+    expect(destination.credentials).toEqual({
+      deliveryMethod: 'webhook',
+      configured: false,
+    });
+  });
+});

--- a/apps/web/src/features/data-destination/shared/model/mappers/google-chat.mapper.test.ts
+++ b/apps/web/src/features/data-destination/shared/model/mappers/google-chat.mapper.test.ts
@@ -43,6 +43,16 @@ describe('GoogleChatMapper', () => {
     });
   });
 
+  it('rejects a webhook create request without a URL', () => {
+    expect(() =>
+      mapper.mapToCreateRequest({
+        title: 'Marketing Chat',
+        type: DataDestinationType.GOOGLE_CHAT,
+        credentials: { deliveryMethod: 'webhook' },
+      })
+    ).toThrow('Google Chat webhook URL is required');
+  });
+
   it('preserves an existing email-based Google Chat destination', () => {
     const destination = mapper.mapFromDto({
       id: 'destination-1',

--- a/apps/web/src/features/data-destination/shared/model/mappers/google-chat.mapper.ts
+++ b/apps/web/src/features/data-destination/shared/model/mappers/google-chat.mapper.ts
@@ -1,0 +1,81 @@
+import type { DestinationMapper } from './destination-mapper.interface.ts';
+import type { DataDestinationResponseDto } from '../../services/types';
+import type { GoogleChatDataDestination } from '../types';
+import { DataDestinationCredentialsType, DataDestinationType } from '../../enums';
+import type { DataDestinationFormData } from '../../types';
+import type {
+  UpdateDataDestinationRequestDto,
+  CreateDataDestinationRequestDto,
+} from '../../services/types';
+
+export class GoogleChatMapper implements DestinationMapper {
+  mapFromDto(dto: DataDestinationResponseDto): GoogleChatDataDestination {
+    const credentials: GoogleChatDataDestination['credentials'] =
+      dto.credentials.type === DataDestinationCredentialsType.EMAIL_CREDENTIALS &&
+      dto.credentials.to.length > 0
+        ? { deliveryMethod: 'email', to: dto.credentials.to }
+        : {
+            deliveryMethod: 'webhook',
+            configured:
+              dto.credentials.type === DataDestinationCredentialsType.GOOGLE_CHAT_CREDENTIALS &&
+              dto.credentials.configured,
+          };
+
+    return {
+      id: dto.id,
+      title: dto.title,
+      type: DataDestinationType.GOOGLE_CHAT,
+      projectId: dto.projectId,
+      credentials,
+      createdAt: new Date(dto.createdAt),
+      modifiedAt: new Date(dto.modifiedAt),
+      createdByUser: dto.createdByUser,
+      ownerUsers: dto.ownerUsers ?? [],
+    };
+  }
+
+  mapToUpdateRequest(formData: Partial<DataDestinationFormData>): UpdateDataDestinationRequestDto {
+    const result: UpdateDataDestinationRequestDto = {
+      title: formData.title ?? '',
+    };
+    const credentials =
+      formData.type === DataDestinationType.GOOGLE_CHAT ? formData.credentials : undefined;
+
+    if (credentials?.deliveryMethod === 'email') {
+      result.credentials = {
+        type: DataDestinationCredentialsType.EMAIL_CREDENTIALS,
+        to: credentials.to,
+      };
+    } else if (credentials?.deliveryMethod === 'webhook' && credentials.webhookUrl?.trim()) {
+      result.credentials = {
+        type: DataDestinationCredentialsType.GOOGLE_CHAT_CREDENTIALS,
+        webhookUrl: credentials.webhookUrl.trim(),
+      };
+    }
+
+    return result;
+  }
+
+  mapToCreateRequest(formData: DataDestinationFormData): CreateDataDestinationRequestDto {
+    if (formData.type !== DataDestinationType.GOOGLE_CHAT) {
+      throw new Error('Invalid form data for Google Chat destination');
+    }
+
+    const credentials =
+      formData.credentials.deliveryMethod === 'email'
+        ? {
+            type: DataDestinationCredentialsType.EMAIL_CREDENTIALS as const,
+            to: formData.credentials.to,
+          }
+        : {
+            type: DataDestinationCredentialsType.GOOGLE_CHAT_CREDENTIALS as const,
+            webhookUrl: formData.credentials.webhookUrl ?? '',
+          };
+
+    return {
+      title: formData.title,
+      type: DataDestinationType.GOOGLE_CHAT,
+      credentials,
+    };
+  }
+}

--- a/apps/web/src/features/data-destination/shared/model/mappers/google-chat.mapper.ts
+++ b/apps/web/src/features/data-destination/shared/model/mappers/google-chat.mapper.ts
@@ -61,16 +61,22 @@ export class GoogleChatMapper implements DestinationMapper {
       throw new Error('Invalid form data for Google Chat destination');
     }
 
-    const credentials =
-      formData.credentials.deliveryMethod === 'email'
-        ? {
-            type: DataDestinationCredentialsType.EMAIL_CREDENTIALS as const,
-            to: formData.credentials.to,
-          }
-        : {
-            type: DataDestinationCredentialsType.GOOGLE_CHAT_CREDENTIALS as const,
-            webhookUrl: formData.credentials.webhookUrl ?? '',
-          };
+    let credentials: CreateDataDestinationRequestDto['credentials'];
+    if (formData.credentials.deliveryMethod === 'email') {
+      credentials = {
+        type: DataDestinationCredentialsType.EMAIL_CREDENTIALS,
+        to: formData.credentials.to,
+      };
+    } else {
+      const webhookUrl = formData.credentials.webhookUrl?.trim();
+      if (!webhookUrl) {
+        throw new Error('Google Chat webhook URL is required');
+      }
+      credentials = {
+        type: DataDestinationCredentialsType.GOOGLE_CHAT_CREDENTIALS,
+        webhookUrl,
+      };
+    }
 
     return {
       title: formData.title,

--- a/apps/web/src/features/data-destination/shared/model/mappers/google-chat.mapper.ts
+++ b/apps/web/src/features/data-destination/shared/model/mappers/google-chat.mapper.ts
@@ -61,7 +61,10 @@ export class GoogleChatMapper implements DestinationMapper {
       throw new Error('Invalid form data for Google Chat destination');
     }
 
-    let credentials: CreateDataDestinationRequestDto['credentials'];
+    let credentials: Extract<
+      CreateDataDestinationRequestDto,
+      { type: DataDestinationType.GOOGLE_CHAT }
+    >['credentials'];
     if (formData.credentials.deliveryMethod === 'email') {
       credentials = {
         type: DataDestinationCredentialsType.EMAIL_CREDENTIALS,

--- a/apps/web/src/features/data-destination/shared/model/types/credentials.ts
+++ b/apps/web/src/features/data-destination/shared/model/types/credentials.ts
@@ -2,9 +2,11 @@ import type { GoogleServiceAccountCredentials } from '../../../../../shared/type
 import type { EmailCredentials } from './email-credentials.ts';
 import type { LookerStudioCredentials } from './looker-studio-credentials.ts';
 import type { GoogleSheetsOAuthCredentials } from './data-destination.ts';
+import type { GoogleChatCredentials } from './google-chat-credentials.ts';
 
 export type DataDestinationCredentials =
   | GoogleServiceAccountCredentials
   | GoogleSheetsOAuthCredentials
   | LookerStudioCredentials
-  | EmailCredentials;
+  | EmailCredentials
+  | GoogleChatCredentials;

--- a/apps/web/src/features/data-destination/shared/model/types/data-destination.ts
+++ b/apps/web/src/features/data-destination/shared/model/types/data-destination.ts
@@ -3,6 +3,7 @@ import type { CredentialIdentity, UserProjection } from '../../../../../shared/t
 import type { DataDestinationCredentials } from './credentials.ts';
 import type { EmailCredentials } from './email-credentials.ts';
 import type { LookerStudioCredentials } from './looker-studio-credentials.ts';
+import type { GoogleChatCredentials } from './google-chat-credentials.ts';
 
 export interface BaseDataDestination<T extends DataDestinationCredentials> {
   id: string;
@@ -56,9 +57,9 @@ export interface MsTeamsDataDestination extends BaseDataDestination<EmailCredent
   credentials: EmailCredentials;
 }
 
-export interface GoogleChatDataDestination extends BaseDataDestination<EmailCredentials> {
+export interface GoogleChatDataDestination extends BaseDataDestination<GoogleChatCredentials> {
   type: DataDestinationType.GOOGLE_CHAT;
-  credentials: EmailCredentials;
+  credentials: GoogleChatCredentials;
 }
 
 export type DataDestination =

--- a/apps/web/src/features/data-destination/shared/model/types/google-chat-credentials.ts
+++ b/apps/web/src/features/data-destination/shared/model/types/google-chat-credentials.ts
@@ -1,0 +1,11 @@
+export type GoogleChatCredentials =
+  | {
+      deliveryMethod: 'webhook';
+      /** Empty for an existing destination because webhook URLs are never returned by the API. */
+      webhookUrl?: string;
+      configured?: boolean;
+    }
+  | {
+      deliveryMethod: 'email';
+      to: string[];
+    };

--- a/apps/web/src/features/data-destination/shared/model/types/index.ts
+++ b/apps/web/src/features/data-destination/shared/model/types/index.ts
@@ -1,3 +1,4 @@
 export * from './data-destination';
 export * from './data-destination-list';
 export * from './credentials';
+export * from './google-chat-credentials';

--- a/apps/web/src/features/data-destination/shared/services/types/create-data-destination.request.dto.ts
+++ b/apps/web/src/features/data-destination/shared/services/types/create-data-destination.request.dto.ts
@@ -50,7 +50,15 @@ export type CreateDataDestinationRequestDto =
   | {
       title: string;
       type: DataDestinationType.GOOGLE_CHAT;
-      credentials: { type: DataDestinationCredentialsType.EMAIL_CREDENTIALS; to: string[] };
+      credentials:
+        | {
+            type: DataDestinationCredentialsType.GOOGLE_CHAT_CREDENTIALS;
+            webhookUrl: string;
+          }
+        | {
+            type: DataDestinationCredentialsType.EMAIL_CREDENTIALS;
+            to: string[];
+          };
       ownerIds?: string[];
     };
 

--- a/apps/web/src/features/data-destination/shared/services/types/data-destination.response.dto.ts
+++ b/apps/web/src/features/data-destination/shared/services/types/data-destination.response.dto.ts
@@ -29,6 +29,11 @@ export interface EmailCredentialsResponse {
   type: DataDestinationCredentialsType.EMAIL_CREDENTIALS;
 }
 
+export interface GoogleChatCredentialsResponse {
+  configured: true;
+  type: DataDestinationCredentialsType.GOOGLE_CHAT_CREDENTIALS;
+}
+
 /**
  * Data destination response data transfer object
  */
@@ -60,7 +65,8 @@ export interface DataDestinationResponseDto {
     | GoogleSheetsCredentialsResponse
     | GoogleSheetsOAuthCredentialsResponse
     | LookerStudioCredentialsResponse
-    | EmailCredentialsResponse;
+    | EmailCredentialsResponse
+    | GoogleChatCredentialsResponse;
 
   /**
    * Creation timestamp

--- a/apps/web/src/features/data-destination/shared/services/types/update-data-destination.request.dto.ts
+++ b/apps/web/src/features/data-destination/shared/services/types/update-data-destination.request.dto.ts
@@ -1,5 +1,6 @@
 import { type GoogleServiceAccountCredentialsDto } from '../../../../../shared/types';
 import type { EmailCredentials } from '../../model/types/email-credentials.ts';
+import { DataDestinationCredentialsType } from '../../enums';
 
 /**
  * Data transfer object for updating a data destination
@@ -13,7 +14,13 @@ export interface UpdateDataDestinationRequestDto {
   /**
    * Credentials for the selected destination type
    */
-  credentials?: GoogleServiceAccountCredentialsDto | EmailCredentials;
+  credentials?:
+    | GoogleServiceAccountCredentialsDto
+    | EmailCredentials
+    | {
+        type: DataDestinationCredentialsType.GOOGLE_CHAT_CREDENTIALS;
+        webhookUrl: string;
+      };
 
   /**
    * Credential ID for OAuth-based authentication (null to disconnect)

--- a/apps/web/src/features/data-destination/shared/types/data-destination.schema.ts
+++ b/apps/web/src/features/data-destination/shared/types/data-destination.schema.ts
@@ -4,6 +4,7 @@ import { googleCredentialsWithOAuthSchema } from '../../../../shared';
 import { lookerStudioCredentialsSchema } from './looker-studio-credentials.schema.ts';
 import { emailCredentialsSchema } from './email-credentials.schema.ts';
 import { isValidGoogleDriveFolderUrl } from '../utils/drive-folder-url.utils.ts';
+import { googleChatCredentialsSchema } from './google-chat-credentials.schema.ts';
 
 // Base schema for all data destinations
 const baseDataDestinationSchema = z.object({
@@ -51,8 +52,9 @@ const msTeamsDestinationSchema = emailLikeBase.extend({
   type: z.literal(DataDestinationType.MS_TEAMS),
 });
 
-const googleChatDestinationSchema = emailLikeBase.extend({
+const googleChatDestinationSchema = baseDataDestinationSchema.extend({
   type: z.literal(DataDestinationType.GOOGLE_CHAT),
+  credentials: googleChatCredentialsSchema,
 });
 
 // Combined schema with conditional validation based on type

--- a/apps/web/src/features/data-destination/shared/types/google-chat-credentials.schema.test.ts
+++ b/apps/web/src/features/data-destination/shared/types/google-chat-credentials.schema.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { googleChatCredentialsSchema } from './google-chat-credentials.schema';
+
+describe('googleChatCredentialsSchema', () => {
+  const webhookUrl =
+    'https://chat.googleapis.com/v1/spaces/space-1/messages?key=key-1&token=token-1';
+
+  it('accepts a new incoming webhook', () => {
+    expect(googleChatCredentialsSchema.parse({ deliveryMethod: 'webhook', webhookUrl })).toEqual({
+      deliveryMethod: 'webhook',
+      webhookUrl,
+    });
+  });
+
+  it('accepts a hidden existing webhook', () => {
+    expect(
+      googleChatCredentialsSchema.parse({ deliveryMethod: 'webhook', configured: true })
+    ).toEqual({ deliveryMethod: 'webhook', configured: true });
+  });
+
+  it('accepts channel email delivery', () => {
+    expect(
+      googleChatCredentialsSchema.parse({
+        deliveryMethod: 'email',
+        to: ['space@example.com'],
+      })
+    ).toEqual({ deliveryMethod: 'email', to: ['space@example.com'] });
+  });
+
+  it('rejects incomplete credentials for the selected delivery method', () => {
+    expect(
+      googleChatCredentialsSchema.safeParse({
+        deliveryMethod: 'webhook',
+        webhookUrl: 'https://example.com/webhook',
+      }).success
+    ).toBe(false);
+    expect(googleChatCredentialsSchema.safeParse({ deliveryMethod: 'email', to: [] }).success).toBe(
+      false
+    );
+  });
+});

--- a/apps/web/src/features/data-destination/shared/types/google-chat-credentials.schema.ts
+++ b/apps/web/src/features/data-destination/shared/types/google-chat-credentials.schema.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+const GOOGLE_CHAT_WEBHOOK_PATH = /^\/v1\/spaces\/[^/]+\/messages$/;
+
+export function isGoogleChatWebhookUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === 'https:' &&
+      url.hostname === 'chat.googleapis.com' &&
+      !url.port &&
+      !url.username &&
+      !url.password &&
+      !url.hash &&
+      GOOGLE_CHAT_WEBHOOK_PATH.test(url.pathname) &&
+      Boolean(url.searchParams.get('key')) &&
+      Boolean(url.searchParams.get('token'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+const googleChatWebhookCredentialsSchema = z
+  .object({
+    deliveryMethod: z.literal('webhook'),
+    webhookUrl: z.string().trim().optional(),
+    configured: z.boolean().optional(),
+  })
+  .superRefine((credentials, context) => {
+    if (credentials.webhookUrl && isGoogleChatWebhookUrl(credentials.webhookUrl)) return;
+    if (credentials.configured && !credentials.webhookUrl) return;
+
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['webhookUrl'],
+      message: 'Enter a valid Google Chat incoming webhook URL',
+    });
+  });
+
+const googleChatEmailCredentialsSchema = z.object({
+  deliveryMethod: z.literal('email'),
+  to: z.array(z.string().email()).min(1, 'Enter at least one Google Chat channel email'),
+});
+
+export const googleChatCredentialsSchema = z.union([
+  googleChatWebhookCredentialsSchema,
+  googleChatEmailCredentialsSchema,
+]);

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/RecipientsDisplay.test.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/RecipientsDisplay.test.tsx
@@ -9,7 +9,7 @@ import { RecipientsDisplay } from './RecipientsDisplay.tsx';
 const baseDestination = {
   id: 'destination-1',
   title: 'Google Chat',
-  type: DataDestinationType.GOOGLE_CHAT,
+  type: DataDestinationType.GOOGLE_CHAT as const,
   projectId: 'project-1',
   createdAt: new Date('2026-07-17T12:00:00Z'),
   modifiedAt: new Date('2026-07-17T12:00:00Z'),

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/RecipientsDisplay.test.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/RecipientsDisplay.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useForm } from 'react-hook-form';
+
+import { Form } from '@owox/ui/components/form';
+import { DataDestinationType } from '../../../../../data-destination';
+import { RecipientsDisplay } from './RecipientsDisplay.tsx';
+
+const baseDestination = {
+  id: 'destination-1',
+  title: 'Google Chat',
+  type: DataDestinationType.GOOGLE_CHAT,
+  projectId: 'project-1',
+  createdAt: new Date('2026-07-17T12:00:00Z'),
+  modifiedAt: new Date('2026-07-17T12:00:00Z'),
+};
+
+function TestForm({ children }: { children: React.ReactNode }) {
+  const form = useForm();
+  return <Form {...form}>{children}</Form>;
+}
+
+describe('RecipientsDisplay', () => {
+  it('hides the recipients block for Google Chat webhook delivery', () => {
+    render(
+      <RecipientsDisplay
+        destination={{
+          ...baseDestination,
+          credentials: { deliveryMethod: 'webhook', configured: true },
+        }}
+      />
+    );
+
+    expect(screen.queryByText('Recipients of this report')).not.toBeInTheDocument();
+    expect(screen.queryByText('No recipients found')).not.toBeInTheDocument();
+  });
+
+  it('keeps showing recipients for Google Chat channel-email delivery', () => {
+    render(
+      <TestForm>
+        <RecipientsDisplay
+          destination={{
+            ...baseDestination,
+            credentials: { deliveryMethod: 'email', to: ['space@example.com'] },
+          }}
+        />
+      </TestForm>
+    );
+
+    expect(screen.getByText('Recipients of this report')).toBeInTheDocument();
+    expect(screen.getByText('space@example.com')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/RecipientsDisplay.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/RecipientsDisplay.tsx
@@ -1,7 +1,7 @@
 import { FormLabel } from '@owox/ui/components/form';
 import { CopyableField } from '@owox/ui/components/common/copyable-field';
 import { isEmailCredentials } from '../../../../../data-destination/shared/model/types/email-credentials.ts';
-import type { DataDestination } from '../../../../../data-destination';
+import { isGoogleChatDataDestination, type DataDestination } from '../../../../../data-destination';
 
 export interface RecipientsDisplayProps {
   destination: DataDestination | null;
@@ -9,6 +9,12 @@ export interface RecipientsDisplayProps {
 
 export const RecipientsDisplay = ({ destination }: RecipientsDisplayProps) => {
   if (!destination) return null;
+  if (
+    isGoogleChatDataDestination(destination) &&
+    destination.credentials.deliveryMethod === 'webhook'
+  ) {
+    return null;
+  }
 
   const creds = destination.credentials;
   const recipients = isEmailCredentials(creds) && creds.to.length ? creds.to.join(', ') : '';

--- a/docs/destinations/supported-destinations/google-chat.md
+++ b/docs/destinations/supported-destinations/google-chat.md
@@ -1,6 +1,6 @@
 # Google Chat
 
-Configure **Google Chat** as a Destination in OWOX Data Marts to allow business users to receive messages with Insights based on the results of each Data Mart run.  
+Configure **Google Chat** as a Destination in OWOX Data Marts to deliver Insights to a Chat space after each Data Mart run. New destinations default to direct, formatted delivery through an incoming webhook, while channel-email delivery remains available for backward compatibility.
 
 For example, you may want to notify a stakeholder in a Google Chat room every time a scheduled run produces updated data (such as new results from the Facebook Ads connector). You can also choose to receive a message only when the run result is empty.
 
@@ -22,9 +22,26 @@ Choose **Google Chat** from the **Destination Type** dropdown.
 
 #### 1.3. Configure Destination details
 
-- **Title**: Enter a unique name for the Destination (for example, “Marketing Team”).  
-- **Google Chat channel emails list**: Add recipient emails or Google Chat room email addresses separated by commas, semicolons, or new lines  
-  (for example: `your-space-name-####@your-domain.gserviceaccount.com`).
+- **Title**: Enter a unique name for the Destination (for example, “Marketing Team”).
+- **Delivery Method**:
+  - **Google Chat API** (default): posts the complete Insight as a formatted Google Chat card.
+  - **Channel Email**: uses the previous email-based delivery and Google Chat's email rendering.
+- For **Google Chat API**, provide a **Google Chat incoming webhook URL**:
+  1. Open the target space in Google Chat.
+  2. Next to the space title, open **Apps & integrations**.
+  3. Click **Add webhooks**, enter a name, and save the webhook.
+  4. Copy its URL and paste it into OWOX.
+- For **Channel Email**, enter one or more Google Chat channel email addresses.
+
+Existing Google Chat destinations with saved email addresses continue to open with **Channel Email**
+selected. If an existing destination has no email address, the form defaults to **Google Chat API**.
+
+> The webhook URL contains a secret token. Store it as a credential and do not share it in chat,
+> documentation, or source control. If **Add webhooks** is unavailable, ask your Google Workspace
+> administrator to allow incoming webhooks.
+
+Incoming webhooks authenticate through the key and token in the URL, so this delivery method does
+not require a separate OAuth connection or service-account JSON.
 
 #### 1.4. Save the Destination
 
@@ -46,20 +63,22 @@ In the block labeled with the name of your Destination, click **+ Add report**.
 
 #### 2.3. Configure general settings
 
-Enter a report title and make sure the report is assigned to the correct Destination.  
-You can also view and copy the list of report recipients.
+Enter a report title and make sure the report is assigned to the correct Destination.
 
 #### 2.4. Configure the template
 
-Write your **Message** using Markdown.  
-Switch to **Preview** to check how the message will appear in Google Chat.
+Write your **Message** using Markdown. Switch to **Preview** to check the content. With **Google Chat
+API**, OWOX posts the rendered Insight as a card with the subject, Data Mart name, complete message
+body, and a link back to the report. Messages that exceed Google Chat's per-message size limit are
+split into as many as 20 numbered parts. Insights requiring more parts are rejected before sending.
+With **Channel Email**, Google Chat controls how the emailed content is rendered.
 
 #### 2.5. Set sending conditions
 
 Decide when the report should be sent based on the Data Mart run result:
 
-- **Send always** – the report is sent after every run.  
-- **Send only when result is empty** – the report is sent only if the Data Mart returns no data.  
+- **Send always** – the report is sent after every run.
+- **Send only when result is empty** – the report is sent only if the Data Mart returns no data.
 - **Send only when result is not empty** – the report is sent only if the Data Mart returns data.
 
 OWOX automatically runs the Data Mart before sending the report and checks the result. Your selected condition determines whether the message is sent.

--- a/docs/destinations/supported-destinations/google-chat.md
+++ b/docs/destinations/supported-destinations/google-chat.md
@@ -71,6 +71,10 @@ Write your **Message** using Markdown. Switch to **Preview** to check the conten
 API**, OWOX posts the rendered Insight as a card with the subject, Data Mart name, complete message
 body, and a link back to the report. Messages that exceed Google Chat's per-message size limit are
 split into as many as 20 numbered parts. Insights requiring more parts are rejected before sending.
+Because Google Chat cards support only a subset of Markdown, headings are rendered as bold lines and
+tables as monospace code blocks; supported emphasis, lists, links, and code formatting are preserved.
+Parts are sent sequentially. If a later part fails, earlier parts remain visible because incoming
+webhooks do not support transactional delivery or rollback; running the report again may resend them.
 With **Channel Email**, Google Chat controls how the emailed content is rendered.
 
 #### 2.5. Set sending conditions

--- a/docs/destinations/supported-destinations/google-chat.md
+++ b/docs/destinations/supported-destinations/google-chat.md
@@ -24,9 +24,9 @@ Choose **Google Chat** from the **Destination Type** dropdown.
 
 - **Title**: Enter a unique name for the Destination (for example, “Marketing Team”).
 - **Delivery Method**:
-  - **Google Chat API** (default): posts the complete Insight as a formatted Google Chat card.
-  - **Channel Email**: uses the previous email-based delivery and Google Chat's email rendering.
-- For **Google Chat API**, provide a **Google Chat incoming webhook URL**:
+  - **Incoming Webhook** (default): sends the report directly to the space as formatted Google Chat messages.
+  - **Channel Email**: sends the report by email to the Google Chat space address.
+- For **Incoming Webhook**, provide a **Google Chat incoming webhook URL**:
   1. Open the target space in Google Chat.
   2. Next to the space title, open **Apps & integrations**.
   3. Click **Add webhooks**, enter a name, and save the webhook.
@@ -34,7 +34,7 @@ Choose **Google Chat** from the **Destination Type** dropdown.
 - For **Channel Email**, enter one or more Google Chat channel email addresses.
 
 Existing Google Chat destinations with saved email addresses continue to open with **Channel Email**
-selected. If an existing destination has no email address, the form defaults to **Google Chat API**.
+selected. If an existing destination has no email address, the form defaults to **Incoming Webhook**.
 
 > The webhook URL contains a secret token. Store it as a credential and do not share it in chat,
 > documentation, or source control. If **Add webhooks** is unavailable, ask your Google Workspace
@@ -67,10 +67,10 @@ Enter a report title and make sure the report is assigned to the correct Destina
 
 #### 2.4. Configure the template
 
-Write your **Message** using Markdown. Switch to **Preview** to check the content. With **Google Chat
-API**, OWOX posts the rendered Insight as a card with the subject, Data Mart name, complete message
-body, and a link back to the report. Messages that exceed Google Chat's per-message size limit are
-split into as many as 20 numbered parts. Insights requiring more parts are rejected before sending.
+Write your **Message** using Markdown. Switch to **Preview** to check the content. With **Incoming
+Webhook**, OWOX posts the rendered report as a card with the subject, Data Mart name, message body,
+and a link back to the report. Messages that exceed Google Chat's per-message size limit are split
+into as many as 20 numbered parts. Reports requiring more parts are rejected before sending.
 Because Google Chat cards support only a subset of Markdown, headings are rendered as bold lines and
 tables as monospace code blocks; supported emphasis, lists, links, and code formatting are preserved.
 Parts are sent sequentially. If a later part fails, earlier parts remain visible because incoming


### PR DESCRIPTION
Google Chat Destinations now offer Google Chat API and Channel Email delivery methods. Existing
email-based destinations keep their current method, while new destinations default to direct API
delivery through a space-specific incoming webhook. API messages are formatted cards containing the
subject, Data Mart, complete rendered Insight, and a link back to OWOX.