### PR TITLE
fix: allow sorting a report by a column not in the output

### DIFF
--- a/.changeset/6768-sort-by-unselected-column.md
+++ b/.changeset/6768-sort-by-unselected-column.md
@@ -1,0 +1,15 @@
+---
+'owox': patch
+---
+
+# Allow sorting a report by a column that is not in the output
+
+Report sorting no longer requires the sorted column to be among the selected
+output columns. A non-aggregated report can now sort by any column of its data
+mart (including joined/blended columns when the report has an explicit column
+selection), the same way filters already work — so the `Output controls
+validation failed` error no longer appears for a valid sort on a hidden column.
+
+Aggregated (grouped) reports are unchanged: they can still sort only by a
+projected dimension or an aggregated metric, because SQL `GROUP BY` cannot
+order by a column that is neither grouped nor aggregated.

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -840,7 +840,37 @@ describe('OutputControlsValidatorService', () => {
       expect(response.details.errors[0].code).toBe('INVALID_OPERATOR_FOR_TYPE');
     });
 
-    it('throws BadRequestException with SORT_COLUMN_NOT_SELECTED for sort on non-selected column', async () => {
+    it('accepts sort on a known native column that is NOT in the explicit columnConfig', async () => {
+      // A non-aggregated report with an explicit projection resolves ORDER BY against the
+      // source row (src.<col>), so sorting by a known-but-unselected column is valid SQL —
+      // symmetric with filters. (Regression guard for #6768.)
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([
+        { name: 'date', type: BigQueryFieldType.DATE },
+        { name: 'amount', type: BigQueryFieldType.INTEGER },
+      ]);
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      await expect(
+        validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: ['date'],
+          filterConfig: null,
+          sortConfig: [{ column: 'amount', direction: 'asc' }],
+          limitConfig: null,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects a sort on a non-projected column in an AGGREGATED report', async () => {
+      // GROUP BY: ORDER BY references the alias resolver, which can only see a projected
+      // dimension or an aggregated metric — a sort on a column that is neither is invalid SQL.
       const capabilitySvc = makeCapabilityService(true);
       const schemaSvc = makeBlendableSchemaService([
         { name: 'date', type: BigQueryFieldType.DATE },
@@ -861,6 +891,7 @@ describe('OutputControlsValidatorService', () => {
           filterConfig: null,
           sortConfig: [{ column: 'amount', direction: 'asc' }],
           limitConfig: null,
+          aggregationConfig: [{ column: 'date', function: 'COUNT' }],
           accessor: { userId: 'user-1', roles: ['admin'] },
         });
       } catch (e) {
@@ -946,6 +977,44 @@ describe('OutputControlsValidatorService', () => {
         code: 'SORT_COLUMN_NOT_SELECTED',
         column: 'partner_revenue',
       });
+    });
+
+    // Counterpart to the null-columnConfig rejection above: with an EXPLICIT projection the
+    // blended builder materializes any referenced column into its CTE and qualifies ORDER BY
+    // to it, so a non-aggregated report may sort by a known blended column even when it isn't
+    // among the selected output columns. (#6768)
+    it('accepts sort on a BLENDED column not in the explicit columnConfig', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService(
+        [{ name: 'amount', type: BigQueryFieldType.INTEGER }],
+        {
+          blendedFields: [
+            {
+              name: 'partner_revenue',
+              aliasPath: 'partner',
+              originalFieldName: 'revenue',
+              type: BigQueryFieldType.INTEGER,
+            },
+          ],
+        }
+      );
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      await expect(
+        validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: ['amount'],
+          filterConfig: null,
+          sortConfig: [{ column: 'partner_revenue', direction: 'asc' }],
+          limitConfig: null,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        })
+      ).resolves.toBeUndefined();
     });
 
     it('rejects payload with mismatched filter shape via Zod (defence-in-depth)', async () => {

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.ts
@@ -631,13 +631,29 @@ export class OutputControlsValidatorService {
           );
         }
         if (parsedSort.length > 0) {
-          // With no explicit columnConfig the projection is `SELECT *` over the home
-          // mart's NATIVE fields only — blended output aliases are NOT projected, and
-          // the blended run path rejects output controls without an explicit column
-          // selection. Validate sort against that same native-only set so a sort on a
-          // blended column is caught here at save time instead of failing at run time.
-          const selectedSet = new Set(args.columnConfig ?? connectedNativeNames);
-          errors.push(...this.validateSort(parsedSort, selectedSet));
+          // An AGGREGATED report (GROUP BY) constrains ORDER BY: the alias resolver can
+          // reference only a projected dimension or an aggregated metric, so a sort on a
+          // column that is neither grouped nor aggregated emits invalid SQL. Enforce the
+          // "must be projected" rule against the selected columns for that case.
+          const isAggregated =
+            parsedAggregations.length > 0 ||
+            parsedDateTruncs.length > 0 ||
+            args.uniqueCountConfig === true;
+          if (isAggregated) {
+            const selectedSet = new Set(args.columnConfig ?? connectedNativeNames);
+            errors.push(...this.validateSort(parsedSort, selectedSet));
+          } else if (!hasColumnConfig) {
+            // Non-aggregated with NO explicit projection → `SELECT *` over the home mart's
+            // NATIVE fields only (blended aliases aren't projected, and the blended run path
+            // rejects output controls without an explicit column selection). Sorting is valid
+            // only on a native column, so validate against that native-only set.
+            errors.push(...this.validateSort(parsedSort, new Set(connectedNativeNames)));
+          }
+          // Non-aggregated WITH an explicit columnConfig: the builder materializes any
+          // referenced column (native → `main`, blended → its joined CTE) and resolves
+          // ORDER BY against the source row, so a sort on an unselected-but-known column is
+          // valid SQL, exactly like a filter. No projection constraint here; a sort on a
+          // genuinely unknown column is still surfaced below as a disconnected ref.
         }
         if (parsedAggregations.length > 0) {
           // Post-join aggregation over the (flat) blended result is an outer GROUP BY

--- a/apps/backend/test/output-controls.e2e-spec.ts
+++ b/apps/backend/test/output-controls.e2e-spec.ts
@@ -105,15 +105,33 @@ describe('Output controls API (e2e)', () => {
     });
   });
 
-  it('PUT rejects sort on existing non-selected column with SORT_COLUMN_NOT_SELECTED', async () => {
+  it('PUT accepts sort on a known column that is not in columnConfig (#6768)', async () => {
+    // Non-aggregated report: ORDER BY resolves against the source row, so sorting by a
+    // known-but-unselected column is valid SQL — symmetric with filters.
     const res = await agent
       .put(`/api/reports/${reportId}`)
       .set(AUTH_HEADER)
       .send({
-        title: 'Bad sort',
+        title: 'Sort by unselected',
         dataDestinationId,
         destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
         columnConfig: ['col_a'],
+        sortConfig: [{ column: 'col_b', direction: 'asc' }],
+      });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('PUT rejects sort on a non-projected column in an AGGREGATED report', async () => {
+    const res = await agent
+      .put(`/api/reports/${reportId}`)
+      .set(AUTH_HEADER)
+      .send({
+        title: 'Bad aggregated sort',
+        dataDestinationId,
+        destinationConfig: { type: 'looker-studio-config', cacheLifetime: 3600 },
+        columnConfig: ['col_a'],
+        aggregationConfig: [{ column: 'col_a', function: 'COUNT' }],
         sortConfig: [{ column: 'col_b', direction: 'asc' }],
       });
 

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.invariant.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.invariant.test.tsx
@@ -80,6 +80,7 @@ describe('OutputSettingsDropdown stored-identifier invariant', () => {
         onChange={onChange}
         allColumns={[productId]}
         selectedColumns={[]}
+        hasExplicitColumns={true}
         joinedSources={[]}
       />
     );
@@ -101,6 +102,7 @@ describe('OutputSettingsDropdown stored-identifier invariant', () => {
         onChange={onChange}
         allColumns={[]}
         selectedColumns={[]}
+        hasExplicitColumns={true}
         joinedSources={[
           {
             aliasPath: 'orders',
@@ -133,6 +135,7 @@ describe('OutputSettingsDropdown stored-identifier invariant', () => {
         onChange={onChange}
         allColumns={[]}
         selectedColumns={[productId]}
+        hasExplicitColumns={false}
         joinedSources={[]}
       />
     );

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
@@ -40,6 +40,7 @@ describe('OutputSettingsDropdown disconnected controls', () => {
         onChange={() => {}}
         allColumns={[{ name: 'native_one', type: 'STRING', label: 'native_one' }]}
         selectedColumns={[{ name: 'native_one', type: 'STRING', label: 'native_one' }]}
+        hasExplicitColumns={true}
         joinedSources={[]}
       />
     );
@@ -74,6 +75,7 @@ describe('OutputSettingsDropdown disconnected controls', () => {
         onChange={() => {}}
         allColumns={[]}
         selectedColumns={[]}
+        hasExplicitColumns={true}
         joinedSources={[]}
       />
     );
@@ -103,6 +105,7 @@ describe('OutputSettingsDropdown disconnected controls', () => {
         onChange={onChange}
         allColumns={[]}
         selectedColumns={[]}
+        hasExplicitColumns={true}
         joinedSources={[
           {
             aliasPath: 'users',
@@ -140,6 +143,7 @@ describe('OutputSettingsDropdown readable labels', () => {
         onChange={() => {}}
         allColumns={[productId]}
         selectedColumns={[productId]}
+        hasExplicitColumns={true}
         joinedSources={[]}
       />
     );
@@ -165,6 +169,7 @@ describe('OutputSettingsDropdown readable labels', () => {
         onChange={() => {}}
         allColumns={[productId]}
         selectedColumns={[productId]}
+        hasExplicitColumns={true}
         joinedSources={[]}
       />
     );
@@ -194,6 +199,7 @@ describe('OutputSettingsDropdown no longer hosts aggregation controls', () => {
         onChange={() => {}}
         allColumns={[revenue]}
         selectedColumns={[revenue]}
+        hasExplicitColumns={true}
         joinedSources={[]}
       />
     );

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
@@ -86,6 +86,12 @@ interface OutputSettingsDropdownProps {
   onChange: (next: OutputConfig) => void;
   selectedColumns: readonly OutputSettingsDropdownColumn[];
   allColumns: readonly OutputSettingsDropdownColumn[];
+  /**
+   * Whether the report has an EXPLICIT column projection (columnConfig !== null). Without it
+   * the projection is `SELECT *` over native fields only, so a non-aggregated report can sort
+   * only by native columns; with it the builder can sort by any known column (native/blended).
+   */
+  hasExplicitColumns: boolean;
   joinedSources?: readonly JoinedSource[];
 }
 
@@ -94,6 +100,7 @@ export function OutputSettingsDropdown({
   onChange,
   selectedColumns,
   allColumns,
+  hasExplicitColumns,
   joinedSources,
 }: OutputSettingsDropdownProps) {
   const indexed = value.filterConfig.map((rule, index) => ({ rule, index }));
@@ -138,6 +145,13 @@ export function OutputSettingsDropdown({
       <SortSection
         sort={value.sortConfig}
         selectedColumns={selectedColumns}
+        allColumns={allColumns}
+        isAggregated={
+          value.aggregationConfig.length > 0 ||
+          value.dateTruncConfig.length > 0 ||
+          value.uniqueCountConfig
+        }
+        hasExplicitColumns={hasExplicitColumns}
         onChange={s => {
           onChange({ ...value, sortConfig: s });
         }}
@@ -411,15 +425,32 @@ function AddFilterPicker({
 interface SortSectionProps {
   sort: SortRule[];
   selectedColumns: readonly OutputSettingsDropdownColumn[];
+  allColumns: readonly OutputSettingsDropdownColumn[];
+  /** GROUP BY report: ORDER BY can only reference a projected dimension / aggregated metric. */
+  isAggregated: boolean;
+  /** Explicit columnConfig — required before a non-aggregated report can sort by a non-native column. */
+  hasExplicitColumns: boolean;
   onChange: (next: SortRule[]) => void;
 }
 
-function SortSection({ sort, selectedColumns, onChange }: SortSectionProps) {
+function SortSection({
+  sort,
+  selectedColumns,
+  allColumns,
+  isAggregated,
+  hasExplicitColumns,
+  onChange,
+}: SortSectionProps) {
+  // A non-aggregated report with an explicit projection resolves ORDER BY against the source
+  // row, so it can sort by any known column (like a filter). An aggregated (GROUP BY) report —
+  // or a `SELECT *` report with no explicit projection (native-only output) — can sort only by
+  // its selected output columns.
+  const sortableColumns = isAggregated || !hasExplicitColumns ? selectedColumns : allColumns;
   const sortColumns = new Set(sort.map(s => s.column));
-  const selectedColumnSet = new Set(selectedColumns.map(c => c.name));
-  const labelByName = new Map(selectedColumns.map(c => [c.name, c.label]));
-  const dataMartByName = new Map(selectedColumns.map(c => [c.name, c.dataMartName]));
-  const available = selectedColumns.filter(c => !sortColumns.has(c.name));
+  const sortableColumnSet = new Set(sortableColumns.map(c => c.name));
+  const labelByName = new Map(sortableColumns.map(c => [c.name, c.label]));
+  const dataMartByName = new Map(sortableColumns.map(c => [c.name, c.dataMartName]));
+  const available = sortableColumns.filter(c => !sortColumns.has(c.name));
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
@@ -479,7 +510,7 @@ function SortSection({ sort, selectedColumns, onChange }: SortSectionProps) {
             <SortRow
               rule={rule}
               index={index}
-              isOrphaned={!selectedColumnSet.has(rule.column)}
+              isOrphaned={!sortableColumnSet.has(rule.column)}
               displayLabel={labelByName.get(rule.column)}
               dataMartName={dataMartByName.get(rule.column)}
               onChange={next => {
@@ -497,7 +528,7 @@ function SortSection({ sort, selectedColumns, onChange }: SortSectionProps) {
       <div className='mt-2'>
         {available.length === 0 ? (
           <span className='text-muted-foreground text-xs'>
-            All selected columns are already sorted.
+            All available columns are already sorted.
           </span>
         ) : (
           <FieldSearchPicker

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -1149,6 +1149,7 @@ export function ReportColumnPicker({
             onChange={onOutputConfigChange}
             selectedColumns={selectedDropdownColumns}
             allColumns={dropdownColumns}
+            hasExplicitColumns={value !== null}
             joinedSources={joinedSources}
           />
         </div>


### PR DESCRIPTION
## Problem

Configuring a report sort on a column that was **not** among the selected output columns failed with `Output controls validation failed` (`SORT_COLUMN_NOT_SELECTED`). Filtering already allowed hidden columns, so the two controls behaved inconsistently — you could filter by a column you didn't output, but not sort by it.

## Root cause

`OutputControlsValidatorService.validateSort` required every sort column to be in the selected set, while filters validate against **all** known fields. The SQL builders (plain and blended/multi-storage) already support `ORDER BY` on a non-selected column for non-aggregated reports:

- Plain builder qualifies sort to `src.<col>`, and the full source table is available.
- Blended builder already adds sort columns to the CTE `referencedColumns` and qualifies them to `main.<col>` or the joined CTE.

The only place the restriction is genuinely required is **aggregated (`GROUP BY`) reports**, where `ORDER BY` resolves through the aggregated-alias resolver and can reference only a projected dimension or an aggregated metric.

## Changes

**Backend** (`output-controls-validator.service.ts`)
- Non-aggregated report **with an explicit column selection** → sort by any known column is allowed (native or joined/blended). An unknown column is still surfaced as a disconnected-column error.
- Aggregated report (`GROUP BY`) → unchanged: sort must reference a projected dimension or aggregated metric.
- No explicit column selection (`SELECT *` over native fields) → sort still limited to native columns (blended aliases aren't projected on that path).

**Frontend** (`OutputSettingsDropdown` / `SortSection`, new `hasExplicitColumns` prop)
- The "Add sort by" picker offers **all** columns for a non-aggregated report with an explicit selection, mirroring the Filters section.
- Aggregated reports (and the `SELECT *` case) keep offering only the selected output columns, so an invalid sort target is never presented.

## Multi-storage

Verified against the blended query builder: sort columns are materialized into the relevant CTE and qualified correctly, so sorting by a non-selected joined column works end to end; the `SELECT *` + blended combination is still rejected as before.

## Tests

- Backend unit: added cases for sort on a non-selected native/blended column (accepted) and on a non-projected column in an aggregated report (rejected). Full suite: 175 passing.
- Backend e2e (`output-controls`): updated to accept the previously-rejected sort and added an aggregated-report rejection case.
- Frontend: `OutputSettingsDropdown` and `ReportColumnPicker` suites passing; `tsc --noEmit` clean.
- Added a changeset.