### PR TITLE
feat(api): cover Data Mart run lifecycle

### DIFF
--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -26,9 +26,9 @@ consumers should prefer typed resource abstractions when available.
 the Data-Mart-scoped `runs.forDataMart(id)` client and its `start()`, `list()`, `get()`, and `cancel()`
 methods. Starting and cancelling require Technical User access; listing and inspecting require
 Business User access. `start()` accepts typed incremental or manual-backfill options, including
-connector-specific backfill fields. Serialized start options are limited to 1 MB. List pagination
-defaults to 100 items, caps the limit at 100 and offset at 100,000, and normalizes invalid numeric
-values. Responses are type-checked at runtime, including Data Quality details.
+connector-specific backfill fields. List pagination defaults to 100 items, caps the limit at 100 and
+offset at 100,000, and normalizes invalid numeric values. Responses are type-checked at runtime,
+including Data Quality details.
 
 The existing project-wide `runs.list()` method is unchanged, so current integrations require no
 migration.

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -23,12 +23,12 @@ consumers should prefer typed resource abstractions when available.
 ## Manage Data Mart run lifecycles through the API client
 
 `@owox/api-client` now supports starting, listing, inspecting, and cancelling Data Mart runs through
-`runs.start()`, `runs.listForDataMart()`, `runs.get()`, and `runs.cancel()`. Starting and cancelling
-require Technical User access; listing and inspecting require Business User access. `runs.start()`
-accepts typed incremental or manual-backfill options, including connector-specific backfill fields.
-Serialized start options are limited to 1 MB. List pagination defaults to 100 items, caps the limit
-at 100 and offset at 100,000, and normalizes invalid numeric values. Responses are type-checked at
-runtime, including Data Quality details.
+the Data-Mart-scoped `runs.forDataMart(id)` client and its `start()`, `list()`, `get()`, and `cancel()`
+methods. Starting and cancelling require Technical User access; listing and inspecting require
+Business User access. `start()` accepts typed incremental or manual-backfill options, including
+connector-specific backfill fields. Serialized start options are limited to 1 MB. List pagination
+defaults to 100 items, caps the limit at 100 and offset at 100,000, and normalizes invalid numeric
+values. Responses are type-checked at runtime, including Data Quality details.
 
 The existing project-wide `runs.list()` method is unchanged, so current integrations require no
 migration.

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -2,7 +2,9 @@
 'owox': minor
 ---
 
-# Low-level API client transport methods
+# API surface maintenance
+
+## Low-level API client transport methods
 
 OWOX API clients can now use `patchJson()` and `deleteJson()` alongside
 `getJson()`, `postJson()`, `putJson()`, and `getStream()` for `/api/...`
@@ -17,3 +19,19 @@ The existing plugin protocol adds PATCH and DELETE through `ctx.owox` as an
 additive capability while preserving compatibility with existing plugins.
 Low-level JSON return values are caller-typed and are not runtime-validated;
 consumers should prefer typed resource abstractions when available.
+
+## Add Data Mart run lifecycle client support
+
+The Data Mart run lifecycle endpoints now publish their complete request, response, visibility,
+pagination, and cancellation contracts. Manual runs and cancellation require Technical User
+access; listing and inspecting runs require Business User access to the Data Mart. Manual connector
+payloads must be JSON objects no larger than 1 MB. Run list pagination defaults to 100, caps the
+limit at 100 and the offset at 100,000, and normalizes fractional, non-finite, and non-positive
+values.
+
+`@owox/api-client` adds `dataMarts.run(dataMartId, request)`,
+`dataMarts.listRuns(dataMartId, options)`, `dataMarts.getRun(dataMartId, runId)`, and
+`dataMarts.cancelRun(dataMartId, runId)`. It exports the Data Mart run, request, response,
+pagination, status, type, author, and Data Quality types and validates the complete runtime
+response before returning it. Existing `runs.list()` remains the separate project-wide run-history
+method; no existing call needs migration.

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -24,10 +24,11 @@ consumers should prefer typed resource abstractions when available.
 
 `@owox/api-client` now supports starting, listing, inspecting, and cancelling Data Mart runs through
 `runs.start()`, `runs.listForDataMart()`, `runs.get()`, and `runs.cancel()`. Starting and cancelling
-require Technical User access; listing and inspecting require Business User access. Manual payloads
-must be objects no larger than 1 MB, and list pagination defaults to 100 items, caps the limit at 100
-and offset at 100,000, and normalizes invalid numeric values. Responses are type-checked at runtime,
-including Data Quality details.
+require Technical User access; listing and inspecting require Business User access. `runs.start()`
+accepts typed incremental or manual-backfill options, including connector-specific backfill fields.
+Serialized start options are limited to 1 MB. List pagination defaults to 100 items, caps the limit
+at 100 and offset at 100,000, and normalizes invalid numeric values. Responses are type-checked at
+runtime, including Data Quality details.
 
 The existing project-wide `runs.list()` method is unchanged, so current integrations require no
 migration.

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -26,19 +26,19 @@ consumers should prefer typed resource abstractions when available.
 the Data-Mart-scoped `runs.forDataMart(id)` client and its `start()`, `list()`, `get()`, and `cancel()`
 methods. Starting and cancelling require Technical User access; listing and inspecting require
 Business User access. `start()` accepts typed incremental or manual-backfill options, including
-connector-specific backfill fields. Manual-backfill `data` now requires an explicit
-`runType: 'MANUAL_BACKFILL'`; incremental runs reject `data` instead of silently ignoring it. The
-client also rejects empty or dot-segment Data Mart and run IDs before sending a request. Serialized
-manual-run options are limited to 1 MiB by both the client and HTTP API; requests above the HTTP
-transport ceiling return `413` instead of an internal-server error. Packaged authentication
-middleware now limits its body parsers to `/auth`, so it no longer overrides the backend API's 2 MiB
-transport ceiling.
+connector-specific fields. Manual-backfill `data` is optional for connectors without backfill
+fields, and object-valued `data` remains accepted for incremental runs so existing run forms and
+API consumers do not fail when they retain hidden field values. The client also rejects empty or
+dot-segment Data Mart and run IDs before sending a request. Serialized manual-run options are
+limited to 1 MiB by both the client and HTTP API; requests above the HTTP transport ceiling return
+`413` instead of an internal-server error. Packaged authentication middleware now limits its body
+parsers to `/auth`, so it no longer overrides the backend API's 2 MiB transport ceiling.
 
 Scoped list pagination defaults to 100 items when omitted and preserves valid caller-provided limits
 and offsets without silently capping them. Both scoped and project-wide list methods reject unknown,
 zero or negative limits, negative offsets, non-integer values, non-finite values, and integers outside
 JavaScript's safe range before authentication or network access.
-Project-wide `runs.list()` remains compatible with older self-hosted deployments that omit
-`qualitySummary`, and Data Quality response validation tolerates additive server fields while still
-checking known values. Existing typed integrations need no migration unless they passed backfill
-`data` without the required manual-backfill run type or relied on invalid pagination values.
+Project-wide and Data-Mart-scoped run methods remain compatible with older self-hosted deployments
+that omit Data Quality fields, and Data Quality response validation tolerates additive server fields
+while still checking known values. Existing typed integrations need no migration unless they relied
+on invalid pagination values.

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -36,8 +36,8 @@ transport ceiling.
 
 Scoped list pagination defaults to 100 items when omitted and preserves valid caller-provided limits
 and offsets without silently capping them. Both scoped and project-wide list methods reject unknown,
-zero or negative limits, negative offsets, non-integer values, and non-finite values before
-authentication or network access.
+zero or negative limits, negative offsets, non-integer values, non-finite values, and integers outside
+JavaScript's safe range before authentication or network access.
 Project-wide `runs.list()` remains compatible with older self-hosted deployments that omit
 `qualitySummary`, and Data Quality response validation tolerates additive server fields while still
 checking known values. Existing typed integrations need no migration unless they passed backfill

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -30,17 +30,17 @@ connector-specific fields. Manual-backfill `data` is optional for connectors wit
 fields. The API client requires an explicit `MANUAL_BACKFILL` run type whenever `data` is supplied
 and rejects `data` on implicit or explicit incremental runs before sending a request. The backend
 HTTP endpoint separately accepts retained object-valued `data` on incremental requests so existing
-run forms remain compatible. The client also rejects empty or dot-segment Data Mart and run IDs
-before sending a request. Serialized manual-run options are limited to 1 MiB by both the client and
-HTTP API; requests above the HTTP transport ceiling return `413` instead of an internal-server
-error. Packaged authentication middleware now limits its body parsers to `/auth`, so it no longer
-overrides the backend API's 2 MiB transport ceiling.
+run forms remain compatible. The client also rejects empty, dot-segment, or separator-bearing Data
+Mart and run IDs before sending a request. Serialized manual-run options are limited to 1 MiB by
+both the client and HTTP API; requests above the HTTP transport ceiling return `413` instead of an
+internal-server error. Packaged authentication middleware now limits its body parsers to `/auth`,
+so it no longer overrides the backend API's 2 MiB transport ceiling.
 
 Scoped list pagination defaults to 100 items when omitted and preserves valid caller-provided limits
-and offsets without silently capping them. Both scoped and project-wide list methods reject unknown,
-zero or negative limits, negative offsets, non-integer values, non-finite values, and integers outside
-JavaScript's safe range before authentication or network access.
+and offsets without silently capping them. The scoped list method rejects unknown, zero or negative
+limits, negative offsets, non-integer values, non-finite values, and integers outside JavaScript's
+safe range before authentication or network access. Project-wide `runs.list()` pagination remains
+unchanged and relies on server normalization.
 Project-wide and Data-Mart-scoped run methods remain compatible with older self-hosted deployments
 that omit Data Quality fields, and Data Quality response validation tolerates additive server fields
-while still checking known values. Existing typed integrations need no migration unless they relied
-on invalid pagination values.
+while still checking known values. Existing typed integrations need no migration.

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -26,9 +26,17 @@ consumers should prefer typed resource abstractions when available.
 the Data-Mart-scoped `runs.forDataMart(id)` client and its `start()`, `list()`, `get()`, and `cancel()`
 methods. Starting and cancelling require Technical User access; listing and inspecting require
 Business User access. `start()` accepts typed incremental or manual-backfill options, including
-connector-specific backfill fields. List pagination defaults to 100 items, caps the limit at 100 and
-offset at 100,000, and normalizes invalid numeric values. Responses are type-checked at runtime,
-including Data Quality details.
+connector-specific backfill fields. Manual-backfill `data` now requires an explicit
+`runType: 'MANUAL_BACKFILL'`; incremental runs reject `data` instead of silently ignoring it. The
+client also rejects empty or dot-segment Data Mart and run IDs before sending a request. Serialized
+manual-run options are limited to 1 MiB by both the client and HTTP API; requests above the HTTP
+transport ceiling return `413` instead of an internal-server error.
 
-The existing project-wide `runs.list()` method is unchanged, so current integrations require no
-migration.
+Scoped list pagination defaults to 100 items when omitted and preserves valid caller-provided limits
+and offsets without silently capping them. Both scoped and project-wide list methods reject unknown,
+zero or negative limits, negative offsets, non-integer values, and non-finite values before
+authentication or network access.
+Project-wide `runs.list()` remains compatible with older self-hosted deployments that omit
+`qualitySummary`, and Data Quality response validation tolerates additive server fields while still
+checking known values. Existing typed integrations need no migration unless they passed backfill
+`data` without the required manual-backfill run type or relied on invalid pagination values.

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -20,18 +20,8 @@ additive capability while preserving compatibility with existing plugins.
 Low-level JSON return values are caller-typed and are not runtime-validated;
 consumers should prefer typed resource abstractions when available.
 
-## Add Data Mart run lifecycle client support
+## Manage Data Mart run lifecycles through the API client
 
-The Data Mart run lifecycle endpoints now publish their complete request, response, visibility,
-pagination, and cancellation contracts. Manual runs and cancellation require Technical User
-access; listing and inspecting runs require Business User access to the Data Mart. Manual connector
-payloads must be JSON objects no larger than 1 MB. Run list pagination defaults to 100, caps the
-limit at 100 and the offset at 100,000, and normalizes fractional, non-finite, and non-positive
-values.
-
-`@owox/api-client` adds `dataMarts.run(dataMartId, request)`,
-`dataMarts.listRuns(dataMartId, options)`, `dataMarts.getRun(dataMartId, runId)`, and
-`dataMarts.cancelRun(dataMartId, runId)`. It exports the Data Mart run, request, response,
-pagination, status, type, author, and Data Quality types and validates the complete runtime
-response before returning it. Existing `runs.list()` remains the separate project-wide run-history
-method; no existing call needs migration.
+`@owox/api-client` now supports starting, listing, inspecting, and cancelling Data Mart runs through
+`runs.start()`, `runs.listForDataMart()`, `runs.get()`, and `runs.cancel()`. These methods enforce the
+same access, payload, pagination, and response contracts as the service API.

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -30,7 +30,9 @@ connector-specific backfill fields. Manual-backfill `data` now requires an expli
 `runType: 'MANUAL_BACKFILL'`; incremental runs reject `data` instead of silently ignoring it. The
 client also rejects empty or dot-segment Data Mart and run IDs before sending a request. Serialized
 manual-run options are limited to 1 MiB by both the client and HTTP API; requests above the HTTP
-transport ceiling return `413` instead of an internal-server error.
+transport ceiling return `413` instead of an internal-server error. Packaged authentication
+middleware now limits its body parsers to `/auth`, so it no longer overrides the backend API's 2 MiB
+transport ceiling.
 
 Scoped list pagination defaults to 100 items when omitted and preserves valid caller-provided limits
 and offsets without silently capping them. Both scoped and project-wide list methods reject unknown,

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -27,12 +27,14 @@ the Data-Mart-scoped `runs.forDataMart(id)` client and its `start()`, `list()`, 
 methods. Starting and cancelling require Technical User access; listing and inspecting require
 Business User access. `start()` accepts typed incremental or manual-backfill options, including
 connector-specific fields. Manual-backfill `data` is optional for connectors without backfill
-fields, and object-valued `data` remains accepted for incremental runs so existing run forms and
-API consumers do not fail when they retain hidden field values. The client also rejects empty or
-dot-segment Data Mart and run IDs before sending a request. Serialized manual-run options are
-limited to 1 MiB by both the client and HTTP API; requests above the HTTP transport ceiling return
-`413` instead of an internal-server error. Packaged authentication middleware now limits its body
-parsers to `/auth`, so it no longer overrides the backend API's 2 MiB transport ceiling.
+fields. The API client requires an explicit `MANUAL_BACKFILL` run type whenever `data` is supplied
+and rejects `data` on implicit or explicit incremental runs before sending a request. The backend
+HTTP endpoint separately accepts retained object-valued `data` on incremental requests so existing
+run forms remain compatible. The client also rejects empty or dot-segment Data Mart and run IDs
+before sending a request. Serialized manual-run options are limited to 1 MiB by both the client and
+HTTP API; requests above the HTTP transport ceiling return `413` instead of an internal-server
+error. Packaged authentication middleware now limits its body parsers to `/auth`, so it no longer
+overrides the backend API's 2 MiB transport ceiling.
 
 Scoped list pagination defaults to 100 items when omitted and preserves valid caller-provided limits
 and offsets without silently capping them. Both scoped and project-wide list methods reject unknown,

--- a/.changeset/api-surface-maintenance.md
+++ b/.changeset/api-surface-maintenance.md
@@ -23,5 +23,11 @@ consumers should prefer typed resource abstractions when available.
 ## Manage Data Mart run lifecycles through the API client
 
 `@owox/api-client` now supports starting, listing, inspecting, and cancelling Data Mart runs through
-`runs.start()`, `runs.listForDataMart()`, `runs.get()`, and `runs.cancel()`. These methods enforce the
-same access, payload, pagination, and response contracts as the service API.
+`runs.start()`, `runs.listForDataMart()`, `runs.get()`, and `runs.cancel()`. Starting and cancelling
+require Technical User access; listing and inspecting require Business User access. Manual payloads
+must be objects no larger than 1 MB, and list pagination defaults to 100 items, caps the limit at 100
+and offset at 100,000, and normalizes invalid numeric values. Responses are type-checked at runtime,
+including Data Quality details.
+
+The existing project-wide `runs.list()` method is unchanged, so current integrations require no
+migration.

--- a/apps/backend/src/bootstrap.ts
+++ b/apps/backend/src/bootstrap.ts
@@ -12,6 +12,7 @@ import { GlobalExceptionFilter } from './common/exceptions/global-exception.filt
 import { createLogger } from './common/logger/logger.service';
 import { DEFAULT_PORT } from './config/constants';
 import { setupGlobalPipes } from './config/global-pipes.config';
+import { setupBodyParsers } from './config/body-parser.config';
 import { runMigrationsIfNeeded } from './config/migrations.config';
 import { PROTOCOL_ROUTE_EXCLUSIONS } from './config/protocol-route-exclusions.config';
 import { setupSwagger } from './config/swagger.config';
@@ -44,6 +45,8 @@ export async function bootstrap(options: BootstrapOptions): Promise<NestExpressA
     new ExpressAdapter(options.express),
     { logger }
   );
+
+  setupBodyParsers(app);
 
   app.useLogger(createLogger());
   app.useGlobalFilters(new GlobalExceptionFilter(), new BaseExceptionFilter());

--- a/apps/backend/src/common/exceptions/global-exception.filter.spec.ts
+++ b/apps/backend/src/common/exceptions/global-exception.filter.spec.ts
@@ -93,6 +93,20 @@ describe('GlobalExceptionFilter', () => {
   });
 
   describe('other exceptions are unchanged', () => {
+    it('maps body-parser payload errors to 413 instead of an internal error', () => {
+      const error = Object.assign(new Error('request entity too large'), {
+        status: 413,
+        type: 'entity.too.large',
+      });
+
+      filter.catch(error, hostFor(json));
+
+      expect(body()).toMatchObject({
+        statusCode: 413,
+        message: 'Request body too large',
+      });
+    });
+
     it('prefers a written message over the exception name', () => {
       filter.catch(new NotFoundException('Data Mart not found'), hostFor(json));
 

--- a/apps/backend/src/common/exceptions/global-exception.filter.ts
+++ b/apps/backend/src/common/exceptions/global-exception.filter.ts
@@ -29,6 +29,14 @@ function isHttpError(e: unknown): e is { getStatus(): number; getResponse?: () =
   );
 }
 
+function isPayloadTooLargeError(e: unknown): e is Error & { status: 413; type: string } {
+  return (
+    e instanceof Error &&
+    (e as Error & { status?: unknown }).status === HttpStatus.PAYLOAD_TOO_LARGE &&
+    (e as Error & { type?: unknown }).type === 'entity.too.large'
+  );
+}
+
 /**
  * Extract a human-readable `message` string from a structured exception
  * response when present. NestJS HttpException accepts either a string, or an
@@ -90,7 +98,12 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const request = ctx.getRequest<AuthenticatedRequest>();
 
     const isHttp = isHttpError(exception);
-    const status = isHttp ? exception.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
+    const isPayloadTooLarge = isPayloadTooLargeError(exception);
+    const status = isHttp
+      ? exception.getStatus()
+      : isPayloadTooLarge
+        ? HttpStatus.PAYLOAD_TOO_LARGE
+        : HttpStatus.INTERNAL_SERVER_ERROR;
 
     const structured =
       isHttp && typeof exception.getResponse === 'function' ? exception.getResponse() : undefined;
@@ -103,6 +116,7 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       message:
         responseBodyMessage(structured) ??
         (constraints ? VALIDATION_FAILED_MESSAGE : undefined) ??
+        (isPayloadTooLarge ? 'Request body too large' : undefined) ??
         (isHttp && exception instanceof Error ? exception.message : undefined),
       // Structured rather than folded into `message`, which stays a string every caller can call
       // string methods on; `details.errors[]` is already rendered capped and de-duplicated.

--- a/apps/backend/src/config/body-parser.config.ts
+++ b/apps/backend/src/config/body-parser.config.ts
@@ -1,0 +1,13 @@
+import type { NestExpressApplication } from '@nestjs/platform-express';
+
+// Keep the transport ceiling above endpoint-level DTO limits so validation can
+// return the endpoint's documented client error instead of failing in middleware.
+export const MAX_JSON_BODY_SIZE_BYTES = 2 * 1024 * 1024;
+
+export function setupBodyParsers(app: NestExpressApplication): void {
+  app.useBodyParser('json', { limit: MAX_JSON_BODY_SIZE_BYTES });
+  app.useBodyParser('urlencoded', {
+    limit: MAX_JSON_BODY_SIZE_BYTES,
+    extended: true,
+  });
+}

--- a/apps/backend/src/config/swagger.config.spec.ts
+++ b/apps/backend/src/config/swagger.config.spec.ts
@@ -1,0 +1,48 @@
+import { Body, Controller, Get, INestApplication, Post } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ApiBody, ApiProperty } from '@nestjs/swagger';
+import { createSwaggerDocument } from './swagger.config';
+
+class RequestBodyDto {
+  @ApiProperty()
+  value: string;
+}
+
+@Controller('transport-contract')
+class TransportContractController {
+  @Post()
+  @ApiBody({ type: RequestBodyDto })
+  create(@Body() body: RequestBodyDto): RequestBodyDto {
+    return body;
+  }
+
+  @Get()
+  list(): string[] {
+    return [];
+  }
+}
+
+describe('Swagger transport contract', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [TransportContractController],
+    }).compile();
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('publishes the shared parser ceiling response for request-body operations only', () => {
+    const document = createSwaggerDocument(app);
+
+    expect(document.paths['/transport-contract']?.post?.responses['413']).toEqual({
+      description: 'Request body too large',
+    });
+    expect(document.paths['/transport-contract']?.get?.responses['413']).toBeUndefined();
+  });
+});

--- a/apps/backend/src/config/swagger.config.ts
+++ b/apps/backend/src/config/swagger.config.ts
@@ -49,13 +49,22 @@ export function createSwaggerDocument(app: INestApplication): OpenAPIObject {
   for (const path of Object.values(document.paths)) {
     for (const method of HTTP_METHODS) {
       const operation = path[method];
-      if (operation && usesOwoxAuthorization(operation)) {
-        applyOwoxAuthenticationContract(operation);
+      if (operation) {
+        if (usesOwoxAuthorization(operation)) {
+          applyOwoxAuthenticationContract(operation);
+        }
+        applyRequestBodySizeContract(operation);
       }
     }
   }
 
   return document;
+}
+
+function applyRequestBodySizeContract(operation: OperationObject): void {
+  if (operation.requestBody && !operation.responses['413']) {
+    operation.responses['413'] = { description: 'Request body too large' };
+  }
 }
 
 function usesOwoxAuthorization(operation: OperationObject): boolean {

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
@@ -328,12 +328,13 @@ describe('DataMartController list OpenAPI', () => {
       additionalProperties: false,
       properties: {
         runType: { type: 'string', enum: ['INCREMENTAL'] },
+        data: { type: 'object', additionalProperties: true },
       },
     });
     expect(resolveRef('#/components/schemas/ManualBackfillRunDataMartPayloadApiDto')).toMatchObject(
       {
         additionalProperties: false,
-        required: ['runType', 'data'],
+        required: ['runType'],
         properties: {
           runType: { type: 'string', enum: ['MANUAL_BACKFILL'] },
           data: { type: 'object', additionalProperties: true },

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
@@ -289,4 +289,88 @@ describe('DataMartController list OpenAPI', () => {
       resolveRef('#/components/schemas/DataMartRunDetailResponseApiDto').properties
     ).toHaveProperty('dataQuality');
   });
+
+  it('publishes the complete Data Mart run lifecycle with stable operation identities', () => {
+    const manualRun = document.paths['/api/data-marts/{id}/manual-run']?.post;
+    const listRuns = document.paths['/api/data-marts/{id}/runs']?.get;
+    const getRun = document.paths['/api/data-marts/{id}/runs/{runId}']?.get;
+    const cancelRun = document.paths['/api/data-marts/{id}/runs/{runId}/cancel']?.post;
+
+    expect(manualRun).toMatchObject({
+      operationId: 'DataMartController_manualRun',
+      summary: 'Start a manual Data Mart run',
+      tags: ['DataMarts'],
+    });
+    expect(manualRun?.description).toMatch(/technical user/i);
+    expect(manualRun?.requestBody).toMatchObject({
+      required: false,
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/RunDataMartRequestApiDto' },
+        },
+      },
+    });
+    expect(manualRun?.responses['201']).toMatchObject({
+      description: expect.stringMatching(/created/i),
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/RunDataMartResponseApiDto' },
+        },
+      },
+    });
+    expect(resolveRef('#/components/schemas/RunDataMartResponseApiDto')).toMatchObject({
+      required: ['runId'],
+      properties: { runId: { type: 'string', format: 'uuid' } },
+    });
+
+    expect(listRuns).toMatchObject({
+      operationId: 'DataMartController_getRunHistory',
+      summary: 'List Data Mart runs',
+      tags: ['DataMarts'],
+    });
+    expect(listRuns?.description).toMatch(/business user/i);
+    const listParameters = Object.fromEntries(
+      (listRuns?.parameters ?? []).map(parameter => {
+        if ('$ref' in parameter) {
+          throw new Error('Data Mart run list parameters must be declared inline');
+        }
+        return [parameter.name, parameter];
+      })
+    );
+    expect(listParameters.limit).toMatchObject({
+      in: 'query',
+      required: false,
+      schema: { type: 'number', default: 100, minimum: 1, maximum: 100 },
+    });
+    expect(listParameters.offset).toMatchObject({
+      in: 'query',
+      required: false,
+      schema: { type: 'number', default: 0, minimum: 0, maximum: 100000 },
+    });
+
+    expect(getRun).toMatchObject({
+      operationId: 'DataMartController_getRunById',
+      summary: 'Get a Data Mart run',
+      tags: ['DataMarts'],
+    });
+    expect(getRun?.description).toMatch(/business user/i);
+
+    expect(cancelRun).toMatchObject({
+      operationId: 'DataMartController_cancelRun',
+      summary: 'Cancel a Data Mart run',
+      tags: ['DataMarts'],
+    });
+    expect(cancelRun?.description).toMatch(/technical user/i);
+    expect(cancelRun?.responses['204']).toEqual({ description: 'Data Mart run cancelled' });
+  });
+
+  it('marks mapper-owned nullable Data Quality fields as present in every run response', () => {
+    const runSchema = resolveRef('#/components/schemas/DataMartRunResponseApiDto');
+    const detailSchema = resolveRef('#/components/schemas/DataMartRunDetailResponseApiDto');
+
+    expect(runSchema.required).toContain('qualitySummary');
+    expect(runSchema.properties.qualitySummary).toMatchObject({ nullable: true });
+    expect(detailSchema.required).toContain('dataQuality');
+    expect(detailSchema.properties.dataQuality).toMatchObject({ nullable: true });
+  });
 });

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
@@ -244,17 +244,17 @@ describe('DataMartController list OpenAPI', () => {
 
     const runSchema = resolveRef('#/components/schemas/DataMartRunResponseApiDto');
     expect(runSchema.required).toContain('createdByUser');
+    expect(runSchema.properties.status).not.toHaveProperty('nullable');
+    expect(runSchema.properties.type).not.toHaveProperty('nullable');
+    expect(runSchema.properties.runType).not.toHaveProperty('nullable');
     expect(runSchema.properties).toMatchObject({
       status: {
-        nullable: true,
         allOf: [{ $ref: '#/components/schemas/DataMartRunStatus' }],
       },
       type: {
-        nullable: true,
         allOf: [{ $ref: '#/components/schemas/DataMartRunType' }],
       },
       runType: {
-        nullable: true,
         allOf: [{ $ref: '#/components/schemas/RunType' }],
       },
       createdByUser: {

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication, Type } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '@nestjs/swagger';
+import { OpenAPIObject } from '@nestjs/swagger';
 
 jest.mock('@owox/connectors', () => ({
   AvailableConnectors: {},
@@ -34,12 +34,19 @@ jest.mock('../use-cases/batch-data-mart-health-status.service', () => ({
   BatchDataMartHealthStatusService: jest.fn(),
 }));
 
-import { Role, Strategy } from '../../idp';
+import { Role, Strategy, type AuthorizationContext } from '../../idp';
 import { DataMartController } from './data-mart.controller';
+import { createSwaggerDocument } from '../../config/swagger.config';
 
 describe('DataMartController list OpenAPI', () => {
   let app: INestApplication;
   let document: OpenAPIObject;
+  let controller: DataMartController;
+  const mapper = {
+    toGetDataMartRunsCommand: jest.fn(),
+    toRunsResponse: jest.fn().mockReturnValue({ runs: [] }),
+  };
+  const getDataMartRunsService = { run: jest.fn().mockResolvedValue([]) };
 
   beforeAll(async () => {
     const dependencies = [
@@ -50,14 +57,14 @@ describe('DataMartController list OpenAPI', () => {
       providers: dependencies.map(provide => ({ provide, useValue: {} })),
     }).compile();
 
+    controller = moduleRef.get(DataMartController);
+    Object.assign(controller, { mapper, getDataMartRunsService });
+
     app = moduleRef.createNestApplication();
     app.setGlobalPrefix('api');
     await app.init();
 
-    document = SwaggerModule.createDocument(
-      app,
-      new DocumentBuilder().setTitle('Test API').setVersion('1.0').build()
-    );
+    document = createSwaggerDocument(app);
   });
 
   afterAll(async () => {
@@ -310,6 +317,29 @@ describe('DataMartController list OpenAPI', () => {
         },
       },
     });
+    const requestSchema = resolveRef('#/components/schemas/RunDataMartRequestApiDto');
+    expect(requestSchema.properties.payload).toMatchObject({
+      oneOf: [
+        { $ref: '#/components/schemas/IncrementalRunDataMartPayloadApiDto' },
+        { $ref: '#/components/schemas/ManualBackfillRunDataMartPayloadApiDto' },
+      ],
+    });
+    expect(resolveRef('#/components/schemas/IncrementalRunDataMartPayloadApiDto')).toMatchObject({
+      additionalProperties: false,
+      properties: {
+        runType: { type: 'string', enum: ['INCREMENTAL'] },
+      },
+    });
+    expect(resolveRef('#/components/schemas/ManualBackfillRunDataMartPayloadApiDto')).toMatchObject(
+      {
+        additionalProperties: false,
+        required: ['runType', 'data'],
+        properties: {
+          runType: { type: 'string', enum: ['MANUAL_BACKFILL'] },
+          data: { type: 'object', additionalProperties: true },
+        },
+      }
+    );
     expect(manualRun?.responses['201']).toMatchObject({
       description: expect.stringMatching(/created/i),
       content: {
@@ -318,6 +348,7 @@ describe('DataMartController list OpenAPI', () => {
         },
       },
     });
+    expect(manualRun?.responses['413']).toEqual({ description: 'Request body too large' });
     expect(resolveRef('#/components/schemas/RunDataMartResponseApiDto')).toMatchObject({
       required: ['runId'],
       properties: { runId: { type: 'string', format: 'uuid' } },
@@ -368,11 +399,25 @@ describe('DataMartController list OpenAPI', () => {
     expect(cancelRun?.responses['204']).toEqual({ description: 'Data Mart run cancelled' });
   });
 
+  it('preserves caller-provided scoped run-history pagination values', async () => {
+    const context = {
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+    } as AuthorizationContext;
+    mapper.toGetDataMartRunsCommand.mockReturnValue({ kind: 'list-runs' });
+
+    await controller.getRunHistory(context, 'dm-1', 500, 100_001);
+
+    expect(mapper.toGetDataMartRunsCommand).toHaveBeenCalledWith('dm-1', context, 500, 100_001);
+  });
+
   it('marks mapper-owned nullable Data Quality fields as present in every run response', () => {
     const runSchema = resolveRef('#/components/schemas/DataMartRunResponseApiDto');
     const detailSchema = resolveRef('#/components/schemas/DataMartRunDetailResponseApiDto');
 
     expect(runSchema.required).toContain('qualitySummary');
+    expect(runSchema.required).toContain('totals');
     expect(runSchema.properties.qualitySummary).toMatchObject({ nullable: true });
     expect(detailSchema.required).toContain('dataQuality');
     expect(detailSchema.properties.dataQuality).toMatchObject({ nullable: true });

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.openapi.spec.ts
@@ -340,13 +340,17 @@ describe('DataMartController list OpenAPI', () => {
     expect(listParameters.limit).toMatchObject({
       in: 'query',
       required: false,
-      schema: { type: 'number', default: 100, minimum: 1, maximum: 100 },
+      schema: { type: 'number', default: 100 },
     });
+    expect(listParameters.limit.schema).not.toHaveProperty('minimum');
+    expect(listParameters.limit.schema).not.toHaveProperty('maximum');
     expect(listParameters.offset).toMatchObject({
       in: 'query',
       required: false,
-      schema: { type: 'number', default: 0, minimum: 0, maximum: 100000 },
+      schema: { type: 'number', default: 0 },
     });
+    expect(listParameters.offset.schema).not.toHaveProperty('minimum');
+    expect(listParameters.offset.schema).not.toHaveProperty('maximum');
 
     expect(getRun).toMatchObject({
       operationId: 'DataMartController_getRunById',

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.ts
@@ -13,6 +13,7 @@ import { DataMartValidationResponseApiDto } from '../dto/presentation/data-mart-
 import { ListDataMartsQueryApiDto } from '../dto/presentation/list-data-marts-query-api.dto';
 import { PaginatedDataMartsResponseApiDto } from '../dto/presentation/paginated-data-marts-response-api.dto';
 import { RunDataMartRequestApiDto } from '../dto/presentation/run-data-mart-request-api.dto';
+import { RunDataMartResponseApiDto } from '../dto/presentation/run-data-mart-response-api.dto';
 import { UpdateDataMartDefinitionApiDto } from '../dto/presentation/update-data-mart-definition-api.dto';
 import { UpdateBlendedFieldsConfigApiDto } from '../dto/presentation/update-blended-fields-config-api.dto';
 import { UpdateDataMartDescriptionApiDto } from '../dto/presentation/update-data-mart-description-api.dto';
@@ -78,6 +79,7 @@ import {
   ValidateDataMartDefinitionSpec,
   DataMartAiHelperAvailabilitySpec,
 } from './spec/data-mart.api';
+import { normalizeProjectListPagination } from '../utils/normalize-project-list-pagination';
 
 @Controller('data-marts')
 @ApiTags('DataMarts')
@@ -285,7 +287,7 @@ export class DataMartController {
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string,
     @Body() dto: RunDataMartRequestApiDto
-  ): Promise<{ runId: string }> {
+  ): Promise<RunDataMartResponseApiDto> {
     const command = this.mapper.toRunCommand(id, context, dto.payload);
     const runId = await this.runDataMartService.run(command);
     return { runId };
@@ -348,10 +350,16 @@ export class DataMartController {
   async getRunHistory(
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string,
-    @Query('limit') limit: number = 100,
-    @Query('offset') offset: number = 0
+    @Query('limit') limit?: string | number,
+    @Query('offset') offset?: string | number
   ): Promise<DataMartRunsResponseApiDto> {
-    const command = this.mapper.toGetDataMartRunsCommand(id, context, limit, offset);
+    const pagination = normalizeProjectListPagination(limit, offset);
+    const command = this.mapper.toGetDataMartRunsCommand(
+      id,
+      context,
+      pagination.limit,
+      pagination.offset
+    );
     const runs = await this.getDataMartRunsService.run(command);
     return this.mapper.toRunsResponse(runs);
   }

--- a/apps/backend/src/data-marts/controllers/data-mart.controller.ts
+++ b/apps/backend/src/data-marts/controllers/data-mart.controller.ts
@@ -79,7 +79,6 @@ import {
   ValidateDataMartDefinitionSpec,
   DataMartAiHelperAvailabilitySpec,
 } from './spec/data-mart.api';
-import { normalizeProjectListPagination } from '../utils/normalize-project-list-pagination';
 
 @Controller('data-marts')
 @ApiTags('DataMarts')
@@ -350,16 +349,10 @@ export class DataMartController {
   async getRunHistory(
     @AuthContext() context: AuthorizationContext,
     @Param('id') id: string,
-    @Query('limit') limit?: string | number,
-    @Query('offset') offset?: string | number
+    @Query('limit') limit: number = 100,
+    @Query('offset') offset: number = 0
   ): Promise<DataMartRunsResponseApiDto> {
-    const pagination = normalizeProjectListPagination(limit, offset);
-    const command = this.mapper.toGetDataMartRunsCommand(
-      id,
-      context,
-      pagination.limit,
-      pagination.offset
-    );
+    const command = this.mapper.toGetDataMartRunsCommand(id, context, limit, offset);
     const runs = await this.getDataMartRunsService.run(command);
     return this.mapper.toRunsResponse(runs);
   }

--- a/apps/backend/src/data-marts/controllers/project-data-mart-runs.controller.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/project-data-mart-runs.controller.openapi.spec.ts
@@ -152,6 +152,7 @@ describe('ProjectDataMartRunsController OpenAPI', () => {
         'finishedAt',
         'additionalParams',
         'totals',
+        'qualitySummary',
         'dataMart',
         'createdByUser',
       ],

--- a/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
@@ -33,11 +33,7 @@ import { UpdateEntityContextsRequestApiDto } from '../../dto/presentation/contex
 import { DATA_MARTS_PAGE_SIZE } from '../../use-cases/list-data-marts.service';
 import { BatchDataMartDataLastUpdatedResponseApiDto } from '../../dto/presentation/data-mart-data-last-updated-response-api.dto';
 import { RefreshDataMartDataLastUpdatedRequestApiDto } from '../../dto/presentation/refresh-data-mart-data-last-updated-request-api.dto';
-import {
-  DEFAULT_PROJECT_LIST_LIMIT,
-  MAX_PROJECT_LIST_LIMIT,
-  MAX_PROJECT_LIST_OFFSET,
-} from '../../utils/normalize-project-list-pagination';
+import { DEFAULT_PROJECT_LIST_LIMIT } from '../../utils/normalize-project-list-pagination';
 
 export function CreateDataMartSpec() {
   return applyDecorators(
@@ -221,8 +217,6 @@ export function GetDataMartRunsSpec() {
       required: false,
       type: Number,
       default: DEFAULT_PROJECT_LIST_LIMIT,
-      minimum: 1,
-      maximum: MAX_PROJECT_LIST_LIMIT,
       description:
         'Maximum number of runs to return. Non-positive or non-finite values use the default; fractions are floored and larger values are capped.',
     }),
@@ -231,8 +225,6 @@ export function GetDataMartRunsSpec() {
       required: false,
       type: Number,
       default: 0,
-      minimum: 0,
-      maximum: MAX_PROJECT_LIST_OFFSET,
       description:
         'Number of runs to skip. Non-positive or non-finite values use zero; fractions are floored and larger values are capped.',
     }),

--- a/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
@@ -27,11 +27,17 @@ import { DataMartRunDetailResponseApiDto } from '../../dto/presentation/data-mar
 import { UpdateDataMartOwnersApiDto } from '../../dto/presentation/update-data-mart-owners-api.dto';
 import { PaginatedDataMartsResponseApiDto } from '../../dto/presentation/paginated-data-marts-response-api.dto';
 import { RunDataMartRequestApiDto } from '../../dto/presentation/run-data-mart-request-api.dto';
+import { RunDataMartResponseApiDto } from '../../dto/presentation/run-data-mart-response-api.dto';
 import { UpdateDataMartAvailabilityApiDto } from '../../dto/presentation/update-availability-api.dto';
 import { UpdateEntityContextsRequestApiDto } from '../../dto/presentation/context-api.dto';
 import { DATA_MARTS_PAGE_SIZE } from '../../use-cases/list-data-marts.service';
 import { BatchDataMartDataLastUpdatedResponseApiDto } from '../../dto/presentation/data-mart-data-last-updated-response-api.dto';
 import { RefreshDataMartDataLastUpdatedRequestApiDto } from '../../dto/presentation/refresh-data-mart-data-last-updated-request-api.dto';
+import {
+  DEFAULT_PROJECT_LIST_LIMIT,
+  MAX_PROJECT_LIST_LIMIT,
+  MAX_PROJECT_LIST_OFFSET,
+} from '../../utils/normalize-project-list-pagination';
 
 export function CreateDataMartSpec() {
   return applyDecorators(
@@ -168,24 +174,20 @@ export function DeleteDataMartSpec() {
 
 export function RunDataMartSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'Manual run DataMart' }),
-    ApiParam({ name: 'id', description: 'DataMart ID' }),
+    ApiOperation({
+      summary: 'Start a manual Data Mart run',
+      description:
+        'Starts a connector Data Mart run. Technical User access to the Data Mart is required.',
+    }),
+    ApiParam({ name: 'id', description: 'Data Mart ID' }),
     ApiBody({ type: RunDataMartRequestApiDto, required: false }),
     ApiResponse({
       status: 201,
       description: 'DataMart run created',
-      schema: {
-        type: 'object',
-        required: ['runId'],
-        properties: {
-          runId: {
-            type: 'string',
-            format: 'uuid',
-            example: '123e4567-e89b-12d3-a456-426614174000',
-          },
-        },
-      },
-    })
+      type: RunDataMartResponseApiDto,
+    }),
+    ApiResponse({ status: 400, description: 'Invalid payload or unsupported Data Mart type' }),
+    ApiResponse({ status: 404, description: 'Data Mart not found' })
   );
 }
 
@@ -208,32 +210,53 @@ export function UpdateDataMartSchemaSpec() {
 
 export function GetDataMartRunsSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'Get DataMart run history' }),
-    ApiParam({ name: 'id', description: 'DataMart ID' }),
+    ApiOperation({
+      summary: 'List Data Mart runs',
+      description:
+        'Returns newest-first run history for one visible Data Mart. Business User access is required.',
+    }),
+    ApiParam({ name: 'id', description: 'Data Mart ID' }),
     ApiQuery({
       name: 'limit',
       required: false,
       type: Number,
-      example: 100,
-      description: 'Maximum number of runs to return. Defaults to 100.',
+      default: DEFAULT_PROJECT_LIST_LIMIT,
+      minimum: 1,
+      maximum: MAX_PROJECT_LIST_LIMIT,
+      description:
+        'Maximum number of runs to return. Non-positive or non-finite values use the default; fractions are floored and larger values are capped.',
     }),
     ApiQuery({
       name: 'offset',
       required: false,
       type: Number,
-      example: 0,
-      description: 'Number of runs to skip before returning results',
+      default: 0,
+      minimum: 0,
+      maximum: MAX_PROJECT_LIST_OFFSET,
+      description:
+        'Number of runs to skip. Non-positive or non-finite values use zero; fractions are floored and larger values are capped.',
     }),
-    ApiOkResponse({ type: DataMartRunsResponseApiDto })
+    ApiOkResponse({
+      description: 'Newest-first page of Data Mart runs.',
+      type: DataMartRunsResponseApiDto,
+    }),
+    ApiResponse({ status: 404, description: 'Data Mart not found' })
   );
 }
 
 export function CancelDataMartRunSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'Cancel a DataMart run' }),
-    ApiParam({ name: 'id', description: 'DataMart ID' }),
+    ApiOperation({
+      summary: 'Cancel a Data Mart run',
+      description:
+        'Cancels an active connector, standard report, or Data Quality run. Technical User access to the Data Mart is required.',
+    }),
+    ApiParam({ name: 'id', description: 'Data Mart ID' }),
     ApiParam({ name: 'runId', description: 'Run ID' }),
-    ApiNoContentResponse({ description: 'DataMart run cancelled' })
+    ApiNoContentResponse({ description: 'Data Mart run cancelled' }),
+    ApiResponse({ status: 400, description: 'The run type cannot be cancelled' }),
+    ApiResponse({ status: 404, description: 'Data Mart or run not found' }),
+    ApiResponse({ status: 409, description: 'The run is no longer active' })
   );
 }
 
@@ -247,10 +270,15 @@ export function ListDataMartsByConnectorNameSpec() {
 
 export function GetDataMartRunByIdSpec() {
   return applyDecorators(
-    ApiOperation({ summary: 'Get DataMart run by ID' }),
-    ApiParam({ name: 'id', description: 'DataMart ID' }),
+    ApiOperation({
+      summary: 'Get a Data Mart run',
+      description:
+        'Returns one run belonging to a visible Data Mart, including Data Quality detail when applicable. Business User access is required.',
+    }),
+    ApiParam({ name: 'id', description: 'Data Mart ID' }),
     ApiParam({ name: 'runId', description: 'Run ID' }),
-    ApiOkResponse({ type: DataMartRunDetailResponseApiDto })
+    ApiOkResponse({ type: DataMartRunDetailResponseApiDto }),
+    ApiResponse({ status: 404, description: 'Data Mart or run not found' })
   );
 }
 

--- a/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/data-mart.api.ts
@@ -182,7 +182,10 @@ export function RunDataMartSpec() {
       description: 'DataMart run created',
       type: RunDataMartResponseApiDto,
     }),
-    ApiResponse({ status: 400, description: 'Invalid payload or unsupported Data Mart type' }),
+    ApiResponse({
+      status: 400,
+      description: 'Invalid payload, unsupported Data Mart type, or unpublished Data Mart',
+    }),
     ApiResponse({ status: 404, description: 'Data Mart not found' })
   );
 }
@@ -217,16 +220,14 @@ export function GetDataMartRunsSpec() {
       required: false,
       type: Number,
       default: DEFAULT_PROJECT_LIST_LIMIT,
-      description:
-        'Maximum number of runs to return. Non-positive or non-finite values use the default; fractions are floored and larger values are capped.',
+      description: 'Maximum number of runs to return. Defaults to 100 when omitted.',
     }),
     ApiQuery({
       name: 'offset',
       required: false,
       type: Number,
       default: 0,
-      description:
-        'Number of runs to skip. Non-positive or non-finite values use zero; fractions are floored and larger values are capped.',
+      description: 'Number of runs to skip. Defaults to zero when omitted.',
     }),
     ApiOkResponse({
       description: 'Newest-first page of Data Mart runs.',

--- a/apps/backend/src/data-marts/dto/presentation/data-mart-run-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-mart-run-response-api.dto.ts
@@ -53,27 +53,24 @@ export class DataMartRunResponseApiDto {
     description: 'Current run lifecycle status.',
     enum: DataMartRunStatus,
     enumName: 'DataMartRunStatus',
-    nullable: true,
   })
-  status: DataMartRunStatus | null;
+  status: DataMartRunStatus;
 
   @ApiProperty({
     example: 'CONNECTOR',
     description: 'Execution category that produced the run.',
     enum: DataMartRunType,
     enumName: 'DataMartRunType',
-    nullable: true,
   })
-  type: DataMartRunType | null;
+  type: DataMartRunType;
 
   @ApiProperty({
     example: 'manual',
     description: 'Run trigger type (manual, scheduled)',
     enum: RunType,
     enumName: 'RunType',
-    nullable: true,
   })
-  runType: RunType | null;
+  runType: RunType;
 
   @ApiProperty({ example: 'a5c9b1d2-3456-7890-abcd-ef0123456789' })
   dataMartId: string;

--- a/apps/backend/src/data-marts/dto/presentation/data-mart-run-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-mart-run-response-api.dto.ts
@@ -207,7 +207,7 @@ export class DataMartRunResponseApiDto {
   })
   additionalParams: Record<string, unknown> | null;
 
-  @DataMartRunTotalsApiProperty()
+  @DataMartRunTotalsApiProperty(true)
   totals: DataMartRunTotals;
 
   @ApiProperty({ type: CompactDataQualitySummaryApiDto, nullable: true })

--- a/apps/backend/src/data-marts/dto/presentation/data-mart-run-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/data-mart-run-response-api.dto.ts
@@ -213,11 +213,11 @@ export class DataMartRunResponseApiDto {
   @DataMartRunTotalsApiProperty()
   totals: DataMartRunTotals;
 
-  @ApiProperty({ type: CompactDataQualitySummaryApiDto, required: false, nullable: true })
+  @ApiProperty({ type: CompactDataQualitySummaryApiDto, nullable: true })
   qualitySummary: CompactDataQualitySummaryApiDto | null;
 }
 
 export class DataMartRunDetailResponseApiDto extends DataMartRunResponseApiDto {
-  @ApiProperty({ type: DataQualityRunDetailsResponseApiDto, required: false, nullable: true })
-  dataQuality?: DataQualityRunDetailsDto | null;
+  @ApiProperty({ type: DataQualityRunDetailsResponseApiDto, nullable: true })
+  dataQuality: DataQualityRunDetailsDto | null;
 }

--- a/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.spec.ts
+++ b/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.spec.ts
@@ -15,6 +15,19 @@ describe('RunDataMartRequestApiDto', () => {
     );
   });
 
+  it('rejects an explicit null payload instead of treating it as omitted', async () => {
+    const dto = Object.assign(new RunDataMartRequestApiDto(), { payload: null });
+
+    await expect(validate(dto)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          property: 'payload',
+          constraints: expect.objectContaining({ isObject: expect.any(String) }),
+        }),
+      ])
+    );
+  });
+
   it('rejects a payload larger than the documented one-megabyte limit', async () => {
     const dto = Object.assign(new RunDataMartRequestApiDto(), {
       payload: { value: 'x'.repeat(1024 * 1024) },

--- a/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.spec.ts
+++ b/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.spec.ts
@@ -29,4 +29,33 @@ describe('RunDataMartRequestApiDto', () => {
       ])
     );
   });
+
+  it.each([
+    { data: { StartDate: '2026-07-01' } },
+    { runType: 'MANUAL_BACKFILL' },
+    { runType: 'INCREMENTAL', data: {} },
+    { runType: 'INCREMENTAL', typo: true },
+  ])('rejects a payload whose run type and data do not form a supported pair', async payload => {
+    const dto = Object.assign(new RunDataMartRequestApiDto(), { payload });
+
+    await expect(validate(dto)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          property: 'payload',
+          constraints: expect.objectContaining({ isRunDataMartPayload: expect.any(String) }),
+        }),
+      ])
+    );
+  });
+
+  it('accepts explicit manual-backfill data', async () => {
+    const dto = Object.assign(new RunDataMartRequestApiDto(), {
+      payload: {
+        runType: 'MANUAL_BACKFILL',
+        data: { StartDate: '2026-07-01', EndDate: '2026-07-31' },
+      },
+    });
+
+    await expect(validate(dto)).resolves.toEqual([]);
+  });
 });

--- a/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.spec.ts
+++ b/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.spec.ts
@@ -1,0 +1,32 @@
+import { validate } from 'class-validator';
+import { RunDataMartRequestApiDto } from './run-data-mart-request-api.dto';
+
+describe('RunDataMartRequestApiDto', () => {
+  it('rejects a primitive payload that cannot satisfy the documented object contract', async () => {
+    const dto = Object.assign(new RunDataMartRequestApiDto(), { payload: 'not-an-object' });
+
+    await expect(validate(dto)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          property: 'payload',
+          constraints: expect.objectContaining({ isObject: expect.any(String) }),
+        }),
+      ])
+    );
+  });
+
+  it('rejects a payload larger than the documented one-megabyte limit', async () => {
+    const dto = Object.assign(new RunDataMartRequestApiDto(), {
+      payload: { value: 'x'.repeat(1024 * 1024) },
+    });
+
+    await expect(validate(dto)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          property: 'payload',
+          constraints: expect.objectContaining({ maxJsonSize: expect.any(String) }),
+        }),
+      ])
+    );
+  });
+});

--- a/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.spec.ts
+++ b/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.spec.ts
@@ -44,9 +44,8 @@ describe('RunDataMartRequestApiDto', () => {
   });
 
   it.each([
-    { data: { StartDate: '2026-07-01' } },
-    { runType: 'MANUAL_BACKFILL' },
-    { runType: 'INCREMENTAL', data: {} },
+    { runType: 'FULL_REFRESH' },
+    { runType: 'MANUAL_BACKFILL', data: [] },
     { runType: 'INCREMENTAL', typo: true },
   ])('rejects a payload whose run type and data do not form a supported pair', async payload => {
     const dto = Object.assign(new RunDataMartRequestApiDto(), { payload });
@@ -68,6 +67,15 @@ describe('RunDataMartRequestApiDto', () => {
         data: { StartDate: '2026-07-01', EndDate: '2026-07-31' },
       },
     });
+
+    await expect(validate(dto)).resolves.toEqual([]);
+  });
+
+  it.each([
+    { runType: 'INCREMENTAL', data: { StartDate: '2026-07-01' } },
+    { runType: 'MANUAL_BACKFILL' },
+  ])('accepts connector payload variants produced by the existing run form', async payload => {
+    const dto = Object.assign(new RunDataMartRequestApiDto(), { payload });
 
     await expect(validate(dto)).resolves.toEqual([]);
   });

--- a/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.ts
@@ -22,14 +22,12 @@ function IsRunDataMartPayload(validationOptions?: ValidationOptions) {
         validate(value: unknown): boolean {
           if (!isRecord(value)) return false;
           if (Object.keys(value).some(key => key !== 'runType' && key !== 'data')) return false;
-          if (value.runType === 'MANUAL_BACKFILL') return isRecord(value.data);
-          return (
-            (value.runType === undefined || value.runType === 'INCREMENTAL') &&
-            value.data === undefined
-          );
+          const hasValidData = value.data === undefined || isRecord(value.data);
+          if (value.runType === 'MANUAL_BACKFILL') return hasValidData;
+          return (value.runType === undefined || value.runType === 'INCREMENTAL') && hasValidData;
         },
         defaultMessage: () =>
-          'payload must be incremental without data, or MANUAL_BACKFILL with object data',
+          'payload must select INCREMENTAL or MANUAL_BACKFILL and use object data when provided',
       },
     },
     validationOptions
@@ -54,6 +52,13 @@ const manualBackfillSchema: ClosedApiSchemaOptions = {
 export class IncrementalRunDataMartPayloadApiDto {
   @ApiPropertyOptional({ enum: ['INCREMENTAL'], default: 'INCREMENTAL' })
   runType?: 'INCREMENTAL';
+
+  @ApiPropertyOptional({
+    type: Object,
+    additionalProperties: true,
+    description: 'Connector-specific fields retained for compatibility with existing run forms.',
+  })
+  data?: Record<string, unknown>;
 }
 
 @ApiSchema(manualBackfillSchema)
@@ -61,19 +66,19 @@ export class ManualBackfillRunDataMartPayloadApiDto {
   @ApiProperty({ enum: ['MANUAL_BACKFILL'] })
   runType: 'MANUAL_BACKFILL';
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     type: Object,
     additionalProperties: true,
-    description: 'Connector-specific manual-backfill fields.',
+    description: 'Connector-specific manual-backfill fields, when the connector defines them.',
   })
-  data: Record<string, unknown>;
+  data?: Record<string, unknown>;
 }
 
 @ApiExtraModels(IncrementalRunDataMartPayloadApiDto, ManualBackfillRunDataMartPayloadApiDto)
 export class RunDataMartRequestApiDto {
   /**
-   * Payload for the manual run. Omit it or select INCREMENTAL without data for an incremental run.
-   * MANUAL_BACKFILL requires connector-specific fields in data.
+   * Payload for the manual run. Omit it or select INCREMENTAL for an incremental run.
+   * MANUAL_BACKFILL can include connector-specific fields in data.
    */
   @ValidateIf((_object, value: unknown) => value !== undefined)
   @IsObject()
@@ -88,8 +93,8 @@ export class RunDataMartRequestApiDto {
       runType: 'MANUAL_BACKFILL',
       data: { StartDate: '2026-07-01', EndDate: '2026-07-31' },
     },
-    description: `Payload for the manual run. Omit it or select INCREMENTAL without data for an incremental run.
-    MANUAL_BACKFILL requires connector-specific fields in data.`,
+    description: `Payload for the manual run. Omit it or select INCREMENTAL for an incremental run.
+    MANUAL_BACKFILL can include connector-specific fields in data.`,
   })
   payload?: Record<string, unknown> | undefined;
 }

--- a/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.ts
@@ -1,24 +1,95 @@
-import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsObject, IsOptional } from 'class-validator';
+import {
+  ApiExtraModels,
+  ApiProperty,
+  ApiPropertyOptional,
+  ApiSchema,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { IsObject, IsOptional, ValidateBy, type ValidationOptions } from 'class-validator';
 import { MaxJsonSize } from '../../../common/validators/max-json-size.validator';
 
 const MAX_PAYLOAD_SIZE_BYTES = 1024 * 1024; // 1MB
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function IsRunDataMartPayload(validationOptions?: ValidationOptions) {
+  return ValidateBy(
+    {
+      name: 'isRunDataMartPayload',
+      validator: {
+        validate(value: unknown): boolean {
+          if (!isRecord(value)) return false;
+          if (Object.keys(value).some(key => key !== 'runType' && key !== 'data')) return false;
+          if (value.runType === 'MANUAL_BACKFILL') return isRecord(value.data);
+          return (
+            (value.runType === undefined || value.runType === 'INCREMENTAL') &&
+            value.data === undefined
+          );
+        },
+        defaultMessage: () =>
+          'payload must be incremental without data, or MANUAL_BACKFILL with object data',
+      },
+    },
+    validationOptions
+  );
+}
+
+type ClosedApiSchemaOptions = NonNullable<Parameters<typeof ApiSchema>[0]> & {
+  additionalProperties: false;
+};
+
+const incrementalSchema: ClosedApiSchemaOptions = {
+  description: 'Incremental connector run options.',
+  additionalProperties: false,
+};
+
+const manualBackfillSchema: ClosedApiSchemaOptions = {
+  description: 'Manual-backfill connector run options.',
+  additionalProperties: false,
+};
+
+@ApiSchema(incrementalSchema)
+export class IncrementalRunDataMartPayloadApiDto {
+  @ApiPropertyOptional({ enum: ['INCREMENTAL'], default: 'INCREMENTAL' })
+  runType?: 'INCREMENTAL';
+}
+
+@ApiSchema(manualBackfillSchema)
+export class ManualBackfillRunDataMartPayloadApiDto {
+  @ApiProperty({ enum: ['MANUAL_BACKFILL'] })
+  runType: 'MANUAL_BACKFILL';
+
+  @ApiProperty({
+    type: Object,
+    additionalProperties: true,
+    description: 'Connector-specific manual-backfill fields.',
+  })
+  data: Record<string, unknown>;
+}
+
+@ApiExtraModels(IncrementalRunDataMartPayloadApiDto, ManualBackfillRunDataMartPayloadApiDto)
 export class RunDataMartRequestApiDto {
   /**
-   * Payload for the manual run. If not provided, the data mart will be run with the default payload.
-   * The payload is specific to the data mart definition type.
-   * For example, for a connector data mart, the payload is the connector configuration fields with unknown structure.
+   * Payload for the manual run. Omit it or select INCREMENTAL without data for an incremental run.
+   * MANUAL_BACKFILL requires connector-specific fields in data.
    */
   @IsOptional()
   @IsObject()
+  @IsRunDataMartPayload()
   @MaxJsonSize(MAX_PAYLOAD_SIZE_BYTES)
   @ApiPropertyOptional({
-    example: { key: 'value' },
-    description: `Payload for the manual run.
-    If not provided, the data mart will be run with the default payload.
-    The payload is specific to the data mart definition type.
-    For example, for a connector data mart, the payload is the connector configuration fields with unknown structure.`,
+    oneOf: [
+      { $ref: getSchemaPath(IncrementalRunDataMartPayloadApiDto) },
+      { $ref: getSchemaPath(ManualBackfillRunDataMartPayloadApiDto) },
+    ],
+    example: {
+      runType: 'MANUAL_BACKFILL',
+      data: { StartDate: '2026-07-01', EndDate: '2026-07-31' },
+    },
+    description: `Payload for the manual run. Omit it or select INCREMENTAL without data for an incremental run.
+    MANUAL_BACKFILL requires connector-specific fields in data.`,
   })
   payload?: Record<string, unknown> | undefined;
 }

--- a/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.ts
@@ -5,7 +5,7 @@ import {
   ApiSchema,
   getSchemaPath,
 } from '@nestjs/swagger';
-import { IsObject, IsOptional, ValidateBy, type ValidationOptions } from 'class-validator';
+import { IsObject, ValidateBy, ValidateIf, type ValidationOptions } from 'class-validator';
 import { MaxJsonSize } from '../../../common/validators/max-json-size.validator';
 
 const MAX_PAYLOAD_SIZE_BYTES = 1024 * 1024; // 1MB
@@ -75,7 +75,7 @@ export class RunDataMartRequestApiDto {
    * Payload for the manual run. Omit it or select INCREMENTAL without data for an incremental run.
    * MANUAL_BACKFILL requires connector-specific fields in data.
    */
-  @IsOptional()
+  @ValidateIf((_object, value: unknown) => value !== undefined)
   @IsObject()
   @IsRunDataMartPayload()
   @MaxJsonSize(MAX_PAYLOAD_SIZE_BYTES)

--- a/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/run-data-mart-request-api.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional } from 'class-validator';
+import { IsObject, IsOptional } from 'class-validator';
 import { MaxJsonSize } from '../../../common/validators/max-json-size.validator';
 
 const MAX_PAYLOAD_SIZE_BYTES = 1024 * 1024; // 1MB
@@ -11,6 +11,7 @@ export class RunDataMartRequestApiDto {
    * For example, for a connector data mart, the payload is the connector configuration fields with unknown structure.
    */
   @IsOptional()
+  @IsObject()
   @MaxJsonSize(MAX_PAYLOAD_SIZE_BYTES)
   @ApiPropertyOptional({
     example: { key: 'value' },

--- a/apps/backend/src/data-marts/dto/presentation/run-data-mart-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/run-data-mart-response-api.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RunDataMartResponseApiDto {
+  @ApiProperty({
+    format: 'uuid',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    description: 'Identifier of the newly created Data Mart run.',
+  })
+  runId: string;
+}

--- a/apps/backend/src/data-marts/use-cases/run-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-data-mart.service.spec.ts
@@ -4,12 +4,14 @@ import { RunDataMartCommand } from '../dto/domain/run-data-mart.command';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { ValidationResultCode } from '../data-storage-types/interfaces/data-storage-access-validator.interface';
 import { CredentialsExpiredException } from '../exceptions/google-oauth.exceptions';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
 
 describe('RunDataMartService', () => {
   const mockDataMart = {
     id: 'dm-1',
     projectId: 'proj-1',
     definitionType: DataMartDefinitionType.CONNECTOR,
+    status: DataMartStatus.PUBLISHED,
     storage: {
       id: 'storage-1',
       type: 'GOOGLE_BIGQUERY',
@@ -100,6 +102,26 @@ describe('RunDataMartService', () => {
     dataMartService.getByIdAndProjectId.mockResolvedValue({
       ...mockDataMart,
       definitionType: DataMartDefinitionType.SQL,
+    });
+
+    const command = new RunDataMartCommand(
+      'dm-1',
+      'proj-1',
+      'user-1',
+      'manual' as never,
+      undefined,
+      ['editor']
+    );
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(BadRequestException);
+    expect(connectorExecutionService.run).not.toHaveBeenCalled();
+  });
+
+  it('returns a bad request instead of dispatching an unpublished connector Data Mart', async () => {
+    const { service, dataMartService, connectorExecutionService } = createService();
+    dataMartService.getByIdAndProjectId.mockResolvedValue({
+      ...mockDataMart,
+      status: DataMartStatus.DRAFT,
     });
 
     const command = new RunDataMartCommand(

--- a/apps/backend/src/data-marts/use-cases/run-data-mart.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/run-data-mart.service.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { RunDataMartService } from './run-data-mart.service';
 import { RunDataMartCommand } from '../dto/domain/run-data-mart.command';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
@@ -93,6 +93,26 @@ describe('RunDataMartService', () => {
     );
 
     await expect(service.run(command)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('returns a bad request when a manual run targets a non-connector Data Mart', async () => {
+    const { service, dataMartService, connectorExecutionService } = createService();
+    dataMartService.getByIdAndProjectId.mockResolvedValue({
+      ...mockDataMart,
+      definitionType: DataMartDefinitionType.SQL,
+    });
+
+    const command = new RunDataMartCommand(
+      'dm-1',
+      'proj-1',
+      'user-1',
+      'manual' as never,
+      undefined,
+      ['editor']
+    );
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(BadRequestException);
+    expect(connectorExecutionService.run).not.toHaveBeenCalled();
   });
 
   it('should skip access check for scheduled runs (roles=[])', async () => {

--- a/apps/backend/src/data-marts/use-cases/run-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-data-mart.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ForbiddenException, Logger } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { DataMartService } from '../services/data-mart.service';
 import { DataMartDefinitionType } from '../enums/data-mart-definition-type.enum';
 import { ConnectorExecutionService } from '../services/connector/connector-execution.service';
@@ -44,7 +44,9 @@ export class RunDataMartService {
     }
 
     if (dataMart.definitionType !== DataMartDefinitionType.CONNECTOR) {
-      throw new Error('Only data marts with connector definition type can be run manually');
+      throw new BadRequestException(
+        'Only data marts with connector definition type can be run manually'
+      );
     }
 
     // Pre-check is for user-initiated runs only, where it surfaces an immediate, clear error.

--- a/apps/backend/src/data-marts/use-cases/run-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/run-data-mart.service.ts
@@ -11,6 +11,7 @@ import { DataStorageCredentialsResolver } from '../data-storage-types/data-stora
 import { ValidationResultCode } from '../data-storage-types/interfaces/data-storage-access-validator.interface';
 import { CredentialsExpiredException } from '../exceptions/google-oauth.exceptions';
 import { isBigQueryOAuthCredentials } from '../data-storage-types/data-storage-credentials.guards';
+import { DataMartStatus } from '../enums/data-mart-status.enum';
 
 @Injectable()
 export class RunDataMartService {
@@ -47,6 +48,10 @@ export class RunDataMartService {
       throw new BadRequestException(
         'Only data marts with connector definition type can be run manually'
       );
+    }
+
+    if (command.runType === RunType.manual && dataMart.status !== DataMartStatus.PUBLISHED) {
+      throw new BadRequestException('Only published data marts can be run manually');
     }
 
     // Pre-check is for user-initiated runs only, where it surfaces an immediate, clear error.

--- a/apps/backend/test/data-mart-runs.e2e-spec.ts
+++ b/apps/backend/test/data-mart-runs.e2e-spec.ts
@@ -130,4 +130,47 @@ describe('DataMart Manual Runs API (e2e)', () => {
 
     expect(res.status).toBe(404);
   });
+
+  it('parses a manual-run request larger than the framework default before routing it', async () => {
+    const res = await agent
+      .post(`/api/data-marts/${NONEXISTENT_UUID}/manual-run`)
+      .set(AUTH_HEADER)
+      .send({
+        payload: {
+          runType: 'MANUAL_BACKFILL',
+          data: { value: 'x'.repeat(150 * 1024) },
+        },
+      });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects a manual-run payload larger than 1 MiB through HTTP validation', async () => {
+    const res = await agent
+      .post(`/api/data-marts/${NONEXISTENT_UUID}/manual-run`)
+      .set(AUTH_HEADER)
+      .send({
+        payload: {
+          runType: 'MANUAL_BACKFILL',
+          data: { value: 'x'.repeat(1024 * 1024) },
+        },
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 413 instead of 500 when the request exceeds the transport ceiling', async () => {
+    const res = await agent
+      .post(`/api/data-marts/${NONEXISTENT_UUID}/manual-run`)
+      .set(AUTH_HEADER)
+      .send({
+        payload: {
+          runType: 'MANUAL_BACKFILL',
+          data: { value: 'x'.repeat(2 * 1024 * 1024) },
+        },
+      });
+
+    expect(res.status).toBe(413);
+    expect(res.body).toMatchObject({ statusCode: 413, message: 'Request body too large' });
+  });
 });

--- a/apps/docs/scripts/api-coverage-matrix.mjs
+++ b/apps/docs/scripts/api-coverage-matrix.mjs
@@ -32,6 +32,34 @@ const COVERED_TARGETS = new Map([
     },
   ],
   [
+    'POST /api/data-marts/{id}/manual-run',
+    {
+      OpenAPI: 'https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_manualRun',
+      'API client': './api-client/#manage-data-mart-runs',
+    },
+  ],
+  [
+    'GET /api/data-marts/{id}/runs',
+    {
+      OpenAPI: 'https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_getRunHistory',
+      'API client': './api-client/#manage-data-mart-runs',
+    },
+  ],
+  [
+    'GET /api/data-marts/{id}/runs/{runId}',
+    {
+      OpenAPI: 'https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_getRunById',
+      'API client': './api-client/#manage-data-mart-runs',
+    },
+  ],
+  [
+    'POST /api/data-marts/{id}/runs/{runId}/cancel',
+    {
+      OpenAPI: 'https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_cancelRun',
+      'API client': './api-client/#manage-data-mart-runs',
+    },
+  ],
+  [
     'GET /api/external/http-data/data-marts/{dataMartId}.ndjson',
     {
       OpenAPI: 'https://app.owox.com/api/swagger-ui#/HTTP%20Data/HttpDataController_stream',

--- a/apps/owox/test/integration/idp-body-parser.test.ts
+++ b/apps/owox/test/integration/idp-body-parser.test.ts
@@ -1,0 +1,48 @@
+import { OwoxBetterAuthIdp } from '@owox/idp-owox-better-auth';
+import { expect } from 'chai';
+import express from 'express';
+import request from 'supertest';
+
+function createProvider(): OwoxBetterAuthIdp {
+  return Object.assign(Object.create(OwoxBetterAuthIdp.prototype), {
+    authErrorController: { registerRoutes: () => null },
+    authFlowMiddleware: { idpStartMiddleware: () => null },
+    betterAuthProxyHandler: { setupBetterAuthHandler: () => null },
+    googleSheetsAuthController: { registerRoutes: () => null },
+    onboardingController: { registerRoutes: () => null },
+    pageController: { registerRoutes: () => null },
+    passwordFlowController: { registerRoutes: () => null },
+  }) as OwoxBetterAuthIdp;
+}
+
+describe('packaged IDP body parsing', () => {
+  it('does not apply the auth parser limit to backend API routes', async () => {
+    const app = express();
+    createProvider().registerRoutes(app);
+
+    app.use(express.json({ limit: '2mb' }));
+    app.post('/api/body-parser-probe', (req, res) => {
+      res.json({ size: req.body.value.length });
+    });
+
+    const value = 'x'.repeat(128 * 1024);
+    const response = await request(app).post('/api/body-parser-probe').send({ value });
+
+    expect(response.status).to.equal(200);
+    expect(response.body).to.deep.equal({ size: value.length });
+  });
+
+  it('still parses JSON bodies for auth routes', async () => {
+    const app = express();
+    createProvider().registerRoutes(app);
+
+    app.post('/auth/body-parser-probe', (req, res) => {
+      res.json(req.body);
+    });
+
+    const response = await request(app).post('/auth/body-parser-probe').send({ parsed: true });
+
+    expect(response.status).to.equal(200);
+    expect(response.body).to.deep.equal({ parsed: true });
+  });
+});

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -301,9 +301,10 @@ authentication or any network request.
 
 Create a Data-Mart-scoped run client with `runs.forDataMart(dataMartId)`. Its `start(options)` method
 starts a manual connector run and requires Technical User access to the Data Mart. Omit the options
-for an incremental run, or set `runType` to `MANUAL_BACKFILL` and pass the connector-specific
-backfill fields in `data`. The method returns the new run ID. The serialized options must not exceed
-1 MB.
+for an incremental run, or set `runType` to `MANUAL_BACKFILL` and pass any connector-specific
+backfill fields in `data`. Connectors without backfill fields can omit `data`. Object-valued `data`
+is also accepted for incremental runs for compatibility with existing run forms that retain hidden
+field values. The method returns the new run ID. The serialized options must not exceed 1 MB.
 
 ```ts
 const dataMartRuns = client.runs.forDataMart('data-mart-id');
@@ -359,7 +360,8 @@ The package exports `OWOXDataMartRun`, `OWOXDataMartRunDetail`,
 `OWOXDataMartRunsScope`, and the run and Data Quality enum and nested-object types. The client
 validates response field presence, nullability, enums, RFC 3339 timestamps, totals, author metadata,
 compact Data Quality summaries, and full Data Quality detail. An incompatible response throws
-`OWOXApiError`.
+`OWOXApiError`. Scoped list and detail methods normalize Data Quality fields omitted by older
+self-hosted deployments to `null`.
 
 ## Read the Models canvas
 

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -147,15 +147,14 @@ can also see shared Data Marts available for reporting or maintenance, subject t
 context access; viewers can see shared Data Marts available for reporting, subject to the same
 context-access filter.
 
-Pass a positive safe integer `limit` and a non-negative safe integer `offset` to page through the
-newest-first history. The client rejects invalid values before authentication or a network request.
-When omitted, the server defaults `limit` to 100 and `offset` to 0; it caps them at 100 and 100,000
-respectively.
-The response has no total or next-page marker. Increment `offset` by the number of returned runs and
-stop when a page contains fewer runs than the server-effective limit
-(`Math.min(requestedLimit, 100)`, or 100 when omitted) or the next offset would exceed 100,000.
-Because new runs can shift newest-first offset pages while a consumer is paging, deduplicate by
-`run.id` when walking multiple pages.
+Pass optional `limit` and `offset` values to page through the newest-first history. `limit` defaults
+to 100, floors finite fractions, falls back to 100 for non-finite or non-positive values, and caps
+at 100. `offset` defaults to 0, floors finite fractions, falls back to 0 for non-finite or
+non-positive values, and caps at 100,000. The response has no total or next-page marker. Prefer a
+`limit` from 1 through 100, increment `offset` by the number of returned runs, and stop when a page
+contains fewer runs than the server-normalized effective limit or the next offset would exceed
+100,000. Because new runs can shift newest-first offset pages while a consumer is paging, deduplicate
+by `run.id` when walking multiple pages.
 
 ```ts
 const history = await client.runs.list({ limit: 50, offset: 0 });
@@ -183,7 +182,6 @@ compatibility with older self-hosted deployments that did not return the field.
 nullable fields, logs and errors, totals, and the backend's RFC3339 timestamp profile: uppercase
 `T`/`Z`, seconds from `00` through `59`, optional fractional seconds, and valid numeric offsets. It
 throws `OWOXApiError` when the endpoint returns an incompatible payload.
-Invalid pagination options are rejected before authentication or any network request.
 
 ## List project insight templates
 
@@ -307,6 +305,9 @@ omit `data`. The API client rejects `data` on implicit or explicit incremental r
 authentication or any network request. The backend HTTP endpoint separately tolerates retained
 object-valued `data` on incremental requests for compatibility with existing run forms. The method
 returns the new run ID. The serialized options must not exceed 1 MB.
+
+Data Mart and run IDs must not be blank, dot segments, or contain `/`, `\`, or `%`. The client
+rejects invalid scoped IDs before authentication or any network request.
 
 ```ts
 const dataMartRuns = client.runs.forDataMart('data-mart-id');

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -294,13 +294,16 @@ authentication or any network request.
 
 ## Manage Data Mart runs
 
-Use `runs.start(dataMartId, options)` to start a manual connector run. Technical User access
-to the Data Mart is required. Omit the options for an incremental run, or set `runType` to
-`MANUAL_BACKFILL` and pass the connector-specific backfill fields in `data`. The method returns the
-new run ID. The serialized options must not exceed 1 MB.
+Create a Data-Mart-scoped run client with `runs.forDataMart(dataMartId)`. Its `start(options)` method
+starts a manual connector run and requires Technical User access to the Data Mart. Omit the options
+for an incremental run, or set `runType` to `MANUAL_BACKFILL` and pass the connector-specific
+backfill fields in `data`. The method returns the new run ID. The serialized options must not exceed
+1 MB.
 
 ```ts
-const { runId } = await client.runs.start('data-mart-id', {
+const dataMartRuns = client.runs.forDataMart('data-mart-id');
+
+const { runId } = await dataMartRuns.start({
   runType: 'MANUAL_BACKFILL',
   data: {
     StartDate: '2026-07-01',
@@ -309,19 +312,23 @@ const { runId } = await client.runs.start('data-mart-id', {
 });
 ```
 
-Business Users can inspect runs for a Data Mart they can see. `runs.listForDataMart()` returns a
-newest-first page, while `runs.get()` returns one run and includes full Data Quality detail
-when the run is a Data Quality run.
+Business Users can inspect runs for a Data Mart they can see. The scoped `list()` method returns a
+newest-first page, while `get(runId)` returns one run and includes full Data Quality detail when the
+run is a Data Quality run.
 
 ```ts
-const history = await client.runs.listForDataMart('data-mart-id', {
+const history = await dataMartRuns.list({
   limit: 50,
   offset: 0,
 });
 
-const run = await client.runs.get('data-mart-id', history.runs[0].id);
+const run = await dataMartRuns.get(history.runs[0].id);
 console.log(run.status, run.qualitySummary, run.dataQuality);
 ```
+
+The existing `client.runs.list()` method remains the project-wide run history and includes each
+run's Data Mart reference. The scoped `dataMartRuns.list()` method uses the Data-Mart-specific route
+and omits that redundant reference.
 
 The list endpoint defaults to 100 runs, caps `limit` at 100 and `offset` at 100,000, floors finite
 fractions, and replaces non-finite or non-positive values with its defaults. The response has no
@@ -329,19 +336,20 @@ total or next-page marker. Increment `offset` by the number of returned runs and
 contains fewer runs than the effective limit or the next offset would exceed 100,000. New runs can
 shift offset pages, so deduplicate by `run.id` while paging.
 
-Use `runs.cancel(dataMartId, runId)` to cancel an active connector, standard report, or
-Data Quality run. Technical User access is required. The method resolves with no value after the
-API returns `204 No Content`; cancelling a terminal run returns a conflict error.
+Use the scoped `cancel(runId)` method to cancel an active connector, standard report, or Data Quality
+run. Technical User access is required. The method resolves with no value after the API returns
+`204 No Content`; cancelling a terminal run returns a conflict error.
 
 ```ts
-await client.runs.cancel('data-mart-id', runId);
+await dataMartRuns.cancel(runId);
 ```
 
 The package exports `OWOXDataMartRun`, `OWOXDataMartRunDetail`,
-`OWOXDataMartRunListOptions`, `OWOXDataMartRunStartOptions`, `OWOXDataMartRunsResponse`, and the run
-and Data Quality enum and nested-object types. The client validates response field presence,
-nullability, enums, RFC 3339 timestamps, totals, author metadata, compact Data Quality summaries,
-and full Data Quality detail. An incompatible response throws `OWOXApiError`.
+`OWOXDataMartRunListOptions`, `OWOXDataMartRunStartOptions`, `OWOXDataMartRunsResponse`,
+`OWOXDataMartRunsScope`, and the run and Data Quality enum and nested-object types. The client
+validates response field presence, nullability, enums, RFC 3339 timestamps, totals, author metadata,
+compact Data Quality summaries, and full Data Quality detail. An incompatible response throws
+`OWOXApiError`.
 
 ## Read the Models canvas
 

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -147,12 +147,11 @@ can also see shared Data Marts available for reporting or maintenance, subject t
 context access; viewers can see shared Data Marts available for reporting, subject to the same
 context-access filter.
 
-Pass optional `limit` and `offset` values to page through the newest-first history. `limit` defaults
-to 100, floors finite fractions, falls back to 100 for non-finite or non-positive values, and caps
-at 100. `offset` defaults to 0, floors finite fractions, falls back to 0 for non-finite or
-non-positive values, and caps at 100,000. The response has no total or next-page marker. Prefer a
-`limit` from 1 through 100, increment `offset` by the number of returned runs, and stop when a page
-contains fewer runs than the server-normalized effective limit or the next offset would exceed
+Pass a positive integer `limit` and a non-negative integer `offset` to page through the newest-first
+history. The client rejects invalid values before authentication or a network request. When omitted,
+the server defaults `limit` to 100 and `offset` to 0; it caps them at 100 and 100,000 respectively.
+The response has no total or next-page marker. Increment `offset` by the number of returned runs and
+stop when a page contains fewer runs than the requested limit or the next offset would exceed
 100,000. Because new runs can shift newest-first offset pages while a consumer is paging, deduplicate
 by `run.id` when walking multiple pages.
 
@@ -175,10 +174,14 @@ creator ID or the corresponding user projection is unavailable. When an author i
 `definitionRun` is always present but can be `null` when a historical definition snapshot is
 unavailable.
 
+`qualitySummary` is either the compact Data Quality summary or `null`. It is optional for
+compatibility with older self-hosted deployments that did not return the field.
+
 `@owox/api-client` validates the response shape, enum values, nested references and author data,
 nullable fields, logs and errors, totals, and the backend's RFC3339 timestamp profile: uppercase
 `T`/`Z`, seconds from `00` through `59`, optional fractional seconds, and valid numeric offsets. It
 throws `OWOXApiError` when the endpoint returns an incompatible payload.
+Invalid pagination options are rejected before authentication or any network request.
 
 ## List project insight templates
 
@@ -322,23 +325,28 @@ const history = await dataMartRuns.list({
   offset: 0,
 });
 
-const run = await dataMartRuns.get(history.runs[0].id);
-console.log(run.status, run.qualitySummary, run.dataQuality);
+const [latest] = history.runs;
+if (latest) {
+  const run = await dataMartRuns.get(latest.id);
+  console.log(run.status, run.qualitySummary, run.dataQuality);
+}
 ```
 
 The existing `client.runs.list()` method remains the project-wide run history and includes each
 run's Data Mart reference. The scoped `dataMartRuns.list()` method uses the Data-Mart-specific route
 and omits that redundant reference.
 
-The list endpoint defaults to 100 runs, caps `limit` at 100 and `offset` at 100,000, floors finite
-fractions, and replaces non-finite or non-positive values with its defaults. The response has no
-total or next-page marker. Increment `offset` by the number of returned runs and stop when a page
-contains fewer runs than the effective limit or the next offset would exceed 100,000. New runs can
-shift offset pages, so deduplicate by `run.id` while paging.
+The scoped list endpoint defaults to 100 runs when `limit` is omitted and does not silently cap a
+valid caller-provided limit or offset. The client accepts positive integer limits and non-negative
+integer offsets, and rejects invalid list options before authentication or any network request. The
+response has no total or next-page marker. Increment `offset` by the number of returned runs and stop
+when a page contains fewer runs than the requested limit. New runs can shift offset pages, so
+deduplicate by `run.id` while paging.
 
 Use the scoped `cancel(runId)` method to cancel an active connector, standard report, or Data Quality
 run. Technical User access is required. The method resolves with no value after the API returns
-`204 No Content`; cancelling a terminal run returns a conflict error.
+`204 No Content`. A cancellable run that is already terminal returns a conflict error; a run type
+that does not support cancellation returns a bad-request error.
 
 ```ts
 await dataMartRuns.cancel(runId);

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -151,9 +151,10 @@ Pass a positive integer `limit` and a non-negative integer `offset` to page thro
 history. The client rejects invalid values before authentication or a network request. When omitted,
 the server defaults `limit` to 100 and `offset` to 0; it caps them at 100 and 100,000 respectively.
 The response has no total or next-page marker. Increment `offset` by the number of returned runs and
-stop when a page contains fewer runs than the requested limit or the next offset would exceed
-100,000. Because new runs can shift newest-first offset pages while a consumer is paging, deduplicate
-by `run.id` when walking multiple pages.
+stop when a page contains fewer runs than the server-effective limit
+(`Math.min(requestedLimit, 100)`, or 100 when omitted) or the next offset would exceed 100,000.
+Because new runs can shift newest-first offset pages while a consumer is paging, deduplicate by
+`run.id` when walking multiple pages.
 
 ```ts
 const history = await client.runs.list({ limit: 50, offset: 0 });

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -147,9 +147,10 @@ can also see shared Data Marts available for reporting or maintenance, subject t
 context access; viewers can see shared Data Marts available for reporting, subject to the same
 context-access filter.
 
-Pass a positive integer `limit` and a non-negative integer `offset` to page through the newest-first
-history. The client rejects invalid values before authentication or a network request. When omitted,
-the server defaults `limit` to 100 and `offset` to 0; it caps them at 100 and 100,000 respectively.
+Pass a positive safe integer `limit` and a non-negative safe integer `offset` to page through the
+newest-first history. The client rejects invalid values before authentication or a network request.
+When omitted, the server defaults `limit` to 100 and `offset` to 0; it caps them at 100 and 100,000
+respectively.
 The response has no total or next-page marker. Increment `offset` by the number of returned runs and
 stop when a page contains fewer runs than the server-effective limit
 (`Math.min(requestedLimit, 100)`, or 100 when omitted) or the next offset would exceed 100,000.
@@ -338,11 +339,11 @@ run's Data Mart reference. The scoped `dataMartRuns.list()` method uses the Data
 and omits that redundant reference.
 
 The scoped list endpoint defaults to 100 runs when `limit` is omitted and does not silently cap a
-valid caller-provided limit or offset. The client accepts positive integer limits and non-negative
-integer offsets, and rejects invalid list options before authentication or any network request. The
-response has no total or next-page marker. Increment `offset` by the number of returned runs and stop
-when a page contains fewer runs than the requested limit. New runs can shift offset pages, so
-deduplicate by `run.id` while paging.
+valid caller-provided limit or offset. The client accepts positive safe integer limits and
+non-negative safe integer offsets, and rejects invalid list options before authentication or any
+network request. The response has no total or next-page marker. Increment `offset` by the number of
+returned runs and stop when a page contains fewer runs than the requested limit. New runs can shift
+offset pages, so deduplicate by `run.id` while paging.
 
 Use the scoped `cancel(runId)` method to cancel an active connector, standard report, or Data Quality
 run. Technical User access is required. The method resolves with no value after the API returns

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -294,13 +294,18 @@ authentication or any network request.
 
 ## Manage Data Mart runs
 
-Use `runs.start(dataMartId, request)` to start a manual connector run. Technical User access
-to the Data Mart is required. The optional `payload` must be a JSON object no larger than 1 MB;
-omit it to use the Data Mart's default connector payload. The method returns the new run ID.
+Use `runs.start(dataMartId, options)` to start a manual connector run. Technical User access
+to the Data Mart is required. Omit the options for an incremental run, or set `runType` to
+`MANUAL_BACKFILL` and pass the connector-specific backfill fields in `data`. The method returns the
+new run ID. The serialized options must not exceed 1 MB.
 
 ```ts
 const { runId } = await client.runs.start('data-mart-id', {
-  payload: { cursor: 'next-page' },
+  runType: 'MANUAL_BACKFILL',
+  data: {
+    StartDate: '2026-07-01',
+    EndDate: '2026-07-31',
+  },
 });
 ```
 
@@ -333,10 +338,10 @@ await client.runs.cancel('data-mart-id', runId);
 ```
 
 The package exports `OWOXDataMartRun`, `OWOXDataMartRunDetail`,
-`OWOXDataMartRunListOptions`, `OWOXDataMartRunsResponse`, `OWOXRunDataMartRequest`, and the run and
-Data Quality enum and nested-object types. The client validates response field presence,
+`OWOXDataMartRunListOptions`, `OWOXDataMartRunStartOptions`, `OWOXDataMartRunsResponse`, and the run
+and Data Quality enum and nested-object types. The client validates response field presence,
 nullability, enums, RFC 3339 timestamps, totals, author metadata, compact Data Quality summaries,
-and full Data Quality detail. An incompatible payload throws `OWOXApiError`.
+and full Data Quality detail. An incompatible response throws `OWOXApiError`.
 
 ## Read the Models canvas
 

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -294,27 +294,27 @@ authentication or any network request.
 
 ## Manage Data Mart runs
 
-Use `dataMarts.run(dataMartId, request)` to start a manual connector run. Technical User access
+Use `runs.start(dataMartId, request)` to start a manual connector run. Technical User access
 to the Data Mart is required. The optional `payload` must be a JSON object no larger than 1 MB;
 omit it to use the Data Mart's default connector payload. The method returns the new run ID.
 
 ```ts
-const { runId } = await client.dataMarts.run('data-mart-id', {
+const { runId } = await client.runs.start('data-mart-id', {
   payload: { cursor: 'next-page' },
 });
 ```
 
-Business Users can inspect runs for a Data Mart they can see. `dataMarts.listRuns()` returns a
-newest-first page, while `dataMarts.getRun()` returns one run and includes full Data Quality detail
+Business Users can inspect runs for a Data Mart they can see. `runs.listForDataMart()` returns a
+newest-first page, while `runs.get()` returns one run and includes full Data Quality detail
 when the run is a Data Quality run.
 
 ```ts
-const history = await client.dataMarts.listRuns('data-mart-id', {
+const history = await client.runs.listForDataMart('data-mart-id', {
   limit: 50,
   offset: 0,
 });
 
-const run = await client.dataMarts.getRun('data-mart-id', history.runs[0].id);
+const run = await client.runs.get('data-mart-id', history.runs[0].id);
 console.log(run.status, run.qualitySummary, run.dataQuality);
 ```
 
@@ -324,12 +324,12 @@ total or next-page marker. Increment `offset` by the number of returned runs and
 contains fewer runs than the effective limit or the next offset would exceed 100,000. New runs can
 shift offset pages, so deduplicate by `run.id` while paging.
 
-Use `dataMarts.cancelRun(dataMartId, runId)` to cancel an active connector, standard report, or
+Use `runs.cancel(dataMartId, runId)` to cancel an active connector, standard report, or
 Data Quality run. Technical User access is required. The method resolves with no value after the
 API returns `204 No Content`; cancelling a terminal run returns a conflict error.
 
 ```ts
-await client.dataMarts.cancelRun('data-mart-id', runId);
+await client.runs.cancel('data-mart-id', runId);
 ```
 
 The package exports `OWOXDataMartRun`, `OWOXDataMartRunDetail`,

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -300,11 +300,13 @@ authentication or any network request.
 ## Manage Data Mart runs
 
 Create a Data-Mart-scoped run client with `runs.forDataMart(dataMartId)`. Its `start(options)` method
-starts a manual connector run and requires Technical User access to the Data Mart. Omit the options
-for an incremental run, or set `runType` to `MANUAL_BACKFILL` and pass any connector-specific
-backfill fields in `data`. Connectors without backfill fields can omit `data`. Object-valued `data`
-is also accepted for incremental runs for compatibility with existing run forms that retain hidden
-field values. The method returns the new run ID. The serialized options must not exceed 1 MB.
+starts a manual connector run and requires Technical User access to the Data Mart. Omit the options,
+or set `runType` to `INCREMENTAL` without `data`, for an incremental run. To send connector-specific
+backfill fields in `data`, set `runType` to `MANUAL_BACKFILL`; connectors without backfill fields can
+omit `data`. The API client rejects `data` on implicit or explicit incremental runs before
+authentication or any network request. The backend HTTP endpoint separately tolerates retained
+object-valued `data` on incremental requests for compatibility with existing run forms. The method
+returns the new run ID. The serialized options must not exceed 1 MB.
 
 ```ts
 const dataMartRuns = client.runs.forDataMart('data-mart-id');

--- a/docs/api/api-client.md
+++ b/docs/api/api-client.md
@@ -292,6 +292,52 @@ unknown enum value, malformed user, storage, or context, invalid timestamp, miss
 field, or invalid pagination value with `OWOXApiError`. Invalid list options are rejected before
 authentication or any network request.
 
+## Manage Data Mart runs
+
+Use `dataMarts.run(dataMartId, request)` to start a manual connector run. Technical User access
+to the Data Mart is required. The optional `payload` must be a JSON object no larger than 1 MB;
+omit it to use the Data Mart's default connector payload. The method returns the new run ID.
+
+```ts
+const { runId } = await client.dataMarts.run('data-mart-id', {
+  payload: { cursor: 'next-page' },
+});
+```
+
+Business Users can inspect runs for a Data Mart they can see. `dataMarts.listRuns()` returns a
+newest-first page, while `dataMarts.getRun()` returns one run and includes full Data Quality detail
+when the run is a Data Quality run.
+
+```ts
+const history = await client.dataMarts.listRuns('data-mart-id', {
+  limit: 50,
+  offset: 0,
+});
+
+const run = await client.dataMarts.getRun('data-mart-id', history.runs[0].id);
+console.log(run.status, run.qualitySummary, run.dataQuality);
+```
+
+The list endpoint defaults to 100 runs, caps `limit` at 100 and `offset` at 100,000, floors finite
+fractions, and replaces non-finite or non-positive values with its defaults. The response has no
+total or next-page marker. Increment `offset` by the number of returned runs and stop when a page
+contains fewer runs than the effective limit or the next offset would exceed 100,000. New runs can
+shift offset pages, so deduplicate by `run.id` while paging.
+
+Use `dataMarts.cancelRun(dataMartId, runId)` to cancel an active connector, standard report, or
+Data Quality run. Technical User access is required. The method resolves with no value after the
+API returns `204 No Content`; cancelling a terminal run returns a conflict error.
+
+```ts
+await client.dataMarts.cancelRun('data-mart-id', runId);
+```
+
+The package exports `OWOXDataMartRun`, `OWOXDataMartRunDetail`,
+`OWOXDataMartRunListOptions`, `OWOXDataMartRunsResponse`, `OWOXRunDataMartRequest`, and the run and
+Data Quality enum and nested-object types. The client validates response field presence,
+nullability, enums, RFC 3339 timestamps, totals, author metadata, compact Data Quality summaries,
+and full Data Quality detail. An incompatible payload throws `OWOXApiError`.
+
 ## Read the Models canvas
 
 Use `models.getDataMarts()` to read one page of the data marts visible to the current project

--- a/docs/api/coverage.md
+++ b/docs/api/coverage.md
@@ -17,7 +17,7 @@ means the dimension has not been evaluated and does not imply a gap.
 ## Summary
 
 | API-key endpoints | Fully covered | OpenAPI covered | API client covered | Unassessed |
-| ----------------: | ------------: | --------------: | -----------------: | ---------: |
+| ----------------: | ------------: | ---------------: | -----------------: | ---------: |
 |               139 |  16/139 (12%) |    16/139 (12%) |       16/139 (12%) |        123 |
 
 Fully covered means both OpenAPI and API client coverage are complete. All
@@ -32,121 +32,121 @@ as API-client coverage.
 
 ## Authentication
 
-| Endpoint                | OpenAPI                                                                                                      | API client                                             |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
 | `GET /api/auth/context` | [Covered](https://app.owox.com/api/swagger-ui#/Authentication/AuthContextController_getContext) · 2026-07-22 | [Covered](./api-client/#get-auth-context) · 2026-07-22 |
 
 ## Connectors
 
-| Endpoint                                            | OpenAPI    | API client |
-| --------------------------------------------------- | ---------- | ---------- |
-| `GET /api/connectors`                               | Unassessed | Unassessed |
-| `GET /api/connectors/{connectorName}/fields`        | Unassessed | Unassessed |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `GET /api/connectors` | Unassessed | Unassessed |
+| `GET /api/connectors/{connectorName}/fields` | Unassessed | Unassessed |
 | `GET /api/connectors/{connectorName}/specification` | Unassessed | Unassessed |
 
 ## Contexts
 
-| Endpoint                         | OpenAPI    | API client |
-| -------------------------------- | ---------- | ---------- |
-| `GET /api/contexts`              | Unassessed | Unassessed |
-| `POST /api/contexts`             | Unassessed | Unassessed |
-| `DELETE /api/contexts/{id}`      | Unassessed | Unassessed |
-| `PUT /api/contexts/{id}`         | Unassessed | Unassessed |
-| `GET /api/contexts/{id}/impact`  | Unassessed | Unassessed |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `GET /api/contexts` | Unassessed | Unassessed |
+| `POST /api/contexts` | Unassessed | Unassessed |
+| `DELETE /api/contexts/{id}` | Unassessed | Unassessed |
+| `PUT /api/contexts/{id}` | Unassessed | Unassessed |
+| `GET /api/contexts/{id}/impact` | Unassessed | Unassessed |
 | `PUT /api/contexts/{id}/members` | Unassessed | Unassessed |
 
 ## Data Mart Relationships
 
-| Endpoint                                                 | OpenAPI    | API client |
-| -------------------------------------------------------- | ---------- | ---------- |
-| `POST /api/data-marts/{dataMartId}/relationships`        | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/relationships/graph`   | Unassessed | Unassessed |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `POST /api/data-marts/{dataMartId}/relationships` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/relationships/graph` | Unassessed | Unassessed |
 | `DELETE /api/data-marts/{dataMartId}/relationships/{id}` | Unassessed | Unassessed |
-| `PATCH /api/data-marts/{dataMartId}/relationships/{id}`  | Unassessed | Unassessed |
+| `PATCH /api/data-marts/{dataMartId}/relationships/{id}` | Unassessed | Unassessed |
 
 ## Data Storage Relationships
 
-| Endpoint                                           | OpenAPI    | API client |
-| -------------------------------------------------- | ---------- | ---------- |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
 | `GET /api/data-storages/{storageId}/relationships` | Unassessed | Unassessed |
 
 ## Data destinations
 
-| Endpoint                                                   | OpenAPI    | API client |
-| ---------------------------------------------------------- | ---------- | ---------- |
-| `GET /api/data-destinations`                               | Unassessed | Unassessed |
-| `POST /api/data-destinations`                              | Unassessed | Unassessed |
-| `GET /api/data-destinations/by-type/{type}`                | Unassessed | Unassessed |
-| `DELETE /api/data-destinations/{id}`                       | Unassessed | Unassessed |
-| `GET /api/data-destinations/{id}`                          | Unassessed | Unassessed |
-| `PUT /api/data-destinations/{id}`                          | Unassessed | Unassessed |
-| `PUT /api/data-destinations/{id}/availability`             | Unassessed | Unassessed |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `GET /api/data-destinations` | Unassessed | Unassessed |
+| `POST /api/data-destinations` | Unassessed | Unassessed |
+| `GET /api/data-destinations/by-type/{type}` | Unassessed | Unassessed |
+| `DELETE /api/data-destinations/{id}` | Unassessed | Unassessed |
+| `GET /api/data-destinations/{id}` | Unassessed | Unassessed |
+| `PUT /api/data-destinations/{id}` | Unassessed | Unassessed |
+| `PUT /api/data-destinations/{id}/availability` | Unassessed | Unassessed |
 | `POST /api/data-destinations/{id}/google-sheets/documents` | Unassessed | Unassessed |
-| `GET /api/data-destinations/{id}/impact`                   | Unassessed | Unassessed |
-| `POST /api/data-destinations/{id}/rotate-secret-key`       | Unassessed | Unassessed |
+| `GET /api/data-destinations/{id}/impact` | Unassessed | Unassessed |
+| `POST /api/data-destinations/{id}/rotate-secret-key` | Unassessed | Unassessed |
 
 ## Data Marts
 
-| Endpoint                                                                        | OpenAPI                                                                                                 | API client                                                  |
-| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| `GET /api/data-marts`                                                           | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_list) · 2026-07-23          | [Covered](./api-client/#list-data-marts) · 2026-07-23       |
-| `POST /api/data-marts`                                                          | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/ai-helper/availability`                                    | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/by-connector/{connectorName}`                              | Unassessed                                                                                              | Unassessed                                                  |
-| `POST /api/data-marts/health-status`                                            | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/member-ownership-warnings`                                 | Unassessed                                                                                              | Unassessed                                                  |
-| `POST /api/data-marts/{dataMartId}/ai-helper/triggers`                          | Unassessed                                                                                              | Unassessed                                                  |
-| `DELETE /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}`            | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}`               | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}/status`        | Unassessed                                                                                              | Unassessed                                                  |
-| `POST /api/data-marts/{dataMartId}/schema-actualize-triggers`                   | Unassessed                                                                                              | Unassessed                                                  |
-| `DELETE /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}`     | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}`        | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}/status` | Unassessed                                                                                              | Unassessed                                                  |
-| `POST /api/data-marts/{dataMartId}/sql-dry-run-triggers`                        | Unassessed                                                                                              | Unassessed                                                  |
-| `DELETE /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}`          | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}`             | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}/status`      | Unassessed                                                                                              | Unassessed                                                  |
-| `DELETE /api/data-marts/{id}`                                                   | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/{id}`                                                      | Unassessed                                                                                              | Unassessed                                                  |
-| `PUT /api/data-marts/{id}/availability`                                         | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/{id}/blendable-schema`                                     | Unassessed                                                                                              | Unassessed                                                  |
-| `PUT /api/data-marts/{id}/blended-fields-config`                                | Unassessed                                                                                              | Unassessed                                                  |
-| `PUT /api/data-marts/{id}/contexts`                                             | Unassessed                                                                                              | Unassessed                                                  |
-| `PUT /api/data-marts/{id}/definition`                                           | Unassessed                                                                                              | Unassessed                                                  |
-| `PUT /api/data-marts/{id}/description`                                          | Unassessed                                                                                              | Unassessed                                                  |
-| `POST /api/data-marts/{id}/manual-run`                                          | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_manualRun) · 2026-08-07     | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
-| `PUT /api/data-marts/{id}/owners`                                               | Unassessed                                                                                              | Unassessed                                                  |
-| `PUT /api/data-marts/{id}/publish`                                              | Unassessed                                                                                              | Unassessed                                                  |
-| `GET /api/data-marts/{id}/runs`                                                 | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_getRunHistory) · 2026-08-07 | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
-| `GET /api/data-marts/{id}/runs/{runId}`                                         | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_getRunById) · 2026-08-07    | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
-| `POST /api/data-marts/{id}/runs/{runId}/cancel`                                 | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_cancelRun) · 2026-08-07     | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
-| `PUT /api/data-marts/{id}/schema`                                               | Unassessed                                                                                              | Unassessed                                                  |
-| `PUT /api/data-marts/{id}/title`                                                | Unassessed                                                                                              | Unassessed                                                  |
-| `POST /api/data-marts/{id}/validate-definition`                                 | Unassessed                                                                                              | Unassessed                                                  |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `GET /api/data-marts` | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_list) · 2026-07-23 | [Covered](./api-client/#list-data-marts) · 2026-07-23 |
+| `POST /api/data-marts` | Unassessed | Unassessed |
+| `GET /api/data-marts/ai-helper/availability` | Unassessed | Unassessed |
+| `GET /api/data-marts/by-connector/{connectorName}` | Unassessed | Unassessed |
+| `POST /api/data-marts/health-status` | Unassessed | Unassessed |
+| `GET /api/data-marts/member-ownership-warnings` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/ai-helper/triggers` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}/status` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/schema-actualize-triggers` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}/status` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/sql-dry-run-triggers` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}/status` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{id}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{id}` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{id}/availability` | Unassessed | Unassessed |
+| `GET /api/data-marts/{id}/blendable-schema` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{id}/blended-fields-config` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{id}/contexts` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{id}/definition` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{id}/description` | Unassessed | Unassessed |
+| `POST /api/data-marts/{id}/manual-run` | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_manualRun) · 2026-08-07 | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
+| `PUT /api/data-marts/{id}/owners` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{id}/publish` | Unassessed | Unassessed |
+| `GET /api/data-marts/{id}/runs` | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_getRunHistory) · 2026-08-07 | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
+| `GET /api/data-marts/{id}/runs/{runId}` | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_getRunById) · 2026-08-07 | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
+| `POST /api/data-marts/{id}/runs/{runId}/cancel` | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_cancelRun) · 2026-08-07 | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
+| `PUT /api/data-marts/{id}/schema` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{id}/title` | Unassessed | Unassessed |
+| `POST /api/data-marts/{id}/validate-definition` | Unassessed | Unassessed |
 
 ## Data storages
 
-| Endpoint                                                                            | OpenAPI    | API client |
-| ----------------------------------------------------------------------------------- | ---------- | ---------- |
-| `GET /api/data-storages`                                                            | Unassessed | Unassessed |
-| `POST /api/data-storages`                                                           | Unassessed | Unassessed |
-| `GET /api/data-storages/by-type/{type}`                                             | Unassessed | Unassessed |
-| `POST /api/data-storages/{dataStorageId}/publish-drafts-triggers`                   | Unassessed | Unassessed |
-| `DELETE /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}`     | Unassessed | Unassessed |
-| `GET /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}`        | Unassessed | Unassessed |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `GET /api/data-storages` | Unassessed | Unassessed |
+| `POST /api/data-storages` | Unassessed | Unassessed |
+| `GET /api/data-storages/by-type/{type}` | Unassessed | Unassessed |
+| `POST /api/data-storages/{dataStorageId}/publish-drafts-triggers` | Unassessed | Unassessed |
+| `DELETE /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}` | Unassessed | Unassessed |
 | `GET /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}/status` | Unassessed | Unassessed |
-| `DELETE /api/data-storages/{id}`                                                    | Unassessed | Unassessed |
-| `GET /api/data-storages/{id}`                                                       | Unassessed | Unassessed |
-| `PUT /api/data-storages/{id}`                                                       | Unassessed | Unassessed |
-| `PUT /api/data-storages/{id}/availability`                                          | Unassessed | Unassessed |
-| `GET /api/data-storages/{id}/resources`                                             | Unassessed | Unassessed |
-| `POST /api/data-storages/{id}/validate-access`                                      | Unassessed | Unassessed |
+| `DELETE /api/data-storages/{id}` | Unassessed | Unassessed |
+| `GET /api/data-storages/{id}` | Unassessed | Unassessed |
+| `PUT /api/data-storages/{id}` | Unassessed | Unassessed |
+| `PUT /api/data-storages/{id}/availability` | Unassessed | Unassessed |
+| `GET /api/data-storages/{id}/resources` | Unassessed | Unassessed |
+| `POST /api/data-storages/{id}/validate-access` | Unassessed | Unassessed |
 
 ## HTTP Data
 
-| Endpoint                                                     | OpenAPI                                                                                            | API client                                                  |
-| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
 | `GET /api/external/http-data/data-marts/{dataMartId}.ndjson` | [Covered](https://app.owox.com/api/swagger-ui#/HTTP%20Data/HttpDataController_stream) · 2026-07-23 | [Covered](./api-client/#stream-data-mart-rows) · 2026-07-23 |
 
 ## Insights
@@ -154,115 +154,115 @@ as API-client coverage.
 This section includes only the current Insights family. The deprecated family
 whose UI is reachable only through direct links is excluded.
 
-| Endpoint                                                                                                         | OpenAPI                                                                                                      | API client                                                           |
-| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| `GET /api/data-marts/insight-templates`                                                                          | [Covered](https://app.owox.com/api/swagger-ui#/Insights/ProjectInsightTemplatesController_list) · 2026-07-21 | [Covered](./api-client/#list-project-insight-templates) · 2026-07-21 |
-| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers`                                                     | Unassessed                                                                                                   | Unassessed                                                           |
-| `DELETE /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}`                                      | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}`                                         | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}/status`                                  | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/ai-assistant/sessions`                                                         | Unassessed                                                                                                   | Unassessed                                                           |
-| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions`                                                        | Unassessed                                                                                                   | Unassessed                                                           |
-| `DELETE /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}`                                          | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}`                                             | Unassessed                                                                                                   | Unassessed                                                           |
-| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/apply`                                      | Unassessed                                                                                                   | Unassessed                                                           |
-| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/messages`                                   | Unassessed                                                                                                   | Unassessed                                                           |
-| `PATCH /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/title`                                     | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/insight-artifacts`                                                             | Unassessed                                                                                                   | Unassessed                                                           |
-| `POST /api/data-marts/{dataMartId}/insight-artifacts`                                                            | Unassessed                                                                                                   | Unassessed                                                           |
-| `DELETE /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}`                                      | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}`                                         | Unassessed                                                                                                   | Unassessed                                                           |
-| `PUT /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}`                                         | Unassessed                                                                                                   | Unassessed                                                           |
-| `POST /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers`                   | Unassessed                                                                                                   | Unassessed                                                           |
-| `DELETE /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}`     | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}`        | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}/status` | Unassessed                                                                                                   | Unassessed                                                           |
-| `PUT /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/title`                                   | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/insight-templates`                                                             | Unassessed                                                                                                   | Unassessed                                                           |
-| `POST /api/data-marts/{dataMartId}/insight-templates`                                                            | Unassessed                                                                                                   | Unassessed                                                           |
-| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}`                                      | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}`                                         | Unassessed                                                                                                   | Unassessed                                                           |
-| `PUT /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}`                                         | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers`                            | Unassessed                                                                                                   | Unassessed                                                           |
-| `POST /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers`                           | Unassessed                                                                                                   | Unassessed                                                           |
-| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}`             | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}`                | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}/status`         | Unassessed                                                                                                   | Unassessed                                                           |
-| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources`                                 | Unassessed                                                                                                   | Unassessed                                                           |
-| `POST /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources`                                | Unassessed                                                                                                   | Unassessed                                                           |
-| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources/{sourceId}`                   | Unassessed                                                                                                   | Unassessed                                                           |
-| `PATCH /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources/{sourceId}`                    | Unassessed                                                                                                   | Unassessed                                                           |
-| `PUT /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/title`                                   | Unassessed                                                                                                   | Unassessed                                                           |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `GET /api/data-marts/insight-templates` | [Covered](https://app.owox.com/api/swagger-ui#/Insights/ProjectInsightTemplatesController_list) · 2026-07-21 | [Covered](./api-client/#list-project-insight-templates) · 2026-07-21 |
+| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}/status` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/ai-assistant/sessions` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/apply` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/messages` | Unassessed | Unassessed |
+| `PATCH /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/title` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/insight-artifacts` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/insight-artifacts` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}/status` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/title` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/insight-templates` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/insight-templates` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}/status` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources` | Unassessed | Unassessed |
+| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources/{sourceId}` | Unassessed | Unassessed |
+| `PATCH /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources/{sourceId}` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/title` | Unassessed | Unassessed |
 
 ## Model Canvas
 
-| Endpoint                           | OpenAPI                                                                                                        | API client                                                   |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
 | `GET /api/model-canvas/data-marts` | [Covered](https://app.owox.com/api/swagger-ui#/Model%20Canvas/ModelCanvasController_getDataMarts) · 2026-07-21 | [Covered](./api-client/#read-the-models-canvas) · 2026-07-21 |
-| `GET /api/model-canvas/edges`      | [Covered](https://app.owox.com/api/swagger-ui#/Model%20Canvas/ModelCanvasController_getEdges) · 2026-07-21     | [Covered](./api-client/#read-the-models-canvas) · 2026-07-21 |
+| `GET /api/model-canvas/edges` | [Covered](https://app.owox.com/api/swagger-ui#/Model%20Canvas/ModelCanvasController_getEdges) · 2026-07-21 | [Covered](./api-client/#read-the-models-canvas) · 2026-07-21 |
 
 ## Project notification settings
 
-| Endpoint                                                                   | OpenAPI    | API client |
-| -------------------------------------------------------------------------- | ---------- | ---------- |
-| `GET /api/projects/notification-settings`                                  | Unassessed | Unassessed |
-| `GET /api/projects/notification-settings/members`                          | Unassessed | Unassessed |
-| `PUT /api/projects/notification-settings/{notificationType}`               | Unassessed | Unassessed |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `GET /api/projects/notification-settings` | Unassessed | Unassessed |
+| `GET /api/projects/notification-settings/members` | Unassessed | Unassessed |
+| `PUT /api/projects/notification-settings/{notificationType}` | Unassessed | Unassessed |
 | `POST /api/projects/notification-settings/{notificationType}/test-webhook` | Unassessed | Unassessed |
 
 ## Project settings
 
-| Endpoint                                 | OpenAPI                                                                                                                  | API client                                                    |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| `GET /api/projects/settings`             | [Covered](https://app.owox.com/api/swagger-ui#/ProjectSettings/ProjectSettingsController_getSettings) · 2026-07-21       | [Covered](./api-client/#manage-project-settings) · 2026-07-21 |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `GET /api/projects/settings` | [Covered](https://app.owox.com/api/swagger-ui#/ProjectSettings/ProjectSettingsController_getSettings) · 2026-07-21 | [Covered](./api-client/#manage-project-settings) · 2026-07-21 |
 | `PUT /api/projects/settings/description` | [Covered](https://app.owox.com/api/swagger-ui#/ProjectSettings/ProjectSettingsController_updateDescription) · 2026-07-21 | [Covered](./api-client/#manage-project-settings) · 2026-07-21 |
 
 ## Reports
 
-| Endpoint                                                                       | OpenAPI    | API client |
-| ------------------------------------------------------------------------------ | ---------- | ---------- |
-| `GET /api/reports`                                                             | Unassessed | Unassessed |
-| `POST /api/reports`                                                            | Unassessed | Unassessed |
-| `GET /api/reports/data-mart/{dataMartId}`                                      | Unassessed | Unassessed |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `GET /api/reports` | Unassessed | Unassessed |
+| `POST /api/reports` | Unassessed | Unassessed |
+| `GET /api/reports/data-mart/{dataMartId}` | Unassessed | Unassessed |
 | `GET /api/reports/data-mart/{dataMartId}/insight-template/{insightTemplateId}` | Unassessed | Unassessed |
-| `DELETE /api/reports/{id}`                                                     | Unassessed | Unassessed |
-| `GET /api/reports/{id}`                                                        | Unassessed | Unassessed |
-| `PUT /api/reports/{id}`                                                        | Unassessed | Unassessed |
-| `POST /api/reports/{id}/copy-as-data-mart`                                     | Unassessed | Unassessed |
-| `GET /api/reports/{id}/generated-sql`                                          | Unassessed | Unassessed |
-| `POST /api/reports/{id}/run`                                                   | Unassessed | Unassessed |
+| `DELETE /api/reports/{id}` | Unassessed | Unassessed |
+| `GET /api/reports/{id}` | Unassessed | Unassessed |
+| `PUT /api/reports/{id}` | Unassessed | Unassessed |
+| `POST /api/reports/{id}/copy-as-data-mart` | Unassessed | Unassessed |
+| `GET /api/reports/{id}/generated-sql` | Unassessed | Unassessed |
+| `POST /api/reports/{id}/run` | Unassessed | Unassessed |
 
 ## Run History
 
-| Endpoint                   | OpenAPI                                                                                                       | API client                                                     |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
 | `GET /api/data-marts/runs` | [Covered](https://app.owox.com/api/swagger-ui#/Run%20History/ProjectDataMartRunsController_list) · 2026-07-23 | [Covered](./api-client/#read-project-run-history) · 2026-07-23 |
 
 ## Scheduled triggers
 
-| Endpoint                                                      | OpenAPI    | API client |
-| ------------------------------------------------------------- | ---------- | ---------- |
-| `GET /api/data-marts/scheduled-triggers`                      | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/scheduled-triggers`         | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/scheduled-triggers`        | Unassessed | Unassessed |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
+| `GET /api/data-marts/scheduled-triggers` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/scheduled-triggers` | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/scheduled-triggers` | Unassessed | Unassessed |
 | `DELETE /api/data-marts/{dataMartId}/scheduled-triggers/{id}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/scheduled-triggers/{id}`    | Unassessed | Unassessed |
-| `PUT /api/data-marts/{dataMartId}/scheduled-triggers/{id}`    | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/scheduled-triggers/{id}` | Unassessed | Unassessed |
+| `PUT /api/data-marts/{dataMartId}/scheduled-triggers/{id}` | Unassessed | Unassessed |
 
 ## Search
 
-| Endpoint          | OpenAPI                                                                                     | API client                                                    |
-| ----------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
 | `GET /api/search` | [Covered](https://app.owox.com/api/swagger-ui#/Search/SearchController_search) · 2026-07-23 | [Covered](./api-client/#search-project-entities) · 2026-07-23 |
 
 ## Project setup progress
 
-| Endpoint                          | OpenAPI                                                                                                                        | API client                                                         |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
 | `GET /api/project-setup-progress` | [Covered](https://app.owox.com/api/swagger-ui#/project-setup-progress/ProjectSetupProgressController_getProgress) · 2026-07-21 | [Covered](./api-client/#check-project-setup-progress) · 2026-07-21 |
 
 ## Utilities
 
-| Endpoint                           | OpenAPI                                                                                                 | API client                                                     |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| Endpoint | OpenAPI | API client |
+| --- | --- | --- |
 | `POST /api/markdown/parse-to-html` | [Covered](https://app.owox.com/api/swagger-ui#/Utils/MarkdownParserController_parseToHtml) · 2026-07-22 | [Covered](./api-client/#convert-markdown-to-html) · 2026-07-22 |

--- a/docs/api/coverage.md
+++ b/docs/api/coverage.md
@@ -17,8 +17,8 @@ means the dimension has not been evaluated and does not imply a gap.
 ## Summary
 
 | API-key endpoints | Fully covered | OpenAPI covered | API client covered | Unassessed |
-| ----------------: | ------------: | ---------------: | -----------------: | ---------: |
-|               139 |    12/139 (9%) |      12/139 (9%) |        12/139 (9%) |        127 |
+| ----------------: | ------------: | --------------: | -----------------: | ---------: |
+|               139 |  16/139 (12%) |    16/139 (12%) |       16/139 (12%) |        123 |
 
 Fully covered means both OpenAPI and API client coverage are complete. All
 percentages use the complete endpoint inventory below as their denominator.
@@ -32,121 +32,121 @@ as API-client coverage.
 
 ## Authentication
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
+| Endpoint                | OpenAPI                                                                                                      | API client                                             |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
 | `GET /api/auth/context` | [Covered](https://app.owox.com/api/swagger-ui#/Authentication/AuthContextController_getContext) · 2026-07-22 | [Covered](./api-client/#get-auth-context) · 2026-07-22 |
 
 ## Connectors
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `GET /api/connectors` | Unassessed | Unassessed |
-| `GET /api/connectors/{connectorName}/fields` | Unassessed | Unassessed |
+| Endpoint                                            | OpenAPI    | API client |
+| --------------------------------------------------- | ---------- | ---------- |
+| `GET /api/connectors`                               | Unassessed | Unassessed |
+| `GET /api/connectors/{connectorName}/fields`        | Unassessed | Unassessed |
 | `GET /api/connectors/{connectorName}/specification` | Unassessed | Unassessed |
 
 ## Contexts
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `GET /api/contexts` | Unassessed | Unassessed |
-| `POST /api/contexts` | Unassessed | Unassessed |
-| `DELETE /api/contexts/{id}` | Unassessed | Unassessed |
-| `PUT /api/contexts/{id}` | Unassessed | Unassessed |
-| `GET /api/contexts/{id}/impact` | Unassessed | Unassessed |
+| Endpoint                         | OpenAPI    | API client |
+| -------------------------------- | ---------- | ---------- |
+| `GET /api/contexts`              | Unassessed | Unassessed |
+| `POST /api/contexts`             | Unassessed | Unassessed |
+| `DELETE /api/contexts/{id}`      | Unassessed | Unassessed |
+| `PUT /api/contexts/{id}`         | Unassessed | Unassessed |
+| `GET /api/contexts/{id}/impact`  | Unassessed | Unassessed |
 | `PUT /api/contexts/{id}/members` | Unassessed | Unassessed |
 
 ## Data Mart Relationships
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `POST /api/data-marts/{dataMartId}/relationships` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/relationships/graph` | Unassessed | Unassessed |
+| Endpoint                                                 | OpenAPI    | API client |
+| -------------------------------------------------------- | ---------- | ---------- |
+| `POST /api/data-marts/{dataMartId}/relationships`        | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/relationships/graph`   | Unassessed | Unassessed |
 | `DELETE /api/data-marts/{dataMartId}/relationships/{id}` | Unassessed | Unassessed |
-| `PATCH /api/data-marts/{dataMartId}/relationships/{id}` | Unassessed | Unassessed |
+| `PATCH /api/data-marts/{dataMartId}/relationships/{id}`  | Unassessed | Unassessed |
 
 ## Data Storage Relationships
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
+| Endpoint                                           | OpenAPI    | API client |
+| -------------------------------------------------- | ---------- | ---------- |
 | `GET /api/data-storages/{storageId}/relationships` | Unassessed | Unassessed |
 
 ## Data destinations
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `GET /api/data-destinations` | Unassessed | Unassessed |
-| `POST /api/data-destinations` | Unassessed | Unassessed |
-| `GET /api/data-destinations/by-type/{type}` | Unassessed | Unassessed |
-| `DELETE /api/data-destinations/{id}` | Unassessed | Unassessed |
-| `GET /api/data-destinations/{id}` | Unassessed | Unassessed |
-| `PUT /api/data-destinations/{id}` | Unassessed | Unassessed |
-| `PUT /api/data-destinations/{id}/availability` | Unassessed | Unassessed |
+| Endpoint                                                   | OpenAPI    | API client |
+| ---------------------------------------------------------- | ---------- | ---------- |
+| `GET /api/data-destinations`                               | Unassessed | Unassessed |
+| `POST /api/data-destinations`                              | Unassessed | Unassessed |
+| `GET /api/data-destinations/by-type/{type}`                | Unassessed | Unassessed |
+| `DELETE /api/data-destinations/{id}`                       | Unassessed | Unassessed |
+| `GET /api/data-destinations/{id}`                          | Unassessed | Unassessed |
+| `PUT /api/data-destinations/{id}`                          | Unassessed | Unassessed |
+| `PUT /api/data-destinations/{id}/availability`             | Unassessed | Unassessed |
 | `POST /api/data-destinations/{id}/google-sheets/documents` | Unassessed | Unassessed |
-| `GET /api/data-destinations/{id}/impact` | Unassessed | Unassessed |
-| `POST /api/data-destinations/{id}/rotate-secret-key` | Unassessed | Unassessed |
+| `GET /api/data-destinations/{id}/impact`                   | Unassessed | Unassessed |
+| `POST /api/data-destinations/{id}/rotate-secret-key`       | Unassessed | Unassessed |
 
 ## Data Marts
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `GET /api/data-marts` | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_list) · 2026-07-23 | [Covered](./api-client/#list-data-marts) · 2026-07-23 |
-| `POST /api/data-marts` | Unassessed | Unassessed |
-| `GET /api/data-marts/ai-helper/availability` | Unassessed | Unassessed |
-| `GET /api/data-marts/by-connector/{connectorName}` | Unassessed | Unassessed |
-| `POST /api/data-marts/health-status` | Unassessed | Unassessed |
-| `GET /api/data-marts/member-ownership-warnings` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/ai-helper/triggers` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}/status` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/schema-actualize-triggers` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}/status` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/sql-dry-run-triggers` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}/status` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{id}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{id}` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{id}/availability` | Unassessed | Unassessed |
-| `GET /api/data-marts/{id}/blendable-schema` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{id}/blended-fields-config` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{id}/contexts` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{id}/definition` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{id}/description` | Unassessed | Unassessed |
-| `POST /api/data-marts/{id}/manual-run` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{id}/owners` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{id}/publish` | Unassessed | Unassessed |
-| `GET /api/data-marts/{id}/runs` | Unassessed | Unassessed |
-| `GET /api/data-marts/{id}/runs/{runId}` | Unassessed | Unassessed |
-| `POST /api/data-marts/{id}/runs/{runId}/cancel` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{id}/schema` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{id}/title` | Unassessed | Unassessed |
-| `POST /api/data-marts/{id}/validate-definition` | Unassessed | Unassessed |
+| Endpoint                                                                        | OpenAPI                                                                                                 | API client                                                  |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `GET /api/data-marts`                                                           | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_list) · 2026-07-23          | [Covered](./api-client/#list-data-marts) · 2026-07-23       |
+| `POST /api/data-marts`                                                          | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/ai-helper/availability`                                    | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/by-connector/{connectorName}`                              | Unassessed                                                                                              | Unassessed                                                  |
+| `POST /api/data-marts/health-status`                                            | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/member-ownership-warnings`                                 | Unassessed                                                                                              | Unassessed                                                  |
+| `POST /api/data-marts/{dataMartId}/ai-helper/triggers`                          | Unassessed                                                                                              | Unassessed                                                  |
+| `DELETE /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}`            | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}`               | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/{dataMartId}/ai-helper/triggers/{triggerId}/status`        | Unassessed                                                                                              | Unassessed                                                  |
+| `POST /api/data-marts/{dataMartId}/schema-actualize-triggers`                   | Unassessed                                                                                              | Unassessed                                                  |
+| `DELETE /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}`     | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}`        | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/{dataMartId}/schema-actualize-triggers/{triggerId}/status` | Unassessed                                                                                              | Unassessed                                                  |
+| `POST /api/data-marts/{dataMartId}/sql-dry-run-triggers`                        | Unassessed                                                                                              | Unassessed                                                  |
+| `DELETE /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}`          | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}`             | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/{dataMartId}/sql-dry-run-triggers/{triggerId}/status`      | Unassessed                                                                                              | Unassessed                                                  |
+| `DELETE /api/data-marts/{id}`                                                   | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/{id}`                                                      | Unassessed                                                                                              | Unassessed                                                  |
+| `PUT /api/data-marts/{id}/availability`                                         | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/{id}/blendable-schema`                                     | Unassessed                                                                                              | Unassessed                                                  |
+| `PUT /api/data-marts/{id}/blended-fields-config`                                | Unassessed                                                                                              | Unassessed                                                  |
+| `PUT /api/data-marts/{id}/contexts`                                             | Unassessed                                                                                              | Unassessed                                                  |
+| `PUT /api/data-marts/{id}/definition`                                           | Unassessed                                                                                              | Unassessed                                                  |
+| `PUT /api/data-marts/{id}/description`                                          | Unassessed                                                                                              | Unassessed                                                  |
+| `POST /api/data-marts/{id}/manual-run`                                          | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_manualRun) · 2026-08-07     | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
+| `PUT /api/data-marts/{id}/owners`                                               | Unassessed                                                                                              | Unassessed                                                  |
+| `PUT /api/data-marts/{id}/publish`                                              | Unassessed                                                                                              | Unassessed                                                  |
+| `GET /api/data-marts/{id}/runs`                                                 | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_getRunHistory) · 2026-08-07 | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
+| `GET /api/data-marts/{id}/runs/{runId}`                                         | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_getRunById) · 2026-08-07    | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
+| `POST /api/data-marts/{id}/runs/{runId}/cancel`                                 | [Covered](https://app.owox.com/api/swagger-ui#/DataMarts/DataMartController_cancelRun) · 2026-08-07     | [Covered](./api-client/#manage-data-mart-runs) · 2026-08-07 |
+| `PUT /api/data-marts/{id}/schema`                                               | Unassessed                                                                                              | Unassessed                                                  |
+| `PUT /api/data-marts/{id}/title`                                                | Unassessed                                                                                              | Unassessed                                                  |
+| `POST /api/data-marts/{id}/validate-definition`                                 | Unassessed                                                                                              | Unassessed                                                  |
 
 ## Data storages
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `GET /api/data-storages` | Unassessed | Unassessed |
-| `POST /api/data-storages` | Unassessed | Unassessed |
-| `GET /api/data-storages/by-type/{type}` | Unassessed | Unassessed |
-| `POST /api/data-storages/{dataStorageId}/publish-drafts-triggers` | Unassessed | Unassessed |
-| `DELETE /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}` | Unassessed | Unassessed |
+| Endpoint                                                                            | OpenAPI    | API client |
+| ----------------------------------------------------------------------------------- | ---------- | ---------- |
+| `GET /api/data-storages`                                                            | Unassessed | Unassessed |
+| `POST /api/data-storages`                                                           | Unassessed | Unassessed |
+| `GET /api/data-storages/by-type/{type}`                                             | Unassessed | Unassessed |
+| `POST /api/data-storages/{dataStorageId}/publish-drafts-triggers`                   | Unassessed | Unassessed |
+| `DELETE /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}`     | Unassessed | Unassessed |
+| `GET /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}`        | Unassessed | Unassessed |
 | `GET /api/data-storages/{dataStorageId}/publish-drafts-triggers/{triggerId}/status` | Unassessed | Unassessed |
-| `DELETE /api/data-storages/{id}` | Unassessed | Unassessed |
-| `GET /api/data-storages/{id}` | Unassessed | Unassessed |
-| `PUT /api/data-storages/{id}` | Unassessed | Unassessed |
-| `PUT /api/data-storages/{id}/availability` | Unassessed | Unassessed |
-| `GET /api/data-storages/{id}/resources` | Unassessed | Unassessed |
-| `POST /api/data-storages/{id}/validate-access` | Unassessed | Unassessed |
+| `DELETE /api/data-storages/{id}`                                                    | Unassessed | Unassessed |
+| `GET /api/data-storages/{id}`                                                       | Unassessed | Unassessed |
+| `PUT /api/data-storages/{id}`                                                       | Unassessed | Unassessed |
+| `PUT /api/data-storages/{id}/availability`                                          | Unassessed | Unassessed |
+| `GET /api/data-storages/{id}/resources`                                             | Unassessed | Unassessed |
+| `POST /api/data-storages/{id}/validate-access`                                      | Unassessed | Unassessed |
 
 ## HTTP Data
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
+| Endpoint                                                     | OpenAPI                                                                                            | API client                                                  |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | `GET /api/external/http-data/data-marts/{dataMartId}.ndjson` | [Covered](https://app.owox.com/api/swagger-ui#/HTTP%20Data/HttpDataController_stream) · 2026-07-23 | [Covered](./api-client/#stream-data-mart-rows) · 2026-07-23 |
 
 ## Insights
@@ -154,115 +154,115 @@ as API-client coverage.
 This section includes only the current Insights family. The deprecated family
 whose UI is reachable only through direct links is excluded.
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `GET /api/data-marts/insight-templates` | [Covered](https://app.owox.com/api/swagger-ui#/Insights/ProjectInsightTemplatesController_list) · 2026-07-21 | [Covered](./api-client/#list-project-insight-templates) · 2026-07-21 |
-| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}/status` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/ai-assistant/sessions` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/apply` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/messages` | Unassessed | Unassessed |
-| `PATCH /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/title` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/insight-artifacts` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/insight-artifacts` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}/status` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/title` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/insight-templates` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/insight-templates` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}/status` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources` | Unassessed | Unassessed |
-| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources/{sourceId}` | Unassessed | Unassessed |
-| `PATCH /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources/{sourceId}` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/title` | Unassessed | Unassessed |
+| Endpoint                                                                                                         | OpenAPI                                                                                                      | API client                                                           |
+| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `GET /api/data-marts/insight-templates`                                                                          | [Covered](https://app.owox.com/api/swagger-ui#/Insights/ProjectInsightTemplatesController_list) · 2026-07-21 | [Covered](./api-client/#list-project-insight-templates) · 2026-07-21 |
+| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers`                                                     | Unassessed                                                                                                   | Unassessed                                                           |
+| `DELETE /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}`                                      | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}`                                         | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/ai-assistant/run-triggers/{triggerId}/status`                                  | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/ai-assistant/sessions`                                                         | Unassessed                                                                                                   | Unassessed                                                           |
+| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions`                                                        | Unassessed                                                                                                   | Unassessed                                                           |
+| `DELETE /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}`                                          | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}`                                             | Unassessed                                                                                                   | Unassessed                                                           |
+| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/apply`                                      | Unassessed                                                                                                   | Unassessed                                                           |
+| `POST /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/messages`                                   | Unassessed                                                                                                   | Unassessed                                                           |
+| `PATCH /api/data-marts/{dataMartId}/ai-assistant/sessions/{sessionId}/title`                                     | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/insight-artifacts`                                                             | Unassessed                                                                                                   | Unassessed                                                           |
+| `POST /api/data-marts/{dataMartId}/insight-artifacts`                                                            | Unassessed                                                                                                   | Unassessed                                                           |
+| `DELETE /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}`                                      | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}`                                         | Unassessed                                                                                                   | Unassessed                                                           |
+| `PUT /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}`                                         | Unassessed                                                                                                   | Unassessed                                                           |
+| `POST /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers`                   | Unassessed                                                                                                   | Unassessed                                                           |
+| `DELETE /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}`     | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}`        | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/sql-preview-triggers/{triggerId}/status` | Unassessed                                                                                                   | Unassessed                                                           |
+| `PUT /api/data-marts/{dataMartId}/insight-artifacts/{insightArtifactId}/title`                                   | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/insight-templates`                                                             | Unassessed                                                                                                   | Unassessed                                                           |
+| `POST /api/data-marts/{dataMartId}/insight-templates`                                                            | Unassessed                                                                                                   | Unassessed                                                           |
+| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}`                                      | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}`                                         | Unassessed                                                                                                   | Unassessed                                                           |
+| `PUT /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}`                                         | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers`                            | Unassessed                                                                                                   | Unassessed                                                           |
+| `POST /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers`                           | Unassessed                                                                                                   | Unassessed                                                           |
+| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}`             | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}`                | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/run-triggers/{triggerId}/status`         | Unassessed                                                                                                   | Unassessed                                                           |
+| `GET /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources`                                 | Unassessed                                                                                                   | Unassessed                                                           |
+| `POST /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources`                                | Unassessed                                                                                                   | Unassessed                                                           |
+| `DELETE /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources/{sourceId}`                   | Unassessed                                                                                                   | Unassessed                                                           |
+| `PATCH /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/sources/{sourceId}`                    | Unassessed                                                                                                   | Unassessed                                                           |
+| `PUT /api/data-marts/{dataMartId}/insight-templates/{insightTemplateId}/title`                                   | Unassessed                                                                                                   | Unassessed                                                           |
 
 ## Model Canvas
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
+| Endpoint                           | OpenAPI                                                                                                        | API client                                                   |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | `GET /api/model-canvas/data-marts` | [Covered](https://app.owox.com/api/swagger-ui#/Model%20Canvas/ModelCanvasController_getDataMarts) · 2026-07-21 | [Covered](./api-client/#read-the-models-canvas) · 2026-07-21 |
-| `GET /api/model-canvas/edges` | [Covered](https://app.owox.com/api/swagger-ui#/Model%20Canvas/ModelCanvasController_getEdges) · 2026-07-21 | [Covered](./api-client/#read-the-models-canvas) · 2026-07-21 |
+| `GET /api/model-canvas/edges`      | [Covered](https://app.owox.com/api/swagger-ui#/Model%20Canvas/ModelCanvasController_getEdges) · 2026-07-21     | [Covered](./api-client/#read-the-models-canvas) · 2026-07-21 |
 
 ## Project notification settings
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `GET /api/projects/notification-settings` | Unassessed | Unassessed |
-| `GET /api/projects/notification-settings/members` | Unassessed | Unassessed |
-| `PUT /api/projects/notification-settings/{notificationType}` | Unassessed | Unassessed |
+| Endpoint                                                                   | OpenAPI    | API client |
+| -------------------------------------------------------------------------- | ---------- | ---------- |
+| `GET /api/projects/notification-settings`                                  | Unassessed | Unassessed |
+| `GET /api/projects/notification-settings/members`                          | Unassessed | Unassessed |
+| `PUT /api/projects/notification-settings/{notificationType}`               | Unassessed | Unassessed |
 | `POST /api/projects/notification-settings/{notificationType}/test-webhook` | Unassessed | Unassessed |
 
 ## Project settings
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `GET /api/projects/settings` | [Covered](https://app.owox.com/api/swagger-ui#/ProjectSettings/ProjectSettingsController_getSettings) · 2026-07-21 | [Covered](./api-client/#manage-project-settings) · 2026-07-21 |
+| Endpoint                                 | OpenAPI                                                                                                                  | API client                                                    |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `GET /api/projects/settings`             | [Covered](https://app.owox.com/api/swagger-ui#/ProjectSettings/ProjectSettingsController_getSettings) · 2026-07-21       | [Covered](./api-client/#manage-project-settings) · 2026-07-21 |
 | `PUT /api/projects/settings/description` | [Covered](https://app.owox.com/api/swagger-ui#/ProjectSettings/ProjectSettingsController_updateDescription) · 2026-07-21 | [Covered](./api-client/#manage-project-settings) · 2026-07-21 |
 
 ## Reports
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `GET /api/reports` | Unassessed | Unassessed |
-| `POST /api/reports` | Unassessed | Unassessed |
-| `GET /api/reports/data-mart/{dataMartId}` | Unassessed | Unassessed |
+| Endpoint                                                                       | OpenAPI    | API client |
+| ------------------------------------------------------------------------------ | ---------- | ---------- |
+| `GET /api/reports`                                                             | Unassessed | Unassessed |
+| `POST /api/reports`                                                            | Unassessed | Unassessed |
+| `GET /api/reports/data-mart/{dataMartId}`                                      | Unassessed | Unassessed |
 | `GET /api/reports/data-mart/{dataMartId}/insight-template/{insightTemplateId}` | Unassessed | Unassessed |
-| `DELETE /api/reports/{id}` | Unassessed | Unassessed |
-| `GET /api/reports/{id}` | Unassessed | Unassessed |
-| `PUT /api/reports/{id}` | Unassessed | Unassessed |
-| `POST /api/reports/{id}/copy-as-data-mart` | Unassessed | Unassessed |
-| `GET /api/reports/{id}/generated-sql` | Unassessed | Unassessed |
-| `POST /api/reports/{id}/run` | Unassessed | Unassessed |
+| `DELETE /api/reports/{id}`                                                     | Unassessed | Unassessed |
+| `GET /api/reports/{id}`                                                        | Unassessed | Unassessed |
+| `PUT /api/reports/{id}`                                                        | Unassessed | Unassessed |
+| `POST /api/reports/{id}/copy-as-data-mart`                                     | Unassessed | Unassessed |
+| `GET /api/reports/{id}/generated-sql`                                          | Unassessed | Unassessed |
+| `POST /api/reports/{id}/run`                                                   | Unassessed | Unassessed |
 
 ## Run History
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
+| Endpoint                   | OpenAPI                                                                                                       | API client                                                     |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | `GET /api/data-marts/runs` | [Covered](https://app.owox.com/api/swagger-ui#/Run%20History/ProjectDataMartRunsController_list) · 2026-07-23 | [Covered](./api-client/#read-project-run-history) · 2026-07-23 |
 
 ## Scheduled triggers
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
-| `GET /api/data-marts/scheduled-triggers` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/scheduled-triggers` | Unassessed | Unassessed |
-| `POST /api/data-marts/{dataMartId}/scheduled-triggers` | Unassessed | Unassessed |
+| Endpoint                                                      | OpenAPI    | API client |
+| ------------------------------------------------------------- | ---------- | ---------- |
+| `GET /api/data-marts/scheduled-triggers`                      | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/scheduled-triggers`         | Unassessed | Unassessed |
+| `POST /api/data-marts/{dataMartId}/scheduled-triggers`        | Unassessed | Unassessed |
 | `DELETE /api/data-marts/{dataMartId}/scheduled-triggers/{id}` | Unassessed | Unassessed |
-| `GET /api/data-marts/{dataMartId}/scheduled-triggers/{id}` | Unassessed | Unassessed |
-| `PUT /api/data-marts/{dataMartId}/scheduled-triggers/{id}` | Unassessed | Unassessed |
+| `GET /api/data-marts/{dataMartId}/scheduled-triggers/{id}`    | Unassessed | Unassessed |
+| `PUT /api/data-marts/{dataMartId}/scheduled-triggers/{id}`    | Unassessed | Unassessed |
 
 ## Search
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
+| Endpoint          | OpenAPI                                                                                     | API client                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
 | `GET /api/search` | [Covered](https://app.owox.com/api/swagger-ui#/Search/SearchController_search) · 2026-07-23 | [Covered](./api-client/#search-project-entities) · 2026-07-23 |
 
 ## Project setup progress
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
+| Endpoint                          | OpenAPI                                                                                                                        | API client                                                         |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
 | `GET /api/project-setup-progress` | [Covered](https://app.owox.com/api/swagger-ui#/project-setup-progress/ProjectSetupProgressController_getProgress) · 2026-07-21 | [Covered](./api-client/#check-project-setup-progress) · 2026-07-21 |
 
 ## Utilities
 
-| Endpoint | OpenAPI | API client |
-| --- | --- | --- |
+| Endpoint                           | OpenAPI                                                                                                 | API client                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | `POST /api/markdown/parse-to-html` | [Covered](https://app.owox.com/api/swagger-ui#/Utils/MarkdownParserController_parseToHtml) · 2026-07-22 | [Covered](./api-client/#convert-markdown-to-html) · 2026-07-22 |

--- a/packages/api-client/src/data-mart-runs.test.ts
+++ b/packages/api-client/src/data-mart-runs.test.ts
@@ -3,6 +3,7 @@ import {
   OWOXApiError,
   type OWOXDataMartRun,
   type OWOXDataMartRunDetail,
+  type OWOXDataQualityRule,
 } from './index.js';
 import { jest } from '@jest/globals';
 
@@ -82,6 +83,40 @@ const run: OWOXDataMartRun = {
 
 const runDetail: OWOXDataMartRunDetail = { ...run, dataQuality: null };
 
+const dataQualityRule: OWOXDataQualityRule = {
+  key: 'null_rate:field:["email"]',
+  category: 'null_rate',
+  scope: { type: 'FIELD', fieldPath: ['email'] },
+  severity: 'warning',
+  enabled: true,
+  parameters: { thresholdPercent: 0 },
+  isApplicable: true,
+};
+
+const dataQualityDetail = {
+  snapshot: {
+    config: { rules: [dataQualityRule] },
+    schema: null,
+    relationships: [],
+    definitionType: 'CONNECTOR',
+  },
+  summary: {
+    state: 'PASSED',
+    enabledChecks: 1,
+    totalChecks: 1,
+    passedChecks: 1,
+    failedChecks: 0,
+    notApplicableChecks: 0,
+    errorChecks: 0,
+    noticeFindings: 0,
+    warningFindings: 0,
+    errorFindings: 0,
+    violationCount: 0,
+    highestSeverity: null,
+  },
+  results: [],
+} as const;
+
 describe('Data Mart run lifecycle API', () => {
   it('starts, lists, reads, and cancels a Data Mart run through authenticated requests', async () => {
     const fetchImpl = createFetchMock(request => {
@@ -145,6 +180,21 @@ describe('Data Mart run lifecycle API', () => {
     });
   });
 
+  it.each(['status', 'type', 'runType'] as const)(
+    'rejects a null %s that the backend cannot produce',
+    async field => {
+      const fetchImpl = createFetchMock(request => {
+        if (request.url === '/api/auth/api-keys/exchange') {
+          return createJsonResponse(200, { accessToken: 'access-token-1' });
+        }
+        return createJsonResponse(200, { ...runDetail, [field]: null });
+      });
+      const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+      await expect(client.dataMarts.getRun('dm-1', 'run-1')).rejects.toBeInstanceOf(OWOXApiError);
+    }
+  );
+
   it('rejects invalid request options before making a network request', async () => {
     const fetchImpl = jest.fn<typeof fetch>();
     const client = new OWOXApiClient({ apiKey, fetchImpl });
@@ -207,5 +257,62 @@ describe('Data Mart run lifecycle API', () => {
       name: 'OWOXApiError',
       message: 'OWOX Data Mart Run API returned an unexpected response shape',
     });
+  });
+
+  it('accepts a nested Data Quality detail that matches the backend schema', async () => {
+    const response = { ...runDetail, dataQuality: dataQualityDetail };
+    const fetchImpl = createFetchMock(request => {
+      if (request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      return createJsonResponse(200, response);
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.dataMarts.getRun('dm-1', 'run-1')).resolves.toEqual(response);
+  });
+
+  it('rejects nested Data Quality values outside the backend schema constraints', async () => {
+    const invalidRules = [
+      { ...dataQualityRule, scope: { type: 'FIELD', fieldPath: [] } },
+      { ...dataQualityRule, scope: { type: 'FIELD', fieldPath: ['   '] } },
+      { ...dataQualityRule, parameters: { thresholdPercent: -1 } },
+      { ...dataQualityRule, parameters: { thresholdPercent: 101 } },
+      { ...dataQualityRule, notApplicableReason: '' },
+      {
+        ...dataQualityRule,
+        key: 'data_freshness:field:["email"]',
+        category: 'data_freshness',
+        parameters: { thresholdHours: -1 },
+      },
+      {
+        ...dataQualityRule,
+        key: 'data_freshness:field:["email"]',
+        category: 'data_freshness',
+        parameters: { thresholdHours: Number.MAX_SAFE_INTEGER },
+      },
+    ];
+
+    for (const invalidRule of invalidRules) {
+      const response = {
+        ...runDetail,
+        dataQuality: {
+          ...dataQualityDetail,
+          snapshot: {
+            ...dataQualityDetail.snapshot,
+            config: { rules: [invalidRule] },
+          },
+        },
+      };
+      const fetchImpl = createFetchMock(request => {
+        if (request.url === '/api/auth/api-keys/exchange') {
+          return createJsonResponse(200, { accessToken: 'access-token-1' });
+        }
+        return createJsonResponse(200, response);
+      });
+      const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+      await expect(client.dataMarts.getRun('dm-1', 'run-1')).rejects.toBeInstanceOf(OWOXApiError);
+    }
   });
 });

--- a/packages/api-client/src/data-mart-runs.test.ts
+++ b/packages/api-client/src/data-mart-runs.test.ts
@@ -152,13 +152,13 @@ describe('Data Mart run lifecycle API', () => {
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
     await expect(
-      client.dataMarts.run('data/mart', { payload: { cursor: 'next-page' } })
+      client.runs.start('data/mart', { payload: { cursor: 'next-page' } })
     ).resolves.toEqual({ runId: '123e4567-e89b-12d3-a456-426614174000' });
     await expect(
-      client.dataMarts.listRuns('data/mart', { limit: 25, offset: 50 })
+      client.runs.listForDataMart('data/mart', { limit: 25, offset: 50 })
     ).resolves.toEqual({ runs: [run] });
-    await expect(client.dataMarts.getRun('data/mart', 'run/1')).resolves.toEqual(runDetail);
-    await expect(client.dataMarts.cancelRun('data/mart', 'run/1')).resolves.toBeUndefined();
+    await expect(client.runs.get('data/mart', 'run/1')).resolves.toEqual(runDetail);
+    await expect(client.runs.cancel('data/mart', 'run/1')).resolves.toBeUndefined();
   });
 
   it('rejects malformed manual-run and run-history responses', async () => {
@@ -173,8 +173,8 @@ describe('Data Mart run lifecycle API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.dataMarts.run('dm-1')).rejects.toBeInstanceOf(OWOXApiError);
-    await expect(client.dataMarts.listRuns('dm-1')).rejects.toMatchObject({
+    await expect(client.runs.start('dm-1')).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(client.runs.listForDataMart('dm-1')).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart Runs API returned an unexpected response shape',
     });
@@ -191,7 +191,7 @@ describe('Data Mart run lifecycle API', () => {
       });
       const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-      await expect(client.dataMarts.getRun('dm-1', 'run-1')).rejects.toBeInstanceOf(OWOXApiError);
+      await expect(client.runs.get('dm-1', 'run-1')).rejects.toBeInstanceOf(OWOXApiError);
     }
   );
 
@@ -199,22 +199,22 @@ describe('Data Mart run lifecycle API', () => {
     const fetchImpl = jest.fn<typeof fetch>();
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.dataMarts.run('dm-1', { payload: [] } as never)).rejects.toMatchObject({
+    await expect(client.runs.start('dm-1', { payload: [] } as never)).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'Invalid OWOX Data Mart manual-run request',
     });
     await expect(
-      client.dataMarts.run('dm-1', { payload: { value: 'x'.repeat(1024 * 1024) } })
+      client.runs.start('dm-1', { payload: { value: 'x'.repeat(1024 * 1024) } })
     ).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart manual-run payload exceeds 1MB',
     });
-    await expect(client.dataMarts.listRuns('dm-1', { limit: '25' } as never)).rejects.toMatchObject(
-      {
-        name: 'OWOXApiError',
-        message: 'Invalid OWOX Data Mart run-list options',
-      }
-    );
+    await expect(
+      client.runs.listForDataMart('dm-1', { limit: '25' } as never)
+    ).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'Invalid OWOX Data Mart run-list options',
+    });
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
@@ -253,7 +253,7 @@ describe('Data Mart run lifecycle API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.dataMarts.getRun('dm-1', 'run-1')).rejects.toMatchObject({
+    await expect(client.runs.get('dm-1', 'run-1')).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart Run API returned an unexpected response shape',
     });
@@ -269,7 +269,7 @@ describe('Data Mart run lifecycle API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.dataMarts.getRun('dm-1', 'run-1')).resolves.toEqual(response);
+    await expect(client.runs.get('dm-1', 'run-1')).resolves.toEqual(response);
   });
 
   it('wraps a non-object Data Quality result as an API response-shape error', async () => {
@@ -285,7 +285,7 @@ describe('Data Mart run lifecycle API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.dataMarts.getRun('dm-1', 'run-1')).rejects.toMatchObject({
+    await expect(client.runs.get('dm-1', 'run-1')).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart Run API returned an unexpected response shape',
     });
@@ -331,7 +331,7 @@ describe('Data Mart run lifecycle API', () => {
       });
       const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-      await expect(client.dataMarts.getRun('dm-1', 'run-1')).rejects.toBeInstanceOf(OWOXApiError);
+      await expect(client.runs.get('dm-1', 'run-1')).rejects.toBeInstanceOf(OWOXApiError);
     }
   });
 });

--- a/packages/api-client/src/data-mart-runs.test.ts
+++ b/packages/api-client/src/data-mart-runs.test.ts
@@ -155,18 +155,17 @@ describe('Data Mart run lifecycle API', () => {
       return createJsonResponse(404, { message: 'Not found' });
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
+    const dataMartRuns = client.runs.forDataMart('data/mart');
 
     await expect(
-      client.runs.start('data/mart', {
+      dataMartRuns.start({
         runType: 'MANUAL_BACKFILL',
         data: { StartDate: '2026-07-01', EndDate: '2026-07-31' },
       })
     ).resolves.toEqual({ runId: '123e4567-e89b-12d3-a456-426614174000' });
-    await expect(
-      client.runs.listForDataMart('data/mart', { limit: 25, offset: 50 })
-    ).resolves.toEqual({ runs: [run] });
-    await expect(client.runs.get('data/mart', 'run/1')).resolves.toEqual(runDetail);
-    await expect(client.runs.cancel('data/mart', 'run/1')).resolves.toBeUndefined();
+    await expect(dataMartRuns.list({ limit: 25, offset: 50 })).resolves.toEqual({ runs: [run] });
+    await expect(dataMartRuns.get('run/1')).resolves.toEqual(runDetail);
+    await expect(dataMartRuns.cancel('run/1')).resolves.toBeUndefined();
   });
 
   it('rejects malformed manual-run and run-history responses', async () => {
@@ -181,8 +180,8 @@ describe('Data Mart run lifecycle API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.runs.start('dm-1')).rejects.toBeInstanceOf(OWOXApiError);
-    await expect(client.runs.listForDataMart('dm-1')).rejects.toMatchObject({
+    await expect(client.runs.forDataMart('dm-1').start()).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(client.runs.forDataMart('dm-1').list()).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart Runs API returned an unexpected response shape',
     });
@@ -199,7 +198,9 @@ describe('Data Mart run lifecycle API', () => {
       });
       const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-      await expect(client.runs.get('dm-1', 'run-1')).rejects.toBeInstanceOf(OWOXApiError);
+      await expect(client.runs.forDataMart('dm-1').get('run-1')).rejects.toBeInstanceOf(
+        OWOXApiError
+      );
     }
   );
 
@@ -208,23 +209,25 @@ describe('Data Mart run lifecycle API', () => {
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
     await expect(
-      client.runs.start('dm-1', { runType: 'FULL_REFRESH' } as never)
+      client.runs.forDataMart('dm-1').start({ runType: 'FULL_REFRESH' } as never)
     ).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'Invalid OWOX Data Mart run-start options',
     });
-    await expect(client.runs.start('dm-1', { data: [] } as never)).rejects.toMatchObject({
+    await expect(
+      client.runs.forDataMart('dm-1').start({ data: [] } as never)
+    ).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'Invalid OWOX Data Mart run-start options',
     });
     await expect(
-      client.runs.start('dm-1', { data: { value: 'x'.repeat(1024 * 1024) } })
+      client.runs.forDataMart('dm-1').start({ data: { value: 'x'.repeat(1024 * 1024) } })
     ).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart manual-run payload exceeds 1MB',
     });
     await expect(
-      client.runs.listForDataMart('dm-1', { limit: '25' } as never)
+      client.runs.forDataMart('dm-1').list({ limit: '25' } as never)
     ).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'Invalid OWOX Data Mart run-list options',
@@ -267,7 +270,7 @@ describe('Data Mart run lifecycle API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.runs.get('dm-1', 'run-1')).rejects.toMatchObject({
+    await expect(client.runs.forDataMart('dm-1').get('run-1')).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart Run API returned an unexpected response shape',
     });
@@ -283,7 +286,7 @@ describe('Data Mart run lifecycle API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.runs.get('dm-1', 'run-1')).resolves.toEqual(response);
+    await expect(client.runs.forDataMart('dm-1').get('run-1')).resolves.toEqual(response);
   });
 
   it('wraps a non-object Data Quality result as an API response-shape error', async () => {
@@ -299,7 +302,7 @@ describe('Data Mart run lifecycle API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.runs.get('dm-1', 'run-1')).rejects.toMatchObject({
+    await expect(client.runs.forDataMart('dm-1').get('run-1')).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart Run API returned an unexpected response shape',
     });
@@ -345,7 +348,9 @@ describe('Data Mart run lifecycle API', () => {
       });
       const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-      await expect(client.runs.get('dm-1', 'run-1')).rejects.toBeInstanceOf(OWOXApiError);
+      await expect(client.runs.forDataMart('dm-1').get('run-1')).rejects.toBeInstanceOf(
+        OWOXApiError
+      );
     }
   });
 });

--- a/packages/api-client/src/data-mart-runs.test.ts
+++ b/packages/api-client/src/data-mart-runs.test.ts
@@ -3,6 +3,7 @@ import {
   OWOXApiError,
   type OWOXDataMartRun,
   type OWOXDataMartRunDetail,
+  type OWOXDataMartRunStartOptions,
   type OWOXDataQualityRule,
 } from './index.js';
 import { jest } from '@jest/globals';
@@ -13,6 +14,10 @@ type RecordedRequest = {
   headers: Record<string, string>;
   body: unknown;
 };
+
+// @ts-expect-error connector data requires an explicit MANUAL_BACKFILL run type
+const invalidImplicitBackfill: OWOXDataMartRunStartOptions = { data: { StartDate: '2026-07-01' } };
+void invalidImplicitBackfill;
 
 const apiOrigin = 'https://example.test';
 const apiKeyId = 'pmk_AbCdEfGhIjKlMnOpQrStUv';
@@ -214,10 +219,8 @@ describe('Data Mart run lifecycle API', () => {
     });
   });
 
-  it.each([
-    ['incremental data retained by the run form', { runType: 'INCREMENTAL', data: {} }],
-    ['manual backfill without connector-specific fields', { runType: 'MANUAL_BACKFILL' }],
-  ] as const)('accepts %s', async (_case, options) => {
+  it('accepts a manual backfill without connector-specific fields', async () => {
+    const options = { runType: 'MANUAL_BACKFILL' } as const;
     const fetchImpl = createFetchMock(request => {
       if (request.url === '/api/auth/api-keys/exchange') {
         return createJsonResponse(200, { accessToken: 'access-token-1' });
@@ -266,6 +269,20 @@ describe('Data Mart run lifecycle API', () => {
       message: 'Invalid OWOX Data Mart run-start options',
     });
     await expect(
+      client.runs.forDataMart('dm-1').start({ data: { value: 'silently ignored' } } as never)
+    ).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'Invalid OWOX Data Mart run-start options',
+    });
+    await expect(
+      client.runs
+        .forDataMart('dm-1')
+        .start({ runType: 'INCREMENTAL', data: { value: 'silently ignored' } } as never)
+    ).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'Invalid OWOX Data Mart run-start options',
+    });
+    await expect(
       client.runs.forDataMart('dm-1').start({
         runType: 'MANUAL_BACKFILL',
         data: { value: 'x'.repeat(1024 * 1024) },
@@ -273,12 +290,6 @@ describe('Data Mart run lifecycle API', () => {
     ).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart manual-run payload exceeds 1MB',
-    });
-    await expect(
-      client.runs.forDataMart('dm-1').start({ data: [] } as never)
-    ).rejects.toMatchObject({
-      name: 'OWOXApiError',
-      message: 'Invalid OWOX Data Mart run-start options',
     });
     await expect(
       client.runs.forDataMart('dm-1').list({ limit: '25' } as never)

--- a/packages/api-client/src/data-mart-runs.test.ts
+++ b/packages/api-client/src/data-mart-runs.test.ts
@@ -132,7 +132,7 @@ describe('Data Mart run lifecycle API', () => {
       expect(request.headers['x-owox-authorization']).toBe('Bearer access-token-1');
       expect(request.headers['x-owox-api-key-id']).toBe(apiKeyId);
 
-      if (request.method === 'POST' && request.url === '/api/data-marts/data%2Fmart/manual-run') {
+      if (request.method === 'POST' && request.url === '/api/data-marts/data%20mart/manual-run') {
         expect(request.body).toEqual({
           payload: {
             runType: 'MANUAL_BACKFILL',
@@ -143,16 +143,16 @@ describe('Data Mart run lifecycle API', () => {
       }
       if (
         request.method === 'GET' &&
-        request.url === '/api/data-marts/data%2Fmart/runs?limit=25&offset=50'
+        request.url === '/api/data-marts/data%20mart/runs?limit=25&offset=50'
       ) {
         return createJsonResponse(200, { runs: [run] });
       }
-      if (request.method === 'GET' && request.url === '/api/data-marts/data%2Fmart/runs/run%2F1') {
+      if (request.method === 'GET' && request.url === '/api/data-marts/data%20mart/runs/run%3A1') {
         return createJsonResponse(200, runDetail);
       }
       if (
         request.method === 'POST' &&
-        request.url === '/api/data-marts/data%2Fmart/runs/run%2F1/cancel'
+        request.url === '/api/data-marts/data%20mart/runs/run%3A1/cancel'
       ) {
         expect(request.body).toBeUndefined();
         return new Response(null, { status: 204 });
@@ -160,7 +160,7 @@ describe('Data Mart run lifecycle API', () => {
       return createJsonResponse(404, { message: 'Not found' });
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
-    const dataMartRuns = client.runs.forDataMart('data/mart');
+    const dataMartRuns = client.runs.forDataMart('data mart');
 
     await expect(
       dataMartRuns.start({
@@ -169,8 +169,8 @@ describe('Data Mart run lifecycle API', () => {
       })
     ).resolves.toEqual({ runId: '123e4567-e89b-12d3-a456-426614174000' });
     await expect(dataMartRuns.list({ limit: 25, offset: 50 })).resolves.toEqual({ runs: [run] });
-    await expect(dataMartRuns.get('run/1')).resolves.toEqual(runDetail);
-    await expect(dataMartRuns.cancel('run/1')).resolves.toBeUndefined();
+    await expect(dataMartRuns.get('run:1')).resolves.toEqual(runDetail);
+    await expect(dataMartRuns.cancel('run:1')).resolves.toBeUndefined();
   });
 
   it('rejects malformed manual-run and run-history responses', async () => {
@@ -306,10 +306,15 @@ describe('Data Mart run lifecycle API', () => {
 
     expect(() => client.runs.forDataMart('.')).toThrow(OWOXApiError);
     expect(() => client.runs.forDataMart('  ')).toThrow(OWOXApiError);
+    expect(() => client.runs.forDataMart('data/mart')).toThrow(OWOXApiError);
+    expect(() => client.runs.forDataMart('data\\mart')).toThrow(OWOXApiError);
+    expect(() => client.runs.forDataMart('data%2Fmart')).toThrow(OWOXApiError);
 
     const runs = client.runs.forDataMart('dm-1');
     await expect(runs.get('')).rejects.toBeInstanceOf(OWOXApiError);
     await expect(runs.cancel('..')).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(runs.get('run/1')).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(runs.cancel('run\\1')).rejects.toBeInstanceOf(OWOXApiError);
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 

--- a/packages/api-client/src/data-mart-runs.test.ts
+++ b/packages/api-client/src/data-mart-runs.test.ts
@@ -221,10 +221,25 @@ describe('Data Mart run lifecycle API', () => {
       message: 'Invalid OWOX Data Mart run-start options',
     });
     await expect(
-      client.runs.forDataMart('dm-1').start({ data: { value: 'x'.repeat(1024 * 1024) } })
+      client.runs.forDataMart('dm-1').start({
+        runType: 'MANUAL_BACKFILL',
+        data: { value: 'x'.repeat(1024 * 1024) },
+      })
     ).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart manual-run payload exceeds 1MB',
+    });
+    await expect(
+      client.runs.forDataMart('dm-1').start({ data: { value: 'silently ignored' } } as never)
+    ).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'Invalid OWOX Data Mart run-start options',
+    });
+    await expect(
+      client.runs.forDataMart('dm-1').start({ runType: 'MANUAL_BACKFILL' } as never)
+    ).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'Invalid OWOX Data Mart run-start options',
     });
     await expect(
       client.runs.forDataMart('dm-1').list({ limit: '25' } as never)
@@ -232,6 +247,19 @@ describe('Data Mart run lifecycle API', () => {
       name: 'OWOXApiError',
       message: 'Invalid OWOX Data Mart run-list options',
     });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('rejects ambiguous Data Mart and run IDs before making a network request', async () => {
+    const fetchImpl = jest.fn<typeof fetch>();
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    expect(() => client.runs.forDataMart('.')).toThrow(OWOXApiError);
+    expect(() => client.runs.forDataMart('  ')).toThrow(OWOXApiError);
+
+    const runs = client.runs.forDataMart('dm-1');
+    await expect(runs.get('')).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(runs.cancel('..')).rejects.toBeInstanceOf(OWOXApiError);
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
@@ -289,6 +317,38 @@ describe('Data Mart run lifecycle API', () => {
     await expect(client.runs.forDataMart('dm-1').get('run-1')).resolves.toEqual(response);
   });
 
+  it('accepts additive Data Quality fields and server-owned rule invariants', async () => {
+    const response = {
+      ...runDetail,
+      dataQuality: {
+        ...dataQualityDetail,
+        snapshot: {
+          ...dataQualityDetail.snapshot,
+          config: {
+            rules: [
+              {
+                ...dataQualityRule,
+                key: 'server-defined-rule-key',
+                scope: { type: 'DATA_MART', futureScopeField: true },
+                parameters: { thresholdPercent: 101, futureParameter: 'supported' },
+                futureRuleField: { version: 2 },
+              },
+            ],
+          },
+        },
+      },
+    };
+    const fetchImpl = createFetchMock(request => {
+      if (request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      return createJsonResponse(200, response);
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.runs.forDataMart('dm-1').get('run-1')).resolves.toEqual(response);
+  });
+
   it('wraps a non-object Data Quality result as an API response-shape error', async () => {
     const response = {
       ...runDetail,
@@ -312,21 +372,7 @@ describe('Data Mart run lifecycle API', () => {
     const invalidRules = [
       { ...dataQualityRule, scope: { type: 'FIELD', fieldPath: [] } },
       { ...dataQualityRule, scope: { type: 'FIELD', fieldPath: ['   '] } },
-      { ...dataQualityRule, parameters: { thresholdPercent: -1 } },
-      { ...dataQualityRule, parameters: { thresholdPercent: 101 } },
       { ...dataQualityRule, notApplicableReason: '' },
-      {
-        ...dataQualityRule,
-        key: 'data_freshness:field:["email"]',
-        category: 'data_freshness',
-        parameters: { thresholdHours: -1 },
-      },
-      {
-        ...dataQualityRule,
-        key: 'data_freshness:field:["email"]',
-        category: 'data_freshness',
-        parameters: { thresholdHours: Number.MAX_SAFE_INTEGER },
-      },
     ];
 
     for (const invalidRule of invalidRules) {

--- a/packages/api-client/src/data-mart-runs.test.ts
+++ b/packages/api-client/src/data-mart-runs.test.ts
@@ -176,7 +176,7 @@ describe('Data Mart run lifecycle API', () => {
       if (request.method === 'POST') {
         return createJsonResponse(201, { runId: 42 });
       }
-      return createJsonResponse(200, { runs: [{ ...run, qualitySummary: undefined }] });
+      return createJsonResponse(200, { runs: [{ ...run, status: 'UNKNOWN' }] });
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
@@ -184,6 +184,51 @@ describe('Data Mart run lifecycle API', () => {
     await expect(client.runs.forDataMart('dm-1').list()).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart Runs API returned an unexpected response shape',
+    });
+  });
+
+  it('normalizes run responses from deployments that predate Data Quality fields', async () => {
+    const { qualitySummary: _qualitySummary, ...legacyRun } = run;
+    const {
+      qualitySummary: _detailQualitySummary,
+      dataQuality: _dataQuality,
+      ...legacyRunDetail
+    } = runDetail;
+    const fetchImpl = createFetchMock(request => {
+      if (request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      if (request.url === '/api/data-marts/dm-1/runs/run-1') {
+        return createJsonResponse(200, legacyRunDetail);
+      }
+      return createJsonResponse(200, { runs: [legacyRun] });
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+    const runs = client.runs.forDataMart('dm-1');
+
+    await expect(runs.list()).resolves.toEqual({ runs: [{ ...legacyRun, qualitySummary: null }] });
+    await expect(runs.get('run-1')).resolves.toEqual({
+      ...legacyRunDetail,
+      qualitySummary: null,
+      dataQuality: null,
+    });
+  });
+
+  it.each([
+    ['incremental data retained by the run form', { runType: 'INCREMENTAL', data: {} }],
+    ['manual backfill without connector-specific fields', { runType: 'MANUAL_BACKFILL' }],
+  ] as const)('accepts %s', async (_case, options) => {
+    const fetchImpl = createFetchMock(request => {
+      if (request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      expect(request.body).toEqual({ payload: options });
+      return createJsonResponse(201, { runId: '123e4567-e89b-12d3-a456-426614174000' });
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.runs.forDataMart('dm-1').start(options)).resolves.toEqual({
+      runId: '123e4567-e89b-12d3-a456-426614174000',
     });
   });
 
@@ -230,13 +275,7 @@ describe('Data Mart run lifecycle API', () => {
       message: 'OWOX Data Mart manual-run payload exceeds 1MB',
     });
     await expect(
-      client.runs.forDataMart('dm-1').start({ data: { value: 'silently ignored' } } as never)
-    ).rejects.toMatchObject({
-      name: 'OWOXApiError',
-      message: 'Invalid OWOX Data Mart run-start options',
-    });
-    await expect(
-      client.runs.forDataMart('dm-1').start({ runType: 'MANUAL_BACKFILL' } as never)
+      client.runs.forDataMart('dm-1').start({ data: [] } as never)
     ).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'Invalid OWOX Data Mart run-start options',

--- a/packages/api-client/src/data-mart-runs.test.ts
+++ b/packages/api-client/src/data-mart-runs.test.ts
@@ -128,7 +128,12 @@ describe('Data Mart run lifecycle API', () => {
       expect(request.headers['x-owox-api-key-id']).toBe(apiKeyId);
 
       if (request.method === 'POST' && request.url === '/api/data-marts/data%2Fmart/manual-run') {
-        expect(request.body).toEqual({ payload: { cursor: 'next-page' } });
+        expect(request.body).toEqual({
+          payload: {
+            runType: 'MANUAL_BACKFILL',
+            data: { StartDate: '2026-07-01', EndDate: '2026-07-31' },
+          },
+        });
         return createJsonResponse(201, { runId: '123e4567-e89b-12d3-a456-426614174000' });
       }
       if (
@@ -152,7 +157,10 @@ describe('Data Mart run lifecycle API', () => {
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
     await expect(
-      client.runs.start('data/mart', { payload: { cursor: 'next-page' } })
+      client.runs.start('data/mart', {
+        runType: 'MANUAL_BACKFILL',
+        data: { StartDate: '2026-07-01', EndDate: '2026-07-31' },
+      })
     ).resolves.toEqual({ runId: '123e4567-e89b-12d3-a456-426614174000' });
     await expect(
       client.runs.listForDataMart('data/mart', { limit: 25, offset: 50 })
@@ -199,12 +207,18 @@ describe('Data Mart run lifecycle API', () => {
     const fetchImpl = jest.fn<typeof fetch>();
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.runs.start('dm-1', { payload: [] } as never)).rejects.toMatchObject({
+    await expect(
+      client.runs.start('dm-1', { runType: 'FULL_REFRESH' } as never)
+    ).rejects.toMatchObject({
       name: 'OWOXApiError',
-      message: 'Invalid OWOX Data Mart manual-run request',
+      message: 'Invalid OWOX Data Mart run-start options',
+    });
+    await expect(client.runs.start('dm-1', { data: [] } as never)).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'Invalid OWOX Data Mart run-start options',
     });
     await expect(
-      client.runs.start('dm-1', { payload: { value: 'x'.repeat(1024 * 1024) } })
+      client.runs.start('dm-1', { data: { value: 'x'.repeat(1024 * 1024) } })
     ).rejects.toMatchObject({
       name: 'OWOXApiError',
       message: 'OWOX Data Mart manual-run payload exceeds 1MB',

--- a/packages/api-client/src/data-mart-runs.test.ts
+++ b/packages/api-client/src/data-mart-runs.test.ts
@@ -272,6 +272,25 @@ describe('Data Mart run lifecycle API', () => {
     await expect(client.dataMarts.getRun('dm-1', 'run-1')).resolves.toEqual(response);
   });
 
+  it('wraps a non-object Data Quality result as an API response-shape error', async () => {
+    const response = {
+      ...runDetail,
+      dataQuality: { ...dataQualityDetail, results: [null] },
+    };
+    const fetchImpl = createFetchMock(request => {
+      if (request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      return createJsonResponse(200, response);
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.dataMarts.getRun('dm-1', 'run-1')).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'OWOX Data Mart Run API returned an unexpected response shape',
+    });
+  });
+
   it('rejects nested Data Quality values outside the backend schema constraints', async () => {
     const invalidRules = [
       { ...dataQualityRule, scope: { type: 'FIELD', fieldPath: [] } },

--- a/packages/api-client/src/data-mart-runs.test.ts
+++ b/packages/api-client/src/data-mart-runs.test.ts
@@ -1,0 +1,211 @@
+import {
+  OWOXApiClient,
+  OWOXApiError,
+  type OWOXDataMartRun,
+  type OWOXDataMartRunDetail,
+} from './index.js';
+import { jest } from '@jest/globals';
+
+type RecordedRequest = {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+};
+
+const apiOrigin = 'https://example.test';
+const apiKeyId = 'pmk_AbCdEfGhIjKlMnOpQrStUv';
+const apiKey = `owox_key_${Buffer.from(
+  JSON.stringify({
+    apiOrigin,
+    apiKeyId,
+    apiKeySecret: 'secret-value-that-must-not-leak',
+  }),
+  'utf8'
+).toString('base64url')}`;
+
+function createJsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+async function readRequestBody(request: Request): Promise<unknown> {
+  const text = await request.text();
+  return text ? JSON.parse(text) : undefined;
+}
+
+function createFetchMock(
+  handler: (request: RecordedRequest) => Response | Promise<Response>
+): typeof fetch {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const headers: Record<string, string> = {};
+    request.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    const parsedUrl = new URL(request.url);
+    return handler({
+      method: request.method,
+      url: `${parsedUrl.pathname}${parsedUrl.search}`,
+      headers,
+      body: await readRequestBody(request),
+    });
+  }) as typeof fetch;
+}
+
+const run: OWOXDataMartRun = {
+  id: 'run-1',
+  status: 'SUCCESS',
+  type: 'CONNECTOR',
+  runType: 'manual',
+  dataMartId: 'data-mart-1',
+  definitionRun: { type: 'connector' },
+  reportId: null,
+  reportDefinition: null,
+  insightId: null,
+  insightDefinition: null,
+  insightTemplateId: null,
+  insightTemplateDefinition: null,
+  aiSourceDefinition: null,
+  logs: [],
+  errors: null,
+  createdAt: '2026-08-07T08:00:00.000Z',
+  startedAt: '2026-08-07T08:00:01.000Z',
+  finishedAt: '2026-08-07T08:01:00.000Z',
+  createdByUser: null,
+  additionalParams: null,
+  totals: null,
+  qualitySummary: null,
+};
+
+const runDetail: OWOXDataMartRunDetail = { ...run, dataQuality: null };
+
+describe('Data Mart run lifecycle API', () => {
+  it('starts, lists, reads, and cancels a Data Mart run through authenticated requests', async () => {
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST' && request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+
+      expect(request.headers['x-owox-authorization']).toBe('Bearer access-token-1');
+      expect(request.headers['x-owox-api-key-id']).toBe(apiKeyId);
+
+      if (request.method === 'POST' && request.url === '/api/data-marts/data%2Fmart/manual-run') {
+        expect(request.body).toEqual({ payload: { cursor: 'next-page' } });
+        return createJsonResponse(201, { runId: '123e4567-e89b-12d3-a456-426614174000' });
+      }
+      if (
+        request.method === 'GET' &&
+        request.url === '/api/data-marts/data%2Fmart/runs?limit=25&offset=50'
+      ) {
+        return createJsonResponse(200, { runs: [run] });
+      }
+      if (request.method === 'GET' && request.url === '/api/data-marts/data%2Fmart/runs/run%2F1') {
+        return createJsonResponse(200, runDetail);
+      }
+      if (
+        request.method === 'POST' &&
+        request.url === '/api/data-marts/data%2Fmart/runs/run%2F1/cancel'
+      ) {
+        expect(request.body).toBeUndefined();
+        return new Response(null, { status: 204 });
+      }
+      return createJsonResponse(404, { message: 'Not found' });
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(
+      client.dataMarts.run('data/mart', { payload: { cursor: 'next-page' } })
+    ).resolves.toEqual({ runId: '123e4567-e89b-12d3-a456-426614174000' });
+    await expect(
+      client.dataMarts.listRuns('data/mart', { limit: 25, offset: 50 })
+    ).resolves.toEqual({ runs: [run] });
+    await expect(client.dataMarts.getRun('data/mart', 'run/1')).resolves.toEqual(runDetail);
+    await expect(client.dataMarts.cancelRun('data/mart', 'run/1')).resolves.toBeUndefined();
+  });
+
+  it('rejects malformed manual-run and run-history responses', async () => {
+    const fetchImpl = createFetchMock(request => {
+      if (request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      if (request.method === 'POST') {
+        return createJsonResponse(201, { runId: 42 });
+      }
+      return createJsonResponse(200, { runs: [{ ...run, qualitySummary: undefined }] });
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.dataMarts.run('dm-1')).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(client.dataMarts.listRuns('dm-1')).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'OWOX Data Mart Runs API returned an unexpected response shape',
+    });
+  });
+
+  it('rejects invalid request options before making a network request', async () => {
+    const fetchImpl = jest.fn<typeof fetch>();
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.dataMarts.run('dm-1', { payload: [] } as never)).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'Invalid OWOX Data Mart manual-run request',
+    });
+    await expect(
+      client.dataMarts.run('dm-1', { payload: { value: 'x'.repeat(1024 * 1024) } })
+    ).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'OWOX Data Mart manual-run payload exceeds 1MB',
+    });
+    await expect(client.dataMarts.listRuns('dm-1', { limit: '25' } as never)).rejects.toMatchObject(
+      {
+        name: 'OWOXApiError',
+        message: 'Invalid OWOX Data Mart run-list options',
+      }
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed Data Quality detail instead of returning an unchecked nested object', async () => {
+    const malformedDetail = {
+      ...runDetail,
+      dataQuality: {
+        snapshot: {
+          config: { rules: [] },
+          schema: null,
+          relationships: [],
+          definitionType: 'CONNECTOR',
+        },
+        summary: {
+          state: 'NOT_A_REAL_STATE',
+          enabledChecks: 0,
+          totalChecks: 0,
+          passedChecks: 0,
+          failedChecks: 0,
+          notApplicableChecks: 0,
+          errorChecks: 0,
+          noticeFindings: 0,
+          warningFindings: 0,
+          errorFindings: 0,
+          violationCount: 0,
+          highestSeverity: null,
+        },
+        results: [],
+      },
+    };
+    const fetchImpl = createFetchMock(request => {
+      if (request.url === '/api/auth/api-keys/exchange') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      return createJsonResponse(200, malformedDetail);
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.dataMarts.getRun('dm-1', 'run-1')).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'OWOX Data Mart Run API returned an unexpected response shape',
+    });
+  });
+});

--- a/packages/api-client/src/data-mart-runs.ts
+++ b/packages/api-client/src/data-mart-runs.ts
@@ -151,9 +151,9 @@ export type OWOXDataQualityRunDetail = {
 
 export type OWOXDataMartRun = {
   id: string;
-  status: OWOXDataMartRunStatus | null;
-  type: OWOXDataMartRunType | null;
-  runType: OWOXDataMartRunTriggerType | null;
+  status: OWOXDataMartRunStatus;
+  type: OWOXDataMartRunType;
+  runType: OWOXDataMartRunTriggerType;
   dataMartId: string;
   definitionRun: Record<string, unknown> | null;
   reportId: string | null;
@@ -191,9 +191,29 @@ const SEVERITIES = new Set<string>(DATA_QUALITY_SEVERITY_VALUES);
 const CATEGORIES = new Set<string>(DATA_QUALITY_CATEGORY_VALUES);
 const CHECK_STATUSES = new Set<string>(DATA_QUALITY_CHECK_STATUS_VALUES);
 const DEFINITION_TYPES = new Set<string>(DATA_MART_DEFINITION_TYPE_VALUES);
+const MAX_DATA_QUALITY_THRESHOLD_HOURS = Math.floor(Number.MAX_SAFE_INTEGER / (60 * 60 * 1000));
+const DATA_QUALITY_CATEGORY_SCOPES: Readonly<Record<OWOXDataQualityCategory, string>> = {
+  pk_uniqueness: 'DATA_MART',
+  duplicate_rows: 'DATA_MART',
+  null_rate: 'FIELD',
+  column_uniqueness: 'FIELD',
+  constant_column: 'FIELD',
+  empty_table: 'DATA_MART',
+  type_mismatch: 'FIELD',
+  data_freshness: 'FIELD',
+  negative_values: 'FIELD',
+  relationship_integrity: 'RELATIONSHIP',
+  reverse_relationship: 'RELATIONSHIP',
+};
 
 function isNullableString(value: unknown): boolean {
   return value === null || typeof value === 'string';
+}
+
+function isNullableBoundedString(value: unknown, maxLength: number): boolean {
+  return (
+    value === null || (typeof value === 'string' && value.length >= 1 && value.length <= maxLength)
+  );
 }
 
 function isNullableRecord(value: unknown): boolean {
@@ -208,12 +228,21 @@ function isNullableDateTime(value: unknown): boolean {
   return value === null || isRfc3339DateTimeString(value);
 }
 
-function isNullableEnum(value: unknown, values: ReadonlySet<string>): boolean {
-  return value === null || (typeof value === 'string' && values.has(value));
+function isEnum(value: unknown, values: ReadonlySet<string>): boolean {
+  return typeof value === 'string' && values.has(value);
 }
 
 function isNonNegativeInteger(value: unknown): boolean {
   return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function isDataQualityIdentifier(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.trim().length > 0;
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const allowed = new Set(keys);
+  return Object.keys(value).every(key => allowed.has(key));
 }
 
 function isNullableTotals(value: unknown): boolean {
@@ -261,31 +290,79 @@ function isCompactDataQualitySummary(value: unknown): value is OWOXCompactDataQu
 
 function isDataQualityScope(value: unknown): value is OWOXDataQualityScope {
   if (!isRecord(value) || typeof value.type !== 'string') return false;
-  if (value.type === 'DATA_MART') return true;
+  if (value.type === 'DATA_MART') return hasOnlyKeys(value, ['type']);
   if (value.type === 'FIELD') {
     return (
-      Array.isArray(value.fieldPath) && value.fieldPath.every(item => typeof item === 'string')
+      hasOnlyKeys(value, ['type', 'fieldPath']) &&
+      Array.isArray(value.fieldPath) &&
+      value.fieldPath.length > 0 &&
+      value.fieldPath.every(isDataQualityIdentifier)
     );
   }
-  return value.type === 'RELATIONSHIP' && typeof value.relationshipId === 'string';
+  return (
+    value.type === 'RELATIONSHIP' &&
+    hasOnlyKeys(value, ['type', 'relationshipId']) &&
+    isDataQualityIdentifier(value.relationshipId)
+  );
+}
+
+function buildDataQualityRuleKey(
+  category: OWOXDataQualityCategory,
+  scope: OWOXDataQualityScope
+): string {
+  if (scope.type === 'DATA_MART') return `${category}:data_mart`;
+  if (scope.type === 'FIELD') return `${category}:field:${JSON.stringify(scope.fieldPath)}`;
+  return `${category}:relationship:${scope.relationshipId}`;
 }
 
 function isDataQualityRule(value: unknown): value is OWOXDataQualityRule {
   if (!isRecord(value) || !isRecord(value.parameters)) return false;
+  if (
+    !hasOnlyKeys(value, [
+      'key',
+      'category',
+      'scope',
+      'severity',
+      'enabled',
+      'parameters',
+      'isApplicable',
+      'notApplicableReason',
+    ]) ||
+    !hasOnlyKeys(value.parameters, ['thresholdPercent', 'thresholdHours']) ||
+    typeof value.category !== 'string' ||
+    !CATEGORIES.has(value.category) ||
+    !isDataQualityScope(value.scope)
+  ) {
+    return false;
+  }
+  const category = value.category as OWOXDataQualityCategory;
+  const scope = value.scope;
+  const thresholdPercent = value.parameters.thresholdPercent;
+  const thresholdHours = value.parameters.thresholdHours;
   return (
     typeof value.key === 'string' &&
-    typeof value.category === 'string' &&
-    CATEGORIES.has(value.category) &&
-    isDataQualityScope(value.scope) &&
+    value.key === buildDataQualityRuleKey(category, scope) &&
+    DATA_QUALITY_CATEGORY_SCOPES[category] === scope.type &&
     typeof value.severity === 'string' &&
     SEVERITIES.has(value.severity) &&
     typeof value.enabled === 'boolean' &&
-    (value.parameters.thresholdPercent === undefined ||
-      typeof value.parameters.thresholdPercent === 'number') &&
-    (value.parameters.thresholdHours === undefined ||
-      typeof value.parameters.thresholdHours === 'number') &&
+    (thresholdPercent === undefined ||
+      (typeof thresholdPercent === 'number' &&
+        Number.isFinite(thresholdPercent) &&
+        thresholdPercent >= 0 &&
+        thresholdPercent <= 100)) &&
+    (thresholdHours === undefined ||
+      (typeof thresholdHours === 'number' &&
+        Number.isFinite(thresholdHours) &&
+        thresholdHours >= 0 &&
+        thresholdHours <= MAX_DATA_QUALITY_THRESHOLD_HOURS)) &&
+    (category === 'null_rate' ? thresholdPercent !== undefined : thresholdPercent === undefined) &&
+    (category === 'data_freshness' ? thresholdHours !== undefined : thresholdHours === undefined) &&
     typeof value.isApplicable === 'boolean' &&
-    (value.notApplicableReason === undefined || typeof value.notApplicableReason === 'string')
+    (value.notApplicableReason === undefined ||
+      (typeof value.notApplicableReason === 'string' &&
+        value.notApplicableReason.length >= 1 &&
+        value.notApplicableReason.length <= 1000))
   );
 }
 
@@ -295,24 +372,28 @@ function isDataQualityRunDetail(value: unknown): value is OWOXDataQualityRunDeta
   }
   const relationships = value.snapshot.relationships;
   const results = value.results;
+  const rules = value.snapshot.config.rules;
   return (
-    Array.isArray(value.snapshot.config.rules) &&
-    value.snapshot.config.rules.every(isDataQualityRule) &&
+    Array.isArray(rules) &&
+    rules.every(isDataQualityRule) &&
+    new Set(rules.map(rule => (rule as Record<string, unknown>).key)).size === rules.length &&
     isNullableRecord(value.snapshot.schema) &&
     Array.isArray(relationships) &&
     relationships.every(
       relationship =>
         isRecord(relationship) &&
-        typeof relationship.id === 'string' &&
-        typeof relationship.sourceDataMartId === 'string' &&
-        typeof relationship.targetDataMartId === 'string' &&
-        typeof relationship.targetAlias === 'string' &&
+        isDataQualityIdentifier(relationship.id) &&
+        isDataQualityIdentifier(relationship.sourceDataMartId) &&
+        isDataQualityIdentifier(relationship.targetDataMartId) &&
+        isDataQualityIdentifier(relationship.targetAlias) &&
         Array.isArray(relationship.joinConditions) &&
         relationship.joinConditions.every(
           condition =>
             isRecord(condition) &&
             typeof condition.sourceFieldName === 'string' &&
-            typeof condition.targetFieldName === 'string'
+            condition.sourceFieldName.length > 0 &&
+            typeof condition.targetFieldName === 'string' &&
+            condition.targetFieldName.length > 0
         ) &&
         (relationship.targetAccessible === undefined ||
           typeof relationship.targetAccessible === 'boolean')
@@ -321,11 +402,14 @@ function isDataQualityRunDetail(value: unknown): value is OWOXDataQualityRunDeta
     DEFINITION_TYPES.has(value.snapshot.definitionType) &&
     isDataQualitySummary(value.summary) &&
     Array.isArray(results) &&
+    new Set(results.map(result => (result as Record<string, unknown>).ruleKey)).size ===
+      results.length &&
     results.every(
       result =>
         isRecord(result) &&
-        typeof result.id === 'string' &&
+        isDataQualityIdentifier(result.id) &&
         typeof result.ruleKey === 'string' &&
+        result.ruleKey.length > 0 &&
         typeof result.category === 'string' &&
         CATEGORIES.has(result.category) &&
         isDataQualityScope(result.scope) &&
@@ -336,12 +420,14 @@ function isDataQualityRunDetail(value: unknown): value is OWOXDataQualityRunDeta
         isNonNegativeInteger(result.violationCount) &&
         typeof result.description === 'string' &&
         Array.isArray(result.examples) &&
+        result.examples.length <= 3 &&
         result.examples.every(example => isRecord(example) && isRecord(example.values)) &&
         isNullableString(result.sql) &&
         (result.error === null ||
           (isRecord(result.error) &&
-            isNullableString(result.error.code) &&
+            isNullableBoundedString(result.error.code, 255) &&
             typeof result.error.message === 'string' &&
+            result.error.message.length > 0 &&
             isNullableRecord(result.error.details))) &&
         isRfc3339DateTimeString(result.createdAt) &&
         typeof result.redacted === 'boolean'
@@ -353,9 +439,9 @@ export function isDataMartRun(value: unknown): value is OWOXDataMartRun {
   if (!isRecord(value)) return false;
   return (
     typeof value.id === 'string' &&
-    isNullableEnum(value.status, RUN_STATUSES) &&
-    isNullableEnum(value.type, RUN_TYPES) &&
-    isNullableEnum(value.runType, RUN_TRIGGERS) &&
+    isEnum(value.status, RUN_STATUSES) &&
+    isEnum(value.type, RUN_TYPES) &&
+    isEnum(value.runType, RUN_TRIGGERS) &&
     typeof value.dataMartId === 'string' &&
     isNullableRecord(value.definitionRun) &&
     isNullableString(value.reportId) &&

--- a/packages/api-client/src/data-mart-runs.ts
+++ b/packages/api-client/src/data-mart-runs.ts
@@ -173,7 +173,7 @@ export type OWOXDataMartRunDetail = OWOXDataMartRun & {
 export type OWOXDataMartRunsResponse = { runs: OWOXDataMartRun[] };
 export type OWOXDataMartRunListOptions = { limit?: number; offset?: number };
 export type OWOXDataMartRunStartOptions =
-  | { runType?: 'INCREMENTAL'; data?: Record<string, unknown> }
+  | { runType?: 'INCREMENTAL'; data?: never }
   | { runType: 'MANUAL_BACKFILL'; data?: Record<string, unknown> };
 export type OWOXRunDataMartResponse = { runId: string };
 

--- a/packages/api-client/src/data-mart-runs.ts
+++ b/packages/api-client/src/data-mart-runs.ts
@@ -173,8 +173,8 @@ export type OWOXDataMartRunDetail = OWOXDataMartRun & {
 export type OWOXDataMartRunsResponse = { runs: OWOXDataMartRun[] };
 export type OWOXDataMartRunListOptions = { limit?: number; offset?: number };
 export type OWOXDataMartRunStartOptions =
-  | { runType?: 'INCREMENTAL'; data?: never }
-  | { runType: 'MANUAL_BACKFILL'; data: Record<string, unknown> };
+  | { runType?: 'INCREMENTAL'; data?: Record<string, unknown> }
+  | { runType: 'MANUAL_BACKFILL'; data?: Record<string, unknown> };
 export type OWOXRunDataMartResponse = { runId: string };
 
 const RUN_STATUSES = new Set<string>(DATA_MART_RUN_STATUS_VALUES);

--- a/packages/api-client/src/data-mart-runs.ts
+++ b/packages/api-client/src/data-mart-runs.ts
@@ -1,0 +1,386 @@
+import { isRecord, isRfc3339DateTimeString, isUserProjection } from './validation.js';
+
+const DATA_MART_RUN_STATUS_VALUES = [
+  'PENDING',
+  'RUNNING',
+  'SUCCESS',
+  'FAILED',
+  'CANCELLED',
+  'INTERRUPTED',
+  'RESTRICTED',
+] as const;
+export type OWOXDataMartRunStatus = (typeof DATA_MART_RUN_STATUS_VALUES)[number];
+
+const DATA_MART_RUN_TYPE_VALUES = [
+  'CONNECTOR',
+  'GOOGLE_SHEETS_EXPORT',
+  'LOOKER_STUDIO',
+  'EMAIL',
+  'SLACK',
+  'MS_TEAMS',
+  'GOOGLE_CHAT',
+  'INSIGHT',
+  'INSIGHT_TEMPLATE',
+  'AI_ASSISTANT',
+  'HTTP_DATA',
+  'MCP_QUERY',
+  'DATA_QUALITY',
+] as const;
+export type OWOXDataMartRunType = (typeof DATA_MART_RUN_TYPE_VALUES)[number];
+
+const DATA_MART_RUN_TRIGGER_VALUES = ['manual', 'scheduled'] as const;
+export type OWOXDataMartRunTriggerType = (typeof DATA_MART_RUN_TRIGGER_VALUES)[number];
+
+const DATA_QUALITY_SUMMARY_STATE_VALUES = [
+  'NEVER_RUN',
+  'QUEUED',
+  'RUNNING',
+  'PASSED',
+  'ISSUES',
+  'EXECUTION_FAILED',
+  'RESTRICTED',
+  'CANCELLED',
+  'ALL_DISABLED',
+] as const;
+export type OWOXDataQualitySummaryState = (typeof DATA_QUALITY_SUMMARY_STATE_VALUES)[number];
+
+const DATA_QUALITY_SEVERITY_VALUES = ['notice', 'warning', 'error'] as const;
+export type OWOXDataQualitySeverity = (typeof DATA_QUALITY_SEVERITY_VALUES)[number];
+
+const DATA_QUALITY_CATEGORY_VALUES = [
+  'pk_uniqueness',
+  'duplicate_rows',
+  'null_rate',
+  'column_uniqueness',
+  'constant_column',
+  'empty_table',
+  'type_mismatch',
+  'data_freshness',
+  'negative_values',
+  'relationship_integrity',
+  'reverse_relationship',
+] as const;
+export type OWOXDataQualityCategory = (typeof DATA_QUALITY_CATEGORY_VALUES)[number];
+
+const DATA_QUALITY_CHECK_STATUS_VALUES = ['PASSED', 'FAILED', 'NOT_APPLICABLE', 'ERROR'] as const;
+export type OWOXDataQualityCheckStatus = (typeof DATA_QUALITY_CHECK_STATUS_VALUES)[number];
+
+const DATA_MART_DEFINITION_TYPE_VALUES = [
+  'SQL',
+  'TABLE',
+  'VIEW',
+  'TABLE_PATTERN',
+  'CONNECTOR',
+] as const;
+export type OWOXRunDataMartDefinitionType = (typeof DATA_MART_DEFINITION_TYPE_VALUES)[number];
+
+export type OWOXDataMartRunUser = {
+  userId: string;
+  fullName?: string | null;
+  email?: string | null;
+  avatar?: string | null;
+};
+
+export type OWOXDataQualitySummary = {
+  state: OWOXDataQualitySummaryState;
+  enabledChecks: number;
+  totalChecks: number;
+  passedChecks: number;
+  failedChecks: number;
+  notApplicableChecks: number;
+  errorChecks: number;
+  noticeFindings: number;
+  warningFindings: number;
+  errorFindings: number;
+  violationCount: number;
+  highestSeverity: OWOXDataQualitySeverity | null;
+};
+
+export type OWOXCompactDataQualitySummary = OWOXDataQualitySummary & {
+  dataMartRunId: string | null;
+  lastRunAt: string | null;
+};
+
+export type OWOXDataQualityScope =
+  | { type: 'DATA_MART' }
+  | { type: 'FIELD'; fieldPath: string[] }
+  | { type: 'RELATIONSHIP'; relationshipId: string };
+
+export type OWOXDataQualityRule = {
+  key: string;
+  category: OWOXDataQualityCategory;
+  scope: OWOXDataQualityScope;
+  severity: OWOXDataQualitySeverity;
+  enabled: boolean;
+  parameters: { thresholdPercent?: number; thresholdHours?: number };
+  isApplicable: boolean;
+  notApplicableReason?: string;
+};
+
+export type OWOXDataQualityRunDetail = {
+  snapshot: {
+    config: { rules: OWOXDataQualityRule[] };
+    schema: Record<string, unknown> | null;
+    relationships: Array<{
+      id: string;
+      sourceDataMartId: string;
+      targetDataMartId: string;
+      targetAlias: string;
+      joinConditions: Array<{ sourceFieldName: string; targetFieldName: string }>;
+      targetAccessible?: boolean;
+    }>;
+    definitionType: OWOXRunDataMartDefinitionType;
+  };
+  summary: OWOXDataQualitySummary;
+  results: Array<{
+    id: string;
+    ruleKey: string;
+    category: OWOXDataQualityCategory;
+    scope: OWOXDataQualityScope;
+    severity: OWOXDataQualitySeverity;
+    status: OWOXDataQualityCheckStatus;
+    violationCount: number;
+    description: string;
+    examples: Array<{ values: Record<string, unknown> }>;
+    sql: string | null;
+    error: { code: string | null; message: string; details: Record<string, unknown> | null } | null;
+    createdAt: string;
+    redacted: boolean;
+  }>;
+};
+
+export type OWOXDataMartRun = {
+  id: string;
+  status: OWOXDataMartRunStatus | null;
+  type: OWOXDataMartRunType | null;
+  runType: OWOXDataMartRunTriggerType | null;
+  dataMartId: string;
+  definitionRun: Record<string, unknown> | null;
+  reportId: string | null;
+  reportDefinition: Record<string, unknown> | null;
+  insightId: string | null;
+  insightDefinition: Record<string, unknown> | null;
+  insightTemplateId: string | null;
+  insightTemplateDefinition: Record<string, unknown> | null;
+  aiSourceDefinition: Record<string, unknown> | null;
+  logs: string[] | null;
+  errors: string[] | null;
+  createdAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  createdByUser: OWOXDataMartRunUser | null;
+  additionalParams: Record<string, unknown> | null;
+  totals: Record<string, number | string | boolean | null> | null;
+  qualitySummary: OWOXCompactDataQualitySummary | null;
+};
+
+export type OWOXDataMartRunDetail = OWOXDataMartRun & {
+  dataQuality: OWOXDataQualityRunDetail | null;
+};
+
+export type OWOXDataMartRunsResponse = { runs: OWOXDataMartRun[] };
+export type OWOXDataMartRunListOptions = { limit?: number; offset?: number };
+export type OWOXRunDataMartRequest = { payload?: Record<string, unknown> };
+export type OWOXRunDataMartResponse = { runId: string };
+
+const RUN_STATUSES = new Set<string>(DATA_MART_RUN_STATUS_VALUES);
+const RUN_TYPES = new Set<string>(DATA_MART_RUN_TYPE_VALUES);
+const RUN_TRIGGERS = new Set<string>(DATA_MART_RUN_TRIGGER_VALUES);
+const SUMMARY_STATES = new Set<string>(DATA_QUALITY_SUMMARY_STATE_VALUES);
+const SEVERITIES = new Set<string>(DATA_QUALITY_SEVERITY_VALUES);
+const CATEGORIES = new Set<string>(DATA_QUALITY_CATEGORY_VALUES);
+const CHECK_STATUSES = new Set<string>(DATA_QUALITY_CHECK_STATUS_VALUES);
+const DEFINITION_TYPES = new Set<string>(DATA_MART_DEFINITION_TYPE_VALUES);
+
+function isNullableString(value: unknown): boolean {
+  return value === null || typeof value === 'string';
+}
+
+function isNullableRecord(value: unknown): boolean {
+  return value === null || isRecord(value);
+}
+
+function isNullableStringArray(value: unknown): boolean {
+  return value === null || (Array.isArray(value) && value.every(item => typeof item === 'string'));
+}
+
+function isNullableDateTime(value: unknown): boolean {
+  return value === null || isRfc3339DateTimeString(value);
+}
+
+function isNullableEnum(value: unknown, values: ReadonlySet<string>): boolean {
+  return value === null || (typeof value === 'string' && values.has(value));
+}
+
+function isNonNegativeInteger(value: unknown): boolean {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function isNullableTotals(value: unknown): boolean {
+  return (
+    value === null ||
+    (isRecord(value) &&
+      Object.values(value).every(
+        item =>
+          item === null ||
+          typeof item === 'number' ||
+          typeof item === 'string' ||
+          typeof item === 'boolean'
+      ))
+  );
+}
+
+function isDataQualitySummary(value: unknown): value is OWOXDataQualitySummary {
+  return (
+    isRecord(value) &&
+    typeof value.state === 'string' &&
+    SUMMARY_STATES.has(value.state) &&
+    isNonNegativeInteger(value.enabledChecks) &&
+    isNonNegativeInteger(value.totalChecks) &&
+    isNonNegativeInteger(value.passedChecks) &&
+    isNonNegativeInteger(value.failedChecks) &&
+    isNonNegativeInteger(value.notApplicableChecks) &&
+    isNonNegativeInteger(value.errorChecks) &&
+    isNonNegativeInteger(value.noticeFindings) &&
+    isNonNegativeInteger(value.warningFindings) &&
+    isNonNegativeInteger(value.errorFindings) &&
+    isNonNegativeInteger(value.violationCount) &&
+    (value.highestSeverity === null ||
+      (typeof value.highestSeverity === 'string' && SEVERITIES.has(value.highestSeverity)))
+  );
+}
+
+function isCompactDataQualitySummary(value: unknown): value is OWOXCompactDataQualitySummary {
+  const summary = value as Record<string, unknown>;
+  return (
+    isDataQualitySummary(value) &&
+    isNullableString(summary.dataMartRunId) &&
+    isNullableDateTime(summary.lastRunAt)
+  );
+}
+
+function isDataQualityScope(value: unknown): value is OWOXDataQualityScope {
+  if (!isRecord(value) || typeof value.type !== 'string') return false;
+  if (value.type === 'DATA_MART') return true;
+  if (value.type === 'FIELD') {
+    return (
+      Array.isArray(value.fieldPath) && value.fieldPath.every(item => typeof item === 'string')
+    );
+  }
+  return value.type === 'RELATIONSHIP' && typeof value.relationshipId === 'string';
+}
+
+function isDataQualityRule(value: unknown): value is OWOXDataQualityRule {
+  if (!isRecord(value) || !isRecord(value.parameters)) return false;
+  return (
+    typeof value.key === 'string' &&
+    typeof value.category === 'string' &&
+    CATEGORIES.has(value.category) &&
+    isDataQualityScope(value.scope) &&
+    typeof value.severity === 'string' &&
+    SEVERITIES.has(value.severity) &&
+    typeof value.enabled === 'boolean' &&
+    (value.parameters.thresholdPercent === undefined ||
+      typeof value.parameters.thresholdPercent === 'number') &&
+    (value.parameters.thresholdHours === undefined ||
+      typeof value.parameters.thresholdHours === 'number') &&
+    typeof value.isApplicable === 'boolean' &&
+    (value.notApplicableReason === undefined || typeof value.notApplicableReason === 'string')
+  );
+}
+
+function isDataQualityRunDetail(value: unknown): value is OWOXDataQualityRunDetail {
+  if (!isRecord(value) || !isRecord(value.snapshot) || !isRecord(value.snapshot.config)) {
+    return false;
+  }
+  const relationships = value.snapshot.relationships;
+  const results = value.results;
+  return (
+    Array.isArray(value.snapshot.config.rules) &&
+    value.snapshot.config.rules.every(isDataQualityRule) &&
+    isNullableRecord(value.snapshot.schema) &&
+    Array.isArray(relationships) &&
+    relationships.every(
+      relationship =>
+        isRecord(relationship) &&
+        typeof relationship.id === 'string' &&
+        typeof relationship.sourceDataMartId === 'string' &&
+        typeof relationship.targetDataMartId === 'string' &&
+        typeof relationship.targetAlias === 'string' &&
+        Array.isArray(relationship.joinConditions) &&
+        relationship.joinConditions.every(
+          condition =>
+            isRecord(condition) &&
+            typeof condition.sourceFieldName === 'string' &&
+            typeof condition.targetFieldName === 'string'
+        ) &&
+        (relationship.targetAccessible === undefined ||
+          typeof relationship.targetAccessible === 'boolean')
+    ) &&
+    typeof value.snapshot.definitionType === 'string' &&
+    DEFINITION_TYPES.has(value.snapshot.definitionType) &&
+    isDataQualitySummary(value.summary) &&
+    Array.isArray(results) &&
+    results.every(
+      result =>
+        isRecord(result) &&
+        typeof result.id === 'string' &&
+        typeof result.ruleKey === 'string' &&
+        typeof result.category === 'string' &&
+        CATEGORIES.has(result.category) &&
+        isDataQualityScope(result.scope) &&
+        typeof result.severity === 'string' &&
+        SEVERITIES.has(result.severity) &&
+        typeof result.status === 'string' &&
+        CHECK_STATUSES.has(result.status) &&
+        isNonNegativeInteger(result.violationCount) &&
+        typeof result.description === 'string' &&
+        Array.isArray(result.examples) &&
+        result.examples.every(example => isRecord(example) && isRecord(example.values)) &&
+        isNullableString(result.sql) &&
+        (result.error === null ||
+          (isRecord(result.error) &&
+            isNullableString(result.error.code) &&
+            typeof result.error.message === 'string' &&
+            isNullableRecord(result.error.details))) &&
+        isRfc3339DateTimeString(result.createdAt) &&
+        typeof result.redacted === 'boolean'
+    )
+  );
+}
+
+export function isDataMartRun(value: unknown): value is OWOXDataMartRun {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === 'string' &&
+    isNullableEnum(value.status, RUN_STATUSES) &&
+    isNullableEnum(value.type, RUN_TYPES) &&
+    isNullableEnum(value.runType, RUN_TRIGGERS) &&
+    typeof value.dataMartId === 'string' &&
+    isNullableRecord(value.definitionRun) &&
+    isNullableString(value.reportId) &&
+    isNullableRecord(value.reportDefinition) &&
+    isNullableString(value.insightId) &&
+    isNullableRecord(value.insightDefinition) &&
+    isNullableString(value.insightTemplateId) &&
+    isNullableRecord(value.insightTemplateDefinition) &&
+    isNullableRecord(value.aiSourceDefinition) &&
+    isNullableStringArray(value.logs) &&
+    isNullableStringArray(value.errors) &&
+    isRfc3339DateTimeString(value.createdAt) &&
+    isNullableDateTime(value.startedAt) &&
+    isNullableDateTime(value.finishedAt) &&
+    (value.createdByUser === null || isUserProjection(value.createdByUser)) &&
+    isNullableRecord(value.additionalParams) &&
+    isNullableTotals(value.totals) &&
+    (value.qualitySummary === null || isCompactDataQualitySummary(value.qualitySummary))
+  );
+}
+
+export function isDataMartRunDetail(value: unknown): value is OWOXDataMartRunDetail {
+  const detail = value as Record<string, unknown>;
+  return (
+    isDataMartRun(value) &&
+    (detail.dataQuality === null || isDataQualityRunDetail(detail.dataQuality))
+  );
+}

--- a/packages/api-client/src/data-mart-runs.ts
+++ b/packages/api-client/src/data-mart-runs.ts
@@ -1,4 +1,5 @@
 import { isRecord, isRfc3339DateTimeString, isUserProjection } from './validation.js';
+import { DATA_MART_DEFINITION_TYPE_VALUES, type OWOXDataMartDefinitionType } from './data-marts.js';
 
 const DATA_MART_RUN_STATUS_VALUES = [
   'PENDING',
@@ -65,15 +66,6 @@ export type OWOXDataQualityCategory = (typeof DATA_QUALITY_CATEGORY_VALUES)[numb
 const DATA_QUALITY_CHECK_STATUS_VALUES = ['PASSED', 'FAILED', 'NOT_APPLICABLE', 'ERROR'] as const;
 export type OWOXDataQualityCheckStatus = (typeof DATA_QUALITY_CHECK_STATUS_VALUES)[number];
 
-const DATA_MART_DEFINITION_TYPE_VALUES = [
-  'SQL',
-  'TABLE',
-  'VIEW',
-  'TABLE_PATTERN',
-  'CONNECTOR',
-] as const;
-export type OWOXRunDataMartDefinitionType = (typeof DATA_MART_DEFINITION_TYPE_VALUES)[number];
-
 export type OWOXDataMartRunUser = {
   userId: string;
   fullName?: string | null;
@@ -129,7 +121,7 @@ export type OWOXDataQualityRunDetail = {
       joinConditions: Array<{ sourceFieldName: string; targetFieldName: string }>;
       targetAccessible?: boolean;
     }>;
-    definitionType: OWOXRunDataMartDefinitionType;
+    definitionType: OWOXDataMartDefinitionType;
   };
   summary: OWOXDataQualitySummary;
   results: Array<{
@@ -180,10 +172,9 @@ export type OWOXDataMartRunDetail = OWOXDataMartRun & {
 
 export type OWOXDataMartRunsResponse = { runs: OWOXDataMartRun[] };
 export type OWOXDataMartRunListOptions = { limit?: number; offset?: number };
-export type OWOXDataMartRunStartOptions = {
-  runType?: 'INCREMENTAL' | 'MANUAL_BACKFILL';
-  data?: Record<string, unknown>;
-};
+export type OWOXDataMartRunStartOptions =
+  | { runType?: 'INCREMENTAL'; data?: never }
+  | { runType: 'MANUAL_BACKFILL'; data: Record<string, unknown> };
 export type OWOXRunDataMartResponse = { runId: string };
 
 const RUN_STATUSES = new Set<string>(DATA_MART_RUN_STATUS_VALUES);
@@ -194,20 +185,6 @@ const SEVERITIES = new Set<string>(DATA_QUALITY_SEVERITY_VALUES);
 const CATEGORIES = new Set<string>(DATA_QUALITY_CATEGORY_VALUES);
 const CHECK_STATUSES = new Set<string>(DATA_QUALITY_CHECK_STATUS_VALUES);
 const DEFINITION_TYPES = new Set<string>(DATA_MART_DEFINITION_TYPE_VALUES);
-const MAX_DATA_QUALITY_THRESHOLD_HOURS = Math.floor(Number.MAX_SAFE_INTEGER / (60 * 60 * 1000));
-const DATA_QUALITY_CATEGORY_SCOPES: Readonly<Record<OWOXDataQualityCategory, string>> = {
-  pk_uniqueness: 'DATA_MART',
-  duplicate_rows: 'DATA_MART',
-  null_rate: 'FIELD',
-  column_uniqueness: 'FIELD',
-  constant_column: 'FIELD',
-  empty_table: 'DATA_MART',
-  type_mismatch: 'FIELD',
-  data_freshness: 'FIELD',
-  negative_values: 'FIELD',
-  relationship_integrity: 'RELATIONSHIP',
-  reverse_relationship: 'RELATIONSHIP',
-};
 
 function isNullableString(value: unknown): boolean {
   return value === null || typeof value === 'string';
@@ -241,11 +218,6 @@ function isNonNegativeInteger(value: unknown): boolean {
 
 function isDataQualityIdentifier(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0 && value.trim().length > 0;
-}
-
-function hasOnlyKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
-  const allowed = new Set(keys);
-  return Object.keys(value).every(key => allowed.has(key));
 }
 
 function isNullableTotals(value: unknown): boolean {
@@ -293,74 +265,37 @@ function isCompactDataQualitySummary(value: unknown): value is OWOXCompactDataQu
 
 function isDataQualityScope(value: unknown): value is OWOXDataQualityScope {
   if (!isRecord(value) || typeof value.type !== 'string') return false;
-  if (value.type === 'DATA_MART') return hasOnlyKeys(value, ['type']);
+  if (value.type === 'DATA_MART') return true;
   if (value.type === 'FIELD') {
     return (
-      hasOnlyKeys(value, ['type', 'fieldPath']) &&
       Array.isArray(value.fieldPath) &&
       value.fieldPath.length > 0 &&
       value.fieldPath.every(isDataQualityIdentifier)
     );
   }
-  return (
-    value.type === 'RELATIONSHIP' &&
-    hasOnlyKeys(value, ['type', 'relationshipId']) &&
-    isDataQualityIdentifier(value.relationshipId)
-  );
-}
-
-function buildDataQualityRuleKey(
-  category: OWOXDataQualityCategory,
-  scope: OWOXDataQualityScope
-): string {
-  if (scope.type === 'DATA_MART') return `${category}:data_mart`;
-  if (scope.type === 'FIELD') return `${category}:field:${JSON.stringify(scope.fieldPath)}`;
-  return `${category}:relationship:${scope.relationshipId}`;
+  return value.type === 'RELATIONSHIP' && isDataQualityIdentifier(value.relationshipId);
 }
 
 function isDataQualityRule(value: unknown): value is OWOXDataQualityRule {
   if (!isRecord(value) || !isRecord(value.parameters)) return false;
   if (
-    !hasOnlyKeys(value, [
-      'key',
-      'category',
-      'scope',
-      'severity',
-      'enabled',
-      'parameters',
-      'isApplicable',
-      'notApplicableReason',
-    ]) ||
-    !hasOnlyKeys(value.parameters, ['thresholdPercent', 'thresholdHours']) ||
     typeof value.category !== 'string' ||
     !CATEGORIES.has(value.category) ||
     !isDataQualityScope(value.scope)
   ) {
     return false;
   }
-  const category = value.category as OWOXDataQualityCategory;
-  const scope = value.scope;
   const thresholdPercent = value.parameters.thresholdPercent;
   const thresholdHours = value.parameters.thresholdHours;
   return (
-    typeof value.key === 'string' &&
-    value.key === buildDataQualityRuleKey(category, scope) &&
-    DATA_QUALITY_CATEGORY_SCOPES[category] === scope.type &&
+    isDataQualityIdentifier(value.key) &&
     typeof value.severity === 'string' &&
     SEVERITIES.has(value.severity) &&
     typeof value.enabled === 'boolean' &&
     (thresholdPercent === undefined ||
-      (typeof thresholdPercent === 'number' &&
-        Number.isFinite(thresholdPercent) &&
-        thresholdPercent >= 0 &&
-        thresholdPercent <= 100)) &&
+      (typeof thresholdPercent === 'number' && Number.isFinite(thresholdPercent))) &&
     (thresholdHours === undefined ||
-      (typeof thresholdHours === 'number' &&
-        Number.isFinite(thresholdHours) &&
-        thresholdHours >= 0 &&
-        thresholdHours <= MAX_DATA_QUALITY_THRESHOLD_HOURS)) &&
-    (category === 'null_rate' ? thresholdPercent !== undefined : thresholdPercent === undefined) &&
-    (category === 'data_freshness' ? thresholdHours !== undefined : thresholdHours === undefined) &&
+      (typeof thresholdHours === 'number' && Number.isFinite(thresholdHours))) &&
     typeof value.isApplicable === 'boolean' &&
     (value.notApplicableReason === undefined ||
       (typeof value.notApplicableReason === 'string' &&
@@ -379,7 +314,6 @@ function isDataQualityRunDetail(value: unknown): value is OWOXDataQualityRunDeta
   return (
     Array.isArray(rules) &&
     rules.every(isDataQualityRule) &&
-    new Set(rules.map(rule => (rule as Record<string, unknown>).key)).size === rules.length &&
     isNullableRecord(value.snapshot.schema) &&
     Array.isArray(relationships) &&
     relationships.every(
@@ -432,9 +366,7 @@ function isDataQualityRunDetail(value: unknown): value is OWOXDataQualityRunDeta
             isNullableRecord(result.error.details))) &&
         isRfc3339DateTimeString(result.createdAt) &&
         typeof result.redacted === 'boolean'
-    ) &&
-    new Set(results.map(result => (result as Record<string, unknown>).ruleKey)).size ===
-      results.length
+    )
   );
 }
 

--- a/packages/api-client/src/data-mart-runs.ts
+++ b/packages/api-client/src/data-mart-runs.ts
@@ -180,7 +180,10 @@ export type OWOXDataMartRunDetail = OWOXDataMartRun & {
 
 export type OWOXDataMartRunsResponse = { runs: OWOXDataMartRun[] };
 export type OWOXDataMartRunListOptions = { limit?: number; offset?: number };
-export type OWOXRunDataMartRequest = { payload?: Record<string, unknown> };
+export type OWOXDataMartRunStartOptions = {
+  runType?: 'INCREMENTAL' | 'MANUAL_BACKFILL';
+  data?: Record<string, unknown>;
+};
 export type OWOXRunDataMartResponse = { runId: string };
 
 const RUN_STATUSES = new Set<string>(DATA_MART_RUN_STATUS_VALUES);

--- a/packages/api-client/src/data-mart-runs.ts
+++ b/packages/api-client/src/data-mart-runs.ts
@@ -402,8 +402,6 @@ function isDataQualityRunDetail(value: unknown): value is OWOXDataQualityRunDeta
     DEFINITION_TYPES.has(value.snapshot.definitionType) &&
     isDataQualitySummary(value.summary) &&
     Array.isArray(results) &&
-    new Set(results.map(result => (result as Record<string, unknown>).ruleKey)).size ===
-      results.length &&
     results.every(
       result =>
         isRecord(result) &&
@@ -431,7 +429,9 @@ function isDataQualityRunDetail(value: unknown): value is OWOXDataQualityRunDeta
             isNullableRecord(result.error.details))) &&
         isRfc3339DateTimeString(result.createdAt) &&
         typeof result.redacted === 'boolean'
-    )
+    ) &&
+    new Set(results.map(result => (result as Record<string, unknown>).ruleKey)).size ===
+      results.length
   );
 }
 

--- a/packages/api-client/src/data-marts.ts
+++ b/packages/api-client/src/data-marts.ts
@@ -14,7 +14,7 @@ import { isRecord, isRfc3339DateTimeString, isUserProjection } from './validatio
 const DATA_MART_STATUS_VALUES = ['DRAFT', 'PUBLISHED'] as const;
 export type OWOXDataMartStatus = (typeof DATA_MART_STATUS_VALUES)[number];
 
-const DATA_MART_DEFINITION_TYPE_VALUES = [
+export const DATA_MART_DEFINITION_TYPE_VALUES = [
   'SQL',
   'TABLE',
   'VIEW',

--- a/packages/api-client/src/data-marts.ts
+++ b/packages/api-client/src/data-marts.ts
@@ -8,15 +8,6 @@ import {
   withSourceContext,
 } from './traversal.js';
 import { isRecord, isRfc3339DateTimeString, isUserProjection } from './validation.js';
-import {
-  isDataMartRun,
-  isDataMartRunDetail,
-  type OWOXDataMartRunDetail,
-  type OWOXDataMartRunListOptions,
-  type OWOXDataMartRunsResponse,
-  type OWOXRunDataMartRequest,
-  type OWOXRunDataMartResponse,
-} from './data-mart-runs.js';
 
 // Keep the traversal rule literals below in sync with the backend schemas in
 // `apps/backend/src/data-marts/dto/schemas/{aggregate-function,filter-config,sort-config,date-trunc-config}.schema.ts`.
@@ -193,10 +184,6 @@ export type TraverseDataOptions = {
   limit?: number;
 };
 
-type DataMartsRequester = JsonRequester & {
-  postJson<T>(path: string, jsonBody: unknown, accept?: string): Promise<T>;
-};
-
 type DataMartsPage = {
   items: OWOXDataMart[];
   total: number;
@@ -327,7 +314,7 @@ const DATA_MART_TRAVERSAL_SOURCE: TraversalSource = {
 };
 
 export class DataMartsApi {
-  constructor(private readonly requester: DataMartsRequester) {}
+  constructor(private readonly requester: JsonRequester) {}
 
   async list(options: OWOXDataMartListOptions = {}): Promise<OWOXDataMart[]> {
     validateListOptions(options);
@@ -367,76 +354,6 @@ export class DataMartsApi {
     }
   }
 
-  async run(
-    dataMartId: string,
-    request: OWOXRunDataMartRequest = {}
-  ): Promise<OWOXRunDataMartResponse> {
-    validateRunRequest(request);
-    const response = await this.requester.postJson<unknown>(
-      `/api/data-marts/${encodeURIComponent(dataMartId)}/manual-run`,
-      request
-    );
-    if (
-      !isRecord(response) ||
-      typeof response.runId !== 'string' ||
-      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-        response.runId
-      )
-    ) {
-      throw new OWOXApiError(
-        'OWOX Data Mart Manual Run API returned an unexpected response shape',
-        {
-          details: response,
-        }
-      );
-    }
-    return response as OWOXRunDataMartResponse;
-  }
-
-  async listRuns(
-    dataMartId: string,
-    options: OWOXDataMartRunListOptions = {}
-  ): Promise<OWOXDataMartRunsResponse> {
-    validateRunListOptions(options);
-    const query = {
-      ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
-      ...(options.offset === undefined ? {} : { offset: String(options.offset) }),
-    };
-    const response = await this.requester.getJson<unknown>(
-      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs`,
-      Object.keys(query).length === 0 ? undefined : query
-    );
-    if (
-      !isRecord(response) ||
-      !Array.isArray(response.runs) ||
-      !response.runs.every(isDataMartRun)
-    ) {
-      throw new OWOXApiError('OWOX Data Mart Runs API returned an unexpected response shape', {
-        details: response,
-      });
-    }
-    return response as OWOXDataMartRunsResponse;
-  }
-
-  async getRun(dataMartId: string, runId: string): Promise<OWOXDataMartRunDetail> {
-    const response = await this.requester.getJson<unknown>(
-      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs/${encodeURIComponent(runId)}`
-    );
-    if (!isDataMartRunDetail(response)) {
-      throw new OWOXApiError('OWOX Data Mart Run API returned an unexpected response shape', {
-        details: response,
-      });
-    }
-    return response;
-  }
-
-  async cancelRun(dataMartId: string, runId: string): Promise<void> {
-    await this.requester.postJson<void>(
-      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs/${encodeURIComponent(runId)}/cancel`,
-      undefined
-    );
-  }
-
   async traverseData(
     dataMartId: string,
     options: TraverseDataOptions = {}
@@ -473,45 +390,5 @@ export class DataMartsApi {
     }
 
     return new HttpNdjsonTraversal(response, dataMartId, DATA_MART_TRAVERSAL_SOURCE);
-  }
-}
-
-const MAX_MANUAL_RUN_PAYLOAD_BYTES = 1024 * 1024;
-
-function validateRunRequest(request: unknown): asserts request is OWOXRunDataMartRequest {
-  if (
-    !isRecord(request) ||
-    Object.keys(request).some(key => key !== 'payload') ||
-    (request.payload !== undefined && !isRecord(request.payload))
-  ) {
-    throw new OWOXApiError('Invalid OWOX Data Mart manual-run request', { details: request });
-  }
-
-  if (request.payload !== undefined) {
-    let json: string;
-    try {
-      json = JSON.stringify(request.payload);
-    } catch (error) {
-      throw new OWOXApiError('Invalid OWOX Data Mart manual-run request', {
-        details: request,
-        cause: error,
-      });
-    }
-    if (new TextEncoder().encode(json).byteLength > MAX_MANUAL_RUN_PAYLOAD_BYTES) {
-      throw new OWOXApiError('OWOX Data Mart manual-run payload exceeds 1MB', {
-        details: { maxSizeBytes: MAX_MANUAL_RUN_PAYLOAD_BYTES },
-      });
-    }
-  }
-}
-
-function validateRunListOptions(options: unknown): asserts options is OWOXDataMartRunListOptions {
-  if (
-    !isRecord(options) ||
-    Object.keys(options).some(key => key !== 'limit' && key !== 'offset') ||
-    (options.limit !== undefined && typeof options.limit !== 'number') ||
-    (options.offset !== undefined && typeof options.offset !== 'number')
-  ) {
-    throw new OWOXApiError('Invalid OWOX Data Mart run-list options', { details: options });
   }
 }

--- a/packages/api-client/src/data-marts.ts
+++ b/packages/api-client/src/data-marts.ts
@@ -8,6 +8,15 @@ import {
   withSourceContext,
 } from './traversal.js';
 import { isRecord, isRfc3339DateTimeString, isUserProjection } from './validation.js';
+import {
+  isDataMartRun,
+  isDataMartRunDetail,
+  type OWOXDataMartRunDetail,
+  type OWOXDataMartRunListOptions,
+  type OWOXDataMartRunsResponse,
+  type OWOXRunDataMartRequest,
+  type OWOXRunDataMartResponse,
+} from './data-mart-runs.js';
 
 // Keep the traversal rule literals below in sync with the backend schemas in
 // `apps/backend/src/data-marts/dto/schemas/{aggregate-function,filter-config,sort-config,date-trunc-config}.schema.ts`.
@@ -184,6 +193,10 @@ export type TraverseDataOptions = {
   limit?: number;
 };
 
+type DataMartsRequester = JsonRequester & {
+  postJson<T>(path: string, jsonBody: unknown, accept?: string): Promise<T>;
+};
+
 type DataMartsPage = {
   items: OWOXDataMart[];
   total: number;
@@ -314,7 +327,7 @@ const DATA_MART_TRAVERSAL_SOURCE: TraversalSource = {
 };
 
 export class DataMartsApi {
-  constructor(private readonly requester: JsonRequester) {}
+  constructor(private readonly requester: DataMartsRequester) {}
 
   async list(options: OWOXDataMartListOptions = {}): Promise<OWOXDataMart[]> {
     validateListOptions(options);
@@ -354,6 +367,76 @@ export class DataMartsApi {
     }
   }
 
+  async run(
+    dataMartId: string,
+    request: OWOXRunDataMartRequest = {}
+  ): Promise<OWOXRunDataMartResponse> {
+    validateRunRequest(request);
+    const response = await this.requester.postJson<unknown>(
+      `/api/data-marts/${encodeURIComponent(dataMartId)}/manual-run`,
+      request
+    );
+    if (
+      !isRecord(response) ||
+      typeof response.runId !== 'string' ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        response.runId
+      )
+    ) {
+      throw new OWOXApiError(
+        'OWOX Data Mart Manual Run API returned an unexpected response shape',
+        {
+          details: response,
+        }
+      );
+    }
+    return response as OWOXRunDataMartResponse;
+  }
+
+  async listRuns(
+    dataMartId: string,
+    options: OWOXDataMartRunListOptions = {}
+  ): Promise<OWOXDataMartRunsResponse> {
+    validateRunListOptions(options);
+    const query = {
+      ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
+      ...(options.offset === undefined ? {} : { offset: String(options.offset) }),
+    };
+    const response = await this.requester.getJson<unknown>(
+      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs`,
+      Object.keys(query).length === 0 ? undefined : query
+    );
+    if (
+      !isRecord(response) ||
+      !Array.isArray(response.runs) ||
+      !response.runs.every(isDataMartRun)
+    ) {
+      throw new OWOXApiError('OWOX Data Mart Runs API returned an unexpected response shape', {
+        details: response,
+      });
+    }
+    return response as OWOXDataMartRunsResponse;
+  }
+
+  async getRun(dataMartId: string, runId: string): Promise<OWOXDataMartRunDetail> {
+    const response = await this.requester.getJson<unknown>(
+      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs/${encodeURIComponent(runId)}`
+    );
+    if (!isDataMartRunDetail(response)) {
+      throw new OWOXApiError('OWOX Data Mart Run API returned an unexpected response shape', {
+        details: response,
+      });
+    }
+    return response;
+  }
+
+  async cancelRun(dataMartId: string, runId: string): Promise<void> {
+    await this.requester.postJson<void>(
+      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs/${encodeURIComponent(runId)}/cancel`,
+      undefined
+    );
+  }
+
   async traverseData(
     dataMartId: string,
     options: TraverseDataOptions = {}
@@ -390,5 +473,45 @@ export class DataMartsApi {
     }
 
     return new HttpNdjsonTraversal(response, dataMartId, DATA_MART_TRAVERSAL_SOURCE);
+  }
+}
+
+const MAX_MANUAL_RUN_PAYLOAD_BYTES = 1024 * 1024;
+
+function validateRunRequest(request: unknown): asserts request is OWOXRunDataMartRequest {
+  if (
+    !isRecord(request) ||
+    Object.keys(request).some(key => key !== 'payload') ||
+    (request.payload !== undefined && !isRecord(request.payload))
+  ) {
+    throw new OWOXApiError('Invalid OWOX Data Mart manual-run request', { details: request });
+  }
+
+  if (request.payload !== undefined) {
+    let json: string;
+    try {
+      json = JSON.stringify(request.payload);
+    } catch (error) {
+      throw new OWOXApiError('Invalid OWOX Data Mart manual-run request', {
+        details: request,
+        cause: error,
+      });
+    }
+    if (new TextEncoder().encode(json).byteLength > MAX_MANUAL_RUN_PAYLOAD_BYTES) {
+      throw new OWOXApiError('OWOX Data Mart manual-run payload exceeds 1MB', {
+        details: { maxSizeBytes: MAX_MANUAL_RUN_PAYLOAD_BYTES },
+      });
+    }
+  }
+}
+
+function validateRunListOptions(options: unknown): asserts options is OWOXDataMartRunListOptions {
+  if (
+    !isRecord(options) ||
+    Object.keys(options).some(key => key !== 'limit' && key !== 'offset') ||
+    (options.limit !== undefined && typeof options.limit !== 'number') ||
+    (options.offset !== undefined && typeof options.offset !== 'number')
+  ) {
+    throw new OWOXApiError('Invalid OWOX Data Mart run-list options', { details: options });
   }
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -22,6 +22,27 @@ export {
   type TraverseDataSortRule,
 } from './data-marts.js';
 export {
+  type OWOXCompactDataQualitySummary,
+  type OWOXDataMartRun,
+  type OWOXDataMartRunDetail,
+  type OWOXDataMartRunListOptions,
+  type OWOXDataMartRunsResponse,
+  type OWOXDataMartRunStatus,
+  type OWOXDataMartRunTriggerType,
+  type OWOXDataMartRunType,
+  type OWOXDataMartRunUser,
+  type OWOXDataQualityCategory,
+  type OWOXDataQualityCheckStatus,
+  type OWOXDataQualityRunDetail,
+  type OWOXDataQualityScope,
+  type OWOXDataQualitySeverity,
+  type OWOXDataQualitySummary,
+  type OWOXDataQualitySummaryState,
+  type OWOXRunDataMartDefinitionType,
+  type OWOXRunDataMartRequest,
+  type OWOXRunDataMartResponse,
+} from './data-mart-runs.js';
+export {
   type OWOXDeploymentAudience,
   type OWOXPluginPublication,
   type OWOXPluginPublicationScope,

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -79,6 +79,7 @@ export {
   type OWOXProjectDataMartRunType,
   type OWOXProjectDataMartRunUser,
   type OWOXProjectRunHistoryOptions,
+  type OWOXDataMartRunsScope,
 } from './runs.js';
 export {
   type OWOXProjectSettings,

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -26,6 +26,7 @@ export {
   type OWOXDataMartRun,
   type OWOXDataMartRunDetail,
   type OWOXDataMartRunListOptions,
+  type OWOXDataMartRunStartOptions,
   type OWOXDataMartRunsResponse,
   type OWOXDataMartRunStatus,
   type OWOXDataMartRunTriggerType,
@@ -40,7 +41,6 @@ export {
   type OWOXDataQualitySummary,
   type OWOXDataQualitySummaryState,
   type OWOXRunDataMartDefinitionType,
-  type OWOXRunDataMartRequest,
   type OWOXRunDataMartResponse,
 } from './data-mart-runs.js';
 export {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -34,6 +34,7 @@ export {
   type OWOXDataQualityCategory,
   type OWOXDataQualityCheckStatus,
   type OWOXDataQualityRunDetail,
+  type OWOXDataQualityRule,
   type OWOXDataQualityScope,
   type OWOXDataQualitySeverity,
   type OWOXDataQualitySummary,

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -40,7 +40,6 @@ export {
   type OWOXDataQualitySeverity,
   type OWOXDataQualitySummary,
   type OWOXDataQualitySummaryState,
-  type OWOXRunDataMartDefinitionType,
   type OWOXRunDataMartResponse,
 } from './data-mart-runs.js';
 export {

--- a/packages/api-client/src/project-run-history.test.ts
+++ b/packages/api-client/src/project-run-history.test.ts
@@ -234,7 +234,7 @@ describe('Runs API', () => {
   });
 
   it('accepts project run history from deployments that predate qualitySummary', async () => {
-    const { qualitySummary: _qualitySummary, ...runWithoutQualitySummary } = runHistory.runs[0];
+    const { qualitySummary: _qualitySummary, ...runWithoutQualitySummary } = runHistory.runs[0]!;
     const response = { runs: [runWithoutQualitySummary] };
     const fetchImpl = createFetchMock(request => {
       if (request.method === 'POST') {

--- a/packages/api-client/src/project-run-history.test.ts
+++ b/packages/api-client/src/project-run-history.test.ts
@@ -1,5 +1,4 @@
 import { OWOXApiClient, OWOXApiError, type OWOXProjectDataMartRunsResponse } from './index.js';
-import { jest } from '@jest/globals';
 
 type RecordedRequest = {
   method: string;
@@ -247,22 +246,17 @@ describe('Runs API', () => {
     await expect(client.runs.list()).resolves.toEqual(response);
   });
 
-  it('rejects invalid pagination before authentication or a network request', async () => {
-    const fetchImpl = jest.fn<typeof fetch>();
+  it('preserves project-wide pagination values for server normalization', async () => {
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      expect(request.url).toBe('/api/data-marts/runs?limit=0&offset=-1');
+      return createJsonResponse(200, runHistory);
+    });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.runs.list({ limit: Number.NaN })).rejects.toBeInstanceOf(OWOXApiError);
-    await expect(client.runs.list({ limit: 0 })).rejects.toBeInstanceOf(OWOXApiError);
-    await expect(client.runs.list({ offset: -1 })).rejects.toBeInstanceOf(OWOXApiError);
-    await expect(client.runs.list({ limit: 1.5 })).rejects.toBeInstanceOf(OWOXApiError);
-    await expect(client.runs.list({ limit: Number.MAX_SAFE_INTEGER + 1 })).rejects.toBeInstanceOf(
-      OWOXApiError
-    );
-    await expect(client.runs.list({ offset: Number.MAX_SAFE_INTEGER + 1 })).rejects.toBeInstanceOf(
-      OWOXApiError
-    );
-    await expect(client.runs.list({ typo: 1 } as never)).rejects.toBeInstanceOf(OWOXApiError);
-    expect(fetchImpl).not.toHaveBeenCalled();
+    await expect(client.runs.list({ limit: 0, offset: -1 })).resolves.toEqual(runHistory);
   });
 
   it.each([

--- a/packages/api-client/src/project-run-history.test.ts
+++ b/packages/api-client/src/project-run-history.test.ts
@@ -1,4 +1,5 @@
 import { OWOXApiClient, OWOXApiError, type OWOXProjectDataMartRunsResponse } from './index.js';
+import { jest } from '@jest/globals';
 
 type RecordedRequest = {
   method: string;
@@ -178,6 +179,18 @@ describe('Runs API', () => {
     await expect(result).rejects.toBeInstanceOf(OWOXApiError);
   });
 
+  it('wraps a non-object project run as a response-shape error', async () => {
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      return createJsonResponse(200, { runs: [null] });
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.runs.list()).rejects.toBeInstanceOf(OWOXApiError);
+  });
+
   it('rejects malformed run creator metadata', async () => {
     const response = {
       runs: [
@@ -220,7 +233,7 @@ describe('Runs API', () => {
     });
   });
 
-  it('rejects a run without the shared Data Quality summary field', async () => {
+  it('accepts project run history from deployments that predate qualitySummary', async () => {
     const { qualitySummary: _qualitySummary, ...runWithoutQualitySummary } = runHistory.runs[0];
     const response = { runs: [runWithoutQualitySummary] };
     const fetchImpl = createFetchMock(request => {
@@ -231,11 +244,19 @@ describe('Runs API', () => {
     });
     const client = new OWOXApiClient({ apiKey, fetchImpl });
 
-    await expect(client.runs.list()).rejects.toMatchObject({
-      name: 'OWOXApiError',
-      message: 'OWOX Project Run History API returned an unexpected response shape',
-      details: response,
-    });
+    await expect(client.runs.list()).resolves.toEqual(response);
+  });
+
+  it('rejects invalid pagination before authentication or a network request', async () => {
+    const fetchImpl = jest.fn<typeof fetch>();
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.runs.list({ limit: Number.NaN })).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(client.runs.list({ limit: 0 })).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(client.runs.list({ offset: -1 })).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(client.runs.list({ limit: 1.5 })).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(client.runs.list({ typo: 1 } as never)).rejects.toBeInstanceOf(OWOXApiError);
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/packages/api-client/src/project-run-history.test.ts
+++ b/packages/api-client/src/project-run-history.test.ts
@@ -64,6 +64,7 @@ const runHistory: OWOXProjectDataMartRunsResponse = {
       errors: null,
       additionalParams: null,
       totals: null,
+      qualitySummary: null,
       createdByUser: {
         userId: 'user-1',
         fullName: 'Ada Lovelace',
@@ -204,6 +205,24 @@ describe('Runs API', () => {
   it('rejects a run without creator metadata', async () => {
     const { createdByUser: _createdByUser, ...runWithoutCreator } = runHistory.runs[0]!;
     const response = { runs: [runWithoutCreator] };
+    const fetchImpl = createFetchMock(request => {
+      if (request.method === 'POST') {
+        return createJsonResponse(200, { accessToken: 'access-token-1' });
+      }
+      return createJsonResponse(200, response);
+    });
+    const client = new OWOXApiClient({ apiKey, fetchImpl });
+
+    await expect(client.runs.list()).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'OWOX Project Run History API returned an unexpected response shape',
+      details: response,
+    });
+  });
+
+  it('rejects a run without the shared Data Quality summary field', async () => {
+    const { qualitySummary: _qualitySummary, ...runWithoutQualitySummary } = runHistory.runs[0];
+    const response = { runs: [runWithoutQualitySummary] };
     const fetchImpl = createFetchMock(request => {
       if (request.method === 'POST') {
         return createJsonResponse(200, { accessToken: 'access-token-1' });

--- a/packages/api-client/src/project-run-history.test.ts
+++ b/packages/api-client/src/project-run-history.test.ts
@@ -255,6 +255,12 @@ describe('Runs API', () => {
     await expect(client.runs.list({ limit: 0 })).rejects.toBeInstanceOf(OWOXApiError);
     await expect(client.runs.list({ offset: -1 })).rejects.toBeInstanceOf(OWOXApiError);
     await expect(client.runs.list({ limit: 1.5 })).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(client.runs.list({ limit: Number.MAX_SAFE_INTEGER + 1 })).rejects.toBeInstanceOf(
+      OWOXApiError
+    );
+    await expect(client.runs.list({ offset: Number.MAX_SAFE_INTEGER + 1 })).rejects.toBeInstanceOf(
+      OWOXApiError
+    );
     await expect(client.runs.list({ typo: 1 } as never)).rejects.toBeInstanceOf(OWOXApiError);
     expect(fetchImpl).not.toHaveBeenCalled();
   });

--- a/packages/api-client/src/runs.ts
+++ b/packages/api-client/src/runs.ts
@@ -101,9 +101,9 @@ function validateRunListOptions(options: unknown): asserts options is OWOXDataMa
     !isRecord(options) ||
     Object.keys(options).some(key => key !== 'limit' && key !== 'offset') ||
     (options.limit !== undefined &&
-      (!Number.isInteger(options.limit) || (options.limit as number) <= 0)) ||
+      (!Number.isSafeInteger(options.limit) || (options.limit as number) <= 0)) ||
     (options.offset !== undefined &&
-      (!Number.isInteger(options.offset) || (options.offset as number) < 0))
+      (!Number.isSafeInteger(options.offset) || (options.offset as number) < 0))
   ) {
     throw new OWOXApiError('Invalid OWOX Data Mart run-list options', { details: options });
   }

--- a/packages/api-client/src/runs.ts
+++ b/packages/api-client/src/runs.ts
@@ -115,30 +115,27 @@ function parseProjectRunHistory(response: unknown): OWOXProjectDataMartRunsRespo
   return response as OWOXProjectDataMartRunsResponse;
 }
 
-export class RunsApi {
-  constructor(private readonly requester: RunsRequester) {}
+export type OWOXDataMartRunsScope = {
+  start(options?: OWOXDataMartRunStartOptions): Promise<OWOXRunDataMartResponse>;
+  list(options?: OWOXDataMartRunListOptions): Promise<OWOXDataMartRunsResponse>;
+  get(runId: string): Promise<OWOXDataMartRunDetail>;
+  cancel(runId: string): Promise<void>;
+};
 
-  async list(options: OWOXProjectRunHistoryOptions = {}): Promise<OWOXProjectDataMartRunsResponse> {
-    const query = {
-      ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
-      ...(options.offset === undefined ? {} : { offset: String(options.offset) }),
-    };
+class DataMartRunsScope implements OWOXDataMartRunsScope {
+  private readonly path: string;
 
-    return parseProjectRunHistory(
-      await this.requester.getJson<unknown>(
-        '/api/data-marts/runs',
-        Object.keys(query).length === 0 ? undefined : query
-      )
-    );
+  constructor(
+    private readonly requester: RunsRequester,
+    dataMartId: string
+  ) {
+    this.path = `/api/data-marts/${encodeURIComponent(dataMartId)}`;
   }
 
-  async start(
-    dataMartId: string,
-    options: OWOXDataMartRunStartOptions = {}
-  ): Promise<OWOXRunDataMartResponse> {
+  async start(options: OWOXDataMartRunStartOptions = {}): Promise<OWOXRunDataMartResponse> {
     validateRunStartOptions(options);
     const response = await this.requester.postJson<unknown>(
-      `/api/data-marts/${encodeURIComponent(dataMartId)}/manual-run`,
+      `${this.path}/manual-run`,
       Object.keys(options).length === 0 ? {} : { payload: options }
     );
     if (
@@ -156,17 +153,14 @@ export class RunsApi {
     return response as OWOXRunDataMartResponse;
   }
 
-  async listForDataMart(
-    dataMartId: string,
-    options: OWOXDataMartRunListOptions = {}
-  ): Promise<OWOXDataMartRunsResponse> {
+  async list(options: OWOXDataMartRunListOptions = {}): Promise<OWOXDataMartRunsResponse> {
     validateRunListOptions(options);
     const query = {
       ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
       ...(options.offset === undefined ? {} : { offset: String(options.offset) }),
     };
     const response = await this.requester.getJson<unknown>(
-      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs`,
+      `${this.path}/runs`,
       Object.keys(query).length === 0 ? undefined : query
     );
     if (
@@ -181,9 +175,9 @@ export class RunsApi {
     return response as OWOXDataMartRunsResponse;
   }
 
-  async get(dataMartId: string, runId: string): Promise<OWOXDataMartRunDetail> {
+  async get(runId: string): Promise<OWOXDataMartRunDetail> {
     const response = await this.requester.getJson<unknown>(
-      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs/${encodeURIComponent(runId)}`
+      `${this.path}/runs/${encodeURIComponent(runId)}`
     );
     if (!isDataMartRunDetail(response)) {
       throw new OWOXApiError('OWOX Data Mart Run API returned an unexpected response shape', {
@@ -193,10 +187,32 @@ export class RunsApi {
     return response;
   }
 
-  async cancel(dataMartId: string, runId: string): Promise<void> {
+  async cancel(runId: string): Promise<void> {
     await this.requester.postJson<void>(
-      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs/${encodeURIComponent(runId)}/cancel`,
+      `${this.path}/runs/${encodeURIComponent(runId)}/cancel`,
       undefined
     );
+  }
+}
+
+export class RunsApi {
+  constructor(private readonly requester: RunsRequester) {}
+
+  async list(options: OWOXProjectRunHistoryOptions = {}): Promise<OWOXProjectDataMartRunsResponse> {
+    const query = {
+      ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
+      ...(options.offset === undefined ? {} : { offset: String(options.offset) }),
+    };
+
+    return parseProjectRunHistory(
+      await this.requester.getJson<unknown>(
+        '/api/data-marts/runs',
+        Object.keys(query).length === 0 ? undefined : query
+      )
+    );
+  }
+
+  forDataMart(dataMartId: string): OWOXDataMartRunsScope {
+    return new DataMartRunsScope(this.requester, dataMartId);
   }
 }

--- a/packages/api-client/src/runs.ts
+++ b/packages/api-client/src/runs.ts
@@ -6,12 +6,12 @@ import {
   type OWOXDataMartRun,
   type OWOXDataMartRunDetail,
   type OWOXDataMartRunListOptions,
+  type OWOXDataMartRunStartOptions,
   type OWOXDataMartRunsResponse,
   type OWOXDataMartRunStatus,
   type OWOXDataMartRunTriggerType,
   type OWOXDataMartRunType,
   type OWOXDataMartRunUser,
-  type OWOXRunDataMartRequest,
   type OWOXRunDataMartResponse,
 } from './data-mart-runs.js';
 
@@ -49,22 +49,25 @@ type RunsRequester = {
 
 const MAX_MANUAL_RUN_PAYLOAD_BYTES = 1024 * 1024;
 
-function validateRunRequest(request: unknown): asserts request is OWOXRunDataMartRequest {
+function validateRunStartOptions(options: unknown): asserts options is OWOXDataMartRunStartOptions {
   if (
-    !isRecord(request) ||
-    Object.keys(request).some(key => key !== 'payload') ||
-    (request.payload !== undefined && !isRecord(request.payload))
+    !isRecord(options) ||
+    Object.keys(options).some(key => key !== 'runType' && key !== 'data') ||
+    (options.runType !== undefined &&
+      options.runType !== 'INCREMENTAL' &&
+      options.runType !== 'MANUAL_BACKFILL') ||
+    (options.data !== undefined && !isRecord(options.data))
   ) {
-    throw new OWOXApiError('Invalid OWOX Data Mart manual-run request', { details: request });
+    throw new OWOXApiError('Invalid OWOX Data Mart run-start options', { details: options });
   }
 
-  if (request.payload !== undefined) {
+  if (Object.keys(options).length > 0) {
     let json: string;
     try {
-      json = JSON.stringify(request.payload);
+      json = JSON.stringify(options);
     } catch (error) {
-      throw new OWOXApiError('Invalid OWOX Data Mart manual-run request', {
-        details: request,
+      throw new OWOXApiError('Invalid OWOX Data Mart run-start options', {
+        details: options,
         cause: error,
       });
     }
@@ -131,12 +134,12 @@ export class RunsApi {
 
   async start(
     dataMartId: string,
-    request: OWOXRunDataMartRequest = {}
+    options: OWOXDataMartRunStartOptions = {}
   ): Promise<OWOXRunDataMartResponse> {
-    validateRunRequest(request);
+    validateRunStartOptions(options);
     const response = await this.requester.postJson<unknown>(
       `/api/data-marts/${encodeURIComponent(dataMartId)}/manual-run`,
-      request
+      Object.keys(options).length === 0 ? {} : { payload: options }
     );
     if (
       !isRecord(response) ||

--- a/packages/api-client/src/runs.ts
+++ b/packages/api-client/src/runs.ts
@@ -1,40 +1,17 @@
 import { OWOXApiError } from './errors.js';
-import { isRecord, isRfc3339DateTimeString, isUserProjection } from './validation.js';
+import { isRecord } from './validation.js';
+import {
+  isDataMartRun,
+  type OWOXDataMartRun,
+  type OWOXDataMartRunStatus,
+  type OWOXDataMartRunTriggerType,
+  type OWOXDataMartRunType,
+  type OWOXDataMartRunUser,
+} from './data-mart-runs.js';
 
-const PROJECT_DATA_MART_RUN_STATUS_VALUES = [
-  'PENDING',
-  'RUNNING',
-  'SUCCESS',
-  'FAILED',
-  'CANCELLED',
-  'INTERRUPTED',
-  'RESTRICTED',
-] as const;
-
-export type OWOXProjectDataMartRunStatus = (typeof PROJECT_DATA_MART_RUN_STATUS_VALUES)[number];
-
-const PROJECT_DATA_MART_RUN_TYPE_VALUES = [
-  'CONNECTOR',
-  'GOOGLE_SHEETS_EXPORT',
-  'LOOKER_STUDIO',
-  'EMAIL',
-  'SLACK',
-  'MS_TEAMS',
-  'GOOGLE_CHAT',
-  'INSIGHT',
-  'INSIGHT_TEMPLATE',
-  'AI_ASSISTANT',
-  'HTTP_DATA',
-  'MCP_QUERY',
-  'DATA_QUALITY',
-] as const;
-
-export type OWOXProjectDataMartRunType = (typeof PROJECT_DATA_MART_RUN_TYPE_VALUES)[number];
-
-const PROJECT_DATA_MART_RUN_TRIGGER_VALUES = ['manual', 'scheduled'] as const;
-
-export type OWOXProjectDataMartRunTriggerType =
-  (typeof PROJECT_DATA_MART_RUN_TRIGGER_VALUES)[number];
+export type OWOXProjectDataMartRunStatus = OWOXDataMartRunStatus;
+export type OWOXProjectDataMartRunType = OWOXDataMartRunType;
+export type OWOXProjectDataMartRunTriggerType = OWOXDataMartRunTriggerType;
 
 export type OWOXProjectDataMartRunRef = {
   /** Data Mart identifier. */
@@ -44,45 +21,10 @@ export type OWOXProjectDataMartRunRef = {
 };
 
 /** The author attributable to a run. */
-export type OWOXProjectDataMartRunUser = {
-  /** Run author user identifier. */
-  userId: string;
-  /** Run author full name when available. */
-  fullName?: string | null;
-  /** Run author email address when available. */
-  email?: string | null;
-  /** Run author avatar URL when available. */
-  avatar?: string | null;
-};
+export type OWOXProjectDataMartRunUser = OWOXDataMartRunUser;
 
-export type OWOXProjectDataMartRun = {
-  id: string;
-  status: OWOXProjectDataMartRunStatus;
-  type: OWOXProjectDataMartRunType;
-  runType: OWOXProjectDataMartRunTriggerType;
-  dataMartId: string;
+export type OWOXProjectDataMartRun = OWOXDataMartRun & {
   dataMart: OWOXProjectDataMartRunRef;
-  /**
-   * The run author. Null when the run has no creator ID or its user projection
-   * is unavailable.
-   */
-  createdByUser: OWOXProjectDataMartRunUser | null;
-  /** Masked definition snapshot, or null when unavailable for a historical run. */
-  definitionRun: Record<string, unknown> | null;
-  reportId: string | null;
-  reportDefinition: Record<string, unknown> | null;
-  insightId: string | null;
-  insightDefinition: Record<string, unknown> | null;
-  insightTemplateId: string | null;
-  insightTemplateDefinition: Record<string, unknown> | null;
-  aiSourceDefinition: Record<string, unknown> | null;
-  logs: string[] | null;
-  errors: string[] | null;
-  createdAt: string;
-  startedAt: string | null;
-  finishedAt: string | null;
-  additionalParams: Record<string, unknown> | null;
-  totals: Record<string, number | string | boolean | null> | null;
 };
 
 export type OWOXProjectDataMartRunsResponse = {
@@ -98,76 +40,14 @@ type RunsRequester = {
   getJson<T>(path: string, query?: Record<string, string>): Promise<T>;
 };
 
-const PROJECT_DATA_MART_RUN_STATUSES = new Set<string>(PROJECT_DATA_MART_RUN_STATUS_VALUES);
-const PROJECT_DATA_MART_RUN_TYPES = new Set<string>(PROJECT_DATA_MART_RUN_TYPE_VALUES);
-const PROJECT_DATA_MART_RUN_TRIGGERS = new Set<string>(PROJECT_DATA_MART_RUN_TRIGGER_VALUES);
-
-function isNullableRecord(value: unknown): boolean {
-  return value === null || isRecord(value);
-}
-
-function isNullableString(value: unknown): boolean {
-  return value === null || typeof value === 'string';
-}
-
-function isNullableDateTimeString(value: unknown): boolean {
-  return value === null || isRfc3339DateTimeString(value);
-}
-
-function isNullableStringArray(value: unknown): boolean {
-  return value === null || (Array.isArray(value) && value.every(item => typeof item === 'string'));
-}
-
-function isNullableProjectDataMartRunUser(value: unknown): boolean {
-  return value === null || isUserProjection(value);
-}
-
-function isNullableTotals(value: unknown): boolean {
-  return (
-    value === null ||
-    (isRecord(value) &&
-      Object.values(value).every(
-        item =>
-          item === null ||
-          typeof item === 'number' ||
-          typeof item === 'string' ||
-          typeof item === 'boolean'
-      ))
-  );
-}
-
 function isProjectDataMartRun(value: unknown): value is OWOXProjectDataMartRun {
-  if (!isRecord(value) || !isRecord(value.dataMart)) {
+  const projectRun = value as Record<string, unknown>;
+  if (!isDataMartRun(value) || !isRecord(projectRun.dataMart)) {
     return false;
   }
 
   return (
-    typeof value.id === 'string' &&
-    typeof value.status === 'string' &&
-    PROJECT_DATA_MART_RUN_STATUSES.has(value.status) &&
-    typeof value.type === 'string' &&
-    PROJECT_DATA_MART_RUN_TYPES.has(value.type) &&
-    typeof value.runType === 'string' &&
-    PROJECT_DATA_MART_RUN_TRIGGERS.has(value.runType) &&
-    typeof value.dataMartId === 'string' &&
-    typeof value.dataMart.id === 'string' &&
-    typeof value.dataMart.title === 'string' &&
-    isNullableProjectDataMartRunUser(value.createdByUser) &&
-    isNullableRecord(value.definitionRun) &&
-    isNullableString(value.reportId) &&
-    isNullableRecord(value.reportDefinition) &&
-    isNullableString(value.insightId) &&
-    isNullableRecord(value.insightDefinition) &&
-    isNullableString(value.insightTemplateId) &&
-    isNullableRecord(value.insightTemplateDefinition) &&
-    isNullableRecord(value.aiSourceDefinition) &&
-    isNullableStringArray(value.logs) &&
-    isNullableStringArray(value.errors) &&
-    isRfc3339DateTimeString(value.createdAt) &&
-    isNullableDateTimeString(value.startedAt) &&
-    isNullableDateTimeString(value.finishedAt) &&
-    isNullableRecord(value.additionalParams) &&
-    isNullableTotals(value.totals)
+    typeof projectRun.dataMart.id === 'string' && typeof projectRun.dataMart.title === 'string'
   );
 }
 

--- a/packages/api-client/src/runs.ts
+++ b/packages/api-client/src/runs.ts
@@ -59,7 +59,7 @@ function validateRunStartOptions(options: unknown): asserts options is OWOXDataM
     options.runType === 'MANUAL_BACKFILL'
       ? options.data === undefined || isRecord(options.data)
       : (options.runType === undefined || options.runType === 'INCREMENTAL') &&
-        (options.data === undefined || isRecord(options.data));
+        options.data === undefined;
   if (
     Object.keys(options).some(key => key !== 'runType' && key !== 'data') ||
     !hasValidRunConfiguration

--- a/packages/api-client/src/runs.ts
+++ b/packages/api-client/src/runs.ts
@@ -29,8 +29,10 @@ export type OWOXProjectDataMartRunRef = {
 /** The author attributable to a run. */
 export type OWOXProjectDataMartRunUser = OWOXDataMartRunUser;
 
-export type OWOXProjectDataMartRun = OWOXDataMartRun & {
+export type OWOXProjectDataMartRun = Omit<OWOXDataMartRun, 'qualitySummary'> & {
   dataMart: OWOXProjectDataMartRunRef;
+  /** Absent on older compatible deployments. */
+  qualitySummary?: OWOXDataMartRun['qualitySummary'];
 };
 
 export type OWOXProjectDataMartRunsResponse = {
@@ -50,13 +52,17 @@ type RunsRequester = {
 const MAX_MANUAL_RUN_PAYLOAD_BYTES = 1024 * 1024;
 
 function validateRunStartOptions(options: unknown): asserts options is OWOXDataMartRunStartOptions {
+  if (!isRecord(options)) {
+    throw new OWOXApiError('Invalid OWOX Data Mart run-start options', { details: options });
+  }
+  const hasValidRunConfiguration =
+    options.runType === 'MANUAL_BACKFILL'
+      ? isRecord(options.data)
+      : (options.runType === undefined || options.runType === 'INCREMENTAL') &&
+        options.data === undefined;
   if (
-    !isRecord(options) ||
     Object.keys(options).some(key => key !== 'runType' && key !== 'data') ||
-    (options.runType !== undefined &&
-      options.runType !== 'INCREMENTAL' &&
-      options.runType !== 'MANUAL_BACKFILL') ||
-    (options.data !== undefined && !isRecord(options.data))
+    !hasValidRunConfiguration
   ) {
     throw new OWOXApiError('Invalid OWOX Data Mart run-start options', { details: options });
   }
@@ -79,20 +85,36 @@ function validateRunStartOptions(options: unknown): asserts options is OWOXDataM
   }
 }
 
+function validatePathId(value: unknown, label: string): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    value.trim().length === 0 ||
+    value.trim() === '.' ||
+    value.trim() === '..'
+  ) {
+    throw new OWOXApiError(`Invalid OWOX ${label} ID`, { details: value });
+  }
+}
+
 function validateRunListOptions(options: unknown): asserts options is OWOXDataMartRunListOptions {
   if (
     !isRecord(options) ||
     Object.keys(options).some(key => key !== 'limit' && key !== 'offset') ||
-    (options.limit !== undefined && typeof options.limit !== 'number') ||
-    (options.offset !== undefined && typeof options.offset !== 'number')
+    (options.limit !== undefined &&
+      (!Number.isInteger(options.limit) || (options.limit as number) <= 0)) ||
+    (options.offset !== undefined &&
+      (!Number.isInteger(options.offset) || (options.offset as number) < 0))
   ) {
     throw new OWOXApiError('Invalid OWOX Data Mart run-list options', { details: options });
   }
 }
 
 function isProjectDataMartRun(value: unknown): value is OWOXProjectDataMartRun {
-  const projectRun = value as Record<string, unknown>;
-  if (!isDataMartRun(value) || !isRecord(projectRun.dataMart)) {
+  if (!isRecord(value)) return false;
+  const projectRun = value;
+  const sharedRun =
+    projectRun.qualitySummary === undefined ? { ...projectRun, qualitySummary: null } : projectRun;
+  if (!isDataMartRun(sharedRun) || !isRecord(projectRun.dataMart)) {
     return false;
   }
 
@@ -129,6 +151,7 @@ class DataMartRunsScope implements OWOXDataMartRunsScope {
     private readonly requester: RunsRequester,
     dataMartId: string
   ) {
+    validatePathId(dataMartId, 'Data Mart');
     this.path = `/api/data-marts/${encodeURIComponent(dataMartId)}`;
   }
 
@@ -176,6 +199,7 @@ class DataMartRunsScope implements OWOXDataMartRunsScope {
   }
 
   async get(runId: string): Promise<OWOXDataMartRunDetail> {
+    validatePathId(runId, 'run');
     const response = await this.requester.getJson<unknown>(
       `${this.path}/runs/${encodeURIComponent(runId)}`
     );
@@ -188,6 +212,7 @@ class DataMartRunsScope implements OWOXDataMartRunsScope {
   }
 
   async cancel(runId: string): Promise<void> {
+    validatePathId(runId, 'run');
     await this.requester.postJson<void>(
       `${this.path}/runs/${encodeURIComponent(runId)}/cancel`,
       undefined
@@ -199,6 +224,7 @@ export class RunsApi {
   constructor(private readonly requester: RunsRequester) {}
 
   async list(options: OWOXProjectRunHistoryOptions = {}): Promise<OWOXProjectDataMartRunsResponse> {
+    validateRunListOptions(options);
     const query = {
       ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
       ...(options.offset === undefined ? {} : { offset: String(options.offset) }),

--- a/packages/api-client/src/runs.ts
+++ b/packages/api-client/src/runs.ts
@@ -90,7 +90,8 @@ function validatePathId(value: unknown, label: string): asserts value is string 
     typeof value !== 'string' ||
     value.trim().length === 0 ||
     value.trim() === '.' ||
-    value.trim() === '..'
+    value.trim() === '..' ||
+    /[\\/%]/.test(value)
   ) {
     throw new OWOXApiError(`Invalid OWOX ${label} ID`, { details: value });
   }
@@ -240,7 +241,6 @@ export class RunsApi {
   constructor(private readonly requester: RunsRequester) {}
 
   async list(options: OWOXProjectRunHistoryOptions = {}): Promise<OWOXProjectDataMartRunsResponse> {
-    validateRunListOptions(options);
     const query = {
       ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
       ...(options.offset === undefined ? {} : { offset: String(options.offset) }),

--- a/packages/api-client/src/runs.ts
+++ b/packages/api-client/src/runs.ts
@@ -57,9 +57,9 @@ function validateRunStartOptions(options: unknown): asserts options is OWOXDataM
   }
   const hasValidRunConfiguration =
     options.runType === 'MANUAL_BACKFILL'
-      ? isRecord(options.data)
+      ? options.data === undefined || isRecord(options.data)
       : (options.runType === undefined || options.runType === 'INCREMENTAL') &&
-        options.data === undefined;
+        (options.data === undefined || isRecord(options.data));
   if (
     Object.keys(options).some(key => key !== 'runType' && key !== 'data') ||
     !hasValidRunConfiguration
@@ -137,6 +137,17 @@ function parseProjectRunHistory(response: unknown): OWOXProjectDataMartRunsRespo
   return response as OWOXProjectDataMartRunsResponse;
 }
 
+function normalizeDataMartRun(value: unknown): unknown {
+  return isRecord(value) && value.qualitySummary === undefined
+    ? { ...value, qualitySummary: null }
+    : value;
+}
+
+function normalizeDataMartRunDetail(value: unknown): unknown {
+  const run = normalizeDataMartRun(value);
+  return isRecord(run) && run.dataQuality === undefined ? { ...run, dataQuality: null } : run;
+}
+
 export type OWOXDataMartRunsScope = {
   start(options?: OWOXDataMartRunStartOptions): Promise<OWOXRunDataMartResponse>;
   list(options?: OWOXDataMartRunListOptions): Promise<OWOXDataMartRunsResponse>;
@@ -186,16 +197,20 @@ class DataMartRunsScope implements OWOXDataMartRunsScope {
       `${this.path}/runs`,
       Object.keys(query).length === 0 ? undefined : query
     );
+    const normalizedResponse =
+      isRecord(response) && Array.isArray(response.runs)
+        ? { ...response, runs: response.runs.map(normalizeDataMartRun) }
+        : response;
     if (
-      !isRecord(response) ||
-      !Array.isArray(response.runs) ||
-      !response.runs.every(isDataMartRun)
+      !isRecord(normalizedResponse) ||
+      !Array.isArray(normalizedResponse.runs) ||
+      !normalizedResponse.runs.every(isDataMartRun)
     ) {
       throw new OWOXApiError('OWOX Data Mart Runs API returned an unexpected response shape', {
         details: response,
       });
     }
-    return response as OWOXDataMartRunsResponse;
+    return normalizedResponse as OWOXDataMartRunsResponse;
   }
 
   async get(runId: string): Promise<OWOXDataMartRunDetail> {
@@ -203,12 +218,13 @@ class DataMartRunsScope implements OWOXDataMartRunsScope {
     const response = await this.requester.getJson<unknown>(
       `${this.path}/runs/${encodeURIComponent(runId)}`
     );
-    if (!isDataMartRunDetail(response)) {
+    const normalizedResponse = normalizeDataMartRunDetail(response);
+    if (!isDataMartRunDetail(normalizedResponse)) {
       throw new OWOXApiError('OWOX Data Mart Run API returned an unexpected response shape', {
         details: response,
       });
     }
-    return response;
+    return normalizedResponse;
   }
 
   async cancel(runId: string): Promise<void> {

--- a/packages/api-client/src/runs.ts
+++ b/packages/api-client/src/runs.ts
@@ -2,11 +2,17 @@ import { OWOXApiError } from './errors.js';
 import { isRecord } from './validation.js';
 import {
   isDataMartRun,
+  isDataMartRunDetail,
   type OWOXDataMartRun,
+  type OWOXDataMartRunDetail,
+  type OWOXDataMartRunListOptions,
+  type OWOXDataMartRunsResponse,
   type OWOXDataMartRunStatus,
   type OWOXDataMartRunTriggerType,
   type OWOXDataMartRunType,
   type OWOXDataMartRunUser,
+  type OWOXRunDataMartRequest,
+  type OWOXRunDataMartResponse,
 } from './data-mart-runs.js';
 
 export type OWOXProjectDataMartRunStatus = OWOXDataMartRunStatus;
@@ -38,7 +44,48 @@ export type OWOXProjectRunHistoryOptions = {
 
 type RunsRequester = {
   getJson<T>(path: string, query?: Record<string, string>): Promise<T>;
+  postJson<T>(path: string, jsonBody: unknown, accept?: string): Promise<T>;
 };
+
+const MAX_MANUAL_RUN_PAYLOAD_BYTES = 1024 * 1024;
+
+function validateRunRequest(request: unknown): asserts request is OWOXRunDataMartRequest {
+  if (
+    !isRecord(request) ||
+    Object.keys(request).some(key => key !== 'payload') ||
+    (request.payload !== undefined && !isRecord(request.payload))
+  ) {
+    throw new OWOXApiError('Invalid OWOX Data Mart manual-run request', { details: request });
+  }
+
+  if (request.payload !== undefined) {
+    let json: string;
+    try {
+      json = JSON.stringify(request.payload);
+    } catch (error) {
+      throw new OWOXApiError('Invalid OWOX Data Mart manual-run request', {
+        details: request,
+        cause: error,
+      });
+    }
+    if (new TextEncoder().encode(json).byteLength > MAX_MANUAL_RUN_PAYLOAD_BYTES) {
+      throw new OWOXApiError('OWOX Data Mart manual-run payload exceeds 1MB', {
+        details: { maxSizeBytes: MAX_MANUAL_RUN_PAYLOAD_BYTES },
+      });
+    }
+  }
+}
+
+function validateRunListOptions(options: unknown): asserts options is OWOXDataMartRunListOptions {
+  if (
+    !isRecord(options) ||
+    Object.keys(options).some(key => key !== 'limit' && key !== 'offset') ||
+    (options.limit !== undefined && typeof options.limit !== 'number') ||
+    (options.offset !== undefined && typeof options.offset !== 'number')
+  ) {
+    throw new OWOXApiError('Invalid OWOX Data Mart run-list options', { details: options });
+  }
+}
 
 function isProjectDataMartRun(value: unknown): value is OWOXProjectDataMartRun {
   const projectRun = value as Record<string, unknown>;
@@ -79,6 +126,74 @@ export class RunsApi {
         '/api/data-marts/runs',
         Object.keys(query).length === 0 ? undefined : query
       )
+    );
+  }
+
+  async start(
+    dataMartId: string,
+    request: OWOXRunDataMartRequest = {}
+  ): Promise<OWOXRunDataMartResponse> {
+    validateRunRequest(request);
+    const response = await this.requester.postJson<unknown>(
+      `/api/data-marts/${encodeURIComponent(dataMartId)}/manual-run`,
+      request
+    );
+    if (
+      !isRecord(response) ||
+      typeof response.runId !== 'string' ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        response.runId
+      )
+    ) {
+      throw new OWOXApiError(
+        'OWOX Data Mart Manual Run API returned an unexpected response shape',
+        { details: response }
+      );
+    }
+    return response as OWOXRunDataMartResponse;
+  }
+
+  async listForDataMart(
+    dataMartId: string,
+    options: OWOXDataMartRunListOptions = {}
+  ): Promise<OWOXDataMartRunsResponse> {
+    validateRunListOptions(options);
+    const query = {
+      ...(options.limit === undefined ? {} : { limit: String(options.limit) }),
+      ...(options.offset === undefined ? {} : { offset: String(options.offset) }),
+    };
+    const response = await this.requester.getJson<unknown>(
+      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs`,
+      Object.keys(query).length === 0 ? undefined : query
+    );
+    if (
+      !isRecord(response) ||
+      !Array.isArray(response.runs) ||
+      !response.runs.every(isDataMartRun)
+    ) {
+      throw new OWOXApiError('OWOX Data Mart Runs API returned an unexpected response shape', {
+        details: response,
+      });
+    }
+    return response as OWOXDataMartRunsResponse;
+  }
+
+  async get(dataMartId: string, runId: string): Promise<OWOXDataMartRunDetail> {
+    const response = await this.requester.getJson<unknown>(
+      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs/${encodeURIComponent(runId)}`
+    );
+    if (!isDataMartRunDetail(response)) {
+      throw new OWOXApiError('OWOX Data Mart Run API returned an unexpected response shape', {
+        details: response,
+      });
+    }
+    return response;
+  }
+
+  async cancel(dataMartId: string, runId: string): Promise<void> {
+    await this.requester.postJson<void>(
+      `/api/data-marts/${encodeURIComponent(dataMartId)}/runs/${encodeURIComponent(runId)}/cancel`,
+      undefined
     );
   }
 }

--- a/packages/idp-better-auth/src/providers/better-auth-provider.ts
+++ b/packages/idp-better-auth/src/providers/better-auth-provider.ts
@@ -109,8 +109,8 @@ export class BetterAuthProvider
 
   registerRoutes(app: Express): void {
     // Setup middleware
-    app.use(express.json()); // Add JSON parsing middleware
-    app.use(express.urlencoded({ extended: true }));
+    app.use('/auth', express.json()); // Add JSON parsing middleware
+    app.use('/auth', express.urlencoded({ extended: true }));
 
     // Setup Better Auth handler
     this.requestHandlerService.setupBetterAuthHandler(app);

--- a/packages/idp-owox-better-auth/src/owox-better-auth-idp.ts
+++ b/packages/idp-owox-better-auth/src/owox-better-auth-idp.ts
@@ -336,8 +336,8 @@ export class OwoxBetterAuthIdp implements IdpProvider {
   }
 
   registerRoutes(app: Express): void {
-    app.use(e.json());
-    app.use(e.urlencoded({ extended: true }));
+    app.use(AUTH_BASE_PATH, e.json());
+    app.use(AUTH_BASE_PATH, e.urlencoded({ extended: true }));
     app.use(cookieParser());
 
     this.betterAuthProxyHandler.setupBetterAuthHandler(app);

--- a/packages/test-utils/src/helpers/create-test-app.ts
+++ b/packages/test-utils/src/helpers/create-test-app.ts
@@ -67,6 +67,9 @@ export async function createTestApp(
   const { setupGlobalPipes } = await import(
     /* webpackIgnore: true */ '../../../../apps/backend/src/config/global-pipes.config'
   );
+  const { setupBodyParsers } = await import(
+    /* webpackIgnore: true */ '../../../../apps/backend/src/config/body-parser.config'
+  );
   const { PROTOCOL_ROUTE_EXCLUSIONS } = await import(
     /* webpackIgnore: true */ '../../../../apps/backend/src/config/protocol-route-exclusions.config'
   );
@@ -91,7 +94,8 @@ export async function createTestApp(
 
   const moduleRef = await builder.compile();
 
-  const app: INestApplication = moduleRef.createNestApplication(new ExpressAdapter(expressApp));
+  const app = moduleRef.createNestApplication(new ExpressAdapter(expressApp));
+  setupBodyParsers(app);
   app.setGlobalPrefix('api', {
     exclude: PROTOCOL_ROUTE_EXCLUSIONS,
   });


### PR DESCRIPTION
<!-- owox-factory:api-surface-maintenance case=owox-data-marts/data-mart-run-lifecycle -->

## Summary

- add a typed, Data-Mart-scoped `@owox/api-client` run lifecycle under `runs.forDataMart(id)`
- make the four lifecycle operations explicit, named OpenAPI contracts and preserve existing scoped pagination behavior
- document the client surface and mark both coverage dimensions as covered

## Scope

Audited base: `60b1151a86b7ede6d877f78b9e6b7cae91e40d9f`

| Endpoint | OpenAPI | API client |
| --- | --- | --- |
| `POST /api/data-marts/{id}/manual-run` | Unassessed → Covered | Unassessed → Covered (`runs.forDataMart(id).start`) |
| `GET /api/data-marts/{id}/runs` | Unassessed → Covered | Unassessed → Covered (`runs.forDataMart(id).list`) |
| `GET /api/data-marts/{id}/runs/{runId}` | Unassessed → Covered | Unassessed → Covered (`runs.forDataMart(id).get`) |
| `POST /api/data-marts/{id}/runs/{runId}/cancel` | Unassessed → Covered | Unassessed → Covered (`runs.forDataMart(id).cancel`) |

The existing project-wide `runs.list()` remains a separate endpoint with unchanged server-owned pagination normalization. Project-wide and scoped run reads remain compatible with older deployments that omit Data Quality fields.

## Contract checklist

- Authorization: manual run and cancel retain editor access; list and detail retain viewer access. Generated OpenAPI security continues to come from the shared auth decorator.
- Manual run request: named closed incremental and manual-backfill DTO variants own the generated `oneOf` contract. Backend request validation rejects explicit `null` payloads, unknown keys, unsupported run types, and non-object `data`; it accepts retained object-valued `data` on incremental requests and fieldless manual backfills for existing web forms. The public API-client type and runtime validator are intentionally stricter: any `data` requires explicit `MANUAL_BACKFILL`, and implicit or explicit incremental runs with `data` are rejected before authentication or network access. The endpoint-level 1 MiB limit is reachable over HTTP; the shared request-body transport contract publishes and returns `413` beyond the parser ceiling. Packaged authentication body parsers are scoped to `/auth`, so they do not preempt the backend `/api` ceiling.
- Manual run behavior: non-connector and unpublished connector Data Marts return the documented `400` before connector dispatch.
- Pagination: the scoped endpoint preserves its existing caller-provided limit/offset behavior and 100/0 omission defaults. The scoped client rejects invalid pagination, including integers outside JavaScript's safe range, before authentication or network access. Project-wide `runs.list()` remains outside this slice and continues to rely on server normalization.
- Responses: manual run has a named UUID response; list and detail use named run DTOs; status/type/trigger and mapper-owned totals are required; Data Quality summaries/details are required-nullable; cancel is `204 No Content`.
- Runtime client validation: blank, dot-segment, separator-bearing, and percent-bearing Data Mart/run IDs; malformed run states, timestamps, known nested Data Quality values, scoped start/list options, and response shapes are rejected with `OWOXApiError`. Safe ID characters that require encoding remain encoded. Scoped reads normalize Data Quality fields omitted by older deployments to `null`; additive Data Quality response fields and server-owned invariants remain forward-compatible.
- Operation identities: generated-spec tests pin `manualRun`, `getRunHistory`, `getRunById`, and `cancelRun` operation IDs used by the coverage matrix.
- Cross-cutting ownership: authentication stays in the shared auth decorator; request-body `413` responses stay in the generated-document transform; request/response shapes use named DTOs; shared run literals and validators have one client source.
- Exclusions: none.

## Verification

- backend request-DTO and generated-OpenAPI suites on the final rebased head: 15 tests passed
- backend Data Mart runs e2e suite: 10 tests passed, including omitted-payload behavior, 1 MiB validation, and transport-level `413`
- packaged-server body-parser regression: 2 tests passed, including a 128 KiB `/api` request and retained `/auth` JSON parsing
- legacy Better Auth focused provider suite: 34 tests passed
- focused API-client lifecycle, project run-history, and transport-seam suites: 81 tests passed, including the strict manual-backfill discriminator, backend-compatible fieldless backfills, legacy scoped-response normalization, safe ID encoding, unsafe-ID rejection, and unchanged project-wide pagination behavior
- backend production TypeScript graph: passed (`tsconfig.build.json`)
- API-client and both changed IDP provider typechecks: passed
- affected backend, API-client, IDP-provider, and OWOX ESLint checks: passed
- Prettier, Markdown lint, and diff whitespace checks: passed
- API coverage validator: passed (139 endpoints, 16 fully covered)
- Changesets status against current `origin/main`: passed with the single canonical minor changeset
- `docs/api/openapi.md`: unchanged from current `main`
- current-main update `ec28b5ea7`: rebased and re-audited; its low-level PATCH/DELETE release section is preserved in the canonical changeset, and scoped resource paths comply with its authenticated-path security contract
- independent full-diff and repeated delta reviews: all published blocking feedback addressed; final review found no blocker or non-blocker

The broader backend spec-inclusive TypeScript graph still reports pre-existing errors outside this diff; the production graph and every affected focused suite pass.

## Blocker register

- Review blockers: none.
- Merge blockers: all reported checks passed on `f361648f520e55adb2cb0082c3c4ec9e0324b4a1`; an authorized engineer approval is still required.

🤖 Codex (GPT-5.6 Sol High)