### PR TITLE
feat(data-marts): sample SQL data marts via subquery — no bigquery.datasets.create required

### DIFF
--- a/.changeset/6831-ai-metadata-sql-data-marts-subquery-sampling.md
+++ b/.changeset/6831-ai-metadata-sql-data-marts-subquery-sampling.md
@@ -8,6 +8,6 @@ Generating AI metadata (field aliases and descriptions, data mart title and desc
 
 Sample rows for AI generation are now fetched through an inline derived table built from the data mart's own SQL (`SELECT <columns> FROM (<data mart sql>) LIMIT <n>`), so the AI helper needs exactly the permissions a regular report run needs:
 
-- Plain `SELECT` definitions are inlined on every storage type.
-- `WITH`/CTE definitions are additionally inlined on Google BigQuery storages (including legacy), where the SQL dialect accepts a CTE inside a parenthesized derived table; other storages keep the previous behavior for CTEs.
-- SQL that cannot be inlined, explicit table references, and non-SQL definitions (table, view, pattern, connector) continue to use the technical-view path, with the existing human-readable error if permissions are missing there.
+- Plain `SELECT` definitions are inlined on every storage type except legacy Google BigQuery.
+- `WITH`/CTE definitions are additionally inlined on Google BigQuery storage, where the SQL dialect accepts a CTE inside a parenthesized derived table; other storages keep the previous behavior for CTEs.
+- Legacy Google BigQuery data marts, SQL that cannot be inlined, explicit table references, and non-SQL definitions (table, view, pattern, connector) continue to use the technical-view path, with the existing human-readable error if permissions are missing there.

--- a/.changeset/6831-ai-metadata-sql-data-marts-subquery-sampling.md
+++ b/.changeset/6831-ai-metadata-sql-data-marts-subquery-sampling.md
@@ -1,0 +1,13 @@
+---
+'owox': minor
+---
+
+# AI metadata generation for SQL data marts no longer requires dataset-creation permission
+
+Generating AI metadata (field aliases and descriptions, data mart title and description) for a SQL-based data mart previously materialized a technical view in the `owox_internal_<location>` dataset, and creating that dataset on first use required the project-level `bigquery.datasets.create` permission — so users with data-only access (e.g. `BigQuery Job User` plus `BigQuery Data Viewer`) could not use the AI helper at all.
+
+Sample rows for AI generation are now fetched through an inline derived table built from the data mart's own SQL (`SELECT <columns> FROM (<data mart sql>) LIMIT <n>`), so the AI helper needs exactly the permissions a regular report run needs:
+
+- Plain `SELECT` definitions are inlined on every storage type.
+- `WITH`/CTE definitions are additionally inlined on Google BigQuery storages (including legacy), where the SQL dialect accepts a CTE inside a parenthesized derived table; other storages keep the previous behavior for CTEs.
+- SQL that cannot be inlined, explicit table references, and non-SQL definitions (table, view, pattern, connector) continue to use the technical-view path, with the existing human-readable error if permissions are missing there.

--- a/apps/backend/src/data-marts/services/data-mart-sample-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-sample-data.service.spec.ts
@@ -93,29 +93,79 @@ describe('DataMartSampleDataService', () => {
     expect(dataMartTableReferenceService.resolveTableName).not.toHaveBeenCalled();
     expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
       dataMart,
-      'SELECT `report_date` FROM (SELECT report_date, amount FROM `src.dataset.orders`) AS owox_sample_source LIMIT 5',
+      'SELECT `report_date` FROM (SELECT report_date, amount FROM `src.dataset.orders`\n) AS owox_sample_source LIMIT 5',
       { limit: 5 }
     );
   });
 
-  it.each([DataStorageType.GOOGLE_BIGQUERY, DataStorageType.LEGACY_GOOGLE_BIGQUERY])(
-    'inlines a WITH/CTE SQL data mart as a derived table on %s',
-    async storageType => {
-      const { service, dataMart, dataMartSqlTableService, dataMartTableReferenceService } =
-        createService(storageType, {
-          sqlQuery: 'WITH src AS (SELECT 1 AS report_date) SELECT * FROM src;',
-        });
+  it('inlines a WITH/CTE SQL data mart as a derived table on BigQuery', async () => {
+    const { service, dataMart, dataMartSqlTableService, dataMartTableReferenceService } =
+      createService(DataStorageType.GOOGLE_BIGQUERY, {
+        sqlQuery: 'WITH src AS (SELECT 1 AS report_date) SELECT * FROM src;',
+      });
 
-      await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
+    await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
 
-      expect(dataMartTableReferenceService.resolveTableName).not.toHaveBeenCalled();
-      expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
-        dataMart,
-        'SELECT `report_date` FROM (WITH src AS (SELECT 1 AS report_date) SELECT * FROM src) AS owox_sample_source LIMIT 5',
-        { limit: 5 }
-      );
-    }
-  );
+    expect(dataMartTableReferenceService.resolveTableName).not.toHaveBeenCalled();
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      dataMart,
+      'SELECT `report_date` FROM (WITH src AS (SELECT 1 AS report_date) SELECT * FROM src\n) AS owox_sample_source LIMIT 5',
+      { limit: 5 }
+    );
+  });
+
+  it('keeps the technical-view path for legacy BigQuery, whose raw ODM SQL needs preprocessing', async () => {
+    const { service, dataMartSqlTableService, dataMartTableReferenceService } = createService(
+      DataStorageType.LEGACY_GOOGLE_BIGQUERY,
+      { sqlQuery: 'SELECT report_date FROM {{ source }}' }
+    );
+
+    await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
+
+    expect(dataMartTableReferenceService.resolveTableName).toHaveBeenCalledWith(
+      'data-mart-1',
+      'project-1'
+    );
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      expect.anything(),
+      'SELECT `report_date` FROM `test-project`.`TestDataset`.`dashed-table-name` LIMIT 5',
+      { limit: 5 }
+    );
+  });
+
+  it('survives a trailing line comment in the inlined SQL definition', async () => {
+    const { service, dataMart, dataMartSqlTableService } = createService(
+      DataStorageType.GOOGLE_BIGQUERY,
+      { sqlQuery: 'SELECT report_date FROM `src.dataset.orders` -- daily orders' }
+    );
+
+    await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
+
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      dataMart,
+      'SELECT `report_date` FROM (SELECT report_date FROM `src.dataset.orders` -- daily orders\n) AS owox_sample_source LIMIT 5',
+      { limit: 5 }
+    );
+  });
+
+  it('keeps the technical-view path for a multi-statement SQL definition', async () => {
+    const { service, dataMartSqlTableService, dataMartTableReferenceService } = createService(
+      DataStorageType.GOOGLE_BIGQUERY,
+      { sqlQuery: 'SELECT 1 AS report_date; SELECT 2 AS report_date' }
+    );
+
+    await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
+
+    expect(dataMartTableReferenceService.resolveTableName).toHaveBeenCalledWith(
+      'data-mart-1',
+      'project-1'
+    );
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      expect.anything(),
+      'SELECT `report_date` FROM `test-project`.`TestDataset`.`dashed-table-name` LIMIT 5',
+      { limit: 5 }
+    );
+  });
 
   it('keeps the technical-view path for WITH/CTE SQL on a storage without CTE-in-derived-table support', async () => {
     const { service, dataMartSqlTableService, dataMartTableReferenceService } = createService(
@@ -147,7 +197,7 @@ describe('DataMartSampleDataService', () => {
     expect(dataMartTableReferenceService.resolveTableName).not.toHaveBeenCalled();
     expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
       dataMart,
-      'SELECT "report_date" FROM (SELECT report_date FROM orders) AS owox_sample_source LIMIT 5',
+      'SELECT "report_date" FROM (SELECT report_date FROM orders\n) AS owox_sample_source LIMIT 5',
       { limit: 5 }
     );
   });

--- a/apps/backend/src/data-marts/services/data-mart-sample-data.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-sample-data.service.spec.ts
@@ -1,5 +1,6 @@
 import { TypeResolver } from '../../common/resolver/type-resolver';
 import { BigQueryIdentifierEscaper } from '../data-storage-types/bigquery/services/bigquery-identifier.escaper';
+import { LegacyBigQueryIdentifierEscaper } from '../data-storage-types/bigquery/services/legacy/legacy-bigquery-identifier.escaper';
 import { SnowflakeIdentifierEscaper } from '../data-storage-types/snowflake/services/snowflake-identifier.escaper';
 import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { IdentifierEscaperFacade } from '../data-storage-types/facades/identifier-escaper.facade';
@@ -8,17 +9,18 @@ import { DataMart } from '../entities/data-mart.entity';
 import { DataMartSampleDataService } from './data-mart-sample-data.service';
 
 describe('DataMartSampleDataService', () => {
-  const createDataMart = (storageType: DataStorageType): DataMart =>
+  const createDataMart = (storageType: DataStorageType, definition?: unknown): DataMart =>
     ({
       id: 'data-mart-1',
       projectId: 'project-1',
+      definition,
       storage: {
         type: storageType,
       },
     }) as unknown as DataMart;
 
-  const createService = (storageType = DataStorageType.GOOGLE_BIGQUERY) => {
-    const dataMart = createDataMart(storageType);
+  const createService = (storageType = DataStorageType.GOOGLE_BIGQUERY, definition?: unknown) => {
+    const dataMart = createDataMart(storageType, definition);
     const dataMartService = {
       getByIdAndProjectId: jest.fn().mockResolvedValue(dataMart),
     };
@@ -31,6 +33,7 @@ describe('DataMartSampleDataService', () => {
     const identifierEscaperFacade = new IdentifierEscaperFacade(
       new TypeResolver<DataStorageType, IdentifierEscaper>([
         new BigQueryIdentifierEscaper(),
+        new LegacyBigQueryIdentifierEscaper(),
         new SnowflakeIdentifierEscaper(),
       ])
     );
@@ -76,6 +79,116 @@ describe('DataMartSampleDataService', () => {
       expect.anything(),
       'SELECT `report_date`, `amount` FROM `test-project`.`TestDataset`.`another-dashed-table` LIMIT 10',
       { limit: 10 }
+    );
+  });
+
+  it('inlines a SQL data mart as a derived table without touching the technical view', async () => {
+    const { service, dataMart, dataMartSqlTableService, dataMartTableReferenceService } =
+      createService(DataStorageType.GOOGLE_BIGQUERY, {
+        sqlQuery: '  SELECT report_date, amount FROM `src.dataset.orders` ; ',
+      });
+
+    await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
+
+    expect(dataMartTableReferenceService.resolveTableName).not.toHaveBeenCalled();
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      dataMart,
+      'SELECT `report_date` FROM (SELECT report_date, amount FROM `src.dataset.orders`) AS owox_sample_source LIMIT 5',
+      { limit: 5 }
+    );
+  });
+
+  it.each([DataStorageType.GOOGLE_BIGQUERY, DataStorageType.LEGACY_GOOGLE_BIGQUERY])(
+    'inlines a WITH/CTE SQL data mart as a derived table on %s',
+    async storageType => {
+      const { service, dataMart, dataMartSqlTableService, dataMartTableReferenceService } =
+        createService(storageType, {
+          sqlQuery: 'WITH src AS (SELECT 1 AS report_date) SELECT * FROM src;',
+        });
+
+      await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
+
+      expect(dataMartTableReferenceService.resolveTableName).not.toHaveBeenCalled();
+      expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+        dataMart,
+        'SELECT `report_date` FROM (WITH src AS (SELECT 1 AS report_date) SELECT * FROM src) AS owox_sample_source LIMIT 5',
+        { limit: 5 }
+      );
+    }
+  );
+
+  it('keeps the technical-view path for WITH/CTE SQL on a storage without CTE-in-derived-table support', async () => {
+    const { service, dataMartSqlTableService, dataMartTableReferenceService } = createService(
+      DataStorageType.SNOWFLAKE,
+      { sqlQuery: 'WITH src AS (SELECT 1 AS report_date) SELECT * FROM src' }
+    );
+
+    await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
+
+    expect(dataMartTableReferenceService.resolveTableName).toHaveBeenCalledWith(
+      'data-mart-1',
+      'project-1'
+    );
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      expect.anything(),
+      'SELECT "report_date" FROM "test-project"."TestDataset"."dashed-table-name" LIMIT 5',
+      { limit: 5 }
+    );
+  });
+
+  it('inlines a plain SELECT on a non-BigQuery storage', async () => {
+    const { service, dataMart, dataMartSqlTableService, dataMartTableReferenceService } =
+      createService(DataStorageType.SNOWFLAKE, {
+        sqlQuery: 'SELECT report_date FROM orders',
+      });
+
+    await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
+
+    expect(dataMartTableReferenceService.resolveTableName).not.toHaveBeenCalled();
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      dataMart,
+      'SELECT "report_date" FROM (SELECT report_date FROM orders) AS owox_sample_source LIMIT 5',
+      { limit: 5 }
+    );
+  });
+
+  it('keeps the technical-view path for SQL that is neither SELECT nor WITH', async () => {
+    const { service, dataMartSqlTableService, dataMartTableReferenceService } = createService(
+      DataStorageType.GOOGLE_BIGQUERY,
+      { sqlQuery: 'DECLARE x INT64; SELECT x AS report_date' }
+    );
+
+    await service.sampleColumns('data-mart-1', 'project-1', ['report_date']);
+
+    expect(dataMartTableReferenceService.resolveTableName).toHaveBeenCalledWith(
+      'data-mart-1',
+      'project-1'
+    );
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      expect.anything(),
+      'SELECT `report_date` FROM `test-project`.`TestDataset`.`dashed-table-name` LIMIT 5',
+      { limit: 5 }
+    );
+  });
+
+  it('prefers an explicitly provided table name over inlining the SQL definition', async () => {
+    const { service, dataMartSqlTableService, dataMartTableReferenceService } = createService(
+      DataStorageType.GOOGLE_BIGQUERY,
+      { sqlQuery: 'SELECT 1 AS report_date' }
+    );
+
+    await service.sampleColumns(
+      'data-mart-1',
+      'project-1',
+      ['report_date'],
+      'test-project.TestDataset.explicit-table'
+    );
+
+    expect(dataMartTableReferenceService.resolveTableName).not.toHaveBeenCalled();
+    expect(dataMartSqlTableService.executeSqlToTable).toHaveBeenCalledWith(
+      expect.anything(),
+      'SELECT `report_date` FROM `test-project`.`TestDataset`.`explicit-table` LIMIT 5',
+      { limit: 5 }
     );
   });
 

--- a/apps/backend/src/data-marts/services/data-mart-sample-data.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-sample-data.service.ts
@@ -19,7 +19,6 @@ export interface SampleTableDataResult {
  */
 const CTE_INLINE_STORAGE_TYPES: ReadonlySet<DataStorageType> = new Set([
   DataStorageType.GOOGLE_BIGQUERY,
-  DataStorageType.LEGACY_GOOGLE_BIGQUERY,
 ]);
 
 /**
@@ -27,9 +26,21 @@ const CTE_INLINE_STORAGE_TYPES: ReadonlySet<DataStorageType> = new Set([
  * `FROM (...)`: plain SELECT statements on any storage, WITH/CTE statements only on
  * storages known to accept a CTE inside a derived table. Trailing semicolons and
  * whitespace are stripped. Anything else returns null and keeps the technical-view path.
+ *
+ * Legacy BigQuery is never inlined: `definition.sqlQuery` holds the raw legacy ODM
+ * query, which is executable only after `LegacyBigQuerySqlPreprocessor.prepare` — and
+ * `executeSqlToTable` bypasses the query builder where that preprocessing happens.
  */
 function toInlineSubquerySql(sqlQuery: string, storageType: DataStorageType): string | null {
+  if (storageType === DataStorageType.LEGACY_GOOGLE_BIGQUERY) {
+    return null;
+  }
   const trimmed = sqlQuery.trim().replace(/[;\s]+$/, '');
+  if (trimmed.includes(';')) {
+    // A remaining semicolon means a multi-statement script (or a semicolon inside a
+    // literal, which we cannot distinguish without a parser) — not wrappable in FROM (...).
+    return null;
+  }
   if (/^select\b/i.test(trimmed)) {
     return trimmed;
   }
@@ -93,7 +104,9 @@ export class DataMartSampleDataService {
       if (definition && isSqlDefinition(definition)) {
         const inlineSql = toInlineSubquerySql(definition.sqlQuery, storageType);
         if (inlineSql) {
-          return `(${inlineSql}) AS owox_sample_source`;
+          // The newline before ')' keeps a trailing `--`/`#` line comment in the data
+          // mart SQL from commenting out the closing parenthesis.
+          return `(${inlineSql}\n) AS owox_sample_source`;
         }
       }
     }

--- a/apps/backend/src/data-marts/services/data-mart-sample-data.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-sample-data.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
+import { isSqlDefinition } from '../dto/schemas/data-mart-table-definitions/data-mart-definition.guards';
+import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { IdentifierEscaperFacade } from '../data-storage-types/facades/identifier-escaper.facade';
+import { DataMart } from '../entities/data-mart.entity';
 import { DataMartService } from './data-mart.service';
 import { DataMartSqlTableService } from './data-mart-sql-table.service';
 import { DataMartTableReferenceService } from './data-mart-table-reference.service';
@@ -7,6 +10,33 @@ import { DataMartTableReferenceService } from './data-mart-table-reference.servi
 export interface SampleTableDataResult {
   columns: string[];
   rows: unknown[][];
+}
+
+/**
+ * Storage types whose SQL dialect accepts a WITH clause inside a parenthesized derived
+ * table (GoogleSQL allows a full query expression in FROM parentheses). Other warehouses
+ * vary here (e.g. Athena, Redshift), so for them only plain SELECT is inlined.
+ */
+const CTE_INLINE_STORAGE_TYPES: ReadonlySet<DataStorageType> = new Set([
+  DataStorageType.GOOGLE_BIGQUERY,
+  DataStorageType.LEGACY_GOOGLE_BIGQUERY,
+]);
+
+/**
+ * Inlines a data mart's SQL as a derived-table body when it can safely appear inside
+ * `FROM (...)`: plain SELECT statements on any storage, WITH/CTE statements only on
+ * storages known to accept a CTE inside a derived table. Trailing semicolons and
+ * whitespace are stripped. Anything else returns null and keeps the technical-view path.
+ */
+function toInlineSubquerySql(sqlQuery: string, storageType: DataStorageType): string | null {
+  const trimmed = sqlQuery.trim().replace(/[;\s]+$/, '');
+  if (/^select\b/i.test(trimmed)) {
+    return trimmed;
+  }
+  if (/^with\b/i.test(trimmed) && CTE_INLINE_STORAGE_TYPES.has(storageType)) {
+    return trimmed;
+  }
+  return null;
 }
 
 @Injectable()
@@ -27,16 +57,12 @@ export class DataMartSampleDataService {
   ): Promise<SampleTableDataResult> {
     const dataMart = await this.dataMartService.getByIdAndProjectId(dataMartId, projectId);
 
-    const fqn =
-      fullyQualifiedTableName ??
-      (await this.dataMartTableReferenceService.resolveTableName(dataMartId, projectId));
-
     const storageType = dataMart.storage.type;
     const escapedColumns = await Promise.all(
       columns.map(column => this.identifierEscaperFacade.escapeIdentifier(storageType, column))
     );
-    const escapedFqn = await this.identifierEscaperFacade.escapeIdentifier(storageType, fqn);
-    const sql = `SELECT ${escapedColumns.join(', ')} FROM ${escapedFqn} LIMIT ${limit}`;
+    const source = await this.resolveSampleSource(dataMart, fullyQualifiedTableName);
+    const sql = `SELECT ${escapedColumns.join(', ')} FROM ${source} LIMIT ${limit}`;
 
     const result = await this.dataMartSqlTableService.executeSqlToTable(dataMart, sql, { limit });
 
@@ -44,5 +70,38 @@ export class DataMartSampleDataService {
       columns: result.columns,
       rows: result.rows,
     };
+  }
+
+  /**
+   * Builds the FROM source for the sample query.
+   *
+   * SQL-based data marts are inlined as a derived table whenever possible: sampling then
+   * needs exactly the permissions a plain report run needs. The alternative — resolving
+   * the technical view — creates the `owox_internal_<location>` dataset on first use,
+   * which requires project-level `bigquery.datasets.create` that data-only users lack.
+   * The view path remains for explicit table names, non-SQL definitions, and SQL that
+   * cannot be inlined.
+   */
+  private async resolveSampleSource(
+    dataMart: DataMart,
+    fullyQualifiedTableName?: string
+  ): Promise<string> {
+    const storageType = dataMart.storage.type;
+
+    if (!fullyQualifiedTableName) {
+      const definition = dataMart.definition;
+      if (definition && isSqlDefinition(definition)) {
+        const inlineSql = toInlineSubquerySql(definition.sqlQuery, storageType);
+        if (inlineSql) {
+          return `(${inlineSql}) AS owox_sample_source`;
+        }
+      }
+    }
+
+    const fqn =
+      fullyQualifiedTableName ??
+      (await this.dataMartTableReferenceService.resolveTableName(dataMart.id, dataMart.projectId));
+
+    return this.identifierEscaperFacade.escapeIdentifier(storageType, fqn);
   }
 }


### PR DESCRIPTION
## Why

Generating AI metadata (field aliases and descriptions, data mart title and description) for a SQL-based data mart resolved the data mart to a table reference, which materializes a technical view in the `owox_internal_<location>` dataset. Creating that dataset on first use runs `CREATE SCHEMA IF NOT EXISTS` — a DDL that requires project-level `bigquery.datasets.create` even when the dataset already exists. Users whose BigQuery access is data-only (e.g. `roles/bigquery.jobUser` + `roles/bigquery.dataViewer`) could not use the AI helper at all.

## What changed

`DataMartSampleDataService.sampleColumns` now builds the sample for SQL definitions as an inline derived table instead of resolving the technical view:

```sql
SELECT <escaped columns> FROM (<data mart sql>
) AS owox_sample_source LIMIT <n>
```

- Plain `SELECT` definitions are inlined on every storage type except `LEGACY_GOOGLE_BIGQUERY`.
- `WITH`/CTE definitions are additionally inlined on `GOOGLE_BIGQUERY`, whose dialect accepts a full query expression — including `WITH` — inside parenthesized `FROM (...)`. Other storages keep the technical-view path for CTEs, since support there varies (e.g. Athena, Redshift).
- `LEGACY_GOOGLE_BIGQUERY` is never inlined: its `definition.sqlQuery` holds the raw legacy SQL that is executable only after `LegacyBigQuerySqlPreprocessor` runs, and the sample path bypasses the query builder where that happens. Legacy marts keep the technical-view path, where the preprocessor runs at view creation.
- Wrap safety: the closing parenthesis starts on a new line so a trailing `--`/`#` line comment cannot swallow it; trailing semicolons and whitespace are stripped; a residual `;` (multi-statement script) falls back to the technical view.
- An explicitly passed `fullyQualifiedTableName` keeps priority over inlining.
- Non-SQL definitions (table, view, pattern, connector) and SQL that cannot be inlined are unaffected and keep the technical-view path, with the existing persistent human-readable error if permissions are missing there (#1516).

Out of scope (unchanged): `DataMartTableReferenceService`, `BigQueryCreateViewExecutor`, joined/blended reports, reports with output controls, data quality.

## Tests

`data-mart-sample-data.service.spec.ts` (12 tests passing):

- plain `SELECT` inlined as a derived table, technical view untouched, trailing `;` stripped
- `WITH`/CTE inlined on `GOOGLE_BIGQUERY`
- `LEGACY_GOOGLE_BIGQUERY` keeps the technical-view path (raw legacy SQL needs preprocessing)
- `WITH`/CTE falls back to the technical-view path on a non-BigQuery storage
- plain `SELECT` inlined on a non-BigQuery storage
- a definition ending in a `--` line comment still produces a valid derived table
- a multi-statement definition (`SELECT 1; SELECT 2`) falls back to the technical-view path
- SQL that is neither `SELECT` nor `WITH` (e.g. leading `DECLARE`) falls back to the technical-view path
- explicitly provided table name keeps priority over inlining
- existing identifier-escaping tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
