### PR TITLE
docs(data-marts): Data Last Updated user guide

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -74,6 +74,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 'docs/getting-started/setup-guide/pattern-data-mart',
                 'docs/getting-started/setup-guide/joinable-data-marts',
                 'docs/getting-started/setup-guide/data-quality-checks',
+                'docs/getting-started/setup-guide/data-last-updated',
                 'docs/getting-started/setup-guide/output-controls',
                 'docs/getting-started/setup-guide/report-aggregations',
                 'docs/getting-started/setup-guide/connector-triggers',

--- a/docs/getting-started/setup-guide/data-last-updated.md
+++ b/docs/getting-started/setup-guide/data-last-updated.md
@@ -1,6 +1,6 @@
 # Data Last Updated
 
-Data Last Updated shows when the source tables behind a Data Mart last changed in the storage. It answers the question "how current is what I am looking at?" before you build a report or act on an answer from an AI assistant.
+Data Last Updated shows when the source tables/views behind a Data Mart last changed in the storage. It answers the question "how current is what I am looking at?" before you build a report or act on an answer from an AI assistant.
 
 Data Last Updated is currently measured for **Google BigQuery** Data Marts. Data Marts on other storages show **Unknown** until their support lands.
 

--- a/docs/getting-started/setup-guide/data-last-updated.md
+++ b/docs/getting-started/setup-guide/data-last-updated.md
@@ -1,0 +1,64 @@
+# Data Last Updated
+
+Data Last Updated shows when the source tables behind a Data Mart last changed in the storage. It answers the question "how current is what I am looking at?" before you build a report or act on an answer from an AI assistant.
+
+Data Last Updated is currently measured for **Google BigQuery** Data Marts. Data Marts on other storages show **Unknown** until their support lands.
+
+## What the value means
+
+Read the value precisely. It is a **storage** timestamp, not a statement about the data's content:
+
+- It says when something last **wrote to** the source tables. A backfill can rewrite a table today with figures from 2021, so "updated today" does not mean "covers today".
+- **Unknown** means OWOX could not determine the time. It does not mean the data is stale — or fresh.
+- A value marked **≥** ("at least as recent as") means some source tables could not be checked. The real time can only be more recent than shown.
+
+Hover over any Data Last Updated value or icon to see the details: the exact timestamp, when OWOX ran the check, how complete the coverage is, and the per-table breakdown.
+
+## Where you see it
+
+| Surface | What is shown |
+| --- | --- |
+| **Data Mart page** → Overview → Details | A **Data Last Updated** tile with a *Check now* button |
+| **Data Marts list** | A sortable **Data Last Updated** column |
+| **Models canvas** | A clock icon on every node, next to the Data Quality shield, plus a **Data Last Updated** toolbar button |
+| **MCP** | A `data_last_updated` block in every `query_data_mart` response — see [MCP Server](./mcp.md#data-last-updated) |
+
+The list and the canvas show the **last-known** value — the result of the most recent check, with its time visible in the hover card. They never query the storage on page load.
+
+## How to check it
+
+Two buttons measure the value live and save the result:
+
+- **Check now** (⟳) on the Data Mart page measures that one Data Mart.
+- **Data Last Updated** in the canvas toolbar measures every Data Mart currently visible on the canvas, in one pass.
+
+Checking is free. It reads storage metadata only, consumes no [credits](../billing/consumption-units.md), and records no run. Any project member who can see the Data Mart can run the check.
+
+A check that cannot determine the time reports Unknown and **keeps the previously saved value** — a failed lookup never erases the last-known answer.
+
+## When the value updates
+
+| Trigger | Effect |
+| --- | --- |
+| *Check now* on the Data Mart page | Measures and **saves** the value |
+| Toolbar button on the canvas | Measures and **saves** the value for all visible Data Marts |
+| Every MCP `query_data_mart` call | Measures live for that response and records it in the run's history entry. Does **not** overwrite the saved value, because an MCP query can span several joined Data Marts |
+| On a schedule | Never. OWOX does not re-measure Data Marts in the background |
+
+## How OWOX determines the value
+
+OWOX asks the storage which tables the Data Mart reads, then takes the newest modification time among them:
+
+- **Views and SQL Data Marts** resolve through to their underlying base tables, nested views included. Views themselves are excluded from the per-table breakdown — a view's own modification time reflects a change to its definition, not to any data.
+- **Sharded and wildcard table sets** (`events_YYYYMMDD`) collapse into a single entry showing the newest shard. Neighbouring tables that merely share the prefix, such as `events_backup`, do not count.
+- **External tables** (for example, Google Sheets) have no modification time in the storage. They appear in the breakdown as unknown, and the coverage becomes partial.
+- Queries referencing more than ~50 tables are reported with partial coverage, because the storage truncates the list.
+
+## Data Last Updated vs. the Data freshness check
+
+These are different tools that answer different questions:
+
+- **Data Last Updated** is storage metadata: when the source tables were last written to. It requires no configuration and costs nothing.
+- The **Data freshness** check in [Data Quality Checks](./data-quality-checks.md) validates the data itself: it reads a timestamp field and alerts when its latest value is older than a threshold you configure.
+
+A table can pass one and fail the other. A backfill makes Data Last Updated show "today" while the Data freshness check still fails, because the newest timestamp inside the data is old.

--- a/docs/getting-started/setup-guide/mcp.md
+++ b/docs/getting-started/setup-guide/mcp.md
@@ -280,7 +280,7 @@ When presenting results, the assistant must name the source Data Mart. It must d
 
 #### Data last updated
 
-`data_last_updated` answers "how current is what I am looking at?". Each query measures it live, in the same call that reads the data. OWOX never caches this value and never bills it separately — the call's own credits cover it.
+`data_last_updated` answers "how current is what I am looking at?". Each query measures it live, in the same call that reads the data. OWOX never caches this value and never bills it separately — the call's own credits cover it. The same value appears across the OWOX UI — see [Data Last Updated](./data-last-updated.md).
 
 | Field                  | Description                                                                                                                                                          |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

Adds a dedicated user-guide page for **Data Last Updated** (shipped in #1472): `docs/getting-started/setup-guide/data-last-updated.md`, registered in the docs sidebar right after Data Quality Checks. The MCP page's `data_last_updated` section now cross-links to it.

Replaces #1481, re-cut from `main` per the team flow — and since #1472 has merged, `main` already contains everything the page documents.

## Why this location

`docs/getting-started/setup-guide/` is where per-feature guides live (`data-quality-checks.md`, `output-controls.md`, `report-aggregations.md`, `joinable-data-marts.md`). Data Last Updated sits beside Data Quality Checks because the two answer neighbouring questions about a Data Mart's state — and because they need explicit disambiguation:

- Data Quality ships a check named **"Data freshness"** that validates a timestamp *field inside the data* against a configured threshold.
- **Data Last Updated** is *storage metadata*: when the source tables were last written to.

The page spells out the difference with the backfill example (Data Last Updated says "today", the Data freshness check still fails), so the adjacent names stop being a trap.

## What the page covers

- What the value means: a storage write time, not data recency; **Unknown** = could not determine (neither stale nor fresh); **≥** = partial coverage, a floor.
- Where it appears: Data Mart page tile, sortable list column, canvas clock icon + toolbar sweep, and the MCP `data_last_updated` block.
- How to check it: the two buttons; free of credits, no run recorded; a failed check never erases the last-known value.
- When it updates: manual checks persist; MCP measures live per query without overwriting; never on a schedule.
- How OWOX determines it: views resolved to base tables, sharded sets collapsed to the newest shard (prefix-only neighbours like `events_backup` excluded), external tables and the ~50-table cap reported as partial coverage.

## Verification

- `markdownlint-cli2`: 0 errors on both touched pages.
- Full docs site build (`apps/docs npm run build`) from this branch: 147 pages, links validation green — the new page, the sidebar entry, and both cross-links (including the `mcp.md#data-last-updated` anchor) resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
