### PR TITLE
feat(data-marts): make copy-credentials permission error actionable

### DIFF
--- a/.changeset/6850-actionable-copy-credentials-error.md
+++ b/.changeset/6850-actionable-copy-credentials-error.md
@@ -1,0 +1,14 @@
+---
+'owox': minor
+---
+
+# Improve: actionable error when copying connector credentials without access
+
+Saving a connector Data Mart with a configuration copied via "Copy from…"
+requires edit access to the source Data Mart. The error shown without that
+access now explains how to get it: ask an owner to add you as a Technical
+Owner or to turn on "Shared for maintenance", or enter the credentials
+manually.
+
+The connector setup guide now documents the "Copy from…" option: who can
+copy credentials, the exact error text, and how to resolve it.

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.spec.ts
@@ -326,7 +326,7 @@ describe('UpdateDataMartDefinitionService', () => {
     );
 
     await expect(service.run(command)).rejects.toThrow(
-      'You do not have permission to copy connector credentials from the source DataMart'
+      'You do not have permission to copy connector credentials from the source Data Mart'
     );
     expect(accessDecisionService.canAccess).toHaveBeenNthCalledWith(
       2,
@@ -366,7 +366,7 @@ describe('UpdateDataMartDefinitionService', () => {
     );
 
     await expect(service.run(command)).rejects.toThrow(
-      'You do not have permission to copy connector credentials from the source DataMart'
+      'You do not have permission to copy connector credentials from the source Data Mart'
     );
     expect(accessDecisionService.canAccess).toHaveBeenNthCalledWith(
       2,

--- a/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.ts
+++ b/apps/backend/src/data-marts/use-cases/update-data-mart-definition.service.ts
@@ -247,7 +247,9 @@ export class UpdateDataMartDefinitionService {
     );
     if (!canCopyCredentials) {
       throw new ForbiddenException(
-        'You do not have permission to copy connector credentials from the source DataMart'
+        'You do not have permission to copy connector credentials from the source Data Mart. ' +
+          'Ask its owner to add you as a Technical Owner or to turn on "Shared for maintenance", ' +
+          'or enter the credentials manually.'
       );
     }
   }

--- a/docs/getting-started/setup-guide/connector-data-mart.md
+++ b/docs/getting-started/setup-guide/connector-data-mart.md
@@ -59,6 +59,29 @@ Each connector requires authentication. Here is how you can obtain the required 
 
 Use the **credentials screen** to manage access per platform.
 
+### Copy a configuration from another Data Mart
+
+The **Copy from…** option reuses a connector configuration from another Data Mart, including its stored credentials.
+
+Copying credentials requires **Edit** access to the source Data Mart. You have it in one of these cases:
+
+- You are a Project Admin.
+- You are a Technical User and a Technical Owner of the source Data Mart.
+- You are a Technical User, and the source Data Mart is **Shared for maintenance**.
+
+Without this access, saving the Data Mart fails with this error:
+
+> You do not have permission to copy connector credentials from the source Data Mart.
+
+To resolve it, choose one of these options:
+
+- Ask an owner of the source Data Mart to add you as a Technical Owner.
+- Ask them to turn on **Shared for maintenance** on the source Data Mart.
+- If you are a Business User, ask a Project Admin to change your role to Technical User.
+- Enter your own credentials instead of copying.
+
+One more check applies when your role scope is **Selected contexts only**. You also need a context overlap with the source Data Mart. See [Ownership and Sharing](../../project/ownership-and-sharing.md) for the full access model.
+
 ## Step 4: Customize export schema
 
 Once the connector and parameters are set, click **Next** to select the node you want to import in this data mart.


### PR DESCRIPTION
# Problem

When a user copies a connector configuration from another Data Mart with "Copy from…" and lacks edit access to that source Data Mart, saving fails with a bare error: "You do not have permission to copy connector credentials from the source DataMart". The message names the problem but not the way out — it does not say which role or sharing setting grants the access, so users cannot tell what to ask for or whom to ask. The requirement itself is intentional (copying a configuration silently carries over the source's stored credentials), but nothing in the product or docs explained how to satisfy it.

# Solution

- Extended the `ForbiddenException` message in `UpdateDataMartDefinitionService.validateCredentialCopyAccess` to state the two remedies that grant edit access on the source Data Mart — being added as a Technical Owner, or the source being *Shared for maintenance* — plus the fallback of entering credentials manually. The wording follows the access matrix exactly (Project Admin / Technical Owner with Technical User role / Technical User via the maintenance sharing path).
- Documented the "Copy from…" option in the connector setup guide: what it copies, who has the required access, the exact error text, four resolution paths (including the role upgrade a Business User needs), and the context-overlap requirement for `Selected contexts only` members, with a link to the Ownership and Sharing page.
- Also normalized the "DataMart" spelling to "Data Mart" in the message to match product terminology, so the docs can quote it verbatim.

# Changes

- Replaced the bare permission error in `update-data-mart-definition.service.ts` with an actionable message naming the required role and sharing setting
- Updated the two assertions in `update-data-mart-definition.service.spec.ts` to the new message (40/40 tests pass)
- Added a "Copy a configuration from another Data Mart" section to `docs/getting-started/setup-guide/connector-data-mart.md` covering access requirements, the exact error, and how to resolve it
- Added changeset `6850-actionable-copy-credentials-error.md` (`owox: minor`)

![Data Setup page showing a red error banner: "You do not have permission to copy connector credentials from the source Data Mart. Ask its owner to add you as a Technical Owner or to turn on 'Shared for maintenance', or enter the credentials manually."](https://imagedelivery.net/zKr-4bdC5CBGL2DuuEmvYw/5cb014bd-a1ca-4068-cf5a-25e16ab3b700/public)
