### PR TITLE
fix(data-quality): optimize saves and relationship checks

### DIFF
--- a/apps/backend/src/data-marts/data-quality/__snapshots__/data-quality-check-compiler.spec.ts.snap
+++ b/apps/backend/src/data-marts/data-quality/__snapshots__/data-quality-check-compiler.spec.ts.snap
@@ -626,11 +626,13 @@ WITH
 
   dq_violations AS (
     SELECT
-      *
-    FROM dq_source
+      source."amount" AS negative_value,
+      source."id" AS primary_key_value_1,
+      source."tenant_id" AS primary_key_value_2
+    FROM dq_source AS source
     WHERE
-      "amount" IS NOT NULL
-      AND "amount" < 0
+      source."amount" IS NOT NULL
+      AND source."amount" < 0
   ),
 
   dq_summary AS (
@@ -643,9 +645,9 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation."amount" AS negative_value,
-      violation."id" AS primary_key_value_1,
-      violation."tenant_id" AS primary_key_value_2
+      violation.negative_value AS negative_value,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -694,7 +696,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      source.*
+      source."tenant_id" AS source_join_value_1,
+      source."customer_id" AS source_join_value_2,
+      source."id" AS primary_key_value_1,
+      source."tenant_id" AS primary_key_value_2
     FROM dq_source AS source
     WHERE
       source."tenant_id" IS NOT NULL
@@ -719,10 +724,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation."tenant_id" AS source_join_value_1,
-      violation."customer_id" AS source_join_value_2,
-      violation."id" AS primary_key_value_1,
-      violation."tenant_id" AS primary_key_value_2
+      violation.source_join_value_1 AS source_join_value_1,
+      violation.source_join_value_2 AS source_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -772,7 +777,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      target.*
+      target."tenant_id" AS target_join_value_1,
+      target."id" AS target_join_value_2,
+      target."id" AS primary_key_value_1,
+      target."tenant_id" AS primary_key_value_2
     FROM dq_target AS target
     WHERE
       target."tenant_id" IS NOT NULL
@@ -797,10 +805,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation."tenant_id" AS target_join_value_1,
-      violation."id" AS target_join_value_2,
-      violation."id" AS primary_key_value_1,
-      violation."tenant_id" AS primary_key_value_2
+      violation.target_join_value_1 AS target_join_value_1,
+      violation.target_join_value_2 AS target_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -1478,11 +1486,13 @@ WITH
 
   dq_violations AS (
     SELECT
-      *
-    FROM dq_source
+      source."amount" AS negative_value,
+      source."id" AS primary_key_value_1,
+      source."tenant_id" AS primary_key_value_2
+    FROM dq_source AS source
     WHERE
-      "amount" IS NOT NULL
-      AND "amount" < 0
+      source."amount" IS NOT NULL
+      AND source."amount" < 0
   ),
 
   dq_summary AS (
@@ -1495,9 +1505,9 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation."amount" AS negative_value,
-      violation."id" AS primary_key_value_1,
-      violation."tenant_id" AS primary_key_value_2
+      violation.negative_value AS negative_value,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -1546,7 +1556,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      source.*
+      source."tenant_id" AS source_join_value_1,
+      source."customer_id" AS source_join_value_2,
+      source."id" AS primary_key_value_1,
+      source."tenant_id" AS primary_key_value_2
     FROM dq_source AS source
     WHERE
       source."tenant_id" IS NOT NULL
@@ -1571,10 +1584,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation."tenant_id" AS source_join_value_1,
-      violation."customer_id" AS source_join_value_2,
-      violation."id" AS primary_key_value_1,
-      violation."tenant_id" AS primary_key_value_2
+      violation.source_join_value_1 AS source_join_value_1,
+      violation.source_join_value_2 AS source_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -1624,7 +1637,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      target.*
+      target."tenant_id" AS target_join_value_1,
+      target."id" AS target_join_value_2,
+      target."id" AS primary_key_value_1,
+      target."tenant_id" AS primary_key_value_2
     FROM dq_target AS target
     WHERE
       target."tenant_id" IS NOT NULL
@@ -1649,10 +1665,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation."tenant_id" AS target_join_value_1,
-      violation."id" AS target_join_value_2,
-      violation."id" AS primary_key_value_1,
-      violation."tenant_id" AS primary_key_value_2
+      violation.target_join_value_1 AS target_join_value_1,
+      violation.target_join_value_2 AS target_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -2299,11 +2315,13 @@ WITH
 
   dq_violations AS (
     SELECT
-      *
-    FROM dq_source
+      source.\`amount\` AS negative_value,
+      source.\`id\` AS primary_key_value_1,
+      source.\`tenant_id\` AS primary_key_value_2
+    FROM dq_source AS source
     WHERE
-      \`amount\` IS NOT NULL
-      AND \`amount\` < 0
+      source.\`amount\` IS NOT NULL
+      AND source.\`amount\` < 0
   ),
 
   dq_summary AS (
@@ -2316,9 +2334,9 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation.\`amount\` AS negative_value,
-      violation.\`id\` AS primary_key_value_1,
-      violation.\`tenant_id\` AS primary_key_value_2
+      violation.negative_value AS negative_value,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -2367,7 +2385,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      source.*
+      source.\`tenant_id\` AS source_join_value_1,
+      source.\`customer_id\` AS source_join_value_2,
+      source.\`id\` AS primary_key_value_1,
+      source.\`tenant_id\` AS primary_key_value_2
     FROM dq_source AS source
     WHERE
       source.\`tenant_id\` IS NOT NULL
@@ -2392,10 +2413,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation.\`tenant_id\` AS source_join_value_1,
-      violation.\`customer_id\` AS source_join_value_2,
-      violation.\`id\` AS primary_key_value_1,
-      violation.\`tenant_id\` AS primary_key_value_2
+      violation.source_join_value_1 AS source_join_value_1,
+      violation.source_join_value_2 AS source_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -2445,7 +2466,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      target.*
+      target.\`tenant_id\` AS target_join_value_1,
+      target.\`id\` AS target_join_value_2,
+      target.\`id\` AS primary_key_value_1,
+      target.\`tenant_id\` AS primary_key_value_2
     FROM dq_target AS target
     WHERE
       target.\`tenant_id\` IS NOT NULL
@@ -2470,10 +2494,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation.\`tenant_id\` AS target_join_value_1,
-      violation.\`id\` AS target_join_value_2,
-      violation.\`id\` AS primary_key_value_1,
-      violation.\`tenant_id\` AS primary_key_value_2
+      violation.target_join_value_1 AS target_join_value_1,
+      violation.target_join_value_2 AS target_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -3118,11 +3142,13 @@ WITH
 
   dq_violations AS (
     SELECT
-      *
-    FROM dq_source
+      source.\`amount\` AS negative_value,
+      source.\`id\` AS primary_key_value_1,
+      source.\`tenant_id\` AS primary_key_value_2
+    FROM dq_source AS source
     WHERE
-      \`amount\` IS NOT NULL
-      AND \`amount\` < 0
+      source.\`amount\` IS NOT NULL
+      AND source.\`amount\` < 0
   ),
 
   dq_summary AS (
@@ -3135,9 +3161,9 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation.\`amount\` AS negative_value,
-      violation.\`id\` AS primary_key_value_1,
-      violation.\`tenant_id\` AS primary_key_value_2
+      violation.negative_value AS negative_value,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -3186,7 +3212,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      source.*
+      source.\`tenant_id\` AS source_join_value_1,
+      source.\`customer_id\` AS source_join_value_2,
+      source.\`id\` AS primary_key_value_1,
+      source.\`tenant_id\` AS primary_key_value_2
     FROM dq_source AS source
     WHERE
       source.\`tenant_id\` IS NOT NULL
@@ -3211,10 +3240,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation.\`tenant_id\` AS source_join_value_1,
-      violation.\`customer_id\` AS source_join_value_2,
-      violation.\`id\` AS primary_key_value_1,
-      violation.\`tenant_id\` AS primary_key_value_2
+      violation.source_join_value_1 AS source_join_value_1,
+      violation.source_join_value_2 AS source_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -3264,7 +3293,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      target.*
+      target.\`tenant_id\` AS target_join_value_1,
+      target.\`id\` AS target_join_value_2,
+      target.\`id\` AS primary_key_value_1,
+      target.\`tenant_id\` AS primary_key_value_2
     FROM dq_target AS target
     WHERE
       target.\`tenant_id\` IS NOT NULL
@@ -3289,10 +3321,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation.\`tenant_id\` AS target_join_value_1,
-      violation.\`id\` AS target_join_value_2,
-      violation.\`id\` AS primary_key_value_1,
-      violation.\`tenant_id\` AS primary_key_value_2
+      violation.target_join_value_1 AS target_join_value_1,
+      violation.target_join_value_2 AS target_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -3937,11 +3969,13 @@ WITH
 
   dq_violations AS (
     SELECT
-      *
-    FROM dq_source
+      source.\`amount\` AS negative_value,
+      source.\`id\` AS primary_key_value_1,
+      source.\`tenant_id\` AS primary_key_value_2
+    FROM dq_source AS source
     WHERE
-      \`amount\` IS NOT NULL
-      AND \`amount\` < 0
+      source.\`amount\` IS NOT NULL
+      AND source.\`amount\` < 0
   ),
 
   dq_summary AS (
@@ -3954,9 +3988,9 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation.\`amount\` AS negative_value,
-      violation.\`id\` AS primary_key_value_1,
-      violation.\`tenant_id\` AS primary_key_value_2
+      violation.negative_value AS negative_value,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -4005,7 +4039,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      source.*
+      source.\`tenant_id\` AS source_join_value_1,
+      source.\`customer_id\` AS source_join_value_2,
+      source.\`id\` AS primary_key_value_1,
+      source.\`tenant_id\` AS primary_key_value_2
     FROM dq_source AS source
     WHERE
       source.\`tenant_id\` IS NOT NULL
@@ -4030,10 +4067,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation.\`tenant_id\` AS source_join_value_1,
-      violation.\`customer_id\` AS source_join_value_2,
-      violation.\`id\` AS primary_key_value_1,
-      violation.\`tenant_id\` AS primary_key_value_2
+      violation.source_join_value_1 AS source_join_value_1,
+      violation.source_join_value_2 AS source_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -4083,7 +4120,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      target.*
+      target.\`tenant_id\` AS target_join_value_1,
+      target.\`id\` AS target_join_value_2,
+      target.\`id\` AS primary_key_value_1,
+      target.\`tenant_id\` AS primary_key_value_2
     FROM dq_target AS target
     WHERE
       target.\`tenant_id\` IS NOT NULL
@@ -4108,10 +4148,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation.\`tenant_id\` AS target_join_value_1,
-      violation.\`id\` AS target_join_value_2,
-      violation.\`id\` AS primary_key_value_1,
-      violation.\`tenant_id\` AS primary_key_value_2
+      violation.target_join_value_1 AS target_join_value_1,
+      violation.target_join_value_2 AS target_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -4677,11 +4717,13 @@ WITH
 
   dq_violations AS (
     SELECT
-      *
-    FROM dq_source
+      source."amount" AS negative_value,
+      source."id" AS primary_key_value_1,
+      source."tenant_id" AS primary_key_value_2
+    FROM dq_source AS source
     WHERE
-      "amount" IS NOT NULL
-      AND "amount" < 0
+      source."amount" IS NOT NULL
+      AND source."amount" < 0
   ),
 
   dq_summary AS (
@@ -4694,9 +4736,9 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation."amount" AS negative_value,
-      violation."id" AS primary_key_value_1,
-      violation."tenant_id" AS primary_key_value_2
+      violation.negative_value AS negative_value,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -4745,7 +4787,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      source.*
+      source."tenant_id" AS source_join_value_1,
+      source."customer_id" AS source_join_value_2,
+      source."id" AS primary_key_value_1,
+      source."tenant_id" AS primary_key_value_2
     FROM dq_source AS source
     WHERE
       source."tenant_id" IS NOT NULL
@@ -4770,10 +4815,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation."tenant_id" AS source_join_value_1,
-      violation."customer_id" AS source_join_value_2,
-      violation."id" AS primary_key_value_1,
-      violation."tenant_id" AS primary_key_value_2
+      violation.source_join_value_1 AS source_join_value_1,
+      violation.source_join_value_2 AS source_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )
@@ -4823,7 +4868,10 @@ WITH
 
   dq_violations AS (
     SELECT
-      target.*
+      target."tenant_id" AS target_join_value_1,
+      target."id" AS target_join_value_2,
+      target."id" AS primary_key_value_1,
+      target."tenant_id" AS primary_key_value_2
     FROM dq_target AS target
     WHERE
       target."tenant_id" IS NOT NULL
@@ -4848,10 +4896,10 @@ WITH
   dq_examples AS (
     SELECT
       1 AS example_available,
-      violation."tenant_id" AS target_join_value_1,
-      violation."id" AS target_join_value_2,
-      violation."id" AS primary_key_value_1,
-      violation."tenant_id" AS primary_key_value_2
+      violation.target_join_value_1 AS target_join_value_1,
+      violation.target_join_value_2 AS target_join_value_2,
+      violation.primary_key_value_1 AS primary_key_value_1,
+      violation.primary_key_value_2 AS primary_key_value_2
     FROM dq_violations AS violation
     LIMIT 3
   )

--- a/apps/backend/src/data-marts/data-quality/data-quality-check-compiler.spec.ts
+++ b/apps/backend/src/data-marts/data-quality/data-quality-check-compiler.spec.ts
@@ -246,6 +246,114 @@ describe('DataQualityCheckCompiler', () => {
     return plan.sql;
   };
 
+  it('requests only the source columns used by each check family', async () => {
+    const compiler = createDataQualityCheckCompiler();
+    const cases = [
+      {
+        rule: tableRule(DataQualityCategory.EMPTY_TABLE),
+        expectedColumns: ['`id`'],
+      },
+      {
+        rule: tableRule(DataQualityCategory.PK_UNIQUENESS),
+        expectedColumns: ['`id`', '`tenant_id`'],
+      },
+      {
+        rule: fieldRule(DataQualityCategory.NEGATIVE_VALUES, 'amount'),
+        expectedColumns: ['`amount`', '`id`', '`tenant_id`'],
+      },
+      {
+        rule: tableRule(DataQualityCategory.DUPLICATE_ROWS),
+        expectedColumns: [],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const resolveSourceQuery = jest.fn(async (_columns?: string[]) => sourceQuery);
+      const input = {
+        storageType: DataStorageType.GOOGLE_BIGQUERY,
+        sourceQuery,
+        resolveSourceQuery,
+        schema: schema(DataStorageType.GOOGLE_BIGQUERY),
+        rule: testCase.rule,
+      };
+
+      await compiler.compile(input);
+
+      expect(resolveSourceQuery).toHaveBeenCalledWith(testCase.expectedColumns);
+    }
+  });
+
+  it.each([
+    {
+      category: DataQualityCategory.RELATIONSHIP_INTEGRITY,
+      sourceColumns: ['`customer_id`', '`id`', '`tenant_id`'],
+      targetColumns: ['`id`'],
+    },
+    {
+      category: DataQualityCategory.REVERSE_RELATIONSHIP,
+      sourceColumns: ['`customer_id`'],
+      targetColumns: ['`id`', '`tenant_id`'],
+    },
+  ])(
+    'requests only relationship columns for $category',
+    async ({ category, sourceColumns, targetColumns }) => {
+      const compiler = createDataQualityCheckCompiler();
+      const resolveSourceQuery = jest.fn(async (_columns?: string[]) => sourceQuery);
+      const resolveTargetSourceQuery = jest.fn(async (_columns?: string[]) => targetQuery);
+      const singleJoinRelationship = {
+        ...relationship,
+        joinConditions: [{ sourceFieldName: 'customer_id', targetFieldName: 'id' }],
+      };
+      const input = {
+        storageType: DataStorageType.GOOGLE_BIGQUERY,
+        sourceQuery,
+        resolveSourceQuery,
+        schema: schema(DataStorageType.GOOGLE_BIGQUERY),
+        rule: relationshipRule(category),
+        relationship: {
+          snapshot: singleJoinRelationship,
+          resolveTargetSourceQuery,
+          targetSchema: schema(DataStorageType.GOOGLE_BIGQUERY),
+          targetStorageType: DataStorageType.GOOGLE_BIGQUERY,
+          sourceConnectionId: 'connection-1',
+          targetConnectionId: 'connection-1',
+        },
+      };
+
+      await compiler.compile(input);
+
+      expect(resolveSourceQuery).toHaveBeenCalledWith(sourceColumns);
+      expect(resolveTargetSourceQuery).toHaveBeenCalledWith(targetColumns);
+    }
+  );
+
+  it('does not copy whole rows into violation CTEs', async () => {
+    const compiler = createDataQualityCheckCompiler();
+    const negative = await compiler.compile({
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      sourceQuery,
+      schema: schema(DataStorageType.GOOGLE_BIGQUERY),
+      rule: fieldRule(DataQualityCategory.NEGATIVE_VALUES, 'amount'),
+    });
+    const relationshipPlan = await compiler.compile({
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      sourceQuery,
+      schema: schema(DataStorageType.GOOGLE_BIGQUERY),
+      rule: relationshipRule(DataQualityCategory.RELATIONSHIP_INTEGRITY),
+      relationship: {
+        snapshot: relationship,
+        targetSourceQuery: targetQuery,
+        targetSchema: schema(DataStorageType.GOOGLE_BIGQUERY),
+        targetStorageType: DataStorageType.GOOGLE_BIGQUERY,
+        sourceConnectionId: 'connection-1',
+        targetConnectionId: 'connection-1',
+      },
+    });
+
+    expect(sql(negative)).not.toMatch(/SELECT\s+\*\s+FROM dq_source/);
+    expect(sql(relationshipPlan)).not.toMatch(/SELECT\s+\w+\.\*\s+FROM dq_source/);
+  });
+
   it('keeps a literal dotted field distinct from a segmented nested field', async () => {
     const nestedSchema = {
       type: 'bigquery-data-mart-schema',
@@ -279,27 +387,36 @@ describe('DataQualityCheckCompiler', () => {
       ],
     } as DataMartSchema;
     const compiler = createDataQualityCheckCompiler();
+    const resolveLiteralSourceQuery = jest.fn(async (_columns?: string[]) => sourceQuery);
+    const resolveNestedSourceQuery = jest.fn(async (_columns?: string[]) => sourceQuery);
 
-    const literal = await compiler.compile({
+    const literalInput = {
       storageType: DataStorageType.GOOGLE_BIGQUERY,
       sourceQuery,
+      resolveSourceQuery: resolveLiteralSourceQuery,
       schema: nestedSchema,
       rule: fieldRule(DataQualityCategory.NULL_RATE, ['customer.id'], {
         thresholdPercent: 0,
       }),
-    });
-    const nested = await compiler.compile({
+    };
+    const nestedInput = {
       storageType: DataStorageType.GOOGLE_BIGQUERY,
       sourceQuery,
+      resolveSourceQuery: resolveNestedSourceQuery,
       schema: nestedSchema,
       rule: fieldRule(DataQualityCategory.NULL_RATE, ['customer', 'id'], {
         thresholdPercent: 0,
       }),
-    });
+    };
+
+    const literal = await compiler.compile(literalInput);
+    const nested = await compiler.compile(nestedInput);
 
     expect(sql(literal)).toContain('`customer.id`');
     expect(sql(literal)).not.toContain('`customer`.`id`');
     expect(sql(nested)).toContain('`customer`.`id`');
+    expect(resolveLiteralSourceQuery).toHaveBeenCalledWith(['`customer.id`']);
+    expect(resolveNestedSourceQuery).toHaveBeenCalledWith(['`customer`']);
   });
 
   it('quotes a dotted relationship join field as one physical identifier', async () => {
@@ -333,6 +450,54 @@ describe('DataQualityCheckCompiler', () => {
     expect(sql(plan)).toContain('source.`customer.id` = target.`customer.id`');
     expect(sql(plan)).not.toContain('`customer`.`id`');
   });
+
+  it.each([DataQualityCategory.RELATIONSHIP_INTEGRITY, DataQualityCategory.REVERSE_RELATIONSHIP])(
+    'avoids range aliases shadowed by relationship columns for %s',
+    async category => {
+      const sourceSchema = schema(DataStorageType.GOOGLE_BIGQUERY) as unknown as {
+        fields: Array<Record<string, unknown>>;
+      };
+      const targetSchema = schema(DataStorageType.GOOGLE_BIGQUERY) as unknown as {
+        fields: Array<Record<string, unknown>>;
+      };
+      sourceSchema.fields.push({
+        name: 'target',
+        type: 'STRING',
+        mode: 'NULLABLE',
+        status: DataMartSchemaFieldStatus.CONNECTED,
+        isPrimaryKey: false,
+        isHiddenForReporting: false,
+      });
+      targetSchema.fields.push({
+        name: 'source',
+        type: 'STRING',
+        mode: 'NULLABLE',
+        status: DataMartSchemaFieldStatus.CONNECTED,
+        isPrimaryKey: false,
+        isHiddenForReporting: false,
+      });
+      const plan = await createDataQualityCheckCompiler().compile({
+        storageType: DataStorageType.GOOGLE_BIGQUERY,
+        sourceQuery,
+        schema: sourceSchema as unknown as DataMartSchema,
+        rule: relationshipRule(category),
+        relationship: {
+          snapshot: relationship,
+          targetSourceQuery: targetQuery,
+          targetSchema: targetSchema as unknown as DataMartSchema,
+          targetStorageType: DataStorageType.GOOGLE_BIGQUERY,
+          sourceConnectionId: 'connection-1',
+          targetConnectionId: 'connection-1',
+        },
+      });
+      const measurement = sql(plan);
+
+      expect(measurement).toContain('FROM dq_source AS dq_row_source');
+      expect(measurement).toContain('FROM dq_target AS dq_row_target');
+      expect(measurement).toContain('dq_row_source.`tenant_id` = dq_row_target.`tenant_id`');
+      expect(measurement).toContain('dq_row_source.`customer_id` = dq_row_target.`id`');
+    }
+  );
 
   it('keeps every generated header line commented when details contain control characters', async () => {
     const plan = await createDataQualityCheckCompiler().compile({

--- a/apps/backend/src/data-marts/data-quality/data-quality-check-compiler.ts
+++ b/apps/backend/src/data-marts/data-quality/data-quality-check-compiler.ts
@@ -53,12 +53,14 @@ export interface DataQualityNotApplicableCheck extends DataQualityCompiledBase {
 
 export type DataQualityCompiledCheck = DataQualityExecutableCheck | DataQualityNotApplicableCheck;
 
+type DataQualityQueryResolver = (columns: string[]) => Promise<string | QueryBuildResult>;
+
 export interface DataQualityRelationshipCompileContext {
   snapshot: DataQualityRelationshipSnapshot;
   /** Existing eager input retained for direct compiler callers. */
   targetSourceQuery?: string | QueryBuildResult;
   /** Preferred runtime input: invoked only after relationship applicability is validated. */
-  resolveTargetSourceQuery?: () => Promise<string | QueryBuildResult>;
+  resolveTargetSourceQuery?: DataQualityQueryResolver;
   targetSchema: DataMartSchema | null;
   targetStorageType: DataStorageType;
   sourceConnectionId: string;
@@ -67,7 +69,8 @@ export interface DataQualityRelationshipCompileContext {
 
 export interface DataQualityCompileInput {
   storageType: DataStorageType;
-  sourceQuery: string | QueryBuildResult;
+  sourceQuery?: string | QueryBuildResult;
+  resolveSourceQuery?: DataQualityQueryResolver;
   schema: DataMartSchema | null;
   rule: DataQualityRuleConfig;
   relationship?: DataQualityRelationshipCompileContext;
@@ -94,7 +97,6 @@ export class DataQualityCheckCompiler {
     const rule = DataQualityRuleConfigSchema.parse(rawInput.rule);
     const input = { ...rawInput, rule };
     const dialect = await this.dialectResolver.resolve(input.storageType);
-    const sourceSql = extractSql(input.sourceQuery);
 
     if (!rule.enabled) return notApplicable(rule, 'The check is disabled');
     if (!rule.isApplicable) {
@@ -110,6 +112,7 @@ export class DataQualityCheckCompiler {
         return notApplicable(rule, NESTED_COLLECTION_FIELD_REASON);
       }
     }
+    const sourceSql = await resolveSourceSql(input, dialect);
 
     switch (rule.category) {
       case DataQualityCategory.EMPTY_TABLE:
@@ -765,7 +768,7 @@ export class DataQualityCheckCompiler {
       rule,
       sourceSql,
       field,
-      [`${expression} IS NOT NULL`, `${expression} < 0`],
+      [`source.${expression} IS NOT NULL`, `source.${expression} < 0`],
       schema,
       dialect
     );
@@ -783,7 +786,7 @@ export class DataQualityCheckCompiler {
       field,
       collectFields(schema),
       dialect,
-      'violation',
+      'source',
       'negative_value'
     );
     return executable(
@@ -799,7 +802,9 @@ export class DataQualityCheckCompiler {
         ctes: [
           {
             name: 'dq_violations',
-            body: renderSelect(['*'], 'dq_source', { where: predicates }),
+            body: renderSelect(splitProjection(readableExample.sql), 'dq_source AS source', {
+              where: predicates,
+            }),
           },
           {
             name: 'dq_summary',
@@ -812,7 +817,7 @@ export class DataQualityCheckCompiler {
         summaryColumns: ['is_applicable', 'violation_count'],
         examples: {
           from: 'dq_violations AS violation',
-          columns: splitProjection(readableExample.sql),
+          columns: readableExample.aliases.map(alias => `violation.${alias} AS ${alias}`),
           aliases: readableExample.aliases,
           dialect,
         },
@@ -844,6 +849,14 @@ export class DataQualityCheckCompiler {
     const targetFields = new Map(
       collectFields(relationship.targetSchema).map(field => [fieldPathKey(field.path), field])
     );
+    const occupiedAliases = new Set(
+      [...sourceFields.values(), ...targetFields.values()]
+        .filter(field => field.path.length === 1)
+        .map(field => field.path[0].toLowerCase())
+    );
+    const sourceAlias = availableRelationshipAlias('source', occupiedAliases);
+    occupiedAliases.add(sourceAlias.toLowerCase());
+    const targetAlias = availableRelationshipAlias('target', occupiedAliases);
     const missing = relationship.snapshot.joinConditions.find(
       condition =>
         !sourceFields.has(fieldPathKey([condition.sourceFieldName])) ||
@@ -860,14 +873,23 @@ export class DataQualityCheckCompiler {
       return notApplicable(input.rule, NESTED_COLLECTION_FIELD_REASON);
     }
 
+    const targetColumns = quoteTopLevelColumns(
+      [
+        ...relationship.snapshot.joinConditions.map(condition => [condition.targetFieldName]),
+        ...(reverse
+          ? readablePrimaryKeyFields([...targetFields.values()]).map(field => field.path)
+          : []),
+      ],
+      dialect
+    );
     const targetSourceQuery = relationship.resolveTargetSourceQuery
-      ? await relationship.resolveTargetSourceQuery()
+      ? await relationship.resolveTargetSourceQuery(targetColumns)
       : relationship.targetSourceQuery;
     if (targetSourceQuery === undefined) {
       return notApplicable(input.rule, 'Relationship target source is unavailable');
     }
     const targetSql = extractSql(targetSourceQuery);
-    const tupleSide = reverse ? 'target' : 'source';
+    const tupleSide = reverse ? targetAlias : sourceAlias;
     const tupleFields = relationship.snapshot.joinConditions.map(condition =>
       dialect.quoteIdentifierPath([reverse ? condition.targetFieldName : condition.sourceFieldName])
     );
@@ -876,11 +898,11 @@ export class DataQualityCheckCompiler {
     );
     const equalityPredicates = relationship.snapshot.joinConditions.map(
       condition =>
-        `source.${dialect.quoteIdentifierPath([condition.sourceFieldName])} = target.${dialect.quoteIdentifierPath([condition.targetFieldName])}`
+        `${sourceAlias}.${dialect.quoteIdentifierPath([condition.sourceFieldName])} = ${targetAlias}.${dialect.quoteIdentifierPath([condition.targetFieldName])}`
     );
-    const primary = reverse ? 'dq_target AS target' : 'dq_source AS source';
-    const secondary = reverse ? 'dq_source AS source' : 'dq_target AS target';
-    const violationAlias = reverse ? 'target' : 'source';
+    const primary = reverse ? `dq_target AS ${targetAlias}` : `dq_source AS ${sourceAlias}`;
+    const secondary = reverse ? `dq_source AS ${sourceAlias}` : `dq_target AS ${targetAlias}`;
+    const violationAlias = reverse ? targetAlias : sourceAlias;
     const projectionFields = reverse
       ? relationship.snapshot.joinConditions.map(condition => condition.targetFieldName)
       : relationship.snapshot.joinConditions.map(condition => condition.sourceFieldName);
@@ -891,7 +913,7 @@ export class DataQualityCheckCompiler {
       projectionFields,
       schemaFields,
       dialect,
-      'violation',
+      violationAlias,
       reverse ? 'target_join_value' : 'source_join_value'
     );
     const joinMappings = relationship.snapshot.joinConditions.map(
@@ -919,7 +941,7 @@ export class DataQualityCheckCompiler {
         ctes: [
           {
             name: 'dq_violations',
-            body: renderSelect([`${violationAlias}.*`], primary, {
+            body: renderSelect(splitProjection(projection.sql), primary, {
               where: [
                 ...nonNullPredicates,
                 [
@@ -944,7 +966,7 @@ export class DataQualityCheckCompiler {
         summaryColumns: ['is_applicable', 'violation_count'],
         examples: {
           from: 'dq_violations AS violation',
-          columns: splitProjection(projection.sql),
+          columns: projection.aliases.map(alias => `violation.${alias} AS ${alias}`),
           aliases: projection.aliases,
           dialect,
         },
@@ -1002,6 +1024,17 @@ function notApplicable(rule: DataQualityRuleConfig, reason: string): DataQuality
   };
 }
 
+async function resolveSourceSql(
+  input: DataQualityCompileInput & { rule: DataQualityRuleConfig },
+  dialect: DataQualitySqlDialect
+): Promise<string> {
+  const query = input.resolveSourceQuery
+    ? await input.resolveSourceQuery(requiredSourceColumns(input, dialect))
+    : input.sourceQuery;
+  if (query === undefined) throw new Error('Data Quality source query is unavailable');
+  return extractSql(query);
+}
+
 function extractSql(queryValue: string | QueryBuildResult): string {
   if (!isQueryBuildResult(queryValue)) return ensureSourceSql(queryValue);
   if (queryValue.params?.length) {
@@ -1014,6 +1047,12 @@ function ensureSourceSql(sql: string): string {
   const normalized = sql.trim().replace(/;\s*$/, '');
   if (!normalized) throw new Error('Data Quality source SQL must not be empty');
   return normalized;
+}
+
+function availableRelationshipAlias(preferred: string, occupied: ReadonlySet<string>): string {
+  let alias = preferred;
+  while (occupied.has(alias.toLowerCase())) alias = `dq_row_${alias}`;
+  return alias;
 }
 
 function collectFields(
@@ -1075,6 +1114,61 @@ function collectTopLevelMaterializedFields(
     }));
 }
 
+function requiredSourceColumns(
+  input: DataQualityCompileInput & { rule: DataQualityRuleConfig },
+  dialect: DataQualitySqlDialect
+): string[] {
+  const fields = collectFields(input.schema);
+  const primaryKeys = readablePrimaryKeyFields(fields);
+  switch (input.rule.category) {
+    case DataQualityCategory.EMPTY_TABLE:
+      return quoteTopLevelColumns(
+        collectTopLevelMaterializedFields(input.schema)
+          .slice(0, 1)
+          .map(field => field.path),
+        dialect
+      );
+    case DataQualityCategory.PK_UNIQUENESS:
+      return quoteTopLevelColumns(
+        fields.filter(field => field.isPrimaryKey).map(field => field.path),
+        dialect
+      );
+    case DataQualityCategory.DUPLICATE_ROWS:
+      return [];
+    case DataQualityCategory.RELATIONSHIP_INTEGRITY:
+    case DataQualityCategory.REVERSE_RELATIONSHIP:
+      return quoteTopLevelColumns(
+        [
+          ...(input.relationship?.snapshot.joinConditions.map(condition => [
+            condition.sourceFieldName,
+          ]) ?? []),
+          ...(input.rule.category === DataQualityCategory.RELATIONSHIP_INTEGRITY
+            ? primaryKeys.map(field => field.path)
+            : []),
+        ],
+        dialect
+      );
+    default: {
+      const field = resolveFieldRule(input.rule, input.schema);
+      return quoteTopLevelColumns(
+        field ? [field.path, ...primaryKeys.map(primaryKey => primaryKey.path)] : [],
+        dialect
+      );
+    }
+  }
+}
+
+function quoteTopLevelColumns(
+  paths: readonly (readonly string[])[],
+  dialect: DataQualitySqlDialect
+): string[] {
+  const names = new Set<string>();
+  for (const path of paths) {
+    if (path[0]) names.add(path[0]);
+  }
+  return [...names].map(name => dialect.quoteIdentifierPath([name]));
+}
+
 function descendantsRequireFlattening(field: DataMartSchemaField): boolean {
   const mode = 'mode' in field && typeof field.mode === 'string' ? field.mode.toUpperCase() : '';
   const type = String(field.type).trim().toUpperCase();
@@ -1096,6 +1190,18 @@ function resolveFieldRule(
   return collectFields(schema).find(field => fieldPathKey(field.path) === scopeKey) ?? null;
 }
 
+function readablePrimaryKeyFields(
+  fields: DataQualityFieldDescriptor[],
+  excludedFieldPath?: readonly string[]
+): DataQualityFieldDescriptor[] {
+  return fields.filter(
+    field =>
+      field.isPrimaryKey &&
+      !field.requiresFlattening &&
+      (!excludedFieldPath || fieldPathKey(field.path) !== fieldPathKey(excludedFieldPath))
+  );
+}
+
 function readableFieldExampleProjection(
   field: DataQualityFieldDescriptor,
   fields: DataQualityFieldDescriptor[],
@@ -1103,12 +1209,7 @@ function readableFieldExampleProjection(
   alias: string,
   valueAlias: string
 ): { sql: string; aliases: string[] } {
-  const primaryKeys = fields.filter(
-    candidate =>
-      candidate.isPrimaryKey &&
-      !candidate.requiresFlattening &&
-      fieldPathKey(candidate.path) !== fieldPathKey(field.path)
-  );
+  const primaryKeys = readablePrimaryKeyFields(fields, field.path);
   const aliases = [
     valueAlias,
     ...primaryKeys.map((_candidate, index) => `primary_key_value_${index + 1}`),
@@ -1129,12 +1230,7 @@ function readablePrimaryKeyProjection(
   tableAlias: string,
   excludedFieldPath?: readonly string[]
 ): { sql: string; aliases: string[] } {
-  const primaryKeys = fields.filter(
-    field =>
-      field.isPrimaryKey &&
-      !field.requiresFlattening &&
-      (!excludedFieldPath || fieldPathKey(field.path) !== fieldPathKey(excludedFieldPath))
-  );
+  const primaryKeys = readablePrimaryKeyFields(fields, excludedFieldPath);
   const aliases = primaryKeys.map((_field, index) => `primary_key_value_${index + 1}`);
   return {
     sql: primaryKeys

--- a/apps/backend/src/data-marts/data-quality/data-quality-snapshot-table-reference.service.spec.ts
+++ b/apps/backend/src/data-marts/data-quality/data-quality-snapshot-table-reference.service.spec.ts
@@ -24,85 +24,54 @@ describe('DataQualitySnapshotTableReferenceService', () => {
     jest.resetAllMocks();
   });
 
-  it('uses the shared stable Data Mart view for a SQL source', async () => {
+  it('builds an explicit projection from the stable SQL Data Mart view', async () => {
     tableReferenceService.resolveTableName.mockResolvedValue('warehouse.internal.view_dm_source');
     identifierEscaper.escapeIdentifier.mockResolvedValue('`warehouse`.`internal`.`view_dm_source`');
-
-    await expect(
-      service.resolve({
-        dataMartId: 'dm-source',
-        projectId: 'project-1',
-        definition: { sqlQuery: 'SELECT saved_value FROM saved_source' },
-        storage: {
-          id: 'storage-1',
-          type: DataStorageType.GOOGLE_BIGQUERY,
-        },
-        liveStorage: {
-          id: 'storage-1',
-          type: DataStorageType.GOOGLE_BIGQUERY,
-        },
-      })
-    ).resolves.toEqual({
-      query: 'SELECT * FROM `warehouse`.`internal`.`view_dm_source`',
+    const reference = await service.resolve({
+      dataMartId: 'dm-source',
+      projectId: 'project-1',
+      definition: { sqlQuery: 'SELECT saved_value FROM saved_source' },
+      storage: {
+        id: 'storage-1',
+        type: DataStorageType.GOOGLE_BIGQUERY,
+      },
+      liveStorage: {
+        id: 'storage-1',
+        type: DataStorageType.GOOGLE_BIGQUERY,
+      },
     });
 
-    expect(tableReferenceService.resolveTableName).toHaveBeenCalledWith('dm-source', 'project-1');
-    expect(identifierEscaper.escapeIdentifier).toHaveBeenCalledWith(
-      DataStorageType.GOOGLE_BIGQUERY,
-      'warehouse.internal.view_dm_source'
+    expect(reference).toEqual({ buildQuery: expect.any(Function) });
+    await expect(reference.buildQuery(['`customer_id`', '`source_pk`'])).resolves.toBe(
+      'SELECT `customer_id`, `source_pk` FROM `warehouse`.`internal`.`view_dm_source`'
     );
     expect(queryBuilder.buildQuery).not.toHaveBeenCalled();
-  });
-
-  it('uses the shared stable Data Mart view for a SQL relationship target', async () => {
-    tableReferenceService.resolveTableName.mockResolvedValue('warehouse.internal.view_dm_target');
-    identifierEscaper.escapeIdentifier.mockResolvedValue('`warehouse`.`internal`.`view_dm_target`');
-
-    await expect(
-      service.resolve({
-        dataMartId: 'dm-target',
-        projectId: 'project-1',
-        definition: { sqlQuery: 'SELECT saved_value FROM saved_target' },
-        storage: {
-          id: 'storage-1',
-          type: DataStorageType.GOOGLE_BIGQUERY,
-        },
-        liveStorage: {
-          id: 'storage-1',
-          type: DataStorageType.GOOGLE_BIGQUERY,
-        },
-      })
-    ).resolves.toEqual({
-      query: 'SELECT * FROM `warehouse`.`internal`.`view_dm_target`',
-    });
-
-    expect(tableReferenceService.resolveTableName).toHaveBeenCalledWith('dm-target', 'project-1');
+    expect(tableReferenceService.resolveTableName).toHaveBeenCalledTimes(1);
   });
 
   it('builds a non-SQL query from the saved definition after validating storage identity', async () => {
-    queryBuilder.buildQuery.mockResolvedValue('SELECT * FROM saved_table');
+    queryBuilder.buildQuery.mockResolvedValue('SELECT `id` FROM saved_table');
 
-    await expect(
-      service.resolve({
-        dataMartId: 'dm-source',
-        projectId: 'project-1',
-        definition: { fullyQualifiedName: 'warehouse.dataset.saved_table' },
-        storage: {
-          id: 'storage-1',
-          type: DataStorageType.GOOGLE_BIGQUERY,
-        },
-        liveStorage: {
-          id: 'storage-1',
-          type: DataStorageType.GOOGLE_BIGQUERY,
-        },
-      })
-    ).resolves.toEqual({
-      query: 'SELECT * FROM saved_table',
+    const reference = await service.resolve({
+      dataMartId: 'dm-source',
+      projectId: 'project-1',
+      definition: { fullyQualifiedName: 'warehouse.dataset.saved_table' },
+      storage: {
+        id: 'storage-1',
+        type: DataStorageType.GOOGLE_BIGQUERY,
+      },
+      liveStorage: {
+        id: 'storage-1',
+        type: DataStorageType.GOOGLE_BIGQUERY,
+      },
     });
 
-    expect(queryBuilder.buildQuery).toHaveBeenCalledWith(DataStorageType.GOOGLE_BIGQUERY, {
-      fullyQualifiedName: 'warehouse.dataset.saved_table',
-    });
+    await expect(reference.buildQuery(['`id`'])).resolves.toBe('SELECT `id` FROM saved_table');
+    expect(queryBuilder.buildQuery).toHaveBeenCalledWith(
+      DataStorageType.GOOGLE_BIGQUERY,
+      { fullyQualifiedName: 'warehouse.dataset.saved_table' },
+      { columns: ['`id`'] }
+    );
     expect(tableReferenceService.resolveTableName).not.toHaveBeenCalled();
   });
 

--- a/apps/backend/src/data-marts/data-quality/data-quality-snapshot-table-reference.service.ts
+++ b/apps/backend/src/data-marts/data-quality/data-quality-snapshot-table-reference.service.ts
@@ -16,7 +16,7 @@ export interface DataQualitySnapshotTableReferenceInput {
 }
 
 interface DataQualitySnapshotTableReference {
-  query: string | QueryBuildResult;
+  buildQuery(columns: string[]): Promise<string | QueryBuildResult>;
 }
 
 export class DataQualitySnapshotStorageMismatchError extends Error {
@@ -38,26 +38,29 @@ export class DataQualitySnapshotTableReferenceService {
     input: DataQualitySnapshotTableReferenceInput
   ): Promise<DataQualitySnapshotTableReference> {
     this.validateStorage(input.storage, input.liveStorage);
-    if (!input.definition) {
+    const definition = input.definition;
+    if (!definition) {
       throw new Error('Data Mart definition snapshot is unavailable');
     }
-    if (!isSqlDefinition(input.definition)) {
-      return {
-        query: await this.queryBuilder.buildQuery(input.storage.type, input.definition),
-      };
-    }
+    const mainTableReference = isSqlDefinition(definition)
+      ? await this.resolveSqlTableReference(input)
+      : undefined;
+    return {
+      buildQuery: async columns =>
+        mainTableReference
+          ? `SELECT ${columns.length > 0 ? columns.join(', ') : '*'} FROM ${mainTableReference}`
+          : this.queryBuilder.buildQuery(input.storage.type, definition, { columns }),
+    };
+  }
 
+  private async resolveSqlTableReference(
+    input: DataQualitySnapshotTableReferenceInput
+  ): Promise<string> {
     const tableReference = await this.tableReferenceService.resolveTableName(
       input.dataMartId,
       input.projectId
     );
-    const escapedReference = await this.identifierEscaper.escapeIdentifier(
-      input.storage.type,
-      tableReference
-    );
-    return {
-      query: `SELECT * FROM ${escapedReference}`,
-    };
+    return this.identifierEscaper.escapeIdentifier(input.storage.type, tableReference);
   }
 
   private validateStorage(

--- a/apps/backend/src/data-marts/use-cases/run-data-quality.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-data-quality.service.spec.ts
@@ -82,6 +82,17 @@ const stored = (
   ...parsed(key, status),
 });
 
+const snapshotReference = (query: string) => ({
+  buildQuery: jest.fn(async () => query),
+});
+
+const projectedSnapshotReference = (table: string) => ({
+  buildQuery: jest.fn(async (columns: string[]) => {
+    const projection = columns.length > 0 ? columns.join(', ') : '*';
+    return `SELECT ${projection} FROM ${table}`;
+  }),
+});
+
 describe('RunDataQualityService', () => {
   let dataMart: DataMart;
   let dataMartRun: DataMartRun;
@@ -213,9 +224,7 @@ describe('RunDataQualityService', () => {
       registerDataQualityRunConsumption: jest.fn().mockResolvedValue(undefined),
     } as never;
     snapshotTableReference = {
-      resolve: jest.fn().mockResolvedValue({
-        query: 'SELECT * FROM source',
-      }),
+      resolve: jest.fn().mockResolvedValue(snapshotReference('SELECT * FROM source')),
     } as unknown as jest.Mocked<DataQualitySnapshotTableReferenceService>;
     const clock = {
       now: jest.fn().mockReturnValueOnce(startedAt).mockReturnValue(finishedAt),
@@ -236,9 +245,9 @@ describe('RunDataQualityService', () => {
     dataMart.definition = { sqlQuery: 'SELECT current_value FROM changed_source' } as never;
     dataMartRun.definitionRun = { sqlQuery: 'SELECT saved_value FROM saved_source' };
     dataMartRun.dataQualitySnapshot!.definitionType = DataMartDefinitionType.SQL;
-    snapshotTableReference.resolve.mockResolvedValue({
-      query: 'SELECT * FROM `project`.`internal`.`dq_run_source`',
-    });
+    snapshotTableReference.resolve.mockResolvedValue(
+      projectedSnapshotReference('`project`.`internal`.`dq_run_source`')
+    );
 
     await service.executeExistingRun('run-1', 'project-1');
 
@@ -256,7 +265,11 @@ describe('RunDataQualityService', () => {
       },
     });
     expect(compiler.compile).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceQuery: 'SELECT * FROM `project`.`internal`.`dq_run_source`' })
+      expect.objectContaining({ resolveSourceQuery: expect.any(Function) })
+    );
+    const resolveSourceQuery = compiler.compile.mock.calls[0][0].resolveSourceQuery;
+    await expect(resolveSourceQuery?.(['`id`'])).resolves.toBe(
+      'SELECT `id` FROM `project`.`internal`.`dq_run_source`'
     );
     expect(JSON.stringify(compiler.compile.mock.calls)).not.toContain('changed_source');
     expect(JSON.stringify(compiler.compile.mock.calls)).not.toContain('saved_source');
@@ -358,12 +371,8 @@ describe('RunDataQualityService', () => {
     repositories.get(DataMart)!.find.mockResolvedValue([target] as never);
     snapshotTableReference.resolve.mockImplementation(async input =>
       input.dataMartId === 'dm-1'
-        ? {
-            query: 'SELECT * FROM `project`.`internal`.`dq_run_source`',
-          }
-        : {
-            query: 'SELECT * FROM `project`.`internal`.`dq_run_target`',
-          }
+        ? projectedSnapshotReference('`project`.`internal`.`dq_run_source`')
+        : projectedSnapshotReference('`project`.`internal`.`dq_run_target`')
     );
     const realCompiler = createDataQualityCheckCompiler();
     const realParser = createDataQualityResultParser();
@@ -399,9 +408,12 @@ describe('RunDataQualityService', () => {
 
     expect(dataMartRun.dataQualityResults).toHaveLength(2);
     expect(emittedSql).toHaveLength(2);
-    expect(emittedSql[0]).toContain('SELECT * FROM `project`.`internal`.`dq_run_source`');
-    expect(emittedSql[1]).toContain('SELECT * FROM `project`.`internal`.`dq_run_source`');
-    expect(emittedSql[1]).toContain('SELECT * FROM `project`.`internal`.`dq_run_target`');
+    expect(emittedSql[0]).toContain('SELECT `source_pk` FROM `project`.`internal`.`dq_run_source`');
+    expect(emittedSql[1]).toContain(
+      'SELECT `customer_id`, `source_pk` FROM `project`.`internal`.`dq_run_source`'
+    );
+    expect(emittedSql[1]).toContain('SELECT `id` FROM `project`.`internal`.`dq_run_target`');
+    expect(emittedSql.join('\n')).not.toContain('SELECT *');
 
     const mainResult = dataMartRun.dataQualityResults?.find(
       result => result.ruleKey === mainRule.key
@@ -489,18 +501,14 @@ describe('RunDataQualityService', () => {
     repositories.get(DataMart)!.find.mockResolvedValue([target] as never);
     snapshotTableReference.resolve.mockImplementation(async input =>
       input.dataMartId === 'dm-1'
-        ? {
-            query: 'SELECT * FROM `project`.`internal`.`dq_run_source`',
-          }
-        : {
-            query: 'SELECT * FROM `project`.`internal`.`dq_run_target`',
-          }
+        ? projectedSnapshotReference('`project`.`internal`.`dq_run_source`')
+        : projectedSnapshotReference('`project`.`internal`.`dq_run_target`')
     );
     compiler.compile.mockImplementation(async input => {
       const relationship = input.relationship as
-        | { resolveTargetSourceQuery?: () => Promise<unknown> }
+        | { resolveTargetSourceQuery?: (columns: string[]) => Promise<unknown> }
         | undefined;
-      await relationship?.resolveTargetSourceQuery?.();
+      await relationship?.resolveTargetSourceQuery?.(['`id`']);
       return plan(input.rule.key);
     });
 
@@ -691,9 +699,7 @@ describe('RunDataQualityService', () => {
       if (input.dataMartId === 'dm-2') {
         throw providerError;
       }
-      return {
-        query: 'SELECT * FROM source',
-      };
+      return snapshotReference('SELECT * FROM source');
     });
     const realCompiler = createDataQualityCheckCompiler();
     let capturedBoundaryError: unknown;
@@ -894,9 +900,7 @@ describe('RunDataQualityService', () => {
       );
       snapshotTableReference.resolve.mockImplementation(async input => {
         if (input.dataMartId === 'dm-1') {
-          return {
-            query: 'SELECT * FROM source',
-          };
+          return snapshotReference('SELECT * FROM source');
         }
         expect(input.definition).toEqual({ sqlQuery: 'SELECT id FROM saved_target' });
         expect(input.liveStorage).toEqual(liveStorage);

--- a/apps/backend/src/data-marts/use-cases/run-data-quality.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-data-quality.service.ts
@@ -43,6 +43,8 @@ interface ClaimedDataQualityRun {
   dataMart: DataMart;
 }
 
+type DataQualityQueryResolver = (columns: string[]) => Promise<string | QueryBuildResult>;
+
 interface ProviderErrorIdentity {
   code?: unknown;
   errorCode?: unknown;
@@ -113,7 +115,7 @@ export class RunDataQualityService {
           definition: definitionRun,
           schema: snapshot.schema ?? undefined,
         } as DataMart;
-        const sourceQuery = await this.resolveSnapshotTableReference({
+        const resolveSourceQuery = await this.resolveSnapshotTableReference({
           dataMartId: dataMart.id,
           projectId: expectedProjectId,
           definition: definitionRun,
@@ -121,7 +123,7 @@ export class RunDataQualityService {
           liveStorage: toStorageSnapshot(dataMart),
         });
         const targets = await this.loadRelationshipTargets(snapshot, expectedProjectId);
-        const targetSourceQueries = new Map<string, Promise<string | QueryBuildResult>>();
+        const targetSourceQueries = new Map<string, Promise<DataQualityQueryResolver>>();
         const compiled: DataQualityCompiledCheck[] = [];
 
         for (const originalRule of pendingRules) {
@@ -145,7 +147,7 @@ export class RunDataQualityService {
             compiled.push(
               await this.compiler.compile({
                 storageType: dataMart.storage.type,
-                sourceQuery,
+                resolveSourceQuery,
                 schema: snapshot.schema,
                 rule,
                 relationship: relationshipSnapshot
@@ -313,7 +315,7 @@ export class RunDataQualityService {
     snapshot: DataQualityRelationshipSnapshot,
     targetSnapshot: DataQualityRelationshipTargetSnapshot | undefined,
     target: DataMart | undefined,
-    targetSourceQueries: Map<string, Promise<string | QueryBuildResult>>,
+    targetSourceQueries: Map<string, Promise<DataQualityQueryResolver>>,
     projectId: string
   ): DataQualityRelationshipCompileContext | undefined {
     if (snapshot.targetAccessible === false) {
@@ -324,19 +326,19 @@ export class RunDataQualityService {
     }
     return {
       snapshot,
-      resolveTargetSourceQuery: () => {
-        let targetSourceQuery = targetSourceQueries.get(snapshot.id);
-        if (!targetSourceQuery) {
-          targetSourceQuery = this.resolveRelationshipTargetSourceQuery(
+      resolveTargetSourceQuery: async columns => {
+        let targetSourceQueryResolver = targetSourceQueries.get(snapshot.id);
+        if (!targetSourceQueryResolver) {
+          targetSourceQueryResolver = this.resolveRelationshipTargetSourceQuery(
             dataMartRun,
             snapshot,
             targetSnapshot,
             target,
             projectId
           );
-          targetSourceQueries.set(snapshot.id, targetSourceQuery);
+          targetSourceQueries.set(snapshot.id, targetSourceQueryResolver);
         }
-        return targetSourceQuery;
+        return (await targetSourceQueryResolver)(columns);
       },
       targetSchema: targetSnapshot.schema,
       targetStorageType: targetSnapshot.storage.type,
@@ -351,7 +353,7 @@ export class RunDataQualityService {
     targetSnapshot: DataQualityRelationshipTargetSnapshot,
     target: DataMart | undefined,
     projectId: string
-  ): Promise<string | QueryBuildResult> {
+  ): Promise<DataQualityQueryResolver> {
     return this.resolveSnapshotTableReference({
       dataMartId: relationship.targetDataMartId,
       projectId,
@@ -363,9 +365,16 @@ export class RunDataQualityService {
 
   private async resolveSnapshotTableReference(
     input: DataQualitySnapshotTableReferenceInput
-  ): Promise<string | QueryBuildResult> {
+  ): Promise<DataQualityQueryResolver> {
     try {
-      return (await this.snapshotTableReference.resolve(input)).query;
+      const reference = await this.snapshotTableReference.resolve(input);
+      return async columns => {
+        try {
+          return await reference.buildQuery(columns);
+        } catch (error) {
+          throw new DataQualitySourceQueryError(error);
+        }
+      };
     } catch (error) {
       if (error instanceof DataQualitySnapshotStorageMismatchError) {
         throw error;

--- a/apps/web/src/features/data-marts/data-quality/api/data-quality.service.test.ts
+++ b/apps/web/src/features/data-marts/data-quality/api/data-quality.service.test.ts
@@ -92,8 +92,27 @@ describe('DataQualityService', () => {
     );
   });
 
-  it('sends only the stored config on save', async () => {
-    const config = effectiveConfig as unknown as DataQualityConfig;
+  it('omits disabled rules from the saved config', async () => {
+    const config: DataQualityConfig = {
+      rules: [
+        {
+          key: 'null_rate:field:["email"]',
+          category: 'null_rate',
+          scope: { type: 'FIELD', fieldPath: ['email'] },
+          severity: 'warning',
+          enabled: true,
+          parameters: { thresholdPercent: 2 },
+        },
+        {
+          key: 'duplicate_rows:data_mart',
+          category: 'duplicate_rows',
+          scope: { type: 'DATA_MART' },
+          severity: 'error',
+          enabled: false,
+          parameters: {},
+        },
+      ],
+    };
     vi.mocked(apiClient.put).mockResolvedValueOnce({
       data: {
         savedConfig: config,

--- a/apps/web/src/features/data-marts/data-quality/api/data-quality.service.ts
+++ b/apps/web/src/features/data-marts/data-quality/api/data-quality.service.ts
@@ -132,20 +132,26 @@ class DataQualityService extends ApiService {
 
 function toStoredConfig(config: DataQualityConfig | EffectiveDataQualityConfig): DataQualityConfig {
   if (config.rules.some(rule => 'isApplicable' in rule)) {
-    return toStoredDataQualityConfig(config as EffectiveDataQualityConfig);
+    return {
+      rules: toStoredDataQualityConfig(config as EffectiveDataQualityConfig).rules.filter(
+        rule => rule.enabled
+      ),
+    };
   }
   return {
-    rules: config.rules.map(rule => ({
-      key: rule.key,
-      category: rule.category,
-      scope:
-        rule.scope.type === 'FIELD'
-          ? { type: rule.scope.type, fieldPath: [...rule.scope.fieldPath] }
-          : { ...rule.scope },
-      severity: rule.severity,
-      enabled: rule.enabled,
-      parameters: { ...rule.parameters },
-    })),
+    rules: config.rules
+      .filter(rule => rule.enabled)
+      .map(rule => ({
+        key: rule.key,
+        category: rule.category,
+        scope:
+          rule.scope.type === 'FIELD'
+            ? { type: rule.scope.type, fieldPath: [...rule.scope.fieldPath] }
+            : { ...rule.scope },
+        severity: rule.severity,
+        enabled: rule.enabled,
+        parameters: { ...rule.parameters },
+      })),
   };
 }
 

--- a/apps/web/src/features/data-marts/data-quality/components/DataQualityResultCard.test.tsx
+++ b/apps/web/src/features/data-marts/data-quality/components/DataQualityResultCard.test.tsx
@@ -158,7 +158,7 @@ describe('DataQualityResultCard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Show details for Negative values' }));
     fireEvent.click(screen.getByRole('button', { name: 'SQL' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Copy SQL' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy to Clipboard' }));
 
     await waitFor(() => {
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith(result.sql);
@@ -251,7 +251,7 @@ describe('DataQualityResultCard', () => {
         "SQL and examples are hidden because you don't have access to the target Data Mart orders. The counts above are still accurate."
       )
     ).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Copy SQL' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Copy to Clipboard' })).not.toBeInTheDocument();
   });
 
   it('does not infer access redaction from naturally empty relationship output', () => {

--- a/apps/web/src/features/data-marts/data-quality/components/DataQualityResultCard.tsx
+++ b/apps/web/src/features/data-marts/data-quality/components/DataQualityResultCard.tsx
@@ -220,13 +220,13 @@ export function DataQualityResultCard({
                     <Button
                       variant='outline'
                       size='sm'
-                      aria-label={isCopied ? 'Copied' : 'Copy SQL'}
+                      aria-label={isCopied ? 'Copied' : 'Copy to Clipboard'}
                       onClick={() => {
                         handleCopy(result.sql ?? '', result.id);
                       }}
                     >
                       {isCopied ? <Check className='size-4' /> : <Copy className='size-4' />}
-                      {isCopied ? 'Copied' : 'Copy SQL'}
+                      {isCopied ? 'Copied' : 'Copy to Clipboard'}
                     </Button>
                   </div>
                 </>

--- a/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/DataQualityRunHistoryDetails.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRunHistoryView/DataQualityRunHistoryDetails.test.tsx
@@ -112,7 +112,7 @@ describe('DataQualityRunHistoryDetails', () => {
     fireEvent.click(screen.getByRole('button', { name: 'SQL' }));
 
     expect(screen.getByText('SELECT * FROM source WHERE amount < 0')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Copy SQL' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy to Clipboard' })).toBeInTheDocument();
 
     expect(screen.getByText('Run snapshot')).toBeInTheDocument();
     expect(screen.getAllByText('SQL')).toHaveLength(2);


### PR DESCRIPTION
## Summary

- omit disabled Data Quality rules from save requests so payload size follows the enabled configuration
- project only the source and relationship columns each check consumes, while retaining `SELECT *` only for full-row duplicate detection
- avoid relationship SQL alias collisions with schema fields and rename the shared SQL action to `Copy to Clipboard`

## Root cause

The UI serialized generated disabled rules for every schema field. Relationship checks also used generic `source` and `target` aliases while expanding full rows, so a schema field with the same name could shadow the range alias in BigQuery and produce invalid correlated SQL.

## Validation

- `npm run build --workspaces --if-present`
- `AWS_EC2_METADATA_DISABLED=true NODE_ENV=test npm run test`
- `npm run lint`
- `npm run format:check`
- Playwright save check on the affected local Data Mart: request reduced from 202,932 bytes / 945 rules to 906 bytes / 5 enabled rules and returned HTTP 200
