### PR TITLE
test(web): pin the clock in formatDataLastUpdatedLabel specs

### DIFF
--- a/apps/web/src/features/data-marts/shared/utils/data-last-updated.utils.test.ts
+++ b/apps/web/src/features/data-marts/shared/utils/data-last-updated.utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   describeCoverage,
   formatDataLastUpdatedLabel,
@@ -29,6 +29,18 @@ describe('formatRelativeTime', () => {
 });
 
 describe('formatDataLastUpdatedLabel', () => {
+  // formatDataLastUpdatedLabel reads the real clock, so the fixture's distance from
+  // "now" grows every day — 30 days after the fixture date, the day step gives way
+  // to the month step and numeric:'auto' renders "last month", which has no "ago"
+  // suffix. Pin the clock so the fixture is always 3 days old.
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   const block = {
     dataLastUpdatedAt: '2026-07-25T08:30:00.000Z',
     computedAt: '2026-07-28T00:00:00.000Z',


### PR DESCRIPTION
## Why

`formatDataLastUpdatedLabel` reads the real clock, so the spec's fixed fixture drifts one day further from "now" on every run. Thirty days after the fixture date the day step gives way to the month step, `Intl.RelativeTimeFormat` with `numeric: 'auto'` renders **"last month"** instead of "N days ago", and the `/ago$/` assertion fails. The time bomb went off today at 08:30 UTC — CI runs before that passed, runs after it fail, on **every** branch (`Overall test @owox/web`).

## What

Freeze the system time with vitest fake timers in the `formatDataLastUpdatedLabel` describe block, so the fixture is always three days old. The `formatRelativeTime` specs already inject `now` explicitly and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)