### PR TITLE
docs(facebook-marketing): document ad-account rate limits

### DIFF
--- a/packages/connectors/src/Sources/FacebookMarketing/TROUBLESHOOTING.md
+++ b/packages/connectors/src/Sources/FacebookMarketing/TROUBLESHOOTING.md
@@ -13,7 +13,7 @@ Before changing credentials or app settings, check these items:
 - Check **Facebook access**: the authorized Facebook user must access every selected ad account.
 - Check **Permissions**: the token must include `ads_read` and `ads_management`.
 - For large backfills, reduce the date range, selected fields, or breakdowns.
-- If the error continues, open the Data Mart settings, expand **Advanced settings**, lower **API Page Limit** (for example to `25`), then save and rerun.
+- If Meta asks you to reduce the amount of data, open the Data Mart settings, expand **Advanced settings**, lower **API Page Limit** (for example to `25`), then save and rerun. Do not lower it for rate limit errors, because a smaller page size increases the number of calls.
 
 If these checks look correct, match the **Run history** error with the cases below.
 
@@ -26,9 +26,32 @@ If these checks look correct, match the **Run history** error with the cases bel
 | App is not approved, app is in Development mode, or the app cannot access this ad account | The Meta app or user cannot access the selected ad account. Development mode only works for app roles. | Test with a user assigned to the Meta app and ad account. For external accounts, check App Review, advanced access, Marketing API access, and Business Verification. |
 | Account does not exist, account cannot load, or `Unsupported get request` | The Account ID is wrong. It may include `act_`, or the user lacks access. | Enter the numeric Account ID only. Remove `act_`. Confirm Admin, Advertiser, or Analyst access. |
 | Import fails for only one account in a multi-account setup | One Account ID is invalid, or the user lacks access to that account. | Run the Data Mart with one Account ID at a time. Find the failing account. Then fix the ID or Meta access. |
+| `There have been too many calls to this ad-account` (code `80004`, subcode `2446079`) | Meta throttled ads management calls for one ad account. Every account has an hourly call budget. | See [Ad Account Rate Limits](#ad-account-rate-limits). |
 | Rate limit errors, `Application request limit reached`, or `User request limit reached` | Meta throttled requests for the app, user, or ad account. | Wait and rerun later. If the error repeats, reduce run frequency, date range, selected accounts, fields, or breakdowns. |
 | `Please reduce the amount of data you're asking for, then retry your request` or request timeout errors | The request asks Meta for too much data. | Reduce the date range, fields, or breakdowns. Then lower **API Page Limit** in **Advanced settings** and rerun. |
 | Empty results with no obvious API error | The date range has no delivery data. The selected fields may have no values. | Check the same date range in Meta Ads Manager. Then try **Ad Account Insights** with spend, clicks, and impressions. |
+
+## Ad Account Rate Limits
+
+Meta counts API calls per ad account in a rolling one-hour window. Your Meta app's access tier sets the budget:
+
+| Access tier | Calls per hour, per ad account |
+| --- | --- |
+| Development access | 300 + 40 × active ads |
+| Advanced access | 100 000 + 40 × active ads |
+
+Meta counts requests, not rows. An ad account with 7 000 creatives costs 70 calls at an **API Page Limit** of `100`.
+
+After a rate limit error, do this:
+
+1. Stop the Data Mart and wait at least one hour. More calls extend the block.
+2. Raise **API Page Limit** in **Advanced settings**. A limit of `500` cuts the call count fivefold.
+3. Remove fields you do not report on. Large fields slow every call.
+4. Split ad accounts across several Data Marts. Stagger the schedules by an hour.
+5. Lower the run frequency. Catalog endpoints such as Ad Creatives change slowly.
+6. Apply for Advanced Access in your Meta app. This raises the budget to 100 000 calls.
+
+Meta explains the full model in [Marketing API rate limiting](https://developers.facebook.com/docs/marketing-api/overview/rate-limiting).
 
 ## Still Blocked
 


### PR DESCRIPTION
# Problem

Facebook Ads imports fail with `There have been too many calls to this ad-account` (Meta error code `80004`, subcode `2446079`) when a Data Mart pulls many ad accounts in one run. Nothing in the troubleshooting guide matched that message: the existing rate limit row only covered `Application request limit reached` and `User request limit reached`, which are app- and user-level errors with a different cause. Worse, the guide's generic advice pointed the wrong way — Quick Checks told users to lower **API Page Limit** whenever an error persisted, but Meta budgets calls per ad account, not rows, so a smaller page size multiplies the number of calls and makes the throttling worse. Users following the docs deepened the problem they were trying to fix.

# Solution

Add a dedicated troubleshooting entry keyed to the exact error string users see, and scope the misleading page-limit advice so it no longer fires on rate limits.

- Added a row to **Common Import Errors** that quotes the Meta message plus its code and subcode, placed above the generic rate limit row so the specific case matches first.
- Added an **Ad Account Rate Limits** section explaining the hourly per-account budget by Meta access tier, the calls-not-rows distinction, and six ordered recovery steps, from waiting out the block to applying for Advanced Access.
- Reworded the Quick Checks bullet so lowering **API Page Limit** is tied to "reduce the amount of data" errors, with an explicit warning against using it for rate limits.

Only the connector source file changed. The docs site page at `packages/connectors/src/sources/facebook-marketing/troubleshooting` is generated from it by `apps/docs/scripts/sync-docs.js`, so it needs no separate edit.

# Changes

- Added a Common Import Errors row for Meta error `80004` / subcode `2446079`, linking to the new section.
- Added an `Ad Account Rate Limits` section with the per-tier hourly call budget table, an explanation that Meta counts requests rather than rows, six recovery steps, and a link to Meta's Marketing API rate limiting reference.
- Rescoped the Quick Checks **API Page Limit** bullet to data-size errors and warned that lowering it worsens rate limit errors.