### PR TITLE
fix(data-marts): authorize the copy source and support copying from several Data Marts

### DIFF
--- a/.changeset/6784-authorize-copy-source-data-mart.md
+++ b/.changeset/6784-authorize-copy-source-data-mart.md
@@ -1,0 +1,15 @@
+---
+'owox': minor
+---
+
+# Fix: copying a connector configuration now requires access to the Data Mart it comes from
+
+Reusing another Data Mart's connector configuration through "Copy from..."
+brings that Data Mart's stored credentials along with it, but only the Data
+Mart being edited was checked for permission. A user could therefore copy from
+a Data Mart that was never shared with them.
+
+Copying now requires the same permission as it does for storages and
+destinations: you must own the source Data Mart, or it must be shared with you
+for maintenance. Copying from a Data Mart shared only for reporting, or not
+shared at all, is refused.

--- a/.changeset/6785-copy-configurations-from-several-data-marts.md
+++ b/.changeset/6785-copy-configurations-from-several-data-marts.md
@@ -1,0 +1,15 @@
+---
+'owox': minor
+---
+
+# Fix: copying configurations from more than one Data Mart in a single save
+
+Adding one connector configuration copied from one Data Mart and another
+copied from a different one failed the whole save with a generic server error,
+losing both edits. Only the first source was sent to the server, which then
+tried to find every copied configuration in it.
+
+Each copied configuration is now resolved against the Data Mart it was actually
+copied from, so a single save can draw on as many as you like. Copying a
+configuration that has since been deleted from its source now reports what
+happened instead of failing as an unexpected error.

--- a/apps/backend/src/data-marts/dto/domain/update-data-mart-definition.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/update-data-mart-definition.command.ts
@@ -8,7 +8,6 @@ export class UpdateDataMartDefinitionCommand {
     public readonly definitionType: DataMartDefinitionType,
     public readonly definition: DataMartDefinition,
     public readonly sourceDataMartId?: string,
-    public readonly sourceConfigurationId?: string,
     public readonly userId: string = '',
     public readonly roles: string[] = []
   ) {}

--- a/apps/backend/src/data-marts/dto/presentation/update-data-mart-definition-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-data-mart-definition-api.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { DataMartDefinition } from '../schemas/data-mart-table-definitions/data-mart-definition';
 import { DataMartDefinitionType } from '../../enums/data-mart-definition-type.enum';
-import { IsEnum, IsNotEmptyObject, IsOptional, IsUUID, IsString } from 'class-validator';
+import { IsEnum, IsNotEmptyObject, IsOptional, IsUUID } from 'class-validator';
 
 export class UpdateDataMartDefinitionApiDto {
   @ApiProperty({ enum: DataMartDefinitionType, example: DataMartDefinitionType.SQL })
@@ -12,13 +12,13 @@ export class UpdateDataMartDefinitionApiDto {
   @IsNotEmptyObject()
   definition: DataMartDefinition;
 
-  @ApiProperty({ required: false, description: 'Source Data Mart ID to copy secrets from' })
+  @ApiProperty({
+    required: false,
+    description:
+      'Source Data Mart ID to copy secrets from. Only used for copied configuration items ' +
+      'that do not name their own source in _copiedFrom.dataMartId.',
+  })
   @IsOptional()
   @IsUUID()
   sourceDataMartId?: string;
-
-  @ApiProperty({ required: false, description: 'Source configuration ID to copy from' })
-  @IsOptional()
-  @IsString()
-  sourceConfigurationId?: string;
 }

--- a/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/data-mart.mapper.ts
@@ -235,7 +235,6 @@ export class DataMartMapper {
       dto.definitionType,
       dto.definition,
       dto.sourceDataMartId,
-      dto.sourceConfigurationId,
       context.userId,
       context.roles ?? []
     );

--- a/apps/backend/src/data-marts/services/access-decision/access-decision-e2e.spec.ts
+++ b/apps/backend/src/data-marts/services/access-decision/access-decision-e2e.spec.ts
@@ -227,6 +227,93 @@ describe('AccessDecisionService — E2E sharing flows', () => {
     });
   });
 
+  describe('Scenario: Copy credentials from a DataMart', () => {
+    const mockDataMart = (
+      m: ReturnType<typeof createService>,
+      sharing: { availableForReporting: boolean; availableForMaintenance: boolean },
+      isTechOwner = false
+    ) => {
+      m.dataMartRepository.findOne.mockResolvedValue({ id: 'dm-1', ...sharing });
+      m.dataMartTechnicalOwnerRepository.count.mockResolvedValue(isTechOwner ? 1 : 0);
+      m.dataMartBusinessOwnerRepository.count.mockResolvedValue(0);
+    };
+
+    it('should deny COPY_CREDENTIALS on a not-shared DataMart', async () => {
+      const m = createService();
+      mockDataMart(m, { availableForReporting: false, availableForMaintenance: false });
+
+      const result = await m.service.canAccess(
+        'tu-user',
+        ['editor'],
+        EntityType.DATA_MART,
+        'dm-1',
+        Action.COPY_CREDENTIALS,
+        'proj-1'
+      );
+      expect(result).toBe(false);
+    });
+
+    it('should deny COPY_CREDENTIALS on a DataMart shared for reporting only', async () => {
+      const m = createService();
+      mockDataMart(m, { availableForReporting: true, availableForMaintenance: false });
+
+      const result = await m.service.canAccess(
+        'tu-user',
+        ['editor'],
+        EntityType.DATA_MART,
+        'dm-1',
+        Action.COPY_CREDENTIALS,
+        'proj-1'
+      );
+      expect(result).toBe(false);
+    });
+
+    it('should allow COPY_CREDENTIALS on a DataMart shared for maintenance', async () => {
+      const m = createService();
+      mockDataMart(m, { availableForReporting: false, availableForMaintenance: true });
+
+      const result = await m.service.canAccess(
+        'tu-user',
+        ['editor'],
+        EntityType.DATA_MART,
+        'dm-1',
+        Action.COPY_CREDENTIALS,
+        'proj-1'
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should allow COPY_CREDENTIALS for the technical owner', async () => {
+      const m = createService();
+      mockDataMart(m, { availableForReporting: false, availableForMaintenance: false }, true);
+
+      const result = await m.service.canAccess(
+        'tu-user',
+        ['editor'],
+        EntityType.DATA_MART,
+        'dm-1',
+        Action.COPY_CREDENTIALS,
+        'proj-1'
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should deny COPY_CREDENTIALS to a BU even when shared for maintenance', async () => {
+      const m = createService();
+      mockDataMart(m, { availableForReporting: false, availableForMaintenance: true });
+
+      const result = await m.service.canAccess(
+        'bu-user',
+        ['viewer'],
+        EntityType.DATA_MART,
+        'dm-1',
+        Action.COPY_CREDENTIALS,
+        'proj-1'
+      );
+      expect(result).toBe(false);
+    });
+  });
+
   describe('Scenario: Copy credentials: non-owner on "Shared for use" → 403', () => {
     it('should deny COPY_CREDENTIALS on shared-for-use destination', async () => {
       const m = createService();

--- a/apps/backend/src/data-marts/services/access-decision/access-matrix.config.ts
+++ b/apps/backend/src/data-marts/services/access-decision/access-matrix.config.ts
@@ -47,6 +47,7 @@ function allActions(entityType: EntityType): Action[] {
       return [
         Action.SEE,
         Action.USE,
+        Action.COPY_CREDENTIALS,
         Action.EDIT,
         Action.DELETE,
         Action.CONFIGURE_SHARING,
@@ -244,11 +245,16 @@ const dmNonOwnerTuSharedReporting: AccessRule[] = dmActions.flatMap(action => {
   );
 });
 
-// Non-owner TU + Shared for maintenance = SEE + USE + EDIT + DELETE + MANAGE_TRIGGERS
+// Non-owner TU + Shared for maintenance
+// = SEE + USE + COPY_CREDENTIALS + EDIT + DELETE + MANAGE_TRIGGERS
+// COPY_CREDENTIALS follows EDIT here, as it does for Storage and Destination:
+// whoever may edit the Data Mart's connector configuration can already run it
+// with those credentials, so copying them grants no further capability.
 const dmNonOwnerTuSharedMaint: AccessRule[] = dmActions.flatMap(action => {
   const allowed = [
     Action.SEE,
     Action.USE,
+    Action.COPY_CREDENTIALS,
     Action.EDIT,
     Action.DELETE,
     Action.MANAGE_TRIGGERS,
@@ -268,6 +274,7 @@ const dmNonOwnerTuSharedBoth: AccessRule[] = dmActions.flatMap(action => {
   const allowed = [
     Action.SEE,
     Action.USE,
+    Action.COPY_CREDENTIALS,
     Action.EDIT,
     Action.DELETE,
     Action.MANAGE_TRIGGERS,

--- a/apps/backend/src/data-marts/services/connector/connector-secret.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-secret.service.spec.ts
@@ -101,6 +101,49 @@ describe('ConnectorSecretService', () => {
   });
 
   describe('mergeDefinitionSecrets', () => {
+    // The merge only ever dereferences a pointer this DataMart already has
+    // stored. That is what lets a Data Mart still carrying a pointer into
+    // another one's record recover its values (extractAndSaveSecrets then forks
+    // them onto a record of its own), while a pointer supplied by the caller
+    // buys nothing.
+    it('never loads secrets for a _secrets_id supplied by the caller', async () => {
+      const { service, credentialsService } = createService(['AccessToken']);
+
+      const previous = makeDefinition([{ _id: 'a', _secrets_id: 'ours', AccountIDs: '33' }]);
+      const incoming = makeDefinition([
+        // Unknown _id, plus a pointer at another DataMart's record.
+        { _id: 'invented', _secrets_id: 'belongs-to-another-datamart', AccessToken: SECRET_MASK },
+      ]);
+
+      const merged = await service.mergeDefinitionSecrets(incoming, previous);
+      const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
+
+      expect(credentialsService.getCredentialsById).not.toHaveBeenCalled();
+      // Nothing was resolved, so the mask stands - and extractAndSaveSecrets
+      // drops it rather than storing it as a credential.
+      expect(cfg[0].AccessToken).toBe(SECRET_MASK);
+    });
+
+    it('replaces a caller-supplied _secrets_id with the stored one', async () => {
+      const { service, credentialsService } = createService(['AccessToken']);
+      (credentialsService.getCredentialsById as jest.Mock).mockResolvedValue({
+        id: 'ours',
+        credentials: { AccessToken: 'our-token' },
+      });
+
+      const previous = makeDefinition([{ _id: 'a', _secrets_id: 'ours', AccountIDs: '33' }]);
+      const incoming = makeDefinition([
+        { _id: 'a', _secrets_id: 'belongs-to-another-datamart', AccessToken: SECRET_MASK },
+      ]);
+
+      const merged = await service.mergeDefinitionSecrets(incoming, previous);
+      const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
+
+      expect(credentialsService.getCredentialsById).toHaveBeenCalledWith('ours');
+      expect(cfg[0]._secrets_id).toBe('ours');
+      expect(cfg[0].AccessToken).toBe('our-token');
+    });
+
     it('keeps previous secret when incoming has SECRET_MASK', async () => {
       const { service } = createService(['AccessToken']);
       const previous = makeDefinition([

--- a/apps/backend/src/data-marts/services/connector/connector-secret.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-secret.service.spec.ts
@@ -1,3 +1,4 @@
+import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
 import type { ConnectorDefinition } from '../../dto/schemas/data-mart-table-definitions/connector-definition.schema';
 import { ConnectorService } from './connector.service';
 import { ConnectorSecretService, SECRET_MASK } from './connector-secret.service';
@@ -58,6 +59,12 @@ describe('ConnectorSecretService', () => {
       },
     } as unknown as ConnectorDefinition;
   };
+
+  // Copied items name their own source Data Mart; these cover the items that
+  // do not, which fall back to the source named by the request itself.
+  const SOURCE_DATA_MART_ID = 'source-datamart';
+  const fromSingleSource = (definition: ConnectorDefinition) =>
+    new Map([[SOURCE_DATA_MART_ID, definition]]);
 
   describe('mask', () => {
     it('masks secret fields using SECRET_MASK', async () => {
@@ -662,7 +669,7 @@ describe('ConnectorSecretService', () => {
         },
       ]);
 
-      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, fromSingleSource(sourceDefinition), SOURCE_DATA_MART_ID);
       const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
 
       expect(cfg[0].AccessToken).toBe('access1');
@@ -707,7 +714,7 @@ describe('ConnectorSecretService', () => {
         },
       ]);
 
-      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, fromSingleSource(sourceDefinition), SOURCE_DATA_MART_ID);
       const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
       const authType = cfg[0].AuthType as Record<string, Record<string, unknown>>;
 
@@ -746,7 +753,7 @@ describe('ConnectorSecretService', () => {
         },
       ]);
 
-      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, fromSingleSource(sourceDefinition), SOURCE_DATA_MART_ID);
       const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
       const authType = cfg[0].AuthType as Record<string, Record<string, unknown>>;
 
@@ -787,7 +794,7 @@ describe('ConnectorSecretService', () => {
         },
       ]);
 
-      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, fromSingleSource(sourceDefinition), SOURCE_DATA_MART_ID);
       const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
 
       expect(cfg[0]).not.toHaveProperty('generated_refresh_token');
@@ -816,8 +823,8 @@ describe('ConnectorSecretService', () => {
       } as unknown as ConnectorDefinition;
 
       await expect(
-        service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition)
-      ).rejects.toThrow('Cannot copy secrets from different connector type');
+        service.mergeDefinitionSecretsFromSource(incoming, fromSingleSource(sourceDefinition), SOURCE_DATA_MART_ID)
+      ).rejects.toThrow('Cannot copy a configuration between different connector types');
     });
 
     it('returns configuration as is when _copiedFrom.configId metadata is missing (existing config)', async () => {
@@ -833,7 +840,7 @@ describe('ConnectorSecretService', () => {
         },
       ]);
 
-      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, fromSingleSource(sourceDefinition), SOURCE_DATA_MART_ID);
       const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
 
       // Should return the item unchanged (will be merged with previous in the next step)
@@ -855,8 +862,61 @@ describe('ConnectorSecretService', () => {
       ]);
 
       await expect(
-        service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition)
-      ).rejects.toThrow('Source configuration with _id "non-existent-id" not found');
+        service.mergeDefinitionSecretsFromSource(incoming, fromSingleSource(sourceDefinition), SOURCE_DATA_MART_ID)
+      ).rejects.toThrow(BusinessViolationException);
+    });
+
+    it('copies each item from the Data Mart its own metadata names', async () => {
+      const { service, credentialsService } = createService(['AccessToken']);
+      (credentialsService.getCredentialsByIds as jest.Mock).mockResolvedValue(
+        new Map([
+          ['secrets-a', { id: 'secrets-a', credentials: { AccessToken: 'token-a' } }],
+          ['secrets-b', { id: 'secrets-b', credentials: { AccessToken: 'token-b' } }],
+        ])
+      );
+
+      const sourceA = makeDefinition([{ _id: 'a-1', _secrets_id: 'secrets-a', AccountIDs: '1' }]);
+      const sourceB = makeDefinition([{ _id: 'b-1', _secrets_id: 'secrets-b', AccountIDs: '2' }]);
+
+      const incoming = makeDefinition([
+        {
+          AccessToken: SECRET_MASK,
+          AccountIDs: '1',
+          _copiedFrom: { dataMartId: 'dm-a', configId: 'a-1' },
+        },
+        {
+          AccessToken: SECRET_MASK,
+          AccountIDs: '2',
+          _copiedFrom: { dataMartId: 'dm-b', configId: 'b-1' },
+        },
+      ]);
+
+      const merged = await service.mergeDefinitionSecretsFromSource(
+        incoming,
+        new Map([
+          ['dm-a', sourceA],
+          ['dm-b', sourceB],
+        ])
+      );
+      const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
+
+      expect(cfg[0].AccessToken).toBe('token-a');
+      expect(cfg[1].AccessToken).toBe('token-b');
+      expect(cfg[0]).not.toHaveProperty('_copiedFrom');
+      expect(cfg[1]).not.toHaveProperty('_copiedFrom');
+      expect(cfg[0]._id).not.toBe(cfg[1]._id);
+    });
+
+    it('rejects a copy whose source Data Mart was not resolved', async () => {
+      const { service } = createService(['AccessToken']);
+
+      const incoming = makeDefinition([
+        { AccessToken: SECRET_MASK, _copiedFrom: { dataMartId: 'dm-unknown', configId: 'a-1' } },
+      ]);
+
+      await expect(
+        service.mergeDefinitionSecretsFromSource(incoming, new Map())
+      ).rejects.toThrow(BusinessViolationException);
     });
 
     it('generates new _id for each copied configuration', async () => {
@@ -871,7 +931,7 @@ describe('ConnectorSecretService', () => {
         },
       ]);
 
-      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, fromSingleSource(sourceDefinition), SOURCE_DATA_MART_ID);
       const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
 
       expect(cfg[0]._id).not.toBe('source-1');
@@ -904,7 +964,7 @@ describe('ConnectorSecretService', () => {
         },
       ]);
 
-      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, fromSingleSource(sourceDefinition), SOURCE_DATA_MART_ID);
       const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
 
       // The value is carried over from the source's credentials record, but the
@@ -947,7 +1007,7 @@ describe('ConnectorSecretService', () => {
         },
       ]);
 
-      const merged = await service.mergeDefinitionSecretsFromSource(incoming, sourceDefinition);
+      const merged = await service.mergeDefinitionSecretsFromSource(incoming, fromSingleSource(sourceDefinition), SOURCE_DATA_MART_ID);
       const cfg = merged.connector.source.configuration as Array<Record<string, unknown>>;
 
       // First config (existing) should be unchanged

--- a/apps/backend/src/data-marts/services/connector/connector-secret.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-secret.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { randomUUID } from 'crypto';
+import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
 import { ConnectorDefinition } from '../../dto/schemas/data-mart-table-definitions/connector-definition.schema';
 import { ConnectorService } from './connector.service';
 import { ConnectorSourceCredentialsService } from './connector-source-credentials.service';
@@ -827,34 +828,33 @@ export class ConnectorSecretService {
    *    configuration array containing items with properly merged secrets from their
    *    respective source configurations.
    *
+   * Each copied item names its own source Data Mart, so one save may copy from
+   * several of them.
+   *
    * @param incoming New definition coming from the client, may have mixed configurations (some with _copiedFrom, some without)
-   * @param sourceDefinition Definition from the source Data Mart to copy secrets from
+   * @param sourceDefinitionsByDataMartId Definitions of every Data Mart being copied from, keyed by their id
+   * @param defaultSourceDataMartId Source used by copied items that name none (clients predating per-item sources)
    * @returns Definition with correctly merged secret values from source configurations
-   * @throws Error if connector types don't match
-   * @throws Error if source configuration with specified _id is not found (when _copiedFrom is present)
+   * @throws BusinessViolationException if connector types don't match
+   * @throws BusinessViolationException if the source Data Mart or configuration cannot be resolved
    */
   async mergeDefinitionSecretsFromSource(
     incoming: ConnectorDefinition,
-    sourceDefinition: ConnectorDefinition
+    sourceDefinitionsByDataMartId: Map<string, ConnectorDefinition>,
+    defaultSourceDataMartId?: string
   ): Promise<ConnectorDefinition> {
-    if (incoming.connector.source.name !== sourceDefinition.connector.source.name) {
-      throw new Error(
-        `Cannot copy secrets from different connector type. ` +
-          `Source: ${sourceDefinition.connector.source.name}, ` +
-          `Target: ${incoming.connector.source.name}`
-      );
-    }
-
     const secretFieldNames = await this.getAllSecretFieldNames(incoming.connector.source.name);
-    const sourceSecretsIds = sourceDefinition.connector.source.configuration
-      .map(item => (item as Record<string, unknown>)._secrets_id as string | undefined)
-      .filter((id): id is string => !!id);
+    const sourceSecretsIds = [...sourceDefinitionsByDataMartId.values()].flatMap(definition =>
+      definition.connector.source.configuration
+        .map(item => (item as Record<string, unknown>)._secrets_id as string | undefined)
+        .filter((id): id is string => !!id)
+    );
     const sourceSecretsMap =
       await this.connectorSourceCredentialsService.getCredentialsByIds(sourceSecretsIds);
 
     const mergedConfiguration = incoming.connector.source.configuration.map(incomingItem => {
       const itemWithMetadata = incomingItem as Record<string, unknown> & {
-        _copiedFrom?: { configId: string };
+        _copiedFrom?: { configId: string; dataMartId?: string };
       };
 
       if (!itemWithMetadata._copiedFrom?.configId) {
@@ -862,15 +862,36 @@ export class ConnectorSecretService {
       }
 
       const sourceConfigId = itemWithMetadata._copiedFrom.configId;
+      const sourceDataMartId = itemWithMetadata._copiedFrom.dataMartId ?? defaultSourceDataMartId;
+      const sourceDefinition = sourceDataMartId
+        ? sourceDefinitionsByDataMartId.get(sourceDataMartId)
+        : undefined;
+
+      if (!sourceDefinition) {
+        throw new BusinessViolationException(
+          'Cannot copy a configuration from a Data Mart that is not part of this request.',
+          { sourceDataMartId, sourceConfigId }
+        );
+      }
+
+      if (incoming.connector.source.name !== sourceDefinition.connector.source.name) {
+        throw new BusinessViolationException(
+          `Cannot copy a configuration between different connector types. ` +
+            `Source: ${sourceDefinition.connector.source.name}, ` +
+            `target: ${incoming.connector.source.name}.`,
+          { sourceDataMartId, sourceConfigId }
+        );
+      }
 
       const sourceConfig = sourceDefinition.connector.source.configuration.find(
         config => (config as Record<string, unknown> & { _id?: string })._id === sourceConfigId
       );
 
       if (!sourceConfig) {
-        throw new Error(
-          `Source configuration with _id "${sourceConfigId}" not found. ` +
-            `Source has ${sourceDefinition.connector.source.configuration.length} configurations.`
+        throw new BusinessViolationException(
+          'The copied configuration no longer exists in the Data Mart it came from. ' +
+            'Reopen the source Data Mart and copy the configuration again.',
+          { sourceDataMartId, sourceConfigId }
         );
       }
 

--- a/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.spec.ts
@@ -112,7 +112,6 @@ describe('CopyReportAsDataMartService', () => {
         DataMartDefinitionType.SQL,
         { sqlQuery: 'SELECT 1' },
         undefined,
-        undefined,
         'user-1',
         ['editor']
       )

--- a/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/copy-report-as-data-mart.service.ts
@@ -107,7 +107,6 @@ export class CopyReportAsDataMartService {
         DataMartDefinitionType.SQL,
         { sqlQuery: sql } as SqlDefinition,
         undefined,
-        undefined,
         command.userId,
         command.roles
       )

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.spec.ts
@@ -76,7 +76,6 @@ describe('UpdateDataMartDefinitionService', () => {
         definitionType,
         definition,
         undefined,
-        undefined,
         'user-1',
         ['editor']
       );
@@ -146,7 +145,6 @@ describe('UpdateDataMartDefinitionService', () => {
       DataMartDefinitionType.CONNECTOR,
       incomingDefinition as any,
       'dm-source',
-      undefined,
       'user-1',
       ['editor']
     );
@@ -155,7 +153,8 @@ describe('UpdateDataMartDefinitionService', () => {
 
     expect(connectorSecretService.mergeDefinitionSecretsFromSource).toHaveBeenCalledWith(
       incomingDefinition,
-      sourceDataMart.definition
+      new Map([['dm-source', sourceDataMart.definition]]),
+      'dm-source'
     );
     expect(connectorSecretService.mergeDefinitionSecrets).toHaveBeenCalledWith(
       mergedFromSource,
@@ -167,6 +166,112 @@ describe('UpdateDataMartDefinitionService', () => {
       previousDefinition
     );
     expect(dataMart.definition).toBe(savedDefinition);
+  });
+
+  it('copies configurations from several Data Marts in one save', async () => {
+    const { service, dataMartService, accessDecisionService, connectorSecretService, dataMart } =
+      createService();
+
+    dataMart.definitionType = DataMartDefinitionType.CONNECTOR;
+
+    const makeSource = (id: string, configId: string) => ({
+      id,
+      projectId: 'proj-1',
+      definitionType: DataMartDefinitionType.CONNECTOR,
+      definition: {
+        connector: {
+          source: { name: 'FacebookMarketing', configuration: [{ _id: configId }] },
+        },
+      },
+    });
+    const sourceA = makeSource('dm-a', 'a-1');
+    const sourceB = makeSource('dm-b', 'b-1');
+    dataMartService.getByIdAndProjectId.mockImplementation(async (id: string) => {
+      if (id === 'dm-a') return sourceA;
+      if (id === 'dm-b') return sourceB;
+      return dataMart;
+    });
+    connectorSecretService.extractAndSaveSecrets.mockResolvedValue({
+      connector: { source: { name: 'FacebookMarketing', configuration: [] } },
+    });
+
+    const incomingDefinition = {
+      connector: {
+        source: {
+          name: 'FacebookMarketing',
+          configuration: [
+            { _copiedFrom: { dataMartId: 'dm-a', configId: 'a-1' } },
+            { _copiedFrom: { dataMartId: 'dm-b', configId: 'b-1' } },
+          ],
+        },
+      },
+    };
+    const command = new UpdateDataMartDefinitionCommand(
+      'dm-1',
+      'proj-1',
+      DataMartDefinitionType.CONNECTOR,
+      incomingDefinition as any,
+      // The client still sends the first source only; the per-item metadata is
+      // what actually resolves each copy.
+      'dm-a',
+      'user-1',
+      ['editor']
+    );
+
+    await service.run(command);
+
+    // Both sources are authorized, and both definitions reach the merge.
+    for (const sourceDataMartId of ['dm-a', 'dm-b']) {
+      expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+        'user-1',
+        ['editor'],
+        EntityType.DATA_MART,
+        sourceDataMartId,
+        Action.COPY_CREDENTIALS,
+        'proj-1'
+      );
+    }
+    expect(connectorSecretService.mergeDefinitionSecretsFromSource).toHaveBeenCalledWith(
+      incomingDefinition,
+      new Map([
+        ['dm-a', sourceA.definition],
+        ['dm-b', sourceB.definition],
+      ]),
+      'dm-a'
+    );
+    expect(dataMartService.save).toHaveBeenCalled();
+  });
+
+  it('refuses the whole save when one of several copy sources is not permitted', async () => {
+    const { service, connectorSecretService, accessDecisionService, dataMart } = createService();
+
+    dataMart.definitionType = DataMartDefinitionType.CONNECTOR;
+    accessDecisionService.canAccess.mockImplementation(
+      async (...args: unknown[]) => args[4] !== Action.COPY_CREDENTIALS || args[3] !== 'dm-b'
+    );
+
+    const command = new UpdateDataMartDefinitionCommand(
+      'dm-1',
+      'proj-1',
+      DataMartDefinitionType.CONNECTOR,
+      {
+        connector: {
+          source: {
+            name: 'FacebookMarketing',
+            configuration: [
+              { _copiedFrom: { dataMartId: 'dm-a', configId: 'a-1' } },
+              { _copiedFrom: { dataMartId: 'dm-b', configId: 'b-1' } },
+            ],
+          },
+        },
+      } as any,
+      undefined,
+      'user-1',
+      ['editor']
+    );
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+    expect(connectorSecretService.mergeDefinitionSecretsFromSource).not.toHaveBeenCalled();
   });
 
   it('refuses to copy a configuration from a Data Mart the user cannot copy credentials from', async () => {
@@ -192,7 +297,6 @@ describe('UpdateDataMartDefinitionService', () => {
         },
       } as any,
       'dm-source',
-      undefined,
       'user-1',
       ['editor']
     );
@@ -222,7 +326,6 @@ describe('UpdateDataMartDefinitionService', () => {
       'proj-1',
       DataMartDefinitionType.TABLE,
       { tableName: 'my_table' },
-      undefined,
       undefined,
       'user-1',
       ['editor']

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.spec.ts
@@ -8,6 +8,7 @@ import { UpdateDataMartDefinitionService } from './update-data-mart-definition.s
 import { UpdateDataMartDefinitionCommand } from '../dto/domain/update-data-mart-definition.command';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
+import { EntityType, Action } from '../services/access-decision';
 
 describe('UpdateDataMartDefinitionService', () => {
   const createService = () => {
@@ -166,6 +167,50 @@ describe('UpdateDataMartDefinitionService', () => {
       previousDefinition
     );
     expect(dataMart.definition).toBe(savedDefinition);
+  });
+
+  it('refuses to copy a configuration from a Data Mart the user cannot copy credentials from', async () => {
+    const { service, dataMartService, accessDecisionService, connectorSecretService, dataMart } =
+      createService();
+
+    dataMart.definitionType = DataMartDefinitionType.CONNECTOR;
+    // EDIT on the target is granted, COPY_CREDENTIALS on the source is not.
+    accessDecisionService.canAccess.mockImplementation(async (...args: unknown[]) =>
+      args[4] !== Action.COPY_CREDENTIALS
+    );
+
+    const command = new UpdateDataMartDefinitionCommand(
+      'dm-1',
+      'proj-1',
+      DataMartDefinitionType.CONNECTOR,
+      {
+        connector: {
+          source: {
+            name: 'FacebookMarketing',
+            configuration: [{ _copiedFrom: { configId: 'src-1' } }],
+          },
+        },
+      } as any,
+      'dm-source',
+      undefined,
+      'user-1',
+      ['editor']
+    );
+
+    await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+
+    expect(accessDecisionService.canAccess).toHaveBeenCalledWith(
+      'user-1',
+      ['editor'],
+      EntityType.DATA_MART,
+      'dm-source',
+      Action.COPY_CREDENTIALS,
+      'proj-1'
+    );
+    // The source is never read and no secrets are touched.
+    expect(dataMartService.getByIdAndProjectId).not.toHaveBeenCalledWith('dm-source', 'proj-1');
+    expect(connectorSecretService.mergeDefinitionSecretsFromSource).not.toHaveBeenCalled();
+    expect(dataMartService.save).not.toHaveBeenCalled();
   });
 
   it('should throw ForbiddenException when user has no edit access to data mart', async () => {

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.ts
@@ -29,6 +29,43 @@ export class UpdateDataMartDefinitionService {
     private readonly advancedSearchIndexSync?: AdvancedSearchIndexSyncService
   ) {}
 
+  /**
+   * Collects the Data Marts a save copies configurations from.
+   *
+   * Each copied item names its own source, so one save can draw on several.
+   * `command.sourceDataMartId` covers items that name none, which is what
+   * clients predating per-item sources send.
+   */
+  private collectSourceDataMartIds(
+    definition: ConnectorDefinition,
+    command: UpdateDataMartDefinitionCommand
+  ): string[] {
+    const sourceDataMartIds = new Set<string>();
+
+    for (const item of definition.connector?.source?.configuration || []) {
+      const copiedFrom = (item as Record<string, unknown>)._copiedFrom as
+        | { dataMartId?: string; configId?: string }
+        | undefined;
+
+      if (!copiedFrom?.configId) {
+        continue;
+      }
+
+      const sourceDataMartId = copiedFrom.dataMartId ?? command.sourceDataMartId;
+      if (sourceDataMartId) {
+        sourceDataMartIds.add(sourceDataMartId);
+      }
+    }
+
+    // A source named by the request but by no item still has to be honoured:
+    // older clients sent the id without marking up the items.
+    if (sourceDataMartIds.size === 0 && command.sourceDataMartId) {
+      sourceDataMartIds.add(command.sourceDataMartId);
+    }
+
+    return [...sourceDataMartIds];
+  }
+
   async run(command: UpdateDataMartDefinitionCommand): Promise<DataMartDto> {
     const dataMart = await this.dataMartService.getByIdAndProjectId(command.id, command.projectId);
 
@@ -72,43 +109,55 @@ export class UpdateDataMartDefinitionService {
       const connectorDefinition = command.definition as ConnectorDefinition;
       let mergedDefinition: ConnectorDefinition;
 
-      if (command.sourceDataMartId) {
+      const sourceDataMartIds = this.collectSourceDataMartIds(connectorDefinition, command);
+
+      if (sourceDataMartIds.length > 0) {
+        const sourceDefinitions = new Map<string, ConnectorDefinition>();
+
         // Copying a configuration carries the source's stored credentials into
         // this Data Mart, so it takes permission on the source and not only on
-        // the target being edited.
+        // the target being edited. Every source is checked before any of them is
+        // read, so a save that is not fully permitted touches nothing.
         if (command.userId) {
-          const canCopyCredentials = await this.accessDecisionService.canAccess(
-            command.userId,
-            command.roles,
-            EntityType.DATA_MART,
-            command.sourceDataMartId,
-            Action.COPY_CREDENTIALS,
-            command.projectId
-          );
-          if (!canCopyCredentials) {
-            throw new ForbiddenException(
-              'You do not have permission to copy the configuration of this DataMart'
+          for (const sourceDataMartId of sourceDataMartIds) {
+            const canCopyCredentials = await this.accessDecisionService.canAccess(
+              command.userId,
+              command.roles,
+              EntityType.DATA_MART,
+              sourceDataMartId,
+              Action.COPY_CREDENTIALS,
+              command.projectId
             );
+            if (!canCopyCredentials) {
+              throw new ForbiddenException(
+                'You do not have permission to copy the configuration of this DataMart'
+              );
+            }
           }
         }
 
-        const sourceDataMart = await this.dataMartService.getByIdAndProjectId(
-          command.sourceDataMartId,
-          command.projectId
-        );
-
-        if (
-          !sourceDataMart.definition ||
-          sourceDataMart.definitionType !== DataMartDefinitionType.CONNECTOR
-        ) {
-          throw new BusinessViolationException(
-            'Source Data Mart does not have a connector definition'
+        for (const sourceDataMartId of sourceDataMartIds) {
+          const sourceDataMart = await this.dataMartService.getByIdAndProjectId(
+            sourceDataMartId,
+            command.projectId
           );
+
+          if (
+            !sourceDataMart.definition ||
+            sourceDataMart.definitionType !== DataMartDefinitionType.CONNECTOR
+          ) {
+            throw new BusinessViolationException(
+              'Source Data Mart does not have a connector definition'
+            );
+          }
+
+          sourceDefinitions.set(sourceDataMartId, sourceDataMart.definition as ConnectorDefinition);
         }
 
         mergedDefinition = await this.connectorSecretService.mergeDefinitionSecretsFromSource(
           connectorDefinition,
-          sourceDataMart.definition as ConnectorDefinition
+          sourceDefinitions,
+          command.sourceDataMartId
         );
 
         mergedDefinition = await this.connectorSecretService.mergeDefinitionSecrets(

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.ts
@@ -73,6 +73,25 @@ export class UpdateDataMartDefinitionService {
       let mergedDefinition: ConnectorDefinition;
 
       if (command.sourceDataMartId) {
+        // Copying a configuration carries the source's stored credentials into
+        // this Data Mart, so it takes permission on the source and not only on
+        // the target being edited.
+        if (command.userId) {
+          const canCopyCredentials = await this.accessDecisionService.canAccess(
+            command.userId,
+            command.roles,
+            EntityType.DATA_MART,
+            command.sourceDataMartId,
+            Action.COPY_CREDENTIALS,
+            command.projectId
+          );
+          if (!canCopyCredentials) {
+            throw new ForbiddenException(
+              'You do not have permission to copy the configuration of this DataMart'
+            );
+          }
+        }
+
         const sourceDataMart = await this.dataMartService.getByIdAndProjectId(
           command.sourceDataMartId,
           command.projectId

--- a/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
+++ b/apps/web/src/features/data-marts/edit/model/context/DataMartContext.tsx
@@ -329,6 +329,10 @@ export function DataMartProvider({ children }: DataMartProviderProps) {
           case DataMartDefinitionType.CONNECTOR: {
             const connectorDef = definition as ConnectorDefinitionConfig;
 
+            // Each copied configuration carries its own source, and they need
+            // not agree: the backend resolves every item against the Data Mart
+            // named in its own _copiedFrom. sourceDataMartId stays in the
+            // request for older backends, which only understand one source.
             let sourceDataMartId: string | undefined;
 
             for (const config of connectorDef.connector.source.configuration) {

--- a/apps/web/src/features/data-marts/shared/types/api/request/update-data-mart-connector-definition.request.dto.ts
+++ b/apps/web/src/features/data-marts/shared/types/api/request/update-data-mart-connector-definition.request.dto.ts
@@ -5,5 +5,4 @@ export interface UpdateDataMartConnectorDefinitionRequestDto {
   definitionType: DataMartDefinitionType.CONNECTOR;
   definition: ConnectorDefinitionDto;
   sourceDataMartId?: string;
-  sourceConfigurationId?: string;
 }


### PR DESCRIPTION
Stacked on #1480 — the base is that branch, so this diff shows only the two commits below. GitHub retargets it to `main` once #1480 merges.

Both commits are about the same thing: how **Copy from…** resolves the Data Mart a configuration comes from. They rewrite the same block of `update-data-mart-definition.service.ts`, which is why they travel together.

## 1. Copying requires permission on the source Data Mart

Copying a configuration carries the source's stored credentials into the target, but only the Data Mart being edited was authorized. The source named by `sourceDataMartId` was fetched with `getByIdAndProjectId` — by project alone.

Per-Data-Mart access is a real boundary here: `apply-data-mart-visibility-filter` hides Data Marts that are neither owned nor shared, and the matrix denies a non-owner with no sharing every action. So an editor could name a Data Mart invisible to them as the copy source and have its secret values merged into a configuration their own connector then runs with. The ids needed are discoverable from `GET /data-marts/by-connector/:connectorName`, which is viewer-level and applies no visibility filter.

The copy now requires `COPY_CREDENTIALS` on the source, matching what `create-data-destination` and `update-data-storage` already do for their own copy flows. The action was missing from `EntityType.DATA_MART` entirely, so the matrix never modelled this case. It follows `EDIT`: granted to the technical owner, and to a non-owner when the Data Mart is shared for maintenance. **Sharing for reporting does not grant it** — that shares the data, not the credentials behind it.

Rationale for tying it to `EDIT`: whoever may edit a Data Mart's connector configuration can already run it with those credentials, so copying them grants no further capability.

## 2. Each copied configuration resolves against its own source

Copying one configuration from Data Mart A and another from Data Mart B in a single save failed the whole update with a 500 and lost both edits. The client derived a single `sourceDataMartId` from the first copied item, and the server then looked for every `_copiedFrom.configId` in that one Data Mart — the second item was never found and the merge threw a bare `Error`, which the global filter reports as an internal error.

Each copied item already records its origin in `_copiedFrom.dataMartId` and the web client already sends it; the server simply never read it. The merge now resolves each item against its own source, so one save may draw on as many sources as it likes. **No frontend change was needed.**

`sourceDataMartId` stays in the request as the source for items that name none, which is what clients predating the per-item metadata send.

Two things fall out of this:

- **Every source is authorized before any is read**, so a save that is only partly permitted touches nothing, rather than failing on whichever source happened to be loaded first.
- **Failures are domain errors now.** Copying between different connector types, naming a source that is not part of the request, and copying a configuration that no longer exists in its source all raise `BusinessViolationException` → 400 with a message the user can act on.

Also removed `sourceConfigurationId`, which was declared on the API DTO, the command and the mapper but never read by any use case nor sent by the web client.

## Tests

`access-decision-e2e.spec.ts`, `update-data-mart-definition.service.spec.ts`, `connector-secret.service.spec.ts`, `copy-report-as-data-mart.service.spec.ts`.

New: `COPY_CREDENTIALS` denied on a not-shared Data Mart, denied when shared for reporting only, allowed when shared for maintenance, allowed for the technical owner, denied to a business user throughout; the use case refusing a copy from a Data Mart the user cannot copy from, and touching nothing when it does; copying from two Data Marts in one save, with both authorized and both definitions reaching the merge; the whole save refused when one of several sources is not permitted; and a copy whose source was not resolved.

Backend and web typecheck and lint are clean on the changed files; CI runs the full suites.
