### PR TITLE
fix(microsoft-ads): prevent out-of-memory crash when importing keywords

### DIFF
--- a/.changeset/6853-microsoft-ads-keywords-oom.md
+++ b/.changeset/6853-microsoft-ads-keywords-oom.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Memory-safe Keywords import for Microsoft Ads
+
+Previously, importing Keywords from a large Microsoft Ads account crashed the run with an out-of-memory error. The connector now streams records to storage in small chunks instead of loading the whole download at once. Imports of any account size now complete within normal memory limits.

--- a/packages/connectors/src/Sources/MicrosoftAds/Helper.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Helper.js
@@ -78,8 +78,9 @@ const MicrosoftAdsHelper = {
   /**
    * Download and unzip a CSV file, converting rows to objects in chunks that are
    * flushed to the callback as soon as they fill up. Unlike downloadCsvRows +
-   * csvRowsToObjects, this never holds the full row array or full object array in
-   * memory — only the CSV text of one file and one chunk at a time.
+   * csvRowsToObjects, this never builds the full cell-array or record-object
+   * arrays. Peak memory is one file's CSV text plus its split line strings
+   * (V8 slices sharing the parent string's memory) plus one chunk of records.
    * @param {string} url
    * @param {function(Array<Object>): Promise<void>} onRecordsChunk
    * @param {number} [chunkSize=2000]
@@ -99,10 +100,10 @@ const MicrosoftAdsHelper = {
    * the header (sanitized like csvRowsToObjects); 'Format Version' rows are skipped.
    * @param {string} csvText
    * @param {function(Array<Object>): Promise<void>} onRecordsChunk
-   * @param {number} chunkSize
+   * @param {number} [chunkSize=2000]
    * @returns {Promise<void>}
    */
-  async processCsvTextInChunks(csvText, onRecordsChunk, chunkSize) {
+  async processCsvTextInChunks(csvText, onRecordsChunk, chunkSize = 2000) {
     const lines = csvText.split('\n');
     let headerNames = null;
     let chunk = [];

--- a/packages/connectors/src/Sources/MicrosoftAds/Helper.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Helper.js
@@ -76,6 +76,65 @@ const MicrosoftAdsHelper = {
   },
 
   /**
+   * Download and unzip a CSV file, converting rows to objects in chunks that are
+   * flushed to the callback as soon as they fill up. Unlike downloadCsvRows +
+   * csvRowsToObjects, this never holds the full row array or full object array in
+   * memory — only the CSV text of one file and one chunk at a time.
+   * @param {string} url
+   * @param {function(Array<Object>): Promise<void>} onRecordsChunk
+   * @param {number} [chunkSize=2000]
+   * @returns {Promise<void>}
+   */
+  async processCsvRecordsFromUrl(url, onRecordsChunk, chunkSize = 2000) {
+    const response = await HttpUtils.fetch(url);
+    const blob = await response.getBlob();
+    const files = FileUtils.unzip(blob);
+    for (const file of files) {
+      await this.processCsvTextInChunks(file.getDataAsString(), onRecordsChunk, chunkSize);
+    }
+  },
+
+  /**
+   * Convert CSV text to record objects chunk by chunk. The first non-empty line is
+   * the header (sanitized like csvRowsToObjects); 'Format Version' rows are skipped.
+   * @param {string} csvText
+   * @param {function(Array<Object>): Promise<void>} onRecordsChunk
+   * @param {number} chunkSize
+   * @returns {Promise<void>}
+   */
+  async processCsvTextInChunks(csvText, onRecordsChunk, chunkSize) {
+    const lines = csvText.split('\n');
+    let headerNames = null;
+    let chunk = [];
+
+    for (const line of lines) {
+      if (line.trim() === '') continue;
+      const rowValues = FileUtils.parseCsv(line)[0];
+
+      if (headerNames === null) {
+        headerNames = rowValues.map(rawHeader => rawHeader.replace(/[^a-zA-Z0-9]/g, ''));
+        continue;
+      }
+      if (rowValues[0] === 'Format Version') continue;
+
+      const record = {};
+      headerNames.forEach((headerName, colIndex) => {
+        record[headerName] = rowValues[colIndex];
+      });
+      chunk.push(record);
+
+      if (chunk.length >= chunkSize) {
+        await onRecordsChunk(chunk);
+        chunk = [];
+      }
+    }
+
+    if (chunk.length > 0) {
+      await onRecordsChunk(chunk);
+    }
+  },
+
+  /**
    * Convert a 2D array of CSV rows into an array of objects
    * @param {Array<Array<string>>} csvRows
    * @returns {Array<Object>}

--- a/packages/connectors/src/Sources/MicrosoftAds/Source.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Source.js
@@ -483,10 +483,12 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
    * @param {string} opts.submitUrl - API endpoint URL
    * @param {Object} opts.downloadBody - Request body
    * @param {Object} opts.submitOpts - Request options
-   * @returns {Array<Object>}
+   * @param {Function} [opts.onRecordsChunk] - When provided, records are streamed to this
+   *   callback in chunks instead of being returned as one array (keeps peak memory low)
+   * @returns {Array<Object>} - Empty array when onRecordsChunk is provided
    * @private
    */
-  async _downloadEntity({ submitUrl, submitOpts }) {
+  async _downloadEntity({ submitUrl, submitOpts, onRecordsChunk }) {
     const submitResp = await HttpUtils.fetch(submitUrl, submitOpts);
     const text = await submitResp.getContentText();
     const responseData = JSON.parse(text);
@@ -512,6 +514,11 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
         return status.RequestStatus === 'Completed';
       }
     });
+    if (onRecordsChunk) {
+      await MicrosoftAdsHelper.processCsvRecordsFromUrl(pollResult.ResultFileUrl, onRecordsChunk);
+      return [];
+    }
+
     const csvRows = await MicrosoftAdsHelper.downloadCsvRows(pollResult.ResultFileUrl);
     const result = MicrosoftAdsHelper.csvRowsToObjects(csvRows);
 
@@ -542,10 +549,19 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
       this.config.logMessage(`Fetching ${entityType} for campaigns batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(campaignIds.length / batchSize)} (${campaignBatch.length} campaigns)`);
 
       try {
-        const batchRecords = await this._downloadEntityBatch({ accountId, entityType, campaignBatch });
-        this.config.logMessage(`Fetched ${batchRecords.length} ${entityType.toLowerCase()} from current batch`);
-
-        await onBatchReady(batchRecords);
+        // Stream records to storage chunk by chunk: buffering a whole batch of
+        // keyword rows in memory OOMs the runner process on large accounts.
+        let batchRecordCount = 0;
+        await this._downloadEntityBatch({
+          accountId,
+          entityType,
+          campaignBatch,
+          onRecordsChunk: async (recordsChunk) => {
+            batchRecordCount += recordsChunk.length;
+            await onBatchReady(recordsChunk);
+          }
+        });
+        this.config.logMessage(`Fetched ${batchRecordCount} ${entityType.toLowerCase()} from current batch`);
       } catch (error) {
         if (error.message && error.message.includes('100MB')) {
           // If still too large, reduce batch size and retry
@@ -556,9 +572,17 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
           for (let j = i; j < Math.min(i + batchSize, campaignIds.length); j += newBatchSize) {
             const smallerBatch = campaignIds.slice(j, j + newBatchSize);
             try {
-              const smallerBatchRecords = await this._downloadEntityBatch({ accountId, entityType, campaignBatch: smallerBatch });
-              this.config.logMessage(`Fetched ${smallerBatchRecords.length} ${entityType.toLowerCase()} from smaller batch (${smallerBatch.length} campaigns)`);
-              await onBatchReady(smallerBatchRecords);
+              let smallerBatchRecordCount = 0;
+              await this._downloadEntityBatch({
+                accountId,
+                entityType,
+                campaignBatch: smallerBatch,
+                onRecordsChunk: async (recordsChunk) => {
+                  smallerBatchRecordCount += recordsChunk.length;
+                  await onBatchReady(recordsChunk);
+                }
+              });
+              this.config.logMessage(`Fetched ${smallerBatchRecordCount} ${entityType.toLowerCase()} from smaller batch (${smallerBatch.length} campaigns)`);
             } catch (smallerError) {
               if (smallerError.message && smallerError.message.includes('100MB')) {
                 throw new Error(`Failed to fetch ${entityType}: batch size of ${smallerBatch.length} campaigns still exceeds 100MB limit`);
@@ -586,10 +610,11 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
    * @param {string} opts.accountId
    * @param {string} opts.entityType
    * @param {Array<string>} opts.campaignBatch
+   * @param {Function} [opts.onRecordsChunk] - Streams records in chunks when provided
    * @returns {Array<Object>}
    * @private
    */
-  async _downloadEntityBatch({ accountId, entityType, campaignBatch }) {
+  async _downloadEntityBatch({ accountId, entityType, campaignBatch, onRecordsChunk }) {
     const developerToken = this._getDeveloperToken();
 
     const downloadBody = {
@@ -620,7 +645,8 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
 
     return await this._downloadEntity({
       submitUrl: 'https://bulk.api.bingads.microsoft.com/Bulk/v13/Campaigns/DownloadByCampaignIds',
-      submitOpts
+      submitOpts,
+      onRecordsChunk
     });
   }
 

--- a/packages/connectors/src/Sources/MicrosoftAds/Source.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Source.js
@@ -544,47 +544,55 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
     // Start with batch size of 100 campaigns per batch
     let batchSize = Math.max(1, Math.min(50, Math.floor(campaignIds.length / 10)));
 
-    for (let i = 0; i < campaignIds.length; i += batchSize) {
+    // Stream records to storage chunk by chunk: buffering a whole batch of
+    // keyword rows in memory OOMs the runner process on large accounts.
+    // Storage errors are tagged so a message containing '100MB' coming from
+    // onBatchReady can never trigger the download batch-halving retry below.
+    const streamBatch = async (batch) => {
+      let recordCount = 0;
+      await this._downloadEntityBatch({
+        accountId,
+        entityType,
+        campaignBatch: batch,
+        onRecordsChunk: async (recordsChunk) => {
+          recordCount += recordsChunk.length;
+          try {
+            await onBatchReady(recordsChunk);
+          } catch (storageError) {
+            storageError.isStorageError = true;
+            throw storageError;
+          }
+        }
+      });
+      return recordCount;
+    };
+    const isTooLargeError = (error) =>
+      !error.isStorageError && error.message && error.message.includes('100MB');
+
+    let i = 0;
+    while (i < campaignIds.length) {
       const campaignBatch = campaignIds.slice(i, i + batchSize);
       this.config.logMessage(`Fetching ${entityType} for campaigns batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(campaignIds.length / batchSize)} (${campaignBatch.length} campaigns)`);
 
       try {
-        // Stream records to storage chunk by chunk: buffering a whole batch of
-        // keyword rows in memory OOMs the runner process on large accounts.
-        let batchRecordCount = 0;
-        await this._downloadEntityBatch({
-          accountId,
-          entityType,
-          campaignBatch,
-          onRecordsChunk: async (recordsChunk) => {
-            batchRecordCount += recordsChunk.length;
-            await onBatchReady(recordsChunk);
-          }
-        });
+        const batchRecordCount = await streamBatch(campaignBatch);
         this.config.logMessage(`Fetched ${batchRecordCount} ${entityType.toLowerCase()} from current batch`);
+        i += campaignBatch.length;
       } catch (error) {
-        if (error.message && error.message.includes('100MB')) {
+        if (isTooLargeError(error)) {
           // If still too large, reduce batch size and retry
+          const retryRangeEnd = Math.min(i + batchSize, campaignIds.length);
           const newBatchSize = Math.max(1, Math.floor(batchSize / 2));
           this.config.logMessage(`Batch too large (${batchSize} campaigns), retrying with smaller batch size: ${newBatchSize}`);
 
           // Retry current batch with smaller size
-          for (let j = i; j < Math.min(i + batchSize, campaignIds.length); j += newBatchSize) {
+          for (let j = i; j < retryRangeEnd; j += newBatchSize) {
             const smallerBatch = campaignIds.slice(j, j + newBatchSize);
             try {
-              let smallerBatchRecordCount = 0;
-              await this._downloadEntityBatch({
-                accountId,
-                entityType,
-                campaignBatch: smallerBatch,
-                onRecordsChunk: async (recordsChunk) => {
-                  smallerBatchRecordCount += recordsChunk.length;
-                  await onBatchReady(recordsChunk);
-                }
-              });
+              const smallerBatchRecordCount = await streamBatch(smallerBatch);
               this.config.logMessage(`Fetched ${smallerBatchRecordCount} ${entityType.toLowerCase()} from smaller batch (${smallerBatch.length} campaigns)`);
             } catch (smallerError) {
-              if (smallerError.message && smallerError.message.includes('100MB')) {
+              if (isTooLargeError(smallerError)) {
                 throw new Error(`Failed to fetch ${entityType}: batch size of ${smallerBatch.length} campaigns still exceeds 100MB limit`);
               } else {
                 throw new Error(`Failed to fetch ${entityType}: ${smallerError.message}`);
@@ -592,7 +600,9 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
             }
           }
 
-          // Update batch size for future iterations
+          // Advance past the whole retried range so its tail is not fetched twice,
+          // and keep the smaller batch size for future iterations
+          i = retryRangeEnd;
           batchSize = newBatchSize;
         } else {
           this.config.logMessage(`Failed to fetch ${entityType.toLowerCase()} for campaigns ${campaignBatch.join(', ')}: ${error.message}`);
@@ -611,7 +621,7 @@ var MicrosoftAdsSource = class MicrosoftAdsSource extends AbstractSource {
    * @param {string} opts.entityType
    * @param {Array<string>} opts.campaignBatch
    * @param {Function} [opts.onRecordsChunk] - Streams records in chunks when provided
-   * @returns {Array<Object>}
+   * @returns {Array<Object>} - Empty array when onRecordsChunk is provided
    * @private
    */
   async _downloadEntityBatch({ accountId, entityType, campaignBatch, onRecordsChunk }) {

--- a/packages/connectors/test/Sources/MicrosoftAds/Source.test.js
+++ b/packages/connectors/test/Sources/MicrosoftAds/Source.test.js
@@ -100,16 +100,16 @@ describe('_fetchEntityByCampaigns streaming', () => {
     expect(fake.logs).toContain('Fetched 4 keywords from current batch');
   });
 
-  it('halves the batch size and refetches when the API reports the 100MB limit', async () => {
+  it('halves the batch size and refetches each campaign exactly once on the 100MB limit', async () => {
     const campaignIds = Array.from({ length: 20 }, (_, i) => `c${i}`);
-    const fetched = new Set();
+    const fetchCounts = new Map();
     let threw = false;
     const fake = makeFakeSource(async ({ campaignBatch, onRecordsChunk }) => {
       if (campaignBatch.length > 1 && !threw) {
         threw = true;
         throw new Error('Download exceeds 100MB limit');
       }
-      campaignBatch.forEach(id => fetched.add(id));
+      campaignBatch.forEach(id => fetchCounts.set(id, (fetchCounts.get(id) ?? 0) + 1));
       await onRecordsChunk(campaignBatch.map(id => ({ Id: id })));
       return [];
     });
@@ -122,7 +122,80 @@ describe('_fetchEntityByCampaigns streaming', () => {
       onBatchReady: async records => received.push(...records),
     });
 
-    campaignIds.forEach(id => expect(fetched).toContain(id));
+    // The retried range must not be fetched again by the outer loop
+    expect(received).toHaveLength(20);
+    campaignIds.forEach(id => expect(fetchCounts.get(id)).toBe(1));
     expect(fake.logs.some(m => m.includes('retrying with smaller batch size: 1'))).toBe(true);
+  });
+
+  it('does not halve the batch when a storage error mentions 100MB', async () => {
+    const campaignIds = Array.from({ length: 20 }, (_, i) => `c${i}`);
+    const fake = makeFakeSource(async ({ campaignBatch, onRecordsChunk }) => {
+      await onRecordsChunk(campaignBatch.map(id => ({ Id: id })));
+      return [];
+    });
+
+    await expect(
+      proto._fetchEntityByCampaigns.call(fake, {
+        accountId: '1',
+        entityType: 'Keywords',
+        campaignIds,
+        onBatchReady: async () => {
+          throw new Error('BigQuery: request payload exceeds 100MB');
+        },
+      })
+    ).rejects.toThrow('Failed to fetch Keywords: BigQuery: request payload exceeds 100MB');
+    expect(fake.logs.some(m => m.includes('retrying with smaller batch size'))).toBe(false);
+  });
+});
+
+describe('_downloadEntity streaming', () => {
+  it('streams records per zip file with per-file headers and returns []', async () => {
+    const submitUrl = 'https://bulk.test/submit';
+    const fileUrl = 'https://bulk.test/result.zip';
+    const originalHttpUtils = globalThis.HttpUtils;
+    const originalUnzip = globalThis.FileUtils.unzip;
+    globalThis.HttpUtils = {
+      fetch: async url => {
+        if (url === submitUrl) {
+          return { getContentText: async () => JSON.stringify({ DownloadRequestId: 'r1' }) };
+        }
+        if (url.includes('BulkDownloadStatus')) {
+          return {
+            getContentText: async () =>
+              JSON.stringify({ RequestStatus: 'Completed', ResultFileUrl: fileUrl }),
+          };
+        }
+        return { getBlob: async () => 'zip-bytes' };
+      },
+    };
+    globalThis.FileUtils.unzip = () => [
+      { getDataAsString: () => 'Id,Name\n1,a\n2,b' },
+      { getDataAsString: () => 'Code,Label\n9,x' },
+    ];
+
+    try {
+      const chunks = [];
+      const result = await proto._downloadEntity.call(
+        {},
+        {
+          submitUrl,
+          submitOpts: {},
+          onRecordsChunk: async chunk => chunks.push(chunk),
+        }
+      );
+
+      expect(result).toEqual([]);
+      // Each zip entry gets its own header — the legacy array pipeline reused the
+      // first file's header and emitted later header rows as junk records
+      expect(chunks.flat()).toEqual([
+        { Id: '1', Name: 'a' },
+        { Id: '2', Name: 'b' },
+        { Code: '9', Label: 'x' },
+      ]);
+    } finally {
+      globalThis.HttpUtils = originalHttpUtils;
+      globalThis.FileUtils.unzip = originalUnzip;
+    }
   });
 });

--- a/packages/connectors/test/Sources/MicrosoftAds/Source.test.js
+++ b/packages/connectors/test/Sources/MicrosoftAds/Source.test.js
@@ -1,0 +1,128 @@
+import path from 'path';
+import vm from 'vm';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fileUtilsPath = path.join(__dirname, '../../../src/Core/Utils/FileUtils.js');
+const coreSourcePath = path.join(__dirname, '../../../src/Core/AbstractSource.js');
+const helperPath = path.join(__dirname, '../../../src/Sources/MicrosoftAds/Helper.js');
+const sourcePath = path.join(__dirname, '../../../src/Sources/MicrosoftAds/Source.js');
+
+// GAS-style files: `var X = ...` lands on globalThis, but Helper.js uses a top-level
+// `const`, which only enters the global lexical scope — read it back with a vm eval.
+loadGasClass(fileUtilsPath);
+loadGasClass(coreSourcePath);
+loadGasClass(helperPath);
+loadGasClass(sourcePath);
+const MicrosoftAdsHelper = vm.runInThisContext('MicrosoftAdsHelper');
+const proto = globalThis.MicrosoftAdsSource.prototype;
+
+const CSV_FIXTURE = [
+  'Type,Id,Parent Id,Keyword',
+  'Format Version,,,6.0',
+  'Keyword,101,201,"running shoes"',
+  'Keyword,102,201,"say ""hi"" now"',
+  '',
+  'Keyword,103,202,plain term',
+].join('\n');
+
+describe('processCsvTextInChunks', () => {
+  const collectChunks = async (csvText, chunkSize) => {
+    const chunks = [];
+    await MicrosoftAdsHelper.processCsvTextInChunks(
+      csvText,
+      async chunk => {
+        chunks.push(chunk);
+      },
+      chunkSize
+    );
+    return chunks;
+  };
+
+  it('produces the same records as the legacy csvRowsToObjects pipeline', async () => {
+    const legacy = MicrosoftAdsHelper.csvRowsToObjects(globalThis.FileUtils.parseCsv(CSV_FIXTURE));
+    const chunks = await collectChunks(CSV_FIXTURE, 2000);
+
+    expect(chunks.flat()).toEqual(legacy);
+    expect(chunks.flat()).toEqual([
+      { Type: 'Keyword', Id: '101', ParentId: '201', Keyword: 'running shoes' },
+      { Type: 'Keyword', Id: '102', ParentId: '201', Keyword: 'say "hi" now' },
+      { Type: 'Keyword', Id: '103', ParentId: '202', Keyword: 'plain term' },
+    ]);
+  });
+
+  it('flushes full chunks as they fill and a final partial chunk', async () => {
+    const header = 'Id,Keyword';
+    const rows = Array.from({ length: 5 }, (_, i) => `${i},term${i}`);
+    const chunks = await collectChunks([header, ...rows].join('\n'), 2);
+
+    expect(chunks.map(c => c.length)).toEqual([2, 2, 1]);
+    expect(chunks.flat().map(r => r.Id)).toEqual(['0', '1', '2', '3', '4']);
+  });
+
+  it('handles an empty file (header only) without invoking the callback', async () => {
+    const chunks = await collectChunks('Id,Keyword\n', 2000);
+    expect(chunks).toEqual([]);
+  });
+});
+
+describe('_fetchEntityByCampaigns streaming', () => {
+  const makeFakeSource = downloadEntityBatch => {
+    const logs = [];
+    return {
+      logs,
+      config: { logMessage: message => logs.push(message) },
+      _downloadEntityBatch: downloadEntityBatch,
+    };
+  };
+
+  it('streams chunks straight to onBatchReady and logs the accumulated count', async () => {
+    const campaignIds = Array.from({ length: 20 }, (_, i) => `c${i}`);
+    const fake = makeFakeSource(async ({ campaignBatch, onRecordsChunk }) => {
+      // Two chunks per batch, one record per campaign in each
+      await onRecordsChunk(campaignBatch.map(id => ({ Id: `${id}-a` })));
+      await onRecordsChunk(campaignBatch.map(id => ({ Id: `${id}-b` })));
+      return [];
+    });
+
+    const received = [];
+    await proto._fetchEntityByCampaigns.call(fake, {
+      accountId: '1',
+      entityType: 'Keywords',
+      campaignIds,
+      onBatchReady: async records => received.push(...records),
+    });
+
+    // batchSize = min(50, floor(20/10)) = 2 -> 10 batches x 2 campaigns x 2 chunks
+    expect(received).toHaveLength(40);
+    expect(fake.logs).toContain('Fetched 4 keywords from current batch');
+  });
+
+  it('halves the batch size and refetches when the API reports the 100MB limit', async () => {
+    const campaignIds = Array.from({ length: 20 }, (_, i) => `c${i}`);
+    const fetched = new Set();
+    let threw = false;
+    const fake = makeFakeSource(async ({ campaignBatch, onRecordsChunk }) => {
+      if (campaignBatch.length > 1 && !threw) {
+        threw = true;
+        throw new Error('Download exceeds 100MB limit');
+      }
+      campaignBatch.forEach(id => fetched.add(id));
+      await onRecordsChunk(campaignBatch.map(id => ({ Id: id })));
+      return [];
+    });
+
+    const received = [];
+    await proto._fetchEntityByCampaigns.call(fake, {
+      accountId: '1',
+      entityType: 'Keywords',
+      campaignIds,
+      onBatchReady: async records => received.push(...records),
+    });
+
+    campaignIds.forEach(id => expect(fetched).toContain(id));
+    expect(fake.logs.some(m => m.includes('retrying with smaller batch size: 1'))).toBe(true);
+  });
+});


### PR DESCRIPTION
# Problem

Connector runs for the Microsoft Ads `campaigns` node failed on large accounts with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`, killing the runner process mid-import (observed on an account with 4,085 campaigns and 32k ad groups). The root cause was in the Keywords bulk-download path: after downloading a zip for a batch of 50 campaigns, the connector held the full CSV text, a full parsed row array (doubled again by `concat`), a full record-object array, and a filtered copy in memory at the same time — roughly 5× the file size in simultaneous allocations, which exceeded Node's default ~2 GB heap.

# Solution

Stream keyword records to storage in small chunks instead of materializing whole batches:

- `Helper.js` gains `processCsvRecordsFromUrl()` / `processCsvTextInChunks()`, which parse the downloaded CSV line by line and flush record objects to a callback every 2,000 records. The full row array and full object array are never built, so peak memory drops to the CSV text plus one chunk.
- `Source.js` threads an optional `onRecordsChunk` callback through `_downloadEntity` → `_downloadEntityBatch` → `_fetchEntityByCampaigns`, so each chunk flows through `filterByFields` straight into the storage `onBatchReady`. Per-batch record counts are still logged after each batch completes.
- The existing 100 MB batch-halving retry, the Campaigns/AssetGroups/AdGroups path, and the reporting path are intentionally untouched — they keep their current return-array contract. A streaming unzip was considered and rejected as unnecessary given Microsoft's own 100 MB per-file cap.

Partial chunks saved before a mid-download failure are safe: the BigQuery MERGE is idempotent on `uniqueKeys`, so a re-run converges.

# Changes

- Added `processCsvRecordsFromUrl()` and `processCsvTextInChunks()` to the Microsoft Ads helper for chunked CSV-to-record conversion with identical parsing semantics to the legacy `csvRowsToObjects` pipeline (header sanitization, quote handling, `Format Version` row skipping)
- Added an optional `onRecordsChunk` streaming callback to `_downloadEntity` and `_downloadEntityBatch`
- Replaced whole-batch buffering in `_fetchEntityByCampaigns` (both the normal and the halved-batch retry path) with chunked streaming to `onBatchReady`
- Added `test/Sources/MicrosoftAds/Source.test.js` covering legacy-parity parsing, chunk-boundary flushing, header-only files, streaming through `onBatchReady`, and the 100 MB batch-halving retry (5 tests; full suite 135/135 green)