### PR TITLE
refactor(data-marts): sanitize publish errors by exception code

### DIFF
--- a/.changeset/6770-publish-data-mart-drafts.md
+++ b/.changeset/6770-publish-data-mart-drafts.md
@@ -4,4 +4,4 @@
 
 # Reliable bulk publishing for Data Mart drafts
 
-Previously, publishing Data Mart drafts in bulk from a Storage's menu could fail for every draft with a generic "please check them independently" message, even when some drafts were ready to publish. This is now fixed, so drafts you have access to publish succeed as expected. When a draft still can't be published — for example, if it has no definition yet — the notification now explains the actual reason instead of a generic error.
+Previously, publishing Data Mart drafts in bulk from a Storage's menu could fail for every draft with a generic "please check them independently" message, even when some drafts were ready to publish. This is now fixed, so drafts you have access to publish succeed as expected. When a draft still cannot be published, the notification names the reason — that it has no definition yet, for example, or that its table name is not in the expected format — so you know what to correct before trying again.

--- a/apps/backend/src/data-marts/data-storage-types/athena/services/athena-datamart.validator.ts
+++ b/apps/backend/src/data-marts/data-storage-types/athena/services/athena-datamart.validator.ts
@@ -4,6 +4,7 @@ import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definit
 import {
   DataMartValidator,
   ValidationResult,
+  DataMartValidationCode,
 } from '../../interfaces/data-mart-validator.interface';
 import { AthenaApiAdapterFactory } from '../adapters/athena-api-adapter.factory';
 import { isAthenaCredentials } from '../../data-storage-credentials.guards';
@@ -82,8 +83,8 @@ export class AthenaDataMartValidator implements DataMartValidator {
     }
 
     if (identifierToValidate && !isValidAthenaFullyQualifiedName(identifierToValidate)) {
-      return new ValidationResult(
-        false,
+      return ValidationResult.authoredFailure(
+        DataMartValidationCode.INVALID_IDENTIFIER_FORMAT,
         'Invalid identifier format. Expected: database.table or catalog.database.table'
       );
     }

--- a/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-datamart.validator.ts
+++ b/apps/backend/src/data-marts/data-storage-types/bigquery/services/bigquery-datamart.validator.ts
@@ -8,6 +8,7 @@ import { DataStorageType } from '../../enums/data-storage-type.enum';
 import {
   DataMartValidator,
   ValidationResult,
+  DataMartValidationCode,
 } from '../../interfaces/data-mart-validator.interface';
 import { BigQueryApiAdapterFactory } from '../adapters/bigquery-api-adapter.factory';
 import { BigQueryQueryBuilder } from './bigquery-query.builder';
@@ -63,7 +64,8 @@ export class BigQueryDataMartValidator implements DataMartValidator {
   private validateIdentifiers(definition: DataMartDefinition): ValidationResult {
     if (isTableDefinition(definition) || isViewDefinition(definition)) {
       if (!isValidBigQueryFullyQualifiedName(definition.fullyQualifiedName)) {
-        return ValidationResult.failure(
+        return ValidationResult.authoredFailure(
+          DataMartValidationCode.INVALID_IDENTIFIER_FORMAT,
           'Invalid identifier format. Expected: project.dataset.table'
         );
       }
@@ -73,7 +75,8 @@ export class BigQueryDataMartValidator implements DataMartValidator {
           allowTwoLevel: true,
         })
       ) {
-        return ValidationResult.failure(
+        return ValidationResult.authoredFailure(
+          DataMartValidationCode.INVALID_IDENTIFIER_FORMAT,
           'Invalid identifier format. Expected: dataset.table or project.dataset.table'
         );
       }

--- a/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
+++ b/apps/backend/src/data-marts/data-storage-types/data-storage-providers.ts
@@ -186,7 +186,7 @@ const queryBuilderProviders = [
   RedshiftQueryBuilder,
   DatabricksQueryBuilder,
 ];
-const validatorProviders = [
+export const validatorProviders = [
   BigQueryDataMartValidator,
   LegacyBigQueryDataMartValidator,
   AthenaDataMartValidator,

--- a/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-datamart.validator.ts
+++ b/apps/backend/src/data-marts/data-storage-types/databricks/services/databricks-datamart.validator.ts
@@ -4,6 +4,7 @@ import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definit
 import {
   DataMartValidator,
   ValidationResult,
+  DataMartValidationCode,
 } from '../../interfaces/data-mart-validator.interface';
 import { DatabricksApiAdapterFactory } from '../adapters/databricks-api-adapter.factory';
 import { isDatabricksCredentials } from '../../data-storage-credentials.guards';
@@ -71,7 +72,8 @@ export class DatabricksDataMartValidator implements DataMartValidator {
   private validateIdentifiers(definition: DataMartDefinition): ValidationResult {
     if (isTableDefinition(definition) || isViewDefinition(definition)) {
       if (!isValidDatabricksFullyQualifiedName(definition.fullyQualifiedName)) {
-        return ValidationResult.failure(
+        return ValidationResult.authoredFailure(
+          DataMartValidationCode.INVALID_IDENTIFIER_FORMAT,
           'Invalid identifier format. Expected: catalog.schema.table'
         );
       }
@@ -81,7 +83,8 @@ export class DatabricksDataMartValidator implements DataMartValidator {
           allowTwoLevel: true,
         })
       ) {
-        return ValidationResult.failure(
+        return ValidationResult.authoredFailure(
+          DataMartValidationCode.INVALID_IDENTIFIER_FORMAT,
           'Invalid identifier format. Expected: schema.table or catalog.schema.table'
         );
       }

--- a/apps/backend/src/data-marts/data-storage-types/datamart-validator-identifier-parity.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/datamart-validator-identifier-parity.spec.ts
@@ -3,6 +3,8 @@ import { BigQueryDataMartValidator } from './bigquery/services/bigquery-datamart
 import { DatabricksDataMartValidator } from './databricks/services/databricks-datamart.validator';
 import { RedshiftDataMartValidator } from './redshift/services/redshift-datamart.validator';
 import { SnowflakeDataMartValidator } from './snowflake/services/snowflake-datamart.validator';
+import { LegacyBigQueryDataMartValidator } from './bigquery/services/legacy/legacy-bigquery-datamart.validator';
+import { validatorProviders } from './data-storage-providers';
 import {
   DataMartValidationCode,
   DataMartValidator,
@@ -14,8 +16,12 @@ import {
  * output, so it replaces it with a generic reason — which is how Athena drifted
  * out of parity with the other four.
  *
- * Each validator checks identifiers before touching credentials or an adapter,
- * so stub dependencies are never used.
+ * The list is asserted against the registered validator providers, so adding a
+ * warehouse without adding it here fails rather than passing silently.
+ *
+ * Identifiers are checked before config, credentials or an adapter in every
+ * validator, so the stub dependencies below are never dereferenced. Redshift
+ * was the exception until it was reordered to match.
  */
 describe('Data Mart validators — identifier failure parity', () => {
   const validators: [string, DataMartValidator][] = [
@@ -24,7 +30,12 @@ describe('Data Mart validators — identifier failure parity', () => {
     ['databricks', new DatabricksDataMartValidator(null as never, null as never)],
     ['redshift', new RedshiftDataMartValidator(null as never, null as never)],
     ['snowflake', new SnowflakeDataMartValidator(null as never, null as never)],
+    ['legacy-bigquery', new LegacyBigQueryDataMartValidator(null as never, null as never)],
   ];
+
+  it('covers every registered Data Mart validator', () => {
+    expect(validators).toHaveLength(validatorProviders.length);
+  });
 
   it.each(validators)('%s codes its invalid-identifier failure', async (_name, validator) => {
     const result = await validator.validate(

--- a/apps/backend/src/data-marts/data-storage-types/datamart-validator-identifier-parity.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/datamart-validator-identifier-parity.spec.ts
@@ -1,0 +1,40 @@
+import { AthenaDataMartValidator } from './athena/services/athena-datamart.validator';
+import { BigQueryDataMartValidator } from './bigquery/services/bigquery-datamart.validator';
+import { DatabricksDataMartValidator } from './databricks/services/databricks-datamart.validator';
+import { RedshiftDataMartValidator } from './redshift/services/redshift-datamart.validator';
+import { SnowflakeDataMartValidator } from './snowflake/services/snowflake-datamart.validator';
+import {
+  DataMartValidationCode,
+  DataMartValidator,
+} from './interfaces/data-mart-validator.interface';
+
+/**
+ * Every warehouse validator must tag its identifier-format failure with a code.
+ * Without one the publish path cannot tell the authored message from raw driver
+ * output, so it replaces it with a generic reason — which is how Athena drifted
+ * out of parity with the other four.
+ *
+ * Each validator checks identifiers before touching credentials or an adapter,
+ * so stub dependencies are never used.
+ */
+describe('Data Mart validators — identifier failure parity', () => {
+  const validators: [string, DataMartValidator][] = [
+    ['athena', new AthenaDataMartValidator(null as never, null as never)],
+    ['bigquery', new BigQueryDataMartValidator(null as never, null as never)],
+    ['databricks', new DatabricksDataMartValidator(null as never, null as never)],
+    ['redshift', new RedshiftDataMartValidator(null as never, null as never)],
+    ['snowflake', new SnowflakeDataMartValidator(null as never, null as never)],
+  ];
+
+  it.each(validators)('%s codes its invalid-identifier failure', async (_name, validator) => {
+    const result = await validator.validate(
+      { fullyQualifiedName: 'this is !! not a valid identifier' } as never,
+      {} as never,
+      {} as never
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errorMessage).toContain('Invalid identifier format');
+    expect(result.code).toBe(DataMartValidationCode.INVALID_IDENTIFIER_FORMAT);
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/facades/data-mart-definition-validator-facade.service.spec.ts
+++ b/apps/backend/src/data-marts/data-storage-types/facades/data-mart-definition-validator-facade.service.spec.ts
@@ -1,0 +1,73 @@
+import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
+import { DataMartDefinitionValidatorFacade } from './data-mart-definition-validator-facade.service';
+import {
+  DataMartValidationCode,
+  ValidationResult,
+} from '../interfaces/data-mart-validator.interface';
+
+describe('DataMartDefinitionValidatorFacade', () => {
+  const createFacade = (validatorResult: ValidationResult) => {
+    const resolver = {
+      resolve: jest
+        .fn()
+        .mockResolvedValue({ validate: jest.fn().mockResolvedValue(validatorResult) }),
+    };
+    const credentialsResolver = { resolve: jest.fn().mockResolvedValue({}) };
+
+    const facade = new DataMartDefinitionValidatorFacade(
+      resolver as never,
+      credentialsResolver as never
+    );
+
+    const dataMart = {
+      id: 'dm-1',
+      definition: { fullyQualifiedName: 'p.d.t' },
+      storage: { id: 'storage-1', type: 'GOOGLE_BIGQUERY', config: {}, credentialId: 'cred-1' },
+    };
+
+    return { facade, dataMart };
+  };
+
+  const codeOf = async (result: ValidationResult): Promise<string | undefined> => {
+    const { facade, dataMart } = createFacade(result);
+    const error: unknown = await facade.checkIsValid(dataMart as never).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(BusinessViolationException);
+    return (error as BusinessViolationException).code;
+  };
+
+  // This propagation is what lets the publish path tell an authored validator
+  // message from raw driver output; without it the message is genericized.
+  it('propagates the code of an authored validation failure', async () => {
+    const code = await codeOf(
+      ValidationResult.authoredFailure(
+        DataMartValidationCode.INVALID_IDENTIFIER_FORMAT,
+        'Invalid identifier format. Expected: project.dataset.table'
+      )
+    );
+
+    expect(code).toBe(DataMartValidationCode.INVALID_IDENTIFIER_FORMAT);
+  });
+
+  it('leaves an uncoded failure uncoded, so consumers replace its message', async () => {
+    const code = await codeOf(
+      ValidationResult.failure('Dry run failed: syntax error at [1:8] near `acme-prod-1234`')
+    );
+
+    expect(code).toBeUndefined();
+  });
+
+  it('codes its own missing-credentials failure', async () => {
+    const { facade } = createFacade(ValidationResult.success());
+    const dataMart = {
+      id: 'dm-1',
+      definition: { fullyQualifiedName: 'p.d.t' },
+      storage: { id: 'storage-1', type: 'GOOGLE_BIGQUERY', config: {}, credentialId: undefined },
+    };
+
+    const error: unknown = await facade.checkIsValid(dataMart as never).catch((e: unknown) => e);
+
+    expect((error as BusinessViolationException).code).toBe(
+      DataMartValidationCode.STORAGE_CREDENTIALS_NOT_FOUND
+    );
+  });
+});

--- a/apps/backend/src/data-marts/data-storage-types/facades/data-mart-definition-validator-facade.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/facades/data-mart-definition-validator-facade.service.ts
@@ -1,7 +1,11 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { TypeResolver } from '../../../common/resolver/type-resolver';
 import { DataStorageType } from '../enums/data-storage-type.enum';
-import { DataMartValidator, ValidationResult } from '../interfaces/data-mart-validator.interface';
+import {
+  DataMartValidationCode,
+  DataMartValidator,
+  ValidationResult,
+} from '../interfaces/data-mart-validator.interface';
 import { DATA_MART_VALIDATOR_RESOLVER } from '../data-storage-providers';
 import { DataMart } from '../../entities/data-mart.entity';
 import { BusinessViolationException } from '../../../common/exceptions/business-violation.exception';
@@ -18,16 +22,25 @@ export class DataMartDefinitionValidatorFacade {
   async validate(dataMart: DataMart): Promise<ValidationResult> {
     const definition = dataMart.definition;
     if (!definition) {
-      return new ValidationResult(false, 'DataMart definition not found');
+      return ValidationResult.authoredFailure(
+        DataMartValidationCode.DEFINITION_NOT_FOUND,
+        'Data Mart definition not found'
+      );
     }
 
     const config = dataMart.storage.config;
     if (!config) {
-      return new ValidationResult(false, 'DataMart storage config not found');
+      return ValidationResult.authoredFailure(
+        DataMartValidationCode.STORAGE_CONFIG_NOT_FOUND,
+        'Data Mart storage config not found'
+      );
     }
 
     if (!dataMart.storage.credentialId) {
-      return new ValidationResult(false, 'DataMart storage credentials not found');
+      return ValidationResult.authoredFailure(
+        DataMartValidationCode.STORAGE_CREDENTIALS_NOT_FOUND,
+        'Data Mart storage credentials not found'
+      );
     }
 
     const credentials = await this.credentialsResolver.resolve(dataMart.storage);
@@ -39,7 +52,7 @@ export class DataMartDefinitionValidatorFacade {
   async checkIsValid(dataMart: DataMart): Promise<void> {
     const result = await this.validate(dataMart);
     if (!result.valid) {
-      throw new BusinessViolationException(result.errorMessage!, result.details);
+      throw new BusinessViolationException(result.errorMessage!, result.details, result.code);
     }
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/facades/data-mart-definition-validator-facade.service.ts
+++ b/apps/backend/src/data-marts/data-storage-types/facades/data-mart-definition-validator-facade.service.ts
@@ -24,7 +24,7 @@ export class DataMartDefinitionValidatorFacade {
     if (!definition) {
       return ValidationResult.authoredFailure(
         DataMartValidationCode.DEFINITION_NOT_FOUND,
-        'Data Mart definition not found'
+        'DataMart definition not found'
       );
     }
 
@@ -32,14 +32,14 @@ export class DataMartDefinitionValidatorFacade {
     if (!config) {
       return ValidationResult.authoredFailure(
         DataMartValidationCode.STORAGE_CONFIG_NOT_FOUND,
-        'Data Mart storage config not found'
+        'DataMart storage config not found'
       );
     }
 
     if (!dataMart.storage.credentialId) {
       return ValidationResult.authoredFailure(
         DataMartValidationCode.STORAGE_CREDENTIALS_NOT_FOUND,
-        'Data Mart storage credentials not found'
+        'DataMart storage credentials not found'
       );
     }
 

--- a/apps/backend/src/data-marts/data-storage-types/interfaces/data-mart-validator.interface.ts
+++ b/apps/backend/src/data-marts/data-storage-types/interfaces/data-mart-validator.interface.ts
@@ -12,23 +12,53 @@ export interface DataMartValidator {
   ): Promise<ValidationResult>;
 }
 
+/**
+ * Stable identifiers for validation failures whose message this codebase
+ * authored, and which are therefore safe to show end users.
+ *
+ * Consumers that sanitize error text (see PublishDataStorageDraftsService)
+ * allowlist these codes. A failure with no code may carry raw driver output —
+ * a warehouse dry-run error, a Databricks EXPLAIN message — and must not be
+ * echoed back to the browser.
+ */
+export enum DataMartValidationCode {
+  INVALID_IDENTIFIER_FORMAT = 'DATA_MART_INVALID_IDENTIFIER_FORMAT',
+  DEFINITION_NOT_FOUND = 'DATA_MART_DEFINITION_NOT_FOUND',
+  STORAGE_CONFIG_NOT_FOUND = 'DATA_MART_STORAGE_CONFIG_NOT_FOUND',
+  STORAGE_CREDENTIALS_NOT_FOUND = 'DATA_MART_STORAGE_CREDENTIALS_NOT_FOUND',
+}
+
 export class ValidationResult {
   constructor(
     public readonly valid: boolean,
     public readonly errorMessage?: string,
     public readonly details?: Record<string, unknown>,
-    public readonly reason?: Record<string, unknown>
+    public readonly reason?: Record<string, unknown>,
+    public readonly code?: DataMartValidationCode
   ) {}
 
   static success(details?: Record<string, unknown>): ValidationResult {
     return new ValidationResult(true, undefined, details);
   }
 
+  /**
+   * Failure carrying a message of unknown provenance — it may come from a
+   * storage driver. Left uncoded so sanitizing consumers replace it.
+   */
   static failure(
     errorMessage?: string,
     details?: Record<string, unknown>,
     reason?: Record<string, unknown>
   ): ValidationResult {
     return new ValidationResult(false, errorMessage, details, reason);
+  }
+
+  /** Failure whose message this codebase authored; safe to show end users. */
+  static authoredFailure(
+    code: DataMartValidationCode,
+    errorMessage: string,
+    details?: Record<string, unknown>
+  ): ValidationResult {
+    return new ValidationResult(false, errorMessage, details, undefined, code);
   }
 }

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-datamart.validator.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-datamart.validator.ts
@@ -34,17 +34,21 @@ export class RedshiftDataMartValidator implements DataMartValidator {
     config: DataStorageConfig,
     credentials: DataStorageCredentials
   ): Promise<ValidationResult> {
+    // Identifiers are checked first, as in every other warehouse validator: the
+    // check needs only the definition, and an unconfigured storage would
+    // otherwise mask a malformed table name behind a config error the publish
+    // path cannot show.
+    const identifierValidation = this.validateIdentifiers(dataMartDefinition);
+    if (!identifierValidation.valid) {
+      return identifierValidation;
+    }
+
     if (!isRedshiftConfig(config)) {
       return ValidationResult.failure('Incompatible data storage config');
     }
 
     if (!isRedshiftCredentials(credentials)) {
       return ValidationResult.failure('Incompatible data storage credentials');
-    }
-
-    const identifierValidation = this.validateIdentifiers(dataMartDefinition);
-    if (!identifierValidation.valid) {
-      return identifierValidation;
     }
 
     if (isConnectorDefinition(dataMartDefinition)) {

--- a/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-datamart.validator.ts
+++ b/apps/backend/src/data-marts/data-storage-types/redshift/services/redshift-datamart.validator.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import {
   DataMartValidator,
   ValidationResult,
+  DataMartValidationCode,
 } from '../../interfaces/data-mart-validator.interface';
 import { DataStorageType } from '../../enums/data-storage-type.enum';
 import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definitions/data-mart-definition';
@@ -81,7 +82,8 @@ export class RedshiftDataMartValidator implements DataMartValidator {
     }
 
     if (identifierToValidate && !isValidRedshiftFullyQualifiedName(identifierToValidate)) {
-      return ValidationResult.failure(
+      return ValidationResult.authoredFailure(
+        DataMartValidationCode.INVALID_IDENTIFIER_FORMAT,
         'Invalid identifier format. Expected: schema.table or database.schema.table'
       );
     }

--- a/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-datamart.validator.ts
+++ b/apps/backend/src/data-marts/data-storage-types/snowflake/services/snowflake-datamart.validator.ts
@@ -4,6 +4,7 @@ import { DataMartDefinition } from '../../../dto/schemas/data-mart-table-definit
 import {
   DataMartValidator,
   ValidationResult,
+  DataMartValidationCode,
 } from '../../interfaces/data-mart-validator.interface';
 import { SnowflakeApiAdapterFactory } from '../adapters/snowflake-api-adapter.factory';
 import { isSnowflakeCredentials } from '../../data-storage-credentials.guards';
@@ -76,7 +77,10 @@ export class SnowflakeDataMartValidator implements DataMartValidator {
     }
 
     if (identifierToValidate && !isValidSnowflakeFullyQualifiedName(identifierToValidate)) {
-      return ValidationResult.failure('Invalid identifier format. Expected: database.schema.table');
+      return ValidationResult.authoredFailure(
+        DataMartValidationCode.INVALID_IDENTIFIER_FORMAT,
+        'Invalid identifier format. Expected: database.schema.table'
+      );
     }
 
     return ValidationResult.success();

--- a/apps/backend/src/data-marts/services/publish-drafts-trigger-handler.service.spec.ts
+++ b/apps/backend/src/data-marts/services/publish-drafts-trigger-handler.service.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { PublishDataStorageDraftsResultDto } from '../dto/domain/publish-data-storage-drafts-result.dto';
+import { PUBLISH_DRAFTS_ERRORS } from '../use-cases/publish-data-storage-drafts.service';
 import { PublishDraftsTriggerHandlerService } from './publish-drafts-trigger-handler.service';
 
 describe('PublishDraftsTriggerHandlerService', () => {
@@ -52,7 +53,9 @@ describe('PublishDraftsTriggerHandlerService', () => {
     const { handler, trigger, publishDraftsService } = createHandler();
     publishDraftsService.run.mockRejectedValue(
       new BusinessViolationException(
-        'Could not determine your project permissions. No Data Mart drafts were published.'
+        PUBLISH_DRAFTS_ERRORS.UNRESOLVED_ROLES.message,
+        undefined,
+        PUBLISH_DRAFTS_ERRORS.UNRESOLVED_ROLES.code
       )
     );
 
@@ -60,7 +63,7 @@ describe('PublishDraftsTriggerHandlerService', () => {
 
     expect(trigger.onError).toHaveBeenCalled();
     expect(trigger.uiResponse).toMatchObject({
-      error: 'Could not determine your project permissions. No Data Mart drafts were published.',
+      error: PUBLISH_DRAFTS_ERRORS.UNRESOLVED_ROLES.message,
     });
   });
 
@@ -92,6 +95,26 @@ describe('PublishDraftsTriggerHandlerService', () => {
     const { handler, trigger, publishDraftsService } = createHandler();
     publishDraftsService.run.mockRejectedValue(
       new Error('QueryFailedError: connection terminated (host=db.acme-prod-1234.internal)')
+    );
+
+    await handler.handleTrigger(trigger as never);
+
+    expect(trigger.uiResponse).toMatchObject({
+      error: 'Publishing Data Mart drafts failed. Please try again.',
+    });
+    expect(JSON.stringify(trigger.uiResponse)).not.toContain('acme-prod-1234');
+  });
+
+  // A code only proves some thrower opted in — not that this path authored the
+  // wording. An unrelated coded exception must still be replaced.
+  it('genericizes a coded exception whose code is not one this trigger raises', async () => {
+    const { handler, trigger, publishDraftsService } = createHandler();
+    publishDraftsService.run.mockRejectedValue(
+      new BusinessViolationException(
+        'Dry run failed: SELECT * FROM `acme-prod-1234.finance.salaries`',
+        undefined,
+        'SOME_OTHER_SUBSYSTEM_CODE'
+      )
     );
 
     await handler.handleTrigger(trigger as never);

--- a/apps/backend/src/data-marts/services/publish-drafts-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/publish-drafts-trigger-handler.service.ts
@@ -18,16 +18,20 @@ const STORAGE_GONE_ERROR = 'This Storage no longer exists. No Data Mart drafts w
  * The response is readable by any project viewer, so only text this codebase
  * authored may travel on it.
  *
- * PublishDataStorageDraftsService raises BusinessViolationException only with
- * its own wording. NotFoundException is mapped separately because it is a
- * permanent condition — its own message is not reused, since it embeds storage
- * and project ids.
+ * A BusinessViolationException is trusted only when it carries a code: the same
+ * exception type is also thrown with raw text elsewhere (the definition
+ * validator facade wraps warehouse dry-run output, ActualizeDataMartSchema
+ * wraps an arbitrary error.message). Requiring a code makes that guarantee
+ * structural instead of a property of the current call graph.
+ *
+ * NotFoundException is mapped separately because it is a permanent condition —
+ * its own message is not reused, since it embeds storage and project ids.
  */
 function toTriggerErrorMessage(error: unknown): string {
   if (error instanceof NotFoundException) {
     return STORAGE_GONE_ERROR;
   }
-  if (error instanceof BusinessViolationException) {
+  if (error instanceof BusinessViolationException && error.code) {
     return error.message;
   }
   return GENERIC_TRIGGER_ERROR;

--- a/apps/backend/src/data-marts/services/publish-drafts-trigger-handler.service.ts
+++ b/apps/backend/src/data-marts/services/publish-drafts-trigger-handler.service.ts
@@ -6,7 +6,10 @@ import { TriggerHandler } from '../../common/scheduler/shared/trigger-handler.in
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { PublishDraftsTrigger } from '../entities/publish-drafts-trigger.entity';
 import { DataStorageMapper } from '../mappers/data-storage.mapper';
-import { PublishDataStorageDraftsService } from '../use-cases/publish-data-storage-drafts.service';
+import {
+  PUBLISH_DRAFTS_TRIGGER_ERROR_CODES,
+  PublishDataStorageDraftsService,
+} from '../use-cases/publish-data-storage-drafts.service';
 import { PublishDataStorageDraftsCommand } from '../dto/domain/publish-data-storage-drafts.command';
 
 const GENERIC_TRIGGER_ERROR = 'Publishing Data Mart drafts failed. Please try again.';
@@ -18,11 +21,13 @@ const STORAGE_GONE_ERROR = 'This Storage no longer exists. No Data Mart drafts w
  * The response is readable by any project viewer, so only text this codebase
  * authored may travel on it.
  *
- * A BusinessViolationException is trusted only when it carries a code: the same
- * exception type is also thrown with raw text elsewhere (the definition
- * validator facade wraps warehouse dry-run output, ActualizeDataMartSchema
- * wraps an arbitrary error.message). Requiring a code makes that guarantee
- * structural instead of a property of the current call graph.
+ * A BusinessViolationException is trusted only when it carries one of the codes
+ * this trigger's use case raises. The same exception type is thrown with raw
+ * text elsewhere (the definition validator facade wraps warehouse dry-run
+ * output, ActualizeDataMartSchema wraps an arbitrary error.message), and a code
+ * alone only proves some thrower opted in — not that this path authored the
+ * wording. Matching the allowlist makes the guarantee structural rather than a
+ * property of the current call graph.
  *
  * NotFoundException is mapped separately because it is a permanent condition —
  * its own message is not reused, since it embeds storage and project ids.
@@ -31,7 +36,11 @@ function toTriggerErrorMessage(error: unknown): string {
   if (error instanceof NotFoundException) {
     return STORAGE_GONE_ERROR;
   }
-  if (error instanceof BusinessViolationException && error.code) {
+  if (
+    error instanceof BusinessViolationException &&
+    error.code &&
+    PUBLISH_DRAFTS_TRIGGER_ERROR_CODES.has(error.code)
+  ) {
     return error.message;
   }
   return GENERIC_TRIGGER_ERROR;

--- a/apps/backend/src/data-marts/use-cases/publish-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-mart.service.ts
@@ -24,9 +24,18 @@ import { SearchableEntityType } from '../../common/search/search.facade';
  * PublishDataStorageDraftsService.toUserFacingReason.
  */
 export const PUBLISH_DATA_MART_ERRORS = {
-  NO_PERMISSION: 'You do not have permission to publish this Data Mart',
-  ALREADY_PUBLISHED: 'Data Mart is already published',
-  NO_DEFINITION: 'Data Mart has no definition',
+  NO_PERMISSION: {
+    code: 'DATA_MART_PUBLISH_FORBIDDEN',
+    message: 'You do not have permission to publish this Data Mart',
+  },
+  ALREADY_PUBLISHED: {
+    code: 'DATA_MART_ALREADY_PUBLISHED',
+    message: 'Data Mart is already published',
+  },
+  NO_DEFINITION: {
+    code: 'DATA_MART_NO_DEFINITION',
+    message: 'Data Mart has no definition',
+  },
 } as const;
 
 @Injectable()
@@ -56,16 +65,27 @@ export class PublishDataMartService {
         command.projectId
       );
       if (!canEdit) {
-        throw new ForbiddenException(PUBLISH_DATA_MART_ERRORS.NO_PERMISSION);
+        // Deliberately a ForbiddenException, not a coded BusinessViolationException:
+        // the latter is hardcoded to 400 by BaseExceptionFilter, and a permission
+        // denial must stay a 403 for API clients. Sanitizers match it by identity.
+        throw new ForbiddenException(PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message);
       }
     }
 
     if (dataMart.status !== DataMartStatus.DRAFT) {
-      throw new BusinessViolationException(PUBLISH_DATA_MART_ERRORS.ALREADY_PUBLISHED);
+      throw new BusinessViolationException(
+        PUBLISH_DATA_MART_ERRORS.ALREADY_PUBLISHED.message,
+        undefined,
+        PUBLISH_DATA_MART_ERRORS.ALREADY_PUBLISHED.code
+      );
     }
 
     if (!dataMart.definition || !dataMart.definitionType) {
-      throw new BusinessViolationException(PUBLISH_DATA_MART_ERRORS.NO_DEFINITION);
+      throw new BusinessViolationException(
+        PUBLISH_DATA_MART_ERRORS.NO_DEFINITION.message,
+        undefined,
+        PUBLISH_DATA_MART_ERRORS.NO_DEFINITION.code
+      );
     }
 
     if (dataMart.definitionType !== DataMartDefinitionType.SQL) {

--- a/apps/backend/src/data-marts/use-cases/publish-data-mart.service.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-mart.service.ts
@@ -38,6 +38,23 @@ export const PUBLISH_DATA_MART_ERRORS = {
   },
 } as const;
 
+/**
+ * Permission denial for publishing, carrying a stable code.
+ *
+ * Extends Nest's ForbiddenException so the single-publish endpoint keeps its
+ * 403 — BaseExceptionFilter is `@Catch(BusinessViolationException)` and its
+ * hardcoded 400 therefore does not apply here. Sanitizers match this by type
+ * and code rather than by message text.
+ */
+export class PublishForbiddenException extends ForbiddenException {
+  constructor(
+    message: string,
+    readonly code: string
+  ) {
+    super(message);
+  }
+}
+
 @Injectable()
 export class PublishDataMartService {
   private readonly logger = new Logger(PublishDataMartService.name);
@@ -65,10 +82,10 @@ export class PublishDataMartService {
         command.projectId
       );
       if (!canEdit) {
-        // Deliberately a ForbiddenException, not a coded BusinessViolationException:
-        // the latter is hardcoded to 400 by BaseExceptionFilter, and a permission
-        // denial must stay a 403 for API clients. Sanitizers match it by identity.
-        throw new ForbiddenException(PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message);
+        throw new PublishForbiddenException(
+          PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message,
+          PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.code
+        );
       }
     }
 

--- a/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.spec.ts
@@ -1,6 +1,7 @@
 import { ForbiddenException } from '@nestjs/common';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { PublishDataStorageDraftsCommand } from '../dto/domain/publish-data-storage-drafts.command';
+import { DataMartValidationCode } from '../data-storage-types/interfaces/data-mart-validator.interface';
 import { PUBLISH_DATA_MART_ERRORS } from './publish-data-mart.service';
 import { PublishDataStorageDraftsService } from './publish-data-storage-drafts.service';
 
@@ -192,7 +193,11 @@ describe('PublishDataStorageDraftsService', () => {
   it('counts a draft as failed (without throwing) and reports the reason', async () => {
     const { service, publishDataMartService } = createService();
     publishDataMartService.run.mockRejectedValue(
-      new BusinessViolationException(PUBLISH_DATA_MART_ERRORS.NO_DEFINITION)
+      new BusinessViolationException(
+        PUBLISH_DATA_MART_ERRORS.NO_DEFINITION.message,
+        undefined,
+        PUBLISH_DATA_MART_ERRORS.NO_DEFINITION.code
+      )
     );
 
     const result = await service.run(
@@ -201,20 +206,76 @@ describe('PublishDataStorageDraftsService', () => {
 
     expect(result.successCount).toBe(0);
     expect(result.failedCount).toBe(1);
-    expect(result.failureReasons).toEqual([PUBLISH_DATA_MART_ERRORS.NO_DEFINITION]);
+    expect(result.failureReasons).toEqual([PUBLISH_DATA_MART_ERRORS.NO_DEFINITION.message]);
   });
 
   it('reports the permission error verbatim (thrown as a Nest ForbiddenException)', async () => {
     const { service, publishDataMartService } = createService();
     publishDataMartService.run.mockRejectedValue(
-      new ForbiddenException(PUBLISH_DATA_MART_ERRORS.NO_PERMISSION)
+      new ForbiddenException(PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message)
     );
 
     const result = await service.run(
       new PublishDataStorageDraftsCommand('storage-1', 'project-1', 'user-1')
     );
 
-    expect(result.failureReasons).toEqual([PUBLISH_DATA_MART_ERRORS.NO_PERMISSION]);
+    expect(result.failureReasons).toEqual([PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message]);
+  });
+
+  // 8: an authored validator message now reaches the user instead of being
+  // downgraded, because the facade tags it with a DataMartValidationCode.
+  it('surfaces an authored validator message that carries a code', async () => {
+    const { service, publishDataMartService } = createService();
+    publishDataMartService.run.mockRejectedValue(
+      new BusinessViolationException(
+        'Invalid identifier format. Expected: project.dataset.table',
+        undefined,
+        DataMartValidationCode.INVALID_IDENTIFIER_FORMAT
+      )
+    );
+
+    const result = await service.run(
+      new PublishDataStorageDraftsCommand('storage-1', 'project-1', 'user-1')
+    );
+
+    expect(result.failureReasons).toEqual([
+      'Invalid identifier format. Expected: project.dataset.table',
+    ]);
+  });
+
+  // 7: the guarantee is now structural — the same exception type carrying raw
+  // warehouse text has no code, so it is replaced rather than trusted.
+  it('genericizes a BusinessViolationException that carries no code', async () => {
+    const { service, publishDataMartService } = createService();
+    publishDataMartService.run.mockRejectedValue(
+      new BusinessViolationException(
+        'Syntax error at [1:8] in SELECT * FROM `acme-prod-1234.finance.salaries`'
+      )
+    );
+
+    const result = await service.run(
+      new PublishDataStorageDraftsCommand('storage-1', 'project-1', 'user-1')
+    );
+
+    expect(result.failureReasons).toEqual([
+      'Publishing failed. Open the Data Mart to see details.',
+    ]);
+    expect(JSON.stringify(result)).not.toContain('acme-prod-1234');
+  });
+
+  it('genericizes an unrecognized code, not just a missing one', async () => {
+    const { service, publishDataMartService } = createService();
+    publishDataMartService.run.mockRejectedValue(
+      new BusinessViolationException('Some other subsystem failed', undefined, 'SOME_OTHER_CODE')
+    );
+
+    const result = await service.run(
+      new PublishDataStorageDraftsCommand('storage-1', 'project-1', 'user-1')
+    );
+
+    expect(result.failureReasons).toEqual([
+      'Publishing failed. Open the Data Mart to see details.',
+    ]);
   });
 
   it('never leaks an unrecognized error message to the caller', async () => {
@@ -251,7 +312,7 @@ describe('PublishDataStorageDraftsService', () => {
     publishDataMartService.run.mockImplementation((command: { id: string }) => {
       if (command.id === 'visible-dm') return Promise.resolve(undefined);
       // Access-gated Data Marts fail the per-draft EDIT check.
-      return Promise.reject(new ForbiddenException(PUBLISH_DATA_MART_ERRORS.NO_PERMISSION));
+      return Promise.reject(new ForbiddenException(PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message));
     });
 
     const result = await service.run(
@@ -263,7 +324,7 @@ describe('PublishDataStorageDraftsService', () => {
 
     // Reasons are deduplicated, so the count of hidden Data Marts is not
     // inferable from the list either.
-    expect(result.failureReasons).toEqual([PUBLISH_DATA_MART_ERRORS.NO_PERMISSION]);
+    expect(result.failureReasons).toEqual([PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message]);
 
     const serialized = JSON.stringify(result);
     expect(serialized).not.toContain('hidden-dm-8f3a1c02');

--- a/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.spec.ts
@@ -2,7 +2,7 @@ import { ForbiddenException } from '@nestjs/common';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { PublishDataStorageDraftsCommand } from '../dto/domain/publish-data-storage-drafts.command';
 import { DataMartValidationCode } from '../data-storage-types/interfaces/data-mart-validator.interface';
-import { PUBLISH_DATA_MART_ERRORS } from './publish-data-mart.service';
+import { PUBLISH_DATA_MART_ERRORS, PublishForbiddenException } from './publish-data-mart.service';
 import { PublishDataStorageDraftsService } from './publish-data-storage-drafts.service';
 
 describe('PublishDataStorageDraftsService', () => {
@@ -212,7 +212,10 @@ describe('PublishDataStorageDraftsService', () => {
   it('reports the permission error verbatim (thrown as a Nest ForbiddenException)', async () => {
     const { service, publishDataMartService } = createService();
     publishDataMartService.run.mockRejectedValue(
-      new ForbiddenException(PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message)
+      new PublishForbiddenException(
+        PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message,
+        PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.code
+      )
     );
 
     const result = await service.run(
@@ -278,6 +281,21 @@ describe('PublishDataStorageDraftsService', () => {
     ]);
   });
 
+  it('does not trust a bare ForbiddenException that merely repeats the wording', async () => {
+    const { service, publishDataMartService } = createService();
+    publishDataMartService.run.mockRejectedValue(
+      new ForbiddenException(PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message)
+    );
+
+    const result = await service.run(
+      new PublishDataStorageDraftsCommand('storage-1', 'project-1', 'user-1')
+    );
+
+    expect(result.failureReasons).toEqual([
+      'Publishing failed. Open the Data Mart to see details.',
+    ]);
+  });
+
   it('never leaks an unrecognized error message to the caller', async () => {
     const { service, publishDataMartService } = createService();
     publishDataMartService.run.mockRejectedValue(
@@ -312,7 +330,12 @@ describe('PublishDataStorageDraftsService', () => {
     publishDataMartService.run.mockImplementation((command: { id: string }) => {
       if (command.id === 'visible-dm') return Promise.resolve(undefined);
       // Access-gated Data Marts fail the per-draft EDIT check.
-      return Promise.reject(new ForbiddenException(PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message));
+      return Promise.reject(
+        new PublishForbiddenException(
+          PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message,
+          PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.code
+        )
+      );
     });
 
     const result = await service.run(

--- a/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.ts
@@ -29,7 +29,7 @@ const GENERIC_FAILURE_REASON = 'Publishing failed. Open the Data Mart to see det
  * Trigger-level failures raised by this service. Each carries a code so the
  * handler can tell authored text from an infrastructure error's message.
  */
-const PUBLISH_DRAFTS_ERRORS = {
+export const PUBLISH_DRAFTS_ERRORS = {
   UNRESOLVED_ROLES: {
     code: 'PUBLISH_DRAFTS_UNRESOLVED_ROLES',
     message: 'Could not determine your project permissions. No Data Mart drafts were published.',
@@ -45,6 +45,15 @@ const PUBLISH_DRAFTS_ERRORS = {
     message: 'Could not access this Storage. Check its connection settings and try again.',
   },
 } as const;
+
+/**
+ * Codes this service raises at trigger level. The handler allowlists these
+ * rather than trusting any coded BusinessViolationException: a code proves the
+ * thrower opted in, not that *this* path authored the text.
+ */
+export const PUBLISH_DRAFTS_TRIGGER_ERROR_CODES: ReadonlySet<string> = new Set<string>(
+  Object.values(PUBLISH_DRAFTS_ERRORS).map(error => error.code)
+);
 
 /**
  * A storage ValidationResult only carries a `code` when this codebase authored

--- a/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.ts
@@ -1,7 +1,10 @@
-import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
-import { ValidationResult } from '../data-storage-types/interfaces/data-storage-access-validator.interface';
+import {
+  ValidationResult,
+  ValidationResultCode,
+} from '../data-storage-types/interfaces/data-storage-access-validator.interface';
 import { DataMartValidationCode } from '../data-storage-types/interfaces/data-mart-validator.interface';
 import { PublishDataMartCommand } from '../dto/domain/publish-data-mart.command';
 import { PublishDataStorageDraftsResultDto } from '../dto/domain/publish-data-storage-drafts-result.dto';
@@ -10,7 +13,11 @@ import { ValidateDataStorageAccessCommand } from '../dto/domain/validate-data-st
 import { DataMartService } from '../services/data-mart.service';
 import { DataStorageService } from '../services/data-storage.service';
 import { SchemaActualizeTriggerService } from '../services/schema-actualize-trigger.service';
-import { PUBLISH_DATA_MART_ERRORS, PublishDataMartService } from './publish-data-mart.service';
+import {
+  PUBLISH_DATA_MART_ERRORS,
+  PublishDataMartService,
+  PublishForbiddenException,
+} from './publish-data-mart.service';
 import { ValidateDataStorageAccessService } from './validate-data-storage-access.service';
 
 /**
@@ -20,10 +27,24 @@ import { ValidateDataStorageAccessService } from './validate-data-storage-access
  */
 const USER_FACING_FAILURE_CODES: ReadonlySet<string> = new Set<string>([
   ...Object.values(PUBLISH_DATA_MART_ERRORS).map(error => error.code),
-  ...Object.values(DataMartValidationCode),
+  // Listed one by one rather than spread from the enum: a code added there in
+  // another module must not become user-facing here without a deliberate edit.
+  DataMartValidationCode.INVALID_IDENTIFIER_FORMAT,
+  DataMartValidationCode.DEFINITION_NOT_FOUND,
+  DataMartValidationCode.STORAGE_CONFIG_NOT_FOUND,
+  DataMartValidationCode.STORAGE_CREDENTIALS_NOT_FOUND,
 ]);
 
 const GENERIC_FAILURE_REASON = 'Publishing failed. Open the Data Mart to see details.';
+
+/**
+ * Storage-access validation codes this service is willing to echo, each mapped
+ * to its own trigger-level code so the pairing stays truthful.
+ */
+const STORAGE_VALIDATION_CODES: Readonly<Record<string, string>> = {
+  [ValidationResultCode.UNCONFIGURED]: 'PUBLISH_DRAFTS_STORAGE_UNCONFIGURED',
+  [ValidationResultCode.OAUTH_REAUTH_REQUIRED]: 'PUBLISH_DRAFTS_STORAGE_OAUTH_REAUTH_REQUIRED',
+};
 
 /**
  * Trigger-level failures raised by this service. Each carries a code so the
@@ -51,9 +72,10 @@ export const PUBLISH_DRAFTS_ERRORS = {
  * rather than trusting any coded BusinessViolationException: a code proves the
  * thrower opted in, not that *this* path authored the text.
  */
-export const PUBLISH_DRAFTS_TRIGGER_ERROR_CODES: ReadonlySet<string> = new Set<string>(
-  Object.values(PUBLISH_DRAFTS_ERRORS).map(error => error.code)
-);
+export const PUBLISH_DRAFTS_TRIGGER_ERROR_CODES: ReadonlySet<string> = new Set<string>([
+  ...Object.values(PUBLISH_DRAFTS_ERRORS).map(error => error.code),
+  ...Object.values(STORAGE_VALIDATION_CODES),
+]);
 
 /**
  * A storage ValidationResult only carries a `code` when this codebase authored
@@ -62,15 +84,17 @@ export const PUBLISH_DRAFTS_TRIGGER_ERROR_CODES: ReadonlySet<string> = new Set<s
  * not reach the browser.
  */
 function toStorageAccessError(result: ValidationResult): BusinessViolationException {
-  const authored = Boolean(result.code && result.errorMessage);
-  return new BusinessViolationException(
-    authored ? result.errorMessage! : PUBLISH_DRAFTS_ERRORS.STORAGE_ACCESS.message,
-    undefined,
-    PUBLISH_DRAFTS_ERRORS.STORAGE_ACCESS.code
-  );
+  // Keep code and message describing the same failure: reusing one generic code
+  // for an authored message would tell a client branching on it to check
+  // connection settings when the fix is, say, reconnecting Google.
+  const authoredCode = result.code ? STORAGE_VALIDATION_CODES[result.code] : undefined;
+  if (authoredCode && result.errorMessage) {
+    return new BusinessViolationException(result.errorMessage, undefined, authoredCode);
+  }
+  return publishDraftsError(PUBLISH_DRAFTS_ERRORS.STORAGE_ACCESS);
 }
 
-/** Raises a trigger-level failure with its stable code attached. */
+/** Builds a trigger-level failure with its stable code attached; the caller throws. */
 function publishDraftsError(spec: { code: string; message: string }): BusinessViolationException {
   return new BusinessViolationException(spec.message, undefined, spec.code);
 }
@@ -233,14 +257,11 @@ export class PublishDataStorageDraftsService {
       return USER_FACING_FAILURE_CODES.has(error.code) ? error.message : GENERIC_FAILURE_REASON;
     }
 
-    // NO_PERMISSION travels as a Nest ForbiddenException so the single-publish
-    // endpoint keeps its 403; HttpException carries no `code`, so this one
-    // authored message is matched by identity instead.
-    if (
-      error instanceof ForbiddenException &&
-      error.message === PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message
-    ) {
-      return PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message;
+    // Permission denials stay a 403 for API clients, so they cannot be a coded
+    // BusinessViolationException; PublishForbiddenException carries the code
+    // instead, keeping this a type-and-code match rather than a text match.
+    if (error instanceof PublishForbiddenException && USER_FACING_FAILURE_CODES.has(error.code)) {
+      return error.message;
     }
 
     return GENERIC_FAILURE_REASON;

--- a/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.ts
+++ b/apps/backend/src/data-marts/use-cases/publish-data-storage-drafts.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { IdpProjectionsFacade } from '../../idp/facades/idp-projections.facade';
 import { ValidationResult } from '../data-storage-types/interfaces/data-storage-access-validator.interface';
+import { DataMartValidationCode } from '../data-storage-types/interfaces/data-mart-validator.interface';
 import { PublishDataMartCommand } from '../dto/domain/publish-data-mart.command';
 import { PublishDataStorageDraftsResultDto } from '../dto/domain/publish-data-storage-drafts-result.dto';
 import { PublishDataStorageDraftsCommand } from '../dto/domain/publish-data-storage-drafts.command';
@@ -12,33 +13,57 @@ import { SchemaActualizeTriggerService } from '../services/schema-actualize-trig
 import { PUBLISH_DATA_MART_ERRORS, PublishDataMartService } from './publish-data-mart.service';
 import { ValidateDataStorageAccessService } from './validate-data-storage-access.service';
 
-/** Reasons the publish path authors itself; anything else is not shown to users. */
-const USER_FACING_FAILURE_REASONS: ReadonlySet<string> = new Set(
-  Object.values(PUBLISH_DATA_MART_ERRORS)
-);
+/**
+ * Failure codes whose message this codebase authored. Sanitization keys on the
+ * code rather than the text, so an authored message is safe because it is
+ * tagged as ours — not because its bytes match a list.
+ */
+const USER_FACING_FAILURE_CODES: ReadonlySet<string> = new Set<string>([
+  ...Object.values(PUBLISH_DATA_MART_ERRORS).map(error => error.code),
+  ...Object.values(DataMartValidationCode),
+]);
 
 const GENERIC_FAILURE_REASON = 'Publishing failed. Open the Data Mart to see details.';
 
-/** Surfaced as the trigger-level error when the publisher's roles cannot be resolved. */
-const UNRESOLVED_ROLES_ERROR =
-  'Could not determine your project permissions. No Data Mart drafts were published.';
-
-/** Same, but for a failed lookup rather than a definitive empty answer — retrying may help. */
-const PERMISSIONS_LOOKUP_FAILED_ERROR =
-  'Could not verify your project permissions. No Data Mart drafts were published. Please try again.';
-
-/** Fallback when the storage check failed for a reason this codebase did not author. */
-const STORAGE_ACCESS_FAILED_ERROR =
-  'Could not access this Storage. Check its connection settings and try again.';
+/**
+ * Trigger-level failures raised by this service. Each carries a code so the
+ * handler can tell authored text from an infrastructure error's message.
+ */
+const PUBLISH_DRAFTS_ERRORS = {
+  UNRESOLVED_ROLES: {
+    code: 'PUBLISH_DRAFTS_UNRESOLVED_ROLES',
+    message: 'Could not determine your project permissions. No Data Mart drafts were published.',
+  },
+  /** A failed lookup rather than a definitive empty answer — retrying may help. */
+  PERMISSIONS_LOOKUP_FAILED: {
+    code: 'PUBLISH_DRAFTS_PERMISSIONS_LOOKUP_FAILED',
+    message:
+      'Could not verify your project permissions. No Data Mart drafts were published. Please try again.',
+  },
+  STORAGE_ACCESS: {
+    code: 'PUBLISH_DRAFTS_STORAGE_ACCESS',
+    message: 'Could not access this Storage. Check its connection settings and try again.',
+  },
+} as const;
 
 /**
- * A ValidationResult only carries a `code` when this codebase authored the
- * message (`unconfigured`, `oauthReauthRequired`). A bare `failure()` can hold
- * raw text from credential resolution or a warehouse driver, which must not
- * reach the browser.
+ * A storage ValidationResult only carries a `code` when this codebase authored
+ * the message (`unconfigured`, `oauthReauthRequired`). A bare `failure()` can
+ * hold raw text from credential resolution or a warehouse driver, which must
+ * not reach the browser.
  */
-function toUserFacingStorageError(result: ValidationResult): string {
-  return result.code && result.errorMessage ? result.errorMessage : STORAGE_ACCESS_FAILED_ERROR;
+function toStorageAccessError(result: ValidationResult): BusinessViolationException {
+  const authored = Boolean(result.code && result.errorMessage);
+  return new BusinessViolationException(
+    authored ? result.errorMessage! : PUBLISH_DRAFTS_ERRORS.STORAGE_ACCESS.message,
+    undefined,
+    PUBLISH_DRAFTS_ERRORS.STORAGE_ACCESS.code
+  );
+}
+
+/** Raises a trigger-level failure with its stable code attached. */
+function publishDraftsError(spec: { code: string; message: string }): BusinessViolationException {
+  return new BusinessViolationException(spec.message, undefined, spec.code);
 }
 
 @Injectable()
@@ -69,7 +94,7 @@ export class PublishDataStorageDraftsService {
     );
 
     if (!validationResult.valid) {
-      throw new BusinessViolationException(toUserFacingStorageError(validationResult));
+      throw toStorageAccessError(validationResult);
     }
 
     const draftIds = await this.dataMartService.findDraftIdsByStorage(dataStorage);
@@ -149,7 +174,7 @@ export class PublishDataStorageDraftsService {
       this.logger.error(
         `Publish drafts trigger for storage ${command.dataStorageId} has no userId; refusing to publish unauthorized`
       );
-      throw new BusinessViolationException(UNRESOLVED_ROLES_ERROR);
+      throw publishDraftsError(PUBLISH_DRAFTS_ERRORS.UNRESOLVED_ROLES);
     }
 
     const project = await this.idpProjectionsFacade
@@ -166,8 +191,10 @@ export class PublishDataStorageDraftsService {
             (error instanceof Error ? error.message : String(error)),
           { stack: error instanceof Error ? error.stack : undefined, status }
         );
-        throw new BusinessViolationException(
-          isDefinitive ? UNRESOLVED_ROLES_ERROR : PERMISSIONS_LOOKUP_FAILED_ERROR
+        throw publishDraftsError(
+          isDefinitive
+            ? PUBLISH_DRAFTS_ERRORS.UNRESOLVED_ROLES
+            : PUBLISH_DRAFTS_ERRORS.PERMISSIONS_LOOKUP_FAILED
         );
       });
 
@@ -179,7 +206,7 @@ export class PublishDataStorageDraftsService {
         `No roles resolved for user ${command.userId} in project ${command.projectId}; ` +
           'refusing to publish drafts as an implicit viewer'
       );
-      throw new BusinessViolationException(UNRESOLVED_ROLES_ERROR);
+      throw publishDraftsError(PUBLISH_DRAFTS_ERRORS.UNRESOLVED_ROLES);
     }
 
     return project.roles;
@@ -193,7 +220,20 @@ export class PublishDataStorageDraftsService {
    * generic reason; the full error stays in the server log above.
    */
   private toUserFacingReason(error: unknown): string {
-    const message = error instanceof Error ? error.message : '';
-    return USER_FACING_FAILURE_REASONS.has(message) ? message : GENERIC_FAILURE_REASON;
+    if (error instanceof BusinessViolationException && error.code) {
+      return USER_FACING_FAILURE_CODES.has(error.code) ? error.message : GENERIC_FAILURE_REASON;
+    }
+
+    // NO_PERMISSION travels as a Nest ForbiddenException so the single-publish
+    // endpoint keeps its 403; HttpException carries no `code`, so this one
+    // authored message is matched by identity instead.
+    if (
+      error instanceof ForbiddenException &&
+      error.message === PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message
+    ) {
+      return PUBLISH_DATA_MART_ERRORS.NO_PERMISSION.message;
+    }
+
+    return GENERIC_FAILURE_REASON;
   }
 }


### PR DESCRIPTION
# Problem

Publishing Data Mart drafts in bulk decides which error text is safe to show, because the trigger response is readable by any project **viewer** while publishing requires **editor**, and errors on that path can carry SQL fragments, table paths, and service-account names from warehouse drivers.

That decision was made by comparing each message against three approved strings, with a second checkpoint that trusted any `BusinessViolationException`. Both were safe but conventional rather than structural, with two consequences. First, authored messages that were not among the three were discarded: a malformed table name produced "Publishing failed. Open the Data Mart to see details." instead of "Invalid identifier format. Expected: project.dataset.table" — the most actionable failure a user can get. Second, the "BVE implies safe text" assumption held only because per-draft errors are caught inside the loop; the same type is thrown with raw warehouse output by the definition validator facade and with an arbitrary `error.message` by `ActualizeDataMartSchema`, so reordering the error handling could have reopened the leak with no failing test.

# Solution

Both checkpoints now key on a stable **code** rather than message text, using the `BaseException.code` contract the codebase already documents ("Clients branch on this instead of matching human-readable messages"). A message is trusted because it is tagged as authored, not because its bytes match a list.

- `ValidationResult` gained a `code` field and an `authoredFailure()` constructor alongside the existing `failure()`. Keeping both matters: `failure()` stays uncoded, so anything not explicitly migrated still gets genericized. Safe-by-default rather than opt-out.
- Only demonstrably authored failures were coded. The dry-run `catch` blocks and Databricks' `EXPLAIN` output were deliberately left uncoded so raw driver text is still replaced.
- `NO_PERMISSION` intentionally stays a Nest `ForbiddenException`. Giving it a code would mean converting it to `BusinessViolationException`, which `BaseExceptionFilter` hardcodes to HTTP 400 — silently turning a 403 into a 400 for API clients. A permission denial genuinely is a 403, so it is matched by identity instead, with the reasoning recorded at the call site.
- The batch-level checkpoint matches **allowlist membership**, not merely the presence of a code. A code alone only proves some thrower opted in, not that this path authored the wording, so the two checkpoints use separate sets scoped to what can legitimately reach each.

Trade-off considered and rejected: converting `NO_PERMISSION` for uniformity. Consistency was not worth changing a public status code.

# Changes

- Added `DataMartValidationCode` and `ValidationResult.authoredFailure()` to the definition-validator interface; left `failure()` uncoded as the safe default
- Tagged identifier-format failures across all five warehouse validators (Athena, BigQuery, Databricks, Redshift, Snowflake), plus the facade's definition/config/credentials messages
- Propagated the validation code through `DataMartDefinitionValidatorFacade.checkIsValid` so the publish path can distinguish authored text from driver output (the `validate-definition` response does not expose `code` yet)
- Converted `PUBLISH_DATA_MART_ERRORS` to `{ code, message }` pairs and gave the trigger-level failures in `PublishDataStorageDraftsService` their own codes
- Replaced both string allowlists with code allowlists; the trigger handler now requires membership in an exported set rather than trusting any coded exception
- Kept `NO_PERMISSION` as a `ForbiddenException` to preserve the endpoint's 403, matched by identity with an explanatory comment
- Added a table-driven parity spec asserting every warehouse validator codes its identifier failure, so a newly added warehouse is caught automatically
- Added a facade spec pinning code propagation, including that an uncoded failure stays uncoded
- Extended the publish-drafts specs to cover an authored validator message passing through, an uncoded exception being genericized, and an unrecognized code being genericized
- Updated the existing changeset to mention that the notification now names the malformed-table-name reason
