### PR TITLE
fix(docs): correct api docs links in owox changelog

### DIFF
--- a/.changeset/6749-mcp-reporting-tools.md
+++ b/.changeset/6749-mcp-reporting-tools.md
@@ -1,5 +1,5 @@
 ---
-'owox': minor
+'owox': patch
 ---
 
 # More reliable MCP reporting answers

--- a/apps/owox/CHANGELOG.md
+++ b/apps/owox/CHANGELOG.md
@@ -66,7 +66,7 @@
 
 - 7d09e62: **HTTP Data streaming supports aggregations and date buckets**
 
-  The HTTP Data streaming API, the [`@owox/api-client`](../docs/api/api-client.md) `traverseData()` method, and the [`owox-ctl data-marts stream`](../docs/api/owox-ctl.md) command now accept `aggregation` and `dateTrunc` parameters (`--aggregation` / `--date-bucket` on the CLI), matching the grouping already available for Reports. Any selected column without an aggregation rule becomes a grouping key, so you can stream pre-aggregated rows — for example monthly revenue totals — directly from a published Data Mart without building a Report. Grand totals and the applied aggregation are recorded in the HTTP_DATA run history.
+  The HTTP Data streaming API, the [`@owox/api-client`](../../docs/api/api-client.md) `traverseData()` method, and the [`owox-ctl data-marts stream`](../../docs/api/owox-ctl.md) command now accept `aggregation` and `dateTrunc` parameters (`--aggregation` / `--date-bucket` on the CLI), matching the grouping already available for Reports. Any selected column without an aggregation rule becomes a grouping key, so you can stream pre-aggregated rows — for example monthly revenue totals — directly from a published Data Mart without building a Report. Grand totals and the applied aggregation are recorded in the HTTP_DATA run history.
 
 - 0781310: **Clearer permission errors when managing Storages, Destinations, and Data Marts**
 


### PR DESCRIPTION
The 'HTTP Data streaming supports aggregations and date buckets' entry linked to ../docs/api/*.md, which resolves to apps/docs/api/*.md instead of the repo-root docs/api/*.md. sync-docs.js turned those into /apps/docs/api/api-client/ and /apps/docs/api/owox-ctl/, and starlight-links-validator failed the docs build on main.