### PR TITLE
fix(data-marts): escape leading + values when exporting to Google Sheets

### DIFF
--- a/.changeset/6654-apostrophe-for-plus-values-google-sheets.md
+++ b/.changeset/6654-apostrophe-for-plus-values-google-sheets.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Values starting with "+" no longer break in Google Sheets reports
+
+Google Sheets treats a cell value that starts with `+` as the beginning of a formula, so exported values like session identifiers of the form `+Dri7…` used to show up as `#ERROR! Formula parse error` instead of the data.
+
+Now the Google Sheets destination prefixes such values with an apostrophe (`'`) — the standard Sheets escape symbol. The cell displays the original value exactly as stored; the apostrophe is not part of the cell content. Only values starting with `+` are escaped: everything else, including formulas inserted as data (values starting with `=`), is exported unchanged.

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.spec.ts
@@ -6,6 +6,7 @@ import { ReportDataDescription } from '../../../dto/domain/report-data-descripti
 import { ReportDataHeader } from '../../../dto/domain/report-data-header.dto';
 import { GoogleSheetsReportWriter } from './google-sheets-report-writer';
 import { ColumnPlanBuilder } from './column-plan-builder';
+import { SheetValuesFormatter } from './sheet-formatters/sheet-values-formatter';
 
 /**
  * Targeted unit spec for {@link GoogleSheetsReportWriter}'s pre-clear
@@ -75,6 +76,12 @@ interface BuildOpts {
    * ("Automatic") column. Defaults to all-`undefined`.
    */
   columnFormats?: (sheets_v4.Schema$CellFormat | undefined)[];
+  /**
+   * Wire the real {@link SheetValuesFormatter} instead of the identity mock,
+   * so tests can prove formatter output (e.g. `+` escaping) actually reaches
+   * `adapter.updateValues` rather than being lost between collaborators.
+   */
+  useRealValuesFormatter?: boolean;
 }
 
 /**
@@ -175,9 +182,12 @@ function buildWriter(opts: BuildOpts) {
     createOwoxColumnsMetadataRequest: jest.fn().mockReturnValue({}),
     updateOwoxColumnsMetadataRequest: jest.fn().mockReturnValue({}),
   };
-  const valuesFormatter = {
-    formatRowsValuesByName: jest.fn().mockImplementation((rows: unknown[][]) => rows),
-  };
+  const valuesFormatter = opts.useRealValuesFormatter
+    ? new SheetValuesFormatter()
+    : {
+        formatRowsValuesByName: jest.fn().mockImplementation((rows: unknown[][]) => rows),
+        escapeRowValues: jest.fn().mockImplementation((row: unknown[]) => row),
+      };
 
   const appEditionConfig = { isEnterpriseEdition: jest.fn().mockReturnValue(true) };
   const publicOriginService = {
@@ -1058,6 +1068,7 @@ function buildStructuralWriter(opts: {
   };
   const valuesFormatter = {
     formatRowsValuesByName: jest.fn().mockImplementation((rows: unknown[][]) => rows),
+    escapeRowValues: jest.fn().mockImplementation((row: unknown[]) => row),
   };
   const appEditionConfig = { isEnterpriseEdition: jest.fn().mockReturnValue(true) };
   const publicOriginService = {
@@ -1319,5 +1330,28 @@ describe('GoogleSheetsReportWriter — insertDimension grid-size guard (sentinel
     );
     expect(colAppends).toEqual([]);
     expect(h.structuralBatch()).toHaveLength(h.columnPlan.ops.length);
+  });
+});
+
+describe('GoogleSheetsReportWriter — leading-+ escaping reaches the adapter (real formatter)', () => {
+  it('writes +-leading data values and header aliases apostrophe-escaped', async () => {
+    const { writer, adapter, report, finalImportedNames } = buildWriter({
+      availableRowsCount: 11,
+      useRealValuesFormatter: true,
+    });
+
+    const headers = [
+      new ReportDataHeader(finalImportedNames[0], '+Country'),
+      new ReportDataHeader(finalImportedNames[1]),
+      new ReportDataHeader(finalImportedNames[2]),
+    ];
+    await writer.prepareToWriteReport(report as never, new ReportDataDescription(headers, 1));
+    await writer.writeReportDataBatch(new ReportDataBatch([['+38050', '10', '2']]));
+
+    const writtenRows = adapter.updateValues.mock.calls.map(call => call[2]);
+    expect(writtenRows).toContainEqual([
+      ["'+Country", finalImportedNames[1], finalImportedNames[2]],
+    ]);
+    expect(writtenRows).toContainEqual([["'+38050", '10', '2']]);
   });
 });

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/google-sheets-report-writer.ts
@@ -1018,7 +1018,9 @@ export class GoogleSheetsReportWriter implements DataDestinationReportWriter {
 
       const lastA1 = GoogleSheetsApiAdapter.colToA1(finalNames.length);
       await this.adapter.updateValues(spreadsheetId, `'${this.sheetTitle}'!A1:${lastA1}1`, [
-        headerRow,
+        // An alias is free text, so it can start with `+` just like a data
+        // value — escape it the same way to keep row 1 out of formula parsing.
+        this.valuesFormatter.escapeRowValues(headerRow),
       ]);
 
       // Per-column short marker only at header-write time. Full A1 provenance

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.spec.ts
@@ -1,0 +1,90 @@
+import { BigQueryFieldType } from '../../../../data-storage-types/bigquery/enums/bigquery-field-type.enum';
+import { ReportDataHeader } from '../../../../dto/domain/report-data-header.dto';
+import { SheetValuesFormatter } from './sheet-values-formatter';
+
+describe('SheetValuesFormatter', () => {
+  let formatter: SheetValuesFormatter;
+
+  beforeEach(() => {
+    formatter = new SheetValuesFormatter();
+  });
+
+  describe('formatRowsValuesByName', () => {
+    const headersByName = new Map<string, ReportDataHeader>([
+      [
+        'session_id',
+        new ReportDataHeader('session_id', undefined, undefined, BigQueryFieldType.STRING),
+      ],
+      ['clicks', new ReportDataHeader('clicks', undefined, undefined, BigQueryFieldType.INTEGER)],
+    ]);
+    const finalNames = ['session_id', 'clicks'];
+
+    it('prefixes values starting with + with an apostrophe', () => {
+      const rows = [['+Dri7CMMPMBcFIRWcd8RP3AAIi0eVSDWK0PB7RnFQIc=', 42]];
+
+      const result = formatter.formatRowsValuesByName(rows, finalNames, headersByName, 'UTC');
+
+      expect(result).toEqual([["'+Dri7CMMPMBcFIRWcd8RP3AAIi0eVSDWK0PB7RnFQIc=", 42]]);
+    });
+
+    it('escapes + values in columns without a registered type formatter', () => {
+      const rows = [['+380501234567', '+1']];
+      const names = ['phone', 'delta'];
+
+      const result = formatter.formatRowsValuesByName(rows, names, new Map(), 'UTC');
+
+      expect(result).toEqual([["'+380501234567", "'+1"]]);
+    });
+
+    it('leaves values starting with = untouched so formulas can be inserted as data', () => {
+      const rows = [['=SUM(A1:A2)', 1]];
+
+      const result = formatter.formatRowsValuesByName(rows, finalNames, headersByName, 'UTC');
+
+      expect(result).toEqual([['=SUM(A1:A2)', 1]]);
+    });
+
+    it('leaves non-string values and strings without leading + untouched', () => {
+      const rows = [
+        ['plain text', 0],
+        ['a+b', -5],
+        [null, undefined],
+        [true, 3.14],
+      ];
+
+      const result = formatter.formatRowsValuesByName(rows, finalNames, headersByName, 'UTC');
+
+      expect(result).toEqual([
+        ['plain text', 0],
+        ['a+b', -5],
+        [null, undefined],
+        [true, 3.14],
+      ]);
+    });
+
+    it('still applies the timestamp formatter alongside + escaping', () => {
+      const timestampHeaders = new Map<string, ReportDataHeader>([
+        ['ts', new ReportDataHeader('ts', undefined, undefined, BigQueryFieldType.TIMESTAMP)],
+        ['id', new ReportDataHeader('id', undefined, undefined, BigQueryFieldType.STRING)],
+      ]);
+      const rows = [['2026-01-02T03:04:05Z', '+abc']];
+
+      const result = formatter.formatRowsValuesByName(rows, ['ts', 'id'], timestampHeaders, 'UTC');
+
+      expect(result).toEqual([['2026-01-02 03:04:05', "'+abc"]]);
+    });
+  });
+
+  describe('formatRowsValues', () => {
+    it('prefixes values starting with + with an apostrophe', () => {
+      const headers = [
+        new ReportDataHeader('session_id', undefined, undefined, BigQueryFieldType.STRING),
+      ];
+      const rows = [['+value'], ['regular'], [123]];
+
+      const result = formatter.formatRowsValues(rows, headers, 'UTC');
+
+      expect(result).toEqual([["'+value"], ['regular'], [123]]);
+    });
+  });
+});

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.spec.ts
@@ -85,17 +85,4 @@ describe('SheetValuesFormatter', () => {
       expect(row).toEqual(["'+Header alias", 'plain', 42, null]);
     });
   });
-
-  describe('formatRowsValues', () => {
-    it('prefixes values starting with + with an apostrophe', () => {
-      const headers = [
-        new ReportDataHeader('session_id', undefined, undefined, BigQueryFieldType.STRING),
-      ];
-      const rows = [['+value'], ['regular'], [123]];
-
-      const result = formatter.formatRowsValues(rows, headers, 'UTC');
-
-      expect(result).toEqual([["'+value"], ['regular'], [123]]);
-    });
-  });
 });

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.spec.ts
@@ -75,6 +75,17 @@ describe('SheetValuesFormatter', () => {
     });
   });
 
+  describe('escapeRowValues', () => {
+    it('escapes + values in place and returns the same row', () => {
+      const row = ['+Header alias', 'plain', 42, null];
+
+      const result = formatter.escapeRowValues(row);
+
+      expect(result).toBe(row);
+      expect(row).toEqual(["'+Header alias", 'plain', 42, null]);
+    });
+  });
+
   describe('formatRowsValues', () => {
     it('prefixes values starting with + with an apostrophe', () => {
       const headers = [

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
@@ -22,40 +22,11 @@ export class SheetValuesFormatter {
   ]);
 
   /**
-   * Formats values in rows based on field types
-   * @param rows - Rows to format
-   * @param dataHeaders - Headers for the rows
-   * @param sheetTimeZone - Time zone of the sheet
-   * @returns Formatted rows
-   */
-  public formatRowsValues(
-    rows: unknown[][],
-    dataHeaders: ReportDataHeader[],
-    sheetTimeZone: string
-  ): unknown[][] {
-    const columnsToFormat = dataHeaders
-      .map((header, index) => ({
-        index,
-        formatter: this.formatters.get(header.storageFieldType!),
-      }))
-      .filter(item => item.formatter);
-
-    rows.forEach(row => {
-      columnsToFormat.forEach(({ index, formatter }) => {
-        row[index] = formatter!(row[index], sheetTimeZone);
-      });
-      this.escapeRowValues(row);
-    });
-
-    return rows;
-  }
-
-  /**
-   * Same as {@link formatRowsValues} but resolves the per-column formatter by
-   * column **name** instead of position. Used by the diff-based writer where
-   * each row has already been reordered to match the user's column layout in
-   * the destination sheet, so positional alignment with the SQL output schema
-   * no longer holds.
+   * Formats values in rows based on field types, resolving the per-column
+   * formatter by column **name**. Used by the diff-based writer where each
+   * row has already been reordered to match the user's column layout in the
+   * destination sheet, so positional alignment with the SQL output schema
+   * does not hold.
    *
    * Nullish cells (SQL `NULL` → JavaScript `null`/`undefined`) pass through
    * unchanged. The writer pre-clears the imported rectangle before writing

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
@@ -44,7 +44,7 @@ export class SheetValuesFormatter {
       columnsToFormat.forEach(({ index, formatter }) => {
         row[index] = formatter!(row[index], sheetTimeZone);
       });
-      this.escapeLeadingPlus(row);
+      this.escapeRowValues(row);
     });
 
     return rows;
@@ -88,7 +88,7 @@ export class SheetValuesFormatter {
       columnsToFormat.forEach(({ index, formatter }) => {
         row[index] = formatter!(row[index], sheetTimeZone);
       });
-      this.escapeLeadingPlus(row);
+      this.escapeRowValues(row);
     });
 
     return orderedRows;
@@ -101,14 +101,19 @@ export class SheetValuesFormatter {
    * symbol: the cell shows the original value and the apostrophe itself is not
    * part of the cell content. Only `+` is escaped — values starting with `=`
    * intentionally stay untouched so that formulas can be inserted as data.
+   *
+   * Mutates the row in place and returns it. Public so that every row written
+   * through `USER_ENTERED` — including the header row, where a user-defined
+   * column alias may start with `+` — is escaped the same way.
    */
-  private escapeLeadingPlus(row: unknown[]): void {
+  public escapeRowValues<T extends unknown[]>(row: T): T {
     for (let i = 0; i < row.length; i++) {
       const value = row[i];
       if (typeof value === 'string' && value.startsWith('+')) {
         row[i] = `'${value}`;
       }
     }
+    return row;
   }
 
   private formatTimestamp(value: unknown, sheetTimeZone: string): unknown {

--- a/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
+++ b/apps/backend/src/data-marts/data-destination-types/google-sheets/services/sheet-formatters/sheet-values-formatter.ts
@@ -40,13 +40,12 @@ export class SheetValuesFormatter {
       }))
       .filter(item => item.formatter);
 
-    if (columnsToFormat.length > 0) {
-      rows.forEach(row => {
-        columnsToFormat.forEach(({ index, formatter }) => {
-          row[index] = formatter!(row[index], sheetTimeZone);
-        });
+    rows.forEach(row => {
+      columnsToFormat.forEach(({ index, formatter }) => {
+        row[index] = formatter!(row[index], sheetTimeZone);
       });
-    }
+      this.escapeLeadingPlus(row);
+    });
 
     return rows;
   }
@@ -85,15 +84,31 @@ export class SheetValuesFormatter {
       })
       .filter(item => item.formatter);
 
-    if (columnsToFormat.length > 0) {
-      orderedRows.forEach(row => {
-        columnsToFormat.forEach(({ index, formatter }) => {
-          row[index] = formatter!(row[index], sheetTimeZone);
-        });
+    orderedRows.forEach(row => {
+      columnsToFormat.forEach(({ index, formatter }) => {
+        row[index] = formatter!(row[index], sheetTimeZone);
       });
-    }
+      this.escapeLeadingPlus(row);
+    });
 
     return orderedRows;
+  }
+
+  /**
+   * The data write uses `valueInputOption: 'USER_ENTERED'`, which makes Sheets
+   * parse a leading `+` as the start of a formula and render the cell as
+   * `#ERROR! Formula parse error`. A leading apostrophe is the Sheets escape
+   * symbol: the cell shows the original value and the apostrophe itself is not
+   * part of the cell content. Only `+` is escaped — values starting with `=`
+   * intentionally stay untouched so that formulas can be inserted as data.
+   */
+  private escapeLeadingPlus(row: unknown[]): void {
+    for (let i = 0; i < row.length; i++) {
+      const value = row[i];
+      if (typeof value === 'string' && value.startsWith('+')) {
+        row[i] = `'${value}`;
+      }
+    }
   }
 
   private formatTimestamp(value: unknown, sheetTimeZone: string): unknown {


### PR DESCRIPTION
## Problem

Google Sheets parses a cell value that starts with `+` as the beginning of a formula. Exported values like `+Dri7…` (e.g. session identifiers) rendered as `#ERROR! Formula parse error` instead of the data, because the destination writes values with `valueInputOption: 'USER_ENTERED'`.

## Solution

`SheetValuesFormatter` now prefixes string values that start with `+` with an apostrophe (`'`) — the standard Sheets escape symbol. The cell displays the original value exactly as stored; the apostrophe is not part of the cell content.

Only `+` is escaped, deliberately:
- values starting with `=` stay untouched, so formulas can still be inserted as data (unlike Connected Sheets, which escapes everything and blocks formulas);
- numbers, dates, nulls and all other values are exported unchanged.

The escape is applied in the single value-formatting layer used by every write path (manual report runs, scheduled runs, MCP), so all export scenarios are covered. It is a first-char check per cell — no measurable impact on write time.

## Testing

- New `sheet-values-formatter.spec.ts`: `+` values get the apostrophe (including columns without a registered type formatter), `=` formulas and non-string values stay untouched, timestamp formatting still applies.
- `google-sheets-report-writer.spec.ts` — 35/35 green.
- `nest build`, eslint, prettier — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)