### PR TITLE
feat(web): add FieldWithActions component for enhanced service account email handling

### DIFF
--- a/.changeset/6576-copy-service-account-button.md
+++ b/.changeset/6576-copy-service-account-button.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Easier access to service account details
+
+When viewing Google service account credentials, you can now copy the service account email with one click or open its details in Google Cloud Console. The email remains visible and can still be selected manually when you only need part of it.

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleSheetsFields.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleSheetsFields.tsx
@@ -17,10 +17,11 @@ import GoogleSheetsServiceAccountDescription from './FormDescriptions/GoogleShee
 import GoogleSheetsOAuthDescription from './FormDescriptions/GoogleSheetsOAuthDescription';
 import GoogleSheetsAuthMethodDescription from './FormDescriptions/GoogleSheetsAuthMethodDescription';
 import { CopyableField } from '@owox/ui/components/common/copyable-field';
+import { FieldWithActions } from '@owox/ui/components/common/field-with-actions';
 import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { getServiceAccountLink } from '../../../../../utils';
-import { Copy, Check, ExternalLink } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
 import {
   isValidGoogleDriveFolderUrl,
   buildDriveFolderUrl,
@@ -55,7 +56,6 @@ export function GoogleSheetsFields({ form }: GoogleSheetsFieldsProps) {
     undefined
   );
   const [oauthEmail, setOauthEmail] = useState<string | null>(null);
-  const [saCopied, setSaCopied] = useState(false);
   const [oauthClientId, setOauthClientId] = useState<string | undefined>(undefined);
   const [pickerApiKey, setPickerApiKey] = useState<string | undefined>(undefined);
   const [isPickingFolder, setIsPickingFolder] = useState(false);
@@ -321,33 +321,17 @@ export function GoogleSheetsFields({ form }: GoogleSheetsFieldsProps) {
                   </div>
                   <FormControl>
                     {!isEditing && serviceAccountLink ? (
-                      <div className='flex items-center gap-2'>
-                        <ExternalAnchor
-                          href={serviceAccountLink.url}
-                          variant='field'
-                          className='flex-1 truncate'
-                        >
-                          {serviceAccountLink.email}
-                        </ExternalAnchor>
-                        <button
-                          type='button'
-                          onClick={() => {
-                            void navigator.clipboard.writeText(serviceAccountLink.email);
-                            setSaCopied(true);
-                            setTimeout(() => {
-                              setSaCopied(false);
-                            }, 2000);
-                          }}
-                          className='text-muted-foreground hover:text-foreground hover:bg-accent shrink-0 rounded-md p-1 transition-colors'
-                          aria-label='Copy email'
-                        >
-                          {saCopied ? (
-                            <Check className='h-4 w-4 text-green-500' />
-                          ) : (
-                            <Copy className='h-4 w-4' />
-                          )}
-                        </button>
-                      </div>
+                      <FieldWithActions
+                        value={serviceAccountLink.email}
+                        actions={[
+                          { type: 'copy', tooltip: 'Copy email' },
+                          {
+                            type: 'external-link',
+                            href: serviceAccountLink.url,
+                            tooltip: 'Open details',
+                          },
+                        ]}
+                      />
                     ) : (
                       <FileDropTextarea
                         {...field}

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/FormDescriptions/DocumentLinkDescription.test.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/FormDescriptions/DocumentLinkDescription.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DocumentLinkDescription from './DocumentLinkDescription';
+
+describe('DocumentLinkDescription', () => {
+  const accessEmail = 'report-writer@example.iam.gserviceaccount.com';
+  const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    writeText.mockClear();
+  });
+
+  it('shows and copies the selected destination access email', async () => {
+    render(<DocumentLinkDescription accessEmail={accessEmail} />);
+
+    fireEvent.click(screen.getByText('How do I get a correct document link?'));
+
+    const copyableEmail = screen.getByRole('button', { name: accessEmail });
+    fireEvent.click(copyableEmail);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(accessEmail);
+    });
+    expect(screen.getByText(/following email/i)).toBeInTheDocument();
+  });
+
+  it('keeps the generic instruction when the destination email is unavailable', () => {
+    render(<DocumentLinkDescription />);
+
+    fireEvent.click(screen.getByText('How do I get a correct document link?'));
+
+    expect(screen.getByText(/service account email/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: accessEmail })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/FormDescriptions/DocumentLinkDescription.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/FormDescriptions/DocumentLinkDescription.tsx
@@ -4,11 +4,16 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@owox/ui/components/accordion';
+import { CopyableField } from '@owox/ui/components/common/copyable-field';
+
+interface DocumentLinkDescriptionProps {
+  accessEmail?: string;
+}
 
 /**
  * Accordion with step-by-step instructions for copy and paste document link.
  */
-export default function DocumentLinkDescription() {
+export default function DocumentLinkDescription({ accessEmail }: DocumentLinkDescriptionProps) {
   return (
     <Accordion variant='common' type='single' collapsible>
       <AccordionItem value='service-account-details'>
@@ -28,8 +33,23 @@ export default function DocumentLinkDescription() {
               where the data should be inserted.
             </li>
             <li>
-              Share the document with the service account email and grant it <strong>Editor</strong>{' '}
-              access.
+              {accessEmail ? (
+                <>
+                  Share the document with the following email and grant it <strong>Editor</strong>{' '}
+                  access:
+                  <CopyableField
+                    value={accessEmail}
+                    className='bg-background mt-1 w-fit max-w-full'
+                  >
+                    {accessEmail}
+                  </CopyableField>
+                </>
+              ) : (
+                <>
+                  Share the document with the service account email and grant it{' '}
+                  <strong>Editor</strong> access.
+                </>
+              )}
             </li>
             <li>
               While the correct sheet is selected, copy the URL from your browser's address bar — it

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -247,6 +247,12 @@ export const GoogleSheetsReportEditForm = forwardRef<
     const isValidDocumentUrl = documentUrl && isValidGoogleSheetsUrl(documentUrl.trim());
 
     const selectedDestinationId = form.watch('dataDestinationId');
+    const selectedDestination = filteredDestinations.find(
+      destination => destination.id === selectedDestinationId
+    );
+    const selectedDestinationEmail = selectedDestination
+      ? getGoogleSheetsDestinationEmail(selectedDestination)
+      : undefined;
     const [isCreatingSheet, setIsCreatingSheet] = useState(false);
 
     const handleCreateGoogleSheet = async () => {
@@ -407,26 +413,16 @@ export const GoogleSheetsReportEditForm = forwardRef<
                         </AlertDescription>
                       </Alert>
                     )}
-                    {field.value &&
-                      filteredDestinations.length > 0 &&
-                      (() => {
-                        const selectedDestination = filteredDestinations.find(
-                          destination => destination.id === field.value
-                        );
-                        if (selectedDestination) {
-                          const accessEmail = getGoogleSheetsDestinationEmail(selectedDestination);
-                          if (!accessEmail) return null;
-                          return (
-                            <div className='mt-2 flex flex-col gap-1'>
-                              <FormLabel tooltip='Share the Google Sheet with this email to allow writing'>
-                                Share document with
-                              </FormLabel>
-                              <CopyableField value={accessEmail}>{accessEmail}</CopyableField>
-                            </div>
-                          );
-                        }
-                        return null;
-                      })()}
+                    {field.value && selectedDestinationEmail && (
+                      <div className='mt-2 flex flex-col gap-1'>
+                        <FormLabel tooltip='Share the Google Sheet with this email to allow writing'>
+                          Share document with
+                        </FormLabel>
+                        <CopyableField value={selectedDestinationEmail}>
+                          {selectedDestinationEmail}
+                        </CopyableField>
+                      </div>
+                    )}
                     <FormMessage />
                   </FormItem>
                 )}
@@ -503,7 +499,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
                       </div>
                     </FormControl>
                     <FormDescription>
-                      <DocumentLinkDescription />
+                      <DocumentLinkDescription accessEmail={selectedDestinationEmail} />
                     </FormDescription>
                     <FormMessage />
                   </FormItem>

--- a/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/GoogleBigQueryFields.tsx
+++ b/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/GoogleBigQueryFields.tsx
@@ -17,9 +17,8 @@ import GoogleBigQueryOAuthDescription from './FormDescriptions/GoogleBigQueryOAu
 import GoogleBigQueryAuthMethodDescription from './FormDescriptions/GoogleBigQueryAuthMethodDescription';
 import GoogleBigQueryProjectIdDescription from './FormDescriptions/GoogleBigQueryProjectIdDescription.tsx';
 import GoogleBigQueryLocationDescription from './FormDescriptions/GoogleBigQueryLocationDescription.tsx';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { Button } from '@owox/ui/components/button';
-import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
+import { FieldWithActions } from '@owox/ui/components/common/field-with-actions';
 import { FileDropTextarea } from '@owox/ui/components/file-drop-textarea';
 import { toast } from 'react-hot-toast';
 import { useState, useEffect } from 'react';
@@ -259,16 +258,17 @@ export const GoogleBigQueryFields = ({ form }: GoogleBigQueryFieldsProps) => {
                     </div>
                     <FormControl>
                       {!isEditing && serviceAccountLink ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <ExternalAnchor href={serviceAccountLink.url} variant='field'>
-                              {serviceAccountLink.email}
-                            </ExternalAnchor>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>View in Google Cloud Console</p>
-                          </TooltipContent>
-                        </Tooltip>
+                        <FieldWithActions
+                          value={serviceAccountLink.email}
+                          actions={[
+                            { type: 'copy', tooltip: 'Copy email' },
+                            {
+                              type: 'external-link',
+                              href: serviceAccountLink.url,
+                              tooltip: 'Open details',
+                            },
+                          ]}
+                        />
                       ) : (
                         <FileDropTextarea
                           {...field}

--- a/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/LegacyGoogleBigQueryFields.tsx
+++ b/apps/web/src/features/data-storage/edit/components/DataStorageEditForm/LegacyGoogleBigQueryFields.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@owox/ui/components/button';
-import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
+import { FieldWithActions } from '@owox/ui/components/common/field-with-actions';
 import {
   FormControl,
   FormDescription,
@@ -13,7 +13,6 @@ import { Input } from '@owox/ui/components/input';
 import { Tabs, TabsList, TabsTrigger } from '@owox/ui/components/tabs';
 import { FileDropTextarea } from '@owox/ui/components/file-drop-textarea';
 import { toast } from 'react-hot-toast';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { useState, useEffect } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import { Combobox } from '../../../../../shared/components/Combobox/combobox.tsx';
@@ -266,16 +265,17 @@ export const LegacyGoogleBigQueryFields = ({ form }: LegacyGoogleBigQueryFieldsP
                     </div>
                     <FormControl>
                       {!isEditing && serviceAccountLink ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <ExternalAnchor href={serviceAccountLink.url} variant='field'>
-                              {serviceAccountLink.email}
-                            </ExternalAnchor>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p>View in Google Cloud Console</p>
-                          </TooltipContent>
-                        </Tooltip>
+                        <FieldWithActions
+                          value={serviceAccountLink.email}
+                          actions={[
+                            { type: 'copy', tooltip: 'Copy email' },
+                            {
+                              type: 'external-link',
+                              href: serviceAccountLink.url,
+                              tooltip: 'Open details',
+                            },
+                          ]}
+                        />
                       ) : (
                         <FileDropTextarea
                           {...field}

--- a/packages/ui/src/components/common/copyable-field.tsx
+++ b/packages/ui/src/components/common/copyable-field.tsx
@@ -12,9 +12,15 @@ interface CopyableFieldProps {
   value: string;
   children?: React.ReactNode;
   doNotTruncateContent?: boolean;
+  className?: string;
 }
 
-export function CopyableField({ value, children, doNotTruncateContent }: CopyableFieldProps) {
+export function CopyableField({
+  value,
+  children,
+  doNotTruncateContent,
+  className,
+}: CopyableFieldProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -36,7 +42,8 @@ export function CopyableField({ value, children, doNotTruncateContent }: Copyabl
             className={cn(
               'flex cursor-pointer items-center justify-between gap-2 select-none',
               'text-muted-foreground border-input rounded-md border px-3 py-1.5 text-sm',
-              'hover:bg-accent hover:text-accent-foreground transition-colors'
+              'hover:bg-accent hover:text-accent-foreground transition-colors',
+              className
             )}
           >
             <span className={doNotTruncateContent ? 'w-[95%]' : 'truncate'}>

--- a/packages/ui/src/components/common/field-with-actions.tsx
+++ b/packages/ui/src/components/common/field-with-actions.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState } from 'react';
+import { Check, Copy, ExternalLink } from 'lucide-react';
+import { Button } from '@owox/ui/components/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { cn } from '@owox/ui/lib/utils';
+
+type CopyAction = {
+  type: 'copy';
+  tooltip?: string;
+  copiedTooltip?: string;
+  onCopyError?: () => void;
+};
+
+type ExternalLinkAction = {
+  type: 'external-link';
+  href: string;
+  tooltip?: string;
+};
+
+export type FieldWithActionsAction = CopyAction | ExternalLinkAction;
+
+interface FieldWithActionsProps {
+  value: string;
+  actions: FieldWithActionsAction[];
+  className?: string;
+}
+
+export function FieldWithActions({ value, actions, className }: FieldWithActionsProps) {
+  const [copied, setCopied] = useState(false);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async (onCopyError?: () => void) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+
+      resetTimeoutRef.current = setTimeout(() => {
+        setCopied(false);
+        resetTimeoutRef.current = null;
+      }, 2000);
+    } catch {
+      onCopyError?.();
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'text-foreground flex w-full items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-normal',
+        className
+      )}
+    >
+      <span className='min-w-0 flex-1 truncate select-text'>{value}</span>
+      <div className='flex shrink-0 items-center gap-1'>
+        {actions.map((action, index) => {
+          if (action.type === 'copy') {
+            const tooltip = copied
+              ? (action.copiedTooltip ?? 'Copied!')
+              : (action.tooltip ?? 'Copy');
+
+            return (
+              <Tooltip key={`copy-${index}`}>
+                <TooltipTrigger asChild>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='icon-sm'
+                    className='size-6'
+                    onClick={() => void handleCopy(action.onCopyError)}
+                    aria-label={tooltip}
+                  >
+                    {copied ? (
+                      <Check className='h-3 w-3' strokeWidth={1.5} aria-hidden='true' />
+                    ) : (
+                      <Copy className='h-3 w-3' strokeWidth={1.5} aria-hidden='true' />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{tooltip}</p>
+                </TooltipContent>
+              </Tooltip>
+            );
+          }
+
+          const tooltip = action.tooltip ?? 'Open link';
+
+          return (
+            <Tooltip key={`external-link-${index}`}>
+              <TooltipTrigger asChild>
+                <Button
+                  asChild
+                  variant='ghost'
+                  size='icon-sm'
+                  className='size-6'
+                  aria-label={tooltip}
+                >
+                  <a href={action.href} target='_blank' rel='noopener noreferrer'>
+                    <ExternalLink className='h-3 w-3' strokeWidth={1.5} aria-hidden='true' />
+                  </a>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{tooltip}</p>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/common/index.ts
+++ b/packages/ui/src/components/common/index.ts
@@ -1,4 +1,6 @@
 export { CopyButton } from './copy-button';
+export { FieldWithActions } from './field-with-actions';
+export type { FieldWithActionsAction } from './field-with-actions';
 export { LoadingSpinner, FullScreenLoader } from './loading-spinner';
 export { MultiSelect } from './multi-select';
 export { default as RelativeTime } from './relative-time';


### PR DESCRIPTION
# Easier access to service account details

When viewing Google service account credentials, you can now copy the service account email with one click or open its details in Google Cloud Console. The email remains visible and can still be selected manually when you only need part of it.

<img width="565" height="154" alt="Screenshot 2026-07-29 222953" src="https://github.com/user-attachments/assets/6a34b12e-60e0-42a8-aa15-a999927a453a" />
