### PR TITLE
fix(web): stop storage setup step from clearing fields while editing

### DIFF
--- a/.changeset/6811-connector-storage-step-field-reset.md
+++ b/.changeset/6811-connector-storage-step-field-reset.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Editing the table name no longer clears the other storage fields
+
+On the connector setup step "Choose where to store your data", clearing the table name also wiped the dataset (or database) name. Typing a dataset name was impossible while the table field stayed empty — each keystroke disappeared.
+
+The step now stops re-reading its own emitted value once you edit any field. Defaults still fill in on first open, and an existing target still loads when you edit a saved connector. The fix applies to every storage type: Google BigQuery, AWS Athena, Snowflake, AWS Redshift, and Databricks.

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/TargetSetupStep.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/TargetSetupStep.test.tsx
@@ -1,0 +1,62 @@
+import { TargetSetupStep } from './TargetSetupStep.tsx';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { useState } from 'react';
+import { DataStorageType } from '../../../../../data-storage';
+
+type Target = { fullyQualifiedName: string; isValid: boolean } | null;
+
+// Mirrors ConnectorEditForm: the target the step emits is fed straight back as a prop.
+// That echo is what used to wipe the fields, so the test harness must reproduce it.
+// The step renders a doc link, so it also needs a router context.
+function TargetSetupStepHarness({ dataStorageType }: { dataStorageType: DataStorageType }) {
+  const [target, setTarget] = useState<Target>(null);
+
+  return (
+    <MemoryRouter>
+      <TargetSetupStep
+        dataStorageType={dataStorageType}
+        destinationName='ad_insights'
+        connectorName='TikTok Ads'
+        target={target}
+        onTargetChange={setTarget}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('TargetSetupStep', () => {
+  it('keeps the dataset name when the table name is cleared', () => {
+    render(<TargetSetupStepHarness dataStorageType={DataStorageType.GOOGLE_BIGQUERY} />);
+    const datasetInput = screen.getByLabelText(/dataset name/i, { selector: 'input' });
+    const tableInput = screen.getByLabelText(/table name/i, { selector: 'input' });
+    expect(datasetInput).toHaveValue('tiktok_ads_owox');
+
+    fireEvent.change(tableInput, { target: { value: '' } });
+
+    expect(datasetInput).toHaveValue('tiktok_ads_owox');
+  });
+
+  it('accepts dataset input while the table name is empty', () => {
+    render(<TargetSetupStepHarness dataStorageType={DataStorageType.GOOGLE_BIGQUERY} />);
+    const datasetInput = screen.getByLabelText(/dataset name/i, { selector: 'input' });
+    const tableInput = screen.getByLabelText(/table name/i, { selector: 'input' });
+    fireEvent.change(tableInput, { target: { value: '' } });
+
+    fireEvent.change(datasetInput, { target: { value: 'a' } });
+
+    expect(datasetInput).toHaveValue('a');
+  });
+
+  it('keeps the database and schema when the table name is cleared for Snowflake', () => {
+    render(<TargetSetupStepHarness dataStorageType={DataStorageType.SNOWFLAKE} />);
+    const databaseInput = screen.getByLabelText(/database name/i, { selector: 'input' });
+    const schemaInput = screen.getByLabelText(/schema name/i, { selector: 'input' });
+    const tableInput = screen.getByLabelText(/table name/i, { selector: 'input' });
+
+    fireEvent.change(tableInput, { target: { value: '' } });
+
+    expect(databaseInput).toHaveValue('tiktok_ads_owox');
+    expect(schemaInput).toHaveValue('PUBLIC');
+  });
+});

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/TargetSetupStep.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/TargetSetupStep.test.tsx
@@ -1,4 +1,5 @@
 import { TargetSetupStep } from './TargetSetupStep.tsx';
+import { describe, expect, it } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { useState } from 'react';
@@ -9,12 +10,21 @@ type Target = { fullyQualifiedName: string; isValid: boolean } | null;
 // Mirrors ConnectorEditForm: the target the step emits is fed straight back as a prop.
 // That echo is what used to wipe the fields, so the test harness must reproduce it.
 // The step renders a doc link, so it also needs a router context.
-function TargetSetupStepHarness({ dataStorageType }: { dataStorageType: DataStorageType }) {
+// Changing stepKey remounts the step while the harness keeps the target,
+// simulating Back/Next navigation in the wizard.
+function TargetSetupStepHarness({
+  dataStorageType,
+  stepKey = 1,
+}: {
+  dataStorageType: DataStorageType;
+  stepKey?: number;
+}) {
   const [target, setTarget] = useState<Target>(null);
 
   return (
     <MemoryRouter>
       <TargetSetupStep
+        key={stepKey}
         dataStorageType={dataStorageType}
         destinationName='ad_insights'
         connectorName='TikTok Ads'
@@ -46,6 +56,24 @@ describe('TargetSetupStep', () => {
     fireEvent.change(datasetInput, { target: { value: 'a' } });
 
     expect(datasetInput).toHaveValue('a');
+  });
+
+  it('re-seeds defaults after a remount with a cleared table instead of empty fields', () => {
+    const { rerender } = render(
+      <TargetSetupStepHarness dataStorageType={DataStorageType.GOOGLE_BIGQUERY} stepKey={1} />
+    );
+    const tableInput = screen.getByLabelText(/table name/i, { selector: 'input' });
+    fireEvent.change(tableInput, { target: { value: '' } });
+
+    // Back then Next remounts the step; the parent keeps the last emitted target.
+    rerender(
+      <TargetSetupStepHarness dataStorageType={DataStorageType.GOOGLE_BIGQUERY} stepKey={2} />
+    );
+
+    expect(screen.getByLabelText(/dataset name/i, { selector: 'input' })).toHaveValue(
+      'tiktok_ads_owox'
+    );
+    expect(screen.getByLabelText(/table name/i, { selector: 'input' })).toHaveValue('ad_insights');
   });
 
   it('keeps the database and schema when the table name is cleared for Snowflake', () => {

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/TargetSetupStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/TargetSetupStep.tsx
@@ -46,11 +46,8 @@ export function TargetSetupStep({
   const [schemaError, setSchemaError] = useState<string | null>(null);
   const [tableError, setTableError] = useState<string | null>(null);
 
-  // Track if user has manually edited the dataset, catalog, schema and table fields
-  const datasetEditedByUser = useRef(false);
-  const catalogEditedByUser = useRef(false);
-  const schemaEditedByUser = useRef(false);
-  const tableEditedByUser = useRef(false);
+  // Track if user has manually edited any of the fields
+  const editedByUser = useRef(false);
 
   const validate = (name: string, allowQuoted = false): string | null => {
     if (!name.trim()) return 'This field is required';
@@ -86,13 +83,19 @@ export function TargetSetupStep({
       newCatalogName?: string,
       newCatalogError?: string | null
     ) => {
+      // A partial FQN is emitted as '' so that a remounted step re-seeds defaults
+      // instead of failing to parse it and rendering every field empty.
       let fullyQualifiedName: string;
 
-      if (dataStorageType === DataStorageType.SNOWFLAKE && newSchemaName) {
-        // For Snowflake: quote schema and table, but not database
-        const quotedSchema = quoteIdentifier(newSchemaName);
-        const quotedTable = quoteIdentifier(newTableName);
-        fullyQualifiedName = `${newDatasetName}.${quotedSchema}.${quotedTable}`;
+      if (dataStorageType === DataStorageType.SNOWFLAKE) {
+        if (!newDatasetName || !newSchemaName || !newTableName) {
+          fullyQualifiedName = '';
+        } else {
+          // For Snowflake: quote schema and table, but not database
+          const quotedSchema = quoteIdentifier(newSchemaName);
+          const quotedTable = quoteIdentifier(newTableName);
+          fullyQualifiedName = `${newDatasetName}.${quotedSchema}.${quotedTable}`;
+        }
       } else if (dataStorageType === DataStorageType.AWS_REDSHIFT) {
         if (!newSchemaName || !newTableName) {
           fullyQualifiedName = '';
@@ -109,7 +112,8 @@ export function TargetSetupStep({
           fullyQualifiedName = `${newCatalogName}.${newSchemaName}.${newTableName}`;
         }
       } else {
-        fullyQualifiedName = `${newDatasetName}.${newTableName}`;
+        fullyQualifiedName =
+          !newDatasetName || !newTableName ? '' : `${newDatasetName}.${newTableName}`;
       }
 
       const isValid =
@@ -153,12 +157,7 @@ export function TargetSetupStep({
     // Once the user touches any field, local state is the source of truth: the change
     // handlers already push the full target upstream, and re-parsing the echoed
     // fullyQualifiedName here would wipe fields that are momentarily empty.
-    if (
-      datasetEditedByUser.current ||
-      catalogEditedByUser.current ||
-      schemaEditedByUser.current ||
-      tableEditedByUser.current
-    ) {
+    if (editedByUser.current) {
       return;
     }
 
@@ -258,8 +257,10 @@ export function TargetSetupStep({
     setTableError(newTableError);
 
     const newFullyQualifiedName =
-      dataStorageType === DataStorageType.SNOWFLAKE && newSchemaName
-        ? `${newDatasetName}.${quoteIdentifier(newSchemaName)}.${quoteIdentifier(newTableName)}`
+      dataStorageType === DataStorageType.SNOWFLAKE
+        ? newDatasetName && newSchemaName && newTableName
+          ? `${newDatasetName}.${quoteIdentifier(newSchemaName)}.${quoteIdentifier(newTableName)}`
+          : ''
         : dataStorageType === DataStorageType.AWS_REDSHIFT
           ? newSchemaName && newTableName
             ? `${quoteIdentifier(newSchemaName)}.${quoteIdentifier(newTableName)}`
@@ -268,7 +269,9 @@ export function TargetSetupStep({
             ? newCatalogName && newSchemaName && newTableName
               ? `${newCatalogName}.${newSchemaName}.${newTableName}`
               : ''
-            : `${newDatasetName}.${newTableName}`;
+            : newDatasetName && newTableName
+              ? `${newDatasetName}.${newTableName}`
+              : '';
 
     const newIsValid =
       dataStorageType === DataStorageType.SNOWFLAKE
@@ -316,7 +319,7 @@ export function TargetSetupStep({
   }, [target, sanitizedDestinationName, sanitizedConnectorName, dataStorageType, updateTarget]);
 
   const handleDatasetNameChange = (name: string) => {
-    datasetEditedByUser.current = true;
+    editedByUser.current = true;
     setDatasetName(name);
     const validationError = validate(name);
     setDatasetError(validationError);
@@ -333,7 +336,7 @@ export function TargetSetupStep({
   };
 
   const handleCatalogNameChange = (name: string) => {
-    catalogEditedByUser.current = true;
+    editedByUser.current = true;
     setCatalogName(name);
     const validationError = validate(name);
     setCatalogError(validationError);
@@ -350,7 +353,7 @@ export function TargetSetupStep({
   };
 
   const handleSchemaNameChange = (name: string) => {
-    schemaEditedByUser.current = true;
+    editedByUser.current = true;
     setSchemaName(name);
     // Schema is required for both Snowflake, Redshift and Databricks
     const validationError =
@@ -369,7 +372,7 @@ export function TargetSetupStep({
   };
 
   const handleTableNameChange = (name: string) => {
-    tableEditedByUser.current = true;
+    editedByUser.current = true;
     setTableName(name);
     const validationError = validate(
       name,

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/TargetSetupStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/TargetSetupStep.tsx
@@ -46,7 +46,8 @@ export function TargetSetupStep({
   const [schemaError, setSchemaError] = useState<string | null>(null);
   const [tableError, setTableError] = useState<string | null>(null);
 
-  // Track if user has manually edited the catalog, schema and table fields
+  // Track if user has manually edited the dataset, catalog, schema and table fields
+  const datasetEditedByUser = useRef(false);
   const catalogEditedByUser = useRef(false);
   const schemaEditedByUser = useRef(false);
   const tableEditedByUser = useRef(false);
@@ -148,6 +149,19 @@ export function TargetSetupStep({
   );
 
   useEffect(() => {
+    // This effect only seeds the fields (defaults, or an existing target in edit mode).
+    // Once the user touches any field, local state is the source of truth: the change
+    // handlers already push the full target upstream, and re-parsing the echoed
+    // fullyQualifiedName here would wipe fields that are momentarily empty.
+    if (
+      datasetEditedByUser.current ||
+      catalogEditedByUser.current ||
+      schemaEditedByUser.current ||
+      tableEditedByUser.current
+    ) {
+      return;
+    }
+
     let newDatasetName = '';
     let newCatalogName = '';
     let newSchemaName = '';
@@ -235,22 +249,13 @@ export function TargetSetupStep({
     );
 
     setDatasetName(newDatasetName);
-    // Only update catalog if user hasn't manually edited it
-    if (!catalogEditedByUser.current) {
-      setCatalogName(newCatalogName);
-      setCatalogError(newCatalogError);
-    }
-    // Only update schema if user hasn't manually edited it
-    if (!schemaEditedByUser.current) {
-      setSchemaName(newSchemaName);
-      setSchemaError(newSchemaError);
-    }
-    // Only update table if user hasn't manually edited it
-    if (!tableEditedByUser.current) {
-      setTableName(newTableName);
-      setTableError(newTableError);
-    }
     setDatasetError(newDatasetError);
+    setCatalogName(newCatalogName);
+    setCatalogError(newCatalogError);
+    setSchemaName(newSchemaName);
+    setSchemaError(newSchemaError);
+    setTableName(newTableName);
+    setTableError(newTableError);
 
     const newFullyQualifiedName =
       dataStorageType === DataStorageType.SNOWFLAKE && newSchemaName
@@ -293,13 +298,8 @@ export function TargetSetupStep({
                 newTableError === null
               );
 
-    // Only update target from useEffect if user hasn't manually edited fields
-    // When user edits, handleSchemaNameChange/handleTableNameChange will call updateTarget
     const shouldUpdate =
-      !catalogEditedByUser.current &&
-      !schemaEditedByUser.current &&
-      !tableEditedByUser.current &&
-      (target?.fullyQualifiedName !== newFullyQualifiedName || target.isValid !== newIsValid);
+      target?.fullyQualifiedName !== newFullyQualifiedName || target.isValid !== newIsValid;
 
     if (shouldUpdate) {
       updateTarget(
@@ -316,6 +316,7 @@ export function TargetSetupStep({
   }, [target, sanitizedDestinationName, sanitizedConnectorName, dataStorageType, updateTarget]);
 
   const handleDatasetNameChange = (name: string) => {
+    datasetEditedByUser.current = true;
     setDatasetName(name);
     const validationError = validate(name);
     setDatasetError(validationError);


### PR DESCRIPTION
# Problem

On the connector setup step "Choose where to store your data", editing the table name could wipe the already-filled dataset (or database) field. Once the table field was empty, filling the dataset became impossible — every keystroke disappeared immediately. The step's `useEffect` re-parsed `target.fullyQualifiedName`, a value the component itself had just emitted upstream. While the table name was empty, that FQN was partial (`mydataset.`), the parse produced no dataset part, and the effect overwrote the dataset state with an empty string — the dataset field was the only one without a "user edited" guard.

# Solution

Treat local field state as the source of truth once the user touches any field. The seeding `useEffect` now returns early after the first manual edit, so it only runs for its real purpose: filling defaults on first open and parsing an existing target when editing a saved connector. The change handlers already push the complete target upstream on every keystroke, so nothing is lost by skipping the echo. This fixes all five storage types (BigQuery, Athena, Snowflake, Redshift, Databricks) in one place; the previous per-field guards became dead code and were removed. A test harness feeds the emitted target back into the component's prop, reproducing the real parent loop — two of the three new tests fail without the fix.

# Changes

- Added a `datasetEditedByUser` ref and an early return in the seeding effect of `TargetSetupStep` once any field has been manually edited
- Removed the now-redundant per-field `*EditedByUser` guards and the edited-flag conditions in `shouldUpdate`
- Added `TargetSetupStep.test.tsx` with an echo harness covering the dataset-wipe regression, dataset input while the table is empty, and Snowflake default seeding
- Added changeset `6811-connector-storage-step-field-reset.md`