### PR TITLE
fix(connectors): resume interrupted Ads imports from last completed date

### DIFF
--- a/.changeset/6865-per-day-checkpoint-ads-connectors.md
+++ b/.changeset/6865-per-day-checkpoint-ads-connectors.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Resumable incremental imports for Google Ads, Reddit Ads, Criteo and X Ads
+
+Previously, an interrupted incremental run restarted the whole date range from the beginning, so long imports could retry endlessly without ever finishing. These connectors now save their progress as the import advances. An interrupted run resumes from the last completed date instead of starting over.

--- a/packages/connectors/CONTRIBUTING.md
+++ b/packages/connectors/CONTRIBUTING.md
@@ -63,6 +63,13 @@ Key responsibilities:
 
 All connectors must extend `AbstractConnector` (in `src/Core/AbstractConnector.js`).
 
+#### Saving incremental progress
+
+For time series nodes, loop dates on the outside and accounts on the inside. Call
+`updateLastRequstedDate(date)` once a date is stored for every account and node, never
+once at the end of the run. A run that saves its progress only at the end loses all of
+it when the process is interrupted, and the retry sweep then restarts the whole range.
+
 ### Source
 
 The `Source` class is responsible for fetching data from the external API. It must implement:

--- a/packages/connectors/src/Sources/CriteoAds/Connector.js
+++ b/packages/connectors/src/Sources/CriteoAds/Connector.js
@@ -19,7 +19,25 @@ var CriteoAdsConnector = class CriteoAdsConnector extends AbstractConnector {
     const fields = CriteoAdsHelper.parseFields(this.config.Fields?.value || "");
     const advertiserIds = CriteoAdsHelper.parseAdvertiserIds(this.config.AdvertiserIDs?.value || "");
 
-    await this.processTimeSeriesNodes({ advertiserIds, timeSeriesNodes: Object.keys(fields), fields });
+    // A blank-but-truthy AdvertiserIDs (e.g. ";") passes required-field validation and parses
+    // to an empty list. Without this the day loop would still run, fetch nothing, and walk the
+    // incremental cursor to today — marking days as imported that never were.
+    if (!advertiserIds.length) {
+      throw new Error('No valid Advertiser IDs found in the AdvertiserIDs parameter');
+    }
+
+    const nodeNames = Object.keys(fields);
+    // Every node in the Criteo schema is a time series, and this connector has no catalog
+    // path, so anything else would silently be re-fetched once per day by the loop below.
+    const unsupportedNodes = nodeNames.filter(
+      nodeName => !this.source.fieldsSchema[nodeName]?.isTimeSeries
+    );
+
+    if (unsupportedNodes.length) {
+      throw new Error(`Only time series nodes are supported. Unsupported: ${unsupportedNodes.join(', ')}`);
+    }
+
+    await this.processTimeSeriesNodes({ advertiserIds, timeSeriesNodes: nodeNames, fields });
   }
 
   /**

--- a/packages/connectors/src/Sources/CriteoAds/Connector.js
+++ b/packages/connectors/src/Sources/CriteoAds/Connector.js
@@ -18,92 +18,81 @@ var CriteoAdsConnector = class CriteoAdsConnector extends AbstractConnector {
   async startImportProcess() {
     const fields = CriteoAdsHelper.parseFields(this.config.Fields?.value || "");
     const advertiserIds = CriteoAdsHelper.parseAdvertiserIds(this.config.AdvertiserIDs?.value || "");
-    let lastProcessedDate = null;
 
-    for (const advertiserId of advertiserIds) {
-      for (const nodeName in fields) {
-        const processedDate = await this.processNode({
-          nodeName,
-          advertiserId,
-          fields: fields[nodeName] || [],
-          updateRequestedDate: false
-        });
-
-        if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
-          lastProcessedDate = processedDate;
-        }
-      }
-    }
-
-    if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL && lastProcessedDate) {
-      this.config.updateLastRequstedDate(lastProcessedDate);
-    }
+    await this.processTimeSeriesNodes({ advertiserIds, timeSeriesNodes: Object.keys(fields), fields });
   }
 
   /**
-   * Process a single node for a specific advertiser
+   * Imports every node for every advertiser, one date at a time.
+   *
+   * The loop is date-outer on purpose: the incremental cursor may only move once a
+   * date is complete for *all* advertisers and nodes, so a run interrupted midway
+   * resumes from the last fully imported date instead of restarting the range.
+   *
    * @param {Object} options - Processing options
-   * @param {string} options.nodeName - Name of the node to process
-   * @param {string} options.advertiserId - Advertiser ID
-   * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
+   * @param {Array<string>} options.advertiserIds - Advertiser IDs to import
+   * @param {Array<string>} options.timeSeriesNodes - Names of the nodes to import
+   * @param {Object} options.fields - Map of node name to the fields selected for it
    */
-  async processNode({ nodeName, advertiserId, fields, updateRequestedDate = true }) {
-    return await this.processTimeSeriesNode({
-      nodeName,
-      advertiserId,
-      fields,
-      updateRequestedDate
-    });
-  }
+  async processTimeSeriesNodes({ advertiserIds, timeSeriesNodes, fields }) {
+    if (!timeSeriesNodes.length) {
+      return;
+    }
 
-  /**
-   * Process a time series node with date-based logic
-   * @param {Object} options - Processing options
-   * @param {string} options.nodeName - Name of the node
-   * @param {string} options.advertiserId - Advertiser ID
-   * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
-   */
-  async processTimeSeriesNode({ nodeName, advertiserId, fields, updateRequestedDate = true }) {
     const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
 
     if (daysToFetch <= 0) {
-      console.log('No days to fetch for time series data');
-      return null;
+      this.config.logMessage('No days to fetch for time series data');
+      return;
     }
 
-    let lastProcessedDate = null;
-
-    for (let i = 0; i < daysToFetch; i++) {
+    for (let dayOffset = 0; dayOffset < daysToFetch; dayOffset++) {
       const currentDate = new Date(startDate);
-      currentDate.setDate(currentDate.getDate() + i);
-      lastProcessedDate = new Date(currentDate);
+      currentDate.setDate(currentDate.getDate() + dayOffset);
 
-      const formattedDate = DateUtils.formatDate(currentDate);
-
-      const data = await this.source.fetchData({
-        nodeName,
-        accountId: advertiserId,
-        date: currentDate,
-        fields
-      });
-
-      this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for ${advertiserId} on ${formattedDate}` : `No records have been fetched`);
-
-      if (data.length || this.config.CreateEmptyTables?.value) {
-        const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
-        const storage = await this.getStorageByNode(nodeName, fields);
-        await storage.saveData(preparedData);
+      for (const nodeName of timeSeriesNodes) {
+        for (const advertiserId of advertiserIds) {
+          await this.processTimeSeriesDay({
+            nodeName,
+            advertiserId,
+            date: currentDate,
+            fields: fields[nodeName] || []
+          });
+        }
       }
 
-      // Some callers defer the checkpoint until all advertisers finish successfully.
-      if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+      // Every advertiser and node stored this date, so the cursor can move past it.
+      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
         this.config.updateLastRequstedDate(currentDate);
       }
     }
+  }
 
-    return lastProcessedDate;
+  /**
+   * Fetch and store a single day of a node for one advertiser
+   * @param {Object} options - Processing options
+   * @param {string} options.nodeName - Name of the node
+   * @param {string} options.advertiserId - Advertiser ID
+   * @param {Date} options.date - The day to import
+   * @param {Array<string>} options.fields - Array of fields to fetch
+   */
+  async processTimeSeriesDay({ nodeName, advertiserId, date, fields }) {
+    const formattedDate = DateUtils.formatDate(date);
+
+    const data = await this.source.fetchData({
+      nodeName,
+      accountId: advertiserId,
+      date,
+      fields
+    });
+
+    this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for ${advertiserId} on ${formattedDate}` : `No records have been fetched`);
+
+    if (data.length || this.config.CreateEmptyTables?.value) {
+      const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
+      const storage = await this.getStorageByNode(nodeName, fields);
+      await storage.saveData(preparedData);
+    }
   }
 
   /**

--- a/packages/connectors/src/Sources/GoogleAds/Connector.js
+++ b/packages/connectors/src/Sources/GoogleAds/Connector.js
@@ -19,108 +19,103 @@ var GoogleAdsConnector = class GoogleAdsConnector extends AbstractConnector {
   async startImportProcess() {
     const customerIds = FormatUtils.parseIds(this.config.CustomerId.value, { stripCharacters: '-' });
     const fields = FormatUtils.parseFields(this.config.Fields.value);
-    let lastProcessedDate = null;
+    const nodeNames = Object.keys(fields);
+    const timeSeriesNodes = nodeNames.filter(nodeName => this.source.fieldsSchema[nodeName].isTimeSeries);
+    const catalogNodes = nodeNames.filter(nodeName => !this.source.fieldsSchema[nodeName].isTimeSeries);
 
-    for (const nodeName in fields) {
-      const processedDate = await this.processNode({
-        nodeName,
-        customerIds,
-        fields: fields[nodeName] || [],
-        updateRequestedDate: false
-      });
-
-      if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
-        lastProcessedDate = processedDate;
-      }
-    }
-
-    if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL && lastProcessedDate) {
-      this.config.updateLastRequstedDate(lastProcessedDate);
-    }
-  }
-
-  /**
-   * Process a single node for all customer IDs
-   * Global resources (isGlobalResource: true) return identical data for any customer ID,
-   * so only the first customer ID is used to avoid redundant fetches.
-   * @param {Object} options - Processing options
-   * @param {string} options.nodeName - Name of the node to process
-   * @param {Array<string>} options.customerIds - Array of customer IDs to process
-   * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
-   */
-  async processNode({ nodeName, customerIds, fields, updateRequestedDate = true }) {
-    const idsToProcess = this.source.fieldsSchema[nodeName].isGlobalResource
-      ? customerIds.slice(0, 1)
-      : customerIds;
-    let lastProcessedDate = null;
-
-    for (const customerId of idsToProcess) {
-      if (this.source.fieldsSchema[nodeName].isTimeSeries) {
-        const processedDate = await this.processTimeSeriesNode({
-          nodeName,
-          customerId,
-          fields,
-          updateRequestedDate
-        });
-
-        if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
-          lastProcessedDate = processedDate;
-        }
-      } else {
+    for (const nodeName of catalogNodes) {
+      for (const customerId of this.customerIdsForNode(nodeName, customerIds)) {
         await this.processCatalogNode({
           nodeName,
           customerId,
-          fields
+          fields: fields[nodeName] || []
         });
       }
     }
 
-    return lastProcessedDate;
+    await this.processTimeSeriesNodes({ customerIds, timeSeriesNodes, fields });
   }
 
   /**
-   * Process a time series node (e.g., campaigns with daily metrics)
-   * @param {Object} options - Processing options
-   * @param {string} options.nodeName - Name of the node
-   * @param {string} options.customerId - Customer ID
-   * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
+   * Customer IDs a node has to be fetched for.
+   * Global resources (isGlobalResource: true) return identical data for any customer ID,
+   * so only the first customer ID is used to avoid redundant fetches.
+   * @param {string} nodeName - Name of the node
+   * @param {Array<string>} customerIds - Every customer ID configured for the run
+   * @returns {Array<string>} - Customer IDs to fetch this node for
    */
-  async processTimeSeriesNode({ nodeName, customerId, fields, updateRequestedDate = true }) {
+  customerIdsForNode(nodeName, customerIds) {
+    return this.source.fieldsSchema[nodeName].isGlobalResource
+      ? customerIds.slice(0, 1)
+      : customerIds;
+  }
+
+  /**
+   * Imports every time series node for every customer, one date at a time.
+   *
+   * The loop is date-outer on purpose: the incremental cursor may only move once a
+   * date is complete for *all* customers and nodes, so a run interrupted midway
+   * resumes from the last fully imported date instead of restarting the range.
+   *
+   * @param {Object} options - Processing options
+   * @param {Array<string>} options.customerIds - Customer IDs to import
+   * @param {Array<string>} options.timeSeriesNodes - Names of the time series nodes to import
+   * @param {Object} options.fields - Map of node name to the fields selected for it
+   */
+  async processTimeSeriesNodes({ customerIds, timeSeriesNodes, fields }) {
+    if (!timeSeriesNodes.length) {
+      return;
+    }
+
     const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
 
     if (daysToFetch <= 0) {
-      console.log('No days to fetch for time series data');
-      return null;
+      this.config.logMessage('No days to fetch for time series data');
+      return;
     }
 
-    let lastProcessedDate = null;
-
-    for (let i = 0; i < daysToFetch; i++) {
+    for (let dayOffset = 0; dayOffset < daysToFetch; dayOffset++) {
       const currentDate = new Date(startDate);
-      currentDate.setDate(currentDate.getDate() + i);
-      lastProcessedDate = new Date(currentDate);
+      currentDate.setDate(currentDate.getDate() + dayOffset);
 
-      const formattedDate = DateUtils.formatDate(currentDate);
-
-      const data = await this.source.fetchData(nodeName, customerId, { fields, startDate: currentDate });
-
-      this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for customer ${customerId} on ${formattedDate}` : `ℹ️ No records have been fetched`);
-
-      if (data.length || this.config.CreateEmptyTables?.value) {
-        const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
-        const storage = await this.getStorageByNode(nodeName);
-        await storage.saveData(preparedData);
+      for (const nodeName of timeSeriesNodes) {
+        for (const customerId of this.customerIdsForNode(nodeName, customerIds)) {
+          await this.processTimeSeriesDay({
+            nodeName,
+            customerId,
+            date: currentDate,
+            fields: fields[nodeName] || []
+          });
+        }
       }
 
-      // Some callers defer the checkpoint until all customers finish successfully.
-      if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+      // Every customer and node stored this date, so the cursor can move past it.
+      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
         this.config.updateLastRequstedDate(currentDate);
       }
     }
+  }
 
-    return lastProcessedDate;
+  /**
+   * Fetch and store a single day of a time series node for one customer
+   * @param {Object} options - Processing options
+   * @param {string} options.nodeName - Name of the node
+   * @param {string} options.customerId - Customer ID
+   * @param {Date} options.date - The day to import
+   * @param {Array<string>} options.fields - Array of fields to fetch
+   */
+  async processTimeSeriesDay({ nodeName, customerId, date, fields }) {
+    const formattedDate = DateUtils.formatDate(date);
+
+    const data = await this.source.fetchData(nodeName, customerId, { fields, startDate: date });
+
+    this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for customer ${customerId} on ${formattedDate}` : `ℹ️ No records have been fetched`);
+
+    if (data.length || this.config.CreateEmptyTables?.value) {
+      const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
+      const storage = await this.getStorageByNode(nodeName);
+      await storage.saveData(preparedData);
+    }
   }
 
   /**

--- a/packages/connectors/src/Sources/RedditAds/Connector.js
+++ b/packages/connectors/src/Sources/RedditAds/Connector.js
@@ -19,98 +19,91 @@ var RedditAdsConnector = class RedditAdsConnector extends AbstractConnector {
   async startImportProcess() {
     const fields = RedditAdsHelper.parseFields(this.config.Fields.value);
     const accountIds = RedditAdsHelper.parseAccountIds(this.config.AccountIDs.value);
-    let lastProcessedDate = null;
+    const nodeNames = Object.keys(fields);
+    const timeSeriesNodes = nodeNames.filter(nodeName => this.source.fieldsSchema[nodeName].isTimeSeries);
+    const catalogNodes = nodeNames.filter(nodeName => !this.source.fieldsSchema[nodeName].isTimeSeries);
 
     for (const accountId of accountIds) {
-      for (const nodeName in fields) {
-        const processedDate = await this.processNode({
+      for (const nodeName of catalogNodes) {
+        await this.processCatalogNode({
           nodeName,
           accountId,
-          fields: fields[nodeName] || [],
-          updateRequestedDate: false
+          fields: fields[nodeName] || []
         });
-
-        if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
-          lastProcessedDate = processedDate;
-        }
       }
     }
 
-    if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL && lastProcessedDate) {
-      this.config.updateLastRequstedDate(lastProcessedDate);
-    }
+    await this.processTimeSeriesNodes({ accountIds, timeSeriesNodes, fields });
   }
 
   /**
-   * Process a single node for a specific account
+   * Imports every time series node for every account, one date at a time.
+   *
+   * The loop is date-outer on purpose: the incremental cursor may only move once a
+   * date is complete for *all* accounts and nodes, so a run interrupted midway
+   * resumes from the last fully imported date instead of restarting the range.
+   *
    * @param {Object} options - Processing options
-   * @param {string} options.nodeName - Name of the node to process
-   * @param {string} options.accountId - Account ID
-   * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
+   * @param {Array<string>} options.accountIds - Account IDs to import
+   * @param {Array<string>} options.timeSeriesNodes - Names of the time series nodes to import
+   * @param {Object} options.fields - Map of node name to the fields selected for it
    */
-  async processNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
-    if (this.source.fieldsSchema[nodeName].isTimeSeries) {
-      return await this.processTimeSeriesNode({
-        nodeName,
-        accountId,
-        fields,
-        updateRequestedDate
-      });
-    } else {
-      await this.processCatalogNode({
-        nodeName,
-        accountId,
-        fields
-      });
-      return null;
+  async processTimeSeriesNodes({ accountIds, timeSeriesNodes, fields }) {
+    if (!timeSeriesNodes.length) {
+      return;
     }
-  }
 
-  /**
-   * Process a time series node (e.g., reports)
-   * @param {Object} options - Processing options
-   * @param {string} options.nodeName - Name of the node
-   * @param {string} options.accountId - Account ID
-   * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
-   */
-  async processTimeSeriesNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
     const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
 
     if (daysToFetch <= 0) {
-      console.log('No days to fetch for time series data');
-      return null;
+      this.config.logMessage('No days to fetch for time series data');
+      return;
     }
 
-    let lastProcessedDate = null;
-
-    for (let i = 0; i < daysToFetch; i++) {
+    for (let dayOffset = 0; dayOffset < daysToFetch; dayOffset++) {
       const currentDate = new Date(startDate);
-      currentDate.setDate(currentDate.getDate() + i);
-      lastProcessedDate = new Date(currentDate);
+      currentDate.setDate(currentDate.getDate() + dayOffset);
 
-      const formattedDate = DateUtils.formatDate(currentDate);
-
-      this.config.logMessage(`Start importing data for ${formattedDate}: ${accountId}/${nodeName}`);
-
-      const data = await this.source.fetchData(nodeName, accountId, fields, currentDate);
-
-      this.config.logMessage(data.length ? `${data.length} records were fetched` : `No records have been fetched`);
-
-      if (data.length || this.config.CreateEmptyTables?.value) {
-        const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
-        const storage = await this.getStorageByNode(nodeName);
-        await storage.saveData(preparedData);
+      for (const nodeName of timeSeriesNodes) {
+        for (const accountId of accountIds) {
+          await this.processTimeSeriesDay({
+            nodeName,
+            accountId,
+            date: currentDate,
+            fields: fields[nodeName] || []
+          });
+        }
       }
 
-      // Some callers defer the checkpoint until all accounts finish successfully.
-      if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+      // Every account and node stored this date, so the cursor can move past it.
+      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
         this.config.updateLastRequstedDate(currentDate);
       }
     }
+  }
 
-    return lastProcessedDate;
+  /**
+   * Fetch and store a single day of a time series node for one account
+   * @param {Object} options - Processing options
+   * @param {string} options.nodeName - Name of the node
+   * @param {string} options.accountId - Account ID
+   * @param {Date} options.date - The day to import
+   * @param {Array<string>} options.fields - Array of fields to fetch
+   */
+  async processTimeSeriesDay({ nodeName, accountId, date, fields }) {
+    const formattedDate = DateUtils.formatDate(date);
+
+    this.config.logMessage(`Start importing data for ${formattedDate}: ${accountId}/${nodeName}`);
+
+    const data = await this.source.fetchData(nodeName, accountId, fields, date);
+
+    this.config.logMessage(data.length ? `${data.length} records were fetched` : `No records have been fetched`);
+
+    if (data.length || this.config.CreateEmptyTables?.value) {
+      const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
+      const storage = await this.getStorageByNode(nodeName);
+      await storage.saveData(preparedData);
+    }
   }
 
   /**

--- a/packages/connectors/src/Sources/XAds/Connector.js
+++ b/packages/connectors/src/Sources/XAds/Connector.js
@@ -19,117 +19,57 @@ var XAdsConnector = class XAdsConnector extends AbstractConnector {
   async startImportProcess() {
     const fields = XAdsHelper.parseFields(this.config.Fields.value);
     const accountIds = XAdsHelper.parseAccountIds(this.config.AccountIDs.value);
-    let lastProcessedDate = null;
+    const nodeNames = Object.keys(fields);
+    const timeSeriesNodes = nodeNames.filter(nodeName => this.source.fieldsSchema[nodeName].isTimeSeries);
+    const catalogNodes = nodeNames.filter(nodeName => !this.source.fieldsSchema[nodeName].isTimeSeries);
+    const asyncNodes = timeSeriesNodes.filter(nodeName => this.source.fieldsSchema[nodeName].asyncTimeSeries);
+    const syncNodes = timeSeriesNodes.filter(nodeName => !this.source.fieldsSchema[nodeName].asyncTimeSeries);
+
+    // A node whose rows cannot be merged into storage is a configuration error, so it is
+    // rejected before the run spends a full catalog import discovering it.
+    asyncNodes.forEach(nodeName => this.assertUniqueKeysSelected(nodeName, fields[nodeName] || []));
 
     for (const accountId of accountIds) {
-      for (const nodeName in fields) {
-        const processedDate = await this.processNode({
-          nodeName,
-          accountId,
-          fields: fields[nodeName] || [],
-          updateRequestedDate: false
-        });
-
-        if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
-          lastProcessedDate = processedDate;
-        }
+      for (const nodeName of catalogNodes) {
+        await this.processCatalogNode({ nodeName, accountId, fields: fields[nodeName] || [] });
       }
-
-      this.source.clearCache(accountId);
     }
 
-    if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL && lastProcessedDate) {
-      this.config.updateLastRequstedDate(lastProcessedDate);
+    try {
+      await this.processTimeSeriesNodes({ accountIds, asyncNodes, syncNodes, fields });
+    } finally {
+      // Every account is revisited on every date now, so its cached promoted tweet IDs
+      // stay in use until the whole range is done and can only be released here.
+      accountIds.forEach(accountId => this.source.clearCache(accountId));
     }
   }
 
   /**
-   * Process a single node for a specific account
-   * @param {Object} options - Processing options
-   * @param {string} options.nodeName - Name of the node to process
-   * @param {string} options.accountId - Account ID
-   * @param {Array<string>} options.fields - Array of fields to fetch
-   * @param {boolean} options.updateRequestedDate - Whether to update incremental state per processed day
-   */
-  async processNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
-    if (this.source.fieldsSchema[nodeName].isTimeSeries) {
-      return await this.processTimeSeriesNode({ nodeName, accountId, fields, updateRequestedDate });
-    } else {
-      await this.processCatalogNode({ nodeName, accountId, fields });
-      return null;
-    }
-  }
-
-  /**
-   * Process a time series node (e.g., stats, stats_by_country).
-   * asyncTimeSeries nodes are routed to processAsyncTimeSeriesNode.
-   * All other nodes use the day-by-day fetchData loop.
-   */
-  async processTimeSeriesNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
-    if (this.source.fieldsSchema[nodeName].asyncTimeSeries) {
-      return await this.processAsyncTimeSeriesNode({
-        nodeName,
-        accountId,
-        fields,
-        updateRequestedDate
-      });
-    }
-
-    const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
-
-    if (daysToFetch <= 0) {
-      console.log('No days to fetch for time series data');
-      return null;
-    }
-
-    let lastProcessedDate = null;
-
-    for (let i = 0; i < daysToFetch; i++) {
-      const currentDate = new Date(startDate);
-      currentDate.setUTCDate(currentDate.getUTCDate() + i);
-      lastProcessedDate = new Date(currentDate);
-
-      const formattedDate = DateUtils.formatDate(currentDate);
-
-      const data = await this.source.fetchData({ nodeName, accountId, start_time: formattedDate, end_time: formattedDate, fields });
-
-      this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for ${accountId} on ${formattedDate}` : `No records have been fetched`);
-
-      if (data.length || this.config.CreateEmptyTables?.value) {
-        const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
-        const storage = await this.getStorageByNode(nodeName);
-        await storage.saveData(preparedData);
-      }
-
-      // Some callers defer the checkpoint until all accounts finish successfully.
-      if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
-        this.config.updateLastRequstedDate(currentDate);
-      }
-    }
-
-    return lastProcessedDate;
-  }
-
-  /**
-   * Process an async time series node (e.g., stats_by_country).
+   * Imports every time series node for every account, one date at a time.
    *
-   * Dates are split into fixed-size chunks. For each chunk, the Source processes
-   * one job at a time (submit → poll → download) and calls onBatchReady after
-   * each date so the Connector can save to BigQuery. The checkpoint can be
-   * deferred by callers until all accounts finish successfully.
+   * The loop is date-outer on purpose: the incremental cursor may only move once a
+   * date is complete for *all* accounts and nodes, so a run interrupted midway
+   * resumes from the last fully imported date instead of restarting the range.
+   *
+   * Async nodes submit one job per chunk of dates, so when any of them is selected
+   * the cursor advances a whole chunk at a time. Otherwise every chunk is one day.
+   *
+   * @param {Object} options - Processing options
+   * @param {Array<string>} options.accountIds - Account IDs to import
+   * @param {Array<string>} options.asyncNodes - Time series nodes served by the async jobs API
+   * @param {Array<string>} options.syncNodes - Time series nodes fetched one day at a time
+   * @param {Object} options.fields - Map of node name to the fields selected for it
    */
-  async processAsyncTimeSeriesNode({ nodeName, accountId, fields, updateRequestedDate = true }) {
-    const uniqueKeys = this.source.fieldsSchema[nodeName].uniqueKeys || [];
-    const missingKeys = uniqueKeys.filter(key => !fields.includes(key));
-    if (missingKeys.length > 0) {
-      throw new Error(`Missing required unique fields for '${nodeName}'. Missing: ${missingKeys.join(', ')}`);
+  async processTimeSeriesNodes({ accountIds, asyncNodes, syncNodes, fields }) {
+    if (!asyncNodes.length && !syncNodes.length) {
+      return;
     }
 
     const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
 
     if (daysToFetch <= 0) {
-      console.log('No days to fetch for time series data');
-      return null;
+      this.config.logMessage('No days to fetch for time series data');
+      return;
     }
 
     // Build date list with both forms needed downstream.
@@ -141,42 +81,136 @@ var XAdsConnector = class XAdsConnector extends AbstractConnector {
       days.push({ date, formatted: DateUtils.formatDate(date) });
     }
 
-    const storage = await this.getStorageByNode(nodeName);
-    const chunks = XAdsHelper.splitDatesIntoChunks(days.map(d => d.formatted));
     const dayLookup = new Map(days.map(d => [d.formatted, d.date]));
-    let lastProcessedDate = null;
+    const formattedDays = days.map(d => d.formatted);
+    const chunks = asyncNodes.length
+      ? XAdsHelper.splitDatesIntoChunks(formattedDays)
+      : formattedDays.map(formatted => [formatted]);
 
     for (const dateChunk of chunks) {
-      await this.source.fetchData({
-        nodeName,
-        accountId,
-        fields,
-        dateChunk,
-        onBatchReady: async (formatted, data) => {
-          this.config.logMessage(data.length
-            ? `${data.length} rows of ${nodeName} were fetched for ${accountId} on ${formatted}`
-            : 'No records have been fetched'
-          );
+      await this.importAsyncNodesForChunk({ dateChunk, asyncNodes, accountIds, fields });
+      await this.importSyncNodesForChunk({ dateChunk, syncNodes, accountIds, fields, dayLookup });
 
-          if (data.length || this.config.CreateEmptyTables?.value) {
-            const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
-            await storage.saveData(preparedData);
-          }
-
-          const processedDate = dayLookup.get(formatted);
-          if (processedDate && (!lastProcessedDate || processedDate > lastProcessedDate)) {
-            lastProcessedDate = processedDate;
-          }
-
-          // Some callers defer the checkpoint until all accounts finish successfully.
-          if (updateRequestedDate && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
-            this.config.updateLastRequstedDate(processedDate);
-          }
-        }
-      });
+      // Every account and node stored every date in this chunk, so the cursor can move past it.
+      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+        this.config.updateLastRequstedDate(dayLookup.get(dateChunk[dateChunk.length - 1]));
+      }
     }
+  }
 
-    return lastProcessedDate;
+  /**
+   * Import one chunk of dates of every async node, for every account
+   * @param {Object} options - Processing options
+   * @param {Array<string>} options.dateChunk - Formatted dates covered by this job
+   * @param {Array<string>} options.asyncNodes - Async time series nodes to import
+   * @param {Array<string>} options.accountIds - Account IDs to import
+   * @param {Object} options.fields - Map of node name to the fields selected for it
+   */
+  async importAsyncNodesForChunk({ dateChunk, asyncNodes, accountIds, fields }) {
+    for (const nodeName of asyncNodes) {
+      for (const accountId of accountIds) {
+        await this.processAsyncTimeSeriesChunk({
+          nodeName,
+          accountId,
+          fields: fields[nodeName] || [],
+          dateChunk
+        });
+      }
+    }
+  }
+
+  /**
+   * Import every date of a chunk of every sync node, for every account
+   * @param {Object} options - Processing options
+   * @param {Array<string>} options.dateChunk - Formatted dates to import
+   * @param {Array<string>} options.syncNodes - Sync time series nodes to import
+   * @param {Array<string>} options.accountIds - Account IDs to import
+   * @param {Object} options.fields - Map of node name to the fields selected for it
+   * @param {Map<string, Date>} options.dayLookup - Formatted date to Date instance
+   */
+  async importSyncNodesForChunk({ dateChunk, syncNodes, accountIds, fields, dayLookup }) {
+    for (const formatted of dateChunk) {
+      for (const nodeName of syncNodes) {
+        for (const accountId of accountIds) {
+          await this.processTimeSeriesDay({
+            nodeName,
+            accountId,
+            date: dayLookup.get(formatted),
+            fields: fields[nodeName] || []
+          });
+        }
+      }
+    }
+  }
+
+  /**
+   * Rejects a node whose unique keys are not all selected, before any data is fetched
+   * @param {string} nodeName - Name of the node
+   * @param {Array<string>} fields - Fields selected for this node
+   */
+  assertUniqueKeysSelected(nodeName, fields) {
+    const uniqueKeys = this.source.fieldsSchema[nodeName].uniqueKeys || [];
+    const missingKeys = uniqueKeys.filter(key => !fields.includes(key));
+
+    if (missingKeys.length > 0) {
+      throw new Error(`Missing required unique fields for '${nodeName}'. Missing: ${missingKeys.join(', ')}`);
+    }
+  }
+
+  /**
+   * Fetch and store a single day of a time series node for one account
+   * @param {Object} options - Processing options
+   * @param {string} options.nodeName - Name of the node
+   * @param {string} options.accountId - Account ID
+   * @param {Date} options.date - The day to import
+   * @param {Array<string>} options.fields - Array of fields to fetch
+   */
+  async processTimeSeriesDay({ nodeName, accountId, date, fields }) {
+    const formattedDate = DateUtils.formatDate(date);
+
+    const data = await this.source.fetchData({ nodeName, accountId, start_time: formattedDate, end_time: formattedDate, fields });
+
+    this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for ${accountId} on ${formattedDate}` : `No records have been fetched`);
+
+    if (data.length || this.config.CreateEmptyTables?.value) {
+      const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
+      const storage = await this.getStorageByNode(nodeName);
+      await storage.saveData(preparedData);
+    }
+  }
+
+  /**
+   * Fetch and store one chunk of dates of an async time series node for one account.
+   *
+   * The Source processes one job at a time (submit → poll → download) and calls
+   * onBatchReady after each date so the Connector can save it.
+   *
+   * @param {Object} options - Processing options
+   * @param {string} options.nodeName - Name of the node
+   * @param {string} options.accountId - Account ID
+   * @param {Array<string>} options.fields - Array of fields to fetch
+   * @param {Array<string>} options.dateChunk - Formatted dates covered by this job
+   */
+  async processAsyncTimeSeriesChunk({ nodeName, accountId, fields, dateChunk }) {
+    const storage = await this.getStorageByNode(nodeName);
+
+    await this.source.fetchData({
+      nodeName,
+      accountId,
+      fields,
+      dateChunk,
+      onBatchReady: async (formatted, data) => {
+        this.config.logMessage(data.length
+          ? `${data.length} rows of ${nodeName} were fetched for ${accountId} on ${formatted}`
+          : 'No records have been fetched'
+        );
+
+        if (data.length || this.config.CreateEmptyTables?.value) {
+          const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
+          await storage.saveData(preparedData);
+        }
+      }
+    });
   }
 
   /**

--- a/packages/connectors/test/Sources/CriteoAds/perDayCheckpoint.test.js
+++ b/packages/connectors/test/Sources/CriteoAds/perDayCheckpoint.test.js
@@ -7,10 +7,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 globalThis.DateUtils = { formatDate: date => date.toISOString().slice(0, 10) };
 globalThis.RUN_CONFIG_TYPE = { INCREMENTAL: 'INCREMENTAL', MANUAL_BACKFILL: 'MANUAL_BACKFILL' };
-globalThis.CriteoAdsHelper = {
-  parseFields: value => JSON.parse(value || '{}'),
-  parseAdvertiserIds: value => (value ? value.split(',') : []),
-};
+
+// Advertiser parsing decides whether the day loop may run at all, and this parser is the
+// only one of the four that filters blanks — so use the real helper rather than a stub
+// that cannot produce the empty list the connector has to reject.
+loadGasClass(path.join(__dirname, '../../../src/Sources/CriteoAds/Helper.js'));
+
+// Fields is configured as a flat "nodeName fieldName, nodeName fieldName" string.
+const toFieldsString = nodes =>
+  Object.entries(nodes)
+    .flatMap(([nodeName, fields]) => fields.map(field => `${nodeName} ${field}`))
+    .join(', ');
 
 loadGasClass(path.join(__dirname, '../../../src/Sources/CriteoAds/Connector.js'), {
   AbstractConnector: class {},
@@ -46,7 +53,7 @@ const buildConnector = ({
   self.getStartDateAndDaysToFetch = () => [startDate, daysToFetch];
   self.config = {
     AdvertiserIDs: { value: advertiserIds },
-    Fields: { value: JSON.stringify(nodes) },
+    Fields: { value: toFieldsString(nodes) },
     CreateEmptyTables: { value: false },
     logMessage: () => {},
     updateLastRequstedDate: date => cursorMovedTo.push(new Date(date).toISOString().slice(0, 10)),
@@ -146,6 +153,32 @@ describe('multiple advertisers', () => {
 });
 
 describe('empty configurations', () => {
+  it('refuses to run when AdvertiserIDs holds no usable id', async () => {
+    // ";" is truthy so it passes required-field validation, but this parser filters blanks
+    // to an empty list. Advancing the cursor over days nothing was fetched for would mark
+    // them imported for good, once the lookback window has passed.
+    const { self, cursorMovedTo, fetched } = buildConnector({ advertiserIds: '; ,' });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      /No valid Advertiser IDs/
+    );
+
+    expect(fetched).toEqual([]);
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('refuses to run a node that is not a time series', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({ nodes: { campaigns: ['id'] } });
+    self.source.fieldsSchema.campaigns = { isTimeSeries: false };
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      /Only time series nodes are supported. Unsupported: campaigns/
+    );
+
+    expect(fetched).toEqual([]);
+    expect(cursorMovedTo).toEqual([]);
+  });
+
   it('imports nothing when no node is selected', async () => {
     const { self, cursorMovedTo, fetched } = buildConnector({ nodes: {} });
 

--- a/packages/connectors/test/Sources/CriteoAds/perDayCheckpoint.test.js
+++ b/packages/connectors/test/Sources/CriteoAds/perDayCheckpoint.test.js
@@ -1,0 +1,166 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+globalThis.DateUtils = { formatDate: date => date.toISOString().slice(0, 10) };
+globalThis.RUN_CONFIG_TYPE = { INCREMENTAL: 'INCREMENTAL', MANUAL_BACKFILL: 'MANUAL_BACKFILL' };
+globalThis.CriteoAdsHelper = {
+  parseFields: value => JSON.parse(value || '{}'),
+  parseAdvertiserIds: value => (value ? value.split(',') : []),
+};
+
+loadGasClass(path.join(__dirname, '../../../src/Sources/CriteoAds/Connector.js'), {
+  AbstractConnector: class {},
+});
+
+const connectorProto = globalThis.CriteoAdsConnector.prototype;
+
+const REPORT_NODE = 'statistics';
+
+const buildConnector = ({
+  advertiserIds = 'adv1',
+  nodes = { [REPORT_NODE]: ['clicks'] },
+  runType = 'INCREMENTAL',
+  startDate = new Date('2026-08-10T00:00:00Z'),
+  daysToFetch = 3,
+  fetchData = async () => [{ clicks: 1 }],
+  saveData = async () => undefined,
+} = {}) => {
+  const cursorMovedTo = [];
+  const fetched = [];
+
+  const self = Object.create(connectorProto);
+  self.runConfig = { type: runType };
+  self.source = {
+    fieldsSchema: { [REPORT_NODE]: { isTimeSeries: true } },
+    fetchData: async params => {
+      fetched.push(`${params.accountId}/${params.nodeName}/${DateUtils.formatDate(params.date)}`);
+      return fetchData(params);
+    },
+  };
+  self.getStorageByNode = async () => ({ saveData });
+  self.addMissingFieldsToData = data => data;
+  self.getStartDateAndDaysToFetch = () => [startDate, daysToFetch];
+  self.config = {
+    AdvertiserIDs: { value: advertiserIds },
+    Fields: { value: JSON.stringify(nodes) },
+    CreateEmptyTables: { value: false },
+    logMessage: () => {},
+    updateLastRequstedDate: date => cursorMovedTo.push(new Date(date).toISOString().slice(0, 10)),
+  };
+
+  return { self, cursorMovedTo, fetched };
+};
+
+describe('incremental checkpointing', () => {
+  it('saves the cursor after each completed day instead of only at the end', async () => {
+    const { self, cursorMovedTo } = buildConnector();
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11', '2026-08-12']);
+  });
+
+  it('keeps the days already imported when a later day fails', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      fetchData: async ({ date }) => {
+        if (DateUtils.formatDate(date) === '2026-08-12') throw new Error('Connector died');
+        return [{ clicks: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow('Connector died');
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not move the cursor past a day whose storage write failed', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      saveData: async () => {
+        throw new Error('BigQuery write failed');
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'BigQuery write failed'
+    );
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('never moves the incremental cursor during a manual backfill', async () => {
+    const { self, cursorMovedTo } = buildConnector({ runType: 'MANUAL_BACKFILL' });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('advances the cursor on a day that returned no rows', async () => {
+    const { self, cursorMovedTo } = buildConnector({ fetchData: async () => [] });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11', '2026-08-12']);
+  });
+});
+
+describe('multiple advertisers', () => {
+  it('completes a date for every advertiser before moving the cursor', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({
+      advertiserIds: 'adv1,adv2',
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([
+      `adv1/${REPORT_NODE}/2026-08-10`,
+      `adv2/${REPORT_NODE}/2026-08-10`,
+      `adv1/${REPORT_NODE}/2026-08-11`,
+      `adv2/${REPORT_NODE}/2026-08-11`,
+    ]);
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not checkpoint a date that only the first advertiser imported', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      advertiserIds: 'adv1,adv2',
+      fetchData: async ({ accountId, date }) => {
+        if (accountId === 'adv2' && DateUtils.formatDate(date) === '2026-08-11') {
+          throw new Error('Advertiser adv2 failed');
+        }
+        return [{ clicks: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'Advertiser adv2 failed'
+    );
+
+    expect(cursorMovedTo).toEqual(['2026-08-10']);
+  });
+});
+
+describe('empty configurations', () => {
+  it('imports nothing when no node is selected', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({ nodes: {} });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([]);
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('imports nothing when the range has no days left to fetch', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({ daysToFetch: 0 });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([]);
+    expect(cursorMovedTo).toEqual([]);
+  });
+});

--- a/packages/connectors/test/Sources/GoogleAds/perDayCheckpoint.test.js
+++ b/packages/connectors/test/Sources/GoogleAds/perDayCheckpoint.test.js
@@ -1,0 +1,189 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+globalThis.DateUtils = { formatDate: date => date.toISOString().slice(0, 10) };
+globalThis.RUN_CONFIG_TYPE = { INCREMENTAL: 'INCREMENTAL', MANUAL_BACKFILL: 'MANUAL_BACKFILL' };
+globalThis.FormatUtils = {
+  parseIds: value => value.split(','),
+  parseFields: value => JSON.parse(value),
+};
+
+loadGasClass(path.join(__dirname, '../../../src/Sources/GoogleAds/Connector.js'), {
+  AbstractConnector: class {},
+});
+
+const connectorProto = globalThis.GoogleAdsConnector.prototype;
+
+const REPORT_NODE = 'campaign';
+const CATALOG_NODE = 'ad_group';
+const GLOBAL_NODE = 'geo_target_constant';
+
+const buildConnector = ({
+  customerIds = 'cust1',
+  nodes = { [REPORT_NODE]: ['metrics.cost_micros'] },
+  runType = 'INCREMENTAL',
+  startDate = new Date('2026-08-10T00:00:00Z'),
+  daysToFetch = 3,
+  fetchData = async () => [{ cost: 1 }],
+  saveData = async () => undefined,
+} = {}) => {
+  const cursorMovedTo = [];
+  const fetched = [];
+
+  const self = Object.create(connectorProto);
+  self.runConfig = { type: runType };
+  self.source = {
+    fieldsSchema: {
+      [REPORT_NODE]: { isTimeSeries: true },
+      [CATALOG_NODE]: { isTimeSeries: false },
+      [GLOBAL_NODE]: { isTimeSeries: false, isGlobalResource: true },
+    },
+    fetchData: async (nodeName, customerId, options) => {
+      const day = options?.startDate ? DateUtils.formatDate(options.startDate) : 'catalog';
+      fetched.push(`${customerId}/${nodeName}/${day}`);
+      return fetchData({ nodeName, customerId, ...options });
+    },
+  };
+  self.getStorageByNode = async () => ({ saveData });
+  self.addMissingFieldsToData = data => data;
+  self.getStartDateAndDaysToFetch = () => [startDate, daysToFetch];
+  self.config = {
+    CustomerId: { value: customerIds },
+    Fields: { value: JSON.stringify(nodes) },
+    CreateEmptyTables: { value: false },
+    logMessage: () => {},
+    updateLastRequstedDate: date => cursorMovedTo.push(new Date(date).toISOString().slice(0, 10)),
+  };
+
+  return { self, cursorMovedTo, fetched };
+};
+
+describe('incremental checkpointing', () => {
+  it('saves the cursor after each completed day instead of only at the end', async () => {
+    const { self, cursorMovedTo } = buildConnector();
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11', '2026-08-12']);
+  });
+
+  it('keeps the days already imported when a later day fails', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      fetchData: async ({ startDate }) => {
+        if (DateUtils.formatDate(startDate) === '2026-08-12') throw new Error('Connector died');
+        return [{ cost: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow('Connector died');
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not move the cursor past a day whose storage write failed', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      saveData: async () => {
+        throw new Error('BigQuery write failed');
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'BigQuery write failed'
+    );
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('never moves the incremental cursor during a manual backfill', async () => {
+    const { self, cursorMovedTo } = buildConnector({ runType: 'MANUAL_BACKFILL' });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+});
+
+describe('multiple customers', () => {
+  it('completes a date for every customer before moving the cursor', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({
+      customerIds: 'cust1,cust2',
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([
+      `cust1/${REPORT_NODE}/2026-08-10`,
+      `cust2/${REPORT_NODE}/2026-08-10`,
+      `cust1/${REPORT_NODE}/2026-08-11`,
+      `cust2/${REPORT_NODE}/2026-08-11`,
+    ]);
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not checkpoint a date that only the first customer imported', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      customerIds: 'cust1,cust2',
+      fetchData: async ({ customerId, startDate }) => {
+        if (customerId === 'cust2' && DateUtils.formatDate(startDate) === '2026-08-11') {
+          throw new Error('Customer cust2 failed');
+        }
+        return [{ cost: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'Customer cust2 failed'
+    );
+
+    expect(cursorMovedTo).toEqual(['2026-08-10']);
+  });
+});
+
+describe('node types', () => {
+  it('fetches a global resource for the first customer only', async () => {
+    // Global resources return identical data for any customer ID, so fetching them
+    // per customer is redundant work against the API.
+    const { self, fetched } = buildConnector({
+      customerIds: 'cust1,cust2',
+      nodes: { [GLOBAL_NODE]: ['id'] },
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([`cust1/${GLOBAL_NODE}/catalog`]);
+  });
+
+  it('imports catalog nodes once per customer, before any day is requested', async () => {
+    const { self, fetched } = buildConnector({
+      nodes: { [CATALOG_NODE]: ['id'], [REPORT_NODE]: ['metrics.cost_micros'] },
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched[0]).toBe(`cust1/${CATALOG_NODE}/catalog`);
+    expect(fetched.filter(entry => entry.includes(CATALOG_NODE))).toHaveLength(1);
+  });
+
+  it('skips the day loop entirely when only catalog nodes are selected', async () => {
+    const { self, cursorMovedTo } = buildConnector({ nodes: { [CATALOG_NODE]: ['id'] } });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('imports nothing when the range has no days left to fetch', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({ daysToFetch: 0 });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([]);
+    expect(cursorMovedTo).toEqual([]);
+  });
+});

--- a/packages/connectors/test/Sources/RedditAds/perDayCheckpoint.test.js
+++ b/packages/connectors/test/Sources/RedditAds/perDayCheckpoint.test.js
@@ -1,0 +1,173 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+globalThis.DateUtils = { formatDate: date => date.toISOString().slice(0, 10) };
+globalThis.RUN_CONFIG_TYPE = { INCREMENTAL: 'INCREMENTAL', MANUAL_BACKFILL: 'MANUAL_BACKFILL' };
+globalThis.RedditAdsHelper = {
+  parseFields: value => JSON.parse(value),
+  parseAccountIds: value => value.split(','),
+};
+
+loadGasClass(path.join(__dirname, '../../../src/Sources/RedditAds/Connector.js'), {
+  AbstractConnector: class {},
+});
+
+const connectorProto = globalThis.RedditAdsConnector.prototype;
+
+const REPORT_NODE = 'ad_account_report';
+const CATALOG_NODE = 'campaigns';
+
+const buildConnector = ({
+  accountIds = 'acc1',
+  nodes = { [REPORT_NODE]: ['spend'] },
+  runType = 'INCREMENTAL',
+  startDate = new Date('2026-08-10T00:00:00Z'),
+  daysToFetch = 3,
+  fetchData = async () => [{ spend: 1 }],
+  saveData = async () => undefined,
+} = {}) => {
+  const cursorMovedTo = [];
+  const fetched = [];
+
+  const self = Object.create(connectorProto);
+  self.runConfig = { type: runType };
+  self.source = {
+    fieldsSchema: {
+      [REPORT_NODE]: { isTimeSeries: true },
+      [CATALOG_NODE]: { isTimeSeries: false },
+    },
+    fetchData: async (nodeName, accountId, fields, date) => {
+      fetched.push(`${accountId}/${nodeName}/${date ? DateUtils.formatDate(date) : 'catalog'}`);
+      return fetchData({ nodeName, accountId, date });
+    },
+  };
+  self.getStorageByNode = async () => ({ saveData });
+  self.addMissingFieldsToData = data => data;
+  self.getStartDateAndDaysToFetch = () => [startDate, daysToFetch];
+  self.config = {
+    AccountIDs: { value: accountIds },
+    Fields: { value: JSON.stringify(nodes) },
+    CreateEmptyTables: { value: false },
+    logMessage: () => {},
+    updateLastRequstedDate: date => cursorMovedTo.push(new Date(date).toISOString().slice(0, 10)),
+  };
+
+  return { self, cursorMovedTo, fetched };
+};
+
+describe('incremental checkpointing', () => {
+  it('saves the cursor after each completed day instead of only at the end', async () => {
+    const { self, cursorMovedTo } = buildConnector();
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11', '2026-08-12']);
+  });
+
+  it('keeps the days already imported when a later day fails', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      fetchData: async ({ date }) => {
+        if (DateUtils.formatDate(date) === '2026-08-12') throw new Error('Connector died');
+        return [{ spend: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow('Connector died');
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not move the cursor past a day whose storage write failed', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      saveData: async () => {
+        throw new Error('BigQuery write failed');
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'BigQuery write failed'
+    );
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('never moves the incremental cursor during a manual backfill', async () => {
+    const { self, cursorMovedTo } = buildConnector({ runType: 'MANUAL_BACKFILL' });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+});
+
+describe('multiple accounts', () => {
+  it('completes a date for every account before moving the cursor', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({
+      accountIds: 'acc1,acc2',
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([
+      `acc1/${REPORT_NODE}/2026-08-10`,
+      `acc2/${REPORT_NODE}/2026-08-10`,
+      `acc1/${REPORT_NODE}/2026-08-11`,
+      `acc2/${REPORT_NODE}/2026-08-11`,
+    ]);
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not checkpoint a date that only the first account imported', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      accountIds: 'acc1,acc2',
+      fetchData: async ({ accountId, date }) => {
+        if (accountId === 'acc2' && DateUtils.formatDate(date) === '2026-08-11') {
+          throw new Error('Account acc2 failed');
+        }
+        return [{ spend: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'Account acc2 failed'
+    );
+
+    expect(cursorMovedTo).toEqual(['2026-08-10']);
+  });
+});
+
+describe('node types', () => {
+  it('imports catalog nodes once per account, before any day is requested', async () => {
+    const { self, fetched } = buildConnector({
+      nodes: { [CATALOG_NODE]: ['id'], [REPORT_NODE]: ['spend'] },
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched[0]).toBe(`acc1/${CATALOG_NODE}/catalog`);
+    expect(fetched.filter(entry => entry.includes(CATALOG_NODE))).toHaveLength(1);
+  });
+
+  it('skips the day loop entirely when only catalog nodes are selected', async () => {
+    const { self, cursorMovedTo } = buildConnector({ nodes: { [CATALOG_NODE]: ['id'] } });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('imports nothing when the range has no days left to fetch', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({ daysToFetch: 0 });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([]);
+    expect(cursorMovedTo).toEqual([]);
+  });
+});

--- a/packages/connectors/test/Sources/XAds/perDayCheckpoint.test.js
+++ b/packages/connectors/test/Sources/XAds/perDayCheckpoint.test.js
@@ -1,0 +1,270 @@
+import path from 'path';
+import vm from 'vm';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+globalThis.DateUtils = { formatDate: date => date.toISOString().slice(0, 10) };
+globalThis.RUN_CONFIG_TYPE = { INCREMENTAL: 'INCREMENTAL', MANUAL_BACKFILL: 'MANUAL_BACKFILL' };
+
+// Chunking decides how far the cursor advances per job, so use the real helper rather
+// than a copy that would keep passing if the production chunk size changed. Its
+// top-level `const` shadows any globalThis stub, so the whole helper is the real one.
+// It has to be read back with a vm eval for the same reason.
+loadGasClass(path.join(__dirname, '../../../src/Sources/XAds/Helper.js'));
+const XAdsHelper = vm.runInThisContext('XAdsHelper');
+const DAYS_PER_CHUNK = XAdsHelper.splitDatesIntoChunks(
+  Array.from({ length: 500 }, (_, i) => `d${i}`)
+)[0].length;
+
+// Fields is configured as a flat "nodeName fieldName, nodeName fieldName" string.
+const toFieldsString = nodes =>
+  Object.entries(nodes)
+    .flatMap(([nodeName, fields]) => fields.map(field => `${nodeName} ${field}`))
+    .join(', ');
+
+loadGasClass(path.join(__dirname, '../../../src/Sources/XAds/Connector.js'), {
+  AbstractConnector: class {},
+});
+
+const connectorProto = globalThis.XAdsConnector.prototype;
+
+const SYNC_NODE = 'stats';
+const ASYNC_NODE = 'stats_by_country';
+const CATALOG_NODE = 'campaigns';
+
+const START_DATE = new Date('2026-08-10T00:00:00Z');
+const dayFromStart = offset =>
+  new Date(START_DATE.getTime() + offset * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+const buildConnector = ({
+  accountIds = 'acc1',
+  nodes = { [SYNC_NODE]: ['spend'] },
+  runType = 'INCREMENTAL',
+  startDate = START_DATE,
+  daysToFetch = 3,
+  fetchData = async () => [{ spend: 1 }],
+  saveData = async () => undefined,
+} = {}) => {
+  const cursorMovedTo = [];
+  const fetched = [];
+  const cacheCleared = [];
+
+  const self = Object.create(connectorProto);
+  self.runConfig = { type: runType };
+  self.source = {
+    fieldsSchema: {
+      [SYNC_NODE]: { isTimeSeries: true, uniqueKeys: ['spend'] },
+      [ASYNC_NODE]: { isTimeSeries: true, asyncTimeSeries: true, uniqueKeys: ['spend'] },
+      [CATALOG_NODE]: { isTimeSeries: false },
+    },
+    clearCache: accountId => cacheCleared.push(accountId),
+    fetchData: async params => {
+      if (params.dateChunk) {
+        fetched.push(`${params.accountId}/${params.nodeName}/[${params.dateChunk.join(',')}]`);
+        for (const formatted of params.dateChunk) {
+          await params.onBatchReady(formatted, await fetchData({ ...params, day: formatted }));
+        }
+        return [];
+      }
+
+      fetched.push(`${params.accountId}/${params.nodeName}/${params.start_time ?? 'catalog'}`);
+      return fetchData({ ...params, day: params.start_time });
+    },
+  };
+  self.getStorageByNode = async () => ({ saveData });
+  self.addMissingFieldsToData = data => data;
+  self.getStartDateAndDaysToFetch = () => [startDate, daysToFetch];
+  self.config = {
+    AccountIDs: { value: accountIds },
+    Fields: { value: toFieldsString(nodes) },
+    CreateEmptyTables: { value: false },
+    logMessage: () => {},
+    updateLastRequstedDate: date => cursorMovedTo.push(new Date(date).toISOString().slice(0, 10)),
+  };
+
+  return { self, cursorMovedTo, fetched, cacheCleared };
+};
+
+describe('incremental checkpointing without async nodes', () => {
+  it('saves the cursor after each completed day instead of only at the end', async () => {
+    const { self, cursorMovedTo } = buildConnector();
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11', '2026-08-12']);
+  });
+
+  it('keeps the days already imported when a later day fails', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      fetchData: async ({ day }) => {
+        if (day === '2026-08-12') throw new Error('Connector died');
+        return [{ spend: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow('Connector died');
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not move the cursor past a day whose storage write failed', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      saveData: async () => {
+        throw new Error('BigQuery write failed');
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'BigQuery write failed'
+    );
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('never moves the incremental cursor during a manual backfill', async () => {
+    const { self, cursorMovedTo } = buildConnector({ runType: 'MANUAL_BACKFILL' });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+});
+
+describe('multiple accounts', () => {
+  it('completes a date for every account before moving the cursor', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({
+      accountIds: 'acc1,acc2',
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([
+      `acc1/${SYNC_NODE}/2026-08-10`,
+      `acc2/${SYNC_NODE}/2026-08-10`,
+      `acc1/${SYNC_NODE}/2026-08-11`,
+      `acc2/${SYNC_NODE}/2026-08-11`,
+    ]);
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not checkpoint a date that only the first account imported', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      accountIds: 'acc1,acc2',
+      fetchData: async ({ accountId, day }) => {
+        if (accountId === 'acc2' && day === '2026-08-11') throw new Error('Account acc2 failed');
+        return [{ spend: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'Account acc2 failed'
+    );
+
+    expect(cursorMovedTo).toEqual(['2026-08-10']);
+  });
+});
+
+describe('async nodes', () => {
+  it('checkpoints once per job chunk, after every account finished the chunk', async () => {
+    // An async node submits one job per chunk of dates, so the cursor can only move
+    // in whole chunks — but it still moves mid-run instead of once at the very end.
+    const { self, cursorMovedTo, fetched } = buildConnector({
+      accountIds: 'acc1,acc2',
+      nodes: { [ASYNC_NODE]: ['spend'] },
+      daysToFetch: DAYS_PER_CHUNK + 1,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toHaveLength(4);
+    expect(fetched[0]).toContain(`acc1/${ASYNC_NODE}/[2026-08-10,`);
+    expect(fetched[1]).toContain(`acc2/${ASYNC_NODE}/[2026-08-10,`);
+    expect(cursorMovedTo).toEqual([dayFromStart(DAYS_PER_CHUNK - 1), dayFromStart(DAYS_PER_CHUNK)]);
+  });
+
+  it('keeps a finished chunk when the next one fails', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      nodes: { [ASYNC_NODE]: ['spend'] },
+      daysToFetch: DAYS_PER_CHUNK + 1,
+      fetchData: async ({ day }) => {
+        if (day === dayFromStart(DAYS_PER_CHUNK)) throw new Error('Async job failed');
+        return [{ spend: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow('Async job failed');
+
+    expect(cursorMovedTo).toEqual([dayFromStart(DAYS_PER_CHUNK - 1)]);
+  });
+
+  it('completes both node kinds for a chunk before checkpointing it', async () => {
+    // Two independent loops would move the cursor forward for one node kind and then
+    // back to day one for the other. A single chunk loop keeps it monotonic.
+    const { self, cursorMovedTo } = buildConnector({
+      nodes: { [SYNC_NODE]: ['spend'], [ASYNC_NODE]: ['spend'] },
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual(['2026-08-11']);
+  });
+
+  it('rejects an async node whose unique keys are not selected, before fetching', async () => {
+    const { self, fetched } = buildConnector({ nodes: { [ASYNC_NODE]: ['impressions'] } });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      /Missing required unique fields for 'stats_by_country'/
+    );
+
+    expect(fetched).toEqual([]);
+  });
+});
+
+describe('cache and node types', () => {
+  it('clears each account cache once the whole range is done', async () => {
+    // Clearing per account mid-run would drop promoted tweet IDs that later dates reuse.
+    const { self, cacheCleared } = buildConnector({ accountIds: 'acc1,acc2' });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cacheCleared).toEqual(['acc1', 'acc2']);
+  });
+
+  it('clears the cache even when the import fails', async () => {
+    const { self, cacheCleared } = buildConnector({
+      fetchData: async () => {
+        throw new Error('Connector died');
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow('Connector died');
+
+    expect(cacheCleared).toEqual(['acc1']);
+  });
+
+  it('imports catalog nodes once per account, before any day is requested', async () => {
+    const { self, fetched } = buildConnector({
+      nodes: { [CATALOG_NODE]: ['id'], [SYNC_NODE]: ['spend'] },
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched[0]).toBe(`acc1/${CATALOG_NODE}/catalog`);
+    expect(fetched.filter(entry => entry.includes(CATALOG_NODE))).toHaveLength(1);
+  });
+
+  it('imports nothing when the range has no days left to fetch', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({ daysToFetch: 0 });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([]);
+    expect(cursorMovedTo).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Problem

Google Ads, Reddit Ads, Criteo and X Ads saved their incremental progress only after every account and every node had finished the entire date range. When a long import died before that point — as a Microsoft Ads run recently did after roughly 10 hours and 42 of 49 days — `LastRequestedDate` was never written, so the interrupted-run sweep restarted the run from day one of the range, which failed the same way, repeating until someone cancelled it by hand. The root cause was the loop shape shared by all four connectors: `startImportProcess` iterated accounts on the outside and days on the inside, passing `updateRequestedDate: false` down so the single checkpoint could only fire at the very end. This applies the fix already shipped for Microsoft Ads in #6864 to the remaining four connectors built on the same pattern.

# Solution

Each connector now runs its time-series import date-outer instead of account-outer, so the incremental cursor advances as the run progresses. A date is checkpointed only after every account and every node has fetched and stored it, which keeps multi-account configurations correct — the reason the checkpoint was deferred in the first place. Catalog nodes still import once per account, up front, and `getStartDateAndDaysToFetch()` is now called once per run instead of once per node.

Connector-specific behavior was preserved rather than flattened:

- **Google Ads** — the `isGlobalResource` rule moved into a `customerIdsForNode()` helper used by both the catalog and date paths, so global resources still fetch for the first customer only.
- **Criteo** — every node in its schema is time-series, so there is no catalog split; `getStorageByNode(nodeName, fields)` is unchanged.
- **X Ads** — the involved case. Async nodes (`stats_by_country`) submit one job per 15-day chunk, so both node kinds run under a single chunk loop: chunks are whole days when no async node is selected, and 15-day chunks when one is. Two independent loops would have advanced the cursor to the last date for one node kind and then dragged it back to day one for the other. `clearCache` moved to the end of the run because, with dates outermost, each account's promoted-tweet cache stays in use until the range finishes.

Two trade-offs worth a reviewer's attention. X Ads now holds every account's promoted-tweet cache simultaneously instead of one at a time — ID arrays, not row data, but it is a real change on wide multi-account configs. And checkpoint granularity for X Ads async nodes is a 15-day chunk rather than a single day; that is a limit of the jobs API, not a shortcut.

No backend or state-storage changes were needed: `updateLastRequstedDate` already emits a message the executor persists as it arrives. After an interruption a resume re-imports only `ReimportLookbackWindow` days, and those rows upsert on each node's unique keys.

# Changes

- Replaced the account-outer day loop with a date-outer loop in the Google Ads, Reddit Ads, Criteo and X Ads connectors, checkpointing after each completed date
- Added `processTimeSeriesNodes` and `processTimeSeriesDay` to each connector, and removed `processNode` along with the `updateRequestedDate` plumbing
- Extracted `customerIdsForNode()` in Google Ads so the global-resource rule is applied on both the catalog and time-series paths
- Unified sync and async X Ads nodes under one chunk loop, split into `importAsyncNodesForChunk` and `importSyncNodesForChunk`, so the cursor stays monotonic when both kinds are selected
- Moved the X Ads unique-key validation into `assertUniqueKeysSelected()` and ran it before any fetch, so a misconfigured node fails before a full catalog import
- Moved X Ads `clearCache` to the end of the run, in a `finally` so it also runs when the import fails
- Replaced bare `console.log` calls for an empty date range with `config.logMessage`, so the message reaches run history
- Added four `perDayCheckpoint.test.js` suites (48 tests) covering per-day checkpointing, mid-run and storage-write failures, manual backfill, empty days, multi-account ordering, catalog-only configurations, empty ranges, Google Ads global resources, and the X Ads chunk boundary, mixed-node cursor and cache-clearing paths
- Used the real `XAdsHelper` in the X Ads tests instead of a reimplemented chunker, deriving the chunk size from the production helper
- Documented the checkpointing rule under "Saving incremental progress" in `packages/connectors/CONTRIBUTING.md`
- Added changeset `6865-per-day-checkpoint-ads-connectors.md`