### PR TITLE
feat(data-marts): export Models canvas as SVG, PNG, JSON, or OKF bundle

### DIFF
--- a/.changeset/6771-canvas-export.md
+++ b/.changeset/6771-canvas-export.md
@@ -1,0 +1,14 @@
+---
+'owox': minor
+---
+
+# Export the Models canvas as SVG, PNG, JSON, or an OKF bundle
+
+The Models canvas now exports the data model through **Actions → Export**. Four formats are available:
+
+- **Image (SVG)** — a vector snapshot of the whole visible model, crisp at any zoom.
+- **Image (PNG)** — the same snapshot rasterized at 2× scale, for chats and tools that do not render SVG.
+- **JSON** — the model graph (Data Marts, schemas, joins, canvas positions) in the OWOX Model Canvas format, sanitized of project identifiers.
+- **OKF (Markdown)** — a zip with one cross-linked Markdown document per Data Mart plus an index: an overview, the schema table, and the join list per mart. Reads as a small wiki and works well as context for AI assistants.
+
+The export covers exactly what the canvas shows — the same filtered set the other Actions target — and captures the whole model regardless of the current pan and zoom. Image backgrounds follow the active theme, so dark-theme exports stay readable outside the app.

--- a/.changeset/6771-canvas-export.md
+++ b/.changeset/6771-canvas-export.md
@@ -12,3 +12,9 @@ The Models canvas now exports the data model through **Actions → Export**. Fou
 - **OKF (Markdown)** — a zip with one cross-linked Markdown document per Data Mart plus an index: an overview, the schema table, and the join list per mart. Reads as a small wiki and works well as context for AI assistants.
 
 The export covers exactly what the canvas shows — the same filtered set the other Actions target — and captures the whole model regardless of the current pan and zoom. Image backgrounds follow the active theme, so dark-theme exports stay readable outside the app.
+
+The canvas itself also got leaner along the way:
+
+- The **Actions** menu moved from an overlay in the canvas corner into the toolbar above the canvas — consistent with the Data Marts list, and it no longer covers canvas content.
+- The field count now sits on the same row as the Data Quality and Data Last Updated indicators instead of taking a line of its own, so every card is one row shorter and the model is easier to scan.
+- The Object labels settings list dropped its decorative glyphs.

--- a/.changeset/6771-canvas-polish.md
+++ b/.changeset/6771-canvas-polish.md
@@ -1,0 +1,9 @@
+---
+'owox': patch
+---
+
+# Leaner Models canvas cards and a relocated Actions menu
+
+The **Actions** menu moved from an overlay in the canvas corner into the toolbar above the canvas — consistent with the Data Marts list, and it no longer covers canvas content.
+
+Cards got more compact: the field count now sits on the same row as the Data Quality and Data Last Updated indicators instead of taking a line of its own, so every card is one row shorter and the model is easier to scan. The Object labels settings list also dropped its decorative glyphs.

--- a/.changeset/6771-canvas-polish.md
+++ b/.changeset/6771-canvas-polish.md
@@ -1,9 +1,0 @@
----
-'owox': patch
----
-
-# Leaner Models canvas cards and a relocated Actions menu
-
-The **Actions** menu moved from an overlay in the canvas corner into the toolbar above the canvas — consistent with the Data Marts list, and it no longer covers canvas content.
-
-Cards got more compact: the field count now sits on the same row as the Data Quality and Data Last Updated indicators instead of taking a line of its own, so every card is one row shorter and the model is easier to scan. The Object labels settings list also dropped its decorative glyphs.

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -73,6 +73,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 'docs/getting-started/setup-guide/view-data-mart',
                 'docs/getting-started/setup-guide/pattern-data-mart',
                 'docs/getting-started/setup-guide/joinable-data-marts',
+                'docs/getting-started/setup-guide/models-canvas-export',
                 'docs/getting-started/setup-guide/data-quality-checks',
                 'docs/getting-started/setup-guide/data-last-updated',
                 'docs/getting-started/setup-guide/output-controls',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,8 @@
     "@tanstack/react-query": "^5.66.0",
     "@xyflow/react": "^12.11.2",
     "axios": "^1.11.0",
+    "fflate": "^0.8.3",
+    "html-to-image": "^1.11.13",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.58.0",

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.test.tsx
@@ -348,32 +348,6 @@ describe('ModelCanvas', () => {
     expect(localStorage.getItem('model-canvas-positions:storage-1')).toBeNull();
   });
 
-  it('renders supplied controls in the top-left canvas overlay', () => {
-    render(
-      <ModelCanvas
-        nodes={[
-          {
-            id: 'orders',
-            title: 'Orders',
-            status: DataMartStatus.PUBLISHED,
-            description: null,
-            fieldCount: 3,
-            qualitySummary: buildQualitySummary(),
-            dataLastUpdated: null,
-          },
-        ]}
-        edges={[]}
-        searchQuery=''
-        onOpenDataMart={vi.fn()}
-        onOpenQuality={vi.fn()}
-        onRunQuality={vi.fn().mockResolvedValue(undefined)}
-        topLeftControls={<button type='button'>Actions 1</button>}
-      />
-    );
-
-    expect(screen.getByRole('button', { name: 'Actions 1' })).toBeVisible();
-  });
-
   it('updates quality status without rerunning layout or fitting the viewport', async () => {
     const node = {
       id: 'orders',

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type ReactNode,
   type Ref,
 } from 'react';
 import {
@@ -81,7 +80,6 @@ interface ModelCanvasProps {
   storageTitle?: string;
   /** Receives the export API — the Actions menu lives outside the flow provider. */
   exportApiRef?: Ref<ModelCanvasExportHandle>;
-  topLeftControls?: ReactNode;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -112,24 +110,20 @@ function loadSavedPositions(storageId: string | undefined): SavedPositions {
   return positions;
 }
 
-const OBJECT_LABEL_META: Record<ObjectLabelPart, { glyph: string; label: string; helper: string }> =
-  {
-    source: {
-      glyph: '⬚',
-      label: 'Input source',
-      helper: 'The source badge (VIEW / TABLE / SQL / CONNECTOR) and its accent stripe',
-    },
-    fields: {
-      glyph: '#',
-      label: 'Field count',
-      helper: 'The field-count line under each object',
-    },
-    status: {
-      glyph: '•',
-      label: 'Status dot',
-      helper: 'The published/draft status dot in the card header',
-    },
-  };
+const OBJECT_LABEL_META: Record<ObjectLabelPart, { label: string; helper: string }> = {
+  source: {
+    label: 'Input source',
+    helper: 'The source badge (VIEW / TABLE / SQL / CONNECTOR) and its accent stripe',
+  },
+  fields: {
+    label: 'Field count',
+    helper: 'The field count shown on each object',
+  },
+  status: {
+    label: 'Status dot',
+    helper: 'The published/draft status dot in the card header',
+  },
+};
 const VIEW_MODE_OPTIONS: { value: CanvasViewMode; label: string }[] = [
   { value: 'compact', label: 'Compact' },
   { value: 'erd', label: 'Detailed' },
@@ -199,8 +193,10 @@ interface FlowNodeParams {
 
 function buildFlowNode(params: FlowNodeParams): ModelCanvasFlowNodeType {
   const { node, highlight, viewMode, objectLabels } = params;
-  const metaRowHidden = objectLabels.source && objectLabels.fields;
-  const statusRowHidden = metaRowHidden && objectLabels.status;
+  // The field count lives in the status icons row, so the meta row only holds
+  // the source badge — hiding the badge drops the whole row.
+  const metaRowHidden = objectLabels.source;
+  const statusRowHidden = objectLabels.source && objectLabels.fields && objectLabels.status;
   return {
     id: node.id,
     type: 'modelCanvasNode',
@@ -378,7 +374,7 @@ function ModelCanvasInner({
       n => n.title
     );
 
-    const metaRowHidden = objectLabels.source && objectLabels.fields;
+    const metaRowHidden = objectLabels.source;
     const dagreNodes: DagreLayoutNode[] = topologyNodes.map(n => ({
       id: n.id,
       width: nodeWidth(viewMode),
@@ -818,7 +814,6 @@ function ModelCanvasInner({
                       <span
                         className={`text-sm font-medium ${shown ? 'text-foreground' : 'text-muted-foreground'}`}
                       >
-                        <span className='text-muted-foreground mr-1 font-bold'>{meta.glyph}</span>
                         {meta.label}
                       </span>
                       <span className='text-muted-foreground text-xs leading-snug'>
@@ -917,7 +912,6 @@ export default function ModelCanvas({
   storageId,
   storageTitle,
   exportApiRef,
-  topLeftControls,
   className,
   style,
 }: ModelCanvasProps) {
@@ -929,7 +923,6 @@ export default function ModelCanvas({
       style={style ?? { height: 480 }}
     >
       <style>{NODE_PULSE_KEYFRAMES}</style>
-      {topLeftControls && <div className='absolute top-3 left-3 z-10'>{topLeftControls}</div>}
       <ReactFlowProvider>
         <ModelCanvasInner
           nodes={nodes}

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.tsx
@@ -351,7 +351,7 @@ function ModelCanvasInner({
     () => ({
       exportCanvas: async format => {
         const { exportModelCanvas } = await import('../export');
-        await exportModelCanvas(format, {
+        return exportModelCanvas(format, {
           viewport: flowDomNode?.querySelector<HTMLElement>('.react-flow__viewport') ?? null,
           flowNodes,
           nodes,

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvas.tsx
@@ -1,5 +1,14 @@
 import { Check, Locate, Settings, ZoomIn, ZoomOut } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type Ref,
+} from 'react';
 import {
   applyEdgeChanges,
   applyNodeChanges,
@@ -53,6 +62,7 @@ import {
   type ObjectLabelPart,
   type ObjectLabelsHidden,
 } from '../model/object-labels';
+import type { ModelCanvasExportHandle } from '../export';
 import ModelCanvasFlowEdge, { type ModelCanvasFlowEdgeType } from './ModelCanvasFlowEdge';
 import ModelCanvasFlowNode, { type ModelCanvasFlowNodeType } from './ModelCanvasFlowNode';
 
@@ -67,6 +77,10 @@ interface ModelCanvasProps {
   isCheckingDataLastUpdated?: boolean;
   /** Scopes the persisted node positions — each storage keeps its own layout. */
   storageId?: string;
+  /** Human-readable storage title — names the export files and OKF bundle. */
+  storageTitle?: string;
+  /** Receives the export API — the Actions menu lives outside the flow provider. */
+  exportApiRef?: Ref<ModelCanvasExportHandle>;
   topLeftControls?: ReactNode;
   className?: string;
   style?: React.CSSProperties;
@@ -269,6 +283,8 @@ interface ModelCanvasInnerProps {
   onRunQuality: (dataMartId: string) => Promise<void>;
   isCheckingDataLastUpdated?: boolean;
   storageId?: string;
+  storageTitle?: string;
+  exportApiRef?: Ref<ModelCanvasExportHandle>;
 }
 
 function ModelCanvasInner({
@@ -280,10 +296,13 @@ function ModelCanvasInner({
   onRunQuality,
   isCheckingDataLastUpdated = false,
   storageId,
+  storageTitle,
+  exportApiRef,
 }: ModelCanvasInnerProps) {
   const reactFlow = useReactFlow<ModelCanvasFlowNodeType, ModelCanvasFlowEdgeType>();
   const paneWidth = useStore(state => state.width);
   const paneHeight = useStore(state => state.height);
+  const flowDomNode = useStore(state => state.domNode);
 
   const onOpenDataMartRef = useRef(onOpenDataMart);
   onOpenDataMartRef.current = onOpenDataMart;
@@ -328,6 +347,25 @@ function ModelCanvasInner({
   const graphBounds = useMemo(() => getCanvasGraphBounds(flowNodes), [flowNodes]);
   const topologyNodes = useStableValue(nodes, getNodeTopologySignature);
   const topologyEdges = useStableValue(edges, getEdgeTopologySignature);
+
+  // The export deps (html-to-image, fflate) load on first use, so the canvas
+  // chunk itself stays lean.
+  useImperativeHandle(
+    exportApiRef,
+    () => ({
+      exportCanvas: async format => {
+        const { exportModelCanvas } = await import('../export');
+        await exportModelCanvas(format, {
+          viewport: flowDomNode?.querySelector<HTMLElement>('.react-flow__viewport') ?? null,
+          flowNodes,
+          nodes,
+          edges,
+          storageTitle,
+        });
+      },
+    }),
+    [flowDomNode, flowNodes, nodes, edges, storageTitle]
+  );
 
   useEffect(() => {
     const hasIncoming = new Set(topologyEdges.map(e => e.targetId));
@@ -877,6 +915,8 @@ export default function ModelCanvas({
   onRunQuality,
   isCheckingDataLastUpdated,
   storageId,
+  storageTitle,
+  exportApiRef,
   topLeftControls,
   className,
   style,
@@ -900,6 +940,8 @@ export default function ModelCanvas({
           onRunQuality={onRunQuality}
           isCheckingDataLastUpdated={isCheckingDataLastUpdated}
           storageId={storageId}
+          storageTitle={storageTitle}
+          exportApiRef={exportApiRef}
         />
       </ReactFlowProvider>
     </div>

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.test.tsx
@@ -234,7 +234,7 @@ describe('ModelCanvasFlowNode', () => {
     ).toHaveClass('-ml-0.5');
   });
 
-  it('renders Data Quality indicators on a row below the definition metadata', () => {
+  it('renders Data Quality indicators and the field count on one row below the badge', () => {
     renderNode();
 
     const qualityRow = screen.getByRole('button', {
@@ -243,7 +243,9 @@ describe('ModelCanvasFlowNode', () => {
     const metadataRow = screen.getByText('View').parentElement;
 
     expect(qualityRow).not.toBe(metadataRow);
-    expect(screen.getByText('3 fields').parentElement).toBe(metadataRow);
+    // The field count shares the status row with the quality indicators, so
+    // cards stay one row shorter than with a dedicated field-count line.
+    expect(screen.getByText('3 fields').parentElement).toBe(qualityRow);
   });
 
   it('provides the non-bubbling run action inside the quality details', async () => {

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasFlowNode.tsx
@@ -188,18 +188,13 @@ export default function ModelCanvasFlowNode({
         </button>
       </div>
 
-      {/* Meta row: definition badge + field count. Skipped entirely when both are hidden. */}
-      {(withSource || withFieldCount) && (
+      {/* Meta row: the definition badge on its own line. */}
+      {withSource && (
         <div className='text-muted-foreground flex items-center gap-2 px-3.5 pt-1 text-[11px]'>
-          {withSource && <ErdDefinitionBadge type={data.definitionType} />}
-          {withFieldCount && (
-            <span className='ml-auto shrink-0'>
-              {data.fieldCount} field{data.fieldCount !== 1 ? 's' : ''}
-            </span>
-          )}
+          <ErdDefinitionBadge type={data.definitionType} />
         </div>
       )}
-      {/* Status icons row: quality shield + data-last-updated clock */}
+      {/* Status icons row: quality shield + data-last-updated clock + field count */}
       {!titleOnly && (
         <div className='text-muted-foreground flex items-center gap-1 px-3.5 pt-1 pb-3 text-[11px]'>
           <DataQualityCanvasStatusIcon
@@ -213,6 +208,11 @@ export default function ModelCanvasFlowNode({
             block={data.dataLastUpdated}
             isChecking={data.isCheckingDataLastUpdated}
           />
+          {withFieldCount && (
+            <span className='ml-auto shrink-0'>
+              {data.fieldCount} field{data.fieldCount !== 1 ? 's' : ''}
+            </span>
+          )}
         </div>
       )}
 

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasToolbar.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasToolbar.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { DataStorageType } from '../../../data-storage/shared/model/types/data-storage-type.enum';
 import { ModelCanvasToolbar } from './ModelCanvasToolbar';
 
-function renderToolbar() {
+function renderToolbar(actions?: ReactNode) {
   return render(
     <ModelCanvasToolbar
+      actions={actions}
       storages={[
         {
           id: 'storage-1',
@@ -36,6 +38,13 @@ describe('ModelCanvasToolbar', () => {
     expect(screen.getByRole('combobox', { name: 'Storage' })).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: 'Status' })).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: 'Relationships' })).toBeInTheDocument();
+  });
+
+  it('renders the actions slot at the start of the row', () => {
+    const { container } = renderToolbar(<button type='button'>Actions</button>);
+
+    const row = container.firstElementChild;
+    expect(row?.firstElementChild).toBe(screen.getByRole('button', { name: 'Actions' }));
   });
 
   it('keeps the controls on one row and constrains the search width', () => {

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasToolbar.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasToolbar.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import { SearchInput } from '@owox/ui/components/common/search-input';
 import {
   Select,
@@ -22,6 +22,8 @@ interface ModelCanvasToolbarProps {
   onRelChange: (rel: CanvasRelFilter) => void;
   searchQuery: string;
   onSearchChange: (query: string) => void;
+  /** The Actions menu — rendered at the row start, mirroring the list page. */
+  actions?: ReactNode;
 }
 
 export function ModelCanvasToolbar(props: ModelCanvasToolbarProps) {
@@ -37,6 +39,7 @@ export function ModelCanvasToolbar(props: ModelCanvasToolbarProps) {
 
   return (
     <div className='flex min-w-0 flex-nowrap items-center gap-2 pb-4'>
+      {props.actions}
       <label className='contents' aria-label='Storage'>
         <Combobox
           options={storageOptions}

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.test.tsx
@@ -97,7 +97,8 @@ vi.mock('../../data-quality/api/data-quality.service', () => ({
 }));
 
 vi.mock('./ModelCanvasToolbar', () => ({
-  ModelCanvasToolbar: () => null,
+  // The Actions menu renders through the toolbar's `actions` slot.
+  ModelCanvasToolbar: ({ actions }: { actions?: React.ReactNode }) => <>{actions}</>,
 }));
 
 vi.mock('./ModelCanvas', () => ({
@@ -107,17 +108,14 @@ vi.mock('./ModelCanvas', () => ({
     onOpenDataMart,
     onOpenQuality,
     onRunQuality,
-    topLeftControls,
   }: {
     nodes: { id: string }[];
     edges: { id: string }[];
     onOpenDataMart: (dataMartId: string) => void;
     onOpenQuality?: (dataMartId: string) => void;
     onRunQuality?: (dataMartId: string) => Promise<void>;
-    topLeftControls?: React.ReactNode;
   }) => (
     <>
-      {topLeftControls}
       <span data-testid='canvas-node-ids'>{nodes.map(node => node.id).join(',')}</span>
       <span data-testid='canvas-edge-ids'>{edges.map(edge => edge.id).join(',')}</span>
       <button

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.test.tsx
@@ -2,6 +2,20 @@ import { StrictMode } from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DataMartStatus } from '../../shared/enums';
+
+const exportMocks = vi.hoisted(() => {
+  const toast = Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() });
+  return { toast, trackEvent: vi.fn() };
+});
+
+vi.mock('react-hot-toast', () => ({
+  default: exportMocks.toast,
+  toast: exportMocks.toast,
+}));
+
+vi.mock('../../../../utils/data-layer', () => ({
+  trackEvent: exportMocks.trackEvent,
+}));
 import type { DataQualityCompactSummary } from '../../shared/types';
 import type { ModelCanvasTopologyData } from '../model/types';
 import { ModelCanvasView } from './ModelCanvasView';
@@ -312,6 +326,28 @@ describe('ModelCanvasView', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
+  it('reports a loading canvas instead of a silent no-op when export is not ready', async () => {
+    // The mocked ModelCanvas never registers the export handle — the same
+    // state as the real lazy chunk still loading behind Suspense.
+    viewState.canvasHook.data = buildCanvasData();
+
+    render(<ModelCanvasView />);
+
+    const trigger = await screen.findByRole('button', { name: 'Actions 2' });
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.keyDown(screen.getByTestId('export-canvas'), { key: 'ArrowRight' });
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'JSON' }));
+
+    await waitFor(() => {
+      expect(exportMocks.toast).toHaveBeenCalledWith(
+        'The canvas is still loading — please try again in a moment.'
+      );
+    });
+    expect(exportMocks.trackEvent).not.toHaveBeenCalled();
+  });
+
+  // The same `bulkActionDataMarts` set feeds the Actions badge AND the export
+  // scope: search only highlights, it never narrows either of them.
   it('counts the Data Marts left by canvas filters without narrowing the count by search', async () => {
     viewState.filters.searchQuery = 'Orders';
     viewState.canvasHook.data = {

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
@@ -155,7 +155,12 @@ function ModelCanvasViewContent({ onActiveQualityRunChange }: ModelCanvasViewPro
   const canvasStyle = { height: 'calc(100vh - 220px)', minHeight: 480 };
 
   const canvasExportRef = useRef<ModelCanvasExportHandle>(null);
+  // Image capture can take seconds on a large model — swallow repeat clicks
+  // instead of kicking off parallel captures and duplicate downloads.
+  const isExportingRef = useRef(false);
   const handleExport = useCallback((format: DataMartCanvasExportFormat) => {
+    if (isExportingRef.current) return;
+    isExportingRef.current = true;
     void (async () => {
       try {
         await canvasExportRef.current?.exportCanvas(format);
@@ -168,6 +173,8 @@ function ModelCanvasViewContent({ onActiveQualityRunChange }: ModelCanvasViewPro
       } catch (caught) {
         console.error('Canvas export failed:', caught);
         toast.error("Couldn't export the model — please try again.");
+      } finally {
+        isExportingRef.current = false;
       }
     })();
   }, []);

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
@@ -163,7 +163,15 @@ function ModelCanvasViewContent({ onActiveQualityRunChange }: ModelCanvasViewPro
     isExportingRef.current = true;
     void (async () => {
       try {
-        await canvasExportRef.current?.exportCanvas(format);
+        // The handle registers once the lazy canvas chunk mounts, and the
+        // export itself declines until the first layout pass — in both windows
+        // nothing downloads, so say so instead of silently succeeding, and
+        // record analytics only for real downloads.
+        const exported = (await canvasExportRef.current?.exportCanvas(format)) ?? false;
+        if (!exported) {
+          toast('The canvas is still loading — please try again in a moment.');
+          return;
+        }
         trackEvent({
           event: 'model_canvas_exported',
           category: 'DataMart',

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
@@ -247,6 +247,23 @@ function ModelCanvasViewContent({ onActiveQualityRunChange }: ModelCanvasViewPro
         onRelChange={filters.setRel}
         searchQuery={filters.searchQuery}
         onSearchChange={filters.setSearchQuery}
+        actions={
+          <DataMartBulkActions
+            onExport={handleExport}
+            onCheckDataLastUpdated={() => {
+              // Meeting decision: the check covers what the user actually sees — the same
+              // filtered set the other bulk actions target.
+              void refreshDataLastUpdated(bulkActionDataMarts.map(dataMart => dataMart.id));
+            }}
+            isCheckingDataLastUpdated={isRefreshingDataLastUpdated}
+            dataMarts={bulkActionDataMarts}
+            projectId={projectId ?? ''}
+            deleteDataMart={deleteDataMart}
+            publishDataMart={publishDataMart}
+            onCompleted={refreshCanvas}
+            targetScope='canvas'
+          />
+        }
       />
       {storageLoadError ? (
         <CanvasMessage role='alert'>
@@ -302,23 +319,6 @@ function ModelCanvasViewContent({ onActiveQualityRunChange }: ModelCanvasViewPro
             isCheckingDataLastUpdated={isRefreshingDataLastUpdated}
             storageTitle={dataStorages.find(storage => storage.id === filters.storageId)?.title}
             exportApiRef={canvasExportRef}
-            topLeftControls={
-              <DataMartBulkActions
-                onExport={handleExport}
-                onCheckDataLastUpdated={() => {
-                  // Meeting decision: the check covers what the user actually sees — the same
-                  // filtered set the other bulk actions target.
-                  void refreshDataLastUpdated(filtered.nodes.map(node => node.id));
-                }}
-                isCheckingDataLastUpdated={isRefreshingDataLastUpdated}
-                dataMarts={bulkActionDataMarts}
-                projectId={projectId ?? ''}
-                deleteDataMart={deleteDataMart}
-                publishDataMart={publishDataMart}
-                onCompleted={refreshCanvas}
-                targetScope='canvas'
-              />
-            }
             style={canvasStyle}
           />
         </Suspense>

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
@@ -14,7 +14,11 @@ import { useModelCanvasFilters } from '../model/use-model-canvas-filters';
 import { ModelCanvasToolbar } from './ModelCanvasToolbar';
 import { dataQualityService } from '../../data-quality/api/data-quality.service';
 import { dataMartService } from '../../shared';
-import { DataMartBulkActions } from '../../shared/components/DataMartBulkActions';
+import {
+  DataMartBulkActions,
+  type DataMartCanvasExportFormat,
+} from '../../shared/components/DataMartBulkActions';
+import type { ModelCanvasExportHandle } from '../export';
 import { trackEvent } from '../../../../utils/data-layer';
 import { isDataQualityActivityState } from '../../shared/components/RunActivityIndicator';
 import { useDataQualitySummaries } from '../../data-quality/model/use-data-quality-workspace';
@@ -150,6 +154,24 @@ function ModelCanvasViewContent({ onActiveQualityRunChange }: ModelCanvasViewPro
 
   const canvasStyle = { height: 'calc(100vh - 220px)', minHeight: 480 };
 
+  const canvasExportRef = useRef<ModelCanvasExportHandle>(null);
+  const handleExport = useCallback((format: DataMartCanvasExportFormat) => {
+    void (async () => {
+      try {
+        await canvasExportRef.current?.exportCanvas(format);
+        trackEvent({
+          event: 'model_canvas_exported',
+          category: 'DataMart',
+          action: 'CanvasExport',
+          label: format,
+        });
+      } catch (caught) {
+        console.error('Canvas export failed:', caught);
+        toast.error("Couldn't export the model — please try again.");
+      }
+    })();
+  }, []);
+
   const runQuality = useCallback(
     async (dataMartId: string) => {
       try {
@@ -278,8 +300,11 @@ function ModelCanvasViewContent({ onActiveQualityRunChange }: ModelCanvasViewPro
             }}
             onRunQuality={runQuality}
             isCheckingDataLastUpdated={isRefreshingDataLastUpdated}
+            storageTitle={dataStorages.find(storage => storage.id === filters.storageId)?.title}
+            exportApiRef={canvasExportRef}
             topLeftControls={
               <DataMartBulkActions
+                onExport={handleExport}
                 onCheckDataLastUpdated={() => {
                   // Meeting decision: the check covers what the user actually sees — the same
                   // filtered set the other bulk actions target.

--- a/apps/web/src/features/data-marts/model-canvas/export/download.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/download.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildExportFileName, downloadBlob, slugifyFileName } from './download';
+import { buildExportFileName, downloadBlob } from './download';
+import { slugify } from './slug';
 
-describe('slugifyFileName', () => {
+describe('slugify', () => {
   it('slugifies titles and falls back when nothing survives', () => {
-    expect(slugifyFileName('BigQuery (Common)', 'model')).toBe('bigquery-common');
-    expect(slugifyFileName('***', 'model')).toBe('model');
+    expect(slugify('BigQuery (Common)', 'model')).toBe('bigquery-common');
+    expect(slugify('***', 'model')).toBe('model');
   });
 });
 

--- a/apps/web/src/features/data-marts/model-canvas/export/download.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/download.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildExportFileName, downloadBlob, slugifyFileName } from './download';
+
+describe('slugifyFileName', () => {
+  it('slugifies titles and falls back when nothing survives', () => {
+    expect(slugifyFileName('BigQuery (Common)', 'model')).toBe('bigquery-common');
+    expect(slugifyFileName('***', 'model')).toBe('model');
+  });
+});
+
+describe('buildExportFileName', () => {
+  it('combines the storage slug with the current date', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-04T12:00:00Z'));
+    expect(buildExportFileName('BigQuery (Common)')).toBe('bigquery-common-2026-08-04');
+    expect(buildExportFileName(undefined)).toBe('data-marts-model-2026-08-04');
+    vi.useRealTimers();
+  });
+});
+
+describe('downloadBlob', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('downloads through a temporary object URL and revokes it', () => {
+    vi.useFakeTimers();
+    const createObjectURL = vi.fn().mockReturnValue('blob:mock');
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => void 0);
+
+    downloadBlob(new Blob(['content']), 'model.json');
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(click).toHaveBeenCalledOnce();
+    vi.runAllTimers();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/export/download.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/download.ts
@@ -1,0 +1,27 @@
+/** Trigger a browser download of a Blob under the given filename. */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  // Deferred so the browser has started the download before the URL dies.
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 1000);
+}
+
+export function slugifyFileName(text: string, fallback: string): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || fallback;
+}
+
+/** `<storage-slug>-YYYY-MM-DD`, shared by every export format. */
+export function buildExportFileName(storageTitle: string | undefined): string {
+  const base = slugifyFileName(storageTitle ?? '', 'data-marts-model');
+  const date = new Date().toISOString().slice(0, 10);
+  return `${base}-${date}`;
+}

--- a/apps/web/src/features/data-marts/model-canvas/export/download.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/download.ts
@@ -1,3 +1,5 @@
+import { slugify } from './slug';
+
 /** Trigger a browser download of a Blob under the given filename. */
 export function downloadBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
@@ -11,17 +13,9 @@ export function downloadBlob(blob: Blob, filename: string): void {
   }, 1000);
 }
 
-export function slugifyFileName(text: string, fallback: string): string {
-  const slug = text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  return slug || fallback;
-}
-
 /** `<storage-slug>-YYYY-MM-DD`, shared by every export format. */
 export function buildExportFileName(storageTitle: string | undefined): string {
-  const base = slugifyFileName(storageTitle ?? '', 'data-marts-model');
+  const base = slugify(storageTitle ?? '', 'data-marts-model');
   const date = new Date().toISOString().slice(0, 10);
   return `${base}-${date}`;
 }

--- a/apps/web/src/features/data-marts/model-canvas/export/export-image.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/export-image.ts
@@ -1,0 +1,144 @@
+import { getNodesBounds, type Node } from '@xyflow/react';
+import { toCanvas, toSvg } from 'html-to-image';
+
+// Image export captures the React Flow viewport element with an overridden
+// transform, so the whole model renders at 1:1 regardless of the user's
+// current pan/zoom. React Flow nodes are HTML, which html-to-image wraps in an
+// SVG <foreignObject>; rasterizing that (the PNG path) can hit Chromium's
+// canvas-tainting rules when any resource fails to inline, so PNG failures
+// must surface as a catchable error rather than a hung promise.
+
+const PAD = 60; // px of breathing room around the model
+const PNG_PIXEL_RATIO = 2;
+const WM_SIZE = 24;
+const WM_INSET = 14;
+
+// OWOX logo paths (512 viewBox), scaled down inside the watermark.
+const LOGO_P0 =
+  'M421.311 119.85C435.258 133.807 440.996 157.327 440.996 157.327C440.996 157.327 449.53 204.69 449.53 268.995C449.53 177.972 418.65 162.348 311.314 162.348H212.327C157.38 162.348 161.097 217.57 157.38 243.85L152.865 283.556C150.697 325.33 157.951 351.215 200.811 351.215C111.444 351.215 61.806 365.847 61.8062 239.866C61.8061 182.846 70.4043 157.327 70.4043 157.327C70.4043 157.327 76.1419 133.807 90.1183 119.85C104.095 105.877 124.809 104.475 124.809 104.475C124.809 104.475 167.579 98.0374 252.066 98.0374C336.554 98.0374 384.285 104.475 384.285 104.475C384.285 104.475 407.321 105.877 421.311 119.85Z';
+const LOGO_P1 =
+  'M449.515 271.888C449.52 273.026 449.523 274.174 449.523 275.333C449.523 329.946 441.393 351.201 441.393 351.201C441.393 351.201 435.03 376.952 424.167 388.075C406.929 405.725 388.495 406.71 388.495 406.71C388.495 406.71 348.836 413.061 263.502 413.061C181.632 413.061 127.111 406.749 127.111 406.749C127.111 406.749 104.091 405.337 90.1144 391.377C76.1379 377.394 70.4004 351.201 70.4004 351.201C70.4004 351.201 61.8062 297.401 61.8062 238.506C61.806 352.055 102.131 351.374 175.525 350.133C183.56 349.998 191.992 349.855 200.811 349.855H299.787C343.122 349.855 352.906 318.315 354.792 282.196L359.32 227.093C360.526 204.443 357.608 188.362 350.507 178.012C342.765 166.722 329.575 160.987 311.314 160.987C424.974 160.987 448.73 176.216 449.515 271.888Z';
+
+function watermarkInner(): string {
+  const logoScale = WM_SIZE / 512;
+  return (
+    '<defs>' +
+    '<linearGradient id="wmg0" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#05D2FF"/><stop offset=".4" stop-color="#1E88E5"/><stop offset="1" stop-color="#182FFF"/></linearGradient>' +
+    '<linearGradient id="wmg1" x1="0" y1="1" x2="1" y2="0"><stop stop-color="#24D8FF"/><stop offset=".4" stop-color="#1E88E5"/><stop offset="1" stop-color="#0046F9"/></linearGradient>' +
+    '</defs>' +
+    `<g transform="scale(${String(logoScale)})"><path d="${LOGO_P0}" fill="url(#wmg0)"/><path d="${LOGO_P1}" fill="url(#wmg1)"/></g>`
+  );
+}
+
+function watermarkGroup(x: number, y: number): string {
+  return `<g transform="translate(${String(x)},${String(y)})" opacity="0.92">${watermarkInner()}</g>`;
+}
+
+function captureOptions(rfNodes: Node[]) {
+  const bounds = getNodesBounds(rfNodes);
+  const width = Math.ceil(bounds.width) + PAD * 2;
+  const height = Math.ceil(bounds.height) + PAD * 2;
+  // Translate so the model's top-left lands at (PAD, PAD); no scaling (1:1).
+  const transform = `translate(${String(PAD - bounds.x)}px, ${String(PAD - bounds.y)}px) scale(1)`;
+  return {
+    width,
+    height,
+    style: { width: `${String(width)}px`, height: `${String(height)}px`, transform },
+  };
+}
+
+/**
+ * The page background the exported image should sit on: the nearest opaque
+ * ancestor background, so dark theme exports stay readable outside the app.
+ */
+export function resolveCanvasBackground(element: HTMLElement): string {
+  let current: HTMLElement | null = element;
+  while (current) {
+    const color = getComputedStyle(current).backgroundColor;
+    if (color && color !== 'transparent' && !/^rgba\(.*,\s*0\)$/.test(color)) return color;
+    current = current.parentElement;
+  }
+  return '#ffffff';
+}
+
+/** Export the model as an SVG file with the OWOX watermark bottom-right. */
+export async function exportCanvasSvg(
+  viewport: HTMLElement,
+  rfNodes: Node[],
+  background: string
+): Promise<Blob> {
+  const { width, height, style } = captureOptions(rfNodes);
+  const dataUrl = await toSvg(viewport, { width, height, style, skipFonts: true });
+  const raw = decodeURIComponent(dataUrl.replace(/^data:image\/svg\+xml;charset=utf-8,/, ''));
+  // The background must be a child <rect>, not a fill on the captured element:
+  // html-to-image would paint that fill on the translated viewport, offsetting it.
+  const withBackground = raw.replace(
+    /(<svg[^>]*>)/,
+    `$1<rect width="100%" height="100%" fill="${background}"/>`
+  );
+  const watermark = watermarkGroup(width - WM_SIZE - WM_INSET, height - WM_SIZE - WM_INSET);
+  const withWatermark = withBackground.replace(/<\/svg>\s*$/, `${watermark}</svg>`);
+  return new Blob([withWatermark], { type: 'image/svg+xml' });
+}
+
+function loadImage(source: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => {
+      resolve(image);
+    };
+    image.onerror = () => {
+      reject(new Error('Failed to load watermark image'));
+    };
+    image.src = source;
+  });
+}
+
+/** Export the model as a PNG at {@link PNG_PIXEL_RATIO}x scale. */
+export async function exportCanvasPng(
+  viewport: HTMLElement,
+  rfNodes: Node[],
+  background: string
+): Promise<Blob> {
+  const { width, height, style } = captureOptions(rfNodes);
+  const captured = await toCanvas(viewport, {
+    width,
+    height,
+    style,
+    skipFonts: true,
+    pixelRatio: PNG_PIXEL_RATIO,
+  });
+
+  // Composite onto a fresh canvas: background fill first (see the SVG note on
+  // why html-to-image's own backgroundColor option cannot be used), then the
+  // capture, then the watermark rendered from a standalone SVG.
+  const output = document.createElement('canvas');
+  output.width = width * PNG_PIXEL_RATIO;
+  output.height = height * PNG_PIXEL_RATIO;
+  const context = output.getContext('2d');
+  if (!context) throw new Error('Canvas 2D context is unavailable');
+  context.fillStyle = background;
+  context.fillRect(0, 0, output.width, output.height);
+  context.drawImage(captured, 0, 0, output.width, output.height);
+
+  const watermarkSvg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${String(WM_SIZE)}" height="${String(WM_SIZE)}" ` +
+    `viewBox="0 0 ${String(WM_SIZE)} ${String(WM_SIZE)}" opacity="0.92">${watermarkInner()}</svg>`;
+  const watermarkImage = await loadImage(
+    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(watermarkSvg)}`
+  );
+  const wmScaled = WM_SIZE * PNG_PIXEL_RATIO;
+  context.drawImage(
+    watermarkImage,
+    output.width - wmScaled - WM_INSET * PNG_PIXEL_RATIO,
+    output.height - wmScaled - WM_INSET * PNG_PIXEL_RATIO,
+    wmScaled,
+    wmScaled
+  );
+
+  const blob = await new Promise<Blob | null>(resolve => {
+    output.toBlob(resolve, 'image/png');
+  });
+  if (!blob) throw new Error('PNG rasterization produced no data');
+  return blob;
+}

--- a/apps/web/src/features/data-marts/model-canvas/export/export-image.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/export-image.ts
@@ -10,8 +10,17 @@ import { toCanvas, toSvg } from 'html-to-image';
 
 const PAD = 60; // px of breathing room around the model
 const PNG_PIXEL_RATIO = 2;
+// Browsers cap canvas dimensions and total area (Safari is the strictest);
+// past the cap toBlob silently yields null. Large models trade resolution for
+// a canvas that stays comfortably inside those limits.
+const MAX_PNG_AREA = 67_108_864; // output pixels, an 8192×8192 equivalent
 const WM_SIZE = 24;
 const WM_INSET = 14;
+
+function pngPixelRatio(width: number, height: number): number {
+  const maxRatio = Math.sqrt(MAX_PNG_AREA / (width * height));
+  return Math.max(1, Math.min(PNG_PIXEL_RATIO, maxRatio));
+}
 
 // OWOX logo paths (512 viewBox), scaled down inside the watermark.
 const LOGO_P0 =
@@ -94,27 +103,28 @@ function loadImage(source: string): Promise<HTMLImageElement> {
   });
 }
 
-/** Export the model as a PNG at {@link PNG_PIXEL_RATIO}x scale. */
+/** Export the model as a PNG at up to {@link PNG_PIXEL_RATIO}x scale. */
 export async function exportCanvasPng(
   viewport: HTMLElement,
   rfNodes: Node[],
   background: string
 ): Promise<Blob> {
   const { width, height, style } = captureOptions(rfNodes);
+  const pixelRatio = pngPixelRatio(width, height);
   const captured = await toCanvas(viewport, {
     width,
     height,
     style,
     skipFonts: true,
-    pixelRatio: PNG_PIXEL_RATIO,
+    pixelRatio,
   });
 
   // Composite onto a fresh canvas: background fill first (see the SVG note on
   // why html-to-image's own backgroundColor option cannot be used), then the
   // capture, then the watermark rendered from a standalone SVG.
   const output = document.createElement('canvas');
-  output.width = width * PNG_PIXEL_RATIO;
-  output.height = height * PNG_PIXEL_RATIO;
+  output.width = Math.round(width * pixelRatio);
+  output.height = Math.round(height * pixelRatio);
   const context = output.getContext('2d');
   if (!context) throw new Error('Canvas 2D context is unavailable');
   context.fillStyle = background;
@@ -127,11 +137,11 @@ export async function exportCanvasPng(
   const watermarkImage = await loadImage(
     `data:image/svg+xml;charset=utf-8,${encodeURIComponent(watermarkSvg)}`
   );
-  const wmScaled = WM_SIZE * PNG_PIXEL_RATIO;
+  const wmScaled = WM_SIZE * pixelRatio;
   context.drawImage(
     watermarkImage,
-    output.width - wmScaled - WM_INSET * PNG_PIXEL_RATIO,
-    output.height - wmScaled - WM_INSET * PNG_PIXEL_RATIO,
+    output.width - wmScaled - WM_INSET * pixelRatio,
+    output.height - wmScaled - WM_INSET * pixelRatio,
     wmScaled,
     wmScaled
   );

--- a/apps/web/src/features/data-marts/model-canvas/export/index.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/index.test.ts
@@ -1,0 +1,88 @@
+import type { Node } from '@xyflow/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DataMartStatus } from '../../shared/enums/data-mart-status.enum';
+import type { ModelCanvasNode } from '../model/types';
+import { exportModelCanvas } from './index';
+
+const NODE: ModelCanvasNode = {
+  id: 'id-orders',
+  title: 'Orders',
+  status: DataMartStatus.PUBLISHED,
+  description: null,
+  fieldCount: 0,
+  qualitySummary: {
+    state: 'NEVER_RUN',
+    enabledChecks: 0,
+    totalChecks: 0,
+    passedChecks: 0,
+    failedChecks: 0,
+    notApplicableChecks: 0,
+    errorChecks: 0,
+    noticeFindings: 0,
+    warningFindings: 0,
+    errorFindings: 0,
+    violationCount: 0,
+    highestSeverity: null,
+    dataMartRunId: null,
+    lastRunAt: null,
+  },
+  dataLastUpdated: null,
+};
+
+const FLOW_NODE = { id: 'id-orders', position: { x: 10, y: 20 } } as Node;
+
+describe('exportModelCanvas readiness', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('declines without downloading before the first layout pass measures nodes', async () => {
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => void 0);
+
+    const exported = await exportModelCanvas('json', {
+      viewport: null,
+      flowNodes: [],
+      nodes: [NODE],
+      edges: [],
+      storageTitle: 'Warehouse',
+    });
+
+    expect(exported).toBe(false);
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it('downloads and reports success once measured nodes exist', async () => {
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn().mockReturnValue('blob:mock'),
+      revokeObjectURL: vi.fn(),
+    });
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => void 0);
+
+    const exported = await exportModelCanvas('json', {
+      viewport: null,
+      flowNodes: [FLOW_NODE],
+      nodes: [NODE],
+      edges: [],
+      storageTitle: 'Warehouse',
+    });
+
+    expect(exported).toBe(true);
+    expect(click).toHaveBeenCalledOnce();
+  });
+
+  it('declines image formats until the viewport element is available', async () => {
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => void 0);
+
+    const exported = await exportModelCanvas('svg', {
+      viewport: null,
+      flowNodes: [FLOW_NODE],
+      nodes: [NODE],
+      edges: [],
+      storageTitle: 'Warehouse',
+    });
+
+    expect(exported).toBe(false);
+    expect(click).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/export/index.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/index.ts
@@ -22,27 +22,32 @@ export interface ModelCanvasExportContext {
 }
 
 export interface ModelCanvasExportHandle {
-  exportCanvas: (format: DataMartCanvasExportFormat) => Promise<void>;
+  /** Resolves `true` once a download was actually triggered. */
+  exportCanvas: (format: DataMartCanvasExportFormat) => Promise<boolean>;
 }
 
+/**
+ * Returns `false` (and downloads nothing) while the canvas is not ready:
+ * before the first layout pass populates the measured nodes, every format
+ * would lie — images would capture nothing and JSON/OKF would serialize all
+ * positions at (0, 0). Capture failures still reject.
+ */
 export async function exportModelCanvas(
   format: DataMartCanvasExportFormat,
   context: ModelCanvasExportContext
-): Promise<void> {
-  if (context.nodes.length === 0) return;
+): Promise<boolean> {
+  if (context.nodes.length === 0 || context.flowNodes.length === 0) return false;
   const filename = buildExportFileName(context.storageTitle);
 
   if (format === 'svg' || format === 'png') {
-    if (!context.viewport || context.flowNodes.length === 0) {
-      throw new Error('Canvas is not ready for image export');
-    }
+    if (!context.viewport) return false;
     const background = resolveCanvasBackground(context.viewport);
     const blob =
       format === 'svg'
         ? await exportCanvasSvg(context.viewport, context.flowNodes, background)
         : await exportCanvasPng(context.viewport, context.flowNodes, background);
     downloadBlob(blob, `${filename}.${format}`);
-    return;
+    return true;
   }
 
   const positions = new Map<string, PathPoint>(
@@ -58,10 +63,11 @@ export async function exportModelCanvas(
   if (format === 'json') {
     const json = JSON.stringify(sanitizeModelGraph(graph), null, 2);
     downloadBlob(new Blob([json], { type: 'application/json' }), `${filename}.json`);
-    return;
+    return true;
   }
 
   const bundle = serializeOkfBundle(graph, context.storageTitle ?? 'Data Marts');
   const zip = bundleToZip(bundle.files);
   downloadBlob(new Blob([zip.slice()], { type: 'application/zip' }), `${filename}.zip`);
+  return true;
 }

--- a/apps/web/src/features/data-marts/model-canvas/export/index.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/index.ts
@@ -1,0 +1,67 @@
+import type { Node } from '@xyflow/react';
+import type { CanvasRenderEdge } from '../model/graph/merge-bidirectional-edges';
+import type { PathPoint } from '../model/graph/path-point';
+import type { ModelCanvasNode } from '../model/types';
+import { buildExportFileName, downloadBlob } from './download';
+import { exportCanvasPng, exportCanvasSvg, resolveCanvasBackground } from './export-image';
+import { canvasToModelGraph, sanitizeModelGraph } from './model-graph';
+import { serializeOkfBundle } from './okf/serialize';
+import { bundleToZip } from './okf/zip';
+
+export type { DataMartCanvasExportFormat } from '../../shared/components/DataMartBulkActions';
+import type { DataMartCanvasExportFormat } from '../../shared/components/DataMartBulkActions';
+
+export interface ModelCanvasExportContext {
+  /** The `.react-flow__viewport` element — required for image formats. */
+  viewport: HTMLElement | null;
+  /** Measured React Flow nodes: bounds for image framing, positions for the graph. */
+  flowNodes: Node[];
+  nodes: ModelCanvasNode[];
+  edges: CanvasRenderEdge[];
+  storageTitle?: string;
+}
+
+export interface ModelCanvasExportHandle {
+  exportCanvas: (format: DataMartCanvasExportFormat) => Promise<void>;
+}
+
+export async function exportModelCanvas(
+  format: DataMartCanvasExportFormat,
+  context: ModelCanvasExportContext
+): Promise<void> {
+  if (context.nodes.length === 0) return;
+  const filename = buildExportFileName(context.storageTitle);
+
+  if (format === 'svg' || format === 'png') {
+    if (!context.viewport || context.flowNodes.length === 0) {
+      throw new Error('Canvas is not ready for image export');
+    }
+    const background = resolveCanvasBackground(context.viewport);
+    const blob =
+      format === 'svg'
+        ? await exportCanvasSvg(context.viewport, context.flowNodes, background)
+        : await exportCanvasPng(context.viewport, context.flowNodes, background);
+    downloadBlob(blob, `${filename}.${format}`);
+    return;
+  }
+
+  const positions = new Map<string, PathPoint>(
+    context.flowNodes.map(node => [node.id, { x: node.position.x, y: node.position.y }])
+  );
+  const graph = canvasToModelGraph({
+    nodes: context.nodes,
+    edges: context.edges,
+    positions,
+    storageLabel: context.storageTitle,
+  });
+
+  if (format === 'json') {
+    const json = JSON.stringify(sanitizeModelGraph(graph), null, 2);
+    downloadBlob(new Blob([json], { type: 'application/json' }), `${filename}.json`);
+    return;
+  }
+
+  const bundle = serializeOkfBundle(graph, context.storageTitle ?? 'Data Marts');
+  const zip = bundleToZip(bundle.files);
+  downloadBlob(new Blob([zip.slice()], { type: 'application/zip' }), `${filename}.zip`);
+}

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
@@ -102,7 +102,6 @@ describe('canvasToModelGraph', () => {
         ],
         position: { x: 10, y: 20 },
         status: 'created',
-        owoxId: 'id-orders',
       },
       {
         key: 'customers',
@@ -112,7 +111,6 @@ describe('canvasToModelGraph', () => {
         schema: [],
         position: { x: 0, y: 0 },
         status: 'pending',
-        owoxId: 'id-customers',
       },
     ]);
     expect(graph.edges).toEqual([
@@ -149,6 +147,7 @@ describe('sanitizeModelGraph', () => {
     });
     const sanitized = sanitizeModelGraph(graph);
     expect(sanitized).not.toHaveProperty('storageId');
-    expect(sanitized.nodes[0]).toMatchObject({ status: 'pending', owoxId: null });
+    expect(sanitized.nodes[0]).toMatchObject({ status: 'pending' });
+    expect(sanitized.nodes[0]).not.toHaveProperty('owoxId');
   });
 });

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { DataMartDefinitionType } from '../../shared/enums/data-mart-definition-type.enum';
+import { DataMartStatus } from '../../shared/enums/data-mart-status.enum';
+import type { CanvasRenderEdge } from '../model/graph/merge-bidirectional-edges';
+import type { ModelCanvasNode } from '../model/types';
+import { canvasToModelGraph, sanitizeModelGraph } from './model-graph';
+
+function buildNode(overrides: Partial<ModelCanvasNode> & { id: string }): ModelCanvasNode {
+  return {
+    title: overrides.id,
+    status: DataMartStatus.PUBLISHED,
+    description: null,
+    fieldCount: 0,
+    qualitySummary: {
+      state: 'NEVER_RUN',
+      enabledChecks: 0,
+      totalChecks: 0,
+      passedChecks: 0,
+      failedChecks: 0,
+      notApplicableChecks: 0,
+      errorChecks: 0,
+      noticeFindings: 0,
+      warningFindings: 0,
+      errorFindings: 0,
+      violationCount: 0,
+      highestSeverity: null,
+      dataMartRunId: null,
+      lastRunAt: null,
+    },
+    dataLastUpdated: null,
+    ...overrides,
+  };
+}
+
+function buildEdge(overrides: Partial<CanvasRenderEdge> & { id: string }): CanvasRenderEdge {
+  return {
+    sourceId: 'a',
+    targetId: 'b',
+    bidirectional: false,
+    joinNotConfigured: false,
+    joinConditions: [],
+    ...overrides,
+  };
+}
+
+describe('canvasToModelGraph', () => {
+  it('maps nodes and edges into the model.owox.com graph shape', () => {
+    const graph = canvasToModelGraph({
+      nodes: [
+        buildNode({
+          id: 'id-orders',
+          title: 'Orders',
+          definitionType: DataMartDefinitionType.SQL,
+          description: 'All orders',
+          fields: [
+            {
+              name: 'order_id',
+              alias: 'Order ID',
+              type: 'STRING',
+              isPrimaryKey: true,
+              isHidden: false,
+            },
+            {
+              name: 'total',
+              alias: 'total',
+              type: 'NUMERIC',
+              isPrimaryKey: false,
+              isHidden: false,
+            },
+          ],
+        }),
+        buildNode({
+          id: 'id-customers',
+          title: 'Customers',
+          status: DataMartStatus.DRAFT,
+          definitionType: DataMartDefinitionType.TABLE_PATTERN,
+        }),
+      ],
+      edges: [
+        buildEdge({
+          id: 'edge-1',
+          sourceId: 'id-orders',
+          targetId: 'id-customers',
+          bidirectional: true,
+          joinConditions: [{ sourceFieldName: 'customer_id', targetFieldName: 'id' }],
+        }),
+      ],
+      positions: new Map([['id-orders', { x: 10, y: 20 }]]),
+      storageLabel: 'BigQuery (Common)',
+    });
+
+    expect(graph.storageId).toBe('BigQuery (Common)');
+    expect(graph.nodes).toEqual([
+      {
+        key: 'orders',
+        title: 'Orders',
+        inputSource: 'SQL',
+        description: 'All orders',
+        schema: [
+          { name: 'order_id', type: 'STRING', pk: true, alias: 'Order ID' },
+          { name: 'total', type: 'NUMERIC', pk: false },
+        ],
+        position: { x: 10, y: 20 },
+        status: 'created',
+        owoxId: 'id-orders',
+      },
+      {
+        key: 'customers',
+        title: 'Customers',
+        inputSource: 'TABLE',
+        description: undefined,
+        schema: [],
+        position: { x: 0, y: 0 },
+        status: 'pending',
+        owoxId: 'id-customers',
+      },
+    ]);
+    expect(graph.edges).toEqual([
+      {
+        id: 'edge-1',
+        from: 'orders',
+        to: 'customers',
+        keys: [{ left: 'customer_id', right: 'id' }],
+        bidirectional: true,
+      },
+    ]);
+  });
+
+  it('de-duplicates keys of same-titled data marts', () => {
+    const graph = canvasToModelGraph({
+      nodes: [
+        buildNode({ id: 'id-1', title: 'Orders' }),
+        buildNode({ id: 'id-2', title: 'Orders' }),
+      ],
+      edges: [],
+      positions: new Map(),
+    });
+    expect(graph.nodes.map(node => node.key)).toEqual(['orders', 'orders-2']);
+  });
+});
+
+describe('sanitizeModelGraph', () => {
+  it('strips storage, ids and statuses before the graph leaves as a file', () => {
+    const graph = canvasToModelGraph({
+      nodes: [buildNode({ id: 'id-orders', title: 'Orders' })],
+      edges: [],
+      positions: new Map(),
+      storageLabel: 'BigQuery (Common)',
+    });
+    const sanitized = sanitizeModelGraph(graph);
+    expect(sanitized.storageId).toBeNull();
+    expect(sanitized.nodes[0]).toMatchObject({ status: 'pending', owoxId: null });
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
@@ -148,7 +148,7 @@ describe('sanitizeModelGraph', () => {
       storageLabel: 'BigQuery (Common)',
     });
     const sanitized = sanitizeModelGraph(graph);
-    expect(sanitized.storageId).toBeNull();
+    expect(sanitized).not.toHaveProperty('storageId');
     expect(sanitized.nodes[0]).toMatchObject({ status: 'pending', owoxId: null });
   });
 });

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
@@ -126,13 +126,17 @@ export function canvasToModelGraph(input: CanvasModelGraphInput): ModelGraph {
   return { storageId: input.storageLabel ?? null, nodes, edges };
 }
 
+/** The JSON-file shape: {@link ModelGraph} without the push-flow-only storage field. */
+export type SanitizedModelGraph = Omit<ModelGraph, 'storageId'>;
+
 /**
  * Strip everything project-specific before the graph leaves the product as a
- * JSON file — the same rules model.owox.com applies to its share links.
+ * JSON file — the same rules model.owox.com applies to its share links. The
+ * `storageId` field is dropped entirely: it only carries meaning in the Model
+ * Canvas push flow, and its import tolerates the field being absent.
  */
-export function sanitizeModelGraph(graph: ModelGraph): ModelGraph {
+export function sanitizeModelGraph(graph: ModelGraph): SanitizedModelGraph {
   return {
-    storageId: null,
     nodes: graph.nodes.map(node => ({
       key: node.key,
       title: node.title,

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
@@ -1,0 +1,154 @@
+import { DataMartDefinitionType } from '../../shared/enums/data-mart-definition-type.enum';
+import { DataMartStatus } from '../../shared/enums/data-mart-status.enum';
+import type { CanvasRenderEdge } from '../model/graph/merge-bidirectional-edges';
+import type { PathPoint } from '../model/graph/path-point';
+import type { ModelCanvasNode } from '../model/types';
+
+// The model graph interchange shape used by model.owox.com (Model Canvas).
+// Exported JSON must stay compatible with it, so these types mirror that
+// project's `ModelGraph` rather than the canvas' own view models.
+
+export type ModelGraphInputSource = 'SQL' | 'CONNECTOR' | 'VIEW' | 'TABLE';
+export type ModelGraphNodeStatus = 'pending' | 'created';
+
+export interface ModelGraphSchemaField {
+  name: string;
+  type: string;
+  pk: boolean;
+  alias?: string;
+}
+
+export interface ModelGraphJoinKey {
+  left: string;
+  right: string;
+}
+
+export interface ModelGraphNode {
+  key: string;
+  title: string;
+  inputSource: ModelGraphInputSource;
+  description?: string;
+  schema: ModelGraphSchemaField[];
+  position: { x: number; y: number };
+  status: ModelGraphNodeStatus;
+  owoxId?: string | null;
+}
+
+export interface ModelGraphEdge {
+  id: string;
+  from: string;
+  to: string;
+  keys: ModelGraphJoinKey[];
+  bidirectional: boolean;
+}
+
+export interface ModelGraph {
+  storageId: string | null;
+  nodes: ModelGraphNode[];
+  edges: ModelGraphEdge[];
+}
+
+const INPUT_SOURCE_BY_DEFINITION_TYPE: Record<DataMartDefinitionType, ModelGraphInputSource> = {
+  [DataMartDefinitionType.SQL]: 'SQL',
+  [DataMartDefinitionType.TABLE]: 'TABLE',
+  [DataMartDefinitionType.VIEW]: 'VIEW',
+  // Model Canvas has no pattern concept — a pattern still resolves to tables.
+  [DataMartDefinitionType.TABLE_PATTERN]: 'TABLE',
+  [DataMartDefinitionType.CONNECTOR]: 'CONNECTOR',
+};
+
+function slugifyKey(text: string, fallback: string): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || fallback;
+}
+
+export interface CanvasModelGraphInput {
+  nodes: ModelCanvasNode[];
+  edges: CanvasRenderEdge[];
+  /** Live canvas positions by data mart id (post-layout / user-dragged). */
+  positions: ReadonlyMap<string, PathPoint>;
+  /** Human-readable storage label rendered into the OKF documents. */
+  storageLabel?: string;
+}
+
+/** Build the full model graph; JSON export runs it through {@link sanitizeModelGraph}. */
+export function canvasToModelGraph(input: CanvasModelGraphInput): ModelGraph {
+  const keyById = new Map<string, string>();
+  const taken = new Set<string>();
+  for (const node of input.nodes) {
+    const base = slugifyKey(node.title, node.id);
+    let unique = base;
+    let suffix = 2;
+    while (taken.has(unique)) unique = `${base}-${String(suffix++)}`;
+    taken.add(unique);
+    keyById.set(node.id, unique);
+  }
+
+  const nodes: ModelGraphNode[] = input.nodes.map(node => ({
+    key: keyById.get(node.id) ?? node.id,
+    title: node.title,
+    inputSource: node.definitionType
+      ? INPUT_SOURCE_BY_DEFINITION_TYPE[node.definitionType]
+      : 'TABLE',
+    description: node.description ?? undefined,
+    schema: (node.fields ?? []).map(field => ({
+      name: field.name,
+      type: field.type,
+      pk: field.isPrimaryKey,
+      ...(field.alias && field.alias !== field.name ? { alias: field.alias } : {}),
+    })),
+    position: input.positions.get(node.id) ?? { x: 0, y: 0 },
+    status: node.status === DataMartStatus.PUBLISHED ? 'created' : 'pending',
+    owoxId: node.id,
+  }));
+
+  const edges: ModelGraphEdge[] = input.edges.flatMap(edge => {
+    const from = keyById.get(edge.sourceId);
+    const to = keyById.get(edge.targetId);
+    if (!from || !to) return [];
+    return [
+      {
+        id: edge.id,
+        from,
+        to,
+        keys: edge.joinConditions.map(condition => ({
+          left: condition.sourceFieldName,
+          right: condition.targetFieldName,
+        })),
+        bidirectional: edge.bidirectional,
+      },
+    ];
+  });
+
+  return { storageId: input.storageLabel ?? null, nodes, edges };
+}
+
+/**
+ * Strip everything project-specific before the graph leaves the product as a
+ * JSON file — the same rules model.owox.com applies to its share links.
+ */
+export function sanitizeModelGraph(graph: ModelGraph): ModelGraph {
+  return {
+    storageId: null,
+    nodes: graph.nodes.map(node => ({
+      key: node.key,
+      title: node.title,
+      inputSource: node.inputSource,
+      description: node.description,
+      schema: node.schema,
+      position: node.position,
+      status: 'pending',
+      owoxId: null,
+    })),
+    edges: graph.edges.map(edge => ({
+      id: edge.id,
+      from: edge.from,
+      to: edge.to,
+      keys: edge.keys,
+      bidirectional: edge.bidirectional,
+    })),
+  };
+}

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
@@ -3,6 +3,7 @@ import { DataMartStatus } from '../../shared/enums/data-mart-status.enum';
 import type { CanvasRenderEdge } from '../model/graph/merge-bidirectional-edges';
 import type { PathPoint } from '../model/graph/path-point';
 import type { ModelCanvasNode } from '../model/types';
+import { slugify } from './slug';
 
 // The model graph interchange shape used by model.owox.com (Model Canvas).
 // Exported JSON must stay compatible with it, so these types mirror that
@@ -23,6 +24,9 @@ export interface ModelGraphJoinKey {
   right: string;
 }
 
+// No `owoxId` on nodes: data mart identifiers carry no meaning outside this
+// project (the LLM/documentation use case reads titles, schemas and joins),
+// so no export format emits them.
 export interface ModelGraphNode {
   key: string;
   title: string;
@@ -31,7 +35,6 @@ export interface ModelGraphNode {
   schema: ModelGraphSchemaField[];
   position: { x: number; y: number };
   status: ModelGraphNodeStatus;
-  owoxId?: string | null;
 }
 
 export interface ModelGraphEdge {
@@ -57,14 +60,6 @@ const INPUT_SOURCE_BY_DEFINITION_TYPE: Record<DataMartDefinitionType, ModelGraph
   [DataMartDefinitionType.CONNECTOR]: 'CONNECTOR',
 };
 
-function slugifyKey(text: string, fallback: string): string {
-  const slug = text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  return slug || fallback;
-}
-
 export interface CanvasModelGraphInput {
   nodes: ModelCanvasNode[];
   edges: CanvasRenderEdge[];
@@ -79,7 +74,7 @@ export function canvasToModelGraph(input: CanvasModelGraphInput): ModelGraph {
   const keyById = new Map<string, string>();
   const taken = new Set<string>();
   for (const node of input.nodes) {
-    const base = slugifyKey(node.title, node.id);
+    const base = slugify(node.title, node.id);
     let unique = base;
     let suffix = 2;
     while (taken.has(unique)) unique = `${base}-${String(suffix++)}`;
@@ -102,7 +97,6 @@ export function canvasToModelGraph(input: CanvasModelGraphInput): ModelGraph {
     })),
     position: input.positions.get(node.id) ?? { x: 0, y: 0 },
     status: node.status === DataMartStatus.PUBLISHED ? 'created' : 'pending',
-    owoxId: node.id,
   }));
 
   const edges: ModelGraphEdge[] = input.edges.flatMap(edge => {
@@ -145,7 +139,6 @@ export function sanitizeModelGraph(graph: ModelGraph): SanitizedModelGraph {
       schema: node.schema,
       position: node.position,
       status: 'pending',
-      owoxId: null,
     })),
     edges: graph.edges.map(edge => ({
       id: edge.id,

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/frontmatter.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/frontmatter.ts
@@ -1,11 +1,3 @@
-export function slugify(text: string, fallback = ''): string {
-  const slug = (text || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  return slug || fallback;
-}
-
 /** Render a flat object as OKF YAML frontmatter lines (scalars and string arrays only). */
 export function renderFrontmatter(values: Record<string, unknown>): string {
   const lines: string[] = [];

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/frontmatter.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/frontmatter.ts
@@ -1,0 +1,23 @@
+export function slugify(text: string, fallback = ''): string {
+  const slug = (text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || fallback;
+}
+
+/** Render a flat object as OKF YAML frontmatter lines (scalars and string arrays only). */
+export function renderFrontmatter(values: Record<string, unknown>): string {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(values)) {
+    if (value === null || value === undefined) continue;
+    if (Array.isArray(value)) lines.push(`${key}: [${value.map(scalar).join(', ')}]`);
+    else lines.push(`${key}: ${scalar(value)}`);
+  }
+  return lines.join('\n');
+}
+
+function scalar(value: unknown): string {
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ')}"`;
+}

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { ModelGraph } from '../model-graph';
+import { serializeOkfBundle } from './serialize';
+
+const GRAPH: ModelGraph = {
+  storageId: 'BigQuery (Common)',
+  nodes: [
+    {
+      key: 'orders',
+      title: 'Orders',
+      inputSource: 'SQL',
+      description: 'All orders',
+      schema: [
+        { name: 'order_id', type: 'STRING', pk: true },
+        { name: 'customer_id', type: 'STRING', pk: false },
+      ],
+      position: { x: 0, y: 0 },
+      status: 'created',
+      owoxId: 'id-orders',
+    },
+    {
+      key: 'customers',
+      title: 'Customers',
+      inputSource: 'TABLE',
+      schema: [{ name: 'id', type: 'STRING', pk: true, alias: 'Customer ID' }],
+      position: { x: 100, y: 0 },
+      status: 'pending',
+      owoxId: 'id-customers',
+    },
+  ],
+  edges: [
+    {
+      id: 'edge-1',
+      from: 'orders',
+      to: 'customers',
+      keys: [{ left: 'customer_id', right: 'id' }],
+      bidirectional: true,
+    },
+  ],
+};
+
+describe('serializeOkfBundle', () => {
+  it('emits one document per data mart plus an index, under the bundle folder', () => {
+    const { files } = serializeOkfBundle(GRAPH, 'BigQuery (Common)');
+    expect(Object.keys(files).sort()).toEqual([
+      'bigquery-common/customers.md',
+      'bigquery-common/index.md',
+      'bigquery-common/orders.md',
+    ]);
+  });
+
+  it('renders joins as links whose slugs match the target filenames', () => {
+    const { files } = serializeOkfBundle(GRAPH);
+    expect(files['data-marts/orders.md']).toContain(
+      '- [Customers](./customers.md) — `customer_id = id`'
+    );
+    // Bidirectional edge: the reverse side flips the join condition.
+    expect(files['data-marts/customers.md']).toContain(
+      '- [Orders](./orders.md) — `id = customer_id`'
+    );
+  });
+
+  it('annotates FK columns and keeps the alias column only when aliases exist', () => {
+    const { files } = serializeOkfBundle(GRAPH);
+    expect(files['data-marts/orders.md']).toContain('| Column | Type | Description |');
+    expect(files['data-marts/orders.md']).toContain('FK to [Customers](./customers.md)');
+    expect(files['data-marts/customers.md']).toContain('| Column | Type | Alias | Description |');
+    expect(files['data-marts/customers.md']).toContain('Customer ID');
+  });
+
+  it('renders the index table with statuses resolved and the product footer', () => {
+    const { files } = serializeOkfBundle(GRAPH, 'My Storage');
+    const index = files['my-storage/index.md'];
+    expect(index).toContain('| [Orders](./orders.md) | SQL | BigQuery (Common) |');
+    expect(index).toContain('Generated with [OWOX Data Marts]');
+    expect(files['my-storage/orders.md']).toContain('- **Status:** PUBLISHED');
+    expect(files['my-storage/customers.md']).toContain('- **Status:** DRAFT');
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
@@ -97,4 +97,17 @@ describe('serializeOkfBundle', () => {
     expect(files['data-marts/index.md']).toContain('[Customers \\| VIP]');
     expect(files['data-marts/customers-vip.md']).toContain('Customer \\| ID');
   });
+
+  it('escapes square brackets so titles cannot terminate their links early', () => {
+    const { files } = serializeOkfBundle({
+      ...GRAPH,
+      nodes: GRAPH.nodes.map(node =>
+        node.key === 'customers' ? { ...node, title: 'Customers [EU]' } : node
+      ),
+    });
+    expect(files['data-marts/index.md']).toContain('[Customers \\[EU\\]](./customers-eu.md)');
+    expect(files['data-marts/orders.md']).toContain(
+      '- [Customers \\[EU\\]](./customers-eu.md) — `customer_id = id`'
+    );
+  });
 });

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
@@ -16,7 +16,6 @@ const GRAPH: ModelGraph = {
       ],
       position: { x: 0, y: 0 },
       status: 'created',
-      owoxId: 'id-orders',
     },
     {
       key: 'customers',
@@ -25,7 +24,6 @@ const GRAPH: ModelGraph = {
       schema: [{ name: 'id', type: 'STRING', pk: true, alias: 'Customer ID' }],
       position: { x: 100, y: 0 },
       status: 'pending',
-      owoxId: 'id-customers',
     },
   ],
   edges: [
@@ -75,5 +73,28 @@ describe('serializeOkfBundle', () => {
     expect(index).toContain('Generated with [OWOX Data Marts]');
     expect(files['my-storage/orders.md']).toContain('- **Status:** PUBLISHED');
     expect(files['my-storage/customers.md']).toContain('- **Status:** DRAFT');
+  });
+
+  it('emits no data mart identifiers, matching the sanitized JSON export', () => {
+    const { files } = serializeOkfBundle(GRAPH);
+    expect(files['data-marts/orders.md']).not.toContain('**ID:**');
+    expect(files['data-marts/orders.md']).not.toContain('id-orders');
+  });
+
+  it('escapes pipes so titles and aliases cannot break the tables', () => {
+    const { files } = serializeOkfBundle({
+      ...GRAPH,
+      nodes: GRAPH.nodes.map(node =>
+        node.key === 'customers'
+          ? {
+              ...node,
+              title: 'Customers | VIP',
+              schema: [{ name: 'id', type: 'STRING', pk: true, alias: 'Customer | ID' }],
+            }
+          : node
+      ),
+    });
+    expect(files['data-marts/index.md']).toContain('[Customers \\| VIP]');
+    expect(files['data-marts/customers-vip.md']).toContain('Customer \\| ID');
   });
 });

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
@@ -1,0 +1,153 @@
+import type { ModelGraph, ModelGraphNode } from '../model-graph';
+import { renderFrontmatter, slugify } from './frontmatter';
+
+// OKF (Open Knowledge Format) bundle: one Markdown document per data mart plus
+// an index, matching the format model.owox.com produces and imports. Joins are
+// rendered as `- [Title](./slug.md) — \`left = right\`` — the link target slug
+// must equal the target document's filename, which is why one slug map feeds
+// both the filenames and every cross-reference.
+
+const OKF_FOOTER =
+  '\n\n---\n\n_Generated with [OWOX Data Marts](https://www.owox.com/) · ' +
+  '[open source](https://github.com/OWOX/owox-data-marts)_\n';
+
+export interface OkfBundle {
+  files: Record<string, string>;
+}
+
+export function serializeOkfBundle(graph: ModelGraph, bundleTitle = 'Data Marts'): OkfBundle {
+  const folder = slugify(bundleTitle, 'data-marts');
+  const slugByKey = new Map<string, string>();
+  const taken = new Set<string>();
+  for (const node of graph.nodes) {
+    const base = slugify(node.title, node.key);
+    let unique = base;
+    let suffix = 2;
+    while (taken.has(unique)) unique = `${base}-${String(suffix++)}`;
+    taken.add(unique);
+    slugByKey.set(node.key, unique);
+  }
+
+  const files: Record<string, string> = {};
+  for (const node of graph.nodes) {
+    files[`${folder}/${slugByKey.get(node.key) ?? node.key}.md`] = renderNode(
+      node,
+      graph,
+      slugByKey
+    );
+  }
+
+  const rows = graph.nodes
+    .map(
+      node =>
+        `| [${node.title}](./${slugByKey.get(node.key) ?? node.key}.md) | ${node.inputSource} | ${graph.storageId ?? '—'} |`
+    )
+    .join('\n');
+  files[`${folder}/index.md`] = `---\n${renderFrontmatter({
+    type: 'index',
+    title: bundleTitle,
+    description: 'Index of exported OWOX data marts.',
+    tags: ['owox', 'index'],
+  })}\n---\n\n# ${bundleTitle}\n\n| Data Mart | Type | Storage |\n|-----------|------|---------|\n${rows}\n${OKF_FOOTER}`;
+
+  return { files };
+}
+
+// Map each of a node's own FK columns to the target mart it points at, so the
+// FK note can be rendered inside that column's Description cell.
+function fkColumns(
+  node: ModelGraphNode,
+  graph: ModelGraph,
+  slugByKey: Map<string, string>
+): Map<string, { title: string; slug: string }> {
+  const out = new Map<string, { title: string; slug: string }>();
+  for (const edge of graph.edges) {
+    if (edge.from === node.key) {
+      const target = graph.nodes.find(other => other.key === edge.to);
+      if (!target) continue;
+      const slug = slugByKey.get(edge.to);
+      if (!slug) continue;
+      for (const key of edge.keys) out.set(key.left, { title: target.title, slug });
+    } else if (edge.bidirectional && edge.to === node.key) {
+      const target = graph.nodes.find(other => other.key === edge.from);
+      if (!target) continue;
+      const slug = slugByKey.get(edge.from);
+      if (!slug) continue;
+      for (const key of edge.keys) out.set(key.right, { title: target.title, slug });
+    }
+  }
+  return out;
+}
+
+function renderNode(
+  node: ModelGraphNode,
+  graph: ModelGraph,
+  slugByKey: Map<string, string>
+): string {
+  const frontmatter = renderFrontmatter({
+    type: 'OWOX Data Mart',
+    title: node.title,
+    description: node.description === '' ? undefined : node.description,
+    tags: ['owox', node.inputSource.toLowerCase()],
+  });
+
+  const overview = [
+    '## Overview',
+    '',
+    `- **ID:** \`${node.owoxId ?? '—'}\``,
+    `- **Status:** ${node.status === 'created' ? 'PUBLISHED' : 'DRAFT'}`,
+    `- **Definition type:** ${node.inputSource}`,
+    `- **Storage:** ${graph.storageId ?? '—'}`,
+    '',
+  ].join('\n');
+
+  const fk = fkColumns(node, graph, slugByKey);
+  // The Alias column is emitted only when some field has one, so marts without
+  // aliases keep the leaner 3-column table.
+  const withAlias = node.schema.some(field => field.alias);
+  const header = withAlias
+    ? '| Column | Type | Alias | Description |\n|--------|------|-------|-------------|\n'
+    : '| Column | Type | Description |\n|--------|------|-------------|\n';
+  const schema = node.schema.length
+    ? '# Schema\n\n' +
+      header +
+      node.schema
+        .map(field => {
+          const parts: string[] = [];
+          if (field.pk) parts.push('PK.');
+          const ref = fk.get(field.name);
+          if (ref) parts.push(`FK to [${ref.title}](./${ref.slug}.md)`);
+          const cells = withAlias
+            ? [`\`${field.name}\``, field.type, field.alias ?? '', parts.join(' ').trim()]
+            : [`\`${field.name}\``, field.type, parts.join(' ').trim()];
+          return `| ${cells.join(' | ')} |`;
+        })
+        .join('\n') +
+      '\n\n'
+    : '';
+
+  const outgoing = graph.edges.filter(
+    edge => edge.from === node.key || (edge.bidirectional && edge.to === node.key)
+  );
+  const joins = outgoing.length
+    ? '## Joins\n\n' +
+      outgoing
+        .map(edge => {
+          const forward = edge.from === node.key;
+          const otherKey = forward ? edge.to : edge.from;
+          const other = graph.nodes.find(candidate => candidate.key === otherKey);
+          const slug = slugByKey.get(otherKey);
+          if (!other || !slug) return null;
+          const keys = forward
+            ? edge.keys
+            : edge.keys.map(key => ({ left: key.right, right: key.left }));
+          const condition = keys.map(key => `\`${key.left} = ${key.right}\``).join(', ');
+          return `- [${other.title}](./${slug}.md) — ${condition}`;
+        })
+        .filter(Boolean)
+        .join('\n') +
+      '\n'
+    : '';
+
+  return `---\n${frontmatter}\n---\n\n# ${node.title}\n${node.description ? '\n' + node.description + '\n' : ''}\n${overview}${schema}${joins}`;
+}

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
@@ -7,6 +7,11 @@ function escapeTableCell(value: string): string {
   return value.replace(/\|/g, '\\|');
 }
 
+/** Keep a title from terminating its `[text](./slug.md)` link early. */
+function escapeLinkText(value: string): string {
+  return value.replace(/([[\]])/g, '\\$1');
+}
+
 // OKF (Open Knowledge Format) bundle: one Markdown document per data mart plus
 // an index, matching the format model.owox.com produces and imports. Joins are
 // rendered as `- [Title](./slug.md) — \`left = right\`` — the link target slug
@@ -46,7 +51,7 @@ export function serializeOkfBundle(graph: ModelGraph, bundleTitle = 'Data Marts'
   const rows = graph.nodes
     .map(
       node =>
-        `| [${escapeTableCell(node.title)}](./${slugByKey.get(node.key) ?? node.key}.md) | ${node.inputSource} | ${escapeTableCell(graph.storageId ?? '—')} |`
+        `| [${escapeLinkText(escapeTableCell(node.title))}](./${slugByKey.get(node.key) ?? node.key}.md) | ${node.inputSource} | ${escapeTableCell(graph.storageId ?? '—')} |`
     )
     .join('\n');
   files[`${folder}/index.md`] = `---\n${renderFrontmatter({
@@ -121,7 +126,7 @@ function renderNode(
           const parts: string[] = [];
           if (field.pk) parts.push('PK.');
           const ref = fk.get(field.name);
-          if (ref) parts.push(`FK to [${ref.title}](./${ref.slug}.md)`);
+          if (ref) parts.push(`FK to [${escapeLinkText(ref.title)}](./${ref.slug}.md)`);
           const cells = withAlias
             ? [`\`${field.name}\``, field.type, field.alias ?? '', parts.join(' ').trim()]
             : [`\`${field.name}\``, field.type, parts.join(' ').trim()];
@@ -147,7 +152,7 @@ function renderNode(
             ? edge.keys
             : edge.keys.map(key => ({ left: key.right, right: key.left }));
           const condition = keys.map(key => `\`${key.left} = ${key.right}\``).join(', ');
-          return `- [${other.title}](./${slug}.md) — ${condition}`;
+          return `- [${escapeLinkText(other.title)}](./${slug}.md) — ${condition}`;
         })
         .filter(Boolean)
         .join('\n') +

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
@@ -1,5 +1,11 @@
 import type { ModelGraph, ModelGraphNode } from '../model-graph';
-import { renderFrontmatter, slugify } from './frontmatter';
+import { slugify } from '../slug';
+import { renderFrontmatter } from './frontmatter';
+
+/** Keep a value from breaking out of its Markdown table cell. */
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/g, '\\|');
+}
 
 // OKF (Open Knowledge Format) bundle: one Markdown document per data mart plus
 // an index, matching the format model.owox.com produces and imports. Joins are
@@ -40,7 +46,7 @@ export function serializeOkfBundle(graph: ModelGraph, bundleTitle = 'Data Marts'
   const rows = graph.nodes
     .map(
       node =>
-        `| [${node.title}](./${slugByKey.get(node.key) ?? node.key}.md) | ${node.inputSource} | ${graph.storageId ?? '—'} |`
+        `| [${escapeTableCell(node.title)}](./${slugByKey.get(node.key) ?? node.key}.md) | ${node.inputSource} | ${escapeTableCell(graph.storageId ?? '—')} |`
     )
     .join('\n');
   files[`${folder}/index.md`] = `---\n${renderFrontmatter({
@@ -94,7 +100,6 @@ function renderNode(
   const overview = [
     '## Overview',
     '',
-    `- **ID:** \`${node.owoxId ?? '—'}\``,
     `- **Status:** ${node.status === 'created' ? 'PUBLISHED' : 'DRAFT'}`,
     `- **Definition type:** ${node.inputSource}`,
     `- **Storage:** ${graph.storageId ?? '—'}`,
@@ -120,7 +125,7 @@ function renderNode(
           const cells = withAlias
             ? [`\`${field.name}\``, field.type, field.alias ?? '', parts.join(' ').trim()]
             : [`\`${field.name}\``, field.type, parts.join(' ').trim()];
-          return `| ${cells.join(' | ')} |`;
+          return `| ${cells.map(escapeTableCell).join(' | ')} |`;
         })
         .join('\n') +
       '\n\n'

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/zip.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/zip.ts
@@ -1,0 +1,8 @@
+import { strToU8, zipSync } from 'fflate';
+
+/** Pack OKF bundle files into a zip archive, preserving the folder layout. */
+export function bundleToZip(files: Record<string, string>): Uint8Array {
+  const entries: Record<string, Uint8Array> = {};
+  for (const [path, content] of Object.entries(files)) entries[path] = strToU8(content);
+  return zipSync(entries, { level: 6 });
+}

--- a/apps/web/src/features/data-marts/model-canvas/export/slug.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/slug.ts
@@ -1,0 +1,12 @@
+/**
+ * Lowercase, with every non-alphanumeric run collapsed to a dash. One shared
+ * implementation on purpose: model-graph keys and OKF document filenames must
+ * stay in lockstep, or the join links inside a bundle stop resolving.
+ */
+export function slugify(text: string, fallback = ''): string {
+  const slug = (text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || fallback;
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/erd-node.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/erd-node.ts
@@ -18,9 +18,9 @@ export const ERD_ROW_HEIGHT = 26;
 export const ERD_EXPAND_ROW_HEIGHT = 26;
 /** ERD nodes show at most this many rows before collapsing behind a toggle. */
 export const ERD_COLLAPSED_ROWS = 4;
-/** Height of the meta row (badge + field count), subtracted when object labels hide it. */
+/** Height of the meta row (the source badge), subtracted when object labels hide it. */
 export const CARD_META_ROW_HEIGHT = 36;
-/** Height of the status icons row (quality shield + Data Last Updated), dropped in title-only mode. */
+/** Height of the status icons row (quality shield + Data Last Updated + field count), dropped in title-only mode. */
 export const CARD_STATUS_ROW_HEIGHT = 30;
 
 export function nodeWidth(viewMode: CanvasViewMode): number {
@@ -44,8 +44,9 @@ export function collapsedRowCount(fields: CanvasNodeField[]): number {
 
 /**
  * Collapsed layout height for a node, used by dagre and as the initial render
- * size. `metaRowHidden` reflects the object-labels preference: when both the
- * source badge and the field count are hidden, the card drops its meta row.
+ * size. `metaRowHidden` reflects the object-labels preference: when the
+ * source badge is hidden, the card drops its meta row (the field count lives
+ * in the status icons row).
  * `statusRowHidden` reflects title-only mode, which also drops the quality
  * indicators row (Data Quality shield + Data Last Updated clock).
  */

--- a/apps/web/src/features/data-marts/shared/components/DataMartBulkActions/DataMartBulkActions.test.tsx
+++ b/apps/web/src/features/data-marts/shared/components/DataMartBulkActions/DataMartBulkActions.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { DataMartStatus } from '../../enums';
+import { DataMartBulkActions } from './DataMartBulkActions';
+
+// Radix dropdowns need real pointer events — render everything inline instead
+// (the established pattern for menu tests in this codebase).
+vi.mock('@owox/ui/components/dropdown-menu', () => {
+  const passthrough = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    DropdownMenu: passthrough,
+    DropdownMenuTrigger: passthrough,
+    DropdownMenuContent: passthrough,
+    DropdownMenuPortal: passthrough,
+    DropdownMenuSeparator: () => null,
+    DropdownMenuSub: passthrough,
+    DropdownMenuSubContent: passthrough,
+    DropdownMenuSubTrigger: ({
+      children,
+      ...props
+    }: {
+      children?: ReactNode;
+      'data-testid'?: string;
+    }) => <div data-testid={props['data-testid']}>{children}</div>,
+    DropdownMenuItem: ({
+      children,
+      onSelect,
+      ...props
+    }: {
+      children?: ReactNode;
+      onSelect?: () => void;
+      'data-testid'?: string;
+    }) => (
+      <button type='button' data-testid={props['data-testid']} onClick={onSelect}>
+        {children}
+      </button>
+    ),
+  };
+});
+
+function renderBulkActions(onExport?: (format: string) => void) {
+  return render(
+    <DataMartBulkActions
+      dataMarts={[{ id: 'mart-1', status: DataMartStatus.PUBLISHED }]}
+      projectId='project-1'
+      deleteDataMart={vi.fn()}
+      publishDataMart={vi.fn()}
+      onCompleted={vi.fn()}
+      targetScope='canvas'
+      onExport={onExport}
+    />
+  );
+}
+
+describe('DataMartBulkActions export submenu', () => {
+  it('is absent when no export handler is provided', () => {
+    renderBulkActions();
+    expect(screen.queryByTestId('export-canvas')).not.toBeInTheDocument();
+  });
+
+  it('offers every canvas export format and reports the picked one', () => {
+    const onExport = vi.fn();
+    renderBulkActions(onExport);
+
+    expect(screen.getByTestId('export-canvas')).toBeInTheDocument();
+    expect(screen.getByText('Image (SVG)')).toBeInTheDocument();
+    expect(screen.getByText('Image (PNG)')).toBeInTheDocument();
+    expect(screen.getByText('JSON')).toBeInTheDocument();
+    expect(screen.getByText('OKF (Markdown)')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('export-canvas-svg'));
+    fireEvent.click(screen.getByTestId('export-canvas-okf'));
+    expect(onExport.mock.calls.map(call => call[0])).toEqual(['svg', 'okf']);
+  });
+});

--- a/apps/web/src/features/data-marts/shared/components/DataMartBulkActions/DataMartBulkActions.tsx
+++ b/apps/web/src/features/data-marts/shared/components/DataMartBulkActions/DataMartBulkActions.tsx
@@ -14,10 +14,25 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuPortal,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@owox/ui/components/dropdown-menu';
-import { ChevronDown, CircleCheckBig, History, ShieldCheck, Trash2 } from 'lucide-react';
+import {
+  ChevronDown,
+  CircleCheckBig,
+  Download,
+  FileImage,
+  FileJson,
+  FileText,
+  History,
+  Image as ImageIcon,
+  ShieldCheck,
+  Trash2,
+} from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { DataStorageType } from '../../../../data-storage';
@@ -29,6 +44,16 @@ export interface DataMartBulkActionTarget {
   status: DataMartStatus;
   storageType?: DataStorageType;
 }
+
+export type DataMartCanvasExportFormat = 'svg' | 'png' | 'json' | 'okf';
+
+const EXPORT_ITEMS: { format: DataMartCanvasExportFormat; label: string; icon: typeof Download }[] =
+  [
+    { format: 'svg', label: 'Image (SVG)', icon: ImageIcon },
+    { format: 'png', label: 'Image (PNG)', icon: FileImage },
+    { format: 'json', label: 'JSON', icon: FileJson },
+    { format: 'okf', label: 'OKF (Markdown)', icon: FileText },
+  ];
 
 interface DataMartBulkActionsProps {
   dataMarts: DataMartBulkActionTarget[];
@@ -45,6 +70,11 @@ interface DataMartBulkActionsProps {
    */
   onCheckDataLastUpdated?: () => void;
   isCheckingDataLastUpdated?: boolean;
+  /**
+   * When provided, adds an "Export" submenu with the canvas export formats.
+   * Only the canvas surface passes it — the list page has no model to export.
+   */
+  onExport?: (format: DataMartCanvasExportFormat) => void;
 }
 
 export function DataMartBulkActions({
@@ -57,6 +87,7 @@ export function DataMartBulkActions({
   targetScope = 'selection',
   onCheckDataLastUpdated,
   isCheckingDataLastUpdated = false,
+  onExport,
 }: DataMartBulkActionsProps) {
   const [actionDataMarts, setActionDataMarts] = useState<DataMartBulkActionTarget[]>([]);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
@@ -204,6 +235,30 @@ export function DataMartBulkActions({
                 ? 'Checking Data Last Updated…'
                 : 'Check Data Last Updated'}
             </DropdownMenuItem>
+          )}
+          {onExport && (
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger data-testid='export-canvas' className='gap-2'>
+                <Download className='text-muted-foreground size-4 shrink-0' aria-hidden='true' />
+                Export
+              </DropdownMenuSubTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent>
+                  {EXPORT_ITEMS.map(item => (
+                    <DropdownMenuItem
+                      key={item.format}
+                      data-testid={`export-canvas-${item.format}`}
+                      onSelect={() => {
+                        onExport(item.format);
+                      }}
+                    >
+                      <item.icon aria-hidden='true' />
+                      {item.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
           )}
           <DropdownMenuSeparator />
           <DropdownMenuItem

--- a/apps/web/src/features/data-marts/shared/components/DataMartBulkActions/index.ts
+++ b/apps/web/src/features/data-marts/shared/components/DataMartBulkActions/index.ts
@@ -1,1 +1,5 @@
-export { DataMartBulkActions, type DataMartBulkActionTarget } from './DataMartBulkActions';
+export {
+  DataMartBulkActions,
+  type DataMartBulkActionTarget,
+  type DataMartCanvasExportFormat,
+} from './DataMartBulkActions';

--- a/docs/getting-started/setup-guide/models-canvas-export.md
+++ b/docs/getting-started/setup-guide/models-canvas-export.md
@@ -1,0 +1,33 @@
+# Export the Models Canvas
+
+The **Models** canvas shows your Data Marts as an entity-relationship diagram: every Data Mart is a card, every join is an arrow. The canvas can be exported — as an image for a presentation or documentation, or as a machine-readable model you can archive, diff, or open in other tools.
+
+## Where to find it
+
+Open **Data Marts → Models**, pick a storage, and open the **Actions** menu in the top-left corner of the canvas. The **Export** submenu lists the available formats.
+
+The export always covers **what the canvas currently shows**: the same filtered set of Data Marts the other Actions target. Narrow the canvas with the storage, status, relationship, or search filters first if you want to export a subset. When the canvas is empty, there is nothing to export and the menu is not shown.
+
+## Formats
+
+| Format | File | Best for |
+| --- | --- | --- |
+| **Image (SVG)** | `<storage>-<date>.svg` | Documentation and presentations — vector, crisp at any zoom |
+| **Image (PNG)** | `<storage>-<date>.png` | Chats and tools that do not render SVG — raster at 2× scale |
+| **JSON** | `<storage>-<date>.json` | Programmatic use — the model graph in the Model Canvas format |
+| **OKF (Markdown)** | `<storage>-<date>.zip` | Human- and LLM-readable model documentation |
+
+Both images capture the **whole visible model**, not just the part of it inside the viewport — the current pan and zoom do not affect the output. The image background matches your current theme, so dark-theme exports stay readable outside the app.
+
+### JSON
+
+The JSON file contains the model graph — Data Marts with their schemas and canvas positions, and the joins between them — in the format used by [OWOX Model Canvas](https://model.owox.com/). The file is sanitized: it carries no project identifiers, so it is safe to share.
+
+### OKF bundle
+
+OKF (Open Knowledge Format) is a Markdown-based description of a data model: the zip contains one `.md` document per Data Mart — with an overview, the schema table, and the join list — plus an `index.md` catalog. Each join links to the document of the Data Mart it points at, so the bundle reads as a small cross-linked wiki. The same format is produced and imported by [OWOX Model Canvas](https://model.owox.com/), and it works well as context for AI assistants.
+
+## Notes
+
+- Schemas appear in JSON and OKF exports once the canvas has loaded Data Mart details; on a very large model, wait for the cards to show their fields before exporting.
+- Field aliases are included alongside technical field names where they differ.

--- a/docs/getting-started/setup-guide/models-canvas-export.md
+++ b/docs/getting-started/setup-guide/models-canvas-export.md
@@ -4,7 +4,7 @@ The **Models** canvas shows your Data Marts as an entity-relationship diagram: e
 
 ## Where to find it
 
-Open **Data Marts → Models**, pick a storage, and open the **Actions** menu in the top-left corner of the canvas. The **Export** submenu lists the available formats.
+Open **Data Marts → Models**, pick a storage, and open the **Actions** menu in the toolbar above the canvas. The **Export** submenu lists the available formats.
 
 The export always covers **what the canvas currently shows**: the same filtered set of Data Marts the other Actions target. Narrow the canvas with the storage, status, relationship, or search filters first if you want to export a subset. When the canvas is empty, there is nothing to export and the menu is not shown.
 

--- a/docs/getting-started/setup-guide/models-canvas-export.md
+++ b/docs/getting-started/setup-guide/models-canvas-export.md
@@ -6,7 +6,7 @@ The **Models** canvas shows your Data Marts as an entity-relationship diagram: e
 
 Open **Data Marts → Models**, pick a storage, and open the **Actions** menu in the toolbar above the canvas. The **Export** submenu lists the available formats.
 
-The export always covers **what the canvas currently shows**: the same filtered set of Data Marts the other Actions target. Narrow the canvas with the storage, status, relationship, or search filters first if you want to export a subset. When the canvas is empty, there is nothing to export and the menu is not shown.
+The export always covers **what the canvas currently shows**: the same filtered set of Data Marts the other Actions target. Narrow the canvas with the storage, status, or relationship filters first if you want to export a subset. The search box only highlights matching Data Marts — it does not narrow the export, just as it does not narrow the other Actions. When the canvas is empty, there is nothing to export and the menu is not shown.
 
 ## Formats
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -594,6 +594,8 @@
         "@tanstack/react-query": "^5.66.0",
         "@xyflow/react": "^12.11.2",
         "axios": "^1.11.0",
+        "fflate": "^0.8.3",
+        "html-to-image": "^1.11.13",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.58.0",
@@ -19717,6 +19719,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -21771,6 +21779,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/html-void-elements": {


### PR DESCRIPTION
## Preview

https://github.com/user-attachments/assets/8b051d59-c188-42b5-b1eb-850dc52328ab

## What

The **Models** canvas gets an **Export** submenu in the **Actions** menu, with four formats:

| Format | File | Notes |
| --- | --- | --- |
| **Image (SVG)** | `<storage>-<date>.svg` | Vector snapshot of the whole visible model — pan/zoom never crops it |
| **Image (PNG)** | `<storage>-<date>.png` | Same capture rasterized at 2× via an offscreen composite |
| **JSON** | `<storage>-<date>.json` | Model graph in the [OWOX Model Canvas](https://model.owox.com/) interchange format, sanitized of storage and data mart identifiers |
| **OKF (Markdown)** | `<storage>-<date>.zip` | One cross-linked Markdown document per data mart (overview, schema with PK/FK notes, joins) plus an `index.md` catalog |

Both images take a theme-aware background layer (dark-theme exports stay readable outside the app) and an OWOX watermark in the bottom-right corner.

The PR also ships feedback-driven canvas polish:

- The **Actions** menu moves from a canvas-corner overlay into the toolbar row — consistent with the Data Marts list, and it no longer covers canvas content.
- The **field count** joins the status icons row instead of occupying its own line, so every card is one row shorter.
- The Object labels settings list drops its decorative glyphs.

## How

- The export targets exactly the **filtered/visible** model — the same set the other Actions cover — and the submenu appears only on the canvas surface, following the established optional-prop pattern in `DataMartBulkActions`.
- Image framing uses `getNodesBounds` with a transform override on the React Flow viewport, so the whole model renders at 1:1 regardless of the user's pan/zoom. The background is composited as a separate layer because `html-to-image`'s own `backgroundColor` would paint on the translated viewport and end up offset.
- The canvas exposes the export API through an imperative handle: the Actions menu renders outside the `ReactFlowProvider`, while measured nodes and the viewport element live inside it.
- New dependencies `html-to-image` and `fflate` load in a separate lazy chunk (~31 kB) on first export, keeping the canvas bundle unchanged.
- Docs: a new user-guide page describing the formats and what OKF is.

## Testing

- New unit tests: model-graph mapping + sanitization, OKF serializer (documents, joins, FK notes, index, slug de-duplication), download helper, Export submenu rendering and callbacks; card-layout tests updated for the merged field-count row.
- All existing model-canvas and list tests pass; `tsc -b`, eslint, prettier, markdownlint, and the production build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)