### PR TITLE
fix(data-marts): SQL editor loses keystrokes on connected data marts

### DIFF
--- a/.changeset/6614-1-input-source-form-discards-unsaved-query.md
+++ b/.changeset/6614-1-input-source-form-discards-unsaved-query.md
@@ -2,10 +2,11 @@
 'owox': minor
 ---
 
-# Stop the Joinable Data Marts diagram from eating spaces typed into the SQL editor
+# Typing in the SQL editor now works reliably on connected Data Marts
 
-With the Joinable Data Marts section in diagram view, pressing Space in the SQL Query editor inserted nothing. React Flow's default Space pan shortcut listens on the whole document and calls `preventDefault()` on its match; its is-this-an-input check recognizes only `input`/`select`/`textarea`/`contenteditable`, while Monaco's new EditContext input is a plain `div` — so the canvas killed every space before it reached the editor. This is why the symptom appeared only on Data Marts that have relationships (the diagram never mounts otherwise) and looked tied to switching the input source to SQL.
+On Data Marts joined with other Data Marts, the SQL Query editor could refuse to insert spaces: you would type `select * from`, press the spacebar, and nothing would appear. This happened whenever the Joinable Data Marts section was set to the diagram view — the diagram was silently capturing the spacebar for itself. The editor now always receives everything you type, regardless of how the Joinable Data Marts section is displayed.
 
-Two changes close it: the embedded relationship canvas no longer registers any global key shortcut (`panActivationKeyCode` is disabled, like `deleteKeyCode` already was), and the SQL editor container carries React Flow's `nokey` marker so no canvas on the page can grab keystrokes typed into Monaco.
+Two more editing annoyances are gone as well:
 
-Also fixed on the same path: the Input Source form used to re-read the saved definition whenever the Data Mart object was rebuilt in the page context — schema actualization after a save, a publish, a relationship change — discarding everything typed since the last save; in the staged type-change state the same reset left Save silently disabled with a valid query on screen. The form now resets only when the definition type actually changes, and never over unsaved edits; the SQL editor is fully controlled, so the form value and the editor content cannot drift apart.
+- A query you were still writing no longer disappears when the page refreshes its data in the background (for example, right after saving, publishing, or updating the output schema).
+- After picking a different input source type, the Save button no longer stays greyed out while a valid query is on screen.

--- a/.changeset/6614-1-input-source-form-discards-unsaved-query.md
+++ b/.changeset/6614-1-input-source-form-discards-unsaved-query.md
@@ -2,12 +2,10 @@
 'owox': minor
 ---
 
-# Keep an unsaved SQL query when the Data Mart refreshes underneath the editor
+# Stop the Joinable Data Marts diagram from eating spaces typed into the SQL editor
 
-The Input Source form re-read the saved definition whenever the Data Mart object was rebuilt in the page context — schema actualization after a save, a publish, a relationship change — and not only when the user picked another definition type. The SQL editor kept its own copy of the text and synced one way from the form, so that reset pushed the saved query back into Monaco and discarded everything typed since the last save.
+With the Joinable Data Marts section in diagram view, pressing Space in the SQL Query editor inserted nothing. React Flow's default Space pan shortcut listens on the whole document and calls `preventDefault()` on its match; its is-this-an-input check recognizes only `input`/`select`/`textarea`/`contenteditable`, while Monaco's new EditContext input is a plain `div` — so the canvas killed every space before it reached the editor. This is why the symptom appeared only on Data Marts that have relationships (the diagram never mounts otherwise) and looked tied to switching the input source to SQL.
 
-Changing an existing Data Mart's input source to SQL runs schema actualization right after the save; it finishes seconds later, while the user is usually still editing the query, so the keystrokes made in the meantime disappeared.
+Two changes close it: the embedded relationship canvas no longer registers any global key shortcut (`panActivationKeyCode` is disabled, like `deleteKeyCode` already was), and the SQL editor container carries React Flow's `nokey` marker so no canvas on the page can grab keystrokes typed into Monaco.
 
-In the staged type-change state the same reset resolves to an empty definition instead, which left the editor showing a query the form no longer held: Save silently disabled with a valid query on screen.
-
-The form now resets only when the definition type actually changes, and never over unsaved edits. The SQL editor is fully controlled, so the form value and the editor content cannot drift apart.
+Also fixed on the same path: the Input Source form used to re-read the saved definition whenever the Data Mart object was rebuilt in the page context — schema actualization after a save, a publish, a relationship change — discarding everything typed since the last save; in the staged type-change state the same reset left Save silently disabled with a valid query on screen. The form now resets only when the definition type actually changes, and never over unsaved edits; the SQL editor is fully controlled, so the form value and the editor content cannot drift apart.

--- a/.changeset/6614-1-input-source-form-discards-unsaved-query.md
+++ b/.changeset/6614-1-input-source-form-discards-unsaved-query.md
@@ -1,0 +1,13 @@
+---
+'owox': minor
+---
+
+# Keep an unsaved SQL query when the Data Mart refreshes underneath the editor
+
+The Input Source form re-read the saved definition whenever the Data Mart object was rebuilt in the page context — schema actualization after a save, a publish, a relationship change — and not only when the user picked another definition type. The SQL editor kept its own copy of the text and synced one way from the form, so that reset pushed the saved query back into Monaco and discarded everything typed since the last save.
+
+Changing an existing Data Mart's input source to SQL runs schema actualization right after the save; it finishes seconds later, while the user is usually still editing the query, so the keystrokes made in the meantime disappeared.
+
+In the staged type-change state the same reset resolves to an empty definition instead, which left the editor showing a query the form no longer held: Save silently disabled with a valid query on screen.
+
+The form now resets only when the definition type actually changes, and never over unsaved edits. The SQL editor is fully controlled, so the form value and the editor content cannot drift apart.

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.test.tsx
@@ -75,6 +75,7 @@ vi.mock('./form/DataMartDefinitionForm.tsx', async () => {
         <div data-testid='definition-form'>
           <span>{definitionType}</span>
           <input aria-label='SQL query' {...register('definition.sqlQuery')} />
+          <input aria-label='Table name' {...register('definition.fullyQualifiedName')} />
         </div>
       );
     },
@@ -88,7 +89,12 @@ const buildDataMart = (
   id: 'dm-1',
   title: 'Orders',
   definitionType,
-  definition: definitionType ? { fullyQualifiedName: 'project.dataset.orders' } : null,
+  definition:
+    definitionType === DataMartDefinitionType.SQL
+      ? { sqlQuery: 'select saved' }
+      : definitionType
+        ? { fullyQualifiedName: 'project.dataset.orders' }
+        : null,
   storage: {
     id: 'storage-1',
     type: storageType,
@@ -108,7 +114,7 @@ const renderSettings = (
     runSchemaActualization: testState.runSchemaActualization,
   } as unknown as DataMartContextType;
 
-  render(
+  const { rerender } = render(
     <DataMartDefinitionSettings
       definitionType={definitionType}
       initialDefinitionType={initialDefinitionType}
@@ -116,7 +122,26 @@ const renderSettings = (
     />
   );
 
-  return { setDefinitionType };
+  /**
+   * Re-renders the way the page does after any Data Mart refresh — schema actualization, a
+   * relationship change, a publish — which hands down a freshly built `dataMart` object.
+   */
+  const refreshDataMart = (nextDefinitionType = definitionType) => {
+    testState.outletContext = {
+      ...(testState.outletContext as object),
+      dataMart: buildDataMart(initialDefinitionType, storageType),
+    } as unknown as DataMartContextType;
+
+    rerender(
+      <DataMartDefinitionSettings
+        definitionType={nextDefinitionType}
+        initialDefinitionType={initialDefinitionType}
+        setDefinitionType={setDefinitionType}
+      />
+    );
+  };
+
+  return { setDefinitionType, refreshDataMart };
 };
 
 /** Validation runs on change, so the Save button only enables once it settles. */
@@ -271,6 +296,56 @@ describe('DataMartDefinitionSettings — changing the input source type', () => 
     // Data Mart whose definition never changed.
     expect(screen.getByLabelText('SQL query')).toHaveValue('select from');
     expect(testState.runSchemaActualization).not.toHaveBeenCalled();
+  });
+
+  it('keeps an unsaved query when the Data Mart is refreshed underneath the editor', async () => {
+    const { refreshDataMart } = renderSettings(
+      DataMartDefinitionType.SQL,
+      DataMartDefinitionType.SQL
+    );
+
+    fireEvent.change(screen.getByLabelText('SQL query'), {
+      target: { value: 'select saved where x = 1' },
+    });
+    refreshDataMart();
+
+    // The refresh carries the *saved* query; re-applying it here would silently swallow
+    // everything typed since the last save.
+    expect(screen.getByLabelText('SQL query')).toHaveValue('select saved where x = 1');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+  });
+
+  it('keeps a staged query when the Data Mart is refreshed underneath the editor', async () => {
+    const { refreshDataMart } = renderSettings(
+      DataMartDefinitionType.SQL,
+      DataMartDefinitionType.TABLE
+    );
+
+    fireEvent.change(screen.getByLabelText('SQL query'), { target: { value: 'select 1' } });
+    refreshDataMart();
+
+    // A staged type change resets to an *empty* definition, so a refresh mid-edit would leave the
+    // editor showing a query the form no longer holds — and Save disabled with text on screen.
+    expect(screen.getByLabelText('SQL query')).toHaveValue('select 1');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+  });
+
+  it('re-shapes the form when another type is picked, even with unsaved edits', () => {
+    const { refreshDataMart } = renderSettings(
+      DataMartDefinitionType.SQL,
+      DataMartDefinitionType.TABLE
+    );
+
+    fireEvent.change(screen.getByLabelText('SQL query'), { target: { value: 'select 1' } });
+    // Going back to the saved type has to load the saved definition; unsaved edits to the type
+    // being abandoned must not hold that off.
+    refreshDataMart(DataMartDefinitionType.TABLE);
+
+    expect(screen.getByLabelText('Table name')).toHaveValue('project.dataset.orders');
   });
 
   it('reports an unknown impact as unknown, never as zero dependencies', async () => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.test.tsx
@@ -298,6 +298,35 @@ describe('DataMartDefinitionSettings — changing the input source type', () => 
     expect(testState.runSchemaActualization).not.toHaveBeenCalled();
   });
 
+  it('keeps keystrokes typed while a save request is in flight', async () => {
+    let resolveSave!: () => void;
+    testState.updateDataMartDefinition.mockReturnValue(
+      new Promise<void>(resolve => {
+        resolveSave = resolve;
+      })
+    );
+    renderSettings(DataMartDefinitionType.SQL, DataMartDefinitionType.SQL);
+
+    fireEvent.change(screen.getByLabelText('SQL query'), { target: { value: 'select 1' } });
+    await clickSaveWhenEnabled();
+    // The user keeps editing while the request is on the wire.
+    fireEvent.change(screen.getByLabelText('SQL query'), {
+      target: { value: 'select 1 where x' },
+    });
+
+    resolveSave();
+
+    // Settling the save re-baselines dirtiness on the submitted snapshot but must not snap the
+    // editor back to it — the newer text stays, and Save re-enables for it.
+    await waitFor(() => {
+      expect(testState.runSchemaActualization).toHaveBeenCalled();
+    });
+    expect(screen.getByLabelText('SQL query')).toHaveValue('select 1 where x');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+  });
+
   it('keeps an unsaved query when the Data Mart is refreshed underneath the editor', async () => {
     const { refreshDataMart } = renderSettings(
       DataMartDefinitionType.SQL,

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useForm, FormProvider, type SubmitHandler, type Resolver } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { DataMartDefinitionTypeSelector } from './form/DataMartDefinitionTypeSelector.tsx';
@@ -144,11 +144,22 @@ export function DataMartDefinitionSettings({
   const currentDefinition = watch('definition');
   const sqlCode = getSqlQueryFromDefinition(definitionType, currentDefinition);
 
+  const lastResetTypeRef = useRef<DataMartDefinitionType | null>(null);
+
   useEffect(() => {
-    if (definitionType) {
-      reset(getInitialFormValues());
-    }
-  }, [definitionType, reset, getInitialFormValues]);
+    if (!definitionType) return;
+
+    // Picking another type has to re-shape the form, so that reset always runs. Every other reason
+    // this effect re-runs is a Data Mart refresh handing us a new `definition` object — schema
+    // actualization after a save, a relationship change, a publish. Those must not overwrite what
+    // the user is typing: `getInitialFormValues` returns the *saved* definition (or an empty one
+    // while a type change is staged), so resetting mid-edit throws the unsaved query away.
+    const isTypeSwitch = definitionType !== lastResetTypeRef.current;
+    lastResetTypeRef.current = definitionType;
+    if (!isTypeSwitch && isDirty) return;
+
+    reset(getInitialFormValues());
+  }, [definitionType, reset, getInitialFormValues, isDirty]);
 
   useEffect(() => {
     if (!definitionType && !initialDefinitionType && preset?.definitionType) {

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/DataMartDefinitionSettings.tsx
@@ -203,7 +203,10 @@ export function DataMartDefinitionSettings({
         try {
           await updateDataMartDefinition(dataMartId, data.definitionType, data.definition);
           setShouldActualizeSchema(true);
-          reset(data);
+          // Re-baseline dirtiness on the snapshot that was actually saved, but keep the live
+          // values: anything typed while the request was in flight stays in the editor and
+          // simply leaves the form dirty again instead of being snapped back to the snapshot.
+          reset(data, { keepValues: true });
         } catch (error) {
           console.error('Failed to update data mart definition:', error);
         }

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DataMartCodeEditor.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DataMartCodeEditor.tsx
@@ -22,7 +22,11 @@ export function DataMartCodeEditor({ value, onChange }: DataMartCodeEditorProps)
   }
   return (
     <div
-      className='resize-y overflow-auto rounded-md border border-gray-200 shadow-xs dark:border-gray-200/4'
+      // `nokey` is React Flow's opt-out marker: its document-level key hooks skip events coming
+      // from inside it. Monaco's EditContext input is a plain div that xyflow's is-input check
+      // does not recognize, so without this a canvas elsewhere on the page (Joinable Data Marts
+      // diagram) grabs keys like Space away from the editor.
+      className='nokey resize-y overflow-auto rounded-md border border-gray-200 shadow-xs dark:border-gray-200/4'
       style={{ height: '30vh', minHeight: '240px' }}
     >
       <Editor

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DataMartCodeEditor.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/DataMartCodeEditor.tsx
@@ -1,27 +1,23 @@
 import { Editor } from '@monaco-editor/react';
-import { useState, useEffect } from 'react';
 import { useTheme } from 'next-themes';
 import type { SqlDefinitionConfig } from '../../../model';
 
 interface DataMartCodeEditorProps {
-  initialValue?: SqlDefinitionConfig;
+  value?: SqlDefinitionConfig;
   onChange: (config: SqlDefinitionConfig) => void;
 }
 
-export function DataMartCodeEditor({ initialValue, onChange }: DataMartCodeEditorProps) {
-  const [sqlCode, setSqlCode] = useState<string>(initialValue?.sqlQuery ?? '');
+/**
+ * Fully controlled: the query lives in the form, never in a local mirror. A mirror lets the two
+ * drift — the editor showing text the form no longer holds, or the form pushing a stale query back
+ * over what is being typed — and the drift is invisible until a save writes the wrong thing.
+ */
+export function DataMartCodeEditor({ value, onChange }: DataMartCodeEditorProps) {
   const { resolvedTheme } = useTheme();
 
-  useEffect(() => {
-    if (initialValue?.sqlQuery && initialValue.sqlQuery !== sqlCode) {
-      setSqlCode(initialValue.sqlQuery);
-    }
-  }, [initialValue, sqlCode]);
-
-  function handleEditorChange(value: string | undefined) {
-    if (value !== undefined) {
-      setSqlCode(value);
-      onChange({ sqlQuery: value });
+  function handleEditorChange(nextValue: string | undefined) {
+    if (nextValue !== undefined) {
+      onChange({ sqlQuery: nextValue });
     }
   }
   return (
@@ -33,7 +29,7 @@ export function DataMartCodeEditor({ initialValue, onChange }: DataMartCodeEdito
         className='h-full w-full'
         height='100%'
         language='sql'
-        value={sqlCode}
+        value={value?.sqlQuery ?? ''}
         onChange={handleEditorChange}
         theme={resolvedTheme === 'dark' ? 'vs-dark' : 'light'}
         options={{

--- a/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/SqlDefinitionField.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDefinitionSettings/form/SqlDefinitionField.tsx
@@ -17,7 +17,7 @@ export function SqlDefinitionField({ control }: SqlDefinitionFieldProps) {
           <FormLabel className='text-foreground'>SQL Query</FormLabel>
           <FormControl>
             <DataMartCodeEditor
-              initialValue={field.value ? { sqlQuery: field.value } : undefined}
+              value={{ sqlQuery: field.value }}
               onChange={config => {
                 field.onChange(config.sqlQuery);
               }}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.test.tsx
@@ -20,6 +20,7 @@ interface ReactFlowStubProps {
   }[];
   edges?: { id: string; source: string; target: string; selected?: boolean }[];
   deleteKeyCode?: string | null;
+  panActivationKeyCode?: string | null;
   onMove?: (event: unknown, viewport: ViewportStub) => void;
   onMoveStart?: (event: unknown) => void;
   onNodeClick?: (event: unknown, node: { id: string }) => void;
@@ -85,6 +86,19 @@ describe('RelationshipCanvas viewport', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('keeps every global key shortcut disabled on this embedded canvas', async () => {
+    render(<RelationshipCanvas {...buildCanvasProps([buildRelationship('rel-1', 'target-1')])} />);
+
+    await waitFor(() => {
+      expect(reactFlowHarness.latestProps).not.toBeNull();
+    });
+    // React Flow's key hooks listen on the whole document and preventDefault their matches, so
+    // any non-null key code here steals keystrokes from the rest of the page — the default
+    // Space pan shortcut used to eat spaces typed into the SQL editor above this canvas.
+    expect(reactFlowHarness.latestProps?.deleteKeyCode).toBeNull();
+    expect(reactFlowHarness.latestProps?.panActivationKeyCode).toBeNull();
   });
 
   it('opens relationship targets without exposing the opener or referrer', async () => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
@@ -952,6 +952,12 @@ function RelationshipCanvasInner({
           onNodeClick={handleNodeClick}
           onPaneClick={handlePaneClick}
           deleteKeyCode={null}
+          // React Flow's key hooks listen on the whole document and preventDefault their
+          // matches. Monaco's EditContext input is a plain div, which xyflow's is-input check
+          // does not recognize, so with the default Space pan shortcut this embedded canvas
+          // silently ate every space typed into the SQL editor above it. No canvas shortcut
+          // is worth a global key grab on a form page.
+          panActivationKeyCode={null}
           onMove={handleMove}
           onMoveStart={(event: unknown) => {
             if (event) markUserInteracted();


### PR DESCRIPTION
## Symptom

After changing an existing Data Mart's input source to SQL, spaces could not be typed into the query. On a freshly created Data Mart the editor worked fine.

## Root cause

**React Flow (the Joinable Data Marts diagram) swallows Space for the whole page.** Its key hooks listen for keydown on the entire document and call `preventDefault()` on their matches; the is-this-an-input check recognizes only `input`/`select`/`textarea`/`contenteditable`. Monaco in current versions accepts text through **EditContext** — a plain `div` that fails that check. The default pan shortcut, `panActivationKeyCode="Space"`, therefore killed every space before the editor ever saw it.

That is also why a new Data Mart seemed unaffected: the diagram mounts only when the Data Mart has relationships and the diagram view is selected (the view mode is persisted in localStorage). Letters survive because they match no shortcut; Backspace survives because Monaco handles command keys through its own keydown path; only plain Space depends on the browser's default action. The input-source change itself was never involved — the type is simply what people change on long-lived, well-connected Data Marts.

Reproduced and verified live against a running instance: same Data Mart, same diagram view, same keystrokes — `select*from` on the unfixed bundle, `select * from x` with the fix.

## What changed

- `RelationshipCanvas` no longer registers any global key shortcut: `panActivationKeyCode={null}` (joining the already-disabled `deleteKeyCode`), with a regression test.
- The `DataMartCodeEditor` container carries React Flow's `nokey` marker — the library's own opt-out — so no present or future canvas on the page can grab keystrokes typed into Monaco.

## Deliberate tradeoff (no separate fix planned)

The full-page **Models canvas** keeps React Flow's default global shortcuts, including Space-to-pan. That is safe today: the Models page has no editable surface, so there is nothing to steal keystrokes from, and the shortcut is genuinely useful there. The mechanism is unchanged though — if a Monaco or other EditContext-based editor ever lands next to that canvas (a side panel, an inline SQL view), this class of bug returns. The `nokey` marker on the SQL editor container protects that editor on any page; for new editable surfaces next to an xyflow canvas the rule is: either disable the canvas key codes or mark the editor with `nokey`. We are intentionally not opening a separate task for this.

## Also in this PR (found on the same path)

The Input Source form re-read the saved definition whenever the Data Mart object was rebuilt in the page context — schema actualization after a save, a publish, a relationship change — discarding everything typed since the last save. In the staged type-change state the same reset left Save silently disabled with a valid query on screen. The form now resets only when the definition type actually changes, and never over unsaved edits; the SQL editor is fully controlled, so the form value and the editor content cannot drift apart.

## Testing

Full `apps/web` data-marts suite (945 tests), lint, and type-check pass. Regression tests: the canvas registers no global key shortcuts; an unsaved query survives a Data Mart refresh in both the normal and the staged state; picking another type still re-shapes the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)