### PR TITLE
fix(connectors): bump LinkedIn and Shopify off sunset-risk API versions

### DIFF
--- a/.changeset/6810-google-ads-api-v25.md
+++ b/.changeset/6810-google-ads-api-v25.md
@@ -2,9 +2,16 @@
 'owox': minor
 ---
 
-# Google Ads connector uses a supported API version
+# Connectors use supported API versions
 
 Previously, the Google Ads connector called API version v21, which Google
 sunset on 2026-08-05, causing every import to fail with an
-`UNSUPPORTED_VERSION` error. Now, the connector uses v25, the current stable
-version. This means Google Ads imports run successfully again.
+`UNSUPPORTED_VERSION` error. The LinkedIn Ads and LinkedIn Pages connectors
+were also close to hitting the same wall: they called a version only two
+months newer than one LinkedIn had already sunset. The Shopify connector was
+two releases behind, with its version nearing its own support cutoff.
+
+Now, Google Ads uses v25, LinkedIn Ads and LinkedIn Pages use the 2026-07
+version, and Shopify uses the 2026-07 version — all current, supported
+releases. This means imports for these connectors keep running instead of
+failing once their old versions are sunset.

--- a/packages/connectors/src/Sources/LinkedInAds/Source.js
+++ b/packages/connectors/src/Sources/LinkedInAds/Source.js
@@ -548,7 +548,7 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
     });
 
     const headers = {
-      "LinkedIn-Version": "202509",
+      "LinkedIn-Version": "202607",
       "X-RestLi-Protocol-Version": "2.0.0",
     };
 

--- a/packages/connectors/src/Sources/LinkedInPages/Source.js
+++ b/packages/connectors/src/Sources/LinkedInPages/Source.js
@@ -364,7 +364,7 @@ var LinkedInPagesSource = class LinkedInPagesSource extends AbstractSource {
     });
 
     const headers = {
-      "LinkedIn-Version": "202509",
+      "LinkedIn-Version": "202607",
       "X-RestLi-Protocol-Version": "2.0.0",
     };
 

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/FieldsSchema.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/FieldsSchema.js
@@ -9,7 +9,7 @@ var ShopifyFieldsSchema = {
   "abandoned-checkouts": {
     "overview": "Abandoned Checkouts",
     "description": "Checkout sessions that did not complete — customer info, items, and pricing for recovery campaigns.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/queries/abandonedcheckouts",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/queries/abandonedcheckouts",
     "fields": abandonedCheckoutsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "createdAt", "updatedAt", "completedAt", "totalPriceSet", "lineItemsQuantity", "customerId", "customerEmail", "shippingAddressCity", "shippingAddressCountry"],
@@ -22,7 +22,7 @@ var ShopifyFieldsSchema = {
   "articles": {
     "overview": "Articles",
     "description": "Blog articles — title, author, publication status, and timestamps.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Article",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Article",
     "fields": articlesFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "title", "handle", "blogId", "blogTitle", "isPublished", "publishedAt", "authorName", "createdAt", "updatedAt"],
@@ -34,7 +34,7 @@ var ShopifyFieldsSchema = {
   "blogs": {
     "overview": "Blogs",
     "description": "Blogs in the store — title, handle, and template settings.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Blog",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Blog",
     "fields": blogsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "title", "handle", "templateSuffix", "createdAt", "updatedAt"],
@@ -46,7 +46,7 @@ var ShopifyFieldsSchema = {
   "collections": {
     "overview": "Collections",
     "description": "Product collections — title, sort order, product count, and last updated.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Collection",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Collection",
     "fields": collectionsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "title", "handle", "description", "sortOrder", "productsCount", "updatedAt"],
@@ -58,7 +58,7 @@ var ShopifyFieldsSchema = {
   "customers": {
     "overview": "Customers",
     "description": "Customer accounts — contact info, marketing consent, order history, and lifetime spend.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Customer",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Customer",
     "fields": customersFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "displayName", "email", "phone", "state", "numberOfOrders", "amountSpent", "emailMarketingConsentState", "defaultAddressCity", "defaultAddressCountry", "createdAt", "updatedAt"],
@@ -71,7 +71,7 @@ var ShopifyFieldsSchema = {
   "discount-codes": {
     "overview": "Discount Codes",
     "description": "Discount codes — type, status, usage limits, and validity window.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/DiscountCodeNode",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/DiscountCodeNode",
     "fields": discountCodesFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "code", "discountType", "title", "status", "startsAt", "endsAt", "usageLimit", "asyncUsageCount"],
@@ -85,7 +85,7 @@ var ShopifyFieldsSchema = {
   "fulfillment-orders": {
     "overview": "Fulfillment Orders",
     "description": "Fulfillment orders — items to ship, assigned location, delivery method, and status.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/FulfillmentOrder",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/FulfillmentOrder",
     "fields": fulfillmentOrdersFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "status", "requestStatus", "orderId", "orderName", "assignedLocationId", "assignedLocationName", "deliveryMethod", "createdAt", "updatedAt"],
@@ -97,7 +97,7 @@ var ShopifyFieldsSchema = {
   "inventory-items": {
     "overview": "Inventory Items",
     "description": "Inventory items (SKUs) — tracking status, shipping requirements, and country of origin.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/InventoryItem",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/InventoryItem",
     "fields": inventoryItemsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "sku", "tracked", "requiresShipping", "variantId", "countryCodeOfOrigin", "createdAt", "updatedAt"],
@@ -109,7 +109,7 @@ var ShopifyFieldsSchema = {
   "locations": {
     "overview": "Locations",
     "description": "Physical and virtual store locations — activity status, fulfillment capabilities, and address.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Location",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Location",
     "fields": locationsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "name", "isActive", "isPrimary", "fulfillsOnlineOrders", "city", "country", "createdAt", "updatedAt"],
@@ -121,7 +121,7 @@ var ShopifyFieldsSchema = {
   "orders": {
     "overview": "Orders",
     "description": "Orders placed in the store — financial and fulfillment status, customer info, totals, and timestamps.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Order",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Order",
     "fields": ordersFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "name", "displayFinancialStatus", "displayFulfillmentStatus", "customerId", "customerEmail", "currencyCode", "totalPrice", "totalTax", "totalShippingPrice", "totalDiscounts", "totalRefunded", "processedAt", "createdAt", "updatedAt"],
@@ -134,7 +134,7 @@ var ShopifyFieldsSchema = {
   "products": {
     "overview": "Products",
     "description": "Products in the store catalog — vendor, type, status, inventory, and price range.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Product",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Product",
     "fields": productsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "title", "handle", "vendor", "productType", "status", "totalInventory", "variantsCount", "priceRangeMinAmount", "priceRangeMaxAmount", "publishedAt", "createdAt", "updatedAt"],
@@ -147,7 +147,7 @@ var ShopifyFieldsSchema = {
   "product-variants": {
     "overview": "Product Variants",
     "description": "Product variants — SKU, price, inventory quantity, and availability.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/ProductVariant",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/ProductVariant",
     "fields": productVariantsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "displayName", "sku", "productId", "productTitle", "price", "compareAtPrice", "inventoryQuantity", "availableForSale", "createdAt", "updatedAt"],
@@ -159,7 +159,7 @@ var ShopifyFieldsSchema = {
   "pages": {
     "overview": "Pages",
     "description": "Static store pages — title, handle, publication status, and timestamps.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Page",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Page",
     "fields": pagesFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "title", "handle", "isPublished", "publishedAt", "createdAt", "updatedAt"],
@@ -171,7 +171,7 @@ var ShopifyFieldsSchema = {
   "shop": {
     "overview": "Shop",
     "description": "Store settings — domain, currency, timezone, and plan details.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Shop",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Shop",
     "fields": shopFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "name", "email", "myshopifyDomain", "primaryDomain", "currencyCode", "ianaTimezone", "plan", "createdAt"],
@@ -184,7 +184,7 @@ var ShopifyFieldsSchema = {
   "tender-transactions": {
     "overview": "Tender Transactions",
     "description": "Payment tender transactions — amount, currency, order reference, and processing time.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/TenderTransaction",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/TenderTransaction",
     "fields": tenderTransactionsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "amount", "currencyCode", "orderId", "remoteReference", "test", "processedAt"],
@@ -196,7 +196,7 @@ var ShopifyFieldsSchema = {
   "metafield-articles": {
     "overview": "Article Metafields",
     "description": "Custom metadata attached to articles — namespace, key, value, and type.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield",
     "fields": metafieldsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "namespace", "key", "value", "type", "ownerId", "ownerType", "createdAt", "updatedAt"],
@@ -208,7 +208,7 @@ var ShopifyFieldsSchema = {
   "metafield-blogs": {
     "overview": "Blog Metafields",
     "description": "Custom metadata attached to blogs — namespace, key, value, and type.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield",
     "fields": metafieldsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "namespace", "key", "value", "type", "ownerId", "ownerType", "createdAt", "updatedAt"],
@@ -220,7 +220,7 @@ var ShopifyFieldsSchema = {
   "metafield-collections": {
     "overview": "Collection Metafields",
     "description": "Custom metadata attached to collections — namespace, key, value, and type.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield",
     "fields": metafieldsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "namespace", "key", "value", "type", "ownerId", "ownerType", "createdAt", "updatedAt"],
@@ -232,7 +232,7 @@ var ShopifyFieldsSchema = {
   "metafield-customers": {
     "overview": "Customer Metafields",
     "description": "Custom metadata attached to customers — namespace, key, value, and type.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield",
     "fields": metafieldsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "namespace", "key", "value", "type", "ownerId", "ownerType", "createdAt", "updatedAt"],
@@ -244,7 +244,7 @@ var ShopifyFieldsSchema = {
   "metafield-locations": {
     "overview": "Location Metafields",
     "description": "Custom metadata attached to locations — namespace, key, value, and type.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield",
     "fields": metafieldsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "namespace", "key", "value", "type", "ownerId", "ownerType", "createdAt", "updatedAt"],
@@ -256,7 +256,7 @@ var ShopifyFieldsSchema = {
   "metafield-orders": {
     "overview": "Order Metafields",
     "description": "Custom metadata attached to orders — namespace, key, value, and type.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield",
     "fields": metafieldsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "namespace", "key", "value", "type", "ownerId", "ownerType", "createdAt", "updatedAt"],
@@ -268,7 +268,7 @@ var ShopifyFieldsSchema = {
   "metafield-pages": {
     "overview": "Page Metafields",
     "description": "Custom metadata attached to pages — namespace, key, value, and type.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield",
     "fields": metafieldsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "namespace", "key", "value", "type", "ownerId", "ownerType", "createdAt", "updatedAt"],
@@ -280,7 +280,7 @@ var ShopifyFieldsSchema = {
   "metafield-product-variants": {
     "overview": "Product Variant Metafields",
     "description": "Custom metadata attached to product variants — namespace, key, value, and type.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield",
     "fields": metafieldsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "namespace", "key", "value", "type", "ownerId", "ownerType", "createdAt", "updatedAt"],
@@ -292,7 +292,7 @@ var ShopifyFieldsSchema = {
   "metafield-products": {
     "overview": "Product Metafields",
     "description": "Custom metadata attached to products — namespace, key, value, and type.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield",
     "fields": metafieldsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "namespace", "key", "value", "type", "ownerId", "ownerType", "createdAt", "updatedAt"],
@@ -304,7 +304,7 @@ var ShopifyFieldsSchema = {
   "metafield-shops": {
     "overview": "Shop Metafields",
     "description": "Custom metadata attached to the shop — namespace, key, value, and type.",
-    "documentation": "https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield",
+    "documentation": "https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield",
     "fields": metafieldsFields,
     "uniqueKeys": ["id"],
     "defaultFields": ["id", "namespace", "key", "value", "type", "ownerId", "ownerType", "createdAt", "updatedAt"],

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/abandonedCheckoutsFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/abandonedCheckoutsFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/AbandonedCheckout
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/AbandonedCheckout
 
 var abandonedCheckoutsFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/articlesFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/articlesFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Article
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Article
 
 var articlesFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/blogsFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/blogsFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Blog
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Blog
 
 var blogsFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/collectionsFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/collectionsFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Collection
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Collection
 
 var collectionsFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/customersFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/customersFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Customer
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Customer
 
 var customersFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/discountCodesFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/discountCodesFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/DiscountCodeNode
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/DiscountCodeNode
 // Note: codeDiscount is a union type (DiscountCodeBasic | DiscountCodeBxgy | DiscountCodeFreeShipping)
 
 var discountCodesFields = {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/fulfillmentOrdersFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/fulfillmentOrdersFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/FulfillmentOrder
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/FulfillmentOrder
 
 var fulfillmentOrdersFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/inventoryItemsFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/inventoryItemsFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/InventoryItem
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/InventoryItem
 
 var inventoryItemsFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/locationsFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/locationsFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Location
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Location
 
 var locationsFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/metafieldsFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/metafieldsFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Metafield
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Metafield
 // Used for all metafield_* nodes
 
 var metafieldsFields = {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/ordersFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/ordersFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Order
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Order
 
 var ordersFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/pagesFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/pagesFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Page
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Page
 
 var pagesFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/productVariantsFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/productVariantsFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/ProductVariant
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/ProductVariant
 
 var productVariantsFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/productsFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/productsFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Product
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Product
 
 var productsFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/shopFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/shopFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/Shop
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/Shop
 
 var shopFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/tenderTransactionsFields.js
+++ b/packages/connectors/src/Sources/Shopify/ShopifyAPIReference/tenderTransactionsFields.js
@@ -5,7 +5,7 @@
  * file that was distributed with this source code.
  */
 
-// API reference: https://shopify.dev/docs/api/admin-graphql/2025-10/objects/TenderTransaction
+// API reference: https://shopify.dev/docs/api/admin-graphql/2026-07/objects/TenderTransaction
 
 var tenderTransactionsFields = {
   'id': {

--- a/packages/connectors/src/Sources/Shopify/Source.js
+++ b/packages/connectors/src/Sources/Shopify/Source.js
@@ -347,7 +347,7 @@ var ShopifySource = class ShopifySource extends AbstractSource {
 
   _buildGraphqlUrl() {
     const domain = String(this.config.ShopDomain.value).replace(/^https?:\/\//, "").replace(/\/$/, "");
-    return `https://${domain}/admin/api/2025-10/graphql.json`;
+    return `https://${domain}/admin/api/2026-07/graphql.json`;
   }
 
   _buildHeaders() {


### PR DESCRIPTION
# Problem

The LinkedIn Ads and LinkedIn Pages connectors send every request with a hardcoded `LinkedIn-Version: 202509` header. LinkedIn's own versioning docs confirm that `202507` — just two months older — has already sunset, and each version is guaranteed a minimum support window of only one year, so `202509` was on track to start failing requests around September 2026. The Shopify connector had the same problem: it called Admin API version `2025-10`, which had roughly two months of support left before its own cutoff. This is the same failure mode that recently broke the Google Ads connector when its hardcoded `v21` was sunset by Google mid-run with no grace period.

# Solution

Bumped both connectors to their current stable API versions per each vendor's official documentation, rather than waiting for them to fail in production like Google Ads did:

- LinkedIn Ads and LinkedIn Pages: `LinkedIn-Version` header updated from `202509` to `202607`, the latest published version per Microsoft Learn's LinkedIn Marketing API docs
- Shopify: Admin API version updated from `2025-10` to `2026-07`, the current version recommended for production per Shopify's official release schedule
- Also swept each connector's field-schema documentation links (`ShopifyAPIReference/*.js`) for the same stale version string, so in-app documentation links stay accurate
- Updated the existing Google Ads API-version changeset to describe all three connector fixes together instead of adding a separate entry

# Changes

- Updated `LinkedInAds/Source.js` and `LinkedInPages/Source.js` to send `LinkedIn-Version: 202607`
- Updated `Shopify/Source.js` to call Admin API version `2026-07`
- Updated 19 files under `Shopify/ShopifyAPIReference/` to point documentation links at `2026-07`
- Rewrote `.changeset/6810-google-ads-api-v25.md` to cover the Google Ads, LinkedIn, and Shopify version fixes as one changeset