### PR TITLE
feat(data-marts): show report SQL without edit access

### DIFF
--- a/.changeset/6776-show-sql-for-business-users.md
+++ b/.changeset/6776-show-sql-for-business-users.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Preview SQL no longer requires edit access
+
+Opening **Preview SQL** on a report used to fail with "edit access to the source data mart is required" for anyone without maintenance access — including Business Users on a Data Mart shared for reporting, and Technical Users who are not owners of it. Reading the query a report runs is now tied to seeing the report: if a Data Mart is visible to you, you can open the generated SQL of any report on it and copy it to the clipboard.
+
+The two actions in that dialog that genuinely need maintenance access — the SQL validator (dry run) and **Copy as Data Mart** — are now hidden for users without it instead of failing on click. Reports that join a Data Mart the viewer cannot access still refuse to render SQL, naming the inaccessible Data Mart.

--- a/apps/backend/src/data-marts/controllers/report.controller.ts
+++ b/apps/backend/src/data-marts/controllers/report.controller.ts
@@ -137,7 +137,7 @@ export class ReportController {
   async getGeneratedSql(
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string
-  ): Promise<{ sql: string }> {
+  ): Promise<{ sql: string; canModifySource: boolean }> {
     const command = this.mapper.toGetGeneratedSqlCommand(id, context);
     return this.getReportGeneratedSqlService.run(command);
   }

--- a/apps/backend/src/data-marts/controllers/spec/report.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.api.ts
@@ -101,8 +101,15 @@ export function GetReportGeneratedSqlSpec() {
       description: 'The generated SQL query for the report.',
       schema: {
         type: 'object',
-        required: ['sql'],
-        properties: { sql: { type: 'string' } },
+        required: ['sql', 'canModifySource'],
+        properties: {
+          sql: { type: 'string' },
+          canModifySource: {
+            type: 'boolean',
+            description:
+              'Whether the caller has maintenance (edit) access to the source data mart. False for read-only viewers, who can read and copy the SQL but cannot dry-run it or copy it as a new data mart.',
+          },
+        },
       },
     })
   );

--- a/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
@@ -281,8 +281,11 @@ describe('ReportController OpenAPI', () => {
         'application/json': {
           schema: {
             type: 'object',
-            required: ['sql'],
-            properties: { sql: { type: 'string' } },
+            required: ['sql', 'canModifySource'],
+            properties: {
+              sql: { type: 'string' },
+              canModifySource: { type: 'boolean' },
+            },
           },
         },
       },

--- a/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.spec.ts
@@ -20,7 +20,7 @@ describe('GetReportGeneratedSqlService', () => {
     dataDestination: { id: 'dest-1' },
   };
 
-  const createService = (canEditDataMart = true) => {
+  const createService = ({ canSee = true, canEdit = true } = {}) => {
     const reportRepository = {
       findOne: jest.fn().mockResolvedValue(report),
     };
@@ -28,7 +28,11 @@ describe('GetReportGeneratedSqlService', () => {
       composeStatic: jest.fn().mockResolvedValue({ sql: 'SELECT 1' }),
     };
     const accessDecisionService = {
-      canAccess: jest.fn().mockResolvedValue(canEditDataMart),
+      canAccess: jest
+        .fn()
+        .mockImplementation((_userId, _roles, _entityType, _entityId, action) =>
+          Promise.resolve(action === Action.EDIT ? canEdit : canSee)
+        ),
     };
 
     const service = new GetReportGeneratedSqlService(
@@ -42,8 +46,11 @@ describe('GetReportGeneratedSqlService', () => {
 
   beforeEach(() => jest.clearAllMocks());
 
-  it('returns generated SQL when user has EDIT on source data mart', async () => {
-    const { service, accessDecisionService, reportSqlComposerService } = createService(true);
+  it('returns generated SQL when user has SEE on source data mart', async () => {
+    const { service, accessDecisionService, reportSqlComposerService } = createService({
+      canSee: true,
+      canEdit: true,
+    });
 
     const command = new GetReportGeneratedSqlCommand('report-1', 'user-1', 'proj-1', ['editor']);
 
@@ -54,18 +61,29 @@ describe('GetReportGeneratedSqlService', () => {
       ['editor'],
       EntityType.DATA_MART,
       'dm-1',
-      Action.EDIT,
+      Action.SEE,
       'proj-1'
     );
     expect(reportSqlComposerService.composeStatic).toHaveBeenCalledWith(report, {
       userId: 'user-1',
       roles: ['editor'],
     });
-    expect(result).toEqual({ sql: 'SELECT 1' });
+    expect(result).toEqual({ sql: 'SELECT 1', canModifySource: true });
+  });
+
+  it('returns generated SQL with canModifySource false for a viewer who only has SEE', async () => {
+    const { service, reportSqlComposerService } = createService({ canSee: true, canEdit: false });
+
+    const command = new GetReportGeneratedSqlCommand('report-1', 'user-1', 'proj-1', ['viewer']);
+
+    const result = await service.run(command);
+
+    expect(reportSqlComposerService.composeStatic).toHaveBeenCalled();
+    expect(result).toEqual({ sql: 'SELECT 1', canModifySource: false });
   });
 
   it('throws UnauthorizedException when userId is empty', async () => {
-    const { service, accessDecisionService, reportRepository } = createService(true);
+    const { service, accessDecisionService, reportRepository } = createService();
 
     const command = new GetReportGeneratedSqlCommand('report-1', '', 'proj-1', []);
 
@@ -75,7 +93,7 @@ describe('GetReportGeneratedSqlService', () => {
   });
 
   it('throws NotFoundException when report is not found', async () => {
-    const { service, reportRepository } = createService(true);
+    const { service, reportRepository } = createService();
     reportRepository.findOne = jest.fn().mockResolvedValue(null);
 
     const command = new GetReportGeneratedSqlCommand('missing', 'user-1', 'proj-1', ['editor']);
@@ -83,8 +101,8 @@ describe('GetReportGeneratedSqlService', () => {
     await expect(service.run(command)).rejects.toThrow(NotFoundException);
   });
 
-  it('throws ForbiddenException when user lacks EDIT on source data mart', async () => {
-    const { service, reportSqlComposerService } = createService(false);
+  it('throws ForbiddenException when user lacks SEE on source data mart', async () => {
+    const { service, reportSqlComposerService } = createService({ canSee: false, canEdit: false });
 
     const command = new GetReportGeneratedSqlCommand('report-1', 'user-1', 'proj-1', ['viewer']);
 
@@ -93,7 +111,7 @@ describe('GetReportGeneratedSqlService', () => {
   });
 
   it('throws BadRequestException for TABLE_PATTERN on unsupported storages', async () => {
-    const { service, reportRepository, reportSqlComposerService } = createService(true);
+    const { service, reportRepository, reportSqlComposerService } = createService();
     reportRepository.findOne = jest.fn().mockResolvedValue({
       id: 'report-1',
       dataMart: {
@@ -111,7 +129,7 @@ describe('GetReportGeneratedSqlService', () => {
   });
 
   it('allows TABLE_PATTERN on GOOGLE_BIGQUERY', async () => {
-    const { service, reportRepository, reportSqlComposerService } = createService(true);
+    const { service, reportRepository, reportSqlComposerService } = createService();
     reportRepository.findOne = jest.fn().mockResolvedValue({
       id: 'report-1',
       dataMart: {
@@ -126,6 +144,6 @@ describe('GetReportGeneratedSqlService', () => {
 
     const result = await service.run(command);
     expect(reportSqlComposerService.composeStatic).toHaveBeenCalled();
-    expect(result).toEqual({ sql: 'SELECT 1' });
+    expect(result).toEqual({ sql: 'SELECT 1', canModifySource: true });
   });
 });

--- a/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-generated-sql.service.ts
@@ -23,7 +23,9 @@ export class GetReportGeneratedSqlService {
     private readonly accessDecisionService: AccessDecisionService
   ) {}
 
-  async run(command: GetReportGeneratedSqlCommand): Promise<{ sql: string }> {
+  async run(
+    command: GetReportGeneratedSqlCommand
+  ): Promise<{ sql: string; canModifySource: boolean }> {
     if (!command.userId) {
       throw new UnauthorizedException('Authenticated user is required');
     }
@@ -40,17 +42,30 @@ export class GetReportGeneratedSqlService {
       throw new NotFoundException(`Report with ID ${command.reportId} not found`);
     }
 
-    const canEditDataMart = await this.accessDecisionService.canAccess(
-      command.userId,
-      command.roles,
-      EntityType.DATA_MART,
-      report.dataMart.id,
-      Action.EDIT,
-      command.projectId
-    );
-    if (!canEditDataMart) {
+    // Reading SQL is transparency, not a maintenance privilege: anyone who can see the
+    // report (i.e. sees its source data mart) may read it. Access to the joined sources
+    // is enforced separately by the composer — see BlendedReportDataService.
+    const [canSeeDataMart, canModifySource] = await Promise.all([
+      this.accessDecisionService.canAccess(
+        command.userId,
+        command.roles,
+        EntityType.DATA_MART,
+        report.dataMart.id,
+        Action.SEE,
+        command.projectId
+      ),
+      this.accessDecisionService.canAccess(
+        command.userId,
+        command.roles,
+        EntityType.DATA_MART,
+        report.dataMart.id,
+        Action.EDIT,
+        command.projectId
+      ),
+    ]);
+    if (!canSeeDataMart) {
       throw new ForbiddenException(
-        'You do not have permission to view the generated SQL of this report: edit access to the source data mart is required.'
+        'You do not have permission to view the generated SQL of this report: access to the source data mart is required.'
       );
     }
 
@@ -71,6 +86,6 @@ export class GetReportGeneratedSqlService {
       userId: command.userId,
       roles: command.roles,
     });
-    return { sql };
+    return { sql, canModifySource };
   }
 }

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { GeneratedSqlViewer } from './GeneratedSqlViewer';
+
+const getGeneratedSql = vi.fn();
+
+vi.mock('../../../reports/shared/services/report.service', () => ({
+  reportService: {
+    getGeneratedSql: (...args: unknown[]) => getGeneratedSql(...args) as unknown,
+  },
+}));
+
+// Monaco pulls in web workers that happy-dom cannot run — render the SQL as a
+// plain textarea so assertions can still see it.
+vi.mock('@monaco-editor/react', () => ({
+  Editor: ({ value }: { value: string }) => <textarea readOnly value={value} />,
+}));
+
+// The dry-run validator is the thing we assert is absent for read-only viewers;
+// give it a stable test id instead of reaching into its internals.
+vi.mock('../SqlValidator/SqlValidator', () => ({
+  default: () => <div data-testid='sql-validator' />,
+}));
+
+vi.mock('../../../../../shared/hooks', () => ({
+  useProjectRoute: () => ({ scope: (path: string) => path }),
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' }),
+}));
+
+async function openDialog() {
+  render(<GeneratedSqlViewer reportId='report-1' dataMartId='dm-1' variant='outline-button' />);
+  fireEvent.click(screen.getByRole('button', { name: 'Preview SQL' }));
+  await waitFor(() => {
+    expect(screen.getByDisplayValue('SELECT 1')).toBeInTheDocument();
+  });
+}
+
+describe('GeneratedSqlViewer — read-only viewers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the SQL and Copy to Clipboard, but no edit-only actions, when canModifySource is false', async () => {
+    getGeneratedSql.mockResolvedValue({ sql: 'SELECT 1', canModifySource: false });
+
+    await openDialog();
+
+    expect(screen.getByRole('button', { name: /Copy to Clipboard/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Copy as Data Mart' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sql-validator')).not.toBeInTheDocument();
+  });
+
+  it('shows the validator and Copy as Data Mart when canModifySource is true', async () => {
+    getGeneratedSql.mockResolvedValue({ sql: 'SELECT 1', canModifySource: true });
+
+    await openDialog();
+
+    expect(screen.getByRole('button', { name: 'Copy as Data Mart' })).toBeInTheDocument();
+    expect(screen.getByTestId('sql-validator')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/GeneratedSqlViewer.tsx
@@ -17,6 +17,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/too
 import { Skeleton } from '@owox/ui/components/skeleton';
 import { reportService } from '../../../reports/shared/services/report.service';
 import { useProjectRoute } from '../../../../../shared/hooks';
+import { extractApiError, type ApiError } from '../../../../../app/api';
 import SqlValidator from '../SqlValidator/SqlValidator';
 
 type GeneratedSqlViewerVariant = 'action-icon' | 'outline-button';
@@ -58,6 +59,12 @@ export function GeneratedSqlViewer({
   const [sql, setSql] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isCopyingAsDataMart, setIsCopyingAsDataMart] = useState(false);
+  /**
+   * Whether the viewer has maintenance access to the source Data Mart. Reading the SQL
+   * only needs visibility, but the dry-run validator and "Copy as Data Mart" both require
+   * edit access — hide them rather than let the user click into a guaranteed 403.
+   */
+  const [canModifySource, setCanModifySource] = useState(false);
   const { resolvedTheme } = useTheme();
   const { scope } = useProjectRoute();
 
@@ -66,9 +73,17 @@ export function GeneratedSqlViewer({
     try {
       const result = await reportService.getGeneratedSql(reportId);
       setSql(result.sql);
-    } catch {
-      toast.error('Failed to load generated SQL');
+      setCanModifySource(result.canModifySource);
+    } catch (error) {
+      // The API client already surfaces server-provided messages (missing access to the
+      // source or to a joined Data Mart). Only fall back to a generic toast when there
+      // is none — otherwise the specific reason gets buried under it.
+      const apiError = extractApiError(error) as ApiError | undefined;
+      if (!apiError?.message?.trim()) {
+        toast.error('Failed to load generated SQL');
+      }
       setSql('');
+      setCanModifySource(false);
     } finally {
       setIsLoading(false);
     }
@@ -79,6 +94,7 @@ export function GeneratedSqlViewer({
     if (open) {
       // Always refetch on open — skip cache, show fresh SQL.
       setSql(null);
+      setCanModifySource(false);
       void loadSql();
     }
   }
@@ -192,8 +208,10 @@ export function GeneratedSqlViewer({
                 <span className='text-sm'>Generating SQL...</span>
               </div>
             </div>
-          ) : (
+          ) : canModifySource ? (
             <SqlValidator sql={sql} dataMartId={dataMartId} />
+          ) : (
+            <div />
           )}
           <div className='flex gap-2'>
             <Button
@@ -205,14 +223,16 @@ export function GeneratedSqlViewer({
               <Copy className='mr-2 h-4 w-4' />
               Copy to Clipboard
             </Button>
-            <Button
-              type='button'
-              variant='default'
-              onClick={() => void handleCopyAsDataMart()}
-              disabled={isLoading || isCopyingAsDataMart}
-            >
-              Copy as Data Mart
-            </Button>
+            {canModifySource && (
+              <Button
+                type='button'
+                variant='default'
+                onClick={() => void handleCopyAsDataMart()}
+                disabled={isLoading || isCopyingAsDataMart}
+              >
+                Copy as Data Mart
+              </Button>
+            )}
           </div>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
+++ b/apps/web/src/features/data-marts/reports/shared/services/report.service.ts
@@ -130,10 +130,11 @@ export class ReportService extends ApiService {
   /**
    * Get the generated SQL for a report
    * @param id Report ID
-   * @returns Object containing the generated SQL string
+   * @returns The generated SQL plus whether the caller has maintenance access to the
+   *          source data mart (drives the dry-run validator / "Copy as Data Mart" actions)
    */
-  async getGeneratedSql(id: string): Promise<{ sql: string }> {
-    return this.get<{ sql: string }>(`/${id}/generated-sql`);
+  async getGeneratedSql(id: string): Promise<{ sql: string; canModifySource: boolean }> {
+    return this.get<{ sql: string; canModifySource: boolean }>(`/${id}/generated-sql`);
   }
 
   /**

--- a/docs/project/ownership-and-sharing.md
+++ b/docs/project/ownership-and-sharing.md
@@ -249,6 +249,10 @@ Access to edit, delete, or run a Report requires one of two conditions:
 
 > ☝️ A Report owner can edit, delete, and run the Report only while its Destination still exists. If the Destination is deleted, the owner can still see the Report but cannot edit, delete, or run it until the Destination is restored or ownership is reassigned by a Technical User.
 
+**Viewing the Report's SQL follows visibility, not maintenance access.** Anyone who can see a Report can open **Preview SQL** and read or copy the generated query — including Business Users and Technical Users without maintenance access to the parent Data Mart. Two actions in that dialog stay restricted to users with Data Mart maintenance access and are hidden for everyone else: the SQL validator (dry run) and **Copy as Data Mart**.
+
+If the Report pulls fields from a [joined Data Mart](../getting-started/setup-guide/joinable-data-marts.md) that the viewer cannot access, the SQL is not shown at all — the error names the inaccessible Data Mart.
+
 ---
 
 ### Report Trigger


### PR DESCRIPTION
## Problem

Opening **Preview SQL** on a report required `EDIT` on the source Data Mart, so anyone without maintenance access got a 403 and an empty dialog:

> Failed to load generated SQL — You do not have permission to view the generated SQL of this report: edit access to the source data mart is required.

That hit Business Users on a Data Mart *Shared for reporting*, and Technical Users who are not owners of it.

The gate was an outlier rather than a deliberate rule: report **visibility** is gated on `SEE` everywhere else, and a Data Mart's own definition (including its SQL) is already returned to everyone who can see it. Only the report's *generated* SQL was locked behind `EDIT`.

## What changed

- `GetReportGeneratedSqlService` now gates on `Action.SEE` instead of `Action.EDIT` — reading the query a report runs is transparency, not a maintenance privilege.
- The `EDIT` check is kept, but as a `canModifySource` flag on the response instead of a rejection. Both checks run in one `Promise.all`, so there's no extra round-trip and no per-row cost on report lists.
- The SQL dialog **hides** the dry-run validator and **Copy as Data Mart** when `canModifySource` is false, instead of letting the user click into a guaranteed 403. Both endpoints stay `EDIT`-gated server side — hiding is UX, not the boundary.
- The generic `Failed to load generated SQL` toast now only fires when the server gave no message, so specific reasons aren't buried under it.

## Not changed

- Editing someone else's report stays forbidden.
- `copy-as-data-mart` and `sql-dry-run-triggers` keep their `EDIT` gates.
- Access to **joined** sources is untouched: `BlendedReportDataService` still refuses to build SQL spanning a Data Mart the caller cannot use, naming it in the error.

## Access matrix

| Who | SQL visible | Copy to Clipboard | Validator | Copy as Data Mart |
|---|---|---|---|---|
| Admin / Data Mart tech owner | ✅ | ✅ | ✅ | ✅ |
| Technical User, non-owner, shared for reporting | ✅ | ✅ | hidden | hidden |
| Business User, shared for reporting | ✅ | ✅ | hidden | hidden |
| No access to the Data Mart | report not visible | — | — | — |
| Report joining an inaccessible Data Mart | ❌ error naming that Data Mart | — | — | — |

## Tests

- `get-report-generated-sql.service.spec.ts` — the `lacks EDIT → Forbidden` case is replaced by `lacks SEE`, plus two new cases covering `canModifySource` for editor and viewer.
- `GeneratedSqlViewer.test.tsx` (new) — read-only viewers get the SQL and Copy to Clipboard but neither edit-only action.
- `report.openapi.spec.ts` — response schema expectation updated for the new field.
- `blended-report-data.service.spec.ts` and `guard-regression.spec.ts` pass unchanged — the joined-source guard already covers the no-leak case, message and all.

## Docs

`docs/project/ownership-and-sharing.md` → **Report** section now states who can view report SQL and which two actions remain restricted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)