### PR TITLE
fix: intermittent Google OAuth authorization failures in storage and destination

### DIFF
--- a/.changeset/6825-google-oauth-popup-intermittent-auth.md
+++ b/.changeset/6825-google-oauth-popup-intermittent-auth.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Connecting a Google account no longer fails intermittently
+
+Authorizing Google BigQuery storage or a Google Sheets destination could fail at random — the popup would show a sign-in screen or an authorization error, and the connection would only succeed after several attempts.
+
+The cause: the OAuth popup used to boot the entire application and sign in on its own. That sign-in competed with the main tab for the same single-use session credentials, and whichever window lost the race failed. The popup could also end up in a different project context than the tab that started the connection, which made the authorization attempt be rejected.
+
+Now the popup only hands the authorization result back to the tab where you clicked "Connect with Google", and that tab completes the connection using its own session. One attempt is all it takes.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -18,8 +18,28 @@ const queryClient = new QueryClient({
   },
 });
 
+/**
+ * OAuth callback pages run in a short-lived popup and only forward the
+ * authorization result to the opener window. They must not boot the
+ * authenticated app: the auth bootstrap calls /auth/access-token, which
+ * rotates the single-use refresh-token cookie and races the opener tab's
+ * session (intermittent auth failures), and on failure redirects the popup
+ * to sign-in.
+ */
+function isOAuthCallbackWindow(): boolean {
+  return window.location.pathname.startsWith('/oauth/');
+}
+
 function App() {
   const router = createBrowserRouter(routes);
+
+  if (isOAuthCallbackWindow()) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    );
+  }
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/apps/web/src/features/google-oauth/components/GoogleOAuthConnectButton.test.tsx
+++ b/apps/web/src/features/google-oauth/components/GoogleOAuthConnectButton.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GoogleOAuthConnectButton } from './GoogleOAuthConnectButton';
+import { destinationOAuthApi, storageOAuthApi } from '../api/google-oauth-api.service';
+
+vi.mock('../api/google-oauth-api.service', () => ({
+  storageOAuthApi: {
+    generateAuthUrl: vi.fn(),
+    exchangeOAuthCode: vi.fn(),
+    getOAuthStatus: vi.fn(),
+  },
+  destinationOAuthApi: {
+    generateAuthUrl: vi.fn(),
+    generateStandaloneAuthUrl: vi.fn(),
+    exchangeOAuthCode: vi.fn(),
+    getOAuthStatus: vi.fn(),
+    getCredentialStatus: vi.fn(),
+  },
+}));
+
+const STATE = 'state-jwt-1';
+
+describe('GoogleOAuthConnectButton', () => {
+  let windowOpen: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    class MockBroadcastChannel {
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      postMessage = vi.fn();
+      close = vi.fn();
+    }
+    vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
+    windowOpen = vi
+      .spyOn(window, 'open')
+      .mockReturnValue({ closed: false, close: vi.fn() } as unknown as Window);
+    vi.mocked(destinationOAuthApi.generateStandaloneAuthUrl).mockResolvedValue({
+      authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=' + STATE,
+      state: STATE,
+    });
+    vi.mocked(storageOAuthApi.generateAuthUrl).mockResolvedValue({
+      authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth?state=' + STATE,
+      state: STATE,
+    });
+    vi.mocked(storageOAuthApi.getOAuthStatus).mockResolvedValue({ isValid: false });
+  });
+
+  afterEach(() => {
+    windowOpen.mockRestore();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  async function connectAndReceive(message: Record<string, unknown>) {
+    fireEvent.click(await screen.findByRole('button', { name: /Connect with Google/ }));
+    await waitFor(() => {
+      expect(windowOpen).toHaveBeenCalled();
+    });
+    fireEvent(
+      window,
+      new MessageEvent('message', { data: message, origin: window.location.origin })
+    );
+  }
+
+  it('exchanges the forwarded code in the opener window and reports success', async () => {
+    vi.mocked(destinationOAuthApi.exchangeOAuthCode).mockResolvedValue({
+      credentialId: 'cred-1',
+      user: { id: 'u1', email: 'user@example.com' },
+    });
+    vi.mocked(destinationOAuthApi.getCredentialStatus).mockResolvedValue({
+      isValid: true,
+      credentialId: 'cred-1',
+      user: { email: 'user@example.com' },
+    });
+    const onSuccess = vi.fn();
+
+    render(<GoogleOAuthConnectButton resourceType='destination' onSuccess={onSuccess} />);
+    await connectAndReceive({ type: 'OAUTH_CALLBACK', code: 'auth-code-1', state: STATE });
+
+    await waitFor(() => {
+      expect(destinationOAuthApi.exchangeOAuthCode).toHaveBeenCalledWith('auth-code-1', STATE);
+      expect(onSuccess).toHaveBeenCalledWith('cred-1');
+    });
+  });
+
+  it('uses the storage API for storage resources', async () => {
+    vi.mocked(storageOAuthApi.exchangeOAuthCode).mockResolvedValue({
+      credentialId: 'cred-2',
+      user: { id: 'u1', email: 'user@example.com' },
+    });
+    const onSuccess = vi.fn();
+
+    render(
+      <GoogleOAuthConnectButton
+        resourceType='storage'
+        resourceId='storage-1'
+        onSuccess={onSuccess}
+      />
+    );
+    await connectAndReceive({ type: 'OAUTH_CALLBACK', code: 'auth-code-2', state: STATE });
+
+    await waitFor(() => {
+      expect(storageOAuthApi.exchangeOAuthCode).toHaveBeenCalledWith('auth-code-2', STATE);
+      expect(onSuccess).toHaveBeenCalledWith('cred-2');
+    });
+  });
+
+  it('rejects a callback whose state does not match the one generated for this attempt', async () => {
+    const onSuccess = vi.fn();
+
+    render(<GoogleOAuthConnectButton resourceType='destination' onSuccess={onSuccess} />);
+    await connectAndReceive({ type: 'OAUTH_CALLBACK', code: 'auth-code-1', state: 'other-state' });
+
+    expect(await screen.findByText(/Invalid state token/)).toBeInTheDocument();
+    expect(destinationOAuthApi.exchangeOAuthCode).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('shows the error forwarded by the popup', async () => {
+    render(<GoogleOAuthConnectButton resourceType='destination' />);
+    await connectAndReceive({ type: 'OAUTH_CALLBACK', error: 'OAuth error: access_denied' });
+
+    expect(await screen.findByText(/access_denied/)).toBeInTheDocument();
+    expect(destinationOAuthApi.exchangeOAuthCode).not.toHaveBeenCalled();
+  });
+
+  it('shows the exchange failure message when the API call fails', async () => {
+    vi.mocked(destinationOAuthApi.exchangeOAuthCode).mockRejectedValue(
+      new Error('OAuth state does not belong to your project')
+    );
+
+    render(<GoogleOAuthConnectButton resourceType='destination' />);
+    await connectAndReceive({ type: 'OAUTH_CALLBACK', code: 'auth-code-1', state: STATE });
+
+    expect(await screen.findByText(/does not belong to your project/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/google-oauth/components/GoogleOAuthConnectButton.tsx
+++ b/apps/web/src/features/google-oauth/components/GoogleOAuthConnectButton.tsx
@@ -28,8 +28,8 @@ const GoogleLogo = () => (
 
 interface OAuthCallbackData {
   type: string;
-  success: boolean;
-  credentialId?: string;
+  code?: string;
+  state?: string;
   error?: string;
 }
 
@@ -130,11 +130,6 @@ export function GoogleOAuthConnectButton({
         state = result.state;
       }
 
-      // Use sessionStorage (tab-scoped) to avoid multi-tab collisions
-      sessionStorage.setItem('oauth_state', state);
-      sessionStorage.setItem('oauth_resource_type', resourceType);
-      sessionStorage.setItem('oauth_resource_id', resourceId ?? '');
-
       const width = 600;
       const height = 700;
       const left = Math.round(window.screenX + (window.outerWidth - width) / 2);
@@ -145,44 +140,74 @@ export function GoogleOAuthConnectButton({
         `width=${String(width)},height=${String(height)},left=${String(left)},top=${String(top)},resizable=yes,scrollbars=yes`
       );
 
+      // The popup only forwards the authorization code back here; the exchange
+      // runs in THIS window with the same session that generated the state.
+      // The popup itself never authenticates, so it cannot race the rotating
+      // refresh-token cookie or land in a different project context.
+      const bc = new BroadcastChannel(`oauth_channel_${state}`);
+      let completed = false;
+
+      const cleanup = () => {
+        window.removeEventListener('message', handleMessage);
+        bc.close();
+        if (intervalRef.current) clearInterval(intervalRef.current);
+      };
+
+      const processCallbackData = (data: OAuthCallbackData) => {
+        if (data.type !== 'OAUTH_CALLBACK') return;
+        if (completed) return;
+        completed = true;
+        cleanup();
+
+        void (async () => {
+          try {
+            if (data.error || !data.code) {
+              throw new Error(data.error ?? 'No authorization code received from Google');
+            }
+            if (data.state !== state) {
+              throw new Error('Invalid state token. Please try again.');
+            }
+
+            const result =
+              resourceType === 'storage'
+                ? await storageOAuthApi.exchangeOAuthCode(data.code, data.state)
+                : await destinationOAuthApi.exchangeOAuthCode(data.code, data.state);
+
+            setConnecting(false);
+            setCurrentCredentialId(result.credentialId);
+            onSuccess?.(result.credentialId);
+            void fetchStatus();
+          } catch (error) {
+            console.error('Google OAuth connection failed', error);
+            setConnecting(false);
+            setConnectError(
+              error instanceof Error && error.message
+                ? error.message
+                : 'Failed to connect your Google account. Please try again.'
+            );
+          }
+        })();
+      };
+
+      const handleMessage = (event: MessageEvent<OAuthCallbackData>) => {
+        if (event.origin !== window.location.origin) return;
+        processCallbackData(event.data);
+      };
+      window.addEventListener('message', handleMessage);
+      bc.onmessage = (event: MessageEvent<OAuthCallbackData>) => {
+        processCallbackData(event.data);
+      };
+
       if (!popup) {
+        cleanup();
         throw new Error('Popup was blocked. Please allow popups for this site and try again.');
       }
       popupRef.current = popup;
 
-      const handleMessage = (event: MessageEvent<OAuthCallbackData>) => {
-        if (event.origin !== window.location.origin) return;
-        if (event.data.type !== 'OAUTH_CALLBACK') return;
-
-        window.removeEventListener('message', handleMessage);
-        if (intervalRef.current) clearInterval(intervalRef.current);
-        setConnecting(false);
-
-        if (event.data.success) {
-          const credentialId = event.data.credentialId;
-          if (!credentialId) {
-            setConnectError(
-              'Connection succeeded but no credential was returned. Please try again.'
-            );
-            return;
-          }
-          setCurrentCredentialId(credentialId);
-          onSuccess?.(credentialId);
-          void fetchStatus();
-        } else {
-          console.error('Google OAuth callback reported failure', event.data.error);
-          setConnectError(
-            event.data.error ?? 'Failed to connect your Google account. Please try again.'
-          );
-        }
-      };
-      window.addEventListener('message', handleMessage);
-
       intervalRef.current = setInterval(() => {
         try {
-          if (popup.closed) {
-            if (intervalRef.current) clearInterval(intervalRef.current);
-            window.removeEventListener('message', handleMessage);
+          if (popup.closed && !completed) {
+            cleanup();
             setConnecting(false);
           }
         } catch {

--- a/apps/web/src/features/google-oauth/pages/GoogleOAuthCallbackPage.test.tsx
+++ b/apps/web/src/features/google-oauth/pages/GoogleOAuthCallbackPage.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GoogleOAuthCallbackPage } from './GoogleOAuthCallbackPage';
+
+function renderAt(url: string) {
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <GoogleOAuthCallbackPage />
+    </MemoryRouter>
+  );
+}
+
+describe('GoogleOAuthCallbackPage', () => {
+  let postMessage: ReturnType<typeof vi.fn>;
+  let windowClose: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    postMessage = vi.fn();
+    Object.defineProperty(window, 'opener', {
+      value: { postMessage },
+      writable: true,
+      configurable: true,
+    });
+    windowClose = vi.spyOn(window, 'close').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'opener', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+    windowClose.mockRestore();
+  });
+
+  it('forwards code and state to the opener without calling any API', () => {
+    renderAt('/oauth/google/callback?code=auth-code-1&state=state-jwt-1');
+
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'OAUTH_CALLBACK', code: 'auth-code-1', state: 'state-jwt-1' },
+      window.location.origin
+    );
+    expect(windowClose).toHaveBeenCalled();
+  });
+
+  it('forwards a provider error to the opener', () => {
+    renderAt('/oauth/google/callback?error=access_denied');
+
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'OAUTH_CALLBACK', error: 'OAuth error: access_denied' },
+      window.location.origin
+    );
+  });
+
+  it('reports a missing authorization code to the opener', () => {
+    renderAt('/oauth/google/callback?state=state-jwt-1');
+
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'OAUTH_CALLBACK', error: 'Missing authorization code or state' },
+      window.location.origin
+    );
+  });
+
+  it('falls back to a BroadcastChannel when the opener is unavailable', () => {
+    Object.defineProperty(window, 'opener', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+    const channelPostMessage = vi.fn();
+    const channelClose = vi.fn();
+    const channelNames: string[] = [];
+    class MockBroadcastChannel {
+      postMessage = channelPostMessage;
+      close = channelClose;
+      constructor(name: string) {
+        channelNames.push(name);
+      }
+    }
+    vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
+
+    try {
+      renderAt('/oauth/google/callback?code=auth-code-1&state=state-jwt-1');
+
+      expect(channelNames).toContain('oauth_channel_state-jwt-1');
+      expect(channelPostMessage).toHaveBeenCalledWith({
+        type: 'OAUTH_CALLBACK',
+        code: 'auth-code-1',
+        state: 'state-jwt-1',
+      });
+      expect(channelClose).toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('shows a fallback message when neither opener nor state is available', () => {
+    Object.defineProperty(window, 'opener', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    renderAt('/oauth/google/callback?code=auth-code-1');
+
+    expect(screen.getByText(/Missing authorization code/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/google-oauth/pages/GoogleOAuthCallbackPage.tsx
+++ b/apps/web/src/features/google-oauth/pages/GoogleOAuthCallbackPage.tsx
@@ -1,21 +1,40 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
-import { storageOAuthApi, destinationOAuthApi } from '../api/google-oauth-api.service';
 
-function sendToOpener(data: object): boolean {
+/**
+ * Message sent from the OAuth popup back to the window that opened it.
+ * On success carries the authorization code and state; on failure carries an error.
+ * The opener performs the code exchange with its own session, so this page
+ * never calls the API and never needs the app's auth bootstrap.
+ */
+export interface GoogleOAuthCallbackMessage {
+  type: 'OAUTH_CALLBACK';
+  code?: string;
+  state?: string;
+  error?: string;
+}
+
+function sendToOpener(
+  data: Omit<GoogleOAuthCallbackMessage, 'type'>,
+  state: string | null
+): boolean {
+  const message: GoogleOAuthCallbackMessage = { type: 'OAUTH_CALLBACK', ...data };
   const opener = window.opener as Window | null;
   if (opener) {
-    opener.postMessage({ type: 'OAUTH_CALLBACK', ...data }, window.location.origin);
+    opener.postMessage(message, window.location.origin);
+    window.close();
+    return true;
+  }
+  // COOP on the provider side can sever window.opener; fall back to a
+  // state-scoped BroadcastChannel the opener also listens on.
+  if (state) {
+    const bc = new BroadcastChannel(`oauth_channel_${state}`);
+    bc.postMessage(message);
+    bc.close();
     window.close();
     return true;
   }
   return false;
-}
-
-function clearOAuthSessionData() {
-  sessionStorage.removeItem('oauth_state');
-  sessionStorage.removeItem('oauth_resource_type');
-  sessionStorage.removeItem('oauth_resource_id');
 }
 
 export function GoogleOAuthCallbackPage() {
@@ -27,90 +46,33 @@ export function GoogleOAuthCallbackPage() {
     if (processed.current) return;
     processed.current = true;
 
-    const handleCallback = async () => {
-      try {
-        const code = searchParams.get('code');
-        const state = searchParams.get('state');
-        const errorParam = searchParams.get('error');
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    const errorParam = searchParams.get('error');
 
-        if (errorParam) {
-          clearOAuthSessionData();
-          if (!sendToOpener({ success: false, error: `OAuth error: ${errorParam}` })) {
-            setFallbackMessage(`Authentication failed: ${errorParam}. You can close this window.`);
-          }
-          return;
-        }
-
-        if (!code || !state) {
-          clearOAuthSessionData();
-          if (!sendToOpener({ success: false, error: 'Missing authorization code or state' })) {
-            setFallbackMessage(
-              'Missing authorization code. You can close this window and try again.'
-            );
-          }
-          return;
-        }
-
-        // Client-side state check (tab-scoped via sessionStorage).
-        // The real CSRF protection is the server-side JWT signature in the state token.
-        const storedState = sessionStorage.getItem('oauth_state');
-
-        if (state !== storedState) {
-          clearOAuthSessionData();
-          if (
-            !sendToOpener({
-              success: false,
-              error: 'Invalid state token. Possible CSRF attack. Please try again.',
-            })
-          ) {
-            setFallbackMessage('Invalid state token. You can close this window and try again.');
-          }
-          return;
-        }
-
-        const resourceType = sessionStorage.getItem('oauth_resource_type');
-
-        if (!resourceType || (resourceType !== 'storage' && resourceType !== 'destination')) {
-          clearOAuthSessionData();
-          if (
-            !sendToOpener({
-              success: false,
-              error: 'Missing resource information. Please try connecting again.',
-            })
-          ) {
-            setFallbackMessage(
-              'Missing resource information. You can close this window and try again.'
-            );
-          }
-          return;
-        }
-
-        // Exchange code for tokens
-        const result =
-          resourceType === 'storage'
-            ? await storageOAuthApi.exchangeOAuthCode(code, state)
-            : await destinationOAuthApi.exchangeOAuthCode(code, state);
-
-        clearOAuthSessionData();
-
-        if (!sendToOpener({ success: true, credentialId: result.credentialId })) {
-          setFallbackMessage(
-            'Authentication complete. You can close this window and return to the application.'
-          );
-        }
-      } catch (err) {
-        clearOAuthSessionData();
-        const message =
-          err instanceof Error ? err.message : 'Failed to connect your Google account';
-        if (!sendToOpener({ success: false, error: message })) {
-          setFallbackMessage(
-            `Authentication failed: ${message}. You can close this window and try again.`
-          );
-        }
+    if (errorParam) {
+      if (!sendToOpener({ error: `OAuth error: ${errorParam}` }, state)) {
+        setFallbackMessage(`Authentication failed: ${errorParam}. You can close this window.`);
       }
-    };
+      return;
+    }
 
-    void handleCallback();
+    if (!code || !state) {
+      if (!sendToOpener({ error: 'Missing authorization code or state' }, state)) {
+        setFallbackMessage('Missing authorization code. You can close this window and try again.');
+      }
+      return;
+    }
+
+    // The opener validates the state against the value it generated and then
+    // exchanges the code using its own authenticated session. The server-side
+    // JWT signature on the state token remains the real CSRF protection.
+    if (!sendToOpener({ code, state }, state)) {
+      setFallbackMessage(
+        'The window that started the connection is no longer available. ' +
+          'Please close this window and try connecting again.'
+      );
+    }
   }, [searchParams]);
 
   if (fallbackMessage) {


### PR DESCRIPTION
## Problem

Authorizing Google BigQuery storage or a Google Sheets destination failed intermittently: the OAuth popup would show a sign-in screen or an authorization error, and the connection only succeeded after several attempts.

## Root cause

The popup at `/oauth/google/callback` booted the **entire app** and authenticated on its own:

1. **Refresh-token rotation race.** The popup's auth bootstrap calls `POST /auth/access-token`, which rotates the single-use refresh-token cookie shared with the opener tab (and any other open tabs). Whichever window lost the race got rejected, and the popup was redirected to sign-in. Intermittent by nature — matches "works only after several attempts".
2. **Project mismatch.** The code exchange ran with the *popup's* freshly issued token, while the state JWT was generated with the *opener's* token. `/auth/access-token` carries no project hint (the popup URL has no `/ui/:projectId`), so under user impersonation or multi-project accounts the IDP could resolve a different project → `exchangeAuthorizationCode` rejected with 403 "OAuth state does not belong to your project". This is why some users hit it consistently while others could not reproduce it.
3. **Stale popup state.** The named popup window (`google-oauth-popup`) could be reused across attempts with a stale copy of `sessionStorage`, producing false "Invalid state token" errors on retries.

## Fix

Aligned with the existing connector-callback pattern (TikTok/LinkedIn/Microsoft):

- `GoogleOAuthCallbackPage` no longer calls any API: it forwards `{code, state}` (or the provider error) to the opener via `postMessage`, with a `BroadcastChannel('oauth_channel_<state>')` fallback for COOP-severed openers, then closes.
- `GoogleOAuthConnectButton` (the opener) performs the exchange with its **own** session — the same one that generated the state, so the project matches by construction. State is validated against the closure value; `sessionStorage` is gone.
- `App.tsx` renders `/oauth/*` routes without `AuthProvider`/`AppBootstrap`, so the popup never touches the refresh-token cookie. This also removes the same race for the connector OAuth callbacks.

No backend changes; the 403 project check remains as a safety net.

## Testing

- New unit tests: callback page forwarding (opener, BroadcastChannel fallback, error paths) and opener-side exchange (success for storage & destination, state mismatch, forwarded provider error, exchange failure) — 10/10.
- Regression: `GoogleBigQueryFields`, `GoogleSheetsFields`, `ConnectGoogleSheetsPage` tests — 10/10.
- `tsc --noEmit`, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)