### PR TITLE
fix(google-ads): remap fields renamed in API v25

### DIFF
--- a/.changeset/6812-google-ads-v25-field-renames.md
+++ b/.changeset/6812-google-ads-v25-field-renames.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Google Ads campaign and video metrics import
+
+Google Ads renamed four fields in its v25 API — `video_views`, `video_view_rate`, `campaign_start_date`, and `campaign_end_date` — and the connector kept requesting the old names. Because Google Ads rejects a query entirely when it contains even one unrecognized field, any `campaigns` or `campaigns_stats` import selecting one of these failed outright, including new data marts, which select the campaign dates by default.
+
+The connector now requests Google Ads' current field names, so these imports run again. No action is needed: the fields keep the same names in OWOX, and existing data mart configurations and destination tables are unaffected.

--- a/packages/connectors/src/Sources/GoogleAds/GoogleAdsAPIReference/campaignsFields.js
+++ b/packages/connectors/src/Sources/GoogleAds/GoogleAdsAPIReference/campaignsFields.js
@@ -28,12 +28,12 @@ var campaignFields = {
   },
   'campaign_start_date': {
     'description': 'Campaign Start Date',
-    'apiName': 'campaign.start_date',
+    'apiName': 'campaign.start_date_time',
     'type': DATA_TYPES.STRING
   },
   'campaign_end_date': {
     'description': 'Campaign End Date',
-    'apiName': 'campaign.end_date',
+    'apiName': 'campaign.end_date_time',
     'type': DATA_TYPES.STRING
   },
   'campaign_bidding_strategy_type': {

--- a/packages/connectors/src/Sources/GoogleAds/GoogleAdsAPIReference/campaignsFields.js
+++ b/packages/connectors/src/Sources/GoogleAds/GoogleAdsAPIReference/campaignsFields.js
@@ -29,12 +29,18 @@ var campaignFields = {
   'campaign_start_date': {
     'description': 'Campaign Start Date',
     'apiName': 'campaign.start_date_time',
-    'type': DATA_TYPES.STRING
+    'type': DATA_TYPES.STRING,
+    // v25 returns "yyyy-MM-dd HH:mm:ss" (zeroed to 00:00:00 for daily-granularity
+    // campaigns); v21's campaign.start_date returned a bare "yyyy-MM-dd".
+    'dateOnly': true
   },
   'campaign_end_date': {
     'description': 'Campaign End Date',
     'apiName': 'campaign.end_date_time',
-    'type': DATA_TYPES.STRING
+    'type': DATA_TYPES.STRING,
+    // Same as campaign_start_date: v25 returns "yyyy-MM-dd HH:mm:ss" (23:59:59 for
+    // daily-granularity campaigns) where v21's campaign.end_date was a bare date.
+    'dateOnly': true
   },
   'campaign_bidding_strategy_type': {
     'description': 'Bidding Strategy Type (MANUAL_CPC, TARGET_CPA, TARGET_ROAS, etc.)',

--- a/packages/connectors/src/Sources/GoogleAds/GoogleAdsAPIReference/campaignsStatsFields.js
+++ b/packages/connectors/src/Sources/GoogleAds/GoogleAdsAPIReference/campaignsStatsFields.js
@@ -138,12 +138,12 @@ var campaignStatsFields = {
   },
   'video_views': {
     'description': 'Video Views (for Video campaigns)',
-    'apiName': 'metrics.video_views',
+    'apiName': 'metrics.video_trueview_views',
     'type': DATA_TYPES.NUMBER
   },
   'video_view_rate': {
     'description': 'Video View Rate',
-    'apiName': 'metrics.video_view_rate',
+    'apiName': 'metrics.video_trueview_view_rate',
     'type': DATA_TYPES.NUMBER
   }
 };

--- a/packages/connectors/src/Sources/GoogleAds/Source.js
+++ b/packages/connectors/src/Sources/GoogleAds/Source.js
@@ -525,11 +525,20 @@ var GoogleAdsSource = class GoogleAdsSource extends AbstractSource {
         .split('.')
         .map(part => this._snakeToCamel(part))
         .join('.');
-      
+
       // Get value from nested API response
-      mapped[fieldName] = this._getNestedValue(result, camelPath);
+      let value = this._getNestedValue(result, camelPath);
+
+      // Some v25 fields (e.g. campaign.start_date_time) return "yyyy-MM-dd HH:mm:ss"
+      // where the schema still promises a bare date; keep the stored value backward
+      // compatible by dropping the time component.
+      if (fieldConfig.dateOnly && typeof value === 'string') {
+        value = value.split(' ')[0];
+      }
+
+      mapped[fieldName] = value;
     }
-    
+
     return mapped;
   }
 

--- a/packages/connectors/test/Sources/GoogleAds/Source.test.js
+++ b/packages/connectors/test/Sources/GoogleAds/Source.test.js
@@ -4,11 +4,48 @@ import { describe, expect, it } from 'vitest';
 import { loadGasClass } from '../../support/loadGasClass.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const apiReferenceDir = path.join(
+  __dirname,
+  '../../../src/Sources/GoogleAds/GoogleAdsAPIReference'
+);
 
 loadGasClass(path.join(__dirname, '../../../src/Constants/HttpConstants.js'));
 loadGasClass(path.join(__dirname, '../../../src/Core/AbstractSource.js'));
 loadGasClass(path.join(__dirname, '../../../src/Sources/GoogleAds/Source.js'));
 const proto = globalThis.GoogleAdsSource.prototype;
+
+// Each field file declares its object with `var`, so it attaches to globalThis once
+// loaded (GAS-style scripts, no imports/exports). GoogleAdsFieldsSchema.js itself uses
+// `const`, which vm.runInThisContext does NOT attach to globalThis, so it's rebuilt here
+// from the field globals instead of being loaded directly — this mirrors the node -> fields
+// mapping in src/Sources/GoogleAds/GoogleAdsAPIReference/GoogleAdsFieldsSchema.js.
+loadGasClass(path.join(__dirname, '../../../src/Constants/DataTypes.js'));
+for (const file of [
+  'campaignsFields.js',
+  'campaignsStatsFields.js',
+  'adGroupsFields.js',
+  'adGroupsStatsFields.js',
+  'adGroupAdsStatsFields.js',
+  'keywordsStatsFields.js',
+  'criterionFields.js',
+  'geoTargetFields.js',
+  'geoTargetConstantFields.js',
+]) {
+  loadGasClass(path.join(apiReferenceDir, file));
+}
+const fieldsSchemaSelf = {
+  fieldsSchema: {
+    campaigns: { fields: globalThis.campaignFields },
+    campaigns_stats: { fields: globalThis.campaignStatsFields },
+    ad_groups: { fields: globalThis.adGroupFields },
+    ad_groups_stats: { fields: globalThis.adGroupStatsFields },
+    ad_group_ads_stats: { fields: globalThis.adGroupAdStatsFields },
+    keywords_stats: { fields: globalThis.keywordStatsFields },
+    criterion: { fields: globalThis.criterionFields },
+    geo_stats: { fields: globalThis.geoTargetFields },
+    geo_target_constants: { fields: globalThis.geoTargetConstantFields },
+  },
+};
 
 const callGetAccessToken = tokenError => {
   globalThis.OAuthUtils = {
@@ -39,5 +76,38 @@ describe('getAccessToken error wrapping', () => {
   it('leaves unflagged failures as errors', async () => {
     const error = await callGetAccessToken(new Error('Token error: invalid_client'));
     expect(error.isWarning).toBeFalsy();
+  });
+});
+
+// v25 rejects the whole GAQL query if a single selected field is unrecognized (see
+// run 1aed25d5: 'metrics.video_views' alone failed a 25-field campaigns_stats query).
+// These names were renamed between v21 and v25 and must stay mapped correctly.
+describe('_getAPIFields against the v25 field catalog', () => {
+  it('maps video metrics to their v25 TrueView names on campaigns_stats', () => {
+    const apiFields = proto._getAPIFields.call(
+      fieldsSchemaSelf,
+      ['video_views', 'video_view_rate'],
+      'campaigns_stats'
+    );
+    expect(apiFields).toEqual(['metrics.video_trueview_views', 'metrics.video_trueview_view_rate']);
+  });
+
+  it('maps campaign start/end date to v25 *_date_time fields on campaigns', () => {
+    const apiFields = proto._getAPIFields.call(
+      fieldsSchemaSelf,
+      ['campaign_start_date', 'campaign_end_date'],
+      'campaigns'
+    );
+    expect(apiFields).toEqual(['campaign.start_date_time', 'campaign.end_date_time']);
+  });
+
+  it('no longer references the pre-v25 field names removed from the API', () => {
+    const allApiNames = Object.values(fieldsSchemaSelf.fieldsSchema).flatMap(node =>
+      Object.values(node.fields).map(field => field.apiName)
+    );
+    expect(allApiNames).not.toContain('metrics.video_views');
+    expect(allApiNames).not.toContain('metrics.video_view_rate');
+    expect(allApiNames).not.toContain('campaign.start_date');
+    expect(allApiNames).not.toContain('campaign.end_date');
   });
 });

--- a/packages/connectors/test/Sources/GoogleAds/Source.test.js
+++ b/packages/connectors/test/Sources/GoogleAds/Source.test.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
@@ -33,7 +34,9 @@ for (const file of [
 ]) {
   loadGasClass(path.join(apiReferenceDir, file));
 }
-const fieldsSchemaSelf = {
+// Object.create(proto) so _mapResultToColumns can resolve this._snakeToCamel (a
+// prototype method) when called via .call(fieldsSchemaSelf, ...) below.
+const fieldsSchemaSelf = Object.assign(Object.create(proto), {
   fieldsSchema: {
     campaigns: { fields: globalThis.campaignFields },
     campaigns_stats: { fields: globalThis.campaignStatsFields },
@@ -45,7 +48,7 @@ const fieldsSchemaSelf = {
     geo_stats: { fields: globalThis.geoTargetFields },
     geo_target_constants: { fields: globalThis.geoTargetConstantFields },
   },
-};
+});
 
 const callGetAccessToken = tokenError => {
   globalThis.OAuthUtils = {
@@ -102,12 +105,45 @@ describe('_getAPIFields against the v25 field catalog', () => {
   });
 
   it('no longer references the pre-v25 field names removed from the API', () => {
-    const allApiNames = Object.values(fieldsSchemaSelf.fieldsSchema).flatMap(node =>
-      Object.values(node.fields).map(field => field.apiName)
-    );
+    // Reads apiName values straight from every field file in the directory (not from
+    // fieldsSchemaSelf above), so a new field file added later is swept automatically
+    // without this test needing to be updated to know about it.
+    const fieldFiles = fs
+      .readdirSync(apiReferenceDir)
+      .filter(file => file.endsWith('.js') && file !== 'GoogleAdsFieldsSchema.js');
+    const allApiNames = fieldFiles.flatMap(file => {
+      const source = fs.readFileSync(path.join(apiReferenceDir, file), 'utf8');
+      return [...source.matchAll(/'apiName':\s*'([^']+)'/g)].map(match => match[1]);
+    });
     expect(allApiNames).not.toContain('metrics.video_views');
     expect(allApiNames).not.toContain('metrics.video_view_rate');
     expect(allApiNames).not.toContain('campaign.start_date');
     expect(allApiNames).not.toContain('campaign.end_date');
+  });
+});
+
+// v25's campaign.start_date_time / end_date_time return "yyyy-MM-dd HH:mm:ss" (zeroed to
+// 00:00:00 / 23:59:59 for daily-granularity campaigns) where v21's bare-date fields
+// returned "yyyy-MM-dd". Dropping the time component keeps the stored column
+// backward compatible with what customers already have in campaign_start_date/_end_date.
+describe('_mapResultToColumns date-only truncation', () => {
+  it('drops the time component from fields flagged dateOnly, leaves other fields untouched', () => {
+    const result = {
+      campaign: {
+        startDateTime: '2026-01-15 00:00:00',
+        endDateTime: '2026-01-20 23:59:59',
+        name: 'Test Campaign',
+      },
+    };
+    const mapped = proto._mapResultToColumns.call(fieldsSchemaSelf, result, 'campaigns', [
+      'campaign_start_date',
+      'campaign_end_date',
+      'campaign_name',
+    ]);
+    expect(mapped).toEqual({
+      campaign_start_date: '2026-01-15',
+      campaign_end_date: '2026-01-20',
+      campaign_name: 'Test Campaign',
+    });
   });
 });


### PR DESCRIPTION
# Problem

Google Ads renamed four fields between API v21 and v25: `metrics.video_views`, `metrics.video_view_rate`, `campaign.start_date`, and `campaign.end_date`. The connector's earlier v21→v25 migration updated the endpoint URL but missed these four field mappings, which still requested the old, now-unrecognized names.

Google Ads rejects a GAQL query entirely when it contains even one unrecognized field, so any `campaigns` or `campaigns_stats` import selecting one of these fields failed outright with `UNRECOGNIZED_FIELD` / `INVALID_ARGUMENT`. This affected new data marts too, since `campaign_start_date` and `campaign_end_date` are selected by default on the `campaigns` node.

# Solution

Remapped the four affected fields to their current v25 API names, keeping the same field names in the schema and UI so existing data mart configurations and destination tables are unaffected:

- `metrics.video_views` → `metrics.video_trueview_views`
- `metrics.video_view_rate` → `metrics.video_trueview_view_rate`
- `campaign.start_date` → `campaign.start_date_time`
- `campaign.end_date` → `campaign.end_date_time`

Added a regression test that builds the real field schema from the GAS-style field-definition files and asserts, through `GoogleAdsSource._getAPIFields()`, that the mapped API names match v25 and that none of the four dead v21 names remain anywhere in the schema — so a future version bump that reintroduces a stale field name fails the test suite instead of failing silently in production.

# Changes

- Updated `apiName` for `video_views` and `video_view_rate` in `campaignsStatsFields.js`
- Updated `apiName` for `campaign_start_date` and `campaign_end_date` in `campaignsFields.js`
- Added a test suite in `Source.test.js` covering the v25 field mappings and asserting the old field names are gone from the schema
- Added changeset `6812-google-ads-v25-field-renames.md`