### PR TITLE
fix(backend): report an interrupted connector run as a warning

### DIFF
--- a/.changeset/6857-terminal-status-warning.md
+++ b/.changeset/6857-terminal-status-warning.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Interrupted connector runs are reported as a warning
+
+A run that stops without reporting a final status is resumed automatically, and it continues from the last day it finished rather than starting over. Run history now shows this as a warning instead of an error, so a single interrupted attempt no longer looks like a failed import.

--- a/.changeset/6857-terminal-status-warning.md
+++ b/.changeset/6857-terminal-status-warning.md
@@ -2,6 +2,6 @@
 'owox': minor
 ---
 
-# Interrupted connector runs are reported as a warning
+# Connector runs interrupted by a restart are reported as a warning
 
-A run that stops without reporting a final status is resumed automatically, and it continues from the last day it finished rather than starting over. Run history now shows this as a warning instead of an error, so a single interrupted attempt no longer looks like a failed import.
+When a server restart stops a connector run, the run resumes by itself and continues from the last day it finished. Run history now shows this as a warning instead of an error, so a restart no longer looks like a failed import. Runs that stop for any other reason are still reported as errors.

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -702,7 +702,23 @@ describe('ConnectorExecutorService', () => {
     expect(errors.join()).not.toContain('finished without terminal success status');
   });
 
+  // The fallback fires whenever the process resolves with no terminal success status and
+  // no captured error. Only a shutdown makes that resumable, so severity splits on it.
+  const findFallbackEntry = (dataMartRunRepository: Repository<DataMartRun>, status: string) => {
+    const finalUpdate = (dataMartRunRepository.update as jest.Mock).mock.calls.find(
+      call => call[1]?.status === status
+    );
+    const entry = (finalUpdate![1].errors as string[])
+      .map(raw => JSON.parse(raw))
+      .find(parsed => `${parsed.warning ?? parsed.error}`.includes('without terminal success'));
+
+    expect(entry).toBeDefined();
+    return entry;
+  };
+
   it('still reports a failure when the connector sends a status flag and no detail', async () => {
+    // status 5 is the connector explicitly reporting failure on a healthy backend: the run
+    // ends FAILED and is never swept, so this must stay an error rather than a warning.
     const { service, dataMartRunRepository, processSpawner, emitMessage } = createService();
     (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
       emitMessage({
@@ -715,38 +731,37 @@ describe('ConnectorExecutorService', () => {
 
     await service.executeInBackground(createDataMart(), createRun(), null);
 
-    const finalUpdate = (dataMartRunRepository.update as jest.Mock).mock.calls.find(
-      call => call[1]?.status === DataMartRunStatus.FAILED
-    );
-
-    expect((finalUpdate![1].errors as string[]).join()).toContain(
-      'finished without terminal success status'
-    );
+    const fallback = findFallbackEntry(dataMartRunRepository, DataMartRunStatus.FAILED);
+    expect(fallback.type).toBe(ConnectorMessageType.ERROR);
+    expect(fallback.error).toBe('Connector process finished without terminal success status');
+    expect(fallback.warning).toBeUndefined();
   });
 
-  it('records the missing terminal status as a warning, not an error', async () => {
-    // The retry sweep resumes an interrupted run, and per-day checkpointing means it
-    // continues from the last completed date — so one such attempt is not individually
-    // actionable. It still counts as a run failure, hence errors rather than logs.
-    const { service, dataMartRunRepository, processSpawner, emitMessage } = createService();
+  it('keeps a silent exit an error when the backend is healthy', async () => {
+    // A connector that exits 0 without ever emitting IMPORT_DONE is a bug, not a blip —
+    // downgrading it would let a runner regression fail every run with no error signal.
+    const { service, dataMartRunRepository, processSpawner } = createService();
+    (processSpawner.spawnConnector as jest.Mock).mockResolvedValue(undefined);
+
+    await service.executeInBackground(createDataMart(), createRun(), null);
+
+    const fallback = findFallbackEntry(dataMartRunRepository, DataMartRunStatus.FAILED);
+    expect(fallback.type).toBe(ConnectorMessageType.ERROR);
+  });
+
+  it('records a shutdown-interrupted run as a warning, not an error', async () => {
+    // The run is marked INTERRUPTED and the retry sweep resumes it, continuing from its
+    // last completed date, so a single such attempt is not individually actionable.
+    const { service, dataMartRunRepository, processSpawner, gracefulShutdownService } =
+      createService();
     (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
-      emitMessage({
-        type: ConnectorMessageType.STATUS,
-        status: 5,
-        at: new Date().toISOString(),
-        toFormattedString: () => 'STATUS: ERROR',
-      });
+      // The process is killed mid-run; the spawner resolves quietly during shutdown.
+      (gracefulShutdownService.isInShutdownMode as jest.Mock).mockReturnValue(true);
     });
 
     await service.executeInBackground(createDataMart(), createRun(), null);
 
-    const finalUpdate = (dataMartRunRepository.update as jest.Mock).mock.calls.find(
-      call => call[1]?.status === DataMartRunStatus.FAILED
-    );
-    const fallback = (finalUpdate![1].errors as string[])
-      .map(entry => JSON.parse(entry))
-      .find(entry => `${entry.warning ?? entry.error}`.includes('without terminal success status'));
-
+    const fallback = findFallbackEntry(dataMartRunRepository, DataMartRunStatus.INTERRUPTED);
     expect(fallback.type).toBe(ConnectorMessageType.WARNING);
     expect(fallback.warning).toBe('Connector process finished without terminal success status');
     expect(fallback.error).toBeUndefined();

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.spec.ts
@@ -724,6 +724,34 @@ describe('ConnectorExecutorService', () => {
     );
   });
 
+  it('records the missing terminal status as a warning, not an error', async () => {
+    // The retry sweep resumes an interrupted run, and per-day checkpointing means it
+    // continues from the last completed date — so one such attempt is not individually
+    // actionable. It still counts as a run failure, hence errors rather than logs.
+    const { service, dataMartRunRepository, processSpawner, emitMessage } = createService();
+    (processSpawner.spawnConnector as jest.Mock).mockImplementation(async () => {
+      emitMessage({
+        type: ConnectorMessageType.STATUS,
+        status: 5,
+        at: new Date().toISOString(),
+        toFormattedString: () => 'STATUS: ERROR',
+      });
+    });
+
+    await service.executeInBackground(createDataMart(), createRun(), null);
+
+    const finalUpdate = (dataMartRunRepository.update as jest.Mock).mock.calls.find(
+      call => call[1]?.status === DataMartRunStatus.FAILED
+    );
+    const fallback = (finalUpdate![1].errors as string[])
+      .map(entry => JSON.parse(entry))
+      .find(entry => `${entry.warning ?? entry.error}`.includes('without terminal success status'));
+
+    expect(fallback.type).toBe(ConnectorMessageType.WARNING);
+    expect(fallback.warning).toBe('Connector process finished without terminal success status');
+    expect(fallback.error).toBeUndefined();
+  });
+
   it('persists a cancelled configuration as a warning, not an error', async () => {
     const { service, dataMartRunRepository, processSpawner } = createService();
     const controller = new AbortController();

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -508,23 +508,44 @@ export class ConnectorExecutorService {
           });
         } else if (configErrors.length === 0) {
           const errorMessage = 'Connector process finished without terminal success status';
-          // An interrupted attempt is transient: the retry sweep resumes the run, and with
-          // per-day checkpointing it carries on from the last completed date rather than
-          // starting over. Still recorded in configErrors, so the run is not reported as
-          // successful — it is just not paged as an ERROR on its own.
-          addMessageToArray(configErrors, {
-            type: ConnectorMessageType.WARNING,
-            at: this.systemTimeService.now().toISOString(),
-            warning: errorMessage,
-            toFormattedString: () => `[WARNING] ${errorMessage}`,
-          });
-          this.logger.warn(`Configuration ${configIndex + 1} failed: ${errorMessage}`, {
+          // Only a shutdown makes this transient: that run is marked INTERRUPTED and the
+          // retry sweep resumes it, continuing from its last completed date. Every other
+          // cause reaching here — exiting 0 without IMPORT_DONE, or reporting STATUS:ERROR
+          // with no detail — ends FAILED and is never resumed, so it stays an error.
+          // Downgrading those would leave a fleet-wide regression with no error signal.
+          const wasInterrupted = this.gracefulShutdownService.isInShutdownMode();
+          const summary = `Configuration ${configIndex + 1} failed: ${errorMessage}`;
+          const at = this.systemTimeService.now().toISOString();
+          const logMeta = {
             dataMartId: dataMart.id,
             projectId: dataMart.projectId,
             runId,
             configId,
             configIndex,
-          });
+          };
+
+          addMessageToArray(
+            configErrors,
+            wasInterrupted
+              ? {
+                  type: ConnectorMessageType.WARNING,
+                  at,
+                  warning: errorMessage,
+                  toFormattedString: () => `[WARNING] ${errorMessage}`,
+                }
+              : {
+                  type: ConnectorMessageType.ERROR,
+                  at,
+                  error: errorMessage,
+                  toFormattedString: () => `[ERROR] ${errorMessage}`,
+                }
+          );
+
+          if (wasInterrupted) {
+            this.logger.warn(summary, logMeta);
+          } else {
+            this.logger.error(summary, logMeta);
+          }
         }
       } catch (error) {
         success = false;

--- a/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-executor.service.ts
@@ -508,13 +508,17 @@ export class ConnectorExecutorService {
           });
         } else if (configErrors.length === 0) {
           const errorMessage = 'Connector process finished without terminal success status';
+          // An interrupted attempt is transient: the retry sweep resumes the run, and with
+          // per-day checkpointing it carries on from the last completed date rather than
+          // starting over. Still recorded in configErrors, so the run is not reported as
+          // successful — it is just not paged as an ERROR on its own.
           addMessageToArray(configErrors, {
-            type: ConnectorMessageType.ERROR,
+            type: ConnectorMessageType.WARNING,
             at: this.systemTimeService.now().toISOString(),
-            error: errorMessage,
-            toFormattedString: () => `[ERROR] ${errorMessage}`,
+            warning: errorMessage,
+            toFormattedString: () => `[WARNING] ${errorMessage}`,
           });
-          this.logger.error(`Configuration ${configIndex + 1} failed: ${errorMessage}`, {
+          this.logger.warn(`Configuration ${configIndex + 1} failed: ${errorMessage}`, {
             dataMartId: dataMart.id,
             projectId: dataMart.projectId,
             runId,


### PR DESCRIPTION
# Problem

When a connector process exits without sending a terminal status, the backend records a fallback entry so the run is not mistaken for a success. That entry was logged at ERROR severity, which paged on a condition that resolves itself: the interrupted-run sweep picks the run back up within 15 minutes and, now that connectors checkpoint their progress per day, it continues from the last completed date rather than restarting the range. The result was ERROR-level noise for attempts that were about to be retried successfully, sitting alongside the genuine errors that do need attention. Run history showed the same entry as `[ERROR]`, making a resumable interruption look like a failed import.

# Solution

The fallback in `ConnectorExecutorService.executeInBackground` now emits `ConnectorMessageType.WARNING` instead of `ERROR`, with a matching `logger.warn` so the persisted message type and the monitoring severity stay in step — the same pairing the adjacent cancellation and expired-credentials branch already uses.

The message deliberately stays in `configErrors` rather than moving to `configLogs`. That array is what marks the run as unsuccessful, so relocating it would let a run that produced no terminal status finish as SUCCESS. Only the severity and the run-history label change; run status, the retry sweep, and the resume flow behave exactly as before.

An earlier version of this branch also added a five-attempt resume cap. That was dropped: with per-day checkpointing, a resumed run makes forward progress, so a cap would stop long backfills that were advancing normally. Whether to stop a run stays a user decision.

`truncateMessage` in `connector-message.utils.ts` already handles the `WARNING` shape, so long messages truncate correctly on this path with no change.

# Changes

- Changed the "Connector process finished without terminal success status" fallback from `ConnectorMessageType.ERROR` to `WARNING`, including its `error` → `warning` field and `[ERROR]` → `[WARNING]` label
- Changed the accompanying `logger.error` call to `logger.warn`
- Added a comment recording why a single interrupted attempt is not individually actionable
- Added a test asserting the fallback is persisted as a warning, carries the message in `warning`, and leaves `error` unset
- Added changeset `6857-terminal-status-warning.md`