### PR TITLE
fix(auth): disable Intercom chat in view-only sessions

### DIFF
--- a/apps/backend/src/idp/controllers/intercom.controller.spec.ts
+++ b/apps/backend/src/idp/controllers/intercom.controller.spec.ts
@@ -54,10 +54,10 @@ describe('IntercomController', () => {
     expect(Reflect.getMetadata(REJECT_API_KEY_AUTH_METADATA, IntercomController)).toBe(true);
   });
 
-  it('allows Intercom JWT issuance in view-only sessions', () => {
+  it('blocks Intercom JWT issuance in view-only sessions', () => {
     expect(
       Reflect.getMetadata(VIEW_ONLY_SAFE_METADATA, IntercomController.prototype.issueJwt)
-    ).toBe(true);
+    ).toBeUndefined();
   });
 
   it('should propagate BadRequestException from use-case', async () => {

--- a/apps/backend/src/idp/controllers/intercom.controller.ts
+++ b/apps/backend/src/idp/controllers/intercom.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Post, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Auth, AuthContext, RejectApiKeyAuth, ViewOnlySafe } from '../decorators';
+import { Auth, AuthContext, RejectApiKeyAuth } from '../decorators';
 import type { AuthorizationContext } from '../types';
 import { Role, Strategy } from '../types';
 import { IssueIntercomJwtService } from '../use-cases/issue-intercom-jwt.service';
@@ -17,8 +17,9 @@ export class IntercomController {
     private readonly mapper: IntercomMapper
   ) {}
 
+  // Not @ViewOnlySafe: view-only sessions must not get an Intercom JWT, so the
+  // widget can never boot for them (see IntercomChat on the client).
   @Auth(Role.viewer(Strategy.PARSE))
-  @ViewOnlySafe()
   @Post('jwt')
   @HttpCode(HttpStatus.OK)
   @IssueIntercomJwtSpec()

--- a/apps/web/src/app/intercom/IntercomChat.test.tsx
+++ b/apps/web/src/app/intercom/IntercomChat.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../store/hooks', () => {
 vi.mock('../../features/idp', () => {
   return {
     useAuth: vi.fn(),
+    isViewOnlySession: (user: { viewOnly?: boolean } | null) => user?.viewOnly === true,
   };
 });
 
@@ -101,6 +102,20 @@ describe('IntercomChat', () => {
     render(<IntercomChat />);
 
     expect(document.getElementById('intercom-widget-script')).toBeNull();
+    expect(intercomSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not load Intercom in a view-only session', () => {
+    (useFlags as any).mockReturnValue({
+      flags: { INTERCOM_APP_ID: 'app_view_only' },
+      callState: RequestStatus.LOADED,
+    });
+    (useAuth as any).mockReturnValue({ user: { id: 'u4', viewOnly: true } });
+
+    render(<IntercomChat />);
+
+    expect(document.getElementById('intercom-widget-script')).toBeNull();
+    expect(apiClient.post).not.toHaveBeenCalled();
     expect(intercomSpy).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/intercom/IntercomChat.tsx
+++ b/apps/web/src/app/intercom/IntercomChat.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useFlags } from '../store/hooks';
 import { RequestStatus } from '../../shared/types/request-status';
-import { useAuth, type User } from '../../features/idp';
+import { isViewOnlySession, useAuth, type User } from '../../features/idp';
 import apiClient from '../api/apiClient';
 import { resetIntercomLauncher } from './intercomUtils';
 
@@ -75,9 +75,7 @@ function buildIntercomPayload(appId: string, user: User): IntercomPayload {
   return payload;
 }
 
-async function initializeIntercom(appId: string, user: User | null): Promise<void> {
-  if (!user) return;
-
+async function initializeIntercom(appId: string, user: User): Promise<void> {
   const payload = buildIntercomPayload(appId, user);
 
   const token = await fetchIntercomJwt();
@@ -97,6 +95,12 @@ async function initializeIntercom(appId: string, user: User | null): Promise<voi
   }
 }
 
+/**
+ * Boots the Intercom widget when configured via app flags.
+ * Skipped entirely in view-only sessions: the script is never loaded, so
+ * `window.Intercom` stays undefined and `openIntercom()` becomes a no-op.
+ * The backend also refuses to issue an Intercom JWT for such sessions.
+ */
 export function IntercomChat(): null {
   const { flags, callState } = useFlags();
   const { user } = useAuth();
@@ -105,7 +109,9 @@ export function IntercomChat(): null {
 
   useEffect(() => {
     if (initializedRef.current) return;
-    if (callState !== RequestStatus.LOADED || !flags) return;
+    // Fail closed until auth resolves: do not load Intercom without a known user.
+    if (callState !== RequestStatus.LOADED || !flags || !user) return;
+    if (isViewOnlySession(user)) return;
 
     const rawAppId = flags[INTERCOM_APP_ID_FLAG];
     const appId = (typeof rawAppId === 'string' ? rawAppId : '').trim();


### PR DESCRIPTION
## What

View-only sessions already skip GTM, client analytics and PostHog session recordings. Intercom was still reachable there, so a read-only viewer could start a chat.

## Changes

- **backend** — dropped `@ViewOnlySafe()` from `POST /intercom/jwt`. The IDP guard now rejects view-only sessions, so no Intercom JWT is issued. Since the widget refuses to boot without a JWT (existing security policy), this alone blocks the chat even if the client is bypassed.
- **web** — `IntercomChat` skips loading the widget script for view-only sessions (and fails closed until auth resolves). `window.Intercom` stays undefined, so `openIntercom()` becomes a no-op.

Mirrors the pattern already used by `GoogleTagManager`.

## Notes

- The "Online Chat" item in the Help menu stays visible but does nothing in view-only. Deliberately left alone to keep the diff minimal — can be hidden later if it becomes an issue.
- Same known limitation as GTM: a session flipping normal → view-only mid-SPA does not tear down an already-booted widget without a page reload.

## Testing

- `apps/web` — `IntercomChat.test.tsx` 6/6, incl. a new "does not load Intercom in a view-only session" case
- `apps/backend` — `intercom.controller.spec.ts` 4/4, the view-only metadata test flipped to assert the endpoint is *not* view-only-safe
- `tsc --noEmit`, eslint and prettier clean on both workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)