### PR TITLE
docs(changeset): list all connectors in 6810 changeset title

### DIFF
--- a/.changeset/6810-connectors-supported-api-versions.md
+++ b/.changeset/6810-connectors-supported-api-versions.md
@@ -2,7 +2,7 @@
 'owox': minor
 ---
 
-# Connectors use supported API versions
+# Google Ads, LinkedIn Ads, LinkedIn Pages, and Shopify connectors use supported API versions
 
 Previously, the Google Ads connector called API version v21, which Google
 sunset on 2026-08-05, causing every import to fail with an

--- a/.changeset/6824-input-source-form-discards-unsaved-query.md
+++ b/.changeset/6824-input-source-form-discards-unsaved-query.md
@@ -2,9 +2,9 @@
 'owox': minor
 ---
 
-# Typing in the SQL editor now works reliably on connected Data Marts
+# Typing in the SQL editor now works reliably on saved Data Marts
 
-On Data Marts joined with other Data Marts, the SQL Query editor could refuse to insert spaces: you would type `select * from`, press the spacebar, and nothing would appear. This happened whenever the Joinable Data Marts section was set to the diagram view — the diagram was silently capturing the spacebar for itself. The editor now always receives everything you type, regardless of how the Joinable Data Marts section is displayed.
+On any saved Data Mart, the SQL Query editor could refuse to insert spaces: you would type `select * from`, press the spacebar, and nothing would appear. This happened whenever the Joinable Data Marts section was set to the diagram view — the diagram was silently capturing the spacebar for itself. The editor now always receives everything you type, regardless of how the Joinable Data Marts section is displayed.
 
 Two more editing annoyances are gone as well:
 


### PR DESCRIPTION
# Problem

The changeset for the connector API-version bump was originally filed under the filename and heading `Connectors use supported API versions`, which only named Google Ads explicitly in its body copy. Ruslan asked for the changeset title to name every affected connector directly, since the fix also covers LinkedIn Ads, LinkedIn Pages, and Shopify, not just Google Ads.

# Solution

Renamed the changeset file from `6810-google-ads-api-v25.md` to `6810-connectors-supported-api-versions.md` to match its already-generic content, and updated the in-file heading to explicitly list all four affected connectors so the release notes are accurate at a glance.

## Changes

- Renamed `.changeset/6810-google-ads-api-v25.md` to `.changeset/6810-connectors-supported-api-versions.md`
- Updated the changeset heading to `Google Ads, LinkedIn Ads, LinkedIn Pages, and Shopify connectors use supported API versions`