### PR TITLE
fix(google-ads): restore imports after v21 API sunset

### DIFF
--- a/.changeset/6810-google-ads-api-v25.md
+++ b/.changeset/6810-google-ads-api-v25.md
@@ -1,0 +1,10 @@
+---
+'owox': minor
+---
+
+# Google Ads connector uses a supported API version
+
+Previously, the Google Ads connector called API version v21, which Google
+sunset on 2026-08-05, causing every import to fail with an
+`UNSUPPORTED_VERSION` error. Now, the connector uses v25, the current stable
+version. This means Google Ads imports run successfully again.

--- a/packages/connectors/src/Sources/GoogleAds/GoogleAdsAPIReference/GoogleAdsFieldsSchema.js
+++ b/packages/connectors/src/Sources/GoogleAds/GoogleAdsAPIReference/GoogleAdsFieldsSchema.js
@@ -9,7 +9,7 @@ const GoogleAdsFieldsSchema = {
   campaigns: {
     overview: "Google Ads Campaigns",
     description: "Your campaign settings — channel type, bidding strategy, budget, and scheduling.",
-    documentation: "https://developers.google.com/google-ads/api/fields/v21/campaign",
+    documentation: "https://developers.google.com/google-ads/api/fields/v25/campaign",
     fields: campaignFields,
     uniqueKeys: ['campaign_id'],
     defaultFields: ['campaign_id', 'campaign_name', 'campaign_status', 'campaign_advertising_channel_type', 'campaign_start_date', 'campaign_end_date', 'campaign_bidding_strategy_type', 'campaign_budget_amount_micros'],
@@ -19,7 +19,7 @@ const GoogleAdsFieldsSchema = {
   campaigns_stats: {
     overview: "Google Ads Campaigns Stats",
     description: "Daily campaign performance — impressions, clicks, cost, and conversions.",
-    documentation: "https://developers.google.com/google-ads/api/fields/v21/campaign",
+    documentation: "https://developers.google.com/google-ads/api/fields/v25/campaign",
     fields: campaignStatsFields,
     uniqueKeys: ['campaign_id', 'date'],
     defaultFields: ['campaign_id', 'campaign_name', 'date', 'impressions', 'clicks', 'cost_micros', 'conversions', 'conversions_value', 'ctr', 'average_cpc', 'cost_per_conversion'],
@@ -29,7 +29,7 @@ const GoogleAdsFieldsSchema = {
   ad_groups: {
     overview: "Google Ads Ad Groups",
     description: "Your ad group settings — type, status, and bid configuration within each campaign.",
-    documentation: "https://developers.google.com/google-ads/api/fields/v21/ad_group",
+    documentation: "https://developers.google.com/google-ads/api/fields/v25/ad_group",
     fields: adGroupFields,
     uniqueKeys: ['ad_group_id'],
     defaultFields: ['ad_group_id', 'ad_group_name', 'ad_group_status', 'ad_group_type', 'campaign_id', 'campaign_name'],
@@ -39,7 +39,7 @@ const GoogleAdsFieldsSchema = {
   ad_groups_stats: {
     overview: "Google Ads Ad Groups Stats",
     description: "Daily ad group performance — impressions, clicks, cost, and conversions.",
-    documentation: "https://developers.google.com/google-ads/api/fields/v21/ad_group",
+    documentation: "https://developers.google.com/google-ads/api/fields/v25/ad_group",
     fields: adGroupStatsFields,
     uniqueKeys: ['ad_group_id', 'date'],
     defaultFields: ['ad_group_id', 'ad_group_name', 'campaign_id', 'date', 'impressions', 'clicks', 'cost_micros', 'conversions', 'conversions_value', 'ctr', 'average_cpc', 'cost_per_conversion'],
@@ -49,7 +49,7 @@ const GoogleAdsFieldsSchema = {
   ad_group_ads_stats: {
     overview: "Google Ads Ad Group Ads Stats",
     description: "Daily performance for individual ads — impressions, clicks, cost, and conversions.",
-    documentation: "https://developers.google.com/google-ads/api/fields/v21/ad_group_ad",
+    documentation: "https://developers.google.com/google-ads/api/fields/v25/ad_group_ad",
     fields: adGroupAdStatsFields,
     uniqueKeys: ['ad_id', 'date'],
     defaultFields: ['ad_id', 'ad_name', 'ad_type', 'ad_status', 'ad_group_id', 'ad_group_name', 'campaign_id', 'campaign_name', 'date', 'impressions', 'clicks', 'cost_micros', 'conversions', 'conversions_value', 'ctr', 'average_cpc', 'cost_per_conversion'],
@@ -59,7 +59,7 @@ const GoogleAdsFieldsSchema = {
   keywords_stats: {
     overview: "Google Ads Keywords Stats",
     description: "Daily keyword performance — impressions, clicks, cost, conversions, and quality score.",
-    documentation: "https://developers.google.com/google-ads/api/fields/v21/keyword_view",
+    documentation: "https://developers.google.com/google-ads/api/fields/v25/keyword_view",
     fields: keywordStatsFields,
     uniqueKeys: ['keyword_id', 'date'],
     defaultFields: ['keyword_id', 'keyword_text', 'keyword_match_type', 'keyword_status', 'ad_group_id', 'campaign_id', 'date', 'impressions', 'clicks', 'cost_micros', 'conversions', 'conversions_value', 'ctr', 'average_cpc', 'cost_per_conversion', 'quality_score'],
@@ -69,7 +69,7 @@ const GoogleAdsFieldsSchema = {
   criterion: {
     overview: "Google Ads Criterion",
     description: "Ad group targeting criteria — keywords, placements, and negative exclusions with bid settings.",
-    documentation: "https://developers.google.com/google-ads/api/fields/v21/ad_group_criterion",
+    documentation: "https://developers.google.com/google-ads/api/fields/v25/ad_group_criterion",
     fields: criterionFields,
     uniqueKeys: ['criterion_id', 'ad_group_id', 'campaign_id'],
     defaultFields: ['criterion_id', 'criterion_type', 'criterion_status', 'keyword_text', 'keyword_match_type', 'ad_group_id', 'ad_group_name', 'campaign_id', 'campaign_name', 'negative', 'quality_score'],
@@ -79,7 +79,7 @@ const GoogleAdsFieldsSchema = {
   geo_stats: {
     overview: "Google Ads Geo Stats",
     description: "Daily performance by country and targeting type — impressions, clicks, cost, and conversions.",
-    documentation: "https://developers.google.com/google-ads/api/fields/v21/geographic_view",
+    documentation: "https://developers.google.com/google-ads/api/fields/v25/geographic_view",
     fields: geoTargetFields,
     uniqueKeys: ['campaign_id', 'country_criterion_id', 'location_type', 'date'],
     defaultFields: ['campaign_id', 'country_criterion_id', 'location_type', 'date',
@@ -90,7 +90,7 @@ const GoogleAdsFieldsSchema = {
   geo_target_constants: {
     overview: "Google Ads Geo Target Constants",
     description: "Reference table of geographic targets — join with geo_stats on country_criterion_id to resolve country names.",
-    documentation: "https://developers.google.com/google-ads/api/fields/v21/geo_target_constant",
+    documentation: "https://developers.google.com/google-ads/api/fields/v25/geo_target_constant",
     fields: geoTargetConstantFields,
     uniqueKeys: ['geo_target_constant_id'],
     defaultFields: ['geo_target_constant_id', 'name', 'country_code', 'canonical_name'],

--- a/packages/connectors/src/Sources/GoogleAds/Source.js
+++ b/packages/connectors/src/Sources/GoogleAds/Source.js
@@ -423,7 +423,7 @@ var GoogleAdsSource = class GoogleAdsSource extends AbstractSource {
    */
   async makeRequest({ customerId, query, nodeName, fields }) {
     const accessToken = await this.getAccessToken();
-    const url = `https://googleads.googleapis.com/v21/customers/${customerId}/googleAds:search`;
+    const url = `https://googleads.googleapis.com/v25/customers/${customerId}/googleAds:search`;
     
     console.log(`Google Ads API Request URL: ${url}`);
     console.log(`GAQL Query: ${query}`);


### PR DESCRIPTION
# Problem

Google Ads connector runs started failing with `HttpRequestException: Request contains an invalid argument.` and a Google Ads API error of `UNSUPPORTED_VERSION`. The connector hardcoded calls to Google Ads API `v21`, which Google sunset on 2026-08-05 — after that date every `googleAds:search` request is rejected outright, regardless of query, customer, or credentials, so scheduled imports fail mid-run once the cutoff is crossed.

# Solution

Bumped the hardcoded API version in the request URL from `v21` to `v25`, Google's current stable release (GA since 2026-07-22), so `googleAds:search` calls succeed again. Also swept the rest of the Google Ads source for other hardcoded `v21` references and found nine stale documentation links in the field schema metadata, which were updated to `v25` for consistency even though they don't affect runtime calls. Verified no other version references remain anywhere in `packages/connectors`.

# Changes

- Updated the Google Ads API request URL from `v21` to `v25` in `Source.js`
- Updated 9 stale `v21` documentation links to `v25` in `GoogleAdsFieldsSchema.js`
- Added changeset `6810-google-ads-api-v25.md`