### PR TITLE
fix(plugin-host): allow a release to redefine an existing collection

### DIFF
--- a/apps/backend/src/plugin-host/use-cases/sync-plugin-releases.service.spec.ts
+++ b/apps/backend/src/plugin-host/use-cases/sync-plugin-releases.service.spec.ts
@@ -391,11 +391,23 @@ describe('SyncPluginReleasesService', () => {
     // processCandidate. A release that redefines an existing collection must publish.
     it('accepts a release that redefines a collection from the current manifest', async () => {
       const s = setup();
-      s.githubApi.listReleases.mockResolvedValue([release('v2.0.0')]);
+      // The reported case: a patch release binds an already-released collection to an entity.
+      const boundDashboards = {
+        name: 'dashboards',
+        scope: 'project',
+        entityBinding: {
+          type: 'data-mart',
+          actions: { read: 'SEE', create: 'SEE', update: 'EDIT', delete: 'DELETE' },
+        },
+      };
+      s.githubApi.listReleases.mockResolvedValue([release('v0.1.1')]);
+      s.githubApi.getFileAtCommit.mockResolvedValue(
+        JSON.stringify({ ...JSON.parse(MANIFEST), collections: [boundDashboards] })
+      );
       s.versionService.findAllByPluginId.mockResolvedValue([
         {
           id: 'v1',
-          semver: '1.0.0',
+          semver: '0.1.0',
           collections: [{ name: 'dashboards', scope: 'project' }],
         },
       ] as never);
@@ -403,8 +415,11 @@ describe('SyncPluginReleasesService', () => {
       const result = await run(s);
 
       expect(result.report.rejections).toEqual([]);
-      expect(result.report.acceptedSemvers).toEqual(['2.0.0']);
-      expect(s.versionService.insertVersionForLease).toHaveBeenCalled();
+      expect(result.report.acceptedSemvers).toEqual(['0.1.1']);
+      expect(s.versionService.insertVersionForLease).toHaveBeenCalledWith(
+        expect.objectContaining({ collections: [boundDashboards] }),
+        'lease-1'
+      );
     });
 
     // One broken release must not take the good ones down with it.

--- a/apps/backend/src/plugin-host/use-cases/sync-plugin-releases.service.spec.ts
+++ b/apps/backend/src/plugin-host/use-cases/sync-plugin-releases.service.spec.ts
@@ -387,7 +387,9 @@ describe('SyncPluginReleasesService', () => {
       expect(result.report.acceptedSemvers).toEqual(['1.0.0']);
     });
 
-    it('rejects a release that removes a collection from the current manifest', async () => {
+    // The collection-compatibility gate is temporarily off; see the ponytail note in
+    // processCandidate. A release that redefines an existing collection must publish.
+    it('accepts a release that redefines a collection from the current manifest', async () => {
       const s = setup();
       s.githubApi.listReleases.mockResolvedValue([release('v2.0.0')]);
       s.versionService.findAllByPluginId.mockResolvedValue([
@@ -400,11 +402,9 @@ describe('SyncPluginReleasesService', () => {
 
       const result = await run(s);
 
-      expect(result.report.rejections[0]).toMatchObject({
-        code: ReleaseRejectionCode.COLLECTIONS_INCOMPATIBLE,
-      });
-      expect(s.validator.validate).not.toHaveBeenCalled();
-      expect(s.versionService.insertVersionForLease).not.toHaveBeenCalled();
+      expect(result.report.rejections).toEqual([]);
+      expect(result.report.acceptedSemvers).toEqual(['2.0.0']);
+      expect(s.versionService.insertVersionForLease).toHaveBeenCalled();
     });
 
     // One broken release must not take the good ones down with it.

--- a/apps/backend/src/plugin-host/use-cases/sync-plugin-releases.service.ts
+++ b/apps/backend/src/plugin-host/use-cases/sync-plugin-releases.service.ts
@@ -22,10 +22,7 @@ import { PluginService, PluginSyncSlotClaim } from '../services/plugin.service';
 import { PluginVersionService } from '../services/plugin-version.service';
 import { RemoteUrlValidatorService } from '../services/remote-url-validator.service';
 import { GithubRepoRef, parseGithubRepoLocator } from '../utils/github-repo-locator.util';
-import {
-  findIncompatibleCollectionChange,
-  parsePluginManifest,
-} from '../utils/plugin-manifest.util';
+import { parsePluginManifest } from '../utils/plugin-manifest.util';
 import { compareSemver, formatSemver, parseReleaseTag } from '../utils/semver.util';
 
 /** A release that survived the free checks and is worth spending network calls on. */
@@ -214,26 +211,11 @@ export class SyncPluginReleasesService {
       return false;
     }
 
-    const currentVersion = (await this.versionService.findAllByPluginId(pluginId)).reduce<
-      { semver: string; collections: PluginVersionCollections } | undefined
-    >(
-      (highest, version) =>
-        !highest || compareSemver(version.semver, highest.semver) > 0
-          ? { semver: version.semver, collections: version.collections ?? [] }
-          : highest,
-      undefined
-    );
-    const incompatibility = findIncompatibleCollectionChange(
-      currentVersion?.collections ?? [],
-      manifest.manifest.collections
-    );
-    if (incompatibility) {
-      into.rejections.push(
-        this.rejection(release, ReleaseRejectionCode.COLLECTIONS_INCOMPATIBLE, incompatibility)
-      );
-      return false;
-    }
-
+    // ponytail: collection-compatibility gate temporarily off, so a release that redefines
+    // an existing collection publishes instead of being rejected. It returns gated on
+    // SemVer: enforced for minor and patch, waived for a major release, so a plugin author
+    // decides when a breaking change is intended. findIncompatibleCollectionChange and
+    // COLLECTIONS_INCOMPATIBLE are kept for that.
     const delivery = await this.remoteUrlValidator.validate(manifest.manifest.delivery.url);
     if (!delivery.ok) {
       into.rejections.push(this.rejection(release, delivery.code, delivery.detail));
@@ -394,7 +376,3 @@ export class SyncPluginReleasesService {
     return { tagName: release.tagName, githubReleaseId: release.githubReleaseId, code, detail };
   }
 }
-
-type PluginVersionCollections = NonNullable<
-  Awaited<ReturnType<PluginVersionService['findById']>>
->['collections'];


### PR DESCRIPTION
## What

Temporarily turns off the collection-compatibility gate in plugin release sync, so a release that redefines a collection it already declared is published instead of rejected.

## Why

Reported on `OWOX/data-mart-dashboardization-fvl`: the plugin stayed on `0.1.0` while `v0.1.1` and `v0.1.2` existed on GitHub. `v0.1.1` added an `entityBinding` to the already-released `dashboards` collection, so `findIncompatibleCollectionChange` rejected it with `COLLECTIONS_INCOMPATIBLE` — `Collection "dashboards" cannot change entity binding`. The sync stops at the highest valid version, so both releases were refused and the plugin silently stayed put.

The guard itself is intentional — it exists so a plugin update cannot break existing collections. What is too rigid is applying it unconditionally. The agreed direction is to apply it by Semantic Versioning instead: enforce for minor and patch releases, and let a major release carry a deliberate breaking change, so the plugin author decides when incompatibility is intended.

Unblocking today; the SemVer-gated version comes back in the follow-up that also covers communicating rejection reasons in logs, audit and UI.

## Changes

- `sync-plugin-releases.service.ts` — drop the gate from `processCandidate`, with a `ponytail:` note stating the intended SemVer rule.
- `findIncompatibleCollectionChange` and `ReleaseRejectionCode.COLLECTIONS_INCOMPATIBLE` are kept as-is for that follow-up; their own unit tests are untouched.
- The sync spec case flips from "rejects a release that removes a collection" to "accepts a release that redefines a collection", so the new behaviour is actually covered.

## Deliberately not done

Documentation still describes the rule as permanent (`docs/plugins/authoring-guide.md:209`, `packages/plugin-sdk/README.md`). The rule is coming back in a stricter, SemVer-aware form, so rewriting the docs now and again in two weeks is churn. Docs get updated once, with the follow-up.

## Verification

- `npx jest src/plugin-host/use-cases/sync-plugin-releases.service.spec.ts src/plugin-host/utils/plugin-manifest.util.spec.ts` — 58 passed.
- `npm run build` in `apps/backend` — clean.
- ESLint and Prettier clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
