### PR TITLE
ci(docs): run docs build for every file the docs site is assembled from

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -2,8 +2,18 @@ name: Test and Build @owox/docs
 
 on:
   pull_request:
+    # The docs site is assembled from markdown spread across the monorepo, so a build can break
+    # from files far outside apps/docs. Keep this list in sync with the search patterns in
+    # findMarkdownFiles() / findManifestFiles() in apps/docs/scripts/sync-docs.js.
     paths:
       - 'apps/docs/**'
+      - 'apps/owox/CHANGELOG.md'
+      - '*.md'
+      - 'apps/**/*.md'
+      - 'docs/**/*.md'
+      - 'packages/**/*.md'
+      - 'licenses/**/*.md'
+      - 'packages/connectors/**/manifest.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The docs build only ran on pull requests touching `apps/docs/**`, but the docs site is assembled from markdown spread across the monorepo: `sync-docs.js` also pulls in `apps/owox/CHANGELOG.md`, root `docs/**`, READMEs, `licenses/**` and connector manifests.

As a result a change outside `apps/docs/` can break the docs build with every PR check green, and the failure only surfaces on `main` in `Build and Deploy @owox/docs`. That is exactly what happened with #1405: it added a changelog entry linking to `../docs/api/api-client.md`, which resolves to a path that does not exist, and `starlight-links-validator` failed the deploy on `main` (run 30006632705). #1461 fixed the links; this PR closes the gap that let them through.

## What changed

`.github/workflows/test-docs.yml` — the `pull_request` path filter now mirrors the search patterns in `findMarkdownFiles()` / `findManifestFiles()` in `apps/docs/scripts/sync-docs.js`, with a comment pointing at them so the two lists are kept in sync.

## Verification

- The workflow YAML parses and the `paths` list resolves as intended; the build job steps are untouched.
- Path patterns checked against real diffs: #1461 and #1460 (`apps/owox/CHANGELOG.md`), a root `README.md` change, `docs/api/*.md`, and a connector `manifest.json` all trigger the build; a backend-only TypeScript change still skips it.