### PR TITLE
test(backend): align Redshift/Snowflake sort assertions with NULLS FIRST

### DIFF
--- a/apps/backend/test/integration/redshift.integration.ts
+++ b/apps/backend/test/integration/redshift.integration.ts
@@ -625,12 +625,14 @@ describeIfCredentials(
     // Sort + limit
     // -------------------------------------------------------------------------
 
-    it('sort by amount DESC + limit 2 → rows 5,4 (amounts 50,40)', async () => {
+    it('sort by amount DESC + limit 2 → rows 7,5 (NULL amount first, then 50)', async () => {
+      // Seed row 7 has amount=NULL. Redshift follows PostgreSQL NULL ordering:
+      // DESC sorts NULLs first, so the all-NULL row leads before amount 50 (id 5).
       const rows = await runFilter({
         sort: [{ column: 'amount', direction: 'desc' }],
         limit: 2,
       });
-      expect(rows.map(r => r.id)).toEqual(['5', '4']);
+      expect(rows.map(r => r.id)).toEqual(['7', '5']);
     });
 
     // -------------------------------------------------------------------------
@@ -860,19 +862,26 @@ describeIfCredentials(
         expect(Number(row['row count'])).toBe(2);
       }, 60000);
 
-      it('ORDER BY aggregated alias (SUM desc) + limit 1 returns only the larger group', async () => {
+      it('ORDER BY aggregated alias (SUM desc): NULL-status group first, then active (90)', async () => {
+        // Three groups after the all-NULL seed row: active SUM=90, inactive SUM=60,
+        // NULL-status SUM=NULL. Redshift DESC puts NULLs first, so limit 1 alone would
+        // return the NULL-status bucket — pull all groups and assert full order.
         const rows = await runFilter({
           columns: ['status', 'amount'],
           aggregations: [{ column: 'amount', function: 'SUM' }],
           sort: [{ column: 'amount', direction: 'desc' }],
-          limit: 1,
         });
 
-        expect(rows).toHaveLength(1);
-        const row = rows[0];
-        // active SUM=90 > inactive SUM=60
-        expect(row.status).toBe('active');
-        expect(Number(row['amount | sum'])).toBeCloseTo(90, 5);
+        expect(rows).toHaveLength(3);
+        // 1) NULL-status bucket (SUM of NULL amount → NULL) leads under DESC NULLS FIRST
+        expect(rows[0].status).toBeNull();
+        expect(rows[0]['amount | sum']).toBeNull();
+        // 2) active SUM=90 is the highest non-NULL aggregate
+        expect(rows[1].status).toBe('active');
+        expect(Number(rows[1]['amount | sum'])).toBeCloseTo(90, 5);
+        // 3) inactive SUM=60
+        expect(rows[2].status).toBe('inactive');
+        expect(Number(rows[2]['amount | sum'])).toBeCloseTo(60, 5);
       }, 60000);
     });
   }

--- a/apps/backend/test/integration/snowflake.integration.ts
+++ b/apps/backend/test/integration/snowflake.integration.ts
@@ -486,12 +486,14 @@ describeIfSnowflakeCredentials(
     // Sort + limit
     // -------------------------------------------------------------------------
 
-    it('sort by amount DESC + limit 2 → rows 5,4 (amounts 50,40)', async () => {
+    it('sort by amount DESC + limit 2 → rows 7,5 (NULL amount first, then 50)', async () => {
+      // Seed row 7 has amount=NULL. Snowflake treats NULL as highest, so DESC puts
+      // NULLs first — the all-NULL row leads before amount 50 (id 5).
       const rows = await runFilter({
         sort: [{ column: 'amount', direction: 'desc' }],
         limit: 2,
       });
-      expect(rows.map(r => String(r.id ?? r.ID ?? ''))).toEqual(['5', '4']);
+      expect(rows.map(r => String(r.id ?? r.ID ?? ''))).toEqual(['7', '5']);
     }, 30000);
 
     // -------------------------------------------------------------------------
@@ -721,19 +723,29 @@ describeIfSnowflakeCredentials(
         expect(Number(row['Row Count'])).toBe(4);
       }, 60000);
 
-      // Case 9 — ORDER BY aggregated alias (SUM desc) + limit 1 returns larger group.
-      it('ORDER BY SUM desc + limit 1 returns the active group (larger sum 90 vs 60)', async () => {
+      // Case 9 — ORDER BY aggregated alias (SUM desc) with the NULL-status bucket.
+      // Three groups: active SUM=90, inactive SUM=60, NULL-status SUM=NULL.
+      // Snowflake DESC treats NULL as highest, so the NULL-status group leads.
+      it('ORDER BY SUM desc: NULL-status group first, then active (90), then inactive (60)', async () => {
         const rows = await runFilter({
           columns: ['status', 'amount'],
           aggregations: [{ column: 'amount', function: 'SUM' }],
           sort: [{ column: 'amount', direction: 'desc' }],
-          limit: 1,
         });
 
-        expect(rows).toHaveLength(1);
-        const row = rows[0];
-        expect(String(row.status ?? row.STATUS ?? '')).toBe('active');
-        expect(Number(row['amount | SUM'])).toBeCloseTo(90, 5);
+        expect(rows).toHaveLength(3);
+        const statusOf = (r: Record<string, unknown>): unknown =>
+          'status' in r ? r.status : r.STATUS;
+
+        // 1) NULL-status bucket (SUM of NULL amount → NULL) leads under DESC NULLS FIRST
+        expect(statusOf(rows[0])).toBeNull();
+        expect(rows[0]['amount | SUM']).toBeNull();
+        // 2) active SUM=90 is the highest non-NULL aggregate
+        expect(String(statusOf(rows[1]))).toBe('active');
+        expect(Number(rows[1]['amount | SUM'])).toBeCloseTo(90, 5);
+        // 3) inactive SUM=60
+        expect(String(statusOf(rows[2]))).toBe('inactive');
+        expect(Number(rows[2]['amount | SUM'])).toBeCloseTo(60, 5);
       }, 60000);
 
       // Case 10 — multi-dimension group-by (status + date-trunc MONTH).


### PR DESCRIPTION
## Summary

- Real-DB integration suites for Redshift and Snowflake failed after the all-NULL seed row was added for negative filter coverage.
- On both engines, `ORDER BY … DESC` places `NULL` first (PostgreSQL-style / Snowflake default). Sort + limit and grouped `SUM` sort tests still expected non-NULL leaders.
- Update those assertions to the actual order: NULL amount / NULL-status group first, then the highest non-NULL values.

## Test plan

- [ ] CI **Integration Tests (Real DB)** — Redshift job green
- [ ] CI **Integration Tests (Real DB)** — Snowflake job green
- [ ] Confirm BigQuery / Athena / Databricks remain unaffected (different NULL sort defaults / seeds)