### PR TITLE
feat(web): show joined Data Mart details in report column picker

### DIFF
--- a/.changeset/6827-joined-data-mart-details.md
+++ b/.changeset/6827-joined-data-mart-details.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Show joined Data Mart details in report column pickers
+
+Report column pickers in the web app and Google Sheets extension now show each joined Data Mart's description and full join path on hover, using the same user-facing titles as the picker.

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/AggregationRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/AggregationRow.tsx
@@ -40,7 +40,7 @@ export function AggregationRow({
   return (
     <div
       className={cn(
-        'group flex items-center gap-1.5 rounded px-2 py-1.5',
+        'group/control-row flex items-center gap-1.5 rounded px-2 py-1.5',
         isOrphaned ? 'bg-red-50 dark:bg-red-950/30' : 'bg-muted/40'
       )}
     >
@@ -89,7 +89,7 @@ export function AggregationRow({
               variant='ghost'
               size='sm'
               className={cn(
-                'text-muted-foreground hover:text-foreground h-6 w-6 p-0 transition-opacity group-hover:opacity-100',
+                'text-muted-foreground hover:text-foreground h-6 w-6 p-0 transition-opacity group-hover/control-row:opacity-100',
                 editing ? 'opacity-100' : 'opacity-0'
               )}
               aria-label='Edit aggregation'

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/DateTruncRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/DateTruncRow.tsx
@@ -36,7 +36,7 @@ export function DateTruncRow({
   return (
     <div
       className={cn(
-        'group flex items-center gap-1.5 rounded px-2 py-1.5',
+        'group/control-row flex items-center gap-1.5 rounded px-2 py-1.5',
         isOrphaned ? 'bg-red-50 dark:bg-red-950/30' : 'bg-muted/40'
       )}
     >
@@ -84,7 +84,7 @@ export function DateTruncRow({
               variant='ghost'
               size='sm'
               className={cn(
-                'text-muted-foreground hover:text-foreground h-6 w-6 p-0 transition-opacity group-hover:opacity-100',
+                'text-muted-foreground hover:text-foreground h-6 w-6 p-0 transition-opacity group-hover/control-row:opacity-100',
                 editing ? 'opacity-100' : 'opacity-0'
               )}
               aria-label='Edit date bucket'

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldInfoTooltip.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FieldInfoTooltip.tsx
@@ -1,32 +1,53 @@
 import { Info } from 'lucide-react';
+import type { MouseEvent } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@owox/ui/components/tooltip';
 import { cn } from '@owox/ui/lib/utils';
 
 interface FieldInfoTooltipProps {
   text: string | undefined;
   compact?: boolean;
+  dataMartHeader?: boolean;
+  label?: string;
 }
 
-export function FieldInfoTooltip({ text, compact }: FieldInfoTooltipProps) {
+export function FieldInfoTooltip({ text, compact, dataMartHeader, label }: FieldInfoTooltipProps) {
   if (!text) return null;
+  const className = cn(
+    'text-muted-foreground hover:text-foreground inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-0 transition-opacity',
+    dataMartHeader
+      ? 'group-hover/data-mart:opacity-100 focus-visible:opacity-100'
+      : 'group-hover/row:opacity-100'
+  );
+  const stopParentToggle = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+  const icon = (
+    <Info className={cn('shrink-0', compact ? 'size-3.5' : 'size-4')} aria-hidden='true' />
+  );
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span
-          // Both the bare `group` (field rows, group headers) and the named `group/row`, so a row
-          // that must not join an ancestor's anonymous group can declare only the latter.
-          className='text-muted-foreground/50 hover:text-muted-foreground inline-flex shrink-0 opacity-0 transition-opacity group-hover:opacity-100 group-hover/row:opacity-100'
-          onClick={e => {
-            // Prevent parent <label>/<button> from toggling the checkbox or
-            // collapsing the group when the user clicks the info icon.
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-        >
-          <Info className={cn('shrink-0', compact ? 'size-3.5' : 'size-4')} aria-hidden='true' />
-        </span>
+        {dataMartHeader ? (
+          <button
+            type='button'
+            aria-label={`Data Mart details for ${label ?? 'data mart'}`}
+            className={className}
+          >
+            {icon}
+          </button>
+        ) : (
+          <span className={className} onClick={stopParentToggle}>
+            {icon}
+          </span>
+        )}
       </TooltipTrigger>
-      <TooltipContent side='top' className='max-w-xs whitespace-pre-wrap'>
+      <TooltipContent
+        side='top'
+        collisionPadding={8}
+        className='max-h-64 max-w-64 overflow-y-auto whitespace-pre-wrap'
+      >
         {text}
       </TooltipContent>
     </Tooltip>

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/FilterRow.tsx
@@ -38,7 +38,7 @@ export function FilterRow({
   return (
     <div
       className={cn(
-        'group flex items-center gap-1.5 rounded px-2 py-1.5',
+        'group/control-row flex items-center gap-1.5 rounded px-2 py-1.5',
         isOrphaned ? 'bg-red-50 dark:bg-red-950/30' : 'bg-muted/40'
       )}
     >
@@ -100,7 +100,7 @@ export function FilterRow({
               variant='ghost'
               size='sm'
               className={cn(
-                'text-muted-foreground hover:text-foreground h-6 w-6 p-0 transition-opacity group-hover:opacity-100',
+                'text-muted-foreground hover:text-foreground h-6 w-6 p-0 transition-opacity group-hover/control-row:opacity-100',
                 editing ? 'opacity-100' : 'opacity-0'
               )}
               aria-label={isPreJoin ? 'Edit slice' : 'Edit filter'}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.test.tsx
@@ -85,7 +85,13 @@ function renderPicker(
 
   const onChange = vi.fn();
   const utils = render(
-    <ReportColumnPicker dataMartId={DATA_MART_ID} value={value} onChange={onChange} {...props} />,
+    <ReportColumnPicker
+      dataMartId={DATA_MART_ID}
+      dataMartTitle='Main Data Mart'
+      value={value}
+      onChange={onChange}
+      {...props}
+    />,
     { wrapper }
   );
   return { ...utils, onChange, client };
@@ -141,7 +147,7 @@ describe('ReportColumnPicker access flag', () => {
     expect(screen.getByLabelText('You do not have access to this data mart')).toBeInTheDocument();
 
     const trigger = screen.getByRole('button', { name: /Collapse Joined DM/ });
-    const block = trigger.parentElement;
+    const block = trigger.closest<HTMLElement>('.border-destructive');
     expect(block).not.toBeNull();
     expect(block!.className).toMatch(/border-destructive/);
     expect(block!.className).toMatch(/bg-destructive\/10/);
@@ -229,10 +235,138 @@ describe('ReportColumnPicker access flag', () => {
     const next = onChange.mock.calls.at(-1)?.[0] as string[];
     expect(next).not.toContain('b__only');
 
-    rerender(<ReportColumnPicker dataMartId={DATA_MART_ID} value={next} onChange={() => {}} />);
+    rerender(
+      <ReportColumnPicker
+        dataMartId={DATA_MART_ID}
+        dataMartTitle='Main Data Mart'
+        value={next}
+        onChange={() => {}}
+      />
+    );
 
     expect(screen.queryByText('Joined DM')).not.toBeInTheDocument();
     expect(screen.queryByText('only')).not.toBeInTheDocument();
+  });
+});
+
+describe('ReportColumnPicker joined source details', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds a multi-hop join path from the same titles shown by the picker', async () => {
+    const firstSource = buildAvailableSource({
+      aliasPath: 'orders_tech',
+      title: 'Orders native title',
+      defaultAlias: 'Orders for reporting',
+      relationshipId: 'rel-orders',
+      dataMartId: 'dm-orders',
+      depth: 1,
+    });
+    const secondSource = buildAvailableSource({
+      aliasPath: 'orders_tech.items_tech',
+      title: 'Line Items native title',
+      description: 'Line item data mart description.',
+      defaultAlias: 'Line Items for reporting',
+      relationshipId: 'rel-items',
+      dataMartId: 'dm-items',
+      depth: 2,
+    });
+    const schema = buildSchema({
+      nativeFields: [
+        { name: 'native_one', type: 'STRING', description: 'Native field description.' },
+      ] as unknown[],
+      blendedFields: [
+        buildBlendedField({
+          name: 'orders_tech__items_tech__sku',
+          sourceRelationshipId: 'rel-items',
+          sourceDataMartId: 'dm-items',
+          sourceDataMartTitle: 'Line Items native title',
+          targetAlias: 'items_tech',
+          originalFieldName: 'sku',
+          description: 'SKU field description.',
+          transitiveDepth: 2,
+          aliasPath: secondSource.aliasPath,
+          outputPrefix: secondSource.defaultAlias,
+        }),
+      ],
+      availableSources: [firstSource, secondSource],
+    });
+    renderPicker(schema, []);
+
+    const trigger = await screen.findByLabelText('Show join path for Line Items for reporting');
+    const header = screen.getByRole('button', { name: 'Expand Line Items for reporting' });
+    const headerRow = header.parentElement;
+    expect(headerRow).toHaveClass('group/data-mart');
+    expect(header).toHaveClass('flex-1');
+    expect(header).not.toContainElement(trigger);
+    expect(headerRow).toContainElement(trigger);
+    expect(trigger).toHaveAttribute('type', 'button');
+    expect(trigger).toHaveClass('h-6', 'w-6', 'items-center', 'justify-center');
+    expect(header).not.toHaveClass('group');
+    expect(trigger).toHaveClass('group-hover/data-mart:opacity-100');
+    expect(trigger).toHaveClass('focus-visible:opacity-100');
+    expect(trigger).toHaveClass('text-muted-foreground');
+    expect(trigger).not.toHaveClass('text-muted-foreground/50');
+    expect(trigger).not.toHaveClass('group-hover:opacity-100');
+
+    const infoTrigger = screen.getByRole('button', {
+      name: 'Data Mart details for Line Items for reporting',
+    });
+    const infoIcon = infoTrigger.querySelector('.lucide-info');
+    expect(infoIcon).toHaveClass('size-3.5');
+    expect(header).not.toContainElement(infoTrigger);
+    expect(headerRow).toContainElement(infoTrigger);
+    expect(infoTrigger).toHaveAttribute('type', 'button');
+    expect(infoTrigger).toHaveClass('h-6', 'w-6', 'items-center', 'justify-center');
+    expect(infoTrigger).toHaveClass('group-hover/data-mart:opacity-100');
+    expect(infoTrigger).toHaveClass('focus-visible:opacity-100');
+    expect(infoTrigger).toHaveClass('text-muted-foreground');
+    expect(infoTrigger).not.toHaveClass('text-muted-foreground/50');
+    expect(infoTrigger).not.toHaveClass('group-hover:opacity-100');
+    expect(infoTrigger.nextElementSibling).toBe(trigger);
+
+    fireEvent.click(header);
+    for (const fieldName of ['native_one', 'sku']) {
+      const row = screen.getByText(fieldName).closest('label');
+      expect(row).toHaveClass('group/row');
+      expect(row).not.toHaveClass('group');
+
+      const fieldInfoTrigger = row
+        ?.querySelector('.lucide-info')
+        ?.closest('[data-slot="tooltip-trigger"]');
+      expect(row?.querySelector('.ml-auto')).toContainElement(fieldInfoTrigger as HTMLElement);
+      expect(fieldInfoTrigger).toHaveClass('h-6', 'w-6', 'items-center', 'justify-center');
+      expect(fieldInfoTrigger).toHaveClass('group-hover/row:opacity-100');
+      expect(fieldInfoTrigger).not.toHaveClass('group-hover:opacity-100');
+    }
+
+    fireEvent.pointerMove(trigger, { pointerType: 'mouse' });
+    const tooltip = await screen.findByRole('tooltip');
+
+    expect(tooltip).toHaveClass(
+      'max-w-sm',
+      'overflow-auto',
+      'overscroll-contain',
+      'whitespace-nowrap'
+    );
+    expect(tooltip).not.toHaveClass('max-w-64', 'overflow-y-auto');
+    Object.defineProperties(tooltip, {
+      clientHeight: { configurable: true, value: 40 },
+      clientWidth: { configurable: true, value: 384 },
+      scrollHeight: { configurable: true, value: 40 },
+      scrollWidth: { configurable: true, value: 800 },
+    });
+    fireEvent.wheel(tooltip, { deltaX: 0, deltaY: 48 });
+    expect(tooltip.scrollLeft).toBe(48);
+    expect(tooltip).toHaveTextContent('Main Data Mart');
+    expect(tooltip).not.toHaveTextContent('Default Data Mart');
+    expect(tooltip).toHaveTextContent('Orders for reporting');
+    expect(tooltip).toHaveTextContent('Line Items for reporting');
+    expect(tooltip).not.toHaveTextContent('Orders native title');
+    expect(tooltip).not.toHaveTextContent('Line Items native title');
+    expect(tooltip).not.toHaveTextContent('orders_tech');
+    expect(tooltip).not.toHaveTextContent('items_tech');
   });
 });
 
@@ -380,6 +514,7 @@ describe('ReportColumnPicker unresolved columns', () => {
     render(
       <ReportColumnPicker
         dataMartId={DATA_MART_ID}
+        dataMartTitle='Main Data Mart'
         storageType={DataStorageType.GOOGLE_BIGQUERY}
         value={['native_one']}
         onChange={() => {}}
@@ -425,6 +560,7 @@ describe('ReportColumnPicker unresolved columns', () => {
     render(
       <ReportColumnPicker
         dataMartId={DATA_MART_ID}
+        dataMartTitle='Main Data Mart'
         storageType={DataStorageType.GOOGLE_BIGQUERY}
         value={['native_one']}
         onChange={() => {}}
@@ -483,6 +619,7 @@ describe('ReportColumnPicker unresolved columns', () => {
     render(
       <ReportColumnPicker
         dataMartId={DATA_MART_ID}
+        dataMartTitle='Main Data Mart'
         storageType={DataStorageType.GOOGLE_BIGQUERY}
         value={['native_one']}
         onChange={() => {}}
@@ -531,6 +668,7 @@ describe('ReportColumnPicker unresolved columns', () => {
     render(
       <ReportColumnPicker
         dataMartId={DATA_MART_ID}
+        dataMartTitle='Main Data Mart'
         storageType={DataStorageType.GOOGLE_BIGQUERY}
         value={['native_one', 'b__visible_field']}
         onChange={() => {}}
@@ -637,6 +775,7 @@ describe('ReportColumnPicker unresolved columns', () => {
     render(
       <ReportColumnPicker
         dataMartId={DATA_MART_ID}
+        dataMartTitle='Main Data Mart'
         value={['native_one', 'gone__field']}
         onChange={() => {}}
         onCountChange={onCountChange}
@@ -706,6 +845,38 @@ describe('ReportColumnPicker aggregation', () => {
     // AGG panel: no row-count toggle (Row Count is never added to reports).
     fireEvent.click(screen.getByRole('button', { name: 'Aggregations' }));
     expect(screen.queryByLabelText('Add a Row Count metric')).not.toBeInTheDocument();
+  });
+
+  it('scopes every configured-control edit icon to its own row hover', () => {
+    renderPicker(aggSchema(), ['native_one', 'revenue', 'ordered_at'], {
+      storageType: DataStorageType.GOOGLE_BIGQUERY,
+      outputConfig: {
+        filterConfig: [{ column: 'native_one', operator: 'eq', value: 'x' }],
+        sortConfig: [],
+        limitConfig: null,
+        aggregationConfig: [{ column: 'revenue', function: 'SUM' }],
+        dateTruncConfig: [{ column: 'ordered_at', unit: 'MONTH' }],
+        uniqueCountConfig: [],
+      },
+      onOutputConfigChange: () => {},
+    });
+
+    const expectOwnRowHover = (accessibleName: string) => {
+      const editButton = screen.getByRole('button', { name: accessibleName });
+      expect(editButton).toHaveClass('group-hover/control-row:opacity-100');
+      expect(editButton).not.toHaveClass('group-hover:opacity-100');
+
+      const row = editButton.closest('div.rounded');
+      expect(row).toHaveClass('group/control-row');
+      expect(row).not.toHaveClass('group');
+    };
+
+    fireEvent.click(screen.getByRole('button', { name: 'Output controls' }));
+    expectOwnRowHover('Edit filter');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Aggregations' }));
+    expectOwnRowHover('Edit aggregation');
+    expectOwnRowHover('Edit date bucket');
   });
 
   it('shows a per-row AGG icon on a selected aggregatable field, hidden on an unselected one', () => {
@@ -861,7 +1032,9 @@ function queryJoinedUniqueCountRowOf(groupAlias: string): HTMLElement | null {
   const header = screen.queryByRole('button', {
     name: new RegExp(`^(Collapse|Expand) ${groupAlias}$`),
   });
-  return header?.parentElement?.querySelector('[data-slot="unique-count-row"]') ?? null;
+  return (
+    header?.parentElement?.parentElement?.querySelector('[data-slot="unique-count-row"]') ?? null
+  );
 }
 
 function joinedUniqueCountRowOf(groupAlias: string): HTMLElement {
@@ -2152,6 +2325,7 @@ describe('ReportColumnPicker Unique Count per joined source', () => {
       <QueryClientProvider client={client}>
         <ReportColumnPicker
           dataMartId={DATA_MART_ID}
+          dataMartTitle='Main Data Mart'
           value={['id']}
           onChange={vi.fn()}
           storageType={DataStorageType.GOOGLE_BIGQUERY}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/ReportColumnPicker.tsx
@@ -4,7 +4,7 @@ import { cn } from '@owox/ui/lib/utils';
 import { Badge } from '@owox/ui/components/badge';
 import { Button } from '@owox/ui/components/button';
 import { Input } from '@owox/ui/components/input';
-import { Search } from 'lucide-react';
+import { Link2, Search } from 'lucide-react';
 import { Checkbox } from '@owox/ui/components/checkbox';
 import { Collapsible, CollapsibleContent } from '@owox/ui/components/collapsible';
 import { Switch } from '@owox/ui/components/switch';
@@ -73,6 +73,7 @@ import {
 } from './aggregation-config';
 import { buildColumnSearchResult, matchesColumnSearch } from './report-column-search';
 import { SearchButton } from './SearchButton';
+import { PathTree } from './FieldSearchPicker';
 
 // Must stay in sync with the backend collectSchemaFieldPaths walker: hidden and
 // DISCONNECTED nodes (with their subtrees) are unavailable for reporting, so they
@@ -115,6 +116,14 @@ function uniqueCountColumnName(source: string): string {
  */
 const MAIN_UNIQUE_COUNT_ROW_LABEL = UNIQUE_COUNT_LABEL;
 
+function joinedDataMartTitle(
+  displayPrefix: string,
+  nativeTitle: string,
+  aliasPath: string
+): string {
+  return displayPrefix.trim() || nativeTitle || aliasPath;
+}
+
 export interface ReportColumnSelectionCount {
   selected: number;
   total: number;
@@ -131,6 +140,7 @@ export function ReportColumnsCountBadge({ count }: { count: ReportColumnSelectio
 
 export interface ReportColumnPickerProps {
   dataMartId: string;
+  dataMartTitle: string;
   storageType?: DataStorageType;
   value: string[] | null;
   /**
@@ -257,7 +267,7 @@ const NativeFieldRow = memo(function NativeFieldRow({
     />
   );
   return (
-    <label className='group/row group hover:bg-muted/50 flex min-w-0 cursor-pointer items-center gap-2 rounded px-1 py-1'>
+    <label className='group/row hover:bg-muted/50 flex min-w-0 cursor-pointer items-center gap-2 rounded px-1 py-1'>
       <Checkbox
         checked={checked}
         onCheckedChange={c => {
@@ -268,10 +278,10 @@ const NativeFieldRow = memo(function NativeFieldRow({
         {field.alias ?? field.name}
       </span>
       {field.type && <span className='text-muted-foreground shrink-0 text-xs'>({field.type})</span>}
-      <FieldInfoTooltip text={field.description} compact />
-      {/* Fixed height: both icons are conditional, and a row that shows neither would otherwise
+      {/* Fixed height: the actions are conditional, and a row that shows none would otherwise
           sit shorter than its neighbours and grow the moment one appears. */}
       <span className='ml-auto flex h-6 items-center'>
+        <FieldInfoTooltip text={field.description} compact />
         {aggIcon}
         {filterIcon}
       </span>
@@ -371,7 +381,7 @@ const BlendedFieldRow = memo(function BlendedFieldRow({
   return (
     <label
       className={cn(
-        'group/row group flex min-w-0 cursor-pointer items-center gap-2 rounded px-1 py-1',
+        'group/row flex min-w-0 cursor-pointer items-center gap-2 rounded px-1 py-1',
         hoverClassName
       )}
     >
@@ -386,10 +396,10 @@ const BlendedFieldRow = memo(function BlendedFieldRow({
         {field.alias || field.originalFieldName}
       </span>
       {field.type && <span className='text-muted-foreground shrink-0 text-xs'>({field.type})</span>}
-      <FieldInfoTooltip text={field.description} compact />
-      {/* Fixed height: both icons are conditional, and a row that shows neither would otherwise
+      {/* Fixed height: the actions are conditional, and a row that shows none would otherwise
           sit shorter than its neighbours and grow the moment one appears. */}
       <span className='ml-auto flex h-6 items-center'>
+        <FieldInfoTooltip text={field.description} compact />
         {aggIcon}
         {filterIcon}
       </span>
@@ -409,6 +419,7 @@ type GroupUniqueCount = NonNullable<BlendedGroup['uniqueCount']> & {
 
 interface BlendedGroupItemProps {
   group: BlendedGroup;
+  joinPath: readonly string[];
   selectedSet: Set<string>;
   onToggleField: ToggleFieldFn;
   filterableTypeFor?: (fieldName: string) => string | undefined;
@@ -423,8 +434,50 @@ interface BlendedGroupItemProps {
   uniqueCount?: GroupUniqueCount;
 }
 
+function JoinPathTooltip({
+  dataMartName,
+  path,
+}: {
+  dataMartName: string;
+  path: readonly string[];
+}) {
+  if (path.length < 2) return null;
+  return (
+    <Tooltip delayDuration={600}>
+      <TooltipTrigger asChild>
+        <button
+          type='button'
+          aria-label={`Show join path for ${dataMartName}`}
+          className='text-muted-foreground hover:text-foreground inline-flex h-6 w-6 shrink-0 items-center justify-center rounded opacity-0 transition-opacity group-hover/data-mart:opacity-100 focus-visible:opacity-100'
+        >
+          <Link2 className='size-4 shrink-0' aria-hidden='true' />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        side='top'
+        align='start'
+        collisionPadding={8}
+        className='max-h-64 max-w-sm overflow-auto overscroll-contain whitespace-nowrap'
+        onWheel={event => {
+          const tooltip = event.currentTarget;
+          if (
+            tooltip.scrollWidth > tooltip.clientWidth &&
+            tooltip.scrollHeight <= tooltip.clientHeight &&
+            Math.abs(event.deltaY) > Math.abs(event.deltaX)
+          ) {
+            tooltip.scrollLeft += event.deltaY;
+          }
+        }}
+      >
+        <PathTree segments={path} />
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 function BlendedGroupItem({
   group,
+  joinPath,
   selectedSet,
   onToggleField,
   filterableTypeFor,
@@ -462,33 +515,39 @@ function BlendedGroupItem({
       onOpenChange={setIsOpen}
       className={cn('rounded', inaccessible && 'border-destructive bg-destructive/10 border')}
     >
-      <button
-        type='button'
-        aria-expanded={isOpen}
-        aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${group.alias}`}
+      <div
         className={cn(
-          'group flex w-full cursor-pointer items-start gap-1.5 rounded px-1 py-1 text-left transition-colors',
+          'group/data-mart flex w-full items-start gap-1.5 rounded px-1 py-1 transition-colors',
           !inaccessible &&
             'bg-secondary/50 dark:bg-muted/50 hover:bg-secondary/80 dark:hover:bg-muted/80'
         )}
-        onClick={() => {
-          setIsOpen(v => !v);
-        }}
       >
-        <Chevron className={cn('mt-0.5 h-4 w-4 shrink-0', accentClass)} />
-        <div className='min-w-0 flex-1'>
-          <div className='flex min-w-0 items-center gap-1.5'>
-            <span
-              className={cn('truncate text-xs font-semibold', inaccessible && 'text-destructive')}
-              title={group.alias}
-            >
-              {group.alias}
-            </span>
-            <FieldInfoTooltip text={group.description} />
-          </div>
-        </div>
-        {inaccessible && <NoAccessIndicator variant='destructive' className='mt-0.5' />}
-      </button>
+        <button
+          type='button'
+          aria-expanded={isOpen}
+          aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${group.alias}`}
+          className='flex min-w-0 flex-1 cursor-pointer items-start gap-1.5 text-left'
+          onClick={() => {
+            setIsOpen(v => !v);
+          }}
+        >
+          <Chevron className={cn('mt-0.5 h-4 w-4 shrink-0', accentClass)} />
+          <span
+            className={cn(
+              'min-w-0 flex-1 truncate text-xs font-semibold',
+              inaccessible && 'text-destructive'
+            )}
+            title={group.alias}
+          >
+            {group.alias}
+          </span>
+          {inaccessible && <NoAccessIndicator variant='destructive' className='mt-0.5' />}
+        </button>
+        <span className='mt-0.5 flex shrink-0 items-center'>
+          <FieldInfoTooltip text={group.description} compact dataMartHeader label={group.alias} />
+          <JoinPathTooltip dataMartName={group.alias} path={joinPath} />
+        </span>
+      </div>
       <CollapsibleContent>
         {group.visibleFields.map(field => {
           return (
@@ -524,6 +583,7 @@ function BlendedGroupItem({
 
 export function ReportColumnPicker({
   dataMartId,
+  dataMartTitle,
   storageType,
   value,
   onChange,
@@ -810,6 +870,25 @@ export function ReportColumnPicker({
     }
     return map;
   }, [schema?.availableSources]);
+
+  const joinPathFor = useCallback(
+    (aliasPath: string): string[] => {
+      const segments = aliasPath.split('.');
+      const path = [dataMartTitle];
+      for (let index = 0; index < segments.length; index += 1) {
+        const technicalAlias = segments[index];
+        const prefix = segments.slice(0, index + 1).join('.');
+        const source = availableSourceByPath.get(prefix);
+        path.push(
+          source
+            ? joinedDataMartTitle(source.defaultAlias, source.title, source.aliasPath)
+            : technicalAlias
+        );
+      }
+      return path;
+    },
+    [availableSourceByPath, dataMartTitle]
+  );
 
   const accessibleBlendedFieldNames = useMemo(
     () =>
@@ -1289,7 +1368,11 @@ export function ReportColumnPicker({
         group = {
           aliasPath: field.aliasPath,
           title: field.sourceDataMartTitle,
-          alias: field.outputPrefix,
+          alias: joinedDataMartTitle(
+            field.outputPrefix,
+            field.sourceDataMartTitle,
+            field.aliasPath
+          ),
           description: source?.description,
           isAccessibleForReporting: source?.isAccessibleForReporting ?? false,
           visibleFields: [],
@@ -1329,7 +1412,7 @@ export function ReportColumnPicker({
           group = {
             aliasPath: source.aliasPath,
             title: source.title,
-            alias: source.defaultAlias,
+            alias: joinedDataMartTitle(source.defaultAlias, source.title, source.aliasPath),
             description: source.description,
             isAccessibleForReporting: source.isAccessibleForReporting,
             visibleFields: [],
@@ -1600,7 +1683,7 @@ export function ReportColumnPicker({
               return (
                 <label
                   key={name}
-                  className='group/row group hover:bg-destructive/20 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
+                  className='group/row hover:bg-destructive/20 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
                 >
                   <Checkbox
                     checked={selected}
@@ -1628,7 +1711,7 @@ export function ReportColumnPicker({
               return (
                 <label
                   key={column}
-                  className='group/row group hover:bg-destructive/20 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
+                  className='group/row hover:bg-destructive/20 flex cursor-pointer items-center gap-2 rounded px-1 py-1'
                 >
                   <Checkbox checked={false} disabled />
                   <span className='font-mono text-xs'>{column}</span>
@@ -1692,6 +1775,7 @@ export function ReportColumnPicker({
             <BlendedGroupItem
               key={group.aliasPath}
               group={group}
+              joinPath={joinPathFor(group.aliasPath)}
               selectedSet={effectiveValueSet}
               onToggleField={toggleField}
               filterableTypeFor={filterableTypeFor}

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/UniqueCountRow.test.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/UniqueCountRow.test.tsx
@@ -295,6 +295,19 @@ describe('UniqueCountRow — checked but not emitted', () => {
 // the same way. It is NOT the unavailable hint: that one replaces the row's affordance, this one
 // sits beside a fully working row.
 describe('UniqueCountRow — description', () => {
+  it('places the info affordance in the trailing action rail, outside the field label', () => {
+    const { row } = renderRow({ description: 'Counts distinct primary keys' });
+
+    const info = row.querySelector('[data-slot="unique-count-info"]');
+    const trigger = info?.querySelector('[data-slot="tooltip-trigger"]');
+    const actionRail = row.querySelector('.ml-auto');
+    expect(info).not.toBeNull();
+    expect(actionRail).toContainElement(info as HTMLElement);
+    expect(actionRail?.lastElementChild).toBe(info);
+    expect(info?.closest('label')).toBeNull();
+    expect(trigger).toHaveClass('h-6', 'w-6', 'items-center', 'justify-center');
+  });
+
   it('shows the description through the standard info tooltip', async () => {
     const description = 'Unique Orders records, counted by its Primary Key: order_id';
     const { row } = renderRow({ description });

--- a/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/UniqueCountRow.tsx
+++ b/apps/web/src/features/data-marts/edit/components/ReportColumnPicker/UniqueCountRow.tsx
@@ -181,13 +181,11 @@ export function UniqueCountRow({
                 {note}
               </TooltipContent>
             </Tooltip>
-            {info}
           </>
         ) : (
           <label className='flex min-w-0 flex-1 cursor-pointer items-center gap-2'>
             {checkbox}
             <span className='min-w-0 truncate font-mono text-xs'>{label}</span>
-            {info}
           </label>
         )}
         {/* Outside the <label> above: a <span> is not interactive content, so inside it every
@@ -197,6 +195,7 @@ export function UniqueCountRow({
             way: the badge is taller than the row's text, so revealing it with the tick used to
             grow the row from 24px to 32px and shift everything below it. */}
         <span className='ml-auto flex items-center'>
+          {info && <span className='h-6 w-6' aria-hidden='true' />}
           <span className='flex h-6 w-6 items-center justify-center rounded'>
             {checked &&
               (notEmitted ? (
@@ -223,8 +222,7 @@ export function UniqueCountRow({
                 </Tooltip>
               ))}
           </span>
-          {/* Spacer matching the field rows' filter-icon slot so this Σ aligns with them. */}
-          <span className='h-6 w-6' aria-hidden='true' />
+          {info}
         </span>
       </div>
       {/* Outside the row on purpose: inside a <label> it would be read a second time as part of

--- a/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/EmailReportEditForm/EmailReportEditForm.tsx
@@ -938,6 +938,7 @@ export const EmailReportEditForm = forwardRef<HTMLFormElement, EmailReportEditFo
                           <div className='space-y-3' tabIndex={-1}>
                             <ReportColumnPicker
                               dataMartId={dataMart.id}
+                              dataMartTitle={dataMart.title}
                               storageType={dataMart.storage.type}
                               value={form.watch('columnConfig')}
                               onChange={(value, options) => {

--- a/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/GoogleSheetsReportEditForm/GoogleSheetsReportEditForm.tsx
@@ -534,6 +534,7 @@ export const GoogleSheetsReportEditForm = forwardRef<
                         <div className='space-y-3' tabIndex={-1}>
                           <ReportColumnPicker
                             dataMartId={dataMart.id}
+                            dataMartTitle={dataMart.title}
                             storageType={dataMart.storage.type}
                             value={form.watch('columnConfig')}
                             onChange={(value, options) => {

--- a/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
+++ b/apps/web/src/features/data-marts/reports/edit/components/LookerStudioReportEditForm/LookerStudioReportEditForm.tsx
@@ -249,6 +249,7 @@ export const LookerStudioReportEditForm = forwardRef<
                         <div className='space-y-3' tabIndex={-1}>
                           <ReportColumnPicker
                             dataMartId={dataMart.id}
+                            dataMartTitle={dataMart.title}
                             storageType={dataMart.storage.type}
                             value={form.watch('columnConfig')}
                             onChange={(value, options) => {


### PR DESCRIPTION
## Summary

- show joined Data Mart descriptions and full join paths in the report column picker
- reuse the picker user-facing Data Mart titles and start each path with the main Data Mart title
- scope hover actions to their own rows and align trailing field and Data Mart controls
- add the 6827 changeset for the web release

<img width="627" height="551" alt="CleanShot 2026-08-21 at 19 25 29" src="https://github.com/user-attachments/assets/00f9763a-c6e9-483f-ac36-5ea3dc9b6fe1" />


## Testing

- npm run test -w @owox/web
- npm run lint -w @owox/web
- npm run type-check -w @owox/web
- npm run format:check -w @owox/web
- npm run build -w @owox/web