### PR TITLE
fix(web): serve help videos from Cloudflare Stream instead of GitHub

### DIFF
--- a/.changeset/6814-help-videos-cloudflare-stream.md
+++ b/.changeset/6814-help-videos-cloudflare-stream.md
@@ -1,0 +1,11 @@
+---
+'owox': minor
+---
+
+# Help videos now stream from Cloudflare instead of GitHub attachments
+
+Three in-product help videos — "SQL to Google Sheets in Minutes", "Data Studio Setup", and "Getting Started with Data Marts" — used to load from GitHub issue-attachment storage. Those URLs redirect through short-lived signed links and fail entirely for clients whose networks block github.com, so the videos could show up broken.
+
+Now all six help videos use the same Cloudflare Stream player. The three migrated videos keep their previous behavior (autoplay, muted, loop) and their exact aspect ratios.
+
+The documentation site picks up the same fix: pages that embedded the GitHub-hosted files now render the Cloudflare player, while the repository markdown keeps the GitHub links so videos still play inline on github.com. The Google Sheets destination page also gains the setup walkthrough video.

--- a/apps/docs/scripts/sync-docs.js
+++ b/apps/docs/scripts/sync-docs.js
@@ -305,6 +305,45 @@ function processDocumentLinks(fileContent, filePaths) {
 }
 
 /**
+ * GitHub attachment videos that also exist on Cloudflare Stream.
+ * The GitHub URL stays in the source markdown so github.com renders an inline player;
+ * the site build swaps it for the Cloudflare player. paddingTop preserves each video's aspect ratio.
+ */
+const GITHUB_TO_CLOUDFLARE_VIDEOS = {
+  'd2d9d913-a6fc-4949-a8e8-d697abd1631a': {
+    cloudflareId: '4cb8184b0d34d9a293de77e73e405d55',
+    paddingTop: '72.19%',
+  },
+  '95e499eb-0a36-4180-846b-a829294e1afe': {
+    cloudflareId: '93985b60a2758efc77b762f9e291870e',
+    paddingTop: '69.95%',
+  },
+  'dcb60ce1-dd7b-4783-b19c-f2fd85079e1f': {
+    cloudflareId: 'e5dc9849e472884ef88fb5e98e7acc99',
+    paddingTop: '59.11%',
+  },
+};
+
+/**
+ * Renders a Cloudflare Stream iframe embed
+ * @param {string} url - Cloudflare Stream iframe URL
+ * @param {string} paddingTop - Aspect-ratio padding for the responsive wrapper
+ * @returns {string} - HTML embed block
+ */
+function renderCloudflareEmbed(url, paddingTop) {
+  return `<!-- markdownlint-disable-next-line MD033 MD034 -->
+<div style="position: relative; padding-top: ${paddingTop};">
+  <iframe
+    src="${url}"
+    loading="lazy"
+    style="border: none; position: absolute; top: 0; left: 0; height: 100%; width: 100%;"
+    allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+    allowfullscreen="true"
+  ></iframe>
+</div>`;
+}
+
+/**
  * Processes GitHub video links in markdown content, converting bare URLs to HTML video tags
  * @param {string} fileContent - Markdown content
  * @returns {string} - Updated markdown content with GitHub video URLs converted to HTML video elements
@@ -324,6 +363,14 @@ function processGithubVideoLinks(fileContent) {
     ) {
       // Extract clean URL by removing angle brackets if present
       const cleanUrl = trimmedLine.replace(/^<|>$/g, '');
+      const assetId = cleanUrl.split('/assets/')[1];
+      const cloudflareVideo = GITHUB_TO_CLOUDFLARE_VIDEOS[assetId];
+      if (cloudflareVideo) {
+        return renderCloudflareEmbed(
+          `https://customer-4geatlj66rtkaxtz.cloudflarestream.com/${cloudflareVideo.cloudflareId}/iframe`,
+          cloudflareVideo.paddingTop
+        );
+      }
       return `<!-- markdownlint-disable-next-line MD033 MD034 -->
 <video controls playsinline muted style="max-width: 100%; height: auto;">
   <!-- markdownlint-disable-next-line MD033 MD034 -->
@@ -338,16 +385,7 @@ function processGithubVideoLinks(fileContent) {
     ) {
       // Extract clean URL by removing angle brackets if present
       const cleanUrl = trimmedLine.replace(/^<|>$/g, '');
-      return `<!-- markdownlint-disable-next-line MD033 MD034 -->
-<div style="position: relative; padding-top: 56.25%;">
-  <iframe
-    src="${cleanUrl}"
-    loading="lazy"
-    style="border: none; position: absolute; top: 0; left: 0; height: 100%; width: 100%;"
-    allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
-    allowfullscreen="true"
-  ></iframe>
-</div>`;
+      return renderCloudflareEmbed(cleanUrl, '56.25%');
     }
     return line;
   });

--- a/apps/web/src/components/ContentPopovers/popovers/Video1GoogleSheetsReport.tsx
+++ b/apps/web/src/components/ContentPopovers/popovers/Video1GoogleSheetsReport.tsx
@@ -1,17 +1,13 @@
 export function Video1GoogleSheetsReport() {
   return (
-    <>
-      <video
-        src='https://github.com/user-attachments/assets/d2d9d913-a6fc-4949-a8e8-d697abd1631a'
-        controls
-        autoPlay
-        muted
-        loop
-        playsInline
-        className='w-full rounded-md'
-      >
-        Your browser does not support the video tag.
-      </video>
-    </>
+    <div className='relative aspect-[1122/810] rounded-md'>
+      <iframe
+        src='https://customer-4geatlj66rtkaxtz.cloudflarestream.com/4cb8184b0d34d9a293de77e73e405d55/iframe?muted=true&autoplay=true&loop=true&poster=https%3A%2F%2Fcustomer-4geatlj66rtkaxtz.cloudflarestream.com%2F4cb8184b0d34d9a293de77e73e405d55%2Fthumbnails%2Fthumbnail.jpg%3Ftime%3D%26height%3D600'
+        loading='lazy'
+        className='absolute top-0 left-0 h-full w-full rounded-md border-none'
+        allow='accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;'
+        allowFullScreen
+      />
+    </div>
   );
 }

--- a/apps/web/src/components/ContentPopovers/popovers/Video2LookerAsDestination.tsx
+++ b/apps/web/src/components/ContentPopovers/popovers/Video2LookerAsDestination.tsx
@@ -1,17 +1,13 @@
 export function Video2LookerAsDestination() {
   return (
-    <>
-      <video
-        src='https://github.com/user-attachments/assets/95e499eb-0a36-4180-846b-a829294e1afe'
-        controls
-        autoPlay
-        muted
-        loop
-        playsInline
-        className='w-full rounded-md'
-      >
-        Your browser does not support the video tag.
-      </video>
-    </>
+    <div className='relative aspect-[1544/1080] rounded-md'>
+      <iframe
+        src='https://customer-4geatlj66rtkaxtz.cloudflarestream.com/93985b60a2758efc77b762f9e291870e/iframe?muted=true&autoplay=true&loop=true&poster=https%3A%2F%2Fcustomer-4geatlj66rtkaxtz.cloudflarestream.com%2F93985b60a2758efc77b762f9e291870e%2Fthumbnails%2Fthumbnail.jpg%3Ftime%3D%26height%3D600'
+        loading='lazy'
+        className='absolute top-0 left-0 h-full w-full rounded-md border-none'
+        allow='accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;'
+        allowFullScreen
+      />
+    </div>
   );
 }

--- a/apps/web/src/components/ContentPopovers/popovers/Video3GettingStartedDataMarts.tsx
+++ b/apps/web/src/components/ContentPopovers/popovers/Video3GettingStartedDataMarts.tsx
@@ -1,17 +1,13 @@
 export function Video3GettingStartedDataMarts() {
   return (
-    <>
-      <video
-        src='https://github.com/user-attachments/assets/dcb60ce1-dd7b-4783-b19c-f2fd85079e1f'
-        controls
-        autoPlay
-        muted
-        loop
-        playsInline
-        className='w-full rounded-md'
-      >
-        Your browser does not support the video tag.
-      </video>
-    </>
+    <div className='relative aspect-[2436/1440] rounded-md'>
+      <iframe
+        src='https://customer-4geatlj66rtkaxtz.cloudflarestream.com/e5dc9849e472884ef88fb5e98e7acc99/iframe?muted=true&autoplay=true&loop=true&poster=https%3A%2F%2Fcustomer-4geatlj66rtkaxtz.cloudflarestream.com%2Fe5dc9849e472884ef88fb5e98e7acc99%2Fthumbnails%2Fthumbnail.jpg%3Ftime%3D%26height%3D600'
+        loading='lazy'
+        className='absolute top-0 left-0 h-full w-full rounded-md border-none'
+        allow='accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;'
+        allowFullScreen
+      />
+    </div>
   );
 }

--- a/docs/destinations/supported-destinations/google-sheets.md
+++ b/docs/destinations/supported-destinations/google-sheets.md
@@ -3,6 +3,10 @@
 Google Sheets is a cloud-based spreadsheet application that allows users to create, edit, and collaborate on spreadsheets in real-time.  
 Configure Google Sheets as a **Destination** in OWOX Data Marts to enable business users to access and analyze data directly within their spreadsheets.
 
+Watch the walkthrough below for the full setup.
+
+<https://github.com/user-attachments/assets/d2d9d913-a6fc-4949-a8e8-d697abd1631a>
+
 ---
 
 ## Configuration Steps


### PR DESCRIPTION
# Problem

Three in-product help videos ("SQL to Google Sheets in Minutes", "Data Studio Setup", "Getting Started with Data Marts") were embedded straight from GitHub issue-attachment URLs (`github.com/user-attachments/...`). Those URLs 302-redirect to S3 signed links that expire in 5 minutes, and they fail entirely for clients whose corporate networks block github.com — so the videos could render as broken players. The docs site embedded the same fragile URLs on its homepage, quick-start, and Data Studio pages. The other three help videos already streamed from Cloudflare, so the product mixed two hosting mechanisms.

# Solution

The three videos were uploaded to the same Cloudflare Stream account that already hosts the rest (`customer-4geatlj66rtkaxtz`), and every product surface now uses one player:

- The three popover components switch from `<video src="github…">` to the Cloudflare iframe pattern used by the other videos. Player params (`muted`, `autoplay`, `loop`) preserve the previous behavior, and each wrapper uses the video's true aspect ratio (the sources are not 16:9), so nothing letterboxes.
- For the docs, the source markdown in `docs/` keeps the GitHub URLs on purpose: github.com strips iframes, and a GitHub attachment link is the only way to get an inline player in repo markdown. Instead, `sync-docs.js` (which generates the site content) gains a mapping of the three GitHub asset IDs to their Cloudflare IDs, so docs.owox.com renders the Cloudflare player while the repo keeps its inline players. Unmapped GitHub videos (e.g. deployment guides) are unaffected.
- All six popovers were verified playing in the running app through their real triggers (Help menu, Insights-tab onboarding auto-popup), and all six Cloudflare IDs verified serving manifests and thumbnails.

# Changes

- Replaced GitHub-hosted `<video>` embeds with Cloudflare Stream iframes in `Video1GoogleSheetsReport`, `Video2LookerAsDestination`, and `Video3GettingStartedDataMarts`, preserving autoplay/muted/loop and exact aspect ratios
- Added a GitHub-to-Cloudflare video mapping in `apps/docs/scripts/sync-docs.js` so the generated docs site embeds the Cloudflare player for the three migrated videos
- Extracted the Cloudflare iframe markup in `sync-docs.js` into a shared `renderCloudflareEmbed` helper
- Added the setup walkthrough video to the Google Sheets destination docs page (`docs/destinations/supported-destinations/google-sheets.md`)
- Added changeset `6814-help-videos-cloudflare-stream.md` (`owox: minor`)