### PR TITLE
feat(data-marts): share new Data Marts for maintenance by default

### DIFF
--- a/.changeset/6721-shared-for-maintenance-default.md
+++ b/.changeset/6721-shared-for-maintenance-default.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# New Data Marts are shared for maintenance by default
+
+A newly created Data Mart now starts with both sharing toggles on: **Shared for reporting** and **Shared for maintenance**. Other Technical Users can join it to their own Data Marts straight away, instead of first having to find the owner and ask them to share it.
+
+Data Marts that already exist are not changed. The owner can still turn **Shared for maintenance** off on any Data Mart in one click — non-owners then keep reporting access and lose the ability to edit or join it.
+
+Storages and Destinations keep their current defaults: shared for use, not shared for maintenance.

--- a/apps/backend/src/data-marts/entities/data-mart.entity.ts
+++ b/apps/backend/src/data-marts/entities/data-mart.entity.ts
@@ -77,7 +77,7 @@ export class DataMart implements CreatorAwareEntity {
   @Column({ type: 'boolean', default: true })
   availableForReporting: boolean;
 
-  @Column({ type: 'boolean', default: false })
+  @Column({ type: 'boolean', default: true })
   availableForMaintenance: boolean;
 
   @OneToMany(() => DataMartBusinessOwner, owner => owner.dataMart)

--- a/apps/backend/src/data-marts/entities/sharing-fields.spec.ts
+++ b/apps/backend/src/data-marts/entities/sharing-fields.spec.ts
@@ -19,11 +19,11 @@ describe('Sharing fields on entities', () => {
       expect(col!.options.default).toBe(true);
     });
 
-    it('should have availableForMaintenance boolean column defaulting to false', () => {
+    it('should have availableForMaintenance boolean column defaulting to true', () => {
       const col = getColumnMeta(DataMart, 'availableForMaintenance');
       expect(col).toBeDefined();
       expect(col!.options.type).toBe('boolean');
-      expect(col!.options.default).toBe(false);
+      expect(col!.options.default).toBe(true);
     });
   });
 

--- a/apps/backend/src/data-marts/use-cases/create-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-mart.service.spec.ts
@@ -49,7 +49,7 @@ describe('CreateDataMartService', () => {
     jest.clearAllMocks();
   });
 
-  it('should make a new data mart reporting-visible but maintenance-private by default', async () => {
+  it('should make a new data mart shared for reporting and for maintenance by default', async () => {
     const { service, dataMartService } = createService();
     const command = new CreateDataMartCommand('proj-1', 'user-0', 'Test DM', 'storage-1');
 
@@ -58,7 +58,7 @@ describe('CreateDataMartService', () => {
     expect(dataMartService.create).toHaveBeenCalledWith(
       expect.objectContaining({
         availableForReporting: true,
-        availableForMaintenance: false,
+        availableForMaintenance: true,
       })
     );
   });

--- a/apps/backend/src/data-marts/use-cases/create-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/create-data-mart.service.ts
@@ -84,7 +84,7 @@ export class CreateDataMartService {
       createdById: command.userId,
       storage: dataStorage,
       availableForReporting: true,
-      availableForMaintenance: false,
+      availableForMaintenance: true,
       ...(isLegacyDataMart
         ? {
             id: legacyDataMartId,

--- a/apps/backend/src/data-marts/use-cases/legacy-data-marts/sync-legacy-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/legacy-data-marts/sync-legacy-data-mart.service.spec.ts
@@ -184,6 +184,40 @@ describe('SyncLegacyDataMartService', () => {
       expect(dataMartService.save).toHaveBeenCalledWith(existingDataMart);
     });
 
+    it('should share a newly synced data mart for reporting and for maintenance', async () => {
+      legacyDataMartsService.getDataMartDetails.mockResolvedValue(mockProjection);
+      legacyDataStorageService.findByGcpProjectId.mockResolvedValue(mockStorage);
+      dataMartService.findById.mockResolvedValue(null);
+      dataMartService.create.mockReturnValue({ id: 'dm-123' } as DataMart);
+
+      await service.run({ dataMartId: 'dm-123' });
+
+      expect(dataMartService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          availableForReporting: true,
+          availableForMaintenance: true,
+        })
+      );
+    });
+
+    it('should keep the sharing settings of an existing data mart on re-sync', async () => {
+      const existingDataMart = {
+        id: 'dm-123',
+        title: 'Old Title',
+        availableForReporting: false,
+        availableForMaintenance: false,
+      } as DataMart;
+
+      legacyDataMartsService.getDataMartDetails.mockResolvedValue(mockProjection);
+      legacyDataStorageService.findByGcpProjectId.mockResolvedValue(mockStorage);
+      dataMartService.findById.mockResolvedValue(existingDataMart);
+
+      await service.run({ dataMartId: 'dm-123' });
+
+      expect(existingDataMart.availableForReporting).toBe(false);
+      expect(existingDataMart.availableForMaintenance).toBe(false);
+    });
+
     it('should silently skip when AccessValidationException is thrown', async () => {
       legacyDataMartsService.getDataMartDetails.mockResolvedValue(mockProjection);
       legacyDataStorageService.findByGcpProjectId.mockResolvedValue(null);

--- a/apps/backend/src/data-marts/use-cases/legacy-data-marts/sync-legacy-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/legacy-data-marts/sync-legacy-data-mart.service.ts
@@ -114,6 +114,8 @@ export class SyncLegacyDataMartService {
         sqlQuery: projection.query,
       } as SqlDefinition,
       createdById: '',
+      availableForReporting: true,
+      availableForMaintenance: true,
     });
   }
 

--- a/apps/backend/test/data-mart-default-sharing.e2e-spec.ts
+++ b/apps/backend/test/data-mart-default-sharing.e2e-spec.ts
@@ -1,0 +1,174 @@
+import { INestApplication } from '@nestjs/common';
+import * as supertest from 'supertest';
+import {
+  createTestApp,
+  closeTestApp,
+  AUTH_HEADER,
+  StorageBuilder,
+  DataMartBuilder,
+} from '@owox/test-utils';
+import { IdpProjectionsFacade } from '../src/idp/facades/idp-projections.facade';
+import { ProjectMemberDto } from '../src/idp/dto/domain/project-member.dto';
+import type { IdpProvider, Payload } from '@owox/idp-protocol';
+
+const EDITOR_AUTH_HEADER = { 'x-owox-authorization': 'editor-token' };
+
+const ADMIN_PAYLOAD: Payload = {
+  userId: '0',
+  email: 'admin@localhost',
+  roles: ['admin'],
+  fullName: 'Admin',
+  projectId: '0',
+};
+const EDITOR_PAYLOAD: Payload = {
+  userId: '1',
+  email: 'editor@localhost',
+  roles: ['editor'],
+  fullName: 'Technical User',
+  projectId: '0',
+};
+
+function resolvePayload(token: string): Payload {
+  return token.startsWith('editor') ? EDITOR_PAYLOAD : ADMIN_PAYLOAD;
+}
+
+const STRING_FIELD_SCHEMA = (name: string) => ({
+  type: 'bigquery-data-mart-schema',
+  fields: [{ name, type: 'STRING', mode: 'NULLABLE', status: 'CONNECTED' }],
+});
+
+/**
+ * A new Data Mart is shared for maintenance by default, so another Technical User
+ * can join it without the owner sharing it first.
+ *
+ * The default is deliberate: joining is gated by Edit access on both Data Marts,
+ * and requiring the owner to flip a toggle first made the "add one more column"
+ * flow undiscoverable. The owner can still switch maintenance sharing off.
+ */
+describe('Data Mart default sharing (e2e)', () => {
+  let app: INestApplication;
+  let agent: supertest.Agent;
+  let storageId: string;
+  let ownerDataMartId: string;
+  let otherUserDataMartId: string;
+
+  async function createDataMart(
+    title: string,
+    authHeader: Record<string, string>,
+    schemaFieldName: string
+  ): Promise<string> {
+    const createRes = await agent
+      .post('/api/data-marts')
+      .set(authHeader)
+      .send(new DataMartBuilder().withTitle(title).withStorageId(storageId).build());
+    expect(createRes.status).toBe(201);
+    const dataMartId: string = createRes.body.id;
+
+    const defRes = await agent
+      .put(`/api/data-marts/${dataMartId}/definition`)
+      .set(authHeader)
+      .send({ definitionType: 'SQL', definition: { sqlQuery: 'SELECT 1' } });
+    expect(defRes.status).toBe(200);
+
+    const publishRes = await agent.put(`/api/data-marts/${dataMartId}/publish`).set(authHeader);
+    expect(publishRes.status).toBe(200);
+
+    const schemaRes = await agent
+      .put(`/api/data-marts/${dataMartId}/schema`)
+      .set(authHeader)
+      .send({ schema: STRING_FIELD_SCHEMA(schemaFieldName) });
+    expect(schemaRes.status).toBe(200);
+
+    return dataMartId;
+  }
+
+  beforeAll(async () => {
+    const testApp = await createTestApp();
+    app = testApp.app;
+    agent = testApp.agent;
+
+    const expressApp = (
+      app.getHttpAdapter() as { getInstance(): Express.Application }
+    ).getInstance();
+    const idpProvider = expressApp.get('idp') as IdpProvider;
+    jest
+      .spyOn(idpProvider, 'introspectToken')
+      .mockImplementation(async token => resolvePayload(token));
+    jest.spyOn(idpProvider, 'parseToken').mockImplementation(async token => resolvePayload(token));
+
+    const facade = app.get(IdpProjectionsFacade);
+    jest
+      .spyOn(facade, 'getProjectMembers')
+      .mockResolvedValue([
+        new ProjectMemberDto('0', 'admin@localhost', 'Admin', undefined, 'admin', true, false),
+        new ProjectMemberDto(
+          '1',
+          'editor@localhost',
+          'Technical User',
+          undefined,
+          'editor',
+          true,
+          false
+        ),
+      ]);
+
+    const storageRes = await agent
+      .post('/api/data-storages')
+      .set(AUTH_HEADER)
+      .send(new StorageBuilder().build());
+    expect(storageRes.status).toBe(201);
+    storageId = storageRes.body.id;
+
+    // Neither Data Mart gets an explicit availability call — the defaults are under test.
+    ownerDataMartId = await createDataMart('Owner Data Mart', AUTH_HEADER, 'id');
+    otherUserDataMartId = await createDataMart(
+      'Other User Data Mart',
+      EDITOR_AUTH_HEADER,
+      'ref_id'
+    );
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  it('reports a new Data Mart as shared for reporting and for maintenance', async () => {
+    const res = await agent.get(`/api/data-marts/${ownerDataMartId}`).set(AUTH_HEADER);
+
+    expect(res.status).toBe(200);
+    expect(res.body.availableForReporting).toBe(true);
+    expect(res.body.availableForMaintenance).toBe(true);
+  });
+
+  it('lets a non-owner Technical User join a new Data Mart without the owner sharing it', async () => {
+    const res = await agent
+      .post(`/api/data-marts/${otherUserDataMartId}/relationships`)
+      .set(EDITOR_AUTH_HEADER)
+      .send({
+        targetDataMartId: ownerDataMartId,
+        targetAlias: 'owner_mart',
+        joinConditions: [{ sourceFieldName: 'ref_id', targetFieldName: 'id' }],
+      });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('blocks the join once the owner turns maintenance sharing off', async () => {
+    const availabilityRes = await agent
+      .put(`/api/data-marts/${ownerDataMartId}/availability`)
+      .set(AUTH_HEADER)
+      .send({ availableForReporting: true, availableForMaintenance: false });
+    expect(availabilityRes.status).toBe(204);
+
+    const res = await agent
+      .post(`/api/data-marts/${otherUserDataMartId}/relationships`)
+      .set(EDITOR_AUTH_HEADER)
+      .send({
+        targetDataMartId: ownerDataMartId,
+        targetAlias: 'owner_mart_again',
+        joinConditions: [{ sourceFieldName: 'ref_id', targetFieldName: 'id' }],
+      });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/backend/test/ownership.e2e-spec.ts
+++ b/apps/backend/test/ownership.e2e-spec.ts
@@ -250,12 +250,12 @@ describe('Ownership (e2e)', () => {
       expect(dm.businessOwnerUsers).toHaveLength(0);
     });
 
-    it('GET /api/data-marts/:id - new DM is reporting-shared, maintenance-private by default', async () => {
+    it('GET /api/data-marts/:id - new DM is shared for reporting and for maintenance by default', async () => {
       const res = await agent.get(`/api/data-marts/${dataMartId}`).set(AUTH_HEADER);
 
       expect(res.status).toBe(200);
       expect(res.body.availableForReporting).toBe(true);
-      expect(res.body.availableForMaintenance).toBe(false);
+      expect(res.body.availableForMaintenance).toBe(true);
     });
 
     it('PUT /api/data-marts/:id/owners - updates technical and business owners', async () => {

--- a/docs/project/ownership-and-sharing.md
+++ b/docs/project/ownership-and-sharing.md
@@ -86,7 +86,17 @@ The second toggle is **Shared for maintenance** for all resource types. The comb
 | First toggle off, second on | Can see, use, edit, and delete the resource |
 | Both toggles on | Both of the above |
 
-> ☝️ New resources start with both toggles off. Existing resources were migrated to both toggles on to preserve previous access patterns. Owners can gradually reconfigure sharing to match their intended access model.
+### Defaults for new resources
+
+| Resource | Shared for reporting / use | Shared for maintenance |
+|---|---|---|
+| Data Mart | On | On |
+| Storage | On | Off |
+| Destination | On | Off |
+
+A new Data Mart is shared for maintenance so that other Technical Users can join it to their own Data Marts right away, without asking the owner for access first. If you do not want that, turn **Shared for maintenance** off on the Data Mart — non-owners keep reporting access and lose the ability to edit or join it.
+
+> ☝️ Changing the default does not touch Data Marts that already exist. Resources created before the sharing model was introduced were migrated to both toggles on to preserve previous access patterns.
 
 ![Resource settings page with the Shared for reporting and Shared for maintenance toggles](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/f8622cf6-8d75-46ee-e9e2-b869f987a500/public)
 
@@ -192,7 +202,7 @@ Data Mart Triggers have no dedicated ownership. Who can see them and who can man
 
 Relationships between Data Marts have no dedicated ownership. They belong to the source Data Mart and follow its access rules. See [Joinable Data Marts](../getting-started/setup-guide/joinable-data-marts.md) to configure them.
 
-**Creating a relationship** requires `Edit` access on both the source and target Data Marts. The user needs maintenance access on each Data Mart, through one of two paths. First: a Technical Owner with the Technical User role. Second: a Technical User on a Data Mart *Shared for maintenance*.
+**Creating a relationship** requires `Edit` access on both the source and target Data Marts. The user needs maintenance access on each Data Mart, through one of two paths. First: a Technical Owner with the Technical User role. Second: a Technical User on a Data Mart *Shared for maintenance*. Because a new Data Mart is *Shared for maintenance* by default, any Technical User can join it without the owner changing anything; turning that toggle off on a Data Mart also stops others from joining it.
 
 **Editing or deleting a relationship** requires `Edit` access on the source Data Mart only.
 


### PR DESCRIPTION
## Problem

A new Data Mart was created with **Shared for maintenance** off. That toggle is what gates joining: creating a relationship requires `Edit` on *both* Data Marts, and a non-owner Technical User only gets `Edit` through it.

So the advertised "add one more column from another Data Mart" flow did not work out of the box. The analyst who wanted the join had to notice that a toggle exists, find the other Data Mart's owner, and wait for them — or, more likely, build a duplicate Data Mart instead.

The default was protecting a corner case (someone edits my Data Mart) at the cost of the main one (handing a joined model over to a business user).

## What changed

- `CreateDataMartService` now creates Data Marts with `availableForMaintenance: true`. This covers the UI create flow and **Copy report as Data Mart**, which goes through the same service.
- `SyncLegacyDataMartService` sets both sharing flags explicitly for Data Marts it creates. It previously set neither and fell through to the DB column default, so it would have kept producing maintenance-private Data Marts. In the legacy extension anyone with access to the same GCP project could already edit the query, so the new default matches the access those Data Marts used to have.
- `DataMart.availableForMaintenance` column metadata flipped to `default: true`, mirroring `availableForReporting`.

## Not changed

- **No migration, no backfill.** Data Marts that already exist keep their current sharing settings.
- **Storages and Destinations** keep their defaults: shared for use, not shared for maintenance. The maintenance flag there governs credentials and connection configs, which is a different risk.
- **The sharing gate itself.** Joining a Data Mart that is *not* shared for maintenance is still refused. The owner turns the toggle off and everything behaves exactly as before.
- No DB default rewrite: every insert path now passes the value explicitly, so the column default is metadata only.

## Defaults after this change

| Resource | Shared for reporting / use | Shared for maintenance |
|---|---|---|
| Data Mart | On | **On** |
| Storage | On | Off |
| Destination | On | Off |

## Tests

- `data-mart-default-sharing.e2e-spec.ts` (new) — a non-owner Technical User creates a relationship to a freshly created Data Mart with no availability call anywhere in the setup, and gets 403 on the same call once the owner turns maintenance sharing off.
- `sync-legacy-data-mart.service.spec.ts` — a newly synced Data Mart gets both flags; an existing one keeps its own settings on re-sync.
- `create-data-mart.service.spec.ts`, `sharing-fields.spec.ts`, `ownership.e2e-spec.ts` — updated expectations.
- The `permissions-*`, `report-operate-access` and `project-activity-lists` e2e suites pass unchanged; they set sharing explicitly rather than relying on the default.

## Docs

`ownership-and-sharing.md` claimed new resources start with both toggles off, which was already wrong for the first toggle. Replaced with a per-resource defaults table, a note on how to opt out, and a line in the Joinable Data Mart section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
