### PR TITLE
docs(mcp): document what costs credits and add MCP Query Run unit

### DIFF
--- a/docs/getting-started/billing/consumption-units.md
+++ b/docs/getting-started/billing/consumption-units.md
@@ -15,7 +15,7 @@
 
 ### **How Are Report Runs Calculated?**
 
-A **Report Run** means pushing or pulling data (stored in **Storage**) to a **Destination**, or accessing data through the HTTP Data API. Read more about [core concepts](../core-concepts.md).
+A **Report Run** means pushing or pulling data (stored in **Storage**) to a **Destination**. Reading data through the HTTP Data API or the [MCP Server](../setup-guide/mcp.md) also counts. Read more about [core concepts](../core-concepts.md).
 
 - Each **successful** execution of a Data Mart counts as **1 Report Run**, regardless of the volume of processed data.
 - The Data Mart is executed on behalf of the customer's [Storage](../core-concepts.md#storage) within the dedicated OWOX BI Project, and processing costs are charged to the customer's Storage billing account.
@@ -33,6 +33,7 @@ For better transparency and flexibility, Report Runs are broken down into follow
 | Report Run           | Data Studio Report Run | Represents Report Runs executed in the OWOX Data Marts Cloud edition on [app.owox.com](https://app.owox.com). Data was pulled from a Data Mart to the [Data Studio Destination](../../destinations/supported-destinations/data-studio.md).                                                                     |
 | Report Run           | Google Sheets Report Run | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). Data was pushed from a Data Mart to the [Google Sheets Destination](../../destinations/supported-destinations/google-sheets.md).                                                                                     |
 | Report Run           | HTTP Data Report Run   | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). Data was pulled from a Data Mart through the HTTP Data API endpoint.                                                                                                                                              |
+| Report Run           | MCP Query Run          | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). An AI assistant read data from a Data Mart through the [MCP Server](../setup-guide/mcp.md)'s `query_data_mart` tool.                                                                                              |
 | Report Run           | Email Report Run         | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). A message was pushed to the [Email Destination](../../destinations/supported-destinations/email.md).                                                                                                                 |
 | Report Run           | Google Chat Report Run   | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). A message was pushed to the [Google Chat Destination](../../destinations/supported-destinations/google-chat.md).                                                                                                     |
 | Report Run           | MS Teams Report Run      | Represents Report Runs executed in the Cloud edition on [app.owox.com](https://app.owox.com). A message was pushed to the [MS Teams Destination](../../destinations/supported-destinations/microsoft-teams.md).                                                                                                    |
@@ -62,6 +63,9 @@ For better transparency and flexibility, Process Runs are broken down into follo
 
 - **Q:** How can I monitor the number of Runs per month?
   - **A:** In the app.owox.com, open the **Credits consumption** page to see detailed usage.
+
+- **Q:** Does querying data through the MCP Server consume credits?
+  - **A:** Yes. Each successful `query_data_mart` call counts as one **MCP Query Run**, whatever number of rows it returns. Failed, cancelled, and timed-out queries cost nothing. Metadata tools stay free — listing data marts or inspecting fields never costs credits. See [What costs credits](../setup-guide/mcp.md#what-costs-credits) in the MCP Server guide.
 
 - **Q:** Will my reports be updated if I exceed the limit on my subscription?
   - **A:** Yes! Reports will continue to be updated on schedule, and manual runs will work as usual — even if you exceed the limit. No interruptions.

--- a/docs/getting-started/setup-guide/mcp.md
+++ b/docs/getting-started/setup-guide/mcp.md
@@ -551,9 +551,25 @@ Permanently deletes a report. The report stops running and disappears from the p
 | `report_id` | Report identifier  |
 | `status`    | `deleted`          |
 
+## What costs credits
+
+Most of what you ask costs nothing. Only two tools consume [credits](../billing/consumption-units.md):
+
+- **`query_data_mart`** — reads actual data rows. Each successful call counts as one Report Run, billed as an **MCP Query Run**.
+- **`run_report`** — starts a Report Run that delivers data to a destination.
+
+Everything else is free. Listing data marts, inspecting fields, browsing destinations, reading reports and schedules, and checking run status only read metadata. Creating a destination, report, or schedule is also free. You pay when the report runs, not when you set it up.
+
+Four things to expect:
+
+- **Cost does not depend on size.** One call costs the same whether it returns 20 rows or 1,000. Ask one broad question rather than several narrow ones.
+- **One question can cost several credits.** The assistant may run several queries to answer you — for example, one per month you asked about. Ask it to plan the queries first if you want to keep the count down.
+- **Failed queries are free.** If a query fails, times out, or you cancel it, you pay nothing. A wrong guess about a field name costs nothing either.
+- **Running out of credits blocks queries only.** The metadata tools keep working, so the assistant can still explore your catalog.
+
 ## How to use it: example prompts
 
-Once the OWOX server is connected, just ask your assistant in plain language. You do not need to name the tools — the assistant calls them for you. Try prompts like:
+Once the OWOX server is connected, just ask your assistant in plain language. You do not need to name the tools — the assistant calls them for you. Prompts marked **(costs credits)** read or deliver actual data — see [What costs credits](#what-costs-credits). Try prompts like:
 
 - "Which OWOX project am I connected to, and what is my role in it?"
 - "What data is available in this project, and what should I ask next?"
@@ -562,13 +578,13 @@ Once the OWOX server is connected, just ask your assistant in plain language. Yo
 - "Do I have any data marts about Facebook Ads? Show their descriptions."
 - "What fields are available in the Facebook Ads data mart?"
 - "Give me a one-line summary of each data mart and what it is for."
-- "What's the total revenue by month in the Sales data mart?"
-- "Show the top campaigns by spend in the Ads data mart."
+- "What's the total revenue by month in the Sales data mart?" **(costs credits)**
+- "Show the top campaigns by spend in the Ads data mart." **(costs credits)**
 - "Which destinations can I send a report to?"
 - "Connect a Google Sheets destination for my account."
 - "Create an email destination for `analytics-alerts@example.com`."
 - "What reports and schedules already exist for the Sales data mart?"
-- "Run the Weekly Ads Report now and tell me when it finishes."
+- "Run the Weekly Ads Report now and tell me when it finishes." **(costs credits)**
 - "Export the Ads data mart to a new Google Sheet called 'Weekly Ads Report'."
 - "Create a Looker Studio report from the Sales data mart with all fields."
 - "Send the daily revenue table to the Alerts Slack destination with the message 'Yesterday's numbers'."
@@ -605,6 +621,8 @@ The token does not include the write scope required for tools that create, chang
 Project selection is fixed at authorization time. See [Switch projects or disconnect](#switch-projects-or-disconnect) for how to reconnect and choose a different project or use another project-specific URL.
 
 ### A `query_data_mart` call fails
+
+A failed query costs nothing — OWOX bills a call only after it succeeds. This covers queries that time out, queries you cancel, and queries the credit limit blocks.
 
 If the assistant reports that the project is out of credits, `query_data_mart` has hit its credit limit — upgrade the plan to keep querying (the read-only tools keep working). If it says a field wasn't found, it likely guessed a field name; ask it to check the data mart's fields first with `get_data_mart_details_by_id`, then re-run the query.
 


### PR DESCRIPTION
# Problem

Users connecting an AI assistant through the MCP server had no way to tell which prompts cost credits. The MCP guide mentioned that `query_data_mart` costs credits in several scattered places, but never connected that to what a user actually types — all 22 example prompts were unmarked, including the three that bill. Following the "credits" link led to the Consumption Units page, which had no MCP entry at all: its Report Run sub-unit table listed eight units, none covering MCP, and its Report Run definition covered only destinations and the HTTP Data API. The backend has published MCP query billing events via `CONSUMPTION_MCP_QUERY_RUN_TOPIC` since the MCP server shipped, so the billing behavior existed but was undocumented. Nothing documented that failed queries are not billed either, even though the tool tells users exactly that at runtime.

# Solution

Documented the billing behavior on both sides of the link, with every claim verified against the backend rather than inferred:

- Added a `What costs credits` section to the MCP guide that names the only two billing tools (`query_data_mart`, `run_report`), states plainly that everything else is free, and sets four expectations: cost is independent of row count, one question can cost several credits, failures are free, and running out blocks queries but not metadata tools.
- Marked the three billable prompts in the example-prompt list, with a key in the section intro, so the answer sits where readers ask the question.
- Registered `MCP Query Run` as a Report Run sub-consumption unit, placed next to `HTTP Data Report Run` since both are programmatic pull paths with no destination.
- Widened the Report Run definition, which otherwise would have listed a sub-unit it did not cover. Splitting that sentence also brought a pre-existing 22-word sentence under the 20-word house limit.

Verification against `apps/backend`: consumption fires only after a `SUCCESS` audit record (`query-data-mart.service.ts:296`), only four code paths call `consumptionTrackingService.register*`, and report creation is not one of them — so documenting setup as free is accurate.

# Changes

- Added a `What costs credits` section to `docs/getting-started/setup-guide/mcp.md`, naming the two billing tools and four cost expectations.
- Marked the three billable example prompts with `(costs credits)` and added a key to the section intro.
- Documented in Troubleshooting that failed, cancelled, timed-out, and credit-blocked queries cost nothing.
- Added the `MCP Query Run` row to the Report Run sub-consumption unit table in `docs/getting-started/billing/consumption-units.md`.
- Widened the Report Run definition to cover reads through the HTTP Data API and the MCP Server.
- Added an FAQ entry on whether MCP queries consume credits, naming the unit so users can match it to the Credits consumption page.
- No changeset: documentation-only change.