### PR TITLE
fix(microsoft-ads): resume interrupted imports from last completed day

### DIFF
--- a/.changeset/6864-microsoft-ads-per-day-checkpoint.md
+++ b/.changeset/6864-microsoft-ads-per-day-checkpoint.md
@@ -5,3 +5,5 @@
 # Resumable incremental imports for Microsoft Ads
 
 Previously, an interrupted incremental run restarted the whole date range from the beginning, so long imports could retry endlessly without ever finishing. The connector now saves its progress after each imported day. An interrupted run resumes from the last completed day instead of starting over.
+
+The connector also stops early with a clear message when the Account IDs field holds no usable ID, or when Fields references a report the source no longer provides.

--- a/.changeset/6864-microsoft-ads-per-day-checkpoint.md
+++ b/.changeset/6864-microsoft-ads-per-day-checkpoint.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Resumable incremental imports for Microsoft Ads
+
+Previously, an interrupted incremental run restarted the whole date range from the beginning, so long imports could retry endlessly without ever finishing. The connector now saves its progress after each imported day. An interrupted run resumes from the last completed day instead of starting over.

--- a/packages/connectors/src/Core/Utils/FormatUtils.js
+++ b/packages/connectors/src/Core/Utils/FormatUtils.js
@@ -62,7 +62,8 @@ var FormatUtils = {
    */
   parseAccountIds: function (accountIdsString) {
     return String(accountIdsString)
-      .split(/[,;]\s*/)
-      .filter(id => id.trim().length > 0);
+      .split(/[,;]/)
+      .map(id => id.trim())
+      .filter(id => id.length > 0);
   }
 };

--- a/packages/connectors/src/Sources/MicrosoftAds/Connector.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Connector.js
@@ -17,111 +17,106 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
    * Processes all nodes defined in the fields configuration
    */
   async startImportProcess() {
-    const accountIds = FormatUtils.parseAccountIds(this.config.AccountIDs.value);
+    const accountIds = FormatUtils.parseAccountIds(this.config.AccountIDs.value).map(id => id.trim());
     const fields = MicrosoftAdsHelper.parseFields(this.config.Fields.value);
-    let lastProcessedDate = null;
+    const nodeNames = Object.keys(fields);
+    const timeSeriesNodes = nodeNames.filter(nodeName => this.source.fieldsSchema[nodeName].isTimeSeries);
+    const catalogNodes = nodeNames.filter(nodeName => !this.source.fieldsSchema[nodeName].isTimeSeries);
 
-    for (const rawAccountId of accountIds) {
-      const accountId = rawAccountId.trim();
+    for (const accountId of accountIds) {
       this.config.logMessage(`Starting import process for Account ID: ${accountId}`);
 
-      for (const nodeName in fields) {
-        const processedDate = await this.processNode({
+      for (const nodeName of catalogNodes) {
+        await this.processCatalogNode({
           nodeName,
           accountId,
-          fields: fields[nodeName] || [],
-          updateRequestedDate: false
+          fields: fields[nodeName] || []
         });
-
-        if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
-          lastProcessedDate = processedDate;
-        }
       }
     }
 
-    if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL && lastProcessedDate) {
-      this.config.updateLastRequstedDate(lastProcessedDate);
-    }
+    await this.processTimeSeriesNodes({ accountIds, timeSeriesNodes, fields });
   }
 
   /**
-   * Process a single node for a specific account
+   * Imports every time series node for every account, one date at a time.
+   *
+   * The loop is date-outer on purpose: the incremental cursor may only move once a
+   * date is complete for *all* accounts and nodes, so a run interrupted midway
+   * resumes from the last fully imported date instead of restarting the range.
+   *
    * @param {Object} options - Processing options
-   * @param {string} options.nodeName - Name of the node to process
-   * @param {string} options.accountId - Account ID
-   * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
+   * @param {Array<string>} options.accountIds - Account IDs to import
+   * @param {Array<string>} options.timeSeriesNodes - Names of the time series nodes to import
+   * @param {Object} options.fields - Map of node name to the fields selected for it
    */
-  async processNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
-    if (this.source.fieldsSchema[nodeName].isTimeSeries) {
-      return await this.processTimeSeriesNode({
-        nodeName,
-        accountId,
-        fields,
-        updateRequestedDate
-      });
-    } else {
-      await this.processCatalogNode({
-        nodeName,
-        accountId,
-        fields
-      });
-      return null;
+  async processTimeSeriesNodes({ accountIds, timeSeriesNodes, fields }) {
+    if (!timeSeriesNodes.length) {
+      return;
     }
-  }
 
-  /**
-   * Process a time series node (e.g., ad performance report)
-   * @param {Object} options - Processing options
-   * @param {string} options.nodeName - Name of the node
-   * @param {string} options.accountId - Account ID
-   * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
-   */
-  async processTimeSeriesNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
     const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
 
     if (daysToFetch <= 0) {
-      console.log('No days to fetch for time series data');
-      return null;
+      this.config.logMessage('No days to fetch for time series data');
+      return;
     }
 
-    let lastProcessedDate = null;
-
-    // Process data day by day
     for (let dayOffset = 0; dayOffset < daysToFetch; dayOffset++) {
       const currentDate = new Date(startDate);
       currentDate.setDate(currentDate.getDate() + dayOffset);
-      lastProcessedDate = new Date(currentDate);
 
-      const formattedDate = DateUtils.formatDate(currentDate);
-
-      this.config.logMessage(`Processing ${nodeName} for ${accountId} on ${formattedDate} (day ${dayOffset + 1} of ${daysToFetch})`);
-
-      const data = await this.source.fetchData({
-        nodeName,
-        accountId,
-        start_time: formattedDate,
-        end_time: formattedDate,
-        fields
-      });
-
-      this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for ${accountId} on ${formattedDate}` : `No records have been fetched`);
-
-      if (data.length || this.config.CreateEmptyTables?.value) {
-        const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
-        const storage = await this.getStorageByNode(nodeName);
-        await storage.saveData(preparedData);
-        data.length && this.config.logMessage(`Successfully saved ${data.length} rows for ${formattedDate}`);
+      for (const accountId of accountIds) {
+        for (const nodeName of timeSeriesNodes) {
+          await this.processTimeSeriesDay({
+            nodeName,
+            accountId,
+            date: currentDate,
+            fields: fields[nodeName] || [],
+            dayNumber: dayOffset + 1,
+            daysToFetch
+          });
+        }
       }
 
-      // Some callers defer the checkpoint until all accounts finish successfully.
-      if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+      // Every account and node stored this date, so the cursor can move past it.
+      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
         this.config.updateLastRequstedDate(currentDate);
       }
     }
+  }
 
-    return lastProcessedDate;
+  /**
+   * Fetch and store a single day of a time series node for one account
+   * @param {Object} options - Processing options
+   * @param {string} options.nodeName - Name of the node
+   * @param {string} options.accountId - Account ID
+   * @param {Date} options.date - The day to import
+   * @param {Array<string>} options.fields - Array of fields to fetch
+   * @param {number} options.dayNumber - 1-based position of the day within the run
+   * @param {number} options.daysToFetch - Total number of days in the run
+   */
+  async processTimeSeriesDay({ nodeName, accountId, date, fields, dayNumber, daysToFetch }) {
+    const formattedDate = DateUtils.formatDate(date);
+
+    this.config.logMessage(`Processing ${nodeName} for ${accountId} on ${formattedDate} (day ${dayNumber} of ${daysToFetch})`);
+
+    const data = await this.source.fetchData({
+      nodeName,
+      accountId,
+      start_time: formattedDate,
+      end_time: formattedDate,
+      fields
+    });
+
+    this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for ${accountId} on ${formattedDate}` : `No records have been fetched`);
+
+    if (data.length || this.config.CreateEmptyTables?.value) {
+      const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
+      const storage = await this.getStorageByNode(nodeName);
+      await storage.saveData(preparedData);
+      data.length && this.config.logMessage(`Successfully saved ${data.length} rows for ${formattedDate}`);
+    }
   }
 
   /**

--- a/packages/connectors/src/Sources/MicrosoftAds/Connector.js
+++ b/packages/connectors/src/Sources/MicrosoftAds/Connector.js
@@ -17,15 +17,29 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
    * Processes all nodes defined in the fields configuration
    */
   async startImportProcess() {
-    const accountIds = FormatUtils.parseAccountIds(this.config.AccountIDs.value).map(id => id.trim());
+    const accountIds = FormatUtils.parseAccountIds(this.config.AccountIDs.value);
+
+    // A blank-but-truthy AccountIDs (e.g. ",") passes required-field validation and parses
+    // to an empty list. Without this the day loop would still run, import nothing, and walk
+    // the incremental cursor to today — silently skipping every day once the config is fixed.
+    if (!accountIds.length) {
+      throw new Error('No valid Account IDs found in the AccountIDs parameter');
+    }
+
     const fields = MicrosoftAdsHelper.parseFields(this.config.Fields.value);
     const nodeNames = Object.keys(fields);
+    nodeNames.forEach(nodeName => this.assertKnownNode(nodeName));
+
     const timeSeriesNodes = nodeNames.filter(nodeName => this.source.fieldsSchema[nodeName].isTimeSeries);
     const catalogNodes = nodeNames.filter(nodeName => !this.source.fieldsSchema[nodeName].isTimeSeries);
 
-    for (const accountId of accountIds) {
-      this.config.logMessage(`Starting import process for Account ID: ${accountId}`);
+    // Resolve the date range up front so an invalid backfill config (missing StartDate,
+    // EndDate before StartDate) fails before any catalog import rather than after it.
+    const dateRange = timeSeriesNodes.length ? this.getStartDateAndDaysToFetch() : null;
 
+    this.config.logMessage(`Importing ${nodeNames.length} node(s) for account(s): ${accountIds.join(', ')}`);
+
+    for (const accountId of accountIds) {
       for (const nodeName of catalogNodes) {
         await this.processCatalogNode({
           nodeName,
@@ -35,7 +49,21 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
       }
     }
 
-    await this.processTimeSeriesNodes({ accountIds, timeSeriesNodes, fields });
+    if (dateRange) {
+      const [startDate, daysToFetch] = dateRange;
+      await this.processTimeSeriesNodes({ accountIds, timeSeriesNodes, fields, startDate, daysToFetch });
+    }
+  }
+
+  /**
+   * Rejects a configured node that the source no longer defines, so an outdated Fields
+   * value fails with a readable message instead of a bare property-of-undefined error
+   * @param {string} nodeName - Name of the node
+   */
+  assertKnownNode(nodeName) {
+    if (!this.source.fieldsSchema[nodeName]) {
+      throw new Error(`Unknown node '${nodeName}'. Please update the Fields configuration`);
+    }
   }
 
   /**
@@ -49,14 +77,10 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
    * @param {Array<string>} options.accountIds - Account IDs to import
    * @param {Array<string>} options.timeSeriesNodes - Names of the time series nodes to import
    * @param {Object} options.fields - Map of node name to the fields selected for it
+   * @param {Date} options.startDate - First date of the range
+   * @param {number} options.daysToFetch - Number of days to import
    */
-  async processTimeSeriesNodes({ accountIds, timeSeriesNodes, fields }) {
-    if (!timeSeriesNodes.length) {
-      return;
-    }
-
-    const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
-
+  async processTimeSeriesNodes({ accountIds, timeSeriesNodes, fields, startDate, daysToFetch }) {
     if (daysToFetch <= 0) {
       this.config.logMessage('No days to fetch for time series data');
       return;
@@ -65,16 +89,17 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
     for (let dayOffset = 0; dayOffset < daysToFetch; dayOffset++) {
       const currentDate = new Date(startDate);
       currentDate.setDate(currentDate.getDate() + dayOffset);
+      const formattedDate = DateUtils.formatDate(currentDate);
+
+      this.config.logMessage(`Processing ${formattedDate} (day ${dayOffset + 1} of ${daysToFetch})`);
 
       for (const accountId of accountIds) {
         for (const nodeName of timeSeriesNodes) {
           await this.processTimeSeriesDay({
             nodeName,
             accountId,
-            date: currentDate,
-            fields: fields[nodeName] || [],
-            dayNumber: dayOffset + 1,
-            daysToFetch
+            formattedDate,
+            fields: fields[nodeName] || []
           });
         }
       }
@@ -91,16 +116,10 @@ var MicrosoftAdsConnector = class MicrosoftAdsConnector extends AbstractConnecto
    * @param {Object} options - Processing options
    * @param {string} options.nodeName - Name of the node
    * @param {string} options.accountId - Account ID
-   * @param {Date} options.date - The day to import
+   * @param {string} options.formattedDate - The day to import, as YYYY-MM-DD
    * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {number} options.dayNumber - 1-based position of the day within the run
-   * @param {number} options.daysToFetch - Total number of days in the run
    */
-  async processTimeSeriesDay({ nodeName, accountId, date, fields, dayNumber, daysToFetch }) {
-    const formattedDate = DateUtils.formatDate(date);
-
-    this.config.logMessage(`Processing ${nodeName} for ${accountId} on ${formattedDate} (day ${dayNumber} of ${daysToFetch})`);
-
+  async processTimeSeriesDay({ nodeName, accountId, formattedDate, fields }) {
     const data = await this.source.fetchData({
       nodeName,
       accountId,

--- a/packages/connectors/test/Sources/MicrosoftAds/perDayCheckpoint.test.js
+++ b/packages/connectors/test/Sources/MicrosoftAds/perDayCheckpoint.test.js
@@ -7,8 +7,11 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 globalThis.DateUtils = { formatDate: date => date.toISOString().slice(0, 10) };
 globalThis.RUN_CONFIG_TYPE = { INCREMENTAL: 'INCREMENTAL', MANUAL_BACKFILL: 'MANUAL_BACKFILL' };
-globalThis.FormatUtils = { parseAccountIds: value => value.split(',') };
 globalThis.MicrosoftAdsHelper = { parseFields: value => JSON.parse(value) };
+
+// Account parsing decides whether the day loop runs at all, so use the real helper
+// rather than a stub that can never return the empty list the connector must reject.
+loadGasClass(path.join(__dirname, '../../../src/Core/Utils/FormatUtils.js'));
 
 loadGasClass(path.join(__dirname, '../../../src/Sources/MicrosoftAds/Connector.js'), {
   AbstractConnector: class {},
@@ -156,15 +159,31 @@ describe('multiple accounts', () => {
     expect(cursorMovedTo).toEqual(['2026-08-10']);
   });
 
-  it('trims whitespace around configured account IDs', async () => {
+  it('trims whitespace and accepts semicolons in configured account IDs', async () => {
+    // Whitespace before a delimiter is not eaten by the split, so an untrimmed id would
+    // reach the API as " acc1 " and fetch nothing.
     const { self, fetched } = buildConnector({
-      accountIds: 'acc1, acc2',
+      accountIds: ' acc1 ; acc2 ',
       daysToFetch: 1,
     });
 
     await connectorProto.startImportProcess.call(self);
 
     expect(fetched).toEqual([`acc1/${REPORT_NODE}/2026-08-10`, `acc2/${REPORT_NODE}/2026-08-10`]);
+  });
+
+  it('refuses to run when AccountIDs holds no usable id', async () => {
+    // "," is truthy so it passes required-field validation, but parses to an empty list.
+    // Importing nothing while advancing the cursor would skip every one of those days
+    // for good once the config is corrected.
+    const { self, cursorMovedTo, fetched } = buildConnector({ accountIds: ', ;' });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      /No valid Account IDs/
+    );
+
+    expect(fetched).toEqual([]);
+    expect(cursorMovedTo).toEqual([]);
   });
 });
 
@@ -213,5 +232,44 @@ describe('node types', () => {
 
     expect(fetched).toEqual([]);
     expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('names the offending node when Fields references one the source dropped', async () => {
+    // Otherwise the run dies on a bare property-of-undefined before the first log line,
+    // leaving nothing in run history to diagnose it from.
+    const { self, fetched } = buildConnector({ nodes: { removed_report: ['Spend'] } });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      /Unknown node 'removed_report'/
+    );
+
+    expect(fetched).toEqual([]);
+  });
+
+  it('writes an empty day when CreateEmptyTables is on', async () => {
+    const saved = [];
+    const { self } = buildConnector({
+      daysToFetch: 2,
+      fetchData: async () => [],
+      saveData: async rows => saved.push(rows),
+    });
+    self.config.CreateEmptyTables = { value: true };
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(saved).toEqual([[], []]);
+  });
+
+  it('does not touch storage on an empty day when CreateEmptyTables is off', async () => {
+    const saved = [];
+    const { self } = buildConnector({
+      daysToFetch: 2,
+      fetchData: async () => [],
+      saveData: async rows => saved.push(rows),
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(saved).toEqual([]);
   });
 });

--- a/packages/connectors/test/Sources/MicrosoftAds/perDayCheckpoint.test.js
+++ b/packages/connectors/test/Sources/MicrosoftAds/perDayCheckpoint.test.js
@@ -1,0 +1,217 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+globalThis.DateUtils = { formatDate: date => date.toISOString().slice(0, 10) };
+globalThis.RUN_CONFIG_TYPE = { INCREMENTAL: 'INCREMENTAL', MANUAL_BACKFILL: 'MANUAL_BACKFILL' };
+globalThis.FormatUtils = { parseAccountIds: value => value.split(',') };
+globalThis.MicrosoftAdsHelper = { parseFields: value => JSON.parse(value) };
+
+loadGasClass(path.join(__dirname, '../../../src/Sources/MicrosoftAds/Connector.js'), {
+  AbstractConnector: class {},
+});
+
+const connectorProto = globalThis.MicrosoftAdsConnector.prototype;
+
+const REPORT_NODE = 'user_location_performance_report';
+const CATALOG_NODE = 'campaigns';
+
+const buildConnector = ({
+  accountIds = '2603235',
+  nodes = { [REPORT_NODE]: ['Spend'] },
+  runType = 'INCREMENTAL',
+  startDate = new Date('2026-08-10T00:00:00Z'),
+  daysToFetch = 3,
+  fetchData = async () => [{ Spend: 1 }],
+  saveData = async () => undefined,
+} = {}) => {
+  const cursorMovedTo = [];
+  const fetched = [];
+  const logs = [];
+
+  const self = Object.create(connectorProto);
+  self.runConfig = { type: runType };
+  self.source = {
+    fieldsSchema: {
+      [REPORT_NODE]: { isTimeSeries: true },
+      [CATALOG_NODE]: { isTimeSeries: false },
+    },
+    fetchData: async params => {
+      fetched.push(`${params.accountId}/${params.nodeName}/${params.start_time}`);
+      return fetchData(params);
+    },
+  };
+  self.getStorageByNode = async () => ({ saveData });
+  self.addMissingFieldsToData = data => data;
+  self.getStartDateAndDaysToFetch = () => [startDate, daysToFetch];
+  self.config = {
+    AccountIDs: { value: accountIds },
+    Fields: { value: JSON.stringify(nodes) },
+    CreateEmptyTables: { value: false },
+    logMessage: message => logs.push(message),
+    updateLastRequstedDate: date => cursorMovedTo.push(new Date(date).toISOString().slice(0, 10)),
+  };
+
+  return { self, cursorMovedTo, fetched, logs };
+};
+
+describe('incremental checkpointing', () => {
+  it('saves the cursor after each completed day instead of only at the end', async () => {
+    // A run that only checkpoints at the end loses all progress when the process dies,
+    // and the interrupted-run sweep then restarts the whole range — forever.
+    const { self, cursorMovedTo } = buildConnector();
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11', '2026-08-12']);
+  });
+
+  it('keeps the days already imported when a later day fails', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      fetchData: async ({ start_time }) => {
+        if (start_time === '2026-08-12') throw new Error('Connector process died');
+        return [{ Spend: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'Connector process died'
+    );
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not move the cursor past a day whose storage write failed', async () => {
+    // Advancing here would leave a permanent gap: once ReimportLookbackWindow passes,
+    // that day is never requested again.
+    const { self, cursorMovedTo } = buildConnector({
+      saveData: async () => {
+        throw new Error('BigQuery write failed');
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'BigQuery write failed'
+    );
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('never moves the incremental cursor during a manual backfill', async () => {
+    const { self, cursorMovedTo } = buildConnector({ runType: 'MANUAL_BACKFILL' });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('advances the cursor on a day that returned no rows', async () => {
+    // A quiet day must not stall the cursor, otherwise the run never reaches today.
+    const { self, cursorMovedTo } = buildConnector({ fetchData: async () => [] });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11', '2026-08-12']);
+  });
+});
+
+describe('multiple accounts', () => {
+  it('completes a date for every account before moving the cursor', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({
+      accountIds: 'acc1,acc2',
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([
+      `acc1/${REPORT_NODE}/2026-08-10`,
+      `acc2/${REPORT_NODE}/2026-08-10`,
+      `acc1/${REPORT_NODE}/2026-08-11`,
+      `acc2/${REPORT_NODE}/2026-08-11`,
+    ]);
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not checkpoint a date that only the first account imported', async () => {
+    // The account-outer loop this replaced could advance the cursor past days a later
+    // account never loaded, silently dropping that account's data.
+    const { self, cursorMovedTo } = buildConnector({
+      accountIds: 'acc1,acc2',
+      fetchData: async ({ accountId, start_time }) => {
+        if (accountId === 'acc2' && start_time === '2026-08-11') {
+          throw new Error('Account acc2 failed');
+        }
+        return [{ Spend: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'Account acc2 failed'
+    );
+
+    expect(cursorMovedTo).toEqual(['2026-08-10']);
+  });
+
+  it('trims whitespace around configured account IDs', async () => {
+    const { self, fetched } = buildConnector({
+      accountIds: 'acc1, acc2',
+      daysToFetch: 1,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([`acc1/${REPORT_NODE}/2026-08-10`, `acc2/${REPORT_NODE}/2026-08-10`]);
+  });
+});
+
+describe('node types', () => {
+  it('imports catalog nodes once per account, before any day is requested', async () => {
+    const { self, fetched } = buildConnector({
+      nodes: { [CATALOG_NODE]: ['Id'], [REPORT_NODE]: ['Spend'] },
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched[0]).toBe(`2603235/${CATALOG_NODE}/undefined`);
+    expect(fetched.filter(entry => entry.includes(CATALOG_NODE))).toHaveLength(1);
+  });
+
+  it('completes both time series nodes for a date before checkpointing it', async () => {
+    const secondReport = 'ad_performance_report';
+    const { self, cursorMovedTo, fetched } = buildConnector({
+      nodes: { [REPORT_NODE]: ['Spend'], [secondReport]: ['Clicks'] },
+      daysToFetch: 1,
+    });
+    self.source.fieldsSchema[secondReport] = { isTimeSeries: true };
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([
+      `2603235/${REPORT_NODE}/2026-08-10`,
+      `2603235/${secondReport}/2026-08-10`,
+    ]);
+    expect(cursorMovedTo).toEqual(['2026-08-10']);
+  });
+
+  it('skips the day loop entirely when only catalog nodes are selected', async () => {
+    const { self, cursorMovedTo } = buildConnector({ nodes: { [CATALOG_NODE]: ['Id'] } });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('imports nothing when the range has no days left to fetch', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({ daysToFetch: 0 });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([]);
+    expect(cursorMovedTo).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Problem

An incremental Microsoft Ads import saved its progress only after every account and every node had finished the entire date range. Long backfills never reached that point: run `b745d775` processed 42 of 49 days over roughly 10 hours, then the connector process died with `Connector process finished without terminal success status`, leaving `LastRequestedDate` untouched. The interrupted-run sweep picked the run back up 15 minutes later and restarted it from day 1 of the range, which failed the same way, and the cycle repeated until someone cancelled the run by hand — about 14 hours across four attempts with no durable progress. The root cause was the loop shape: `startImportProcess` iterated accounts on the outside and days on the inside, passing `updateRequestedDate: false` down so the single checkpoint could only fire at the very end.

# Solution

The time-series import now runs date-outer instead of account-outer, so the incremental cursor advances once per completed day. A date is checkpointed only after every account and every time-series node has fetched and stored it, which keeps multi-account configurations correct — the reason the checkpoint was deferred in the first place. This is the same shape already used by the FacebookMarketing and TikTokAds connectors.

- `startImportProcess` splits the configured nodes into catalog and time-series groups. Catalog nodes still import once per account, before any day is requested.
- The new `processTimeSeriesNodes` owns the day loop, calls `getStartDateAndDaysToFetch()` once up front, and calls `updateLastRequstedDate(currentDate)` after each fully completed date, still guarded by `RUN_CONFIG_TYPE.INCREMENTAL` so manual backfills never move the cursor.
- `processTimeSeriesDay` holds the per-day fetch, save, and logging that previously sat inside the nested loop, with unchanged behavior.

No backend or state-storage changes were needed: `updateLastRequstedDate` already emits a message that the executor persists to `connector_state` as it arrives. After an interruption a resume now re-imports only `ReimportLookbackWindow` days (2 by default) instead of the full range, and those rows upsert on the node's unique keys.

# Changes

- Replaced the account-outer day loop in `MicrosoftAds/Connector.js` with a date-outer loop that checkpoints after each completed date
- Added `processTimeSeriesNodes` to own the day loop and the incremental checkpoint
- Added `processTimeSeriesDay` for the single-day fetch, save, and log path
- Removed `processNode` and the `updateRequestedDate` plumbing, which no longer had callers
- Moved account ID trimming to a single normalization step in `startImportProcess`
- Replaced a bare `console.log` for an empty date range with `config.logMessage`, so it reaches run history
- Added `test/Sources/MicrosoftAds/perDayCheckpoint.test.js` with 12 tests covering per-day checkpointing, mid-run and storage-write failures, manual backfill, empty days, multi-account ordering, multiple time-series nodes, catalog-only configurations, and an empty date range
- Added changeset `6864-microsoft-ads-per-day-checkpoint.md`