### PR TITLE
feat(data-marts): measure Data Last Updated Date for AWS Redshift storage

### DIFF
--- a/.changeset/6794-data-last-updated-redshift.md
+++ b/.changeset/6794-data-last-updated-redshift.md
@@ -1,0 +1,5 @@
+---
+'owox': minor
+---
+
+Data Last Updated Date is now measured for AWS Redshift Data Marts. OWOX discovers the source tables behind the executed SQL (views resolved to their base tables) and reads each table's last data modification time from Redshift metadata, on every surface where the value already worked for BigQuery: the Data Mart page, lists, the canvas, and MCP responses. Spectrum external tables and tables Redshift cannot report a time for appear as unknown sources with partial coverage; Redshift metadata itself may lag real writes by up to ~5 minutes.

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
@@ -54,6 +54,7 @@ import { LegacyBigQueryStorageErrorMapper } from './bigquery/services/legacy/leg
 import { LegacyBigQueryBlendedQueryBuilder } from './bigquery/services/legacy/legacy-bigquery-blended-query-builder';
 import { BigQueryStorageResourceBrowser } from './bigquery/services/bigquery-storage-resource-browser.service';
 import { BigQuerySourceDataLastUpdatedResolver } from './bigquery/services/bigquery-source-data-last-updated.resolver';
+import { RedshiftSourceDataLastUpdatedResolver } from './redshift/services/redshift-source-data-last-updated.resolver';
 import { DataStorageCredentialsUtils } from './data-mart-schema.utils';
 import { DatabricksApiAdapterFactory } from './databricks/adapters/databricks-api-adapter.factory';
 import { DatabricksAccessValidator } from './databricks/services/databricks-access.validator';
@@ -259,7 +260,10 @@ const identifierEscaperProviders = [
 ];
 // Best-effort family: a storage with no entry here resolves to nothing and the caller reports
 // `unavailable`, so storages can be added one at a time without a placeholder implementation.
-const sourceDataLastUpdatedProviders = [BigQuerySourceDataLastUpdatedResolver];
+const sourceDataLastUpdatedProviders = [
+  BigQuerySourceDataLastUpdatedResolver,
+  RedshiftSourceDataLastUpdatedResolver,
+];
 const publicCredentialsProviders = [
   DataStoragePublicCredentialsFactory,
   DataStorageCredentialsUtils,

--- a/apps/backend/src/data-marts/data-storage-types/redshift/adapters/redshift-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/adapters/redshift-api.adapter.ts
@@ -14,7 +14,28 @@ import { RedshiftConfig } from '../schemas/redshift-config.schema';
 import { RedshiftCredentials } from '../schemas/redshift-credentials.schema';
 import { RedshiftConnectionType } from '../enums/redshift-connection-type.enum';
 
+/**
+ * Tuning for the execute-and-poll cycle of a single statement. Defaults preserve the historic
+ * behaviour (1s polling, no cancellation) for the report/read paths; metadata lookups pass a
+ * shorter interval so a handful of tiny catalog queries does not cost seconds of idle waiting.
+ */
+export interface RedshiftQueryOptions {
+  pollIntervalMs?: number;
+  /** Stops the polling wait early; the statement itself keeps running server-side. */
+  signal?: AbortSignal;
+}
+
 export class RedshiftApiAdapter {
+  /** Overall per-statement deadline; unchanged from the historic 300 × 1s polling loop. */
+  private static readonly QUERY_TIMEOUT_MS = 300_000;
+  private static readonly DEFAULT_POLL_INTERVAL_MS = 1000;
+  /**
+   * Identifiers interpolated into SHOW TABLES, which takes no bind parameters and (unlike
+   * regular SQL) has no documented quoting syntax — so only plain identifiers are accepted and
+   * anything else is refused rather than escaped.
+   */
+  private static readonly SAFE_IDENTIFIER_RE = /^[a-zA-Z_][a-zA-Z0-9_$]*$/;
+
   private readonly logger = new Logger(RedshiftApiAdapter.name);
   private readonly redshiftDataClient: RedshiftDataClient;
   private readonly config: RedshiftConfig;
@@ -65,12 +86,19 @@ export class RedshiftApiAdapter {
   /**
    * Polls until query completes (FINISHED, FAILED, or ABORTED)
    */
-  public async waitForQueryToComplete(statementId: string): Promise<void> {
-    const maxAttempts = 300; // 5 minutes with 1s intervals
+  public async waitForQueryToComplete(
+    statementId: string,
+    options?: RedshiftQueryOptions
+  ): Promise<void> {
+    const intervalMs = options?.pollIntervalMs ?? RedshiftApiAdapter.DEFAULT_POLL_INTERVAL_MS;
+    const maxAttempts = Math.ceil(RedshiftApiAdapter.QUERY_TIMEOUT_MS / intervalMs);
     let attempts = 0;
 
     while (attempts < maxAttempts) {
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await this.sleep(intervalMs, options?.signal);
+      if (options?.signal?.aborted) {
+        throw new Error(`Aborted while waiting for statement ${statementId}`);
+      }
 
       const describeCommand = new DescribeStatementCommand({ Id: statementId });
       const response = await this.redshiftDataClient.send(describeCommand);
@@ -92,8 +120,24 @@ export class RedshiftApiAdapter {
     }
 
     throw new Error(
-      `Query execution timeout after ${maxAttempts} seconds for statement ${statementId}`
+      `Query execution timeout after ${RedshiftApiAdapter.QUERY_TIMEOUT_MS / 1000} seconds for statement ${statementId}`
     );
+  }
+
+  /** Resolves early (without throwing) when the signal aborts mid-wait. */
+  private async sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) return;
+    await new Promise<void>(resolve => {
+      const timer = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
   }
 
   /**
@@ -135,10 +179,11 @@ export class RedshiftApiAdapter {
    * Execute a SELECT query and return rows as plain JS objects
    */
   public async executeQueryAndGetRows(
-    query: string
+    query: string,
+    options?: RedshiftQueryOptions
   ): Promise<Array<Record<string, string | null>>> {
     const { statementId } = await this.executeQuery(query);
-    await this.waitForQueryToComplete(statementId);
+    await this.waitForQueryToComplete(statementId, options);
 
     const rows: Array<Record<string, string | null>> = [];
     let columns: string[] | undefined;
@@ -241,6 +286,98 @@ export class RedshiftApiAdapter {
     await this.waitForQueryToComplete(statementId);
 
     this.logger.debug(`Dry-run validation successful for query ${query}`);
+  }
+
+  /**
+   * Returns the raw plan lines of `EXPLAIN <query>` — one string per plan node. The plan is the
+   * cheapest complete answer to "which tables does this query read": the planner has already
+   * expanded views (late-binding ones included) down to base-table scans.
+   */
+  public async getQueryPlan(query: string, options?: RedshiftQueryOptions): Promise<string[]> {
+    const rows = await this.executeQueryAndGetRows(`EXPLAIN ${query}`, options);
+    return rows
+      .map(row => Object.values(row)[0] ?? '')
+      .filter((line): line is string => line !== '');
+  }
+
+  /**
+   * Maps bare table names (as EXPLAIN prints them, schema-less) to the schemas that actually
+   * contain a so-named table in the given database. A name returning several rows is ambiguous
+   * and the caller must treat it as unresolvable rather than guess.
+   */
+  public async findTablesByName(
+    database: string,
+    tableNames: string[],
+    options?: RedshiftQueryOptions
+  ): Promise<Array<{ schemaName: string; tableName: string }>> {
+    if (tableNames.length === 0) {
+      return [];
+    }
+
+    const nameList = tableNames.map(name => `'${this.escapeLiteral(name)}'`).join(', ');
+    const query = `
+      SELECT schema_name, table_name
+      FROM svv_redshift_tables
+      WHERE database_name = '${this.escapeLiteral(database)}'
+        AND table_type = 'TABLE'
+        AND table_name IN (${nameList})
+    `;
+
+    const rows = await this.executeQueryAndGetRows(query, options);
+    return rows
+      .map(row => ({ schemaName: row.schema_name, tableName: row.table_name }))
+      .filter((row): row is { schemaName: string; tableName: string } =>
+        Boolean(row.schemaName && row.tableName)
+      );
+  }
+
+  /**
+   * Reads per-table modification times for one schema via `SHOW TABLES FROM SCHEMA`.
+   *
+   * SHOW TABLES is currently the ONLY surface where Redshift reports `last_modified_time`
+   * (when the table's DATA last changed, lagging real writes by up to ~5 minutes) — none of the
+   * queryable SVV catalog views carry it. It is schema-scoped with no table filter worth using,
+   * so callers cache the result per schema. On older Redshift releases the column does not
+   * exist yet; those rows come back with a null `lastModifiedTime`.
+   */
+  public async getSchemaTablesInfo(
+    database: string,
+    schema: string,
+    options?: RedshiftQueryOptions
+  ): Promise<Array<{ tableName: string; lastModifiedTime: string | null }>> {
+    for (const identifier of [database, schema]) {
+      if (!RedshiftApiAdapter.SAFE_IDENTIFIER_RE.test(identifier)) {
+        throw new Error(`Unsupported identifier for SHOW TABLES: ${identifier}`);
+      }
+    }
+
+    const rows = await this.executeQueryAndGetRows(
+      `SHOW TABLES FROM SCHEMA ${database}.${schema}`,
+      options
+    );
+    return rows
+      .filter((row): row is Record<string, string | null> & { table_name: string } =>
+        Boolean(row.table_name)
+      )
+      .map(row => ({
+        tableName: row.table_name,
+        lastModifiedTime: this.toIsoUtcTimestamp(row.last_modified_time),
+      }));
+  }
+
+  /**
+   * `2025-11-18 15:44:34.856073` (Redshift timestamps are UTC, reported without a zone) →
+   * ISO-8601 with millisecond precision, or null for anything absent or unrecognised.
+   */
+  private toIsoUtcTimestamp(value: string | null | undefined): string | null {
+    const match = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.(\d+))?$/.exec(
+      value?.trim() ?? ''
+    );
+    if (!match) {
+      return null;
+    }
+    const millis = (match[3] ?? '').padEnd(3, '0').slice(0, 3);
+    return `${match[1]}T${match[2]}.${millis}Z`;
   }
 
   /**

--- a/apps/backend/src/data-marts/data-storage-types/redshift/adapters/redshift-api.adapter.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/adapters/redshift-api.adapter.ts
@@ -13,6 +13,7 @@ import { Logger } from '@nestjs/common';
 import { RedshiftConfig } from '../schemas/redshift-config.schema';
 import { RedshiftCredentials } from '../schemas/redshift-credentials.schema';
 import { RedshiftConnectionType } from '../enums/redshift-connection-type.enum';
+import { redshiftTimestampToIsoUtc } from '../utils/redshift-timestamp.utils';
 
 /**
  * Tuning for the execute-and-poll cycle of a single statement. Defaults preserve the historic
@@ -90,7 +91,12 @@ export class RedshiftApiAdapter {
     statementId: string,
     options?: RedshiftQueryOptions
   ): Promise<void> {
-    const intervalMs = options?.pollIntervalMs ?? RedshiftApiAdapter.DEFAULT_POLL_INTERVAL_MS;
+    // Clamped so a zero/negative interval cannot turn this into a busy-loop with an infinite
+    // attempt budget.
+    const intervalMs = Math.max(
+      1,
+      options?.pollIntervalMs ?? RedshiftApiAdapter.DEFAULT_POLL_INTERVAL_MS
+    );
     const maxAttempts = Math.ceil(RedshiftApiAdapter.QUERY_TIMEOUT_MS / intervalMs);
     let attempts = 0;
 
@@ -361,23 +367,8 @@ export class RedshiftApiAdapter {
       )
       .map(row => ({
         tableName: row.table_name,
-        lastModifiedTime: this.toIsoUtcTimestamp(row.last_modified_time),
+        lastModifiedTime: redshiftTimestampToIsoUtc(row.last_modified_time),
       }));
-  }
-
-  /**
-   * `2025-11-18 15:44:34.856073` (Redshift timestamps are UTC, reported without a zone) →
-   * ISO-8601 with millisecond precision, or null for anything absent or unrecognised.
-   */
-  private toIsoUtcTimestamp(value: string | null | undefined): string | null {
-    const match = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.(\d+))?$/.exec(
-      value?.trim() ?? ''
-    );
-    if (!match) {
-      return null;
-    }
-    const millis = (match[3] ?? '').padEnd(3, '0').slice(0, 3);
-    return `${match[1]}T${match[2]}.${millis}Z`;
   }
 
   /**

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-source-data-last-updated.resolver.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-source-data-last-updated.resolver.spec.ts
@@ -1,0 +1,319 @@
+import { RedshiftSourceDataLastUpdatedResolver } from './redshift-source-data-last-updated.resolver';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import { DataStorage } from '../../../entities/data-storage.entity';
+
+const scan = (table: string) => `  ->  XN Seq Scan on ${table}  (cost=0.00..0.01 rows=1 width=8)`;
+
+describe('RedshiftSourceDataLastUpdatedResolver', () => {
+  const storage = {
+    id: 'storage-1',
+    type: DataStorageType.AWS_REDSHIFT,
+    config: {
+      connectionType: 'SERVERLESS',
+      region: 'us-east-1',
+      database: 'dev',
+      workgroupName: 'wg',
+    },
+  } as unknown as DataStorage;
+
+  const createResolver = (adapter: Record<string, jest.Mock>) => {
+    const adapterFactory = { createFromStorage: jest.fn().mockResolvedValue(adapter) };
+    return {
+      resolver: new RedshiftSourceDataLastUpdatedResolver(adapterFactory as never),
+      adapter,
+    };
+  };
+
+  const SINGLE = 'dm-1';
+
+  /** Batch-of-one: the shape every single-lookup caller goes through. */
+  const run = async (adapter: Record<string, jest.Mock>, sql = 'SELECT 1') => {
+    const results = await createResolver(adapter).resolver.resolveForSqlBatch({
+      storage,
+      items: [{ key: SINGLE, sql }],
+    });
+    return results.get(SINGLE)!;
+  };
+
+  /** The healthy default: every named table lives in `public` and reports a time. */
+  const adapterWith = (overrides: Record<string, jest.Mock> = {}) => ({
+    getQueryPlan: jest.fn().mockResolvedValue([scan('orders'), scan('customers')]),
+    findTablesByName: jest.fn(async (_db: string, names: string[]) =>
+      names.map(name => ({ schemaName: 'public', tableName: name }))
+    ),
+    getSchemaTablesInfo: jest.fn().mockResolvedValue([
+      { tableName: 'orders', lastModifiedTime: '2026-08-01T10:00:00.000Z' },
+      { tableName: 'customers', lastModifiedTime: '2026-08-05T08:30:00.000Z' },
+    ]),
+    ...overrides,
+  });
+
+  it('reports the newest modification time across all scanned tables', async () => {
+    const result = await run(adapterWith());
+
+    expect(result.dataLastUpdatedAt).toBe('2026-08-05T08:30:00.000Z');
+    expect(result.coverage).toBe('complete');
+    expect(result.sources.map(s => s.table)).toEqual(['dev.public.orders', 'dev.public.customers']);
+  });
+
+  it('marks Spectrum external tables as unknown sources and degrades coverage to partial', async () => {
+    const result = await run(
+      adapterWith({
+        getQueryPlan: jest
+          .fn()
+          .mockResolvedValue([
+            scan('orders'),
+            '      ->  S3 Seq Scan spectrum.sales location:"s3://bucket/sales" format:TEXT',
+          ]),
+        getSchemaTablesInfo: jest
+          .fn()
+          .mockResolvedValue([
+            { tableName: 'orders', lastModifiedTime: '2026-08-01T10:00:00.000Z' },
+          ]),
+      })
+    );
+
+    expect(result.coverage).toBe('partial');
+    expect(result.dataLastUpdatedAt).toBe('2026-08-01T10:00:00.000Z');
+    expect(result.sources).toContainEqual(
+      expect.objectContaining({ table: 'dev.spectrum.sales', dataLastUpdatedAt: null })
+    );
+  });
+
+  it('reports an ambiguous bare name as unknown instead of guessing a schema', async () => {
+    const result = await run(
+      adapterWith({
+        getQueryPlan: jest.fn().mockResolvedValue([scan('orders'), scan('customers')]),
+        findTablesByName: jest.fn(async (_db: string, names: string[]) => [
+          // `orders` exists in two schemas; a guess could report a NEWER time than the truth.
+          { schemaName: 'public', tableName: 'orders' },
+          { schemaName: 'staging', tableName: 'orders' },
+          ...names
+            .filter(name => name === 'customers')
+            .map(name => ({ schemaName: 'public', tableName: name })),
+        ]),
+        getSchemaTablesInfo: jest
+          .fn()
+          .mockResolvedValue([
+            { tableName: 'customers', lastModifiedTime: '2026-08-05T08:30:00.000Z' },
+          ]),
+      })
+    );
+
+    expect(result.coverage).toBe('partial');
+    expect(result.dataLastUpdatedAt).toBe('2026-08-05T08:30:00.000Z');
+    expect(result.sources).toContainEqual(
+      expect.objectContaining({
+        table: 'orders',
+        dataLastUpdatedAt: null,
+        note: expect.stringContaining('2 schemas'),
+      })
+    );
+  });
+
+  it('reports a name the catalog cannot place as unknown with a note', async () => {
+    const result = await run(
+      adapterWith({
+        getQueryPlan: jest.fn().mockResolvedValue([scan('orders'), scan('elsewhere_tbl')]),
+        findTablesByName: jest
+          .fn()
+          .mockResolvedValue([{ schemaName: 'public', tableName: 'orders' }]),
+        getSchemaTablesInfo: jest
+          .fn()
+          .mockResolvedValue([
+            { tableName: 'orders', lastModifiedTime: '2026-08-01T10:00:00.000Z' },
+          ]),
+      })
+    );
+
+    expect(result.coverage).toBe('partial');
+    expect(result.sources).toContainEqual(
+      expect.objectContaining({ table: 'elsewhere_tbl', dataLastUpdatedAt: null })
+    );
+  });
+
+  it('degrades to a null source when Redshift reports no modification time (older release)', async () => {
+    const result = await run(
+      adapterWith({
+        getQueryPlan: jest.fn().mockResolvedValue([scan('orders')]),
+        getSchemaTablesInfo: jest
+          .fn()
+          .mockResolvedValue([{ tableName: 'orders', lastModifiedTime: null }]),
+      })
+    );
+
+    expect(result).toMatchObject({ dataLastUpdatedAt: null, coverage: 'unavailable' });
+    expect(result.sources[0]).toMatchObject({
+      table: 'dev.public.orders',
+      dataLastUpdatedAt: null,
+      note: 'no modification time reported by Redshift',
+    });
+  });
+
+  it('keeps the answer when one schema metadata read fails, flagged as partial', async () => {
+    const result = await run(
+      adapterWith({
+        getQueryPlan: jest.fn().mockResolvedValue([scan('orders'), scan('events')]),
+        findTablesByName: jest.fn().mockResolvedValue([
+          { schemaName: 'public', tableName: 'orders' },
+          { schemaName: 'huge_schema', tableName: 'events' },
+        ]),
+        getSchemaTablesInfo: jest.fn(async (_db: string, schema: string) => {
+          if (schema === 'huge_schema') throw new Error('SHOW TABLES limit exceeded');
+          return [{ tableName: 'orders', lastModifiedTime: '2026-08-01T10:00:00.000Z' }];
+        }),
+      })
+    );
+
+    expect(result.coverage).toBe('partial');
+    expect(result.dataLastUpdatedAt).toBe('2026-08-01T10:00:00.000Z');
+    expect(result.sources).toContainEqual(
+      expect.objectContaining({ table: 'dev.huge_schema.events', dataLastUpdatedAt: null })
+    );
+  });
+
+  it('renames a materialized view backing table to the view itself', async () => {
+    const result = await run(
+      adapterWith({
+        getQueryPlan: jest.fn().mockResolvedValue([scan('mv_tbl__daily_totals__0')]),
+        findTablesByName: jest
+          .fn()
+          .mockResolvedValue([{ schemaName: 'public', tableName: 'mv_tbl__daily_totals__0' }]),
+        getSchemaTablesInfo: jest
+          .fn()
+          .mockResolvedValue([
+            { tableName: 'mv_tbl__daily_totals__0', lastModifiedTime: '2026-08-03T00:00:00.000Z' },
+          ]),
+      })
+    );
+
+    expect(result.sources).toEqual([
+      {
+        table: 'dev.public.daily_totals',
+        dataLastUpdatedAt: '2026-08-03T00:00:00.000Z',
+        note: 'materialized view — time of the last refresh',
+      },
+    ]);
+    expect(result.coverage).toBe('complete');
+  });
+
+  it('reports unavailable when the plan contains no table scans', async () => {
+    const result = await run(
+      adapterWith({
+        getQueryPlan: jest.fn().mockResolvedValue(['XN Result  (cost=0.00..0.01 rows=1 width=0)']),
+      })
+    );
+
+    expect(result).toMatchObject({ dataLastUpdatedAt: null, coverage: 'unavailable', sources: [] });
+  });
+
+  it('keeps measuring the batch when one item fails its EXPLAIN', async () => {
+    const { resolver } = createResolver(
+      adapterWith({
+        getQueryPlan: jest.fn(async (sql: string) => {
+          if (sql.includes('broken')) throw new Error('EXPLAIN failed: relation does not exist');
+          return [scan('orders')];
+        }),
+        getSchemaTablesInfo: jest
+          .fn()
+          .mockResolvedValue([
+            { tableName: 'orders', lastModifiedTime: '2026-08-01T10:00:00.000Z' },
+          ]),
+      })
+    );
+
+    const results = await resolver.resolveForSqlBatch({
+      storage,
+      items: [
+        { key: 'dm-broken', sql: 'SELECT * FROM broken' },
+        { key: 'dm-ok', sql: 'SELECT * FROM orders' },
+      ],
+    });
+
+    // The broken item's key is simply absent ("no new information"); the healthy one resolves.
+    expect(results.has('dm-broken')).toBe(false);
+    expect(results.get('dm-ok')?.dataLastUpdatedAt).toBe('2026-08-01T10:00:00.000Z');
+  });
+
+  it('shares catalog and schema lookups across a batch instead of repeating them', async () => {
+    const adapter = adapterWith({
+      getQueryPlan: jest.fn().mockResolvedValue([scan('orders')]),
+      findTablesByName: jest
+        .fn()
+        .mockResolvedValue([{ schemaName: 'public', tableName: 'orders' }]),
+      getSchemaTablesInfo: jest
+        .fn()
+        .mockResolvedValue([{ tableName: 'orders', lastModifiedTime: '2026-08-01T10:00:00.000Z' }]),
+    });
+    const { resolver } = createResolver(adapter);
+
+    const results = await resolver.resolveForSqlBatch({
+      storage,
+      items: [
+        { key: 'dm-1', sql: 'SELECT * FROM orders' },
+        { key: 'dm-2', sql: 'SELECT id FROM orders' },
+      ],
+    });
+
+    expect(results.size).toBe(2);
+    // The expensive per-storage lookups ran once for the whole sweep.
+    expect(adapter.findTablesByName).toHaveBeenCalledTimes(1);
+    expect(adapter.getSchemaTablesInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves nothing when the batch starts already aborted', async () => {
+    const adapter = adapterWith();
+    const { resolver } = createResolver(adapter);
+    const controller = new AbortController();
+    controller.abort();
+
+    const results = await resolver.resolveForSqlBatch({
+      storage,
+      items: [{ key: SINGLE, sql: 'SELECT 1' }],
+      signal: controller.signal,
+    });
+
+    expect(results.size).toBe(0);
+    expect(adapter.getQueryPlan).not.toHaveBeenCalled();
+  });
+
+  it('stops between items once the signal aborts, keeping what already resolved', async () => {
+    const controller = new AbortController();
+    const adapter = adapterWith({
+      getQueryPlan: jest.fn(async () => {
+        // First item resolves normally, then the deadline fires before the second starts.
+        controller.abort();
+        return [scan('orders')];
+      }),
+      getSchemaTablesInfo: jest
+        .fn()
+        .mockResolvedValue([{ tableName: 'orders', lastModifiedTime: '2026-08-01T10:00:00.000Z' }]),
+    });
+    const { resolver } = createResolver(adapter);
+
+    const results = await resolver.resolveForSqlBatch({
+      storage,
+      items: [
+        { key: 'dm-1', sql: 'SELECT * FROM orders' },
+        { key: 'dm-2', sql: 'SELECT * FROM orders' },
+      ],
+      signal: controller.signal,
+    });
+
+    expect([...results.keys()]).toEqual(['dm-1']);
+    expect(adapter.getQueryPlan).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves nothing for a storage whose config is not a Redshift config', async () => {
+    const adapter = adapterWith();
+    const { resolver } = createResolver(adapter);
+
+    const results = await resolver.resolveForSqlBatch({
+      storage: { ...storage, config: { projectId: 'not-redshift' } } as unknown as DataStorage,
+      items: [{ key: SINGLE, sql: 'SELECT 1' }],
+    });
+
+    expect(results.size).toBe(0);
+    expect(adapter.getQueryPlan).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-source-data-last-updated.resolver.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-source-data-last-updated.resolver.ts
@@ -1,0 +1,344 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  SourceDataLastUpdated,
+  SourceDataLastUpdatedEntry,
+  unavailableSourceDataLastUpdated,
+} from '../../../dto/schemas/source-data-last-updated.schema';
+import { isRedshiftConfig } from '../../data-storage-config.guards';
+import { DataStorageType } from '../../enums/data-storage-type.enum';
+import {
+  ResolveSourceDataLastUpdatedBatchInput,
+  ResolveSourceDataLastUpdatedItem,
+  SourceDataLastUpdatedResolver,
+} from '../../interfaces/source-data-last-updated-resolver.interface';
+import { RedshiftApiAdapterFactory } from '../adapters/redshift-api-adapter.factory';
+import { RedshiftApiAdapter, RedshiftQueryOptions } from '../adapters/redshift-api.adapter';
+import {
+  materializedViewNameFromBackingTable,
+  parseScannedTablesFromPlan,
+  RedshiftScannedTableRef,
+} from '../utils/redshift-explain-tables.util';
+
+/**
+ * Redshift answers "which tables does this query read" through EXPLAIN — the planner has already
+ * expanded views down to base-table scans — and "when did each table's data change" through
+ * `SHOW TABLES FROM SCHEMA`, the one surface where Redshift reports `last_modified_time`
+ * (lagging real writes by up to ~5 minutes; absent entirely on older releases).
+ *
+ * Two Redshift quirks shape the flow:
+ *
+ * - EXPLAIN prints local table names WITHOUT their schema, so bare names are mapped back through
+ *   the catalog first. A name existing in several schemas is reported as unknown rather than
+ *   guessed: `partial` coverage promises a value that is only ever OLDER than the truth, and a
+ *   guess could be newer.
+ * - Both lookups are per-schema / per-database, so one batch shares their results across items —
+ *   a canvas sweep touching twenty Data Marts in one schema pays for that schema once.
+ *
+ * External (Spectrum) tables scan data that lives outside Redshift; they are listed as unknown
+ * sources with a note, mirroring how the BigQuery resolver treats EXTERNAL tables.
+ */
+@Injectable()
+export class RedshiftSourceDataLastUpdatedResolver implements SourceDataLastUpdatedResolver {
+  readonly type: DataStorageType = DataStorageType.AWS_REDSHIFT;
+  private readonly logger = new Logger(RedshiftSourceDataLastUpdatedResolver.name);
+
+  /**
+   * The Data API is poll-based; the default 1s interval is tuned for real report queries, but
+   * these are tiny metadata statements that finish in well under a second — polling faster keeps
+   * a three-round-trip resolution inside the orchestrator's soft timeout with room to spare.
+   */
+  private static readonly METADATA_POLL_INTERVAL_MS = 250;
+
+  constructor(private readonly adapterFactory: RedshiftApiAdapterFactory) {}
+
+  async resolveForSqlBatch(
+    input: ResolveSourceDataLastUpdatedBatchInput
+  ): Promise<Map<string, SourceDataLastUpdated>> {
+    const { storage, items, signal } = input;
+    const results = new Map<string, SourceDataLastUpdated>();
+
+    if (!isRedshiftConfig(storage.config) || items.length === 0 || signal?.aborted) {
+      return results;
+    }
+    const database = storage.config.database;
+
+    // Built once for the whole batch: credential resolution and client setup are per-storage
+    // costs, and a canvas-wide sweep over one storage should pay them once, not per Data Mart.
+    const adapter = await this.adapterFactory.createFromStorage(storage);
+    const caches: BatchCaches = { schemasByTableName: new Map(), tablesBySchema: new Map() };
+
+    for (const item of items) {
+      if (signal?.aborted) {
+        // Whatever resolved so far is still useful; the caller treats missing keys as
+        // "no new information" rather than as a reset.
+        break;
+      }
+      try {
+        results.set(item.key, await this.resolveOne(adapter, database, item, caches, signal));
+      } catch (error) {
+        if (signal?.aborted) {
+          // The poll loop surfaces an abort as a throw; that is the deadline firing, not a
+          // broken item — stop quietly with what we have.
+          break;
+        }
+        // One broken item (an invalid definition failing its EXPLAIN) must not sink the sweep
+        // for every healthy Data Mart on the same storage: skip its key — absent already means
+        // "no new information" — and keep measuring the rest.
+        this.logger.warn(
+          `Data last updated lookup failed for item ${item.key}; skipping: ${errorText(error)}`
+        );
+      }
+    }
+
+    return results;
+  }
+
+  private async resolveOne(
+    adapter: RedshiftApiAdapter,
+    database: string,
+    item: ResolveSourceDataLastUpdatedItem,
+    caches: BatchCaches,
+    signal?: AbortSignal
+  ): Promise<SourceDataLastUpdated> {
+    const computedAt = new Date().toISOString();
+
+    const plan = await adapter.getQueryPlan(item.sql, this.queryOptions(signal));
+    const scanned = parseScannedTablesFromPlan(plan);
+
+    if (scanned.local.length === 0 && scanned.external.length === 0) {
+      // Either the query reads no table at all (a constant SELECT) or the plan came in a shape
+      // this parser does not recognise. Both are "we cannot say", which is what unavailable
+      // means — and the raw plan is logged so an unrecognised shape is observable, not silent.
+      this.logger.debug(
+        `No table scans recognised in EXPLAIN output for item ${item.key} (${plan.length} plan line(s)).`
+      );
+      return unavailableSourceDataLastUpdated(computedAt);
+    }
+
+    const located = await this.locateLocalTables(adapter, database, scanned.local, caches, signal);
+
+    const sources: SourceDataLastUpdatedEntry[] = [];
+    let anyFailed = false;
+
+    for (const miss of located.unresolved) {
+      sources.push(miss);
+    }
+
+    for (const table of located.resolved) {
+      if (signal?.aborted) {
+        return unavailableSourceDataLastUpdated(computedAt);
+      }
+      const entry = await this.resolveTableEntry(adapter, table, caches, signal);
+      anyFailed = anyFailed || entry.lookupFailed;
+      sources.push(entry.source);
+    }
+
+    for (const external of scanned.external) {
+      sources.push({
+        table: [database, ...external.parts].join('.'),
+        dataLastUpdatedAt: null,
+        note: 'external table (Spectrum) — data lives outside Redshift, modification time not tracked',
+      });
+    }
+
+    const resolvedTimes = sources
+      .map(source => source.dataLastUpdatedAt)
+      .filter((value): value is string => value !== null);
+
+    if (resolvedTimes.length === 0) {
+      return { dataLastUpdatedAt: null, computedAt, coverage: 'unavailable', sources };
+    }
+
+    // ISO-8601 UTC strings sort lexicographically in chronological order, so a plain max works.
+    const dataLastUpdatedAt = resolvedTimes.reduce((a, b) => (a > b ? a : b));
+    const isPartial = anyFailed || resolvedTimes.length < sources.length;
+
+    return {
+      dataLastUpdatedAt,
+      computedAt,
+      coverage: isPartial ? 'partial' : 'complete',
+      sources,
+    };
+  }
+
+  /**
+   * Turns the schema-less names EXPLAIN prints into concrete `(database, schema, table)`
+   * addresses via one catalog query per batch of unseen names. Names the catalog cannot place
+   * uniquely become unresolved entries right away — with a note saying why — instead of guesses.
+   */
+  private async locateLocalTables(
+    adapter: RedshiftApiAdapter,
+    database: string,
+    refs: RedshiftScannedTableRef[],
+    caches: BatchCaches,
+    signal?: AbortSignal
+  ): Promise<{ resolved: LocatedTable[]; unresolved: SourceDataLastUpdatedEntry[] }> {
+    const resolved: LocatedTable[] = [];
+    const unresolved: SourceDataLastUpdatedEntry[] = [];
+
+    const bareNames: string[] = [];
+    for (const ref of refs) {
+      if (ref.parts.length === 1 && !caches.schemasByTableName.has(ref.parts[0])) {
+        bareNames.push(ref.parts[0]);
+      }
+    }
+
+    if (bareNames.length > 0) {
+      const matches = await adapter.findTablesByName(
+        database,
+        [...new Set(bareNames)],
+        this.queryOptions(signal)
+      );
+      for (const name of bareNames) {
+        caches.schemasByTableName.set(
+          name,
+          matches.filter(match => match.tableName === name).map(match => match.schemaName)
+        );
+      }
+    }
+
+    for (const ref of refs) {
+      if (ref.parts.length >= 2) {
+        // EXPLAIN handed us the schema (and possibly the database) itself — nothing to look up.
+        const [tableName, schemaName, databaseName = database] = [...ref.parts].reverse();
+        resolved.push({ database: databaseName, schema: schemaName, table: tableName });
+        continue;
+      }
+
+      const name = ref.parts[0];
+      const schemas = caches.schemasByTableName.get(name) ?? [];
+      if (schemas.length === 1) {
+        resolved.push({ database, schema: schemas[0], table: name });
+      } else if (schemas.length === 0) {
+        unresolved.push({
+          table: name,
+          dataLastUpdatedAt: null,
+          note: `table not found in database ${database} — cannot locate the source table`,
+        });
+      } else {
+        unresolved.push({
+          table: name,
+          dataLastUpdatedAt: null,
+          note: `table name matches ${schemas.length} schemas — cannot identify the source table`,
+        });
+      }
+    }
+
+    return { resolved, unresolved };
+  }
+
+  private async resolveTableEntry(
+    adapter: RedshiftApiAdapter,
+    table: LocatedTable,
+    caches: BatchCaches,
+    signal?: AbortSignal
+  ): Promise<{ source: SourceDataLastUpdatedEntry; lookupFailed: boolean }> {
+    const fullName = this.displayName(table);
+    const schemaTables = await this.schemaTables(adapter, table, caches, signal);
+
+    if (schemaTables === null) {
+      return {
+        source: {
+          table: fullName,
+          dataLastUpdatedAt: null,
+          note: 'could not read table metadata',
+        },
+        lookupFailed: true,
+      };
+    }
+
+    const lastModifiedTime = schemaTables.get(table.table);
+    if (!lastModifiedTime) {
+      return {
+        source: {
+          table: fullName,
+          dataLastUpdatedAt: null,
+          // Also the honest answer on Redshift releases that predate last_modified_time.
+          note: 'no modification time reported by Redshift',
+        },
+        lookupFailed: false,
+      };
+    }
+
+    const entry: SourceDataLastUpdatedEntry = {
+      table: fullName,
+      dataLastUpdatedAt: lastModifiedTime,
+    };
+    if (materializedViewNameFromBackingTable(table.table)) {
+      entry.note = 'materialized view — time of the last refresh';
+    }
+    return { source: entry, lookupFailed: false };
+  }
+
+  /**
+   * `SHOW TABLES FROM SCHEMA` for one schema, fetched once per batch. A failed fetch is cached
+   * as a failure too: the second Data Mart in the same broken schema should not retry a call
+   * that just demonstrated it cannot succeed.
+   */
+  private async schemaTables(
+    adapter: RedshiftApiAdapter,
+    table: LocatedTable,
+    caches: BatchCaches,
+    signal?: AbortSignal
+  ): Promise<Map<string, string | null> | null> {
+    const key = `${table.database}\0${table.schema}`;
+    const cached = caches.tablesBySchema.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    let result: Map<string, string | null> | null;
+    try {
+      const rows = await adapter.getSchemaTablesInfo(
+        table.database,
+        table.schema,
+        this.queryOptions(signal)
+      );
+      result = new Map(rows.map(row => [row.tableName, row.lastModifiedTime]));
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
+      this.logger.warn(
+        `Failed to read table metadata for schema ${table.database}.${table.schema}: ${errorText(error)}`
+      );
+      result = null;
+    }
+
+    caches.tablesBySchema.set(key, result);
+    return result;
+  }
+
+  private displayName(table: LocatedTable): string {
+    const mvName = materializedViewNameFromBackingTable(table.table);
+    return [table.database, table.schema, mvName ?? table.table].join('.');
+  }
+
+  private queryOptions(signal?: AbortSignal): RedshiftQueryOptions {
+    return {
+      pollIntervalMs: RedshiftSourceDataLastUpdatedResolver.METADATA_POLL_INTERVAL_MS,
+      signal,
+    };
+  }
+}
+
+interface LocatedTable {
+  database: string;
+  schema: string;
+  table: string;
+}
+
+/**
+ * Lookup results shared by every item of one batch. Both underlying calls are schema- or
+ * database-scoped rather than table-scoped, so their answers are valid for the whole sweep.
+ */
+interface BatchCaches {
+  /** Bare table name → schemas of that name in the storage's database ([] = looked up, absent). */
+  schemasByTableName: Map<string, string[]>;
+  /** `database\0schema` → table name → ISO modification time; null = the fetch itself failed. */
+  tablesBySchema: Map<string, Map<string, string | null> | null>;
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/backend/src/data-marts/data-storage-types/redshift/utils/redshift-explain-tables.util.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/utils/redshift-explain-tables.util.spec.ts
@@ -1,0 +1,80 @@
+import {
+  materializedViewNameFromBackingTable,
+  parseScannedTablesFromPlan,
+} from './redshift-explain-tables.util';
+
+describe('parseScannedTablesFromPlan', () => {
+  it('extracts local table names from XN Seq Scan nodes', () => {
+    const result = parseScannedTablesFromPlan([
+      'XN Merge Join DS_DIST_NONE  (cost=0.00..0.05 rows=1 width=16)',
+      '  Merge Cond: ("outer".id = "inner".id)',
+      '  ->  XN Seq Scan on orders  (cost=0.00..0.01 rows=1 width=8)',
+      '  ->  XN Seq Scan on customers c  (cost=0.00..0.01 rows=1 width=8)',
+    ]);
+
+    expect(result.local.map(ref => ref.parts)).toEqual([['orders'], ['customers']]);
+    expect(result.external).toEqual([]);
+  });
+
+  it('accepts plans without the provisioned XN prefix', () => {
+    const result = parseScannedTablesFromPlan(['  ->  Seq Scan on events  (cost=0.00..0.11)']);
+    expect(result.local.map(ref => ref.parts)).toEqual([['events']]);
+  });
+
+  it('deduplicates repeated scans of the same table', () => {
+    const result = parseScannedTablesFromPlan([
+      '->  XN Seq Scan on sales  (cost=0.00..0.01)',
+      '->  XN Seq Scan on sales s2  (cost=0.00..0.01)',
+    ]);
+    expect(result.local.map(ref => ref.parts)).toEqual([['sales']]);
+  });
+
+  it('classifies Spectrum S3 scans as external, keeping their schema', () => {
+    const result = parseScannedTablesFromPlan([
+      '->  XN S3 Query Scan sales  (cost=0.00..0.02)',
+      '      ->  S3 Seq Scan spectrum.sales location:"s3://bucket/sales" format:TEXT',
+      '->  XN Seq Scan on local_dim  (cost=0.00..0.01)',
+    ]);
+
+    expect(result.external.map(ref => ref.parts)).toEqual([['spectrum', 'sales']]);
+    expect(result.local.map(ref => ref.parts)).toEqual([['local_dim']]);
+  });
+
+  it('unquotes quoted identifiers, including embedded quotes', () => {
+    const result = parseScannedTablesFromPlan([
+      '->  XN Seq Scan on "Mixed Case"  (cost=0.00..0.01)',
+      '->  XN Seq Scan on "with""quote"  (cost=0.00..0.01)',
+    ]);
+    expect(result.local.map(ref => ref.parts)).toEqual([['Mixed Case'], ['with"quote']]);
+  });
+
+  it('keeps a schema-qualified local name split into segments', () => {
+    const result = parseScannedTablesFromPlan(['->  XN Seq Scan on analytics.sales  (cost=…)']);
+    expect(result.local.map(ref => ref.parts)).toEqual([['analytics', 'sales']]);
+  });
+
+  it('drops planner-internal volt_ working tables', () => {
+    const result = parseScannedTablesFromPlan([
+      '->  XN Seq Scan on volt_tt_606590308c6a3  (cost=0.00..0.01)',
+      '->  XN Seq Scan on orders  (cost=0.00..0.01)',
+    ]);
+    expect(result.local.map(ref => ref.parts)).toEqual([['orders']]);
+  });
+
+  it('returns nothing for a plan with no table scans', () => {
+    const result = parseScannedTablesFromPlan(['XN Result  (cost=0.00..0.01 rows=1 width=0)']);
+    expect(result.local).toEqual([]);
+    expect(result.external).toEqual([]);
+  });
+});
+
+describe('materializedViewNameFromBackingTable', () => {
+  it('maps a backing table to its materialized view name', () => {
+    expect(materializedViewNameFromBackingTable('mv_tbl__daily_totals__0')).toBe('daily_totals');
+  });
+
+  it('returns null for ordinary tables', () => {
+    expect(materializedViewNameFromBackingTable('daily_totals')).toBeNull();
+    expect(materializedViewNameFromBackingTable('mv_tbl__broken')).toBeNull();
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/redshift/utils/redshift-explain-tables.util.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/utils/redshift-explain-tables.util.ts
@@ -1,0 +1,95 @@
+/**
+ * Extraction of scanned tables from `EXPLAIN` plan text.
+ *
+ * Redshift has no BigQuery-style `referencedTables` metadata, but its planner output carries the
+ * same information: every base table the query reads appears as a scan node, with views (regular
+ * and late-binding) already expanded away. Two node shapes matter:
+ *
+ * - `XN Seq Scan on sales s  (cost=…)`         — a local table; NOTE the name is printed
+ *   WITHOUT its schema (a PostgreSQL-8 inheritance), so callers must map it back to a schema
+ *   through the catalog before they can look its metadata up.
+ * - `S3 Seq Scan spectrum.sales location:…`     — a Spectrum external table, schema-qualified.
+ *
+ * Anything else (subquery scans, joins, network nodes) never carries a base-table name.
+ */
+
+/** One scanned table; `parts` are unquoted name segments, e.g. `['sales']` or `['spectrum','sales']`. */
+export interface RedshiftScannedTableRef {
+  parts: string[];
+}
+
+export interface RedshiftScannedTables {
+  /** Local table scans, deduplicated, in plan order. Names are schema-less — see module doc. */
+  local: RedshiftScannedTableRef[];
+  /** Spectrum (external) table scans, deduplicated. */
+  external: RedshiftScannedTableRef[];
+}
+
+/** A possibly-quoted identifier segment: `sales`, `"Mixed Case"`, `"with""quote"`. */
+const IDENTIFIER_SEGMENT = '(?:"[^"]*(?:""[^"]*)*"|[^\\s".]+)';
+const QUALIFIED_NAME = `${IDENTIFIER_SEGMENT}(?:\\.${IDENTIFIER_SEGMENT}){0,2}`;
+
+const LOCAL_SCAN_RE = new RegExp(`\\bSeq Scan on\\s+(${QUALIFIED_NAME})`);
+const EXTERNAL_SCAN_RE = new RegExp(`\\bS3 Seq Scan\\s+(${QUALIFIED_NAME})`);
+
+/**
+ * Planner-internal working tables (`volt_tt_…` temporaries, other `volt_…` artifacts) that can
+ * appear as scans in rewritten plans. They are not user data sources and carry no meaning for
+ * "when did the data change".
+ */
+const INTERNAL_TABLE_PREFIX = 'volt_';
+
+/**
+ * A materialized view's storage is a real table named `mv_tbl__<view>__<n>`; querying the view
+ * scans that table. Its modification time IS meaningful (it is the last refresh), but the name
+ * is internal, so callers rename the entry back to the view for display.
+ */
+const MV_BACKING_TABLE_RE = /^mv_tbl__(.+)__\d+$/;
+
+export function materializedViewNameFromBackingTable(tableName: string): string | null {
+  return MV_BACKING_TABLE_RE.exec(tableName)?.[1] ?? null;
+}
+
+/** Parses the plan rows of `EXPLAIN <query>` into the sets of scanned local and external tables. */
+export function parseScannedTablesFromPlan(planLines: string[]): RedshiftScannedTables {
+  const local = new Map<string, RedshiftScannedTableRef>();
+  const external = new Map<string, RedshiftScannedTableRef>();
+
+  for (const line of planLines) {
+    const externalMatch = EXTERNAL_SCAN_RE.exec(line);
+    if (externalMatch) {
+      addRef(external, externalMatch[1]);
+      continue;
+    }
+
+    const localMatch = LOCAL_SCAN_RE.exec(line);
+    if (localMatch) {
+      const ref = toRef(localMatch[1]);
+      if (!ref.parts[ref.parts.length - 1].startsWith(INTERNAL_TABLE_PREFIX)) {
+        addRef(local, localMatch[1]);
+      }
+    }
+  }
+
+  return { local: [...local.values()], external: [...external.values()] };
+}
+
+function addRef(target: Map<string, RedshiftScannedTableRef>, rawName: string): void {
+  const ref = toRef(rawName);
+  const key = ref.parts.join('\0');
+  if (!target.has(key)) {
+    target.set(key, ref);
+  }
+}
+
+function toRef(rawName: string): RedshiftScannedTableRef {
+  const parts = (rawName.match(new RegExp(IDENTIFIER_SEGMENT, 'g')) ?? []).map(unquoteSegment);
+  return { parts };
+}
+
+function unquoteSegment(segment: string): string {
+  if (segment.startsWith('"') && segment.endsWith('"')) {
+    return segment.slice(1, -1).replace(/""/g, '"');
+  }
+  return segment;
+}

--- a/apps/backend/src/data-marts/data-storage-types/redshift/utils/redshift-timestamp.utils.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/utils/redshift-timestamp.utils.spec.ts
@@ -1,0 +1,34 @@
+import { redshiftTimestampToIsoUtc } from './redshift-timestamp.utils';
+
+describe('redshiftTimestampToIsoUtc', () => {
+  it('converts the microsecond shape SHOW TABLES actually returns', () => {
+    expect(redshiftTimestampToIsoUtc('2025-11-18 15:44:34.856073')).toBe(
+      '2025-11-18T15:44:34.856Z'
+    );
+  });
+
+  it('converts a timestamp without a fractional part', () => {
+    expect(redshiftTimestampToIsoUtc('2025-11-18 15:44:34')).toBe('2025-11-18T15:44:34.000Z');
+  });
+
+  it('pads short fractional parts to milliseconds', () => {
+    expect(redshiftTimestampToIsoUtc('2025-11-18 15:44:34.8')).toBe('2025-11-18T15:44:34.800Z');
+  });
+
+  it('tolerates explicit UTC markers', () => {
+    expect(redshiftTimestampToIsoUtc('2025-11-18 15:44:34+00')).toBe('2025-11-18T15:44:34.000Z');
+    expect(redshiftTimestampToIsoUtc('2025-11-18T15:44:34.856073Z')).toBe(
+      '2025-11-18T15:44:34.856Z'
+    );
+    expect(redshiftTimestampToIsoUtc('2025-11-18 15:44:34+00:00')).toBe('2025-11-18T15:44:34.000Z');
+  });
+
+  it('returns null for absent or unparseable values, including non-UTC offsets', () => {
+    expect(redshiftTimestampToIsoUtc(null)).toBeNull();
+    expect(redshiftTimestampToIsoUtc(undefined)).toBeNull();
+    expect(redshiftTimestampToIsoUtc('')).toBeNull();
+    expect(redshiftTimestampToIsoUtc('not a timestamp')).toBeNull();
+    // A non-zero offset is NOT silently treated as UTC.
+    expect(redshiftTimestampToIsoUtc('2025-11-18 15:44:34+02')).toBeNull();
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/redshift/utils/redshift-timestamp.utils.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/utils/redshift-timestamp.utils.ts
@@ -1,0 +1,18 @@
+/**
+ * `2025-11-18 15:44:34.856073` — the shape Redshift reports timestamps in over the Data API
+ * (values are UTC, printed without a zone) — converted to ISO-8601 with millisecond precision.
+ *
+ * A trailing UTC marker (`Z`, `+00`, `+0000`, `+00:00`) is tolerated in case a driver or a
+ * future Redshift release starts appending one. Anything else — a NON-zero offset included —
+ * returns null: an honest "could not read it" beats silently mislabeling a local time as UTC.
+ */
+export function redshiftTimestampToIsoUtc(value: string | null | undefined): string | null {
+  const match = /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(?:\.(\d+))?(?:Z|\+00(?::?00)?)?$/.exec(
+    value?.trim() ?? ''
+  );
+  if (!match) {
+    return null;
+  }
+  const millis = (match[3] ?? '').padEnd(3, '0').slice(0, 3);
+  return `${match[1]}T${match[2]}.${millis}Z`;
+}

--- a/docs/getting-started/setup-guide/data-last-updated.md
+++ b/docs/getting-started/setup-guide/data-last-updated.md
@@ -64,7 +64,7 @@ OWOX asks the storage which tables the Data Mart reads, then takes the newest mo
 Storage-specific caveats:
 
 - **BigQuery** reports modification times immediately and exactly.
-- **Redshift** metadata can lag real writes by up to ~5 minutes, so a load that finished a moment ago may not show yet. Older Redshift releases do not report modification times at all — those Data Marts show Unknown. Source tables outside the connection's database cannot be identified and appear as unknown entries with partial coverage.
+- **Redshift** metadata can lag real writes by up to ~5 minutes, so a load that finished a moment ago may not show yet. Older Redshift releases do not report modification times at all — those Data Marts show Unknown. Source tables outside the connection's database, and tables in schemas whose names require quoting (mixed case, hyphens, non-ASCII characters), cannot be identified and appear as unknown entries with partial coverage.
 
 ## Data Last Updated vs. the Data freshness check
 

--- a/docs/getting-started/setup-guide/data-last-updated.md
+++ b/docs/getting-started/setup-guide/data-last-updated.md
@@ -2,7 +2,7 @@
 
 Data Last Updated shows when the source tables/views behind a Data Mart last changed in the storage. It answers the question "how current is what I am looking at?" before you build a report or act on an answer from an AI assistant.
 
-Data Last Updated is currently measured for **Google BigQuery** Data Marts. Data Marts on other storages show **Unknown** until their support lands.
+Data Last Updated is currently measured for **Google BigQuery** and **AWS Redshift** Data Marts. Data Marts on other storages show **Unknown** until their support lands.
 
 ## What the value means
 
@@ -57,8 +57,14 @@ OWOX asks the storage which tables the Data Mart reads, then takes the newest mo
 
 - **Views and SQL Data Marts** resolve through to their underlying base tables, nested views included. Views themselves are excluded from the per-table breakdown — a view's own modification time reflects a change to its definition, not to any data.
 - **Sharded and wildcard table sets** (`events_YYYYMMDD`) collapse into a single entry showing the newest shard. Neighbouring tables that merely share the prefix, such as `events_backup`, do not count.
-- **External tables** (for example, Google Sheets) have no modification time in the storage. They appear in the breakdown as unknown, and the coverage becomes partial.
-- Queries referencing more than ~50 tables are reported with partial coverage, because the storage truncates the list.
+- **External tables** (Google Sheets in BigQuery, Spectrum tables in Redshift) keep their data outside the storage, so no modification time exists there. They appear in the breakdown as unknown, and the coverage becomes partial.
+- **Materialized views** show the time of their last refresh.
+- In BigQuery, queries referencing more than ~50 tables are reported with partial coverage, because the storage truncates the list.
+
+Storage-specific caveats:
+
+- **BigQuery** reports modification times immediately and exactly.
+- **Redshift** metadata can lag real writes by up to ~5 minutes, so a load that finished a moment ago may not show yet. Older Redshift releases do not report modification times at all — those Data Marts show Unknown. Source tables outside the connection's database cannot be identified and appear as unknown entries with partial coverage.
 
 ## Data Last Updated vs. the Data freshness check
 

--- a/docs/getting-started/setup-guide/mcp.md
+++ b/docs/getting-started/setup-guide/mcp.md
@@ -272,7 +272,7 @@ Read the value precisely. It is a **storage** timestamp, not a statement about t
 - With `coverage: "partial"`, treat the timestamp as "at least as recent as" and say the picture is incomplete.
 - The assistant is asked to present the timestamp in a business-friendly form (e.g. "August 4, 2026 at 09:46 UTC") — converted to the user's time zone when the conversation establishes one, otherwise in UTC with the zone named — never as a raw ISO-8601 string. The machine-readable ISO-8601 value stays in the structured response.
 
-Coverage is best effort per storage. Google BigQuery works first, and OWOX resolves views and SQL data marts through to their underlying base tables. Sharded and wildcard table sets collapse into one entry. Other storages currently report `unavailable`. `sources` deliberately omits views: a view's own modification time reflects a change to its definition, not to any data.
+Coverage is best effort per storage. Google BigQuery and AWS Redshift are supported, and OWOX resolves views and SQL data marts through to their underlying base tables. Sharded and wildcard table sets collapse into one entry. Other storages currently report `unavailable`. `sources` deliberately omits views: a view's own modification time reflects a change to its definition, not to any data. Redshift metadata can lag real writes by up to ~5 minutes, and older Redshift releases do not report modification times at all — see [Data Last Updated](./data-last-updated.md) for storage-specific caveats.
 
 ### `list_destinations`
 


### PR DESCRIPTION
## What

Data Last Updated Date is now measured for AWS Redshift Data Marts, on every surface where it already worked for BigQuery: the Data Mart page tile, the Data Marts list, the canvas (badge + Actions sweep), MCP `query_data_mart` responses, and run history. No changes outside the storage layer — the new resolver registers into the existing `SourceDataLastUpdatedResolver` family and everything above it picks Redshift up automatically.

## How

- **Source discovery** — `EXPLAIN` over the composed SQL (the same mechanism the existing Redshift dry-run uses). The planner expands views, nested and late-binding included, down to base-table scans, so no SQL parsing is needed.
- **Schema resolution** — Redshift prints local scan targets without their schema, so bare names are mapped back through `svv_redshift_tables` within the connection's database. A name matching several schemas is reported as an unknown source with a note rather than guessed: `partial` coverage promises a value that is only ever older than the truth, and a guess could be newer.
- **Modification times** — `SHOW TABLES FROM SCHEMA`, currently the only Redshift surface that reports `last_modified_time` (it lags real writes by up to ~5 minutes). Read defensively by column name: older releases without the column degrade to unknown sources instead of failing.
- Spectrum external tables are listed as unknown sources with a note (their data lives outside Redshift). Materialized-view backing tables (`mv_tbl__…`) are renamed back to the view, with the value meaning the last refresh.
- Catalog and per-schema lookups are cached across a batch, so a canvas-wide sweep over one storage pays each schema once. The Data API polling chain gained optional `pollIntervalMs`/`signal` (defaults unchanged) so metadata statements poll at 250ms and abort with the orchestrator's soft timeout.

## Tests

- 13 resolver specs mirroring the BigQuery resolver suite: complete/partial/unavailable coverage, Spectrum, ambiguous and unlocatable names, missing modification times, per-item failure isolation, batch-level lookup sharing, abort before and between items, non-Redshift config.
- 10 specs for the EXPLAIN plan parser (provisioned/serverless shapes, aliases, quoted identifiers, Spectrum scans, `volt_` internals, deduplication).
- All 10 existing Redshift suites pass (137 tests); ESLint and `tsc` clean against the baseline.

Docs updated (`data-last-updated.md`, `mcp.md`) with the Redshift caveats: ~5-minute metadata lag, older releases reporting Unknown, sources outside the connection's database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)