### PR TITLE
feat(data-marts): include the data mart definition in the OKF export

### DIFF
--- a/.changeset/6771-okf-definition.md
+++ b/.changeset/6771-okf-definition.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# OKF export now carries each Data Mart's definition
+
+Every document in the OKF bundle exported from the Models canvas gains a **Definition** section: the fully qualified table or view name, the table pattern, or the SQL query behind the Data Mart. Connector configurations are deliberately excluded — their source settings can carry sensitive parameters, unlike a plain table path or query text.
+
+This closes the gap that made AI assistants ask for your dataset: with the physical references in the bundle, an assistant can now write runnable SQL — real project, dataset, and table names instead of `<YOUR_DATASET>` placeholders. The JSON export intentionally stays definition-free, matching the sanitized share format of OWOX Model Canvas.

--- a/.changeset/6771-okf-definition.md
+++ b/.changeset/6771-okf-definition.md
@@ -1,9 +1,0 @@
----
-'owox': minor
----
-
-# OKF export now carries each Data Mart's definition
-
-Every document in the OKF bundle exported from the Models canvas gains a **Definition** section: the fully qualified table or view name, the table pattern, or the SQL query behind the Data Mart. Connector configurations are deliberately excluded — their source settings can carry sensitive parameters, unlike a plain table path or query text.
-
-This closes the gap that made AI assistants ask for your dataset: with the physical references in the bundle, an assistant can now write runnable SQL — real project, dataset, and table names instead of `<YOUR_DATASET>` placeholders. The JSON export intentionally stays definition-free, matching the sanitized share format of OWOX Model Canvas.

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.test.tsx
@@ -43,7 +43,11 @@ const viewState = vi.hoisted(() => ({
     isLoading: false,
     error: null as unknown,
     refetch: vi.fn().mockResolvedValue(undefined),
+    isEnriching: false,
   },
+  // When set, the mocked ModelCanvas registers it as the export handle —
+  // mirroring the real lazy canvas having mounted.
+  exportHandle: null as { exportCanvas: (format: string) => Promise<boolean> } | null,
   qualitySummariesHook: {
     data: {} as Record<string, ReturnType<typeof buildQualitySummary>>,
     isLoading: false,
@@ -122,31 +126,39 @@ vi.mock('./ModelCanvas', () => ({
     onOpenDataMart,
     onOpenQuality,
     onRunQuality,
+    exportApiRef,
   }: {
     nodes: { id: string }[];
     edges: { id: string }[];
     onOpenDataMart: (dataMartId: string) => void;
     onOpenQuality?: (dataMartId: string) => void;
     onRunQuality?: (dataMartId: string) => Promise<void>;
+    exportApiRef?: { current: unknown };
   }) => (
-    <>
-      <span data-testid='canvas-node-ids'>{nodes.map(node => node.id).join(',')}</span>
-      <span data-testid='canvas-edge-ids'>{edges.map(edge => edge.id).join(',')}</span>
-      <button
-        type='button'
-        onClick={() => {
-          onOpenDataMart('mart-1');
-        }}
-      >
-        Open Orders
-      </button>
-      <button type='button' onClick={() => onOpenQuality?.('mart-1')}>
-        Open Quality Orders
-      </button>
-      <button type='button' onClick={() => void onRunQuality?.('mart-1')}>
-        Run Quality Orders
-      </button>
-    </>
+    (() => {
+      if (exportApiRef && viewState.exportHandle) exportApiRef.current = viewState.exportHandle;
+      return null;
+    })(),
+    (
+      <>
+        <span data-testid='canvas-node-ids'>{nodes.map(node => node.id).join(',')}</span>
+        <span data-testid='canvas-edge-ids'>{edges.map(edge => edge.id).join(',')}</span>
+        <button
+          type='button'
+          onClick={() => {
+            onOpenDataMart('mart-1');
+          }}
+        >
+          Open Orders
+        </button>
+        <button type='button' onClick={() => onOpenQuality?.('mart-1')}>
+          Open Quality Orders
+        </button>
+        <button type='button' onClick={() => void onRunQuality?.('mart-1')}>
+          Run Quality Orders
+        </button>
+      </>
+    )
   ),
 }));
 
@@ -184,6 +196,8 @@ describe('ModelCanvasView', () => {
     viewState.canvasHook.isLoading = false;
     viewState.canvasHook.error = null;
     viewState.canvasHook.refetch.mockResolvedValue(undefined);
+    viewState.canvasHook.isEnriching = false;
+    viewState.exportHandle = null;
     viewState.qualitySummariesHook.data = {};
     viewState.qualitySummariesHook.isLoading = false;
     viewState.qualitySummariesHook.error = null;
@@ -324,6 +338,47 @@ describe('ModelCanvasView', () => {
     expect(screen.getByTestId('canvas-node-ids')).not.toHaveTextContent('mart-2');
     expect(screen.getByTestId('canvas-edge-ids')).toBeEmptyDOMElement();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('blocks export while detail enrichment is still in flight', async () => {
+    viewState.canvasHook.data = buildCanvasData();
+    viewState.canvasHook.isEnriching = true;
+
+    render(<ModelCanvasView />);
+
+    const trigger = await screen.findByRole('button', { name: 'Actions 2' });
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.keyDown(screen.getByTestId('export-canvas'), { key: 'ArrowRight' });
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'JSON' }));
+
+    await waitFor(() => {
+      expect(exportMocks.toast).toHaveBeenCalledWith(
+        'The canvas is still loading details — please try again in a moment.'
+      );
+    });
+    expect(exportMocks.trackEvent).not.toHaveBeenCalled();
+  });
+
+  it('warns when the export ran with nodes that never got their details', async () => {
+    // buildCanvasData nodes carry no `fields` — the shape of a failed detail fetch.
+    viewState.canvasHook.data = buildCanvasData();
+    const exportCanvas = vi.fn().mockResolvedValue(true);
+    viewState.exportHandle = { exportCanvas };
+
+    render(<ModelCanvasView />);
+
+    const trigger = await screen.findByRole('button', { name: 'Actions 2' });
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.keyDown(screen.getByTestId('export-canvas'), { key: 'ArrowRight' });
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'OKF (Markdown)' }));
+
+    await waitFor(() => {
+      expect(exportCanvas).toHaveBeenCalledWith('okf');
+      expect(exportMocks.toast).toHaveBeenCalledWith(
+        'Exported without schema details for 2 data marts — reload the page to retry.'
+      );
+    });
+    expect(exportMocks.trackEvent).toHaveBeenCalledTimes(1);
   });
 
   it('reports a loading canvas instead of a silent no-op when export is not ready', async () => {

--- a/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/components/ModelCanvasView.tsx
@@ -67,6 +67,7 @@ function ModelCanvasViewContent({ onActiveQualityRunChange }: ModelCanvasViewPro
     isLoading: isTopologyLoading,
     error: topologyError,
     refetch,
+    isEnriching,
   } = useModelCanvas(storageKnown ? filters.storageId : null);
   const { refresh: refreshDataLastUpdated, isRefreshing: isRefreshingDataLastUpdated } =
     useRefreshDataLastUpdated(storageKnown ? filters.storageId : null);
@@ -158,8 +159,21 @@ function ModelCanvasViewContent({ onActiveQualityRunChange }: ModelCanvasViewPro
   // Image capture can take seconds on a large model — swallow repeat clicks
   // instead of kicking off parallel captures and duplicate downloads.
   const isExportingRef = useRef(false);
+  // Mirrors for the [] callback below: whether detail enrichment is still in
+  // flight, and how many visible nodes never got their details (a failed
+  // detail fetch keeps the node compact — the export must not be silent about it).
+  const isEnrichingRef = useRef(isEnriching);
+  isEnrichingRef.current = isEnriching;
+  const unenrichedCountRef = useRef(0);
+  unenrichedCountRef.current = filtered?.nodes.filter(node => !node.fields).length ?? 0;
   const handleExport = useCallback((format: DataMartCanvasExportFormat) => {
     if (isExportingRef.current) return;
+    // Definitions and schemas arrive with the follow-up detail query; exporting
+    // before it settles would serialize the model without them.
+    if (isEnrichingRef.current) {
+      toast('The canvas is still loading details — please try again in a moment.');
+      return;
+    }
     isExportingRef.current = true;
     void (async () => {
       try {
@@ -171,6 +185,12 @@ function ModelCanvasViewContent({ onActiveQualityRunChange }: ModelCanvasViewPro
         if (!exported) {
           toast('The canvas is still loading — please try again in a moment.');
           return;
+        }
+        const unenriched = unenrichedCountRef.current;
+        if (unenriched > 0) {
+          toast(
+            `Exported without schema details for ${String(unenriched)} data mart${unenriched === 1 ? '' : 's'} — reload the page to retry.`
+          );
         }
         trackEvent({
           event: 'model_canvas_exported',

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
@@ -127,6 +127,30 @@ describe('canvasToModelGraph', () => {
     ]);
   });
 
+  it('drops the definition for draft data marts — only published ones export it', () => {
+    const graph = canvasToModelGraph({
+      nodes: [
+        buildNode({
+          id: 'id-draft',
+          title: 'Draft mart',
+          status: DataMartStatus.DRAFT,
+          definitionType: DataMartDefinitionType.SQL,
+          definition: 'SELECT secret FROM wip',
+        }),
+        buildNode({
+          id: 'id-live',
+          title: 'Live mart',
+          definitionType: DataMartDefinitionType.TABLE,
+          definition: 'project.dataset.live',
+        }),
+      ],
+      edges: [],
+      positions: new Map(),
+    });
+    expect(graph.nodes[0]?.definition).toBeNull();
+    expect(graph.nodes[1]?.definition).toBe('project.dataset.live');
+  });
+
   it('de-duplicates keys of same-titled data marts', () => {
     const graph = canvasToModelGraph({
       nodes: [

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
@@ -51,6 +51,7 @@ describe('canvasToModelGraph', () => {
           id: 'id-orders',
           title: 'Orders',
           definitionType: DataMartDefinitionType.SQL,
+          definition: 'SELECT * FROM orders',
           description: 'All orders',
           fields: [
             {
@@ -96,6 +97,7 @@ describe('canvasToModelGraph', () => {
         title: 'Orders',
         inputSource: 'SQL',
         description: 'All orders',
+        definition: 'SELECT * FROM orders',
         schema: [
           { name: 'order_id', type: 'STRING', pk: true, alias: 'Order ID' },
           { name: 'total', type: 'NUMERIC', pk: false },
@@ -108,6 +110,7 @@ describe('canvasToModelGraph', () => {
         title: 'Customers',
         inputSource: 'TABLE',
         description: undefined,
+        definition: null,
         schema: [],
         position: { x: 0, y: 0 },
         status: 'pending',
@@ -149,5 +152,6 @@ describe('sanitizeModelGraph', () => {
     expect(sanitized).not.toHaveProperty('storageId');
     expect(sanitized.nodes[0]).toMatchObject({ status: 'pending' });
     expect(sanitized.nodes[0]).not.toHaveProperty('owoxId');
+    expect(sanitized.nodes[0]).not.toHaveProperty('definition');
   });
 });

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
@@ -32,6 +32,8 @@ export interface ModelGraphNode {
   title: string;
   inputSource: ModelGraphInputSource;
   description?: string;
+  /** Physical reference (table/view path, pattern) or SQL text; OKF-only, see sanitize. */
+  definition?: string | null;
   schema: ModelGraphSchemaField[];
   position: { x: number; y: number };
   status: ModelGraphNodeStatus;
@@ -89,6 +91,7 @@ export function canvasToModelGraph(input: CanvasModelGraphInput): ModelGraph {
       ? INPUT_SOURCE_BY_DEFINITION_TYPE[node.definitionType]
       : 'TABLE',
     description: node.description ?? undefined,
+    definition: node.definition ?? null,
     schema: (node.fields ?? []).map(field => ({
       name: field.name,
       type: field.type,
@@ -127,7 +130,9 @@ export type SanitizedModelGraph = Omit<ModelGraph, 'storageId'>;
  * Strip everything project-specific before the graph leaves the product as a
  * JSON file — the same rules model.owox.com applies to its share links. The
  * `storageId` field is dropped entirely: it only carries meaning in the Model
- * Canvas push flow, and its import tolerates the field being absent.
+ * Canvas push flow, and its import tolerates the field being absent. The
+ * `definition` (table paths / SQL text) stays out of JSON too — as in the
+ * reference share links — and is emitted only into the OKF documents.
  */
 export function sanitizeModelGraph(graph: ModelGraph): SanitizedModelGraph {
   return {

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
@@ -91,7 +91,9 @@ export function canvasToModelGraph(input: CanvasModelGraphInput): ModelGraph {
       ? INPUT_SOURCE_BY_DEFINITION_TYPE[node.definitionType]
       : 'TABLE',
     description: node.description ?? undefined,
-    definition: node.definition ?? null,
+    // Product rule: the physical reference / SQL leaves the product only for
+    // PUBLISHED data marts — a draft's definition is not settled yet.
+    definition: node.status === DataMartStatus.PUBLISHED ? (node.definition ?? null) : null,
     schema: (node.fields ?? []).map(field => ({
       name: field.name,
       type: field.type,

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
@@ -118,6 +118,22 @@ describe('serializeOkfBundle', () => {
     expect(bare['data-marts/orders.md']).not.toContain('## Definition');
   });
 
+  it('keeps a backtick-fence line inside a SQL definition from closing the block', () => {
+    const sql = 'SELECT 1\n/*\n```\nsample fence in a comment\n*/\nFROM raw.orders';
+    const { files } = serializeOkfBundle({
+      ...GRAPH,
+      nodes: GRAPH.nodes.map(node =>
+        node.key === 'orders' ? { ...node, inputSource: 'SQL' as const, definition: sql } : node
+      ),
+    });
+    const doc = files['data-marts/orders.md'];
+    // The inner fence line is padded with a space, so it can no longer close the block...
+    expect(doc).toContain('\n ```\nsample fence in a comment');
+    // ...and the Model Canvas parser regex extracts the WHOLE definition (round-trip).
+    const parsed = /^##?\s+Definition\s*\n+```[^\n]*\n([\s\S]*?)\n```/im.exec(doc);
+    expect(parsed?.[1]).toContain('FROM raw.orders');
+  });
+
   it('escapes square brackets so titles cannot terminate their links early', () => {
     const { files } = serializeOkfBundle({
       ...GRAPH,

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
@@ -98,6 +98,26 @@ describe('serializeOkfBundle', () => {
     expect(files['data-marts/customers-vip.md']).toContain('Customer \\| ID');
   });
 
+  it('renders a Definition section with the table path or SQL text when present', () => {
+    const { files } = serializeOkfBundle({
+      ...GRAPH,
+      nodes: GRAPH.nodes.map(node =>
+        node.key === 'orders'
+          ? { ...node, definition: 'SELECT id, revenue FROM raw.orders' }
+          : { ...node, definition: 'project.dataset.customers' }
+      ),
+    });
+    expect(files['data-marts/orders.md']).toContain(
+      '## Definition\n\n```sql\nSELECT id, revenue FROM raw.orders\n```'
+    );
+    expect(files['data-marts/customers.md']).toContain(
+      '## Definition\n\n```text\nproject.dataset.customers\n```'
+    );
+    // Without a definition the section is omitted entirely.
+    const { files: bare } = serializeOkfBundle(GRAPH);
+    expect(bare['data-marts/orders.md']).not.toContain('## Definition');
+  });
+
   it('escapes square brackets so titles cannot terminate their links early', () => {
     const { files } = serializeOkfBundle({
       ...GRAPH,

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
@@ -136,8 +136,13 @@ function renderNode(
       '\n\n'
     : '';
 
-  const definition = node.definition?.trim()
-    ? `## Definition\n\n\`\`\`${node.inputSource === 'SQL' ? 'sql' : 'text'}\n${node.definition.trim()}\n\`\`\`\n\n`
+  // A definition line starting with three-plus backticks would close the fence
+  // early (and the Model Canvas parser cuts at the first such line). A single
+  // leading space keeps the line inert for both renderers; inside SQL it can
+  // only occur in comments or string literals, where the space is harmless.
+  const definitionText = node.definition?.trim().replace(/^( {0,3})(`{3,})/gm, ' $1$2');
+  const definition = definitionText
+    ? `## Definition\n\n\`\`\`${node.inputSource === 'SQL' ? 'sql' : 'text'}\n${definitionText}\n\`\`\`\n\n`
     : '';
 
   const outgoing = graph.edges.filter(

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
@@ -136,6 +136,10 @@ function renderNode(
       '\n\n'
     : '';
 
+  const definition = node.definition?.trim()
+    ? `## Definition\n\n\`\`\`${node.inputSource === 'SQL' ? 'sql' : 'text'}\n${node.definition.trim()}\n\`\`\`\n\n`
+    : '';
+
   const outgoing = graph.edges.filter(
     edge => edge.from === node.key || (edge.bidirectional && edge.to === node.key)
   );
@@ -159,5 +163,5 @@ function renderNode(
       '\n'
     : '';
 
-  return `---\n${frontmatter}\n---\n\n# ${node.title}\n${node.description ? '\n' + node.description + '\n' : ''}\n${overview}${schema}${joins}`;
+  return `---\n${frontmatter}\n---\n\n# ${node.title}\n${node.description ? '\n' + node.description + '\n' : ''}\n${overview}${schema}${definition}${joins}`;
 }

--- a/apps/web/src/features/data-marts/model-canvas/model/definition-text.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/definition-text.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { DataMartDefinitionType } from '../../shared/enums/data-mart-definition-type.enum';
+import { extractDefinitionText } from './definition-text';
+
+describe('extractDefinitionText', () => {
+  it('returns the physical reference or SQL text per definition type', () => {
+    expect(
+      extractDefinitionText(DataMartDefinitionType.TABLE, {
+        fullyQualifiedName: 'project.dataset.orders',
+      })
+    ).toBe('project.dataset.orders');
+    expect(
+      extractDefinitionText(DataMartDefinitionType.VIEW, {
+        fullyQualifiedName: 'project.dataset.orders_view',
+      })
+    ).toBe('project.dataset.orders_view');
+    expect(
+      extractDefinitionText(DataMartDefinitionType.TABLE_PATTERN, {
+        pattern: 'project.dataset.events_*',
+      })
+    ).toBe('project.dataset.events_*');
+    expect(
+      extractDefinitionText(DataMartDefinitionType.SQL, {
+        sqlQuery: 'SELECT 1',
+      })
+    ).toBe('SELECT 1');
+  });
+
+  it('excludes connector definitions and tolerates missing data', () => {
+    expect(
+      extractDefinitionText(DataMartDefinitionType.CONNECTOR, {
+        fullyQualifiedName: 'ignored',
+      })
+    ).toBeNull();
+    expect(extractDefinitionText(null, { sqlQuery: 'SELECT 1' })).toBeNull();
+    expect(extractDefinitionText(DataMartDefinitionType.SQL, null)).toBeNull();
+    // A mismatched shape (wrong dto for the type) degrades to null, not a crash.
+    expect(
+      extractDefinitionText(DataMartDefinitionType.TABLE, { sqlQuery: 'SELECT 1' })
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/features/data-marts/model-canvas/model/definition-text.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/definition-text.ts
@@ -1,0 +1,26 @@
+import { DataMartDefinitionType } from '../../shared/enums/data-mart-definition-type.enum';
+import type { DataMartDefinitionDto } from '../../shared/types/api/response/data-mart-definition.dto';
+
+/**
+ * The data mart definition as a single string for the canvas export: the
+ * physical table/view reference, the table pattern, or the SQL query.
+ * Connector definitions are deliberately excluded — their source config can
+ * carry sensitive parameters, unlike a plain table path or query text.
+ */
+export function extractDefinitionText(
+  definitionType: DataMartDefinitionType | null,
+  definition: DataMartDefinitionDto | null
+): string | null {
+  if (!definitionType || !definition) return null;
+  switch (definitionType) {
+    case DataMartDefinitionType.SQL:
+      return 'sqlQuery' in definition ? definition.sqlQuery : null;
+    case DataMartDefinitionType.TABLE:
+    case DataMartDefinitionType.VIEW:
+      return 'fullyQualifiedName' in definition ? definition.fullyQualifiedName : null;
+    case DataMartDefinitionType.TABLE_PATTERN:
+      return 'pattern' in definition ? definition.pattern : null;
+    case DataMartDefinitionType.CONNECTOR:
+      return null;
+  }
+}

--- a/apps/web/src/features/data-marts/model-canvas/model/types.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/types.ts
@@ -35,6 +35,8 @@ export interface ModelCanvasNode {
    */
   definitionType?: DataMartDefinitionType | null;
   fields?: CanvasNodeField[];
+  /** Physical reference (table/view path, pattern) or SQL text — enriched client-side. */
+  definition?: string | null;
   qualitySummary: DataQualityCompactSummary;
   dataLastUpdated: DataLastUpdatedDto | null;
 }

--- a/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.test.tsx
@@ -132,6 +132,8 @@ describe('useModelCanvas', () => {
     expect(serviceMocks.getEdges).toHaveBeenCalledTimes(1);
     expect(serviceMocks.getDataMartById).toHaveBeenCalledTimes(1);
     expect(serviceMocks.getSummaries).not.toHaveBeenCalled();
+    // The enrichment flag settles once the detail query lands — the export gate reads it.
+    expect(result.current.isEnriching).toBe(false);
   });
 });
 

--- a/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.test.tsx
+++ b/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.test.tsx
@@ -45,6 +45,7 @@ describe('useModelCanvas', () => {
     serviceMocks.getEdges.mockResolvedValue([]);
     serviceMocks.getDataMartById.mockResolvedValue({
       definitionType: 'VIEW',
+      definition: { fullyQualifiedName: 'project.dataset.orders_view' },
       schema: { fields: [] },
     });
   });
@@ -115,7 +116,16 @@ describe('useModelCanvas', () => {
       expect(result.current.data?.nodes[0]?.fields).toEqual([]);
     });
     expect(result.current.data).toEqual({
-      nodes: [{ ...canvasNode(), definitionType: 'VIEW', fields: [] }],
+      nodes: [
+        {
+          ...canvasNode(),
+          definitionType: 'VIEW',
+          // The physical reference must survive the base+details merge — the
+          // OKF export's Definition section reads it from these nodes.
+          definition: 'project.dataset.orders_view',
+          fields: [],
+        },
+      ],
       edges: [],
     });
     expect(serviceMocks.getDataMarts).toHaveBeenCalledTimes(1);

--- a/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.ts
@@ -5,6 +5,7 @@ import type { AxiosRequestConfig } from '../../../../app/api';
 import { dataMartService } from '../../shared/services/data-mart.service';
 import type { DataMartSchema } from '../../shared/types/data-mart-schema.types';
 import { modelCanvasService } from '../api/model-canvas.service';
+import { extractDefinitionText } from './definition-text';
 import type { CanvasNodeField, ModelCanvasTopologyData, ModelCanvasTopologyNode } from './types';
 
 const SILENT_REQUEST_OPTIONS = {
@@ -54,6 +55,7 @@ async function enrichNodes(
       enriched[start + index] = {
         ...target,
         definitionType: detail.definitionType,
+        definition: extractDefinitionText(detail.definitionType, detail.definition),
         fields: mapSchemaFields(detail.schema),
       };
     });

--- a/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.ts
@@ -125,5 +125,11 @@ export function useModelCanvas(storageId: string | null) {
   return {
     ...baseQuery,
     data,
+    /**
+     * True while the follow-up detail query hasn't settled — fields and
+     * definitions may still be missing from the merged nodes. Consumers that
+     * serialize the model (canvas export) should wait this out.
+     */
+    isEnriching: Boolean(baseNodes?.length) && !detailsQuery.isFetched,
   };
 }

--- a/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.ts
@@ -110,7 +110,12 @@ export function useModelCanvas(storageId: string | null) {
       nodes: baseQuery.data.nodes.map(node => {
         const detail = detailById.get(node.id);
         return detail
-          ? { ...node, definitionType: detail.definitionType, fields: detail.fields }
+          ? {
+              ...node,
+              definitionType: detail.definitionType,
+              definition: detail.definition,
+              fields: detail.fields,
+            }
           : node;
       }),
       edges: baseQuery.data.edges,

--- a/docs/getting-started/setup-guide/models-canvas-export.md
+++ b/docs/getting-started/setup-guide/models-canvas-export.md
@@ -25,7 +25,7 @@ The JSON file contains the model graph — Data Marts with their schemas and can
 
 ### OKF bundle
 
-OKF (Open Knowledge Format) is a Markdown-based description of a data model: the zip contains one `.md` document per Data Mart — with an overview, the schema table, the definition (the physical table or view reference, the table pattern, or the SQL query — connector configs stay out), and the join list — plus an `index.md` catalog. Each join links to the document of the Data Mart it points at, so the bundle reads as a small cross-linked wiki. The same format is produced and imported by [OWOX Model Canvas](https://model.owox.com/), and it works well as context for AI assistants: with the table references included, an assistant can write runnable SQL against your storage.
+OKF (Open Knowledge Format) is a Markdown-based description of a data model: the zip contains one `.md` document per Data Mart — with an overview, the schema table, the definition (the physical table or view reference, the table pattern, or the SQL query — included for published Data Marts only, and connector configs stay out), and the join list — plus an `index.md` catalog. Each join links to the document of the Data Mart it points at, so the bundle reads as a small cross-linked wiki. The same format is produced and imported by [OWOX Model Canvas](https://model.owox.com/), and it works well as context for AI assistants: with the table references included, an assistant can write runnable SQL against your storage.
 
 ## Notes
 

--- a/docs/getting-started/setup-guide/models-canvas-export.md
+++ b/docs/getting-started/setup-guide/models-canvas-export.md
@@ -25,7 +25,7 @@ The JSON file contains the model graph — Data Marts with their schemas and can
 
 ### OKF bundle
 
-OKF (Open Knowledge Format) is a Markdown-based description of a data model: the zip contains one `.md` document per Data Mart — with an overview, the schema table, and the join list — plus an `index.md` catalog. Each join links to the document of the Data Mart it points at, so the bundle reads as a small cross-linked wiki. The same format is produced and imported by [OWOX Model Canvas](https://model.owox.com/), and it works well as context for AI assistants.
+OKF (Open Knowledge Format) is a Markdown-based description of a data model: the zip contains one `.md` document per Data Mart — with an overview, the schema table, the definition (the physical table or view reference, the table pattern, or the SQL query — connector configs stay out), and the join list — plus an `index.md` catalog. Each join links to the document of the Data Mart it points at, so the bundle reads as a small cross-linked wiki. The same format is produced and imported by [OWOX Model Canvas](https://model.owox.com/), and it works well as context for AI assistants: with the table references included, an assistant can write runnable SQL against your storage.
 
 ## Notes
 


### PR DESCRIPTION
## What

Every document in the OKF bundle exported from the Models canvas gains a **Definition** section:

- **TABLE / VIEW** — the fully qualified name (`project.dataset.table`)
- **TABLE PATTERN** — the pattern
- **SQL** — the query text
- **CONNECTOR** — deliberately excluded: its source config can carry sensitive parameters, unlike a plain table path or query text

Definitions are included for **published** data marts only — a draft's definition is not settled yet (product decision). Draft documents keep their overview, schema, and joins.

This mirrors the [OWOX Model Canvas](https://model.owox.com/) serializer, which renders the same section.

## Why

The bundle is pitched as context for AI assistants — but without physical references an assistant has to ask for the dataset and emits `<YOUR_DATASET>` placeholders instead of runnable SQL. With the definitions included, the generated queries use the real project, dataset, and table names. Found while preparing the feature demo.

## How

- The canvas enrichment already fetched the full data mart detail; a new `extractDefinitionText` helper flattens the per-type definition DTO into a single string, threaded through `ModelCanvasNode` → `ModelGraph` → the OKF renderer.
- The **JSON export intentionally stays definition-free** — it mirrors the sanitized Model Canvas share format, and the sanitize test now pins that.

## Testing

- Unit tests: `extractDefinitionText` for all five definition types (including mismatched-shape degradation), the graph passthrough, the sanitize exclusion, and the rendered `## Definition` section (sql vs text fencing, omitted when absent).
- Full model-canvas suite green; `tsc -b`, eslint, prettier, markdownlint, and the production build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
