### PR TITLE
Connect Google Sheets source with Google OAuth

### DIFF
--- a/.changeset/google-sheets-source-oauth.md
+++ b/.changeset/google-sheets-source-oauth.md
@@ -1,0 +1,7 @@
+---
+'owox': minor
+---
+
+# Connect Google Sheets sources with Google OAuth
+
+Users can authorize a Google account and choose a spreadsheet with Google Picker when configuring a Google Sheets source. Service account authentication remains available.

--- a/apps/backend/src/data-marts/services/connector/connector-preview-credentials.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-preview-credentials.service.spec.ts
@@ -49,6 +49,22 @@ describe('ConnectorPreviewCredentialsService', () => {
     );
   });
 
+  it('rejects Data-Mart-scoped records used as OAuth credentials', async () => {
+    const { service, credentials } = createService();
+    const config = { AuthType: { oauth2: { _source_credential_id: 'oauth-1' } } };
+    (credentials.getCredentialsById as jest.Mock).mockResolvedValue({
+      id: 'oauth-1',
+      projectId: 'proj-1',
+      connectorName: 'GoogleSheets',
+      dataMartId: 'dm-1',
+      configId: 'config-1',
+    });
+
+    await expect(service.inject('GoogleSheets', config, context)).rejects.toThrow(
+      'The selected credentials cannot be used for this preview'
+    );
+  });
+
   it('allows copied service-account secrets only when the source Data Mart is editable', async () => {
     const { service, credentials, access } = createService();
     const config = {

--- a/apps/backend/src/data-marts/services/connector/connector-preview-credentials.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-preview-credentials.service.spec.ts
@@ -14,6 +14,7 @@ describe('ConnectorPreviewCredentialsService', () => {
   const createService = () => {
     const credentialInjector = {
       injectSecrets: jest.fn().mockImplementation(config => Promise.resolve(config)),
+      injectOAuthCredentials: jest.fn().mockImplementation(config => Promise.resolve(config)),
     } as unknown as ConnectorCredentialInjectorService;
     const credentials = {
       getCredentialsById: jest.fn(),
@@ -29,6 +30,24 @@ describe('ConnectorPreviewCredentialsService', () => {
       access,
     };
   };
+
+  it('allows project-level Google Sheets OAuth credentials', async () => {
+    const { service, credentials, credentialInjector } = createService();
+    const config = { AuthType: { oauth2: { _source_credential_id: 'oauth-1' } } };
+    (credentials.getCredentialsById as jest.Mock).mockResolvedValue({
+      id: 'oauth-1',
+      projectId: 'proj-1',
+      connectorName: 'GoogleSheets',
+    });
+
+    await service.inject('GoogleSheets', config, context);
+
+    expect(credentialInjector.injectOAuthCredentials).toHaveBeenCalledWith(
+      config,
+      'GoogleSheets',
+      'proj-1'
+    );
+  });
 
   it('allows copied service-account secrets only when the source Data Mart is editable', async () => {
     const { service, credentials, access } = createService();
@@ -80,13 +99,17 @@ describe('ConnectorPreviewCredentialsService', () => {
   it('rejects credentials from another connector', async () => {
     const { service, credentials } = createService();
     (credentials.getCredentialsById as jest.Mock).mockResolvedValue({
-      id: 'secret-1',
+      id: 'oauth-1',
       projectId: 'proj-1',
       connectorName: 'GoogleAds',
     });
 
     await expect(
-      service.inject('GoogleSheets', { _id: 'config-1', _secrets_id: 'secret-1' }, context)
+      service.inject(
+        'GoogleSheets',
+        { AuthType: { oauth2: { _source_credential_id: 'oauth-1' } } },
+        context
+      )
     ).rejects.toThrow('The selected credentials cannot be used for this preview');
   });
 

--- a/apps/backend/src/data-marts/services/connector/connector-preview-credentials.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-preview-credentials.service.ts
@@ -6,6 +6,8 @@ import { ConnectorSourceCredentialsService } from './connector-source-credential
 
 const SECRET_MASK = '**********';
 
+type CredentialReference = { id: string; type: 'oauth' | 'secrets' };
+
 @Injectable()
 export class ConnectorPreviewCredentialsService {
   constructor(
@@ -21,7 +23,15 @@ export class ConnectorPreviewCredentialsService {
   ): Promise<Record<string, unknown>> {
     const previewConfig = this.withoutStoredSecretReferenceForInlineKey(config);
     await this.validateReferences(connectorName, previewConfig, context);
-    return this.credentialInjector.injectSecrets(previewConfig, context.projectId);
+    const configWithSecrets = await this.credentialInjector.injectSecrets(
+      previewConfig,
+      context.projectId
+    );
+    return this.credentialInjector.injectOAuthCredentials(
+      configWithSecrets,
+      connectorName,
+      context.projectId
+    );
   }
 
   private withoutStoredSecretReferenceForInlineKey(
@@ -47,9 +57,10 @@ export class ConnectorPreviewCredentialsService {
     const configId = typeof config._id === 'string' ? config._id : undefined;
     const copiedFrom = this.getCopiedFrom(config);
 
-    for (const credentialId of this.collectSecretReferences(config)) {
-      const credential =
-        await this.connectorSourceCredentialsService.getCredentialsById(credentialId);
+    for (const reference of this.collectReferences(config)) {
+      const credential = await this.connectorSourceCredentialsService.getCredentialsById(
+        reference.id
+      );
 
       if (
         !credential ||
@@ -57,6 +68,13 @@ export class ConnectorPreviewCredentialsService {
         credential.connectorName !== connectorName
       ) {
         throw this.invalidCredentials();
+      }
+
+      if (reference.type === 'oauth') {
+        if (credential.dataMartId || credential.configId) {
+          throw this.invalidCredentials();
+        }
+        continue;
       }
 
       const isCurrentConfig = Boolean(configId) && credential.configId === configId;
@@ -101,18 +119,30 @@ export class ConnectorPreviewCredentialsService {
     return { dataMartId: copiedFrom.dataMartId, configId: copiedFrom.configId };
   }
 
-  private collectSecretReferences(value: unknown, references = new Set<string>()): string[] {
+  private collectReferences(
+    value: unknown,
+    references = new Map<string, CredentialReference>()
+  ): CredentialReference[] {
     if (!value || typeof value !== 'object' || Array.isArray(value)) {
       return Array.from(references.values());
     }
 
     const object = value as Record<string, unknown>;
+    if (typeof object._source_credential_id === 'string') {
+      references.set(`oauth:${object._source_credential_id}`, {
+        id: object._source_credential_id,
+        type: 'oauth',
+      });
+    }
     if (typeof object._secrets_id === 'string') {
-      references.add(object._secrets_id);
+      references.set(`secrets:${object._secrets_id}`, {
+        id: object._secrets_id,
+        type: 'secrets',
+      });
     }
 
     for (const child of Object.values(object)) {
-      this.collectSecretReferences(child, references);
+      this.collectReferences(child, references);
     }
 
     return Array.from(references.values());

--- a/apps/backend/src/data-marts/services/connector/connector-preview-credentials.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector-preview-credentials.service.ts
@@ -71,6 +71,9 @@ export class ConnectorPreviewCredentialsService {
       }
 
       if (reference.type === 'oauth') {
+        // Managed OAuth credentials are project-scoped and intentionally match
+        // the access boundary used by connector runs. Data-Mart-scoped secret
+        // records must not be accepted as OAuth credentials for a preview.
         if (credential.dataMartId || credential.configId) {
           throw this.invalidCredentials();
         }

--- a/apps/backend/src/data-marts/services/connector/connector.service.spec.ts
+++ b/apps/backend/src/data-marts/services/connector/connector.service.spec.ts
@@ -133,6 +133,33 @@ describe('ConnectorService', () => {
     });
   });
 
+  describe('isOAuthEnabled', () => {
+    const envKey = 'GOOGLE_CLIENT_ID';
+    const originalValue = process.env[envKey];
+
+    afterEach(() => {
+      if (originalValue === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = originalValue;
+      }
+    });
+
+    it('requires every required environment variable, including UI variables', async () => {
+      const { service } = createService();
+      delete process.env[envKey];
+
+      await expect(service.isOAuthEnabled('TestConnector', 'AuthType.oauth2')).resolves.toBe(false);
+    });
+
+    it('enables OAuth when all required environment variables are configured', async () => {
+      const { service } = createService();
+      process.env[envKey] = 'client-id';
+
+      await expect(service.isOAuthEnabled('TestConnector', 'AuthType.oauth2')).resolves.toBe(true);
+    });
+  });
+
   describe('validateConnectorExists (via getConnectorSpecification)', () => {
     it('throws for unknown connector name', async () => {
       const { service } = createService();

--- a/apps/backend/src/data-marts/services/connector/connector.service.ts
+++ b/apps/backend/src/data-marts/services/connector/connector.service.ts
@@ -162,9 +162,7 @@ export class ConnectorService {
       const config = varConfig as OAuthVar;
 
       const isRequired = config.required === true;
-      const isSecret = config.attributes?.includes('SECRET');
-
-      if (isRequired && isSecret && config.store === 'env') {
+      if (isRequired && config.store === 'env') {
         const envValue = process.env[config.key];
         if (!envValue) {
           return false;

--- a/apps/backend/test/README.md
+++ b/apps/backend/test/README.md
@@ -140,7 +140,7 @@ Verifies all connectors have well-formed specification schemas.
 
 #### `connector-oauth.e2e-spec.ts`
 
-`GET /api/connectors/:name/oauth/settings` for 4 OAuth connectors (GoogleAds, FacebookMarketing,
+`GET /api/connectors/:name/oauth/settings` for OAuth connectors (GoogleAds, GoogleSheets, FacebookMarketing,
 TikTokAds, MicrosoftAds). Dynamically discovers OAuth field path from specification, then
 validates vars (non-empty object, per-var key/value types) and isEnabled (boolean, false in
 test env). Also tests non-OAuth connector edge case (OpenHolidays returns empty vars, isEnabled false).

--- a/apps/backend/test/connector-fields.e2e-spec.ts
+++ b/apps/backend/test/connector-fields.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import * as supertest from 'supertest';
 import { createTestApp, closeTestApp, AUTH_HEADER, ALL_CONNECTORS } from '@owox/test-utils';
+import { ConnectorSourceCredentialsService } from '../src/data-marts/services/connector/connector-source-credentials.service';
 
 describe('Connector Fields (e2e)', () => {
   let app: INestApplication;
@@ -89,6 +90,32 @@ describe('Connector Fields (e2e)', () => {
       expect(res.status).toBe(400);
       expect(res.body.statusCode).toBe(400);
       expect(res.body.message).toContain("parameter 'AuthType' is required");
+    });
+
+    it('POST /api/connectors/GoogleSheets/fields/preview - rejects another connector credential', async () => {
+      const credentialsService = app.get(ConnectorSourceCredentialsService);
+      const credential = await credentialsService.createCredentials(
+        '0',
+        '0',
+        'GoogleAds',
+        { access_token: 'not-a-google-sheets-token' },
+        null
+      );
+
+      const res = await agent
+        .post('/api/connectors/GoogleSheets/fields/preview')
+        .send({
+          configuration: {
+            AuthType: { oauth2: { _source_credential_id: credential.id } },
+            SpreadsheetId: 'sheet-id',
+            SheetName: 'Sheet1',
+            HeaderRow: 1,
+          },
+        })
+        .set(AUTH_HEADER);
+
+      expect(res.status).toBe(403);
+      expect(res.body.message).toBe('The selected credentials cannot be used for this preview');
     });
   });
 

--- a/apps/backend/test/connector-oauth.e2e-spec.ts
+++ b/apps/backend/test/connector-oauth.e2e-spec.ts
@@ -39,7 +39,13 @@ async function getOAuthFieldPath(agent: supertest.Agent, connectorName: string):
   return `${oauthField.name}.${oauthVariant.value}`;
 }
 
-const OAUTH_CONNECTORS = ['GoogleAds', 'FacebookMarketing', 'TikTokAds', 'MicrosoftAds'];
+const OAUTH_CONNECTORS = [
+  'GoogleAds',
+  'GoogleSheets',
+  'FacebookMarketing',
+  'TikTokAds',
+  'MicrosoftAds',
+];
 
 describe('Connector OAuth Settings (e2e)', () => {
   let app: INestApplication;
@@ -56,7 +62,7 @@ describe('Connector OAuth Settings (e2e)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // CAPI-08: OAuth settings for all 4 OAuth connectors
+  // CAPI-08: OAuth settings for OAuth connectors
   // Deep vars validation per user decision: check vars is non-empty object,
   // validate each var entry has a string key and a value of string|null
   // (resolved env values), and isEnabled is boolean.

--- a/apps/backend/test/connector-oauth.e2e-spec.ts
+++ b/apps/backend/test/connector-oauth.e2e-spec.ts
@@ -108,6 +108,11 @@ describe('Connector OAuth Settings (e2e)', () => {
           }
         });
 
+        if (connectorName === 'GoogleSheets') {
+          expect(res.body.vars).toHaveProperty('PickerApiKey');
+          expect(res.body.vars).toHaveProperty('ProjectNumber');
+        }
+
         // isEnabled is a boolean (false in test env because OAuth env vars are not set)
         expect(typeof res.body.isEnabled).toBe('boolean');
       }

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.test.tsx
@@ -243,7 +243,7 @@ describe('ConfigurationStep Google Sheets OAuth fields', () => {
     });
     oauthMocks.checkStatus.mockResolvedValue({
       valid: true,
-      user: { id: 'user-1', email: 'analyst@example.com' },
+      user: { id: 'user-1', name: 'analyst@example.com', email: 'analyst@example.com' },
     });
 
     render(

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.test.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { MemoryRouter } from 'react-router';
 import { describe, it, expect, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ConfigurationStep } from './ConfigurationStep';
 import type { ConnectorSpecificationResponseApiDto } from '../../../../shared/api';
 import { RequiredType } from '../../../../shared/api';
@@ -12,6 +12,16 @@ vi.mock(
 );
 
 vi.mock('../../../../../../utils', () => ({ trackEvent: vi.fn() }));
+
+const oauthMocks = vi.hoisted(() => ({
+  exchangeCredentials: vi.fn(),
+  checkStatus: vi.fn(),
+  getSettings: vi.fn(),
+}));
+
+vi.mock('../../../../shared/model/hooks/useOAuth', () => ({
+  useOAuth: () => oauthMocks,
+}));
 
 const connector = {
   name: 'GoogleAds',
@@ -185,5 +195,81 @@ describe('ConfigurationStep state synchronization', () => {
 
     expect(screen.getByRole('textbox', { name: 'Sheet Name *' })).toHaveValue('Existing Sheet');
     expect(onConfigurationChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConfigurationStep Google Sheets OAuth fields', () => {
+  const spreadsheetUrl = 'https://docs.google.com/spreadsheets/d/sheet-1/edit';
+  const oauthSpecification: ConnectorSpecificationResponseApiDto[] = [
+    {
+      name: 'AuthType',
+      title: 'Auth Type',
+      requiredType: RequiredType.OBJECT,
+      required: true,
+      oneOf: [
+        {
+          label: 'OAuth2',
+          value: 'oauth2',
+          requiredType: RequiredType.OBJECT,
+          attributes: ['OAUTH_FLOW'],
+          items: {
+            RefreshToken: {
+              name: 'RefreshToken',
+              title: 'Refresh Token',
+              requiredType: RequiredType.STRING,
+              required: true,
+            },
+          },
+        },
+      ],
+    },
+    {
+      name: 'SpreadsheetId',
+      title: 'Spreadsheet ID or URL',
+      requiredType: RequiredType.STRING,
+      required: true,
+    },
+  ];
+
+  it('uses a read-only spreadsheet link for managed OAuth and restores the input for manual OAuth', async () => {
+    oauthMocks.getSettings.mockResolvedValue({
+      isEnabled: true,
+      vars: {
+        ClientId: 'client-id',
+        RedirectUri: 'https://app.example.com/oauth/google-sheets/callback',
+        PickerApiKey: 'picker-key',
+        ProjectNumber: '123456789',
+      },
+    });
+    oauthMocks.checkStatus.mockResolvedValue({
+      valid: true,
+      user: { id: 'user-1', email: 'analyst@example.com' },
+    });
+
+    render(
+      <MemoryRouter>
+        <ConfigurationStep
+          connector={googleSheetsConnector}
+          connectorSpecification={oauthSpecification}
+          initialConfiguration={{
+            AuthType: { oauth2: { _source_credential_id: 'credential-1' } },
+            SpreadsheetId: spreadsheetUrl,
+          }}
+        />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('link', { name: spreadsheetUrl })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('textbox', { name: 'Spreadsheet ID or URL *' })
+      ).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Manually' }));
+
+    expect(await screen.findByRole('textbox', { name: 'Spreadsheet ID or URL *' })).toHaveValue(
+      spreadsheetUrl
+    );
   });
 });

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep.tsx
@@ -93,6 +93,7 @@ export function ConfigurationStep({
   // own echo and distinguishes it from a genuine outside change.
   const lastEchoedConfigRef = useRef<Record<string, unknown> | null>(null);
   const [secretEditing, setSecretEditing] = useState<Record<string, boolean>>({});
+  const [managedOAuthModes, setManagedOAuthModes] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     trackEvent({
@@ -174,6 +175,16 @@ export function ConfigurationStep({
       [name]: value,
     }));
   };
+
+  const handleManagedOAuthModeChange = useCallback(
+    (specificationName: string, isManaged: boolean) => {
+      setManagedOAuthModes(current => {
+        if (current[specificationName] === isManaged) return current;
+        return { ...current, [specificationName]: isManaged };
+      });
+    },
+    []
+  );
 
   const validateValue = useCallback(
     (value: unknown, spec?: ConnectorSpecificationResponseApiDto): boolean => {
@@ -332,10 +343,25 @@ export function ConfigurationStep({
       return getPriority(a) - getPriority(b);
     });
 
-  const requiredFields = sortedSpecifications.filter(
+  const selectedAuthType = isRecord(configuration.AuthType)
+    ? Object.keys(configuration.AuthType)[0]
+    : undefined;
+  const usesManagedGoogleSheetsOAuth =
+    connector.name === GOOGLE_SHEETS_CONNECTOR_NAME &&
+    selectedAuthType === 'oauth2' &&
+    managedOAuthModes.AuthType;
+  const visibleSpecifications = usesManagedGoogleSheetsOAuth
+    ? sortedSpecifications.filter(spec => spec.name !== 'SpreadsheetId')
+    : sortedSpecifications;
+
+  const requiredFields = visibleSpecifications.filter(
     spec => !spec.attributes?.includes('ADVANCED')
   );
-  const advancedFields = sortedSpecifications.filter(spec => spec.attributes?.includes('ADVANCED'));
+  const advancedFields = visibleSpecifications.filter(spec =>
+    spec.attributes?.includes('ADVANCED')
+  );
+  const managedOAuthModeChangeHandler =
+    connector.name === GOOGLE_SHEETS_CONNECTOR_NAME ? handleManagedOAuthModeChange : undefined;
 
   return (
     <>
@@ -362,6 +388,7 @@ export function ConfigurationStep({
                 secretEditing={secretEditing}
                 isEditingExisting={isEditingExisting}
                 connectorName={connector.name}
+                onManagedOAuthModeChange={managedOAuthModeChangeHandler}
               />
             )}
             {advancedFields.length > 0 && (
@@ -374,6 +401,7 @@ export function ConfigurationStep({
                 secretEditing={secretEditing}
                 isEditingExisting={isEditingExisting}
                 connectorName={connector.name}
+                onManagedOAuthModeChange={managedOAuthModeChangeHandler}
               />
             )}
           </AppWizardStepSection>

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationListRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationListRender.tsx
@@ -15,6 +15,7 @@ interface ConfigurationListRenderProps {
   isEditingExisting: boolean;
   collapsibleTitle?: string;
   connectorName: string;
+  onManagedOAuthModeChange?: (specificationName: string, isManaged: boolean) => void;
 }
 
 function renderItems(
@@ -24,7 +25,8 @@ function renderItems(
   onSecretEditToggle: (name: string, enable: boolean) => void,
   secretEditing: Record<string, boolean>,
   isEditingExisting: boolean,
-  connectorName: string
+  connectorName: string,
+  onManagedOAuthModeChange?: (specificationName: string, isManaged: boolean) => void
 ) {
   return items.map(specification => {
     const isSecret = Array.isArray(specification.attributes)
@@ -42,6 +44,7 @@ function renderItems(
           onValueChange={onValueChange}
           isEditingExisting={isEditingExisting}
           connectorName={connectorName}
+          onManagedOAuthModeChange={onManagedOAuthModeChange}
         />
       );
     }
@@ -71,6 +74,7 @@ export function ConfigurationListRender({
   secretEditing,
   isEditingExisting,
   connectorName,
+  onManagedOAuthModeChange,
 }: ConfigurationListRenderProps) {
   return collapsibleTitle ? (
     <AppWizardCollapsible title={collapsibleTitle}>
@@ -81,7 +85,8 @@ export function ConfigurationListRender({
         onSecretEditToggle,
         secretEditing,
         isEditingExisting,
-        connectorName
+        connectorName,
+        onManagedOAuthModeChange
       )}
     </AppWizardCollapsible>
   ) : (
@@ -92,7 +97,8 @@ export function ConfigurationListRender({
       onSecretEditToggle,
       secretEditing,
       isEditingExisting,
-      connectorName
+      connectorName,
+      onManagedOAuthModeChange
     )
   );
 }

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationOneOfRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/ConfigurationOneOfRender.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { type ConnectorSpecificationResponseApiDto } from '../../../../../shared/api/types';
 import { AppWizardStepItemOneOf } from '@owox/ui/components/common/wizard';
 import { TabsContent } from '@owox/ui/components/tabs';
@@ -14,6 +14,7 @@ interface ConfigurationOneOfRenderProps {
   onValueChange: (name: string, value: unknown) => void;
   isEditingExisting: boolean;
   connectorName: string;
+  onManagedOAuthModeChange?: (specificationName: string, isManaged: boolean) => void;
 }
 
 export function ConfigurationOneOfRender({
@@ -22,6 +23,7 @@ export function ConfigurationOneOfRender({
   onValueChange,
   isEditingExisting,
   connectorName,
+  onManagedOAuthModeChange,
 }: ConfigurationOneOfRenderProps) {
   const detectSelectedOption = useMemo(() => {
     const configObject = configuration[specification.name];
@@ -56,6 +58,13 @@ export function ConfigurationOneOfRender({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedOption, specification.name]);
+
+  const handleManagedOAuthModeChange = useCallback(
+    (isManaged: boolean) => {
+      onManagedOAuthModeChange?.(specification.name, isManaged);
+    },
+    [onManagedOAuthModeChange, specification.name]
+  );
 
   if (!specification.oneOf) {
     return null;
@@ -127,6 +136,7 @@ export function ConfigurationOneOfRender({
                 onValueChange={onValueChange}
                 connectorName={connectorName}
                 isEditingExisting={isEditingExisting}
+                onManagedModeChange={handleManagedOAuthModeChange}
               />
             ) : (
               Object.entries(option.items).map(([itemName, itemSpec]) => {

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
@@ -7,6 +7,7 @@ import { FacebookOauthRender } from './impl/FacebookOauthRender';
 import { TikTokOauthRender } from './impl/TikTokOauthRender';
 import { MicrosoftOauthRender } from './impl/MicrosoftOauthRender';
 import { GoogleAdsOauthRender } from './impl/GoogleAdsOauthRender';
+import { GoogleSheetsOauthRender } from './impl/GoogleSheetsOauthRender';
 import { LinkedInOauthRender } from './impl/LinkedInOauthRender';
 import { useState, useEffect, useMemo } from 'react';
 import type {
@@ -305,6 +306,20 @@ export function OauthRenderFactory({
       case 'GoogleAds':
         return (
           <GoogleAdsOauthRender
+            specification={specification}
+            option={option}
+            configuration={configuration}
+            onValueChange={onValueChange}
+            connectorName={connectorName}
+            isLoading={isLoading}
+            status={status}
+            settings={settings}
+            onOAuthSuccess={handleOAuthSuccess}
+          />
+        );
+      case 'GoogleSheets':
+        return (
+          <GoogleSheetsOauthRender
             specification={specification}
             option={option}
             configuration={configuration}

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
@@ -39,7 +39,7 @@ export interface OauthRenderComponentProps {
   isLoading: boolean;
   status: OAuthStatusResponseDto | null;
   settings: OAuthSettingsResponseDto | null;
-  onOAuthSuccess: (credentials: Record<string, unknown>) => Promise<void>;
+  onOAuthSuccess: (credentials: Record<string, unknown>) => Promise<boolean>;
 }
 
 export function OauthRenderFactory({
@@ -181,10 +181,12 @@ export function OauthRenderFactory({
           [SOURCE_CREDENTIAL_KEY]: exchanged.credentialId,
         });
       }
+      return true;
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to exchange OAuth credentials';
       console.error('Failed to exchange OAuth credentials:', err);
       setError(message);
+      return false;
     } finally {
       setIsLoading(false);
     }

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
@@ -11,6 +11,7 @@ import { GoogleSheetsOauthRender } from './impl/GoogleSheetsOauthRender';
 import { LinkedInOauthRender } from './impl/LinkedInOauthRender';
 import { useState, useEffect, useMemo } from 'react';
 import type {
+  OAuthCallbackResponseDto,
   OAuthStatusResponseDto,
   OAuthSettingsResponseDto,
 } from '../../../../../../shared/api/types/response/oauth.response.dto';
@@ -39,7 +40,9 @@ export interface OauthRenderComponentProps {
   isLoading: boolean;
   status: OAuthStatusResponseDto | null;
   settings: OAuthSettingsResponseDto | null;
-  onOAuthSuccess: (credentials: Record<string, unknown>) => Promise<boolean>;
+  onOAuthSuccess: (
+    credentials: Record<string, unknown>
+  ) => Promise<OAuthCallbackResponseDto | null>;
 }
 
 export function OauthRenderFactory({
@@ -181,12 +184,12 @@ export function OauthRenderFactory({
           [SOURCE_CREDENTIAL_KEY]: exchanged.credentialId,
         });
       }
-      return true;
+      return exchanged;
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to exchange OAuth credentials';
       console.error('Failed to exchange OAuth credentials:', err);
       setError(message);
-      return false;
+      return null;
     } finally {
       setIsLoading(false);
     }

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/OauthRenderFactory.tsx
@@ -27,6 +27,7 @@ interface OauthRenderFactoryProps {
   onValueChange: (name: string, value: unknown) => void;
   connectorName: string;
   isEditingExisting?: boolean;
+  onManagedModeChange?: (isManaged: boolean) => void;
 }
 
 export interface OauthRenderComponentProps {
@@ -48,6 +49,7 @@ export function OauthRenderFactory({
   onValueChange,
   connectorName,
   isEditingExisting = false,
+  onManagedModeChange,
 }: OauthRenderFactoryProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [fieldSecretEditing, setFieldSecretEditing] = useState<Record<string, boolean>>({});
@@ -236,6 +238,10 @@ export function OauthRenderFactory({
   }, [connectorName, fieldPath, getSettings]);
 
   const isOAuthEnabled = Boolean(settings?.isEnabled);
+
+  useEffect(() => {
+    onManagedModeChange?.(!isManualMode && isOAuthEnabled);
+  }, [isManualMode, isOAuthEnabled, onManagedModeChange]);
 
   if ((isManualMode || !isOAuthEnabled) && option?.items) {
     return (

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.test.tsx
@@ -13,8 +13,22 @@ vi.mock('../../../../../../../../google-oauth/hooks/useGoogleDrivePicker', () =>
 }));
 
 vi.mock('../../../../../../../shared/components/GoogleSheetsLoginButton', () => ({
-  GoogleSheetsLoginButton: ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid='google-login'>{children}</div>
+  GoogleSheetsLoginButton: ({
+    children,
+    onSuccess,
+  }: {
+    children?: React.ReactNode;
+    onSuccess: (response: { code: string }) => void;
+  }) => (
+    <button
+      type='button'
+      data-testid='google-login'
+      onClick={() => {
+        onSuccess({ code: 'code' });
+      }}
+    >
+      {children}
+    </button>
   ),
 }));
 
@@ -38,7 +52,7 @@ function renderGoogleSheetsOAuth(overrides: Partial<OauthRenderComponentProps> =
         ProjectNumber: '123456789',
       },
     },
-    onOAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    onOAuthSuccess: vi.fn().mockResolvedValue(true),
     ...overrides,
   } as OauthRenderComponentProps;
 
@@ -110,5 +124,36 @@ describe('GoogleSheetsOauthRender', () => {
       spreadsheetUrl
     );
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('clears the selected spreadsheet after connecting another account', async () => {
+    const props = renderGoogleSheetsOAuth({
+      configuration: {
+        SpreadsheetId: 'https://docs.google.com/spreadsheets/d/old-sheet/edit',
+      },
+    });
+
+    fireEvent.click(screen.getByTestId('google-login'));
+
+    await waitFor(() => {
+      expect(props.onOAuthSuccess).toHaveBeenCalledWith({ code: 'code' });
+      expect(props.onValueChange).toHaveBeenCalledWith('SpreadsheetId', '');
+    });
+  });
+
+  it('keeps the selected spreadsheet when reconnection fails', async () => {
+    const props = renderGoogleSheetsOAuth({
+      configuration: {
+        SpreadsheetId: 'https://docs.google.com/spreadsheets/d/old-sheet/edit',
+      },
+      onOAuthSuccess: vi.fn().mockResolvedValue(false),
+    });
+
+    fireEvent.click(screen.getByTestId('google-login'));
+
+    await waitFor(() => {
+      expect(props.onOAuthSuccess).toHaveBeenCalledWith({ code: 'code' });
+    });
+    expect(props.onValueChange).not.toHaveBeenCalledWith('SpreadsheetId', '');
   });
 });

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.test.tsx
@@ -96,4 +96,19 @@ describe('GoogleSheetsOauthRender', () => {
       'Google Picker configuration is incomplete'
     );
   });
+
+  it('shows the Picker-selected spreadsheet as a read-only link', () => {
+    const spreadsheetUrl = 'https://docs.google.com/spreadsheets/d/sheet-1/edit';
+
+    renderGoogleSheetsOAuth({
+      configuration: { SpreadsheetId: spreadsheetUrl },
+    });
+
+    expect(screen.getByRole('button', { name: 'Change spreadsheet' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: spreadsheetUrl })).toHaveAttribute(
+      'href',
+      spreadsheetUrl
+    );
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { OpenGoogleSheetsPickerOptions } from '../../../../../../../../google-oauth/hooks/useGoogleDrivePicker';
+import type { OpenGoogleSheetsPickerOptions } from '../../../../../../../../google-oauth';
 import type { OauthRenderComponentProps } from '../OauthRenderFactory';
 import { GoogleSheetsOauthRender } from './GoogleSheetsOauthRender';
 
@@ -8,7 +8,7 @@ const { openPicker } = vi.hoisted(() => ({
   openPicker: vi.fn<(options: OpenGoogleSheetsPickerOptions) => Promise<void>>(),
 }));
 
-vi.mock('../../../../../../../../google-oauth/hooks/useGoogleDrivePicker', () => ({
+vi.mock('../../../../../../../../google-oauth', () => ({
   useGoogleSheetsPicker: () => ({ openPicker }),
 }));
 
@@ -41,7 +41,7 @@ function renderGoogleSheetsOAuth(overrides: Partial<OauthRenderComponentProps> =
     isLoading: false,
     status: {
       valid: true,
-      user: { id: 'user-1', email: 'analyst@example.com' },
+      user: { id: 'user-1', name: 'analyst@example.com', email: 'analyst@example.com' },
     },
     settings: {
       isEnabled: true,
@@ -52,7 +52,12 @@ function renderGoogleSheetsOAuth(overrides: Partial<OauthRenderComponentProps> =
         ProjectNumber: '123456789',
       },
     },
-    onOAuthSuccess: vi.fn().mockResolvedValue(true),
+    onOAuthSuccess: vi.fn().mockResolvedValue({
+      success: true,
+      credentialId: 'credential-1',
+      user: { id: 'user-1', name: 'analyst@example.com', email: 'analyst@example.com' },
+      additional: {},
+    }),
     ...overrides,
   } as OauthRenderComponentProps;
 
@@ -131,6 +136,12 @@ describe('GoogleSheetsOauthRender', () => {
       configuration: {
         SpreadsheetId: 'https://docs.google.com/spreadsheets/d/old-sheet/edit',
       },
+      onOAuthSuccess: vi.fn().mockResolvedValue({
+        success: true,
+        credentialId: 'credential-2',
+        user: { id: 'user-2', name: 'other@example.com', email: 'other@example.com' },
+        additional: {},
+      }),
     });
 
     fireEvent.click(screen.getByTestId('google-login'));
@@ -141,12 +152,43 @@ describe('GoogleSheetsOauthRender', () => {
     });
   });
 
+  it('keeps the selected spreadsheet after reconnecting the same account', async () => {
+    const props = renderGoogleSheetsOAuth({
+      configuration: {
+        SpreadsheetId: 'https://docs.google.com/spreadsheets/d/old-sheet/edit',
+      },
+    });
+
+    fireEvent.click(screen.getByTestId('google-login'));
+
+    await waitFor(() => {
+      expect(props.onOAuthSuccess).toHaveBeenCalledWith({ code: 'code' });
+    });
+    expect(props.onValueChange).not.toHaveBeenCalledWith('SpreadsheetId', '');
+  });
+
   it('keeps the selected spreadsheet when reconnection fails', async () => {
     const props = renderGoogleSheetsOAuth({
       configuration: {
         SpreadsheetId: 'https://docs.google.com/spreadsheets/d/old-sheet/edit',
       },
-      onOAuthSuccess: vi.fn().mockResolvedValue(false),
+      onOAuthSuccess: vi.fn().mockResolvedValue(null),
+    });
+
+    fireEvent.click(screen.getByTestId('google-login'));
+
+    await waitFor(() => {
+      expect(props.onOAuthSuccess).toHaveBeenCalledWith({ code: 'code' });
+    });
+    expect(props.onValueChange).not.toHaveBeenCalledWith('SpreadsheetId', '');
+  });
+
+  it('keeps the selected spreadsheet when the previous account identity is unavailable', async () => {
+    const props = renderGoogleSheetsOAuth({
+      configuration: {
+        SpreadsheetId: 'https://docs.google.com/spreadsheets/d/old-sheet/edit',
+      },
+      status: { valid: false },
     });
 
     fireEvent.click(screen.getByTestId('google-login'));

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.test.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OpenGoogleSheetsPickerOptions } from '../../../../../../../../google-oauth/hooks/useGoogleDrivePicker';
+import type { OauthRenderComponentProps } from '../OauthRenderFactory';
+import { GoogleSheetsOauthRender } from './GoogleSheetsOauthRender';
+
+const { openPicker } = vi.hoisted(() => ({
+  openPicker: vi.fn<(options: OpenGoogleSheetsPickerOptions) => Promise<void>>(),
+}));
+
+vi.mock('../../../../../../../../google-oauth/hooks/useGoogleDrivePicker', () => ({
+  useGoogleSheetsPicker: () => ({ openPicker }),
+}));
+
+vi.mock('../../../../../../../shared/components/GoogleSheetsLoginButton', () => ({
+  GoogleSheetsLoginButton: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid='google-login'>{children}</div>
+  ),
+}));
+
+function renderGoogleSheetsOAuth(overrides: Partial<OauthRenderComponentProps> = {}) {
+  const props = {
+    specification: { name: 'AuthType' },
+    configuration: {},
+    onValueChange: vi.fn(),
+    connectorName: 'GoogleSheets',
+    isLoading: false,
+    status: {
+      valid: true,
+      user: { id: 'user-1', email: 'analyst@example.com' },
+    },
+    settings: {
+      isEnabled: true,
+      vars: {
+        ClientId: 'client-id',
+        RedirectUri: 'https://app.example.com/oauth/google-sheets/callback',
+        PickerApiKey: 'picker-key',
+        ProjectNumber: '123456789',
+      },
+    },
+    onOAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as OauthRenderComponentProps;
+
+  render(<GoogleSheetsOauthRender {...props} />);
+  return props;
+}
+
+describe('GoogleSheetsOauthRender', () => {
+  beforeEach(() => {
+    openPicker.mockReset();
+  });
+
+  it('stores the spreadsheet selected with Google Picker', async () => {
+    openPicker.mockImplementation(async options => {
+      options.onPicked({
+        id: 'sheet-1',
+        name: 'Goals',
+        url: 'https://docs.google.com/spreadsheets/d/sheet-1/edit',
+      });
+    });
+    const props = renderGoogleSheetsOAuth();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose spreadsheet' }));
+
+    await waitFor(() => {
+      expect(openPicker).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'picker-key',
+          appId: '123456789',
+          clientId: 'client-id',
+          hintEmail: 'analyst@example.com',
+        })
+      );
+      expect(props.onValueChange).toHaveBeenCalledWith(
+        'SpreadsheetId',
+        'https://docs.google.com/spreadsheets/d/sheet-1/edit'
+      );
+    });
+  });
+
+  it('announces an incomplete Picker configuration', () => {
+    renderGoogleSheetsOAuth({
+      settings: {
+        isEnabled: true,
+        vars: {
+          ClientId: 'client-id',
+          RedirectUri: 'https://app.example.com/oauth/google-sheets/callback',
+        },
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose spreadsheet' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Google Picker configuration is incomplete'
+    );
+  });
+});

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.tsx
@@ -1,0 +1,99 @@
+import {
+  GoogleSheetsLoginButton,
+  type GoogleSheetsLoginResponse,
+} from '../../../../../../../shared/components/GoogleSheetsLoginButton';
+import type { OauthRenderComponentProps } from '../OauthRenderFactory';
+import { useGoogleSheetsPicker } from '../../../../../../../../google-oauth/hooks/useGoogleDrivePicker';
+import { Button } from '@owox/ui/components/button';
+import { FileSpreadsheet } from 'lucide-react';
+import { useState } from 'react';
+
+export function GoogleSheetsOauthRender({
+  isLoading,
+  status,
+  settings,
+  onOAuthSuccess,
+  configuration,
+  onValueChange,
+}: OauthRenderComponentProps) {
+  const [isPickingSpreadsheet, setIsPickingSpreadsheet] = useState(false);
+  const [pickerError, setPickerError] = useState<string | null>(null);
+  const { openPicker } = useGoogleSheetsPicker();
+
+  const handleGoogleLogin = (response: GoogleSheetsLoginResponse) => {
+    void onOAuthSuccess({ code: response.code });
+  };
+
+  const clientId = settings?.vars.ClientId as string | undefined;
+  const pickerApiKey = settings?.vars.PickerApiKey as string | undefined;
+  const projectNumber = settings?.vars.ProjectNumber as string | undefined;
+  const spreadsheetSelected =
+    typeof configuration.SpreadsheetId === 'string' && configuration.SpreadsheetId.trim() !== '';
+  const connectedEmail = status?.user?.email ?? status?.user?.name;
+
+  const handlePickSpreadsheet = () => {
+    if (!clientId || !pickerApiKey || !projectNumber) {
+      setPickerError('Google Picker configuration is incomplete');
+      return;
+    }
+    if (!connectedEmail?.includes('@')) {
+      setPickerError('Reconnect Google Sheets before choosing a spreadsheet');
+      return;
+    }
+
+    setPickerError(null);
+    setIsPickingSpreadsheet(true);
+    void openPicker({
+      apiKey: pickerApiKey,
+      appId: projectNumber,
+      clientId,
+      hintEmail: connectedEmail,
+      onPicked: spreadsheet => {
+        onValueChange('SpreadsheetId', spreadsheet.url);
+      },
+      onError: setPickerError,
+    }).finally(() => {
+      setIsPickingSpreadsheet(false);
+    });
+  };
+
+  return (
+    <div className='mt-2 mb-2 space-y-4'>
+      <GoogleSheetsLoginButton
+        clientId={settings?.vars.ClientId as string}
+        redirectUri={settings?.vars.RedirectUri as string}
+        onSuccess={handleGoogleLogin}
+        disabled={isLoading}
+      >
+        {status?.user ? (
+          <>
+            Connected as <strong>{status.user.name ?? status.user.id}</strong>
+          </>
+        ) : (
+          'Sign in with Google'
+        )}
+      </GoogleSheetsLoginButton>
+      {status?.valid && (
+        <Button
+          type='button'
+          variant='outline'
+          onClick={handlePickSpreadsheet}
+          disabled={isLoading || isPickingSpreadsheet}
+          className='w-full'
+        >
+          <FileSpreadsheet className='h-4 w-4' />
+          {isPickingSpreadsheet
+            ? 'Opening Google Picker...'
+            : spreadsheetSelected
+              ? 'Change spreadsheet'
+              : 'Choose spreadsheet'}
+        </Button>
+      )}
+      {pickerError && (
+        <div role='alert' className='text-destructive text-sm'>
+          {pickerError}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.tsx
@@ -3,7 +3,7 @@ import {
   type GoogleSheetsLoginResponse,
 } from '../../../../../../../shared/components/GoogleSheetsLoginButton';
 import type { OauthRenderComponentProps } from '../OauthRenderFactory';
-import { useGoogleSheetsPicker } from '../../../../../../../../google-oauth/hooks/useGoogleDrivePicker';
+import { useGoogleSheetsPicker } from '../../../../../../../../google-oauth';
 import { Button } from '@owox/ui/components/button';
 import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
 import { FileSpreadsheet } from 'lucide-react';
@@ -21,10 +21,23 @@ export function GoogleSheetsOauthRender({
   const [pickerError, setPickerError] = useState<string | null>(null);
   const { openPicker } = useGoogleSheetsPicker();
 
+  const connectedEmail = status?.user?.email ?? status?.user?.name;
+
   const handleGoogleLogin = async (response: GoogleSheetsLoginResponse) => {
-    const connected = await onOAuthSuccess({ code: response.code });
-    if (connected) {
+    const result = await onOAuthSuccess({ code: response.code });
+    const nextEmail = result?.user.email ?? result?.user.name;
+
+    if (
+      result &&
+      connectedEmail &&
+      nextEmail &&
+      nextEmail.toLowerCase() !== connectedEmail.toLowerCase() &&
+      configuration.SpreadsheetId
+    ) {
       onValueChange('SpreadsheetId', '');
+    }
+    if (result) {
+      setPickerError(null);
     }
   };
 
@@ -34,8 +47,6 @@ export function GoogleSheetsOauthRender({
   const spreadsheetUrl =
     typeof configuration.SpreadsheetId === 'string' ? configuration.SpreadsheetId.trim() : '';
   const spreadsheetSelected = spreadsheetUrl !== '';
-  const connectedEmail = status?.user?.email ?? status?.user?.name;
-
   const handlePickSpreadsheet = () => {
     if (!clientId || !pickerApiKey || !projectNumber) {
       setPickerError('Google Picker configuration is incomplete');

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.tsx
@@ -21,8 +21,11 @@ export function GoogleSheetsOauthRender({
   const [pickerError, setPickerError] = useState<string | null>(null);
   const { openPicker } = useGoogleSheetsPicker();
 
-  const handleGoogleLogin = (response: GoogleSheetsLoginResponse) => {
-    void onOAuthSuccess({ code: response.code });
+  const handleGoogleLogin = async (response: GoogleSheetsLoginResponse) => {
+    const connected = await onOAuthSuccess({ code: response.code });
+    if (connected) {
+      onValueChange('SpreadsheetId', '');
+    }
   };
 
   const clientId = settings?.vars.ClientId as string | undefined;
@@ -64,7 +67,7 @@ export function GoogleSheetsOauthRender({
       <GoogleSheetsLoginButton
         clientId={settings?.vars.ClientId as string}
         redirectUri={settings?.vars.RedirectUri as string}
-        onSuccess={handleGoogleLogin}
+        onSuccess={response => void handleGoogleLogin(response)}
         disabled={isLoading}
       >
         {status?.user ? (

--- a/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.tsx
+++ b/apps/web/src/features/connectors/edit/components/ConnectorEditForm/steps/ConfigurationStep/Oauth/impl/GoogleSheetsOauthRender.tsx
@@ -5,6 +5,7 @@ import {
 import type { OauthRenderComponentProps } from '../OauthRenderFactory';
 import { useGoogleSheetsPicker } from '../../../../../../../../google-oauth/hooks/useGoogleDrivePicker';
 import { Button } from '@owox/ui/components/button';
+import { ExternalAnchor } from '@owox/ui/components/common/external-anchor';
 import { FileSpreadsheet } from 'lucide-react';
 import { useState } from 'react';
 
@@ -27,8 +28,9 @@ export function GoogleSheetsOauthRender({
   const clientId = settings?.vars.ClientId as string | undefined;
   const pickerApiKey = settings?.vars.PickerApiKey as string | undefined;
   const projectNumber = settings?.vars.ProjectNumber as string | undefined;
-  const spreadsheetSelected =
-    typeof configuration.SpreadsheetId === 'string' && configuration.SpreadsheetId.trim() !== '';
+  const spreadsheetUrl =
+    typeof configuration.SpreadsheetId === 'string' ? configuration.SpreadsheetId.trim() : '';
+  const spreadsheetSelected = spreadsheetUrl !== '';
   const connectedEmail = status?.user?.email ?? status?.user?.name;
 
   const handlePickSpreadsheet = () => {
@@ -74,20 +76,27 @@ export function GoogleSheetsOauthRender({
         )}
       </GoogleSheetsLoginButton>
       {status?.valid && (
-        <Button
-          type='button'
-          variant='outline'
-          onClick={handlePickSpreadsheet}
-          disabled={isLoading || isPickingSpreadsheet}
-          className='w-full'
-        >
-          <FileSpreadsheet className='h-4 w-4' />
-          {isPickingSpreadsheet
-            ? 'Opening Google Picker...'
-            : spreadsheetSelected
-              ? 'Change spreadsheet'
-              : 'Choose spreadsheet'}
-        </Button>
+        <div className='space-y-2'>
+          <Button
+            type='button'
+            variant='outline'
+            onClick={handlePickSpreadsheet}
+            disabled={isLoading || isPickingSpreadsheet}
+            className='w-full'
+          >
+            <FileSpreadsheet className='h-4 w-4' />
+            {isPickingSpreadsheet
+              ? 'Opening Google Picker...'
+              : spreadsheetSelected
+                ? 'Change spreadsheet'
+                : 'Choose spreadsheet'}
+          </Button>
+          {spreadsheetSelected && (
+            <ExternalAnchor href={spreadsheetUrl} variant='field'>
+              {spreadsheetUrl}
+            </ExternalAnchor>
+          )}
+        </div>
       )}
       {pickerError && (
         <div role='alert' className='text-destructive text-sm'>

--- a/apps/web/src/features/connectors/shared/components/GoogleSheetsLoginButton/GoogleSheetsLoginButton.tsx
+++ b/apps/web/src/features/connectors/shared/components/GoogleSheetsLoginButton/GoogleSheetsLoginButton.tsx
@@ -1,0 +1,133 @@
+import { Button } from '@owox/ui/components/button';
+import { useOAuthPopup } from '../../hooks/useOAuthPopup';
+
+interface GoogleSheetsLoginButtonProps {
+  clientId: string;
+  redirectUri: string;
+  onSuccess: (response: GoogleSheetsLoginResponse) => void;
+  onError?: (error: Error) => void;
+  disabled?: boolean;
+  children?: React.ReactNode;
+}
+
+export interface GoogleSheetsLoginResponse {
+  code: string;
+}
+
+type GoogleSheetsAuthMessage =
+  | { type: 'GOOGLE_SHEETS_AUTH_SUCCESS'; code: string; state: string | null }
+  | { type: 'GOOGLE_SHEETS_AUTH_ERROR'; error: string };
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const SCOPE =
+  'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/userinfo.email';
+
+const GoogleLogo = () => (
+  <svg className='h-5 w-5 shrink-0' viewBox='0 0 24 24'>
+    <path
+      fill='#4285F4'
+      d='M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z'
+    />
+    <path
+      fill='#34A853'
+      d='M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z'
+    />
+    <path
+      fill='#FBBC05'
+      d='M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z'
+    />
+    <path
+      fill='#EA4335'
+      d='M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z'
+    />
+  </svg>
+);
+
+function isGoogleSheetsAuthMessage(data: unknown): data is GoogleSheetsAuthMessage {
+  if (typeof data !== 'object' || data === null) return false;
+  const message = data as Record<string, unknown>;
+
+  if (message.type === 'GOOGLE_SHEETS_AUTH_SUCCESS') {
+    return typeof message.code === 'string';
+  }
+
+  if (message.type === 'GOOGLE_SHEETS_AUTH_ERROR') {
+    return typeof message.error === 'string';
+  }
+
+  return false;
+}
+
+export function GoogleSheetsLoginButton({
+  clientId,
+  redirectUri,
+  onSuccess,
+  onError,
+  disabled = false,
+  children,
+}: GoogleSheetsLoginButtonProps) {
+  const { openPopup, isLoading, error } = useOAuthPopup<
+    GoogleSheetsLoginResponse,
+    GoogleSheetsAuthMessage
+  >({
+    redirectUri,
+    buildAuthUrl: (state: string) => {
+      const url = new URL(GOOGLE_AUTH_URL);
+      url.searchParams.set('client_id', clientId);
+      url.searchParams.set('response_type', 'code');
+      url.searchParams.set('redirect_uri', redirectUri);
+      url.searchParams.set('scope', SCOPE);
+      url.searchParams.set('state', state);
+      url.searchParams.set('access_type', 'offline');
+      url.searchParams.set('prompt', 'consent');
+      return url.toString();
+    },
+    onSuccess,
+    onError,
+    isAuthMessage: isGoogleSheetsAuthMessage,
+    getSuccessResponse: message => {
+      if (message.type === 'GOOGLE_SHEETS_AUTH_SUCCESS') {
+        return { code: message.code };
+      }
+      throw new Error('Invalid response');
+    },
+    getErrorMessage: message => {
+      if (message.type === 'GOOGLE_SHEETS_AUTH_ERROR') {
+        return message.error;
+      }
+      return 'Unknown error';
+    },
+  });
+
+  const handleLogin = () => {
+    if (!clientId || !redirectUri) {
+      onError?.(new Error('Google Sheets OAuth configuration is incomplete'));
+      return;
+    }
+    openPopup();
+  };
+
+  const isDisabled = disabled || isLoading || !clientId || !redirectUri;
+  const content = isLoading
+    ? 'Connecting...'
+    : (children ?? (clientId && redirectUri ? 'Sign in with Google' : 'OAuth not configured'));
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <Button
+        type='button'
+        onClick={handleLogin}
+        disabled={isDisabled}
+        className='flex items-center justify-center gap-2 rounded-md border border-[#DADCE0] bg-white px-4 py-2.5 text-sm font-semibold text-[#3C4043] hover:bg-[#F8F9FA] disabled:cursor-not-allowed disabled:opacity-60'
+      >
+        <GoogleLogo />
+        {content}
+      </Button>
+      {error && (
+        <div role='alert' className='mt-1 text-xs text-red-600'>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/connectors/shared/components/GoogleSheetsLoginButton/index.ts
+++ b/apps/web/src/features/connectors/shared/components/GoogleSheetsLoginButton/index.ts
@@ -1,0 +1,2 @@
+export { GoogleSheetsLoginButton } from './GoogleSheetsLoginButton';
+export type { GoogleSheetsLoginResponse } from './GoogleSheetsLoginButton';

--- a/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.test.ts
+++ b/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.test.ts
@@ -59,7 +59,9 @@ describe('verifyGooglePickerAccount', () => {
 describe('useGoogleSheetsPicker', () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     delete (window as unknown as { gapi?: unknown }).gapi;
+    delete (window as unknown as { google?: unknown }).google;
   });
 
   it('reports when the Picker module does not initialize', async () => {
@@ -82,5 +84,114 @@ describe('useGoogleSheetsPicker', () => {
     await opening;
 
     expect(onError).toHaveBeenCalledWith('Google Picker failed to initialize. Please try again.');
+  });
+
+  it('closes the active Picker when the component unmounts', async () => {
+    const setVisible = vi.fn();
+    const dispose = vi.fn();
+    const onPicked = vi.fn();
+    let pickerCallback: ((response: { action: string; docs?: unknown[] }) => void) | undefined;
+    const requestAccessToken = vi.fn();
+    const initTokenClient = vi.fn(
+      (config: { callback: (response: Record<string, unknown>) => void }) => {
+        requestAccessToken.mockImplementation(() => {
+          config.callback({
+            access_token: 'access-token',
+            scope: `${DRIVE_FILE_SCOPE} ${USERINFO_EMAIL_SCOPE}`,
+          });
+        });
+        return { requestAccessToken };
+      }
+    );
+
+    class DocsView {
+      setMimeTypes() {
+        return this;
+      }
+      setMode() {
+        return this;
+      }
+    }
+
+    class PickerBuilder {
+      setOAuthToken() {
+        return this;
+      }
+      setDeveloperKey() {
+        return this;
+      }
+      setAppId() {
+        return this;
+      }
+      addView() {
+        return this;
+      }
+      enableFeature() {
+        return this;
+      }
+      setCallback(callback: (response: { action: string; docs?: unknown[] }) => void) {
+        pickerCallback = callback;
+        return this;
+      }
+      build() {
+        return { setVisible, dispose };
+      }
+    }
+
+    (window as unknown as { gapi: { load: (_api: string, callback: () => void) => void } }).gapi = {
+      load: (_api, callback) => {
+        callback();
+      },
+    };
+    (
+      window as unknown as {
+        google: {
+          accounts: { oauth2: { initTokenClient: typeof initTokenClient } };
+          picker: Record<string, unknown>;
+        };
+      }
+    ).google = {
+      accounts: { oauth2: { initTokenClient } },
+      picker: {
+        PickerBuilder,
+        DocsView,
+        ViewId: { SPREADSHEETS: 'spreadsheets' },
+        DocsViewMode: { LIST: 'list' },
+        Action: { PICKED: 'picked', CANCEL: 'cancel' },
+        Feature: { SUPPORT_DRIVES: 'support-drives' },
+      },
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ email: 'analyst@example.com' }), { status: 200 })
+    );
+
+    const { result, unmount } = renderHook(() => useGoogleSheetsPicker());
+    const opening = result.current.openPicker({
+      apiKey: 'api-key',
+      appId: 'project-number',
+      clientId: 'client-id',
+      hintEmail: 'analyst@example.com',
+      onPicked,
+    });
+
+    await vi.waitFor(() => {
+      expect(setVisible).toHaveBeenCalledWith(true);
+    });
+    expect(initTokenClient).toHaveBeenCalledWith(
+      expect.objectContaining({ login_hint: 'analyst@example.com' })
+    );
+    expect(requestAccessToken).toHaveBeenCalledWith({ login_hint: 'analyst@example.com' });
+
+    unmount();
+    await opening;
+
+    expect(setVisible).toHaveBeenLastCalledWith(false);
+    expect(dispose).toHaveBeenCalledOnce();
+
+    pickerCallback?.({
+      action: 'picked',
+      docs: [{ id: 'sheet-id', name: 'Sheet', url: 'https://example.com' }],
+    });
+    expect(onPicked).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.test.ts
+++ b/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  useGoogleSheetsPicker,
   validateGoogleSheetsPickerScopes,
   verifyGooglePickerAccount,
 } from './useGoogleDrivePicker';
@@ -51,5 +53,34 @@ describe('verifyGooglePickerAccount', () => {
     await expect(verifyGooglePickerAccount('access-token', 'analyst@example.com')).rejects.toThrow(
       'Open Google Picker with the connected account analyst@example.com'
     );
+  });
+});
+
+describe('useGoogleSheetsPicker', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { gapi?: unknown }).gapi;
+  });
+
+  it('reports when the Picker module does not initialize', async () => {
+    vi.useFakeTimers();
+    (window as unknown as { gapi: { load: () => void } }).gapi = {
+      load: vi.fn(),
+    };
+    const onError = vi.fn();
+    const { result } = renderHook(() => useGoogleSheetsPicker());
+
+    const opening = result.current.openPicker({
+      apiKey: 'api-key',
+      appId: 'project-number',
+      clientId: 'client-id',
+      onPicked: vi.fn(),
+      onError,
+    });
+
+    await vi.advanceTimersByTimeAsync(10000);
+    await opening;
+
+    expect(onError).toHaveBeenCalledWith('Google Picker failed to initialize. Please try again.');
   });
 });

--- a/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.test.ts
+++ b/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  validateGoogleSheetsPickerScopes,
+  verifyGooglePickerAccount,
+} from './useGoogleDrivePicker';
+
+const DRIVE_FILE_SCOPE = 'https://www.googleapis.com/auth/drive.file';
+const USERINFO_EMAIL_SCOPE = 'https://www.googleapis.com/auth/userinfo.email';
+
+describe('validateGoogleSheetsPickerScopes', () => {
+  it('accepts the required Picker permissions', () => {
+    expect(() => {
+      validateGoogleSheetsPickerScopes(`${DRIVE_FILE_SCOPE} ${USERINFO_EMAIL_SCOPE}`);
+    }).not.toThrow();
+  });
+
+  it('rejects a partial Google grant', () => {
+    expect(() => {
+      validateGoogleSheetsPickerScopes(USERINFO_EMAIL_SCOPE);
+    }).toThrow('Google Sheets access was not fully granted');
+  });
+});
+
+describe('verifyGooglePickerAccount', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requires connected-account metadata', async () => {
+    await expect(verifyGooglePickerAccount('access-token')).rejects.toThrow(
+      'Reconnect Google Sheets before choosing a spreadsheet'
+    );
+  });
+
+  it('accepts the same Google account case-insensitively', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ email: 'Analyst@Example.com' }), { status: 200 })
+    );
+
+    await expect(
+      verifyGooglePickerAccount('access-token', 'analyst@example.com')
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a Picker token issued for a different Google account', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ email: 'other@example.com' }), { status: 200 })
+    );
+
+    await expect(verifyGooglePickerAccount('access-token', 'analyst@example.com')).rejects.toThrow(
+      'Open Google Picker with the connected account analyst@example.com'
+    );
+  });
+});

--- a/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.ts
+++ b/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.ts
@@ -7,6 +7,7 @@ const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
 const GAPI_SRC = 'https://apis.google.com/js/api.js';
 const GIS_SRC = 'https://accounts.google.com/gsi/client';
 const GOOGLE_SHEETS_MIME_TYPE = 'application/vnd.google-apps.spreadsheet';
+const PICKER_LOAD_TIMEOUT_MS = 10000;
 
 export interface PickedGoogleSpreadsheet {
   id: string;
@@ -136,11 +137,30 @@ function loadPicker(): Promise<void> {
   return loadGapi.then(
     () =>
       new Promise<void>((resolve, reject) => {
-        if (!googleWindow.gapi) {
+        const gapi = googleWindow.gapi;
+        if (!gapi) {
           reject(new Error('gapi failed to initialize'));
           return;
         }
-        googleWindow.gapi.load('picker', resolve);
+
+        let settled = false;
+        const timeoutId = window.setTimeout(() => {
+          settled = true;
+          reject(new Error('Google Picker failed to initialize. Please try again.'));
+        }, PICKER_LOAD_TIMEOUT_MS);
+
+        try {
+          gapi.load('picker', () => {
+            if (settled) return;
+            settled = true;
+            window.clearTimeout(timeoutId);
+            resolve();
+          });
+        } catch (error) {
+          settled = true;
+          window.clearTimeout(timeoutId);
+          reject(error instanceof Error ? error : new Error('Google Picker failed to initialize'));
+        }
       })
   );
 }

--- a/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.ts
+++ b/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 const DRIVE_FILE_SCOPE = 'https://www.googleapis.com/auth/drive.file';
 const USERINFO_EMAIL_SCOPE = 'https://www.googleapis.com/auth/userinfo.email';
@@ -47,7 +47,12 @@ interface PickerBuilderLike {
   addView(view: DocsViewLike): PickerBuilderLike;
   enableFeature(feature: unknown): PickerBuilderLike;
   setCallback(callback: (response: PickerResponse) => void): PickerBuilderLike;
-  build(): { setVisible(visible: boolean): void };
+  build(): PickerInstanceLike;
+}
+
+interface PickerInstanceLike {
+  setVisible(visible: boolean): void;
+  dispose?: () => void;
 }
 
 interface GooglePicker {
@@ -237,47 +242,103 @@ function buildItemUrl(doc: PickerDoc): string {
 }
 
 export function useGoogleSheetsPicker() {
-  const openPicker = useCallback(async (options: OpenGoogleSheetsPickerOptions): Promise<void> => {
-    const { apiKey, appId, clientId, hintEmail, onPicked, onError } = options;
+  const activePickerRef = useRef<PickerInstanceLike | null>(null);
+  const pendingPickerResolveRef = useRef<(() => void) | null>(null);
+  const isMountedRef = useRef(true);
 
-    try {
-      await loadPicker();
-      const token = await requestAccessToken(clientId, hintEmail);
-      await verifyGooglePickerAccount(token, hintEmail);
-      const picker = googleWindow.google?.picker;
-      if (!picker) {
-        throw new Error('Google Picker failed to initialize');
-      }
+  const closeActivePicker = useCallback(() => {
+    const picker = activePickerRef.current;
+    activePickerRef.current = null;
+    picker?.setVisible(false);
+    picker?.dispose?.();
 
-      await new Promise<void>(resolve => {
-        const builder = new picker.PickerBuilder()
-          .setOAuthToken(token)
-          .setDeveloperKey(apiKey)
-          .setAppId(appId)
-          .addView(buildPickerView(picker))
-          .enableFeature(picker.Feature.SUPPORT_DRIVES)
-          .setCallback(response => {
-            if (response.action === picker.Action.PICKED) {
-              const doc = response.docs?.[0];
-              if (doc) {
-                onPicked({
-                  id: doc.id,
-                  name: doc.name,
-                  url: buildItemUrl(doc),
-                });
-              }
-              resolve();
-            } else if (response.action === picker.Action.CANCEL) {
-              resolve();
-            }
-          });
-
-        builder.build().setVisible(true);
-      });
-    } catch (error) {
-      onError?.(error instanceof Error ? error.message : 'Failed to open the Google Sheets picker');
-    }
+    const resolve = pendingPickerResolveRef.current;
+    pendingPickerResolveRef.current = null;
+    resolve?.();
   }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      closeActivePicker();
+    };
+  }, [closeActivePicker]);
+
+  const openPicker = useCallback(
+    async (options: OpenGoogleSheetsPickerOptions): Promise<void> => {
+      const { apiKey, appId, clientId, hintEmail, onPicked, onError } = options;
+
+      try {
+        closeActivePicker();
+        await loadPicker();
+        const token = await requestAccessToken(clientId, hintEmail);
+        await verifyGooglePickerAccount(token, hintEmail);
+        if (!isMountedRef.current) return;
+
+        const picker = googleWindow.google?.picker;
+        if (!picker) {
+          throw new Error('Google Picker failed to initialize');
+        }
+
+        await new Promise<void>(resolve => {
+          const settle = () => {
+            if (pendingPickerResolveRef.current === settle) {
+              pendingPickerResolveRef.current = null;
+            }
+            resolve();
+          };
+          const finish = () => {
+            if (activePickerRef.current === builtPicker) {
+              activePickerRef.current = null;
+            }
+            builtPicker.setVisible(false);
+            builtPicker.dispose?.();
+            settle();
+          };
+
+          const builtPicker = new picker.PickerBuilder()
+            .setOAuthToken(token)
+            .setDeveloperKey(apiKey)
+            .setAppId(appId)
+            .addView(buildPickerView(picker))
+            .enableFeature(picker.Feature.SUPPORT_DRIVES)
+            .setCallback(response => {
+              if (!isMountedRef.current || activePickerRef.current !== builtPicker) {
+                return;
+              }
+
+              if (response.action === picker.Action.PICKED) {
+                const doc = response.docs?.[0];
+                if (doc) {
+                  onPicked({
+                    id: doc.id,
+                    name: doc.name,
+                    url: buildItemUrl(doc),
+                  });
+                }
+                finish();
+              } else if (response.action === picker.Action.CANCEL) {
+                finish();
+              }
+            })
+            .build();
+
+          activePickerRef.current = builtPicker;
+          pendingPickerResolveRef.current = settle;
+          builtPicker.setVisible(true);
+        });
+      } catch (error) {
+        closeActivePicker();
+        if (isMountedRef.current) {
+          onError?.(
+            error instanceof Error ? error.message : 'Failed to open the Google Sheets picker'
+          );
+        }
+      }
+    },
+    [closeActivePicker]
+  );
 
   return { openPicker };
 }

--- a/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.ts
+++ b/apps/web/src/features/google-oauth/hooks/useGoogleDrivePicker.ts
@@ -1,0 +1,263 @@
+import { useCallback } from 'react';
+
+const DRIVE_FILE_SCOPE = 'https://www.googleapis.com/auth/drive.file';
+const USERINFO_EMAIL_SCOPE = 'https://www.googleapis.com/auth/userinfo.email';
+const GOOGLE_SHEETS_PICKER_SCOPES = `${DRIVE_FILE_SCOPE} ${USERINFO_EMAIL_SCOPE}`;
+const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+const GAPI_SRC = 'https://apis.google.com/js/api.js';
+const GIS_SRC = 'https://accounts.google.com/gsi/client';
+const GOOGLE_SHEETS_MIME_TYPE = 'application/vnd.google-apps.spreadsheet';
+
+export interface PickedGoogleSpreadsheet {
+  id: string;
+  name: string;
+  url: string;
+}
+
+export interface OpenGoogleSheetsPickerOptions {
+  apiKey: string;
+  appId: string;
+  clientId: string;
+  hintEmail?: string;
+  onPicked: (spreadsheet: PickedGoogleSpreadsheet) => void;
+  onError?: (message: string) => void;
+}
+
+interface PickerDoc {
+  id: string;
+  name: string;
+  url?: string;
+}
+
+interface PickerResponse {
+  action: string;
+  docs?: PickerDoc[];
+}
+
+interface DocsViewLike {
+  setMimeTypes(mimeTypes: string): DocsViewLike;
+  setMode(mode: unknown): DocsViewLike;
+}
+
+interface PickerBuilderLike {
+  setOAuthToken(token: string): PickerBuilderLike;
+  setDeveloperKey(key: string): PickerBuilderLike;
+  setAppId(appId: string): PickerBuilderLike;
+  addView(view: DocsViewLike): PickerBuilderLike;
+  enableFeature(feature: unknown): PickerBuilderLike;
+  setCallback(callback: (response: PickerResponse) => void): PickerBuilderLike;
+  build(): { setVisible(visible: boolean): void };
+}
+
+interface GooglePicker {
+  PickerBuilder: new () => PickerBuilderLike;
+  DocsView: new (viewId?: unknown) => DocsViewLike;
+  ViewId: { SPREADSHEETS: unknown };
+  DocsViewMode: { LIST: unknown };
+  Action: { PICKED: string; CANCEL: string };
+  Feature: { SUPPORT_DRIVES: unknown };
+}
+
+interface TokenClient {
+  requestAccessToken(overrides?: { login_hint?: string }): void;
+}
+
+interface TokenResponse {
+  access_token?: string;
+  error?: string;
+  scope?: string;
+}
+
+export function validateGoogleSheetsPickerScopes(scope?: string): void {
+  const grantedScopes = new Set((scope ?? '').split(/\s+/).filter(Boolean));
+  const missingScopes = [DRIVE_FILE_SCOPE, USERINFO_EMAIL_SCOPE].filter(
+    requiredScope => !grantedScopes.has(requiredScope)
+  );
+  if (missingScopes.length > 0) {
+    throw new Error(
+      'Google Sheets access was not fully granted. Reconnect and allow file and email access.'
+    );
+  }
+}
+
+interface GoogleAccountsOauth2 {
+  initTokenClient(config: {
+    client_id: string;
+    scope: string;
+    callback: (response: TokenResponse) => void;
+    error_callback?: (error: { type?: string; message?: string }) => void;
+    login_hint?: string;
+  }): TokenClient;
+}
+
+interface GapiGlobal {
+  load(api: string, callback: () => void): void;
+}
+
+interface GooglePickerWindow {
+  gapi?: GapiGlobal;
+  google?: {
+    picker?: GooglePicker;
+    accounts?: { oauth2?: GoogleAccountsOauth2 };
+  };
+}
+
+const googleWindow = window as unknown as GooglePickerWindow;
+
+const scriptPromises = new Map<string, Promise<void>>();
+
+function loadScript(src: string): Promise<void> {
+  const existing = scriptPromises.get(src);
+  if (existing) {
+    return existing;
+  }
+
+  const promise = new Promise<void>((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.onload = () => {
+      resolve();
+    };
+    script.onerror = () => {
+      scriptPromises.delete(src);
+      script.remove();
+      reject(new Error(`Failed to load ${src}`));
+    };
+    document.head.appendChild(script);
+  });
+
+  scriptPromises.set(src, promise);
+  return promise;
+}
+
+function loadPicker(): Promise<void> {
+  const loadGapi = googleWindow.gapi ? Promise.resolve() : loadScript(GAPI_SRC);
+  return loadGapi.then(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        if (!googleWindow.gapi) {
+          reject(new Error('gapi failed to initialize'));
+          return;
+        }
+        googleWindow.gapi.load('picker', resolve);
+      })
+  );
+}
+
+function requestAccessToken(clientId: string, hintEmail?: string): Promise<string> {
+  const loadGis = googleWindow.google?.accounts?.oauth2 ? Promise.resolve() : loadScript(GIS_SRC);
+  return loadGis.then(
+    () =>
+      new Promise<string>((resolve, reject) => {
+        const oauth2 = googleWindow.google?.accounts?.oauth2;
+        if (!oauth2) {
+          reject(new Error('Google Identity Services failed to initialize'));
+          return;
+        }
+
+        const client = oauth2.initTokenClient({
+          client_id: clientId,
+          scope: GOOGLE_SHEETS_PICKER_SCOPES,
+          login_hint: hintEmail,
+          callback: response => {
+            if (response.access_token) {
+              try {
+                validateGoogleSheetsPickerScopes(response.scope);
+              } catch (error) {
+                reject(error instanceof Error ? error : new Error(String(error)));
+                return;
+              }
+              resolve(response.access_token);
+            } else {
+              reject(new Error(response.error ?? 'Could not obtain a Google access token'));
+            }
+          },
+          error_callback: error => {
+            reject(new Error(error.message ?? 'Google authorization was cancelled'));
+          },
+        });
+        client.requestAccessToken({ login_hint: hintEmail });
+      })
+  );
+}
+
+export async function verifyGooglePickerAccount(
+  accessToken: string,
+  expectedEmail?: string
+): Promise<void> {
+  if (!expectedEmail?.includes('@')) {
+    throw new Error('Reconnect Google Sheets before choosing a spreadsheet');
+  }
+
+  const response = await fetch(GOOGLE_USERINFO_URL, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!response.ok) {
+    throw new Error('Could not verify the Google account used by Google Picker');
+  }
+
+  const userInfo = (await response.json()) as { email?: string };
+  if (userInfo.email?.toLowerCase() !== expectedEmail.toLowerCase()) {
+    throw new Error(`Open Google Picker with the connected account ${expectedEmail}`);
+  }
+}
+
+function buildPickerView(picker: GooglePicker) {
+  return new picker.DocsView(picker.ViewId.SPREADSHEETS)
+    .setMimeTypes(GOOGLE_SHEETS_MIME_TYPE)
+    .setMode(picker.DocsViewMode.LIST);
+}
+
+function buildItemUrl(doc: PickerDoc): string {
+  if (doc.url) {
+    return doc.url;
+  }
+  return `https://docs.google.com/spreadsheets/d/${doc.id}/edit`;
+}
+
+export function useGoogleSheetsPicker() {
+  const openPicker = useCallback(async (options: OpenGoogleSheetsPickerOptions): Promise<void> => {
+    const { apiKey, appId, clientId, hintEmail, onPicked, onError } = options;
+
+    try {
+      await loadPicker();
+      const token = await requestAccessToken(clientId, hintEmail);
+      await verifyGooglePickerAccount(token, hintEmail);
+      const picker = googleWindow.google?.picker;
+      if (!picker) {
+        throw new Error('Google Picker failed to initialize');
+      }
+
+      await new Promise<void>(resolve => {
+        const builder = new picker.PickerBuilder()
+          .setOAuthToken(token)
+          .setDeveloperKey(apiKey)
+          .setAppId(appId)
+          .addView(buildPickerView(picker))
+          .enableFeature(picker.Feature.SUPPORT_DRIVES)
+          .setCallback(response => {
+            if (response.action === picker.Action.PICKED) {
+              const doc = response.docs?.[0];
+              if (doc) {
+                onPicked({
+                  id: doc.id,
+                  name: doc.name,
+                  url: buildItemUrl(doc),
+                });
+              }
+              resolve();
+            } else if (response.action === picker.Action.CANCEL) {
+              resolve();
+            }
+          });
+
+        builder.build().setVisible(true);
+      });
+    } catch (error) {
+      onError?.(error instanceof Error ? error.message : 'Failed to open the Google Sheets picker');
+    }
+  }, []);
+
+  return { openPicker };
+}

--- a/apps/web/src/features/google-oauth/index.ts
+++ b/apps/web/src/features/google-oauth/index.ts
@@ -1,3 +1,8 @@
 export * from './components';
 export * from './api';
 export { GoogleOAuthCallbackPage } from './pages/GoogleOAuthCallbackPage';
+export { useGoogleSheetsPicker } from './hooks/useGoogleDrivePicker';
+export type {
+  OpenGoogleSheetsPickerOptions,
+  PickedGoogleSpreadsheet,
+} from './hooks/useGoogleDrivePicker';

--- a/apps/web/src/pages/oauth/GoogleSheetsCallback.tsx
+++ b/apps/web/src/pages/oauth/GoogleSheetsCallback.tsx
@@ -1,0 +1,16 @@
+import { useOAuthCallback } from '../../features/connectors/shared/hooks/useOAuthCallback';
+import { OAuthCallbackUI } from '../../features/connectors/shared/components/OAuthCallbackUI';
+
+export function GoogleSheetsCallback() {
+  const { status, errorMessage } = useOAuthCallback({
+    providerName: 'GoogleSheets',
+    successType: 'GOOGLE_SHEETS_AUTH_SUCCESS',
+    errorType: 'GOOGLE_SHEETS_AUTH_ERROR',
+    getSuccessPayload: searchParams => ({
+      code: searchParams.get('code') ?? '',
+    }),
+    hasSuccessData: searchParams => !!searchParams.get('code'),
+  });
+
+  return <OAuthCallbackUI status={status} errorMessage={errorMessage} />;
+}

--- a/apps/web/src/pages/oauth/index.ts
+++ b/apps/web/src/pages/oauth/index.ts
@@ -1,4 +1,5 @@
 export { TikTokCallback } from './TikTokCallback';
 export { MicrosoftCallback } from './MicrosoftCallback';
 export { GoogleAdsCallback } from './GoogleAdsCallback';
+export { GoogleSheetsCallback } from './GoogleSheetsCallback';
 export { LinkedInCallback } from './LinkedInCallback';

--- a/apps/web/src/routes/oauth.routes.tsx
+++ b/apps/web/src/routes/oauth.routes.tsx
@@ -4,6 +4,7 @@ import {
   TikTokCallback,
   MicrosoftCallback,
   GoogleAdsCallback,
+  GoogleSheetsCallback,
   LinkedInCallback,
 } from '../pages/oauth';
 
@@ -21,6 +22,10 @@ export const oauthRoutes: RouteObject = {
     {
       path: 'google-ads/callback',
       element: <GoogleAdsCallback />,
+    },
+    {
+      path: 'google-sheets/callback',
+      element: <GoogleSheetsCallback />,
     },
     {
       path: 'google/callback',

--- a/packages/connectors/src/Sources/GoogleSheets/CREDENTIALS.md
+++ b/packages/connectors/src/Sources/GoogleSheets/CREDENTIALS.md
@@ -1,5 +1,37 @@
 # Credentials
 
+The Google Sheets source supports two authentication methods:
+
+1. OAuth2
+2. Service Account JSON
+
+## OAuth2
+
+Use OAuth2 when a business user should connect a spreadsheet from their own Google account.
+
+Required environment variables for the Google Sheets source connector:
+
+- `OAUTH_GOOGLE_SHEETS_CLIENT_ID`
+- `OAUTH_GOOGLE_SHEETS_CLIENT_SECRET`
+- `OAUTH_GOOGLE_SHEETS_REDIRECT_URI`
+- `OAUTH_GOOGLE_SHEETS_PICKER_API_KEY`
+- `OAUTH_GOOGLE_SHEETS_PROJECT_NUMBER`
+
+The redirect URI should point to the web app callback route: `/oauth/google-sheets/callback`.
+
+Do not use `OAUTH_GOOGLE_REDIRECT_URI` unless the connector OAuth callback is explicitly refactored to use the shared Google OAuth flow. That existing variable is used by the storage/destination OAuth flow at `/oauth/google/callback`.
+
+Enable the Google Sheets API and Google Picker API in the same Google Cloud project. Configure the OAuth client as a Web application with the web app origins and callback URLs, and restrict the Picker API key to the Google Picker API and those HTTP referrers.
+
+The source requests these scopes:
+
+- `https://www.googleapis.com/auth/drive.file`
+- `https://www.googleapis.com/auth/userinfo.email`
+
+`drive.file` grants access only to files the user selects through Google Picker or creates with the app. The connector only reads the selected spreadsheet. `OAUTH_GOOGLE_SHEETS_PROJECT_NUMBER` is the numeric Google Cloud project number used as the Picker App ID.
+
+## Service Account JSON
+
 Use Service Account JSON when scheduled imports should not depend on a personal Google account.
 
 Steps:
@@ -7,7 +39,8 @@ Steps:
 1. Create a Google Cloud service account.
 2. Create and download a JSON key for it.
 3. Share the spreadsheet with the service account email.
-4. Paste the service account JSON key into `Service Account Key (JSON)`.
+4. Select `Service Account` in the source authentication method.
+5. Paste the service account JSON key into `Service Account Key (JSON)`.
 
 The service account email is the `client_email` value inside the downloaded JSON key.
 

--- a/packages/connectors/src/Sources/GoogleSheets/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/GoogleSheets/GETTING_STARTED.md
@@ -1,8 +1,8 @@
 # Getting Started
 
 1. Create a Data Mart with the Google Sheets source.
-2. Paste a Google Service Account JSON key.
-3. Provide the ID or URL of a spreadsheet shared with the service account.
+2. Authorize Google Sheets access with OAuth or Service Account JSON.
+3. Choose the spreadsheet with Google Picker for OAuth, or provide its ID or URL for a service account.
 4. Provide the sheet tab name.
 5. Click Next to preview detected columns from the configured header row.
 6. Keep all-columns mode enabled, or switch to explicit subset mode and choose columns.
@@ -19,4 +19,4 @@ Field preview includes all supported columns and up to 100 sample data rows. The
 
 Text identifiers retain their text type and leading zeros. A sheet with headers but no data rows performs a zero-row full refresh so the warehouse always reflects the current sheet.
 
-Share the spreadsheet with the service account email before running the refresh.
+Use OAuth for quick user setup. Use Service Account JSON for scheduled imports that should not depend on a personal Google account; share the spreadsheet with the service account email before running the refresh.

--- a/packages/connectors/src/Sources/GoogleSheets/README.md
+++ b/packages/connectors/src/Sources/GoogleSheets/README.md
@@ -2,7 +2,7 @@
 
 The Google Sheets source imports one spreadsheet tab into a materialized table in the user's storage.
 
-Authentication uses a Google Service Account JSON key. The spreadsheet must be shared with the service account email.
+Authentication can use OAuth2 or Service Account JSON. OAuth2 is best for quick user setup; Service Account JSON is best for scheduled imports that should not depend on a personal Google account.
 
 On each refresh the connector:
 

--- a/packages/connectors/src/Sources/GoogleSheets/Source.js
+++ b/packages/connectors/src/Sources/GoogleSheets/Source.js
@@ -11,6 +11,10 @@ var GOOGLE_SHEETS_MAX_IMPORT_ROWS = 100000;
 var GOOGLE_SHEETS_MAX_IMPORT_COLUMNS = 1598;
 var GOOGLE_SHEETS_MAX_RESPONSE_BYTES = 50 * 1024 * 1024;
 var GOOGLE_SHEETS_MAX_RETRY_AFTER_MS = 300000;
+var GOOGLE_SHEETS_REQUIRED_OAUTH_SCOPES = [
+  'https://www.googleapis.com/auth/drive.file',
+  'https://www.googleapis.com/auth/userinfo.email',
+];
 
 var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
   constructor(config) {
@@ -25,6 +29,111 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
           description: 'Authentication type',
           isRequired: true,
           oneOf: [
+            {
+              label: 'OAuth2',
+              value: 'oauth2',
+              requiredType: 'object',
+              attributes: [CONFIG_ATTRIBUTES.OAUTH_FLOW],
+              oauthParams: {
+                vars: {
+                  ClientId: {
+                    type: 'string',
+                    required: true,
+                    store: 'env',
+                    key: 'OAUTH_GOOGLE_SHEETS_CLIENT_ID',
+                    attributes: [
+                      OAUTH_CONSTANTS.UI,
+                      OAUTH_CONSTANTS.SECRET,
+                      OAUTH_CONSTANTS.REQUIRED,
+                    ],
+                  },
+                  ClientSecret: {
+                    type: 'string',
+                    required: true,
+                    store: 'env',
+                    key: 'OAUTH_GOOGLE_SHEETS_CLIENT_SECRET',
+                    attributes: [OAUTH_CONSTANTS.SECRET, OAUTH_CONSTANTS.REQUIRED],
+                  },
+                  RedirectUri: {
+                    type: 'string',
+                    required: true,
+                    store: 'env',
+                    key: 'OAUTH_GOOGLE_SHEETS_REDIRECT_URI',
+                    attributes: [OAUTH_CONSTANTS.UI, OAUTH_CONSTANTS.REQUIRED],
+                  },
+                  PickerApiKey: {
+                    type: 'string',
+                    required: true,
+                    store: 'env',
+                    key: 'OAUTH_GOOGLE_SHEETS_PICKER_API_KEY',
+                    attributes: [
+                      OAUTH_CONSTANTS.UI,
+                      OAUTH_CONSTANTS.SECRET,
+                      OAUTH_CONSTANTS.REQUIRED,
+                    ],
+                  },
+                  ProjectNumber: {
+                    type: 'string',
+                    required: true,
+                    store: 'env',
+                    key: 'OAUTH_GOOGLE_SHEETS_PROJECT_NUMBER',
+                    attributes: [
+                      OAUTH_CONSTANTS.UI,
+                      OAUTH_CONSTANTS.SECRET,
+                      OAUTH_CONSTANTS.REQUIRED,
+                    ],
+                  },
+                },
+                mapping: {
+                  RefreshToken: {
+                    type: 'string',
+                    required: true,
+                    store: 'secret',
+                    key: 'refresh_token',
+                  },
+                  AccessToken: {
+                    type: 'string',
+                    required: true,
+                    store: 'secret',
+                    key: 'access_token',
+                  },
+                  ClientId: {
+                    type: 'string',
+                    required: true,
+                    store: 'secret',
+                    key: 'client_id',
+                  },
+                  ClientSecret: {
+                    type: 'string',
+                    required: true,
+                    store: 'secret',
+                    key: 'client_secret',
+                  },
+                },
+              },
+              items: {
+                RefreshToken: {
+                  isRequired: true,
+                  requiredType: 'string',
+                  label: 'Refresh Token',
+                  description: 'OAuth2 Refresh Token',
+                  attributes: [CONFIG_ATTRIBUTES.SECRET],
+                },
+                ClientId: {
+                  isRequired: true,
+                  requiredType: 'string',
+                  label: 'Client ID',
+                  description: 'OAuth2 Client ID',
+                },
+                ClientSecret: {
+                  isRequired: true,
+                  requiredType: 'string',
+                  label: 'Client Secret',
+                  description: 'OAuth2 Client Secret',
+                  attributes: [CONFIG_ATTRIBUTES.SECRET],
+                },
+              },
+            },
             {
               label: 'Service Account',
               value: 'service_account',
@@ -47,7 +156,8 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
           isRequired: true,
           requiredType: 'string',
           label: 'Spreadsheet ID or URL',
-          description: 'Enter the spreadsheet ID or URL shared with the service account.',
+          description:
+            'Choose a spreadsheet with Google Picker for OAuth, or enter its ID or URL for a service account.',
         },
         SheetName: {
           isRequired: true,
@@ -102,6 +212,102 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
     this.tokenExpiryTime = null;
   }
 
+  async exchangeOauthCredentials(credentials, variables) {
+    try {
+      const tokenUrl = 'https://oauth2.googleapis.com/token';
+      const payload = {
+        client_id: variables.ClientId,
+        client_secret: variables.ClientSecret,
+        grant_type: 'authorization_code',
+        code: credentials.code,
+        redirect_uri: variables.RedirectUri,
+      };
+
+      const response = await HttpUtils.fetch(tokenUrl, {
+        method: 'post',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: Object.entries(payload)
+          .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+          .join('&'),
+      });
+      const data = await response.getAsJson();
+
+      if (data.error) {
+        throw new OauthFlowException({
+          message: `Token exchange failed: ${data.error_description || data.error}`,
+          payload: data,
+        });
+      }
+
+      if (!data.refresh_token) {
+        throw new OauthFlowException({
+          message:
+            'No refresh_token returned. Please revoke access at https://myaccount.google.com/permissions and try again.',
+          payload: data,
+        });
+      }
+
+      const grantedScopes = new Set(
+        String(data.scope || '')
+          .split(/\s+/)
+          .filter(Boolean)
+      );
+      const missingScopes = GOOGLE_SHEETS_REQUIRED_OAUTH_SCOPES.filter(
+        scope => !grantedScopes.has(scope)
+      );
+      if (missingScopes.length) {
+        throw new OauthFlowException({
+          message:
+            'Google Sheets authorization is missing required permissions. Reconnect and allow Google Drive file access and email address access.',
+          payload: { missingScopes },
+        });
+      }
+
+      let userInfo;
+      try {
+        const userResponse = await HttpUtils.fetch(
+          'https://www.googleapis.com/oauth2/v2/userinfo',
+          { headers: { Authorization: `Bearer ${data.access_token}` } }
+        );
+        userInfo = await userResponse.getAsJson();
+      } catch (error) {
+        throw new OauthFlowException({
+          message: 'Could not verify the Google account connected to Google Sheets',
+          payload: error.message,
+        });
+      }
+
+      if (typeof userInfo.email !== 'string' || !userInfo.email.includes('@')) {
+        throw new OauthFlowException({
+          message: 'Google did not return the email address required by Google Picker',
+          payload: userInfo,
+        });
+      }
+
+      const userData = { id: userInfo.id || userInfo.email, name: userInfo.email };
+
+      return OauthCredentialsDto.builder()
+        .withUser(userData)
+        .withSecret({
+          refresh_token: data.refresh_token,
+          access_token: data.access_token,
+          client_id: variables.ClientId,
+          client_secret: variables.ClientSecret,
+        })
+        .withExpiresIn(data.expires_in ?? 3600)
+        .build()
+        .toObject();
+    } catch (error) {
+      if (error instanceof OauthFlowException) {
+        throw error;
+      }
+      throw new OauthFlowException({
+        message: 'Failed to exchange Google Sheets tokens',
+        payload: error.message,
+      });
+    }
+  }
+
   async getAccessToken({ forceRefresh = false } = {}) {
     if (
       !forceRefresh &&
@@ -123,7 +329,18 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
     }
 
     const authConfig = this.config.AuthType.items;
-    if (authType === 'service_account') {
+    if (authType === 'oauth2') {
+      this.accessToken = await OAuthUtils.getAccessToken({
+        config: this.config,
+        tokenUrl: 'https://oauth2.googleapis.com/token',
+        formData: {
+          grant_type: 'refresh_token',
+          client_id: authConfig.ClientId.value,
+          client_secret: authConfig.ClientSecret.value,
+          refresh_token: authConfig.RefreshToken.value,
+        },
+      });
+    } else if (authType === 'service_account') {
       this.accessToken = await OAuthUtils.getServiceAccountToken({
         config: this.config,
         tokenUrl: 'https://oauth2.googleapis.com/token',
@@ -380,8 +597,8 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
     if (statusCode === 403) {
       const serviceAccountEmail = this._getConfiguredServiceAccountEmail();
       const accessHint = serviceAccountEmail
-        ? ` Share the spreadsheet with ${serviceAccountEmail}.`
-        : ' Share the spreadsheet with the configured service account.';
+        ? ` Share the spreadsheet with ${serviceAccountEmail}, or use OAuth if the sheet should be read from a user account.`
+        : ' Share the spreadsheet with the configured service account, or use OAuth if the sheet should be read from a user account.';
 
       return `Google Sheets access denied: ${message}.${accessHint}`;
     }

--- a/packages/connectors/src/Sources/GoogleSheets/Source.js
+++ b/packages/connectors/src/Sources/GoogleSheets/Source.js
@@ -284,7 +284,11 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
         });
       }
 
-      const userData = { id: userInfo.id || userInfo.email, name: userInfo.email };
+      const userData = {
+        id: userInfo.id || userInfo.email,
+        name: userInfo.email,
+        email: userInfo.email,
+      };
 
       return OauthCredentialsDto.builder()
         .withUser(userData)
@@ -597,6 +601,13 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
     const message = error instanceof Error ? error.message : String(error);
 
     if (statusCode === 403) {
+      if (this.config.AuthType?.value === 'oauth2') {
+        return (
+          `Google Sheets access denied: ${message}. ` +
+          'Reconnect Google Sheets and choose the spreadsheet with Google Picker.'
+        );
+      }
+
       const serviceAccountEmail = this._getConfiguredServiceAccountEmail();
       const accessHint = serviceAccountEmail
         ? ` Share the spreadsheet with ${serviceAccountEmail}, or use OAuth if the sheet should be read from a user account.`

--- a/packages/connectors/src/Sources/GoogleSheets/Source.js
+++ b/packages/connectors/src/Sources/GoogleSheets/Source.js
@@ -294,7 +294,9 @@ var GoogleSheetsSource = class GoogleSheetsSource extends AbstractSource {
           client_id: variables.ClientId,
           client_secret: variables.ClientSecret,
         })
-        .withExpiresIn(data.expires_in ?? 3600)
+        // The stored credential is backed by the refresh token. The access
+        // token's one-hour lifetime must not make the connection look expired.
+        .withExpiresIn(data.refresh_token_expires_in ?? null)
         .build()
         .toObject();
     } catch (error) {

--- a/packages/connectors/test/GoogleSheets.test.js
+++ b/packages/connectors/test/GoogleSheets.test.js
@@ -23,9 +23,40 @@ class HttpRequestException extends Error {
 
 class ConnectorConfigurationException extends Error {}
 
+class OauthFlowException extends Error {
+  constructor({ message, payload }) {
+    super(message);
+    this.payload = payload;
+  }
+}
+
 const HttpUtils = {
   async fetch() {
     throw new Error('Unexpected HTTP request');
+  },
+};
+
+const OauthCredentialsDto = {
+  builder() {
+    const value = {};
+    const builder = {
+      withUser(user) {
+        value.user = user;
+        return builder;
+      },
+      withSecret(secret) {
+        value.secret = secret;
+        return builder;
+      },
+      withExpiresIn(expiresIn) {
+        value.expiresIn = expiresIn;
+        return builder;
+      },
+      build() {
+        return { toObject: () => value };
+      },
+    };
+    return builder;
   },
 };
 
@@ -50,10 +81,18 @@ const GoogleSheetsSource = loadScript(
     HttpRequestException,
     ConnectorConfigurationException,
     HttpUtils,
+    OauthCredentialsDto,
+    OauthFlowException,
     CONFIG_ATTRIBUTES: {
       SECRET: 'SECRET',
       ADVANCED: 'ADVANCED',
       HIDE_IN_CONFIG_FORM: 'HIDE_IN_CONFIG_FORM',
+      OAUTH_FLOW: 'OAUTH_FLOW',
+    },
+    OAUTH_CONSTANTS: {
+      UI: 'UI',
+      SECRET: 'SECRET',
+      REQUIRED: 'REQUIRED',
     },
   }
 );
@@ -114,10 +153,105 @@ test('preserves explicit false defaults inside the Google Sheets configuration o
 
   assert.deepEqual(
     Array.from(mergedParameters.AuthType.oneOf, option => option.value),
-    ['service_account']
+    ['oauth2', 'service_account']
   );
   assert.equal(mergedParameters.InferTypes.default, false);
   assert.equal(mergedParameters.ImportAllColumns.default, false);
+});
+
+test('rejects OAuth authorization when required Google Sheets permissions were not granted', async () => {
+  const originalFetch = HttpUtils.fetch;
+  HttpUtils.fetch = async () => ({
+    getAsJson: async () => ({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_in: 3600,
+      scope: 'https://www.googleapis.com/auth/userinfo.email',
+    }),
+  });
+  const source = Object.create(GoogleSheetsSource.prototype);
+
+  try {
+    await assert.rejects(
+      source.exchangeOauthCredentials(
+        { code: 'authorization-code' },
+        {
+          ClientId: 'client-id',
+          ClientSecret: 'client-secret',
+          RedirectUri: 'https://app.example.com/oauth/google-sheets/callback',
+        }
+      ),
+      /authorization is missing required permissions/
+    );
+  } finally {
+    HttpUtils.fetch = originalFetch;
+  }
+});
+
+test('stores the verified Google account used by Google Picker', async () => {
+  const originalFetch = HttpUtils.fetch;
+  const responses = [
+    {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_in: 3600,
+      scope:
+        'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/userinfo.email',
+    },
+    { id: 'google-user-1', email: 'analyst@example.com' },
+  ];
+  HttpUtils.fetch = async () => ({ getAsJson: async () => responses.shift() });
+  const source = Object.create(GoogleSheetsSource.prototype);
+
+  try {
+    const credentials = await source.exchangeOauthCredentials(
+      { code: 'authorization-code' },
+      {
+        ClientId: 'client-id',
+        ClientSecret: 'client-secret',
+        RedirectUri: 'https://app.example.com/oauth/google-sheets/callback',
+      }
+    );
+
+    assert.deepEqual(plain(credentials.user), {
+      id: 'google-user-1',
+      name: 'analyst@example.com',
+    });
+  } finally {
+    HttpUtils.fetch = originalFetch;
+  }
+});
+
+test('rejects OAuth authorization when Google does not return an email address', async () => {
+  const originalFetch = HttpUtils.fetch;
+  const responses = [
+    {
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_in: 3600,
+      scope:
+        'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/userinfo.email',
+    },
+    { id: 'google-user-1' },
+  ];
+  HttpUtils.fetch = async () => ({ getAsJson: async () => responses.shift() });
+  const source = Object.create(GoogleSheetsSource.prototype);
+
+  try {
+    await assert.rejects(
+      source.exchangeOauthCredentials(
+        { code: 'authorization-code' },
+        {
+          ClientId: 'client-id',
+          ClientSecret: 'client-secret',
+          RedirectUri: 'https://app.example.com/oauth/google-sheets/callback',
+        }
+      ),
+      /email address required by Google Picker/
+    );
+  } finally {
+    HttpUtils.fetch = originalFetch;
+  }
 });
 
 test('maps an absolute header row into an offset range and preserves absolute row numbers', () => {

--- a/packages/connectors/test/GoogleSheets.test.js
+++ b/packages/connectors/test/GoogleSheets.test.js
@@ -26,6 +26,7 @@ class ConnectorConfigurationException extends Error {}
 class OauthFlowException extends Error {
   constructor({ message, payload }) {
     super(message);
+    this.name = 'OauthFlowException';
     this.payload = payload;
   }
 }
@@ -181,7 +182,10 @@ test('rejects OAuth authorization when required Google Sheets permissions were n
           RedirectUri: 'https://app.example.com/oauth/google-sheets/callback',
         }
       ),
-      /authorization is missing required permissions/
+      error =>
+        error instanceof OauthFlowException &&
+        error.name === 'OauthFlowException' &&
+        /authorization is missing required permissions/.test(error.message)
     );
   } finally {
     HttpUtils.fetch = originalFetch;
@@ -216,11 +220,26 @@ test('stores the verified Google account used by Google Picker', async () => {
     assert.deepEqual(plain(credentials.user), {
       id: 'google-user-1',
       name: 'analyst@example.com',
+      email: 'analyst@example.com',
     });
     assert.equal(credentials.expiresIn, null);
   } finally {
     HttpUtils.fetch = originalFetch;
   }
+});
+
+test('gives OAuth users Picker-specific guidance for access errors', () => {
+  const source = createSource();
+  source.config.AuthType = { value: 'oauth2', items: {} };
+
+  assert.match(
+    source._buildSheetRequestErrorMessage({ statusCode: 403, message: 'Forbidden' }),
+    /choose the spreadsheet with Google Picker/
+  );
+  assert.doesNotMatch(
+    source._buildSheetRequestErrorMessage({ statusCode: 403, message: 'Forbidden' }),
+    /service account/
+  );
 });
 
 test('rejects OAuth authorization when Google does not return an email address', async () => {

--- a/packages/connectors/test/GoogleSheets.test.js
+++ b/packages/connectors/test/GoogleSheets.test.js
@@ -217,6 +217,7 @@ test('stores the verified Google account used by Google Picker', async () => {
       id: 'google-user-1',
       name: 'analyst@example.com',
     });
+    assert.equal(credentials.expiresIn, null);
   } finally {
     HttpUtils.fetch = originalFetch;
   }


### PR DESCRIPTION
Users can authorize a Google account and choose a spreadsheet with Google Picker when configuring a Google Sheets source. Service account authentication remains available.