### PR TITLE
Configure npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,10 @@ on:
   push:
     branches: [main]
 
-env:
-  NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+permissions:
+  contents: read
+  id-token: write
+  packages: write
 
 jobs:
   publish:
@@ -35,6 +37,11 @@ jobs:
           node-version: 22
           cache: 'npm'
           registry-url: https://registry.npmjs.org
+
+      - name: Install npm with trusted publishing support
+        run: |
+          npm install --global npm@11.19.0
+          npm --version
 
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --ignore-scripts --no-fund --loglevel error

--- a/apps/ctl/package.json
+++ b/apps/ctl/package.json
@@ -55,7 +55,10 @@
     ],
     "topicSeparator": " "
   },
-  "repository": "OWOX/owox-data-marts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OWOX/owox-data-marts.git"
+  },
   "scripts": {
     "build": "tsc",
     "build:clean": "shx rm -rf dist oclif.manifest.json tsconfig.tsbuildinfo",

--- a/apps/owox/package.json
+++ b/apps/owox/package.json
@@ -70,7 +70,10 @@
     "plugins": ["@oclif/plugin-help"],
     "topicSeparator": " "
   },
-  "repository": "OWOX/owox-data-marts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OWOX/owox-data-marts.git"
+  },
   "scripts": {
     "build": "tsc",
     "build:backend": "npm run build -w @owox/backend --prefix ../..",

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -2,6 +2,10 @@
   "name": "@owox/connectors",
   "version": "0.31.0",
   "description": "Connectors and storages for different data sources",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OWOX/owox-data-marts.git"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/idp-better-auth/package.json
+++ b/packages/idp-better-auth/package.json
@@ -5,6 +5,10 @@
   "author": "OWOX",
   "license": "ELv2",
   "description": "Better Auth implementation for OWOX IDP Protocol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OWOX/owox-data-marts.git"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/idp-owox-better-auth/package.json
+++ b/packages/idp-owox-better-auth/package.json
@@ -5,6 +5,10 @@
   "author": "OWOX",
   "license": "ELv2",
   "description": "OWOX Better Auth implementation for OWOX IDP Protocol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OWOX/owox-data-marts.git"
+  },
   "scripts": {
     "build": "tsc && node ./scripts/copy-public.cjs",
     "build:dep": "npm run build:internal-helpers && npm run build:idp-protocol",

--- a/packages/idp-protocol/package.json
+++ b/packages/idp-protocol/package.json
@@ -5,6 +5,10 @@
   "author": "OWOX",
   "license": "ELv2",
   "description": "Identity Provider protocol contracts and interfaces for OWOX Data Marts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OWOX/owox-data-marts.git"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

- replace the expired `NODE_AUTH_TOKEN` publishing path with GitHub Actions OIDC permissions
- install npm 11.19.0 in the publish job so the npm CLI supports Trusted Publishing
- preserve read access for checkout and write access for GHCR publication
- normalize repository metadata for the six publishable packages that were missing or using shorthand values

## Why

The npm access token used by the release workflow has expired. All published packages are now configured on npm with `OWOX/owox-data-marts` and `publish.yml` as their trusted GitHub Actions publisher, so the workflow can use short-lived OIDC credentials instead of another long-lived token.

## Validation

- `npm ci --prefer-offline --no-audit --ignore-scripts --no-fund --loglevel error`
- `npm run format:packages -- --check`
- `npx prettier --check .github/workflows/publish.yml`
- parsed `publish.yml` and asserted the exact permissions, npm version setup, and absence of `NODE_AUTH_TOKEN`
- parsed all 11 published package manifests and asserted the canonical repository URL
- `git diff --check origin/main..HEAD`
- independent read-only review completed with no findings

No npm publication was performed locally; the first OIDC publication will occur through the trusted `publish.yml` workflow after merge.

🤖 Codex (GPT-5.6 Sol High)
