### PR TITLE
feat(backend): add report output-schema endpoint

### DIFF
--- a/.changeset/6807-report-output-schema.md
+++ b/.changeset/6807-report-output-schema.md
@@ -1,0 +1,9 @@
+---
+'owox': minor
+---
+
+# Report output column schema
+
+`GET /reports/:id/output-schema` returns the columns a report's rows will carry — name, title, description and type — including aggregated columns (`revenue | SUM`), Unique Count and calculated fields, which do not exist on the Data Mart schema.
+
+Joined fields in Excel reports now use the same header form as Google Sheets: `Field name (Data Mart name)`, so the field name stays visible in a narrow spreadsheet cell.

--- a/apps/backend/src/data-marts/controllers/report.controller.ts
+++ b/apps/backend/src/data-marts/controllers/report.controller.ts
@@ -6,6 +6,7 @@ import { ReportMapper } from '../mappers/report.mapper';
 import { CreateReportRequestApiDto } from '../dto/presentation/create-report-request-api.dto';
 import { UpdateReportRequestApiDto } from '../dto/presentation/update-report-request-api.dto';
 import { ReportResponseApiDto } from '../dto/presentation/report-response-api.dto';
+import { ReportOutputSchemaFieldApiDto } from '../dto/presentation/report-output-schema-field-api.dto';
 import { CreateReportService } from '../use-cases/create-report.service';
 import { GetReportService } from '../use-cases/get-report.service';
 import { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
@@ -14,6 +15,7 @@ import { DeleteReportService } from '../use-cases/delete-report.service';
 import { RunReportService } from '../use-cases/run-report.service';
 import { UpdateReportService } from '../use-cases/update-report.service';
 import { GetReportGeneratedSqlService } from '../use-cases/get-report-generated-sql.service';
+import { GetReportOutputSchemaService } from '../use-cases/get-report-output-schema.service';
 import { CopyReportAsDataMartService } from '../use-cases/copy-report-as-data-mart.service';
 import { ReconnectGoogleSheetService } from '../use-cases/google-sheets/reconnect-google-sheet.service';
 import { ReconnectGoogleSheetResponseDto } from '../dto/presentation/google-sheets/reconnect-google-sheet-response.dto';
@@ -27,6 +29,7 @@ import {
   UpdateReportSpec,
   ListReportsByInsightTemplateSpec,
   GetReportGeneratedSqlSpec,
+  GetReportOutputSchemaSpec,
   CopyReportAsDataMartSpec,
 } from './spec/report.api';
 
@@ -42,6 +45,7 @@ export class ReportController {
     private readonly runReportService: RunReportService,
     private readonly updateReportService: UpdateReportService,
     private readonly getReportGeneratedSqlService: GetReportGeneratedSqlService,
+    private readonly getReportOutputSchemaService: GetReportOutputSchemaService,
     private readonly copyReportAsDataMartService: CopyReportAsDataMartService,
     private readonly reconnectGoogleSheetService: ReconnectGoogleSheetService,
     private readonly mapper: ReportMapper
@@ -144,6 +148,18 @@ export class ReportController {
   ): Promise<ReconnectGoogleSheetResponseDto> {
     const command = this.mapper.toReconnectGoogleSheetCommand(id, context);
     return this.reconnectGoogleSheetService.run(command);
+  }
+
+  @Auth(Role.viewer(Strategy.PARSE))
+  @Get(':id/output-schema')
+  @GetReportOutputSchemaSpec()
+  async getOutputSchema(
+    @AuthContext() context: AuthorizationContext,
+    @Param('id') id: string
+  ): Promise<ReportOutputSchemaFieldApiDto[]> {
+    const command = this.mapper.toGetOutputSchemaCommand(id, context);
+    const headers = await this.getReportOutputSchemaService.run(command);
+    return this.mapper.toOutputSchemaResponse(headers);
   }
 
   @Auth(Role.viewer(Strategy.PARSE))

--- a/apps/backend/src/data-marts/controllers/spec/report.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.api.ts
@@ -118,7 +118,7 @@ export function GetReportOutputSchemaSpec() {
     ApiParam({ name: 'id', description: 'Report ID' }),
     ApiOkResponse({
       description:
-        "The columns the report's rows will carry, in the order they are projected. `name` is the key each row is keyed by; `title` is the alias configured for it, absent when there is none. Columns the report synthesises — aggregated (`<column> | <FN>`), Unique Count, calculated fields — appear here and nowhere in the Data Mart schema.",
+        "The columns the report's rows will carry, in the order they are projected, as of the Data Mart's last schema actualization. `name` is the key each row is keyed by; `title` is the alias configured for it, absent when there is none. Columns the report synthesises — aggregated (`<column> | <FN>`), Unique Count, calculated fields — appear here and nowhere in the Data Mart schema. This reads the stored schema rather than the warehouse, so a column added warehouse-side and not yet actualized is missing here until a run or a data read picks it up.",
       type: [ReportOutputSchemaFieldApiDto],
     })
   );

--- a/apps/backend/src/data-marts/controllers/spec/report.api.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.api.ts
@@ -8,6 +8,7 @@ import {
   ApiParam,
 } from '@nestjs/swagger';
 import { ReportResponseApiDto } from '../../dto/presentation/report-response-api.dto';
+import { ReportOutputSchemaFieldApiDto } from '../../dto/presentation/report-output-schema-field-api.dto';
 import { ReconnectGoogleSheetResponseDto } from '../../dto/presentation/google-sheets/reconnect-google-sheet-response.dto';
 import {
   createReportRequestBodySchema,
@@ -107,6 +108,18 @@ export function ListReportsByInsightTemplateSpec() {
     ApiOkResponse({
       description: 'List of email reports that use the insight template as their template source',
       type: [ReportResponseApiDto],
+    })
+  );
+}
+
+export function GetReportOutputSchemaSpec() {
+  return applyDecorators(
+    ApiOperation({ summary: "Get the resolved column schema of a report's output" }),
+    ApiParam({ name: 'id', description: 'Report ID' }),
+    ApiOkResponse({
+      description:
+        "The columns the report's rows will carry, in the order they are projected. `name` is the key each row is keyed by; `title` is the alias configured for it, absent when there is none. Columns the report synthesises — aggregated (`<column> | <FN>`), Unique Count, calculated fields — appear here and nowhere in the Data Mart schema.",
+      type: [ReportOutputSchemaFieldApiDto],
     })
   );
 }

--- a/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
+++ b/apps/backend/src/data-marts/controllers/spec/report.openapi.spec.ts
@@ -21,6 +21,7 @@ import { CopyReportAsDataMartService } from '../../use-cases/copy-report-as-data
 import { CreateReportService } from '../../use-cases/create-report.service';
 import { DeleteReportService } from '../../use-cases/delete-report.service';
 import { GetReportGeneratedSqlService } from '../../use-cases/get-report-generated-sql.service';
+import { GetReportOutputSchemaService } from '../../use-cases/get-report-output-schema.service';
 import { GetReportService } from '../../use-cases/get-report.service';
 import { ListReportsByDataMartService } from '../../use-cases/list-reports-by-data-mart.service';
 import { ListReportsByInsightTemplateService } from '../../use-cases/list-reports-by-insight-template.service';
@@ -40,6 +41,7 @@ describe('ReportController OpenAPI', () => {
       CreateReportService,
       DeleteReportService,
       GetReportGeneratedSqlService,
+      GetReportOutputSchemaService,
       GetReportService,
       ListReportsByDataMartService,
       ListReportsByInsightTemplateService,
@@ -287,6 +289,16 @@ describe('ReportController OpenAPI', () => {
   });
 
   it('documents small object responses', () => {
+    expect(document.paths['/api/reports/{id}/output-schema']?.get?.responses['200']).toMatchObject({
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: { $ref: expect.stringContaining('ReportOutputSchemaFieldApiDto') },
+          },
+        },
+      },
+    });
     expect(document.paths['/api/reports/{id}/generated-sql']?.get?.responses['200']).toMatchObject({
       content: {
         'application/json': {

--- a/apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum.spec.ts
+++ b/apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum.spec.ts
@@ -10,10 +10,16 @@ describe('usesSuffixedJoinedFieldNames', () => {
     expect(usesSuffixedJoinedFieldNames(DataDestinationType.GOOGLE_SHEETS)).toBe(true);
   });
 
+  it('is enabled for Excel', () => {
+    expect(usesSuffixedJoinedFieldNames(DataDestinationType.EXCEL)).toBe(true);
+  });
+
   // Driven off the enum rather than a hand-written list so a newly added destination type is
   // covered the moment it appears, pinning the prefix default until someone opts it in explicitly.
   it.each(
-    Object.values(DataDestinationType).filter(type => type !== DataDestinationType.GOOGLE_SHEETS)
+    Object.values(DataDestinationType).filter(
+      type => type !== DataDestinationType.GOOGLE_SHEETS && type !== DataDestinationType.EXCEL
+    )
   )('keeps the prefix for %s', type => {
     expect(usesSuffixedJoinedFieldNames(type)).toBe(false);
   });

--- a/apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum.ts
+++ b/apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum.ts
@@ -72,8 +72,16 @@ export function requiresCredentials(type: DataDestinationType): boolean {
  * on every column at once. The other destinations render the label with enough room that the
  * prefix reads fine, so they keep it.
  *
- * Excel qualifies on that same ground. Left out here, a run's recorded label disagreed with the
- * header written into the worksheet.
+ * Excel qualifies on that same ground, but reaches the label by a different road than Google
+ * Sheets: nothing pushes rows into a workbook, so its add-in pulls the worksheet header from
+ * `GET /reports/:id/output-schema`, which resolves the style from the Report. This opt-in is what
+ * that header follows, and it is the only surface it reaches.
+ *
+ * It deliberately does NOT reach the same report's stream metadata or run record. Those are built
+ * from a `ReportLikeReadPlan`, which drops `dataDestination` on purpose (see `streamReport` in
+ * `stream-http-data.service.ts`) so that NDJSON — where a prefix has room to read fine — does not
+ * change shape just because a report happens to write to a spreadsheet. So the two differ by
+ * design: suffix in the worksheet header, prefix in the recorded run. Nothing keys on either.
  *
  * What this pins is the POSITION of the Data Mart name, not a byte-exact label: every surface
  * still normalizes whitespace (see `formatBlendedFieldDisplayName`), and no consumer keys on the

--- a/apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum.ts
+++ b/apps/backend/src/data-marts/data-destination-types/enums/data-destination-type.enum.ts
@@ -67,10 +67,13 @@ export function requiresCredentials(type: DataDestinationType): boolean {
  * Destinations that render a field from a joined Data Mart as `Field name (Data Mart name)`.
  * Everywhere else the Data Mart name stays a prefix: `Data Mart name Field name`.
  *
- * Google Sheets writes the label into a spreadsheet header cell, which is narrow and not resizable
- * per column by the reader — a leading Data Mart name pushes the field name out of view on every
- * column at once. The other destinations render the label with enough room that the prefix reads
- * fine, so they keep it.
+ * Both spreadsheet destinations write the label into a header cell, which is narrow and not
+ * resizable per column by the reader — a leading Data Mart name pushes the field name out of view
+ * on every column at once. The other destinations render the label with enough room that the
+ * prefix reads fine, so they keep it.
+ *
+ * Excel qualifies on that same ground. Left out here, a run's recorded label disagreed with the
+ * header written into the worksheet.
  *
  * What this pins is the POSITION of the Data Mart name, not a byte-exact label: every surface
  * still normalizes whitespace (see `formatBlendedFieldDisplayName`), and no consumer keys on the
@@ -80,5 +83,5 @@ export function requiresCredentials(type: DataDestinationType): boolean {
  * New destination types default to the prefix; opt in here deliberately.
  */
 export function usesSuffixedJoinedFieldNames(type: DataDestinationType): boolean {
-  return type === DataDestinationType.GOOGLE_SHEETS;
+  return type === DataDestinationType.GOOGLE_SHEETS || type === DataDestinationType.EXCEL;
 }

--- a/apps/backend/src/data-marts/data-marts.module.ts
+++ b/apps/backend/src/data-marts/data-marts.module.ts
@@ -382,6 +382,7 @@ import { ListRelationshipsByStorageService } from './use-cases/list-relationship
 import { GetDataMartRelationshipGraphService } from './use-cases/get-data-mart-relationship-graph.service';
 import { GetBlendableSchemaService } from './use-cases/get-blendable-schema.service';
 import { GetReportGeneratedSqlService } from './use-cases/get-report-generated-sql.service';
+import { GetReportOutputSchemaService } from './use-cases/get-report-output-schema.service';
 import { CopyReportAsDataMartService } from './use-cases/copy-report-as-data-mart.service';
 import { DataMartRelationshipController } from './controllers/data-mart-relationship.controller';
 import { DataStorageRelationshipController } from './controllers/data-storage-relationship.controller';
@@ -884,6 +885,7 @@ import { PluginEntityAuthorizationFacadeImpl } from './facades/plugin-entity-aut
     GetDataMartRelationshipGraphService,
     GetBlendableSchemaService,
     GetReportGeneratedSqlService,
+    GetReportOutputSchemaService,
     CopyReportAsDataMartService,
     ContextService,
     ContextAccessService,

--- a/apps/backend/src/data-marts/dto/domain/blending-decision.dto.ts
+++ b/apps/backend/src/data-marts/dto/domain/blending-decision.dto.ts
@@ -36,9 +36,17 @@ export interface BlendingDecision {
    */
   uniqueCountSources?: JoinedUniqueCountSource[];
   /**
-   * Calculated fields the blended SQL projects through its own formula-substitution channel.
-   * Their names are already stripped out of `columnFilter` — a reader must forward BOTH, or the
-   * metric is emitted by the SQL with no header naming it.
+   * The report's selected calculated fields, as plans.
+   *
+   * On the BLENDED path these are what the SQL projects through its own formula-substitution
+   * channel, and their names are already stripped out of `columnFilter` — a reader must forward
+   * BOTH, or the metric is emitted by the SQL with no header naming it.
+   *
+   * On the NON-blended path no SQL is produced here, so the plans are carried purely so a caller
+   * that only needs to NAME the columns does not have to rebuild them (or compose SQL to get at
+   * them). `columnFilter` is the raw column config there and still holds the metric names, so such
+   * a caller strips them itself. A caller that goes on to execute must keep taking its plans from
+   * `compose()`, which is the one that renders them.
    */
   calculatedFields?: CalculatedFieldPlan[];
 }

--- a/apps/backend/src/data-marts/dto/domain/get-report-output-schema.command.ts
+++ b/apps/backend/src/data-marts/dto/domain/get-report-output-schema.command.ts
@@ -1,0 +1,8 @@
+export class GetReportOutputSchemaCommand {
+  constructor(
+    public readonly reportId: string,
+    public readonly userId: string,
+    public readonly projectId: string,
+    public readonly roles: string[]
+  ) {}
+}

--- a/apps/backend/src/data-marts/dto/domain/report-like-read-plan.spec.ts
+++ b/apps/backend/src/data-marts/dto/domain/report-like-read-plan.spec.ts
@@ -124,6 +124,14 @@ describe('usesSuffixedJoinedFieldNames', () => {
     ).toBe(true);
   });
 
+  it('is enabled for a report writing to Excel', () => {
+    // Same ground as Google Sheets: the label lands in a header cell the reader cannot widen for
+    // one column alone.
+    expect(
+      usesSuffixedJoinedFieldNames(reportWithDestination({ type: DataDestinationType.EXCEL }))
+    ).toBe(true);
+  });
+
   it('is disabled for a report writing to any other destination', () => {
     expect(
       usesSuffixedJoinedFieldNames(

--- a/apps/backend/src/data-marts/dto/presentation/report-output-schema-field-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/report-output-schema-field-api.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/** One column of a report's output, as a reader of the rows would name and understand it. */
+export class ReportOutputSchemaFieldApiDto {
+  @ApiProperty({
+    description: 'Key each output row is keyed by',
+    example: 'revenue | SUM',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: 'Alias configured for the column; absent when there is none',
+    example: 'Revenue, $ | SUM',
+    required: false,
+  })
+  title?: string;
+
+  @ApiProperty({
+    description: 'Field description from the Data Mart schema, when the column has one',
+    required: false,
+  })
+  description?: string;
+
+  @ApiProperty({
+    description: 'Storage field type of the column, when known',
+    example: 'NUMERIC',
+    required: false,
+  })
+  type?: string;
+}

--- a/apps/backend/src/data-marts/dto/presentation/report-output-schema-field-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/report-output-schema-field-api.dto.ts
@@ -1,4 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
+import {
+  CALCULATED_FIELD_LEVELS,
+  type CalculatedFieldLevel,
+} from '../../calculated-fields/formula-level';
 
 /** One column of a report's output, as a reader of the rows would name and understand it. */
 export class ReportOutputSchemaFieldApiDto {
@@ -39,8 +43,8 @@ export class ReportOutputSchemaFieldApiDto {
   @ApiProperty({
     description:
       "Set only for a calculated field, carrying the level its formula was derived to have. `metric` means the formula AGGREGATES: re-aggregating it is wrong at any grain, whatever `type` says. `column` means it is row-level and behaves like a column of its declared type, but no warehouse column backs it. Absent means an ordinary native column, which a consumer may treat as re-summable — so do not read an absent value as 'unknown'.",
-    enum: ['metric', 'column'],
+    enum: CALCULATED_FIELD_LEVELS,
     required: false,
   })
-  calculatedFieldLevel?: string;
+  calculatedFieldLevel?: CalculatedFieldLevel;
 }

--- a/apps/backend/src/data-marts/dto/presentation/report-output-schema-field-api.dto.ts
+++ b/apps/backend/src/data-marts/dto/presentation/report-output-schema-field-api.dto.ts
@@ -27,4 +27,20 @@ export class ReportOutputSchemaFieldApiDto {
     required: false,
   })
   type?: string;
+
+  @ApiProperty({
+    description:
+      'The aggregate function the report applies to this column, when it applies one. Absent for a plain projected column.',
+    example: 'SUM',
+    required: false,
+  })
+  aggregateFunction?: string;
+
+  @ApiProperty({
+    description:
+      "Set only for a calculated field, carrying the level its formula was derived to have. `metric` means the formula AGGREGATES: re-aggregating it is wrong at any grain, whatever `type` says. `column` means it is row-level and behaves like a column of its declared type, but no warehouse column backs it. Absent means an ordinary native column, which a consumer may treat as re-summable — so do not read an absent value as 'unknown'.",
+    enum: ['metric', 'column'],
+    required: false,
+  })
+  calculatedFieldLevel?: string;
 }

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
@@ -73,6 +73,10 @@ import type { ScheduledTriggerService } from '../services/scheduled-trigger.serv
 import type { CreateReportService } from '../use-cases/create-report.service';
 import type { CreateGoogleSheetDocumentService } from '../use-cases/google-sheets/create-google-sheet-document.service';
 import type { DeleteReportService } from '../use-cases/delete-report.service';
+import type { GetReportOutputSchemaService } from '../use-cases/get-report-output-schema.service';
+import { GetReportOutputSchemaCommand } from '../dto/domain/get-report-output-schema.command';
+import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
+import { BigQueryFieldType } from '../data-storage-types/bigquery/enums/bigquery-field-type.enum';
 import type { GetReportService } from '../use-cases/get-report.service';
 import type { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
 import type { RunReportService } from '../use-cases/run-report.service';
@@ -196,6 +200,9 @@ function createMocks() {
     reportService: {
       existsByDataMartIdAndDestinationIdAndProjectId: jest.fn().mockResolvedValue(false),
     } as unknown as jest.Mocked<ReportService>,
+    getReportOutputSchemaService: {
+      run: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<GetReportOutputSchemaService>,
   };
 }
 
@@ -229,7 +236,8 @@ function createFacade(overrides?: {
       mocks.accessDecisionService,
       mocks.reportAccessService,
       mocks.outputControlsValidator,
-      mocks.reportService
+      mocks.reportService,
+      mocks.getReportOutputSchemaService
     ),
     ...mocks,
   };
@@ -1902,5 +1910,61 @@ describe('McpReportsFacadeImpl.getReportRunStatus', () => {
       'report-1',
       'project-1'
     );
+  });
+});
+
+describe('McpReportsFacadeImpl.getReportOutputSchema', () => {
+  it('delegates to the output-schema service with the caller identity', async () => {
+    const { facade, getReportOutputSchemaService } = createFacade();
+
+    await facade.getReportOutputSchema({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      reportId: 'report-1',
+    });
+
+    expect(getReportOutputSchemaService.run).toHaveBeenCalledWith(
+      new GetReportOutputSchemaCommand('report-1', 'user-1', 'project-1', ['viewer'])
+    );
+  });
+
+  // An MCP result is serialized to JSON, where an absent key reads as "unknown" rather than
+  // "this column has no alias". Every optional header field is published as an explicit null.
+  it('publishes a header with no alias, description or type as explicit nulls', async () => {
+    const { facade, getReportOutputSchemaService } = createFacade();
+    getReportOutputSchemaService.run.mockResolvedValue([
+      new ReportDataHeader('date', 'Date', 'Reporting day', BigQueryFieldType.DATE),
+      new ReportDataHeader('clicks'),
+    ]);
+
+    await expect(
+      facade.getReportOutputSchema({
+        projectId: 'project-1',
+        userId: 'user-1',
+        roles: ['viewer'],
+        reportId: 'report-1',
+      })
+    ).resolves.toEqual({
+      reportId: 'report-1',
+      columns: [
+        { name: 'date', title: 'Date', description: 'Reporting day', type: BigQueryFieldType.DATE },
+        { name: 'clicks', title: null, description: null, type: null },
+      ],
+    });
+  });
+
+  it('lets the service refuse a caller who cannot see the source data mart', async () => {
+    const { facade, getReportOutputSchemaService } = createFacade();
+    getReportOutputSchemaService.run.mockRejectedValue(new ForbiddenException('nope'));
+
+    await expect(
+      facade.getReportOutputSchema({
+        projectId: 'project-1',
+        userId: 'user-1',
+        roles: ['viewer'],
+        reportId: 'report-1',
+      })
+    ).rejects.toBeInstanceOf(ForbiddenException);
   });
 });

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.spec.ts
@@ -1948,8 +1948,22 @@ describe('McpReportsFacadeImpl.getReportOutputSchema', () => {
     ).resolves.toEqual({
       reportId: 'report-1',
       columns: [
-        { name: 'date', title: 'Date', description: 'Reporting day', type: BigQueryFieldType.DATE },
-        { name: 'clicks', title: null, description: null, type: null },
+        {
+          name: 'date',
+          title: 'Date',
+          description: 'Reporting day',
+          type: BigQueryFieldType.DATE,
+          aggregateFunction: null,
+          calculatedFieldLevel: null,
+        },
+        {
+          name: 'clicks',
+          title: null,
+          description: null,
+          type: null,
+          aggregateFunction: null,
+          calculatedFieldLevel: null,
+        },
       ],
     });
   });

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
@@ -178,6 +178,8 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
         title: header.alias ?? null,
         description: header.description ?? null,
         type: header.storageFieldType ?? null,
+        aggregateFunction: header.aggregateFunction ?? null,
+        calculatedFieldLevel: header.calculatedFieldLevel ?? null,
       })),
     };
   }

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.impl.ts
@@ -22,6 +22,7 @@ import { LookerStudioConnectorConfigType } from '../data-destination-types/looke
 import { TemplateSourceTypeEnum } from '../enums/template-source-type.enum';
 import { CreateReportCommand } from '../dto/domain/create-report.command';
 import { DeleteReportCommand } from '../dto/domain/delete-report.command';
+import { GetReportOutputSchemaCommand } from '../dto/domain/get-report-output-schema.command';
 import { GetReportCommand } from '../dto/domain/get-report.command';
 import { CreateGoogleSheetDocumentCommand } from '../dto/domain/google-sheets/create-google-sheet-document.command';
 import { ListReportsByDataMartCommand } from '../dto/domain/list-reports-by-data-mart.command';
@@ -49,6 +50,7 @@ import { ReportService } from '../services/report.service';
 import { ScheduledTriggerService } from '../services/scheduled-trigger.service';
 import { CreateReportService } from '../use-cases/create-report.service';
 import { DeleteReportService } from '../use-cases/delete-report.service';
+import { GetReportOutputSchemaService } from '../use-cases/get-report-output-schema.service';
 import { GetReportService } from '../use-cases/get-report.service';
 import { CreateGoogleSheetDocumentService } from '../use-cases/google-sheets/create-google-sheet-document.service';
 import { ListReportsByDataMartService } from '../use-cases/list-reports-by-data-mart.service';
@@ -64,6 +66,8 @@ import {
   McpDeleteReportResult,
   McpGetDataMartReportsRequest,
   McpGetDataMartReportsResponse,
+  McpGetReportOutputSchemaRequest,
+  McpGetReportOutputSchemaResponse,
   McpGetReportRunStatusRequest,
   McpGetReportRunStatusResponse,
   McpReportRunStatus,
@@ -145,8 +149,38 @@ export class McpReportsFacadeImpl implements McpReportsFacade {
     private readonly accessDecisionService: AccessDecisionService,
     private readonly reportAccessService: ReportAccessService,
     private readonly outputControlsValidator: OutputControlsValidatorService,
-    private readonly reportService: ReportService
+    private readonly reportService: ReportService,
+    private readonly getReportOutputSchemaService: GetReportOutputSchemaService
   ) {}
+
+  /**
+   * Delegated whole: the service enforces authentication, not-found and the
+   * see-the-source-data-mart rule itself, and resolves the headers without reading report data.
+   * Only the header shape is remapped — `undefined` becomes `null`, because an MCP result is
+   * serialized to JSON and an absent key reads as "unknown" rather than "no alias".
+   */
+  async getReportOutputSchema(
+    request: McpGetReportOutputSchemaRequest
+  ): Promise<McpGetReportOutputSchemaResponse> {
+    const headers = await this.getReportOutputSchemaService.run(
+      new GetReportOutputSchemaCommand(
+        request.reportId,
+        request.userId,
+        request.projectId,
+        request.roles
+      )
+    );
+
+    return {
+      reportId: request.reportId,
+      columns: headers.map(header => ({
+        name: header.name,
+        title: header.alias ?? null,
+        description: header.description ?? null,
+        type: header.storageFieldType ?? null,
+      })),
+    };
+  }
 
   async deleteReport(request: McpDeleteReportRequest): Promise<McpDeleteReportResult> {
     // The service enforces not-found and mutate-access itself and returns

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
@@ -246,6 +246,14 @@ export interface McpReportOutputSchemaColumn {
   description: string | null;
   /** Storage field type, null when it cannot be derived (e.g. an SQL-override column). */
   type: string | null;
+  /** The aggregate function the report applies to this column; null when it applies none. */
+  aggregateFunction: string | null;
+  /**
+   * Set only for a calculated field: `metric` means the formula aggregates and must NOT be
+   * re-aggregated at any grain, `column` means it is row-level with no warehouse column behind it.
+   * Null is an ordinary native column a consumer may roll up — not "unknown".
+   */
+  calculatedFieldLevel: string | null;
 }
 
 export interface McpGetReportOutputSchemaResponse {

--- a/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
+++ b/apps/backend/src/data-marts/facades/mcp-reports.facade.ts
@@ -230,6 +230,29 @@ export interface McpGetReportRunStatusResponse {
   error: string | null;
 }
 
+export interface McpGetReportOutputSchemaRequest {
+  projectId: string;
+  userId: string;
+  roles: string[];
+  reportId: string;
+}
+
+/** One column of a report's output, as a reader of the rows would name and understand it. */
+export interface McpReportOutputSchemaColumn {
+  /** The key each output row is keyed by. */
+  name: string;
+  /** The alias configured for the column; null when there is none. */
+  title: string | null;
+  description: string | null;
+  /** Storage field type, null when it cannot be derived (e.g. an SQL-override column). */
+  type: string | null;
+}
+
+export interface McpGetReportOutputSchemaResponse {
+  reportId: string;
+  columns: McpReportOutputSchemaColumn[];
+}
+
 export interface McpReportsFacade {
   getDataMartReports(request: McpGetDataMartReportsRequest): Promise<McpGetDataMartReportsResponse>;
   /**
@@ -264,4 +287,15 @@ export interface McpReportsFacade {
   deleteReport(request: McpDeleteReportRequest): Promise<McpDeleteReportResult>;
   runReport(request: McpRunReportRequest): Promise<McpRunReportResponse>;
   getReportRunStatus(request: McpGetReportRunStatusRequest): Promise<McpGetReportRunStatusResponse>;
+  /**
+   * The columns a report's rows will carry, in the order they are projected — the names to put
+   * above the values `query_data_mart` and the HTTP data stream return.
+   *
+   * Includes the columns the report synthesises (aggregated `revenue | SUM`, Unique Count,
+   * calculated fields), which appear in no Data Mart schema. Resolved from the stored schema and
+   * the report config, so it answers without reading any report data.
+   */
+  getReportOutputSchema(
+    request: McpGetReportOutputSchemaRequest
+  ): Promise<McpGetReportOutputSchemaResponse>;
 }

--- a/apps/backend/src/data-marts/mappers/report.mapper.spec.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.spec.ts
@@ -234,8 +234,49 @@ describe('ReportMapper — uniqueCountConfig round-trip', () => {
         new ReportDataHeader('clicks'),
       ])
     ).toEqual([
-      { name: 'date', title: 'Date', description: 'Reporting day', type: 'DATE' },
-      { name: 'clicks', title: undefined, description: undefined, type: undefined },
+      {
+        name: 'date',
+        title: 'Date',
+        description: 'Reporting day',
+        type: 'DATE',
+        aggregateFunction: undefined,
+        calculatedFieldLevel: undefined,
+      },
+      {
+        name: 'clicks',
+        title: undefined,
+        description: undefined,
+        type: undefined,
+        aggregateFunction: undefined,
+        calculatedFieldLevel: undefined,
+      },
+    ]);
+  });
+
+  // `type` alone cannot separate a non-additive calculated metric from an ordinary numeric column,
+  // and a consumer that re-aggregates the first is wrong at any grain. Both discriminators travel.
+  it('toOutputSchemaResponse: carries the aggregate function and the calculated-field level', () => {
+    expect(
+      mapper.toOutputSchemaResponse([
+        new ReportDataHeader(
+          'revenue | SUM',
+          'Revenue, $ | SUM',
+          undefined,
+          BigQueryFieldType.NUMERIC,
+          'SUM'
+        ),
+        new ReportDataHeader(
+          'ctr',
+          'CTR, %',
+          undefined,
+          BigQueryFieldType.FLOAT,
+          undefined,
+          'metric'
+        ),
+      ])
+    ).toEqual([
+      expect.objectContaining({ name: 'revenue | SUM', aggregateFunction: 'SUM' }),
+      expect.objectContaining({ name: 'ctr', calculatedFieldLevel: 'metric' }),
     ]);
   });
 });

--- a/apps/backend/src/data-marts/mappers/report.mapper.spec.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.spec.ts
@@ -5,6 +5,8 @@ import { DataMartMapper } from './data-mart.mapper';
 import { DataDestinationMapper } from './data-destination.mapper';
 import { Report } from '../entities/report.entity';
 import { ReportDto } from '../dto/domain/report.dto';
+import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
+import { BigQueryFieldType } from '../data-storage-types/bigquery/enums/bigquery-field-type.enum';
 import { CreateReportRequestApiDto } from '../dto/presentation/create-report-request-api.dto';
 import { UpdateReportRequestApiDto } from '../dto/presentation/update-report-request-api.dto';
 import { AuthorizationContext } from '../../idp';
@@ -223,5 +225,17 @@ describe('ReportMapper — uniqueCountConfig round-trip', () => {
 
     expect(cmd.aggregationConfig).toEqual([{ column: 'revenue', function: 'SUM' }]);
     expect(cmd.dateTruncConfig).toEqual([{ column: 'date', unit: 'MONTH' }]);
+  });
+
+  it('toOutputSchemaResponse: publishes alias as title', () => {
+    expect(
+      mapper.toOutputSchemaResponse([
+        new ReportDataHeader('date', 'Date', 'Reporting day', BigQueryFieldType.DATE),
+        new ReportDataHeader('clicks'),
+      ])
+    ).toEqual([
+      { name: 'date', title: 'Date', description: 'Reporting day', type: 'DATE' },
+      { name: 'clicks', title: undefined, description: undefined, type: undefined },
+    ]);
   });
 });

--- a/apps/backend/src/data-marts/mappers/report.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.ts
@@ -273,6 +273,11 @@ export class ReportMapper {
       title: header.alias,
       description: header.description,
       type: header.storageFieldType,
+      aggregateFunction: header.aggregateFunction,
+      // Carried rather than dropped: `type` alone cannot separate a non-additive calculated metric
+      // from an ordinary numeric column, and a consumer that re-aggregates the first is wrong at
+      // any grain. See the field's own doc on ReportDataHeader.
+      calculatedFieldLevel: header.calculatedFieldLevel,
     }));
   }
 

--- a/apps/backend/src/data-marts/mappers/report.mapper.ts
+++ b/apps/backend/src/data-marts/mappers/report.mapper.ts
@@ -15,7 +15,10 @@ import { ListReportsByInsightTemplateCommand } from '../dto/domain/list-reports-
 import { ManualRunReportCommand } from '../dto/domain/run-report.command';
 import { CopyReportAsDataMartCommand } from '../dto/domain/copy-report-as-data-mart.command';
 import { ReconnectGoogleSheetCommand } from '../dto/domain/google-sheets/reconnect-google-sheet.command';
+import { GetReportOutputSchemaCommand } from '../dto/domain/get-report-output-schema.command';
 import { GetReportGeneratedSqlCommand } from '../dto/domain/get-report-generated-sql.command';
+import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
+import { ReportOutputSchemaFieldApiDto } from '../dto/presentation/report-output-schema-field-api.dto';
 import { AuthorizationContext } from '../../idp';
 import { DataMartMapper } from './data-mart.mapper';
 import { DataDestinationMapper } from './data-destination.mapper';
@@ -250,6 +253,27 @@ export class ReportMapper {
       context.projectId,
       context.roles ?? []
     );
+  }
+
+  toGetOutputSchemaCommand(
+    reportId: string,
+    context: AuthorizationContext
+  ): GetReportOutputSchemaCommand {
+    return new GetReportOutputSchemaCommand(
+      reportId,
+      context.userId,
+      context.projectId,
+      context.roles ?? []
+    );
+  }
+
+  toOutputSchemaResponse(headers: ReportDataHeader[]): ReportOutputSchemaFieldApiDto[] {
+    return headers.map(header => ({
+      name: header.name,
+      title: header.alias,
+      description: header.description,
+      type: header.storageFieldType,
+    }));
   }
 
   toGetGeneratedSqlCommand(

--- a/apps/backend/src/data-marts/services/blended-report-data.service.ts
+++ b/apps/backend/src/data-marts/services/blended-report-data.service.ts
@@ -306,6 +306,11 @@ export class BlendedReportDataService {
         columnFilter: columnConfig,
         blendedDataHeaders,
         primaryKeyColumns,
+        // Carried rather than dropped: they are already built above, and a caller that only names
+        // the report's columns would otherwise parse every formula a second time. Callers that
+        // execute overwrite this from `compose()` on this path anyway — safe because non-empty
+        // plans mean a calculated field is selected, which makes `hasOutputControls` true.
+        calculatedFields: calculatedFields.length > 0 ? calculatedFields : undefined,
       };
     }
 

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -478,7 +478,10 @@ export class ReportSqlComposerService {
    * them for the grain question: a row-level field the report aggregates stops being a grouping
    * key, and every site downstream reads that off the plan.
    */
-  private buildCalculatedFieldPlans(
+  // Pure: reads the stored schema only, no warehouse access. Public so a caller that needs the
+  // plans WITHOUT the SQL (the output-schema describe) does not have to compose — composing
+  // refreshes a SQL Data Mart's view, which a describe must not do.
+  buildCalculatedFieldPlans(
     schemaFields: readonly DataMartSchemaField[],
     names: readonly string[],
     aggregations: AggregationRule[] | undefined

--- a/apps/backend/src/data-marts/services/report-sql-composer.service.ts
+++ b/apps/backend/src/data-marts/services/report-sql-composer.service.ts
@@ -478,10 +478,7 @@ export class ReportSqlComposerService {
    * them for the grain question: a row-level field the report aggregates stops being a grouping
    * key, and every site downstream reads that off the plan.
    */
-  // Pure: reads the stored schema only, no warehouse access. Public so a caller that needs the
-  // plans WITHOUT the SQL (the output-schema describe) does not have to compose — composing
-  // refreshes a SQL Data Mart's view, which a describe must not do.
-  buildCalculatedFieldPlans(
+  private buildCalculatedFieldPlans(
     schemaFields: readonly DataMartSchemaField[],
     names: readonly string[],
     aggregations: AggregationRule[] | undefined

--- a/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.spec.ts
@@ -1,0 +1,107 @@
+import { ForbiddenException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { BigQueryFieldType } from '../data-storage-types/bigquery/enums/bigquery-field-type.enum';
+import { GetReportOutputSchemaCommand } from '../dto/domain/get-report-output-schema.command';
+import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
+import { GetReportOutputSchemaService } from './get-report-output-schema.service';
+
+describe('GetReportOutputSchemaService', () => {
+  const schema = { fields: [] };
+  const report = {
+    id: 'report-1',
+    dataMart: { id: 'dm-1', storage: { id: 'storage-1', type: 'BIGQUERY' }, schema },
+    dataDestination: { id: 'dest-1' },
+    aggregationConfig: null,
+    uniqueCountConfig: null,
+  };
+
+  const createService = ({
+    canSee = true,
+    found = true,
+    nativeHeaders = [] as ReportDataHeader[],
+    decision = {} as Record<string, unknown>,
+  } = {}) => {
+    const reportRepository = {
+      findOne: jest.fn().mockResolvedValue(found ? report : null),
+    };
+    const generateHeadersFromSchema = jest.fn().mockResolvedValue(nativeHeaders);
+    const compose = jest.fn().mockResolvedValue({ calculatedFields: undefined });
+    const service = new GetReportOutputSchemaService(
+      reportRepository as never,
+      {
+        resolveBlendingDecision: jest.fn().mockResolvedValue({ needsBlending: false, ...decision }),
+      } as never,
+      { compose } as never,
+      { canAccess: jest.fn().mockResolvedValue(canSee) } as never,
+      { generateHeadersFromSchema } as never
+    );
+    return { service, reportRepository, generateHeadersFromSchema, compose };
+  };
+
+  const command = new GetReportOutputSchemaCommand('report-1', 'user-1', 'project-1', ['admin']);
+
+  it('names the columns a report synthesises, which no schema field describes', async () => {
+    const { service, generateHeadersFromSchema } = createService({
+      nativeHeaders: [
+        new ReportDataHeader('date', 'Date', 'Reporting day', BigQueryFieldType.DATE),
+        new ReportDataHeader('revenue', 'Revenue, $', undefined, BigQueryFieldType.NUMERIC),
+        new ReportDataHeader('clicks'),
+      ],
+      decision: {
+        columnFilter: ['date', 'revenue', 'clicks'],
+        aggregations: [{ column: 'revenue', function: 'SUM' }],
+      },
+    });
+
+    await expect(service.run(command)).resolves.toEqual([
+      expect.objectContaining({
+        name: 'date',
+        alias: 'Date',
+        description: 'Reporting day',
+        storageFieldType: BigQueryFieldType.DATE,
+      }),
+      expect.objectContaining({
+        name: 'revenue | SUM',
+        alias: 'Revenue, $ | SUM',
+        storageFieldType: BigQueryFieldType.NUMERIC,
+      }),
+      expect.objectContaining({ name: 'clicks' }),
+    ]);
+
+    expect(generateHeadersFromSchema).toHaveBeenCalledWith('BIGQUERY', schema);
+  });
+
+  it('describes the output from the stored schema, without a storage reader', async () => {
+    const { service, generateHeadersFromSchema, reportRepository } = createService();
+
+    await service.run(command);
+
+    expect(generateHeadersFromSchema).toHaveBeenCalledTimes(1);
+    expect(reportRepository.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        relations: ['dataMart', 'dataMart.storage', 'dataDestination'],
+      })
+    );
+  });
+
+  it('refuses a caller who cannot see the source data mart', async () => {
+    const { service, generateHeadersFromSchema } = createService({ canSee: false });
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(ForbiddenException);
+    expect(generateHeadersFromSchema).not.toHaveBeenCalled();
+  });
+
+  it('reports a report that is not there', async () => {
+    const { service, generateHeadersFromSchema } = createService({ found: false });
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(NotFoundException);
+    expect(generateHeadersFromSchema).not.toHaveBeenCalled();
+  });
+
+  it('requires an authenticated user', async () => {
+    const { service, generateHeadersFromSchema } = createService();
+    const anonymous = new GetReportOutputSchemaCommand('report-1', '', 'project-1', []);
+
+    await expect(service.run(anonymous)).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(generateHeadersFromSchema).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.spec.ts
@@ -1,4 +1,6 @@
 import { ForbiddenException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { DataStorageType } from '../data-storage-types/enums/data-storage-type.enum';
 import { BigQueryFieldType } from '../data-storage-types/bigquery/enums/bigquery-field-type.enum';
 import { GetReportOutputSchemaCommand } from '../dto/domain/get-report-output-schema.command';
 import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
@@ -19,25 +21,42 @@ describe('GetReportOutputSchemaService', () => {
     found = true,
     nativeHeaders = [] as ReportDataHeader[],
     decision = {} as Record<string, unknown>,
+    reportOverrides = {} as Record<string, unknown>,
   } = {}) => {
     const reportRepository = {
-      findOne: jest.fn().mockResolvedValue(found ? report : null),
+      findOne: jest.fn().mockResolvedValue(found ? { ...report, ...reportOverrides } : null),
     };
     const generateHeadersFromSchema = jest.fn().mockResolvedValue(nativeHeaders);
     const compose = jest.fn().mockResolvedValue({ calculatedFields: undefined });
+    const buildCalculatedFieldPlans = jest.fn().mockReturnValue([]);
     const service = new GetReportOutputSchemaService(
       reportRepository as never,
       {
         resolveBlendingDecision: jest.fn().mockResolvedValue({ needsBlending: false, ...decision }),
       } as never,
-      { compose } as never,
+      { compose, buildCalculatedFieldPlans } as never,
       { canAccess: jest.fn().mockResolvedValue(canSee) } as never,
       { generateHeadersFromSchema } as never
     );
-    return { service, reportRepository, generateHeadersFromSchema, compose };
+    return {
+      service,
+      reportRepository,
+      generateHeadersFromSchema,
+      compose,
+      buildCalculatedFieldPlans,
+    };
   };
 
   const command = new GetReportOutputSchemaCommand('report-1', 'user-1', 'project-1', ['admin']);
+
+  // `integerTypeFor` refuses an unrecognized storage type, so anything synthesising a Unique Count
+  // header needs a real one rather than the bare 'BIGQUERY' the base fixture carries.
+  const onBigQuery = {
+    dataMart: {
+      ...report.dataMart,
+      storage: { id: 'storage-1', type: DataStorageType.GOOGLE_BIGQUERY },
+    },
+  };
 
   it('names the columns a report synthesises, which no schema field describes', async () => {
     const { service, generateHeadersFromSchema } = createService({
@@ -81,6 +100,94 @@ describe('GetReportOutputSchemaService', () => {
         relations: ['dataMart', 'dataMart.storage', 'dataDestination'],
       })
     );
+  });
+
+  // `compose` resolves the main table reference, which for a SQL-defined Data Mart runs
+  // `CREATE OR REPLACE VIEW` against the customer's warehouse. Describing a report is a read, so
+  // the plans are built straight from the stored schema instead.
+  it('builds calculated-field plans for a report with output controls without composing SQL', async () => {
+    const { service, compose, buildCalculatedFieldPlans } = createService({
+      reportOverrides: { limitConfig: 100 },
+      decision: { columnFilter: ['clicks', 'ctr'] },
+    });
+
+    await service.run(command);
+
+    expect(compose).not.toHaveBeenCalled();
+    expect(buildCalculatedFieldPlans).toHaveBeenCalledWith([], ['clicks', 'ctr'], undefined);
+  });
+
+  // The blended branch: joined headers and calculated fields have no Data Mart schema field behind
+  // them, so the decision is their only source. Order is pinned too — a calculated field stripped
+  // out of `columnFilter` lands AFTER the joined Unique Count, not at the position it was selected.
+  it('describes a blended report from the decision: joined columns, Unique Count sources, metrics', async () => {
+    const { service } = createService({
+      reportOverrides: onBigQuery,
+      nativeHeaders: [
+        new ReportDataHeader('date', 'Date', 'Reporting day', BigQueryFieldType.DATE),
+      ],
+      decision: {
+        needsBlending: true,
+        columnFilter: ['date', 'orders_amount', 'ctr'],
+        blendedDataHeaders: [
+          new ReportDataHeader(
+            'orders_amount',
+            'Amount (Orders)',
+            undefined,
+            BigQueryFieldType.NUMERIC
+          ),
+        ],
+        uniqueCountSources: [
+          { outputLabel: 'orders__unique_count', displayLabel: 'Unique Count (Orders)' },
+        ],
+        calculatedFields: [
+          {
+            outputName: 'ctr',
+            type: 'FLOAT',
+            formula: 'clicks / impressions',
+            level: 'metric',
+            alias: 'CTR, %',
+          },
+        ],
+      },
+    });
+
+    await expect(service.run(command)).resolves.toEqual([
+      expect.objectContaining({ name: 'date', alias: 'Date' }),
+      expect.objectContaining({ name: 'orders_amount', alias: 'Amount (Orders)' }),
+      expect.objectContaining({
+        name: 'orders__unique_count',
+        alias: 'Unique Count (Orders)',
+        storageFieldType: BigQueryFieldType.INTEGER,
+      }),
+      expect.objectContaining({ name: 'ctr', alias: 'CTR, %' }),
+    ]);
+  });
+
+  it('publishes the main Unique Count column, which the Data Mart schema does not carry', async () => {
+    const { service } = createService({
+      reportOverrides: { ...onBigQuery, uniqueCountConfig: true },
+      nativeHeaders: [new ReportDataHeader('date', 'Date', undefined, BigQueryFieldType.DATE)],
+      decision: { columnFilter: ['date'], primaryKeyColumns: ['id'] },
+    });
+
+    await expect(service.run(command)).resolves.toEqual([
+      expect.objectContaining({ name: 'date' }),
+      expect.objectContaining({
+        name: 'Unique Count',
+        storageFieldType: BigQueryFieldType.INTEGER,
+        aggregateFunction: 'COUNT_DISTINCT',
+      }),
+    ]);
+  });
+
+  it('refuses a Data Mart whose schema was never stored', async () => {
+    const { service, generateHeadersFromSchema } = createService({
+      reportOverrides: { dataMart: { ...report.dataMart, schema: undefined } },
+    });
+
+    await expect(service.run(command)).rejects.toBeInstanceOf(BusinessViolationException);
+    expect(generateHeadersFromSchema).not.toHaveBeenCalled();
   });
 
   it('refuses a caller who cannot see the source data mart', async () => {

--- a/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.spec.ts
@@ -27,15 +27,12 @@ describe('GetReportOutputSchemaService', () => {
       findOne: jest.fn().mockResolvedValue(found ? { ...report, ...reportOverrides } : null),
     };
     const generateHeadersFromSchema = jest.fn().mockResolvedValue(nativeHeaders);
-    const compose = jest.fn().mockResolvedValue({ calculatedFields: undefined });
-    const buildCalculatedFieldPlans = jest.fn().mockReturnValue([]);
     const resolveBlendingDecision = jest
       .fn()
       .mockResolvedValue({ needsBlending: false, ...decision });
     const service = new GetReportOutputSchemaService(
       reportRepository as never,
       { resolveBlendingDecision } as never,
-      { compose, buildCalculatedFieldPlans } as never,
       { canAccess: jest.fn().mockResolvedValue(canSee) } as never,
       { generateHeadersFromSchema } as never
     );
@@ -43,8 +40,6 @@ describe('GetReportOutputSchemaService', () => {
       service,
       reportRepository,
       generateHeadersFromSchema,
-      compose,
-      buildCalculatedFieldPlans,
       resolveBlendingDecision,
     };
   };
@@ -120,19 +115,20 @@ describe('GetReportOutputSchemaService', () => {
     );
   });
 
-  // `compose` resolves the main table reference, which for a SQL-defined Data Mart runs
-  // `CREATE OR REPLACE VIEW` against the customer's warehouse. Describing a report is a read, so
-  // the plans are built straight from the stored schema instead.
-  it('builds calculated-field plans for a report with output controls without composing SQL', async () => {
-    const { service, compose, buildCalculatedFieldPlans } = createService({
+  // The plans come off the decision on BOTH paths, so naming a report's columns never parses a
+  // formula twice and never calls `compose()` — which would refresh a SQL Data Mart's view.
+  it('takes calculated-field plans from the decision on the non-blended path', async () => {
+    const plans = [{ outputName: 'ctr', type: 'FLOAT', formula: 'clicks / impressions' }];
+    const { service } = createService({
       reportOverrides: { limitConfig: 100 },
-      decision: { columnFilter: ['clicks', 'ctr'] },
+      nativeHeaders: [new ReportDataHeader('clicks')],
+      decision: { columnFilter: ['clicks', 'ctr'], calculatedFields: plans },
     });
 
-    await service.run(command);
-
-    expect(compose).not.toHaveBeenCalled();
-    expect(buildCalculatedFieldPlans).toHaveBeenCalledWith([], ['clicks', 'ctr'], undefined);
+    await expect(service.run(command)).resolves.toEqual([
+      expect.objectContaining({ name: 'clicks' }),
+      expect.objectContaining({ name: 'ctr' }),
+    ]);
   });
 
   // The blended branch: joined headers and calculated fields have no Data Mart schema field behind

--- a/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.spec.ts
@@ -102,6 +102,22 @@ describe('GetReportOutputSchemaService', () => {
     );
   });
 
+  // Cross-project isolation lives in the QUERY, not in a later check: a report id belonging to
+  // another project must not resolve at all, so the caller cannot tell it apart from one that does
+  // not exist. Asserted explicitly because the repository is mocked here — dropping the projectId
+  // clause would otherwise pass every other test in this file.
+  it('looks the report up only within the caller project', async () => {
+    const { service, reportRepository } = createService();
+
+    await service.run(command);
+
+    expect(reportRepository.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'report-1', dataMart: { projectId: 'project-1' } },
+      })
+    );
+  });
+
   // `compose` resolves the main table reference, which for a SQL-defined Data Mart runs
   // `CREATE OR REPLACE VIEW` against the customer's warehouse. Describing a report is a read, so
   // the plans are built straight from the stored schema instead.

--- a/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.spec.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.spec.ts
@@ -29,11 +29,12 @@ describe('GetReportOutputSchemaService', () => {
     const generateHeadersFromSchema = jest.fn().mockResolvedValue(nativeHeaders);
     const compose = jest.fn().mockResolvedValue({ calculatedFields: undefined });
     const buildCalculatedFieldPlans = jest.fn().mockReturnValue([]);
+    const resolveBlendingDecision = jest
+      .fn()
+      .mockResolvedValue({ needsBlending: false, ...decision });
     const service = new GetReportOutputSchemaService(
       reportRepository as never,
-      {
-        resolveBlendingDecision: jest.fn().mockResolvedValue({ needsBlending: false, ...decision }),
-      } as never,
+      { resolveBlendingDecision } as never,
       { compose, buildCalculatedFieldPlans } as never,
       { canAccess: jest.fn().mockResolvedValue(canSee) } as never,
       { generateHeadersFromSchema } as never
@@ -44,6 +45,7 @@ describe('GetReportOutputSchemaService', () => {
       generateHeadersFromSchema,
       compose,
       buildCalculatedFieldPlans,
+      resolveBlendingDecision,
     };
   };
 
@@ -197,12 +199,15 @@ describe('GetReportOutputSchemaService', () => {
     ]);
   });
 
-  it('refuses a Data Mart whose schema was never stored', async () => {
-    const { service, generateHeadersFromSchema } = createService({
+  // The order matters, not just the exception: the blending decision refreshes a SQL-defined
+  // source's view on the joined path, so a request that can only fail must not reach it.
+  it('refuses a Data Mart whose schema was never stored, before resolving any blending', async () => {
+    const { service, generateHeadersFromSchema, resolveBlendingDecision } = createService({
       reportOverrides: { dataMart: { ...report.dataMart, schema: undefined } },
     });
 
     await expect(service.run(command)).rejects.toBeInstanceOf(BusinessViolationException);
+    expect(resolveBlendingDecision).not.toHaveBeenCalled();
     expect(generateHeadersFromSchema).not.toHaveBeenCalled();
   });
 

--- a/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.ts
@@ -78,12 +78,16 @@ export class GetReportOutputSchemaService {
       );
     }
 
-    const accessor = { userId: command.userId, roles: command.roles };
-    const decision = await this.blendedReportDataService.resolveBlendingDecision(report, accessor);
-
+    // Ahead of the blending decision, not just ahead of the header build: without a stored schema
+    // this request can only end in the exception below, and the decision is the one step here that
+    // still writes — it refreshes a SQL-defined source's view on the joined path. Failing first
+    // keeps a doomed request from touching the warehouse at all.
     if (!report.dataMart.schema) {
       throw new BusinessViolationException('Data mart schema must be provided');
     }
+
+    const accessor = { userId: command.userId, roles: command.roles };
+    const decision = await this.blendedReportDataService.resolveBlendingDecision(report, accessor);
 
     // Calculated fields are named by their formula and exist only in the plan that built them.
     //

--- a/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.ts
@@ -1,0 +1,107 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BusinessViolationException } from '../../common/exceptions/business-violation.exception';
+import { columnFilterWithoutCalculatedFields } from '../calculated-fields/calculated-field.utils';
+import { ReportHeadersGeneratorFacade } from '../data-storage-types/facades/report-headers-generator.facade';
+import { resolveReportDataHeaders } from '../data-storage-types/utils/report-data-headers.utils';
+import { CalculatedFieldPlan } from '../data-storage-types/utils/sql-clause-renderer';
+import { GetReportOutputSchemaCommand } from '../dto/domain/get-report-output-schema.command';
+import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
+import { hasOutputControls } from '../dto/domain/report-like-read-plan';
+import { hasMainUniqueCount } from '../dto/schemas/unique-count-sources';
+import { Report } from '../entities/report.entity';
+import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
+import { BlendedReportDataService } from '../services/blended-report-data.service';
+import { ReportSqlComposerService } from '../services/report-sql-composer.service';
+
+/**
+ * The columns a report's rows will carry. Headers come from the stored schema plus the report
+ * config — the same `resolveReportDataHeaders` path a run uses — and must not open a storage
+ * reader: `prepareReportData` starts a warehouse query on some storages.
+ */
+@Injectable()
+export class GetReportOutputSchemaService {
+  constructor(
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    private readonly blendedReportDataService: BlendedReportDataService,
+    private readonly reportSqlComposerService: ReportSqlComposerService,
+    private readonly accessDecisionService: AccessDecisionService,
+    private readonly reportHeadersGeneratorFacade: ReportHeadersGeneratorFacade
+  ) {}
+
+  async run(command: GetReportOutputSchemaCommand): Promise<ReportDataHeader[]> {
+    if (!command.userId) {
+      throw new UnauthorizedException('Authenticated user is required');
+    }
+
+    const report = await this.reportRepository.findOne({
+      where: {
+        id: command.reportId,
+        dataMart: { projectId: command.projectId },
+      },
+      relations: ['dataMart', 'dataMart.storage', 'dataDestination'],
+    });
+
+    if (!report) {
+      throw new NotFoundException(`Report with ID ${command.reportId} not found`);
+    }
+
+    // Same rule as the generated-SQL preview: describing a report is transparency, not a
+    // maintenance privilege. Access to joined sources is enforced by the blending decision.
+    const canSeeDataMart = await this.accessDecisionService.canAccess(
+      command.userId,
+      command.roles,
+      EntityType.DATA_MART,
+      report.dataMart.id,
+      Action.SEE,
+      command.projectId
+    );
+    if (!canSeeDataMart) {
+      throw new ForbiddenException(
+        'You do not have permission to view the output schema of this report: access to the source data mart is required.'
+      );
+    }
+
+    const accessor = { userId: command.userId, roles: command.roles };
+    const decision = await this.blendedReportDataService.resolveBlendingDecision(report, accessor);
+
+    // Calculated fields are named by their formula and exist only in the plan that built them.
+    let calculatedFields: CalculatedFieldPlan[] | undefined;
+    if (decision.needsBlending) {
+      calculatedFields = decision.calculatedFields;
+    } else if (hasOutputControls(report)) {
+      calculatedFields = (await this.reportSqlComposerService.compose(report, accessor))
+        .calculatedFields;
+    }
+
+    if (!report.dataMart.schema) {
+      throw new BusinessViolationException('Data mart schema must be provided');
+    }
+
+    const nativeHeaders = await this.reportHeadersGeneratorFacade.generateHeadersFromSchema(
+      report.dataMart.storage.type,
+      report.dataMart.schema
+    );
+
+    return resolveReportDataHeaders(
+      nativeHeaders,
+      {
+        columnFilter: columnFilterWithoutCalculatedFields(decision.columnFilter, calculatedFields),
+        blendedDataHeaders: decision.blendedDataHeaders,
+        aggregationConfig: decision.aggregations ?? report.aggregationConfig ?? undefined,
+        uniqueCount: hasMainUniqueCount(report.uniqueCountConfig),
+        primaryKeyColumns: decision.primaryKeyColumns,
+        uniqueCountSources: decision.uniqueCountSources,
+        calculatedFields,
+      },
+      report.dataMart.storage.type
+    );
+  }
+}

--- a/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.ts
@@ -10,15 +10,12 @@ import { BusinessViolationException } from '../../common/exceptions/business-vio
 import { columnFilterWithoutCalculatedFields } from '../calculated-fields/calculated-field.utils';
 import { ReportHeadersGeneratorFacade } from '../data-storage-types/facades/report-headers-generator.facade';
 import { resolveReportDataHeaders } from '../data-storage-types/utils/report-data-headers.utils';
-import { CalculatedFieldPlan } from '../data-storage-types/utils/sql-clause-renderer';
 import { GetReportOutputSchemaCommand } from '../dto/domain/get-report-output-schema.command';
 import { ReportDataHeader } from '../dto/domain/report-data-header.dto';
-import { hasOutputControls } from '../dto/domain/report-like-read-plan';
 import { hasMainUniqueCount } from '../dto/schemas/unique-count-sources';
 import { Report } from '../entities/report.entity';
 import { AccessDecisionService, Action, EntityType } from '../services/access-decision';
 import { BlendedReportDataService } from '../services/blended-report-data.service';
-import { ReportSqlComposerService } from '../services/report-sql-composer.service';
 
 /**
  * The columns a report's rows will carry. Headers come from the stored schema plus the report
@@ -40,7 +37,6 @@ export class GetReportOutputSchemaService {
     @InjectRepository(Report)
     private readonly reportRepository: Repository<Report>,
     private readonly blendedReportDataService: BlendedReportDataService,
-    private readonly reportSqlComposerService: ReportSqlComposerService,
     private readonly accessDecisionService: AccessDecisionService,
     private readonly reportHeadersGeneratorFacade: ReportHeadersGeneratorFacade
   ) {}
@@ -90,24 +86,11 @@ export class GetReportOutputSchemaService {
     const decision = await this.blendedReportDataService.resolveBlendingDecision(report, accessor);
 
     // Calculated fields are named by their formula and exist only in the plan that built them.
-    //
-    // Built directly rather than through `compose`: composing resolves the main table reference,
-    // and for a SQL-defined Data Mart that runs `CREATE OR REPLACE VIEW` against the customer's
-    // warehouse — DDL a describe endpoint under `Role.viewer` must not issue. The plans are the
-    // same ones `compose` derives before it ever reaches that step, so nothing about the headers
-    // changes; what goes away is the warehouse write, a second `resolveBlendingDecision`, and the
-    // SQL-composition errors that used to fail a request that only ever needed to name columns.
-    let calculatedFields: CalculatedFieldPlan[] | undefined;
-    if (decision.needsBlending) {
-      calculatedFields = decision.calculatedFields;
-    } else if (hasOutputControls(report)) {
-      const plans = this.reportSqlComposerService.buildCalculatedFieldPlans(
-        report.dataMart.schema.fields ?? [],
-        decision.columnFilter ?? [],
-        report.aggregationConfig ?? undefined
-      );
-      calculatedFields = plans.length > 0 ? plans : undefined;
-    }
+    // Both branches read the decision: it builds these plans on either path, so naming the columns
+    // needs neither a second parse of every formula nor `compose()` — which would resolve the main
+    // table reference and, for a SQL-defined Data Mart, run `CREATE OR REPLACE VIEW` against the
+    // customer's warehouse from a describe endpoint under `Role.viewer`.
+    const calculatedFields = decision.calculatedFields;
 
     const nativeHeaders = await this.reportHeadersGeneratorFacade.generateHeadersFromSchema(
       report.dataMart.storage.type,

--- a/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.ts
+++ b/apps/backend/src/data-marts/use-cases/get-report-output-schema.service.ts
@@ -22,8 +22,17 @@ import { ReportSqlComposerService } from '../services/report-sql-composer.servic
 
 /**
  * The columns a report's rows will carry. Headers come from the stored schema plus the report
- * config — the same `resolveReportDataHeaders` path a run uses — and must not open a storage
- * reader: `prepareReportData` starts a warehouse query on some storages.
+ * config — the same `resolveReportDataHeaders` path a run uses — and opens no storage reader:
+ * `prepareReportData` starts a warehouse query on some storages, and describing a report is a read
+ * under `Role.viewer`.
+ *
+ * `ReportSqlComposerService.compose` is avoided for the same reason: it resolves the main table
+ * reference, which for a SQL-defined Data Mart runs `CREATE OR REPLACE VIEW`. That leaves ONE
+ * warehouse write still reachable from here — a BLENDED report, where
+ * `resolveBlendingDecision` resolves table references itself on its way to the joined SQL, which
+ * this service needs for `blendedDataHeaders` and `uniqueCountSources`. Closing that one needs a
+ * headers-only mode on `resolveBlendingDecision`; until then a blended report on a SQL-defined
+ * Data Mart still refreshes its view when its schema is described.
  */
 @Injectable()
 export class GetReportOutputSchemaService {
@@ -72,17 +81,28 @@ export class GetReportOutputSchemaService {
     const accessor = { userId: command.userId, roles: command.roles };
     const decision = await this.blendedReportDataService.resolveBlendingDecision(report, accessor);
 
+    if (!report.dataMart.schema) {
+      throw new BusinessViolationException('Data mart schema must be provided');
+    }
+
     // Calculated fields are named by their formula and exist only in the plan that built them.
+    //
+    // Built directly rather than through `compose`: composing resolves the main table reference,
+    // and for a SQL-defined Data Mart that runs `CREATE OR REPLACE VIEW` against the customer's
+    // warehouse — DDL a describe endpoint under `Role.viewer` must not issue. The plans are the
+    // same ones `compose` derives before it ever reaches that step, so nothing about the headers
+    // changes; what goes away is the warehouse write, a second `resolveBlendingDecision`, and the
+    // SQL-composition errors that used to fail a request that only ever needed to name columns.
     let calculatedFields: CalculatedFieldPlan[] | undefined;
     if (decision.needsBlending) {
       calculatedFields = decision.calculatedFields;
     } else if (hasOutputControls(report)) {
-      calculatedFields = (await this.reportSqlComposerService.compose(report, accessor))
-        .calculatedFields;
-    }
-
-    if (!report.dataMart.schema) {
-      throw new BusinessViolationException('Data mart schema must be provided');
+      const plans = this.reportSqlComposerService.buildCalculatedFieldPlans(
+        report.dataMart.schema.fields ?? [],
+        decision.columnFilter ?? [],
+        report.aggregationConfig ?? undefined
+      );
+      calculatedFields = plans.length > 0 ? plans : undefined;
     }
 
     const nativeHeaders = await this.reportHeadersGeneratorFacade.generateHeadersFromSchema(

--- a/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/data-mart-catalog.tool.spec.ts
@@ -191,6 +191,7 @@ describe('ListDataMartsTool', () => {
       'GetProjectContextTool',
       'ListDestinationsTool',
       'GetDataMartReportsTool',
+      'GetReportOutputSchemaTool',
       'ListReportRunSchedulesTool',
       'CreateReportRunScheduleTool',
       'UpdateReportRunScheduleTool',

--- a/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.spec.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { McpReportsFacade } from '../../../data-marts/facades/mcp-reports.facade';
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import { GetReportOutputSchemaTool } from './get-report-output-schema.tool';
@@ -73,6 +74,29 @@ describe('GetReportOutputSchemaTool', () => {
     });
   });
 
+  // The SDK validates every structuredContent against this schema, so a hardcoded level vocabulary
+  // would turn "a level was added to the domain" into an McpError from this tool. The level must
+  // pass through as whatever the facade forwarded.
+  it('accepts a calculated-field level the tool does not know about', () => {
+    const tool = new GetReportOutputSchemaTool({} as McpReportsFacade);
+
+    const parsed = z.object(tool.outputSchema).safeParse({
+      report_id: 'report-1',
+      columns: [
+        {
+          name: 'ctr',
+          title: null,
+          description: null,
+          type: 'FLOAT',
+          aggregate_function: null,
+          calculated_field_level: 'a-level-added-later',
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
   it('rejects an input that names no report, or carries anything extra', () => {
     const tool = new GetReportOutputSchemaTool({} as McpReportsFacade);
 
@@ -80,6 +104,10 @@ describe('GetReportOutputSchemaTool', () => {
     expect(() => tool.parseInput({ report_id: '' })).toThrow();
     expect(() => tool.parseInput({ report_id: 'report-1', limit: 10 })).toThrow();
     expect(tool.parseInput({ report_id: 'report-1' })).toEqual({ report_id: 'report-1' });
+    // A padded id is what an LLM caller copying a value out of a previous answer produces; the
+    // sibling report tools trim it, and a 404 here for whitespace alone would be gratuitous.
+    expect(tool.parseInput({ report_id: '  report-1  ' })).toEqual({ report_id: 'report-1' });
+    expect(() => tool.parseInput({ report_id: '   ' })).toThrow();
   });
 
   // Describing a report reads no report data and changes no OWOX entity, so a client holding only

--- a/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.spec.ts
@@ -16,10 +16,42 @@ describe('GetReportOutputSchemaTool', () => {
   };
 
   const columns = [
-    { name: 'date', title: 'Date', description: 'Reporting day', type: 'DATE' },
-    { name: 'revenue | SUM', title: 'Revenue, $ | SUM', description: null, type: 'NUMERIC' },
-    { name: 'Unique Count', title: null, description: null, type: 'INTEGER' },
+    {
+      name: 'date',
+      title: 'Date',
+      description: 'Reporting day',
+      type: 'DATE',
+      aggregateFunction: null,
+      calculatedFieldLevel: null,
+    },
+    {
+      name: 'revenue | SUM',
+      title: 'Revenue, $ | SUM',
+      description: null,
+      type: 'NUMERIC',
+      aggregateFunction: 'SUM',
+      calculatedFieldLevel: null,
+    },
+    {
+      name: 'ctr',
+      title: 'CTR, %',
+      description: null,
+      type: 'FLOAT',
+      aggregateFunction: null,
+      calculatedFieldLevel: 'metric',
+    },
   ];
+
+  // The tool renames to snake_case at its edge; the two discriminators must survive that hop, or a
+  // consumer cannot tell a non-additive metric from an ordinary numeric column.
+  const snakeColumns = columns.map(column => ({
+    name: column.name,
+    title: column.title,
+    description: column.description,
+    type: column.type,
+    aggregate_function: column.aggregateFunction,
+    calculated_field_level: column.calculatedFieldLevel,
+  }));
 
   it('returns the report columns using token project-member context', async () => {
     const facade = {
@@ -27,7 +59,7 @@ describe('GetReportOutputSchemaTool', () => {
     } as unknown as jest.Mocked<McpReportsFacade>;
     const tool = new GetReportOutputSchemaTool(facade);
 
-    const structuredContent = { report_id: 'report-1', columns };
+    const structuredContent = { report_id: 'report-1', columns: snakeColumns };
 
     await expect(tool.handler({ report_id: 'report-1' }, context)).resolves.toEqual({
       structuredContent,
@@ -50,8 +82,11 @@ describe('GetReportOutputSchemaTool', () => {
     expect(tool.parseInput({ report_id: 'report-1' })).toEqual({ report_id: 'report-1' });
   });
 
-  // Describing a report reads nothing and changes nothing: an MCP client that only holds
-  // `mcp:read` must be able to call it, and it must not be advertised as a mutation.
+  // Describing a report reads no report data and changes no OWOX entity, so a client holding only
+  // `mcp:read` must be able to call it. The hint stays optimistic deliberately: a JOINED report on
+  // a SQL-defined Data Mart still refreshes each source's technical view through the blending
+  // decision, which the description warns about — unlike `query_data_mart`, which sets the hint to
+  // false because every call costs credits and records a billable run.
   it('is registered as a read-only tool requiring only the read scope', () => {
     const registry = new McpToolRegistry([new GetReportOutputSchemaTool({} as McpReportsFacade)]);
 

--- a/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.spec.ts
+++ b/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.spec.ts
@@ -1,0 +1,66 @@
+import type { McpReportsFacade } from '../../../data-marts/facades/mcp-reports.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import { GetReportOutputSchemaTool } from './get-report-output-schema.tool';
+import { McpToolRegistry } from './mcp-tool.registry';
+import { MCP_TOOL_PROVIDER_CLASSES } from './mcp-tool.providers';
+
+describe('GetReportOutputSchemaTool', () => {
+  const context: McpAuthContext = {
+    clientId: 'mcp-client-1',
+    userId: 'user-1',
+    projectId: 'project-1',
+    roles: ['viewer'],
+    resource: 'https://mcp.owox.com/mcp',
+    scopes: ['mcp:read'],
+    authFlow: 'mcp',
+  };
+
+  const columns = [
+    { name: 'date', title: 'Date', description: 'Reporting day', type: 'DATE' },
+    { name: 'revenue | SUM', title: 'Revenue, $ | SUM', description: null, type: 'NUMERIC' },
+    { name: 'Unique Count', title: null, description: null, type: 'INTEGER' },
+  ];
+
+  it('returns the report columns using token project-member context', async () => {
+    const facade = {
+      getReportOutputSchema: jest.fn().mockResolvedValue({ reportId: 'report-1', columns }),
+    } as unknown as jest.Mocked<McpReportsFacade>;
+    const tool = new GetReportOutputSchemaTool(facade);
+
+    const structuredContent = { report_id: 'report-1', columns };
+
+    await expect(tool.handler({ report_id: 'report-1' }, context)).resolves.toEqual({
+      structuredContent,
+      content: [{ type: 'text', text: JSON.stringify(structuredContent, null, 2) }],
+    });
+    expect(facade.getReportOutputSchema).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      userId: 'user-1',
+      roles: ['viewer'],
+      reportId: 'report-1',
+    });
+  });
+
+  it('rejects an input that names no report, or carries anything extra', () => {
+    const tool = new GetReportOutputSchemaTool({} as McpReportsFacade);
+
+    expect(() => tool.parseInput({})).toThrow();
+    expect(() => tool.parseInput({ report_id: '' })).toThrow();
+    expect(() => tool.parseInput({ report_id: 'report-1', limit: 10 })).toThrow();
+    expect(tool.parseInput({ report_id: 'report-1' })).toEqual({ report_id: 'report-1' });
+  });
+
+  // Describing a report reads nothing and changes nothing: an MCP client that only holds
+  // `mcp:read` must be able to call it, and it must not be advertised as a mutation.
+  it('is registered as a read-only tool requiring only the read scope', () => {
+    const registry = new McpToolRegistry([new GetReportOutputSchemaTool({} as McpReportsFacade)]);
+
+    expect(new GetReportOutputSchemaTool({} as McpReportsFacade)).toMatchObject({
+      name: 'get_report_output_schema',
+      requiredScopes: ['mcp:read'],
+      annotations: { readOnlyHint: true, destructiveHint: false },
+    });
+    expect(MCP_TOOL_PROVIDER_CLASSES.map(tool => tool.name)).toContain('GetReportOutputSchemaTool');
+    expect(registry.getTool('get_report_output_schema')).toBeDefined();
+  });
+});

--- a/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.ts
@@ -19,7 +19,10 @@ export class GetReportOutputSchemaTool implements McpToolDefinition<GetReportOut
     "The columns a report's rows will carry, in the order they are projected — the names to put " +
     'above the values the report delivers. Includes the columns a report synthesises (aggregated ' +
     '`revenue | SUM`, Unique Count, calculated fields), which appear in no data mart schema. ' +
-    'Answers from the stored schema and the report config, so it reads no report data.';
+    'Answers from the stored schema and the report config, so it reads no report data. One ' +
+    'caveat behind the read-only hint: for a report that joins other data marts, resolving the ' +
+    "join refreshes each SQL-defined source's technical view, so a repeated call is not free on " +
+    'the warehouse.';
   readonly zodSchema = inputSchema.shape;
   readonly outputSchema = {
     report_id: z.string(),
@@ -29,6 +32,16 @@ export class GetReportOutputSchemaTool implements McpToolDefinition<GetReportOut
         title: z.string().nullable().describe('Alias configured for the column, if any.'),
         description: z.string().nullable(),
         type: z.string().nullable().describe('Storage field type, when it can be derived.'),
+        aggregate_function: z
+          .string()
+          .nullable()
+          .describe('The aggregate function the report applies to this column, if any.'),
+        calculated_field_level: z
+          .enum(['metric', 'column'])
+          .nullable()
+          .describe(
+            'Calculated fields only. `metric` AGGREGATES — never re-aggregate it, whatever `type` says. `column` is row-level with no warehouse column behind it. null is an ordinary native column, which may be rolled up.'
+          ),
       })
     ),
   };
@@ -64,7 +77,14 @@ export class GetReportOutputSchemaTool implements McpToolDefinition<GetReportOut
 
     return jsonToolResult({
       report_id: result.reportId,
-      columns: result.columns,
+      columns: result.columns.map(column => ({
+        name: column.name,
+        title: column.title,
+        description: column.description,
+        type: column.type,
+        aggregate_function: column.aggregateFunction,
+        calculated_field_level: column.calculatedFieldLevel,
+      })),
     });
   }
 }

--- a/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.ts
@@ -1,0 +1,70 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { z } from 'zod';
+import type { McpScope } from '@owox/idp-protocol';
+import {
+  MCP_REPORTS_FACADE,
+  type McpReportsFacade,
+} from '../../../data-marts/facades/mcp-reports.facade';
+import type { McpAuthContext } from '../auth/mcp-auth-context';
+import { jsonToolResult, type McpToolDefinition, type McpToolResult } from './mcp-tool.definition';
+
+const inputSchema = z.object({ report_id: z.string().min(1) }).strict();
+
+type GetReportOutputSchemaInput = z.infer<typeof inputSchema>;
+
+@Injectable()
+export class GetReportOutputSchemaTool implements McpToolDefinition<GetReportOutputSchemaInput> {
+  readonly name = 'get_report_output_schema';
+  readonly description =
+    "The columns a report's rows will carry, in the order they are projected — the names to put " +
+    'above the values the report delivers. Includes the columns a report synthesises (aggregated ' +
+    '`revenue | SUM`, Unique Count, calculated fields), which appear in no data mart schema. ' +
+    'Answers from the stored schema and the report config, so it reads no report data.';
+  readonly zodSchema = inputSchema.shape;
+  readonly outputSchema = {
+    report_id: z.string(),
+    columns: z.array(
+      z.object({
+        name: z.string().describe('The key each output row is keyed by.'),
+        title: z.string().nullable().describe('Alias configured for the column, if any.'),
+        description: z.string().nullable(),
+        type: z.string().nullable().describe('Storage field type, when it can be derived.'),
+      })
+    ),
+  };
+  readonly annotations = {
+    title: 'Get Report Output Schema',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: false,
+  };
+  readonly requiredScopes: McpScope[] = ['mcp:read'];
+
+  constructor(
+    @Inject(MCP_REPORTS_FACADE)
+    private readonly reports: McpReportsFacade
+  ) {}
+
+  parseInput(input: unknown): GetReportOutputSchemaInput {
+    return inputSchema.parse(input);
+  }
+
+  async handler(
+    input: GetReportOutputSchemaInput,
+    context: McpAuthContext
+  ): Promise<McpToolResult> {
+    const parsed = this.parseInput(input);
+
+    const result = await this.reports.getReportOutputSchema({
+      projectId: context.projectId,
+      userId: context.userId,
+      roles: context.roles,
+      reportId: parsed.report_id,
+    });
+
+    return jsonToolResult({
+      report_id: result.reportId,
+      columns: result.columns,
+    });
+  }
+}

--- a/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.ts
+++ b/apps/backend/src/ee/mcp/tools/get-report-output-schema.tool.ts
@@ -8,7 +8,7 @@ import {
 import type { McpAuthContext } from '../auth/mcp-auth-context';
 import { jsonToolResult, type McpToolDefinition, type McpToolResult } from './mcp-tool.definition';
 
-const inputSchema = z.object({ report_id: z.string().min(1) }).strict();
+const inputSchema = z.object({ report_id: z.string().trim().min(1) }).strict();
 
 type GetReportOutputSchemaInput = z.infer<typeof inputSchema>;
 
@@ -19,7 +19,9 @@ export class GetReportOutputSchemaTool implements McpToolDefinition<GetReportOut
     "The columns a report's rows will carry, in the order they are projected — the names to put " +
     'above the values the report delivers. Includes the columns a report synthesises (aggregated ' +
     '`revenue | SUM`, Unique Count, calculated fields), which appear in no data mart schema. ' +
-    'Answers from the stored schema and the report config, so it reads no report data. One ' +
+    'Answers from the stored schema and the report config, so it reads no report data — the ' +
+    "columns are as of the Data Mart's last schema actualization, so one added warehouse-side and " +
+    'not yet actualized is missing until a run or a data read picks it up. One ' +
     'caveat behind the read-only hint: for a report that joins other data marts, resolving the ' +
     "join refreshes each SQL-defined source's technical view, so a repeated call is not free on " +
     'the warehouse.';
@@ -36,8 +38,12 @@ export class GetReportOutputSchemaTool implements McpToolDefinition<GetReportOut
           .string()
           .nullable()
           .describe('The aggregate function the report applies to this column, if any.'),
+        // A bare string, not z.enum: this is an OUTPUT schema over a level the facade forwards
+        // from persisted JSON, and the SDK validates structuredContent against it — so a hardcoded
+        // vocabulary would turn "a level was added to the domain" into an McpError from this tool.
+        // Same call `data-mart-details.tool.ts` makes for its own `level`, for the same reason.
         calculated_field_level: z
-          .enum(['metric', 'column'])
+          .string()
           .nullable()
           .describe(
             'Calculated fields only. `metric` AGGREGATES — never re-aggregate it, whatever `type` says. `column` is row-level with no warehouse column behind it. null is an ordinary native column, which may be rolled up.'

--- a/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
+++ b/apps/backend/src/ee/mcp/tools/mcp-tool.providers.ts
@@ -6,6 +6,7 @@ import { GetDataMartDetailsTool } from './data-mart-details.tool';
 import { DeleteReportTool } from './delete-report.tool';
 import { DeleteReportRunScheduleTool } from './delete-report-run-schedule.tool';
 import { GetDataMartReportsTool } from './get-data-mart-reports.tool';
+import { GetReportOutputSchemaTool } from './get-report-output-schema.tool';
 import { GetReportRunStatusTool } from './get-report-run-status.tool';
 import { ListDestinationsTool } from './list-destinations.tool';
 import { ListReportRunSchedulesTool } from './list-report-run-schedules.tool';
@@ -27,6 +28,7 @@ export const MCP_TOOL_PROVIDER_CLASSES: Array<Type<McpToolDefinition>> = [
   GetProjectContextTool,
   ListDestinationsTool,
   GetDataMartReportsTool,
+  GetReportOutputSchemaTool,
   ListReportRunSchedulesTool,
   CreateReportRunScheduleTool,
   UpdateReportRunScheduleTool,

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -86,6 +86,7 @@ export {
   type OWOXProjectSetupProgressSteps,
   type OWOXProjectSetupStepState,
 } from './project.js';
+export { type OWOXReportOutputSchemaField } from './reports.js';
 export {
   type OWOXSearchEntityType,
   type OWOXSearchOptions,

--- a/packages/api-client/src/reports.test.ts
+++ b/packages/api-client/src/reports.test.ts
@@ -129,6 +129,29 @@ describe('ReportsApi.traverseData', () => {
     });
   });
 
+  it('reports malformed NDJSON lines with report and run context', async () => {
+    const requester = {
+      getJson: async () => ({}) as never,
+      getStream: async () => malformedStreamResponse('run-bad'),
+    };
+
+    const traversal = await new ReportsApi(requester).traverseData('report-1');
+
+    const rows = collectRows(traversal);
+    await expect(rows).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(rows).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'Malformed NDJSON line 2 in OWOX report data stream',
+      details: {
+        reportId: 'report-1',
+        lineNumber: 2,
+        runId: 'run-bad',
+      },
+    });
+  });
+});
+
+describe('ReportsApi.getOutputSchema', () => {
   it('reads the output schema from the report route and passes the columns through', async () => {
     const calls: Array<{ path: string; query?: Record<string, string> }> = [];
     const columns = [
@@ -212,27 +235,6 @@ describe('ReportsApi.traverseData', () => {
     await expect(schema).rejects.toMatchObject({
       message: 'Failed to read OWOX report output schema',
       details: { reportId: 'report-1' },
-    });
-  });
-
-  it('reports malformed NDJSON lines with report and run context', async () => {
-    const requester = {
-      getJson: async () => ({}) as never,
-      getStream: async () => malformedStreamResponse('run-bad'),
-    };
-
-    const traversal = await new ReportsApi(requester).traverseData('report-1');
-
-    const rows = collectRows(traversal);
-    await expect(rows).rejects.toBeInstanceOf(OWOXApiError);
-    await expect(rows).rejects.toMatchObject({
-      name: 'OWOXApiError',
-      message: 'Malformed NDJSON line 2 in OWOX report data stream',
-      details: {
-        reportId: 'report-1',
-        lineNumber: 2,
-        runId: 'run-bad',
-      },
     });
   });
 });

--- a/packages/api-client/src/reports.test.ts
+++ b/packages/api-client/src/reports.test.ts
@@ -129,6 +129,92 @@ describe('ReportsApi.traverseData', () => {
     });
   });
 
+  it('reads the output schema from the report route and passes the columns through', async () => {
+    const calls: Array<{ path: string; query?: Record<string, string> }> = [];
+    const columns = [
+      { name: 'date', title: 'Date', description: 'Reporting day', type: 'DATE' },
+      { name: 'revenue | SUM', title: 'Revenue, $ | SUM', type: 'NUMERIC' },
+      { name: 'clicks' },
+    ];
+    const requester = {
+      getJson: async (path: string, query?: Record<string, string>) => {
+        calls.push({ path, query });
+        return columns as never;
+      },
+      getStream: async () => streamResponse('run-1'),
+    };
+
+    const schema = await new ReportsApi(requester).getOutputSchema('report-1');
+
+    expect(calls[0]!.path).toBe('/api/reports/report-1/output-schema');
+    expect(schema).toEqual(columns);
+  });
+
+  it('encodes the report id into the output schema path', async () => {
+    const calls: string[] = [];
+    const requester = {
+      getJson: async (path: string) => {
+        calls.push(path);
+        return [] as never;
+      },
+      getStream: async () => streamResponse('run-1'),
+    };
+
+    await new ReportsApi(requester).getOutputSchema('report/1 2');
+
+    expect(calls[0]).toBe('/api/reports/report%2F1%202/output-schema');
+  });
+
+  it('rejects an output schema response that is not a list of columns', async () => {
+    const requester = {
+      getJson: async () => ({ columns: [] }) as never,
+      getStream: async () => streamResponse('run-1'),
+    };
+
+    const schema = new ReportsApi(requester).getOutputSchema('report-1');
+
+    await expect(schema).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(schema).rejects.toMatchObject({
+      message: 'OWOX report output schema API returned an unexpected response shape',
+      details: { reportId: 'report-1' },
+    });
+  });
+
+  it('carries the report id on an API error raised while reading the output schema', async () => {
+    const requester = {
+      getJson: async () => {
+        throw new OWOXApiError('Report not found', { status: 404 });
+      },
+      getStream: async () => streamResponse('run-1'),
+    };
+
+    const schema = new ReportsApi(requester).getOutputSchema('report-1');
+
+    await expect(schema).rejects.toMatchObject({
+      name: 'OWOXApiError',
+      message: 'Report not found',
+      status: 404,
+      details: { reportId: 'report-1' },
+    });
+  });
+
+  it('wraps a non-API failure while reading the output schema', async () => {
+    const requester = {
+      getJson: async () => {
+        throw new TypeError('socket hang up');
+      },
+      getStream: async () => streamResponse('run-1'),
+    };
+
+    const schema = new ReportsApi(requester).getOutputSchema('report-1');
+
+    await expect(schema).rejects.toBeInstanceOf(OWOXApiError);
+    await expect(schema).rejects.toMatchObject({
+      message: 'Failed to read OWOX report output schema',
+      details: { reportId: 'report-1' },
+    });
+  });
+
   it('reports malformed NDJSON lines with report and run context', async () => {
     const requester = {
       getJson: async () => ({}) as never,

--- a/packages/api-client/src/reports.ts
+++ b/packages/api-client/src/reports.ts
@@ -25,6 +25,14 @@ export type OWOXReportOutputSchemaField = {
   title?: string;
   description?: string;
   type?: string;
+  /** The aggregate function the report applies to this column, when it applies one. */
+  aggregateFunction?: string;
+  /**
+   * Calculated fields only. `metric` means the formula AGGREGATES — re-aggregating it is wrong at
+   * any grain, whatever `type` says. `column` means row-level, with no warehouse column behind it.
+   * Absent is an ordinary native column, which may be rolled up.
+   */
+  calculatedFieldLevel?: 'metric' | 'column';
 };
 
 export class ReportsApi {

--- a/packages/api-client/src/reports.ts
+++ b/packages/api-client/src/reports.ts
@@ -12,6 +12,21 @@ export type TraverseReportDataOptions = {
   limit?: number;
 };
 
+/**
+ * One column of a report's output, as a reader of the rows would name and understand it.
+ *
+ * `name` is the key each row from {@link ReportsApi.traverseData} is keyed by — the pairing is the
+ * point: the stream carries values, this carries the names to put above them. Columns the report
+ * synthesises (aggregated `revenue | SUM`, Unique Count, calculated fields) appear here and nowhere
+ * in the Data Mart schema.
+ */
+export type OWOXReportOutputSchemaField = {
+  name: string;
+  title?: string;
+  description?: string;
+  type?: string;
+};
+
 export class ReportsApi {
   constructor(private readonly requester: JsonRequester) {}
 
@@ -41,5 +56,39 @@ export class ReportsApi {
     }
 
     return new HttpNdjsonTraversal(response, reportId, REPORT_TRAVERSAL_SOURCE);
+  }
+
+  /**
+   * The columns the report's rows will carry, in the order they are projected.
+   *
+   * Resolved from the stored schema and the report config, so it can be read before — or without —
+   * traversing any data.
+   */
+  async getOutputSchema(reportId: string): Promise<OWOXReportOutputSchemaField[]> {
+    let response: unknown;
+    try {
+      response = await this.requester.getJson<unknown>(
+        `/api/reports/${encodeURIComponent(reportId)}/output-schema`
+      );
+    } catch (error) {
+      if (error instanceof OWOXApiError) {
+        throw withSourceContext(error, REPORT_TRAVERSAL_SOURCE.idKey, reportId);
+      }
+      throw new OWOXApiError('Failed to read OWOX report output schema', {
+        details: { reportId },
+        cause: error,
+      });
+    }
+
+    if (!Array.isArray(response)) {
+      throw new OWOXApiError(
+        'OWOX report output schema API returned an unexpected response shape',
+        {
+          details: { reportId, response },
+        }
+      );
+    }
+
+    return response as OWOXReportOutputSchemaField[];
   }
 }

--- a/packages/plugin-sdk/src/iframe-transport.test.ts
+++ b/packages/plugin-sdk/src/iframe-transport.test.ts
@@ -1,3 +1,4 @@
+import { OWOXApiClient } from '@owox/api-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createIframeTransport, PluginTransportError } from './iframe-transport.js';
 import type { PluginRequest, PluginResponse } from './protocol.js';
@@ -54,6 +55,40 @@ describe('iframe transport', () => {
     });
 
     await expect(pending).resolves.toEqual({ ok: true });
+  });
+
+  /**
+   * A plugin reaches a report's output schema with no plugin-sdk code of its own: `connect()` hands
+   * it a real `OWOXApiClient` over this transport, and the host bridge forwards any root-relative
+   * `/api/` path without a per-endpoint allowlist. This pins that chain end to end — if either the
+   * api-client method or this transport stops carrying it, the failure lands here rather than in a
+   * plugin at runtime.
+   */
+  it('carries an api-client report output schema call through to the host', async () => {
+    const host = hostSide();
+    const owox = new OWOXApiClient({ transport: host.transport });
+    const columns = [
+      { name: 'date', title: 'Date', type: 'DATE' },
+      { name: 'revenue | SUM', title: 'Revenue, $ | SUM', type: 'NUMERIC' },
+    ];
+
+    const pending = owox.reports.getOutputSchema('report-1');
+    await host.waitForReceived();
+
+    expect(host.received[0]).toMatchObject({
+      kind: 'api',
+      method: 'GET',
+      path: '/api/reports/report-1/output-schema',
+    });
+    host.answer({
+      id: host.received[0].id,
+      ok: true,
+      status: 200,
+      headers: {},
+      body: columns,
+    });
+
+    await expect(pending).resolves.toEqual(columns);
   });
 
   it('forwards a PATCH JSON request with its body', async () => {


### PR DESCRIPTION
## Summary

Adds `GET /reports/:id/output-schema`: the columns a report's rows will carry (`name`, `title`, `description`, `type`, plus `aggregateFunction` and `calculatedFieldLevel`), including aggregated columns, Unique Count and calculated fields, which do not exist on the Data Mart schema. Resolved from the stored schema and report config, without opening a storage reader. Not warehouse-free, though: resolving the report's blending decision resolves its table references, which refreshes a SQL-defined Data Mart's view — the same `GET /reports/:id/generated-sql` already does.

`calculatedFieldLevel` travels because `type` alone cannot separate a non-additive calculated metric from an ordinary numeric column, and a consumer that re-aggregates the first is wrong at any grain. An absent value means a native column, not "unknown".

Excel joined-field labels now use the same form as Google Sheets: `Field name (Data Mart name)`.

## Reaching it from the clients

A backend route alone is not usable by the clients that need it. In pull mode the Excel add-in reads rows from the HTTP data stream and has no way to learn the real column names — that is what this schema is for.

- `@owox/api-client` — `ReportsApi.getOutputSchema`, beside the existing `traverseData`, with `OWOXReportOutputSchemaField` exported.
- MCP — `get_report_output_schema`, a read-only tool on `mcp:read`, over a new `McpReportsFacade.getReportOutputSchema`. Optional fields are published as explicit nulls: in JSON an absent key reads as "unknown" rather than "no alias".
- `@owox/plugin-sdk` — no code of its own. `connect()` already hands plugins a real `OWOXApiClient` over the iframe transport, and the host bridge forwards any root-relative `/api/` path. A test pins that chain end to end.

Access is unchanged and enforced where it already was: the report is looked up scoped to the caller's project, then gated on SEE of the source data mart — the same level `get_data_mart_reports` requires. The MCP tool takes only `report_id`; project, user and roles come from the verified token.
