### PR TITLE
feat(data-marts): allow sorting reports by Unique Count

### DIFF
--- a/.changeset/6764-sort-by-unique-count.md
+++ b/.changeset/6764-sort-by-unique-count.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Sort by Unique Count
+
+Reports can now sort by the Unique Count metric. Previously, enabling Unique Count added the column to a report, but it couldn't be used as a sort column — the Sort section had no way to reference it. Now, once Unique Count is enabled, it shows up as an option in the Sort section like any other column, in ascending or descending order.

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.spec.ts
@@ -2155,6 +2155,40 @@ describe('AbstractBlendedQueryBuilder — post-join aggregation', () => {
     expect(sql).toContain('COUNT(DISTINCT main.user_id) AS `Unique Count`');
     expect(sql).toContain('GROUP BY');
   });
+
+  // Regression: `Unique Count` is an OUTER-SELECT alias, not a column of any CTE. The
+  // sort-derived refs feed the main raw CTE projection, so an unfiltered sort column would
+  // emit `SELECT \`Unique Count\` FROM main_table` — a column that does not exist.
+  it('does NOT project the synthetic Unique Count label into the main raw CTE when sorted by it', () => {
+    const { sql } = builder.buildBlendedQuery({
+      ...buildContext([spendChain()], ['channel', 'spend__cost']),
+      aggregations: [{ column: 'spend__cost', function: 'SUM' }],
+      uniqueCount: true,
+      primaryKeyColumns: ['user_id'],
+      sort: [{ column: 'Unique Count', direction: 'desc' }],
+    });
+
+    const mainCte = /main AS \(([\s\S]+?)\n {2}\)/m.exec(sql);
+    expect(mainCte).not.toBeNull();
+    expect(mainCte![1]).not.toContain('Unique Count');
+    // The PK is still projected (Unique Count aggregates it) and the outer ORDER BY still works.
+    expect(mainCte![1]).toContain('user_id');
+    expect(sql).toContain('COUNT(DISTINCT main.user_id) AS `Unique Count`');
+    expect(sql).toContain('ORDER BY\n  `Unique Count` DESC');
+  });
+
+  // A real main-mart column legitimately named `Unique Count` must still reach the CTE —
+  // it arrives via `columns`, so the synthetic exclusion must not strip it.
+  it('still projects a REAL main column named "Unique Count" into the main raw CTE', () => {
+    const { sql } = builder.buildBlendedQuery({
+      ...buildContext([spendChain()], ['Unique Count', 'spend__cost']),
+      sort: [{ column: 'Unique Count', direction: 'desc' }],
+    });
+
+    const mainCte = /main AS \(([\s\S]+?)\n {2}\)/m.exec(sql);
+    expect(mainCte).not.toBeNull();
+    expect(mainCte![1]).toContain('Unique Count');
+  });
 });
 
 describe('AbstractBlendedQueryBuilder — regression: ambiguous column in WHERE/ORDER BY', () => {

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/abstract-blended-query-builder.ts
@@ -13,6 +13,7 @@ import {
   SqlParameter,
 } from '../utils/sql-clause-renderer';
 import { FilterRule } from '../../dto/schemas/filter-config.schema';
+import { ROW_COUNT_LABEL, UNIQUE_COUNT_LABEL } from '../../dto/schemas/aggregation-labels';
 import { DateTruncUnit } from '../../dto/schemas/date-trunc-config.schema';
 import { buildTimeZoneMap } from '../utils/date-trunc-maps.utils';
 import { effectiveComparisonType } from '../field-aggregation';
@@ -164,6 +165,15 @@ export abstract class AbstractBlendedQueryBuilder implements BlendedQueryBuilder
       // must project the PK columns even when they aren't a selected/filtered/sorted column.
       ...(context.uniqueCount === true ? (context.primaryKeyColumns ?? []) : []),
     ]);
+    // Row Count / Unique Count are OUTER-SELECT aliases, not columns of any CTE. A sort (or
+    // HAVING) on one would otherwise flow through collectMainReferences into the main raw CTE
+    // and emit `SELECT "Unique Count" FROM <main table>` — a column that does not exist, so
+    // every run and Generated SQL preview fails in the warehouse. Dropped here rather than
+    // per-source so filters and any future ref source are covered too. A real column that
+    // legitimately owns the name arrives via `columns`, so keep it when it is selected.
+    for (const label of [UNIQUE_COUNT_LABEL, ROW_COUNT_LABEL]) {
+      if (!columnSet.has(label)) referencedColumns.delete(label);
+    }
 
     const roots = this.buildTree(chains);
 

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -3489,6 +3489,10 @@ describe('OutputControlsValidatorService', () => {
       }
 
       expect(caught).toBeDefined();
+      // Assert the class before getResponse(): if a regression routes this to the
+      // BusinessViolationException (disconnected-columns) path instead, that surfaces as a
+      // readable assertion diff rather than `TypeError: caught.getResponse is not a function`.
+      expect(caught).toBeInstanceOf(BadRequestException);
       const response = caught!.getResponse() as { details: { errors: { code: string }[] } };
       expect(response.details.errors.some(e => e.code === 'SORT_COLUMN_NOT_SELECTED')).toBe(true);
     });

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.spec.ts
@@ -3433,6 +3433,65 @@ describe('OutputControlsValidatorService', () => {
         })
       ).resolves.toBeUndefined();
     });
+
+    it('accepts sorting by "Unique Count" when uniqueCountConfig is true', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([
+        { name: 'id', type: 'INTEGER', isPrimaryKey: true },
+        { name: 'name', type: 'STRING' },
+      ]);
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      await expect(
+        validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: null,
+          filterConfig: null,
+          sortConfig: [{ column: 'Unique Count', direction: 'desc' }],
+          limitConfig: null,
+          uniqueCountConfig: true,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects sorting by "Unique Count" when uniqueCountConfig is not enabled → SORT_COLUMN_NOT_SELECTED', async () => {
+      const capabilitySvc = makeCapabilityService(true);
+      const schemaSvc = makeBlendableSchemaService([
+        { name: 'id', type: 'INTEGER', isPrimaryKey: true },
+        { name: 'name', type: 'STRING' },
+      ]);
+      const validator = new OutputControlsValidatorService(
+        capabilitySvc as never,
+        schemaSvc as never
+      );
+
+      let caught: BadRequestException | undefined;
+      try {
+        await validator.validateForReport({
+          storageType: supportedStorageType,
+          dataMartId: 'dm-1',
+          projectId: 'proj-1',
+          columnConfig: null,
+          filterConfig: null,
+          sortConfig: [{ column: 'Unique Count', direction: 'desc' }],
+          limitConfig: null,
+          uniqueCountConfig: false,
+          accessor: { userId: 'user-1', roles: ['admin'] },
+        });
+      } catch (e) {
+        caught = e as BadRequestException;
+      }
+
+      expect(caught).toBeDefined();
+      const response = caught!.getResponse() as { details: { errors: { code: string }[] } };
+      expect(response.details.errors.some(e => e.code === 'SORT_COLUMN_NOT_SELECTED')).toBe(true);
+    });
   });
 
   describe('validateHavingFilters (post-aggregation)', () => {

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.ts
@@ -557,8 +557,12 @@ export class OutputControlsValidatorService {
         }
         // Unique Count is always a KNOWN sort target (like a schema field) — whether it's
         // currently SELECTED (projected) depends on uniqueCountConfig, checked below by
-        // validateSort. Keeps a stale sort-by-Unique-Count after disabling the toggle a
-        // SORT_COLUMN_NOT_SELECTED error, not a misleading "disconnected from schema" one.
+        // validateSort. So a stale sort-by-Unique-Count left after disabling the toggle is
+        // classified SORT_COLUMN_NOT_SELECTED (a 400) rather than routed to the harsher
+        // DISCONNECTED_REPORT_COLUMNS path, which is reserved for names absent from the
+        // schema entirely. NOTE: this is a code-level classification only — the web renders
+        // just `message`, not `details.errors[].code`, so the two read the same to the user.
+        // The web prunes this rule when the PK disappears, keeping the 400 largely unreachable.
         knownOutputColumns.add(UNIQUE_COUNT_LABEL);
 
         if (parsedFilters.length > 0) {

--- a/apps/backend/src/data-marts/services/output-controls-validator.service.ts
+++ b/apps/backend/src/data-marts/services/output-controls-validator.service.ts
@@ -555,6 +555,11 @@ export class OutputControlsValidatorService {
           homeFieldTypes.set(blended.name, blended.type);
           knownOutputColumns.add(blended.name);
         }
+        // Unique Count is always a KNOWN sort target (like a schema field) — whether it's
+        // currently SELECTED (projected) depends on uniqueCountConfig, checked below by
+        // validateSort. Keeps a stale sort-by-Unique-Count after disabling the toggle a
+        // SORT_COLUMN_NOT_SELECTED error, not a misleading "disconnected from schema" one.
+        knownOutputColumns.add(UNIQUE_COUNT_LABEL);
 
         if (parsedFilters.length > 0) {
           const fieldIndex = buildBlendedFieldIndex(blendableSchema);
@@ -577,6 +582,9 @@ export class OutputControlsValidatorService {
           // selection. Validate sort against that same native-only set so a sort on a
           // blended column is caught here at save time instead of failing at run time.
           const selectedSet = new Set(args.columnConfig ?? connectedNativeNames);
+          // Unique Count is a synthetic metric column (COUNT(DISTINCT <pk>)), not a
+          // projected field — allow sorting by it whenever it's enabled.
+          if (args.uniqueCountConfig === true) selectedSet.add(UNIQUE_COUNT_LABEL);
           errors.push(...this.validateSort(parsedSort, selectedSet));
         }
         if (parsedAggregations.length > 0) {

--- a/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.aggregation.spec.ts
@@ -159,6 +159,66 @@ describe('ReportSqlComposerService — aggregations wiring', () => {
     );
   });
 
+  // Regression: the renderer omits the Unique Count metric when there is no PK, so a stored sort
+  // on that label must be dropped too — otherwise ORDER BY references a column the SELECT lacks.
+  it('drops a "Unique Count" sort rule when uniqueCountConfig is true but the PK was removed', async () => {
+    const { service, queryBuilderFacade } = createService();
+    const report = buildReport({
+      uniqueCountConfig: true,
+      sortConfig: [
+        { column: 'channel', direction: 'asc' },
+        { column: 'Unique Count', direction: 'desc' },
+      ],
+      dataMart: {
+        id: 'dm-1',
+        projectId: 'proj-1',
+        definition: { type: 'table', fullyQualifiedName: 'p.d.t' },
+        storage: { id: 'storage-1', type: 'GOOGLE_BIGQUERY' },
+        // PK removed from the schema after the report was saved.
+        schema: { fields: [{ name: 'channel', type: 'STRING', isPrimaryKey: false }] },
+      },
+    } as Partial<Report>);
+
+    await service.compose(report, {} as never);
+
+    expect(queryBuilderFacade.buildQuery).toHaveBeenCalledWith(
+      'GOOGLE_BIGQUERY',
+      expect.anything(),
+      expect.objectContaining({
+        primaryKeyColumns: [],
+        sort: [{ column: 'channel', direction: 'asc' }],
+      })
+    );
+  });
+
+  it('keeps a "Unique Count" sort rule while the PK still exists', async () => {
+    const { service, queryBuilderFacade } = createService();
+    const report = buildReport({
+      uniqueCountConfig: true,
+      sortConfig: [{ column: 'Unique Count', direction: 'desc' }],
+      dataMart: {
+        id: 'dm-1',
+        projectId: 'proj-1',
+        definition: { type: 'table', fullyQualifiedName: 'p.d.t' },
+        storage: { id: 'storage-1', type: 'GOOGLE_BIGQUERY' },
+        schema: {
+          fields: [
+            { name: 'id', type: 'INTEGER', isPrimaryKey: true },
+            { name: 'channel', type: 'STRING', isPrimaryKey: false },
+          ],
+        },
+      },
+    } as Partial<Report>);
+
+    await service.compose(report, {} as never);
+
+    expect(queryBuilderFacade.buildQuery).toHaveBeenCalledWith(
+      'GOOGLE_BIGQUERY',
+      expect.anything(),
+      expect.objectContaining({ sort: [{ column: 'Unique Count', direction: 'desc' }] })
+    );
+  });
+
   it('passes uniqueCount: false and primaryKeyColumns: [] when uniqueCountConfig is null/false', async () => {
     const { service, queryBuilderFacade } = createService();
     const report = buildReport({

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -28,6 +28,7 @@ import {
   NON_SUMMARIZABLE_AGGREGATIONS,
   type AggregationRole,
 } from '../dto/schemas/field-aggregation-governance';
+import { UNIQUE_COUNT_LABEL } from '../dto/schemas/aggregation-labels';
 import { categorizeFieldType } from '../dto/schemas/field-type-category';
 import { AggregationRule } from '../dto/schemas/aggregation-config.schema';
 import { ReportAggregateFunction } from '../dto/schemas/aggregate-function.schema';
@@ -128,13 +129,25 @@ export class ReportSqlComposerService {
     const pkFields = getPrimaryKeyFields(schemaFields);
     const uniqueCount = report.uniqueCountConfig === true;
 
+    // `primaryKeyColumns` comes from the CURRENT schema while `uniqueCountConfig` comes from the
+    // STORED report, so removing the mart's PK after saving leaves them disagreeing. The renderer
+    // then silently omits the Unique Count metric (no PK to COUNT DISTINCT), but a stored sort on
+    // that label would still render `ORDER BY "Unique Count"` against a SELECT that no longer has
+    // it — a hard warehouse error on every run, scheduled run, and Generated SQL preview. Drop
+    // those sort rules alongside the metric so the report degrades the same way the SELECT does.
+    // The editor prunes this on open, but scheduled runs never load the editor.
+    const sortConfig =
+      uniqueCount && pkFields.length === 0
+        ? (report.sortConfig ?? []).filter(rule => rule.column !== UNIQUE_COUNT_LABEL)
+        : report.sortConfig;
+
     const queryResult = await this.queryBuilderFacade.buildQuery(
       dataMart.storage.type,
       dataMart.definition,
       {
         columns: decision.columnFilter,
         filters: report.filterConfig ?? undefined,
-        sort: report.sortConfig ?? undefined,
+        sort: sortConfig ?? undefined,
         aggregations: report.aggregationConfig ?? undefined,
         dateTruncs: report.dateTruncConfig ?? undefined,
         rowCount: shouldIncludeRowCount(report),

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.invariant.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.invariant.test.tsx
@@ -79,7 +79,7 @@ describe('OutputSettingsDropdown stored-identifier invariant', () => {
         value={EMPTY}
         onChange={onChange}
         allColumns={[productId]}
-        selectedColumns={[]}
+        sortColumns={[]}
         joinedSources={[]}
       />
     );
@@ -100,7 +100,7 @@ describe('OutputSettingsDropdown stored-identifier invariant', () => {
         value={EMPTY}
         onChange={onChange}
         allColumns={[]}
-        selectedColumns={[]}
+        sortColumns={[]}
         joinedSources={[
           {
             aliasPath: 'orders',
@@ -132,7 +132,7 @@ describe('OutputSettingsDropdown stored-identifier invariant', () => {
         value={EMPTY}
         onChange={onChange}
         allColumns={[]}
-        selectedColumns={[productId]}
+        sortColumns={[productId]}
         joinedSources={[]}
       />
     );

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
@@ -174,6 +174,54 @@ describe('OutputSettingsDropdown readable labels', () => {
   });
 });
 
+describe('OutputSettingsDropdown sort by Unique Count', () => {
+  const uniqueCount: OutputSettingsDropdownColumn = {
+    name: 'Unique Count',
+    type: 'INTEGER',
+    label: 'Unique Count',
+  };
+
+  it('does not mark a sort on "Unique Count" as disconnected when it is a selected column', () => {
+    const value: OutputConfig = {
+      ...EMPTY_CONFIG,
+      sortConfig: [{ column: 'Unique Count', direction: 'desc' }],
+    };
+
+    render(
+      <OutputSettingsDropdown
+        value={value}
+        onChange={() => {}}
+        allColumns={[]}
+        selectedColumns={[uniqueCount]}
+        joinedSources={[]}
+      />
+    );
+
+    expect(screen.getByText('Unique Count')).not.toHaveClass('line-through');
+    expect(screen.queryByLabelText('Column not found in schema')).not.toBeInTheDocument();
+  });
+
+  it('marks a sort on "Unique Count" as disconnected once it is no longer a selected column (toggle turned off)', () => {
+    const value: OutputConfig = {
+      ...EMPTY_CONFIG,
+      sortConfig: [{ column: 'Unique Count', direction: 'desc' }],
+    };
+
+    render(
+      <OutputSettingsDropdown
+        value={value}
+        onChange={() => {}}
+        allColumns={[]}
+        selectedColumns={[]}
+        joinedSources={[]}
+      />
+    );
+
+    expect(screen.getByText('Unique Count')).toHaveClass('line-through');
+    expect(screen.getByLabelText('Column not found in schema')).toBeInTheDocument();
+  });
+});
+
 describe('OutputSettingsDropdown no longer hosts aggregation controls', () => {
   const revenue: OutputSettingsDropdownColumn = {
     name: 'orders.revenue',

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.test.tsx
@@ -39,7 +39,7 @@ describe('OutputSettingsDropdown disconnected controls', () => {
         value={value}
         onChange={() => {}}
         allColumns={[{ name: 'native_one', type: 'STRING', label: 'native_one' }]}
-        selectedColumns={[{ name: 'native_one', type: 'STRING', label: 'native_one' }]}
+        sortColumns={[{ name: 'native_one', type: 'STRING', label: 'native_one' }]}
         joinedSources={[]}
       />
     );
@@ -73,7 +73,7 @@ describe('OutputSettingsDropdown disconnected controls', () => {
         value={value}
         onChange={() => {}}
         allColumns={[]}
-        selectedColumns={[]}
+        sortColumns={[]}
         joinedSources={[]}
       />
     );
@@ -102,7 +102,7 @@ describe('OutputSettingsDropdown disconnected controls', () => {
         value={value}
         onChange={onChange}
         allColumns={[]}
-        selectedColumns={[]}
+        sortColumns={[]}
         joinedSources={[
           {
             aliasPath: 'users',
@@ -139,7 +139,7 @@ describe('OutputSettingsDropdown readable labels', () => {
         value={value}
         onChange={() => {}}
         allColumns={[productId]}
-        selectedColumns={[productId]}
+        sortColumns={[productId]}
         joinedSources={[]}
       />
     );
@@ -164,7 +164,7 @@ describe('OutputSettingsDropdown readable labels', () => {
         value={value}
         onChange={() => {}}
         allColumns={[productId]}
-        selectedColumns={[productId]}
+        sortColumns={[productId]}
         joinedSources={[]}
       />
     );
@@ -192,7 +192,7 @@ describe('OutputSettingsDropdown sort by Unique Count', () => {
         value={value}
         onChange={() => {}}
         allColumns={[]}
-        selectedColumns={[uniqueCount]}
+        sortColumns={[uniqueCount]}
         joinedSources={[]}
       />
     );
@@ -212,7 +212,7 @@ describe('OutputSettingsDropdown sort by Unique Count', () => {
         value={value}
         onChange={() => {}}
         allColumns={[]}
-        selectedColumns={[]}
+        sortColumns={[]}
         joinedSources={[]}
       />
     );
@@ -241,7 +241,7 @@ describe('OutputSettingsDropdown no longer hosts aggregation controls', () => {
         value={value}
         onChange={() => {}}
         allColumns={[revenue]}
-        selectedColumns={[revenue]}
+        sortColumns={[revenue]}
         joinedSources={[]}
       />
     );

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/OutputSettingsDropdown.tsx
@@ -84,7 +84,11 @@ function columnToPickerItem(c: OutputSettingsDropdownColumn): FieldPickerItem {
 interface OutputSettingsDropdownProps {
   value: OutputConfig;
   onChange: (next: OutputConfig) => void;
-  selectedColumns: readonly OutputSettingsDropdownColumn[];
+  /**
+   * Sort-only column list. May include synthetic metrics (e.g. Unique Count) that are
+   * orderable but NOT filterable/aggregatable — never pass this to the filter surfaces.
+   */
+  sortColumns: readonly OutputSettingsDropdownColumn[];
   allColumns: readonly OutputSettingsDropdownColumn[];
   joinedSources?: readonly JoinedSource[];
 }
@@ -92,7 +96,7 @@ interface OutputSettingsDropdownProps {
 export function OutputSettingsDropdown({
   value,
   onChange,
-  selectedColumns,
+  sortColumns,
   allColumns,
   joinedSources,
 }: OutputSettingsDropdownProps) {
@@ -137,7 +141,7 @@ export function OutputSettingsDropdown({
       )}
       <SortSection
         sort={value.sortConfig}
-        selectedColumns={selectedColumns}
+        selectedColumns={sortColumns}
         onChange={s => {
           onChange({ ...value, sortConfig: s });
         }}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
@@ -1202,6 +1202,26 @@ describe('ReportColumnPicker Unique count virtual row', () => {
     expect(within(listbox).queryByText('Unique Count')).not.toBeInTheDocument();
   });
 
+  // The badge and the sort row must agree: when the synthetic is suppressed because a real
+  // field owns the name, an unselected real field's rule is genuinely broken and both the
+  // struck-through row and the badge must say so.
+  it('reports a sort as disconnected when the synthetic is suppressed by an UNSELECTED real field', () => {
+    renderPicker(collisionSchema(), ['id'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: {
+        ...baseOutputConfig,
+        uniqueCountConfig: true,
+        sortConfig: [{ column: 'Unique Count', direction: 'desc' }],
+      },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    expect(screen.getByLabelText('Disconnected output controls')).toHaveTextContent('1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Output controls' }));
+    expect(screen.getByLabelText('Column not found in schema')).toBeInTheDocument();
+  });
+
   // The PK-loss auto-heal must prune the stranded sort rule in the SAME update that clears
   // the flag — otherwise validateSort rejects the leftover rule on every save and run.
   it('prunes a stranded "Unique Count" sort rule when the schema loses its primary key', () => {

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
@@ -1075,6 +1075,116 @@ describe('ReportColumnPicker Unique count virtual row', () => {
     expect(screen.getByText('Unique Count')).toHaveClass('line-through');
     expect(screen.getByLabelText('Column not found in schema')).toBeInTheDocument();
   });
+
+  // Per-row icons reuse these accessible names, so scope to the FieldSearchPicker
+  // trigger — it is the only one that opens a listbox.
+  const openPicker = (name: RegExp) => {
+    const trigger = screen
+      .getAllByRole('button', { name })
+      .find(b => b.getAttribute('aria-haspopup') === 'listbox');
+    fireEvent.click(trigger!);
+  };
+
+  // Unique Count is sortable ONLY. It is not a real projected column, so a filter or an
+  // aggregation on it would be rejected by backend validation — it must never be offered
+  // in those pickers, even while the toggle is on.
+  it('offers "Unique Count" in the Add sort by picker while the toggle is on', async () => {
+    renderPicker(pkSchema(), ['id', 'name'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: { ...baseOutputConfig, uniqueCountConfig: true },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Output controls' }));
+    openPicker(/Add sort by/);
+
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByText('Unique Count')).toBeInTheDocument();
+  });
+
+  it('does NOT offer "Unique Count" in the Add filter picker while the toggle is on', async () => {
+    renderPicker(pkSchema(), ['id', 'name'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: { ...baseOutputConfig, uniqueCountConfig: true },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Output controls' }));
+    openPicker(/Add filter/);
+
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByText('id')).toBeInTheDocument();
+    expect(within(listbox).queryByText('Unique Count')).not.toBeInTheDocument();
+  });
+
+  it('does NOT offer "Unique Count" in the Add aggregation picker while the toggle is on', async () => {
+    renderPicker(pkSchema(), ['id', 'name'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: { ...baseOutputConfig, uniqueCountConfig: true },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Aggregations' }));
+    openPicker(/Add aggregation/);
+
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByText('id')).toBeInTheDocument();
+    expect(within(listbox).queryByText('Unique Count')).not.toBeInTheDocument();
+  });
+
+  // A real schema field can legitimately be named "Unique Count" (quoted identifiers on
+  // Snowflake/Redshift/Athena allow spaces) — the backend has a dedicated
+  // OUTPUT_COLUMN_NAME_COLLISION error for exactly this. The synthetic-metric special
+  // cases must not hijack the name from a real field that owns it.
+  const collisionSchema = () =>
+    buildSchema({
+      nativeFields: [
+        { name: 'id', type: 'INTEGER', isPrimaryKey: true },
+        { name: 'Unique Count', type: 'STRING' },
+      ] as unknown[],
+    });
+
+  it('does not flag a sort on a REAL field named "Unique Count" as disconnected when the toggle is off', () => {
+    renderPicker(collisionSchema(), ['id', 'Unique Count'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: {
+        ...baseOutputConfig,
+        uniqueCountConfig: false,
+        sortConfig: [{ column: 'Unique Count', direction: 'asc' }],
+      },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    expect(screen.queryByLabelText('Disconnected output controls')).not.toBeInTheDocument();
+  });
+
+  it('still flags a sort on an UNSELECTED real field named "Unique Count" when the toggle is off', () => {
+    renderPicker(collisionSchema(), ['id'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: {
+        ...baseOutputConfig,
+        uniqueCountConfig: false,
+        sortConfig: [{ column: 'Unique Count', direction: 'asc' }],
+      },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    expect(screen.getByLabelText('Disconnected output controls')).toHaveTextContent('1');
+  });
+
+  it('does not offer a duplicate "Unique Count" entry when a real field already owns the name', async () => {
+    renderPicker(collisionSchema(), ['id', 'Unique Count'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: { ...baseOutputConfig, uniqueCountConfig: true },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Output controls' }));
+    openPicker(/Add sort by/);
+
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getAllByText('Unique Count')).toHaveLength(1);
+  });
 });
 
 describe('ReportColumnPicker search', () => {

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
@@ -1037,6 +1037,44 @@ describe('ReportColumnPicker Unique count virtual row', () => {
     // uniqueCountConfig must remain unchanged
     expect(onOutputConfigChange).not.toHaveBeenCalled();
   });
+
+  it('keeps a sort by "Unique Count" connected (not disconnected) while the toggle is on', () => {
+    renderPicker(pkSchema(), ['id', 'name'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: {
+        ...baseOutputConfig,
+        uniqueCountConfig: true,
+        sortConfig: [{ column: 'Unique Count', direction: 'desc' }],
+      },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    expect(screen.queryByLabelText('Disconnected output controls')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Output controls' }));
+
+    expect(screen.getByText('Unique Count')).not.toHaveClass('line-through');
+    expect(screen.queryByLabelText('Column not found in schema')).not.toBeInTheDocument();
+  });
+
+  it('flags a sort by "Unique Count" as disconnected once the toggle is off', () => {
+    renderPicker(pkSchema(), ['id', 'name'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: {
+        ...baseOutputConfig,
+        uniqueCountConfig: false,
+        sortConfig: [{ column: 'Unique Count', direction: 'desc' }],
+      },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    expect(screen.getByLabelText('Disconnected output controls')).toHaveTextContent('1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Output controls' }));
+
+    expect(screen.getByText('Unique Count')).toHaveClass('line-through');
+    expect(screen.getByLabelText('Column not found in schema')).toBeInTheDocument();
+  });
 });
 
 describe('ReportColumnPicker search', () => {

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
@@ -1185,6 +1185,74 @@ describe('ReportColumnPicker Unique count virtual row', () => {
     const listbox = await screen.findByRole('listbox');
     expect(within(listbox).getAllByText('Unique Count')).toHaveLength(1);
   });
+
+  // An UNSELECTED real field owning the name would make `ORDER BY "Unique Count"` ambiguous
+  // between the outer alias and the base column, so the synthetic is suppressed there too.
+  it('does not offer the synthetic when an UNSELECTED real field owns the name', async () => {
+    renderPicker(collisionSchema(), ['id'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: { ...baseOutputConfig, uniqueCountConfig: true },
+      onOutputConfigChange: vi.fn(),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Output controls' }));
+    openPicker(/Add sort by/);
+
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).queryByText('Unique Count')).not.toBeInTheDocument();
+  });
+
+  // The PK-loss auto-heal must prune the stranded sort rule in the SAME update that clears
+  // the flag — otherwise validateSort rejects the leftover rule on every save and run.
+  it('prunes a stranded "Unique Count" sort rule when the schema loses its primary key', () => {
+    const onOutputConfigChange = vi.fn();
+    renderPicker(noPkSchema(), ['col_a'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: {
+        ...baseOutputConfig,
+        uniqueCountConfig: true,
+        sortConfig: [
+          { column: 'col_a', direction: 'asc' },
+          { column: 'Unique Count', direction: 'desc' },
+        ],
+      },
+      onOutputConfigChange,
+    });
+
+    expect(onOutputConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uniqueCountConfig: false,
+        sortConfig: [{ column: 'col_a', direction: 'asc' }],
+      })
+    );
+  });
+
+  it('leaves a "Unique Count" sort rule alone on PK loss when a real field owns the name', () => {
+    const onOutputConfigChange = vi.fn();
+    const schema = buildSchema({
+      nativeFields: [
+        { name: 'col_a', type: 'STRING' },
+        { name: 'Unique Count', type: 'STRING' },
+      ] as unknown[],
+    });
+    renderPicker(schema, ['col_a', 'Unique Count'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: {
+        ...baseOutputConfig,
+        uniqueCountConfig: true,
+        sortConfig: [{ column: 'Unique Count', direction: 'desc' }],
+      },
+      onOutputConfigChange,
+    });
+
+    // The flag is still cleared (no PK), but the real field's sort rule survives.
+    expect(onOutputConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uniqueCountConfig: false,
+        sortConfig: [{ column: 'Unique Count', direction: 'desc' }],
+      })
+    );
+  });
 });
 
 describe('ReportColumnPicker search', () => {

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -813,6 +813,15 @@ export function ReportColumnPicker({
   const hasUniqueCountMetric =
     hasPrimaryKey && outputControlsAvailable && effectiveOutputConfig.uniqueCountConfig;
 
+  // Whether the SYNTHETIC metric is the thing a `Unique Count` sort resolves to. False when a
+  // real schema field owns the name: if it is selected it owns the sort outright, and if it is
+  // merely present, emitting the label would produce an `ORDER BY "Unique Count"` ambiguous
+  // between the outer SELECT alias and the base column (precedence unspecified across
+  // dialects). Shared by the sort list and the disconnected-controls badge so a suppressed
+  // synthetic can never be reported as still supplying the column.
+  const syntheticUniqueCountAvailable =
+    hasUniqueCountMetric && !knownFieldNames.has(UNIQUE_COUNT_LABEL);
+
   // Sort-ONLY column list. Unique Count is a synthetic COUNT(DISTINCT <pk>) metric, not a
   // projected field: it can be ordered by (the ORDER BY resolves to the SELECT alias), but a
   // filter or aggregation on it has no column to bind to and the backend rejects it. So it
@@ -825,14 +834,14 @@ export function ReportColumnPicker({
     // `key={item.value}`; if it is merely present but unselected, emitting the label would
     // produce an `ORDER BY "Unique Count"` that is ambiguous between the outer SELECT alias
     // and the base column, whose resolution precedence is not specified across dialects.
-    if (!hasUniqueCountMetric || knownFieldNames.has(UNIQUE_COUNT_LABEL)) {
+    if (!syntheticUniqueCountAvailable) {
       return selectedDropdownColumns;
     }
     return [
       ...selectedDropdownColumns,
       { name: UNIQUE_COUNT_LABEL, type: 'INTEGER', label: UNIQUE_COUNT_LABEL },
     ];
-  }, [selectedDropdownColumns, hasUniqueCountMetric, knownFieldNames]);
+  }, [selectedDropdownColumns, syntheticUniqueCountAvailable]);
 
   const controlsCount = useMemo(() => {
     return (
@@ -938,12 +947,12 @@ export function ReportColumnPicker({
       if (effectiveValueSet.has(rule.column) && knownFieldNames.has(rule.column)) return false;
       // Otherwise the synthetic metric can still supply the column, matching the backend's
       // validateSort (which adds the label to the selected set when uniqueCountConfig is on).
-      return !(rule.column === UNIQUE_COUNT_LABEL && hasUniqueCountMetric);
+      return !(rule.column === UNIQUE_COUNT_LABEL && syntheticUniqueCountAvailable);
     });
   }, [
     effectiveOutputConfig.filterConfig,
     effectiveOutputConfig.sortConfig,
-    hasUniqueCountMetric,
+    syntheticUniqueCountAvailable,
     knownFieldNames,
     knownSliceKeys,
     effectiveValueSet,

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -38,7 +38,8 @@ import { OutputSettingsDropdown } from './OutputSettingsDropdown';
 import type { OutputSettingsDropdownColumn } from './OutputSettingsDropdown';
 import { AggregationSettingsButton } from './AggregationSettingsButton';
 import { AggregationSettingsDropdown } from './AggregationSettingsDropdown';
-import { fieldDisplayLabel, UNIQUE_COUNT_LABEL } from './output-controls-display';
+import { fieldDisplayLabel } from './output-controls-display';
+import { UNIQUE_COUNT_LABEL } from '../../../shared/utils/aggregation-labels';
 import { RowFilterIcon } from './RowFilterIcon';
 import { RowAggregationIcon } from './RowAggregationIcon';
 import { isFilterableType } from './output-controls-operators';
@@ -482,19 +483,6 @@ export function ReportColumnPicker({
     [nativeFields]
   );
 
-  // Unique Count requires a primary key. If the mart's PK is later removed, the toggle
-  // (rendered only under hasPrimaryKey) disappears, yet a stored `true` keeps
-  // round-tripping on every save and the backend rejects it — a trap the user cannot
-  // escape through the UI. Once the schema has loaded WITHOUT a PK, auto-clear the
-  // stranded flag so the report stays editable. Gated on `schema` so the empty
-  // pre-load field list never clears a legitimately PK-backed config.
-  useEffect(() => {
-    if (!schema || hasPrimaryKey || !onOutputConfigChange) return;
-    if (effectiveOutputConfig.uniqueCountConfig) {
-      onOutputConfigChange({ ...effectiveOutputConfig, uniqueCountConfig: false });
-    }
-  }, [schema, hasPrimaryKey, onOutputConfigChange, effectiveOutputConfig]);
-
   const includedPaths = useMemo(() => {
     if (!schema?.availableSources) return new Set<string>();
     return new Set(schema.availableSources.filter(s => s.isIncluded).map(s => s.aliasPath));
@@ -527,6 +515,33 @@ export function ReportColumnPicker({
     }
     return names;
   }, [nativeFields, schema]);
+
+  // Unique Count requires a primary key. If the mart's PK is later removed, the toggle
+  // (rendered only under hasPrimaryKey) disappears, yet a stored `true` keeps
+  // round-tripping on every save and the backend rejects it — a trap the user cannot
+  // escape through the UI. Once the schema has loaded WITHOUT a PK, auto-clear the
+  // stranded flag so the report stays editable. Gated on `schema` so the empty
+  // pre-load field list never clears a legitimately PK-backed config.
+  //
+  // A `Unique Count` sort rule is stranded by the SAME schema change and must be pruned in
+  // the same update: with the flag cleared, validateSort no longer accepts the label, so
+  // leaving the rule behind fails every save and every scheduled run. Skipped when a real
+  // field owns the name — then the rule refers to that field, not the synthetic metric.
+  useEffect(() => {
+    if (!schema || hasPrimaryKey || !onOutputConfigChange) return;
+    const strandedSort = knownFieldNames.has(UNIQUE_COUNT_LABEL)
+      ? []
+      : effectiveOutputConfig.sortConfig.filter(r => r.column === UNIQUE_COUNT_LABEL);
+    if (!effectiveOutputConfig.uniqueCountConfig && strandedSort.length === 0) return;
+    onOutputConfigChange({
+      ...effectiveOutputConfig,
+      uniqueCountConfig: false,
+      sortConfig:
+        strandedSort.length > 0
+          ? effectiveOutputConfig.sortConfig.filter(r => r.column !== UNIQUE_COUNT_LABEL)
+          : effectiveOutputConfig.sortConfig,
+    });
+  }, [schema, hasPrimaryKey, onOutputConfigChange, effectiveOutputConfig, knownFieldNames]);
 
   const unresolvedColumns = useMemo(
     () => (schema ? effectiveValue.filter(name => !knownFieldNames.has(name)) : []),
@@ -804,17 +819,20 @@ export function ReportColumnPicker({
   // must stay out of dropdownColumns / selectedDropdownColumns, which feed those surfaces.
   const sortColumns = useMemo(() => {
     // A real schema field may legitimately be named "Unique Count" (the backend has a
-    // dedicated OUTPUT_COLUMN_NAME_COLLISION error for it). If one is already selected it
-    // owns the name here — appending the synthetic too would duplicate the picker entry
-    // and collide on FieldSearchPicker's `key={item.value}`.
-    if (!hasUniqueCountMetric || selectedDropdownColumns.some(c => c.name === UNIQUE_COUNT_LABEL)) {
+    // dedicated OUTPUT_COLUMN_NAME_COLLISION error for it). Whenever ANY real field owns the
+    // name the real field wins and the synthetic is suppressed: if it is selected, appending
+    // the synthetic would duplicate the picker entry and collide on FieldSearchPicker's
+    // `key={item.value}`; if it is merely present but unselected, emitting the label would
+    // produce an `ORDER BY "Unique Count"` that is ambiguous between the outer SELECT alias
+    // and the base column, whose resolution precedence is not specified across dialects.
+    if (!hasUniqueCountMetric || knownFieldNames.has(UNIQUE_COUNT_LABEL)) {
       return selectedDropdownColumns;
     }
     return [
       ...selectedDropdownColumns,
       { name: UNIQUE_COUNT_LABEL, type: 'INTEGER', label: UNIQUE_COUNT_LABEL },
     ];
-  }, [selectedDropdownColumns, hasUniqueCountMetric]);
+  }, [selectedDropdownColumns, hasUniqueCountMetric, knownFieldNames]);
 
   const controlsCount = useMemo(() => {
     return (

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -785,28 +785,36 @@ export function ReportColumnPicker({
         postJoinAggregations: f.postJoinAggregations,
       });
     }
-    // Unique Count is a synthetic COUNT(DISTINCT <pk>) metric, not a schema field — expose it
-    // as a sortable pseudo-column only while the toggle (below) is on.
-    if (hasPrimaryKey && outputControlsAvailable && effectiveOutputConfig.uniqueCountConfig) {
-      cols.push({ name: UNIQUE_COUNT_LABEL, type: 'INTEGER', label: UNIQUE_COUNT_LABEL });
-    }
     return cols;
-  }, [
-    nativeFields,
-    includedBlendedFields,
-    availableSourceByPath,
-    hasPrimaryKey,
-    outputControlsAvailable,
-    effectiveOutputConfig.uniqueCountConfig,
-  ]);
+  }, [nativeFields, includedBlendedFields, availableSourceByPath]);
 
-  // dropdownColumns only ever contains the Unique Count pseudo-column while it's enabled,
-  // so the plain membership check already keeps it selected without a redundant gate here.
   const selectedDropdownColumns = useMemo(
-    () =>
-      dropdownColumns.filter(c => effectiveValueSet.has(c.name) || c.name === UNIQUE_COUNT_LABEL),
+    () => dropdownColumns.filter(c => effectiveValueSet.has(c.name)),
     [dropdownColumns, effectiveValueSet]
   );
+
+  // Whether the synthetic Unique Count metric is actually part of the output. Same gate as
+  // the toggle row below, so the two can never disagree.
+  const hasUniqueCountMetric =
+    hasPrimaryKey && outputControlsAvailable && effectiveOutputConfig.uniqueCountConfig;
+
+  // Sort-ONLY column list. Unique Count is a synthetic COUNT(DISTINCT <pk>) metric, not a
+  // projected field: it can be ordered by (the ORDER BY resolves to the SELECT alias), but a
+  // filter or aggregation on it has no column to bind to and the backend rejects it. So it
+  // must stay out of dropdownColumns / selectedDropdownColumns, which feed those surfaces.
+  const sortColumns = useMemo(() => {
+    // A real schema field may legitimately be named "Unique Count" (the backend has a
+    // dedicated OUTPUT_COLUMN_NAME_COLLISION error for it). If one is already selected it
+    // owns the name here — appending the synthetic too would duplicate the picker entry
+    // and collide on FieldSearchPicker's `key={item.value}`.
+    if (!hasUniqueCountMetric || selectedDropdownColumns.some(c => c.name === UNIQUE_COUNT_LABEL)) {
+      return selectedDropdownColumns;
+    }
+    return [
+      ...selectedDropdownColumns,
+      { name: UNIQUE_COUNT_LABEL, type: 'INTEGER', label: UNIQUE_COUNT_LABEL },
+    ];
+  }, [selectedDropdownColumns, hasUniqueCountMetric]);
 
   const controlsCount = useMemo(() => {
     return (
@@ -907,15 +915,17 @@ export function ReportColumnPicker({
     }
 
     return effectiveOutputConfig.sortConfig.some(rule => {
-      // Unique Count is a synthetic metric, never a member of effectiveValueSet /
-      // knownFieldNames — its "selected" status is the uniqueCountConfig toggle instead.
-      if (rule.column === UNIQUE_COUNT_LABEL) return !effectiveOutputConfig.uniqueCountConfig;
-      return !effectiveValueSet.has(rule.column) || !knownFieldNames.has(rule.column);
+      // A real selected field resolves the sort regardless of its name — check that first so
+      // a schema field literally named "Unique Count" is never hijacked by the synthetic case.
+      if (effectiveValueSet.has(rule.column) && knownFieldNames.has(rule.column)) return false;
+      // Otherwise the synthetic metric can still supply the column, matching the backend's
+      // validateSort (which adds the label to the selected set when uniqueCountConfig is on).
+      return !(rule.column === UNIQUE_COUNT_LABEL && hasUniqueCountMetric);
     });
   }, [
     effectiveOutputConfig.filterConfig,
     effectiveOutputConfig.sortConfig,
-    effectiveOutputConfig.uniqueCountConfig,
+    hasUniqueCountMetric,
     knownFieldNames,
     knownSliceKeys,
     effectiveValueSet,
@@ -1166,7 +1176,7 @@ export function ReportColumnPicker({
           <OutputSettingsDropdown
             value={effectiveOutputConfig}
             onChange={onOutputConfigChange}
-            selectedColumns={selectedDropdownColumns}
+            sortColumns={sortColumns}
             allColumns={dropdownColumns}
             joinedSources={joinedSources}
           />

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -38,7 +38,7 @@ import { OutputSettingsDropdown } from './OutputSettingsDropdown';
 import type { OutputSettingsDropdownColumn } from './OutputSettingsDropdown';
 import { AggregationSettingsButton } from './AggregationSettingsButton';
 import { AggregationSettingsDropdown } from './AggregationSettingsDropdown';
-import { fieldDisplayLabel } from './output-controls-display';
+import { fieldDisplayLabel, UNIQUE_COUNT_LABEL } from './output-controls-display';
 import { RowFilterIcon } from './RowFilterIcon';
 import { RowAggregationIcon } from './RowAggregationIcon';
 import { isFilterableType } from './output-controls-operators';
@@ -785,11 +785,26 @@ export function ReportColumnPicker({
         postJoinAggregations: f.postJoinAggregations,
       });
     }
+    // Unique Count is a synthetic COUNT(DISTINCT <pk>) metric, not a schema field — expose it
+    // as a sortable pseudo-column only while the toggle (below) is on.
+    if (hasPrimaryKey && outputControlsAvailable && effectiveOutputConfig.uniqueCountConfig) {
+      cols.push({ name: UNIQUE_COUNT_LABEL, type: 'INTEGER', label: UNIQUE_COUNT_LABEL });
+    }
     return cols;
-  }, [nativeFields, includedBlendedFields, availableSourceByPath]);
+  }, [
+    nativeFields,
+    includedBlendedFields,
+    availableSourceByPath,
+    hasPrimaryKey,
+    outputControlsAvailable,
+    effectiveOutputConfig.uniqueCountConfig,
+  ]);
 
+  // dropdownColumns only ever contains the Unique Count pseudo-column while it's enabled,
+  // so the plain membership check already keeps it selected without a redundant gate here.
   const selectedDropdownColumns = useMemo(
-    () => dropdownColumns.filter(c => effectiveValueSet.has(c.name)),
+    () =>
+      dropdownColumns.filter(c => effectiveValueSet.has(c.name) || c.name === UNIQUE_COUNT_LABEL),
     [dropdownColumns, effectiveValueSet]
   );
 
@@ -891,12 +906,16 @@ export function ReportColumnPicker({
       }
     }
 
-    return effectiveOutputConfig.sortConfig.some(
-      rule => !effectiveValueSet.has(rule.column) || !knownFieldNames.has(rule.column)
-    );
+    return effectiveOutputConfig.sortConfig.some(rule => {
+      // Unique Count is a synthetic metric, never a member of effectiveValueSet /
+      // knownFieldNames — its "selected" status is the uniqueCountConfig toggle instead.
+      if (rule.column === UNIQUE_COUNT_LABEL) return !effectiveOutputConfig.uniqueCountConfig;
+      return !effectiveValueSet.has(rule.column) || !knownFieldNames.has(rule.column);
+    });
   }, [
     effectiveOutputConfig.filterConfig,
     effectiveOutputConfig.sortConfig,
+    effectiveOutputConfig.uniqueCountConfig,
     knownFieldNames,
     knownSliceKeys,
     effectiveValueSet,

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-display.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-display.ts
@@ -1,6 +1,3 @@
-/** Must match `UNIQUE_COUNT_LABEL` in the backend's aggregation-labels.ts. */
-export const UNIQUE_COUNT_LABEL = 'Unique Count';
-
 /** Last dotted segment of a flattened field name: `a.b.c` → `c`. */
 export function fieldLeafName(name: string): string {
   const i = name.lastIndexOf('.');

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-display.ts
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/output-controls-display.ts
@@ -1,3 +1,6 @@
+/** Must match `UNIQUE_COUNT_LABEL` in the backend's aggregation-labels.ts. */
+export const UNIQUE_COUNT_LABEL = 'Unique Count';
+
 /** Last dotted segment of a flattened field name: `a.b.c` → `c`. */
 export function fieldLeafName(name: string): string {
   const i = name.lastIndexOf('.');

--- a/apps/web/src/features/data-marts/shared/utils/aggregation-labels.test.ts
+++ b/apps/web/src/features/data-marts/shared/utils/aggregation-labels.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { REPORT_AGGREGATE_FUNCTION_LABELS, aggregateFunctionLabel } from './aggregation-labels';
+import {
+  REPORT_AGGREGATE_FUNCTION_LABELS,
+  ROW_COUNT_LABEL,
+  UNIQUE_COUNT_LABEL,
+  aggregateFunctionLabel,
+} from './aggregation-labels';
 import { REPORT_AGGREGATE_FUNCTIONS } from '../types/relationship.types';
 
 // Drift guard. This web map MUST stay byte-for-byte identical to the backend
@@ -25,6 +30,13 @@ describe('REPORT_AGGREGATE_FUNCTION_LABELS (web mirror — drift guard)', () => 
       P75: '75th Percentile',
       P95: '95th Percentile',
     });
+  });
+
+  // Same drift contract as the map above: the backend emits these as the literal SQL alias
+  // and header name, and the web builds sort rules from them, so a silent edit must fail CI.
+  it('pins the synthetic output-column labels', () => {
+    expect(ROW_COUNT_LABEL).toBe('Row Count');
+    expect(UNIQUE_COUNT_LABEL).toBe('Unique Count');
   });
 
   it('has exactly one non-empty label for every aggregate function (no missing/extra key)', () => {

--- a/apps/web/src/features/data-marts/shared/utils/aggregation-labels.ts
+++ b/apps/web/src/features/data-marts/shared/utils/aggregation-labels.ts
@@ -25,3 +25,12 @@ export const REPORT_AGGREGATE_FUNCTION_LABELS: Record<ReportAggregateFunction, s
 export function aggregateFunctionLabel(fn: ReportAggregateFunction): string {
   return REPORT_AGGREGATE_FUNCTION_LABELS[fn];
 }
+
+/**
+ * Synthetic output-column labels. Mirror of the backend `ROW_COUNT_LABEL` /
+ * `UNIQUE_COUNT_LABEL` (same backend module as the map above). The backend emits these
+ * as the literal SQL `AS` alias and as the `ReportDataHeader.name`, so a drift here means
+ * the web references a column the query never produces. Pinned by the drift-guard test.
+ */
+export const ROW_COUNT_LABEL = 'Row Count';
+export const UNIQUE_COUNT_LABEL = 'Unique Count';


### PR DESCRIPTION
# Problem

Reports can add a Unique Count column — a synthetic `COUNT(DISTINCT <primary key>)` metric — but there was no way to sort by it. The Sort section of Output settings only lists schema-backed columns, so Unique Count never appeared in the "Add sort by" picker. Even a hand-crafted config was rejected at save time with `SORT_COLUMN_NOT_SELECTED`: `validateSort` checks each sort rule against the projected column set (`columnConfig` or the native field names), which never contains the synthetic `Unique Count` label. Users who wanted rows ranked by distinct-key volume had to export the report and sort it elsewhere.

# Solution

Sorting by the metric is now permitted end to end, across both the flat and the blended (joined-data-mart) query paths.

**Query builders.** The five flat builders already handled this: each renders the aggregated `ORDER BY` through `buildAggregatedAliasResolver`, which falls back to `quoteIdentifier(col)` for any column absent from the alias map — producing exactly the `"Unique Count"` alias that `renderAggregatedSelect` emits. There is a **sixth** user of that resolver, `abstract-blended-query-builder.ts`, and it needed work. Its outer `ORDER BY` was already correct, but upstream of it `referencedColumns` unions the sort columns verbatim, so the label flowed through `collectMainReferences` into the `main` raw CTE and emitted `SELECT "Unique Count" FROM <main table>` — a column that does not exist, failing every run and every Generated SQL preview. Synthetic labels are now dropped from that union (`Row Count` too, which is the same trap one validator line away), with a `columnSet` guard so a real column legitimately owning the name still reaches the CTE.

**Backend validation.** `Unique Count` is registered as an always-*known* output column, while its *selected* status is gated on `uniqueCountConfig`. Both additions use `Set.add`, so a real schema field owning that name is a harmless union rather than an override. This classifies a stale sort left after disabling the toggle as `SORT_COLUMN_NOT_SELECTED` rather than routing it to the harsher disconnected-columns path — a code-level distinction only, since the web renders `message` and not `details.errors[].code`.

**Frontend.** The synthetic column is kept in a dedicated sort-only list rather than the shared `dropdownColumns`. That shared list also feeds Filters (via `allColumns`) and Aggregations, and because the pseudo-column types as `INTEGER` it would otherwise pass `isFilterableType` and resolve a non-empty aggregation set — offering filter and aggregation options the backend then rejects. The `OutputSettingsDropdown` prop was renamed `selectedColumns` → `sortColumns` (it was already consumed only by `SortSection`); behaviour-preserving, but it makes the sort-only contract explicit so the list cannot silently be wired into the filter surfaces again. A single `hasUniqueCountMetric` gate is shared by the sort list and the disconnected-controls badge so the two cannot drift.

**Name collisions.** A real schema field may legitimately be named `Unique Count` (quoted identifiers on Snowflake/Redshift/Athena permit spaces, and the backend has a dedicated `OUTPUT_COLUMN_NAME_COLLISION` error for it). The real field always wins: the disconnected check resolves a selected real field before considering the synthetic case, and the sort list suppresses the synthetic whenever any known field owns the name — when selected it would duplicate the picker entry and collide on `FieldSearchPicker`'s `key={item.value}`; when merely present it would make `ORDER BY "Unique Count"` ambiguous between the outer alias and the base column, whose resolution precedence is unspecified across dialects.

**Stranded state.** Removing the mart's primary key hides the Unique count toggle, so the existing effect auto-clears a stored `uniqueCountConfig: true` that the user can no longer reach. That effect now prunes a stranded `Unique Count` sort rule in the same update — without it, `validateSort` rejects the leftover rule and every save and scheduled run fails. Skipped when a real field owns the name.

Row Count has the same synthetic-column shape and remains unsortable; only its blended-CTE trap is closed here.

# Changes

- Excluded `Unique Count` / `Row Count` from the blended builder's `referencedColumns`, so the synthetic labels are never projected into the `main` raw CTE while the outer `ORDER BY` still references them.
- Added `Unique Count` to the known-output-column set in `validateForReport`, and to the selected-column set passed to `validateSort` when `uniqueCountConfig` is enabled.
- Added `UNIQUE_COUNT_LABEL` / `ROW_COUNT_LABEL` to the existing web mirror `shared/utils/aggregation-labels.ts` and extended its CI drift-guard test.
- Added a sort-only `sortColumns` list carrying the synthetic column, leaving `dropdownColumns` and `selectedDropdownColumns` schema-pure so Filters and Aggregations are unaffected.
- Renamed the `OutputSettingsDropdown` prop `selectedColumns` → `sortColumns` and documented it as sort-only.
- Extracted a shared `hasUniqueCountMetric` gate used by both the sort list and the disconnected-controls badge.
- Replaced the disconnected-controls sort predicate so a selected real field resolves the rule before the synthetic special case, and suppressed the synthetic whenever any known field owns the name.
- Pruned stranded `Unique Count` sort rules in the primary-key-loss auto-heal effect.
- Added query-builder tests asserting the `main` CTE excludes the synthetic label while the outer `ORDER BY` keeps it, plus a real-column carve-out test.
- Added backend tests covering accept-when-enabled and reject-when-disabled for sorting by `Unique Count`.
- Added frontend tests covering: connected/disconnected rendering of a `Unique Count` sort rule, presence in "Add sort by", absence from "Add filter" and "Add aggregation", four real-field name-collision regressions, and the PK-loss prune.