### PR TITLE
feat(data-marts): turn on STRING_AGG and ANY_VALUE by default for text fields (#6791)

### DIFF
--- a/.changeset/6791-string-default-aggregations.md
+++ b/.changeset/6791-string-default-aggregations.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Combined and Sample are now on by default for text fields
+
+Text columns now offer `Combined` (`STRING_AGG`) and `Sample` (`ANY_VALUE`) out of the box, alongside `Count` and `Count Unique`. Previously both were supported but switched off, so you had to enable them field by field before a report could use them.
+
+Existing Data Marts pick this up automatically — a field only keeps a narrower list if you explicitly chose one for it. Numeric, date, time, boolean, and complex-type fields are unchanged, and neither function is ever included in Totals.

--- a/apps/backend/src/data-marts/dto/schemas/field-aggregation-governance.spec.ts
+++ b/apps/backend/src/data-marts/dto/schemas/field-aggregation-governance.spec.ts
@@ -32,10 +32,10 @@ describe('resolveFieldGovernance — default allowed aggregations (no explicit o
     expect(resolveFieldGovernance('TIME').allowedAggregations).toEqual(['MIN', 'MAX']);
   });
 
-  it('string → dimension with [COUNT, COUNT_DISTINCT]', () => {
+  it('string → dimension with [COUNT, COUNT_DISTINCT, STRING_AGG, ANY_VALUE]', () => {
     expect(resolveFieldGovernance('STRING')).toEqual({
       role: 'dimension',
-      allowedAggregations: ['COUNT', 'COUNT_DISTINCT'],
+      allowedAggregations: ['COUNT', 'COUNT_DISTINCT', 'STRING_AGG', 'ANY_VALUE'],
     });
   });
 
@@ -66,10 +66,14 @@ describe('resolveFieldGovernance — default allowed aggregations (no explicit o
     expect(num).not.toContain('P50');
   });
 
-  it('ANY_VALUE is never a default for any category (supported but off by default)', () => {
-    for (const type of ['INTEGER', 'STRING', 'DATE', 'BOOLEAN', 'JSON']) {
+  it('ANY_VALUE and STRING_AGG are defaults for string only', () => {
+    for (const type of ['INTEGER', 'DATE', 'BOOLEAN', 'JSON']) {
       expect(resolveFieldGovernance(type).allowedAggregations).not.toContain('ANY_VALUE');
+      expect(resolveFieldGovernance(type).allowedAggregations).not.toContain('STRING_AGG');
     }
+    expect(resolveFieldGovernance('STRING').allowedAggregations).toEqual(
+      expect.arrayContaining(['ANY_VALUE', 'STRING_AGG'])
+    );
   });
 });
 
@@ -165,7 +169,12 @@ describe('resolveFieldGovernance — explicit overrides', () => {
   it('role override and allowed override are independent (only one set)', () => {
     const onlyRole = resolveFieldGovernance('STRING', { aggregationRole: 'metric' });
     expect(onlyRole.role).toBe('metric');
-    expect(onlyRole.allowedAggregations).toEqual(['COUNT', 'COUNT_DISTINCT']);
+    expect(onlyRole.allowedAggregations).toEqual([
+      'COUNT',
+      'COUNT_DISTINCT',
+      'STRING_AGG',
+      'ANY_VALUE',
+    ]);
 
     const onlyAllowed = resolveFieldGovernance('STRING', { allowedAggregations: ['COUNT'] });
     expect(onlyAllowed.role).toBe('dimension');

--- a/apps/backend/src/data-marts/dto/schemas/field-aggregation-governance.ts
+++ b/apps/backend/src/data-marts/dto/schemas/field-aggregation-governance.ts
@@ -45,13 +45,15 @@ const SUPPORTED_BY_CATEGORY: Record<FieldTypeCategory, ReportAggregateFunction[]
 
 /**
  * The subset of aggregations turned ON by default per type (2026-06-29 meeting, point 3),
- * used when a field carries no explicit `allowedAggregations` override. ANY_VALUE is
- * supported (above) but never a default. Single source so the governance map and any UI
- * hint cannot diverge.
+ * used when a field carries no explicit `allowedAggregations` override. Single source so
+ * the governance map and any UI hint cannot diverge.
  */
 const DEFAULTS_BY_CATEGORY: Record<FieldTypeCategory, CategoryDefault> = {
   number: { role: 'metric', allowedAggregations: ['SUM', 'AVG', 'MIN', 'MAX'] },
-  string: { role: 'dimension', allowedAggregations: ['COUNT', 'COUNT_DISTINCT'] },
+  string: {
+    role: 'dimension',
+    allowedAggregations: ['COUNT', 'COUNT_DISTINCT', 'STRING_AGG', 'ANY_VALUE'],
+  },
   date: { role: 'dimension', allowedAggregations: ['MIN', 'MAX'] },
   time: { role: 'dimension', allowedAggregations: ['MIN', 'MAX'] },
   boolean: { role: 'dimension', allowedAggregations: ['COUNT', 'COUNT_DISTINCT'] },

--- a/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/services/blendable-schema.service.spec.ts
@@ -533,10 +533,14 @@ describe('BlendableSchemaService', () => {
       const revenueField = result.blendedFields.find(f => f.originalFieldName === 'revenue')!;
       expect(revenueField.postJoinAggregations).toEqual(['MIN', 'MAX']);
 
-      // no override → type-derived governance default (STRING) = [COUNT, COUNT_DISTINCT]
-      // (STRING_AGG is supported but off by default per the 2026-06-29 meeting)
+      // no override → type-derived governance default (STRING)
       const statusField = result.blendedFields.find(f => f.originalFieldName === 'status')!;
-      expect(statusField.postJoinAggregations).toEqual(['COUNT', 'COUNT_DISTINCT']);
+      expect(statusField.postJoinAggregations).toEqual([
+        'COUNT',
+        'COUNT_DISTINCT',
+        'STRING_AGG',
+        'ANY_VALUE',
+      ]);
 
       // explicit empty array → none allowed (NOT the default)
       const notesField = result.blendedFields.find(f => f.originalFieldName === 'notes')!;

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SourceFieldsTable.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/SourceFieldsTable.test.tsx
@@ -317,7 +317,7 @@ describe('SourceFieldsTable — available aggregations follow the dedup EFFECTIV
     await waitFor(() => {
       expect(onFieldOverrideChange).toHaveBeenCalledWith('hitId', {
         aggregateFunction: 'MIN',
-        postJoinAggregations: ['COUNT', 'COUNT_DISTINCT'],
+        postJoinAggregations: ['COUNT', 'COUNT_DISTINCT', 'STRING_AGG', 'ANY_VALUE'],
       });
     });
   });

--- a/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartSchemaSettings/tables/BaseSchemaTable.test.tsx
@@ -66,7 +66,7 @@ describe('BaseSchemaTable — Aggregations column', () => {
     expect(screen.getByLabelText('Available aggregations')).toBeInTheDocument();
   });
 
-  it('shows the STRING default (COUNT, COUNT_DISTINCT) as joined names for a STRING field with no allowedAggregations', () => {
+  it('shows "4 selected" for a STRING field with no allowedAggregations (default: COUNT, COUNT_DISTINCT, STRING_AGG, ANY_VALUE)', () => {
     const fields = [buildAthenaField({ name: 'my_string', type: AthenaFieldType.STRING })];
     render(
       <AthenaSchemaTable
@@ -76,8 +76,7 @@ describe('BaseSchemaTable — Aggregations column', () => {
       />
     );
 
-    // STRING default is [COUNT, COUNT_DISTINCT] — 2 items → joined names.
-    expect(screen.getByText('COUNT, COUNT_DISTINCT')).toBeInTheDocument();
+    expect(screen.getByText('4 selected')).toBeInTheDocument();
   });
 
   it('shows "4 selected" for a numeric field with no allowedAggregations (type-derived default: SUM, AVG, MIN, MAX)', () => {
@@ -122,7 +121,7 @@ describe('BaseSchemaTable — Aggregations column', () => {
 
   it('toggling a function OFF calls onFieldsChange with narrowed allowedAggregations array', async () => {
     const onFieldsChange = vi.fn();
-    // STRING default is [COUNT, COUNT_DISTINCT] — both checked by default.
+    // STRING default is [COUNT, COUNT_DISTINCT, STRING_AGG, ANY_VALUE] — all checked by default.
     const fields = [buildAthenaField({ name: 'my_string', type: AthenaFieldType.STRING })];
     render(
       <AthenaSchemaTable
@@ -147,7 +146,7 @@ describe('BaseSchemaTable — Aggregations column', () => {
     });
 
     const [updatedFields] = onFieldsChange.mock.calls[0] as [AthenaSchemaField[]];
-    expect(updatedFields[0].allowedAggregations).toEqual(['COUNT']);
+    expect(updatedFields[0].allowedAggregations).toEqual(['ANY_VALUE', 'COUNT', 'STRING_AGG']);
   });
 
   it('clearing all aggregations writes an explicit empty array [] (not dropped)', async () => {

--- a/apps/web/src/features/data-marts/shared/utils/aggregation-governance.test.ts
+++ b/apps/web/src/features/data-marts/shared/utils/aggregation-governance.test.ts
@@ -20,11 +20,11 @@ describe('resolveFieldGovernance — type-derived defaults (on-by-default subset
     }
   });
 
-  it('string types are dimensions with [COUNT, COUNT_DISTINCT]', () => {
+  it('string types are dimensions with [COUNT, COUNT_DISTINCT, STRING_AGG, ANY_VALUE]', () => {
     for (const t of ['STRING', 'VARCHAR', 'TEXT', 'CHAR', 'BPCHAR']) {
       const { role, allowedAggregations } = resolveFieldGovernance(t);
       expect(role).toBe('dimension');
-      expect(allowedAggregations).toEqual(['COUNT', 'COUNT_DISTINCT']);
+      expect(allowedAggregations).toEqual(['COUNT', 'COUNT_DISTINCT', 'STRING_AGG', 'ANY_VALUE']);
     }
   });
 

--- a/apps/web/src/features/data-marts/shared/utils/aggregation-governance.ts
+++ b/apps/web/src/features/data-marts/shared/utils/aggregation-governance.ts
@@ -43,7 +43,10 @@ const SUPPORTED_BY_CATEGORY: Record<FieldTypeCategory, ReportAggregateFunction[]
 
 const DEFAULTS_BY_CATEGORY: Record<FieldTypeCategory, FieldGovernance> = {
   number: { role: 'metric', allowedAggregations: ['SUM', 'AVG', 'MIN', 'MAX'] },
-  string: { role: 'dimension', allowedAggregations: ['COUNT', 'COUNT_DISTINCT'] },
+  string: {
+    role: 'dimension',
+    allowedAggregations: ['COUNT', 'COUNT_DISTINCT', 'STRING_AGG', 'ANY_VALUE'],
+  },
   date: { role: 'dimension', allowedAggregations: ['MIN', 'MAX'] },
   time: { role: 'dimension', allowedAggregations: ['MIN', 'MAX'] },
   boolean: { role: 'dimension', allowedAggregations: ['COUNT', 'COUNT_DISTINCT'] },

--- a/docs/getting-started/setup-guide/report-aggregations.md
+++ b/docs/getting-started/setup-guide/report-aggregations.md
@@ -44,7 +44,7 @@ The supported menu and on-by-default subset per type:
 | --------------- | ----------------------- | ----------------------------------------------- |
 | Numeric         | `SUM`, `AVG`, `MIN`, `MAX` | percentiles (`P25`/`P50`/`P75`/`P95`), `ANY_VALUE` |
 | Date / time     | `MIN`, `MAX`            | `COUNT`, `COUNT_DISTINCT`, `STRING_AGG`, `ANY_VALUE` |
-| Text            | `COUNT`, `COUNT_DISTINCT` | `MIN`, `MAX`, `STRING_AGG`, `ANY_VALUE`        |
+| Text            | `COUNT`, `COUNT_DISTINCT`, `STRING_AGG`, `ANY_VALUE` | `MIN`, `MAX`               |
 | Boolean         | `COUNT`, `COUNT_DISTINCT` | `ANY_VALUE`                                    |
 | Other (JSON, geography, array, struct, …) | `COUNT` | `ANY_VALUE`                                    |
 


### PR DESCRIPTION
Closes [#6791](https://owox.fibery.io/Sprint_Work/Work_Item/Add-by-default-STRING_AGG-and-ANY_VALUE-possible-aggs-for-string-fields-6791)

## What

Text fields now ship with `STRING_AGG` (Combined) and `ANY_VALUE` (Sample) turned on, alongside `COUNT` and `COUNT_DISTINCT`. Both were already in the supported menu for text — they were just off by default, so analysts had to enable them field by field before any report could use them.

```diff
-string: { role: 'dimension', allowedAggregations: ['COUNT', 'COUNT_DISTINCT'] },
+string: {
+  role: 'dimension',
+  allowedAggregations: ['COUNT', 'COUNT_DISTINCT', 'STRING_AGG', 'ANY_VALUE'],
+},
```

Applied in all three governance copies the source comments require to stay in sync: backend `field-aggregation-governance.ts`, web `aggregation-governance.ts`, and the extension mirror (separate PR in `google-sheets-extension`).

Only the `string` category changes. Numeric, date, time, boolean and complex types are untouched.

## Existing Data Marts pick this up without a migration

`allowedAggregations` is optional on the schema field — *"absent = derive defaults by type"* — and no schema provider writes the resolved defaults back. Governance is resolved on read, so:

- a field with **no** explicit list gains the two functions immediately;
- a field where someone deliberately narrowed the list keeps exactly what they chose.

That is the semantics the ticket asks for, and it is why there is no migration in this PR.

## Checked for blast radius

| Area | Result |
| --- | --- |
| MCP | `STRING_AGG` / `ANY_VALUE` are not in `MCP_AGGREGATE_FUNCTIONS`, so the advertised MCP matrix is unchanged |
| Totals | `NON_SUMMARIZABLE_AGGREGATIONS` already excludes both — no meaningless grand totals appear |
| Looker Studio | the aggregation mapper already maps both to `DIMENSION` |

## Visible UI change worth knowing

`AllowedAggregationsSelect` prints the joined function names only while `value.length <= 2`, otherwise `"N selected"`. Text fields now have four defaults, so the **Σ available** column reads **"4 selected"** instead of `COUNT, COUNT_DISTINCT`. The test for that is updated explicitly rather than deleted, so the change is visible in review.

## Verification

| Check | Result |
| --- | --- |
| backend jest | 511 suites / 6873 tests pass |
| web vitest | 181 files / 1370 tests pass |
| `nest build` | clean |
| web `tsc -b` | clean |
| eslint, markdownlint | clean |

Three test expectations that pinned the old default were updated: the governance specs, `BlendableSchemaService` post-join defaults, and the two schema-settings table tests.

## Docs

`docs/getting-started/setup-guide/report-aggregations.md` — the "Default (on) / Also available" table now lists both functions under Default for Text.

## Out of scope

Date and time fields have the same supported menu and the same argument could be made for them, but the ticket scopes this to text fields only.
