### PR TITLE
chore: add changeset for Google Sheets extension fix (#6769)

### DIFF
--- a/.changeset/6769-extension-reset-columns-on-mart-switch.md
+++ b/.changeset/6769-extension-reset-columns-on-mart-switch.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# No more leftover columns when switching Data Marts in Google Sheets
+
+When creating a report in the Google Sheets extension, switching to another Data Mart now resets the column selection. Previously, columns picked for the first Data Mart stuck around and showed up as scary "Disconnected columns" under the new one — and could even sneak into the created report and make it fail.


### PR DESCRIPTION
Adds a changeset documenting the Google Sheets extension fix: column selection made for one Data Mart no longer persists (as "Disconnected columns") after switching to another Data Mart in the create-report form.

Extension PR: OWOX/google-sheets-extension#41