### PR TITLE
Improve Google Chat setup guidance and delivery logs

### DIFF
--- a/.changeset/google-chat-webhook-adjustments.md
+++ b/.changeset/google-chat-webhook-adjustments.md
@@ -1,0 +1,10 @@
+---
+'owox': minor
+---
+
+# Improve Google Chat setup guidance and delivery logs
+
+Google Chat destination settings now provide contextual instructions for choosing a delivery
+method and obtaining an incoming webhook URL or space email address. Report run logs also identify
+the delivery method and destination without exposing webhook credentials, with per-part entries
+shown only when a report is split across multiple Google Chat messages.

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.spec.ts
@@ -31,6 +31,7 @@ describe('GoogleChatReportWriter', () => {
       },
       dataDestination: {
         id: 'destination-1',
+        title: 'Team Chat',
         type: DataDestinationType.GOOGLE_CHAT,
       },
       dataMart: {
@@ -103,13 +104,15 @@ describe('GoogleChatReportWriter', () => {
     expect(eventDispatcher.publishExternal.mock.calls[0][0].name).toBe(
       'google-chat.report.run.successfully'
     );
-    expect(executionLogger.log).toHaveBeenCalledWith({
-      type: 'google_chat_part_sent',
-      part: 1,
-      totalParts: 1,
-    });
+    expect(executionLogger.log).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'google_chat_part_sent' })
+    );
     expect(executionLogger.log).toHaveBeenCalledWith({
       type: 'google_chat_sent',
+      deliveryMethod: 'incoming_webhook',
+      destinationId: 'destination-1',
+      destinationTitle: 'Team Chat',
+      spaceId: 'space-1',
       messageCount: 1,
     });
   });
@@ -128,11 +131,19 @@ describe('GoogleChatReportWriter', () => {
 
     expect(executionLogger.log).toHaveBeenCalledWith({
       type: 'google_chat_part_sent',
+      deliveryMethod: 'incoming_webhook',
+      destinationId: 'destination-1',
+      destinationTitle: 'Team Chat',
+      spaceId: 'space-1',
       part: 1,
       totalParts: 2,
     });
     expect(executionLogger.log).toHaveBeenCalledWith({
       type: 'google_chat_part_failed',
+      deliveryMethod: 'incoming_webhook',
+      destinationId: 'destination-1',
+      destinationTitle: 'Team Chat',
+      spaceId: 'space-1',
       part: 2,
       totalParts: 2,
       deliveredParts: 1,
@@ -143,7 +154,7 @@ describe('GoogleChatReportWriter', () => {
   });
 
   it('delivers through the Google Chat channel email when configured', async () => {
-    const { writer, emailProvider, webhookClient } = createWriter({
+    const { writer, emailProvider, webhookClient, executionLogger } = createWriter({
       type: 'email-credentials',
       to: ['space@example.com'],
     });
@@ -157,6 +168,13 @@ describe('GoogleChatReportWriter', () => {
       expect.any(String)
     );
     expect(webhookClient.send).not.toHaveBeenCalled();
+    expect(executionLogger.log).toHaveBeenCalledWith({
+      type: 'google_chat_sent',
+      deliveryMethod: 'channel_email',
+      destinationId: 'destination-1',
+      destinationTitle: 'Team Chat',
+      recipients: ['space@example.com'],
+    });
   });
 
   it('reports invalid Google Chat credentials without an email-specific error', async () => {

--- a/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
+++ b/apps/backend/src/data-marts/data-destination-types/ee/google-chat/services/google-chat-report-writer.ts
@@ -270,6 +270,7 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
   readonly type = DataDestinationType.GOOGLE_CHAT;
 
   private googleChatCredentials?: GoogleChatCredentials;
+  private channelEmailRecipients?: string[];
   private usesEmailDelivery = false;
 
   constructor(
@@ -303,17 +304,21 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
 
     if (parsed.success) {
       this.googleChatCredentials = parsed.data;
+      this.channelEmailRecipients = undefined;
       this.usesEmailDelivery = false;
       return;
     }
 
-    if (!EmailCredentialsSchema.safeParse(resolvedCredentials).success) {
+    const emailCredentials = EmailCredentialsSchema.safeParse(resolvedCredentials);
+    if (!emailCredentials.success) {
       throw new Error(
         'Google Chat destination has neither valid webhook nor channel-email credentials'
       );
     }
 
     // Channel email remains a supported delivery method for existing and new destinations.
+    this.googleChatCredentials = undefined;
+    this.channelEmailRecipients = emailCredentials.data.to;
     this.usesEmailDelivery = true;
     await super.prepareDeliveryCredentials(report);
   }
@@ -321,6 +326,13 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
   protected override async sendRenderedMessage(markdownContent: string): Promise<void> {
     if (this.usesEmailDelivery) {
       await super.sendRenderedMessage(markdownContent);
+      this.executionLogger?.log({
+        type: 'google_chat_sent',
+        deliveryMethod: 'channel_email',
+        destinationId: this.report.dataDestination.id,
+        destinationTitle: this.report.dataDestination.title,
+        recipients: this.channelEmailRecipients,
+      });
       return;
     }
 
@@ -340,6 +352,13 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
       dataMartTitle: this.report.dataMart.title,
       reportUrl,
     });
+    const spaceId = new URL(this.googleChatCredentials.webhookUrl).pathname.split('/')[3];
+    const deliveryDetails = {
+      deliveryMethod: 'incoming_webhook',
+      destinationId: this.report.dataDestination.id,
+      destinationTitle: this.report.dataDestination.title,
+      spaceId,
+    } as const;
 
     // Incoming webhooks do not support transactions or rollback. If a later part fails,
     // earlier parts remain delivered, so record each outcome for troubleshooting.
@@ -350,14 +369,18 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
 
       try {
         await this.webhookClient.send(this.googleChatCredentials.webhookUrl, messages[index]);
-        this.executionLogger?.log({
-          type: 'google_chat_part_sent',
-          part: index + 1,
-          totalParts: messages.length,
-        });
+        if (messages.length > 1) {
+          this.executionLogger?.log({
+            type: 'google_chat_part_sent',
+            ...deliveryDetails,
+            part: index + 1,
+            totalParts: messages.length,
+          });
+        }
       } catch (error) {
         this.executionLogger?.log({
           type: 'google_chat_part_failed',
+          ...deliveryDetails,
           part: index + 1,
           totalParts: messages.length,
           deliveredParts: index,
@@ -368,6 +391,7 @@ export class GoogleChatReportWriter extends BaseEmailReportWriter {
 
     this.executionLogger?.log({
       type: 'google_chat_sent',
+      ...deliveryDetails,
       messageCount: messages.length,
     });
   }

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/EmailFields.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/EmailFields.tsx
@@ -1,7 +1,14 @@
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@owox/ui/components/form';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@owox/ui/components/form';
 import { Textarea } from '@owox/ui/components/textarea';
 import { type UseFormReturn, type Path, type FieldPathValue } from 'react-hook-form';
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { type DataDestinationFormData } from '../../../shared';
 
 const EMAILS_FIELD_PATH = 'credentials.to' as Path<DataDestinationFormData>;
@@ -99,9 +106,11 @@ function EmailTextarea({
 export function EmailFields({
   form,
   emailsFieldTitle = DEFAULT_EMAILS_FIELD_TITLE, // default param instead of nullish coalescing
+  description,
 }: {
   form: UseFormReturn<DataDestinationFormData>;
   emailsFieldTitle?: string;
+  description?: ReactNode;
 }) {
   return (
     <FormField
@@ -115,6 +124,7 @@ export function EmailFields({
           <FormControl>
             <EmailTextarea field={field} form={form} />
           </FormControl>
+          {description && <FormDescription>{description}</FormDescription>}
           <FormMessage />
         </FormItem>
       )}

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/GoogleChatChannelEmailDescription.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/GoogleChatChannelEmailDescription.tsx
@@ -1,0 +1,38 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@owox/ui/components/accordion';
+import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
+
+export default function GoogleChatChannelEmailDescription() {
+  return (
+    <Accordion variant='common' type='single' collapsible>
+      <AccordionItem value='google-chat-channel-email-details'>
+        <AccordionTrigger>How do I get a Google Chat space email address?</AccordionTrigger>
+        <AccordionContent>
+          <ol className='list-inside list-decimal space-y-2 text-sm'>
+            <li>Open the target space in Google Chat on a computer.</li>
+            <li>
+              Click the space name, then select <strong>Space settings</strong>.
+            </li>
+            <li>
+              Under <strong>Email</strong>, click <strong>Generate email</strong> if the space does
+              not have an address yet.
+            </li>
+            <li>Copy the space email address and paste it above.</li>
+          </ol>
+          <p className='mt-2 text-sm'>Only space managers can generate the email address.</p>
+          <p className='mt-2 text-sm'>
+            See the{' '}
+            <ExternalAnchor href='https://support.google.com/chat/answer/14929313'>
+              Google Chat email guide
+            </ExternalAnchor>{' '}
+            for more details.
+          </p>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/GoogleChatDeliveryMethodDescription.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/GoogleChatDeliveryMethodDescription.tsx
@@ -1,0 +1,33 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@owox/ui/components/accordion';
+
+export default function GoogleChatDeliveryMethodDescription({
+  deliveryMethod,
+}: {
+  deliveryMethod: 'webhook' | 'email';
+}) {
+  const isWebhook = deliveryMethod === 'webhook';
+
+  return (
+    <Accordion variant='common' type='single' collapsible>
+      <AccordionItem value='google-chat-delivery-method-details'>
+        <AccordionTrigger>
+          {isWebhook
+            ? 'How does Incoming Webhook delivery work?'
+            : 'How does Channel Email delivery work?'}
+        </AccordionTrigger>
+        <AccordionContent>
+          <p className='text-sm'>
+            {isWebhook
+              ? 'Sends the report directly to the space as formatted Google Chat messages.'
+              : 'Sends the report by email to the Google Chat space address. The report appears as an email card in the space.'}
+          </p>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/GoogleChatWebhookDescription.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/FormDescriptions/GoogleChatWebhookDescription.tsx
@@ -1,0 +1,42 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@owox/ui/components/accordion';
+import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
+
+export default function GoogleChatWebhookDescription() {
+  return (
+    <Accordion variant='common' type='single' collapsible>
+      <AccordionItem value='google-chat-webhook-details'>
+        <AccordionTrigger>How do I get an incoming webhook URL?</AccordionTrigger>
+        <AccordionContent>
+          <ol className='list-inside list-decimal space-y-2 text-sm'>
+            <li>Open the target space in Google Chat on a computer.</li>
+            <li>
+              Click the space name, then select <strong>Apps &amp; integrations</strong>.
+            </li>
+            <li>
+              Click <strong>Add webhooks</strong>, enter a name, and save the webhook.
+            </li>
+            <li>
+              Open the webhook's menu, select <strong>Copy link</strong>, and paste the URL above.
+            </li>
+          </ol>
+          <p className='mt-2 text-sm'>
+            If you cannot add a webhook, your Google Workspace administrator might have disabled
+            this option. Keep the webhook URL secret.
+          </p>
+          <p className='mt-2 text-sm'>
+            See the{' '}
+            <ExternalAnchor href='https://developers.google.com/workspace/chat/quickstart/webhooks'>
+              Google Chat webhook guide
+            </ExternalAnchor>{' '}
+            for more details.
+          </p>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.test.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.test.tsx
@@ -58,9 +58,10 @@ describe('GoogleChatFields', () => {
       'data-state',
       'active'
     );
-    expect(
-      screen.getByText('Sends the report by email to the Google Chat space address.')
-    ).toBeInTheDocument();
+    expect(screen.getByText('How does Channel Email delivery work?')).toBeInTheDocument();
+    expect(screen.queryByText('How does Incoming Webhook delivery work?')).not.toBeInTheDocument();
+    expect(screen.getByText('How do I get a Google Chat space email address?')).toBeInTheDocument();
+    expect(screen.queryByText('How do I get an incoming webhook URL?')).not.toBeInTheDocument();
     expect(screen.getByRole('textbox')).toHaveValue('space@example.com');
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -83,9 +84,12 @@ describe('GoogleChatFields', () => {
         'active'
       );
     });
+    expect(screen.getByText('How does Incoming Webhook delivery work?')).toBeInTheDocument();
+    expect(screen.queryByText('How does Channel Email delivery work?')).not.toBeInTheDocument();
+    expect(screen.getByText('How do I get an incoming webhook URL?')).toBeInTheDocument();
     expect(
-      screen.getByText('Sends the report directly to the space as formatted Google Chat messages.')
-    ).toBeInTheDocument();
+      screen.queryByText('How do I get a Google Chat space email address?')
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId('dirty')).toHaveTextContent('false');
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));

--- a/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.tsx
+++ b/apps/web/src/features/data-destination/edit/components/DataDestinationEditForm/GoogleChatFields.tsx
@@ -12,6 +12,9 @@ import { useEffect } from 'react';
 import { type FieldPathValue, type Path, type UseFormReturn } from 'react-hook-form';
 import { type DataDestinationFormData } from '../../../shared';
 import { EmailFields } from './EmailFields';
+import GoogleChatChannelEmailDescription from './FormDescriptions/GoogleChatChannelEmailDescription';
+import GoogleChatDeliveryMethodDescription from './FormDescriptions/GoogleChatDeliveryMethodDescription';
+import GoogleChatWebhookDescription from './FormDescriptions/GoogleChatWebhookDescription';
 
 const WEBHOOK_FIELD_PATH = 'credentials.webhookUrl' as Path<DataDestinationFormData>;
 const DELIVERY_METHOD_FIELD_PATH = 'credentials.deliveryMethod' as Path<DataDestinationFormData>;
@@ -57,9 +60,7 @@ export function GoogleChatFields({ form }: { form: UseFormReturn<DataDestination
           </Tabs>
         </div>
         <FormDescription>
-          {deliveryMethod === 'webhook'
-            ? 'Sends the report directly to the space as formatted Google Chat messages.'
-            : 'Sends the report by email to the Google Chat space address.'}
+          <GoogleChatDeliveryMethodDescription deliveryMethod={deliveryMethod} />
         </FormDescription>
       </FormItem>
 
@@ -83,12 +84,19 @@ export function GoogleChatFields({ form }: { form: UseFormReturn<DataDestination
                   }
                 />
               </FormControl>
+              <FormDescription>
+                <GoogleChatWebhookDescription />
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}
         />
       ) : (
-        <EmailFields form={form} emailsFieldTitle='Enter Google Chat channel emails list' />
+        <EmailFields
+          form={form}
+          emailsFieldTitle='Enter Google Chat channel emails list'
+          description={<GoogleChatChannelEmailDescription />}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
Google Chat destination settings now provide contextual instructions for choosing a delivery
method and obtaining an incoming webhook URL or space email address. Report run logs also identify
the delivery method and destination without exposing webhook credentials, with per-part entries
shown only when a report is split across multiple Google Chat messages.