### PR TITLE
fix(backend): assert the new PK identity shape in the BigQuery integration test

### DIFF
--- a/apps/backend/test/integration/bigquery.integration.ts
+++ b/apps/backend/test/integration/bigquery.integration.ts
@@ -4323,8 +4323,13 @@ describeIfCredentials(
 
     it('counts a duplicated joined row ONCE: EU=170, and keeps contradictory rows apart: US=81', async () => {
       const { sql } = builder.buildBlendedQuery(context(['orderId']));
-      expect(sql).not.toContain('__owox_rid');
-      expect(sql).not.toContain('ROW_NUMBER()');
+      // The key rides as its own DISTINCT slot, uncast and unconcatenated. The surrogate stays
+      // projected, but only as the fallback for a row whose key is NULL — which this seed has
+      // none of, so it contributes nothing here.
+      expect(sql).toContain('orders_raw.orderId AS _oid_k0');
+      expect(sql).toContain(
+        'CASE WHEN orders_raw.orderId IS NULL THEN orders_raw.__owox_rid ELSE NULL END AS _oid'
+      );
 
       const byRegion = sumByRegion(await runBlend(context(['orderId'])));
 
@@ -4335,7 +4340,11 @@ describeIfCredentials(
 
     it('without a declared key the same data reads EU=270 — the duplicate is summed twice', async () => {
       const { sql } = builder.buildBlendedQuery(context([]));
-      expect(sql).toContain('AS __owox_rid');
+      // With no key to identify a row by, the surrogate IS the identity: unguarded, and with no
+      // key slot beside it. That is what separates this query from the keyed one — the mere
+      // presence of `__owox_rid` does not, since a keyed source projects it as a fallback too.
+      expect(sql).toContain('orders_raw.__owox_rid AS _oid');
+      expect(sql).not.toContain('_oid_k0');
 
       const byRegion = sumByRegion(await runBlend(context([])));
 


### PR DESCRIPTION
## Why

The nightly `Integration Tests (Real DB)` workflow has been red since 2026-08-12, always on the same single test — 1 failure out of 141, BigQuery job only:

```
● value sleeve de-duplicates by a declared primary key (real BigQuery)
  › counts a duplicated joined row ONCE: EU=170, and keeps contradictory rows apart: US=81

expect(received).not.toContain(expected)
Expected substring: not "__owox_rid"
```

The last green run was 06:07 UTC that day, the first red one 14:15 UTC. #1522 landed at 09:47 UTC and is the only commit in that window touching `data-storage-types/blending/`.

This is a stale assertion, not a product regression. #1522 deliberately changed what identifies a row in a value sleeve: a declared primary key with a NULL component is no longer an identity, so such rows fall back to the per-row surrogate instead of collapsing together. The surrogate is therefore projected for a keyed source too, as `blend-cte.builder.ts` states:

```ts
// Every identity owner, not just a keyless one: a declared key with a NULL component
// falls back to the surrogate, so the sleeve needs it projected either way.
```

The test still asserted the previous contract — no `__owox_rid` and no `ROW_NUMBER()` whenever a key is declared.

## What

Assert what identifies a row now:

- **keyed** — the key rides as its own `_oid_k0` slot, with the surrogate guarded behind a NULL check;
- **keyless** — the unguarded surrogate, and no key slot beside it.

The keyless assertion had lost its meaning: `toContain('AS __owox_rid')` is true of both queries since #1522, so it no longer told them apart. The new one does.

Data expectations are untouched. They never ran — the shape assertion failed first.

## Verification

Both SQL shapes were generated with the real `BigQueryBlendedQueryBuilder` (throwaway spec, not committed):

- each set of assertions passes on its own shape;
- each **fails** on the opposite shape — checked explicitly, so the assertions are discriminating rather than merely true.

The data expectations were replayed against the test's seed rows in SQLite using the same sleeve semantics:

| | EU | US | APAC |
|---|---|---|---|
| keyed | 170 | 81 | 60 |
| keyless | 270 | 81 | 180 |

Matches what the tests expect.

No changeset: test-only change.

## Note

`test-integration.yml` runs on `schedule` and `workflow_dispatch` only — never on pull requests. That is why #1522 merged green, and it means this fix cannot be confirmed by PR CI either. It needs a manual `workflow_dispatch` run on this branch.
