### PR TITLE
feat(web): add copyable direct link for the report edit sidebar

### DIFF
--- a/.changeset/6801-copy-link-report-sheet.md
+++ b/.changeset/6801-copy-link-report-sheet.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Copy a link to a Report
+
+Reports now have a permanent direct link. Opening a report on the Data Mart Destinations tab puts it into the page URL, and a **Copy link** button in the report panel header lets you share that link with a teammate — opening it shows the page with the same report already open.

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditSheet/EmailReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditSheet/EmailReportEditSheet.tsx
@@ -109,7 +109,9 @@ export function EmailReportEditSheet({
                 ? 'Fill in the details to create a new report'
                 : 'Update details of an existing report'}
             </SheetDescription>
-            {reportLink && <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />}
+            {reportLink && (
+              <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />
+            )}
           </div>
         </SheetHeader>
 

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditSheet/EmailReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditSheet/EmailReportEditSheet.tsx
@@ -1,11 +1,4 @@
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from '@owox/ui/components/sheet';
-import { CopyLinkButton } from '@owox/ui/components/common/copy-link-button';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@owox/ui/components/sheet';
 import { useCallback } from 'react';
 import { UnsavedChangesConfirmationDialog } from '../../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import { DataDestinationProvider } from '../../../../../data-destination';
@@ -18,7 +11,7 @@ import { toast } from 'sonner';
 import { Link, useLocation, useParams } from 'react-router';
 import { useUnsavedGuard } from '../../../../../../hooks/useUnsavedGuard';
 import { useIntercomLauncher } from '../../../../../../shared/hooks/useIntercomLauncher';
-import { useReportDeepLink } from '../../hooks/useReportDeepLink';
+import { ReportSheetDescription } from '../ReportSheetDescription';
 
 interface EmailReportEditSheetProps {
   isOpen: boolean;
@@ -86,8 +79,6 @@ export function EmailReportEditSheet({
 
   useIntercomLauncher(isOpen);
 
-  const reportLink = useReportDeepLink(mode === ReportFormMode.EDIT ? initialReport : undefined);
-
   return (
     <Sheet
       open={isOpen}
@@ -103,16 +94,11 @@ export function EmailReportEditSheet({
             {preSelectedDestination?.title ??
               (mode === ReportFormMode.CREATE ? 'Create Report' : 'Report')}
           </SheetTitle>
-          <div className='flex w-full items-center gap-4'>
-            <SheetDescription>
-              {mode === ReportFormMode.CREATE
-                ? 'Fill in the details to create a new report'
-                : 'Update details of an existing report'}
-            </SheetDescription>
-            {reportLink && (
-              <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />
-            )}
-          </div>
+          <ReportSheetDescription mode={mode} report={initialReport}>
+            {mode === ReportFormMode.CREATE
+              ? 'Fill in the details to create a new report'
+              : 'Update details of an existing report'}
+          </ReportSheetDescription>
         </SheetHeader>
 
         <DataDestinationProvider>

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditSheet/EmailReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditSheet/EmailReportEditSheet.tsx
@@ -5,6 +5,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@owox/ui/components/sheet';
+import { CopyLinkButton } from '@owox/ui/components/common/copy-link-button';
 import { useCallback } from 'react';
 import { UnsavedChangesConfirmationDialog } from '../../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import { DataDestinationProvider } from '../../../../../data-destination';
@@ -17,6 +18,7 @@ import { toast } from 'sonner';
 import { Link, useLocation, useParams } from 'react-router';
 import { useUnsavedGuard } from '../../../../../../hooks/useUnsavedGuard';
 import { useIntercomLauncher } from '../../../../../../shared/hooks/useIntercomLauncher';
+import { useReportDeepLink } from '../../hooks/useReportDeepLink';
 
 interface EmailReportEditSheetProps {
   isOpen: boolean;
@@ -84,6 +86,8 @@ export function EmailReportEditSheet({
 
   useIntercomLauncher(isOpen);
 
+  const reportLink = useReportDeepLink(mode === ReportFormMode.EDIT ? initialReport : undefined);
+
   return (
     <Sheet
       open={isOpen}
@@ -99,11 +103,14 @@ export function EmailReportEditSheet({
             {preSelectedDestination?.title ??
               (mode === ReportFormMode.CREATE ? 'Create Report' : 'Report')}
           </SheetTitle>
-          <SheetDescription>
-            {mode === ReportFormMode.CREATE
-              ? 'Fill in the details to create a new report'
-              : 'Update details of an existing report'}
-          </SheetDescription>
+          <div className='flex w-full items-center gap-4'>
+            <SheetDescription>
+              {mode === ReportFormMode.CREATE
+                ? 'Fill in the details to create a new report'
+                : 'Update details of an existing report'}
+            </SheetDescription>
+            {reportLink && <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />}
+          </div>
         </SheetHeader>
 
         <DataDestinationProvider>

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.test.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.test.tsx
@@ -1,0 +1,106 @@
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReportFormMode } from '../../../shared';
+import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
+import { GoogleSheetsReportEditSheet } from './GoogleSheetsReportEditSheet';
+
+const authMock = vi.hoisted(() => ({
+  value: {
+    status: 'authenticated',
+    user: { id: 'user-1', projectId: 'project-1', roles: ['admin'] },
+    signOut: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../../idp', () => ({
+  useAuth: () => authMock.value,
+}));
+
+vi.mock('../GoogleSheetsReportEditForm', () => ({
+  GoogleSheetsReportEditForm: () => null,
+}));
+
+vi.mock('../../../../../data-destination', () => ({
+  DataDestinationProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../../../../../shared/hooks/useIntercomLauncher', () => ({
+  useIntercomLauncher: () => undefined,
+}));
+
+vi.mock('@owox/ui/components/sheet', () => ({
+  Sheet: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  SheetContent: ({ children }: { children: ReactNode }) => <aside role='dialog'>{children}</aside>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  SheetDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+}));
+
+const initialReport = {
+  id: 'report-1',
+  title: 'Weekly report',
+  dataMart: { id: 'mart-1', title: 'Mart' },
+} as unknown as DataMartReport;
+
+function renderSheet(mode: ReportFormMode = ReportFormMode.EDIT) {
+  return render(
+    <MemoryRouter initialEntries={['/ui/project-1/data-marts/mart-1/reports']}>
+      <GoogleSheetsReportEditSheet
+        isOpen
+        onClose={vi.fn()}
+        mode={mode}
+        initialReport={mode === ReportFormMode.EDIT ? initialReport : undefined}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('GoogleSheetsReportEditSheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+
+    authMock.value = {
+      status: 'authenticated',
+      user: { id: 'user-1', projectId: 'project-1', roles: ['admin'] },
+      signOut: vi.fn(),
+    };
+  });
+
+  it('copies the project-scoped deep link for the report', async () => {
+    renderSheet();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy link to this report' }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        `${window.location.origin}/ui/project-1/data-marts/mart-1/reports?reportId=report-1`
+      );
+    });
+  });
+
+  it('hides the copy link button in create mode', () => {
+    renderSheet(ReportFormMode.CREATE);
+
+    expect(screen.queryByRole('button', { name: 'Copy link to this report' })).toBeNull();
+  });
+
+  it('hides the copy link button when no project id is resolvable', () => {
+    authMock.value = {
+      status: 'authenticated',
+      user: { id: 'user-1', projectId: '', roles: ['admin'] },
+      signOut: vi.fn(),
+    };
+
+    renderSheet();
+
+    expect(screen.queryByRole('button', { name: 'Copy link to this report' })).toBeNull();
+  });
+});

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
@@ -66,7 +66,9 @@ export function GoogleSheetsReportEditSheet({
                 ? 'Fill in the details to create a new Google Sheets report'
                 : 'Update details of an existing Google Sheets report'}
             </SheetDescription>
-            {reportLink && <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />}
+            {reportLink && (
+              <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />
+            )}
           </div>
         </SheetHeader>
 

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
@@ -5,6 +5,7 @@ import {
   SheetTitle,
   SheetDescription,
 } from '@owox/ui/components/sheet';
+import { CopyLinkButton } from '@owox/ui/components/common/copy-link-button';
 import { UnsavedChangesConfirmationDialog } from '../../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report.ts';
 import { GoogleSheetsReportEditForm } from '../GoogleSheetsReportEditForm';
@@ -13,6 +14,7 @@ import { ReportFormMode } from '../../../shared';
 import type { DataDestination } from '../../../../../data-destination';
 import { useUnsavedGuard } from '../../../../../../hooks/useUnsavedGuard';
 import { useIntercomLauncher } from '../../../../../../shared/hooks/useIntercomLauncher';
+import { useReportDeepLink } from '../../hooks/useReportDeepLink';
 
 interface GoogleSheetsReportEditSheetProps {
   isOpen: boolean;
@@ -42,6 +44,8 @@ export function GoogleSheetsReportEditSheet({
 
   useIntercomLauncher(isOpen);
 
+  const reportLink = useReportDeepLink(mode === ReportFormMode.EDIT ? initialReport : undefined);
+
   return (
     <Sheet
       open={isOpen}
@@ -56,11 +60,14 @@ export function GoogleSheetsReportEditSheet({
           <SheetTitle>
             {mode === ReportFormMode.CREATE ? 'Create new report' : 'Edit report'}
           </SheetTitle>
-          <SheetDescription>
-            {mode === ReportFormMode.CREATE
-              ? 'Fill in the details to create a new Google Sheets report'
-              : 'Update details of an existing Google Sheets report'}
-          </SheetDescription>
+          <div className='flex w-full items-center gap-4'>
+            <SheetDescription>
+              {mode === ReportFormMode.CREATE
+                ? 'Fill in the details to create a new Google Sheets report'
+                : 'Update details of an existing Google Sheets report'}
+            </SheetDescription>
+            {reportLink && <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />}
+          </div>
         </SheetHeader>
 
         <DataDestinationProvider>

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditSheet/GoogleSheetsReportEditSheet.tsx
@@ -1,11 +1,4 @@
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@owox/ui/components/sheet';
-import { CopyLinkButton } from '@owox/ui/components/common/copy-link-button';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@owox/ui/components/sheet';
 import { UnsavedChangesConfirmationDialog } from '../../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report.ts';
 import { GoogleSheetsReportEditForm } from '../GoogleSheetsReportEditForm';
@@ -14,7 +7,7 @@ import { ReportFormMode } from '../../../shared';
 import type { DataDestination } from '../../../../../data-destination';
 import { useUnsavedGuard } from '../../../../../../hooks/useUnsavedGuard';
 import { useIntercomLauncher } from '../../../../../../shared/hooks/useIntercomLauncher';
-import { useReportDeepLink } from '../../hooks/useReportDeepLink';
+import { ReportSheetDescription } from '../ReportSheetDescription';
 
 interface GoogleSheetsReportEditSheetProps {
   isOpen: boolean;
@@ -44,8 +37,6 @@ export function GoogleSheetsReportEditSheet({
 
   useIntercomLauncher(isOpen);
 
-  const reportLink = useReportDeepLink(mode === ReportFormMode.EDIT ? initialReport : undefined);
-
   return (
     <Sheet
       open={isOpen}
@@ -60,16 +51,11 @@ export function GoogleSheetsReportEditSheet({
           <SheetTitle>
             {mode === ReportFormMode.CREATE ? 'Create new report' : 'Edit report'}
           </SheetTitle>
-          <div className='flex w-full items-center gap-4'>
-            <SheetDescription>
-              {mode === ReportFormMode.CREATE
-                ? 'Fill in the details to create a new Google Sheets report'
-                : 'Update details of an existing Google Sheets report'}
-            </SheetDescription>
-            {reportLink && (
-              <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />
-            )}
-          </div>
+          <ReportSheetDescription mode={mode} report={initialReport}>
+            {mode === ReportFormMode.CREATE
+              ? 'Fill in the details to create a new Google Sheets report'
+              : 'Update details of an existing Google Sheets report'}
+          </ReportSheetDescription>
         </SheetHeader>
 
         <DataDestinationProvider>

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
@@ -1,11 +1,4 @@
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetDescription,
-} from '@owox/ui/components/sheet';
-import { CopyLinkButton } from '@owox/ui/components/common/copy-link-button';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@owox/ui/components/sheet';
 import { UnsavedChangesConfirmationDialog } from '../../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report.ts';
 import { LookerStudioReportEditForm } from '../LookerStudioReportEditForm';
@@ -14,7 +7,7 @@ import { ReportFormMode } from '../../../shared';
 import type { DataDestination } from '../../../../../data-destination';
 import { useUnsavedGuard } from '../../../../../../hooks/useUnsavedGuard';
 import { useIntercomLauncher } from '../../../../../../shared/hooks/useIntercomLauncher';
-import { useReportDeepLink } from '../../hooks/useReportDeepLink';
+import { ReportSheetDescription } from '../ReportSheetDescription';
 
 interface LookerStudioReportEditSheetProps {
   isOpen: boolean;
@@ -44,8 +37,6 @@ export function LookerStudioReportEditSheet({
 
   useIntercomLauncher(isOpen);
 
-  const reportLink = useReportDeepLink(mode === ReportFormMode.EDIT ? initialReport : undefined);
-
   return (
     <Sheet
       open={isOpen}
@@ -58,16 +49,11 @@ export function LookerStudioReportEditSheet({
       <SheetContent data-testid='reportEditSheet'>
         <SheetHeader>
           <SheetTitle>{preSelectedDestination?.title ?? 'Data Studio'}</SheetTitle>
-          <div className='flex w-full items-center gap-4'>
-            <SheetDescription>
-              {mode === ReportFormMode.CREATE
-                ? 'Set up Data Mart as a data source'
-                : 'Update connection details'}
-            </SheetDescription>
-            {reportLink && (
-              <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />
-            )}
-          </div>
+          <ReportSheetDescription mode={mode} report={initialReport}>
+            {mode === ReportFormMode.CREATE
+              ? 'Set up Data Mart as a data source'
+              : 'Update connection details'}
+          </ReportSheetDescription>
         </SheetHeader>
 
         <DataDestinationProvider>

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
@@ -64,7 +64,9 @@ export function LookerStudioReportEditSheet({
                 ? 'Set up Data Mart as a data source'
                 : 'Update connection details'}
             </SheetDescription>
-            {reportLink && <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />}
+            {reportLink && (
+              <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />
+            )}
           </div>
         </SheetHeader>
 

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditSheet/LookerStudioReportEditSheet.tsx
@@ -5,6 +5,7 @@ import {
   SheetTitle,
   SheetDescription,
 } from '@owox/ui/components/sheet';
+import { CopyLinkButton } from '@owox/ui/components/common/copy-link-button';
 import { UnsavedChangesConfirmationDialog } from '../../../../../../shared/components/UnsavedChangesConfirmationDialog';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report.ts';
 import { LookerStudioReportEditForm } from '../LookerStudioReportEditForm';
@@ -13,6 +14,7 @@ import { ReportFormMode } from '../../../shared';
 import type { DataDestination } from '../../../../../data-destination';
 import { useUnsavedGuard } from '../../../../../../hooks/useUnsavedGuard';
 import { useIntercomLauncher } from '../../../../../../shared/hooks/useIntercomLauncher';
+import { useReportDeepLink } from '../../hooks/useReportDeepLink';
 
 interface LookerStudioReportEditSheetProps {
   isOpen: boolean;
@@ -42,6 +44,8 @@ export function LookerStudioReportEditSheet({
 
   useIntercomLauncher(isOpen);
 
+  const reportLink = useReportDeepLink(mode === ReportFormMode.EDIT ? initialReport : undefined);
+
   return (
     <Sheet
       open={isOpen}
@@ -54,11 +58,14 @@ export function LookerStudioReportEditSheet({
       <SheetContent data-testid='reportEditSheet'>
         <SheetHeader>
           <SheetTitle>{preSelectedDestination?.title ?? 'Data Studio'}</SheetTitle>
-          <SheetDescription>
-            {mode === ReportFormMode.CREATE
-              ? 'Set up Data Mart as a data source'
-              : 'Update connection details'}
-          </SheetDescription>
+          <div className='flex w-full items-center gap-4'>
+            <SheetDescription>
+              {mode === ReportFormMode.CREATE
+                ? 'Set up Data Mart as a data source'
+                : 'Update connection details'}
+            </SheetDescription>
+            {reportLink && <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />}
+          </div>
         </SheetHeader>
 
         <DataDestinationProvider>

--- a/apps/web/src/features/data-marts/reports/edit/components/ReportSheetDescription/ReportSheetDescription.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/ReportSheetDescription/ReportSheetDescription.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import { SheetDescription } from '@owox/ui/components/sheet';
+import { CopyLinkButton } from '@owox/ui/components/common/copy-link-button';
+import { ReportFormMode } from '../../../shared';
+import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
+import { useReportDeepLink } from '../../hooks/useReportDeepLink';
+
+interface ReportSheetDescriptionProps {
+  mode: ReportFormMode;
+  report?: DataMartReport | null;
+  children: ReactNode;
+}
+
+/**
+ * Sheet header description row shared by the report edit sheets:
+ * renders the description text and, in EDIT mode, a Copy link button
+ * with the report's deep link.
+ */
+export function ReportSheetDescription({ mode, report, children }: ReportSheetDescriptionProps) {
+  const reportLink = useReportDeepLink(mode === ReportFormMode.EDIT ? report : undefined);
+
+  return (
+    <div className='flex w-full items-center gap-4'>
+      <SheetDescription>{children}</SheetDescription>
+      {reportLink && <CopyLinkButton link={reportLink} ariaLabel='Copy link to this report' />}
+    </div>
+  );
+}

--- a/apps/web/src/features/data-marts/reports/edit/components/ReportSheetDescription/index.ts
+++ b/apps/web/src/features/data-marts/reports/edit/components/ReportSheetDescription/index.ts
@@ -1,0 +1,1 @@
+export * from './ReportSheetDescription';

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useReportDeepLink.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useReportDeepLink.ts
@@ -1,0 +1,20 @@
+import { useProjectRoute } from '../../../../../shared/hooks';
+import { REPORT_ID_URL_PARAM } from '../../list/model/hooks';
+import type { DataMartReport } from '../../shared/model/types/data-mart-report';
+
+/**
+ * Builds a shareable deep link that opens the Data Mart Reports tab
+ * with the given report sidesheet already open.
+ * Returns null when there is no report to link to or the project is unresolved.
+ */
+export function useReportDeepLink(report: DataMartReport | undefined | null): string | null {
+  const { scope, projectId } = useProjectRoute();
+
+  if (!report || !projectId) {
+    return null;
+  }
+
+  return `${window.location.origin}${scope(
+    `/data-marts/${report.dataMart.id}/reports?${REPORT_ID_URL_PARAM}=${report.id}`
+  )}`;
+}

--- a/apps/web/src/features/data-marts/reports/edit/hooks/useReportDeepLink.ts
+++ b/apps/web/src/features/data-marts/reports/edit/hooks/useReportDeepLink.ts
@@ -15,6 +15,6 @@ export function useReportDeepLink(report: DataMartReport | undefined | null): st
   }
 
   return `${window.location.origin}${scope(
-    `/data-marts/${report.dataMart.id}/reports?${REPORT_ID_URL_PARAM}=${report.id}`
+    `/data-marts/${encodeURIComponent(report.dataMart.id)}/reports?${REPORT_ID_URL_PARAM}=${encodeURIComponent(report.id)}`
   )}`;
 }

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
@@ -51,22 +51,6 @@ const reportDestinationTypes = [
 type ReportCreationDialog = 'publish' | 'setup';
 
 /**
- * Returns stats for a destination: report count and total Google Sheets destinations.
- */
-function useDestinationStats(destinationId: string) {
-  const { reports } = useReport();
-  const { dataDestinations } = useDataDestination();
-  return useMemo(
-    () => ({
-      reportsCount: reports.filter(r => r.dataDestination.id === destinationId).length,
-      googleSheetsCount: dataDestinations.filter(d => d.type === DataDestinationType.GOOGLE_SHEETS)
-        .length,
-    }),
-    [reports, dataDestinations, destinationId]
-  );
-}
-
-/**
  * Returns the reports that belong to a destination.
  */
 function useDestinationReports(destinationId: string) {
@@ -76,6 +60,19 @@ function useDestinationReports(destinationId: string) {
     [reports, destinationId]
   );
 }
+
+/**
+ * Returns the total number of Google Sheets destinations in the project.
+ */
+function useGoogleSheetsDestinationCount() {
+  const { dataDestinations } = useDataDestination();
+  return useMemo(
+    () => dataDestinations.filter(d => d.type === DataDestinationType.GOOGLE_SHEETS).length,
+    [dataDestinations]
+  );
+}
+
+const NO_DEEP_LINK_REPORTS: never[] = [];
 
 /**
  * DestinationCard component
@@ -97,13 +94,15 @@ export function DestinationCard({
   const [isPublishing, setIsPublishing] = useState(false);
 
   // Modal state and handlers for creating/editing reports.
-  // Passing the destination reports enables deep linking via the reportId query param.
+  // Passing the destination reports enables deep linking via the reportId query param;
+  // an invisible card never renders its sheet, so it must not consume the param.
   const destinationReports = useDestinationReports(destination.id);
   const { isOpen, mode, editingReport, handleAddReport, handleEditReport, handleCloseModal } =
-    useReportSidesheet({ deepLinkReports: destinationReports });
+    useReportSidesheet({ deepLinkReports: isVisible ? destinationReports : NO_DEEP_LINK_REPORTS });
 
   // Condition to show InviteTeammatesCard
-  const { reportsCount, googleSheetsCount } = useDestinationStats(destination.id);
+  const reportsCount = destinationReports.length;
+  const googleSheetsCount = useGoogleSheetsDestinationCount();
   const shouldShowInviteCard =
     destination.type === DataDestinationType.GOOGLE_SHEETS &&
     reportsCount === 0 &&

--- a/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
+++ b/apps/web/src/features/data-marts/reports/list/components/DestinationCard/DestinationCard.tsx
@@ -67,6 +67,17 @@ function useDestinationStats(destinationId: string) {
 }
 
 /**
+ * Returns the reports that belong to a destination.
+ */
+function useDestinationReports(destinationId: string) {
+  const { reports } = useReport();
+  return useMemo(
+    () => reports.filter(report => report.dataDestination.id === destinationId),
+    [reports, destinationId]
+  );
+}
+
+/**
  * DestinationCard component
  * - Displays a collapsible card for each Data Destination
  * - Allows adding and editing reports via a modal
@@ -85,9 +96,11 @@ export function DestinationCard({
   const [dialogContent, setDialogContent] = useState<ReportCreationDialog>('setup');
   const [isPublishing, setIsPublishing] = useState(false);
 
-  // Modal state and handlers for creating/editing reports
+  // Modal state and handlers for creating/editing reports.
+  // Passing the destination reports enables deep linking via the reportId query param.
+  const destinationReports = useDestinationReports(destination.id);
   const { isOpen, mode, editingReport, handleAddReport, handleEditReport, handleCloseModal } =
-    useReportSidesheet();
+    useReportSidesheet({ deepLinkReports: destinationReports });
 
   // Condition to show InviteTeammatesCard
   const { reportsCount, googleSheetsCount } = useDestinationStats(destination.id);

--- a/apps/web/src/features/data-marts/reports/list/model/hooks/useReportSidesheet.test.tsx
+++ b/apps/web/src/features/data-marts/reports/list/model/hooks/useReportSidesheet.test.tsx
@@ -30,9 +30,10 @@ function renderSidesheetHook(initialEntry: string, deepLinkReports?: DataMartRep
 
 describe('useReportSidesheet deep linking', () => {
   it('auto-opens the sidesheet for a matching reportId query param', () => {
-    const { result } = renderSidesheetHook('/ui/project-1/data-marts/mart-1/reports?reportId=report-1', [
-      report,
-    ]);
+    const { result } = renderSidesheetHook(
+      '/ui/project-1/data-marts/mart-1/reports?reportId=report-1',
+      [report]
+    );
 
     expect(result.current.sidesheet.isOpen).toBe(true);
     expect(result.current.sidesheet.editingReport?.id).toBe('report-1');

--- a/apps/web/src/features/data-marts/reports/list/model/hooks/useReportSidesheet.test.tsx
+++ b/apps/web/src/features/data-marts/reports/list/model/hooks/useReportSidesheet.test.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { MemoryRouter, useSearchParams } from 'react-router';
+import { describe, expect, it } from 'vitest';
+import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
+import { REPORT_ID_URL_PARAM, useReportSidesheet } from './useReportSidesheet';
+
+const report = {
+  id: 'report-1',
+  title: 'Weekly report',
+  dataMart: { id: 'mart-1', title: 'Mart' },
+  dataDestination: { id: 'destination-1', type: 'GOOGLE_SHEETS' },
+} as unknown as DataMartReport;
+
+function createWrapper(initialEntry: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <MemoryRouter initialEntries={[initialEntry]}>{children}</MemoryRouter>;
+  };
+}
+
+function renderSidesheetHook(initialEntry: string, deepLinkReports?: DataMartReport[]) {
+  return renderHook(
+    () => ({
+      sidesheet: useReportSidesheet(deepLinkReports ? { deepLinkReports } : undefined),
+      searchParams: useSearchParams()[0],
+    }),
+    { wrapper: createWrapper(initialEntry) }
+  );
+}
+
+describe('useReportSidesheet deep linking', () => {
+  it('auto-opens the sidesheet for a matching reportId query param', () => {
+    const { result } = renderSidesheetHook('/ui/project-1/data-marts/mart-1/reports?reportId=report-1', [
+      report,
+    ]);
+
+    expect(result.current.sidesheet.isOpen).toBe(true);
+    expect(result.current.sidesheet.editingReport?.id).toBe('report-1');
+  });
+
+  it('does not open the sidesheet when the reportId param matches none of the reports', () => {
+    const { result } = renderSidesheetHook(
+      '/ui/project-1/data-marts/mart-1/reports?reportId=unknown',
+      [report]
+    );
+
+    expect(result.current.sidesheet.isOpen).toBe(false);
+  });
+
+  it('syncs the reportId param with open/close actions', () => {
+    const { result } = renderSidesheetHook('/ui/project-1/data-marts/mart-1/reports', [report]);
+
+    act(() => {
+      result.current.sidesheet.handleEditReport(report);
+    });
+    expect(result.current.searchParams.get(REPORT_ID_URL_PARAM)).toBe('report-1');
+
+    act(() => {
+      result.current.sidesheet.handleCloseModal();
+    });
+    expect(result.current.searchParams.get(REPORT_ID_URL_PARAM)).toBeNull();
+    expect(result.current.sidesheet.isOpen).toBe(false);
+  });
+
+  it('does not reopen the sidesheet from the same param after it was closed', () => {
+    const { result } = renderSidesheetHook(
+      '/ui/project-1/data-marts/mart-1/reports?reportId=report-1',
+      [report]
+    );
+
+    act(() => {
+      result.current.sidesheet.handleCloseModal();
+    });
+
+    expect(result.current.sidesheet.isOpen).toBe(false);
+    expect(result.current.searchParams.get(REPORT_ID_URL_PARAM)).toBeNull();
+  });
+
+  it('leaves the URL untouched when deep linking is not enabled', () => {
+    const { result } = renderSidesheetHook('/ui/project-1/data-marts/reports');
+
+    act(() => {
+      result.current.sidesheet.handleEditReport(report);
+    });
+
+    expect(result.current.sidesheet.isOpen).toBe(true);
+    expect(result.current.searchParams.get(REPORT_ID_URL_PARAM)).toBeNull();
+  });
+});

--- a/apps/web/src/features/data-marts/reports/list/model/hooks/useReportSidesheet.test.tsx
+++ b/apps/web/src/features/data-marts/reports/list/model/hooks/useReportSidesheet.test.tsx
@@ -20,10 +20,14 @@ function createWrapper(initialEntry: string) {
 
 function renderSidesheetHook(initialEntry: string, deepLinkReports?: DataMartReport[]) {
   return renderHook(
-    () => ({
-      sidesheet: useReportSidesheet(deepLinkReports ? { deepLinkReports } : undefined),
-      searchParams: useSearchParams()[0],
-    }),
+    () => {
+      const [searchParams, setSearchParams] = useSearchParams();
+      return {
+        sidesheet: useReportSidesheet(deepLinkReports ? { deepLinkReports } : undefined),
+        searchParams,
+        setSearchParams,
+      };
+    },
     { wrapper: createWrapper(initialEntry) }
   );
 }
@@ -75,6 +79,43 @@ describe('useReportSidesheet deep linking', () => {
 
     expect(result.current.sidesheet.isOpen).toBe(false);
     expect(result.current.searchParams.get(REPORT_ID_URL_PARAM)).toBeNull();
+  });
+
+  it('opens a deep link that arrives after a previous sidesheet was closed', () => {
+    const { result } = renderSidesheetHook(
+      '/ui/project-1/data-marts/mart-1/reports?reportId=report-1',
+      [report]
+    );
+
+    act(() => {
+      result.current.sidesheet.handleCloseModal();
+    });
+    expect(result.current.sidesheet.isOpen).toBe(false);
+
+    act(() => {
+      result.current.setSearchParams({ [REPORT_ID_URL_PARAM]: 'report-1' });
+    });
+
+    expect(result.current.sidesheet.isOpen).toBe(true);
+    expect(result.current.sidesheet.editingReport?.id).toBe('report-1');
+  });
+
+  it('keeps a pending deep link when an unrelated create sidesheet is closed', () => {
+    // This instance's list does not contain the deep-linked report (it belongs to
+    // another destination card), so closing a create sheet here must not strip it.
+    const { result } = renderSidesheetHook(
+      '/ui/project-1/data-marts/mart-1/reports?reportId=report-1',
+      []
+    );
+
+    act(() => {
+      result.current.sidesheet.handleAddReport();
+    });
+    act(() => {
+      result.current.sidesheet.handleCloseModal();
+    });
+
+    expect(result.current.searchParams.get(REPORT_ID_URL_PARAM)).toBe('report-1');
   });
 
   it('leaves the URL untouched when deep linking is not enabled', () => {

--- a/apps/web/src/features/data-marts/reports/list/model/hooks/useReportSidesheet.ts
+++ b/apps/web/src/features/data-marts/reports/list/model/hooks/useReportSidesheet.ts
@@ -1,15 +1,32 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { DataMartReport } from '../../../shared/model/types/data-mart-report';
 import { ReportFormMode } from '../../../shared';
 import { trackEvent } from '../../../../../../utils/data-layer';
+import { useUrlParam } from '../../../../../../shared/hooks';
+
+/**
+ * Name of the query parameter that deep-links to an open report sidesheet.
+ */
+export const REPORT_ID_URL_PARAM = 'reportId';
+
+interface UseReportSidesheetOptions {
+  /**
+   * Enables deep linking via the `reportId` query parameter.
+   * When provided, the hook keeps the parameter in sync with the open sidesheet
+   * and auto-opens the sidesheet for a report from this list that matches the
+   * parameter on initial load.
+   */
+  deepLinkReports?: DataMartReport[];
+}
 
 /**
  * Custom hook for managing report modal states
  * - Handles opening/closing of the modal
  * - Manages "create" and "edit" modes
  * - Stores the currently edited report (if any)
+ * - Optionally syncs the edited report id with the URL (deep linking)
  */
-export function useReportSidesheet() {
+export function useReportSidesheet({ deepLinkReports }: UseReportSidesheetOptions = {}) {
   // Controls whether the modal is open
   const [isOpen, setIsOpen] = useState(false);
 
@@ -18,6 +35,14 @@ export function useReportSidesheet() {
 
   // Stores the report being edited (null when creating a new one)
   const [editingReport, setEditingReport] = useState<DataMartReport | null>(null);
+
+  const isDeepLinkEnabled = deepLinkReports !== undefined;
+  const {
+    value: deepLinkReportId,
+    setParam: setReportIdParam,
+    removeParam: removeReportIdParam,
+  } = useUrlParam(REPORT_ID_URL_PARAM);
+  const hasAttemptedDeepLink = useRef(false);
 
   /**
    * Opens the modal in CREATE mode
@@ -39,17 +64,23 @@ export function useReportSidesheet() {
    * Opens the modal in EDIT mode for a specific report
    * Memoized to prevent unnecessary re-renders of child components
    */
-  const handleEditReport = useCallback((report: DataMartReport) => {
-    setMode(ReportFormMode.EDIT);
-    setEditingReport(report);
-    setIsOpen(true);
-    trackEvent({
-      event: 'report_open',
-      category: 'Report',
-      action: 'EditReport',
-      label: report.dataDestination.type,
-    });
-  }, []);
+  const handleEditReport = useCallback(
+    (report: DataMartReport) => {
+      setMode(ReportFormMode.EDIT);
+      setEditingReport(report);
+      setIsOpen(true);
+      if (isDeepLinkEnabled) {
+        setReportIdParam(report.id);
+      }
+      trackEvent({
+        event: 'report_open',
+        category: 'Report',
+        action: 'EditReport',
+        label: report.dataDestination.type,
+      });
+    },
+    [isDeepLinkEnabled, setReportIdParam]
+  );
 
   /**
    * Closes the modal and resets the editing report
@@ -58,13 +89,28 @@ export function useReportSidesheet() {
   const handleCloseModal = useCallback(() => {
     setIsOpen(false);
     setEditingReport(null);
+    if (isDeepLinkEnabled) {
+      removeReportIdParam();
+    }
     trackEvent({
       event: 'report_close',
       category: 'Report',
       action: mode === ReportFormMode.EDIT ? 'Edit' : 'Create',
       label: 'ReportForm',
     });
-  }, [mode]);
+  }, [isDeepLinkEnabled, mode, removeReportIdParam]);
+
+  // Auto-open the sidesheet for a deep-linked report once it appears in the list
+  useEffect(() => {
+    if (!isDeepLinkEnabled || !deepLinkReportId || hasAttemptedDeepLink.current) {
+      return;
+    }
+    const report = deepLinkReports.find(item => item.id === deepLinkReportId);
+    if (report) {
+      hasAttemptedDeepLink.current = true;
+      handleEditReport(report);
+    }
+  }, [isDeepLinkEnabled, deepLinkReports, deepLinkReportId, handleEditReport]);
 
   return {
     isOpen,

--- a/apps/web/src/features/data-marts/reports/list/model/hooks/useReportSidesheet.ts
+++ b/apps/web/src/features/data-marts/reports/list/model/hooks/useReportSidesheet.ts
@@ -42,7 +42,6 @@ export function useReportSidesheet({ deepLinkReports }: UseReportSidesheetOption
     setParam: setReportIdParam,
     removeParam: removeReportIdParam,
   } = useUrlParam(REPORT_ID_URL_PARAM);
-  const hasAttemptedDeepLink = useRef(false);
 
   /**
    * Opens the modal in CREATE mode
@@ -86,10 +85,19 @@ export function useReportSidesheet({ deepLinkReports }: UseReportSidesheetOption
    * Closes the modal and resets the editing report
    * Memoized to prevent unnecessary re-renders of child components
    */
+  // Param removal goes through a router transition, so for a few renders after a
+  // close the sidesheet is already closed while the param still reads the old value.
+  // Remember the value being removed so the auto-open effect does not re-open from it.
+  const justClosedReportIdRef = useRef<string | null>(null);
+
   const handleCloseModal = useCallback(() => {
     setIsOpen(false);
     setEditingReport(null);
-    if (isDeepLinkEnabled) {
+    // Remove the param only when this sidesheet instance owns it — every card on
+    // the page shares the param, and closing an unrelated (e.g. CREATE-mode) sheet
+    // must not clobber a deep link another card has not resolved yet.
+    if (isDeepLinkEnabled && editingReport?.id === deepLinkReportId) {
+      justClosedReportIdRef.current = deepLinkReportId;
       removeReportIdParam();
     }
     trackEvent({
@@ -98,19 +106,28 @@ export function useReportSidesheet({ deepLinkReports }: UseReportSidesheetOption
       action: mode === ReportFormMode.EDIT ? 'Edit' : 'Create',
       label: 'ReportForm',
     });
-  }, [isDeepLinkEnabled, mode, removeReportIdParam]);
+  }, [isDeepLinkEnabled, mode, editingReport, deepLinkReportId, removeReportIdParam]);
 
-  // Auto-open the sidesheet for a deep-linked report once it appears in the list
+  // Auto-open the sidesheet for a deep-linked report once it appears in the list.
+  // Guarded by isOpen (not a one-shot ref): a manual open sets the param itself, so
+  // the effect must not re-fire handleEditReport for it, while a new param arriving
+  // after a close must still open — both fall out of the isOpen check.
   useEffect(() => {
-    if (!isDeepLinkEnabled || !deepLinkReportId || hasAttemptedDeepLink.current) {
+    if (!isDeepLinkEnabled) {
+      return;
+    }
+    if (!deepLinkReportId) {
+      justClosedReportIdRef.current = null;
+      return;
+    }
+    if (isOpen || deepLinkReportId === justClosedReportIdRef.current) {
       return;
     }
     const report = deepLinkReports.find(item => item.id === deepLinkReportId);
     if (report) {
-      hasAttemptedDeepLink.current = true;
       handleEditReport(report);
     }
-  }, [isDeepLinkEnabled, deepLinkReports, deepLinkReportId, handleEditReport]);
+  }, [isDeepLinkEnabled, deepLinkReports, deepLinkReportId, isOpen, handleEditReport]);
 
   return {
     isOpen,

--- a/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
+++ b/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
@@ -1,8 +1,11 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
 import {
   DestinationCard,
   EmptyDataMartDestinationsState,
 } from '../../../features/data-marts/reports/list/components';
+import { REPORT_ID_URL_PARAM } from '../../../features/data-marts/reports/list/model/hooks';
+import { useReport } from '../../../features/data-marts/reports/shared';
 import { useOutletContext } from 'react-router';
 import type { DataMartContextType } from '../../../features/data-marts/edit/model/context/types';
 import { SkeletonList } from '@owox/ui/components/common/skeleton-list';
@@ -21,6 +24,7 @@ import { PromoBlock } from '../../../shared/components/PromoBlock/PromoBlock';
 import { GoogleSheetsIcon } from '../../../shared/icons/google-sheets-icon';
 import { InviteTeammatesCard } from '../../../shared/components/InviteTeammatesCard';
 import { useProjectRoute } from '../../../shared/hooks/useProjectRoute';
+import { useUrlParam } from '../../../shared/hooks';
 
 function DataMartDestinationsContentInner() {
   const { dataMart, publishDataMartWithEffects } = useOutletContext<DataMartContextType>();
@@ -36,6 +40,28 @@ function DataMartDestinationsContentInner() {
   }, []);
   // Centralized reports polling for this Data Mart
   useDataMartReportsAutoRefresh({ enabled: true, intervalMs: 5000 });
+
+  // Deep link handling: DestinationCard opens the report sidesheet for a matching
+  // reportId query param; here we only clean up a param that matches no report.
+  const { value: deepLinkReportId, removeParam: removeReportIdParam } =
+    useUrlParam(REPORT_ID_URL_PARAM);
+  const { reports, loading: reportsLoading } = useReport();
+  const hasReportsFetchStarted = useRef(false);
+  const hasCheckedDeepLink = useRef(false);
+  useEffect(() => {
+    if (reportsLoading) {
+      hasReportsFetchStarted.current = true;
+      return;
+    }
+    if (!hasReportsFetchStarted.current || hasCheckedDeepLink.current || !deepLinkReportId) {
+      return;
+    }
+    hasCheckedDeepLink.current = true;
+    if (!reports.some(report => report.id === deepLinkReportId)) {
+      toast.error(`Report not found by id ${deepLinkReportId}`);
+      removeReportIdParam();
+    }
+  }, [reportsLoading, reports, deepLinkReportId, removeReportIdParam]);
 
   // Show onboarding video about email reports if the user has not seen it yet
   const shouldShowOnboarding = !isLoading && dataDestinations.length === 0;

--- a/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
+++ b/apps/web/src/pages/data-marts/edit/DataMartDestinationsContent.tsx
@@ -46,17 +46,21 @@ function DataMartDestinationsContentInner() {
   const { value: deepLinkReportId, removeParam: removeReportIdParam } =
     useUrlParam(REPORT_ID_URL_PARAM);
   const { reports, loading: reportsLoading } = useReport();
-  const hasReportsFetchStarted = useRef(false);
-  const hasCheckedDeepLink = useRef(false);
+  // The context starts with an empty reports array and keeps it on a failed fetch,
+  // so "a successful fetch happened" is detected by the array identity changing —
+  // never conclude "not found" from the initial (or error-preserved) state.
+  const initialReportsRef = useRef(reports);
+  const checkedReportIdRef = useRef<string | null>(null);
   useEffect(() => {
-    if (reportsLoading) {
-      hasReportsFetchStarted.current = true;
+    if (
+      !deepLinkReportId ||
+      reportsLoading ||
+      reports === initialReportsRef.current ||
+      checkedReportIdRef.current === deepLinkReportId
+    ) {
       return;
     }
-    if (!hasReportsFetchStarted.current || hasCheckedDeepLink.current || !deepLinkReportId) {
-      return;
-    }
-    hasCheckedDeepLink.current = true;
+    checkedReportIdRef.current = deepLinkReportId;
     if (!reports.some(report => report.id === deepLinkReportId)) {
       toast.error(`Report not found by id ${deepLinkReportId}`);
       removeReportIdParam();

--- a/apps/web/src/shared/hooks/useUrlParam.ts
+++ b/apps/web/src/shared/hooks/useUrlParam.ts
@@ -1,19 +1,27 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useSearchParams } from 'react-router';
 
 /**
  * Hook for managing a specific URL query parameter.
+ * `setParam` and `removeParam` keep a stable identity across renders
+ * (react-router recreates `setSearchParams` on every search change),
+ * so they are safe to use in dependency arrays and memoized callbacks.
  * @param name - The name of the query parameter.
  * @returns An object containing the current value, a setter, and a remover.
  */
 export function useUrlParam(name: string) {
   const [searchParams, setSearchParams] = useSearchParams();
 
+  const setSearchParamsRef = useRef(setSearchParams);
+  useEffect(() => {
+    setSearchParamsRef.current = setSearchParams;
+  });
+
   const value = searchParams.get(name);
 
   const setParam = useCallback(
     (newValue: string) => {
-      setSearchParams(
+      setSearchParamsRef.current(
         prev => {
           const next = new URLSearchParams(prev);
           next.set(name, newValue);
@@ -22,11 +30,11 @@ export function useUrlParam(name: string) {
         { replace: true }
       );
     },
-    [name, setSearchParams]
+    [name]
   );
 
   const removeParam = useCallback(() => {
-    setSearchParams(
+    setSearchParamsRef.current(
       prev => {
         const next = new URLSearchParams(prev);
         next.delete(name);
@@ -34,7 +42,7 @@ export function useUrlParam(name: string) {
       },
       { replace: true }
     );
-  }, [name, setSearchParams]);
+  }, [name]);
 
   return { value, setParam, removeParam };
 }


### PR DESCRIPTION
# Preview

https://github.com/user-attachments/assets/878b89d9-88f6-45fc-b9ae-b75cbf9cc123



# Copy a link to a Report

Follow-up to #1487, which added **Copy link** to the Destination and Storage config panels. Reports had no direct link at all — the edit sidebar was pure local state, so its URL could not be shared.

Now:

- Opening a report on the Data Mart **Destinations** tab puts `reportId` into the page URL, and closing the sidebar removes it.
- The report edit sidebar header (Google Sheets, Looker Studio, and Email/messenger variants) shows the shared `CopyLinkButton` in edit mode, copying a permanent link of the form `/ui/{projectId}/data-marts/{dataMartId}/reports?reportId={reportId}`.
- Visiting such a link opens the Destinations tab with that report's sidebar already open. An unknown `reportId` shows a "Report not found" toast and cleans the parameter from the URL.

The deep-link handling mirrors the `?id=` pattern used for Destinations/Storages and reuses `CopyLinkButton` from `packages/ui`. The project-wide Reports page keeps its previous behavior (the copied link always points to the canonical Data Mart page).

## Tests

- `useReportSidesheet.test.tsx` — auto-open from the URL param, param sync on open/close, no reopen after close, URL untouched when deep linking is disabled.
- `GoogleSheetsReportEditSheet.test.tsx` — copies the project-scoped deep link, button hidden in create mode and without a resolvable project.
- Verified live: row click sets the param, deep link reopens the sidebar, unknown id shows the toast and cleans the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)