### PR TITLE
fix(deps): bump nanoid to 3.3.18 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29721,9 +29721,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Why

The **Audit all** check fails on every branch (including `main`) because of a high-severity advisory: nanoid <3.3.18 — custom generators can loop indefinitely when size is zero ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)). This blocks the check on every open PR.

## What

Bump the single transitive `nanoid` lockfile entry from 3.3.17 to 3.3.18. The dependency comes in via `@owox/connectors -> vite -> postcss`, and postcss's `^3.3.11` range already allows 3.3.18, so no `package.json` changes are needed — the diff is 3 lines in `package-lock.json` (version, resolved, integrity, as written by `npm audit fix`).

## Verification

- `npm audit --omit=dev` (the exact Audit all CI command): 0 vulnerabilities
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm ci --dry-run`: lockfile resolves cleanly
- `npm run lint:root` and `npm run format:root:check`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)