### PR TITLE
fix(data-marts): carry field descriptions into the canvas exports

### DIFF
--- a/.changeset/6771-1-export-field-descriptions.md
+++ b/.changeset/6771-1-export-field-descriptions.md
@@ -1,0 +1,12 @@
+---
+'owox': minor
+---
+
+# Include field descriptions in the Models canvas exports
+
+The Models canvas export dropped the business descriptions of Output Schema fields: in the OKF bundle the schema table's Description column carried only the PK/FK notes, and the JSON model graph omitted the field descriptions entirely.
+
+Both formats now carry each field's description as stored in the Data Mart:
+
+- **OKF (Markdown)** — the Description cell reads `PK.` → description → `FK to [Target]`, matching the order OWOX Model Canvas produces. Multi-line descriptions collapse to a single line so they cannot break the Markdown table.
+- **JSON** — every schema field gains a `description` property when one is set, staying compatible with the OWOX Model Canvas graph format.

--- a/.changeset/6771-1-export-field-descriptions.md
+++ b/.changeset/6771-1-export-field-descriptions.md
@@ -8,5 +8,5 @@ The Models canvas export dropped the business descriptions of Output Schema fiel
 
 Both formats now carry each field's description as stored in the Data Mart:
 
-- **OKF (Markdown)** — the Description cell reads `PK.` → description → `FK to [Target]`, matching the order OWOX Model Canvas produces. Multi-line descriptions collapse to a single line so they cannot break the Markdown table.
+- **OKF (Markdown)** — the Description cell reads `PK.` → description. Multi-line descriptions collapse to a single line so they cannot break the Markdown table. The `FK to [Target]` notes left the schema table entirely: relationships live only in the Joins section, which already lists every join with its condition.
 - **JSON** — every schema field gains a `description` property when one is set, staying compatible with the OWOX Model Canvas graph format.

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.test.ts
@@ -65,6 +65,7 @@ describe('canvasToModelGraph', () => {
               name: 'total',
               alias: 'total',
               type: 'NUMERIC',
+              description: 'Order total in USD.',
               isPrimaryKey: false,
               isHidden: false,
             },
@@ -100,7 +101,7 @@ describe('canvasToModelGraph', () => {
         definition: 'SELECT * FROM orders',
         schema: [
           { name: 'order_id', type: 'STRING', pk: true, alias: 'Order ID' },
-          { name: 'total', type: 'NUMERIC', pk: false },
+          { name: 'total', type: 'NUMERIC', pk: false, description: 'Order total in USD.' },
         ],
         position: { x: 10, y: 20 },
         status: 'created',
@@ -167,7 +168,22 @@ describe('canvasToModelGraph', () => {
 describe('sanitizeModelGraph', () => {
   it('strips storage, ids and statuses before the graph leaves as a file', () => {
     const graph = canvasToModelGraph({
-      nodes: [buildNode({ id: 'id-orders', title: 'Orders' })],
+      nodes: [
+        buildNode({
+          id: 'id-orders',
+          title: 'Orders',
+          fields: [
+            {
+              name: 'total',
+              alias: 'total',
+              type: 'NUMERIC',
+              description: 'Order total in USD.',
+              isPrimaryKey: false,
+              isHidden: false,
+            },
+          ],
+        }),
+      ],
       edges: [],
       positions: new Map(),
       storageLabel: 'BigQuery (Common)',
@@ -177,5 +193,7 @@ describe('sanitizeModelGraph', () => {
     expect(sanitized.nodes[0]).toMatchObject({ status: 'pending' });
     expect(sanitized.nodes[0]).not.toHaveProperty('owoxId');
     expect(sanitized.nodes[0]).not.toHaveProperty('definition');
+    // Field descriptions stay in the JSON export.
+    expect(sanitized.nodes[0]?.schema[0]?.description).toBe('Order total in USD.');
   });
 });

--- a/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/model-graph.ts
@@ -17,6 +17,7 @@ export interface ModelGraphSchemaField {
   type: string;
   pk: boolean;
   alias?: string;
+  description?: string;
 }
 
 export interface ModelGraphJoinKey {
@@ -99,6 +100,7 @@ export function canvasToModelGraph(input: CanvasModelGraphInput): ModelGraph {
       type: field.type,
       pk: field.isPrimaryKey,
       ...(field.alias && field.alias !== field.name ? { alias: field.alias } : {}),
+      ...(field.description ? { description: field.description } : {}),
     })),
     position: input.positions.get(node.id) ?? { x: 0, y: 0 },
     status: node.status === DataMartStatus.PUBLISHED ? 'created' : 'pending',

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
@@ -119,8 +119,38 @@ describe('serializeOkfBundle', () => {
           : node
       ),
     });
-    expect(files['data-marts/index.md']).toContain('[Customers \\| VIP]');
-    expect(files['data-marts/customers-vip.md']).toContain('Customer \\| ID');
+    expect(files['data-marts/index.md']).toContain('[Customers &#124; VIP]');
+    expect(files['data-marts/customers-vip.md']).toContain('Customer &#124; ID');
+  });
+
+  it('keeps a piped description intact through the importer raw-pipe row split', () => {
+    const { files } = serializeOkfBundle({
+      ...GRAPH,
+      nodes: GRAPH.nodes.map(node =>
+        node.key === 'orders'
+          ? {
+              ...node,
+              schema: [
+                {
+                  name: 'segment',
+                  type: 'STRING',
+                  pk: false,
+                  description: 'Eligible A | B customers',
+                },
+              ],
+            }
+          : node
+      ),
+    });
+    const row = files['data-marts/orders.md'].split('\n').find(line => line.includes('`segment`'));
+    // The Model Canvas importer splits rows on every raw pipe without
+    // recognizing GFM `\|` escapes — the cell must survive that split whole.
+    const cells = String(row).split('|').slice(1, -1);
+    expect(cells.map(cell => cell.trim())).toEqual([
+      '`segment`',
+      'STRING',
+      'Eligible A &#124; B customers',
+    ]);
   });
 
   it('renders a Definition section with the table path or SQL text when present', () => {

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
@@ -58,20 +58,20 @@ describe('serializeOkfBundle', () => {
     );
   });
 
-  it('annotates FK columns and keeps the alias column only when aliases exist', () => {
+  it('keeps the alias column only when aliases exist', () => {
     const { files } = serializeOkfBundle(GRAPH);
     expect(files['data-marts/orders.md']).toContain('| Column | Type | Description |');
-    expect(files['data-marts/orders.md']).toContain('FK to [Customers](./customers.md)');
     expect(files['data-marts/customers.md']).toContain('| Column | Type | Alias | Description |');
     expect(files['data-marts/customers.md']).toContain('Customer ID');
   });
 
-  it('renders field descriptions before the FK note, collapsed to one line', () => {
+  it('renders field descriptions, collapsed to one line, with no FK notes in the table', () => {
     const { files } = serializeOkfBundle(GRAPH);
-    // Description and FK note share the cell, description first (reference order).
     expect(files['data-marts/orders.md']).toContain(
-      '| `customer_id` | STRING | Reference to the buyer. FK to [Customers](./customers.md) |'
+      '| `customer_id` | STRING | Reference to the buyer. |'
     );
+    // Relationships live only in the Joins section, never in the schema table.
+    expect(files['data-marts/orders.md']).not.toContain('FK to');
     // A multi-line description would end the table row, so it collapses.
     const { files: multiline } = serializeOkfBundle({
       ...GRAPH,

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.test.ts
@@ -12,7 +12,7 @@ const GRAPH: ModelGraph = {
       description: 'All orders',
       schema: [
         { name: 'order_id', type: 'STRING', pk: true },
-        { name: 'customer_id', type: 'STRING', pk: false },
+        { name: 'customer_id', type: 'STRING', pk: false, description: 'Reference to the buyer.' },
       ],
       position: { x: 0, y: 0 },
       status: 'created',
@@ -64,6 +64,31 @@ describe('serializeOkfBundle', () => {
     expect(files['data-marts/orders.md']).toContain('FK to [Customers](./customers.md)');
     expect(files['data-marts/customers.md']).toContain('| Column | Type | Alias | Description |');
     expect(files['data-marts/customers.md']).toContain('Customer ID');
+  });
+
+  it('renders field descriptions before the FK note, collapsed to one line', () => {
+    const { files } = serializeOkfBundle(GRAPH);
+    // Description and FK note share the cell, description first (reference order).
+    expect(files['data-marts/orders.md']).toContain(
+      '| `customer_id` | STRING | Reference to the buyer. FK to [Customers](./customers.md) |'
+    );
+    // A multi-line description would end the table row, so it collapses.
+    const { files: multiline } = serializeOkfBundle({
+      ...GRAPH,
+      nodes: GRAPH.nodes.map(node =>
+        node.key === 'orders'
+          ? {
+              ...node,
+              schema: [
+                { name: 'total', type: 'NUMERIC', pk: false, description: 'Line one\nline two' },
+              ],
+            }
+          : node
+      ),
+    });
+    expect(multiline['data-marts/orders.md']).toContain(
+      '| `total` | NUMERIC | Line one line two |'
+    );
   });
 
   it('renders the index table with statuses resolved and the product footer', () => {

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
@@ -2,9 +2,15 @@ import type { ModelGraph, ModelGraphNode } from '../model-graph';
 import { slugify } from '../slug';
 import { renderFrontmatter } from './frontmatter';
 
-/** Keep a value from breaking out of its Markdown table cell. */
+/**
+ * Keep a value from breaking out of its Markdown table cell. The HTML entity is
+ * used instead of the GFM `\|` escape because the Model Canvas importer splits
+ * rows on every raw pipe without recognizing backslash escapes, which would
+ * truncate the cell on re-import; `&#124;` renders as `|` and survives the
+ * split intact.
+ */
 function escapeTableCell(value: string): string {
-  return value.replace(/\|/g, '\\|');
+  return value.replace(/\|/g, '&#124;');
 }
 
 /** Keep a title from terminating its `[text](./slug.md)` link early. */

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
@@ -64,32 +64,6 @@ export function serializeOkfBundle(graph: ModelGraph, bundleTitle = 'Data Marts'
   return { files };
 }
 
-// Map each of a node's own FK columns to the target mart it points at, so the
-// FK note can be rendered inside that column's Description cell.
-function fkColumns(
-  node: ModelGraphNode,
-  graph: ModelGraph,
-  slugByKey: Map<string, string>
-): Map<string, { title: string; slug: string }> {
-  const out = new Map<string, { title: string; slug: string }>();
-  for (const edge of graph.edges) {
-    if (edge.from === node.key) {
-      const target = graph.nodes.find(other => other.key === edge.to);
-      if (!target) continue;
-      const slug = slugByKey.get(edge.to);
-      if (!slug) continue;
-      for (const key of edge.keys) out.set(key.left, { title: target.title, slug });
-    } else if (edge.bidirectional && edge.to === node.key) {
-      const target = graph.nodes.find(other => other.key === edge.from);
-      if (!target) continue;
-      const slug = slugByKey.get(edge.from);
-      if (!slug) continue;
-      for (const key of edge.keys) out.set(key.right, { title: target.title, slug });
-    }
-  }
-  return out;
-}
-
 function renderNode(
   node: ModelGraphNode,
   graph: ModelGraph,
@@ -111,7 +85,6 @@ function renderNode(
     '',
   ].join('\n');
 
-  const fk = fkColumns(node, graph, slugByKey);
   // The Alias column is emitted only when some field has one, so marts without
   // aliases keep the leaner 3-column table.
   const withAlias = node.schema.some(field => field.alias);
@@ -123,13 +96,16 @@ function renderNode(
       header +
       node.schema
         .map(field => {
+          // The Description cell carries the PK marker and the business
+          // description; relationships live only in the Joins section (a
+          // deliberate divergence from model.owox.com, which also annotates FK
+          // columns here — its parser reads joins from the Joins keys first,
+          // so the round-trip is unaffected).
           const parts: string[] = [];
           if (field.pk) parts.push('PK.');
           // Newlines would end the Markdown table row, so multi-line
           // descriptions collapse to a single line.
           if (field.description) parts.push(field.description.replace(/\s+/g, ' ').trim());
-          const ref = fk.get(field.name);
-          if (ref) parts.push(`FK to [${escapeLinkText(ref.title)}](./${ref.slug}.md)`);
           const cells = withAlias
             ? [`\`${field.name}\``, field.type, field.alias ?? '', parts.join(' ').trim()]
             : [`\`${field.name}\``, field.type, parts.join(' ').trim()];

--- a/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
+++ b/apps/web/src/features/data-marts/model-canvas/export/okf/serialize.ts
@@ -125,6 +125,9 @@ function renderNode(
         .map(field => {
           const parts: string[] = [];
           if (field.pk) parts.push('PK.');
+          // Newlines would end the Markdown table row, so multi-line
+          // descriptions collapse to a single line.
+          if (field.description) parts.push(field.description.replace(/\s+/g, ' ').trim());
           const ref = fk.get(field.name);
           if (ref) parts.push(`FK to [${escapeLinkText(ref.title)}](./${ref.slug}.md)`);
           const cells = withAlias

--- a/apps/web/src/features/data-marts/model-canvas/model/types.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/types.ts
@@ -17,6 +17,8 @@ export interface CanvasNodeField {
   /** Human-friendly alias (businessName / displayName) when set, else the raw name. */
   alias: string;
   type: string;
+  /** Business description from the Output Schema — exported, not rendered on the card. */
+  description?: string;
   isPrimaryKey: boolean;
   /** Hidden-for-reporting fields (usually surrogate join keys). */
   isHidden: boolean;

--- a/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.ts
+++ b/apps/web/src/features/data-marts/model-canvas/model/use-model-canvas.ts
@@ -22,6 +22,7 @@ function mapSchemaFields(schema: DataMartSchema | null | undefined): CanvasNodeF
     name: field.name,
     alias: field.alias?.trim() ? field.alias : field.name,
     type: field.type,
+    ...(field.description?.trim() ? { description: field.description } : {}),
     isPrimaryKey: field.isPrimaryKey,
     isHidden: field.isHiddenForReporting ?? false,
   }));


### PR DESCRIPTION
## Problem

Follow-up to #1496. The Models canvas export dropped the business descriptions of Output Schema fields, even though they are stored in the Data Mart and shown in the Output Schema editor:

- **OKF bundle** — the schema table's Description column carried only the `PK.` / `FK to [Target]` notes, so a field like `customers.id` exported as `FK to [Orders](./orders.md)` while its actual description ("Unique numerical identifier assigned to each customer account.") was lost, and fields without joins exported with an empty cell.
- **JSON model graph** — schema fields had no `description` property at all.

The descriptions were dropped at the very first mapping step (`mapSchemaFields`), so no export format ever saw them.

## Fix

Thread `description` through the whole chain — `CanvasNodeField` → `ModelGraphSchemaField` → serializers:

- `mapSchemaFields` now carries the field description from the Data Mart schema (blank values are omitted).
- The OKF Description cell renders `PK.` → description. Multi-line descriptions collapse to a single line so they cannot break the Markdown table row.
- The `FK to [Target]` notes left the schema table entirely: every join already appears in the Joins section with its condition, so the note was a duplicate that crowded out the business description. This deliberately diverges from the model.owox.com serializer — its parser reads joins from the Joins keys first and falls back to FK notes only when the keys are missing, and our export always writes the keys, so the round-trip is unaffected.
- The JSON export picks the field up automatically via `sanitizeModelGraph` (schema passes through unchanged); the reference `SchemaField` type already declares `description?: string`, so the shape stays compatible.

The canvas cards themselves are unchanged — the description is export-only data.

## Tests

- `serialize.test.ts`: description rendered in the Description cell; multi-line description collapses to one line; no FK notes anywhere in the schema table.
- `model-graph.test.ts`: description mapped into the graph; explicit assertion that it survives `sanitizeModelGraph` into the JSON export.
- All model-canvas tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)