### PR TITLE
fix(web): keep Joinable Data Marts zoom controls usable regardless of fit timing

### DIFF
--- a/.changeset/6858-canvas-zoom-after-search.md
+++ b/.changeset/6858-canvas-zoom-after-search.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+Fix the Joinable Data Marts diagram zoom controls dying after opening a data mart page
+
+The +/- zoom buttons on the Joinable Data Marts diagram could stop responding until "Fit to view" was pressed, depending on how the page was opened. The allowed zoom range was captured once from a completed fit, so a fit that ran under transient conditions (a still-loading graph or a settling pane) froze the range in an unusable state. The range is now derived from the live graph and pane geometry, small graphs that fit at the maximum zoom keep a usable zoom-out floor, and a corrupted viewport recovers with a full fit instead of ignoring clicks.

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.test.tsx
@@ -5,7 +5,8 @@ import { NOTHING_HIDDEN } from '../../../shared/canvas/object-labels';
 import type { ErdCardField } from '../../../shared/canvas/erd-fields';
 import type { DataMartRelationship } from '../../../shared/types/relationship.types';
 import { RelationshipCanvas } from './RelationshipCanvas';
-import { getFittedGraphZoom, getGraphZoomRange } from './relationship-canvas-zoom';
+import { getViewportForBounds } from '@xyflow/react';
+import { getGraphZoomRange } from './relationship-canvas-zoom';
 
 const FIT_VIEW_PADDING = 1 / 0.85 - 1;
 
@@ -63,7 +64,11 @@ const reactFlowHarness = vi.hoisted(() => {
   };
 });
 
-vi.mock('@xyflow/react', () => ({
+vi.mock('@xyflow/react', async importOriginal => ({
+  // The real padding/zoom math — the zoom-range derivation under test must
+  // run against the library's actual getViewportForBounds semantics.
+  getViewportForBounds: (await importOriginal<typeof import('@xyflow/react')>())
+    .getViewportForBounds,
   useUpdateNodeInternals: () => () => undefined,
   BaseEdge: () => null,
   Handle: () => null,
@@ -140,16 +145,24 @@ describe('RelationshipCanvas viewport', () => {
     await waitFor(() => {
       expect(reactFlowHarness.latestProps?.nodes).toHaveLength(2);
     });
-    const expectedRange = getGraphZoomRange(
-      getFittedGraphZoom(
-        getRenderedGraphBounds(),
-        reactFlowHarness.store.width,
-        reactFlowHarness.store.height,
-        FIT_VIEW_PADDING
-      )
-    );
-    expect(reactFlowHarness.latestProps?.minZoom).toBe(expectedRange.min);
-    expect(expectedRange.min).toBeGreaterThan(0.05);
+    // Expected floor computed with the library's own fitView math, not with
+    // the function under test — a formula drift must fail here.
+    const bounds = getRenderedGraphBounds();
+    const fittedZoom = getViewportForBounds(
+      {
+        x: bounds.minX,
+        y: bounds.minY,
+        width: bounds.maxX - bounds.minX,
+        height: bounds.maxY - bounds.minY,
+      },
+      reactFlowHarness.store.width,
+      reactFlowHarness.store.height,
+      0.05,
+      3,
+      FIT_VIEW_PADDING
+    ).zoom;
+    expect(reactFlowHarness.latestProps?.minZoom).toBe(getGraphZoomRange(fittedZoom).min);
+    expect(fittedZoom).toBeGreaterThan(0.05);
   });
 
   it('passes the low zoom floor to a full fit while the interactive floor is raised', async () => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.test.tsx
@@ -5,6 +5,9 @@ import { NOTHING_HIDDEN } from '../../../shared/canvas/object-labels';
 import type { ErdCardField } from '../../../shared/canvas/erd-fields';
 import type { DataMartRelationship } from '../../../shared/types/relationship.types';
 import { RelationshipCanvas } from './RelationshipCanvas';
+import { getFittedGraphZoom, getGraphZoomRange } from './relationship-canvas-zoom';
+
+const FIT_VIEW_PADDING = 1 / 0.85 - 1;
 
 interface ReactFlowStubProps {
   children?: ReactNode;
@@ -131,12 +134,29 @@ describe('RelationshipCanvas viewport', () => {
     );
   });
 
-  it('passes the low zoom floor to a full fit after the interactive floor was raised', async () => {
+  it('derives the interactive zoom floor from the graph and pane geometry', async () => {
+    render(<RelationshipCanvas {...buildCanvasProps([buildRelationship('rel-1', 'target-1')])} />);
+
+    await waitFor(() => {
+      expect(reactFlowHarness.latestProps?.nodes).toHaveLength(2);
+    });
+    const expectedRange = getGraphZoomRange(
+      getFittedGraphZoom(
+        getRenderedGraphBounds(),
+        reactFlowHarness.store.width,
+        reactFlowHarness.store.height,
+        FIT_VIEW_PADDING
+      )
+    );
+    expect(reactFlowHarness.latestProps?.minZoom).toBe(expectedRange.min);
+    expect(expectedRange.min).toBeGreaterThan(0.05);
+  });
+
+  it('passes the low zoom floor to a full fit while the interactive floor is raised', async () => {
     render(<RelationshipCanvas {...buildCanvasProps([buildRelationship('rel-1', 'target-1')])} />);
 
     await waitFor(() => {
       expect(reactFlowHarness.fitView).toHaveBeenCalledTimes(1);
-      expect(reactFlowHarness.latestProps?.minZoom).toBe(1.5);
     });
     reactFlowHarness.fitView.mockClear();
 
@@ -153,6 +173,58 @@ describe('RelationshipCanvas viewport', () => {
     });
   });
 
+  it('keeps the zoom buttons working when the initial fit never settles', async () => {
+    // The bug behind this test: the zoom range used to be captured only after
+    // a completed fit, so a fit that ran under transient conditions (opening
+    // the page via search) left both buttons dead until "Fit to view".
+    reactFlowHarness.fitView.mockReset().mockReturnValue(new Promise<boolean>(() => undefined));
+
+    render(<RelationshipCanvas {...buildCanvasProps([buildRelationship('rel-1', 'target-1')])} />);
+
+    await waitFor(() => {
+      expect(reactFlowHarness.latestProps?.nodes).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
+    expect(reactFlowHarness.zoomTo).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom out' }));
+    expect(reactFlowHarness.zoomTo).toHaveBeenCalledTimes(2);
+  });
+
+  it('recovers with a full fit when the viewport zoom is corrupted', async () => {
+    render(<RelationshipCanvas {...buildCanvasProps([buildRelationship('rel-1', 'target-1')])} />);
+
+    await waitFor(() => {
+      expect(reactFlowHarness.fitView).toHaveBeenCalledTimes(1);
+    });
+    reactFlowHarness.fitView.mockClear();
+    reactFlowHarness.getZoom.mockReturnValue(Number.NaN);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
+
+    expect(reactFlowHarness.zoomTo).not.toHaveBeenCalled();
+    expect(reactFlowHarness.fitView).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores viewport moves that carry a non-finite zoom', async () => {
+    render(
+      <RelationshipCanvas
+        {...buildCanvasProps([
+          buildRelationship('rel-1', 'target-1'),
+          buildRelationship('rel-2', 'target-2'),
+        ])}
+      />
+    );
+
+    await waitFor(() => {
+      expect(reactFlowHarness.latestProps?.nodes).toHaveLength(3);
+    });
+
+    reactFlowHarness.latestProps?.onMove?.(null, { x: -10_000, y: 10_000, zoom: Number.NaN });
+
+    expect(reactFlowHarness.setViewport).not.toHaveBeenCalled();
+  });
+
   it('re-enables automatic fit when graph content changes after a user move', async () => {
     const initialRelationship = buildRelationship('rel-1', 'target-1');
     const { rerender } = render(
@@ -161,7 +233,6 @@ describe('RelationshipCanvas viewport', () => {
 
     await waitFor(() => {
       expect(reactFlowHarness.fitView).toHaveBeenCalledTimes(1);
-      expect(reactFlowHarness.latestProps?.minZoom).toBe(1.5);
     });
     reactFlowHarness.latestProps?.onMoveStart?.({ type: 'pointerdown' });
 

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/RelationshipCanvas.tsx
@@ -83,9 +83,10 @@ import {
 } from './relationship-warning-state';
 import {
   GRAPH_ZOOM_MAX,
+  GRAPH_ZOOM_MIN,
+  getFittedGraphZoom,
   getGraphZoomRange,
   getNextGraphZoom,
-  type GraphZoomRange,
 } from './relationship-canvas-zoom';
 import type { RelationshipStatusFilter } from './relationship-filters';
 
@@ -134,7 +135,6 @@ const SRC_H = 48;
 const TGT_H = 92;
 const FIT_VIEW_SCALE = 0.85;
 const FIT_VIEW_PADDING = 1 / FIT_VIEW_SCALE - 1;
-const GRAPH_ZOOM_MIN = 0.05;
 const GRAPH_PAN_PADDING = 150;
 // Functional "attention" (e.g. missing PK) — corporate yellow, distinct from the
 // non-functional (orange) WARNING_COLOR.
@@ -836,10 +836,6 @@ function RelationshipCanvasInner({
   const paneHeight = useStore(s => s.height);
   const hasFitRef = useRef(false);
   const userInteractedRef = useRef(false);
-  const [zoomRange, setZoomRange] = useState<GraphZoomRange>({
-    min: GRAPH_ZOOM_MIN,
-    max: GRAPH_ZOOM_MAX,
-  });
 
   const graphResult = useMemo(
     () =>
@@ -893,6 +889,17 @@ function RelationshipCanvasInner({
   const graphIdentity = useMemo(() => getRelationshipFlowGraphIdentity(graphResult), [graphResult]);
   const graphBounds = useMemo(() => getCanvasGraphBounds(graphResult.nodes), [graphResult.nodes]);
   const previousGraphIdentityRef = useRef(graphIdentity);
+
+  // Derived from the live geometry (not captured after a fit): a fit that ran
+  // against a half-loaded graph or a still-settling pane used to freeze the
+  // range in a state where both zoom buttons were dead until "Fit to view"
+  // recomputed it — the exact "zoom stops working after opening the page via
+  // search" bug.
+  const zoomRange = useMemo(
+    () =>
+      getGraphZoomRange(getFittedGraphZoom(graphBounds, paneWidth, paneHeight, FIT_VIEW_PADDING)),
+    [graphBounds, paneWidth, paneHeight]
+  );
 
   useEffect(() => {
     if (previousGraphIdentityRef.current === graphIdentity) return;
@@ -983,15 +990,11 @@ function RelationshipCanvasInner({
   }, [reactFlow]);
 
   const fitFull = useCallback(() => {
-    return reactFlow
-      .fitView({
-        minZoom: GRAPH_ZOOM_MIN,
-        maxZoom: GRAPH_ZOOM_MAX,
-        padding: FIT_VIEW_PADDING,
-      })
-      .then(() => {
-        setZoomRange(getGraphZoomRange(reactFlow.getZoom()));
-      });
+    return reactFlow.fitView({
+      minZoom: GRAPH_ZOOM_MIN,
+      maxZoom: GRAPH_ZOOM_MAX,
+      padding: FIT_VIEW_PADDING,
+    });
   }, [reactFlow]);
 
   const markUserInteracted = useCallback(() => {
@@ -1017,16 +1020,27 @@ function RelationshipCanvasInner({
   const handleZoom = useCallback(
     (delta: number) => {
       markUserInteracted();
-      const next = getNextGraphZoom(reactFlow.getZoom(), delta, zoomRange);
+      const currentZoom = reactFlow.getZoom();
+      if (!Number.isFinite(currentZoom) || currentZoom <= 0) {
+        // A corrupted viewport (an interrupted init can leave a non-finite
+        // transform behind) would make every zoom step a silent no-op —
+        // recover with a full fit instead of ignoring the click.
+        void fitFull();
+        return;
+      }
+      const next = getNextGraphZoom(currentZoom, delta, zoomRange);
       if (!next) return;
       void reactFlow.zoomTo(next.zoom, { duration: 150 });
     },
-    [markUserInteracted, reactFlow, zoomRange]
+    [fitFull, markUserInteracted, reactFlow, zoomRange]
   );
 
   const handleMove = useCallback(
     (_event: MouseEvent | TouchEvent | null, viewport: Viewport) => {
       if (paneWidth === 0 || paneHeight === 0) return;
+      // A non-finite zoom would poison the clamp math and push a NaN viewport
+      // into React Flow, killing pan and zoom until a full fit.
+      if (!Number.isFinite(viewport.zoom)) return;
 
       const clampedViewport = clampCanvasViewport(
         viewport,

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { GRAPH_ZOOM_MAX, getGraphZoomRange, getNextGraphZoom } from './relationship-canvas-zoom';
+import {
+  GRAPH_ZOOM_MAX,
+  GRAPH_ZOOM_MIN,
+  getFittedGraphZoom,
+  getGraphZoomRange,
+  getNextGraphZoom,
+} from './relationship-canvas-zoom';
 
 describe('relationship canvas zoom', () => {
   it('uses the fitted graph zoom as the minimum zoom', () => {
@@ -27,12 +33,27 @@ describe('relationship canvas zoom', () => {
     expect(next?.delta).toBeCloseTo(GRAPH_ZOOM_MAX / 2.9 - 1);
   });
 
-  it('clamps an oversized fitted zoom to the maximum zoom', () => {
-    expect(getGraphZoomRange(GRAPH_ZOOM_MAX + 1).min).toBe(GRAPH_ZOOM_MAX);
+  it('keeps the range usable when the fit lands on the maximum zoom', () => {
+    // A tiny graph on a large pane fits at the max zoom. min === max here
+    // turns both zoom buttons into permanent no-ops (the reported bug), so the
+    // floor falls back to 1x.
+    const range = getGraphZoomRange(GRAPH_ZOOM_MAX + 1);
+
+    expect(range.min).toBe(1);
+    expect(range.max).toBe(GRAPH_ZOOM_MAX);
+    expect(getNextGraphZoom(GRAPH_ZOOM_MAX, -0.25, range)?.zoom).toBeLessThan(GRAPH_ZOOM_MAX);
+    expect(getNextGraphZoom(1, 0.25, range)?.zoom).toBeGreaterThan(1);
   });
 
   it('returns null when the requested zoom is already on the range boundary', () => {
     expect(getNextGraphZoom(GRAPH_ZOOM_MAX, 0.25, getGraphZoomRange(0.2))).toBeNull();
+  });
+
+  it('never moves opposite to the pressed direction when clamping', () => {
+    // The measured graph can be slightly larger than the layout sizes the
+    // range is derived from, leaving the current zoom below range.min — a
+    // zoom-out press must not zoom in.
+    expect(getNextGraphZoom(0.4, -0.25, { min: 0.5, max: GRAPH_ZOOM_MAX })).toBeNull();
   });
 
   it('guards invalid current zoom values', () => {
@@ -43,5 +64,26 @@ describe('relationship canvas zoom', () => {
   it('falls back to a valid minimum for invalid fitted zoom values', () => {
     expect(getGraphZoomRange(Number.NaN).min).toBe(1);
     expect(getGraphZoomRange(0).min).toBe(1);
+  });
+
+  describe('getFittedGraphZoom', () => {
+    const bounds = { minX: 0, minY: 0, maxX: 800, maxY: 200 };
+
+    it('matches the fitView formula for a fractional padding', () => {
+      // padding 0.1 reserves 10% of the pane on each side: the graph gets
+      // 80% of 1000x500 — the width is the limiting side here.
+      expect(getFittedGraphZoom(bounds, 1000, 500, 0.1)).toBeCloseTo((1000 * 0.8) / 800);
+    });
+
+    it('clamps the fitted zoom into the supported range', () => {
+      expect(getFittedGraphZoom(bounds, 20000, 20000, 0)).toBe(GRAPH_ZOOM_MAX);
+      expect(getFittedGraphZoom(bounds, 10, 10, 0)).toBe(GRAPH_ZOOM_MIN);
+    });
+
+    it('reports degenerate inputs as NaN so the range falls back', () => {
+      expect(getFittedGraphZoom(bounds, 0, 500, 0.1)).toBeNaN();
+      expect(getFittedGraphZoom({ minX: 0, minY: 0, maxX: 0, maxY: 0 }, 1000, 500, 0.1)).toBeNaN();
+      expect(getGraphZoomRange(getFittedGraphZoom(bounds, 0, 0, 0.1)).min).toBe(1);
+    });
   });
 });

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.test.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { getViewportForBounds } from '@xyflow/react';
 import {
   GRAPH_ZOOM_MAX,
   GRAPH_ZOOM_MIN,
@@ -68,11 +69,17 @@ describe('relationship canvas zoom', () => {
 
   describe('getFittedGraphZoom', () => {
     const bounds = { minX: 0, minY: 0, maxX: 800, maxY: 200 };
+    const rect = { x: 0, y: 0, width: 800, height: 200 };
 
-    it('matches the fitView formula for a fractional padding', () => {
-      // padding 0.1 reserves 10% of the pane on each side: the graph gets
-      // 80% of 1000x500 — the width is the limiting side here.
-      expect(getFittedGraphZoom(bounds, 1000, 500, 0.1)).toBeCloseTo((1000 * 0.8) / 800);
+    it('matches the zoom the real fitView math produces', () => {
+      // Asserted against the library function fitView uses internally — an
+      // in-test re-derivation of the padding formula could drift together
+      // with the implementation and hide a mismatch.
+      const expected = getViewportForBounds(rect, 1000, 500, GRAPH_ZOOM_MIN, GRAPH_ZOOM_MAX, 0.1);
+      expect(getFittedGraphZoom(bounds, 1000, 500, 0.1)).toBe(expected.zoom);
+      // Sanity-pin the padding semantics of @xyflow v12 (usable pane is
+      // pane / (1 + padding), floored per side): 1000 -> 910 usable px.
+      expect(expected.zoom).toBeCloseTo(910 / 800, 5);
     });
 
     it('clamps the fitted zoom into the supported range', () => {

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.ts
@@ -1,10 +1,42 @@
+import type { CanvasGraphBounds } from '../../../shared/canvas/viewport';
+
 export const GRAPH_ZOOM_MAX = 3;
+export const GRAPH_ZOOM_MIN = 0.05;
 const GRAPH_ZOOM_EPSILON = 0.0001;
 const GRAPH_ZOOM_FALLBACK_MIN = 1;
 
 export interface GraphZoomRange {
   min: number;
   max: number;
+}
+
+/**
+ * The zoom a full fit lands on for the given graph bounds and pane size —
+ * the same math React Flow's fitView uses for a fractional padding, which
+ * reserves `padding * pane` on each side before fitting the bounds.
+ *
+ * Derived analytically (instead of reading the viewport back after a fit) so
+ * the zoom range never freezes on a value captured under transient conditions
+ * — a mid-load fit, a pane that was still settling, or a layout that changed
+ * after the fit ran.
+ */
+export function getFittedGraphZoom(
+  bounds: CanvasGraphBounds,
+  paneWidth: number,
+  paneHeight: number,
+  padding: number
+): number {
+  const boundsWidth = bounds.maxX - bounds.minX;
+  const boundsHeight = bounds.maxY - bounds.minY;
+  if (boundsWidth <= 0 || boundsHeight <= 0 || paneWidth <= 0 || paneHeight <= 0) {
+    return Number.NaN;
+  }
+
+  const zoom = Math.min(
+    (paneWidth * (1 - 2 * padding)) / boundsWidth,
+    (paneHeight * (1 - 2 * padding)) / boundsHeight
+  );
+  return Math.min(Math.max(zoom, GRAPH_ZOOM_MIN), GRAPH_ZOOM_MAX);
 }
 
 export function getGraphZoomRange(fittedZoom: number): GraphZoomRange {
@@ -14,7 +46,10 @@ export function getGraphZoomRange(fittedZoom: number): GraphZoomRange {
       : GRAPH_ZOOM_FALLBACK_MIN;
 
   return {
-    min: safeFittedZoom,
+    // A small graph on a large pane fits at (or beyond) the max zoom. Keeping
+    // min == max there would turn both zoom buttons into no-ops, so fall back
+    // to the neutral 100% floor and let the user zoom between 1x and the max.
+    min: safeFittedZoom >= GRAPH_ZOOM_MAX ? GRAPH_ZOOM_FALLBACK_MIN : safeFittedZoom,
     max: GRAPH_ZOOM_MAX,
   };
 }
@@ -30,6 +65,10 @@ export function getNextGraphZoom(
   const zoom = Math.min(Math.max(requestedZoom, range.min), range.max);
 
   if (!Number.isFinite(zoom) || Math.abs(zoom - currentZoom) < GRAPH_ZOOM_EPSILON) return null;
+  // The current zoom can sit outside the range (the measured graph can be
+  // slightly larger than the layout sizes the range is derived from). Never
+  // let the clamp move the viewport opposite to what the user pressed.
+  if (delta > 0 !== zoom > currentZoom) return null;
 
   return {
     zoom,

--- a/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.ts
+++ b/apps/web/src/features/data-marts/edit/components/DataMartRelationships/relationship-canvas-zoom.ts
@@ -1,3 +1,4 @@
+import { getViewportForBounds } from '@xyflow/react';
 import type { CanvasGraphBounds } from '../../../shared/canvas/viewport';
 
 export const GRAPH_ZOOM_MAX = 3;
@@ -12,8 +13,9 @@ export interface GraphZoomRange {
 
 /**
  * The zoom a full fit lands on for the given graph bounds and pane size —
- * the same math React Flow's fitView uses for a fractional padding, which
- * reserves `padding * pane` on each side before fitting the bounds.
+ * computed with React Flow's own getViewportForBounds (the function fitView
+ * uses internally), so the value cannot drift from the library's padding
+ * semantics.
  *
  * Derived analytically (instead of reading the viewport back after a fit) so
  * the zoom range never freezes on a value captured under transient conditions
@@ -32,11 +34,14 @@ export function getFittedGraphZoom(
     return Number.NaN;
   }
 
-  const zoom = Math.min(
-    (paneWidth * (1 - 2 * padding)) / boundsWidth,
-    (paneHeight * (1 - 2 * padding)) / boundsHeight
-  );
-  return Math.min(Math.max(zoom, GRAPH_ZOOM_MIN), GRAPH_ZOOM_MAX);
+  return getViewportForBounds(
+    { x: bounds.minX, y: bounds.minY, width: boundsWidth, height: boundsHeight },
+    paneWidth,
+    paneHeight,
+    GRAPH_ZOOM_MIN,
+    GRAPH_ZOOM_MAX,
+    padding
+  ).zoom;
 }
 
 export function getGraphZoomRange(fittedZoom: number): GraphZoomRange {


### PR DESCRIPTION
## Problem

The +/- zoom buttons on the Joinable Data Marts diagram could stop responding until **Fit to view** was pressed, depending on how the data mart page was opened.

The allowed zoom range was captured once, from the viewport read back after a completed `fitView`. In @xyflow v12 the imperative `fitView` is queued and executes later with whatever pane dimensions are current at that moment, so a fit that ran under transient conditions (graph still loading, pane still settling) froze the range in an unusable state. A separate guaranteed-dead case: a small graph on a large pane fits at the maximum zoom, leaving `min == max` — both buttons become permanent no-ops. Pressing **Fit to view** recomputed the range, which is why it "cured" the canvas.

## Fix

- Derive the zoom range from the live graph bounds and pane size (`getFittedGraphZoom`, same math as `fitView`'s `getViewportForBounds` for a fractional padding) instead of freezing it from a one-shot readback — the stale-range class of failures is gone by construction.
- When the fitted zoom lands on (or above) the max zoom, fall back to a 1x zoom-out floor so the range never degenerates into a single value.
- Never let the range clamp move the viewport opposite to the pressed button (the measured graph can be slightly larger than the layout sizes the range is derived from).
- Recover a corrupted (non-finite) viewport with a full fit instead of silently ignoring clicks, and skip the pan clamp for moves carrying a non-finite zoom so NaN can never propagate into the viewport.

## Testing

- New regression tests: zoom buttons work even when the initial fit never settles; NaN viewport recovers via full fit; max-zoom fit keeps a usable range; clamp never reverses direction.
- All 89 tests in `DataMartRelationships/` pass; tsc, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)