### PR TITLE
feat(web): enhance Data Mart publishing flow and report creation

### DIFF
--- a/.changeset/6805-enhance-report-creation-flow.md
+++ b/.changeset/6805-enhance-report-creation-flow.md
@@ -1,0 +1,12 @@
+---
+'owox': minor
+---
+
+# Creating a report no longer stops you at "publish the Data Mart first"
+
+Before, if your Data Mart was still a draft, the **New Report** button was simply greyed out with a tooltip saying "publish the Data Mart first" — you had to leave the page, find the publish button, publish, and come back to try again.
+
+Now clicking **New Report** on a draft Data Mart takes you straight to the next step:
+
+- If the Data Mart is ready to publish, you'll see **"Publish and create report"** — one click publishes it and opens the new report form right away.
+- If something is still missing (like a Storage or an Input Source), you'll see exactly what's missing and a **"Review Data Setup"** button that takes you right there.

--- a/apps/web/src/features/data-destination/shared/model/hooks/useDataDestinationsWithReports.ts
+++ b/apps/web/src/features/data-destination/shared/model/hooks/useDataDestinationsWithReports.ts
@@ -12,6 +12,7 @@ import { useDataDestination } from './useDataDestination';
 export function useDataDestinationsWithReports() {
   // Get the current Data Mart from outlet context
   const { dataMart } = useOutletContext<DataMartContextType>();
+  const dataMartId = dataMart?.id;
 
   // Hook to manage reports
   const { fetchReportsByDataMartId } = useReport();
@@ -27,13 +28,13 @@ export function useDataDestinationsWithReports() {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (!dataMart) return; // If no Data Mart, exit early
+    if (!dataMartId) return; // If no Data Mart, exit early
 
     const fetchData = async () => {
       setIsLoading(true); // Start combined loading
       try {
         // Fetch both destinations and reports concurrently
-        await Promise.all([fetchDataDestinations(), fetchReportsByDataMartId(dataMart.id)]);
+        await Promise.all([fetchDataDestinations(), fetchReportsByDataMartId(dataMartId)]);
       } catch (err) {
         console.error('Failed to fetch Data Mart destinations or reports:', err);
       } finally {
@@ -42,7 +43,7 @@ export function useDataDestinationsWithReports() {
     };
 
     void fetchData();
-  }, [dataMart, fetchDataDestinations, fetchReportsByDataMartId]);
+  }, [dataMartId, fetchDataDestinations, fetchReportsByDataMartId]);
 
   // Combine local loading with destinationsLoading from the DataDestination hook
   const combinedLoading = isLoading || destinationsLoading;

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -204,8 +204,8 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
   const isGeneratingTitle = aiPendingScope?.scope === DataMartMetadataScope.TITLE;
   const showAiTitleHelper = isAiHelperEnabled && !isConnector;
 
-  const handlePublish = useCallback(async () => {
-    if (!dataMartId) return;
+  const publishDataMartWithEffects = useCallback(async (): Promise<boolean> => {
+    if (!dataMartId) return false;
     setIsPublishing(true);
 
     try {
@@ -225,8 +225,10 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
         isInsightsEnabled: shouldShowInsights,
         showOnce: true,
       });
+      return true;
     } catch (error) {
       console.log(error instanceof Error ? error.message : 'Failed to publish Data Mart');
+      return false;
     } finally {
       setIsPublishing(false);
     }
@@ -426,7 +428,9 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
                     <Button
                       variant='default'
                       onClick={() => {
-                        schemaGuard.runGuarded(() => handlePublish(), { intent: 'publish' });
+                        schemaGuard.runGuarded(() => publishDataMartWithEffects(), {
+                          intent: 'publish',
+                        });
                       }}
                       disabled={isPublishing || !canPublish}
                       className={cn(
@@ -567,6 +571,7 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
             getDataMart,
             runSchemaActualization,
             isSchemaActualizationLoading,
+            publishDataMartWithEffects,
             registerSchemaGuard: schemaGuard.registerSchemaGuard,
             runGuarded: schemaGuard.runGuarded,
             projectId,

--- a/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartDetails.tsx
@@ -428,9 +428,14 @@ export function DataMartDetails({ id }: DataMartDetailsProps) {
                     <Button
                       variant='default'
                       onClick={() => {
-                        schemaGuard.runGuarded(() => publishDataMartWithEffects(), {
-                          intent: 'publish',
-                        });
+                        schemaGuard.runGuarded(
+                          () => {
+                            void publishDataMartWithEffects();
+                          },
+                          {
+                            intent: 'publish',
+                          }
+                        );
                       }}
                       disabled={isPublishing || !canPublish}
                       className={cn(

--- a/apps/web/src/features/data-marts/edit/model/context/types.ts
+++ b/apps/web/src/features/data-marts/edit/model/context/types.ts
@@ -113,6 +113,8 @@ export interface DataMartContextType extends DataMartState {
   ) => Promise<void>;
   runSchemaActualization?: () => Promise<void>;
   isSchemaActualizationLoading?: boolean;
+  /** Publishes through the Data Mart page flow and returns whether it succeeded. */
+  publishDataMartWithEffects?: () => Promise<boolean>;
   registerSchemaGuard?: (registration: SchemaGuardRegistration | null) => void;
   runGuarded?: (action: GuardedAction, opts: { intent: SchemaGuardIntent }) => void;
   error: ApiError | null;

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/AddReportButton.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/AddReportButton.tsx
@@ -6,8 +6,8 @@ interface AddReportButtonProps {
 }
 
 /**
- * Add Report Button component with conditional rendering and tooltip
- * Only shows for Google Sheets destinations with proper validation
+ * Button that triggers report creation.
+ * Destination-type filtering and visibility are handled by the parent DestinationCard.
  */
 export function AddReportButton({ onAddReport }: AddReportButtonProps) {
   return (

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/AddReportButton.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/AddReportButton.tsx
@@ -1,11 +1,7 @@
 import { Button } from '@owox/ui/components/button';
 import { PlusIcon } from 'lucide-react';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
-import { DataMartStatus } from '../../../../shared/enums/data-mart-status.enum';
-import type { DataMartStatusInfo } from '../../../../shared/types/data-mart-status.model';
 
 interface AddReportButtonProps {
-  dataMartStatus?: DataMartStatusInfo;
   onAddReport: () => void;
 }
 
@@ -13,32 +9,18 @@ interface AddReportButtonProps {
  * Add Report Button component with conditional rendering and tooltip
  * Only shows for Google Sheets destinations with proper validation
  */
-export function AddReportButton({ dataMartStatus, onAddReport }: AddReportButtonProps) {
-  const isDisabled = dataMartStatus?.code === DataMartStatus.DRAFT;
-
+export function AddReportButton({ onAddReport }: AddReportButtonProps) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span>
-          <Button
-            onClick={onAddReport}
-            variant='outline'
-            size='sm'
-            aria-label='Add new report'
-            disabled={isDisabled}
-            data-testid='reportCreateButton'
-            className='text-foreground'
-          >
-            <PlusIcon className='text-foreground h-4 w-4' />
-            New Report
-          </Button>
-        </span>
-      </TooltipTrigger>
-      {isDisabled && (
-        <TooltipContent>
-          <p>To create a report, publish the Data Mart first</p>
-        </TooltipContent>
-      )}
-    </Tooltip>
+    <Button
+      onClick={onAddReport}
+      variant='outline'
+      size='sm'
+      aria-label='Add new report'
+      data-testid='reportCreateButton'
+      className='text-foreground'
+    >
+      <PlusIcon className='text-foreground h-4 w-4' />
+      New Report
+    </Button>
   );
 }

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.test.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DataDestinationType } from '../../../../../data-destination';
+import { DataMartStatus } from '../../../../shared';
+import type { DataDestination } from '../../../../../data-destination';
+import { DestinationCard } from './DestinationCard';
+
+const mocks = vi.hoisted(() => ({
+  handleAddReport: vi.fn(),
+  handleCloseModal: vi.fn(),
+}));
+
+vi.mock('../../../../../data-destination', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../../../data-destination')>();
+  return {
+    ...actual,
+    useDataDestination: () => ({ dataDestinations: [] }),
+    useDataDestinationVisibility: () => ({
+      destinationInfo: { icon: () => null },
+      isVisible: true,
+    }),
+  };
+});
+
+vi.mock('../../model/hooks', () => ({
+  useReportSidesheet: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return {
+      isOpen,
+      mode: 'create',
+      editingReport: null,
+      handleAddReport: () => {
+        mocks.handleAddReport();
+        setIsOpen(true);
+      },
+      handleEditReport: vi.fn(),
+      handleCloseModal: mocks.handleCloseModal,
+    };
+  },
+}));
+
+vi.mock('../../../shared', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../shared')>();
+  return { ...actual, useReport: () => ({ reports: [] }) };
+});
+
+vi.mock('./index', () => ({
+  AddReportButton: ({ onAddReport }: { onAddReport: () => void }) => (
+    <button type='button' onClick={onAddReport}>
+      New Report
+    </button>
+  ),
+  ReportListRenderer: () => null,
+  ReportEditSheetRenderer: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div role='dialog'>Report form</div> : null,
+}));
+
+const destination = {
+  id: 'destination-1',
+  title: 'Google Sheets',
+  type: DataDestinationType.GOOGLE_SHEETS,
+} as DataDestination;
+
+describe('DestinationCard report creation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the report form immediately for a published Data Mart', () => {
+    render(<DestinationCard destination={destination} dataMartStatus={publishedStatus} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Report' }));
+
+    expect(mocks.handleAddReport).toHaveBeenCalledOnce();
+    expect(screen.getByRole('dialog')).toHaveTextContent('Report form');
+  });
+
+  it('publishes a draft Data Mart, then opens the report form', async () => {
+    const onPublishDataMart = vi.fn().mockResolvedValue(true);
+    render(
+      <DestinationCard
+        destination={destination}
+        dataMartStatus={draftStatus}
+        canPublish
+        onPublishDataMart={onPublishDataMart}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Report' }));
+    expect(screen.getByRole('alertdialog')).toHaveTextContent(
+      'Publish Data Mart to create a report?'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Publish and create report' }));
+
+    await waitFor(() => {
+      expect(onPublishDataMart).toHaveBeenCalledOnce();
+    });
+    await waitFor(() => {
+      expect(mocks.handleAddReport).toHaveBeenCalledOnce();
+    });
+    expect(screen.getByRole('dialog')).toHaveTextContent('Report form');
+  });
+
+  it('shows the setup dialog for a draft Data Mart that cannot be published', () => {
+    const onReviewDataSetup = vi.fn();
+    render(
+      <DestinationCard
+        destination={destination}
+        dataMartStatus={draftStatus}
+        validationErrors={[]}
+        onReviewDataSetup={onReviewDataSetup}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Report' }));
+    expect(screen.getByRole('alertdialog')).toHaveTextContent('Complete Data Mart setup first');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Review Data Setup' }));
+    expect(onReviewDataSetup).toHaveBeenCalledOnce();
+  });
+});
+
+const publishedStatus = {
+  code: DataMartStatus.PUBLISHED,
+  displayName: 'Published',
+  description: '',
+};
+const draftStatus = { code: DataMartStatus.DRAFT, displayName: 'Draft', description: '' };

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.test.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.test.tsx
@@ -117,7 +117,7 @@ describe('DestinationCard report creation', () => {
     fireEvent.click(screen.getByRole('button', { name: 'New Report' }));
     expect(screen.getByRole('alertdialog')).toHaveTextContent('Complete Data Mart setup first');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Review Data Setup' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open Data Setup' }));
     expect(onReviewDataSetup).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
@@ -153,7 +153,6 @@ export function DestinationCard({
             <ReportListRenderer
               destination={destination}
               onEditReport={handleEditReport}
-              dataMartStatus={dataMartStatus}
               onAddReport={handleAddReportRequest}
             />
           </CollapsibleCardContent>

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
@@ -1,4 +1,14 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@owox/ui/components/alert-dialog';
+import { Button } from '@owox/ui/components/button';
 import {
   CollapsibleCard,
   CollapsibleCardHeader,
@@ -7,7 +17,12 @@ import {
   CollapsibleCardFooter,
   CollapsibleCardHeaderActions,
 } from '../../../../../../shared/components/CollapsibleCard';
-import type { DataMartStatusInfo } from '../../../../shared';
+import {
+  DataMartStatus,
+  getRequiredSetupActions,
+  type DataMartStatusInfo,
+  type DataMartValidationError,
+} from '../../../../shared';
 import type { DataDestination } from '../../../../../data-destination';
 import { useDataDestination, useDataDestinationVisibility } from '../../../../../data-destination';
 import { useReportSidesheet } from '../../model/hooks';
@@ -19,6 +34,10 @@ import { useReport } from '../../../shared';
 interface DestinationCardProps {
   destination: DataDestination;
   dataMartStatus?: DataMartStatusInfo;
+  canPublish?: boolean;
+  validationErrors?: DataMartValidationError[];
+  onPublishDataMart?: () => Promise<boolean>;
+  onReviewDataSetup?: () => void;
 }
 
 const reportDestinationTypes = [
@@ -51,8 +70,17 @@ function useDestinationStats(destinationId: string) {
  * - Allows adding and editing reports via a modal
  * - Renders a report table inside the card
  */
-export function DestinationCard({ destination, dataMartStatus }: DestinationCardProps) {
+export function DestinationCard({
+  destination,
+  dataMartStatus,
+  canPublish = false,
+  validationErrors = [],
+  onPublishDataMart,
+  onReviewDataSetup,
+}: DestinationCardProps) {
   const { destinationInfo, isVisible } = useDataDestinationVisibility(destination);
+  const [dialog, setDialog] = useState<'publish' | 'setup' | null>(null);
+  const [isPublishing, setIsPublishing] = useState(false);
 
   // Modal state and handlers for creating/editing reports
   const { isOpen, mode, editingReport, handleAddReport, handleEditReport, handleCloseModal } =
@@ -64,6 +92,36 @@ export function DestinationCard({ destination, dataMartStatus }: DestinationCard
     destination.type === DataDestinationType.GOOGLE_SHEETS &&
     reportsCount === 0 &&
     googleSheetsCount === 1;
+
+  const isDraft = dataMartStatus?.code === DataMartStatus.DRAFT;
+  const requiredSetupActions = getRequiredSetupActions(validationErrors);
+
+  const handleAddReportRequest = useCallback(() => {
+    if (!isDraft) {
+      handleAddReport();
+      return;
+    }
+
+    setDialog(canPublish ? 'publish' : 'setup');
+  }, [canPublish, handleAddReport, isDraft]);
+
+  const handlePublishAndCreateReport = useCallback(async () => {
+    if (!onPublishDataMart) return;
+
+    setIsPublishing(true);
+    const published = await onPublishDataMart().catch(() => false);
+    setIsPublishing(false);
+    setDialog(null);
+
+    if (published) {
+      handleAddReport();
+    }
+  }, [handleAddReport, onPublishDataMart]);
+
+  const handleReviewDataSetup = useCallback(() => {
+    setDialog(null);
+    onReviewDataSetup?.();
+  }, [onReviewDataSetup]);
 
   // Skip rendering if destination is not active
   if (!isVisible) {
@@ -85,7 +143,7 @@ export function DestinationCard({ destination, dataMartStatus }: DestinationCard
             <CollapsibleCardHeaderActions>
               {/* Render AddReportButton only for Google Sheets*/}
               {reportDestinationTypes.includes(destination.type) && (
-                <AddReportButton dataMartStatus={dataMartStatus} onAddReport={handleAddReport} />
+                <AddReportButton onAddReport={handleAddReportRequest} />
               )}
             </CollapsibleCardHeaderActions>
           </CollapsibleCardHeader>
@@ -96,7 +154,7 @@ export function DestinationCard({ destination, dataMartStatus }: DestinationCard
               destination={destination}
               onEditReport={handleEditReport}
               dataMartStatus={dataMartStatus}
-              onAddReport={handleAddReport}
+              onAddReport={handleAddReportRequest}
             />
           </CollapsibleCardContent>
 
@@ -119,6 +177,41 @@ export function DestinationCard({ destination, dataMartStatus }: DestinationCard
         mode={mode}
         initialReport={editingReport}
       />
+
+      <AlertDialog
+        open={dialog !== null}
+        onOpenChange={open => {
+          if (!open && !isPublishing) setDialog(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {dialog === 'publish'
+                ? 'Publish Data Mart to create a report?'
+                : 'Complete Data Mart setup first'}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {dialog === 'publish'
+                ? 'Reports are available only for published Data Marts. We’ll open the new report form when publishing is complete.'
+                : requiredSetupActions.length > 0
+                  ? `Complete the required setup before publishing this Data Mart and creating a report: ${requiredSetupActions.join(', ')}.`
+                  : 'Complete the required setup before publishing this Data Mart and creating a report.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPublishing}>Cancel</AlertDialogCancel>
+            {dialog === 'publish' ? (
+              <Button onClick={() => void handlePublishAndCreateReport()} disabled={isPublishing}>
+                {isPublishing ? 'Publishing…' : 'Publish and create report'}
+              </Button>
+            ) : (
+              <Button onClick={handleReviewDataSetup}>Review Data Setup</Button>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
@@ -48,6 +48,8 @@ const reportDestinationTypes = [
   DataDestinationType.GOOGLE_CHAT,
 ];
 
+type ReportCreationDialog = 'publish' | 'setup';
+
 /**
  * Returns stats for a destination: report count and total Google Sheets destinations.
  */
@@ -79,7 +81,8 @@ export function DestinationCard({
   onReviewDataSetup,
 }: DestinationCardProps) {
   const { destinationInfo, isVisible } = useDataDestinationVisibility(destination);
-  const [dialog, setDialog] = useState<'publish' | 'setup' | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [dialogContent, setDialogContent] = useState<ReportCreationDialog>('setup');
   const [isPublishing, setIsPublishing] = useState(false);
 
   // Modal state and handlers for creating/editing reports
@@ -102,7 +105,8 @@ export function DestinationCard({
       return;
     }
 
-    setDialog(canPublish ? 'publish' : 'setup');
+    setDialogContent(canPublish ? 'publish' : 'setup');
+    setIsDialogOpen(true);
   }, [canPublish, handleAddReport, isDraft]);
 
   const handlePublishAndCreateReport = useCallback(async () => {
@@ -111,7 +115,7 @@ export function DestinationCard({
     setIsPublishing(true);
     const published = await onPublishDataMart().catch(() => false);
     setIsPublishing(false);
-    setDialog(null);
+    setIsDialogOpen(false);
 
     if (published) {
       handleAddReport();
@@ -119,7 +123,7 @@ export function DestinationCard({
   }, [handleAddReport, onPublishDataMart]);
 
   const handleReviewDataSetup = useCallback(() => {
-    setDialog(null);
+    setIsDialogOpen(false);
     onReviewDataSetup?.();
   }, [onReviewDataSetup]);
 
@@ -178,35 +182,42 @@ export function DestinationCard({
       />
 
       <AlertDialog
-        open={dialog !== null}
+        open={isDialogOpen}
         onOpenChange={open => {
-          if (!open && !isPublishing) setDialog(null);
+          if (!open && !isPublishing) setIsDialogOpen(false);
         }}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {dialog === 'publish'
+              {dialogContent === 'publish'
                 ? 'Publish Data Mart to create a report?'
                 : 'Complete Data Mart setup first'}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {dialog === 'publish'
+              {dialogContent === 'publish'
                 ? 'Reports are available only for published Data Marts. We’ll open the new report form when publishing is complete.'
-                : requiredSetupActions.length > 0
-                  ? `Complete the required setup before publishing this Data Mart and creating a report: ${requiredSetupActions.join(', ')}.`
-                  : 'Complete the required setup before publishing this Data Mart and creating a report.'}
+                : requiredSetupActions.length === 1
+                  ? `Before creating a report, ${requiredSetupActions[0]}.`
+                  : 'Before creating a report the required setup is needed:'}
             </AlertDialogDescription>
+            {dialogContent === 'setup' && requiredSetupActions.length > 1 && (
+              <ul className='text-muted-foreground list-disc space-y-0.5 pl-5 text-sm'>
+                {requiredSetupActions.map(action => (
+                  <li key={action}>{action}</li>
+                ))}
+              </ul>
+            )}
           </AlertDialogHeader>
 
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isPublishing}>Cancel</AlertDialogCancel>
-            {dialog === 'publish' ? (
+            {dialogContent === 'publish' ? (
               <Button onClick={() => void handlePublishAndCreateReport()} disabled={isPublishing}>
                 {isPublishing ? 'Publishing…' : 'Publish and create report'}
               </Button>
             ) : (
-              <Button onClick={handleReviewDataSetup}>Review Data Setup</Button>
+              <Button onClick={handleReviewDataSetup}>Open Data Setup</Button>
             )}
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/ReportListRenderer.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/ReportListRenderer.tsx
@@ -4,19 +4,16 @@ import { EmailReportsTable } from '../EmailReportsTable';
 import { LookerStudioReportCard } from '../LookerStudioReportCard';
 import type { DataDestination } from '../../../../../data-destination';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
-import type { DataMartStatusInfo } from '../../../../shared/types/data-mart-status.model';
 
 interface ReportListRendererProps {
   destination: DataDestination;
   onEditReport: (report: DataMartReport) => void;
-  dataMartStatus?: DataMartStatusInfo;
   onAddReport: () => void;
 }
 
 export function ReportListRenderer({
   destination,
   onEditReport,
-  dataMartStatus,
   onAddReport,
 }: ReportListRendererProps) {
   switch (destination.type) {
@@ -25,7 +22,6 @@ export function ReportListRenderer({
         <GoogleSheetsReportsTable
           destination={destination}
           onEditReport={onEditReport}
-          dataMartStatus={dataMartStatus}
           onAddReport={onAddReport}
         />
       );
@@ -39,7 +35,6 @@ export function ReportListRenderer({
           destinationType={destination.type}
           destination={destination}
           onEditReport={onEditReport}
-          dataMartStatus={dataMartStatus}
           onAddReport={onAddReport}
         />
       );

--- a/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailReportsTable.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/EmailReportsTable/EmailReportsTable.tsx
@@ -7,14 +7,12 @@ import { DataDestinationType } from '../../../../../data-destination';
 import type { DataDestination } from '../../../../../data-destination';
 import { useBaseTable } from '../../../../../../shared/hooks';
 import { BaseTable } from '../../../../../../shared/components/Table';
-import type { DataMartStatusInfo } from '../../../../shared/types/data-mart-status.model';
 import { AddReportButton } from '../DestinationCard/AddReportButton';
 
 interface EmailReportsTableProps {
   destinationType: DataDestinationType;
   destination: DataDestination;
   onEditReport: (report: DataMartReport) => void;
-  dataMartStatus?: DataMartStatusInfo;
   onAddReport: () => void;
 }
 
@@ -28,7 +26,6 @@ export function EmailReportsTable({
   destinationType,
   destination,
   onEditReport,
-  dataMartStatus,
   onAddReport,
 }: EmailReportsTableProps) {
   const { reports, setPollingConfig } = useReport();
@@ -98,7 +95,7 @@ export function EmailReportsTable({
           <p className='text-muted-foreground text-sm font-medium'>
             Create your first report for this destination
           </p>
-          <AddReportButton dataMartStatus={dataMartStatus} onAddReport={onAddReport} />
+          <AddReportButton onAddReport={onAddReport} />
         </div>
       )}
     />

--- a/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsReportsTable.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/GoogleSheetsReportsTable/GoogleSheetsReportsTable.tsx
@@ -8,14 +8,12 @@ import type { DataDestination } from '../../../../../data-destination';
 import { useBaseTable } from '../../../../../../shared/hooks';
 import { BaseTable } from '../../../../../../shared/components/Table';
 import { AddReportButton } from '../DestinationCard/AddReportButton';
-import type { DataMartStatusInfo } from '../../../../shared/types/data-mart-status.model';
 import { useRefreshSetupProgress } from '../../../../../../components/AppSidebar/SetupChecklist/useSetupProgress';
 import { ReportStatusEnum } from '../../../shared/enums';
 
 interface GoogleSheetsReportsTableProps {
   destination: DataDestination;
   onEditReport: (report: DataMartReport) => void;
-  dataMartStatus?: DataMartStatusInfo;
   onAddReport: () => void;
 }
 
@@ -28,7 +26,6 @@ interface GoogleSheetsReportsTableProps {
 export function GoogleSheetsReportsTable({
   destination,
   onEditReport,
-  dataMartStatus,
   onAddReport,
 }: GoogleSheetsReportsTableProps) {
   const { reports, setPollingConfig } = useReport();
@@ -113,7 +110,7 @@ export function GoogleSheetsReportsTable({
           <p className='text-muted-foreground text-sm font-medium'>
             Create your first report for this destination
           </p>
-          <AddReportButton dataMartStatus={dataMartStatus} onAddReport={onAddReport} />
+          <AddReportButton onAddReport={onAddReport} />
         </div>
       )}
     />

--- a/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
+++ b/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
@@ -23,10 +23,10 @@ import { InviteTeammatesCard } from '../../../shared/components/InviteTeammatesC
 import { useProjectRoute } from '../../../shared/hooks/useProjectRoute';
 
 function DataMartDestinationsContentInner() {
-  const { dataMart } = useOutletContext<DataMartContextType>();
+  const { dataMart, publishDataMartWithEffects } = useOutletContext<DataMartContextType>();
   const { dataDestinations, isLoading, fetchDataDestinations } = useDataDestinationsWithReports();
   const [isCreateDestinationOpen, setIsCreateDestinationOpen] = useState(false);
-  const { scope } = useProjectRoute();
+  const { scope, navigate } = useProjectRoute();
   const handleOpenCreateDestination = useCallback(() => {
     setIsCreateDestinationOpen(true);
   }, []);
@@ -72,6 +72,12 @@ function DataMartDestinationsContentInner() {
               key={destination.id}
               destination={destination}
               dataMartStatus={dataMart.status}
+              canPublish={dataMart.canPublish}
+              validationErrors={dataMart.validationErrors}
+              onPublishDataMart={publishDataMartWithEffects}
+              onReviewDataSetup={() => {
+                navigate(`/data-marts/${dataMart.id}/data-setup`);
+              }}
             />
           ))}
           {showSheetsUpsellPromo && (


### PR DESCRIPTION
Creating a report from a draft Data Mart no longer dead-ends at a disabled "New Report" button. Clicking it now takes the user straight to the next actionable step instead of forcing them to leave the page, find the publish button, and come back.

- If the Data Mart is ready to publish → a confirmation dialog offers **"Publish and create report"**, which publishes the Data Mart and opens the new report form in one action.
- If something is still missing (e.g. Storage or Input Source) → the dialog explains exactly what's missing and offers **"Review Data Setup"**, which navigates to the Data Setup tab.

<img width="1522" height="605" alt="Screenshot 2026-08-12 222335" src="https://github.com/user-attachments/assets/b09f9b2a-9550-4255-9312-0a5ed57f57d4" />
