### PR TITLE
fix(open-holidays): await storage initialization before saving data

### DIFF
--- a/.changeset/6846-open-holidays-storage-save-fix.md
+++ b/.changeset/6846-open-holidays-storage-save-fix.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# OpenHolidays connector no longer fails when saving fetched data
+
+Every OpenHolidays run failed with `TypeError: storage.saveData is not a function` right after the API returned holiday rows, so no data ever reached the storage table.
+
+The cause: the connector requested its storage instance without waiting for the async initialization to finish, then tried to save data into the still-pending result instead of the ready storage.
+
+Now the connector waits for the storage to initialize before saving, and imports complete successfully.

--- a/packages/connectors/src/Sources/OpenHolidays/Connector.js
+++ b/packages/connectors/src/Sources/OpenHolidays/Connector.js
@@ -34,7 +34,7 @@ var OpenHolidaysConnector = class OpenHolidaysConnector extends AbstractConnecto
    * @param {Array<string>} options.fields - Array of fields to fetch
    */
   async processNode({ nodeName, fields }) {
-    const storage = this.getStorageByNode(nodeName);
+    const storage = await this.getStorageByNode(nodeName);
     if (ConnectorUtils.isTimeSeriesNode(this.source.fieldsSchema[nodeName])) {
       await this.processTimeSeriesNode({ nodeName, fields, storage });
     } else {


### PR DESCRIPTION
# Problem

Every run of the OpenHolidays connector failed with `TypeError: storage.saveData is not a function` immediately after the API returned holiday rows, so no data ever reached the destination table. The root cause was a missing `await` in `processNode`: `getStorageByNode` is an async method (it constructs the storage and runs `storage.init()`), but its result was used directly. The `storage` variable therefore held a pending Promise instead of the storage instance, and calling `.saveData()` on it threw.

# Solution

Added the missing `await` on the `getStorageByNode` call in `packages/connectors/src/Sources/OpenHolidays/Connector.js`, so `processTimeSeriesNode` receives the fully initialized storage instance. Audited all other connectors (XAds, FacebookMarketing, Shopify, BankOfCanada, GoogleAds, TikTokAds, GoogleSheets, LinkedInAds, LinkedInPages, OpenExchangeRates, MicrosoftAds, GitHub, CriteoAds, RedditAds) — all 25 other `getStorageByNode` call sites already use `await`, and all `storage.init()` calls are awaited; OpenHolidays was the only connector with this bug.

# Changes

- Added `await` to the `getStorageByNode` call in `OpenHolidaysConnector.processNode`
- Added a changeset describing the fix