### PR TITLE
fix(linkedin-ads): fetch adAnalytics per day to avoid the 15,000-element truncation

### DIFF
--- a/.changeset/6871-linkedin-ads-adanalytics-truncation.md
+++ b/.changeset/6871-linkedin-ads-adanalytics-truncation.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Fix LinkedIn Ads adAnalytics silently dropping data when response exceeds 15,000 elements
+
+Previously, an adAnalytics export over a large date range could silently lose data: the endpoint does not support pagination and caps its response at 15,000 elements, so campaigns from the beginning of the period were missing from the result. The connector now fetches analytics one day at a time, so a single day cannot exceed the limit.
+
+If a daily response still reaches 15,000 elements, the import finishes with a Warning status and a message about possible truncation (element count and an example day) instead of losing data silently.

--- a/.changeset/6871-linkedin-ads-adanalytics-truncation.md
+++ b/.changeset/6871-linkedin-ads-adanalytics-truncation.md
@@ -6,4 +6,6 @@
 
 Previously, an adAnalytics export over a large date range could silently lose data: the endpoint does not support pagination and caps its response at 15,000 elements, so campaigns from the beginning of the period were missing from the result. The connector now fetches analytics one day at a time, so a single day cannot exceed the limit.
 
-If a daily response still reaches 15,000 elements, the import finishes with a Warning status and a message about possible truncation (element count and an example day) instead of losing data silently.
+If a daily response still reaches 15,000 elements, the import finishes with a Warning status that lists the affected days instead of losing data silently.
+
+The connector also refreshes the LinkedIn access token once per run instead of before every request, and retries rate-limited (429) and server-error (5xx) responses instead of failing the whole import.

--- a/.changeset/6871-linkedin-ads-adanalytics-truncation.md
+++ b/.changeset/6871-linkedin-ads-adanalytics-truncation.md
@@ -4,7 +4,7 @@
 
 # Fix LinkedIn Ads adAnalytics silently dropping data when response exceeds 15,000 elements
 
-Previously, an adAnalytics export over a large date range could silently lose data: the endpoint does not support pagination and caps its response at 15,000 elements, so campaigns from the beginning of the period were missing from the result. The connector now fetches analytics one day at a time, so a single day cannot exceed the limit.
+Previously, an adAnalytics export over a large date range could silently lose data: the endpoint does not support pagination and caps its response at 15,000 elements, so campaigns from the beginning of the period were missing from the result. The connector now fetches, saves, and checkpoints analytics one day at a time, so a single day cannot exceed the limit, and an interrupted run resumes from the last completed day instead of restarting the whole range.
 
 If a daily response still reaches 15,000 elements, the import finishes with a Warning status that lists the affected days instead of losing data silently.
 

--- a/.changeset/6871-linkedin-ads-adanalytics-truncation.md
+++ b/.changeset/6871-linkedin-ads-adanalytics-truncation.md
@@ -8,4 +8,4 @@ Previously, an adAnalytics export over a large date range could silently lose da
 
 If a daily response still reaches 15,000 elements, the import finishes with a Warning status that lists the affected days instead of losing data silently.
 
-The connector also refreshes the LinkedIn access token once per run instead of before every request, and retries rate-limited (429) and server-error (5xx) responses instead of failing the whole import.
+The connector also refreshes the LinkedIn access token once per run instead of before every request. LinkedIn API errors now fail the run instead of silently returning no rows; rate-limit (429) and server (5xx) errors are retried first.

--- a/.changeset/6871-linkedin-ads-adanalytics-truncation.md
+++ b/.changeset/6871-linkedin-ads-adanalytics-truncation.md
@@ -9,3 +9,5 @@ Previously, an adAnalytics export over a large date range could silently lose da
 If a daily response still reaches 15,000 elements, the import finishes with a Warning status that lists the affected days instead of losing data silently.
 
 The connector also refreshes the LinkedIn access token once per run instead of before every request. LinkedIn API errors now fail the run instead of silently returning no rows; rate-limit (429) and server (5xx) errors are retried first.
+
+Analytics days are now computed in UTC, so the day the connector requests always matches the day it logs and checkpoints, regardless of the runner's time zone.

--- a/packages/connectors/src/Sources/LinkedInAds/Connector.js
+++ b/packages/connectors/src/Sources/LinkedInAds/Connector.js
@@ -63,8 +63,10 @@ var LinkedInAdsConnector = class LinkedInAdsConnector extends AbstractConnector 
     }
 
     for (let dayOffset = 0; dayOffset < daysToFetch; dayOffset++) {
+      // UTC arithmetic: start dates are UTC midnight, so this never drifts across DST
+      // and the day fetched, logged and checkpointed is the same calendar day.
       const date = new Date(startDate);
-      date.setDate(date.getDate() + dayOffset);
+      date.setUTCDate(date.getUTCDate() + dayOffset);
 
       for (const nodeName of timeSeriesNodes) {
         for (const urn of urns) {
@@ -81,6 +83,19 @@ var LinkedInAdsConnector = class LinkedInAdsConnector extends AbstractConnector 
       if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
         this.config.updateLastRequstedDate(date);
       }
+    }
+
+    this.reportTruncatedAnalytics();
+  }
+
+  /**
+   * Emit one warning per account for the days whose adAnalytics response hit LinkedIn's
+   * element cap. The Source records them per call; reporting here keeps a saturated
+   * account to a single warning per run instead of one warning per day.
+   */
+  reportTruncatedAnalytics() {
+    for (const [urn, days] of Object.entries(this.source.truncatedAnalyticsDays)) {
+      this.config.addWarningToCurrentStatus(this.source.buildTruncationWarning(urn, days));
     }
   }
 

--- a/packages/connectors/src/Sources/LinkedInAds/Connector.js
+++ b/packages/connectors/src/Sources/LinkedInAds/Connector.js
@@ -18,71 +18,122 @@ var LinkedInAdsConnector = class LinkedInAdsConnector extends AbstractConnector 
    */
   async startImportProcess() {
     const urns = FormatUtils.parseIds(this.config.AccountURNs.value, {prefix: 'urn:li:sponsoredAccount:'});
-    const dataSources = FormatUtils.parseFields(this.config.Fields.value);
+    const fields = FormatUtils.parseFields(this.config.Fields.value);
+    const nodeNames = Object.keys(fields);
+    const isTimeSeries = nodeName => ConnectorUtils.isTimeSeriesNode(this.source.fieldsSchema[nodeName]);
+    const timeSeriesNodes = nodeNames.filter(isTimeSeries);
+    const catalogNodes = nodeNames.filter(nodeName => !isTimeSeries(nodeName));
 
-    for (const nodeName in dataSources) {
-      await this.processNode({
-        nodeName,
-        urns,
-        fields: dataSources[nodeName] || []
-      });
-    }
-  }
-
-  /**
-   * Process a specific node (data entity)
-   * @param {Object} options - Processing options
-   * @param {string} options.nodeName - Name of the node to process
-   * @param {Array} options.urns - URNs to process
-   * @param {Array} options.fields - Fields to fetch
-   */
-  async processNode({ nodeName, urns, fields }) {
-    const isTimeSeriesNode = ConnectorUtils.isTimeSeriesNode(this.source.fieldsSchema[nodeName]);
-    const dateInfo = this.prepareDateRangeIfNeeded(nodeName, isTimeSeriesNode);
-
-    if (isTimeSeriesNode && !dateInfo) {
-      return; // Skip processing if date range preparation failed
-    }
-
-    await this.fetchAndSaveData({
-      nodeName,
-      urns,
-      fields,
-      isTimeSeriesNode,
-      ...dateInfo
-    });
-
-    // Update LastRequestedDate only for time series data and incremental runs
-    if (isTimeSeriesNode && this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
-      this.config.updateLastRequstedDate(dateInfo.endDate);
-    }
-  }
-
-  /**
-   * Fetch data from source and save to storage
-   * @param {Object} options - Fetching options
-   * @param {string} options.nodeName - Name of the node to process
-   * @param {Array} options.urns - URNs to process
-   * @param {Array} options.fields - Fields to fetch
-   * @param {boolean} options.isTimeSeriesNode - Whether node is time series
-   * @param {string} [options.startDate] - Start date for time series data
-   * @param {string} [options.endDate] - End date for time series data
-   */
-  async fetchAndSaveData({ nodeName, urns, fields, isTimeSeriesNode, startDate, endDate }) {
-    for (const urn of urns) {
-      console.log(`Processing ${nodeName} for ${urn}${isTimeSeriesNode ? ` from ${startDate} to ${endDate}` : ''}`);
-
-      const params = { fields, ...(isTimeSeriesNode && { startDate, endDate }) };
-      const data = await this.source.fetchData(nodeName, urn, params);
-
-      this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for ${urn}${endDate ? ` from ${startDate} to ${endDate}` : ''}` : `No records have been fetched`);
-
-      if (data.length || this.config.CreateEmptyTables?.value) {
-        const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
-        const storage = await this.getStorageByNode(nodeName);
-        await storage.saveData(preparedData);
+    for (const nodeName of catalogNodes) {
+      for (const urn of urns) {
+        await this.processCatalogNode({
+          nodeName,
+          urn,
+          fields: fields[nodeName] || []
+        });
       }
     }
+
+    await this.processTimeSeriesNodes({ urns, timeSeriesNodes, fields });
+  }
+
+  /**
+   * Imports every time series node for every account, one date at a time.
+   *
+   * The loop is date-outer on purpose: the incremental cursor may only move once a
+   * date is complete for *all* accounts and nodes, so a run interrupted midway
+   * resumes from the last fully imported date instead of restarting the range.
+   * It also keeps memory bounded to one day of analytics instead of the whole range.
+   *
+   * @param {Object} options - Processing options
+   * @param {Array<string>} options.urns - Account URNs to import
+   * @param {Array<string>} options.timeSeriesNodes - Names of the time series nodes to import
+   * @param {Object} options.fields - Map of node name to the fields selected for it
+   */
+  async processTimeSeriesNodes({ urns, timeSeriesNodes, fields }) {
+    if (!timeSeriesNodes.length) {
+      return;
+    }
+
+    const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
+
+    if (daysToFetch <= 0) {
+      this.config.logMessage('No days to fetch for time series data');
+      return;
+    }
+
+    for (let dayOffset = 0; dayOffset < daysToFetch; dayOffset++) {
+      const date = new Date(startDate);
+      date.setDate(date.getDate() + dayOffset);
+
+      for (const nodeName of timeSeriesNodes) {
+        for (const urn of urns) {
+          await this.processTimeSeriesDay({
+            nodeName,
+            urn,
+            date,
+            fields: fields[nodeName] || []
+          });
+        }
+      }
+
+      // Every account and node stored this date, so the cursor can move past it.
+      if (this.runConfig.type === RUN_CONFIG_TYPE.INCREMENTAL) {
+        this.config.updateLastRequstedDate(date);
+      }
+    }
+  }
+
+  /**
+   * Fetch and store a single day of a time series node for one account
+   * @param {Object} options - Processing options
+   * @param {string} options.nodeName - Name of the node
+   * @param {string} options.urn - Account URN
+   * @param {Date} options.date - The day to import
+   * @param {Array<string>} options.fields - Array of fields to fetch
+   */
+  async processTimeSeriesDay({ nodeName, urn, date, fields }) {
+    const formattedDate = DateUtils.formatDate(date);
+
+    this.config.logMessage(`Start importing data for ${formattedDate}: ${urn}/${nodeName}`);
+
+    const data = await this.source.fetchData(nodeName, urn, { fields, startDate: date, endDate: date });
+
+    this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for ${urn} on ${formattedDate}` : `No records have been fetched`);
+
+    await this.saveNodeData({ nodeName, fields, data });
+  }
+
+  /**
+   * Fetch and store a catalog node (e.g. adCampaigns, creatives) for one account
+   * @param {Object} options - Processing options
+   * @param {string} options.nodeName - Name of the node
+   * @param {string} options.urn - Account URN
+   * @param {Array<string>} options.fields - Array of fields to fetch
+   */
+  async processCatalogNode({ nodeName, urn, fields }) {
+    const data = await this.source.fetchData(nodeName, urn, { fields });
+
+    this.config.logMessage(data.length ? `${data.length} rows of ${nodeName} were fetched for ${urn}` : `No records have been fetched`);
+
+    await this.saveNodeData({ nodeName, fields, data });
+  }
+
+  /**
+   * Save fetched rows to the node's storage, creating an empty table when configured to
+   * @param {Object} options - Save options
+   * @param {string} options.nodeName - Name of the node
+   * @param {Array<string>} options.fields - Fields selected for the node
+   * @param {Array} options.data - Fetched rows
+   */
+  async saveNodeData({ nodeName, fields, data }) {
+    if (!data.length && !this.config.CreateEmptyTables?.value) {
+      return;
+    }
+
+    const preparedData = data.length ? this.addMissingFieldsToData(data, fields) : data;
+    const storage = await this.getStorageByNode(nodeName);
+    await storage.saveData(preparedData);
   }
 
   /**
@@ -117,30 +168,6 @@ var LinkedInAdsConnector = class LinkedInAdsConnector extends AbstractConnector 
     }
 
     return this.storages[nodeName];
-  }
-
-  /**
-   * Prepare date range for time series nodes
-   * @param {string} nodeName - Name of the node
-   * @param {boolean} isTimeSeriesNode - Whether node is time series
-   * @returns {Object|null} - Date range object or null if skipped
-   */
-  prepareDateRangeIfNeeded(nodeName, isTimeSeriesNode) {
-    if (!isTimeSeriesNode) {
-      return null;
-    }
-    
-    const [startDate, daysToFetch] = this.getStartDateAndDaysToFetch();
-    if (daysToFetch <= 0) {
-      console.log(`Skipping ${nodeName} as daysToFetch is ${daysToFetch}`);
-      return null;
-    }
-    
-    const endDate = new Date(startDate);
-    endDate.setDate(endDate.getDate() + daysToFetch - 1);
-    console.log(`Processing time series data from ${startDate} to ${endDate}`);
-    
-    return { startDate, endDate };
   }
 
 };

--- a/packages/connectors/src/Sources/LinkedInAds/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/LinkedInAds/GETTING_STARTED.md
@@ -72,6 +72,12 @@ The process is complete when the **Run history** tab shows the message:
 
 ![LinkedIn Ads Success](res/linkedin_ads_successrun.png)
 
+## FAQ
+
+### Why does my Ad Analytics run finish with a Warning status?
+
+LinkedIn's `adAnalytics` endpoint does not support pagination and caps each response at **15,000 rows**. To avoid silently losing data on long date ranges, the connector fetches analytics **one day at a time**. If a single day's response still reaches that limit (for example, an account with more than 15,000 active creatives), the run finishes with a **Warning** status and names the affected days in the log — data for those days may be incomplete.
+
 ## Access Your Data
 
 Once the run is complete, the data will be written to the dataset you specified earlier.

--- a/packages/connectors/src/Sources/LinkedInAds/GETTING_STARTED.md
+++ b/packages/connectors/src/Sources/LinkedInAds/GETTING_STARTED.md
@@ -76,7 +76,7 @@ The process is complete when the **Run history** tab shows the message:
 
 ### Why does my Ad Analytics run finish with a Warning status?
 
-LinkedIn's `adAnalytics` endpoint does not support pagination and caps each response at **15,000 rows**. To avoid silently losing data on long date ranges, the connector fetches analytics **one day at a time**. If a single day's response still reaches that limit (for example, an account with more than 15,000 active creatives), the run finishes with a **Warning** status and names the affected days in the log — data for those days may be incomplete.
+LinkedIn's `adAnalytics` endpoint does not support pagination and caps each response at **15,000 rows**. To avoid silently losing data on long date ranges, the connector fetches analytics **one day at a time**. A single day can still exceed the limit, for example an account with more than 15,000 active creatives. The run then finishes with a **Warning** status and lists the affected days in the log. Data for those days may be incomplete.
 
 ## Access Your Data
 

--- a/packages/connectors/src/Sources/LinkedInAds/Source.js
+++ b/packages/connectors/src/Sources/LinkedInAds/Source.js
@@ -178,6 +178,9 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
     this.MAX_FIELDS_PER_REQUEST = 20;
     this.MAX_RESPONSE_ELEMENTS = 15000;
     this.MAX_TRUNCATED_DAYS_IN_WARNING = 10;
+    // urn -> [YYYY-MM-DD] days whose adAnalytics response hit MAX_RESPONSE_ELEMENTS.
+    // Filled per fetchAdAnalytics call; the connector reports it once per account per run.
+    this.truncatedAnalyticsDays = {};
     this.BASE_URL = "https://api.linkedin.com/rest/";
   
   }
@@ -323,73 +326,33 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
   }
 
   /**
-   * Fetch analytics data, handling field limits and data merging
+   * Fetch analytics data for one day, handling field limits and data merging.
+   * The connector calls this once per day on purpose: the adAnalytics endpoint does not
+   * support pagination and caps each response at MAX_RESPONSE_ELEMENTS elements, so a
+   * wider range would be silently truncated. A response that still reaches the cap is
+   * recorded in truncatedAnalyticsDays for the connector to report once per account.
    * @param {string} urn - Account identifier
    * @param {Object} params - Request parameters
-   * @param {string} params.startDate - Start date for analytics data
-   * @param {string} params.endDate - End date for analytics data
+   * @param {Date} params.startDate - The day to fetch (UTC midnight)
+   * @param {Date} params.endDate - The same day as startDate
    * @param {Array} params.fields - Fields to fetch
    * @returns {Array} - Combined array of analytics data
    */
   async fetchAdAnalytics(urn, params) {
     const startDate = new Date(params.startDate);
     const endDate = new Date(params.endDate);
-    const accountUrn = `urn:li:sponsoredAccount:${urn}`;
-    const encodedUrn = encodeURIComponent(accountUrn);
-    const allResults = [];
+    const encodedUrn = encodeURIComponent(`urn:li:sponsoredAccount:${urn}`);
     const uniqueApiFields = this.convertFieldsForApi(params.fields || []);
 
     // LinkedIn API has a limitation - it allows a maximum of fields per request
     // To overcome this, split fields into chunks and make multiple requests
     const fieldChunks = this.prepareAnalyticsFieldChunks(uniqueApiFields);
 
-    // The adAnalytics endpoint does not support pagination and caps each response at
-    // MAX_RESPONSE_ELEMENTS elements, so the requested range is fetched one day at a time
-    // to keep every request under the limit.
-    const truncatedDays = [];
-
-    for (let day = new Date(startDate); day <= endDate; day.setDate(day.getDate() + 1)) {
-      const { rows, isTruncated } = await this.fetchAdAnalyticsForDay({ day, encodedUrn, fieldChunks });
-
-      for (const row of rows) {
-        allResults.push(row);
-      }
-
-      if (isTruncated) {
-        truncatedDays.push(this.formatDateFromLinkedInObject(this.toLinkedInDateObject(day)));
-      }
-    }
-
-    if (truncatedDays.length > 0) {
-      this.config.addWarningToCurrentStatus(this.buildTruncationWarning(urn, truncatedDays));
-    }
-
-    // Transform complex dateRange objects to simple Date objects
-    return this.transformAnalyticsDateRanges(allResults);
-  }
-
-  /**
-   * Fetch one day of analytics across all field chunks and merge them into single rows
-   * @param {Object} options - Request options
-   * @param {Date} options.day - The day to fetch
-   * @param {string} options.encodedUrn - URL-encoded account URN
-   * @param {Array<Array<string>>} options.fieldChunks - Field chunks, each within the per-request limit
-   * @returns {Promise<{rows: Array, isTruncated: boolean}>} - Merged rows and whether any chunk hit the element cap
-   */
-  async fetchAdAnalyticsForDay({ day, encodedUrn, fieldChunks }) {
-    // Field chunks are merged within the day only: rows from different days never share
-    // a dateRange, so merging into the multi-day accumulation would only rescan it.
     let rows = [];
     let isTruncated = false;
 
-    // Process each chunk of fields in separate API requests
     for (const fieldChunk of fieldChunks) {
-      const url = this.buildAdAnalyticsUrl({
-        startDate: day,
-        endDate: day,
-        encodedUrn,
-        fields: fieldChunk
-      });
+      const url = this.buildAdAnalyticsUrl({ startDate, endDate, encodedUrn, fields: fieldChunk });
       const res = await this.makeRequest(url);
       const elements = res.elements || [];
 
@@ -402,7 +365,13 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
       rows = this.mergeAnalyticsResults(rows, elements);
     }
 
-    return { rows, isTruncated };
+    if (isTruncated) {
+      const day = this.formatDateFromLinkedInObject(this.toLinkedInDateObject(startDate));
+      this.truncatedAnalyticsDays[urn] = [...(this.truncatedAnalyticsDays[urn] || []), day];
+    }
+
+    // Transform complex dateRange objects to simple Date objects
+    return this.transformAnalyticsDateRanges(rows);
   }
 
   /**
@@ -498,12 +467,15 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
   }
 
   /**
-   * Split a Date into the year/month/day parts LinkedIn uses for dates
+   * Split a Date into the year/month/day parts LinkedIn uses for dates.
+   * Reads the UTC parts: run dates are UTC midnight and the connector logs and checkpoints
+   * them with the UTC DateUtils.formatDate, so the request, the log and the cursor must all
+   * name the same day whatever the runner's time zone.
    * @param {Date} date - Date object
    * @return {{year: number, month: number, day: number}} LinkedIn date object (month is 1-based)
    */
   toLinkedInDateObject(date) {
-    return { year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate() };
+    return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate() };
   }
 
   /**

--- a/packages/connectors/src/Sources/LinkedInAds/Source.js
+++ b/packages/connectors/src/Sources/LinkedInAds/Source.js
@@ -177,6 +177,7 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
     this.fieldsSchema = LinkedInAdsFieldsSchema;
     this.MAX_FIELDS_PER_REQUEST = 20;
     this.MAX_RESPONSE_ELEMENTS = 15000;
+    this.MAX_TRUNCATED_DAYS_IN_WARNING = 10;
     this.BASE_URL = "https://api.linkedin.com/rest/";
   
   }
@@ -335,7 +336,7 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
     const endDate = new Date(params.endDate);
     const accountUrn = `urn:li:sponsoredAccount:${urn}`;
     const encodedUrn = encodeURIComponent(accountUrn);
-    let allResults = [];
+    const allResults = [];
     const uniqueApiFields = this.convertFieldsForApi(params.fields || []);
 
     // LinkedIn API has a limitation - it allows a maximum of fields per request
@@ -348,7 +349,10 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
     const truncatedDays = [];
 
     for (let day = new Date(startDate); day <= endDate; day.setDate(day.getDate() + 1)) {
-      let dayTruncated = false;
+      // Field chunks are merged within the day only: rows from different days never share
+      // a dateRange, so merging into the multi-day accumulation would only rescan it.
+      let dayResults = [];
+      let isDayTruncated = false;
 
       // Process each chunk of fields in separate API requests
       for (const fieldChunk of fieldChunks) {
@@ -362,27 +366,42 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
         const elements = res.elements || [];
 
         if (elements.length >= this.MAX_RESPONSE_ELEMENTS) {
-          dayTruncated = true;
+          isDayTruncated = true;
         }
 
         // Merge results from different chunks into a single dataset
         // Each chunk contains the same rows but different fields
-        allResults = this.mergeAnalyticsResults(allResults, elements);
+        dayResults = this.mergeAnalyticsResults(dayResults, elements);
       }
 
-      if (dayTruncated) {
-        truncatedDays.push(this.formatDateForUrl(day));
+      allResults.push(...dayResults);
+
+      if (isDayTruncated) {
+        truncatedDays.push(this.formatDateFromLinkedInObject(this.toLinkedInDateObject(day)));
       }
     }
 
     if (truncatedDays.length > 0) {
-      this.config.addWarningToCurrentStatus(
-        `adAnalytics responses reached LinkedIn's ${this.MAX_RESPONSE_ELEMENTS}-element limit for ${truncatedDays.length} day(s) of ${urn} (e.g. ${truncatedDays[0]}); data for those days may be incomplete`
-      );
+      this.config.addWarningToCurrentStatus(this.buildTruncationWarning(urn, truncatedDays));
     }
 
     // Transform complex dateRange objects to simple Date objects
     return this.transformAnalyticsDateRanges(allResults);
+  }
+
+  /**
+   * Build the user-facing warning for days whose adAnalytics response hit the element cap
+   * @param {string} urn - Account identifier
+   * @param {Array<string>} truncatedDays - Affected days as YYYY-MM-DD strings
+   * @returns {string} - Warning message listing the affected days (bounded)
+   */
+  buildTruncationWarning(urn, truncatedDays) {
+    const listedDays = truncatedDays.slice(0, this.MAX_TRUNCATED_DAYS_IN_WARNING).join(', ');
+    const hiddenCount = truncatedDays.length - this.MAX_TRUNCATED_DAYS_IN_WARNING;
+    const moreSuffix = hiddenCount > 0 ? ` and ${hiddenCount} more` : '';
+
+    return `adAnalytics responses for account ${urn} reached LinkedIn's ${this.MAX_RESPONSE_ELEMENTS}-element limit ` +
+      `on ${truncatedDays.length} day(s): ${listedDays}${moreSuffix}; data for those days may be incomplete`;
   }
 
   /**
@@ -458,7 +477,17 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
     * @return {string} Formatted date string for LinkedIn API
     */
   formatDateForUrl(date) {
-    return `(year:${date.getFullYear()},month:${date.getMonth() + 1},day:${date.getDate()})`;
+    const { year, month, day } = this.toLinkedInDateObject(date);
+    return `(year:${year},month:${month},day:${day})`;
+  }
+
+  /**
+   * Split a Date into the year/month/day parts LinkedIn uses for dates
+   * @param {Date} date - Date object
+   * @return {{year: number, month: number, day: number}} LinkedIn date object (month is 1-based)
+   */
+  toLinkedInDateObject(date) {
+    return { year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate() };
   }
 
   /**
@@ -477,34 +506,17 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
    * @returns {Array} - The combined results array
    */
   mergeAnalyticsResults(existingResults, newElements) {
-    // If there are no existing results, return the new elements
-    if (existingResults.length === 0) {
-      return [...newElements];
+    // dateRange and pivotValues uniquely identify a row; elements with the same key come
+    // from different field chunks and are combined into one record, others are appended.
+    const keyOf = element => JSON.stringify([element.dateRange, element.pivotValues]);
+    const mergedByKey = new Map(existingResults.map(element => [keyOf(element), element]));
+
+    for (const newElement of newElements) {
+      const key = keyOf(newElement);
+      mergedByKey.set(key, { ...mergedByKey.get(key), ...newElement });
     }
 
-    const mergedResults = [...existingResults];
-    
-    // For each new element, check if it already exists in the results
-    // The uniqueness of a row is determined by dateRange and pivotValues
-    newElements.forEach(newElem => {
-      // Find existing element with the same dateRange and pivotValues
-      // These two fields uniquely identify each data point in the analytics data
-      const existingIndex = mergedResults.findIndex(existing =>
-        JSON.stringify(existing.dateRange) === JSON.stringify(newElem.dateRange) &&
-        JSON.stringify(existing.pivotValues) === JSON.stringify(newElem.pivotValues)
-      );
-      
-      if (existingIndex >= 0) {
-        // If element with the same key exists, merge its fields with the new element's fields
-        // This combines metrics from different requests into a single comprehensive record
-        mergedResults[existingIndex] = { ...mergedResults[existingIndex], ...newElem };
-      } else {
-        // If no matching element exists, add the new element to the results
-        mergedResults.push(newElem);
-      }
-    });
-    
-    return mergedResults;
+    return [...mergedByKey.values()];
   }
 
   /**
@@ -552,6 +564,32 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
    */
   async makeRequest(url) {
     console.log(`LinkedIn Ads API Request URL:`, url);
+    const accessToken = await this.getAccessToken();
+
+    const headers = {
+      "LinkedIn-Version": "202607",
+      "X-RestLi-Protocol-Version": "2.0.0",
+    };
+
+    const authUrl = `${url}${url.includes('?') ? '&' : '?'}oauth2_access_token=${accessToken}`;
+
+    const response = await this.urlFetchWithRetry(authUrl, { headers });
+    const text = await response.getContentText();
+
+    return JSON.parse(text);
+  }
+
+  /**
+   * Get the access token for this run, exchanging the refresh token on first use only.
+   * LinkedIn access tokens are valid for 60 days, so one exchange per run is enough;
+   * exchanging on every request doubled the request count of the per-day analytics loop.
+   * @returns {Promise<string>} - Access token
+   */
+  async getAccessToken() {
+    if (this._isAccessTokenRefreshed) {
+      return this.config.AccessToken.value;
+    }
+
     const clientId = this._getClientId();
     const clientSecret = this._getClientSecret();
     const refreshToken = this._getRefreshToken();
@@ -560,7 +598,7 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
       throw new Error('LinkedIn Ads OAuth credentials are not configured');
     }
 
-    await OAuthUtils.getAccessToken({
+    const accessToken = await OAuthUtils.getAccessToken({
       config: this.config,
       tokenUrl: "https://www.linkedin.com/oauth/v2/accessToken",
       formData: {
@@ -570,19 +608,21 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
         client_secret: clientSecret
       }
     });
+    this._isAccessTokenRefreshed = true;
 
-    const headers = {
-      "LinkedIn-Version": "202607",
-      "X-RestLi-Protocol-Version": "2.0.0",
-    };
+    return accessToken;
+  }
 
-    const authUrl = `${url}${url.includes('?') ? '&' : '?'}oauth2_access_token=${this.config.AccessToken.value}`;
-
-    const response = await HttpUtils.fetch(authUrl, { headers });
-    const text = await response.getContentText();
-    const result = JSON.parse(text);
-
-    return result;
+  /**
+   * Retry transient LinkedIn failures: rate limits (429), server errors (5xx) and
+   * network-level errors (no status code). Auth errors (401/403) are not retried.
+   * @param {HttpRequestException} error - The error to check
+   * @returns {boolean} True if the request should be retried
+   */
+  isValidToRetry(error) {
+    return !error?.statusCode
+      || error.statusCode >= HTTP_STATUS.SERVER_ERROR_MIN
+      || error.statusCode === HTTP_STATUS.TOO_MANY_REQUESTS;
   }
   
   /**

--- a/packages/connectors/src/Sources/LinkedInAds/Source.js
+++ b/packages/connectors/src/Sources/LinkedInAds/Source.js
@@ -349,34 +349,13 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
     const truncatedDays = [];
 
     for (let day = new Date(startDate); day <= endDate; day.setDate(day.getDate() + 1)) {
-      // Field chunks are merged within the day only: rows from different days never share
-      // a dateRange, so merging into the multi-day accumulation would only rescan it.
-      let dayResults = [];
-      let isDayTruncated = false;
+      const { rows, isTruncated } = await this.fetchAdAnalyticsForDay({ day, encodedUrn, fieldChunks });
 
-      // Process each chunk of fields in separate API requests
-      for (const fieldChunk of fieldChunks) {
-        const url = this.buildAdAnalyticsUrl({
-          startDate: day,
-          endDate: day,
-          encodedUrn,
-          fields: fieldChunk
-        });
-        const res = await this.makeRequest(url);
-        const elements = res.elements || [];
-
-        if (elements.length >= this.MAX_RESPONSE_ELEMENTS) {
-          isDayTruncated = true;
-        }
-
-        // Merge results from different chunks into a single dataset
-        // Each chunk contains the same rows but different fields
-        dayResults = this.mergeAnalyticsResults(dayResults, elements);
+      for (const row of rows) {
+        allResults.push(row);
       }
 
-      allResults.push(...dayResults);
-
-      if (isDayTruncated) {
+      if (isTruncated) {
         truncatedDays.push(this.formatDateFromLinkedInObject(this.toLinkedInDateObject(day)));
       }
     }
@@ -387,6 +366,43 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
 
     // Transform complex dateRange objects to simple Date objects
     return this.transformAnalyticsDateRanges(allResults);
+  }
+
+  /**
+   * Fetch one day of analytics across all field chunks and merge them into single rows
+   * @param {Object} options - Request options
+   * @param {Date} options.day - The day to fetch
+   * @param {string} options.encodedUrn - URL-encoded account URN
+   * @param {Array<Array<string>>} options.fieldChunks - Field chunks, each within the per-request limit
+   * @returns {Promise<{rows: Array, isTruncated: boolean}>} - Merged rows and whether any chunk hit the element cap
+   */
+  async fetchAdAnalyticsForDay({ day, encodedUrn, fieldChunks }) {
+    // Field chunks are merged within the day only: rows from different days never share
+    // a dateRange, so merging into the multi-day accumulation would only rescan it.
+    let rows = [];
+    let isTruncated = false;
+
+    // Process each chunk of fields in separate API requests
+    for (const fieldChunk of fieldChunks) {
+      const url = this.buildAdAnalyticsUrl({
+        startDate: day,
+        endDate: day,
+        encodedUrn,
+        fields: fieldChunk
+      });
+      const res = await this.makeRequest(url);
+      const elements = res.elements || [];
+
+      if (elements.length >= this.MAX_RESPONSE_ELEMENTS) {
+        isTruncated = true;
+      }
+
+      // Merge results from different chunks into a single dataset
+      // Each chunk contains the same rows but different fields
+      rows = this.mergeAnalyticsResults(rows, elements);
+    }
+
+    return { rows, isTruncated };
   }
 
   /**

--- a/packages/connectors/src/Sources/LinkedInAds/Source.js
+++ b/packages/connectors/src/Sources/LinkedInAds/Source.js
@@ -176,6 +176,7 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
     
     this.fieldsSchema = LinkedInAdsFieldsSchema;
     this.MAX_FIELDS_PER_REQUEST = 20;
+    this.MAX_RESPONSE_ELEMENTS = 15000;
     this.BASE_URL = "https://api.linkedin.com/rest/";
   
   }
@@ -341,20 +342,43 @@ var LinkedInAdsSource = class LinkedInAdsSource extends AbstractSource {
     // To overcome this, split fields into chunks and make multiple requests
     const fieldChunks = this.prepareAnalyticsFieldChunks(uniqueApiFields);
 
-    // Process each chunk of fields in separate API requests
-    for (const fieldChunk of fieldChunks) {
-      const url = this.buildAdAnalyticsUrl({
-        startDate,
-        endDate,
-        encodedUrn,
-        fields: fieldChunk
-      });
-      const res = await this.makeRequest(url);
-      const elements = res.elements || [];
+    // The adAnalytics endpoint does not support pagination and caps each response at
+    // MAX_RESPONSE_ELEMENTS elements, so the requested range is fetched one day at a time
+    // to keep every request under the limit.
+    const truncatedDays = [];
 
-      // Merge results from different chunks into a single dataset
-      // Each chunk contains the same rows but different fields
-      allResults = this.mergeAnalyticsResults(allResults, elements);
+    for (let day = new Date(startDate); day <= endDate; day.setDate(day.getDate() + 1)) {
+      let dayTruncated = false;
+
+      // Process each chunk of fields in separate API requests
+      for (const fieldChunk of fieldChunks) {
+        const url = this.buildAdAnalyticsUrl({
+          startDate: day,
+          endDate: day,
+          encodedUrn,
+          fields: fieldChunk
+        });
+        const res = await this.makeRequest(url);
+        const elements = res.elements || [];
+
+        if (elements.length >= this.MAX_RESPONSE_ELEMENTS) {
+          dayTruncated = true;
+        }
+
+        // Merge results from different chunks into a single dataset
+        // Each chunk contains the same rows but different fields
+        allResults = this.mergeAnalyticsResults(allResults, elements);
+      }
+
+      if (dayTruncated) {
+        truncatedDays.push(this.formatDateForUrl(day));
+      }
+    }
+
+    if (truncatedDays.length > 0) {
+      this.config.addWarningToCurrentStatus(
+        `adAnalytics responses reached LinkedIn's ${this.MAX_RESPONSE_ELEMENTS}-element limit for ${truncatedDays.length} day(s) of ${urn} (e.g. ${truncatedDays[0]}); data for those days may be incomplete`
+      );
     }
 
     // Transform complex dateRange objects to simple Date objects

--- a/packages/connectors/test/Sources/LinkedInAds/Source.test.js
+++ b/packages/connectors/test/Sources/LinkedInAds/Source.test.js
@@ -8,6 +8,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 globalThis.CONFIG_ATTRIBUTES = new Proxy({}, { get: () => 'attr' });
 globalThis.OAUTH_CONSTANTS = new Proxy({}, { get: () => 'oauth' });
 globalThis.HttpUtils = { fetch: vi.fn() };
+globalThis.HTTP_STATUS = { TOO_MANY_REQUESTS: 429, SERVER_ERROR_MIN: 500 };
 globalThis.LinkedInAdsFieldsSchema = {};
 
 loadGasClass(path.join(__dirname, '../../../src/Sources/LinkedInAds/Source.js'), {
@@ -25,6 +26,16 @@ const buildSource = ({ makeRequest } = {}) => {
 
   return { self, warnings };
 };
+
+const linkedInDate = day => ({ year: 2026, month: 8, day });
+
+const buildRow = (day, pivotValues, metrics = {}) => ({
+  dateRange: { start: linkedInDate(day), end: linkedInDate(day) },
+  pivotValues,
+  ...metrics,
+});
+
+const buildFullDay = day => Array.from({ length: 15000 }, (_, i) => buildRow(day, [String(i)]));
 
 describe('fetchAdAnalytics', () => {
   it('requests one day at a time so each response stays under the API element limit', async () => {
@@ -87,17 +98,30 @@ describe('fetchAdAnalytics', () => {
     });
   });
 
-  it('warns when a day response reaches the API element limit', async () => {
+  it('keeps rows with the same pivot from different days as separate rows', async () => {
+    let requestCount = 0;
+    const { self } = buildSource({
+      makeRequest: vi.fn(async () => {
+        requestCount += 1;
+        return { elements: [buildRow(requestCount, ['creative'], { impressions: requestCount })] };
+      }),
+    });
+
+    const data = await sourceProto.fetchAdAnalytics.call(self, URN, {
+      startDate: new Date(2026, 7, 1),
+      endDate: new Date(2026, 7, 2),
+      fields: ['impressions'],
+    });
+
+    expect(data.map(row => [row.dateRangeStart, row.impressions])).toEqual([
+      ['2026-08-01', 1],
+      ['2026-08-02', 2],
+    ]);
+  });
+
+  it('warns with the affected day in YYYY-MM-DD format when a day response reaches the API element limit', async () => {
     const { self, warnings } = buildSource({
-      makeRequest: vi.fn(async () => ({
-        elements: Array.from({ length: 15000 }, (_, i) => ({
-          dateRange: {
-            start: { year: 2026, month: 8, day: 1 },
-            end: { year: 2026, month: 8, day: 1 },
-          },
-          pivotValues: [String(i)],
-        })),
-      })),
+      makeRequest: vi.fn(async () => ({ elements: buildFullDay(1) })),
     });
 
     await sourceProto.fetchAdAnalytics.call(self, URN, {
@@ -109,5 +133,107 @@ describe('fetchAdAnalytics', () => {
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('15000');
     expect(warnings[0]).toContain(URN);
+    expect(warnings[0]).toContain('1 day(s): 2026-08-01;');
+  });
+
+  it('lists at most 10 truncated days and counts the rest', async () => {
+    let requestCount = 0;
+    const { self, warnings } = buildSource({
+      makeRequest: vi.fn(async () => {
+        requestCount += 1;
+        return { elements: buildFullDay(requestCount) };
+      }),
+    });
+
+    await sourceProto.fetchAdAnalytics.call(self, URN, {
+      startDate: new Date(2026, 7, 1),
+      endDate: new Date(2026, 7, 12),
+      fields: ['impressions'],
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('12 day(s): 2026-08-01, 2026-08-02');
+    expect(warnings[0]).toContain('2026-08-10 and 2 more;');
+    expect(warnings[0]).not.toContain('2026-08-11');
+  });
+});
+
+describe('mergeAnalyticsResults', () => {
+  it('combines fields of rows with the same dateRange and pivotValues and appends the rest', () => {
+    const existing = [
+      buildRow(1, ['a'], { impressions: 1 }),
+      buildRow(1, ['b'], { impressions: 2 }),
+    ];
+    const incoming = [buildRow(1, ['b'], { clicks: 20 }), buildRow(1, ['c'], { clicks: 30 })];
+
+    const merged = sourceProto.mergeAnalyticsResults.call({}, existing, incoming);
+
+    expect(merged).toEqual([
+      buildRow(1, ['a'], { impressions: 1 }),
+      buildRow(1, ['b'], { impressions: 2, clicks: 20 }),
+      buildRow(1, ['c'], { clicks: 30 }),
+    ]);
+    expect(existing[1]).not.toHaveProperty('clicks');
+  });
+});
+
+describe('makeRequest', () => {
+  const buildAuthorizedSource = () => {
+    const self = new globalThis.LinkedInAdsSource({ mergeParameters: params => params });
+    self.config = {
+      AuthType: {
+        value: 'oauth2',
+        items: {
+          ClientId: { value: 'client-id' },
+          ClientSecret: { value: 'client-secret' },
+          RefreshToken: { value: 'refresh-token' },
+        },
+      },
+    };
+    self.urlFetchWithRetry = vi.fn(async () => ({ getContentText: async () => '{"elements":[]}' }));
+    globalThis.OAuthUtils = {
+      getAccessToken: vi.fn(async ({ config }) => {
+        config.AccessToken = { value: 'access-token' };
+        return 'access-token';
+      }),
+    };
+
+    return self;
+  };
+
+  it('exchanges the refresh token once per run and reuses the access token', async () => {
+    const self = buildAuthorizedSource();
+
+    await sourceProto.makeRequest.call(
+      self,
+      'https://api.linkedin.com/rest/adAnalytics?q=statistics'
+    );
+    await sourceProto.makeRequest.call(self, 'https://api.linkedin.com/rest/adAccounts/1');
+
+    expect(globalThis.OAuthUtils.getAccessToken).toHaveBeenCalledTimes(1);
+    expect(self.urlFetchWithRetry).toHaveBeenCalledTimes(2);
+    expect(self.urlFetchWithRetry.mock.calls[0][0]).toContain('&oauth2_access_token=access-token');
+    expect(self.urlFetchWithRetry.mock.calls[1][0]).toContain('?oauth2_access_token=access-token');
+  });
+
+  it('throws when OAuth credentials are missing', async () => {
+    const self = buildAuthorizedSource();
+    self.config = { AuthType: { value: 'oauth2', items: {} } };
+
+    await expect(
+      sourceProto.makeRequest.call(self, 'https://api.linkedin.com/rest/adAccounts/1')
+    ).rejects.toThrow('LinkedIn Ads OAuth credentials are not configured');
+  });
+});
+
+describe('isValidToRetry', () => {
+  it.each([
+    [{ statusCode: 429 }, true],
+    [{ statusCode: 503 }, true],
+    [{}, true],
+    [{ statusCode: 401 }, false],
+    [{ statusCode: 400 }, false],
+  ])('returns %s → %s', (error, expected) => {
+    expect(sourceProto.isValidToRetry.call({}, error)).toBe(expected);
   });
 });

--- a/packages/connectors/test/Sources/LinkedInAds/Source.test.js
+++ b/packages/connectors/test/Sources/LinkedInAds/Source.test.js
@@ -1,0 +1,113 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it, vi } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+globalThis.CONFIG_ATTRIBUTES = new Proxy({}, { get: () => 'attr' });
+globalThis.OAUTH_CONSTANTS = new Proxy({}, { get: () => 'oauth' });
+globalThis.HttpUtils = { fetch: vi.fn() };
+globalThis.LinkedInAdsFieldsSchema = {};
+
+loadGasClass(path.join(__dirname, '../../../src/Sources/LinkedInAds/Source.js'), {
+  AbstractSource: class {},
+});
+
+const sourceProto = globalThis.LinkedInAdsSource.prototype;
+const URN = '123456';
+
+const buildSource = ({ makeRequest } = {}) => {
+  const warnings = [];
+  const self = new globalThis.LinkedInAdsSource({ mergeParameters: params => params });
+  self.config = { addWarningToCurrentStatus: message => warnings.push(message) };
+  self.makeRequest = makeRequest;
+
+  return { self, warnings };
+};
+
+describe('fetchAdAnalytics', () => {
+  it('requests one day at a time so each response stays under the API element limit', async () => {
+    const requestedUrls = [];
+    const { self, warnings } = buildSource({
+      makeRequest: vi.fn(async url => {
+        requestedUrls.push(url);
+        return { elements: [] };
+      }),
+    });
+
+    await sourceProto.fetchAdAnalytics.call(self, URN, {
+      startDate: new Date(2026, 7, 1),
+      endDate: new Date(2026, 7, 3),
+      fields: ['impressions'],
+    });
+
+    expect(requestedUrls).toHaveLength(3);
+    expect(requestedUrls[0]).toContain(
+      'dateRange=(start:(year:2026,month:8,day:1),end:(year:2026,month:8,day:1))'
+    );
+    expect(requestedUrls[1]).toContain(
+      'dateRange=(start:(year:2026,month:8,day:2),end:(year:2026,month:8,day:2))'
+    );
+    expect(requestedUrls[2]).toContain(
+      'dateRange=(start:(year:2026,month:8,day:3),end:(year:2026,month:8,day:3))'
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('merges field chunks across the per-day requests', async () => {
+    const { self } = buildSource({
+      makeRequest: vi.fn(async url => ({
+        elements: [
+          {
+            dateRange: {
+              start: { year: 2026, month: 8, day: 1 },
+              end: { year: 2026, month: 8, day: 1 },
+            },
+            pivotValues: ['creative'],
+            ...(url.includes('impressions') ? { impressions: 10 } : { clicks: 5 }),
+          },
+        ],
+      })),
+    });
+    self.MAX_FIELDS_PER_REQUEST = 3;
+
+    const data = await sourceProto.fetchAdAnalytics.call(self, URN, {
+      startDate: new Date(2026, 7, 1),
+      endDate: new Date(2026, 7, 1),
+      fields: ['impressions', 'clicks'],
+    });
+
+    expect(data).toHaveLength(1);
+    expect(data[0]).toMatchObject({
+      impressions: 10,
+      clicks: 5,
+      dateRangeStart: '2026-08-01',
+      dateRangeEnd: '2026-08-01',
+    });
+  });
+
+  it('warns when a day response reaches the API element limit', async () => {
+    const { self, warnings } = buildSource({
+      makeRequest: vi.fn(async () => ({
+        elements: Array.from({ length: 15000 }, (_, i) => ({
+          dateRange: {
+            start: { year: 2026, month: 8, day: 1 },
+            end: { year: 2026, month: 8, day: 1 },
+          },
+          pivotValues: [String(i)],
+        })),
+      })),
+    });
+
+    await sourceProto.fetchAdAnalytics.call(self, URN, {
+      startDate: new Date(2026, 7, 1),
+      endDate: new Date(2026, 7, 1),
+      fields: ['impressions'],
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('15000');
+    expect(warnings[0]).toContain(URN);
+  });
+});

--- a/packages/connectors/test/Sources/LinkedInAds/Source.test.js
+++ b/packages/connectors/test/Sources/LinkedInAds/Source.test.js
@@ -27,6 +27,9 @@ const buildSource = ({ makeRequest } = {}) => {
   return { self, warnings };
 };
 
+// Run dates are UTC midnight (see AbstractConnector), so tests use the same shape.
+const utcDay = day => new Date(Date.UTC(2026, 7, day));
+
 const linkedInDate = day => ({ year: 2026, month: 8, day });
 
 const buildRow = (day, pivotValues, metrics = {}) => ({
@@ -37,8 +40,15 @@ const buildRow = (day, pivotValues, metrics = {}) => ({
 
 const buildFullDay = day => Array.from({ length: 15000 }, (_, i) => buildRow(day, [String(i)]));
 
+const fetchDay = (self, day, fields = ['impressions']) =>
+  sourceProto.fetchAdAnalytics.call(self, URN, {
+    startDate: utcDay(day),
+    endDate: utcDay(day),
+    fields,
+  });
+
 describe('fetchAdAnalytics', () => {
-  it('requests one day at a time so each response stays under the API element limit', async () => {
+  it('requests exactly the given day and records nothing under the element limit', async () => {
     const requestedUrls = [];
     const { self, warnings } = buildSource({
       makeRequest: vi.fn(async url => {
@@ -47,47 +57,31 @@ describe('fetchAdAnalytics', () => {
       }),
     });
 
-    await sourceProto.fetchAdAnalytics.call(self, URN, {
-      startDate: new Date(2026, 7, 1),
-      endDate: new Date(2026, 7, 3),
-      fields: ['impressions'],
-    });
+    await fetchDay(self, 1);
 
-    expect(requestedUrls).toHaveLength(3);
+    expect(requestedUrls).toHaveLength(1);
     expect(requestedUrls[0]).toContain(
       'dateRange=(start:(year:2026,month:8,day:1),end:(year:2026,month:8,day:1))'
     );
-    expect(requestedUrls[1]).toContain(
-      'dateRange=(start:(year:2026,month:8,day:2),end:(year:2026,month:8,day:2))'
-    );
-    expect(requestedUrls[2]).toContain(
-      'dateRange=(start:(year:2026,month:8,day:3),end:(year:2026,month:8,day:3))'
-    );
     expect(warnings).toHaveLength(0);
+    expect(self.truncatedAnalyticsDays).toEqual({});
   });
 
-  it('merges field chunks across the per-day requests', async () => {
+  it('merges field chunks into single rows', async () => {
     const { self } = buildSource({
       makeRequest: vi.fn(async url => ({
         elements: [
-          {
-            dateRange: {
-              start: { year: 2026, month: 8, day: 1 },
-              end: { year: 2026, month: 8, day: 1 },
-            },
-            pivotValues: ['creative'],
-            ...(url.includes('impressions') ? { impressions: 10 } : { clicks: 5 }),
-          },
+          buildRow(
+            1,
+            ['creative'],
+            url.includes('impressions') ? { impressions: 10 } : { clicks: 5 }
+          ),
         ],
       })),
     });
     self.MAX_FIELDS_PER_REQUEST = 3;
 
-    const data = await sourceProto.fetchAdAnalytics.call(self, URN, {
-      startDate: new Date(2026, 7, 1),
-      endDate: new Date(2026, 7, 1),
-      fields: ['impressions', 'clicks'],
-    });
+    const data = await fetchDay(self, 1, ['impressions', 'clicks']);
 
     expect(data).toHaveLength(1);
     expect(data[0]).toMatchObject({
@@ -98,63 +92,60 @@ describe('fetchAdAnalytics', () => {
     });
   });
 
-  it('keeps rows with the same pivot from different days as separate rows', async () => {
-    let requestCount = 0;
-    const { self } = buildSource({
-      makeRequest: vi.fn(async () => {
-        requestCount += 1;
-        return { elements: [buildRow(requestCount, ['creative'], { impressions: requestCount })] };
-      }),
-    });
-
-    const data = await sourceProto.fetchAdAnalytics.call(self, URN, {
-      startDate: new Date(2026, 7, 1),
-      endDate: new Date(2026, 7, 2),
-      fields: ['impressions'],
-    });
-
-    expect(data.map(row => [row.dateRangeStart, row.impressions])).toEqual([
-      ['2026-08-01', 1],
-      ['2026-08-02', 2],
-    ]);
-  });
-
-  it('warns with the affected day in YYYY-MM-DD format when a day response reaches the API element limit', async () => {
+  it('records a day whose response reaches the element limit instead of warning per call', async () => {
     const { self, warnings } = buildSource({
       makeRequest: vi.fn(async () => ({ elements: buildFullDay(1) })),
     });
 
-    await sourceProto.fetchAdAnalytics.call(self, URN, {
-      startDate: new Date(2026, 7, 1),
-      endDate: new Date(2026, 7, 1),
-      fields: ['impressions'],
-    });
+    await fetchDay(self, 1);
 
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('15000');
-    expect(warnings[0]).toContain(URN);
-    expect(warnings[0]).toContain('1 day(s): 2026-08-01;');
+    expect(warnings).toHaveLength(0);
+    expect(self.truncatedAnalyticsDays).toEqual({ [URN]: ['2026-08-01'] });
   });
 
-  it('lists at most 10 truncated days and counts the rest', async () => {
-    let requestCount = 0;
-    const { self, warnings } = buildSource({
-      makeRequest: vi.fn(async () => {
-        requestCount += 1;
-        return { elements: buildFullDay(requestCount) };
-      }),
+  it('accumulates truncated days per account across calls', async () => {
+    const { self } = buildSource({
+      makeRequest: vi.fn(async () => ({ elements: buildFullDay(1) })),
     });
 
-    await sourceProto.fetchAdAnalytics.call(self, URN, {
-      startDate: new Date(2026, 7, 1),
-      endDate: new Date(2026, 7, 12),
-      fields: ['impressions'],
-    });
+    await fetchDay(self, 1);
+    await fetchDay(self, 2);
 
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('12 day(s): 2026-08-01, 2026-08-02');
-    expect(warnings[0]).toContain('2026-08-10 and 2 more;');
-    expect(warnings[0]).not.toContain('2026-08-11');
+    expect(self.truncatedAnalyticsDays).toEqual({ [URN]: ['2026-08-01', '2026-08-02'] });
+  });
+});
+
+describe('buildTruncationWarning', () => {
+  it('names the account, the limit and the day', () => {
+    const warning = sourceProto.buildTruncationWarning.call(buildSource().self, URN, [
+      '2026-08-01',
+    ]);
+
+    expect(warning).toContain('15000');
+    expect(warning).toContain(URN);
+    expect(warning).toContain('1 day(s): 2026-08-01;');
+  });
+
+  it('lists at most 10 days and counts the rest', () => {
+    const days = Array.from({ length: 12 }, (_, i) => `2026-08-${String(i + 1).padStart(2, '0')}`);
+
+    const warning = sourceProto.buildTruncationWarning.call(buildSource().self, URN, days);
+
+    expect(warning).toContain('12 day(s): 2026-08-01, 2026-08-02');
+    expect(warning).toContain('2026-08-10 and 2 more;');
+    expect(warning).not.toContain('2026-08-11');
+  });
+});
+
+describe('formatDateForUrl', () => {
+  it('reads the UTC date so the request names the same day as the UTC cursor on any runner', () => {
+    // 23:30Z on Jul 31 is already Aug 1 in local time on a UTC+ runner.
+    const formatted = sourceProto.formatDateForUrl.call(
+      sourceProto,
+      new Date('2026-07-31T23:30:00Z')
+    );
+
+    expect(formatted).toBe('(year:2026,month:7,day:31)');
   });
 });
 

--- a/packages/connectors/test/Sources/LinkedInAds/perDayCheckpoint.test.js
+++ b/packages/connectors/test/Sources/LinkedInAds/perDayCheckpoint.test.js
@@ -1,0 +1,189 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { loadGasClass } from '../../support/loadGasClass.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+globalThis.DateUtils = { formatDate: date => date.toISOString().slice(0, 10) };
+globalThis.RUN_CONFIG_TYPE = { INCREMENTAL: 'INCREMENTAL', MANUAL_BACKFILL: 'MANUAL_BACKFILL' };
+globalThis.ConnectorUtils = { isTimeSeriesNode: schema => schema?.isTimeSeries === true };
+globalThis.FormatUtils = {
+  parseIds: value => value.split(','),
+  parseFields: value => JSON.parse(value),
+};
+
+loadGasClass(path.join(__dirname, '../../../src/Sources/LinkedInAds/Connector.js'), {
+  AbstractConnector: class {},
+});
+
+const connectorProto = globalThis.LinkedInAdsConnector.prototype;
+
+const REPORT_NODE = 'adAnalytics';
+const CATALOG_NODE = 'adCampaigns';
+
+const buildConnector = ({
+  urns = 'acc1',
+  nodes = { [REPORT_NODE]: ['impressions'] },
+  runType = 'INCREMENTAL',
+  startDate = new Date('2026-08-10T00:00:00Z'),
+  daysToFetch = 3,
+  fetchData = async () => [{ impressions: 1 }],
+  saveData = async () => undefined,
+} = {}) => {
+  const cursorMovedTo = [];
+  const fetched = [];
+  const requestedRanges = [];
+
+  const self = Object.create(connectorProto);
+  self.runConfig = { type: runType };
+  self.source = {
+    fieldsSchema: {
+      [REPORT_NODE]: { isTimeSeries: true },
+      [CATALOG_NODE]: { isTimeSeries: false },
+    },
+    fetchData: async (nodeName, urn, params) => {
+      const { startDate: from, endDate: to } = params;
+      fetched.push(`${urn}/${nodeName}/${from ? DateUtils.formatDate(from) : 'catalog'}`);
+      if (from) requestedRanges.push([DateUtils.formatDate(from), DateUtils.formatDate(to)]);
+      return fetchData({ nodeName, urn, date: from });
+    },
+  };
+  self.getStorageByNode = async () => ({ saveData });
+  self.addMissingFieldsToData = data => data;
+  self.getStartDateAndDaysToFetch = () => [startDate, daysToFetch];
+  self.config = {
+    AccountURNs: { value: urns },
+    Fields: { value: JSON.stringify(nodes) },
+    CreateEmptyTables: { value: false },
+    logMessage: () => {},
+    updateLastRequstedDate: date => cursorMovedTo.push(DateUtils.formatDate(new Date(date))),
+  };
+
+  return { self, cursorMovedTo, fetched, requestedRanges };
+};
+
+describe('incremental checkpointing', () => {
+  it('saves the cursor after each completed day instead of only at the end', async () => {
+    const { self, cursorMovedTo } = buildConnector();
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11', '2026-08-12']);
+  });
+
+  it('requests every day as a single-day range so no response can span days', async () => {
+    const { self, requestedRanges } = buildConnector();
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(requestedRanges).toEqual([
+      ['2026-08-10', '2026-08-10'],
+      ['2026-08-11', '2026-08-11'],
+      ['2026-08-12', '2026-08-12'],
+    ]);
+  });
+
+  it('keeps the days already imported when a later day fails', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      fetchData: async ({ date }) => {
+        if (DateUtils.formatDate(date) === '2026-08-12') throw new Error('Connector died');
+        return [{ impressions: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow('Connector died');
+
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not move the cursor past a day whose storage write failed', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      saveData: async () => {
+        throw new Error('BigQuery write failed');
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'BigQuery write failed'
+    );
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('never moves the incremental cursor during a manual backfill', async () => {
+    const { self, cursorMovedTo } = buildConnector({ runType: 'MANUAL_BACKFILL' });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+});
+
+describe('multiple accounts', () => {
+  it('completes a date for every account before moving the cursor', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({
+      urns: 'acc1,acc2',
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([
+      `acc1/${REPORT_NODE}/2026-08-10`,
+      `acc2/${REPORT_NODE}/2026-08-10`,
+      `acc1/${REPORT_NODE}/2026-08-11`,
+      `acc2/${REPORT_NODE}/2026-08-11`,
+    ]);
+    expect(cursorMovedTo).toEqual(['2026-08-10', '2026-08-11']);
+  });
+
+  it('does not checkpoint a date that only the first account imported', async () => {
+    const { self, cursorMovedTo } = buildConnector({
+      urns: 'acc1,acc2',
+      fetchData: async ({ urn, date }) => {
+        if (urn === 'acc2' && DateUtils.formatDate(date) === '2026-08-11') {
+          throw new Error('Account acc2 failed');
+        }
+        return [{ impressions: 1 }];
+      },
+    });
+
+    await expect(connectorProto.startImportProcess.call(self)).rejects.toThrow(
+      'Account acc2 failed'
+    );
+
+    expect(cursorMovedTo).toEqual(['2026-08-10']);
+  });
+});
+
+describe('node types', () => {
+  it('imports catalog nodes once per account, before any day is requested', async () => {
+    const { self, fetched } = buildConnector({
+      nodes: { [CATALOG_NODE]: ['id'], [REPORT_NODE]: ['impressions'] },
+      daysToFetch: 2,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched[0]).toBe(`acc1/${CATALOG_NODE}/catalog`);
+    expect(fetched.filter(entry => entry.includes(CATALOG_NODE))).toHaveLength(1);
+  });
+
+  it('skips the day loop entirely when only catalog nodes are selected', async () => {
+    const { self, cursorMovedTo } = buildConnector({ nodes: { [CATALOG_NODE]: ['id'] } });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(cursorMovedTo).toEqual([]);
+  });
+
+  it('imports nothing when the range has no days left to fetch', async () => {
+    const { self, cursorMovedTo, fetched } = buildConnector({ daysToFetch: 0 });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(fetched).toEqual([]);
+    expect(cursorMovedTo).toEqual([]);
+  });
+});

--- a/packages/connectors/test/Sources/LinkedInAds/perDayCheckpoint.test.js
+++ b/packages/connectors/test/Sources/LinkedInAds/perDayCheckpoint.test.js
@@ -30,10 +30,12 @@ const buildConnector = ({
   daysToFetch = 3,
   fetchData = async () => [{ impressions: 1 }],
   saveData = async () => undefined,
+  truncatedAnalyticsDays = {},
 } = {}) => {
   const cursorMovedTo = [];
   const fetched = [];
   const requestedRanges = [];
+  const warnings = [];
 
   const self = Object.create(connectorProto);
   self.runConfig = { type: runType };
@@ -48,6 +50,8 @@ const buildConnector = ({
       if (from) requestedRanges.push([DateUtils.formatDate(from), DateUtils.formatDate(to)]);
       return fetchData({ nodeName, urn, date: from });
     },
+    truncatedAnalyticsDays,
+    buildTruncationWarning: (urn, days) => `${urn} truncated on ${days.join(', ')}`,
   };
   self.getStorageByNode = async () => ({ saveData });
   self.addMissingFieldsToData = data => data;
@@ -57,10 +61,11 @@ const buildConnector = ({
     Fields: { value: JSON.stringify(nodes) },
     CreateEmptyTables: { value: false },
     logMessage: () => {},
+    addWarningToCurrentStatus: message => warnings.push(message),
     updateLastRequstedDate: date => cursorMovedTo.push(DateUtils.formatDate(new Date(date))),
   };
 
-  return { self, cursorMovedTo, fetched, requestedRanges };
+  return { self, cursorMovedTo, fetched, requestedRanges, warnings };
 };
 
 describe('incremental checkpointing', () => {
@@ -82,6 +87,24 @@ describe('incremental checkpointing', () => {
       ['2026-08-11', '2026-08-11'],
       ['2026-08-12', '2026-08-12'],
     ]);
+  });
+
+  it('advances days in UTC so a DST switch on the runner cannot shift or repeat a day', async () => {
+    // Europe switches to summer time on 2026-03-29; local date arithmetic would land
+    // 2026-03-30 at 23:00Z on the 29th and fetch the 29th twice.
+    const { self, requestedRanges, cursorMovedTo } = buildConnector({
+      startDate: new Date('2026-03-28T00:00:00Z'),
+      daysToFetch: 3,
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(requestedRanges.map(([from]) => from)).toEqual([
+      '2026-03-28',
+      '2026-03-29',
+      '2026-03-30',
+    ]);
+    expect(cursorMovedTo).toEqual(['2026-03-28', '2026-03-29', '2026-03-30']);
   });
 
   it('keeps the days already imported when a later day fails', async () => {
@@ -154,6 +177,30 @@ describe('multiple accounts', () => {
     );
 
     expect(cursorMovedTo).toEqual(['2026-08-10']);
+  });
+});
+
+describe('truncation reporting', () => {
+  it('emits one warning per account listing its truncated days after the day loop', async () => {
+    const { self, warnings } = buildConnector({
+      urns: 'acc1,acc2',
+      truncatedAnalyticsDays: { acc1: ['2026-08-10', '2026-08-11'], acc2: ['2026-08-12'] },
+    });
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(warnings).toEqual([
+      'acc1 truncated on 2026-08-10, 2026-08-11',
+      'acc2 truncated on 2026-08-12',
+    ]);
+  });
+
+  it('emits no warning when no day reached the element limit', async () => {
+    const { self, warnings } = buildConnector();
+
+    await connectorProto.startImportProcess.call(self);
+
+    expect(warnings).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Problem

An `adAnalytics` export over a large date range could silently lose data: campaigns from the beginning of the period were missing from the result. Re-exporting a single day recovered them — the data was not gone, it was truncated.

The LinkedIn `adAnalytics` endpoint does not support pagination and caps its response at 15,000 elements (https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting, *Restrictions*). A wide date range × campaigns × creatives easily exceeds the cap, and LinkedIn silently drops the excess.

## Fix

- `fetchAdAnalytics` now requests analytics **one day at a time** (day × field chunks), so a single day cannot exceed the 15,000-element limit.
- If a daily response still reaches 15,000 elements, the import finishes with a **Warning** status and a message about possible truncation (element count + example day) instead of losing data silently.

## Verification

- New tests `packages/connectors/test/Sources/LinkedInAds/Source.test.js` (3 cases): per-day URLs, field-chunk merging, truncation warning.
- Full `packages/connectors` suite: 200/200 passing.
- ESLint clean.

## Docs

- FAQ entry added to `GETTING_STARTED.md` explaining the Warning status case.