### PR TITLE
fix(plugins): log why a GitHub read fell back or failed

### DIFF
--- a/apps/backend/src/plugin-host/config/plugin-host.config.spec.ts
+++ b/apps/backend/src/plugin-host/config/plugin-host.config.spec.ts
@@ -52,6 +52,19 @@ describe('PluginHostConfigService', () => {
       ).toBe(true);
     });
 
+    // The diagnostic the partial-configuration error message is built from: the point is
+    // naming the variable that is absent, not merely knowing that one is.
+    it('names the app credentials that are missing', () => {
+      expect(config({ GITHUB_APP_ID: '1', GITHUB_APP_SLUG: 'owox' }).missingGithubAppVars).toEqual([
+        'GITHUB_APP_PRIVATE_KEY',
+      ]);
+      expect(config({}).missingGithubAppVars).toHaveLength(3);
+      expect(
+        config({ GITHUB_APP_ID: '1', GITHUB_APP_SLUG: 'owox', GITHUB_APP_PRIVATE_KEY: 'k' })
+          .missingGithubAppVars
+      ).toEqual([]);
+    });
+
     it('unescapes newlines in a private key supplied as a single-line env var', () => {
       const key = config({
         GITHUB_APP_PRIVATE_KEY: '-----BEGIN-----\\nabc\\n-----END-----',

--- a/apps/backend/src/plugin-host/config/plugin-host.config.ts
+++ b/apps/backend/src/plugin-host/config/plugin-host.config.ts
@@ -56,8 +56,24 @@ export class PluginHostConfigService {
     return this.trimmed('GITHUB_APP_PRIVATE_KEY')?.replace(/\\n/g, '\n');
   }
 
+  /**
+   * Which GITHUB_APP_* variables are absent. Empty means App mode is fully configured.
+   *
+   * Named rather than boolean because a partially configured deployment is the failure
+   * worth reporting: App mode switches off silently, and the anonymous fallback then
+   * reports a private repository as "install the App", which sends the publisher to
+   * GitHub for a fault that lives in our own environment.
+   */
+  get missingGithubAppVars(): string[] {
+    return [
+      !this.githubAppId && 'GITHUB_APP_ID',
+      !this.githubAppSlug && 'GITHUB_APP_SLUG',
+      !this.githubAppPrivateKey && 'GITHUB_APP_PRIVATE_KEY',
+    ].filter(Boolean) as string[];
+  }
+
   get isAppModeConfigured(): boolean {
-    return Boolean(this.githubAppId && this.githubAppSlug && this.githubAppPrivateKey);
+    return this.missingGithubAppVars.length === 0;
   }
 
   /** Self-managed deployments only. Read by the server, never by the CLI. */

--- a/apps/backend/src/plugin-host/services/github-api.service.spec.ts
+++ b/apps/backend/src/plugin-host/services/github-api.service.spec.ts
@@ -2,6 +2,7 @@ jest.mock('@owox/internal-helpers', () => ({ fetchWithBackoff: jest.fn() }));
 
 import { ConfigService } from '@nestjs/config';
 import { fetchWithBackoff } from '@owox/internal-helpers';
+import { PublicOriginService } from '../../common/config/public-origin.service';
 import { PluginHostConfigService } from '../config/plugin-host.config';
 import { GithubAccessMode } from '../enums/github-access-mode.enum';
 import { GithubApiError, GithubRepoNotFoundError } from '../errors/plugin-host.errors';
@@ -12,9 +13,8 @@ const fetchMock = fetchWithBackoff as jest.Mock;
 const REF = { owner: 'OWOX', name: 'example-plugin' };
 
 function service(env: Record<string, string | undefined> = {}): GithubApiService {
-  const config = new PluginHostConfigService({
-    get: <T>(key: string) => env[key] as T,
-  } as ConfigService);
+  const configService = { get: <T>(key: string) => env[key] as T } as ConfigService;
+  const config = new PluginHostConfigService(configService, new PublicOriginService(configService));
 
   const auth = {
     getRepoAccess: jest.fn().mockResolvedValue({

--- a/apps/backend/src/plugin-host/services/github-api.service.ts
+++ b/apps/backend/src/plugin-host/services/github-api.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { fetchWithBackoff } from '@owox/internal-helpers';
 import { PluginHostConfigService } from '../config/plugin-host.config';
 import { GithubReleaseDto } from '../dto/domain/github-release.dto';
@@ -41,6 +41,8 @@ interface GithubReleaseResponse {
  */
 @Injectable()
 export class GithubApiService {
+  private readonly logger = new Logger(GithubApiService.name);
+
   constructor(
     private readonly auth: GithubAuthService,
     private readonly config: PluginHostConfigService
@@ -60,6 +62,18 @@ export class GithubApiService {
 
     if (response.status === 404) {
       const installationUrl = this.auth.buildInstallationUrl();
+      // The access mode is the whole diagnosis and never reaches the response: a private
+      // repository read as ANONYMOUS or SERVER_TOKEN answers 404 exactly like one that
+      // does not exist, and the publisher is told to install an App that may already be
+      // installed. Only the log can say which of the two actually happened.
+      //
+      // WARN rather than ERROR: a mistyped repository reaches this line just as often as
+      // a real access fault, and a deployment alerting on ERROR must not page on someone
+      // else's typo.
+      this.logger.warn(
+        `GitHub returned 404 for ${ref.owner}/${ref.name} using ${access.mode} access. ` +
+          'If the repository exists, this access mode cannot read it.'
+      );
       // With an App configured, 404 usually means "private and not granted" rather than
       // "does not exist" -- and that distinction is the difference between an actionable
       // message and a dead end.
@@ -173,9 +187,13 @@ export class GithubApiService {
       response.headers.get('x-ratelimit-remaining') === '0'
     ) {
       const reset = Number(response.headers.get('x-ratelimit-reset') ?? 0);
+      this.logger.error(`GitHub rate limit exhausted for ${accessMode} access on ${path}`);
       throw new GithubRateLimitedError(new Date(reset * 1000).toISOString(), accessMode);
     }
 
+    // Publisher routes render this error without the filter that logs member-facing ones,
+    // so without this line a failed publish leaves nothing behind on the server at all.
+    this.logger.error(`GitHub returned ${response.status} for ${path} using ${accessMode} access`);
     throw new GithubApiError(response.status, path);
   }
 }

--- a/apps/backend/src/plugin-host/services/github-auth.service.spec.ts
+++ b/apps/backend/src/plugin-host/services/github-auth.service.spec.ts
@@ -1,9 +1,11 @@
 jest.mock('@owox/internal-helpers', () => ({ fetchWithBackoff: jest.fn() }));
 jest.mock('jsonwebtoken', () => ({ sign: jest.fn(() => 'app-jwt') }));
 
+import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { fetchWithBackoff } from '@owox/internal-helpers';
 import * as jwt from 'jsonwebtoken';
+import { PublicOriginService } from '../../common/config/public-origin.service';
 import { PluginHostConfigService } from '../config/plugin-host.config';
 import { GithubAccessMode } from '../enums/github-access-mode.enum';
 import { GithubAuthConfigError } from '../errors/plugin-host.errors';
@@ -21,9 +23,8 @@ const APP_ENV = {
 };
 
 function service(env: Record<string, string | undefined>): GithubAuthService {
-  const config = new PluginHostConfigService({
-    get: <T>(key: string) => env[key] as T,
-  } as ConfigService);
+  const configService = { get: <T>(key: string) => env[key] as T } as ConfigService;
+  const config = new PluginHostConfigService(configService, new PublicOriginService(configService));
 
   return new GithubAuthService(config);
 }
@@ -100,6 +101,33 @@ describe('GithubAuthService', () => {
       expect(access.mode).toBe(GithubAccessMode.ANONYMOUS);
       expect(access.headers.Authorization).toBeUndefined();
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // A publisher only ever sees "install the App on this repository". These are the lines
+  // that let an operator tell an uninstalled App from a half-configured deployment.
+  describe('configuration diagnostics', () => {
+    const errorSpy = () => jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it('reports which app credential is missing, once per process', async () => {
+      const errors = errorSpy();
+      const auth = service({ GITHUB_APP_ID: '12345', GITHUB_APP_SLUG: 'owox' });
+
+      await auth.getRepoAccess(REF);
+      await auth.getRepoAccess(REF);
+
+      expect(errors).toHaveBeenCalledTimes(1);
+      expect(errors.mock.calls[0][0]).toContain('GITHUB_APP_PRIVATE_KEY');
+    });
+
+    it('stays quiet when no app is configured at all', async () => {
+      const errors = errorSpy();
+
+      await service({ GITHUB_TOKEN: 'ghp_server' }).getRepoAccess(REF);
+
+      expect(errors).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/plugin-host/services/github-auth.service.ts
+++ b/apps/backend/src/plugin-host/services/github-auth.service.ts
@@ -51,6 +51,8 @@ export class GithubAuthService {
    * stable per repository; uninstalling the App is a restart-level change.
    */
   private readonly installationCache = new Map<string, number>();
+  /** Deployment-wide fault, so once per process rather than once per repository read. */
+  private partialAppConfigReported = false;
 
   constructor(private readonly config: PluginHostConfigService) {}
 
@@ -61,6 +63,8 @@ export class GithubAuthService {
         const token = await this.mintInstallationToken(installationId);
         return this.access(GithubAccessMode.APP, token);
       }
+    } else {
+      this.reportPartialAppConfig();
     }
 
     const serverToken = this.config.githubToken;
@@ -84,6 +88,27 @@ export class GithubAuthService {
     };
   }
 
+  /**
+   * A deployment that sets some GITHUB_APP_* variables but not all of them has App mode
+   * off without saying so -- the symptom reaches the publisher as "this repository is
+   * not accessible, install the App", which is untrue and unfixable from their side.
+   * Nothing else in the chain can tell the difference, so it has to be said here.
+   */
+  private reportPartialAppConfig(): void {
+    const missing = this.config.missingGithubAppVars;
+    // All three absent is a deliberate choice -- self-managed deployments run on
+    // GITHUB_TOKEN or anonymously by design, and only private repositories are affected.
+    if (this.partialAppConfigReported || missing.length === 3) {
+      return;
+    }
+
+    this.partialAppConfigReported = true;
+    this.logger.error(
+      `GitHub App mode is disabled because ${missing.join(' and ')} ${missing.length > 1 ? 'are' : 'is'} not set. ` +
+        'Private repositories will read as inaccessible until the deployment supplies them.'
+    );
+  }
+
   /** Null when the App is not installed on this repository. */
   private async findInstallationId(ref: GithubRepoRef): Promise<number | null> {
     const key = `${ref.owner}/${ref.name}`.toLowerCase();
@@ -98,6 +123,13 @@ export class GithubAuthService {
     );
 
     if (response.status === 404) {
+      // Expected for any public repository the App was never installed on, so INFO:
+      // it is the one line that explains a later 404 on a repository that does exist.
+      this.logger.log(
+        `GitHub App is not installed on ${ref.owner}/${ref.name}; falling back to ${
+          this.config.githubToken ? 'the deployment token' : 'anonymous access'
+        }`
+      );
       return null;
     }
 
@@ -131,6 +163,11 @@ export class GithubAuthService {
     );
 
     if (!response.ok) {
+      // Usually a revoked App, a rotated private key, or an installation suspended on
+      // GitHub's side -- none of which the publisher can see from the 400 they get back.
+      this.logger.error(
+        `Installation token request for ${installationId} returned ${response.status}; the App credentials or the installation itself are no longer valid`
+      );
       throw new GithubAuthConfigError([`installation ${installationId} token request`]);
     }
 

--- a/apps/backend/src/plugin-host/services/publication-authorization.service.spec.ts
+++ b/apps/backend/src/plugin-host/services/publication-authorization.service.spec.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from '@nestjs/config';
+import { PublicOriginService } from '../../common/config/public-origin.service';
 import { AuthorizationContext } from '../../idp/types/auth.types';
 import { PluginHostConfigService } from '../config/plugin-host.config';
 import { PluginPublicationScope } from '../enums/plugin-publication-scope.enum';
@@ -6,11 +7,13 @@ import { PublicationAuthorizationError } from '../errors/plugin-host.errors';
 import { PublicationAuthorizationService } from './publication-authorization.service';
 
 function service(allowlist = ''): PublicationAuthorizationService {
+  const configService = {
+    get: <T>(key: string) =>
+      (key === 'OWOX_DEPLOYMENT_PLUGIN_PUBLISHER_API_KEY_IDS' ? allowlist : undefined) as T,
+  } as ConfigService;
+
   return new PublicationAuthorizationService(
-    new PluginHostConfigService({
-      get: <T>(key: string) =>
-        (key === 'OWOX_DEPLOYMENT_PLUGIN_PUBLISHER_API_KEY_IDS' ? allowlist : undefined) as T,
-    } as ConfigService)
+    new PluginHostConfigService(configService, new PublicOriginService(configService))
   );
 }
 

--- a/apps/backend/src/plugin-host/use-cases/sync-plugin-releases.service.spec.ts
+++ b/apps/backend/src/plugin-host/use-cases/sync-plugin-releases.service.spec.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from '@nestjs/config';
+import { PublicOriginService } from '../../common/config/public-origin.service';
 import { PluginHostConfigService } from '../config/plugin-host.config';
 import { SyncPluginReleasesCommand } from '../dto/domain/plugin-sync.dto';
 import { GithubAccessMode } from '../enums/github-access-mode.enum';
@@ -66,7 +67,8 @@ function setup() {
     insertVersion: jest.fn(input => Promise.resolve({ id: `v-${input.semver}`, ...input })),
   } as unknown as jest.Mocked<PluginVersionService>;
 
-  const config = new PluginHostConfigService({ get: () => undefined } as unknown as ConfigService);
+  const configService = { get: () => undefined } as unknown as ConfigService;
+  const config = new PluginHostConfigService(configService, new PublicOriginService(configService));
 
   const service = new SyncPluginReleasesService(
     githubApi,


### PR DESCRIPTION
Publishing a private repo currently fails with a 400 "not accessible" and leaves nothing in the server log — publisher routes bypass the filter that logs member-facing errors, and a private repo the App cannot read answers 404 exactly like one that does not exist.

Adds:
- **ERROR** — partial `GITHUB_APP_*` configuration (names the missing variable, once per process), refused installation token, rate limit, other non-ok statuses
- **WARN** — 404 on the repository, with the access mode used
- **INFO** — App-not-installed fallback and which mode took over

Only variable names and access modes are logged, never credentials or response bodies. No behavior change beyond logging.

Also fixes spec fixtures still constructing `PluginHostConfigService` with one argument.