### PR TITLE
[6749] Allow explicit draft Data Mart catalog listing

### DIFF
--- a/.changeset/6696-mcp-draft-data-mart-catalog.md
+++ b/.changeset/6696-mcp-draft-data-mart-catalog.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+<!-- markdownlint-disable-file MD041 -->
+
+Allow MCP clients to explicitly list draft Data Marts with `list_data_marts` while keeping published Data Marts as the default catalog state.

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.spec.ts
@@ -85,7 +85,7 @@ describe('McpDataMartsFacadeImpl', () => {
       }),
     }) as unknown as jest.Mocked<SummarizeMcpDataCatalogService>;
 
-  it('lists data marts using project-member context', async () => {
+  it('lists only published data marts by default using project-member context', async () => {
     const listDataMartsService = createListDataMartsService([
       new DataMartListItemDto(
         'dm_1',
@@ -144,6 +144,62 @@ describe('McpDataMartsFacadeImpl', () => {
           description: 'Mock Description',
           status: DataMartStatus.PUBLISHED,
           updatedAt: '2026-06-10T10:00:00.000Z',
+        },
+      ],
+    });
+  });
+
+  it('lists only draft data marts when drafts are explicitly requested', async () => {
+    const listDataMartsService = createListDataMartsService([
+      new DataMartListItemDto(
+        'dm_1',
+        'Orders',
+        DataMartStatus.PUBLISHED,
+        DataStorageType.GOOGLE_BIGQUERY,
+        'BigQuery',
+        new Date('2026-06-01T10:00:00.000Z'),
+        new Date('2026-06-10T10:00:00.000Z'),
+        'Published data mart'
+      ),
+      new DataMartListItemDto(
+        'dm_draft',
+        'Draft Orders',
+        DataMartStatus.DRAFT,
+        DataStorageType.GOOGLE_BIGQUERY,
+        'BigQuery',
+        new Date('2026-06-01T10:00:00.000Z'),
+        new Date('2026-06-11T10:00:00.000Z'),
+        'Draft data mart'
+      ),
+    ]);
+    const facade = new McpDataMartsFacadeImpl(
+      listDataMartsService,
+      createGetDataMartService(),
+      createDataMartService(),
+      createQueryDataMartService(),
+      createBlendableSchemaService(),
+      createRelationshipService(),
+      createSummarizeMcpDataCatalogService()
+    );
+
+    const result = await facade.listDataMarts({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      status: 'draft',
+    });
+
+    expect(listDataMartsService.run).toHaveBeenCalledWith(
+      expect.objectContaining({ status: DataMartStatus.DRAFT })
+    );
+    expect(result).toEqual({
+      dataMarts: [
+        {
+          id: 'dm_draft',
+          title: 'Draft Orders',
+          description: 'Draft data mart',
+          status: DataMartStatus.DRAFT,
+          updatedAt: '2026-06-11T10:00:00.000Z',
         },
       ],
     });

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.ts
@@ -46,6 +46,7 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
   ) {}
 
   async listDataMarts(request: McpListDataMartsRequest): Promise<McpListDataMartsResponse> {
+    const status = request.status === 'draft' ? DataMartStatus.DRAFT : DataMartStatus.PUBLISHED;
     const result = await this.listDataMartsService.run(
       new ListDataMartsCommand(
         request.projectId,
@@ -53,15 +54,15 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
         request.roles,
         undefined,
         undefined,
-        DataMartStatus.PUBLISHED
+        status
       )
     );
 
     return {
       dataMarts: result.items
-        // Keep this gate in the MCP facade even though the tool defaults to `published`: a direct
-        // facade caller must not make a draft discoverable through MCP either.
-        .filter(item => item.status === DataMartStatus.PUBLISHED)
+        // Keep this gate at the facade boundary: the underlying list use case is allowed to
+        // return a mixed result, but MCP must return only the explicitly requested state.
+        .filter(item => item.status === status)
         .map(item => ({
           id: item.id,
           title: item.title,

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.ts
@@ -5,16 +5,17 @@ import type { SortConfig } from '../dto/schemas/sort-config.schema';
 
 export const MCP_DATA_MARTS_FACADE = Symbol('MCP_DATA_MARTS_FACADE');
 
+export type McpDataMartCatalogStatus = 'published' | 'draft';
+
 export interface McpListDataMartsRequest {
   projectId: string;
   userId: string;
   roles: string[];
   /**
-   * MCP is a reporting surface, therefore published is deliberately the only supported catalog
-   * state. The explicit property documents the default at the facade boundary as well as in the
-   * tool input, so direct facade users cannot accidentally re-introduce drafts.
+   * Published is the default state for the reporting catalog. Drafts are discoverable only when
+   * explicitly requested; all other MCP Data Mart operations still require published state.
    */
-  status?: 'published';
+  status?: McpDataMartCatalogStatus;
 }
 
 export interface McpSummarizeDataCatalogRequest {
@@ -23,7 +24,10 @@ export interface McpSummarizeDataCatalogRequest {
   roles: string[];
 }
 
-export interface McpGetDataMartDetailsRequest extends McpListDataMartsRequest {
+export interface McpGetDataMartDetailsRequest {
+  projectId: string;
+  userId: string;
+  roles: string[];
   dataMartId: string;
   includeJoinedFields?: boolean;
 }

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -85,6 +85,45 @@ describe('ListDataMartsTool', () => {
     });
   });
 
+  it('lists draft data marts only when explicitly requested', async () => {
+    const facade = {
+      listDataMarts: jest.fn().mockResolvedValue({
+        dataMarts: [
+          {
+            id: 'dm_draft',
+            title: 'Draft Orders',
+            description: 'Unpublished changes',
+            status: 'DRAFT',
+            updatedAt: '2026-06-11T10:00:00.000Z',
+          },
+        ],
+      }),
+    } as unknown as jest.Mocked<McpDataMartsFacade>;
+    const tool = new ListDataMartsTool(facade, publicOrigin, projectContext as never);
+
+    const result = await tool.handler({ status: 'draft' }, context);
+
+    expect(facade.listDataMarts).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      status: 'draft',
+    });
+    expect(result.structuredContent).toEqual({
+      project: { id: 'project-1', title: 'Analytics' },
+      data_marts: [
+        {
+          id: 'dm_draft',
+          title: 'Draft Orders',
+          description: 'Unpublished changes',
+          url: 'https://app.owox.com/ui/project-1/data-marts/dm_draft/data-setup',
+          status: 'DRAFT',
+          updated_at: '2026-06-11T10:00:00.000Z',
+        },
+      ],
+    });
+  });
+
   it('rejects explicit project_id input', async () => {
     const tool = new ListDataMartsTool(
       {} as McpDataMartsFacade,
@@ -93,6 +132,16 @@ describe('ListDataMartsTool', () => {
     );
 
     expect(() => tool.parseInput({ project_id: 'another-project' })).toThrow();
+  });
+
+  it('rejects an unsupported catalog state', () => {
+    const tool = new ListDataMartsTool(
+      {} as McpDataMartsFacade,
+      publicOrigin,
+      projectContext as never
+    );
+
+    expect(() => tool.parseInput({ status: 'archived' })).toThrow();
   });
 
   it('returns the catalog when optional project metadata is unavailable', async () => {

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -1,4 +1,5 @@
 import type { PublicOriginService } from '../../../common/config/public-origin.service';
+import { DataMartStatus } from '../../../data-marts/enums/data-mart-status.enum';
 import type { McpDataMartsFacade } from '../../../data-marts/facades/mcp-data-marts.facade';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import { McpToolRegistry } from './mcp-tool.registry';
@@ -32,7 +33,7 @@ describe('ListDataMartsTool', () => {
             id: 'dm_1',
             title: 'Orders',
             description: null,
-            status: 'published',
+            status: DataMartStatus.PUBLISHED,
             updatedAt: '2026-06-10T10:00:00.000Z',
           },
         ],
@@ -49,7 +50,7 @@ describe('ListDataMartsTool', () => {
             title: 'Orders',
             description: '',
             url: 'https://app.owox.com/ui/project-1/data-marts/dm_1/data-setup',
-            status: 'published',
+            status: DataMartStatus.PUBLISHED,
             updated_at: '2026-06-10T10:00:00.000Z',
           },
         ],
@@ -66,7 +67,7 @@ describe('ListDataMartsTool', () => {
                   title: 'Orders',
                   description: '',
                   url: 'https://app.owox.com/ui/project-1/data-marts/dm_1/data-setup',
-                  status: 'published',
+                  status: DataMartStatus.PUBLISHED,
                   updated_at: '2026-06-10T10:00:00.000Z',
                 },
               ],

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.ts
@@ -19,9 +19,11 @@ import { joinPublicOrigin } from './mcp-public-url.util';
 const inputSchema = z
   .object({
     status: z
-      .literal('published')
+      .enum(['published', 'draft'])
       .optional()
-      .describe('Catalog state filter. Only published Data Marts are available through MCP.'),
+      .describe(
+        'Catalog state filter. Defaults to published. Draft returns draft metadata only; only published Data Marts can be inspected or queried through MCP.'
+      ),
   })
   .strict();
 
@@ -31,7 +33,7 @@ type ListDataMartsInput = z.infer<typeof inputSchema>;
 export class ListDataMartsTool implements McpToolDefinition<ListDataMartsInput> {
   readonly name = 'list_data_marts';
   readonly description =
-    'List data marts available to the current OWOX project member. Use only when the user explicitly asks to list or browse data marts; for a concrete analytical question use get_relevant_data_marts_by_prompt instead, and for open-ended orientation use summarize_data_catalog.';
+    'List data marts available to the current OWOX project member. Defaults to published data marts; use status=draft only to browse draft metadata, because other MCP data-mart tools accept published data marts only. Use only when the user explicitly asks to list or browse data marts; for a concrete analytical question use get_relevant_data_marts_by_prompt instead, and for open-ended orientation use summarize_data_catalog.';
   readonly zodSchema = inputSchema.shape;
   readonly outputSchema = {
     project: z.object({ id: z.string(), title: z.string() }).optional(),

--- a/docs/getting-started/setup-guide/mcp.md
+++ b/docs/getting-started/setup-guide/mcp.md
@@ -164,7 +164,13 @@ Use this tool when you need to confirm which project is active, or when the assi
 
 ### `list_data_marts`
 
-Lists published data marts visible to you in the current project. Draft data marts are never exposed through MCP.
+Lists data marts visible to you in the current project. By default, it returns published data marts. You can explicitly request draft data mart metadata, but drafts cannot be inspected or queried through other MCP data mart tools.
+
+**Input:**
+
+| Field    | Description                                                                                                             |
+| -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `status` | Optional: `published` (default) returns queryable data marts; `draft` returns draft metadata for catalog browsing only. |
 
 **Returns** an array of data mart objects:
 

--- a/docs/getting-started/setup-guide/mcp.md
+++ b/docs/getting-started/setup-guide/mcp.md
@@ -180,7 +180,7 @@ Lists data marts visible to you in the current project. By default, it returns p
 | `title`       | Data mart name                                |
 | `description` | Data mart description                         |
 | `url`         | Link to open the data mart in OWOX Data Marts |
-| `status`      | Current status                                |
+| `status`      | Current status: `PUBLISHED` or `DRAFT`. Response values are uppercase and differ from the lowercase input filter values. |
 | `updated_at`  | Last update timestamp                         |
 
 Use this tool to discover available data marts before running queries or building reports.


### PR DESCRIPTION
## Summary
- Add an explicit status: draft option to list_data_marts.
- Preserve published as the default catalog state.
- Keep draft Data Marts unavailable to details and query tools.

## Validation
- Targeted Jest: 2 suites, 18 tests passed.
- Targeted ESLint passed.
- Targeted Markdownlint passed.