### PR TITLE
feat(data-marts): add an optional description to data mart relationships

### DIFF
--- a/.changeset/6780-relationship-description.md
+++ b/.changeset/6780-relationship-description.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Optional description for Data Mart relationships
+
+Each join between Data Marts can now carry an optional free-text description explaining the business meaning of the relationship (e.g. "Visitors from the website sign up for the product and convert into users").
+
+- **Data Setup UI**: a joined Data Mart's card gets a new **Description** tab next to Join Settings, with an autosaving text area. Inherited (transitive) joins show where to edit the description instead.
+- **API**: `POST`/`PATCH /data-marts/:id/relationships` accept an optional `description`, and relationship responses return it. Sending `null` or an empty string clears it.
+- **MCP**: `get_data_mart_details_by_id` with `detail_level=with_joined_fields` now returns a `joins` array — one entry per join edge with the joined data marts, the join key fields, and the relationship description — so AI assistants understand not only which fields a join contributes but how and why the data marts relate.

--- a/apps/backend/src/data-marts/dto/domain/create-relationship.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/create-relationship.command.ts
@@ -8,6 +8,7 @@ export class CreateRelationshipCommand {
     public readonly joinConditions: JoinCondition[],
     public readonly projectId: string,
     public readonly userId: string,
-    public readonly roles: string[]
+    public readonly roles: string[],
+    public readonly description?: string
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/domain/relationship.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/relationship.dto.ts
@@ -18,6 +18,7 @@ export interface RelationshipDto {
   targetDataMart: RelationshipDataMartRef;
   targetAlias: string;
   joinConditions: JoinCondition[];
+  description?: string;
   createdById: string;
   createdAt: Date;
   modifiedAt: Date;

--- a/apps/backend/src/data-marts/dto/domain/update-relationship.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/update-relationship.command.ts
@@ -8,6 +8,8 @@ export class UpdateRelationshipCommand {
     public readonly userId: string,
     public readonly roles: string[],
     public readonly targetAlias?: string,
-    public readonly joinConditions?: JoinCondition[]
+    public readonly joinConditions?: JoinCondition[],
+    /** undefined = leave untouched; null or empty string = clear. */
+    public readonly description?: string | null
   ) {}
 }

--- a/apps/backend/src/data-marts/dto/presentation/create-relationship-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/create-relationship-request-api.dto.ts
@@ -2,7 +2,7 @@ import {
   IsString,
   IsArray,
   IsNotEmpty,
-  IsOptional,
+  ValidateIf,
   ValidateNested,
   MinLength,
   MaxLength,
@@ -76,7 +76,10 @@ export class CreateRelationshipRequestApiDto {
     description: 'Business meaning of this relationship, shared with AI assistants',
     required: false,
   })
+  // Not @IsOptional(): that would skip validation for an explicit null too, smuggling a null
+  // into the `string | undefined` command field. Omitting the key is fine; null is a 400 —
+  // unlike the update DTO, which deliberately opts INTO null as its "clear" signal.
+  @ValidateIf(obj => obj.description !== undefined)
   @IsString()
-  @IsOptional()
   description?: string;
 }

--- a/apps/backend/src/data-marts/dto/presentation/create-relationship-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/create-relationship-request-api.dto.ts
@@ -2,6 +2,7 @@ import {
   IsString,
   IsArray,
   IsNotEmpty,
+  IsOptional,
   ValidateNested,
   MinLength,
   MaxLength,
@@ -69,4 +70,13 @@ export class CreateRelationshipRequestApiDto {
   @ValidateNested({ each: true })
   @Type(() => JoinConditionApiDto)
   joinConditions: JoinConditionApiDto[];
+
+  @ApiProperty({
+    example: 'Visitors from the website sign up for the product and convert into users',
+    description: 'Business meaning of this relationship, shared with AI assistants',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  description?: string;
 }

--- a/apps/backend/src/data-marts/dto/presentation/relationship-response-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/relationship-response-api.dto.ts
@@ -48,6 +48,13 @@ export class RelationshipResponseApiDto {
   @ApiProperty()
   joinConditions: JoinCondition[];
 
+  @ApiProperty({
+    example: 'Visitors from the website sign up for the product and convert into users',
+    description: 'Business meaning of this relationship, shared with AI assistants',
+    required: false,
+  })
+  description?: string;
+
   @ApiProperty({ example: 'user-id-123' })
   createdById: string;
 

--- a/apps/backend/src/data-marts/dto/presentation/update-relationship-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-relationship-request-api.dto.ts
@@ -2,6 +2,7 @@ import {
   IsString,
   IsArray,
   ValidateNested,
+  ValidateIf,
   MinLength,
   MaxLength,
   IsOptional,
@@ -40,4 +41,16 @@ export class UpdateRelationshipRequestApiDto {
   @Type(() => JoinConditionApiDto)
   @IsOptional()
   joinConditions?: JoinConditionApiDto[];
+
+  @ApiProperty({
+    example: 'Visitors from the website sign up for the product and convert into users',
+    description:
+      'Business meaning of this relationship, shared with AI assistants. Send null or an empty string to clear it.',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @ValidateIf(obj => obj.description !== null)
+  @IsString()
+  description?: string | null;
 }

--- a/apps/backend/src/data-marts/dto/presentation/update-relationship-request-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/update-relationship-request-api.dto.ts
@@ -45,7 +45,7 @@ export class UpdateRelationshipRequestApiDto {
   @ApiProperty({
     example: 'Visitors from the website sign up for the product and convert into users',
     description:
-      'Business meaning of this relationship, shared with AI assistants. Send null or an empty string to clear it.',
+      'Business meaning of this relationship, shared with AI assistants. Values are trimmed; send null or a blank (empty/whitespace-only) string to clear it.',
     required: false,
     nullable: true,
   })

--- a/apps/backend/src/data-marts/entities/data-mart-relationship.entity.ts
+++ b/apps/backend/src/data-marts/entities/data-mart-relationship.entity.ts
@@ -40,6 +40,9 @@ export class DataMartRelationship implements CreatorAwareEntity {
   @Column({ length: 255 })
   targetAlias: string;
 
+  @Column({ type: 'text', nullable: true })
+  description?: string | null;
+
   @Column({
     type: 'json',
     transformer: createZodTransformer<JoinCondition[]>(JoinConditionsSchema),

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.spec.ts
@@ -69,11 +69,12 @@ describe('McpDataMartsFacadeImpl', () => {
       }),
     }) as unknown as jest.Mocked<BlendableSchemaService>;
 
-  const createRelationshipService = (relationshipCount = 1) =>
+  const createRelationshipService = (relationshipCount = 1, relationships: unknown[] = []) =>
     ({
       findBySourceDataMartId: jest
         .fn()
         .mockResolvedValue(Array.from({ length: relationshipCount }, () => ({}))),
+      findByIds: jest.fn().mockResolvedValue(relationships),
     }) as unknown as jest.Mocked<DataMartRelationshipService>;
 
   const createSummarizeMcpDataCatalogService = () =>
@@ -345,6 +346,7 @@ describe('McpDataMartsFacadeImpl', () => {
         },
       ],
       joinedFields: [],
+      joins: [],
       uniqueCountSources: [],
     });
     expect(dataMartService.actualizeSchemaIfExpired).toHaveBeenCalledWith(
@@ -444,6 +446,7 @@ describe('McpDataMartsFacadeImpl', () => {
       description: '',
       fields: [],
       joinedFields: [],
+      joins: [],
       uniqueCountSources: [],
     });
   });
@@ -568,6 +571,77 @@ describe('McpDataMartsFacadeImpl', () => {
         roles: ['viewer'],
       }
     );
+  });
+
+  it('surfaces join edges with their keys and relationship description, omitting inaccessible sources (#6780)', async () => {
+    const dataMartService = createDataMartService({
+      id: 'dm_1',
+      title: 'Users',
+      description: '',
+      schema: { type: BigQueryDataMartSchemaType, fields: [] },
+    });
+    const blendableSchemaService = createBlendableSchemaService(
+      [],
+      [
+        {
+          aliasPath: 'visitors',
+          relationshipId: 'rel_1',
+          isIncluded: true,
+          isAccessibleForReporting: true,
+        },
+        {
+          aliasPath: 'secret',
+          relationshipId: 'rel_2',
+          isIncluded: true,
+          isAccessibleForReporting: false,
+        },
+      ]
+    );
+    const relationshipService = createRelationshipService(1, [
+      {
+        id: 'rel_1',
+        sourceDataMart: { title: 'Users' },
+        targetDataMart: { title: 'Visitors' },
+        joinConditions: [{ sourceFieldName: 'visitor_id', targetFieldName: 'id' }],
+        description: 'Visitors from the website sign up for the product and convert into users',
+      },
+      {
+        id: 'rel_2',
+        sourceDataMart: { title: 'Users' },
+        targetDataMart: { title: 'Secret' },
+        joinConditions: [],
+        description: 'Must not be exposed',
+      },
+    ]);
+    const facade = new McpDataMartsFacadeImpl(
+      createListDataMartsService([]),
+      createGetDataMartService(),
+      dataMartService,
+      createQueryDataMartService(),
+      blendableSchemaService,
+      relationshipService,
+      createSummarizeMcpDataCatalogService()
+    );
+
+    const result = await facade.getDataMartDetails({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      dataMartId: 'dm_1',
+      includeJoinedFields: true,
+    });
+
+    // Only the accessible source's edge is exposed; the description travels with it.
+    expect(result.joins).toEqual([
+      {
+        aliasPath: 'visitors',
+        sourceDataMart: 'Users',
+        targetDataMart: 'Visitors',
+        joinConditions: [{ sourceFieldName: 'visitor_id', targetFieldName: 'id' }],
+        description: 'Visitors from the website sign up for the product and convert into users',
+      },
+    ]);
+    expect(relationshipService.findByIds).toHaveBeenCalledWith(['rel_1']);
   });
 
   it('appends a joined Unique Count pseudo-field per available source, omitting sources that are not available (#6792)', async () => {

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.ts
@@ -229,29 +229,39 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
    * one relationship (`relationshipId`), including transitive ones, so one lookup by ids covers
    * the whole tree. Gives the model the join keys and the analyst-written relationship
    * description (#6780) that `joinedFields` alone cannot carry.
+   *
+   * Failure here degrades only `joins` to [] — by this point the blendable schema has already
+   * resolved, and this extra lookup must not take the joined fields down with it.
    */
   private async resolveJoins(
     accessibleSources: Array<{ aliasPath: string; relationshipId: string }>
   ): Promise<McpJoinDto[]> {
-    const relationshipsById = new Map(
-      (await this.relationshipService.findByIds(accessibleSources.map(s => s.relationshipId))).map(
-        rel => [rel.id, rel]
-      )
-    );
+    try {
+      const relationshipsById = new Map(
+        (
+          await this.relationshipService.findByIds(accessibleSources.map(s => s.relationshipId))
+        ).map(rel => [rel.id, rel])
+      );
 
-    const joins: McpJoinDto[] = [];
-    for (const source of accessibleSources) {
-      const rel = relationshipsById.get(source.relationshipId);
-      if (!rel?.sourceDataMart || !rel.targetDataMart) continue;
-      joins.push({
-        aliasPath: source.aliasPath,
-        sourceDataMart: rel.sourceDataMart.title,
-        targetDataMart: rel.targetDataMart.title,
-        joinConditions: rel.joinConditions,
-        ...(rel.description ? { description: rel.description } : {}),
-      });
+      const joins: McpJoinDto[] = [];
+      for (const source of accessibleSources) {
+        const rel = relationshipsById.get(source.relationshipId);
+        if (!rel?.sourceDataMart || !rel.targetDataMart) continue;
+        joins.push({
+          aliasPath: source.aliasPath,
+          sourceDataMart: rel.sourceDataMart.title,
+          targetDataMart: rel.targetDataMart.title,
+          joinConditions: rel.joinConditions,
+          ...(rel.description ? { description: rel.description } : {}),
+        });
+      }
+      return joins;
+    } catch (err) {
+      this.logger.warn(
+        `resolveJoins failed; returning joined fields without joins: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return [];
     }
-    return joins;
   }
 
   async queryDataMart(

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.impl.ts
@@ -25,6 +25,7 @@ import {
   McpDataMartsFacade,
   McpDataMartDetailsResponse,
   McpGetDataMartDetailsRequest,
+  McpJoinDto,
   McpJoinedFieldDto,
   McpListDataMartsRequest,
   McpListDataMartsResponse,
@@ -93,9 +94,9 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
         } as DataMartSchema) as { fields: Array<Record<string, unknown>> })
       : undefined;
 
-    const { joinedFields, uniqueCountSources } = request.includeJoinedFields
+    const { joinedFields, joins, uniqueCountSources } = request.includeJoinedFields
       ? await this.resolveJoinedFields(request, this.topLevelFieldNames(schema?.fields ?? []))
-      : { joinedFields: [], uniqueCountSources: [] };
+      : { joinedFields: [], joins: [], uniqueCountSources: [] };
 
     return {
       id: dataMart.id,
@@ -103,6 +104,7 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
       description: dataMart.description ?? '',
       fields: this.withDisplayNames(schema?.fields ?? []),
       joinedFields,
+      joins,
       uniqueCountSources,
     };
   }
@@ -122,6 +124,7 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
     nativeFieldNames: ReadonlySet<string>
   ): Promise<{
     joinedFields: McpJoinedFieldDto[];
+    joins: McpJoinDto[];
     uniqueCountSources: McpUniqueCountSourceDto[];
   }> {
     try {
@@ -131,7 +134,7 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
         request.dataMartId
       );
       if (relationships.length === 0) {
-        return { joinedFields: [], uniqueCountSources: [] };
+        return { joinedFields: [], joins: [], uniqueCountSources: [] };
       }
 
       const blendable = await this.blendableSchemaService.computeBlendableSchema(
@@ -148,6 +151,8 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
         s => s.isIncluded && s.isAccessibleForReporting
       );
       const accessiblePaths = new Set(accessibleSources.map(s => s.aliasPath));
+
+      const joins = await this.resolveJoins(accessibleSources);
 
       const blendedFields = blendable.blendedFields
         .filter(f => !f.isHidden && accessiblePaths.has(f.aliasPath))
@@ -210,13 +215,43 @@ export class McpDataMartsFacadeImpl implements McpDataMartsFacade {
         });
       }
 
-      return { joinedFields: [...blendedFields, ...uniqueCountFields], uniqueCountSources };
+      return { joinedFields: [...blendedFields, ...uniqueCountFields], joins, uniqueCountSources };
     } catch (err) {
       this.logger.warn(
         `resolveJoinedFields failed; returning no joined fields: ${err instanceof Error ? err.message : String(err)}`
       );
-      return { joinedFields: [], uniqueCountSources: [] };
+      return { joinedFields: [], joins: [], uniqueCountSources: [] };
     }
+  }
+
+  /**
+   * The join-tree edges behind the accessible sources — every source was pulled through exactly
+   * one relationship (`relationshipId`), including transitive ones, so one lookup by ids covers
+   * the whole tree. Gives the model the join keys and the analyst-written relationship
+   * description (#6780) that `joinedFields` alone cannot carry.
+   */
+  private async resolveJoins(
+    accessibleSources: Array<{ aliasPath: string; relationshipId: string }>
+  ): Promise<McpJoinDto[]> {
+    const relationshipsById = new Map(
+      (await this.relationshipService.findByIds(accessibleSources.map(s => s.relationshipId))).map(
+        rel => [rel.id, rel]
+      )
+    );
+
+    const joins: McpJoinDto[] = [];
+    for (const source of accessibleSources) {
+      const rel = relationshipsById.get(source.relationshipId);
+      if (!rel?.sourceDataMart || !rel.targetDataMart) continue;
+      joins.push({
+        aliasPath: source.aliasPath,
+        sourceDataMart: rel.sourceDataMart.title,
+        targetDataMart: rel.targetDataMart.title,
+        joinConditions: rel.joinConditions,
+        ...(rel.description ? { description: rel.description } : {}),
+      });
+    }
+    return joins;
   }
 
   async queryDataMart(

--- a/apps/backend/src/data-marts/facades/mcp-data-marts.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-data-marts.facade.ts
@@ -80,12 +80,28 @@ export interface McpUniqueCountSourceDto {
   displayName: string;
 }
 
+/**
+ * One edge of the join tree behind `joinedFields`, so the model sees not only WHICH fields a
+ * joined source contributes but HOW the two data marts relate: the join keys (data context) and
+ * the analyst-written relationship description (business context, e.g. "Visitors from the
+ * website sign up for the product and convert into users").
+ */
+export interface McpJoinDto {
+  /** Dotted alias path of the joined source — matches the `<alias>__` prefix of joinedFields. */
+  aliasPath: string;
+  sourceDataMart: string;
+  targetDataMart: string;
+  joinConditions: Array<{ sourceFieldName: string; targetFieldName: string }>;
+  description?: string;
+}
+
 export interface McpDataMartDetailsResponse {
   id: string;
   name: string;
   description: string;
   fields: Array<Record<string, unknown>>;
   joinedFields: McpJoinedFieldDto[];
+  joins: McpJoinDto[];
   uniqueCountSources: McpUniqueCountSourceDto[];
 }
 

--- a/apps/backend/src/data-marts/mappers/relationship.mapper.spec.ts
+++ b/apps/backend/src/data-marts/mappers/relationship.mapper.spec.ts
@@ -55,6 +55,7 @@ describe('RelationshipMapper', () => {
         targetDataMartId: 'target-dm-2',
         targetAlias: 'orders',
         joinConditions: [{ sourceFieldName: 'user_id', targetFieldName: 'user_id' }],
+        description: 'Each user has orders they placed',
       };
 
       const command = mapper.toCreateCommand('source-dm-1', mockContext, dto);
@@ -67,6 +68,7 @@ describe('RelationshipMapper', () => {
       expect(command.joinConditions).toEqual([
         { sourceFieldName: 'user_id', targetFieldName: 'user_id' },
       ]);
+      expect(command.description).toBe('Each user has orders they placed');
     });
   });
 
@@ -75,6 +77,7 @@ describe('RelationshipMapper', () => {
       const dto: UpdateRelationshipRequestApiDto = {
         targetAlias: 'new_alias',
         joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+        description: 'Each user has orders they placed',
       };
 
       const command = mapper.toUpdateCommand('rel-1', 'source-dm-1', mockContext, dto);
@@ -85,6 +88,7 @@ describe('RelationshipMapper', () => {
       expect(command.projectId).toBe('project-456');
       expect(command.targetAlias).toBe('new_alias');
       expect(command.joinConditions).toEqual([{ sourceFieldName: 'id', targetFieldName: 'id' }]);
+      expect(command.description).toBe('Each user has orders they placed');
     });
 
     it('should produce undefined for optional fields when not provided', () => {
@@ -94,6 +98,15 @@ describe('RelationshipMapper', () => {
 
       expect(command.targetAlias).toBeUndefined();
       expect(command.joinConditions).toBeUndefined();
+      expect(command.description).toBeUndefined();
+    });
+
+    it('should pass null description through so the update can clear it', () => {
+      const dto: UpdateRelationshipRequestApiDto = { description: null };
+
+      const command = mapper.toUpdateCommand('rel-1', 'source-dm-1', mockContext, dto);
+
+      expect(command.description).toBeNull();
     });
   });
 
@@ -120,6 +133,15 @@ describe('RelationshipMapper', () => {
       expect(dto.createdAt).toEqual(new Date('2024-01-01T00:00:00.000Z'));
       expect(dto.modifiedAt).toEqual(new Date('2024-01-02T00:00:00.000Z'));
       expect(dto.createdByUser).toBeNull();
+      expect(dto.description).toBeUndefined();
+    });
+
+    it('should carry the relationship description when set', () => {
+      const entity = { ...mockEntity, description: 'Each user has orders they placed' };
+
+      const dto = mapper.toDomainDto(entity, null, fullAccess);
+
+      expect(dto.description).toBe('Each user has orders they placed');
     });
 
     it('falls back to userHasAccess=false when access map lacks the data mart id', () => {

--- a/apps/backend/src/data-marts/mappers/relationship.mapper.spec.ts
+++ b/apps/backend/src/data-marts/mappers/relationship.mapper.spec.ts
@@ -391,6 +391,33 @@ describe('CreateRelationshipRequestApiDto validation', () => {
     const errors = await validate(dto);
     expect(errors).toHaveLength(0);
   });
+
+  it('accepts an omitted description and a string description', async () => {
+    const base = {
+      targetDataMartId: 'target-dm-1',
+      targetAlias: 'orders',
+      joinConditions: [],
+    };
+
+    expect(await validate(plainToInstance(CreateRelationshipRequestApiDto, base))).toHaveLength(0);
+    expect(
+      await validate(
+        plainToInstance(CreateRelationshipRequestApiDto, { ...base, description: 'Buyers' })
+      )
+    ).toHaveLength(0);
+  });
+
+  it('rejects an explicit null description — create has no "clear" semantics to opt into', async () => {
+    const dto = plainToInstance(CreateRelationshipRequestApiDto, {
+      targetDataMartId: 'target-dm-1',
+      targetAlias: 'orders',
+      joinConditions: [],
+      description: null,
+    });
+
+    const errors = await validate(dto);
+    expect(errors.find(e => e.property === 'description')).toBeDefined();
+  });
 });
 
 describe('UpdateRelationshipRequestApiDto validation', () => {
@@ -424,5 +451,21 @@ describe('UpdateRelationshipRequestApiDto validation', () => {
 
     const errors = await validate(dto);
     expect(errors).toHaveLength(0);
+  });
+
+  // Pins the null-clear contract: @IsOptional() skips validation for null, which is exactly
+  // what the update DTO relies on — losing that would break the UI's "clear description" PATCH.
+  it('accepts description as a string, as null (clear), and omitted', async () => {
+    for (const payload of [{ description: 'Buyers' }, { description: null }, {}]) {
+      const errors = await validate(plainToInstance(UpdateRelationshipRequestApiDto, payload));
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  it('rejects a non-string description', async () => {
+    const dto = plainToInstance(UpdateRelationshipRequestApiDto, { description: 42 });
+
+    const errors = await validate(dto);
+    expect(errors.find(e => e.property === 'description')).toBeDefined();
   });
 });

--- a/apps/backend/src/data-marts/mappers/relationship.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/relationship.mapper.ts
@@ -37,7 +37,8 @@ export class RelationshipMapper {
       dto.joinConditions.map(c => this.toJoinCondition(c)),
       context.projectId,
       context.userId,
-      context.roles ?? []
+      context.roles ?? [],
+      dto.description
     );
   }
 
@@ -54,7 +55,8 @@ export class RelationshipMapper {
       context.userId,
       context.roles ?? [],
       dto.targetAlias,
-      dto.joinConditions?.map(c => this.toJoinCondition(c))
+      dto.joinConditions?.map(c => this.toJoinCondition(c)),
+      dto.description
     );
   }
 
@@ -122,6 +124,7 @@ export class RelationshipMapper {
       },
       targetAlias: entity.targetAlias,
       joinConditions: entity.joinConditions,
+      description: entity.description ?? undefined,
       createdById: entity.createdById,
       createdAt: entity.createdAt,
       modifiedAt: entity.modifiedAt,

--- a/apps/backend/src/data-marts/services/data-mart-relationship.service.spec.ts
+++ b/apps/backend/src/data-marts/services/data-mart-relationship.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
 import { CreateRelationshipCommand } from '../dto/domain/create-relationship.command';
+import { UpdateRelationshipCommand } from '../dto/domain/update-relationship.command';
 import { DataMartSchema } from '../data-storage-types/data-mart-schema.type';
 import { DataMartSchemaFieldStatus } from '../data-storage-types/enums/data-mart-schema-field-status.enum';
 import { JoinCondition } from '../dto/schemas/join-condition.schema';
@@ -367,6 +368,7 @@ describe('DataMartRelationshipService', () => {
         dataStorage: storage,
         targetAlias: 'my_alias',
         joinConditions: [],
+        description: null,
         projectId: 'project-1',
         createdById: 'user-1',
       });
@@ -399,6 +401,52 @@ describe('DataMartRelationshipService', () => {
 
       expect(result.joinConditions).toEqual([]);
       expect(repository.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('update', () => {
+    const makeUpdateCommand = (description: string | null | undefined) =>
+      new UpdateRelationshipCommand(
+        'rel-1',
+        'dm-source',
+        'project-1',
+        'user-1',
+        [],
+        undefined,
+        undefined,
+        description
+      );
+
+    it('stores a trimmed description', async () => {
+      const relationship = makeRelationship('dm-source', 'dm-target');
+      repository.save.mockImplementation(entity => Promise.resolve(entity as DataMartRelationship));
+
+      const updated = await service.update(relationship, makeUpdateCommand('  Users convert  '));
+
+      expect(updated.description).toBe('Users convert');
+    });
+
+    it('clears the description on null and on blank input', async () => {
+      repository.save.mockImplementation(entity => Promise.resolve(entity as DataMartRelationship));
+
+      for (const cleared of [null, '   ']) {
+        const relationship = makeRelationship('dm-source', 'dm-target', {
+          description: 'old meaning',
+        });
+        const updated = await service.update(relationship, makeUpdateCommand(cleared));
+        expect(updated.description).toBeNull();
+      }
+    });
+
+    it('leaves the description untouched when the command omits it', async () => {
+      const relationship = makeRelationship('dm-source', 'dm-target', {
+        description: 'old meaning',
+      });
+      repository.save.mockImplementation(entity => Promise.resolve(entity as DataMartRelationship));
+
+      const updated = await service.update(relationship, makeUpdateCommand(undefined));
+
+      expect(updated.description).toBe('old meaning');
     });
   });
 

--- a/apps/backend/src/data-marts/services/data-mart-relationship.service.ts
+++ b/apps/backend/src/data-marts/services/data-mart-relationship.service.ts
@@ -36,6 +36,7 @@ export class DataMartRelationshipService {
       dataStorage: sourceDataMart.storage,
       targetAlias: command.targetAlias,
       joinConditions: command.joinConditions,
+      description: this.normalizeDescription(command.description),
       projectId: command.projectId,
       createdById: command.userId,
     });
@@ -131,8 +132,17 @@ export class DataMartRelationshipService {
     if (command.joinConditions !== undefined) {
       relationship.joinConditions = command.joinConditions;
     }
+    if (command.description !== undefined) {
+      relationship.description = this.normalizeDescription(command.description);
+    }
 
     return this.repository.save(relationship);
+  }
+
+  /** Blank descriptions are stored as NULL, so consumers never see empty strings. */
+  private normalizeDescription(description: string | null | undefined): string | null {
+    const trimmed = description?.trim();
+    return trimmed ? trimmed : null;
   }
 
   async delete(relationship: DataMartRelationship): Promise<void> {

--- a/apps/backend/src/ee/mcp/instructions/mcp-system-instructions.ts
+++ b/apps/backend/src/ee/mcp/instructions/mcp-system-instructions.ts
@@ -4,7 +4,7 @@ For a concrete analytical question:
 1. Call get_relevant_data_marts_by_prompt with the user's question unless the data mart has already been explicitly confirmed in the current conversation.
 2. If no useful result is returned, rephrase the search using different business terms and try again.
 3. If several data marts are plausible, ask the user which one to use.
-4. Call get_data_mart_details_by_id to obtain exact native field names unless that schema is already available in the conversation. It returns native fields by default. Before saying the selected Data Mart cannot answer the question, or after field_not_found, call it again with detail_level=with_joined_fields to inspect available joined fields.
+4. Call get_data_mart_details_by_id to obtain exact native field names unless that schema is already available in the conversation. It returns native fields by default. Before saying the selected Data Mart cannot answer the question, or after field_not_found, call it again with detail_level=with_joined_fields to inspect available joined fields. That response also includes "joins" — how each joined Data Mart relates to this one (join keys plus, when set, the analyst-written business meaning of the relationship); read it before interpreting joined fields or reasoning about cause and effect across them.
 5. Call query_data_mart with only the fields, filters, aggregations, date buckets, and sorting needed to answer the question.
 
 Discovery:

--- a/apps/backend/src/ee/mcp/tools/data-mart-details.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-details.tool.spec.ts
@@ -43,6 +43,15 @@ describe('GetDataMartDetailsTool', () => {
           sourceDataMart: 'blended_org',
         },
       ],
+      joins: [
+        {
+          aliasPath: 'blended_org',
+          sourceDataMart: 'Orders',
+          targetDataMart: 'blended_org',
+          joinConditions: [{ sourceFieldName: 'org_id', targetFieldName: 'id' }],
+          description: 'Each order is placed by one organization',
+        },
+      ],
     };
     const facade = {
       getDataMartDetails: jest.fn().mockResolvedValue(detailsResult),
@@ -59,10 +68,21 @@ describe('GetDataMartDetailsTool', () => {
       joined_fields_included: boolean;
       fields: Array<Record<string, unknown>>;
       joined_fields: Array<Record<string, unknown>>;
+      joins: Array<Record<string, unknown>>;
       operators_by_category: Record<string, string[]>;
     };
 
     expect(sc.id).toBe('dm_1');
+    // Join edges pass through untouched — the relationship description IS the payload (#6780).
+    expect(sc.joins).toEqual([
+      {
+        aliasPath: 'blended_org',
+        sourceDataMart: 'Orders',
+        targetDataMart: 'blended_org',
+        joinConditions: [{ sourceFieldName: 'org_id', targetFieldName: 'id' }],
+        description: 'Each order is placed by one organization',
+      },
+    ]);
     expect(sc.url).toBe('https://app.owox.com/ui/project-1/data-marts/dm_1/data-setup');
     expect(sc.joined_fields_included).toBe(true);
     // Governance defaults, not the full type menu: DATE → MIN/MAX, STRING → COUNT/COUNT_DISTINCT.
@@ -111,6 +131,7 @@ describe('GetDataMartDetailsTool', () => {
         description: 'Orders data mart',
         fields: [],
         joinedFields: [],
+        joins: [],
       }),
     } as unknown as jest.Mocked<McpDataMartsFacade>;
     const tool = new GetDataMartDetailsTool(facade, publicOrigin);
@@ -120,6 +141,7 @@ describe('GetDataMartDetailsTool', () => {
     expect(result.structuredContent).toMatchObject({
       joined_fields_included: false,
       joined_fields: [],
+      joins: [],
     });
     expect(facade.getDataMartDetails).toHaveBeenCalledWith(
       expect.objectContaining({ includeJoinedFields: false })
@@ -168,6 +190,7 @@ describe('GetDataMartDetailsTool', () => {
             sourceDataMart: 'costs',
           },
         ],
+        joins: [],
       }),
     } as unknown as jest.Mocked<McpDataMartsFacade>;
     const tool = new GetDataMartDetailsTool(facade, publicOrigin);
@@ -229,6 +252,7 @@ describe('GetDataMartDetailsTool', () => {
         fields: expect.any(Object),
         joined_fields_included: expect.any(Object),
         joined_fields: expect.any(Object),
+        joins: expect.any(Object),
         operators_by_category: expect.any(Object),
       }),
       annotations: {

--- a/apps/backend/src/ee/mcp/tools/data-mart-details.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-details.tool.ts
@@ -97,6 +97,27 @@ const JoinedFieldSchema = z
   })
   .passthrough();
 
+const JoinSchema = z
+  .object({
+    aliasPath: z
+      .string()
+      .describe(
+        'Dotted alias path of the joined source — matches the "<alias>__" prefix of joined_fields names.'
+      ),
+    sourceDataMart: z.string().describe('Title of the data mart on the left side of this join.'),
+    targetDataMart: z.string().describe('Title of the joined data mart.'),
+    joinConditions: z
+      .array(z.object({ sourceFieldName: z.string(), targetFieldName: z.string() }).passthrough())
+      .describe('Field pairs the rows are matched on (source field = target field).'),
+    description: z
+      .string()
+      .optional()
+      .describe(
+        'Analyst-written business meaning of this relationship (e.g. "Visitors from the website sign up for the product and convert into users"). Use it to interpret joined fields and to reason about cause and effect across the joined data marts.'
+      ),
+  })
+  .passthrough();
+
 type RawField = Record<string, unknown>;
 
 @Injectable()
@@ -120,6 +141,11 @@ export class GetDataMartDetailsTool implements McpToolDefinition<GetDataMartDeta
       .array(JoinedFieldSchema)
       .describe(
         'Fields available from joined/blended data marts when joined_fields_included is true. Reference each by its exact "name" in query_data_mart; because they come from a joined data mart they may also be used in "slices".'
+      ),
+    joins: z
+      .array(JoinSchema)
+      .describe(
+        'How the joined data marts relate to this one — one entry per join edge (populated only when joined_fields_included is true): the matched key fields plus, when set, the business meaning of the relationship. Read these before interpreting joined_fields.'
       ),
     operators_by_category: z
       .record(z.string(), z.array(z.string()))
@@ -182,6 +208,7 @@ export class GetDataMartDetailsTool implements McpToolDefinition<GetDataMartDeta
       fields,
       joined_fields_included: includeJoinedFields,
       joined_fields: joinedFields,
+      joins: result.joins,
       operators_by_category: operatorsByCategory,
     };
 

--- a/apps/backend/src/migrations/1786924800000-add-description-to-data-mart-relationship.ts
+++ b/apps/backend/src/migrations/1786924800000-add-description-to-data-mart-relationship.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+import { getTable } from './migration-utils';
+
+export class AddDescriptionToDataMartRelationship1786924800000 implements MigrationInterface {
+  public readonly name = 'AddDescriptionToDataMartRelationship1786924800000';
+
+  private readonly TABLE = 'data_mart_relationship';
+  private readonly COLUMN = new TableColumn({
+    name: 'description',
+    type: 'text',
+    isNullable: true,
+  });
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, this.TABLE);
+    const exists = table.columns.some(c => c.name === this.COLUMN.name);
+    if (!exists) {
+      await queryRunner.addColumn(table, this.COLUMN);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await getTable(queryRunner, this.TABLE);
+    const exists = table.columns.some(c => c.name === this.COLUMN.name);
+    if (exists) {
+      await queryRunner.dropColumn(table, this.COLUMN.name);
+    }
+  }
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinDescriptionForm.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinDescriptionForm.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { JoinDescriptionForm } from './JoinDescriptionForm';
+import type { DataMartRelationship } from '../../../shared/types/relationship.types';
+
+vi.mock('../../../../../shared/hooks/useProjectRoute', () => ({
+  useProjectRoute: () => ({
+    navigate: vi.fn(),
+    scope: (path: string) => path,
+    projectId: 'project-1',
+  }),
+}));
+
+vi.mock('../../../shared/services/data-mart-relationship.service', () => ({
+  dataMartRelationshipService: {
+    updateRelationship: vi.fn(),
+  },
+}));
+
+import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
+
+const updateRelationship = vi.mocked(dataMartRelationshipService.updateRelationship);
+
+function buildRelationship(overrides: Partial<DataMartRelationship> = {}): DataMartRelationship {
+  return {
+    id: 'rel-1',
+    dataStorageId: 'storage-1',
+    sourceDataMart: {
+      id: 'source-dm-1',
+      title: 'Orders',
+      status: 'PUBLISHED',
+      userHasAccess: true,
+      hasPrimaryKey: true,
+    },
+    targetDataMart: {
+      id: 'target-dm-1',
+      title: 'Customers',
+      status: 'PUBLISHED',
+      userHasAccess: true,
+      hasPrimaryKey: true,
+    },
+    targetAlias: 'customers',
+    joinConditions: [{ sourceFieldName: 'id', targetFieldName: 'id' }],
+    createdById: 'user-1',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    modifiedAt: '2024-01-02T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function renderForm(props: Partial<Parameters<typeof JoinDescriptionForm>[0]> = {}) {
+  const relationship = props.relationship ?? buildRelationship();
+  return render(
+    <JoinDescriptionForm
+      relationship={relationship}
+      dataMartId='source-dm-1'
+      onSaved={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+const getTextarea = () =>
+  screen.getByPlaceholderText<HTMLTextAreaElement>(/visitors from the website/i);
+
+describe('JoinDescriptionForm', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    updateRelationship.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('autosaves the typed description after the debounce settles', async () => {
+    updateRelationship.mockResolvedValue(buildRelationship({ description: 'Buyers of orders' }));
+    renderForm();
+
+    fireEvent.change(getTextarea(), { target: { value: 'Buyers of orders' } });
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(updateRelationship).toHaveBeenCalledTimes(1);
+    expect(updateRelationship).toHaveBeenCalledWith(
+      'source-dm-1',
+      'rel-1',
+      { description: 'Buyers of orders' },
+      { skipErrorToast: true, skipLoadingIndicator: true }
+    );
+  });
+
+  it('sends null for a whitespace-only description (clear)', async () => {
+    updateRelationship.mockResolvedValue(buildRelationship({ description: undefined }));
+    renderForm({ relationship: buildRelationship({ description: 'old meaning' }) });
+
+    fireEvent.change(getTextarea(), { target: { value: '   ' } });
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(updateRelationship).toHaveBeenCalledWith(
+      'source-dm-1',
+      'rel-1',
+      { description: null },
+      expect.anything()
+    );
+  });
+
+  it('keeps text typed during a slow save and retries it afterwards (no silent revert)', async () => {
+    let resolveSave: (value: DataMartRelationship) => void = () => undefined;
+    updateRelationship.mockImplementationOnce(
+      () =>
+        new Promise<DataMartRelationship>(resolve => {
+          resolveSave = resolve;
+        })
+    );
+    updateRelationship.mockResolvedValueOnce(buildRelationship({ description: 'AB' }));
+    renderForm();
+
+    // First edit reaches the debounce and starts a (slow) save.
+    fireEvent.change(getTextarea(), { target: { value: 'A' } });
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(updateRelationship).toHaveBeenCalledTimes(1);
+
+    // User keeps typing while the save is in flight.
+    fireEvent.change(getTextarea(), { target: { value: 'AB' } });
+
+    // The slow save resolves with the STALE server value...
+    await act(async () => {
+      resolveSave(buildRelationship({ description: 'A' }));
+    });
+
+    // ...but the textarea must keep the newer text, and the newer text must be saved.
+    expect(getTextarea().value).toBe('AB');
+    expect(updateRelationship).toHaveBeenCalledTimes(2);
+    expect(updateRelationship).toHaveBeenLastCalledWith(
+      'source-dm-1',
+      'rel-1',
+      { description: 'AB' },
+      expect.anything()
+    );
+  });
+
+  it('flushes a pending edit when the form unmounts before the debounce fires', async () => {
+    updateRelationship.mockResolvedValue(buildRelationship({ description: 'typed then left' }));
+    const { unmount } = renderForm();
+
+    fireEvent.change(getTextarea(), { target: { value: 'typed then left' } });
+    // No debounce advance — switching tabs unmounts the form with the edit pending.
+    unmount();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(updateRelationship).toHaveBeenCalledWith(
+      'source-dm-1',
+      'rel-1',
+      { description: 'typed then left' },
+      expect.anything()
+    );
+  });
+
+  it('renders the inherited banner and disables the textarea for transient joins', () => {
+    renderForm({
+      readOnly: true,
+      inheritedFrom: { id: 'parent-dm-1', title: 'Customers' },
+    });
+
+    expect(screen.getByText(/inherited from/i)).toBeInTheDocument();
+    expect(getTextarea()).toBeDisabled();
+  });
+
+  it('does not save while read-only', async () => {
+    renderForm({ readOnly: true });
+
+    fireEvent.change(getTextarea(), { target: { value: 'attempt' } });
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(updateRelationship).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinDescriptionForm.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinDescriptionForm.test.tsx
@@ -164,6 +164,45 @@ describe('JoinDescriptionForm', () => {
     );
   });
 
+  it('queues the unmount flush behind an in-flight save instead of racing it', async () => {
+    let resolveSave: (value: DataMartRelationship) => void = () => undefined;
+    updateRelationship.mockImplementationOnce(
+      () =>
+        new Promise<DataMartRelationship>(resolve => {
+          resolveSave = resolve;
+        })
+    );
+    updateRelationship.mockResolvedValueOnce(buildRelationship({ description: 'B' }));
+    const { unmount } = renderForm();
+
+    // Slow save A starts...
+    fireEvent.change(getTextarea(), { target: { value: 'A' } });
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(updateRelationship).toHaveBeenCalledTimes(1);
+
+    // ...user types B and leaves the tab while A is still on the wire.
+    fireEvent.change(getTextarea(), { target: { value: 'B' } });
+    unmount();
+
+    // The flush must NOT fire a concurrent PATCH — with no server-side versioning,
+    // out-of-order processing would let stale A overwrite B.
+    expect(updateRelationship).toHaveBeenCalledTimes(1);
+
+    // Once A settles, the queued flush sends B.
+    await act(async () => {
+      resolveSave(buildRelationship({ description: 'A' }));
+    });
+    expect(updateRelationship).toHaveBeenCalledTimes(2);
+    expect(updateRelationship).toHaveBeenLastCalledWith(
+      'source-dm-1',
+      'rel-1',
+      { description: 'B' },
+      expect.anything()
+    );
+  });
+
   it('renders the inherited banner and disables the textarea for transient joins', () => {
     renderForm({
       readOnly: true,

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinDescriptionForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinDescriptionForm.tsx
@@ -33,20 +33,33 @@ export function JoinDescriptionForm({
   const savedValue = relationship.description ?? '';
   const [localValue, setLocalValue] = useState(savedValue);
   const debouncedValue = useDebounce(localValue, 800);
-  const lastSavedRef = useRef(savedValue);
-  const isDirtyRef = useRef(false);
   const [isSaving, setIsSaving] = useState(false);
+  const lastSavedRef = useRef(savedValue);
+  // What the textarea holds RIGHT NOW — the debounced value and the in-flight payload
+  // both lag behind it, and every dirty/clean decision must compare against it.
+  const latestValueRef = useRef(savedValue);
+  const isDirtyRef = useRef(false);
 
   useEffect(() => {
-    setLocalValue(savedValue);
     lastSavedRef.current = savedValue;
-    isDirtyRef.current = false;
+    // Sync from the server only while clean — resetting mid-edit would silently
+    // revert text the user typed while a save was in flight.
+    if (!isDirtyRef.current) {
+      setLocalValue(savedValue);
+      latestValueRef.current = savedValue;
+    }
   }, [savedValue]);
 
-  const save = (value: string) => {
-    if (readOnly || isSaving) return;
+  // Kept in a ref so effects can depend on plain values (debouncedValue, isSaving)
+  // without re-running on every render for a new function identity.
+  const saveRef = useRef<(value: string, opts?: { ignoreInFlight?: boolean }) => void>(() => {
+    /* replaced each render below */
+  });
+  saveRef.current = (value, { ignoreInFlight = false } = {}) => {
+    if (readOnly || (isSaving && !ignoreInFlight)) return;
     if (value.trim() === lastSavedRef.current.trim()) {
-      isDirtyRef.current = false;
+      // Nothing to send; stay dirty only if the textarea has since diverged again.
+      isDirtyRef.current = latestValueRef.current.trim() !== lastSavedRef.current.trim();
       return;
     }
     setIsSaving(true);
@@ -60,7 +73,11 @@ export function JoinDescriptionForm({
       )
       .then(updated => {
         lastSavedRef.current = updated.description ?? '';
-        isDirtyRef.current = false;
+        // Clear the dirty flag only if the textarea still matches what was sent —
+        // text typed during the request stays dirty and is retried below.
+        if (latestValueRef.current.trim() === value.trim()) {
+          isDirtyRef.current = false;
+        }
         onSaved(updated);
       })
       .catch(() => {
@@ -73,11 +90,22 @@ export function JoinDescriptionForm({
       });
   };
 
+  // Fires when the debounce settles AND whenever an in-flight save finishes —
+  // the latter retries edits that were skipped because a save was already running.
   useEffect(() => {
-    if (!isDirtyRef.current) return;
-    save(debouncedValue);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- run only when the debounced value settles
-  }, [debouncedValue]);
+    if (!isDirtyRef.current || isSaving) return;
+    saveRef.current(latestValueRef.current);
+  }, [debouncedValue, isSaving]);
+
+  // Flush a pending edit when the tab unmounts (tab switch, row collapse) — the
+  // debounce timer dies with the component, and blur is not guaranteed to fire first.
+  useEffect(() => {
+    return () => {
+      if (isDirtyRef.current) {
+        saveRef.current(latestValueRef.current, { ignoreInFlight: true });
+      }
+    };
+  }, []);
 
   return (
     <div className='flex flex-col gap-3 p-4'>
@@ -122,10 +150,13 @@ export function JoinDescriptionForm({
         value={localValue}
         onChange={e => {
           setLocalValue(e.target.value);
+          latestValueRef.current = e.target.value;
           isDirtyRef.current = true;
         }}
         onBlur={() => {
-          if (isDirtyRef.current) save(localValue);
+          if (isDirtyRef.current && !isSaving) {
+            saveRef.current(latestValueRef.current);
+          }
         }}
         placeholder='e.g. Visitors from the website sign up for the product and convert into users'
         disabled={readOnly}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinDescriptionForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinDescriptionForm.tsx
@@ -1,0 +1,137 @@
+import { Textarea } from '@owox/ui/components/textarea';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
+import { ExternalLink, Info } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'react-hot-toast';
+import { Button } from '../../../../../shared/components/Button';
+import { useProjectRoute } from '../../../../../shared/hooks/useProjectRoute';
+import { useDebounce } from '../../../../../hooks/useDebounce';
+import { dataMartRelationshipService } from '../../../shared/services/data-mart-relationship.service';
+import type { DataMartRelationship } from '../../../shared/types/relationship.types';
+
+interface JoinDescriptionFormProps {
+  relationship: DataMartRelationship;
+  dataMartId: string;
+  readOnly?: boolean;
+  /**
+   * When set, the join is inherited from a parent data mart and must be edited there.
+   * Renders an informational banner with a link to the parent.
+   */
+  inheritedFrom?: { id: string; title: string } | null;
+  onSaved: (updated: DataMartRelationship) => void;
+}
+
+export function JoinDescriptionForm({
+  relationship,
+  dataMartId,
+  readOnly = false,
+  inheritedFrom,
+  onSaved,
+}: JoinDescriptionFormProps) {
+  const { scope } = useProjectRoute();
+
+  const savedValue = relationship.description ?? '';
+  const [localValue, setLocalValue] = useState(savedValue);
+  const debouncedValue = useDebounce(localValue, 800);
+  const lastSavedRef = useRef(savedValue);
+  const isDirtyRef = useRef(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setLocalValue(savedValue);
+    lastSavedRef.current = savedValue;
+    isDirtyRef.current = false;
+  }, [savedValue]);
+
+  const save = (value: string) => {
+    if (readOnly || isSaving) return;
+    if (value.trim() === lastSavedRef.current.trim()) {
+      isDirtyRef.current = false;
+      return;
+    }
+    setIsSaving(true);
+    dataMartRelationshipService
+      .updateRelationship(
+        dataMartId,
+        relationship.id,
+        // An all-whitespace description is a cleared one: send null so the backend stores NULL.
+        { description: value.trim() === '' ? null : value },
+        { skipErrorToast: true, skipLoadingIndicator: true }
+      )
+      .then(updated => {
+        lastSavedRef.current = updated.description ?? '';
+        isDirtyRef.current = false;
+        onSaved(updated);
+      })
+      .catch(() => {
+        toast.error('Failed to save relationship description', {
+          id: `join-description-save-error-${relationship.id}`,
+        });
+      })
+      .finally(() => {
+        setIsSaving(false);
+      });
+  };
+
+  useEffect(() => {
+    if (!isDirtyRef.current) return;
+    save(debouncedValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run only when the debounced value settles
+  }, [debouncedValue]);
+
+  return (
+    <div className='flex flex-col gap-3 p-4'>
+      {inheritedFrom && (
+        <div className='flex min-w-0 items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200'>
+          <Info className='size-4 shrink-0' />
+          <p className='min-w-0 flex-1 truncate leading-snug'>
+            Inherited from <span className='font-semibold'>{inheritedFrom.title}</span> — edit the
+            description there.
+          </p>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            className='h-7 shrink-0 bg-white/80 text-xs dark:bg-white/5'
+            onClick={() => {
+              window.open(scope(`/data-marts/${inheritedFrom.id}/data-setup`), '_blank');
+            }}
+          >
+            <ExternalLink className='size-3.5' />
+            <span className='max-w-[200px] truncate'>Open {inheritedFrom.title}</span>
+          </Button>
+        </div>
+      )}
+
+      <label className='flex items-center gap-1.5 text-sm font-medium'>
+        Relationship Description
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className='text-muted-foreground/50 hover:text-muted-foreground shrink-0 transition-colors'>
+              <Info className='size-4 shrink-0' />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side='top' className='max-w-xs'>
+            Optional business meaning of this relationship. AI assistants read it through MCP to
+            understand how the joined data relates — not just how the rows are matched.
+          </TooltipContent>
+        </Tooltip>
+      </label>
+
+      <Textarea
+        value={localValue}
+        onChange={e => {
+          setLocalValue(e.target.value);
+          isDirtyRef.current = true;
+        }}
+        onBlur={() => {
+          if (isDirtyRef.current) save(localValue);
+        }}
+        placeholder='e.g. Visitors from the website sign up for the product and convert into users'
+        disabled={readOnly}
+        rows={4}
+        className='bg-background text-sm dark:bg-white/5'
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinDescriptionForm.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/JoinDescriptionForm.tsx
@@ -50,20 +50,25 @@ export function JoinDescriptionForm({
     }
   }, [savedValue]);
 
-  // Kept in a ref so effects can depend on plain values (debouncedValue, isSaving)
-  // without re-running on every render for a new function identity.
-  const saveRef = useRef<(value: string, opts?: { ignoreInFlight?: boolean }) => void>(() => {
+  // The settled-or-null promise of the PATCH currently on the wire. Only one PATCH may
+  // be in flight at a time — the server has no version check, so two concurrent PATCHes
+  // can apply out of order and the stale one would win.
+  const inFlightRef = useRef<Promise<void> | null>(null);
+
+  // Kept in refs so effects and the unmount cleanup can call the latest logic without
+  // depending on a new function identity every render.
+  const sendRef = useRef<(value: string) => void>(() => {
     /* replaced each render below */
   });
-  saveRef.current = (value, { ignoreInFlight = false } = {}) => {
-    if (readOnly || (isSaving && !ignoreInFlight)) return;
+  sendRef.current = value => {
+    if (readOnly) return;
     if (value.trim() === lastSavedRef.current.trim()) {
       // Nothing to send; stay dirty only if the textarea has since diverged again.
       isDirtyRef.current = latestValueRef.current.trim() !== lastSavedRef.current.trim();
       return;
     }
     setIsSaving(true);
-    dataMartRelationshipService
+    const request = dataMartRelationshipService
       .updateRelationship(
         dataMartId,
         relationship.id,
@@ -87,7 +92,19 @@ export function JoinDescriptionForm({
       })
       .finally(() => {
         setIsSaving(false);
+        if (inFlightRef.current === request) {
+          inFlightRef.current = null;
+        }
       });
+    inFlightRef.current = request;
+  };
+
+  const saveRef = useRef<(value: string) => void>(() => {
+    /* replaced each render below */
+  });
+  saveRef.current = value => {
+    if (isSaving) return;
+    sendRef.current(value);
   };
 
   // Fires when the debounce settles AND whenever an in-flight save finishes —
@@ -99,10 +116,21 @@ export function JoinDescriptionForm({
 
   // Flush a pending edit when the tab unmounts (tab switch, row collapse) — the
   // debounce timer dies with the component, and blur is not guaranteed to fire first.
+  // Queued BEHIND any in-flight save, never alongside it: the flush must not start a
+  // second PATCH that could be processed before the first and lose to its stale text.
   useEffect(() => {
     return () => {
-      if (isDirtyRef.current) {
-        saveRef.current(latestValueRef.current, { ignoreInFlight: true });
+      if (!isDirtyRef.current) return;
+      const flushPending = () => {
+        // Re-checked after the in-flight save settles — it may have covered this edit.
+        if (isDirtyRef.current) {
+          sendRef.current(latestValueRef.current);
+        }
+      };
+      if (inFlightRef.current) {
+        void inFlightRef.current.then(flushPending);
+      } else {
+        flushPending();
       }
     };
   }, []);

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipAccordionItem.tsx
@@ -18,6 +18,7 @@ import {
   GitMerge,
   Info,
   MoreHorizontal,
+  Text,
   Trash2,
   TriangleAlert,
 } from 'lucide-react';
@@ -34,6 +35,7 @@ import type {
   TransientRelationshipRow,
 } from '../../../shared/types/relationship.types';
 import { SourceFieldsTable } from '../DataMartSchemaSettings/SourceFieldsTable';
+import { JoinDescriptionForm } from './JoinDescriptionForm';
 import { JoinSettingsForm } from './JoinSettingsForm';
 import { NoAccessIndicator } from './NoAccessIndicator';
 import {
@@ -88,7 +90,7 @@ export interface SourceEntry {
   dataMartId: string;
 }
 
-type AccordionTab = 'fields' | 'join-settings';
+type AccordionTab = 'fields' | 'join-settings' | 'description';
 
 interface RelationshipAccordionItemProps {
   row: TransientRelationshipRow;
@@ -431,6 +433,10 @@ export function RelationshipAccordionItem({
                           <GitMerge className='h-4 w-4' />
                           Join Settings
                         </TabsTrigger>
+                        <TabsTrigger value='description'>
+                          <Text className='h-4 w-4' />
+                          Description
+                        </TabsTrigger>
                       </TabsList>
                     </div>
 
@@ -487,6 +493,22 @@ export function RelationshipAccordionItem({
                         dataMartId={dataMartId}
                         readOnly={readOnly || isTransient}
                         siblingAliases={siblingAliases}
+                        inheritedFrom={
+                          isTransient
+                            ? { id: row.sourceDmId, title: row.parentDataMartTitle }
+                            : null
+                        }
+                        onSaved={updated => {
+                          onRelationshipUpdated(updated);
+                        }}
+                      />
+                    </TabsContent>
+
+                    <TabsContent value='description'>
+                      <JoinDescriptionForm
+                        relationship={rel}
+                        dataMartId={dataMartId}
+                        readOnly={readOnly || isTransient}
                         inheritedFrom={
                           isTransient
                             ? { id: row.sourceDmId, title: row.parentDataMartTitle }

--- a/apps/web/src/features/data-marts/shared/types/relationship.types.ts
+++ b/apps/web/src/features/data-marts/shared/types/relationship.types.ts
@@ -49,6 +49,8 @@ export interface DataMartRelationship {
   targetDataMart: RelatedDataMart;
   targetAlias: string;
   joinConditions: JoinCondition[];
+  /** Business meaning of this relationship, shared with AI assistants. */
+  description?: string;
   createdById: string;
   createdAt: string;
   modifiedAt: string;
@@ -59,11 +61,14 @@ export interface CreateRelationshipRequest {
   targetDataMartId: string;
   targetAlias: string;
   joinConditions: JoinCondition[];
+  description?: string;
 }
 
 export interface UpdateRelationshipRequest {
   targetAlias?: string;
   joinConditions?: JoinCondition[];
+  /** Omit to leave untouched; null or an empty string clears it. */
+  description?: string | null;
 }
 
 export interface RelationshipGraphNode {


### PR DESCRIPTION
## What

Each join between data marts can now carry an optional free-text description explaining the business meaning of the relationship (e.g. *"Visitors from the website sign up for the product and convert into users"*).

## Why

A join definition carries only data context: which fields match. An AI assistant working through MCP could see *which* fields a joined data mart contributes, but not *how and why* the two data marts relate — which limits reasoning like root-cause analysis across joined data. An analyst-written relationship description closes that gap, and is also useful documentation for humans reading the Data Setup page.

## How

**Backend**
- New nullable `description` (text) column on `DataMartRelationship` + migration.
- `POST`/`PATCH /data-marts/:id/relationships` accept an optional `description`; responses return it. `null` or a blank string clears it; values are trimmed before storing.

**Web (Data Setup)**
- A joined data mart's card gets a new **Description** tab next to Join Settings, with an autosaving textarea (same debounce/save pattern as SQL Alias / Join Fields).
- Inherited (transitive) joins render it read-only with a banner linking to the owning data mart.

**MCP**
- `get_data_mart_details_by_id` with `detail_level=with_joined_fields` now returns a `joins` array — one entry per join edge with the source/target data mart titles, the alias path, the join key fields, and the relationship description. Only sources the caller may report on are exposed, matching the existing joined-fields gate.
- System instructions tell the model to read `joins` before interpreting joined fields.

## Tests

- Mapper, relationship service (set/trim/clear/untouched), MCP facade (joins exposure + inaccessible-source filtering), and details tool specs updated/added — all passing.
- Web `RelationshipAccordionItem` tests passing; backend build typecheck and web typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)